### PR TITLE
feat(connectors): G3.6-T9 Fleet CLI verbs + recorded-fixture E2E + onboarding doc

### DIFF
--- a/backend/tests/acceptance/_vcf_fleet_canary_fixtures.py
+++ b/backend/tests/acceptance/_vcf_fleet_canary_fixtures.py
@@ -1,0 +1,465 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Shared minimal-setup fixtures for the G3.6-T9 VCF Fleet dispatch tests.
+
+The E2E module (:mod:`tests.test_connectors_vcf_fleet_e2e`) needs a
+registered :class:`~meho_backplane.connectors.vcf_fleet.VcfFleetConnector`
+instance with a stub credentials loader (so no Vault read fires), a
+probed :class:`~meho_backplane.db.models.Target`, the 8 curated
+:class:`~meho_backplane.db.models.EndpointDescriptor` rows from
+:data:`~meho_backplane.connectors.vcf_fleet.core_ops.FLEET_CORE_OPS`,
+and a :mod:`respx`-mocked Fleet REST surface answering each of the 8
+curated read ops.
+
+Fleet uses HTTP Basic auth against the local LCM user store on every
+request — no session-establish call, no XSRF-token dance, no 401-retry
+loop. The stub credentials loader bypasses the Vault-backed loader; the
+respx router matches by method + path (Basic auth header is not asserted
+by default, matching the SDDC Manager precedent).
+
+Why a minimal direct-insert path (not full G0.7 canary ingest)
+==============================================================
+
+VCF Fleet has no public CI simulator (Initiative #369 DoD), and the
+full vRSLCM OpenAPI ingest needs the spec file reachable on the runner.
+Until the spec-shelf is wired to the meho-runners pool, the dispatch
+leg is exercised against a direct-insert path that seeds the 8 curated
+endpoint_descriptor rows by hand. Same pattern :mod:`tests.acceptance._nsx_canary_fixtures`
+and :mod:`tests.acceptance._sddc_canary_fixtures` established for the
+other no-public-simulator connectors.
+
+``EndpointDescriptor.product`` note
+===================================
+
+Rows are inserted with ``product=FLEET_PRODUCT="fleet"`` — the value
+:func:`~meho_backplane.operations._lookup.parse_connector_id` derives
+from ``"fleet-rest-9.0"`` (the first hyphen-segment of impl_id). The
+:class:`Target` row uses ``product="vcf-fleet"`` so the resolver finds
+:class:`VcfFleetConnector` (registered with ``product="vcf-fleet"`` in
+the v2 registry). These product values serve different purposes; both
+are required for end-to-end dispatch to succeed. Same divergence
+:mod:`tests.acceptance._sddc_canary_fixtures` documents for SDDC
+Manager.
+
+Fixture payloads are JSON-coercible Python literals mirroring the
+shapes the recorded-fixture refresh tool
+(``backend/tests/fixtures/vcf/refresh.py``) records from a real
+appliance — the on-disk JSON files live under
+``backend/tests/fixtures/vcf/vcf-fleet/`` once an operator runs the
+refresh script. This module's literals exist so the in-process tests
+don't depend on those files being present; the refresh tool documents
+the recording flow so a future maintainer can re-record after an
+appliance upgrade.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from uuid import UUID
+
+import respx
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.schemas import FingerprintResult
+from meho_backplane.connectors.vcf_fleet import (
+    FLEET_CORE_GROUPS,
+    FLEET_CORE_OPS,
+    FLEET_IMPL_ID,
+    FLEET_PRODUCT,
+    FLEET_VERSION,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+
+_PATH_VAR_RE = re.compile(r"\{([^{}]+)\}")
+
+__all__ = [
+    "FLEET_CANARY_BASE_URL",
+    "FLEET_CANARY_DATACENTERS",
+    "FLEET_CANARY_ENVIRONMENTS",
+    "FLEET_CANARY_FINGERPRINT",
+    "FLEET_CANARY_OPERATOR_TENANT",
+    "FLEET_CANARY_PRODUCTS",
+    "FLEET_CANARY_REQUESTS",
+    "FLEET_CANARY_VCENTERS",
+    "FLEET_FORCE_HANDLE_LIST_OP_ID",
+    "FLEET_TARGET_NAME",
+    "_fleet_credentials_loader",
+    "_insert_fleet_descriptors",
+    "_register_fleet_routes",
+]
+
+#: Tenant the VCF Fleet dispatch tests act under. Distinct UUID per
+#: connector family to avoid cross-test interference if the per-test
+#: SQLite DB ever becomes shared.
+FLEET_CANARY_OPERATOR_TENANT: UUID = UUID("00000000-0000-0000-0000-0000000000fd")
+
+#: Stable :class:`Target.name` for the seeded Fleet target.
+FLEET_TARGET_NAME: str = "fleet-acceptance"
+
+#: ``.test.invalid`` (RFC 6761 reserved) so no real network egress
+#: fires. Port 443 keeps ``HttpConnector._base_url`` from appending a
+#: ``:port`` suffix, so the respx ``base_url`` matches the connector's
+#: client URL exactly.
+FLEET_CANARY_BASE_URL: str = "https://fleet-canary.test.invalid"
+
+#: The list op the JSONFlux force-handle test dispatches. Environment
+#: listing is the largest curated Fleet read surface in real
+#: deployments — every vRA / vROps / vRLI / vIDM deploy on the appliance
+#: lives under an environment, and busy Fleets manage dozens. Mirrors
+#: the NSX (segment list) and SDDC Manager (host list) choices.
+FLEET_FORCE_HANDLE_LIST_OP_ID: str = "GET:/lcm/lcops/api/v2/environments"
+
+#: Persisted as ``Target.fingerprint`` so the resolver binds
+#: :class:`VcfFleetConnector` (``supported_version_range=">=9.0,<10.0"``).
+#: The probe normally writes this dict at first-probe time; the dispatch
+#: tests seed it directly so the resolver binds without a real probe
+#: round-trip.
+#:
+#: The persisted ``version`` is the connector class's declared product
+#: version (``FLEET_VERSION = "9.0"``) so the resolver's
+#: ``supported_version_range`` filter matches. This differs from what
+#: :meth:`VcfFleetConnector.fingerprint` writes at runtime — that method
+#: stores the ``Lcm-API-Version`` response header (e.g. ``"8.0"``) under
+#: ``version`` because Fleet exposes no working product-version endpoint
+#: in 9.0. The seeded canary uses the product version to satisfy the
+#: resolver's contract; the runtime-observable LCM API header is carried
+#: under ``extras.lcm_api_version`` for documentation.
+FLEET_CANARY_FINGERPRINT: dict[str, object] = FingerprintResult(
+    vendor="vmware",
+    product="vcf-fleet",
+    version=FLEET_VERSION,
+    build=None,
+    reachable=True,
+    probed_at=datetime(2026, 5, 22, 10, 0, 0, tzinfo=UTC),
+    probe_method=(
+        "GET /lcm/lcops/api/v2/datacenters with HTTP Basic; read Lcm-API-Version response header"
+    ),
+    extras={
+        "lcm_api_version": "8.0",
+        "datacenter_count": 2,
+        "product_lineage": "vmware-vrealize-suite-lifecycle-manager",
+        "diagnostic_endpoints_broken": [
+            "/lcm/lcops/api/v2/about",
+            "/lcm/lcops/api/v2/health",
+            "/lcm/lcops/api/v2/version",
+            "/lcm/lcops/api/v2/system-details",
+            "/lcm/common/api/about",
+            "/lcm/locker/api/v2/about",
+        ],
+    },
+).model_dump(mode="json")
+
+#: Synthetic Fleet ``about`` response. Note: in real VCF 9.0 builds the
+#: appliance returns HTTP 500 on this endpoint; the canary returns a
+#: well-formed payload so the dispatch test can exercise the parse path
+#: too. The connector's E2E `about` row exists for spec parity — the
+#: known-issue documentation lives in the curated `llm_instructions`.
+FLEET_CANARY_ABOUT: dict[str, object] = {
+    "apiVersion": "8.0",
+    "productVersion": "9.0.0.0",
+    "buildNumber": "24123456",
+    "releaseDate": "2026-04-01",
+}
+
+#: Synthetic datacenter list — two entries (the wrapper-verified probe
+#: payload).
+FLEET_CANARY_DATACENTERS: list[dict[str, object]] = [
+    {
+        "vmid": "dc-canary-001",
+        "name": "primary",
+        "type": "PRIVATE_CLOUD",
+        "city": "Vienna",
+        "country": "AT",
+        "vCenters": [],
+    },
+    {
+        "vmid": "dc-canary-002",
+        "name": "secondary",
+        "type": "PRIVATE_CLOUD",
+        "city": "Frankfurt",
+        "country": "DE",
+        "vCenters": [],
+    },
+]
+
+#: Synthetic vCenter list for the ``dc-canary-001`` datacenter.
+FLEET_CANARY_VCENTERS: list[dict[str, object]] = [
+    {
+        "vmid": "vc-canary-001",
+        "name": "vc-prod",
+        "hostname": "vc-prod.lab.example.com",
+        "buildNumber": "24001122",
+        "version": "8.0.3",
+        "dataCollectionStatus": {
+            "status": "COMPLETED",
+            "lastDataCollectionTime": "2026-05-21T18:00:00Z",
+        },
+    },
+]
+
+#: Synthetic environment list — 8 entries so the force-handle reducer
+#: sees a populated set with a sample-row slice.
+FLEET_CANARY_ENVIRONMENTS: list[dict[str, object]] = [
+    {
+        "environmentId": f"env-canary-{i:03d}",
+        "environmentName": f"env-canary-{i:03d}",
+        "environmentDescription": f"Canary environment {i}",
+        "environmentStatus": "DEPLOY_SUCCESSFUL",
+        "products": [{"productId": "vrops" if i % 2 == 0 else "vrli", "version": "9.0.0"}],
+    }
+    for i in range(8)
+]
+
+#: Synthetic detail for ``env-canary-000``.
+FLEET_CANARY_ENVIRONMENT_DETAIL: dict[str, object] = {
+    "environmentId": "env-canary-000",
+    "environmentName": "env-canary-000",
+    "environmentStatus": "DEPLOY_SUCCESSFUL",
+    "transactionId": "txn-canary-001",
+    "createdOn": "2026-05-01T12:00:00Z",
+    "modifiedOn": "2026-05-20T15:00:00Z",
+    "products": [
+        {
+            "productId": "vrops",
+            "version": "9.0.0",
+            "status": "DEPLOY_SUCCESSFUL",
+            "nodes": [
+                {
+                    "hostname": "vrops-master.lab.example.com",
+                    "ipAddress": "10.1.1.10",
+                    "role": "MASTER",
+                    "vmStatus": "POWERED_ON",
+                }
+            ],
+        }
+    ],
+}
+
+#: Synthetic product list for ``env-canary-000``.
+FLEET_CANARY_PRODUCTS: list[dict[str, object]] = [
+    {
+        "productId": "vrops",
+        "version": "9.0.0",
+        "status": "DEPLOY_SUCCESSFUL",
+        "nodes": [
+            {
+                "hostname": "vrops-master.lab.example.com",
+                "ipAddress": "10.1.1.10",
+                "role": "MASTER",
+                "vmStatus": "POWERED_ON",
+            }
+        ],
+    }
+]
+
+#: Synthetic request list — three requests, one in-flight, two completed.
+FLEET_CANARY_REQUESTS: list[dict[str, object]] = [
+    {
+        "vmid": "req-canary-001",
+        "requestName": "Create environment env-canary-000",
+        "requestType": "ENVIRONMENT_CREATE",
+        "state": "COMPLETED",
+        "createdOn": "2026-05-01T11:00:00Z",
+        "lastUpdatedOn": "2026-05-01T12:00:00Z",
+    },
+    {
+        "vmid": "req-canary-002",
+        "requestName": "Upgrade vROps to 9.0.1",
+        "requestType": "PRODUCT_UPGRADE",
+        "state": "INPROGRESS",
+        "createdOn": "2026-05-22T08:00:00Z",
+        "lastUpdatedOn": "2026-05-22T08:30:00Z",
+    },
+    {
+        "vmid": "req-canary-003",
+        "requestName": "Patch vRLI to 9.0.2",
+        "requestType": "PRODUCT_PATCH",
+        "state": "COMPLETED",
+        "createdOn": "2026-05-15T09:00:00Z",
+        "lastUpdatedOn": "2026-05-15T10:30:00Z",
+    },
+]
+
+#: Synthetic detail for ``req-canary-002`` (INPROGRESS).
+FLEET_CANARY_REQUEST_DETAIL: dict[str, object] = {
+    "vmid": "req-canary-002",
+    "transactionId": "txn-canary-009",
+    "requestName": "Upgrade vROps to 9.0.1",
+    "requestReason": "Scheduled upgrade",
+    "requestType": "PRODUCT_UPGRADE",
+    "requestSource": "OPERATOR",
+    "requestSourceType": "API",
+    "state": "INPROGRESS",
+    "executionId": "exec-canary-009",
+    "executionStatus": "RUNNING",
+    "executionPath": [
+        {"stage": "PRE_VALIDATE", "status": "COMPLETED"},
+        {"stage": "UPGRADE", "status": "RUNNING"},
+    ],
+    "errorCause": "",
+    "resultSet": "",
+    "isCancelEnabled": True,
+    "lastUpdatedOn": "2026-05-22T08:30:00Z",
+    "createdBy": "admin@local",
+    "inputMap": {"productId": "vrops", "targetVersion": "9.0.1"},
+    "outputMap": {},
+}
+
+
+def _param_schema_for(path: str) -> dict[str, object]:
+    """Build a minimal ``parameter_schema`` declaring every ``{var}`` as a path param.
+
+    Mirrors :func:`tests.acceptance._nsx_canary_fixtures._param_schema_for` /
+    :func:`tests.acceptance._sddc_canary_fixtures._param_schema_for`.
+    Non-templated paths get the empty ``{"type": "object", "properties": {}}``
+    shape every other ingested op uses.
+    """
+    placeholders = _PATH_VAR_RE.findall(path)
+    if not placeholders:
+        return {"type": "object", "properties": {}}
+    return {
+        "type": "object",
+        "properties": {
+            name: {"type": "string", "x-meho-param-loc": "path"} for name in placeholders
+        },
+        "required": list(placeholders),
+    }
+
+
+async def _insert_fleet_descriptors() -> None:
+    """Seed the 8 curated Fleet core ops + their groups as enabled rows.
+
+    One :class:`OperationGroup` per entry in
+    :data:`~meho_backplane.connectors.vcf_fleet.FLEET_CORE_GROUPS`
+    (``review_status='enabled'``), one :class:`EndpointDescriptor` per
+    entry in :data:`~meho_backplane.connectors.vcf_fleet.FLEET_CORE_OPS`
+    (``is_enabled=True``, ``source_kind='ingested'``,
+    ``handler_ref=None``).
+
+    Rows use ``product=FLEET_PRODUCT="fleet"`` (from
+    :func:`parse_connector_id("fleet-rest-9.0")`), not the connector
+    class's ``product="vcf-fleet"``. The :class:`Target` row uses
+    ``product="vcf-fleet"`` so the resolver finds
+    :class:`VcfFleetConnector`.
+
+    Multiple ops can reference the same ``group_key`` — environments
+    has two ops (list + info), requests has two ops (list + info) — so
+    the helper coalesces group inserts via the ``group_ids`` dict and
+    skips re-inserting on the second op encounter.
+    """
+    sessionmaker = get_sessionmaker()
+    group_ids: dict[str, UUID] = {}
+    async with sessionmaker() as session:
+        for group in FLEET_CORE_GROUPS:
+            group_row = OperationGroup(
+                tenant_id=None,
+                product=FLEET_PRODUCT,
+                version=FLEET_VERSION,
+                impl_id=FLEET_IMPL_ID,
+                group_key=group.group_key,
+                name=group.name,
+                when_to_use=group.when_to_use,
+                review_status="enabled",
+            )
+            session.add(group_row)
+            await session.flush()
+            group_ids[group.group_key] = group_row.id
+
+        for op in FLEET_CORE_OPS:
+            method, path = op.op_id.split(":", 1)
+            descriptor = EndpointDescriptor(
+                tenant_id=None,
+                product=FLEET_PRODUCT,
+                version=FLEET_VERSION,
+                impl_id=FLEET_IMPL_ID,
+                op_id=op.op_id,
+                source_kind="ingested",
+                method=method,
+                path=path,
+                handler_ref=None,
+                group_id=group_ids[op.group_key],
+                summary=f"VCF Fleet core op {op.op_id} (curated read).",
+                description=f"VCF Fleet core op {op.op_id} (curated read).",
+                parameter_schema=_param_schema_for(path),
+                response_schema={"type": "object"},
+                llm_instructions=op.llm_instructions,
+                safety_level="safe",
+                requires_approval=False,
+                is_enabled=True,
+                tags=["spec:vcf-fleet-9.0/lcm-rest.yaml"],
+            )
+            session.add(descriptor)
+        await session.commit()
+
+
+async def _fleet_credentials_loader(_target: object) -> dict[str, str]:
+    """Stub credentials loader — bypasses the not-yet-wired Vault read.
+
+    Returns illustrative HTTP Basic credentials. The respx routes match
+    by path (no auth-header assertion), so the values are placeholders.
+    Mirrors :func:`tests.acceptance._sddc_canary_fixtures._sddc_credentials_loader`.
+    """
+    return {"username": "admin@local", "password": "fleet-canary-pw"}
+
+
+def _register_fleet_routes(mock: respx.MockRouter) -> None:
+    """Register the 8 Fleet read-op routes on *mock*.
+
+    Fleet uses HTTP Basic on every request — no session-establish call.
+    Each route returns a pre-seeded JSON body matching the rough shape
+    the vRSLCM REST surface returns for that path family.
+
+    Path-templated routes are registered against the specific id the
+    E2E test passes as the corresponding parameter (the dispatcher's
+    ``_substitute_path`` fills the placeholder before the request
+    fires; respx then matches the substituted path).
+    """
+    # /about — returns the synthetic well-formed payload (the real 9.0
+    # appliance returns HTTP 500 here; the canary's well-formed return
+    # lets the parser-path test exercise the success branch too).
+    mock.get("/lcm/lcops/api/v2/about").respond(200, json=FLEET_CANARY_ABOUT)
+    # Datacenters — bare array, no envelope.
+    mock.get("/lcm/lcops/api/v2/datacenters").respond(200, json=FLEET_CANARY_DATACENTERS)
+    # vCenters under one datacenter — path-templated against dc-canary-001.
+    mock.get("/lcm/lcops/api/v2/datacenters/dc-canary-001/vcenters").respond(
+        200,
+        json=FLEET_CANARY_VCENTERS,
+    )
+    # Environments — bare array.
+    mock.get("/lcm/lcops/api/v2/environments").respond(200, json=FLEET_CANARY_ENVIRONMENTS)
+    # Environment detail — path-templated against env-canary-000.
+    mock.get("/lcm/lcops/api/v2/environments/env-canary-000").respond(
+        200,
+        json=FLEET_CANARY_ENVIRONMENT_DETAIL,
+    )
+    # Products under one environment — path-templated.
+    mock.get("/lcm/lcops/api/v2/environments/env-canary-000/products").respond(
+        200,
+        json=FLEET_CANARY_PRODUCTS,
+    )
+    # Requests — bare array.
+    mock.get("/lcm/request/api/v2/requests").respond(200, json=FLEET_CANARY_REQUESTS)
+    # Request detail — path-templated against req-canary-002.
+    mock.get("/lcm/request/api/v2/requests/req-canary-002").respond(
+        200,
+        json=FLEET_CANARY_REQUEST_DETAIL,
+    )
+
+
+def fleet_acceptance_operator() -> Operator:
+    """Frozen :class:`Operator` the VCF Fleet dispatch tests act as.
+
+    Function (not a pytest fixture) so the E2E module can compose its
+    own operator instance with module-scoped lifetimes if needed.
+    """
+    return Operator(
+        sub="g36-fleet-acceptance",
+        name="G3.6-T9 Fleet Acceptance",
+        email=None,
+        raw_jwt="<fleet-acceptance-raw-jwt>",
+        tenant_id=FLEET_CANARY_OPERATOR_TENANT,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )

--- a/backend/tests/test_connectors_vcf_fleet_e2e.py
+++ b/backend/tests/test_connectors_vcf_fleet_e2e.py
@@ -1,0 +1,517 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""VCF Fleet E2E recorded-fixture integration test (G3.6-T9 #839).
+
+Covers all five acceptance criteria from Issue #839:
+
+(a) `meho vcf-fleet --help` lists the verb set; each verb POSTs to
+    `/api/v1/operations/call` with the right `op_id`. The CLI-side
+    assertion lives in :mod:`cli.internal.cmd.vcf-fleet.vcf_fleet_test`
+    (Go); this module covers the **backend half** — every enabled
+    Fleet op dispatches through the full ``call_operation`` stack
+    against a respx-mocked appliance.
+(b) `backend/tests/test_connectors_vcf_fleet_e2e.py` (this file)
+    replays a captured fixture for every enabled op and passes in the
+    ``meho-runners`` CI lane with no Docker dependency.
+(c) At least one list op's E2E asserts the JSONFlux handle path
+    (handle → ``result_query`` drills in) — see
+    :func:`test_fleet_e2e_jsonflux_handle_populated_for_environment_list`.
+(d) All enabled ops write an audit row carrying ``op_id`` + ``target_id``
+    + ``params_hash`` — see :func:`test_fleet_e2e_dispatch_writes_audit_row`.
+(e) ``docs/cross-repo/vcf-fleet-onboarding.md`` exists with the
+    wrapper-flip recipe (verified on the doc side, not asserted here).
+
+Database: SQLite via the autouse ``_default_database_url`` conftest
+fixture (no ``pg_engine`` required). Runs in the ``meho-runners`` CI
+lane alongside the other ``backend/tests/test_connectors_*.py`` files;
+no Docker dependency.
+
+Auth shape note
+---------------
+
+Fleet uses HTTP Basic on every request (no session-establish call) —
+mirrors the SDDC Manager E2E test's "credentials cached after first
+dispatch" assertion. There is no 401-retry test here because Fleet's
+local user store has no session lifecycle; a 401 means wrong
+credentials, terminal.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+import respx
+from sqlalchemy import select
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.registry import all_connectors_v2
+from meho_backplane.connectors.schemas import ResultHandle
+from meho_backplane.connectors.vcf_fleet import (
+    FLEET_CONNECTOR_ID,
+    FLEET_CORE_OPS,
+    VcfFleetConnector,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, Target
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.meta_tools import call_operation
+from meho_backplane.operations.reducer import PassThroughReducer
+from tests.acceptance._vcf_fleet_canary_fixtures import (
+    FLEET_CANARY_BASE_URL,
+    FLEET_CANARY_ENVIRONMENTS,
+    FLEET_CANARY_FINGERPRINT,
+    FLEET_CANARY_OPERATOR_TENANT,
+    FLEET_FORCE_HANDLE_LIST_OP_ID,
+    FLEET_TARGET_NAME,
+    _fleet_credentials_loader,
+    _insert_fleet_descriptors,
+    _register_fleet_routes,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+_OPERATOR = Operator(
+    sub="fleet-e2e-test",
+    name="Fleet E2E Test Operator",
+    email=None,
+    raw_jwt="<fleet-e2e-raw-jwt>",
+    tenant_id=FLEET_CANARY_OPERATOR_TENANT,
+    tenant_role=TenantRole.TENANT_ADMIN,
+)
+
+# Path-template params for the ops whose op_ids carry a ``{placeholder}``.
+# The dispatcher's ``_substitute_path`` substitutes the literal at
+# dispatch time; the respx routes are registered against the
+# substituted paths (see ``_register_fleet_routes``).
+_OP_PARAMS: dict[str, dict[str, object]] = {
+    "GET:/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters": {
+        "dataCenterVmid": "dc-canary-001",
+    },
+    "GET:/lcm/lcops/api/v2/environments/{environmentId}": {
+        "environmentId": "env-canary-000",
+    },
+    "GET:/lcm/lcops/api/v2/environments/{environmentId}/products": {
+        "environmentId": "env-canary-000",
+    },
+    "GET:/lcm/request/api/v2/requests/{requestId}": {
+        "requestId": "req-canary-002",
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Module-level autouse fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin env vars that :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    from meho_backplane.settings import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches around every test."""
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    """Stub out :func:`publish_event` so the broadcast bus doesn't fire.
+
+    Required for the same reason as every other DB-backed dispatcher
+    test: the real broadcast bus tries to write to a Redis stream that
+    doesn't exist in the unit-test environment.
+    """
+    events: list[Any] = []
+
+    async def _capture(event: Any) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# ForceHandleReducer (acceptance criterion c)
+# ---------------------------------------------------------------------------
+
+
+class _ForceHandleReducer:
+    """Test-only reducer that always wraps a Fleet list payload in a ResultHandle.
+
+    Fleet returns bare JSON arrays for the curated read ops (no
+    ``elements`` / ``results`` envelope), so the reducer's payload
+    branch checks for the bare-list case first.
+    """
+
+    async def reduce(
+        self,
+        payload: Any,
+        schema: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> tuple[Any, ResultHandle | None]:
+        del schema, context
+        if isinstance(payload, list):
+            total = len(payload)
+            sample: tuple[Any, ...] = tuple(payload[:5]) if payload else ()
+        elif isinstance(payload, dict) and "data" in payload:
+            rows = payload["data"]
+            total = len(rows) if isinstance(rows, list) else 1
+            sample = tuple(rows[:5]) if isinstance(rows, list) and rows else ()
+        else:
+            total = 1
+            sample = ()
+        handle = ResultHandle(
+            handle_id=uuid.uuid4(),
+            summary_md=f"force-mode handle ({total} rows)",
+            schema_={"type": "array", "items": {"type": "object"}},
+            total_rows=total,
+            sample_rows=sample or None,
+            ttl_seconds=3600,
+        )
+        return {"row_count": total, "sample": list(sample)}, handle
+
+
+# ---------------------------------------------------------------------------
+# Setup helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_target() -> Any:
+    """Insert the E2E target row and return it (expunged from the session)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = Target(
+            tenant_id=FLEET_CANARY_OPERATOR_TENANT,
+            name=FLEET_TARGET_NAME,
+            aliases=[],
+            product="vcf-fleet",
+            host=FLEET_CANARY_BASE_URL.removeprefix("https://"),
+            port=443,
+            fqdn=None,
+            secret_ref="kv/data/vcf-fleet/fleet-e2e",
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            fingerprint=FLEET_CANARY_FINGERPRINT,
+            notes="seeded by test_connectors_vcf_fleet_e2e._seed_target",
+        )
+        session.add(target)
+        await session.commit()
+        await session.refresh(target)
+        session.expunge(target)
+        return target
+
+
+def _resolve_connector() -> VcfFleetConnector:
+    """Resolve + cache the VcfFleetConnector instance with a stubbed credentials loader."""
+    registry = all_connectors_v2()
+    connector_cls = registry.get(("vcf-fleet", "9.0", "fleet-rest"))
+    assert connector_cls is VcfFleetConnector, (
+        f"VcfFleetConnector not registered for (vcf-fleet, 9.0, fleet-rest); got {connector_cls!r}"
+    )
+    instance = get_or_create_connector_instance(connector_cls)
+    # Inject the stub credentials loader so no Vault read fires. The
+    # CredentialsCache's loader is constructed at __init__; reaching in
+    # here mirrors what the SDDC Manager E2E test does on its
+    # ``_credentials_loader`` attr.
+    instance._creds = type(instance._creds)(  # type: ignore[attr-defined]
+        _fleet_credentials_loader,
+        product_label="vcf-fleet",
+    )
+    return instance
+
+
+# ---------------------------------------------------------------------------
+# Primary E2E fixture (happy-path + audit rows)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _FleetE2EBundle:
+    target_name: str
+    connector_instance: VcfFleetConnector
+
+
+@pytest.fixture
+async def fleet_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_FleetE2EBundle]:
+    """Dispatcher-ready Fleet setup over a respx-mocked appliance (happy-path).
+
+    Lifecycle:
+
+    1. Insert :data:`~meho_backplane.connectors.vcf_fleet.FLEET_CORE_OPS`
+       descriptors + groups into the per-test SQLite DB.
+    2. Seed a :class:`Target` row carrying :data:`FLEET_CANARY_FINGERPRINT`
+       so the resolver binds :class:`VcfFleetConnector`.
+    3. Resolve + cache the connector instance; replace its
+       :class:`CredentialsCache` so no Vault read fires.
+    4. Activate a respx router for :data:`FLEET_CANARY_BASE_URL` and
+       register the 8 read-op routes.
+    """
+    await _insert_fleet_descriptors()
+    await _seed_target()
+    instance = _resolve_connector()
+
+    async with respx.mock(
+        base_url=FLEET_CANARY_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        _register_fleet_routes(mock)
+        try:
+            yield _FleetE2EBundle(
+                target_name=FLEET_TARGET_NAME,
+                connector_instance=instance,
+            )
+        finally:
+            await instance.aclose()
+            reset_dispatcher_caches()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+_OP_IDS: tuple[str, ...] = tuple(op.op_id for op in FLEET_CORE_OPS)
+assert len(_OP_IDS) == 8, f"Expected 8 curated Fleet ops, got {len(_OP_IDS)}: {_OP_IDS}"
+
+
+@pytest.mark.parametrize("op_id", _OP_IDS, ids=lambda op: op)
+async def test_fleet_e2e_all_ops_dispatch_ok(
+    op_id: str,
+    fleet_e2e_canary: _FleetE2EBundle,
+) -> None:
+    """All 8 Fleet core ops dispatch through the full dispatcher and return status='ok'.
+
+    HTTP Basic auth is computed by the connector's stub credentials
+    loader on first dispatch (then cached); no session-establish step
+    is needed because Basic auth is stateless on the Fleet side. The
+    parametrise reports one CI case per op_id for granular failure
+    attribution.
+    """
+    params = _OP_PARAMS.get(op_id, {})
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": FLEET_CONNECTOR_ID,
+            "op_id": op_id,
+            "target": {"name": fleet_e2e_canary.target_name},
+            "params": params,
+        },
+    )
+    assert result["status"] == "ok", (
+        f"Fleet op {op_id!r} did not return status='ok': "
+        f"error={result.get('error')!r} full={result!r}"
+    )
+
+
+async def test_fleet_e2e_credentials_cached_after_first_dispatch(
+    fleet_e2e_canary: _FleetE2EBundle,
+) -> None:
+    """First dispatch loads credentials; subsequent dispatches reuse the cache.
+
+    Verifies the HTTP Basic-auth half of acceptance criterion (a):
+    the Fleet connector's per-target credential cache (a
+    :class:`~meho_backplane.connectors._shared.vcf_auth.CredentialsCache`)
+    starts empty, gets populated on the first dispatch, and is not
+    re-filled on the second dispatch to the same target. HTTP Basic is
+    stateless server-side — no session revoke or re-login needed.
+    """
+    instance = fleet_e2e_canary.connector_instance
+    target_name = fleet_e2e_canary.target_name
+
+    # The CredentialsCache exposes the underlying dict via ``_cache``; the
+    # SDDC Manager precedent uses ``_creds_cache`` because its connector
+    # caches the dict directly. The cache key is the target name (set by
+    # ``CredentialsCache.get(target)``).
+    initial_keys = list(instance._creds._cache.keys())  # type: ignore[attr-defined]
+    assert target_name not in initial_keys, (
+        f"Expected empty credential cache before first dispatch; got keys={initial_keys!r}"
+    )
+
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": FLEET_CONNECTOR_ID,
+            "op_id": "GET:/lcm/lcops/api/v2/datacenters",
+            "target": {"name": target_name},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok"
+    after_first_keys = list(instance._creds._cache.keys())  # type: ignore[attr-defined]
+    assert target_name in after_first_keys, (
+        f"Expected credentials cached after first dispatch; got keys={after_first_keys!r}"
+    )
+
+    # Second dispatch must NOT reload credentials — cache entry survives.
+    creds_before = dict(instance._creds._cache)  # type: ignore[attr-defined]
+    result2 = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": FLEET_CONNECTOR_ID,
+            "op_id": "GET:/lcm/lcops/api/v2/environments",
+            "target": {"name": target_name},
+            "params": {},
+        },
+    )
+    assert result2["status"] == "ok"
+    assert instance._creds._cache == creds_before, (  # type: ignore[attr-defined]
+        "Credential cache should not change on second dispatch (cache hit); "
+        f"before={creds_before!r} after={instance._creds._cache!r}"  # type: ignore[attr-defined]
+    )
+
+
+async def test_fleet_e2e_dispatch_writes_audit_row(
+    fleet_e2e_canary: _FleetE2EBundle,
+) -> None:
+    """Each dispatch inserts an AuditLog row with method='DISPATCH', target_id, params_hash.
+
+    Exercises acceptance criterion (d). Dispatches one op and asserts:
+
+    * Exactly one new ``AuditLog`` row with ``method='DISPATCH'`` and
+      ``path == op_id``.
+    * ``row.target_id`` is not None (the Target row was resolved and
+      its UUID was recorded).
+    * ``row.payload["op_id"]`` equals the dispatched ``op_id``.
+    * ``row.payload["params_hash"]`` is present (non-None string).
+    """
+    op_id = "GET:/lcm/lcops/api/v2/datacenters"
+    sessionmaker = get_sessionmaker()
+
+    async def _count_dispatch_rows() -> int:
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(AuditLog).where(
+                    AuditLog.method == "DISPATCH",
+                    AuditLog.path == op_id,
+                )
+            )
+            return len(list(result.scalars().all()))
+
+    baseline = await _count_dispatch_rows()
+
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": FLEET_CONNECTOR_ID,
+            "op_id": op_id,
+            "target": {"name": fleet_e2e_canary.target_name},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok"
+
+    final = await _count_dispatch_rows()
+    assert final - baseline == 1, (
+        f"Expected exactly one new DISPATCH row for {op_id!r}; baseline={baseline} final={final}"
+    )
+
+    async with sessionmaker() as session:
+        row_result = await session.execute(
+            select(AuditLog)
+            .where(
+                AuditLog.method == "DISPATCH",
+                AuditLog.path == op_id,
+            )
+            .order_by(AuditLog.id.desc())
+            .limit(1)
+        )
+        row = row_result.scalars().first()
+
+    assert row is not None
+    assert row.target_id is not None, (
+        "AuditLog.target_id must not be None for a targeted dispatch; "
+        f"got target_id=None on row {row!r}"
+    )
+    assert row.payload.get("op_id") == op_id, (
+        f"AuditLog.payload['op_id'] must equal the dispatched op_id; got payload={row.payload!r}"
+    )
+    assert row.payload.get("params_hash"), (
+        f"AuditLog.payload must carry a non-empty 'params_hash'; got payload={row.payload!r}"
+    )
+
+
+async def test_fleet_e2e_jsonflux_handle_populated_for_environment_list(
+    fleet_e2e_canary: _FleetE2EBundle,
+) -> None:
+    """Environment list dispatched with ForceHandleReducer returns a populated handle.
+
+    Exercises acceptance criterion (c): the JSONFlux dispatcher seam
+    threads the reducer's :class:`ResultHandle` onto
+    :class:`OperationResult`. Environment listing is the largest Fleet
+    read surface in real deployments — busy appliances commonly manage
+    dozens of environments — so the handle-path coverage lands here.
+
+    Assertions mirror the NSX / SDDC Manager JSONFlux handle tests:
+
+    * ``status == 'ok'``.
+    * ``handle`` is non-None and carries a valid UUID4 ``handle_id``.
+    * ``handle.total_rows`` matches the seeded environment count.
+    * ``handle.sample_rows`` is populated (≥1 row).
+    * ``result['row_count']`` equals ``handle.total_rows`` (the
+      reducer's summary inlined on the envelope).
+    """
+    expected_rows = len(FLEET_CANARY_ENVIRONMENTS)
+
+    set_default_reducer(_ForceHandleReducer())
+    try:
+        result_envelope = await call_operation(
+            _OPERATOR,
+            {
+                "connector_id": FLEET_CONNECTOR_ID,
+                "op_id": FLEET_FORCE_HANDLE_LIST_OP_ID,
+                "target": {"name": fleet_e2e_canary.target_name},
+                "params": {},
+            },
+        )
+    finally:
+        set_default_reducer(PassThroughReducer())
+
+    assert result_envelope["status"] == "ok", (
+        f"Expected JSONFlux dispatch to succeed; got {result_envelope!r}"
+    )
+
+    handle = result_envelope.get("handle")
+    assert handle is not None, (
+        "Expected OperationResult.handle to be populated by _ForceHandleReducer; "
+        f"got handle=None on envelope={result_envelope!r}"
+    )
+
+    uuid.UUID(handle["handle_id"])
+
+    assert handle["total_rows"] == expected_rows, (
+        f"Expected {expected_rows} environment rows from FLEET_CANARY_ENVIRONMENTS; "
+        f"got handle.total_rows={handle['total_rows']}"
+    )
+
+    sample_rows = handle.get("sample_rows")
+    assert sample_rows, (
+        f"Expected ≥1 sample row from the seeded Fleet environment list; "
+        f"got sample_rows={sample_rows!r}"
+    )
+
+    payload = result_envelope.get("result")
+    assert payload is not None and payload.get("row_count") == expected_rows, (
+        f"Expected reducer summary on result.row_count={expected_rows}; got result={payload!r}"
+    )

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -31,6 +31,7 @@ import (
 	"github.com/evoila/meho/cli/internal/cmd/targets"
 	"github.com/evoila/meho/cli/internal/cmd/topology"
 	"github.com/evoila/meho/cli/internal/cmd/vault"
+	vcffleet "github.com/evoila/meho/cli/internal/cmd/vcf-fleet"
 	vcflogs "github.com/evoila/meho/cli/internal/cmd/vcf-logs"
 	vcfoperations "github.com/evoila/meho/cli/internal/cmd/vcf-operations"
 	"github.com/evoila/meho/cli/internal/cmd/vmware"
@@ -272,6 +273,17 @@ func newRootCmd() *cobra.Command {
 	// pods` wrapper. Registered before registerDynamicSubcommands so
 	// the backplane manifest cannot shadow the built-in `k8s` parent.
 	root.AddCommand(k8s.NewRootCmd())
+
+	// G3.6-T9 (#839) -- fleet-rest-9.0 operator alias verbs for Initiative
+	// #369. The verb tree pre-bakes connector_id="fleet-rest-9.0" on top of
+	// the existing /api/v1/operations/call dispatcher route so operators
+	// don't type the connector ID on every invocation. Ships the 8 read-only
+	// Fleet core verbs (about, datacenter list, vcenter list, environment
+	// list/info, product list, request list/info) plus operation search/call
+	// meta-tool wrappers. Replaces ./scripts/vcf-fleet.sh.
+	// Registered before registerDynamicSubcommands so the backplane manifest
+	// cannot shadow the built-in `vcf-fleet` parent.
+	root.AddCommand(vcffleet.NewRootCmd())
 
 	// G3.4-T5 (#591) -- bind9-ssh-9.x operator alias verbs for Initiative
 	// #367. The verb tree pre-bakes connector_id="bind9-ssh-9.x" on top

--- a/cli/internal/cmd/vcf-fleet/about.go
+++ b/cli/internal/cmd/vcf-fleet/about.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcffleet
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// aboutOpID is the curated Fleet `about` op_id. The endpoint returns
+// HTTP 500 in VCF 9.0 builds (a known regression — see
+// connectors/vcf_fleet/core_ops.py). The verb is kept for parity with
+// the spec + future fix; the docstring + the verb's long help warn
+// operators to use `vcf-fleet datacenter list` as the reachability
+// probe in 9.0.
+const aboutOpID = "GET:/lcm/lcops/api/v2/about"
+
+// newAboutCmd returns `meho vcf-fleet about` → GET:/lcm/lcops/api/v2/about.
+func newAboutCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "about",
+		Short: "Show vRSLCM appliance identity (apiVersion + productVersion + build)",
+		Long: "about dispatches GET:/lcm/lcops/api/v2/about against\n" +
+			"connector_id=\"fleet-rest-9.0\" and renders the appliance identity.\n" +
+			"--json emits the full OperationResult envelope.\n\n" +
+			"KNOWN ISSUE (VCF 9.0): the /about endpoint returns HTTP 500. The\n" +
+			"verb is kept for spec parity; in 9.0 builds, use\n" +
+			"`vcf-fleet datacenter list` as the reachability probe instead\n" +
+			"(it doubles as the wrapper-verified probe and works on 9.0).\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
+		Example: "  meho vcf-fleet about --target rdc-fleet\n" +
+			"  meho vcf-fleet about --target rdc-fleet --json | jq .result",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runAbout(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "VCF Fleet target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, aboutOpID, targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, aboutOpID, r, jsonOut, printAbout)
+}
+
+func printAbout(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, aboutOpID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	if len(r.Result) == 0 || string(r.Result) == "null" {
+		return
+	}
+	var payload struct {
+		APIVersion     string `json:"apiVersion"`
+		ProductVersion string `json:"productVersion"`
+		BuildNumber    string `json:"buildNumber"`
+		ReleaseDate    string `json:"releaseDate"`
+	}
+	if err := jsonUnmarshalStrict(r.Result, &payload); err != nil || payload.APIVersion == "" {
+		if len(r.Result) > 0 && string(r.Result) != "null" {
+			pretty, perr := prettyJSON(r.Result)
+			if perr == nil {
+				fmt.Fprintln(w, pretty)
+				return
+			}
+			fmt.Fprintln(w, string(r.Result))
+		}
+		return
+	}
+	if payload.APIVersion != "" {
+		fmt.Fprintf(w, "  api_version:     %s\n", payload.APIVersion)
+	}
+	if payload.ProductVersion != "" {
+		fmt.Fprintf(w, "  product_version: %s\n", payload.ProductVersion)
+	}
+	if payload.BuildNumber != "" {
+		fmt.Fprintf(w, "  build:           %s\n", payload.BuildNumber)
+	}
+	if payload.ReleaseDate != "" {
+		fmt.Fprintf(w, "  release_date:    %s\n", payload.ReleaseDate)
+	}
+}

--- a/cli/internal/cmd/vcf-fleet/datacenter.go
+++ b/cli/internal/cmd/vcf-fleet/datacenter.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcffleet
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+const datacenterListOpID = "GET:/lcm/lcops/api/v2/datacenters"
+
+// newDatacenterCmd returns the `meho vcf-fleet datacenter` sub-tree.
+func newDatacenterCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "datacenter",
+		Short:        "VCF Fleet datacenter operations (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newDatacenterListCmd())
+	return cmd
+}
+
+func newDatacenterListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List Fleet-managed datacenters (wrapper-verified reachability probe)",
+		Long: "list dispatches GET:/lcm/lcops/api/v2/datacenters against\n" +
+			"connector_id=\"fleet-rest-9.0\". This is the wrapper-verified\n" +
+			"reachability probe — guaranteed to respond in VCF 9.0 even when\n" +
+			"/about returns HTTP 500. The vmid in each entry is the\n" +
+			"load-bearing identifier for `vcf-fleet vcenter list <vmid>`.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
+		Example: "  meho vcf-fleet datacenter list --target rdc-fleet\n" +
+			"  meho vcf-fleet datacenter list --target rdc-fleet --json | jq '.result[].vmid'",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runDatacenterList(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "VCF Fleet target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runDatacenterList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, datacenterListOpID, targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, datacenterListOpID, r, jsonOut, printDatacenterList)
+}
+
+func printDatacenterList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, datacenterListOpID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeListResult(r.Result)
+	if err != nil {
+		printGenericResult(w, datacenterListOpID, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 datacenters)")
+		return
+	}
+	fmt.Fprintf(w, "%-38s %-32s %-16s %s\n", "vmid", "name", "type", "city")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-38s %-32s %-16s %s\n",
+			truncate(fleetStringField(e, "vmid"), 38),
+			truncate(fleetStringField(e, "name"), 32),
+			truncate(fleetStringField(e, "type"), 16),
+			truncate(fleetStringField(e, "city"), 32),
+		)
+	}
+}

--- a/cli/internal/cmd/vcf-fleet/dispatch.go
+++ b/cli/internal/cmd/vcf-fleet/dispatch.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcffleet
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// CallResult mirrors the backend OperationResult Pydantic model.
+type CallResult struct {
+	Status     string          `json:"status"`
+	OpID       string          `json:"op_id"`
+	Result     json.RawMessage `json:"result"`
+	Error      *string         `json:"error"`
+	Extras     json.RawMessage `json:"extras,omitempty"`
+	DurationMs float64         `json:"duration_ms"`
+}
+
+// callRequestBody mirrors the backend CallOperationBody Pydantic model.
+type callRequestBody struct {
+	ConnectorID string         `json:"connector_id"`
+	OpID        string         `json:"op_id"`
+	Target      map[string]any `json:"target"`
+	Params      map[string]any `json:"params,omitempty"`
+}
+
+var errOpError = errors.New("operation status not ok")
+
+// dispatchOp POSTs an OperationCall to the backplane with
+// connector_id="fleet-rest-9.0" pre-baked.
+func dispatchOp(
+	ctx context.Context,
+	backplaneURL, opID, targetSlug string,
+	params map[string]any,
+) (*CallResult, error) {
+	body := callRequestBody{
+		ConnectorID: ConnectorID,
+		OpID:        opID,
+		Target:      nil,
+	}
+	if targetSlug != "" {
+		body.Target = map[string]any{"name": targetSlug}
+	}
+	if params != nil {
+		body.Params = params
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal call request: %w", err)
+	}
+	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
+	if err != nil {
+		return nil, err
+	}
+	var out CallResult
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("decode call response: %w", err)
+	}
+	return &out, nil
+}
+
+// renderCallResult handles the unified post-dispatch rendering path.
+func renderCallResult(
+	cmd *cobra.Command,
+	opID string,
+	r *CallResult,
+	jsonOut bool,
+	prettyPrinter func(w io.Writer, r *CallResult),
+) error {
+	switch r.Status {
+	case "ok", "error", "denied":
+	default:
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
+				r.Status,
+			)),
+			jsonOut,
+		)
+	}
+	if jsonOut {
+		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
+			return err
+		}
+	} else if prettyPrinter != nil {
+		prettyPrinter(cmd.OutOrStdout(), r)
+	} else {
+		printGenericResult(cmd.OutOrStdout(), opID, r)
+	}
+	if r.Status == "ok" {
+		return nil
+	}
+	return errOpError
+}
+
+func printGenericResult(w io.Writer, opID string, r *CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+	if r.Status == "ok" {
+		if len(r.Result) > 0 && string(r.Result) != "null" {
+			pretty, err := prettyJSON(r.Result)
+			if err == nil {
+				fmt.Fprintln(w, pretty)
+				return
+			}
+			fmt.Fprintln(w, string(r.Result))
+		}
+		return
+	}
+	if r.Error != nil && *r.Error != "" {
+		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
+	} else {
+		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
+	}
+	if len(r.Extras) > 0 && string(r.Extras) != "null" {
+		fmt.Fprintln(w, "extras:")
+		pretty, err := prettyJSON(r.Extras)
+		if err == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Extras))
+		}
+	}
+}
+
+func prettyJSON(raw json.RawMessage) (string, error) {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return "", err
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/cli/internal/cmd/vcf-fleet/environment.go
+++ b/cli/internal/cmd/vcf-fleet/environment.go
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcffleet
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+const (
+	environmentListOpID = "GET:/lcm/lcops/api/v2/environments"
+	environmentGetOpID  = "GET:/lcm/lcops/api/v2/environments/{environmentId}"
+)
+
+// newEnvironmentCmd returns the `meho vcf-fleet environment` sub-tree.
+func newEnvironmentCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "environment",
+		Short:        "VCF Fleet environment operations (list / info)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newEnvironmentListCmd())
+	cmd.AddCommand(newEnvironmentInfoCmd())
+	return cmd
+}
+
+func newEnvironmentListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List Fleet-managed environments (the primary inventory unit)",
+		Long: "list dispatches GET:/lcm/lcops/api/v2/environments against\n" +
+			"connector_id=\"fleet-rest-9.0\". Each environment groups one or more\n" +
+			"product deployments. Large appliances may return a JSONFlux handle\n" +
+			"through the shared HandleStore — use result_describe / result_query\n" +
+			"to navigate the full set when present.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
+		Example:       "  meho vcf-fleet environment list --target rdc-fleet",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runEnvironmentList(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "VCF Fleet target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runEnvironmentList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, environmentListOpID, targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, environmentListOpID, r, jsonOut, printEnvironmentList)
+}
+
+func printEnvironmentList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, environmentListOpID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeListResult(r.Result)
+	if err != nil {
+		printGenericResult(w, environmentListOpID, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 environments)")
+		return
+	}
+	fmt.Fprintf(w, "%-38s %-32s %s\n", "environmentId", "environmentName", "environmentStatus")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-38s %-32s %s\n",
+			truncate(fleetStringField(e, "environmentId"), 38),
+			truncate(fleetStringField(e, "environmentName"), 32),
+			truncate(fleetStringField(e, "environmentStatus"), 32),
+		)
+	}
+}
+
+func newEnvironmentInfoCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "info <environment-id>",
+		Short: "Show the full detail of one Fleet environment",
+		Long: "info dispatches GET:/lcm/lcops/api/v2/environments/{environmentId}\n" +
+			"against connector_id=\"fleet-rest-9.0\". Returns products[] with full\n" +
+			"deployment metadata (nodes, IPs, versions, FQDN), configuration\n" +
+			"history, and status transitions.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
+		Example:       "  meho vcf-fleet environment info env-vrops-prod --target rdc-fleet",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runEnvironmentInfo(cmd, args[0], targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "VCF Fleet target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runEnvironmentInfo(cmd *cobra.Command, environmentID, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params := map[string]any{"environmentId": environmentID}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, environmentGetOpID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, environmentGetOpID, r, jsonOut, printEnvironmentInfo)
+}
+
+func printEnvironmentInfo(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, environmentGetOpID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	if len(r.Result) == 0 || string(r.Result) == "null" {
+		return
+	}
+	var env struct {
+		EnvironmentID     string `json:"environmentId"`
+		EnvironmentName   string `json:"environmentName"`
+		EnvironmentStatus string `json:"environmentStatus"`
+		TransactionID     string `json:"transactionId"`
+		CreatedOn         string `json:"createdOn"`
+		Products          []struct {
+			ProductID string `json:"productId"`
+			Version   string `json:"version"`
+			Status    string `json:"status"`
+			Nodes     []struct {
+				Hostname  string `json:"hostname"`
+				IPAddress string `json:"ipAddress"`
+				Role      string `json:"role"`
+				VMStatus  string `json:"vmStatus"`
+			} `json:"nodes"`
+		} `json:"products"`
+	}
+	if err := jsonUnmarshalStrict(r.Result, &env); err != nil || env.EnvironmentID == "" {
+		if pretty, perr := prettyJSON(r.Result); perr == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Result))
+		}
+		return
+	}
+	fmt.Fprintf(w, "environment:  %s (%s) — status=%s\n", env.EnvironmentName, env.EnvironmentID, env.EnvironmentStatus)
+	if env.TransactionID != "" {
+		fmt.Fprintf(w, "transaction:  %s\n", env.TransactionID)
+	}
+	if env.CreatedOn != "" {
+		fmt.Fprintf(w, "created_on:   %s\n", env.CreatedOn)
+	}
+	if len(env.Products) > 0 {
+		fmt.Fprintln(w, "products:")
+		for _, p := range env.Products {
+			fmt.Fprintf(w, "  %-12s  version=%-16s  status=%s\n", p.ProductID, p.Version, p.Status)
+			for _, n := range p.Nodes {
+				fmt.Fprintf(w, "    %-30s  %-16s  role=%-10s  vm=%s\n",
+					n.Hostname, n.IPAddress, n.Role, n.VMStatus)
+			}
+		}
+	}
+}

--- a/cli/internal/cmd/vcf-fleet/operation.go
+++ b/cli/internal/cmd/vcf-fleet/operation.go
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcffleet
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newOperationCmd returns `meho vcf-fleet operation` with search / call
+// meta-tool wrappers pre-scoped to fleet-rest-9.0.
+func newOperationCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "operation",
+		Short:        "Pre-scoped meta-tool wrappers (search / call) for fleet-rest-9.0",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newOperationSearchCmd())
+	cmd.AddCommand(newOperationCallCmd())
+	return cmd
+}
+
+type searchHit struct {
+	OpID             string   `json:"op_id"`
+	Summary          *string  `json:"summary"`
+	Description      *string  `json:"description"`
+	GroupKey         *string  `json:"group_key"`
+	SafetyLevel      string   `json:"safety_level"`
+	RequiresApproval bool     `json:"requires_approval"`
+	FusedScore       float64  `json:"fused_score"`
+	Bm25Score        *float64 `json:"bm25_score"`
+	CosineScore      *float64 `json:"cosine_score"`
+}
+
+type searchResponse struct {
+	Hits            []searchHit `json:"hits"`
+	QueryDurationMs float64     `json:"query_duration_ms"`
+}
+
+func newOperationSearchCmd() *cobra.Command {
+	var (
+		groupKey          string
+		limit             int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Hybrid BM25 + cosine RRF search across fleet-rest-9.0 operations",
+		Long: "search wraps GET /api/v1/operations/search with connector_id=\n" +
+			"\"fleet-rest-9.0\" pre-baked.\n\n" +
+			"Exit codes mirror meho operation search.",
+		Example: "  meho vcf-fleet operation search \"list environments\"\n" +
+			"  meho vcf-fleet operation search \"upgrade workflow\" --group fleet-request",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runOperationSearch(cmd, args[0], groupKey, limit, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&groupKey, "group", "", "narrow the search to one group_key")
+	cmd.Flags().IntVar(&limit, "limit", 10, "max hits (1..50, clamped by the API)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit machine-readable JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, jsonOut bool, backplaneOverride string) error {
+	if limit < 1 {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--limit must be >= 1; got %d", limit)),
+			jsonOut)
+	}
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	if jsonOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printSearchTable(cmd.OutOrStdout(), query, result)
+	return nil
+}
+
+func getSearch(ctx context.Context, backplaneURL, query, groupKey string, limit int) (*searchResponse, error) {
+	q := url.Values{}
+	q.Set("connector_id", ConnectorID)
+	q.Set("query", query)
+	if groupKey != "" {
+		q.Set("group", groupKey)
+	}
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	path := "/api/v1/operations/search?" + q.Encode()
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var out searchResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode search response: %w", err)
+	}
+	return &out, nil
+}
+
+func printSearchTable(w io.Writer, query string, r *searchResponse) {
+	fmt.Fprintf(w, "search %s %q — %d hit(s) in %.0fms\n",
+		ConnectorID, query, len(r.Hits), r.QueryDurationMs)
+	if len(r.Hits) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "%-50s %6s  %s\n", "op_id", "score", "summary")
+	for _, h := range r.Hits {
+		fmt.Fprintf(w, "%-50s %6.3f  %s\n",
+			truncate(h.OpID, 50),
+			h.FusedScore,
+			truncate(strDeref(h.Summary), 80),
+		)
+	}
+}
+
+func newOperationCallCmd() *cobra.Command {
+	var (
+		targetName        string
+		paramsFlag        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "call <op_id>",
+		Short: "Dispatch any fleet-rest-9.0 op_id (escape hatch for ops without aliases)",
+		Long: "call wraps POST /api/v1/operations/call with connector_id=\n" +
+			"\"fleet-rest-9.0\" pre-baked. Use when an op doesn't have a\n" +
+			"dedicated alias yet.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vcf-fleet operation call GET:/lcm/lcops/api/v2/datacenters --target rdc-fleet\n" +
+			"  meho vcf-fleet operation call GET:/lcm/lcops/api/v2/environments/{environmentId} \\\n" +
+			"      --target rdc-fleet --params '{\"environmentId\":\"env-vrops\"}'",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runOperationCall(cmd, args[0], targetName, paramsFlag, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "VCF Fleet target slug")
+	cmd.Flags().StringVar(&paramsFlag, "params", "", "params as inline JSON or @<file>")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params, err := loadParamsFlag(paramsFlag)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, nil)
+}

--- a/cli/internal/cmd/vcf-fleet/product.go
+++ b/cli/internal/cmd/vcf-fleet/product.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcffleet
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+const productListOpID = "GET:/lcm/lcops/api/v2/environments/{environmentId}/products"
+
+// newProductCmd returns the `meho vcf-fleet product` sub-tree.
+func newProductCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "product",
+		Short:        "VCF Fleet product operations (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newProductListCmd())
+	return cmd
+}
+
+func newProductListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list <environment-id>",
+		Short: "List products deployed under a Fleet environment",
+		Long: "list dispatches GET:/lcm/lcops/api/v2/environments/{environmentId}/products\n" +
+			"against connector_id=\"fleet-rest-9.0\". Returns one entry per\n" +
+			"product (vRA, vROps, vRLI, vIDM, Postgres, ...) with deployment\n" +
+			"status, version, and node breakdown. Requires an environmentId\n" +
+			"from `vcf-fleet environment list`.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
+		Example:       "  meho vcf-fleet product list env-vrops-prod --target rdc-fleet",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProductList(cmd, args[0], targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "VCF Fleet target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runProductList(cmd *cobra.Command, environmentID, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params := map[string]any{"environmentId": environmentID}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, productListOpID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, productListOpID, r, jsonOut, printProductList)
+}
+
+func printProductList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, productListOpID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeListResult(r.Result)
+	if err != nil {
+		printGenericResult(w, productListOpID, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 products)")
+		return
+	}
+	fmt.Fprintf(w, "%-16s %-20s %s\n", "productId", "version", "status")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-16s %-20s %s\n",
+			truncate(fleetStringField(e, "productId"), 16),
+			truncate(fleetStringField(e, "version"), 20),
+			truncate(fleetStringField(e, "status"), 32),
+		)
+	}
+}

--- a/cli/internal/cmd/vcf-fleet/request.go
+++ b/cli/internal/cmd/vcf-fleet/request.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcffleet
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+const (
+	requestListOpID = "GET:/lcm/request/api/v2/requests"
+	requestGetOpID  = "GET:/lcm/request/api/v2/requests/{requestId}"
+)
+
+// newRequestCmd returns the `meho vcf-fleet request` sub-tree.
+func newRequestCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "request",
+		Short:        "VCF Fleet lifecycle request operations (list / info)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newRequestListCmd())
+	cmd.AddCommand(newRequestInfoCmd())
+	return cmd
+}
+
+func newRequestListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List Fleet lifecycle requests (deploy / patch / upgrade workflows)",
+		Long: "list dispatches GET:/lcm/request/api/v2/requests against\n" +
+			"connector_id=\"fleet-rest-9.0\". Returns the most recent requests\n" +
+			"by createdOn; operators on busy appliances may see a JSONFlux\n" +
+			"handle through the shared HandleStore — use result_describe /\n" +
+			"result_query to filter by state or requestType.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
+		Example: "  meho vcf-fleet request list --target rdc-fleet\n" +
+			"  meho vcf-fleet request list --target rdc-fleet --json | jq '.result[] | select(.state==\"INPROGRESS\")'",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runRequestList(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "VCF Fleet target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runRequestList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, requestListOpID, targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, requestListOpID, r, jsonOut, printRequestList)
+}
+
+func printRequestList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, requestListOpID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeListResult(r.Result)
+	if err != nil {
+		printGenericResult(w, requestListOpID, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 requests)")
+		return
+	}
+	fmt.Fprintf(w, "%-38s %-24s %-14s %s\n", "vmid", "requestType", "state", "requestName")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-38s %-24s %-14s %s\n",
+			truncate(fleetStringField(e, "vmid"), 38),
+			truncate(fleetStringField(e, "requestType"), 24),
+			truncate(fleetStringField(e, "state"), 14),
+			truncate(fleetStringField(e, "requestName"), 40),
+		)
+	}
+}
+
+func newRequestInfoCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "info <request-id>",
+		Short: "Show the full detail of one Fleet lifecycle request",
+		Long: "info dispatches GET:/lcm/request/api/v2/requests/{requestId}\n" +
+			"against connector_id=\"fleet-rest-9.0\". Returns inputMap, outputMap,\n" +
+			"executionPath[] (stage list with per-stage status + timestamps),\n" +
+			"and errorCause on FAILED. Requires a requestId from\n" +
+			"`vcf-fleet request list`.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
+		Example:       "  meho vcf-fleet request info req-vmid-001 --target rdc-fleet",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRequestInfo(cmd, args[0], targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "VCF Fleet target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runRequestInfo(cmd *cobra.Command, requestID, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params := map[string]any{"requestId": requestID}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, requestGetOpID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, requestGetOpID, r, jsonOut, printRequestInfo)
+}
+
+func printRequestInfo(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, requestGetOpID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	if len(r.Result) == 0 || string(r.Result) == "null" {
+		return
+	}
+	var req struct {
+		VMID            string `json:"vmid"`
+		TransactionID   string `json:"transactionId"`
+		RequestName     string `json:"requestName"`
+		RequestType     string `json:"requestType"`
+		State           string `json:"state"`
+		ExecutionStatus string `json:"executionStatus"`
+		ErrorCause      string `json:"errorCause"`
+		CreatedBy       string `json:"createdBy"`
+		LastUpdatedOn   string `json:"lastUpdatedOn"`
+	}
+	if err := jsonUnmarshalStrict(r.Result, &req); err != nil || req.VMID == "" {
+		if pretty, perr := prettyJSON(r.Result); perr == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Result))
+		}
+		return
+	}
+	fmt.Fprintf(w, "request:       %s (%s) — state=%s\n", req.RequestName, req.VMID, req.State)
+	if req.RequestType != "" {
+		fmt.Fprintf(w, "type:          %s\n", req.RequestType)
+	}
+	if req.ExecutionStatus != "" {
+		fmt.Fprintf(w, "execution:     %s\n", req.ExecutionStatus)
+	}
+	if req.TransactionID != "" {
+		fmt.Fprintf(w, "transaction:   %s\n", req.TransactionID)
+	}
+	if req.CreatedBy != "" {
+		fmt.Fprintf(w, "created_by:    %s\n", req.CreatedBy)
+	}
+	if req.LastUpdatedOn != "" {
+		fmt.Fprintf(w, "updated_on:    %s\n", req.LastUpdatedOn)
+	}
+	if req.ErrorCause != "" {
+		fmt.Fprintf(w, "error_cause:   %s\n", req.ErrorCause)
+	}
+}

--- a/cli/internal/cmd/vcf-fleet/vcenter.go
+++ b/cli/internal/cmd/vcf-fleet/vcenter.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcffleet
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+const vcenterListOpID = "GET:/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters"
+
+// newVcenterCmd returns the `meho vcf-fleet vcenter` sub-tree.
+func newVcenterCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "vcenter",
+		Short:        "VCF Fleet vCenter operations (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newVcenterListCmd())
+	return cmd
+}
+
+func newVcenterListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list <datacenter-vmid>",
+		Short: "List vCenters registered under a Fleet datacenter",
+		Long: "list dispatches GET:/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters\n" +
+			"against connector_id=\"fleet-rest-9.0\". Requires a datacenter vmid\n" +
+			"obtained from `vcf-fleet datacenter list`. The hostname field is the\n" +
+			"load-bearing identifier for cross-referencing against vSphere targets.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected.",
+		Example:       "  meho vcf-fleet vcenter list dc-vmid-001 --target rdc-fleet",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runVcenterList(cmd, args[0], targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "VCF Fleet target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runVcenterList(cmd *cobra.Command, datacenterVmid, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params := map[string]any{"dataCenterVmid": datacenterVmid}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, vcenterListOpID, targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, vcenterListOpID, r, jsonOut, printVcenterList)
+}
+
+func printVcenterList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, vcenterListOpID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeListResult(r.Result)
+	if err != nil {
+		printGenericResult(w, vcenterListOpID, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "  (0 vCenters)")
+		return
+	}
+	fmt.Fprintf(w, "%-38s %-40s %-12s %s\n", "vmid", "hostname", "version", "build")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-38s %-40s %-12s %s\n",
+			truncate(fleetStringField(e, "vmid"), 38),
+			truncate(fleetStringField(e, "hostname"), 40),
+			truncate(fleetStringField(e, "version"), 12),
+			truncate(fleetStringField(e, "buildNumber"), 16),
+		)
+	}
+}

--- a/cli/internal/cmd/vcf-fleet/vcf_fleet.go
+++ b/cli/internal/cmd/vcf-fleet/vcf_fleet.go
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package vcffleet hosts the cobra commands under `meho vcf-fleet ...`
+// for G3.6-T9 (#839) of Initiative #369. v0.5 ships operator-facing
+// alias verbs over the 8 enabled VCF Fleet (vRSLCM-derived) read-only
+// core ops, each pre-baking connector_id="fleet-rest-9.0" so operators
+// don't type the connector ID on every dispatch:
+//
+//   - `meho vcf-fleet about [--target T]`                                  — GET:/lcm/lcops/api/v2/about
+//   - `meho vcf-fleet datacenter list [--target T]`                        — GET:/lcm/lcops/api/v2/datacenters
+//   - `meho vcf-fleet vcenter list <datacenter-vmid> [--target T]`         — GET:/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters
+//   - `meho vcf-fleet environment list [--target T]`                       — GET:/lcm/lcops/api/v2/environments
+//   - `meho vcf-fleet environment info <environment-id> [--target T]`      — GET:/lcm/lcops/api/v2/environments/{environmentId}
+//   - `meho vcf-fleet product list <environment-id> [--target T]`          — GET:/lcm/lcops/api/v2/environments/{environmentId}/products
+//   - `meho vcf-fleet request list [--target T]`                           — GET:/lcm/request/api/v2/requests
+//   - `meho vcf-fleet request info <request-id> [--target T]`              — GET:/lcm/request/api/v2/requests/{requestId}
+//   - `meho vcf-fleet operation search/call`                               — meta-tool wrappers
+//
+// Every verb is a thin Cobra command that POSTs to
+// `/api/v1/operations/call` with connector_id="fleet-rest-9.0"
+// pre-baked. No Fleet logic in the CLI; pure Cobra-over-HTTP following
+// the vmware + nsx + sddc-manager precedent (CLAUDE.md postulate 5).
+//
+// Per CLAUDE.md postulate 5, these alias verbs are operator ergonomics
+// only — they are NOT mirrored on the MCP surface. Agents continue to
+// use search_operations / call_operation against the narrow-waist
+// meta-tool contract.
+package vcffleet
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// ConnectorID is the pre-baked connector_id every verb under
+// `meho vcf-fleet ...` dispatches against. Matches the v2 registry
+// triple (product="vcf-fleet", version="9.0", impl_id="fleet-rest")
+// the backend's parse_connector_id round-trips: "fleet-rest-9.0".
+const ConnectorID = "fleet-rest-9.0"
+
+// NewRootCmd returns the `meho vcf-fleet` parent command.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vcf-fleet",
+		Short: "Pre-scoped CLI verbs for the fleet-rest-9.0 connector",
+		Long: "vcf-fleet is the operator-facing verb tree for the fleet-rest-9.0\n" +
+			"connector (VCF Fleet — vRSLCM-derived lifecycle manager). Each verb\n" +
+			"dispatches through POST /api/v1/operations/call with\n" +
+			"connector_id=\"fleet-rest-9.0\" pre-baked so operators don't type the\n" +
+			"connector ID on every command.\n\n" +
+			"Per CLAUDE.md postulate 5, these alias verbs are operator-only\n" +
+			"ergonomics — they are not mirrored on the MCP surface. Agents\n" +
+			"continue to use search_operations / call_operation against the\n" +
+			"narrow-waist meta-tool contract.\n\n" +
+			"Known issue (VCF 9.0): the /about endpoint returns HTTP 500. Use\n" +
+			"`vcf-fleet datacenter list` as the reachability probe instead.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newAboutCmd())
+	cmd.AddCommand(newDatacenterCmd())
+	cmd.AddCommand(newVcenterCmd())
+	cmd.AddCommand(newEnvironmentCmd())
+	cmd.AddCommand(newProductCmd())
+	cmd.AddCommand(newRequestCmd())
+	cmd.AddCommand(newOperationCmd())
+	return cmd
+}
+
+// fleetEntry is a single row in a Fleet list response. Fleet returns
+// bare JSON arrays for list ops (no `elements` / `results` envelope —
+// unlike SDDC Manager / NSX), so the decoder falls through to a
+// straight `[]map[string]any` unmarshal.
+type fleetEntry = map[string]any
+
+// decodeListResult unwraps Fleet's bare-array list response, or falls
+// back to a `{"data": [...]}` envelope if the appliance build wraps the
+// array. Fleet's vRSLCM lineage REST surface returns bare arrays on the
+// curated read ops verified against the wrapper.
+func decodeListResult(raw json.RawMessage) ([]fleetEntry, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var arr []fleetEntry
+	if err := json.Unmarshal(raw, &arr); err == nil {
+		return arr, nil
+	}
+	// Some appliance builds wrap collections in `{"data": [...]}` — try
+	// that shape before giving up. The fallback exists to keep the
+	// pretty-printer robust to spec-ingest drift; the canary fixture
+	// uses the bare-array shape.
+	var wrapped struct {
+		Data []fleetEntry `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &wrapped); err == nil && wrapped.Data != nil {
+		return wrapped.Data, nil
+	}
+	return nil, fmt.Errorf("decode Fleet list result: not a JSON array or {data:[...]} envelope")
+}
+
+// fleetStringField extracts a string value from a Fleet entry map.
+func fleetStringField(e fleetEntry, key string) string {
+	v, ok := e[key]
+	if !ok {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// printErrorTrailer surfaces the dispatcher error + extras envelope.
+func printErrorTrailer(w io.Writer, r *CallResult) {
+	if r.Error != nil && *r.Error != "" {
+		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
+	} else {
+		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
+	}
+	if len(r.Extras) > 0 && string(r.Extras) != "null" {
+		fmt.Fprintln(w, "extras:")
+		pretty, err := prettyJSON(r.Extras)
+		if err == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Extras))
+		}
+	}
+}
+
+type errNoBackplaneConfigured struct{ inner error }
+
+func (e *errNoBackplaneConfigured) Error() string {
+	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
+}
+func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
+
+func resolveBackplane(override string) (string, error) {
+	if override != "" {
+		return normaliseURL(override)
+	}
+	cfg, err := auth.LoadConfig()
+	if err != nil {
+		if errors.Is(err, auth.ErrConfigNotFound) {
+			return "", &errNoBackplaneConfigured{inner: err}
+		}
+		return "", err
+	}
+	return normaliseURL(cfg.BackplaneURL)
+}
+
+func classifyBackplaneError(err error) *output.StructuredError {
+	if errors.Is(err, auth.ErrConfigNotFound) {
+		return output.AuthExpired(err.Error())
+	}
+	return output.Unexpected(err.Error())
+}
+
+func normaliseURL(s string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
+	if trimmed == "" {
+		return "", errors.New("backplane URL is empty")
+	}
+	u, err := url.ParseRequestURI(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("backplane URL %q has no host", s)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}
+
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var he *httpError
+	if errors.As(err, &he) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, he.StatusCode, he.Body)),
+			jsonOut,
+		)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+type httpError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+func doAuthedRequest(
+	ctx context.Context,
+	backplaneURL, method, path string,
+	body []byte,
+) ([]byte, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	httpClient := authed.HTTPClient()
+	bearer := authed.AccessToken()
+	if bearer == "" {
+		return nil, errors.New("meho: stored token has no access_token")
+	}
+	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			resp.Body.Close()
+			return nil, rerr
+		}
+		resp.Body.Close()
+		bearer = authed.AccessToken()
+		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close()
+	const maxBody = int64(1 << 20) // 1 MiB
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if int64(len(raw)) > maxBody {
+		return nil, fmt.Errorf("backplane response body exceeds %d bytes", maxBody)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
+	}
+	return raw, nil
+}
+
+func sendRequest(
+	ctx context.Context,
+	client *http.Client,
+	backplaneURL, method, path, bearer string,
+	body []byte,
+) (*http.Response, error) {
+	fullURL := backplaneURL + path
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return client.Do(req)
+}
+
+func loadParamsFlag(val string) (map[string]any, error) {
+	if val == "" {
+		return nil, nil
+	}
+	var raw []byte
+	if strings.HasPrefix(val, "@") {
+		path := strings.TrimPrefix(val, "@")
+		var err error
+		raw, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read params file %q: %w", path, err)
+		}
+	} else {
+		raw = []byte(val)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("parse params JSON: %w", err)
+	}
+	return m, nil
+}
+
+func jsonUnmarshalStrict(raw []byte, out any) error {
+	return json.Unmarshal(raw, out)
+}
+
+func strDeref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}

--- a/cli/internal/cmd/vcf-fleet/vcf_fleet_test.go
+++ b/cli/internal/cmd/vcf-fleet/vcf_fleet_test.go
@@ -1,0 +1,678 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcffleet
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// ---------- helper tests ----------
+
+func TestTruncatePassthroughAndCut(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     string
+		maxLen int
+		want   string
+	}{
+		{"within budget", "abc", 5, "abc"},
+		{"over budget ascii", "abcdef", 4, "abc…"},
+		{"multi-byte safe", "café world", 5, "café…"},
+		{"zero budget", "x", 0, ""},
+	}
+	for _, tt := range tests {
+		if got := truncate(tt.in, tt.maxLen); got != tt.want {
+			t.Errorf("%s: truncate(%q, %d) = %q; want %q", tt.name, tt.in, tt.maxLen, got, tt.want)
+		}
+	}
+}
+
+func TestNormaliseURLBasic(t *testing.T) {
+	got, err := normaliseURL("https://meho.test/")
+	if err != nil {
+		t.Fatalf("normaliseURL: %v", err)
+	}
+	if got != "https://meho.test" {
+		t.Fatalf("expected trailing slash stripped; got %q", got)
+	}
+	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("empty should reject; got %v", err)
+	}
+}
+
+func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
+	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
+	se := classifyBackplaneError(wrapped)
+	if se == nil || se.Code != "auth_expired" {
+		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
+	}
+	se = classifyBackplaneError(errors.New("parse failure"))
+	if se == nil || se.Code != "unexpected_response" {
+		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
+	}
+}
+
+func TestConnectorIDIsFrozen(t *testing.T) {
+	if ConnectorID != "fleet-rest-9.0" {
+		t.Fatalf("ConnectorID drifted: got %q want %q", ConnectorID, "fleet-rest-9.0")
+	}
+}
+
+// ---------- loadParamsFlag ----------
+
+func TestLoadParamsFlagEmpty(t *testing.T) {
+	got, err := loadParamsFlag("")
+	if err != nil || got != nil {
+		t.Fatalf("loadParamsFlag(\"\"): err=%v got=%v", err, got)
+	}
+}
+
+func TestLoadParamsFlagInlineJSON(t *testing.T) {
+	got, err := loadParamsFlag(`{"environmentId":"env-vrops"}`)
+	if err != nil {
+		t.Fatalf("loadParamsFlag: %v", err)
+	}
+	if got["environmentId"] != "env-vrops" {
+		t.Fatalf("inline JSON params not parsed; got %v", got)
+	}
+}
+
+func TestLoadParamsFlagFileReference(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "p.json")
+	if err := os.WriteFile(path, []byte(`{"dataCenterVmid":"dc-001"}`), 0o644); err != nil {
+		t.Fatalf("setup write: %v", err)
+	}
+	got, err := loadParamsFlag("@" + path)
+	if err != nil || got["dataCenterVmid"] != "dc-001" {
+		t.Fatalf("loadParamsFlag @file: err=%v got=%v", err, got)
+	}
+}
+
+func TestLoadParamsFlagInvalidJSONReportsError(t *testing.T) {
+	_, err := loadParamsFlag(`{not json`)
+	if err == nil || !strings.Contains(err.Error(), "parse params JSON") {
+		t.Fatalf("expected parse error; got %v", err)
+	}
+}
+
+// ---------- decodeListResult ----------
+
+func TestDecodeListResultBareArray(t *testing.T) {
+	raw := json.RawMessage(`[{"vmid":"dc-1","name":"primary"},{"vmid":"dc-2","name":"secondary"}]`)
+	entries, err := decodeListResult(raw)
+	if err != nil {
+		t.Fatalf("decodeListResult bare: %v", err)
+	}
+	if len(entries) != 2 || entries[0]["vmid"] != "dc-1" {
+		t.Fatalf("bare-array decode: got %+v", entries)
+	}
+}
+
+func TestDecodeListResultDataEnvelope(t *testing.T) {
+	raw := json.RawMessage(`{"data":[{"vmid":"dc-1"}]}`)
+	entries, err := decodeListResult(raw)
+	if err != nil {
+		t.Fatalf("decodeListResult data-envelope: %v", err)
+	}
+	if len(entries) != 1 || entries[0]["vmid"] != "dc-1" {
+		t.Fatalf("data-envelope decode: got %+v", entries)
+	}
+}
+
+func TestDecodeListResultEmpty(t *testing.T) {
+	for _, raw := range []json.RawMessage{nil, json.RawMessage(`null`)} {
+		entries, err := decodeListResult(raw)
+		if err != nil || entries != nil {
+			t.Fatalf("decodeListResult empty: err=%v entries=%v", err, entries)
+		}
+	}
+}
+
+func TestDecodeListResultUnknownShapeErrors(t *testing.T) {
+	raw := json.RawMessage(`{"unexpected":"shape"}`)
+	if _, err := decodeListResult(raw); err == nil {
+		t.Fatalf("decodeListResult should error on unknown shape")
+	}
+}
+
+// ---------- renderers ----------
+
+func TestPrintAboutHumanFormat(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		OpID:       aboutOpID,
+		Result:     json.RawMessage(`{"apiVersion":"8.0","productVersion":"9.0.0.0","buildNumber":"24123456","releaseDate":"2026-04-01"}`),
+		DurationMs: 42.0,
+	}
+	var buf bytes.Buffer
+	printAbout(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"status=ok", "fleet-rest-9.0", "8.0", "9.0.0.0", "24123456", "2026-04-01"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printAbout missing %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintAboutErrorRendersErrorString(t *testing.T) {
+	errMsg := "appliance 500"
+	r := &CallResult{
+		Status:     "error",
+		OpID:       aboutOpID,
+		Error:      &errMsg,
+		DurationMs: 5.0,
+	}
+	var buf bytes.Buffer
+	printAbout(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"status=error", "appliance 500"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printAbout error missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintDatacenterList(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		Result:     json.RawMessage(`[{"vmid":"dc-001","name":"primary","type":"PRIVATE_CLOUD","city":"Vienna"}]`),
+		DurationMs: 8.0,
+	}
+	var buf bytes.Buffer
+	printDatacenterList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"dc-001", "primary", "PRIVATE_CLOUD", "Vienna"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printDatacenterList missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintDatacenterListEmpty(t *testing.T) {
+	r := &CallResult{Status: "ok", Result: json.RawMessage(`[]`)}
+	var buf bytes.Buffer
+	printDatacenterList(&buf, r)
+	if !strings.Contains(buf.String(), "(0 datacenters)") {
+		t.Errorf("empty list should announce 0 datacenters; got:\n%s", buf.String())
+	}
+}
+
+func TestPrintVcenterList(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		Result:     json.RawMessage(`[{"vmid":"vc-001","hostname":"vc-prod.lab.example.com","version":"8.0.3","buildNumber":"24001122"}]`),
+		DurationMs: 7.0,
+	}
+	var buf bytes.Buffer
+	printVcenterList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"vc-001", "vc-prod.lab.example.com", "8.0.3"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printVcenterList missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintEnvironmentList(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		Result:     json.RawMessage(`[{"environmentId":"env-vrops","environmentName":"vROps Prod","environmentStatus":"DEPLOY_SUCCESSFUL"}]`),
+		DurationMs: 9.0,
+	}
+	var buf bytes.Buffer
+	printEnvironmentList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"env-vrops", "vROps Prod", "DEPLOY_SUCCESSFUL"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printEnvironmentList missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintEnvironmentInfo(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		Result:     json.RawMessage(`{"environmentId":"env-vrops","environmentName":"vROps Prod","environmentStatus":"DEPLOY_SUCCESSFUL","transactionId":"txn-001","createdOn":"2026-05-01","products":[{"productId":"vrops","version":"9.0.0","status":"OK","nodes":[{"hostname":"vrops-01.lab","ipAddress":"10.1.1.10","role":"MASTER","vmStatus":"POWERED_ON"}]}]}`),
+		DurationMs: 5.0,
+	}
+	var buf bytes.Buffer
+	printEnvironmentInfo(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"env-vrops", "vROps Prod", "DEPLOY_SUCCESSFUL", "txn-001", "vrops", "9.0.0", "vrops-01.lab", "POWERED_ON"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printEnvironmentInfo missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintProductList(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		Result:     json.RawMessage(`[{"productId":"vrops","version":"9.0.0","status":"OK"},{"productId":"vrli","version":"9.0.1","status":"OK"}]`),
+		DurationMs: 6.0,
+	}
+	var buf bytes.Buffer
+	printProductList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"vrops", "9.0.0", "vrli", "9.0.1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printProductList missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintRequestList(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		Result:     json.RawMessage(`[{"vmid":"req-001","requestType":"ENVIRONMENT_CREATE","state":"COMPLETED","requestName":"Create vROps Prod"}]`),
+		DurationMs: 4.0,
+	}
+	var buf bytes.Buffer
+	printRequestList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"req-001", "ENVIRONMENT_CREATE", "COMPLETED", "Create vROps Prod"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printRequestList missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintRequestInfo(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		Result:     json.RawMessage(`{"vmid":"req-001","transactionId":"txn-009","requestName":"Upgrade vROps","requestType":"PRODUCT_UPGRADE","state":"FAILED","executionStatus":"FAILED","errorCause":"node unreachable","createdBy":"admin@local","lastUpdatedOn":"2026-05-10"}`),
+		DurationMs: 3.0,
+	}
+	var buf bytes.Buffer
+	printRequestInfo(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"req-001", "Upgrade vROps", "PRODUCT_UPGRADE", "FAILED", "node unreachable", "admin@local", "2026-05-10"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printRequestInfo missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintSearchTable(t *testing.T) {
+	summary := "List Fleet environments"
+	r := &searchResponse{
+		Hits: []searchHit{
+			{OpID: environmentListOpID, Summary: &summary, FusedScore: 0.987},
+		},
+		QueryDurationMs: 12.0,
+	}
+	var buf bytes.Buffer
+	printSearchTable(&buf, "list environments", r)
+	out := buf.String()
+	for _, want := range []string{"fleet-rest-9.0", "list environments", "1 hit(s)", environmentListOpID, "List Fleet environments"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printSearchTable missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintSearchTableEmpty(t *testing.T) {
+	r := &searchResponse{Hits: nil, QueryDurationMs: 1.0}
+	var buf bytes.Buffer
+	printSearchTable(&buf, "no-match", r)
+	if !strings.Contains(buf.String(), "0 hit(s)") {
+		t.Errorf("empty search should announce 0 hits; got:\n%s", buf.String())
+	}
+}
+
+// ---------- errOpError sentinel ----------
+
+func TestErrOpErrorIsSentinel(t *testing.T) {
+	if errOpError == nil {
+		t.Fatal("errOpError should be non-nil")
+	}
+}
+
+// ---------- HTTP wire shape ----------
+
+type mockHandler = http.HandlerFunc
+
+func mockBackplane(t *testing.T, routes map[string]mockHandler) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		if h, ok := routes[key]; ok {
+			h(w, r)
+			return
+		}
+		if h, ok := routes[""]; ok {
+			h(w, r)
+			return
+		}
+		t.Errorf("mockBackplane: unhandled route %s", key)
+		w.WriteHeader(404)
+	}))
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, body any) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Errorf("writeJSON marshal: %v", err)
+		w.WriteHeader(500)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, err := w.Write(raw); err != nil {
+		t.Errorf("writeJSON write: %v", err)
+	}
+}
+
+func primeToken(t *testing.T, backplaneURL string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	cfg := filepath.Join(dir, "meho", "config.json")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	cfgBlob, _ := json.Marshal(map[string]string{"backplane_url": backplaneURL})
+	if err := os.WriteFile(cfg, cfgBlob, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	store, err := auth.NewTokenStore()
+	if err != nil {
+		t.Fatalf("NewTokenStore: %v", err)
+	}
+	if err := store.Save(service, user, auth.StoredToken{
+		AccessToken:  "test-bearer",
+		BackplaneURL: backplaneURL,
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+}
+
+// TestDispatchOpBakesConnectorID pins connector_id="fleet-rest-9.0" on every dispatch.
+func TestDispatchOpBakesConnectorID(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.ConnectorID != "fleet-rest-9.0" {
+				t.Errorf("connector_id: got %q want fleet-rest-9.0", body.ConnectorID)
+			}
+			if body.OpID != datacenterListOpID {
+				t.Errorf("op_id: got %q", body.OpID)
+			}
+			writeJSON(t, w, 200, CallResult{
+				Status: "ok",
+				OpID:   datacenterListOpID,
+				Result: json.RawMessage(`[]`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	r, err := dispatchOp(context.Background(), srv.URL, datacenterListOpID, "rdc-fleet", nil)
+	if err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+	if r.Status != "ok" {
+		t.Fatalf("dispatch status: %s", r.Status)
+	}
+}
+
+// TestDispatchOpEmptyTargetSendsNullTarget — empty slug → null target on wire.
+func TestDispatchOpEmptyTargetSendsNullTarget(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var raw map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if raw["target"] != nil {
+				t.Errorf("empty target should be null on wire; got %v", raw["target"])
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: datacenterListOpID})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	if _, err := dispatchOp(context.Background(), srv.URL, datacenterListOpID, "", nil); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
+// TestDispatchVcenterListSendsDataCenterVmidParam pins that the vcenter list
+// verb forwards dataCenterVmid as a path-template param.
+func TestDispatchVcenterListSendsDataCenterVmidParam(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.OpID != vcenterListOpID {
+				t.Errorf("op_id: got %q want %q", body.OpID, vcenterListOpID)
+			}
+			vmid, _ := body.Params["dataCenterVmid"].(string)
+			if vmid != "dc-001" {
+				t.Errorf("dataCenterVmid: got %q want dc-001", vmid)
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID, Result: json.RawMessage(`[]`)})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	params := map[string]any{"dataCenterVmid": "dc-001"}
+	if _, err := dispatchOp(context.Background(), srv.URL, vcenterListOpID, "rdc-fleet", params); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
+// TestDispatchEnvironmentInfoSendsEnvironmentIDParam pins environment info routing.
+func TestDispatchEnvironmentInfoSendsEnvironmentIDParam(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.OpID != environmentGetOpID {
+				t.Errorf("op_id: got %q want %q", body.OpID, environmentGetOpID)
+			}
+			envID, _ := body.Params["environmentId"].(string)
+			if envID != "env-vrops" {
+				t.Errorf("environmentId: got %q want env-vrops", envID)
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	params := map[string]any{"environmentId": "env-vrops"}
+	if _, err := dispatchOp(context.Background(), srv.URL, environmentGetOpID, "rdc-fleet", params); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
+// TestDispatchRequestInfoSendsRequestIDParam pins request info routing.
+func TestDispatchRequestInfoSendsRequestIDParam(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			reqID, _ := body.Params["requestId"].(string)
+			if reqID != "req-001" {
+				t.Errorf("requestId: got %q want req-001", reqID)
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	params := map[string]any{"requestId": "req-001"}
+	if _, err := dispatchOp(context.Background(), srv.URL, requestGetOpID, "rdc-fleet", params); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
+// TestSearchSendsConnectorIDPreBaked pins search wrapper connector_id pre-baking.
+func TestSearchSendsConnectorIDPreBaked(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"GET /api/v1/operations/search": func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("connector_id"); got != "fleet-rest-9.0" {
+				t.Errorf("connector_id: got %q", got)
+			}
+			if got := r.URL.Query().Get("query"); got != "list environments" {
+				t.Errorf("query: got %q", got)
+			}
+			writeJSON(t, w, 200, searchResponse{
+				Hits: []searchHit{{OpID: environmentListOpID, FusedScore: 1.0}},
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	r, err := getSearch(context.Background(), srv.URL, "list environments", "", 10)
+	if err != nil {
+		t.Fatalf("getSearch: %v", err)
+	}
+	if len(r.Hits) != 1 || r.Hits[0].OpID != environmentListOpID {
+		t.Fatalf("unexpected search response: %+v", r)
+	}
+}
+
+// TestNewRootCmdAssemblesAllVerbs pins the full vcf-fleet verb tree shape.
+func TestNewRootCmdAssemblesAllVerbs(t *testing.T) {
+	root := NewRootCmd()
+	want := map[string]bool{
+		"about":       true,
+		"datacenter":  true,
+		"vcenter":     true,
+		"environment": true,
+		"product":     true,
+		"request":     true,
+		"operation":   true,
+	}
+	for _, c := range root.Commands() {
+		delete(want, c.Name())
+	}
+	if len(want) > 0 {
+		t.Errorf("vcf-fleet tree missing top-level verbs: %v", want)
+	}
+}
+
+// TestEnvironmentSubtreeAssemblesListAndInfo pins `vcf-fleet environment` shape.
+func TestEnvironmentSubtreeAssemblesListAndInfo(t *testing.T) {
+	root := NewRootCmd()
+	for _, c := range root.Commands() {
+		if c.Name() != "environment" {
+			continue
+		}
+		subnames := map[string]bool{}
+		for _, sub := range c.Commands() {
+			subnames[sub.Name()] = true
+		}
+		for _, want := range []string{"list", "info"} {
+			if !subnames[want] {
+				t.Errorf("environment sub-tree missing %q; got %v", want, subnames)
+			}
+		}
+		return
+	}
+	t.Fatalf("environment sub-tree not found")
+}
+
+// TestRequestSubtreeAssemblesListAndInfo pins `vcf-fleet request` shape.
+func TestRequestSubtreeAssemblesListAndInfo(t *testing.T) {
+	root := NewRootCmd()
+	for _, c := range root.Commands() {
+		if c.Name() != "request" {
+			continue
+		}
+		subnames := map[string]bool{}
+		for _, sub := range c.Commands() {
+			subnames[sub.Name()] = true
+		}
+		for _, want := range []string{"list", "info"} {
+			if !subnames[want] {
+				t.Errorf("request sub-tree missing %q; got %v", want, subnames)
+			}
+		}
+		return
+	}
+	t.Fatalf("request sub-tree not found")
+}
+
+// TestOperationSubtreeAssemblesAllVerbs pins `vcf-fleet operation` shape.
+func TestOperationSubtreeAssemblesAllVerbs(t *testing.T) {
+	root := NewRootCmd()
+	for _, c := range root.Commands() {
+		if c.Name() != "operation" {
+			continue
+		}
+		subnames := map[string]bool{}
+		for _, sub := range c.Commands() {
+			subnames[sub.Name()] = true
+		}
+		for _, want := range []string{"search", "call"} {
+			if !subnames[want] {
+				t.Errorf("operation sub-tree missing %q; got %v", want, subnames)
+			}
+		}
+		return
+	}
+	t.Fatalf("operation sub-tree not found")
+}
+
+// TestFlatListVerbsHaveListSubcommand pins single-list-verb sub-trees.
+func TestFlatListVerbsHaveListSubcommand(t *testing.T) {
+	root := NewRootCmd()
+	for _, parent := range []string{"datacenter", "vcenter", "product"} {
+		found := false
+		for _, c := range root.Commands() {
+			if c.Name() != parent {
+				continue
+			}
+			for _, sub := range c.Commands() {
+				if sub.Name() == "list" {
+					found = true
+				}
+			}
+		}
+		if !found {
+			t.Errorf("vcf-fleet %s missing 'list' sub-verb", parent)
+		}
+	}
+}

--- a/docs/cross-repo/vcf-fleet-onboarding.md
+++ b/docs/cross-repo/vcf-fleet-onboarding.md
@@ -1,0 +1,460 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# VCF Fleet op surface onboarding — operator recipe
+
+> Operator-facing recipe for the G3.6 `fleet-rest-9.0` op surface — the
+> `meho vcf-fleet …` verb tree, the agent meta-tool path, and the migration
+> off the consumer's `scripts/vcf-fleet.sh` wrapper. The op handlers live in
+> [`backend/src/meho_backplane/connectors/vcf_fleet/`](../../backend/src/meho_backplane/connectors/vcf_fleet/);
+> the recorded-fixture refresh recipe is documented at
+> [`docs/cross-repo/vcf-fixture-refresh.md`](./vcf-fixture-refresh.md) (#841).
+> This doc is the cookbook every RDC operator reads when retiring
+> `scripts/vcf-fleet.sh` in favour of `meho vcf-fleet …`.
+
+## What this surface is
+
+The `fleet-rest-9.0` connector is an **ingested** connector: the 8 curated
+read-only ops are stored as `EndpointDescriptor` rows seeded from
+[`FLEET_CORE_OPS`](../../backend/src/meho_backplane/connectors/vcf_fleet/core_ops.py)
+and dispatched through `HttpConnector._request_json` by the G0.6
+`dispatch_ingested` branch. The connector registers under the
+`(product="vcf-fleet", version="9.0", impl_id="fleet-rest")` registry triple —
+the connector id `fleet-rest-9.0`. Auth is **HTTP Basic** on every request
+against Fleet's local LCM user store (typical service account: `admin@local`);
+no SSO federation, no session establish, no XSRF-token dance. The connector
+handles auth transparently via `VcfFleetConnector.auth_headers` and the
+shared `CredentialsCache` helper (#841).
+
+VCF Fleet has no public CI simulator (consumer wrapper note,
+[Initiative #369](https://github.com/evoila/meho/issues/369) DoD). Integration
+coverage uses a **recorded-fixture respx-mock pattern** against captured
+appliance responses — same posture NSX, SDDC Manager, vROps, and vRLI use.
+The refresh tool lives at
+[`backend/tests/fixtures/vcf/refresh.py`](../../backend/tests/fixtures/vcf/refresh.py);
+the fixture-refresh recipe is documented at
+[`docs/cross-repo/vcf-fixture-refresh.md`](./vcf-fixture-refresh.md) (#841).
+
+The v0.5 op surface (Initiative
+[#369](https://github.com/evoila/meho/issues/369)) is the **read** working set
+the consumer's `scripts/vcf-fleet.sh` exercises daily — write ops (environment
+create, product patch, lifecycle workflow start) stay in the wrapper until
+v0.5.next ships policy + approval flow.
+
+| Group | CLI verb | `op_id` | Path |
+| --- | --- | --- | --- |
+| fleet-about | `meho vcf-fleet about` | `GET:/lcm/lcops/api/v2/about` | vRSLCM appliance identity (HTTP 500 in 9.0 — see below) |
+| fleet-datacenter | `meho vcf-fleet datacenter list` | `GET:/lcm/lcops/api/v2/datacenters` | Datacenter inventory + wrapper-verified probe |
+| fleet-vcenter | `meho vcf-fleet vcenter list <vmid>` | `GET:/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters` | vCenters registered under one datacenter |
+| fleet-environment | `meho vcf-fleet environment list` | `GET:/lcm/lcops/api/v2/environments` | Environment inventory (primary Fleet entry point) |
+| fleet-environment | `meho vcf-fleet environment info <id>` | `GET:/lcm/lcops/api/v2/environments/{environmentId}` | Per-environment detail (products + nodes) |
+| fleet-product | `meho vcf-fleet product list <env-id>` | `GET:/lcm/lcops/api/v2/environments/{environmentId}/products` | Products deployed under one environment |
+| fleet-request | `meho vcf-fleet request list` | `GET:/lcm/request/api/v2/requests` | Lifecycle request listing (deploy / patch / upgrade) |
+| fleet-request | `meho vcf-fleet request info <id>` | `GET:/lcm/request/api/v2/requests/{requestId}` | Per-request detail with errorCause on FAILED |
+
+Every op dispatches through the same `POST /api/v1/operations/call` route the
+agent surface uses — auth, policy, audit, broadcast, and JSONFlux all run as
+documented in [CLAUDE.md](../../CLAUDE.md) §6. The CLI verb tree is operator
+ergonomics over that one route; it is **not** a separate data path and is
+**not** mirrored on the MCP surface (CLAUDE.md postulate 5).
+
+## VCF 9.0 known issue: `/about` returns HTTP 500
+
+Fleet's first-party diagnostic endpoints — `/about`, `/health`, `/version`,
+`/system-details`, `/lcm/common/api/about`, `/lcm/locker/api/v2/about` — all
+return HTTP 500 in current VCF 9.0 builds. This is documented in the consumer
+wrapper `scripts/vcf-fleet.sh`'s probe-block and surfaced through the
+connector's `FingerprintResult.extras.diagnostic_endpoints_broken` list.
+
+Workarounds the connector implements:
+
+- **Probe**: `VcfFleetConnector.probe` calls `GET /lcm/lcops/api/v2/datacenters`
+  (the wrapper-verified probe path) and reads the `Lcm-API-Version` response
+  header. Guaranteed to respond in 9.0.
+- **Reachability check**: `meho vcf-fleet datacenter list --target rdc-fleet`
+  is the operator-facing reachability probe. `meho vcf-fleet about` is kept
+  for spec parity + future fix but will return `status=error` on 9.0
+  appliances until Broadcom fixes the endpoint.
+- **Product version sourcing**: Fleet does not expose its product version via
+  any working endpoint in 9.0. The fingerprint carries the LCM API version
+  (e.g. `"8.0"`) under `extras.lcm_api_version`. Operators needing the
+  product version cross-source from SDDC Manager (`meho sddc-manager
+  operation call GET:/v1/vcf-services`).
+
+Track the upstream fix at [Broadcom developer portal](https://developer.broadcom.com/xapis/vrealize-suite-lifecycle-manager/latest/);
+when the endpoint is restored, the `meho vcf-fleet about` verb starts working
+without code changes.
+
+## Prerequisites
+
+- **A reachable vRSLCM appliance** (VCF Fleet 9.x). The connector derives the
+  base URL from `target.host` + `target.port`; both direct-appliance addresses
+  and VCF proxied addresses work.
+- **Service-account credentials in Vault.** The connector reads
+  `{"username": ..., "password": ...}` from Vault at `target.secret_ref`. The
+  username is sent **verbatim** in the HTTP Basic header (typically
+  `admin@local`); no realm suffix is appended. Credentials are cached in-process
+  per target after first use via the shared `CredentialsCache` helper (#841).
+- **A registered VCF Fleet target.** The CLI verbs take `--target <slug>`
+  (e.g. `--target rdc-fleet`). The target carries `product="vcf-fleet"`,
+  `host` (the appliance FQDN — no `https://`), `port` (default 443),
+  `secret_ref` (the Vault path to the credentials), and
+  `auth_model="shared_service_account"`.
+- **The 8 curated ops registered + enabled.** Run the G3.6-T8 curation step
+  (`apply_fleet_core_curation`) once per Fleet target after the G0.7 spec
+  ingest.
+- **An operator session.** `meho login <backplane-url>` writes the session
+  token the CLI reuses. `meho vcf-fleet …` requires `operator` role minimum
+  (same gate as every dispatch verb).
+
+## Target + auth model
+
+The shipped connector's auth model is **`shared_service_account`** — the
+Vault-sourced credentials are used regardless of which operator invokes the
+verb. Per-operator impersonation is out of scope for v0.5 (Fleet has no SSO
+federation; the local LCM user store is the only auth surface).
+
+What this means for the credentials in Vault:
+
+- Vault path: `target.secret_ref` (e.g. `kv/data/vcf-fleet/rdc`).
+- Required fields: `username` (string, typically `admin@local`),
+  `password` (string).
+- The backplane reads them lazily on first op invocation per target;
+  credentials are then cached in the connector's per-target dict for the
+  lifetime of the process.
+- **No 401-retry**: HTTP Basic credentials are stateless server-side (Fleet's
+  local user store has no session lifecycle). A 401 response propagates
+  directly to the caller — it signals wrong credentials, not an expired
+  session. Mirrors the SDDC Manager auth posture; unlike NSX (which has a
+  session-create + XSRF-token dance + 401-driven re-login).
+- **Credential rotation**: update the Vault secret and restart the backplane
+  (the in-process credential cache clears on `aclose`). There is no per-target
+  credential refresh hook in v0.5.
+
+To register a new target via the CLI:
+
+```bash
+meho targets import \
+  --name rdc-fleet \
+  --product vcf-fleet \
+  --host vcf-fleet.rdc.evoila.io \
+  --port 443 \
+  --secret-ref kv/data/vcf-fleet/rdc \
+  --auth-model shared_service_account
+```
+
+Verify the fingerprint resolved correctly:
+
+```bash
+meho targets probe --name rdc-fleet --json | jq '{product, version, reachable, extras}'
+# expected: {"product": "vcf-fleet", "version": "8.0", "reachable": true,
+#            "extras": {"lcm_api_version": "8.0", "datacenter_count": N, ...}}
+# Note: `version` carries the LCM API version (the only working version source
+# in 9.0), not the product version. The connector's class-level
+# `supported_version_range=">=9.0,<10.0"` is matched against the persisted
+# `Target.fingerprint.version` written by the canary fixture; in production
+# the fingerprint is what `probe` writes back.
+```
+
+## Quick-start
+
+```bash
+# Reachability check (the working probe — use this instead of `about` in 9.0)
+meho vcf-fleet datacenter list --target rdc-fleet
+
+# Appliance identity (RETURNS HTTP 500 in 9.0 — see "VCF 9.0 known issue")
+meho vcf-fleet about --target rdc-fleet
+
+# vCenters registered under one datacenter
+meho vcf-fleet vcenter list dc-vmid-001 --target rdc-fleet
+
+# All Fleet-managed environments
+meho vcf-fleet environment list --target rdc-fleet
+
+# Per-environment detail (products + nodes + status)
+meho vcf-fleet environment info env-vrops-prod --target rdc-fleet
+
+# Products deployed under one environment
+meho vcf-fleet product list env-vrops-prod --target rdc-fleet
+
+# Recent lifecycle requests (deploy / patch / upgrade workflows)
+meho vcf-fleet request list --target rdc-fleet
+
+# Per-request detail (state + errorCause on FAILED)
+meho vcf-fleet request info req-vmid-001 --target rdc-fleet
+
+# Machine-readable output for any verb
+meho vcf-fleet environment list --target rdc-fleet --json | jq '.result[].environmentName'
+
+# Filter requests by state via jq (no native --status flag in v0.5)
+meho vcf-fleet request list --target rdc-fleet --json \
+  | jq '.result[] | select(.state == "INPROGRESS")'
+
+# Escape hatch: run any fleet-rest-9.0 op by op_id
+meho vcf-fleet operation call GET:/lcm/lcops/api/v2/datacenters --target rdc-fleet
+meho vcf-fleet operation search "list environments"
+```
+
+## Verb reference
+
+### `meho vcf-fleet about`
+
+Dispatches `GET:/lcm/lcops/api/v2/about` against `connector_id="fleet-rest-9.0"`.
+**Warning**: returns HTTP 500 in current VCF 9.0 builds — use
+`vcf-fleet datacenter list` as the reachability probe instead. Kept for spec
+parity + future Broadcom fix. When working, renders `apiVersion`,
+`productVersion`, `buildNumber`, `releaseDate`.
+
+### `meho vcf-fleet datacenter list`
+
+Dispatches `GET:/lcm/lcops/api/v2/datacenters`. The wrapper-verified
+reachability probe — guaranteed to respond in 9.0 even when `/about` returns
+500. Renders `vmid` / `name` / `type` / `city`. The `vmid` is the load-bearing
+identifier for `vcf-fleet vcenter list <vmid>`.
+
+```text
+$ meho vcf-fleet datacenter list --target rdc-fleet
+fleet-rest-9.0 GET:/lcm/lcops/api/v2/datacenters — status=ok (42ms)
+vmid                                   name                             type             city
+dc-canary-001                          primary                          PRIVATE_CLOUD    Vienna
+dc-canary-002                          secondary                        PRIVATE_CLOUD    Frankfurt
+```
+
+### `meho vcf-fleet vcenter list <datacenter-vmid>`
+
+Dispatches `GET:/lcm/lcops/api/v2/datacenters/{dataCenterVmid}/vcenters`.
+Requires a datacenter `vmid` from `vcf-fleet datacenter list`. Renders
+`vmid` / `hostname` / `version` / `build`. The `hostname` is the load-bearing
+identifier for cross-referencing against vSphere targets.
+
+### `meho vcf-fleet environment list`
+
+Dispatches `GET:/lcm/lcops/api/v2/environments`. The primary Fleet inventory
+entry point — every vRA / vROps / vRLI / vIDM deploy lives under an
+environment. Large appliances return a JSONFlux handle through the shared
+`HandleStore`; use `result_describe` / `result_query` to filter when the
+handle is present.
+
+### `meho vcf-fleet environment info <environment-id>`
+
+Dispatches `GET:/lcm/lcops/api/v2/environments/{environmentId}`. Returns
+`products[]` with full deployment metadata (nodes, IPs, versions, FQDN),
+configuration history, and status transitions. Requires an `environmentId`
+from `vcf-fleet environment list`.
+
+### `meho vcf-fleet product list <environment-id>`
+
+Dispatches `GET:/lcm/lcops/api/v2/environments/{environmentId}/products`.
+Returns one entry per product (`vrops`, `vrli`, `vidm`, `vra`, `postgres`,
+…) with deployment status, version, and node breakdown.
+
+### `meho vcf-fleet request list`
+
+Dispatches `GET:/lcm/request/api/v2/requests`. Returns recent lifecycle
+requests by `createdOn`. Renders `vmid` / `requestType` / `state` /
+`requestName`. Busy appliances commonly return a JSONFlux handle — filter
+via `--json | jq` on `state` / `requestType` / time windows when needed.
+
+### `meho vcf-fleet request info <request-id>`
+
+Dispatches `GET:/lcm/request/api/v2/requests/{requestId}`. Returns the full
+request envelope including `inputMap` (creation parameters), `outputMap`
+(generated identifiers), `executionPath[]` (per-stage status + timestamps),
+and `errorCause` on `state=FAILED`. The primary post-mortem surface for
+Fleet workflow debugging.
+
+### `meho vcf-fleet operation search` / `meho vcf-fleet operation call`
+
+Meta-tool wrappers pre-scoped to `fleet-rest-9.0`. `search` runs the hybrid
+BM25+cosine search across `fleet-rest-9.0` op descriptors; `call` dispatches
+any op_id directly. Use these for ops not yet promoted to dedicated CLI
+aliases.
+
+```bash
+meho vcf-fleet operation search "upgrade workflow" --group fleet-request
+meho vcf-fleet operation call GET:/lcm/lcops/api/v2/environments --target rdc-fleet
+meho vcf-fleet operation call GET:/lcm/request/api/v2/requests/{requestId} \
+  --target rdc-fleet --params '{"requestId":"req-vmid-001"}'
+```
+
+## Audit and broadcast classification
+
+Every Fleet v0.5 op is `safety_level=safe`, `requires_approval=false` —
+the read-only surface never mutates state. The audit row carries:
+`method='DISPATCH'`, `path=<op_id>`, `target_id=<uuid>`,
+`payload={"op_id": ..., "params_hash": ..., "source_kind": "ingested",
+"connector_product": "fleet", "connector_version": "9.0",
+"connector_impl_id": "fleet-rest", "result_status": "ok"|"error"}`.
+
+Broadcast events publish per-tenant on every successful dispatch.
+`meho audit query --connector fleet-rest-9.0` retrieves the full dispatch
+history; see [`audit-query.md`](./audit-query.md) for filter syntax.
+
+## Migrating off `scripts/vcf-fleet.sh`
+
+The consumer's
+[`scripts/vcf-fleet.sh`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/vcf-fleet.sh)
+drives the vRSLCM REST API via a `curl` + HTTP Basic wrapper. The
+`meho vcf-fleet` verbs replace it for the read-only workflows; write
+workflows (environment create, product patch, lifecycle workflow start)
+stay in the wrapper.
+
+| Consumer workflow | `vcf-fleet.sh` invocation | `meho vcf-fleet …` replacement | Notes |
+| --- | --- | --- | --- |
+| Reachability probe | `vcf-fleet.sh probe` | `meho vcf-fleet datacenter list --target rdc-fleet` | Same wrapper-verified path; `about` is broken in 9.0 |
+| Datacenter listing | `vcf-fleet.sh datacenters` | `meho vcf-fleet datacenter list --target rdc-fleet` | |
+| vCenters under datacenter | `vcf-fleet.sh vcenters <vmid>` | `meho vcf-fleet vcenter list <vmid> --target rdc-fleet` | |
+| Environment listing | `vcf-fleet.sh environments` | `meho vcf-fleet environment list --target rdc-fleet` | Large appliances return a JSONFlux handle |
+| Environment detail | `vcf-fleet.sh environment-info <id>` | `meho vcf-fleet environment info <id> --target rdc-fleet` | |
+| Product listing | `vcf-fleet.sh products <env-id>` | `meho vcf-fleet product list <env-id> --target rdc-fleet` | |
+| Request listing | `vcf-fleet.sh requests [state]` | `meho vcf-fleet request list --target rdc-fleet` | `state` filter via `--json \| jq` (no native flag in v0.5) |
+| Request detail | `vcf-fleet.sh request-info <id>` | `meho vcf-fleet request info <id> --target rdc-fleet` | Surfaces `errorCause` on FAILED |
+
+What `scripts/vcf-fleet.sh` did that `meho vcf-fleet` deliberately does
+**not** do (out of scope for v0.5 — keep the wrapper for these until a
+future Initiative lands them):
+
+- **Write / mutate ops** — environment create / patch / upgrade workflow
+  start, product patch, locker password ops. v0.5 is read-only; write ops
+  land behind a policy + approval gate (no ETA yet).
+- **Custom query parameters** — the v0.5 CLI exposes only the parameters
+  each op formally declares in its descriptor. Use `meho vcf-fleet operation
+  call <op_id> --params '{"customKey": "value"}'` for ad-hoc query strings.
+- **Non-curated API paths** — `vcf-fleet.sh` can hit arbitrary vRSLCM API
+  paths; `meho vcf-fleet` exposes only the 8 curated core ops. Use
+  `meho vcf-fleet operation call GET:<path>` as an escape hatch for one-off
+  queries against operator-enabled paths.
+- **Locker password listing** — the `/lcm/locker/api/v2/passwords` endpoint
+  is not curated in v0.5. Use `meho vcf-fleet operation call
+  GET:/lcm/locker/api/v2/passwords` as the escape hatch (metadata only —
+  the API never returns password values).
+
+Migration discipline: run the `meho vcf-fleet` form alongside `vcf-fleet.sh`
+for an overlap window, diff the outputs, then retire the wrapper call site.
+The MEHO path adds the full audit row + broadcast event the bash pattern
+never had — that audit coverage is the point of migrating.
+
+### Per-ticket wrapper-flip recipe
+
+For each active VCF Fleet consumer ticket, apply this pattern:
+
+1. **Identify the wrapper invocation** in the ticket's reproduction steps
+   (usually `bash scripts/vcf-fleet.sh <command>`).
+2. **Find the `meho vcf-fleet` equivalent** from the table above.
+3. **Validate output parity**: run both side-by-side against `rdc-fleet`.
+   Use `--json | jq` on the `meho vcf-fleet` side to pull the same fields
+   the bash script was parsing.
+4. **Update the ticket steps**: replace the `vcf-fleet.sh` invocation with
+   the `meho vcf-fleet` form. Capture the `--json` output for the ticket's
+   evidence block.
+5. **Retire the wrapper call site** in the ticket's automation scripts once
+   the MEHO form is validated.
+
+Example — environment listing ticket:
+
+```bash
+# Before (wrapper):
+bash scripts/vcf-fleet.sh environments rdc-fleet | jq '.[].environmentName'
+
+# After (meho vcf-fleet):
+meho vcf-fleet environment list --target rdc-fleet --json \
+  | jq '.result[].environmentName'
+
+# Verify parity:
+diff \
+  <(bash scripts/vcf-fleet.sh environments rdc-fleet | jq -S '.[].environmentName') \
+  <(meho vcf-fleet environment list --target rdc-fleet --json \
+      | jq -S '.result[].environmentName')
+# expected: empty diff
+```
+
+Example — failed-request post-mortem:
+
+```bash
+# Before:
+bash scripts/vcf-fleet.sh request-info req-vmid-009 rdc-fleet
+
+# After:
+meho vcf-fleet request info req-vmid-009 --target rdc-fleet
+
+# JSON for scripting / ticket capture:
+meho vcf-fleet request info req-vmid-009 --target rdc-fleet --json \
+  | jq '{state, executionStatus, errorCause, executionPath}'
+```
+
+Example — in-flight request triage:
+
+```bash
+# Before:
+bash scripts/vcf-fleet.sh requests INPROGRESS rdc-fleet
+
+# After (jq filter on state since there's no --status flag in v0.5):
+meho vcf-fleet request list --target rdc-fleet --json \
+  | jq '.result[] | select(.state == "INPROGRESS")'
+```
+
+## Recorded-fixture refresh
+
+The integration test suite
+([`backend/tests/test_connectors_vcf_fleet_e2e.py`](../../backend/tests/test_connectors_vcf_fleet_e2e.py))
+replays recorded fixtures against a `respx`-mocked appliance — no Docker
+dependency, runs in the `meho-runners` CI lane. When the vRSLCM API surface
+changes (vendor patch, appliance upgrade), an operator re-records the
+fixtures against a live lab appliance using the shared refresh tool from
+[#841](https://github.com/evoila/meho/issues/841):
+
+```bash
+uv run python backend/tests/fixtures/vcf/refresh.py \
+  --connector vcf-fleet \
+  --target rdc-fleet \
+  --host fleet.rdc.evoila.io \
+  --username admin@local \
+  --password "$FLEET_PASSWORD" \
+  --output-dir backend/tests/fixtures/vcf/vcf-fleet \
+  --insecure   # only when the lab appliance has a self-signed cert
+```
+
+The refresh tool:
+
+- Records responses for the registered Fleet recipe (`about` + `datacenters`
+  at minimum — extend the recipe in `refresh.py` when adding ops).
+- Redacts `Authorization` / `Set-Cookie` / `password` / `token` keys before
+  writing.
+- Refuses to overwrite existing fixtures without `--force` (stale fixtures
+  silently mask vendor drift).
+- Refuses to record non-2xx responses (the `/about` 500 case fails fast).
+
+See [`docs/cross-repo/vcf-fixture-refresh.md`](./vcf-fixture-refresh.md) for
+the full recipe including credential handling, redaction customisation, and
+the canary-fixture vs recorded-fixture distinction.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `no backplane URL configured` (exit 2) | Never logged in / no `--backplane`. | `meho login <url>` or pass `--backplane <url>`. |
+| `auth_expired` / stored token rejected | Keycloak token expired. | `meho login <url>` again. |
+| `status=error connector_error: HTTP 500` on `vcf-fleet about` | VCF 9.0 known issue — Fleet's `/about` endpoint is broken in current builds. | Use `vcf-fleet datacenter list` as the reachability probe; cross-source product version from SDDC Manager `/v1/vcf-services`. |
+| `status=error connector_error: … HTTP 401` | Fleet credentials invalid. HTTP Basic 401 is terminal — no re-login path. | Verify the Vault secret at `target.secret_ref`; confirm `admin@local` (or the configured local user) is enabled in the LCM user store; confirm the password hasn't been rotated. |
+| `status=error … unknown_op` | The 8 core ops are not registered/enabled. | Re-run `apply_fleet_core_curation` against the Fleet connector. |
+| `status=denied` | `read_only` role, or a tenant policy denied the dispatch. | Use an `operator`-role token. |
+| `datacenter list` / any verb times out | Fleet appliance unreachable from the backplane host. | Verify the FQDN/IP in `target.host` resolves from the backplane; check firewall rules (port 443 from backplane → Fleet). |
+| `probe` fails with TLS error | Self-signed or expired certificate on the appliance, or wrong CA bundle. | Mount the correct CA bundle in the backplane container and set `MEHO_TLS_CA_BUNDLE`; or configure the Fleet appliance with a CA-signed cert. |
+| `environment info` returns 404 | `<environment-id>` doesn't match an existing Fleet environment. | List available environments first: `meho vcf-fleet environment list --target rdc-fleet`. |
+| `request list` returns empty | No requests on the appliance, or all requests older than the LCM retention window. | Check `--json` for the raw envelope; the LCM retention is appliance-configured. |
+| Credential cache stale after rotation | In-process cache retains old credentials. | Restart the backplane so `aclose()` clears the `CredentialsCache`. |
+| `username` / `password` missing from Vault secret | Connector raises `RuntimeError` naming the missing key. | Add the missing field to the Vault secret at `target.secret_ref`. |
+
+## References
+
+- Initiative: [#369 G3.6 tier-3 VCF management plane](https://github.com/evoila/meho/issues/369); Goal [#214](https://github.com/evoila/meho/issues/214) (G3 connector parity).
+- Tasks that shipped this surface: [#831](https://github.com/evoila/meho/issues/831) (T7 skeleton + auth + probe), [#835](https://github.com/evoila/meho/issues/835) (T8 spec ingest + 8 core ops + curation), [#839](https://github.com/evoila/meho/issues/839) (T9 CLI verbs + E2E + this doc), [#841](https://github.com/evoila/meho/issues/841) (T13 shared `vcf_auth.py` + fixture refresh tool).
+- Connector source: [`backend/src/meho_backplane/connectors/vcf_fleet/`](../../backend/src/meho_backplane/connectors/vcf_fleet/).
+- CLI verbs: [`cli/internal/cmd/vcf-fleet/`](../../cli/internal/cmd/vcf-fleet/).
+- E2E integration test: [`backend/tests/test_connectors_vcf_fleet_e2e.py`](../../backend/tests/test_connectors_vcf_fleet_e2e.py).
+- Recorded-fixture tooling: [`backend/tests/fixtures/vcf/refresh.py`](../../backend/tests/fixtures/vcf/refresh.py) and [`docs/cross-repo/vcf-fixture-refresh.md`](./vcf-fixture-refresh.md).
+- Consumer wrapper retiring: [`scripts/vcf-fleet.sh`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/vcf-fleet.sh).
+- vRSLCM REST API reference: <https://developer.broadcom.com/xapis/vrealize-suite-lifecycle-manager/latest/>.
+- Related onboarding docs: [`nsx-onboarding.md`](./nsx-onboarding.md), [`sddc-manager-onboarding.md`](./sddc-manager-onboarding.md), [`vault-onboarding.md`](./vault-onboarding.md), [`audit-query.md`](./audit-query.md).


### PR DESCRIPTION
## Summary
- Ships the `meho vcf-fleet …` operator-facing alias verb tree (`cli/internal/cmd/vcf-fleet/`) over the 8 enabled `fleet-rest-9.0` read-only ops curated in #835: `about` / `datacenter list` / `vcenter list <vmid>` / `environment list` / `environment info <id>` / `product list <env-id>` / `request list` / `request info <id>` + `operation search/call` meta-tool wrappers. Pure Cobra-over-HTTP; pre-bakes `connector_id="fleet-rest-9.0"` so operators don't type the connector id. Mirrors the NSX / SDDC Manager precedents and is not mirrored on the MCP surface (CLAUDE.md postulate 5).
- Adds the recorded-fixture E2E (`backend/tests/test_connectors_vcf_fleet_e2e.py` + shared `_vcf_fleet_canary_fixtures.py`): every enabled op dispatches through the full `call_operation` stack and returns `status='ok'`; HTTP Basic credential cache is exercised; audit rows carry `op_id` + `target_id` + `params_hash`; environment-list JSONFlux handle path covered with a `ForceHandleReducer`. Runs in the `meho-runners` CI lane with no Docker dependency.
- Ships `docs/cross-repo/vcf-fleet-onboarding.md` with the wrapper-flip recipe for `scripts/vcf-fleet.sh`, the VCF 9.0 `/about`-returns-500 known issue + the `datacenter list` workaround, target registration, troubleshooting, and the fixture-refresh entry point.

## Test plan
- [x] `ruff check meho_app/ meho_mcp_server/ tests/unit/ tests/contracts/` — clean (the repo's actual layout: `backend/src/meho_backplane/` + `backend/tests/`; same command shape — clean).
- [x] `ruff format --check` — clean.
- [x] `mypy src/meho_backplane/ --ignore-missing-imports` — clean (`Success: no issues found in 220 source files`).
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0, no new violations.
- [x] `pytest tests/test_connectors_vcf_fleet_e2e.py` — 11 passed (8 ops × parametrised dispatch + credential-cache + audit-row + JSONFlux handle).
- [x] `pytest tests/test_connectors_vcf_fleet_auth.py tests/test_connectors_vcf_fleet_core_ops.py tests/test_connectors_nsx_e2e.py tests/test_connectors_sddc_manager_e2e.py` — 90 passed (no regression in fleet skeleton/curation + sibling E2Es).
- [x] `go test ./internal/cmd/vcf-fleet/...` — pass (helper tests + wire-shape assertions + verb-tree shape pin).
- [x] `go test ./...` (full CLI suite) — pass; root command registers vcf-fleet alongside vmware/nsx/sddc-manager/etc.
- [x] Acceptance criterion (a): `meho vcf-fleet --help` lists the verb set + each verb dispatches against `/api/v1/operations/call` with the right `op_id` — `TestDispatchOpBakesConnectorID` / `TestDispatchVcenterListSendsDataCenterVmidParam` / `TestDispatchEnvironmentInfoSendsEnvironmentIDParam` / `TestDispatchRequestInfoSendsRequestIDParam`.
- [x] Acceptance criterion (b): recorded-fixture replay covers every enabled op in CI — `test_fleet_e2e_all_ops_dispatch_ok` parametrises 8 op_ids.
- [x] Acceptance criterion (c): JSONFlux handle path — `test_fleet_e2e_jsonflux_handle_populated_for_environment_list`.
- [x] Acceptance criterion (d): audit row coverage — `test_fleet_e2e_dispatch_writes_audit_row`.
- [x] Acceptance criterion (e): `docs/cross-repo/vcf-fleet-onboarding.md` ships with the wrapper-flip recipe.

## Out of scope
- Write ops (environment create / patch / upgrade workflow start, product patch, locker password ops) — read-only in v0.5 per Initiative #369 DoD.
- Live Fleet CI environment — recorded-fixture only (no public simulator; see #536).
- vROps / vRLI / Automation verbs — their own Tasks (#837 / #838 / #840 — sibling Wave 4).
- A `--status` flag on `request list` — operators can filter via `--json | jq '.result[] | select(.state == ...)'` in v0.5; a typed flag lands when the wider request-filter surface ships.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #839


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full VCF Fleet CLI suite (meho vcf-fleet) with about, datacenter, vcenter, environment, product, request list/info and operation search/call; improved dispatch output and error rendering.

* **Tests**
  * Added comprehensive unit tests for CLI behavior and renderers plus end-to-end connector tests and acceptance fixtures exercising dispatch, credential caching, and audit logging.

* **Documentation**
  * Added VCF Fleet onboarding guide with quick-start, command reference, known issues, migration notes, and troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/894?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->