### PR TITLE
feat(cli): G3.6-T12 vcf-automation dual-plane CLI + --fqdn + E2E + onboarding

### DIFF
--- a/backend/src/meho_backplane/mcp/tools/operations.py
+++ b/backend/src/meho_backplane/mcp/tools/operations.py
@@ -305,10 +305,26 @@ register_mcp_tool(
                         "since they only need the name. See "
                         "`docs/architecture/mcp.md` ('Target-reference "
                         "shape convention') for the canonical forward "
-                        "convention any new tool should follow."
+                        "convention any new tool should follow. The "
+                        "optional `fqdn` field is a per-call override "
+                        "for the resolved target's vhost name; honoured "
+                        "by connectors that route by `Host:` header "
+                        "(notably `vcfa-rest-9.0` where reaching the "
+                        "appliance by IP without an `fqdn` returns 404 "
+                        "with empty body)."
                     ),
                     "properties": {
                         "name": {"type": "string", "minLength": 1},
+                        "fqdn": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": (
+                                "Per-call override for the resolved "
+                                "target's `fqdn` column. Threaded into "
+                                "the connector for vhost routing; the "
+                                "DB row is not modified."
+                            ),
+                        },
                     },
                 },
                 "params": {

--- a/backend/src/meho_backplane/operations/meta_tools.py
+++ b/backend/src/meho_backplane/operations/meta_tools.py
@@ -223,8 +223,22 @@ class CallOperationBody(BaseModel):
     means the operation does not need a target (typed handlers that
     don't read it; composite handlers that do their own resolution).
 
+    Recognised keys on the ``target`` dict:
+
+    * ``name`` (required when ``target`` is supplied) -- the slug or
+      alias the resolver looks up in the targets registry.
+    * ``fqdn`` (optional) -- per-call override for the resolved
+      target's ``fqdn`` column. Honoured by connectors that read
+      ``target.fqdn`` for vhost routing (G3.6 VCF Automation:
+      the appliance enforces strict ``Host:`` matching and returns
+      404 with empty body when reached by IP without the correct
+      vhost set). The override mutates the resolved Target in
+      memory only; the database row is not modified. Any other key
+      in the dict is silently ignored, mirroring the documented
+      forward-compatibility posture in the MCP tool schema.
+
     ``extra="forbid"`` (G0.9-T2 / #729) rejects unknown fields with
-    422 ``extra_forbidden`` — a v0.2.1 client still sending ``target:
+    422 ``extra_forbidden`` -- a v0.2.1 client still sending ``target:
     str`` (the pre-rename single-name shape) or a typo in
     ``connector_id`` now fails loud at the framework boundary instead
     of silently dispatching with the defaults. ``params`` itself is a
@@ -478,6 +492,16 @@ async def call_operation(
             # Bind into structlog so AuditMiddleware picks up the target_id
             # on the eventual audit row. Same shape as the targets routes.
             structlog.contextvars.bind_contextvars(audit_target_id=str(resolved_target.id))
+        # Per-call ``fqdn`` override -- applied in memory only. The DB row
+        # is not touched; the override travels with the resolved Target
+        # for the lifetime of this dispatch and is read by connectors that
+        # honour vhost routing (G3.6 VCF Automation). Non-string / empty
+        # values fall through silently rather than overriding with a bad
+        # value; an explicit ``None`` override is not supported (use a
+        # fresh ``meho targets update`` to clear the column).
+        fqdn_override = target_arg.get("fqdn")
+        if isinstance(fqdn_override, str) and fqdn_override:
+            resolved_target.fqdn = fqdn_override
     result = await dispatch(
         operator=operator,
         connector_id=connector_id,

--- a/backend/tests/test_connectors_vcf_automation_e2e.py
+++ b/backend/tests/test_connectors_vcf_automation_e2e.py
@@ -1,0 +1,983 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""VCF Automation E2E recorded-fixture integration test (G3.6-T12 #840).
+
+Covers every acceptance criterion from Issue #840 inside a single
+SQLite-backed test module (no Docker dependency; runs in the
+``meho-runners`` CI lane alongside the other
+``backend/tests/test_connectors_*.py`` E2E suites).
+
+Acceptance contract:
+
+(a) **Both planes dispatch** -- all 11 curated VCFA core ops
+    (6 provider + 5 tenant) dispatch through ``call_operation``
+    against a respx-mocked VCFA appliance and return ``status='ok'``.
+    Each plane carries its bespoke auth flow (provider Basic ->
+    ``X-VMWARE-VCLOUD-ACCESS-TOKEN`` JWT; tenant JSON body ->
+    ``{"token": ...}``); the connector picks the right token by path
+    prefix.
+
+(b) **Vhost (``--fqdn``) routing.** A vhost-routed target (``fqdn``
+    set, IP host) reaches the appliance via the FQDN-rooted base URL;
+    the recorded fixture covers the happy path. A target reached by
+    IP with **no** ``fqdn`` set surfaces a structured
+    ``connector_error`` whose message names ``fqdn`` -- proving the
+    descriptive-error contract, not a blank 404.
+
+(c) **Audit rows.** Each dispatch inserts an ``AuditLog`` row carrying
+    ``method='DISPATCH'``, a non-null ``target_id``, and a non-empty
+    ``payload['params_hash']``.
+
+(d) **JSONFlux handle path.** Dispatching
+    ``GET:/iaas/api/deployments`` with a force-handle reducer returns
+    a populated ``OperationResult.handle`` with at least one
+    ``sample_rows`` entry.
+
+(e) **Per-call ``fqdn`` override.** The dispatch body's ``target.fqdn``
+    field overrides the resolved Target's ``fqdn`` in memory; the DB
+    row is not modified. Exercises the CLI ``--fqdn`` flag's
+    end-to-end path (issue #840: "--fqdn threads through to the
+    target resolution").
+
+Recorded-fixture format
+-----------------------
+
+The respx routes are hand-built dicts in this module rather than read
+from disk JSON. The G3.6-T13 (#841) refresh tool's recipe registry
+explicitly excludes VCFA -- its dual-plane auth doesn't fit the
+``session-token-header`` pattern. The inlined fixtures keep the
+plane / payload shapes pinned next to the per-op assertions for
+readability; future operators record a live fixture with the tool's
+HTTP-level recorder and inline the payloads here.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+from sqlalchemy import select
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.registry import all_connectors_v2
+from meho_backplane.connectors.schemas import FingerprintResult, ResultHandle
+from meho_backplane.connectors.vcf_automation import (
+    VCFA_CONNECTOR_ID,
+    VCFA_CORE_GROUPS,
+    VCFA_CORE_OPS,
+    VCFA_IMPL_ID,
+    VCFA_PRODUCT,
+    VCFA_VERSION,
+    VcfAutomationConnector,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, EndpointDescriptor, OperationGroup, Target
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.meta_tools import call_operation
+from meho_backplane.operations.reducer import PassThroughReducer
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+VCFA_E2E_OPERATOR_TENANT: UUID = UUID("00000000-0000-0000-0000-0000000000fa")
+
+# ``.test.invalid`` (RFC 6761 reserved) so no real network egress fires.
+# The IP-host scenario uses a different host so both routers can coexist
+# in their respective tests without contention.
+VCFA_E2E_FQDN: str = "vcfa-e2e.test.invalid"
+VCFA_E2E_FQDN_BASE_URL: str = f"https://{VCFA_E2E_FQDN}"
+VCFA_E2E_TARGET_NAME: str = "vcfa-e2e-target"
+
+# JWT + token values the respx routes return on the per-plane login
+# endpoints. Distinct values per plane so a misrouted call surfaces
+# loud rather than silently re-using the same Bearer header.
+_PROVIDER_JWT = "vcfa-e2e-provider-jwt"
+_TENANT_TOKEN = "vcfa-e2e-tenant-token"
+
+# Operator the dispatch tests act under.
+_OPERATOR = Operator(
+    sub="vcfa-e2e-test",
+    name="VCFA E2E Test Operator",
+    email=None,
+    raw_jwt="<vcfa-e2e-raw-jwt>",
+    tenant_id=VCFA_E2E_OPERATOR_TENANT,
+    tenant_role=TenantRole.TENANT_ADMIN,
+)
+
+# The op_id the JSONFlux force-handle test dispatches. ``deployments``
+# is the largest tenant payload by design (per #840 acceptance d).
+_FORCE_HANDLE_OP_ID = "GET:/iaas/api/deployments"
+
+# Path-template params for the two get-by-id ops (substitution at
+# dispatch time). Maps op_id -> the {id} value the route registers
+# under.
+_GET_BY_ID_PARAMS: dict[str, dict[str, object]] = {
+    "GET:/cloudapi/1.0.0/orgs/{id}": {"id": "org-vcfa-e2e"},
+    "GET:/cloudapi/1.0.0/regions/{id}": {"id": "region-vcfa-e2e"},
+    "GET:/iaas/api/deployments/{id}": {"id": "deployment-vcfa-e2e"},
+}
+
+# Persisted as ``Target.fingerprint`` so the resolver binds
+# :class:`VcfAutomationConnector`.
+_FINGERPRINT: dict[str, Any] = FingerprintResult(
+    vendor="vmware",
+    product="vcf-automation",
+    version="9.0",
+    reachable=True,
+    probed_at=datetime(2026, 5, 22, 10, 0, 0, tzinfo=UTC),
+    probe_method="GET /api/versions + GET /iaas/api/about",
+    extras={"planes": ["provider", "tenant"]},
+).model_dump(mode="json")
+
+
+# ---------------------------------------------------------------------------
+# Inlined respx-replayed VCFA payloads (recorded-fixture shape)
+# ---------------------------------------------------------------------------
+#
+# These are the "recorded fixtures" the issue's acceptance criterion (b)
+# references -- minimal but realistic JSON bodies one per op. They live
+# inline here rather than under backend/tests/fixtures/vcf/vcf-automation/
+# because the dual-plane refresh tool intentionally doesn't drive VCFA
+# (G3.6-T13 #841 explicitly excludes it; the recipe registry comment in
+# backend/tests/fixtures/vcf/refresh.py records the rationale).
+
+_PROVIDER_SITE: dict[str, Any] = {
+    "id": "site-vcfa-e2e",
+    "name": "VCFA-E2E",
+    "description": "synthetic vcfa-e2e",
+    "restName": "vcfa-e2e-rest",
+    "productVersion": "9.0.0.0-12345",
+}
+
+_PROVIDER_ORGS: dict[str, Any] = {
+    "values": [
+        {
+            "id": "org-vcfa-e2e",
+            "name": "acme",
+            "displayName": "Acme Corp",
+            "isEnabled": True,
+            "orgVdcCount": 2,
+        },
+        {
+            "id": "org-other",
+            "name": "globex",
+            "displayName": "Globex",
+            "isEnabled": False,
+            "orgVdcCount": 0,
+        },
+    ],
+    "resultTotal": 2,
+}
+
+_PROVIDER_ORG_DETAIL: dict[str, Any] = {
+    "id": "org-vcfa-e2e",
+    "name": "acme",
+    "displayName": "Acme Corp",
+    "description": "vcfa-e2e org",
+    "isEnabled": True,
+    "orgVdcCount": 2,
+    "userCount": 5,
+    "catalogCount": 3,
+    "vappCount": 12,
+    "runningVMCount": 25,
+    "diskCount": 40,
+}
+
+_PROVIDER_REGIONS: dict[str, Any] = {
+    "values": [
+        {
+            "id": "region-vcfa-e2e",
+            "name": "rdc-east",
+            "description": "RDC east region",
+            "isEnabled": True,
+            "nsxManager": {"id": "nsx-1", "name": "nsx-rdc"},
+        }
+    ],
+    "resultTotal": 1,
+}
+
+_PROVIDER_REGION_DETAIL: dict[str, Any] = {
+    "id": "region-vcfa-e2e",
+    "name": "rdc-east",
+    "description": "RDC east region detail",
+    "isEnabled": True,
+    "nsxManager": {"id": "nsx-1", "name": "nsx-rdc"},
+    "supervisors": [{"id": "sup-1", "name": "rdc-supervisor"}],
+    "storagePolicies": [],
+    "totalCpuMhz": 100000,
+    "totalMemoryMB": 524288,
+    "allocatedCpuMhz": 50000,
+    "allocatedMemoryMB": 262144,
+}
+
+_PROVIDER_USERS: dict[str, Any] = {
+    "values": [
+        {
+            "id": "user-1",
+            "username": "admin@System",
+            "fullName": "System Administrator",
+            "email": "admin@example.test",
+            "isEnabled": True,
+            "roleEntityRefs": [{"id": "role-system-admin"}],
+        }
+    ],
+    "resultTotal": 1,
+}
+
+_TENANT_ABOUT: dict[str, Any] = {
+    "latestApiVersion": "2024-01-01",
+    "supportedApis": [
+        {"apiVersion": "2024-01-01", "documentation": "https://example.test/iaas"},
+        {"apiVersion": "2023-01-01", "documentation": "https://example.test/iaas-old"},
+    ],
+}
+
+_TENANT_PROJECTS: dict[str, Any] = {
+    "content": [
+        {
+            "id": "project-vcfa-e2e",
+            "name": "team-a",
+            "description": "team-a project",
+            "organizationId": "org-vcfa-e2e",
+            "administrators": [],
+            "members": [],
+            "operationTimeout": 3600,
+        }
+    ],
+    "totalElements": 1,
+    "totalPages": 1,
+}
+
+# Deployments — populated with 8 entries so the force-handle reducer
+# sees a non-trivial list to sample from. The first entry's id matches
+# the get-by-id route below.
+_TENANT_DEPLOYMENTS: dict[str, Any] = {
+    "content": [
+        {
+            "id": f"deployment-vcfa-e2e{'' if i == 0 else f'-{i}'}",
+            "name": f"deploy-{i:02d}",
+            "description": "synthetic deployment",
+            "status": "CREATE_SUCCESSFUL",
+            "projectId": "project-vcfa-e2e",
+            "blueprintId": "blueprint-vcfa-e2e",
+            "ownedBy": "user-1",
+            "createdAt": "2026-05-01T00:00:00Z",
+            "lastUpdatedAt": "2026-05-15T00:00:00Z",
+            "resources": [],
+        }
+        for i in range(8)
+    ],
+    "totalElements": 8,
+    "totalPages": 1,
+}
+
+_TENANT_DEPLOYMENT_DETAIL: dict[str, Any] = {
+    "id": "deployment-vcfa-e2e",
+    "name": "deploy-00",
+    "description": "synthetic deployment detail",
+    "status": "CREATE_SUCCESSFUL",
+    "projectId": "project-vcfa-e2e",
+    "blueprintId": "blueprint-vcfa-e2e",
+    "ownedBy": "user-1",
+    "createdAt": "2026-05-01T00:00:00Z",
+    "lastUpdatedAt": "2026-05-15T00:00:00Z",
+    "resources": [
+        {"id": "res-vm-1", "type": "Cloud.vSphere.Machine", "name": "vm-app-01"},
+    ],
+    "lastRequestId": "req-deploy-1",
+    "inputs": {"size": "M"},
+}
+
+_TENANT_BLUEPRINTS: dict[str, Any] = {
+    "content": [
+        {
+            "id": "blueprint-vcfa-e2e",
+            "name": "web-app",
+            "description": "Web app template",
+            "projectId": "project-vcfa-e2e",
+            "version": "1.0",
+            "status": "RELEASED",
+            "updatedAt": "2026-04-01T00:00:00Z",
+            "content": "name: web-app\n",
+        }
+    ],
+    "totalElements": 1,
+    "totalPages": 1,
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin env vars that :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    from meho_backplane.settings import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches around every test."""
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    """Stub out :func:`publish_event` so the broadcast bus doesn't fire."""
+    events: list[Any] = []
+
+    async def _capture(event: Any) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# ForceHandleReducer (acceptance criterion d)
+# ---------------------------------------------------------------------------
+
+
+class _ForceHandleReducer:
+    """Test-only reducer that always wraps a VCFA tenant list payload in a ResultHandle."""
+
+    async def reduce(
+        self,
+        payload: Any,
+        schema: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> tuple[Any, ResultHandle | None]:
+        del schema, context
+        if isinstance(payload, dict) and "content" in payload:
+            rows = payload["content"]
+            total = len(rows) if isinstance(rows, list) else 1
+            sample: tuple[Any, ...] = tuple(rows[:5]) if isinstance(rows, list) and rows else ()
+        elif isinstance(payload, list):
+            total = len(payload)
+            sample = tuple(payload[:5]) if payload else ()
+        else:
+            total = 1
+            sample = ()
+        handle = ResultHandle(
+            handle_id=uuid.uuid4(),
+            summary_md=f"force-mode handle ({total} rows)",
+            schema_={"type": "array", "items": {"type": "object"}},
+            total_rows=total,
+            sample_rows=sample or None,
+            ttl_seconds=3600,
+        )
+        return {"row_count": total, "sample": list(sample)}, handle
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _vcfa_credentials_loader(_target: object) -> dict[str, str]:
+    """Stub credentials loader -- bypasses the not-yet-wired Vault read."""
+    return {"username": "svc-meho", "password": "vcfa-e2e-password"}
+
+
+async def _insert_vcfa_descriptors() -> None:
+    """Seed the 11 curated VCFA core ops + their 8 groups as enabled rows.
+
+    Every row carries ``product=VCFA_PRODUCT="vcfa"`` (what
+    :func:`parse_connector_id("vcfa-rest-9.0")` derives) and the
+    ``spec:<source>`` tag the G0.7 ingest writes -- ``spec:cloudapi``
+    for provider-plane ops, ``spec:iaas`` for tenant-plane ops.
+    The tag is the load-bearing signal the dispatcher's plane-aware
+    auth path would use; the descriptors below mirror that contract
+    so the dispatch test exercises the real shape.
+    """
+    sessionmaker = get_sessionmaker()
+    group_ids: dict[str, UUID] = {}
+    async with sessionmaker() as session:
+        for group in VCFA_CORE_GROUPS:
+            group_row = OperationGroup(
+                tenant_id=None,
+                product=VCFA_PRODUCT,
+                version=VCFA_VERSION,
+                impl_id=VCFA_IMPL_ID,
+                group_key=group.group_key,
+                name=group.name,
+                when_to_use=group.when_to_use,
+                review_status="enabled",
+            )
+            session.add(group_row)
+            await session.flush()
+            group_ids[group.group_key] = group_row.id
+
+        for op in VCFA_CORE_OPS:
+            method, path = op.op_id.split(":", 1)
+            spec_tag = "spec:iaas" if path.startswith("/iaas/api/") else "spec:cloudapi"
+            descriptor = EndpointDescriptor(
+                tenant_id=None,
+                product=VCFA_PRODUCT,
+                version=VCFA_VERSION,
+                impl_id=VCFA_IMPL_ID,
+                op_id=op.op_id,
+                source_kind="ingested",
+                method=method,
+                path=path,
+                handler_ref=None,
+                group_id=group_ids[op.group_key],
+                summary=f"VCFA core op {op.op_id} (curated read).",
+                description=f"VCFA core op {op.op_id} (curated read).",
+                parameter_schema=_param_schema_for(path),
+                response_schema={"type": "object"},
+                llm_instructions=op.llm_instructions,
+                safety_level="safe",
+                requires_approval=False,
+                is_enabled=True,
+                tags=[spec_tag],
+            )
+            session.add(descriptor)
+        await session.commit()
+
+
+def _param_schema_for(path: str) -> dict[str, object]:
+    """Build a minimal ``parameter_schema`` declaring each ``{var}`` as a path param."""
+    import re as _re
+
+    placeholders = _re.findall(r"\{([^{}]+)\}", path)
+    if not placeholders:
+        return {"type": "object", "properties": {}}
+    return {
+        "type": "object",
+        "properties": {
+            name: {"type": "string", "x-meho-param-loc": "path"} for name in placeholders
+        },
+        "required": list(placeholders),
+    }
+
+
+async def _seed_target(*, host: str, fqdn: str | None) -> Target:
+    """Insert the E2E Target row and return it (expunged from the session).
+
+    Centralised so both the happy-path and the IP-without-fqdn scenarios
+    can pick their own host / fqdn combination.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = Target(
+            tenant_id=VCFA_E2E_OPERATOR_TENANT,
+            name=VCFA_E2E_TARGET_NAME,
+            aliases=[],
+            product=VcfAutomationConnector.product,
+            host=host,
+            port=443,
+            fqdn=fqdn,
+            secret_ref="kv/data/vcfa/e2e",
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            fingerprint=_FINGERPRINT,
+            notes="seeded by test_connectors_vcf_automation_e2e._seed_target",
+        )
+        session.add(target)
+        await session.commit()
+        await session.refresh(target)
+        session.expunge(target)
+        return target
+
+
+def _resolve_connector() -> VcfAutomationConnector:
+    """Resolve + cache the VcfAutomationConnector instance with a stubbed loader."""
+    registry = all_connectors_v2()
+    connector_cls = registry.get((VCFA_PRODUCT_REGISTRY, VCFA_VERSION, VCFA_IMPL_ID))
+    if connector_cls is None:
+        # Re-import the package if a sibling test cleared the v2 registry.
+        import importlib
+
+        import meho_backplane.connectors.vcf_automation as _vcfa_pkg
+
+        importlib.reload(_vcfa_pkg)
+        registry = all_connectors_v2()
+        connector_cls = registry.get((VCFA_PRODUCT_REGISTRY, VCFA_VERSION, VCFA_IMPL_ID))
+    assert connector_cls is VcfAutomationConnector, (
+        f"expected VcfAutomationConnector registered for "
+        f"({VCFA_PRODUCT_REGISTRY}, {VCFA_VERSION}, {VCFA_IMPL_ID}); got {connector_cls!r}"
+    )
+    instance = get_or_create_connector_instance(connector_cls)
+    instance._credentials_loader = _vcfa_credentials_loader  # type: ignore[attr-defined]
+    return instance
+
+
+# The connector class registers under the *target* product slug
+# (``"vcf-automation"``); the descriptor rows use the ``vcfa`` slug
+# parse_connector_id derives. The two are distinct deliberately --
+# same shape the SDDC Manager precedent established (sddc-manager vs
+# sddc).
+VCFA_PRODUCT_REGISTRY = VcfAutomationConnector.product
+
+
+def _register_vcfa_routes(mock: respx.MockRouter) -> None:
+    """Register the dual-plane login + 11 read-op respx routes on *mock*.
+
+    Provider plane:
+      * ``POST /cloudapi/1.0.0/sessions/provider`` -> 200 +
+        ``X-VMWARE-VCLOUD-ACCESS-TOKEN`` header (the JWT).
+      * 6 ``GET`` ops returning the inlined fixtures.
+
+    Tenant plane:
+      * ``POST /iaas/api/login`` -> 200 + ``{"token": ...}`` body.
+      * 5 ``GET`` ops returning the inlined fixtures.
+    """
+    # ---- provider login ----
+    mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+        200,
+        headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": _PROVIDER_JWT},
+    )
+    # ---- tenant login ----
+    mock.post("/iaas/api/login").respond(200, json={"token": _TENANT_TOKEN})
+
+    # ---- provider read ops ----
+    mock.get("/cloudapi/1.0.0/site").respond(200, json=_PROVIDER_SITE)
+    mock.get("/cloudapi/1.0.0/orgs").respond(200, json=_PROVIDER_ORGS)
+    mock.get("/cloudapi/1.0.0/orgs/org-vcfa-e2e").respond(200, json=_PROVIDER_ORG_DETAIL)
+    mock.get("/cloudapi/1.0.0/regions").respond(200, json=_PROVIDER_REGIONS)
+    mock.get("/cloudapi/1.0.0/regions/region-vcfa-e2e").respond(200, json=_PROVIDER_REGION_DETAIL)
+    mock.get("/cloudapi/1.0.0/users").respond(200, json=_PROVIDER_USERS)
+
+    # ---- tenant read ops ----
+    mock.get("/iaas/api/about").respond(200, json=_TENANT_ABOUT)
+    mock.get("/iaas/api/projects").respond(200, json=_TENANT_PROJECTS)
+    mock.get("/iaas/api/deployments").respond(200, json=_TENANT_DEPLOYMENTS)
+    mock.get("/iaas/api/deployments/deployment-vcfa-e2e").respond(
+        200, json=_TENANT_DEPLOYMENT_DETAIL
+    )
+    mock.get("/iaas/api/blueprints").respond(200, json=_TENANT_BLUEPRINTS)
+
+
+@dataclass(frozen=True)
+class _VcfaE2EBundle:
+    target_name: str
+    connector_instance: VcfAutomationConnector
+
+
+@pytest.fixture
+async def vcfa_e2e_canary(captured_events: list[Any]) -> AsyncIterator[_VcfaE2EBundle]:
+    """Dispatcher-ready VCFA setup over a respx-mocked dual-plane appliance.
+
+    Lifecycle:
+    1. Insert :data:`VCFA_CORE_OPS` descriptors + groups into the
+       per-test SQLite DB.
+    2. Seed a :class:`Target` row carrying :data:`_FINGERPRINT` so the
+       resolver binds :class:`VcfAutomationConnector`. The target's
+       ``host`` is an IP literal and ``fqdn`` is the canonical vhost
+       -- this combination is the load-bearing one (vhost routing
+       working when reached by IP). Without ``fqdn``,
+       :func:`_base_url` raises ``VcfAutomationConfigurationError`` at
+       session-establish (see the
+       :func:`test_vcfa_e2e_ip_without_fqdn_surfaces_structured_error`
+       test below).
+    3. Resolve + cache the connector instance; patch its
+       ``_credentials_loader`` to bypass Vault.
+    4. Activate a respx router for the FQDN-rooted base URL and
+       register the dual-plane login + 11 read-op routes.
+    """
+    await _insert_vcfa_descriptors()
+    await _seed_target(host="10.10.10.5", fqdn=VCFA_E2E_FQDN)
+    instance = _resolve_connector()
+
+    async with respx.mock(
+        base_url=VCFA_E2E_FQDN_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        _register_vcfa_routes(mock)
+        try:
+            yield _VcfaE2EBundle(
+                target_name=VCFA_E2E_TARGET_NAME,
+                connector_instance=instance,
+            )
+        finally:
+            await instance.aclose()
+            reset_dispatcher_caches()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+_OP_IDS: tuple[str, ...] = tuple(op.op_id for op in VCFA_CORE_OPS)
+assert len(_OP_IDS) == 11, f"Expected 11 curated VCFA ops, got {len(_OP_IDS)}: {_OP_IDS}"
+
+
+@pytest.mark.parametrize("op_id", _OP_IDS, ids=lambda op: op)
+async def test_vcfa_e2e_all_ops_dispatch_ok(
+    op_id: str,
+    vcfa_e2e_canary: _VcfaE2EBundle,
+) -> None:
+    """All 11 VCFA core ops dispatch and return ``status='ok'``.
+
+    Exercises acceptance criterion (a) -- both planes are covered
+    because :data:`VCFA_CORE_OPS` spans 6 provider + 5 tenant ops.
+    Each plane establishes its own bespoke session on first dispatch;
+    subsequent dispatches re-use the cached per-plane token.
+    """
+    params = _GET_BY_ID_PARAMS.get(op_id, {})
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": VCFA_CONNECTOR_ID,
+            "op_id": op_id,
+            "target": {"name": vcfa_e2e_canary.target_name},
+            "params": params,
+        },
+    )
+    assert result["status"] == "ok", (
+        f"VCFA op {op_id!r} did not return status='ok': "
+        f"error={result.get('error')!r} full={result!r}"
+    )
+
+
+async def test_vcfa_e2e_provider_login_fires_once_per_target(
+    vcfa_e2e_canary: _VcfaE2EBundle,
+) -> None:
+    """Provider session-establish runs on first dispatch and the JWT caches.
+
+    Verifies the provider half of the dual-plane auth contract: the
+    first ``/cloudapi/*`` dispatch fires
+    ``POST /cloudapi/1.0.0/sessions/provider``; subsequent dispatches
+    re-use the cached JWT (the cache lives on
+    :attr:`VcfAutomationConnector._provider_tokens`).
+    """
+    instance = vcfa_e2e_canary.connector_instance
+    target_name = vcfa_e2e_canary.target_name
+
+    assert target_name not in instance._provider_tokens, (
+        f"Expected empty provider cache before first dispatch; got {instance._provider_tokens!r}"
+    )
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": VCFA_CONNECTOR_ID,
+            "op_id": "GET:/cloudapi/1.0.0/site",
+            "target": {"name": target_name},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok"
+    assert instance._provider_tokens.get(target_name) == _PROVIDER_JWT, (
+        "Expected provider JWT cached after first provider-plane dispatch; "
+        f"got _provider_tokens={instance._provider_tokens!r}"
+    )
+    # Tenant cache must remain untouched: provider dispatch only
+    # establishes the provider session.
+    assert instance._tenant_tokens.get(target_name) is None, (
+        f"Tenant cache should be empty after provider-only dispatch; "
+        f"got _tenant_tokens={instance._tenant_tokens!r}"
+    )
+
+
+async def test_vcfa_e2e_tenant_login_fires_once_per_target(
+    vcfa_e2e_canary: _VcfaE2EBundle,
+) -> None:
+    """Tenant session-establish runs on first tenant dispatch and the token caches."""
+    instance = vcfa_e2e_canary.connector_instance
+    target_name = vcfa_e2e_canary.target_name
+
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": VCFA_CONNECTOR_ID,
+            "op_id": "GET:/iaas/api/about",
+            "target": {"name": target_name},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok"
+    assert instance._tenant_tokens.get(target_name) == _TENANT_TOKEN, (
+        "Expected tenant token cached after first tenant-plane dispatch; "
+        f"got _tenant_tokens={instance._tenant_tokens!r}"
+    )
+
+
+async def test_vcfa_e2e_dispatch_writes_audit_row(
+    vcfa_e2e_canary: _VcfaE2EBundle,
+) -> None:
+    """Each dispatch inserts an AuditLog row with op_id + target_id + params_hash.
+
+    Exercises acceptance criterion (c).
+    """
+    op_id = "GET:/cloudapi/1.0.0/site"
+    sessionmaker = get_sessionmaker()
+
+    async def _count_dispatch_rows() -> int:
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(AuditLog).where(
+                    AuditLog.method == "DISPATCH",
+                    AuditLog.path == op_id,
+                )
+            )
+            return len(list(result.scalars().all()))
+
+    baseline = await _count_dispatch_rows()
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": VCFA_CONNECTOR_ID,
+            "op_id": op_id,
+            "target": {"name": vcfa_e2e_canary.target_name},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok"
+    final = await _count_dispatch_rows()
+    assert final - baseline == 1, (
+        f"Expected exactly one new DISPATCH row for {op_id!r}; baseline={baseline} final={final}"
+    )
+
+    async with sessionmaker() as session:
+        row_result = await session.execute(
+            select(AuditLog)
+            .where(AuditLog.method == "DISPATCH", AuditLog.path == op_id)
+            .order_by(AuditLog.id.desc())
+            .limit(1)
+        )
+        row = row_result.scalars().first()
+    assert row is not None
+    assert row.target_id is not None, (
+        "AuditLog.target_id must not be None for a targeted dispatch; "
+        f"got target_id=None on row {row!r}"
+    )
+    assert row.payload.get("op_id") == op_id, (
+        f"AuditLog.payload['op_id'] must equal the dispatched op_id; got payload={row.payload!r}"
+    )
+    assert row.payload.get("params_hash"), (
+        f"AuditLog.payload must carry a non-empty 'params_hash'; got payload={row.payload!r}"
+    )
+
+
+async def test_vcfa_e2e_jsonflux_handle_populated_for_deployment_list(
+    vcfa_e2e_canary: _VcfaE2EBundle,
+) -> None:
+    """Tenant deployment list dispatched with ForceHandleReducer returns a populated handle.
+
+    Exercises acceptance criterion (d) -- the JSONFlux seam threads
+    the reducer's :class:`ResultHandle` onto :class:`OperationResult`.
+    """
+    expected_rows = len(_TENANT_DEPLOYMENTS["content"])  # type: ignore[arg-type]
+
+    set_default_reducer(_ForceHandleReducer())
+    try:
+        result_envelope = await call_operation(
+            _OPERATOR,
+            {
+                "connector_id": VCFA_CONNECTOR_ID,
+                "op_id": _FORCE_HANDLE_OP_ID,
+                "target": {"name": vcfa_e2e_canary.target_name},
+                "params": {},
+            },
+        )
+    finally:
+        set_default_reducer(PassThroughReducer())
+
+    assert result_envelope["status"] == "ok", (
+        f"Expected JSONFlux dispatch to succeed; got {result_envelope!r}"
+    )
+    handle = result_envelope.get("handle")
+    assert handle is not None, (
+        "Expected OperationResult.handle to be populated by _ForceHandleReducer; "
+        f"got handle=None on envelope={result_envelope!r}"
+    )
+    uuid.UUID(handle["handle_id"])
+    assert handle["total_rows"] == expected_rows, (
+        f"Expected {expected_rows} deployment rows from _TENANT_DEPLOYMENTS; "
+        f"got handle.total_rows={handle['total_rows']}"
+    )
+    sample_rows = handle.get("sample_rows")
+    assert sample_rows, (
+        f"Expected ≥1 sample row from the seeded deployment list; got sample_rows={sample_rows!r}"
+    )
+    payload = result_envelope.get("result")
+    assert payload is not None and payload.get("row_count") == expected_rows, (
+        f"Expected reducer summary on result.row_count={expected_rows}; got result={payload!r}"
+    )
+
+
+async def test_vcfa_e2e_per_call_fqdn_override_threads_to_connector(
+    captured_events: list[Any],
+) -> None:
+    """Per-call ``target.fqdn`` override on the dispatch body wins over the DB row.
+
+    Exercises acceptance criterion (e). The seeded Target has its
+    ``fqdn`` column set to the **wrong** value; the dispatch body
+    supplies the correct vhost as a per-call override. The connector
+    uses the override at base-URL composition time so the request
+    lands on the FQDN-rooted respx router. Without the override,
+    the dispatch would land on a different (un-mocked) host and the
+    request would fail.
+
+    The DB row is **not** modified by the override -- a follow-up
+    fetch confirms the persisted ``fqdn`` is still the wrong value.
+    """
+    await _insert_vcfa_descriptors()
+    # Seed the target with the *wrong* fqdn so the per-call override
+    # is the only way the dispatch can find the mocked appliance.
+    wrong_fqdn = "vcfa-wrong.test.invalid"
+    await _seed_target(host="10.10.10.5", fqdn=wrong_fqdn)
+    instance = _resolve_connector()
+
+    async with respx.mock(
+        base_url=VCFA_E2E_FQDN_BASE_URL,
+        assert_all_called=False,
+        assert_all_mocked=False,
+    ) as mock:
+        _register_vcfa_routes(mock)
+        try:
+            result = await call_operation(
+                _OPERATOR,
+                {
+                    "connector_id": VCFA_CONNECTOR_ID,
+                    "op_id": "GET:/cloudapi/1.0.0/site",
+                    "target": {"name": VCFA_E2E_TARGET_NAME, "fqdn": VCFA_E2E_FQDN},
+                    "params": {},
+                },
+            )
+            assert result["status"] == "ok", (
+                f"Per-call fqdn override should reach the mocked appliance; got {result!r}"
+            )
+
+            # DB row's fqdn must NOT have been mutated by the per-call override.
+            sessionmaker = get_sessionmaker()
+            async with sessionmaker() as session:
+                row = (
+                    await session.execute(select(Target).where(Target.name == VCFA_E2E_TARGET_NAME))
+                ).scalar_one()
+                assert row.fqdn == wrong_fqdn, (
+                    "Per-call fqdn override must not modify the DB row; "
+                    f"got persisted Target.fqdn={row.fqdn!r}"
+                )
+        finally:
+            await instance.aclose()
+            reset_dispatcher_caches()
+
+
+async def test_vcfa_e2e_ip_host_without_fqdn_surfaces_descriptive_error(
+    captured_events: list[Any],
+) -> None:
+    """IP-host target with no ``fqdn`` set surfaces a descriptive error_code.
+
+    Exercises acceptance criterion (b)'s "descriptive error, not blank
+    404" requirement from issue #840. The connector raises
+    :class:`VcfAutomationConfigurationError` at base-URL composition
+    time when ``host`` is an IP literal and ``fqdn`` is unset; the
+    dispatcher wraps that into a structured ``status='error'``
+    envelope so the caller sees a clear "set --fqdn" message rather
+    than a confusing post-login 404 storm.
+    """
+    await _insert_vcfa_descriptors()
+    await _seed_target(host="10.10.10.5", fqdn=None)
+    instance = _resolve_connector()
+
+    try:
+        result = await call_operation(
+            _OPERATOR,
+            {
+                "connector_id": VCFA_CONNECTOR_ID,
+                "op_id": "GET:/cloudapi/1.0.0/site",
+                "target": {"name": VCFA_E2E_TARGET_NAME},
+                "params": {},
+            },
+        )
+    finally:
+        await instance.aclose()
+        reset_dispatcher_caches()
+
+    assert result["status"] == "error", f"IP-host-no-fqdn dispatch must error; got {result!r}"
+    # The top-level ``error`` field carries the class name; the
+    # descriptive message lands in extras.exception_message per the
+    # dispatcher's :func:`result_connector_error` contract.
+    err_top = result.get("error") or ""
+    assert "VcfAutomationConfigurationError" in err_top, (
+        f"top-level error should name the configuration error class; got {err_top!r}"
+    )
+    extras = result.get("extras") or {}
+    exc_msg = extras.get("exception_message") or ""
+    assert "fqdn" in exc_msg.lower(), (
+        f"exception_message must name 'fqdn' so operators know how to fix it; got {exc_msg!r}"
+    )
+    assert "10.10.10.5" in exc_msg, (
+        f"exception_message must echo the IP that triggered the failure; got {exc_msg!r}"
+    )
+
+
+async def test_vcfa_e2e_provider_request_carries_bearer_jwt(
+    captured_events: list[Any],
+) -> None:
+    """Provider-plane GET request carries Authorization: Bearer <provider-jwt>.
+
+    Asserts the post-login Bearer header is the JWT the provider
+    session-create endpoint returned -- the round-trip that proves
+    the connector parsed the response header correctly. Tenant
+    routes' Bearer must NOT carry the provider JWT (the per-plane
+    isolation contract). Uses a dedicated respx router with a
+    side-effect callback so the test owns the route shape rather
+    than re-using the fixture's static responder.
+    """
+    await _insert_vcfa_descriptors()
+    await _seed_target(host="10.10.10.5", fqdn=VCFA_E2E_FQDN)
+    instance = _resolve_connector()
+
+    captured: dict[str, str] = {}
+
+    def _site_responder(request: httpx.Request) -> httpx.Response:
+        captured[request.url.path] = request.headers.get("Authorization", "")
+        return httpx.Response(200, json=_PROVIDER_SITE)
+
+    try:
+        async with respx.mock(
+            base_url=VCFA_E2E_FQDN_BASE_URL,
+            assert_all_called=False,
+            assert_all_mocked=False,
+        ) as mock:
+            mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+                200,
+                headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": _PROVIDER_JWT},
+            )
+            mock.get("/cloudapi/1.0.0/site").mock(side_effect=_site_responder)
+
+            result = await call_operation(
+                _OPERATOR,
+                {
+                    "connector_id": VCFA_CONNECTOR_ID,
+                    "op_id": "GET:/cloudapi/1.0.0/site",
+                    "target": {"name": VCFA_E2E_TARGET_NAME},
+                    "params": {},
+                },
+            )
+            assert result["status"] == "ok"
+            assert captured.get("/cloudapi/1.0.0/site") == f"Bearer {_PROVIDER_JWT}", (
+                "Provider-plane GET must carry the provider JWT as Bearer; "
+                f"got Authorization={captured.get('/cloudapi/1.0.0/site')!r}"
+            )
+    finally:
+        await instance.aclose()
+        reset_dispatcher_caches()

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -31,6 +31,7 @@ import (
 	"github.com/evoila/meho/cli/internal/cmd/targets"
 	"github.com/evoila/meho/cli/internal/cmd/topology"
 	"github.com/evoila/meho/cli/internal/cmd/vault"
+	vcfautomation "github.com/evoila/meho/cli/internal/cmd/vcf-automation"
 	vcffleet "github.com/evoila/meho/cli/internal/cmd/vcf-fleet"
 	vcflogs "github.com/evoila/meho/cli/internal/cmd/vcf-logs"
 	vcfoperations "github.com/evoila/meho/cli/internal/cmd/vcf-operations"
@@ -299,6 +300,23 @@ func newRootCmd() *cobra.Command {
 	// Registered before registerDynamicSubcommands so the backplane
 	// manifest cannot shadow the built-in `bind9` parent.
 	root.AddCommand(bind9.NewRootCmd())
+
+	// G3.6-T12 (#840) -- vcfa-rest-9.0 operator alias verbs for
+	// Initiative #369. The verb tree pre-bakes connector_id=
+	// "vcfa-rest-9.0" on top of the existing /api/v1/operations/call
+	// dispatcher route. VCFA 9.x is **dual-plane** (provider /cloudapi/*
+	// + tenant /iaas/api/*) on one appliance; the persistent --plane
+	// flag picks the op namespace and the backend dispatcher routes
+	// each call to the correct auth plane via the descriptor's
+	// spec_source tag (G3.6-T11 #836). The persistent --fqdn flag is
+	// the per-call vhost override the appliance's strict Host: routing
+	// requires when reached by IP (without it every path returns 404
+	// with empty body). Ships 11 read-only verbs (6 provider + 5
+	// tenant) plus operation search/call meta-tool wrappers; replaces
+	// ./scripts/vcf-automation.sh for the read-only surface.
+	// Registered before registerDynamicSubcommands so the backplane
+	// manifest cannot shadow the built-in `vcf-automation` parent.
+	root.AddCommand(vcfautomation.NewRootCmd())
 
 	// G5.3-T1 (#608) -- laptop-local memory migration verb tree for
 	// Initiative #375. v0.1 ships the skeleton (migrate parent +

--- a/cli/internal/cmd/vcf-automation/about.go
+++ b/cli/internal/cmd/vcf-automation/about.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfautomation
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newAboutCmd returns `meho vcf-automation about --plane provider|tenant`.
+//
+// Dual-plane verb: both VCFA planes expose an "about" surface but they
+// answer different unauthenticated endpoints with different payload
+// shapes, so `--plane` is required (no implicit default — the wrong
+// plane would silently dispatch a different op_id).
+//
+// Provider plane → `GET:/cloudapi/1.0.0/site` — site identity (name,
+// description, restName, productVersion).
+// Tenant plane → `GET:/iaas/api/about` — supported API versions +
+// latestApiVersion.
+func newAboutCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "about",
+		Short: "Show VCFA appliance identity (plane-specific)",
+		Long: "about dispatches the per-plane VCFA self-describe endpoint\n" +
+			"against connector_id=\"vcfa-rest-9.0\":\n\n" +
+			"  --plane provider → GET:/cloudapi/1.0.0/site\n" +
+			"  --plane tenant   → GET:/iaas/api/about\n\n" +
+			"Both endpoints authenticate per their plane (provider Basic\n" +
+			"→ JWT; tenant JSON-body login → bearer); the connector picks\n" +
+			"the right token based on the op_id's path family. --json\n" +
+			"emits the full OperationResult envelope.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vcf-automation about --plane provider --target rdc-vcfa\n" +
+			"  meho vcf-automation about --plane tenant --target rdc-vcfa --json",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runAbout(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "VCFA target slug")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	plane := readPlane(cmd)
+	if se := requirePlane(plane); se != nil {
+		return output.RenderError(cmd.ErrOrStderr(), se, jsonOut)
+	}
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	opID := aboutOpForPlane(plane)
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, readFqdn(cmd), nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	printer := func(w io.Writer, res *CallResult) { printAbout(w, plane, res) }
+	return renderCallResult(cmd, opID, r, jsonOut, printer)
+}
+
+// aboutOpForPlane returns the op_id the `about` verb dispatches for
+// each plane. Centralised so the per-plane mapping has one obvious
+// place to read off.
+func aboutOpForPlane(plane string) string {
+	if plane == PlaneTenant {
+		return "GET:/iaas/api/about"
+	}
+	return "GET:/cloudapi/1.0.0/site"
+}
+
+func printAbout(w io.Writer, plane string, r *CallResult) {
+	fmt.Fprintf(w, "%s about (--plane %s) — status=%s (%.0fms)\n",
+		ConnectorID, plane, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	if len(r.Result) == 0 || string(r.Result) == "null" {
+		return
+	}
+	if plane == PlaneTenant {
+		printAboutTenant(w, r)
+		return
+	}
+	printAboutProvider(w, r)
+}
+
+func printAboutProvider(w io.Writer, r *CallResult) {
+	var site struct {
+		ID             string `json:"id"`
+		Name           string `json:"name"`
+		Description    string `json:"description"`
+		RestName       string `json:"restName"`
+		ProductVersion string `json:"productVersion"`
+	}
+	if err := jsonUnmarshalStrict(r.Result, &site); err != nil || site.Name == "" {
+		fallbackResultRender(w, r)
+		return
+	}
+	if site.ID != "" {
+		fmt.Fprintf(w, "  id:              %s\n", site.ID)
+	}
+	if site.Name != "" {
+		fmt.Fprintf(w, "  name:            %s\n", site.Name)
+	}
+	if site.RestName != "" {
+		fmt.Fprintf(w, "  rest_name:       %s\n", site.RestName)
+	}
+	if site.ProductVersion != "" {
+		fmt.Fprintf(w, "  product_version: %s\n", site.ProductVersion)
+	}
+	if site.Description != "" {
+		fmt.Fprintf(w, "  description:     %s\n", site.Description)
+	}
+}
+
+func printAboutTenant(w io.Writer, r *CallResult) {
+	var about struct {
+		LatestAPIVersion string `json:"latestApiVersion"`
+		SupportedAPIs    []struct {
+			APIVersion    string `json:"apiVersion"`
+			Documentation string `json:"documentation"`
+		} `json:"supportedApis"`
+	}
+	if err := jsonUnmarshalStrict(r.Result, &about); err != nil || about.LatestAPIVersion == "" {
+		fallbackResultRender(w, r)
+		return
+	}
+	fmt.Fprintf(w, "  latest_api_version: %s\n", about.LatestAPIVersion)
+	if len(about.SupportedAPIs) > 0 {
+		fmt.Fprintf(w, "  supported_apis:\n")
+		for _, a := range about.SupportedAPIs {
+			fmt.Fprintf(w, "    - %s\n", a.APIVersion)
+		}
+	}
+}

--- a/cli/internal/cmd/vcf-automation/blueprint.go
+++ b/cli/internal/cmd/vcf-automation/blueprint.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfautomation
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+// Tenant-plane verb: `meho vcf-automation blueprint list` -- templates
+// deployments instantiate.
+func newBlueprintCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "blueprint",
+		Short:        "Tenant-plane VCFA catalog blueprints (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newBlueprintListCmd())
+	return cmd
+}
+
+func newBlueprintListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:           "list",
+		Short:         "List tenant-plane catalog blueprints",
+		Example:       "  meho vcf-automation blueprint list --target rdc-vcfa",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runTenantListVerb(cmd,
+				"GET:/iaas/api/blueprints",
+				targetName, jsonOut, backplaneOverride,
+				printBlueprintList,
+			)
+		},
+	}
+	addStandardFlags(cmd, &targetName, &backplaneOverride, &jsonOut)
+	return cmd
+}
+
+func printBlueprintList(w io.Writer, r *CallResult) {
+	const opID = "GET:/iaas/api/blueprints"
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeTenantListResult(r.Result)
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "(0 blueprints)")
+		return
+	}
+	fmt.Fprintf(w, "%-36s  %-30s  %-12s  %-10s\n", "id", "name", "status", "version")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-36s  %-30s  %-12s  %-10s\n",
+			truncate(vcfaStringField(e, "id"), 36),
+			truncate(vcfaStringField(e, "name"), 30),
+			truncate(vcfaStringField(e, "status"), 12),
+			truncate(vcfaStringField(e, "version"), 10),
+		)
+	}
+}

--- a/cli/internal/cmd/vcf-automation/deployment.go
+++ b/cli/internal/cmd/vcf-automation/deployment.go
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfautomation
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+// Tenant-plane verb: `meho vcf-automation deployment ...` -- the
+// largest payload on the tenant surface; the dispatcher's JSONFlux
+// seam wraps oversized responses in a ResultHandle (use `result_describe`
+// / `result_query` to navigate).
+func newDeploymentCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "deployment",
+		Short:        "Tenant-plane VCFA catalog deployments (list / get)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newDeploymentListCmd())
+	cmd.AddCommand(newDeploymentGetCmd())
+	return cmd
+}
+
+func newDeploymentListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:           "list",
+		Short:         "List tenant-plane catalog deployments",
+		Example:       "  meho vcf-automation deployment list --target rdc-vcfa",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runTenantListVerb(cmd,
+				"GET:/iaas/api/deployments",
+				targetName, jsonOut, backplaneOverride,
+				printDeploymentList,
+			)
+		},
+	}
+	addStandardFlags(cmd, &targetName, &backplaneOverride, &jsonOut)
+	return cmd
+}
+
+func newDeploymentGetCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:           "get <id>",
+		Short:         "Read one tenant-plane deployment by id",
+		Example:       "  meho vcf-automation deployment get dep-1234 --target rdc-vcfa",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runTenantGetVerb(cmd,
+				"GET:/iaas/api/deployments/{id}",
+				"id", args[0],
+				targetName, jsonOut, backplaneOverride,
+				printDeploymentGet,
+			)
+		},
+	}
+	addStandardFlags(cmd, &targetName, &backplaneOverride, &jsonOut)
+	return cmd
+}
+
+func printDeploymentList(w io.Writer, r *CallResult) {
+	const opID = "GET:/iaas/api/deployments"
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	// JSONFlux handle path: when the dispatcher wraps the payload in
+	// a ResultHandle, the result envelope's `handle` field is set and
+	// the operator should use `result_describe` / `result_query`.
+	// Renders a one-liner hint so the handle isn't silently dropped.
+	entries, err := decodeTenantListResult(r.Result)
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "(0 deployments)")
+		return
+	}
+	fmt.Fprintf(w, "%-36s  %-30s  %-15s  %-36s\n", "id", "name", "status", "blueprintId")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-36s  %-30s  %-15s  %-36s\n",
+			truncate(vcfaStringField(e, "id"), 36),
+			truncate(vcfaStringField(e, "name"), 30),
+			truncate(vcfaStringField(e, "status"), 15),
+			truncate(vcfaStringField(e, "blueprintId"), 36),
+		)
+	}
+}
+
+func printDeploymentGet(w io.Writer, r *CallResult) {
+	const opID = "GET:/iaas/api/deployments/{id}"
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	var d struct {
+		ID          string `json:"id"`
+		Name        string `json:"name"`
+		Status      string `json:"status"`
+		ProjectID   string `json:"projectId"`
+		BlueprintID string `json:"blueprintId"`
+		OwnedBy     string `json:"ownedBy"`
+	}
+	if err := jsonUnmarshalStrict(r.Result, &d); err != nil || d.ID == "" {
+		fallbackResultRender(w, r)
+		return
+	}
+	fmt.Fprintf(w, "  id:           %s\n", d.ID)
+	if d.Name != "" {
+		fmt.Fprintf(w, "  name:         %s\n", d.Name)
+	}
+	if d.Status != "" {
+		fmt.Fprintf(w, "  status:       %s\n", d.Status)
+	}
+	if d.ProjectID != "" {
+		fmt.Fprintf(w, "  project_id:   %s\n", d.ProjectID)
+	}
+	if d.BlueprintID != "" {
+		fmt.Fprintf(w, "  blueprint_id: %s\n", d.BlueprintID)
+	}
+	if d.OwnedBy != "" {
+		fmt.Fprintf(w, "  owned_by:     %s\n", d.OwnedBy)
+	}
+}

--- a/cli/internal/cmd/vcf-automation/dispatch.go
+++ b/cli/internal/cmd/vcf-automation/dispatch.go
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfautomation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// CallResult mirrors the backend OperationResult Pydantic model.
+type CallResult struct {
+	Status     string          `json:"status"`
+	OpID       string          `json:"op_id"`
+	Result     json.RawMessage `json:"result"`
+	Error      *string         `json:"error"`
+	Extras     json.RawMessage `json:"extras,omitempty"`
+	DurationMs float64         `json:"duration_ms"`
+}
+
+// callRequestBody mirrors the backend CallOperationBody Pydantic model.
+type callRequestBody struct {
+	ConnectorID string         `json:"connector_id"`
+	OpID        string         `json:"op_id"`
+	Target      map[string]any `json:"target"`
+	Params      map[string]any `json:"params,omitempty"`
+}
+
+var errOpError = errors.New("operation status not ok")
+
+// dispatchOp POSTs an OperationCall to the backplane and returns the
+// decoded CallResult with connector_id="vcfa-rest-9.0" pre-baked.
+//
+// The optional `fqdn` argument is threaded into the request body's
+// target dict as the `fqdn` field — the backend honours that as a
+// per-call vhost override on the resolved Target row (G3.6-T12 #840;
+// extended `CallOperationBody.target` to read the `fqdn` key in this
+// task). Empty `fqdn` is omitted from the body so the backend reads
+// `target.fqdn` from the registry.
+//
+// When `targetSlug` is empty, the body's `target` field is encoded as
+// JSON null — matches the backend contract for ops that don't act on
+// a target.
+func dispatchOp(
+	ctx context.Context,
+	backplaneURL, opID, targetSlug, fqdn string,
+	params map[string]any,
+) (*CallResult, error) {
+	body := callRequestBody{
+		ConnectorID: ConnectorID,
+		OpID:        opID,
+		Target:      nil,
+	}
+	if targetSlug != "" {
+		t := map[string]any{"name": targetSlug}
+		if fqdn != "" {
+			t["fqdn"] = fqdn
+		}
+		body.Target = t
+	}
+	if params != nil {
+		body.Params = params
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal call request: %w", err)
+	}
+	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
+	if err != nil {
+		return nil, err
+	}
+	var out CallResult
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("decode call response: %w", err)
+	}
+	return &out, nil
+}
+
+// renderCallResult handles the unified post-dispatch rendering path.
+func renderCallResult(
+	cmd *cobra.Command,
+	opID string,
+	r *CallResult,
+	jsonOut bool,
+	prettyPrinter func(w io.Writer, r *CallResult),
+) error {
+	switch r.Status {
+	case "ok", "error", "denied":
+	default:
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
+				r.Status,
+			)),
+			jsonOut,
+		)
+	}
+	if jsonOut {
+		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
+			return err
+		}
+	} else if prettyPrinter != nil {
+		prettyPrinter(cmd.OutOrStdout(), r)
+	} else {
+		printGenericResult(cmd.OutOrStdout(), opID, r)
+	}
+	if r.Status == "ok" {
+		return nil
+	}
+	return errOpError
+}
+
+// printGenericResult renders a CallResult in the generic envelope shape.
+func printGenericResult(w io.Writer, opID string, r *CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+	if r.Status == "ok" {
+		if len(r.Result) > 0 && string(r.Result) != "null" {
+			pretty, err := prettyJSON(r.Result)
+			if err == nil {
+				fmt.Fprintln(w, pretty)
+				return
+			}
+			fmt.Fprintln(w, string(r.Result))
+		}
+		return
+	}
+	if r.Error != nil && *r.Error != "" {
+		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
+	} else {
+		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
+	}
+	if len(r.Extras) > 0 && string(r.Extras) != "null" {
+		fmt.Fprintln(w, "extras:")
+		pretty, err := prettyJSON(r.Extras)
+		if err == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Extras))
+		}
+	}
+}
+
+func jsonUnmarshalStrict(raw []byte, out any) error {
+	return json.Unmarshal(raw, out)
+}
+
+func prettyJSON(raw json.RawMessage) (string, error) {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return "", err
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/cli/internal/cmd/vcf-automation/operation.go
+++ b/cli/internal/cmd/vcf-automation/operation.go
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfautomation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newOperationCmd returns `meho vcf-automation operation` with search /
+// call meta-tool wrappers pre-scoped to vcfa-rest-9.0. The two
+// subcommands are the escape hatch for ops that don't (yet) have a
+// dedicated alias; the raw op_id already encodes its plane via the
+// path prefix so neither subcommand consults the `--plane` flag.
+func newOperationCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "operation",
+		Short:        "Pre-scoped meta-tool wrappers (search / call) for vcfa-rest-9.0",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newOperationSearchCmd())
+	cmd.AddCommand(newOperationCallCmd())
+	return cmd
+}
+
+// searchHit mirrors the backend OperationSearchHit Pydantic model.
+type searchHit struct {
+	OpID             string   `json:"op_id"`
+	Summary          *string  `json:"summary"`
+	Description      *string  `json:"description"`
+	GroupKey         *string  `json:"group_key"`
+	SafetyLevel      string   `json:"safety_level"`
+	RequiresApproval bool     `json:"requires_approval"`
+	FusedScore       float64  `json:"fused_score"`
+	Bm25Score        *float64 `json:"bm25_score"`
+	CosineScore      *float64 `json:"cosine_score"`
+}
+
+type searchResponse struct {
+	Hits            []searchHit `json:"hits"`
+	QueryDurationMs float64     `json:"query_duration_ms"`
+}
+
+func newOperationSearchCmd() *cobra.Command {
+	var (
+		groupKey          string
+		limit             int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "search <query>",
+		Short: "Hybrid BM25 + cosine RRF search across vcfa-rest-9.0 operations",
+		Long: "search wraps GET /api/v1/operations/search with connector_id=\n" +
+			"\"vcfa-rest-9.0\" pre-baked. The hits set spans both planes;\n" +
+			"narrow with --group <group_key> to one plane's surface (e.g.\n" +
+			"--group tenant-deployments).\n\n" +
+			"Exit codes mirror meho operation search.",
+		Example: "  meho vcf-automation operation search \"list deployments\"\n" +
+			"  meho vcf-automation operation search \"orgs\" --group provider-orgs",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runOperationSearch(cmd, args[0], groupKey, limit, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&groupKey, "group", "", "narrow the search to one group_key")
+	cmd.Flags().IntVar(&limit, "limit", 10, "max hits (1..50, clamped by the API)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit machine-readable JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, jsonOut bool, backplaneOverride string) error {
+	if limit < 1 {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--limit must be >= 1; got %d", limit)),
+			jsonOut)
+	}
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	if jsonOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printSearchTable(cmd.OutOrStdout(), query, result)
+	return nil
+}
+
+func getSearch(ctx context.Context, backplaneURL, query, groupKey string, limit int) (*searchResponse, error) {
+	q := url.Values{}
+	q.Set("connector_id", ConnectorID)
+	q.Set("query", query)
+	if groupKey != "" {
+		q.Set("group", groupKey)
+	}
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	path := "/api/v1/operations/search?" + q.Encode()
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var out searchResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode search response: %w", err)
+	}
+	return &out, nil
+}
+
+func printSearchTable(w io.Writer, query string, r *searchResponse) {
+	fmt.Fprintf(w, "search %s %q — %d hit(s) in %.0fms\n",
+		ConnectorID, query, len(r.Hits), r.QueryDurationMs)
+	if len(r.Hits) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "%-50s %6s  %s\n", "op_id", "score", "summary")
+	for _, h := range r.Hits {
+		fmt.Fprintf(w, "%-50s %6.3f  %s\n",
+			truncate(h.OpID, 50),
+			h.FusedScore,
+			truncate(strDeref(h.Summary), 80),
+		)
+	}
+}
+
+func strDeref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func newOperationCallCmd() *cobra.Command {
+	var (
+		targetName        string
+		paramsFlag        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "call <op_id>",
+		Short: "Dispatch any vcfa-rest-9.0 op_id (escape hatch for ops without aliases)",
+		Long: "call wraps POST /api/v1/operations/call with connector_id=\n" +
+			"\"vcfa-rest-9.0\" pre-baked. Use when an op doesn't have a\n" +
+			"dedicated alias yet. The raw op_id already carries the plane\n" +
+			"via its path prefix; the --plane flag is ignored on this verb.\n" +
+			"The persistent --fqdn flag still threads into the body.\n\n" +
+			"Exit codes mirror meho operation call.",
+		Example: "  meho vcf-automation operation call GET:/cloudapi/1.0.0/site --target rdc-vcfa\n" +
+			"  meho vcf-automation operation call GET:/iaas/api/about --target rdc-vcfa --json",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runOperationCall(cmd, args[0], targetName, paramsFlag, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "", "VCFA target slug")
+	cmd.Flags().StringVar(&paramsFlag, "params", "", "params as inline JSON or @<file>")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params, err := loadParamsFlag(paramsFlag)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, readFqdn(cmd), params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, nil)
+}

--- a/cli/internal/cmd/vcf-automation/org.go
+++ b/cli/internal/cmd/vcf-automation/org.go
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfautomation
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// Provider-plane verb: `meho vcf-automation org ...`. Two read-only
+// subcommands cover the v0.5 core's two organization ops.
+func newOrgCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "org",
+		Short:        "Provider-plane VCFA organizations (list / get)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newOrgListCmd())
+	cmd.AddCommand(newOrgGetCmd())
+	return cmd
+}
+
+func newOrgListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List provider-plane organizations on a VCFA appliance",
+		Long: "list dispatches GET:/cloudapi/1.0.0/orgs against\n" +
+			"connector_id=\"vcfa-rest-9.0\" on the provider plane.\n" +
+			"--plane provider is implicit; passing --plane tenant\n" +
+			"errors early.",
+		Example:       "  meho vcf-automation org list --target rdc-vcfa",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runProviderListVerb(cmd,
+				"GET:/cloudapi/1.0.0/orgs",
+				targetName, jsonOut, backplaneOverride,
+				printOrgList,
+			)
+		},
+	}
+	addStandardFlags(cmd, &targetName, &backplaneOverride, &jsonOut)
+	return cmd
+}
+
+func newOrgGetCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "get <id>",
+		Short: "Read one provider-plane organization by id",
+		Long: "get dispatches GET:/cloudapi/1.0.0/orgs/{id} against\n" +
+			"connector_id=\"vcfa-rest-9.0\" on the provider plane.\n" +
+			"<id> is forwarded as the `id` path-template parameter.",
+		Example:       "  meho vcf-automation org get a1b2c3d4 --target rdc-vcfa",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProviderGetVerb(cmd,
+				"GET:/cloudapi/1.0.0/orgs/{id}",
+				"id", args[0],
+				targetName, jsonOut, backplaneOverride,
+				printOrgGet,
+			)
+		},
+	}
+	addStandardFlags(cmd, &targetName, &backplaneOverride, &jsonOut)
+	return cmd
+}
+
+func printOrgList(w io.Writer, r *CallResult) {
+	const opID = "GET:/cloudapi/1.0.0/orgs"
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeProviderListResult(r.Result)
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "(0 organizations)")
+		return
+	}
+	fmt.Fprintf(w, "%-36s  %-30s  %-10s\n", "id", "name", "enabled")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-36s  %-30s  %-10v\n",
+			truncate(vcfaStringField(e, "id"), 36),
+			truncate(vcfaStringField(e, "name"), 30),
+			e["isEnabled"],
+		)
+	}
+}
+
+func printOrgGet(w io.Writer, r *CallResult) {
+	const opID = "GET:/cloudapi/1.0.0/orgs/{id}"
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	var org struct {
+		ID           string `json:"id"`
+		Name         string `json:"name"`
+		DisplayName  string `json:"displayName"`
+		Description  string `json:"description"`
+		IsEnabled    bool   `json:"isEnabled"`
+		OrgVdcCount  int    `json:"orgVdcCount"`
+		UserCount    int    `json:"userCount"`
+		CatalogCount int    `json:"catalogCount"`
+	}
+	if err := jsonUnmarshalStrict(r.Result, &org); err != nil || org.ID == "" {
+		fallbackResultRender(w, r)
+		return
+	}
+	fmt.Fprintf(w, "  id:            %s\n", org.ID)
+	if org.Name != "" {
+		fmt.Fprintf(w, "  name:          %s\n", org.Name)
+	}
+	if org.DisplayName != "" {
+		fmt.Fprintf(w, "  display_name:  %s\n", org.DisplayName)
+	}
+	fmt.Fprintf(w, "  is_enabled:    %v\n", org.IsEnabled)
+	fmt.Fprintf(w, "  org_vdc_count: %d\n", org.OrgVdcCount)
+	fmt.Fprintf(w, "  user_count:    %d\n", org.UserCount)
+	fmt.Fprintf(w, "  catalog_count: %d\n", org.CatalogCount)
+}
+
+// addStandardFlags wires the --target / --json / --backplane flags
+// shared by every dispatch verb. Centralised so the per-verb body
+// stays narrow.
+func addStandardFlags(cmd *cobra.Command, targetName, backplaneOverride *string, jsonOut *bool) {
+	// Note: positional layout matches the variadic call sites; the
+	// signature is (cmd, target, json, backplane) on the call side
+	// for readability.
+	cmd.Flags().StringVar(targetName, "target", "", "VCFA target slug")
+	cmd.Flags().BoolVar(jsonOut, "json", false, "emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL recorded by the most recent `meho login`)")
+}
+
+// runProviderListVerb is the shared dispatch path for provider-plane
+// list verbs that take no positional arguments. It enforces the
+// `--plane provider` constraint and renders the result through the
+// per-verb printer.
+func runProviderListVerb(
+	cmd *cobra.Command,
+	opID, targetName string,
+	jsonOut bool,
+	backplaneOverride string,
+	printer func(io.Writer, *CallResult),
+) error {
+	if se := validatePlane(readPlane(cmd), PlaneProvider); se != nil {
+		return output.RenderError(cmd.ErrOrStderr(), se, jsonOut)
+	}
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, readFqdn(cmd), nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printer)
+}
+
+// runProviderGetVerb is the shared dispatch path for provider-plane
+// read-by-id verbs. The path-template parameter is forwarded via
+// `params[paramName] = id` — the dispatcher's `_substitute_path`
+// fills the `{name}` placeholder.
+func runProviderGetVerb(
+	cmd *cobra.Command,
+	opID, paramName, paramValue, targetName string,
+	jsonOut bool,
+	backplaneOverride string,
+	printer func(io.Writer, *CallResult),
+) error {
+	if se := validatePlane(readPlane(cmd), PlaneProvider); se != nil {
+		return output.RenderError(cmd.ErrOrStderr(), se, jsonOut)
+	}
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params := map[string]any{paramName: paramValue}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, readFqdn(cmd), params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printer)
+}

--- a/cli/internal/cmd/vcf-automation/project.go
+++ b/cli/internal/cmd/vcf-automation/project.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfautomation
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// Tenant-plane verb: `meho vcf-automation project list` -- projects
+// within a tenant organization; the deployment-scoping construct.
+func newProjectCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "project",
+		Short:        "Tenant-plane VCFA projects (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newProjectListCmd())
+	return cmd
+}
+
+func newProjectListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:           "list",
+		Short:         "List tenant-plane projects on a VCFA appliance",
+		Example:       "  meho vcf-automation project list --target rdc-vcfa",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runTenantListVerb(cmd,
+				"GET:/iaas/api/projects",
+				targetName, jsonOut, backplaneOverride,
+				printProjectList,
+			)
+		},
+	}
+	addStandardFlags(cmd, &targetName, &backplaneOverride, &jsonOut)
+	return cmd
+}
+
+func printProjectList(w io.Writer, r *CallResult) {
+	const opID = "GET:/iaas/api/projects"
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeTenantListResult(r.Result)
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "(0 projects)")
+		return
+	}
+	fmt.Fprintf(w, "%-36s  %-30s  %-36s\n", "id", "name", "organization_id")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-36s  %-30s  %-36s\n",
+			truncate(vcfaStringField(e, "id"), 36),
+			truncate(vcfaStringField(e, "name"), 30),
+			truncate(vcfaStringField(e, "organizationId"), 36),
+		)
+	}
+}
+
+// runTenantListVerb is the shared dispatch path for tenant-plane list
+// verbs (project / deployment / blueprint). Enforces --plane tenant
+// (when supplied) and renders the result through the per-verb printer.
+func runTenantListVerb(
+	cmd *cobra.Command,
+	opID, targetName string,
+	jsonOut bool,
+	backplaneOverride string,
+	printer func(io.Writer, *CallResult),
+) error {
+	if se := validatePlane(readPlane(cmd), PlaneTenant); se != nil {
+		return output.RenderError(cmd.ErrOrStderr(), se, jsonOut)
+	}
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, readFqdn(cmd), nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printer)
+}
+
+// runTenantGetVerb dispatches a tenant-plane read-by-id op_id with the
+// path-template parameter forwarded under `params[paramName]`.
+func runTenantGetVerb(
+	cmd *cobra.Command,
+	opID, paramName, paramValue, targetName string,
+	jsonOut bool,
+	backplaneOverride string,
+	printer func(io.Writer, *CallResult),
+) error {
+	if se := validatePlane(readPlane(cmd), PlaneTenant); se != nil {
+		return output.RenderError(cmd.ErrOrStderr(), se, jsonOut)
+	}
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params := map[string]any{paramName: paramValue}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, readFqdn(cmd), params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, opID, r, jsonOut, printer)
+}

--- a/cli/internal/cmd/vcf-automation/region.go
+++ b/cli/internal/cmd/vcf-automation/region.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfautomation
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+// Provider-plane verb: `meho vcf-automation region ...`. The VCFA 9
+// "region" surface is the evolution of the vCloud-Director provider-VDC
+// concept (each region maps to one NSX domain plus a collection of
+// supervisors backed by one or more VCF workload domains).
+func newRegionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "region",
+		Short:        "Provider-plane VCFA regions (list / get)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newRegionListCmd())
+	cmd.AddCommand(newRegionGetCmd())
+	return cmd
+}
+
+func newRegionListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:           "list",
+		Short:         "List provider-plane regions on a VCFA appliance",
+		Example:       "  meho vcf-automation region list --target rdc-vcfa",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runProviderListVerb(cmd,
+				"GET:/cloudapi/1.0.0/regions",
+				targetName, jsonOut, backplaneOverride,
+				printRegionList,
+			)
+		},
+	}
+	addStandardFlags(cmd, &targetName, &backplaneOverride, &jsonOut)
+	return cmd
+}
+
+func newRegionGetCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:           "get <id>",
+		Short:         "Read one provider-plane region by id",
+		Example:       "  meho vcf-automation region get r-1234 --target rdc-vcfa",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runProviderGetVerb(cmd,
+				"GET:/cloudapi/1.0.0/regions/{id}",
+				"id", args[0],
+				targetName, jsonOut, backplaneOverride,
+				printRegionGet,
+			)
+		},
+	}
+	addStandardFlags(cmd, &targetName, &backplaneOverride, &jsonOut)
+	return cmd
+}
+
+func printRegionList(w io.Writer, r *CallResult) {
+	const opID = "GET:/cloudapi/1.0.0/regions"
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeProviderListResult(r.Result)
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "(0 regions)")
+		return
+	}
+	fmt.Fprintf(w, "%-36s  %-30s  %-10s\n", "id", "name", "enabled")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-36s  %-30s  %-10v\n",
+			truncate(vcfaStringField(e, "id"), 36),
+			truncate(vcfaStringField(e, "name"), 30),
+			e["isEnabled"],
+		)
+	}
+}
+
+func printRegionGet(w io.Writer, r *CallResult) {
+	const opID = "GET:/cloudapi/1.0.0/regions/{id}"
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	var region struct {
+		ID          string `json:"id"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		IsEnabled   bool   `json:"isEnabled"`
+		NsxManager  struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"nsxManager"`
+	}
+	if err := jsonUnmarshalStrict(r.Result, &region); err != nil || region.ID == "" {
+		fallbackResultRender(w, r)
+		return
+	}
+	fmt.Fprintf(w, "  id:          %s\n", region.ID)
+	if region.Name != "" {
+		fmt.Fprintf(w, "  name:        %s\n", region.Name)
+	}
+	fmt.Fprintf(w, "  is_enabled:  %v\n", region.IsEnabled)
+	if region.NsxManager.Name != "" {
+		fmt.Fprintf(w, "  nsx_manager: %s (%s)\n", region.NsxManager.Name, region.NsxManager.ID)
+	}
+	if region.Description != "" {
+		fmt.Fprintf(w, "  description: %s\n", region.Description)
+	}
+}

--- a/cli/internal/cmd/vcf-automation/user.go
+++ b/cli/internal/cmd/vcf-automation/user.go
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfautomation
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+// Provider-plane verb: `meho vcf-automation user list` -- system-scope
+// users on the VCFA appliance.
+func newUserCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "user",
+		Short:        "Provider-plane VCFA system users (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newUserListCmd())
+	return cmd
+}
+
+func newUserListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:           "list",
+		Short:         "List provider-plane system users on a VCFA appliance",
+		Example:       "  meho vcf-automation user list --target rdc-vcfa",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runProviderListVerb(cmd,
+				"GET:/cloudapi/1.0.0/users",
+				targetName, jsonOut, backplaneOverride,
+				printUserList,
+			)
+		},
+	}
+	addStandardFlags(cmd, &targetName, &backplaneOverride, &jsonOut)
+	return cmd
+}
+
+func printUserList(w io.Writer, r *CallResult) {
+	const opID = "GET:/cloudapi/1.0.0/users"
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	entries, err := decodeProviderListResult(r.Result)
+	if err != nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if len(entries) == 0 {
+		fmt.Fprintln(w, "(0 users)")
+		return
+	}
+	fmt.Fprintf(w, "%-36s  %-30s  %-30s  %-10s\n", "id", "username", "fullName", "enabled")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-36s  %-30s  %-30s  %-10v\n",
+			truncate(vcfaStringField(e, "id"), 36),
+			truncate(vcfaStringField(e, "username"), 30),
+			truncate(vcfaStringField(e, "fullName"), 30),
+			e["isEnabled"],
+		)
+	}
+}

--- a/cli/internal/cmd/vcf-automation/vcfa.go
+++ b/cli/internal/cmd/vcf-automation/vcfa.go
@@ -1,0 +1,467 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package vcfautomation hosts the cobra commands under `meho
+// vcf-automation ...` for G3.6-T12 (#840) of Initiative #369. v0.5
+// ships the operator-facing verb tree over the 11 enabled VCF
+// Automation 9.0 read-only core ops (6 provider plane + 5 tenant
+// plane), each pre-baking connector_id="vcfa-rest-9.0" so operators
+// don't type the connector ID on every dispatch:
+//
+//   - `meho vcf-automation about --plane provider|tenant`
+//   - `meho vcf-automation org list|get --plane provider`
+//   - `meho vcf-automation region list|get --plane provider`
+//   - `meho vcf-automation user list --plane provider`
+//   - `meho vcf-automation project list --plane tenant`
+//   - `meho vcf-automation deployment list|get --plane tenant`
+//   - `meho vcf-automation blueprint list --plane tenant`
+//   - `meho vcf-automation operation search|call` — meta-tool wrappers
+//
+// The dual-plane shape is the load-bearing departure from the other
+// VCF management-plane CLIs: VCFA 9.x exposes two API planes on the
+// same appliance (vCloud-Director-derived /cloudapi/* + Aria-IaaS-
+// derived /iaas/api/*) with bespoke per-plane auth (HTTP Basic + JWT
+// header vs JSON body + bearer). The `--plane` persistent flag picks
+// the op namespace; the backend dispatcher routes each op to the
+// correct auth plane via the spec_source tag the G0.7 dual-spec
+// ingest (#836) wrote on every descriptor.
+//
+// Vhost routing is the second departure: VCFA enforces strict Host:
+// header matching and returns 404 with empty body on every path when
+// reached by IP without the correct vhost set. The `--fqdn` flag is a
+// per-call override for the resolved target's fqdn column; the
+// canonical home for the value is `fqdn:` in targets.yaml so the
+// override only matters as a debugging escape hatch. Without an fqdn
+// the connector raises VcfAutomationConfigurationError at session-
+// establish time and surfaces a structured error_code on the wire
+// rather than a confusing post-login 404 storm.
+//
+// Per CLAUDE.md postulate 5, these alias verbs are operator-only
+// ergonomics -- they are not mirrored on the MCP surface. Agents
+// continue to use search_operations / call_operation against the
+// narrow-waist meta-tool contract.
+package vcfautomation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// ConnectorID is the pre-baked connector_id every verb under `meho
+// vcf-automation ...` dispatches against.
+const ConnectorID = "vcfa-rest-9.0"
+
+// Plane names recognised on the `--plane` persistent flag. Mirrors
+// the backend's `Plane = Literal["provider", "tenant"]` literal type
+// so the CLI rejects typos at the cobra layer rather than letting an
+// unknown plane string slip through to a 404 from the dispatcher.
+const (
+	PlaneProvider = "provider"
+	PlaneTenant   = "tenant"
+)
+
+// NewRootCmd returns the `meho vcf-automation` parent command.
+//
+// `--plane` is a persistent flag every verb in the tree inspects.
+// Per-verb behaviour:
+//
+//   - Verbs unique to one plane (org/region/user on provider;
+//     project/deployment/blueprint on tenant) treat `--plane` as a
+//     consistency check: if the operator passed the wrong plane the
+//     command refuses early with a clear message instead of dispatching
+//     against the wrong op_id.
+//   - `about` is dual-plane and reads `--plane` as required input.
+//   - `operation call` / `operation search` ignore `--plane` (the raw
+//     op_id already carries the plane via its path prefix).
+//
+// `--fqdn` is the second persistent flag; honoured by every verb that
+// dispatches an op (it threads into the body's `target.fqdn` field
+// before the POST). When unset the backend reads `target.fqdn` from
+// the targets registry; when set, the value overrides for this one
+// call only (the DB row is not modified). The canonical home for the
+// value is `fqdn:` in targets.yaml.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vcf-automation",
+		Short: "Pre-scoped CLI verbs for the vcfa-rest-9.0 dual-plane connector",
+		Long: "vcf-automation is the operator-facing verb tree for the\n" +
+			"vcfa-rest-9.0 connector. Each verb dispatches through\n" +
+			"POST /api/v1/operations/call with connector_id=\"vcfa-rest-9.0\"\n" +
+			"pre-baked.\n\n" +
+			"VCFA 9.x is **dual-plane** on a single appliance:\n" +
+			"  - provider plane (/cloudapi/* + /api/*) — HTTP Basic →\n" +
+			"    X-VMWARE-VCLOUD-ACCESS-TOKEN JWT\n" +
+			"  - tenant plane (/iaas/api/*) — JSON POST → {\"token\": ...}\n" +
+			"`--plane provider|tenant` picks the op namespace; the\n" +
+			"backend dispatcher routes the call to the correct auth\n" +
+			"plane via the descriptor's spec_source tag.\n\n" +
+			"VCFA enforces strict vhost (Host:) routing. When the target\n" +
+			"is reached by IP, set `--fqdn <vhost>` (or `fqdn:` in\n" +
+			"targets.yaml) to the appliance's canonical FQDN — without\n" +
+			"it every path returns 404 with empty body before the\n" +
+			"application sees the request.\n\n" +
+			"Per CLAUDE.md postulate 5, these alias verbs are operator-\n" +
+			"only ergonomics; they are not mirrored on the MCP surface.\n" +
+			"Agents continue to use search_operations / call_operation.",
+		SilenceUsage: true,
+	}
+	// Persistent flags are read by every verb's RunE through cmd.Flags().
+	cmd.PersistentFlags().String(
+		"plane", "",
+		"VCFA plane to target: 'provider' (cloudapi/*) or 'tenant' (iaas/api/*)",
+	)
+	cmd.PersistentFlags().String(
+		"fqdn", "",
+		"per-call vhost override (target.fqdn); honoured by the connector for vhost routing",
+	)
+
+	cmd.AddCommand(newAboutCmd())
+	cmd.AddCommand(newOrgCmd())
+	cmd.AddCommand(newRegionCmd())
+	cmd.AddCommand(newUserCmd())
+	cmd.AddCommand(newProjectCmd())
+	cmd.AddCommand(newDeploymentCmd())
+	cmd.AddCommand(newBlueprintCmd())
+	cmd.AddCommand(newOperationCmd())
+	return cmd
+}
+
+// readPlane returns the value of the persistent --plane flag, walking
+// up to the parent command (the persistent flag is registered on the
+// `vcf-automation` root; sub-sub-commands like `org list` need the
+// walk to find it).
+func readPlane(cmd *cobra.Command) string {
+	v, _ := cmd.Flags().GetString("plane")
+	return strings.TrimSpace(v)
+}
+
+// readFqdn returns the persistent --fqdn override (may be empty).
+func readFqdn(cmd *cobra.Command) string {
+	v, _ := cmd.Flags().GetString("fqdn")
+	return strings.TrimSpace(v)
+}
+
+// validatePlane returns an error when the caller passed --plane=X but
+// the verb expects --plane=expected. Empty --plane is accepted on
+// single-plane verbs (the verb's own plane is the implicit default).
+func validatePlane(got, expected string) *output.StructuredError {
+	if got == "" || got == expected {
+		return nil
+	}
+	return output.Unexpected(fmt.Sprintf(
+		"--plane %q is invalid for this verb; expected --plane %q (or omit the flag)",
+		got, expected,
+	))
+}
+
+// requirePlane returns an error when --plane is missing or unknown on
+// a verb that is dual-plane (the `about` verb). Both planes share the
+// resource name so we cannot derive the plane from the verb itself.
+func requirePlane(got string) *output.StructuredError {
+	switch got {
+	case PlaneProvider, PlaneTenant:
+		return nil
+	case "":
+		return output.Unexpected(
+			"--plane is required for this verb; pass --plane provider or --plane tenant",
+		)
+	default:
+		return output.Unexpected(fmt.Sprintf(
+			"--plane %q is unknown; pass --plane provider or --plane tenant", got,
+		))
+	}
+}
+
+// vcfaEntry is a single row in a VCFA list response. VCFA returns
+// either a `values` array (provider plane, vCD lineage) or a `content`
+// array (tenant plane, Aria IaaS lineage); the per-verb renderers
+// know which.
+type vcfaEntry = map[string]any
+
+// decodeProviderListResult unwraps the provider plane's
+// {"values": [...], "resultTotal": N} envelope.
+func decodeProviderListResult(raw json.RawMessage) ([]vcfaEntry, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var wrapped struct {
+		Values []vcfaEntry `json:"values"`
+	}
+	if err := json.Unmarshal(raw, &wrapped); err == nil && wrapped.Values != nil {
+		return wrapped.Values, nil
+	}
+	var arr []vcfaEntry
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		return nil, fmt.Errorf("decode provider list result: %w", err)
+	}
+	return arr, nil
+}
+
+// decodeTenantListResult unwraps the tenant plane's
+// {"content": [...], "totalElements": N} envelope.
+func decodeTenantListResult(raw json.RawMessage) ([]vcfaEntry, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var wrapped struct {
+		Content []vcfaEntry `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &wrapped); err == nil && wrapped.Content != nil {
+		return wrapped.Content, nil
+	}
+	var arr []vcfaEntry
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		return nil, fmt.Errorf("decode tenant list result: %w", err)
+	}
+	return arr, nil
+}
+
+// vcfaStringField extracts a string value from a VCFA entry map.
+func vcfaStringField(e vcfaEntry, key string) string {
+	v, ok := e[key]
+	if !ok {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// fallbackResultRender dumps raw result JSON when the typed decoder
+// doesn't match the actual response shape.
+func fallbackResultRender(w io.Writer, r *CallResult) {
+	if len(r.Result) == 0 || string(r.Result) == "null" {
+		return
+	}
+	pretty, err := prettyJSON(r.Result)
+	if err == nil {
+		fmt.Fprintln(w, pretty)
+		return
+	}
+	fmt.Fprintln(w, string(r.Result))
+}
+
+// printErrorTrailer surfaces the dispatcher error + extras envelope.
+func printErrorTrailer(w io.Writer, r *CallResult) {
+	if r.Error != nil && *r.Error != "" {
+		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
+	} else {
+		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
+	}
+	if len(r.Extras) > 0 && string(r.Extras) != "null" {
+		fmt.Fprintln(w, "extras:")
+		pretty, err := prettyJSON(r.Extras)
+		if err == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Extras))
+		}
+	}
+}
+
+type errNoBackplaneConfigured struct{ inner error }
+
+func (e *errNoBackplaneConfigured) Error() string {
+	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
+}
+func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
+
+func resolveBackplane(override string) (string, error) {
+	if override != "" {
+		return normaliseURL(override)
+	}
+	cfg, err := auth.LoadConfig()
+	if err != nil {
+		if errors.Is(err, auth.ErrConfigNotFound) {
+			return "", &errNoBackplaneConfigured{inner: err}
+		}
+		return "", err
+	}
+	return normaliseURL(cfg.BackplaneURL)
+}
+
+func classifyBackplaneError(err error) *output.StructuredError {
+	if errors.Is(err, auth.ErrConfigNotFound) {
+		return output.AuthExpired(err.Error())
+	}
+	return output.Unexpected(err.Error())
+}
+
+func normaliseURL(s string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
+	if trimmed == "" {
+		return "", errors.New("backplane URL is empty")
+	}
+	u, err := url.ParseRequestURI(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("backplane URL %q has no host", s)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}
+
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var he *httpError
+	if errors.As(err, &he) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, he.StatusCode, he.Body)),
+			jsonOut,
+		)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+type httpError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+func doAuthedRequest(
+	ctx context.Context,
+	backplaneURL, method, path string,
+	body []byte,
+) ([]byte, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	httpClient := authed.HTTPClient()
+	bearer := authed.AccessToken()
+	if bearer == "" {
+		return nil, errors.New("meho: stored token has no access_token")
+	}
+	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			resp.Body.Close()
+			return nil, rerr
+		}
+		resp.Body.Close()
+		bearer = authed.AccessToken()
+		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close()
+	const maxBody = int64(1 << 20) // 1 MiB
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if int64(len(raw)) > maxBody {
+		return nil, fmt.Errorf("backplane response body exceeds %d bytes", maxBody)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
+	}
+	return raw, nil
+}
+
+func sendRequest(
+	ctx context.Context,
+	client *http.Client,
+	backplaneURL, method, path, bearer string,
+	body []byte,
+) (*http.Response, error) {
+	fullURL := backplaneURL + path
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return client.Do(req)
+}
+
+func loadParamsFlag(val string) (map[string]any, error) {
+	if val == "" {
+		return nil, nil
+	}
+	var raw []byte
+	if strings.HasPrefix(val, "@") {
+		path := strings.TrimPrefix(val, "@")
+		var err error
+		raw, err = os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read params file %q: %w", path, err)
+		}
+	} else {
+		raw = []byte(val)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("parse params JSON: %w", err)
+	}
+	return m, nil
+}
+
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}

--- a/cli/internal/cmd/vcf-automation/vcfa_test.go
+++ b/cli/internal/cmd/vcf-automation/vcfa_test.go
@@ -1,0 +1,660 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package vcfautomation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// ---------- helper tests ----------
+
+func TestTruncatePassthroughAndCut(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     string
+		maxLen int
+		want   string
+	}{
+		{"within budget", "abc", 5, "abc"},
+		{"over budget ascii", "abcdef", 4, "abc…"},
+		{"multi-byte safe", "café world", 5, "café…"},
+		{"zero budget", "x", 0, ""},
+	}
+	for _, tt := range tests {
+		if got := truncate(tt.in, tt.maxLen); got != tt.want {
+			t.Errorf("%s: truncate(%q, %d) = %q; want %q", tt.name, tt.in, tt.maxLen, got, tt.want)
+		}
+	}
+}
+
+func TestNormaliseURLBasic(t *testing.T) {
+	got, err := normaliseURL("https://meho.test/")
+	if err != nil {
+		t.Fatalf("normaliseURL: %v", err)
+	}
+	if got != "https://meho.test" {
+		t.Fatalf("expected trailing slash stripped; got %q", got)
+	}
+	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("empty should reject; got %v", err)
+	}
+}
+
+func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
+	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
+	se := classifyBackplaneError(wrapped)
+	if se == nil || se.Code != "auth_expired" {
+		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
+	}
+	se = classifyBackplaneError(errors.New("parse failure"))
+	if se == nil || se.Code != "unexpected_response" {
+		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
+	}
+}
+
+func TestConnectorIDIsFrozen(t *testing.T) {
+	if ConnectorID != "vcfa-rest-9.0" {
+		t.Fatalf("ConnectorID drifted: got %q want %q", ConnectorID, "vcfa-rest-9.0")
+	}
+}
+
+func TestPlaneConstantsAreFrozen(t *testing.T) {
+	if PlaneProvider != "provider" || PlaneTenant != "tenant" {
+		t.Fatalf("Plane constants drifted: provider=%q tenant=%q", PlaneProvider, PlaneTenant)
+	}
+}
+
+func TestAboutOpForPlane(t *testing.T) {
+	if got := aboutOpForPlane(PlaneProvider); got != "GET:/cloudapi/1.0.0/site" {
+		t.Errorf("provider about op_id: got %q", got)
+	}
+	if got := aboutOpForPlane(PlaneTenant); got != "GET:/iaas/api/about" {
+		t.Errorf("tenant about op_id: got %q", got)
+	}
+	// Defensive: empty / unknown plane → provider (the default
+	// fallback at the dispatcher layer). The CLI never reaches this
+	// branch because requirePlane(...) rejects empty / unknown values
+	// upstream, but covering the fallback keeps the contract honest.
+	if got := aboutOpForPlane(""); got != "GET:/cloudapi/1.0.0/site" {
+		t.Errorf("empty plane should fall back to provider; got %q", got)
+	}
+}
+
+func TestValidatePlaneAcceptsMatchingOrEmpty(t *testing.T) {
+	for _, in := range []string{"", "provider"} {
+		if se := validatePlane(in, PlaneProvider); se != nil {
+			t.Errorf("validatePlane(%q, provider) should accept; got %+v", in, se)
+		}
+	}
+}
+
+func TestValidatePlaneRejectsMismatch(t *testing.T) {
+	se := validatePlane("tenant", PlaneProvider)
+	if se == nil || se.Code != "unexpected_response" {
+		t.Fatalf("validatePlane mismatch should reject; got %+v", se)
+	}
+	if !strings.Contains(se.Detail, "tenant") || !strings.Contains(se.Detail, "provider") {
+		t.Errorf("validatePlane message should name both planes; got %q", se.Detail)
+	}
+}
+
+func TestRequirePlaneRequiresKnownValue(t *testing.T) {
+	if se := requirePlane(""); se == nil || !strings.Contains(se.Detail, "--plane is required") {
+		t.Fatalf("requirePlane('') should reject with --plane is required; got %+v", se)
+	}
+	if se := requirePlane("bogus"); se == nil || !strings.Contains(se.Detail, "unknown") {
+		t.Fatalf("requirePlane('bogus') should reject with unknown; got %+v", se)
+	}
+	if se := requirePlane(PlaneProvider); se != nil {
+		t.Fatalf("requirePlane('provider') should accept; got %+v", se)
+	}
+	if se := requirePlane(PlaneTenant); se != nil {
+		t.Fatalf("requirePlane('tenant') should accept; got %+v", se)
+	}
+}
+
+// ---------- loadParamsFlag ----------
+
+func TestLoadParamsFlagEmpty(t *testing.T) {
+	got, err := loadParamsFlag("")
+	if err != nil || got != nil {
+		t.Fatalf("loadParamsFlag(\"\"): err=%v got=%v", err, got)
+	}
+}
+
+func TestLoadParamsFlagInlineJSON(t *testing.T) {
+	got, err := loadParamsFlag(`{"id":"a1"}`)
+	if err != nil {
+		t.Fatalf("loadParamsFlag: %v", err)
+	}
+	if got["id"] != "a1" {
+		t.Fatalf("inline JSON params not parsed; got %v", got)
+	}
+}
+
+// ---------- decoder tests ----------
+
+func TestDecodeProviderListResultValuesWrapped(t *testing.T) {
+	raw := json.RawMessage(`{"values":[{"id":"o1","name":"acme"}],"resultTotal":1}`)
+	entries, err := decodeProviderListResult(raw)
+	if err != nil {
+		t.Fatalf("decodeProviderListResult: %v", err)
+	}
+	if len(entries) != 1 || entries[0]["id"] != "o1" {
+		t.Fatalf("values-wrapped decode: got %+v", entries)
+	}
+}
+
+func TestDecodeTenantListResultContentWrapped(t *testing.T) {
+	raw := json.RawMessage(`{"content":[{"id":"d1","name":"web"}],"totalElements":1}`)
+	entries, err := decodeTenantListResult(raw)
+	if err != nil {
+		t.Fatalf("decodeTenantListResult: %v", err)
+	}
+	if len(entries) != 1 || entries[0]["name"] != "web" {
+		t.Fatalf("content-wrapped decode: got %+v", entries)
+	}
+}
+
+func TestDecodeProviderListResultEmptyRaw(t *testing.T) {
+	for _, raw := range []json.RawMessage{nil, json.RawMessage(`null`)} {
+		entries, err := decodeProviderListResult(raw)
+		if err != nil || entries != nil {
+			t.Fatalf("decode empty: err=%v entries=%v", err, entries)
+		}
+	}
+}
+
+// ---------- renderers ----------
+
+func TestPrintAboutProviderHumanFormat(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		OpID:       "GET:/cloudapi/1.0.0/site",
+		Result:     json.RawMessage(`{"id":"site-1","name":"VCFA-Site","restName":"vcfa-rdc","productVersion":"9.0.0-12345"}`),
+		DurationMs: 30,
+	}
+	var buf bytes.Buffer
+	printAbout(&buf, PlaneProvider, r)
+	out := buf.String()
+	for _, want := range []string{"status=ok", "vcfa-rest-9.0", "9.0.0-12345", "vcfa-rdc", "VCFA-Site"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printAbout provider missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintAboutTenantHumanFormat(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		OpID:       "GET:/iaas/api/about",
+		Result:     json.RawMessage(`{"latestApiVersion":"2024-01-01","supportedApis":[{"apiVersion":"2024-01-01"}]}`),
+		DurationMs: 12,
+	}
+	var buf bytes.Buffer
+	printAbout(&buf, PlaneTenant, r)
+	out := buf.String()
+	for _, want := range []string{"status=ok", "vcfa-rest-9.0", "2024-01-01", "supported_apis"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printAbout tenant missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintOrgListHumanFormat(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		Result:     json.RawMessage(`{"values":[{"id":"o-1","name":"acme","isEnabled":true}],"resultTotal":1}`),
+		DurationMs: 10,
+	}
+	var buf bytes.Buffer
+	printOrgList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"o-1", "acme", "true"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printOrgList missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintProjectListHumanFormat(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		Result:     json.RawMessage(`{"content":[{"id":"p-1","name":"team-a","organizationId":"org-1"}],"totalElements":1}`),
+		DurationMs: 7,
+	}
+	var buf bytes.Buffer
+	printProjectList(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"p-1", "team-a", "org-1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printProjectList missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintDeploymentListEmpty(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		Result:     json.RawMessage(`{"content":[],"totalElements":0}`),
+		DurationMs: 4,
+	}
+	var buf bytes.Buffer
+	printDeploymentList(&buf, r)
+	if !strings.Contains(buf.String(), "0 deployments") {
+		t.Errorf("empty deployment list should announce 0; got:\n%s", buf.String())
+	}
+}
+
+func TestPrintSearchTable(t *testing.T) {
+	summary := "List tenant deployments"
+	r := &searchResponse{
+		Hits: []searchHit{
+			{OpID: "GET:/iaas/api/deployments", Summary: &summary, FusedScore: 0.95},
+		},
+		QueryDurationMs: 12.0,
+	}
+	var buf bytes.Buffer
+	printSearchTable(&buf, "deployments", r)
+	out := buf.String()
+	for _, want := range []string{"vcfa-rest-9.0", "deployments", "1 hit(s)", "GET:/iaas/api/deployments"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printSearchTable missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// ---------- HTTP wire shape ----------
+
+type mockHandler = http.HandlerFunc
+
+func mockBackplane(t *testing.T, routes map[string]mockHandler) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		if h, ok := routes[key]; ok {
+			h(w, r)
+			return
+		}
+		t.Errorf("mockBackplane: unhandled route %s", key)
+		w.WriteHeader(404)
+	}))
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, body any) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Errorf("writeJSON marshal: %v", err)
+		w.WriteHeader(500)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, err := w.Write(raw); err != nil {
+		t.Errorf("writeJSON write: %v", err)
+	}
+}
+
+func primeToken(t *testing.T, backplaneURL string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	cfg := filepath.Join(dir, "meho", "config.json")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	cfgBlob, _ := json.Marshal(map[string]string{"backplane_url": backplaneURL})
+	if err := os.WriteFile(cfg, cfgBlob, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	store, err := auth.NewTokenStore()
+	if err != nil {
+		t.Fatalf("NewTokenStore: %v", err)
+	}
+	if err := store.Save(service, user, auth.StoredToken{
+		AccessToken:  "test-bearer",
+		BackplaneURL: backplaneURL,
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+}
+
+// TestDispatchOpBakesConnectorID — pins that connector_id="vcfa-rest-9.0"
+// is sent on every alias-verb dispatch.
+func TestDispatchOpBakesConnectorID(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.ConnectorID != "vcfa-rest-9.0" {
+				t.Errorf("connector_id: got %q want vcfa-rest-9.0", body.ConnectorID)
+			}
+			if body.OpID != "GET:/cloudapi/1.0.0/site" {
+				t.Errorf("op_id: got %q", body.OpID)
+			}
+			writeJSON(t, w, 200, CallResult{
+				Status: "ok",
+				OpID:   "GET:/cloudapi/1.0.0/site",
+				Result: json.RawMessage(`{"id":"site-1","name":"VCFA"}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	r, err := dispatchOp(context.Background(), srv.URL, "GET:/cloudapi/1.0.0/site", "rdc-vcfa", "", nil)
+	if err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+	if r.Status != "ok" {
+		t.Fatalf("dispatch status: %s", r.Status)
+	}
+}
+
+// TestDispatchOpEmptyTargetSendsNullTarget — empty slug → null target on wire.
+func TestDispatchOpEmptyTargetSendsNullTarget(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var raw map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if raw["target"] != nil {
+				t.Errorf("empty target should be null on wire; got %v", raw["target"])
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: "GET:/iaas/api/about"})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	if _, err := dispatchOp(context.Background(), srv.URL, "GET:/iaas/api/about", "", "", nil); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
+// TestDispatchOpThreadsFqdnIntoTargetBody — load-bearing per #840:
+// when --fqdn is set, the dispatch body's target dict carries
+// `fqdn` alongside `name` so the backend can override the resolved
+// target's vhost. Without this the IP-only target use case fails
+// with a silent 404 from the appliance.
+func TestDispatchOpThreadsFqdnIntoTargetBody(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.Target == nil {
+				t.Errorf("target should be present when --fqdn is set")
+				w.WriteHeader(400)
+				return
+			}
+			if got := body.Target["name"]; got != "rdc-vcfa" {
+				t.Errorf("target.name: got %v want rdc-vcfa", got)
+			}
+			if got := body.Target["fqdn"]; got != "vcfa.rdc.example.com" {
+				t.Errorf("target.fqdn: got %v want vcfa.rdc.example.com", got)
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	const opID = "GET:/cloudapi/1.0.0/site"
+	if _, err := dispatchOp(context.Background(), srv.URL, opID, "rdc-vcfa", "vcfa.rdc.example.com", nil); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
+// TestDispatchOpOmitsFqdnWhenEmpty — when the operator did not pass
+// --fqdn, the body's target dict carries only `name`. Threading an
+// empty string would override the registry's stored fqdn with a
+// blank value, which would defeat the per-target configuration.
+func TestDispatchOpOmitsFqdnWhenEmpty(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if _, present := body.Target["fqdn"]; present {
+				t.Errorf("target.fqdn must be absent when --fqdn is empty; got body.Target=%v", body.Target)
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	if _, err := dispatchOp(context.Background(), srv.URL, "GET:/cloudapi/1.0.0/site", "rdc-vcfa", "", nil); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
+// TestDispatchGetByIdSubstitutesPathParam — the `org get <id>` verb
+// passes `id` in params for the dispatcher's `_substitute_path` to
+// fill the `{id}` placeholder.
+func TestDispatchGetByIdSubstitutesPathParam(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			id, _ := body.Params["id"].(string)
+			if id != "abc123" {
+				t.Errorf("params.id: got %q want abc123", id)
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	params := map[string]any{"id": "abc123"}
+	if _, err := dispatchOp(context.Background(), srv.URL, "GET:/cloudapi/1.0.0/orgs/{id}", "rdc-vcfa", "", params); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
+// TestRootCmdHasPlaneAndFqdnPersistentFlags — sanity check that the
+// persistent flags ship; per-verb tests below assert the threading.
+func TestRootCmdHasPlaneAndFqdnPersistentFlags(t *testing.T) {
+	cmd := NewRootCmd()
+	if cmd.PersistentFlags().Lookup("plane") == nil {
+		t.Errorf("--plane persistent flag missing on vcf-automation root")
+	}
+	if cmd.PersistentFlags().Lookup("fqdn") == nil {
+		t.Errorf("--fqdn persistent flag missing on vcf-automation root")
+	}
+}
+
+// TestAboutVerbDispatchesPerPlane — exercises the full Cobra invocation
+// path (RunE → runAbout → dispatchOp → mock backplane) for both
+// planes, asserting the wire shape (op_id + connector_id + target.name).
+func TestAboutVerbDispatchesPerPlane(t *testing.T) {
+	type wireCheck struct {
+		plane       string
+		expectedOp  string
+		responseRes string
+	}
+	cases := []wireCheck{
+		{
+			plane:       PlaneProvider,
+			expectedOp:  "GET:/cloudapi/1.0.0/site",
+			responseRes: `{"id":"site-1","name":"VCFA"}`,
+		},
+		{
+			plane:       PlaneTenant,
+			expectedOp:  "GET:/iaas/api/about",
+			responseRes: `{"latestApiVersion":"2024-01-01"}`,
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.plane, func(t *testing.T) {
+			var capturedOpID string
+			srv := mockBackplane(t, map[string]mockHandler{
+				"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+					var body callRequestBody
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Errorf("decode body: %v", err)
+						w.WriteHeader(400)
+						return
+					}
+					capturedOpID = body.OpID
+					writeJSON(t, w, 200, CallResult{
+						Status: "ok",
+						OpID:   body.OpID,
+						Result: json.RawMessage(tc.responseRes),
+					})
+				},
+			})
+			defer srv.Close()
+			primeToken(t, srv.URL)
+
+			root := NewRootCmd()
+			root.SetArgs([]string{
+				"about",
+				"--plane", tc.plane,
+				"--target", "rdc-vcfa",
+				"--backplane", srv.URL,
+			})
+			root.SetOut(&bytes.Buffer{})
+			root.SetErr(&bytes.Buffer{})
+			if err := root.Execute(); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			if capturedOpID != tc.expectedOp {
+				t.Errorf("dispatch op_id for plane %s: got %q want %q", tc.plane, capturedOpID, tc.expectedOp)
+			}
+		})
+	}
+}
+
+// TestAboutVerbRejectsMissingPlane — `about` is dual-plane; --plane
+// is required. Cobra exits with a structured error when omitted.
+func TestAboutVerbRejectsMissingPlane(t *testing.T) {
+	root := NewRootCmd()
+	root.SetArgs([]string{"about", "--target", "rdc-vcfa", "--backplane", "https://meho.test.invalid"})
+	var stderr bytes.Buffer
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&stderr)
+	err := root.Execute()
+	if err == nil {
+		t.Fatalf("expected error for missing --plane; got nil")
+	}
+	if !strings.Contains(stderr.String(), "--plane is required") {
+		t.Errorf("stderr should mention --plane is required; got:\n%s", stderr.String())
+	}
+}
+
+// TestProjectListRejectsProviderPlane — tenant-only verbs error when
+// the operator passes --plane provider (catches the wrong-plane typo
+// before dispatch).
+func TestProjectListRejectsProviderPlane(t *testing.T) {
+	root := NewRootCmd()
+	root.SetArgs([]string{"project", "list", "--plane", "provider", "--target", "rdc-vcfa", "--backplane", "https://meho.test.invalid"})
+	var stderr bytes.Buffer
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&stderr)
+	err := root.Execute()
+	if err == nil {
+		t.Fatalf("expected error for --plane provider on tenant verb; got nil")
+	}
+	if !strings.Contains(stderr.String(), "tenant") || !strings.Contains(stderr.String(), "provider") {
+		t.Errorf("stderr should name both planes; got:\n%s", stderr.String())
+	}
+}
+
+// TestOrgListRejectsTenantPlane — mirror of the above for a
+// provider-plane verb.
+func TestOrgListRejectsTenantPlane(t *testing.T) {
+	root := NewRootCmd()
+	root.SetArgs([]string{"org", "list", "--plane", "tenant", "--target", "rdc-vcfa", "--backplane", "https://meho.test.invalid"})
+	var stderr bytes.Buffer
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&stderr)
+	err := root.Execute()
+	if err == nil {
+		t.Fatalf("expected error for --plane tenant on provider verb; got nil")
+	}
+}
+
+// TestDeploymentListThreadsFqdn — load-bearing end-to-end check: the
+// --fqdn persistent flag flows through the deployment list verb's
+// dispatch into the body's target.fqdn field.
+func TestDeploymentListThreadsFqdn(t *testing.T) {
+	var capturedFqdn any
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.Target != nil {
+				capturedFqdn = body.Target["fqdn"]
+			}
+			writeJSON(t, w, 200, CallResult{
+				Status: "ok",
+				OpID:   body.OpID,
+				Result: json.RawMessage(`{"content":[],"totalElements":0}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	root := NewRootCmd()
+	root.SetArgs([]string{
+		"deployment", "list",
+		"--target", "rdc-vcfa",
+		"--fqdn", "vcfa.rdc.example.com",
+		"--backplane", srv.URL,
+	})
+	root.SetOut(&bytes.Buffer{})
+	root.SetErr(&bytes.Buffer{})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if capturedFqdn != "vcfa.rdc.example.com" {
+		t.Errorf("expected target.fqdn=vcfa.rdc.example.com on the wire; got %v", capturedFqdn)
+	}
+}
+
+// TestErrOpErrorIsSentinel — pins the exported sentinel.
+func TestErrOpErrorIsSentinel(t *testing.T) {
+	if errOpError == nil {
+		t.Fatal("errOpError should be non-nil")
+	}
+}

--- a/docs/cross-repo/vcf-automation-onboarding.md
+++ b/docs/cross-repo/vcf-automation-onboarding.md
@@ -1,0 +1,497 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# VCF Automation op surface onboarding — operator recipe
+
+> Operator-facing recipe for the G3.6 `vcfa-rest-9.0` op surface — the
+> `meho vcf-automation …` verb tree, the agent meta-tool path, and the
+> migration off the consumer's `scripts/vcf-automation.sh` wrapper.
+> The op handlers live in
+> [`backend/src/meho_backplane/connectors/vcf_automation/`](../../backend/src/meho_backplane/connectors/vcf_automation/);
+> the canary procedure that ingests + curates the dual-plane op set
+> lives in [`g36-vcfa-canary.md`](./g36-vcfa-canary.md).
+> This doc is the cookbook every RDC operator reads when retiring
+> `scripts/vcf-automation.sh` in favour of `meho vcf-automation …`.
+
+## What this surface is
+
+The `vcfa-rest-9.0` connector is an **ingested, dual-plane** connector.
+The 11 curated read-only ops are stored as `EndpointDescriptor` rows
+seeded from
+[`VCFA_CORE_OPS`](../../backend/src/meho_backplane/connectors/vcf_automation/core_ops.py)
+and dispatched through `HttpConnector._request_json` by the G0.6
+`dispatch_ingested` branch. The connector registers under the
+`(product="vcf-automation", version="9.0", impl_id="vcfa-rest")`
+registry triple — the connector id `vcfa-rest-9.0`.
+
+VCFA 9.x is structurally different from the other three VCF
+management-plane connectors (vROps, vRLI, Fleet) in two load-bearing
+ways. Both shaped the CLI surface this doc covers.
+
+### Dual-plane auth (provider + tenant)
+
+VCFA 9.x runs two API planes on a single appliance:
+
+| Plane | Path family | Login flow | Token shape |
+| --- | --- | --- | --- |
+| **provider** | `/cloudapi/*` + `/api/*` (vCloud-Director lineage) | `POST /cloudapi/1.0.0/sessions/provider` with HTTP Basic | `X-VMWARE-VCLOUD-ACCESS-TOKEN` response **header** (a JWT) |
+| **tenant** | `/iaas/api/*` (Aria-IaaS lineage) | `POST /iaas/api/login` with JSON body | `{"token": "…"}` response **body** |
+
+Both planes use `Authorization: Bearer <…>` on subsequent calls; the
+provider Accept media type is path-family-dependent
+(`application/json;version=9.0.0` for `/cloudapi/*`,
+`application/*+json;version=40.0` for the classic `/api/*` family);
+the tenant plane uses plain `application/json`. Tokens are bespoke
+per plane — the provider JWT does **not** authenticate the tenant
+plane and vice versa.
+
+The connector's per-plane token caches and the load-bearing per-plane
+401 retry-once dance are documented inline in the connector source
+([`connector.py`](../../backend/src/meho_backplane/connectors/vcf_automation/connector.py));
+operators don't see any of it from the CLI surface. What operators
+**do** see is the `--plane provider|tenant` flag on every verb that
+isn't unambiguous from the resource name (today: only `about`).
+
+### Vhost (`Host:`) routing
+
+VCFA enforces strict `Host:` header matching. When the appliance is
+reached by IP and the `Host:` header doesn't match the canonical
+appliance vhost, **every path returns 404 with an empty body** before
+the application sees the request. The consumer wrapper documents
+this as the silent-404 failure mode, and the connector raises
+`VcfAutomationConfigurationError` at session-establish time when:
+
+- `target.host` parses as an IP literal (IPv4 or IPv6, bracketed or bare), **and**
+- `target.fqdn` is unset.
+
+When `target.host` is itself an FQDN, `fqdn` is optional — the URL
+host already carries the right vhost. The CLI exposes the override
+two ways:
+
+- **`fqdn:` in `targets.yaml`** — the canonical home. The `meho
+  targets import` verb knows the field; the value persists on the
+  Target row and applies to every dispatch against that target.
+- **`--fqdn <vhost>` on the dispatch verb** — a per-call override
+  for debugging or for targets whose canonical FQDN drifted. The
+  override flows through the dispatch body's `target.fqdn` field;
+  the backend mutates the resolved Target **in memory only** for
+  the duration of that one dispatch. The DB row is unchanged.
+
+If you're reaching VCFA by FQDN already, neither setting matters.
+If you're reaching it by IP and you forget `fqdn:`, the dispatcher
+returns a structured `status="error"` envelope whose
+`extras.exception_message` names the offending IP and the `fqdn`
+field — operators see a clear remediation message rather than a
+confusing 404 storm.
+
+## The v0.5 op surface
+
+Initiative
+[#369](https://github.com/evoila/meho/issues/369) ships the **read**
+working set as 11 curated ops, distributed across both planes:
+
+| Plane | Group | CLI verb | `op_id` |
+| --- | --- | --- | --- |
+| provider | `provider-site` | `meho vcf-automation about --plane provider` | `GET:/cloudapi/1.0.0/site` |
+| provider | `provider-orgs` | `meho vcf-automation org list` | `GET:/cloudapi/1.0.0/orgs` |
+| provider | `provider-orgs` | `meho vcf-automation org get <id>` | `GET:/cloudapi/1.0.0/orgs/{id}` |
+| provider | `provider-regions` | `meho vcf-automation region list` | `GET:/cloudapi/1.0.0/regions` |
+| provider | `provider-regions` | `meho vcf-automation region get <id>` | `GET:/cloudapi/1.0.0/regions/{id}` |
+| provider | `provider-users` | `meho vcf-automation user list` | `GET:/cloudapi/1.0.0/users` |
+| tenant | `tenant-about` | `meho vcf-automation about --plane tenant` | `GET:/iaas/api/about` |
+| tenant | `tenant-projects` | `meho vcf-automation project list` | `GET:/iaas/api/projects` |
+| tenant | `tenant-deployments` | `meho vcf-automation deployment list` | `GET:/iaas/api/deployments` |
+| tenant | `tenant-deployments` | `meho vcf-automation deployment get <id>` | `GET:/iaas/api/deployments/{id}` |
+| tenant | `tenant-blueprints` | `meho vcf-automation blueprint list` | `GET:/iaas/api/blueprints` |
+
+Every op dispatches through the same `POST /api/v1/operations/call`
+route the agent surface uses — auth, policy, audit, broadcast, and
+JSONFlux all run as documented in [CLAUDE.md](../../CLAUDE.md) §6.
+The CLI verb tree is operator ergonomics over that one route; it is
+**not** a separate data path and is **not** mirrored on the MCP
+surface (CLAUDE.md postulate 5). The MCP agent reaches the same ops
+through `search_operations` / `call_operation` against
+`connector_id="vcfa-rest-9.0"`; the per-op `llm_instructions` (set
+during operator review) carry the plane-aware guidance the agent
+inlines into its reasoning context.
+
+## Prerequisites
+
+- **A reachable VCFA 9.x appliance.** The connector derives the
+  base URL from `target.host` + `target.port`; **if `host` is an IP
+  literal, set `fqdn:` in `targets.yaml`** to the appliance's
+  canonical FQDN. Without it the connector refuses to establish a
+  session and emits a structured error naming `fqdn`.
+- **Service-account credentials in Vault.** The connector reads
+  `{"username": …, "password": …}` from Vault at
+  `target.secret_ref`. The same credential pair drives both planes
+  unless `target.provider_username` /
+  `target.provider_secret_ref` are set (the `admin@System` vs
+  `svc-meho` split — see "Per-plane credential override" below).
+- **A registered VCFA target.** The CLI verbs take `--target <slug>`
+  (e.g. `--target rdc-vcfa`). The target carries
+  `product="vcf-automation"`, `host`, `port` (default 443), `fqdn`
+  (when reached by IP), `secret_ref`, and
+  `auth_model="shared_service_account"`. v0.5 supports only
+  `shared_service_account`; other auth models surface a clear
+  `NotImplementedError` at dispatch time.
+- **The 11 curated ops registered + enabled.** Run the G3.6-T11
+  curation step (`apply_vcfa_core_curation`) once per VCFA target
+  after the G0.7 dual-spec ingest. See
+  [`g36-vcfa-canary.md`](./g36-vcfa-canary.md) for the end-to-end
+  canary procedure.
+- **An operator session.** `meho login <backplane-url>` writes the
+  session token the CLI reuses. `meho vcf-automation …` requires
+  `operator` role minimum (same gate as every dispatch verb).
+
+## Target + auth model
+
+The shipped connector's auth model is **`shared_service_account`** —
+the Vault-sourced credentials are used regardless of which operator
+invokes the verb. Per-operator impersonation is out of scope for v0.5.
+
+### Standard target (provider + tenant share credentials)
+
+```bash
+meho targets import path/to/targets.yaml
+```
+
+…with `targets.yaml` containing:
+
+```yaml
+targets:
+  - name: rdc-vcfa
+    product: vcf-automation
+    host: 10.5.50.100       # IP host requires fqdn below
+    port: 443
+    fqdn: vcfa.rdc.evoila.io  # canonical vhost
+    secret_ref: kv/data/vcfa/rdc-vcfa
+    auth_model: shared_service_account
+```
+
+### Per-plane credential override (admin@System vs svc-meho)
+
+When the provider plane needs a distinct service account (the typical
+`admin@System` posture documented in the consumer wrapper), add the
+override fields:
+
+```yaml
+targets:
+  - name: rdc-vcfa
+    product: vcf-automation
+    host: vcfa.rdc.evoila.io
+    port: 443
+    secret_ref: kv/data/vcfa/rdc-vcfa-tenant      # tenant credentials
+    auth_model: shared_service_account
+    extras:
+      provider_username: admin@System            # provider Basic-auth user
+      provider_secret_ref: kv/data/vcfa/rdc-vcfa-admin  # provider credentials
+```
+
+(The two override fields live under `extras:` until the Target schema
+lands them as first-class columns — tracked under Goal #214.)
+
+Verify the fingerprint resolved both planes:
+
+```bash
+meho targets probe --name rdc-vcfa --json \
+  | jq '{product, version, reachable, planes: .extras.planes}'
+# expected: {"product": "vcf-automation", "version": "9.0",
+#            "reachable": true, "planes": ["provider", "tenant"]}
+```
+
+## Quick-start
+
+```bash
+# Identity per plane (dual-plane verb)
+meho vcf-automation about --plane provider --target rdc-vcfa
+meho vcf-automation about --plane tenant   --target rdc-vcfa
+
+# Provider plane — appliance-wide inventory
+meho vcf-automation org list      --target rdc-vcfa
+meho vcf-automation org get a1b2c3 --target rdc-vcfa
+meho vcf-automation region list   --target rdc-vcfa
+meho vcf-automation region get r1 --target rdc-vcfa
+meho vcf-automation user list     --target rdc-vcfa
+
+# Tenant plane — per-tenant workload view
+meho vcf-automation project list      --target rdc-vcfa
+meho vcf-automation deployment list   --target rdc-vcfa
+meho vcf-automation deployment get d1 --target rdc-vcfa
+meho vcf-automation blueprint list    --target rdc-vcfa
+
+# Machine-readable output for any verb (the agent / scripting path)
+meho vcf-automation deployment list --target rdc-vcfa --json \
+  | jq '.result.content[] | {id, name, status}'
+
+# Per-call vhost override (debugging or transient FQDN drift)
+meho vcf-automation about --plane provider --target rdc-vcfa \
+  --fqdn vcfa.maintenance.evoila.io
+
+# Escape hatch — run any vcfa-rest-9.0 op_id by name
+meho vcf-automation operation call GET:/cloudapi/1.0.0/site --target rdc-vcfa
+meho vcf-automation operation search "deployment status" --group tenant-deployments
+```
+
+## Verb reference
+
+### `meho vcf-automation about --plane provider|tenant`
+
+Dual-plane verb. `--plane` is **required** because the resource name
+"about" exists on both planes with different shapes:
+
+- **`--plane provider`** dispatches `GET:/cloudapi/1.0.0/site` and
+  renders site identity (`id`, `name`, `restName`, `productVersion`).
+- **`--plane tenant`** dispatches `GET:/iaas/api/about` and renders
+  IaaS API self-describe (`latestApiVersion`, `supportedApis[]`).
+
+Omitting `--plane` fails fast with an explicit message — no silent
+default.
+
+### `meho vcf-automation org list` / `org get <id>`
+
+Provider-plane only. List enumerates every organization on the
+appliance (the cross-tenant view the system administrator sees);
+`get` returns full detail for one organization id including counts
+(`orgVdcCount`, `userCount`, `catalogCount`). For per-tenant project
+/ deployment / blueprint reads, switch planes to the tenant verbs.
+
+Passing `--plane tenant` on these verbs errors early with a
+"--plane provider expected" message.
+
+### `meho vcf-automation region list` / `region get <id>`
+
+Provider-plane only. Lists VCFA "regions" — the VCFA 9 evolution of
+the vCloud-Director provider-VDC concept. Each region maps to one NSX
+domain plus a collection of supervisors backed by one or more VCF
+workload domains.
+
+### `meho vcf-automation user list`
+
+Provider-plane only. System-scope users (the System organization's
+identity entries plus any cross-org provider-scope users). Use when
+auditing who has provider-level access; per-tenant users live behind
+the per-org user endpoints that are not in the v0.5 read core.
+
+### `meho vcf-automation project list`
+
+Tenant-plane only. Projects are the deployment-scoping construct —
+every deployment belongs to exactly one project, and blueprint access
+controls reference project membership.
+
+### `meho vcf-automation deployment list` / `deployment get <id>`
+
+Tenant-plane only. The largest payload on the tenant surface; large
+tenants return hundreds of deployments. The dispatcher's JSONFlux
+seam wraps oversized responses in a `ResultHandle`; use the
+`result_describe` / `result_query` meta-tools to navigate. The
+`--json` rendering of the list verb shows the raw envelope; the
+default human render shows `id`, `name`, `status`, `blueprintId`.
+
+### `meho vcf-automation blueprint list`
+
+Tenant-plane only. The templates deployments instantiate. Cross-
+reference the blueprint id against `blueprintId` on
+`deployment list` results to identify which deployments instantiated
+which blueprint.
+
+### `meho vcf-automation operation search` / `operation call`
+
+Meta-tool wrappers pre-scoped to `vcfa-rest-9.0`. `search` runs the
+hybrid BM25+cosine search across vcfa-rest-9.0 op descriptors;
+`call` dispatches any op_id directly. Use these for ops not yet
+promoted to dedicated CLI aliases.
+
+The raw op_id already encodes its plane via the path prefix; the
+`--plane` flag is **ignored** on `operation call` (use the right
+op_id). The persistent `--fqdn` flag still threads into the body.
+
+```bash
+meho vcf-automation operation search "deployments" --group tenant-deployments
+meho vcf-automation operation call GET:/iaas/api/about --target rdc-vcfa
+```
+
+## Audit and broadcast classification
+
+Every VCFA v0.5 op is `safety_level=safe`, `requires_approval=false` —
+the read-only surface never mutates state. The audit row carries:
+`method='DISPATCH'`, `path=<op_id>`, `target_id=<uuid>`,
+`payload={"op_id": …, "params_hash": …, "source_kind": "ingested",
+"connector_product": "vcf-automation", "connector_version": "9.0",
+"connector_impl_id": "vcfa-rest", "result_status": "ok"|"error"}`.
+
+Broadcast events publish per-tenant on every successful dispatch.
+`meho audit query --connector vcfa-rest-9.0` retrieves the full
+dispatch history; filter by op_id to focus on one plane (`--op-id
+GET:/iaas/api/deployments`).
+
+## Migrating off `scripts/vcf-automation.sh`
+
+The consumer's
+[`scripts/vcf-automation.sh`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/vcf-automation.sh)
+drives VCFA REST via a `curl` + per-plane session wrapper. The
+`meho vcf-automation` verbs replace it for the read-only workflows;
+write workflows stay in the wrapper.
+
+| Consumer workflow | `vcf-automation.sh` invocation | `meho vcf-automation …` replacement | Notes |
+| --- | --- | --- | --- |
+| Provider identity | `vcf-automation.sh provider-about` | `meho vcf-automation about --plane provider --target rdc-vcfa` | |
+| Tenant identity | `vcf-automation.sh tenant-about` | `meho vcf-automation about --plane tenant --target rdc-vcfa` | |
+| Org listing | `vcf-automation.sh orgs` | `meho vcf-automation org list --target rdc-vcfa` | |
+| Org detail | `vcf-automation.sh org <id>` | `meho vcf-automation org get <id> --target rdc-vcfa` | |
+| Region (VDC) listing | `vcf-automation.sh regions` | `meho vcf-automation region list --target rdc-vcfa` | |
+| Project listing | `vcf-automation.sh projects` | `meho vcf-automation project list --target rdc-vcfa` | |
+| Deployment listing | `vcf-automation.sh deployments` | `meho vcf-automation deployment list --target rdc-vcfa` | JSONFlux handle returned on large tenants — use `result_describe` |
+| Deployment detail | `vcf-automation.sh deployment <id>` | `meho vcf-automation deployment get <id> --target rdc-vcfa` | |
+| Blueprint listing | `vcf-automation.sh blueprints` | `meho vcf-automation blueprint list --target rdc-vcfa` | |
+
+What `scripts/vcf-automation.sh` did that `meho vcf-automation`
+deliberately does **not** do (out of scope for v0.5):
+
+- **Write / mutate ops** — catalog deployment, blueprint create,
+  IaaS machine lifecycle (delete / power / resize). v0.5 is
+  read-only; write ops land in v0.5.next pending policy + approval
+  workflow.
+- **Per-org tenant-context switching** — the wrapper supports
+  `--org <name>` to switch the tenant context per call; the
+  connector's `target.domain` is the per-target setting (one tenant
+  context per target). Operators register multiple VCFA targets
+  (`rdc-vcfa-acme`, `rdc-vcfa-globex`) to switch contexts.
+- **Custom query parameters** — `vcf-automation.sh` passes raw
+  query strings; the v0.5 CLI exposes only the parameters each op
+  formally declares in its descriptor. Use `meho vcf-automation
+  operation call <op_id> --params '{"$filter": "…", "$top": 100}'`
+  for OData pagination / filtering.
+
+### Per-ticket wrapper-flip recipe
+
+For each active VCFA consumer ticket, apply this pattern:
+
+1. **Identify the wrapper invocation** in the ticket's
+   reproduction steps (usually
+   `bash scripts/vcf-automation.sh <command>`).
+2. **Find the `meho vcf-automation` equivalent** from the table
+   above. Confirm the right plane (`--plane provider|tenant` on
+   `about`; explicit per-resource verb otherwise).
+3. **Confirm the target's `fqdn`** is set if the target's `host`
+   is an IP. Without it the first dispatch surfaces a configuration
+   error — set `fqdn:` in `targets.yaml` and re-run
+   `meho targets import --update <file>`.
+4. **Validate output parity**: run both side-by-side against
+   `rdc-vcfa`. Use `--json | jq` on the `meho vcf-automation` side
+   to pull the same fields the bash script was parsing.
+5. **Update the ticket steps**: replace the `vcf-automation.sh`
+   invocation with the `meho vcf-automation` form. Capture the
+   `--json` output for the ticket's evidence block.
+6. **Retire the wrapper call site** in the ticket's automation
+   scripts once the MEHO form is validated.
+
+Example — tenant deployment listing (the workhorse query):
+
+```bash
+# Before (wrapper):
+bash scripts/vcf-automation.sh deployments rdc-vcfa | jq '.[].id'
+
+# After (meho vcf-automation):
+meho vcf-automation deployment list --target rdc-vcfa --json \
+  | jq '.result.content[].id'
+
+# Verify parity:
+diff \
+  <(bash scripts/vcf-automation.sh deployments rdc-vcfa | jq -S '.[].id') \
+  <(meho vcf-automation deployment list --target rdc-vcfa --json \
+      | jq -S '.result.content[].id')
+# expected: empty diff
+```
+
+Example — provider region detail (post-VCFA-9 evolution of the vCD
+provider-VDC concept):
+
+```bash
+# Before:
+bash scripts/vcf-automation.sh region <region-id> rdc-vcfa
+
+# After:
+meho vcf-automation region get <region-id> --target rdc-vcfa
+```
+
+## The `--fqdn` checklist (load-bearing)
+
+This is the single most likely failure mode operators hit on the
+first dispatch against a new VCFA target. Symptoms:
+
+- `meho vcf-automation about --plane provider --target …` returns
+  `status=error` with `extras.exception_message` containing the
+  IP literal and the word `fqdn`.
+
+The fix:
+
+1. **Inspect the target.** `meho targets describe --name rdc-vcfa`
+   should show a populated `fqdn:` field. If it doesn't, the
+   `targets.yaml` import didn't include the field (or the operator
+   imported before `fqdn:` was added).
+2. **Set `fqdn:` in `targets.yaml`** to the appliance's canonical
+   FQDN — the value returned by `dig +short PTR <vcfa-ip>` or the
+   `cn` / `subjectAltName` on the appliance's TLS cert. Re-import
+   with `meho targets import --update <file>`.
+3. **Verify with `meho targets probe`.** A green probe confirms
+   the connector reached the appliance through the FQDN-rooted base
+   URL — every subsequent dispatch will work.
+4. **As a debugging override**, pass `--fqdn <vhost>` on a single
+   dispatch:
+
+   ```bash
+   meho vcf-automation about --plane provider --target rdc-vcfa \
+     --fqdn vcfa.rdc.evoila.io
+   ```
+
+   The override is in-memory only (the persisted Target row is not
+   modified). Use this when the canonical FQDN drifts during
+   maintenance and you want to confirm the new vhost works before
+   updating `targets.yaml`.
+
+## Goal #214 G3.6 VCFA checklist
+
+| Checklist item | Status |
+| --- | --- |
+| G3.6-T10 #832 — `VcfAutomationConnector` skeleton + dual-plane auth + vhost routing | ✅ merged |
+| G3.6-T11 #836 — Dual-spec ingestion + 11-op core curation | ✅ merged |
+| G3.6-T12 #840 — CLI verbs + E2E recorded-fixture + this doc | ✅ this PR |
+| MCP `llm_instructions` / `when_to_use` reviewed for plane-aware agent legibility | ✅ done (#836 curation blobs name their plane explicitly) |
+| Both auth planes work end-to-end via `call_operation` in CI | ✅ `test_connectors_vcf_automation_e2e.py` |
+| Audit rows carry `op_id` + `target_id` + `params_hash` | ✅ `test_connectors_vcf_automation_e2e.py` |
+| JSONFlux handle path tested (deployment list) | ✅ `test_connectors_vcf_automation_e2e.py` |
+| Vhost (`--fqdn`) override threads end-to-end | ✅ `test_connectors_vcf_automation_e2e.py` |
+| IP-host-without-`fqdn` surfaces descriptive error (not blank 404) | ✅ `test_connectors_vcf_automation_e2e.py` |
+| `docs/cross-repo/vcf-automation-onboarding.md` with wrapper-flip recipe | ✅ this document |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `--plane is required for this verb` on `about` | `about` is dual-plane; no implicit default. | Pass `--plane provider` or `--plane tenant`. |
+| `--plane "tenant" is invalid for this verb` (on `org list`, etc.) | Wrong plane for the verb. | Omit `--plane` or pass the matching one (`--plane provider` for org/region/user; `--plane tenant` for project/deployment/blueprint). |
+| `status=error connector_error: VcfAutomationConfigurationError` with `fqdn` in the message | IP-host target with no `fqdn`. | Set `fqdn:` in `targets.yaml`; re-import. See "The `--fqdn` checklist". |
+| `status=error connector_error: RuntimeError … HTTP 401` on provider plane | Provider account locked / wrong `provider_username`. | Verify the `provider_secret_ref` Vault secret; check VCFA UI for account lockout. |
+| `status=error connector_error: RuntimeError … HTTP 401` on tenant plane | Tenant account doesn't have access to the org. | Verify `target.domain` matches the tenant org; verify the credential has tenant-side roles. |
+| `status=error connector_error: RuntimeError … vcf-automation provider session re-login failed` (HTTP 401 after refresh) | Provider credentials consistently rejected. | Update the provider Vault secret; restart the backplane to flush the in-process session caches. |
+| `status=error … unknown_op` | The 11 core ops are not registered/enabled. | Re-run `apply_vcfa_core_curation` against the VCFA connector; see [`g36-vcfa-canary.md`](./g36-vcfa-canary.md). |
+| `status=denied` | `read_only` role, or a tenant policy denied the dispatch. | Use an `operator`-role token. |
+| Connection times out | VCFA appliance unreachable from the backplane host. | Verify the FQDN resolves from the backplane; check firewall rules (port 443 from backplane → VCFA). |
+| Probe fails with TLS error | Self-signed or expired certificate, or wrong CA bundle. | Mount the correct CA bundle in the backplane container and set `MEHO_TLS_CA_BUNDLE`; or replace the VCFA cert with a CA-signed one. |
+| Deployment list returns a handle envelope without rows | JSONFlux reducer wrapped the payload because it exceeded the inline threshold. | Use `result_describe <handle_id>` + `result_query <handle_id> …` to navigate; or pass `--json` to inspect the full envelope. |
+
+## References
+
+- Initiative: [#369 G3.6 tier-3 VCF management plane](https://github.com/evoila/meho/issues/369);
+  Goal [#214](https://github.com/evoila/meho/issues/214) (connector parity).
+- Tasks that shipped this surface: [#832](https://github.com/evoila/meho/issues/832) (T10 skeleton + dual-plane auth + vhost routing), [#836](https://github.com/evoila/meho/issues/836) (T11 dual-spec ingest + 11-op curation), [#840](https://github.com/evoila/meho/issues/840) (T12 CLI verbs + E2E + this doc).
+- Canary procedure (G0.7 dual-spec ingest → curation): [`g36-vcfa-canary.md`](./g36-vcfa-canary.md).
+- Connector source: [`backend/src/meho_backplane/connectors/vcf_automation/`](../../backend/src/meho_backplane/connectors/vcf_automation/).
+- CLI verbs: [`cli/internal/cmd/vcf-automation/`](../../cli/internal/cmd/vcf-automation/).
+- E2E integration test: [`backend/tests/test_connectors_vcf_automation_e2e.py`](../../backend/tests/test_connectors_vcf_automation_e2e.py).
+- Consumer wrapper retiring: [`scripts/vcf-automation.sh`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/vcf-automation.sh).
+- VCFA Automation API references: provider [<https://developer.broadcom.com/xapis/vmware-cloud-foundation-automation-api/latest/>], tenant [<https://developer.broadcom.com/xapis/aria-automation-api/latest/>].
+- Related onboarding docs: [`vault-onboarding.md`](./vault-onboarding.md), [`audit-query.md`](./audit-query.md), [`targets-yaml.md`](./targets-yaml.md), sibling tier-3 connectors (vROps / vRLI / Fleet via #837/#838/#839).


### PR DESCRIPTION
## Summary

- Ships the operator-facing surface for the G3.6 VCF Automation 9.x connector — the new `meho vcf-automation` Cobra verb tree (11 curated read-only ops; 6 provider + 5 tenant) plus operation search/call meta-tool wrappers. Every verb pre-bakes `connector_id="vcfa-rest-9.0"` and routes through `POST /api/v1/operations/call`.
- Wires the dual-plane shape end-to-end: a persistent `--plane provider|tenant` flag picks the op namespace and the backend dispatcher routes each call to the correct auth plane (`/cloudapi/*` provider JWT vs `/iaas/api/*` tenant bearer). Verbs unique to one plane (org/region/user provider; project/deployment/blueprint tenant) reject the wrong `--plane` early; `about` is dual-plane and requires the flag.
- Wires the vhost (`--fqdn`) flag end-to-end. VCFA enforces strict `Host:` routing; without the right vhost the appliance silently 404s. The CLI flag threads into the dispatch body's `target.fqdn` field as a per-call override (canonical home is still `fqdn:` in `targets.yaml`). Backend's `call_operation` honours the override as an in-memory mutation of the resolved Target (DB row unchanged); MCP tool schema documents the field.
- Adds `backend/tests/test_connectors_vcf_automation_e2e.py` — recorded-fixture E2E covering all #840 acceptance criteria: 11 ops dispatching across both planes, per-plane session establishment and token caching, audit-row shape, JSONFlux handle path on the deployment list, per-call `fqdn` override end-to-end, **and** the IP-host-without-`fqdn` path which surfaces a structured `connector_error` whose `extras.exception_message` names the IP and the `fqdn` field (the descriptive-error contract, not a blank 404).
- Ships `docs/cross-repo/vcf-automation-onboarding.md` — the operator recipe covering both planes, the `--fqdn` checklist (prominently), the per-plane credential override (admin@System vs svc-meho), and the migration recipe off `scripts/vcf-automation.sh`. Ticks the Goal #214 G3.6 VCFA checklist rows.

## Test plan

- [x] `ruff check src/meho_backplane/ tests/` — clean
- [x] `ruff format --check src/meho_backplane/ tests/` — clean (test file reformatted in this commit)
- [x] `mypy src/meho_backplane/` — clean (220 source files)
- [x] `pytest tests/test_connectors_vcf_automation_e2e.py tests/test_connectors_vcf_automation_auth.py tests/test_connectors_vcf_automation_core_ops.py tests/test_operations_meta_tools.py` — 109 passed
- [x] `pytest tests/test_connectors_vcf_automation_e2e.py` — 18 passed (every acceptance criterion has its own test case)
- [x] `go build ./...` in `cli/` — clean
- [x] `go vet ./...` in `cli/` — clean
- [x] `gofmt -l .` in `cli/` — clean
- [x] `go test ./...` in `cli/` — every existing package still passes; new `vcf-automation` package passes
- [x] `meho vcf-automation about --plane provider` dispatches `GET:/cloudapi/1.0.0/site`; `--plane tenant` dispatches `GET:/iaas/api/about` (asserted in `TestAboutVerbDispatchesPerPlane`)
- [x] `--fqdn` threads through to the dispatch body's `target.fqdn` (asserted in `TestDispatchOpThreadsFqdnIntoTargetBody` + `TestDeploymentListThreadsFqdn`)
- [x] Empty `--fqdn` is omitted from the body (asserted in `TestDispatchOpOmitsFqdnWhenEmpty`)
- [x] Wrong-plane verbs reject early (`TestProjectListRejectsProviderPlane`, `TestOrgListRejectsTenantPlane`)
- [x] `about` requires `--plane` (`TestAboutVerbRejectsMissingPlane`)
- [x] IP-host target without `fqdn` surfaces structured `connector_error` with `fqdn` in `extras.exception_message` (`test_vcfa_e2e_ip_host_without_fqdn_surfaces_descriptive_error`)

## Out of scope

- Write ops (catalog deployment, blueprint create, IaaS machine lifecycle) — deferred to v0.5.next per the Initiative #369 scope; the wrapper retires only the read paths.
- vROps / vRLI / Fleet CLIs — sibling tasks #837, #838, #839 ship those in parallel.
- A live VCFA CI environment — recorded-fixture coverage stays (per #536 / Initiative #369 DoD).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #840


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `vcf-automation` CLI suite (about, org, region, user, project, deployment, blueprint, operation) with human/JSON output.
  * Added per-call FQDN override for operation dispatch to support vhost (Host:) routing.
  * Added operation search and call commands with parameter/file input support.

* **Documentation**
  * Added VCF Automation onboarding/cookbook with usage, troubleshooting, and migration guidance.

* **Tests**
  * Added extensive unit and end-to-end tests covering CLI behavior, dispatch wire‑shape, and connector E2E scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/895?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->