### PR TITLE
ci(perf): enforce the Goal #11 unit-job 10-min budget (early-warning gate for CI-perf creep)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,8 +290,27 @@ jobs:
         # coverage caveat (requires `env.PYBEHAVIOR.branch_right_left`)
         # does not apply.
         run: |
+          # Perf-budget guard — early warning for CI-perf creep (the #898 / G3.6
+          # timeout class). The Goal #11 unit budget is 10 min, but it was
+          # aspirational (comment-only): the G3.6 batch crept 9.3 -> 19 min and
+          # nothing failed until the 20-min `timeout-minutes` cliff, blocking a
+          # release. This step measures the pytest wall, always prints it (trend
+          # visibility), and FAILS at the budget — well below the hard cap, so a
+          # regression is caught at the PR that causes it, not at release time.
+          # `timeout-minutes` stays as the hang backstop.
+          # MEASURE before raising budget_s (see #793/#827/#898): re-run with
+          #   MEHO_FIXTURE_TIMING_FILE=/tmp/fixt MEHO_LIFESPAN_TIMING=/tmp/lifespan
+          # then `uv run python tests/_perf_timing_report.py` to attribute the wall.
+          budget_s=600
+          start=$(date +%s)
           COVERAGE_CORE=sysmon uv run pytest -n 6 --dist loadscope --maxfail=1 --ignore=tests/integration \
             --cov=meho_backplane --cov-report=xml tests/
+          dur=$(( $(date +%s) - start ))
+          echo "::notice title=Unit pytest wall::${dur}s (budget ${budget_s}s = Goal #11 10-min; hard cap = job timeout-minutes)"
+          if [ "$dur" -gt "$budget_s" ]; then
+            echo "::error title=Unit perf budget exceeded::unit pytest ${dur}s > budget ${budget_s}s. Early-warning gate for CI-perf creep (#898 / G3.6 class). MEASURE the slow path before raising budget_s: MEHO_FIXTURE_TIMING_FILE + MEHO_LIFESPAN_TIMING + tests/_perf_timing_report.py (#793/#827). Amortize the cost; do not just bump the budget."
+            exit 1
+          fi
 
       - name: Upload Python coverage artifact
         # Consumed by quality-gate.yml (`workflow_run` -> SonarCloud).


### PR DESCRIPTION
## Why

The Goal #11 unit-job **10-min budget was aspirational** (comment-only in `ci.yml`). The G3.6 batch (#369) crept the unit job **9.3 → 19 min** and nothing failed until the **20-min `timeout-minutes` cliff** — which blocked the v0.5.0 release and forced a fire-drill diagnosis + fix (#898). A hard timeout is a cliff with no gradient: everything reads green until it's suddenly a binary timeout, and during the merge storm concurrency-cancellation even made the red `main` read as "cancelled."

## What

A wall-time guard on the `Pytest (unit + coverage)` step:
- **Always** emits the pytest wall as a `::notice::` → per-PR trend visibility (monitor).
- **Fails** the job (`::error::` + `exit 1`) when the wall exceeds `budget_s=600` (10 min) — the Goal #11 budget, now *enforced* (prevent).
- `timeout-minutes` stays as the **hang backstop** (the guard runs only after pytest completes, so a hung test still hits the hard cap).
- The error message points at the **measure-first** workflow (`MEHO_FIXTURE_TIMING_FILE` + `MEHO_LIFESPAN_TIMING` + `tests/_perf_timing_report.py`, per #793/#827) so the response is "amortize the slow path," not "bump the budget."

## Why this threshold

Current wall ~3 min → `budget_s=600` is ~3× headroom: ARC-pod variance won't false-positive, but a real creep toward the cliff fails at the PR that causes it, ~10 min before the hard cap.

## Tradeoff

A wall-time gate can in principle false-positive on a pathologically slow runner; the 3× margin makes that unlikely, and the remediation message tells you to measure first (and, if the growth is legit, raise `budget_s` deliberately rather than silently).

Refs #898, #793, #827, Goal #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI pipeline with automated performance monitoring that tracks test execution duration and enforces performance budgets during builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/899?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->