### PR TITLE
feat(ui): G10.0-T3 BFF session storage — web_session table + encrypted token custody + RFC 9700 refresh rotation

### DIFF
--- a/backend/alembic/versions/0012_create_web_session.py
+++ b/backend/alembic/versions/0012_create_web_session.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Create the ``web_session`` table for BFF session custody.
+
+Revision ID: 0012
+Revises: 0011
+Create Date: 2026-05-22
+
+Initiative #337 (G10.0 Frontend chassis), Task #864 (G10.0-T3). The
+operator-console is locked to the Backend-for-Frontend (BFF) custody
+shape per locked decision #11 (`docs/planning/v0.2-decisions.md`):
+the browser holds nothing but an opaque session-cookie value, the
+real OAuth access + refresh tokens live in a server-side row that
+the backplane decrypts on every authenticated `/ui/*` request.
+
+This migration ships *only* the storage substrate -- the ORM model
+(:class:`meho_backplane.db.models.WebSession`), the
+:func:`meho_backplane.ui.auth.session_store.create_session` /
+``load_session`` / ``revoke_session`` / ``rotate_refresh`` callers,
+and the test suite that asserts the round-trip + replay contracts.
+The login / callback / middleware flow that *uses* the substrate is
+Task #865 (T4) territory.
+
+Schema
+------
+
+* ``id`` -- UUID primary key. The cookie value the browser holds is
+  this UUID's canonical 36-char hex form (Python's ``str(uuid)``);
+  the BFF middleware (#865) sets ``Set-Cookie: meho_session=<id>;
+  HttpOnly; Secure; SameSite=Strict; Path=/`` on session creation
+  and parses the same value on every subsequent request. UUID is
+  the right shape because (a) it's globally unique without a
+  central allocator, (b) PG's ``gen_random_uuid()`` is
+  cryptographically random by default (CSPRNG-backed; ~122 bits of
+  entropy, enough to make session-id guessing computationally
+  infeasible for browser-supplied values), and (c) the existing
+  chassis pattern (``audit_log.id``, ``targets.id``,
+  ``graph_node.id``) uses UUIDs end-to-end so the dialect-portable
+  ``Uuid()`` shape is well-trodden.
+
+* ``operator_sub`` -- Text NOT NULL. The Keycloak ``sub`` claim of
+  the operator who logged in. Mirrors :attr:`AuditLog.operator_sub`
+  (migration ``0001``, ORM ``db/models.py:343``); the chassis has no
+  ``operator`` table, so ``sub`` is the operator's stable identifier
+  end-to-end. Indexed by ``web_session_operator_sub_idx`` so the
+  "list sessions for operator X" query (a likely future revoke-all
+  surface) is a btree probe.
+
+* ``tenant_id`` -- UUID NOT NULL. The operator's active tenant at
+  session-creation time, sourced from the
+  ``settings.jwt_tenant_claim_name`` claim. No FK to ``tenant(id)``
+  -- the same soft-FK discipline ``audit_log.tenant_id`` follows
+  (``0002_create_tenant_and_audit_tenant_id``): a session row is
+  *write-mostly*, a tenant delete is a major operation that must
+  scrub the dependent sessions explicitly before removing the
+  tenant row, and adding the FK now would force a backfill cycle
+  for any pre-existing chassis-era data when v0.2.next tightens
+  the audit FK. Keep the discipline uniform.
+
+* ``access_token`` / ``refresh_token`` -- ``LargeBinary`` NOT NULL.
+  ``bytea`` on PostgreSQL, ``BLOB`` on SQLite (dev/test). The
+  columns hold the Fernet-encrypted ciphertext of the OAuth bearer
+  tokens, never plaintext. Fernet tokens are themselves URL-safe
+  base64 strings, but the chassis stores the *bytes* form to avoid
+  text-search tooling (psql ``\\d``, future grep-the-audit-export
+  flows) ever surfacing what looks like an OAuth token in stable
+  storage. The :mod:`meho_backplane.ui.auth.session_store` module
+  is the only seam that touches these columns; every read / write
+  passes through :class:`cryptography.fernet.Fernet`.
+
+* ``created_at`` / ``expires_at`` -- ``timestamptz`` NOT NULL.
+  ``created_at`` defaults to ``now()`` on PG, ORM-side
+  ``datetime.now(UTC)`` on SQLite; ``expires_at`` is set by the
+  session-creation caller (#865) from the access-token's ``exp``
+  claim. ``load_session`` filters on ``expires_at > now()`` so a
+  natural-expiry session is invisible without a separate sweeper.
+
+* ``last_seen_at`` -- ``timestamptz`` NOT NULL. Refreshed on every
+  successful :func:`load_session` call (server-side write, no
+  client-controlled value); future idle-revocation can run a tick
+  off this column. Initialised to ``now()`` at create time -- the
+  semantics match "last time the operator presented this session
+  cookie", which at row-creation is the create call itself.
+
+* ``revoked_at`` -- ``timestamptz`` NULL. NULL means the session is
+  still active (subject to the expiry check); non-NULL means it has
+  been explicitly revoked (logout, refresh-token replay detection,
+  operator-side global-revoke). Soft-delete shape preserves the
+  audit trail: a revoked-session row stays queryable for
+  forensics; the read-side filter is ``revoked_at IS NULL AND
+  expires_at > now()``.
+
+  Why soft-delete instead of ``DELETE``: the audit row written on
+  refresh-token replay references the revoked session by
+  :attr:`AuditLog.path` (``ui.session.refresh_replay``) and a free-
+  form payload that includes the session id. Hard-deleting the row
+  here would leave the audit row dangling (we cannot back-link via
+  FK because the soft-FK discipline applies); keeping the row
+  visible-but-marked-revoked preserves the audit chain at the cost
+  of one column. The chassis precedent is :class:`Tenant` (deleted
+  via a future "tenant lifecycle" Initiative, not by this layer)
+  and :class:`GraphNode` (refresh-driven soft-deletes set
+  ``last_seen=NULL``); neither hard-deletes from a column-bearing
+  identifier.
+
+Indexes
+-------
+
+* ``web_session_operator_sub_idx`` -- btree on ``operator_sub``.
+  Drives the future "list / revoke all sessions for operator X"
+  surface (no current consumer; the index is cheap to maintain --
+  one column, append-mostly writes -- and worth the ~ms-on-write
+  cost so the read query is not a sequential scan when it lands).
+
+* ``web_session_expires_at_idx`` -- btree on ``expires_at``. Drives
+  the future background sweep "delete expired sessions older than
+  N days" (out of v0.2 scope; the index is the cheap part of the
+  forward-compat). The read-side ``load_session`` query filters on
+  ``id = ?`` and re-checks ``expires_at`` against ``now()`` -- the
+  PK index already does the heavy lifting for that path; this
+  index is for the sweep, not the hot path.
+
+Dialect portability
+-------------------
+
+* ``id`` server default -- ``gen_random_uuid()`` on PG (built-in
+  since PG 13, the chassis floor); SQLite leaves it to the ORM
+  ``default=uuid.uuid4`` (set on the model).
+* ``created_at`` / ``last_seen_at`` server default -- ``now()`` on
+  PG; SQLite leaves it to the ORM ``default=lambda:
+  datetime.now(UTC)``.
+* ``LargeBinary`` -- ``bytea`` on PG, ``BLOB`` on SQLite. Identical
+  Python contract (``bytes``) on both dialects.
+
+Reversibility contract
+----------------------
+
+``upgrade()`` creates the table and its two indexes; ``downgrade()``
+drops the indexes then the table in inverse order. SQLite does not
+always auto-cascade index drops on ``DROP TABLE``; explicit drops
+keep the inverse symmetric across both dialects, matching the
+discipline migrations ``0007`` and ``0008`` established.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0012"
+down_revision: str | None = "0011"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the ``web_session`` table and its indexes."""
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    op.create_table(
+        "web_session",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()") if is_postgres else None,
+        ),
+        # Keycloak ``sub`` claim. Soft-FK discipline -- no FK to an
+        # ``operator`` table (which does not exist in v0.2). Mirrors
+        # ``audit_log.operator_sub`` (migration ``0001``).
+        sa.Column("operator_sub", sa.Text(), nullable=False),
+        # Soft-FK to ``tenant.id`` -- same discipline as
+        # ``audit_log.tenant_id`` (see ``0002`` docstring).
+        sa.Column("tenant_id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+        sa.Column(
+            "expires_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        # Fernet-encrypted OAuth tokens. ``bytea`` on PG, ``BLOB`` on
+        # SQLite. The plaintext never lands in this column -- every
+        # write passes through ``meho_backplane.ui.auth.session_store``
+        # which Fernet-encrypts via the chassis-wide key resolved from
+        # ``settings.ui_session_encryption_key``.
+        sa.Column("access_token", sa.LargeBinary(), nullable=False),
+        sa.Column("refresh_token", sa.LargeBinary(), nullable=False),
+        sa.Column(
+            "last_seen_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+        # NULL = active; non-NULL = revoked (logout, refresh replay,
+        # operator-side global-revoke). Soft-delete shape so the audit
+        # trail (audit_log rows that reference this session id) stays
+        # back-traceable.
+        sa.Column(
+            "revoked_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+    op.create_index(
+        "web_session_operator_sub_idx",
+        "web_session",
+        ["operator_sub"],
+        postgresql_using="btree",
+    )
+    op.create_index(
+        "web_session_expires_at_idx",
+        "web_session",
+        ["expires_at"],
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    """Drop indexes then the ``web_session`` table."""
+    op.drop_index("web_session_expires_at_idx", table_name="web_session")
+    op.drop_index("web_session_operator_sub_idx", table_name="web_session")
+    op.drop_table("web_session")

--- a/backend/alembic/versions/0013_create_web_session.py
+++ b/backend/alembic/versions/0013_create_web_session.py
@@ -3,8 +3,8 @@
 
 """Create the ``web_session`` table for BFF session custody.
 
-Revision ID: 0012
-Revises: 0011
+Revision ID: 0013
+Revises: 0012
 Create Date: 2026-05-22
 
 Initiative #337 (G10.0 Frontend chassis), Task #864 (G10.0-T3). The
@@ -149,8 +149,8 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision: str = "0012"
-down_revision: str | None = "0011"
+revision: str = "0013"
+down_revision: str | None = "0012"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -205,6 +205,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    LargeBinary,
     Numeric,
     Text,
     Uuid,
@@ -230,6 +231,7 @@ __all__ = [
     "OperationGroup",
     "Target",
     "Tenant",
+    "WebSession",
 ]
 
 
@@ -1926,5 +1928,134 @@ class GraphEdgeHistory(Base):
         sa.CheckConstraint(
             _ck_in("change_kind", _GRAPH_HISTORY_CHANGE_KINDS),
             name="ck_graph_edge_history_change_kind",
+        ),
+    )
+
+
+class WebSession(Base):
+    """One row per active BFF (Backend-for-Frontend) operator session.
+
+    Initiative #337 (G10.0 Frontend chassis), Task #864 (T3). The
+    operator-console is locked to the BFF custody shape per decision
+    #11 (``docs/planning/v0.2-decisions.md``): the browser holds an
+    opaque session-cookie value (the row's ``id``), the real OAuth
+    access + refresh tokens live encrypted in this row, and every
+    authenticated ``/ui/*`` request resolves operator identity by
+    looking up the row and decrypting the tokens server-side.
+
+    This model is **storage-only** -- the encryption / rotation /
+    replay-detection contract lives in
+    :mod:`meho_backplane.ui.auth.session_store`. No helper methods on
+    the model itself; the discipline ``AuditLog`` already follows
+    (write-once + helper logic at the call site).
+
+    Schema decisions
+    ----------------
+
+    * ``id`` -- UUID primary key. The cookie value the browser holds
+      is the canonical 36-char form (``str(uuid)``). PG production
+      gets ``gen_random_uuid()`` via migration ``0012``;
+      :func:`uuid.uuid4` (CSPRNG-backed) is the ORM default for the
+      SQLite dev/test path. ~122 bits of entropy makes session-id
+      guessing computationally infeasible.
+
+    * ``operator_sub`` -- Keycloak ``sub`` claim of the logged-in
+      operator. Mirrors :attr:`AuditLog.operator_sub`; the chassis
+      has no ``operator`` table, so the JWT ``sub`` is the operator's
+      stable identifier end-to-end.
+
+    * ``tenant_id`` -- The operator's active tenant at session-creation
+      time, sourced from the JWT ``tenant_id`` claim. Soft-FK
+      discipline: no FK to ``tenant.id``, matching the audit-log
+      pattern (``audit_log.tenant_id``). Tenant deletion is a major
+      ops operation that scrubs dependent sessions explicitly before
+      removing the tenant row.
+
+    * ``access_token`` / ``refresh_token`` -- Fernet-encrypted bytes.
+      ``LargeBinary`` -> ``bytea`` on PG, ``BLOB`` on SQLite. The
+      plaintext never lands in this column: every write passes
+      through :mod:`meho_backplane.ui.auth.session_store` which
+      :class:`cryptography.fernet.Fernet`-encrypts before insert and
+      decrypts on read using the chassis-wide key resolved from
+      :attr:`Settings.ui_session_encryption_key`. Storing bytes (not
+      the URL-safe base64 string Fernet emits) avoids text-search
+      tooling (``psql \\d``, future grep-the-audit-export flows)
+      ever surfacing what looks like an OAuth token in stable
+      storage.
+
+    * ``created_at`` / ``expires_at`` -- timestamptz. ``created_at``
+      gets a PG ``now()`` server default + ORM
+      ``datetime.now(UTC)`` for SQLite; ``expires_at`` is supplied
+      by the session-creation caller (#865) from the access-token's
+      ``exp`` claim. :func:`load_session` filters on
+      ``expires_at > now()``.
+
+    * ``last_seen_at`` -- timestamptz, refreshed on every successful
+      :func:`load_session` call. Drives future idle-revocation
+      sweeps; never accepts a client-controlled value.
+
+    * ``revoked_at`` -- timestamptz, NULL means active.
+      Soft-delete shape: a revoked session row stays queryable for
+      forensics and so the audit row written on refresh-token
+      replay (which references the session id) remains back-
+      traceable. The read-side filter in :func:`load_session` is
+      ``revoked_at IS NULL AND expires_at > now()``.
+
+    Indexes
+    -------
+
+    * ``web_session_operator_sub_idx`` -- btree on ``operator_sub``,
+      drives the future "list / revoke all sessions for operator X"
+      surface.
+    * ``web_session_expires_at_idx`` -- btree on ``expires_at``,
+      drives the future background sweep of naturally-expired
+      sessions. The hot-path ``load_session`` query is a PK probe
+      and does not need this index.
+    """
+
+    __tablename__ = "web_session"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    operator_sub: Mapped[str] = mapped_column(Text, nullable=False)
+    tenant_id: Mapped[uuid.UUID] = mapped_column(Uuid(), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+    # Fernet ciphertext (bytes). Never plaintext -- the session_store
+    # module is the only seam that reads or writes these columns.
+    access_token: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    refresh_token: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    last_seen_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    # NULL = active; non-NULL = revoked (logout, replay, op-revoke).
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+
+    __table_args__ = (
+        Index(
+            "web_session_operator_sub_idx",
+            "operator_sub",
+            postgresql_using="btree",
+        ),
+        Index(
+            "web_session_expires_at_idx",
+            "expires_at",
+            postgresql_using="btree",
         ),
     )

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -1954,7 +1954,7 @@ class WebSession(Base):
 
     * ``id`` -- UUID primary key. The cookie value the browser holds
       is the canonical 36-char form (``str(uuid)``). PG production
-      gets ``gen_random_uuid()`` via migration ``0012``;
+      gets ``gen_random_uuid()`` via migration ``0013``;
       :func:`uuid.uuid4` (CSPRNG-backed) is the ORM default for the
       SQLite dev/test path. ~122 bits of entropy makes session-id
       guessing computationally infeasible.

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -344,6 +344,28 @@ class Settings(BaseModel):
         :func:`~meho_backplane.memory._internal.is_expired` until the
         external job reaps them. Read once at lifespan startup; toggling
         post-start requires a pod restart to take effect.
+    ui_session_encryption_key:
+        URL-safe base64-encoded 32-byte key used by
+        :mod:`meho_backplane.ui.auth.session_store` to Fernet-encrypt
+        the OAuth access + refresh tokens stored in the ``web_session``
+        table. Initiative #337 (G10.0 Frontend chassis), Task #864.
+        The chassis-locked decision #11 keeps tokens server-side; this
+        key is the chassis-wide encryption seam that makes
+        "server-side" mean "ciphertext at rest". Default ``""`` is
+        fail-fast: any session-store call raises
+        :class:`~meho_backplane.ui.auth.session_store.EncryptionKeyMissingError`
+        until the key is provisioned. Production deploys render this
+        from a Vault-managed secret into the pod's environment (same
+        chain that lands ``DATABASE_URL`` / Keycloak client secrets
+        in the env); dev/test pin a per-run key via
+        :meth:`pytest.MonkeyPatch.setenv` (see the autouse fixture in
+        ``backend/tests/conftest.py``). Generate one with
+        ``python -c 'from cryptography.fernet import Fernet;
+        print(Fernet.generate_key().decode())'``. Rotating the key is
+        an Initiative-#337-follow-up surface (every active session
+        becomes un-decryptable on key rotation; the operator-facing
+        contract is "log everyone out, then bump the key"); v0.2
+        ships one key end-to-end.
     """
 
     keycloak_issuer_url: HttpUrl
@@ -394,6 +416,7 @@ class Settings(BaseModel):
     memory_user_default_ttl_days: int = Field(default=7, ge=1, le=365)
     memory_expiry_tick_interval_seconds: int = Field(default=86400, ge=60, le=86400)
     memory_expiry_enabled: bool = True
+    ui_session_encryption_key: str = ""
 
     @field_validator("broadcast_redis_url")
     @classmethod
@@ -527,4 +550,5 @@ def get_settings() -> Settings:
         memory_expiry_enabled=parse_bool_env(
             os.environ.get("MEMORY_EXPIRY_ENABLED", "true"),
         ),
+        ui_session_encryption_key=os.environ.get("UI_SESSION_ENCRYPTION_KEY", ""),
     )

--- a/backend/src/meho_backplane/ui/auth/session_store.py
+++ b/backend/src/meho_backplane/ui/auth/session_store.py
@@ -1,0 +1,715 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""BFF session-store -- encrypted token custody + refresh rotation.
+
+Initiative #337 (G10.0 Frontend chassis), Task #864 (T3). The
+operator-console is locked to the Backend-for-Frontend (BFF) custody
+shape per decision #11 (``docs/planning/v0.2-decisions.md``): the
+browser holds an opaque session-cookie value, the real OAuth access +
+refresh tokens live encrypted in the server-side ``web_session`` row.
+This module owns the encryption / load / revoke / rotation surface
+that the login-flow (Task #865) calls into.
+
+The four entry points
+---------------------
+
+* :func:`create_session` -- write a row at login time. The caller
+  (Task #865's ``/ui/auth/callback`` handler) passes the operator's
+  ``sub``, tenant id, and the freshly-issued OAuth access + refresh
+  tokens; this module Fernet-encrypts both tokens and inserts the
+  row. The returned :class:`DecryptedSession` carries the row's
+  ``id`` -- the value the BFF middleware sets as the
+  ``meho_session`` cookie.
+
+* :func:`load_session` -- hot-path lookup on every ``/ui/*`` request.
+  Reads the row by PK, applies the revocation + expiry filter, and
+  Fernet-decrypts both tokens. Returns ``None`` when the session is
+  missing / revoked / past ``expires_at``. Updates ``last_seen_at``
+  on a successful hit; the column is server-side-controlled (never
+  client-supplied) so refreshing it from the request hot path is
+  safe.
+
+* :func:`revoke_session` -- soft-delete on logout (and on any
+  operator-initiated revoke surface). Sets ``revoked_at = now()``;
+  keeps the row visible-but-marked for audit-trail back-reference.
+  Idempotent on already-revoked rows.
+
+* :func:`rotate_refresh` -- the RFC 9700 § 4.14 contract. Called
+  by the Task #865 refresh handler when the access token has
+  expired but the operator's session has not. Verifies the
+  presented refresh token matches the stored one; on match the
+  row's tokens are swapped to the new pair (one-time-use semantics
+  -- the previous refresh value never decrypts to a valid
+  comparand again). On mismatch *or* on a presented-refresh-after-
+  revoked row, the session is revoked AND an ``audit_log`` row is
+  written ``path='ui.session.refresh_replay'`` so the security
+  surface (G2.4 / G8.1 replay-detection views) sees the event.
+
+Encryption discipline
+---------------------
+
+Every token write passes through one
+:class:`cryptography.fernet.Fernet` instance. The instance is
+constructed lazily from :attr:`Settings.ui_session_encryption_key`
+(a URL-safe base64-encoded 32-byte key resolved from a Vault-rendered
+env var in production) and cached on the module so the same key
+yields the same instance. Cache invalidation is keyed on the key
+string -- :func:`get_settings.cache_clear` followed by a key swap
+under test naturally produces a different cached instance.
+
+Why Fernet (not raw AES-GCM)
+----------------------------
+
+Fernet is the
+`cryptography-library-blessed authenticated-encryption envelope
+<https://cryptography.io/en/latest/fernet/>`_ for the
+"encrypt a blob at rest" use case. The envelope pins AES-128-CBC
++ HMAC-SHA256, includes a timestamp + random IV per token, and
+ships a single ``Fernet`` API that is hard to misuse. Raw AES-GCM
+is faster but the chassis pays one Fernet encrypt per login and
+one Fernet decrypt per ``/ui/*`` request -- not a hot path -- and
+the misuse surface (nonce reuse on raw GCM is catastrophic) is the
+sort of footgun the chassis explicitly avoids by reaching for the
+high-level primitive.
+
+The stored ``bytes`` are the Fernet token in its native bytes form
+(the same value :meth:`Fernet.encrypt` returns). Storing the bytes
+(not the URL-safe base64 string it represents) keeps text-search
+tooling (``psql \\d``, future grep-the-audit-export flows) from
+surfacing what looks like an OAuth token in stable storage.
+
+References
+----------
+
+* RFC 9700 § 4.14 -- OAuth 2.0 Security Best Current Practice on
+  refresh token rotation:
+  https://datatracker.ietf.org/doc/rfc9700/
+* ``cryptography`` Fernet API:
+  https://cryptography.io/en/latest/fernet/
+* Chassis precedent (audit-row write):
+  ``meho_backplane.topology.annotate._build_audit_row``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Final
+
+from cryptography.fernet import Fernet
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, WebSession
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "DecryptedSession",
+    "EncryptionKeyMissingError",
+    "RefreshReplayError",
+    "SessionStoreError",
+    "create_session",
+    "load_session",
+    "reset_fernet_cache_for_testing",
+    "revoke_session",
+    "rotate_refresh",
+]
+
+
+#: ``audit_log.path`` value used to record a refresh-token replay event.
+#: The path is treated as a synthetic op-id so the audit-replay UI
+#: surfaces this alongside other denied / replayed surfaces. Stable
+#: identifier -- referenced by tests and by any future replay-detection
+#: dashboard.
+REFRESH_REPLAY_AUDIT_PATH: Final[str] = "ui.session.refresh_replay"
+
+#: ``audit_log.method`` token for the replay event. Mirrors the
+#: chassis pattern in :mod:`meho_backplane.topology.annotate` (which
+#: writes a verb-style token for non-HTTP audit rows).
+REFRESH_REPLAY_AUDIT_METHOD: Final[str] = "ROTATE"
+
+
+class SessionStoreError(Exception):
+    """Base class for backplane-side session-store failures.
+
+    Catch this when a single error response shape ("could not
+    handle the session-cookie path") is enough; subclasses carry the
+    specific intent.
+    """
+
+
+class EncryptionKeyMissingError(SessionStoreError):
+    """``UI_SESSION_ENCRYPTION_KEY`` is unset.
+
+    Raised by :func:`_get_fernet` on the first session-store call
+    when :attr:`Settings.ui_session_encryption_key` is empty.
+    Production deploys render the key from a Vault secret into the
+    pod's environment; dev/test pin a per-run key via the autouse
+    conftest fixture. Surfacing this as an explicit exception (vs
+    a cryptic ``ValueError`` from inside Fernet's constructor)
+    gives the operator-facing error message a concrete remediation
+    pointer.
+    """
+
+
+@dataclass(frozen=True)
+class RefreshReplayError(SessionStoreError):
+    """A refresh token was reused; the session has been revoked.
+
+    Raised by :func:`rotate_refresh` when the presented refresh
+    value does not match the stored one (or the session is already
+    revoked). The session row is set to ``revoked_at = now()`` and
+    an audit row is written before this exception propagates so
+    the caller (Task #865's refresh handler) can map it to a 401 +
+    cookie-clear without re-deriving any of the side effects.
+
+    Attributes
+    ----------
+    session_id
+        The revoked session's PK -- echo into the response so the
+        operator's session-id can be correlated against the audit
+        row (audit row's ``payload`` carries the same value).
+    audit_id
+        The ``audit_log.id`` of the freshly-written replay row.
+        Lets the caller surface a clickable link to the audit
+        viewer in the operator-facing error response.
+    """
+
+    session_id: uuid.UUID
+    audit_id: uuid.UUID
+
+    def __str__(self) -> str:
+        return f"refresh-token replay on session {self.session_id}; audit_id={self.audit_id}"
+
+
+@dataclass(frozen=True)
+class DecryptedSession:
+    """Plaintext view of a ``web_session`` row.
+
+    The session-store module is the only consumer that ever sees
+    plaintext tokens; this dataclass is the cross-call return shape.
+    Frozen so callers cannot accidentally mutate a token in-place
+    and write it back through the ORM (which would skip the
+    Fernet encrypt path).
+
+    The cookie value the browser holds is ``str(self.id)``.
+    """
+
+    id: uuid.UUID
+    operator_sub: str
+    tenant_id: uuid.UUID
+    created_at: datetime
+    expires_at: datetime
+    access_token: str
+    refresh_token: str
+    last_seen_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Fernet plumbing
+# ---------------------------------------------------------------------------
+
+
+#: Module-level Fernet cache keyed on the configured key string. The
+#: chassis-wide :func:`get_settings` cache + this one-tuple cache
+#: jointly ensure the same key never reconstructs Fernet twice.
+#: Tests that swap the key call :func:`reset_fernet_cache_for_testing`
+#: so a per-test key materialises a fresh Fernet without restarting
+#: the process.
+_FERNET_CACHE: tuple[str, Fernet] | None = None
+
+
+def _get_fernet() -> Fernet:
+    """Return the process-wide Fernet bound to ``UI_SESSION_ENCRYPTION_KEY``.
+
+    Lazy + cached: constructing :class:`Fernet` parses + validates
+    the key (URL-safe base64 of exactly 32 bytes), so the first call
+    pays the parse cost; every subsequent call returns the cached
+    instance. The cache key is the raw key string -- if a test swaps
+    the env var and clears :func:`get_settings.cache_clear`, the
+    next call here observes a different key and rebuilds.
+
+    Raises
+    ------
+    EncryptionKeyMissingError
+        ``settings.ui_session_encryption_key`` is empty. Production
+        misconfiguration; the message names the env var explicitly
+        so the remediation does not require reading code.
+    cryptography.fernet.InvalidToken
+        The key is set but the Fernet constructor rejected it (not
+        URL-safe-base64, wrong length). Fernet's own
+        :class:`ValueError` propagates verbatim -- the chassis does
+        not wrap it because the error message Fernet ships is
+        already operator-actionable.
+    """
+    global _FERNET_CACHE
+    key = get_settings().ui_session_encryption_key
+    if not key:
+        raise EncryptionKeyMissingError(
+            "UI_SESSION_ENCRYPTION_KEY is not set; the operator-console "
+            "session store cannot encrypt tokens. Generate a key with "
+            "`python -c 'from cryptography.fernet import Fernet; "
+            "print(Fernet.generate_key().decode())'` and surface it as "
+            "the UI_SESSION_ENCRYPTION_KEY env var."
+        )
+    if _FERNET_CACHE is None or _FERNET_CACHE[0] != key:
+        _FERNET_CACHE = (key, Fernet(key.encode("ascii")))
+    return _FERNET_CACHE[1]
+
+
+def reset_fernet_cache_for_testing() -> None:
+    """Drop the Fernet cache. Test-only.
+
+    Production never mutates the key under a running process. Tests
+    that swap the key under :func:`pytest.MonkeyPatch.setenv` call
+    this between cases so a subsequent
+    :func:`get_settings.cache_clear` materialises a fresh Fernet
+    rather than reusing the previous key's instance.
+    """
+    global _FERNET_CACHE
+    _FERNET_CACHE = None
+
+
+def _encrypt(value: str) -> bytes:
+    """Fernet-encrypt *value* and return the ciphertext bytes."""
+    return _get_fernet().encrypt(value.encode("utf-8"))
+
+
+def _decrypt(ciphertext: bytes) -> str:
+    """Fernet-decrypt *ciphertext* and return the plaintext string.
+
+    Raises :class:`cryptography.fernet.InvalidToken` on any
+    ciphertext that fails the HMAC check (tampered ciphertext,
+    wrong key, encoded-in-a-different-context blob). Callers above
+    the storage seam translate this into a generic
+    :class:`SessionStoreError`; the storage seam itself does not
+    paper over it -- corrupted ciphertext is a programmer error or
+    a key-rotation bug and should not be swallowed silently.
+    """
+    return _get_fernet().decrypt(ciphertext).decode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+async def create_session(
+    session: AsyncSession,
+    *,
+    operator_sub: str,
+    tenant_id: uuid.UUID,
+    access_token: str,
+    refresh_token: str,
+    lifetime: timedelta,
+) -> DecryptedSession:
+    """Insert a fresh ``web_session`` row and return its decrypted view.
+
+    Called by the BFF login-flow's ``/ui/auth/callback`` handler
+    (Task #865) at the end of a successful OAuth code exchange.
+    The caller passes the freshly-issued OAuth access + refresh
+    tokens; this module is responsible for Fernet-encrypting them
+    before insert.
+
+    Parameters
+    ----------
+    session
+        An open :class:`AsyncSession`. The caller controls the
+        transaction shape; this function flushes (so ``id`` /
+        ``created_at`` / ``last_seen_at`` are populated by the DB)
+        but does **not** commit -- the caller's outer
+        ``async with session.begin():`` block does.
+    operator_sub
+        Keycloak ``sub`` claim of the logged-in operator. Stored on
+        the row verbatim (no transformation); ``AuditLog`` already
+        treats this as the stable operator handle end-to-end.
+    tenant_id
+        The operator's active tenant at session-creation time
+        (sourced from the JWT ``tenant_id`` claim by Task #865).
+    access_token
+        Plaintext OAuth access token from Keycloak's token
+        endpoint. Encrypted before insert; this is the last point
+        in the request lifecycle where the access token appears in
+        plaintext on the DB side.
+    refresh_token
+        Plaintext OAuth refresh token. Encrypted before insert.
+    lifetime
+        How long this session is valid for. ``expires_at`` is set
+        to ``datetime.now(UTC) + lifetime``. The caller computes
+        the lifetime from the access-token's ``exp`` claim minus
+        clock-skew margin so the session expires no later than the
+        token it represents.
+
+    Returns
+    -------
+    DecryptedSession
+        Plaintext view of the inserted row -- the caller uses
+        ``str(result.id)`` as the ``meho_session`` cookie value.
+    """
+    now = datetime.now(UTC)
+    expires_at = now + lifetime
+    row = WebSession(
+        id=uuid.uuid4(),
+        operator_sub=operator_sub,
+        tenant_id=tenant_id,
+        created_at=now,
+        expires_at=expires_at,
+        access_token=_encrypt(access_token),
+        refresh_token=_encrypt(refresh_token),
+        last_seen_at=now,
+        revoked_at=None,
+    )
+    session.add(row)
+    await session.flush()
+    return DecryptedSession(
+        id=row.id,
+        operator_sub=row.operator_sub,
+        tenant_id=row.tenant_id,
+        created_at=row.created_at,
+        expires_at=row.expires_at,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        last_seen_at=row.last_seen_at,
+    )
+
+
+async def load_session(
+    session: AsyncSession,
+    cookie_id: uuid.UUID,
+) -> DecryptedSession | None:
+    """Load and decrypt a session by cookie value, or return ``None``.
+
+    Hot-path lookup for the BFF session-middleware (Task #865).
+    Returns ``None`` (not an exception) for any "no usable session"
+    outcome so the middleware can redirect to ``/ui/auth/login``
+    without distinguishing between "no such cookie", "revoked",
+    "expired" at the policy layer. The audit / log instrumentation
+    Task #865 layers on top can disambiguate by inspecting the row
+    state directly if needed.
+
+    Parameters
+    ----------
+    session
+        Open :class:`AsyncSession`. The function flushes its
+        ``last_seen_at`` update but does not commit; the caller's
+        outer transaction owns the commit.
+    cookie_id
+        Parsed UUID from the ``meho_session`` cookie. Malformed
+        cookie values are the caller's problem -- parse them with
+        :func:`uuid.UUID` and catch :class:`ValueError` upstream.
+
+    Returns
+    -------
+    DecryptedSession | None
+        Decrypted plaintext view when the row is present, active
+        (``revoked_at IS NULL``), and not past ``expires_at``.
+        ``None`` otherwise.
+    """
+    row = await session.get(WebSession, cookie_id)
+    if row is None:
+        return None
+    if row.revoked_at is not None:
+        return None
+    now = datetime.now(UTC)
+    # Naive-vs-aware-datetime portability: SQLite returns naive UTC
+    # datetimes from a ``timestamptz`` column under aiosqlite; PG
+    # returns aware. Coerce naive values to UTC-aware before
+    # comparing so the inequality is well-defined on both dialects.
+    expires_at = _coerce_utc(row.expires_at)
+    if expires_at <= now:
+        return None
+    access_plaintext = _decrypt(row.access_token)
+    refresh_plaintext = _decrypt(row.refresh_token)
+    # Hot-path side effect: refresh ``last_seen_at`` so the future
+    # idle-revocation sweep can see this session is alive. The
+    # update is server-side-controlled (never a client-supplied
+    # value), so this is safe to run on every successful load.
+    row.last_seen_at = now
+    await session.flush()
+    return DecryptedSession(
+        id=row.id,
+        operator_sub=row.operator_sub,
+        tenant_id=row.tenant_id,
+        created_at=_coerce_utc(row.created_at),
+        expires_at=expires_at,
+        access_token=access_plaintext,
+        refresh_token=refresh_plaintext,
+        last_seen_at=row.last_seen_at,
+    )
+
+
+async def revoke_session(
+    session: AsyncSession,
+    cookie_id: uuid.UUID,
+) -> None:
+    """Soft-delete a session row (idempotent).
+
+    Sets ``revoked_at = now()`` on the row. Idempotent: calling
+    twice on the same row leaves ``revoked_at`` pinned to the
+    first-call timestamp (no error, no overwrite). A missing row
+    is a no-op -- the caller (logout handler in Task #865) does
+    not need to distinguish "already-logged-out" from "never-
+    logged-in" for the response shape.
+
+    Parameters
+    ----------
+    session
+        Open :class:`AsyncSession`. Flushes; the caller's outer
+        transaction owns the commit.
+    cookie_id
+        The ``meho_session`` cookie UUID.
+    """
+    row = await session.get(WebSession, cookie_id)
+    if row is None or row.revoked_at is not None:
+        return
+    row.revoked_at = datetime.now(UTC)
+    await session.flush()
+
+
+async def rotate_refresh(
+    session: AsyncSession,
+    cookie_id: uuid.UUID,
+    *,
+    presented_refresh: str,
+    new_access_token: str,
+    new_refresh_token: str,
+) -> DecryptedSession:
+    """Swap the row's tokens for a new pair after a successful refresh.
+
+    The RFC 9700 § 4.14 "refresh-token rotation" contract:
+
+    * On success (presented refresh matches stored refresh AND the
+      session is still active), both columns are overwritten with
+      the fresh ciphertext. The previous refresh value becomes
+      un-presentable (it never decrypts to the new stored value).
+
+    * On replay (presented refresh does not match, OR the session
+      is already revoked, OR the session is past
+      ``expires_at``), the session row is revoked AND an
+      :class:`AuditLog` row is written
+      ``path='ui.session.refresh_replay'`` so the security surface
+      (G2.4 audit-export / G8.1 replay-detection) sees the event.
+      A :class:`RefreshReplayError` carrying the freshly-allocated
+      audit_id propagates to the caller (Task #865's refresh
+      handler) which maps it to a 401 + cookie-clear.
+
+    The replay branch also fires when the row is *missing*
+    altogether -- the caller cannot recover a session that the
+    storage layer cannot find, and the "no row at all" shape is
+    treated as "the cookie was never valid, or the session has
+    been hard-deleted by an out-of-band ops action" -- either way
+    a 401 + cookie-clear is the right response and the audit row
+    documents the attempt.
+
+    Parameters
+    ----------
+    session
+        Open :class:`AsyncSession` for the **happy path**. The
+        caller's outer transaction owns the commit on success; this
+        function flushes after the in-row mutations. On the replay
+        path the function **does not write to this session** at all
+        -- it opens its own dedicated session (via
+        :func:`get_sessionmaker`) for the revoke + audit-row writes
+        and commits that session independently. The replay-path
+        side effects therefore survive even when the caller's
+        outer transaction rolls back on the propagating
+        :class:`RefreshReplayError`.
+    cookie_id
+        The session's UUID PK -- parsed from the ``meho_session``
+        cookie by Task #865's refresh handler.
+    presented_refresh
+        The refresh token the client (or, more correctly, the
+        backplane-side refresh handler operating on behalf of the
+        BFF session) is presenting back to this rotation call.
+        Compared bytes-for-bytes against the decrypted stored
+        value.
+    new_access_token
+        Fresh access token returned by Keycloak's token endpoint.
+        Encrypted before write.
+    new_refresh_token
+        Fresh refresh token returned alongside ``new_access_token``.
+        Encrypted before write.
+
+    Returns
+    -------
+    DecryptedSession
+        Plaintext view of the rotated row -- callers do not need
+        to re-decrypt.
+
+    Raises
+    ------
+    RefreshReplayError
+        ``presented_refresh`` does not match the stored value, or
+        the session is already revoked / past expiry / missing.
+        The session is revoked + an audit row is written
+        **independently of the caller's transaction** before the
+        exception propagates.
+    """
+    row = await session.get(WebSession, cookie_id)
+    now = datetime.now(UTC)
+
+    if row is None:
+        # Cannot replay-revoke a row that does not exist, but the
+        # event is still worth auditing -- a presented cookie with
+        # no row could be a stolen cookie that we already
+        # hard-deleted, or a fishing attempt against a randomly-
+        # generated UUID. The audit row commits on its own session
+        # so it survives the caller's exception-path rollback.
+        audit_id = await _commit_replay_side_effects(
+            session_id=cookie_id,
+            operator_sub="<unknown>",
+            tenant_id=None,
+            reason="missing_session",
+            now=now,
+        )
+        raise RefreshReplayError(session_id=cookie_id, audit_id=audit_id)
+
+    stored_refresh = _decrypt(row.refresh_token)
+    is_revoked = row.revoked_at is not None
+    is_expired = _coerce_utc(row.expires_at) <= now
+    is_mismatch = presented_refresh != stored_refresh
+
+    if is_revoked or is_expired or is_mismatch:
+        reason = (
+            "already_revoked" if is_revoked else ("expired" if is_expired else "value_mismatch")
+        )
+        # Operator_sub / tenant_id captured here so the audit row
+        # gets the correct attribution even though the dedicated
+        # session below re-loads the row by id.
+        audit_id = await _commit_replay_side_effects(
+            session_id=cookie_id,
+            operator_sub=row.operator_sub,
+            tenant_id=row.tenant_id,
+            reason=reason,
+            now=now,
+        )
+        raise RefreshReplayError(session_id=cookie_id, audit_id=audit_id)
+
+    # Happy path -- one-time-use rotation. Both columns
+    # overwritten with the fresh ciphertext; the previous refresh
+    # value becomes un-presentable.
+    row.access_token = _encrypt(new_access_token)
+    row.refresh_token = _encrypt(new_refresh_token)
+    row.last_seen_at = now
+    await session.flush()
+    return DecryptedSession(
+        id=row.id,
+        operator_sub=row.operator_sub,
+        tenant_id=row.tenant_id,
+        created_at=_coerce_utc(row.created_at),
+        expires_at=_coerce_utc(row.expires_at),
+        access_token=new_access_token,
+        refresh_token=new_refresh_token,
+        last_seen_at=row.last_seen_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _coerce_utc(value: datetime) -> datetime:
+    """Return *value* as a UTC-aware ``datetime``.
+
+    SQLite (the dev/test path via aiosqlite) returns naive UTC
+    values from ``timestamptz`` columns; PostgreSQL returns
+    timezone-aware values. The chassis-wide convention is "naive
+    means UTC" (every write goes through ``datetime.now(UTC)``);
+    this helper aligns the read-side to that contract so
+    inequality comparisons against :func:`datetime.now` (always
+    aware in this module) are dialect-portable.
+    """
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+def _build_replay_audit_row(
+    *,
+    session_id: uuid.UUID,
+    operator_sub: str,
+    tenant_id: uuid.UUID | None,
+    reason: str,
+    now: datetime,
+) -> AuditLog:
+    """Construct one ``AuditLog`` row for a refresh-token replay event.
+
+    Mirrors the column shape :mod:`meho_backplane.topology.annotate`
+    uses (``method`` as verb token, ``path`` as op-id).
+    Pre-allocates ``audit_id`` so :class:`RefreshReplayError` can
+    surface the row id without re-querying.
+
+    ``status_code=401`` rather than 200 because the audit row
+    captures a refused-credential event -- the audit-replay
+    surface filters by status to surface the security-relevant
+    rows.
+    """
+    return AuditLog(
+        id=uuid.uuid4(),
+        occurred_at=now,
+        operator_sub=operator_sub,
+        tenant_id=tenant_id,
+        method=REFRESH_REPLAY_AUDIT_METHOD,
+        path=REFRESH_REPLAY_AUDIT_PATH,
+        status_code=401,
+        request_id=None,
+        duration_ms=Decimal("0.00"),
+        payload={
+            "session_id": str(session_id),
+            "reason": reason,
+        },
+    )
+
+
+async def _commit_replay_side_effects(
+    *,
+    session_id: uuid.UUID,
+    operator_sub: str,
+    tenant_id: uuid.UUID | None,
+    reason: str,
+    now: datetime,
+) -> uuid.UUID:
+    """Revoke the session + write the audit row on a dedicated session.
+
+    The replay branch in :func:`rotate_refresh` must persist its
+    side effects (revoke + audit row) **independently** of the
+    caller's transaction. The caller has typically wrapped the
+    ``rotate_refresh`` call in ``async with session.begin():`` --
+    if we wrote through the caller's session, the propagating
+    :class:`RefreshReplayError` would unwind that ``begin()`` and
+    roll the writes back, breaking the AC's "replay revokes the
+    session AND writes an audit row" contract.
+
+    We open a fresh session from the chassis-wide
+    :func:`get_sessionmaker`, do the revoke + insert, commit, and
+    return the new audit row's id. The caller's session is
+    untouched (no flush / no commit / no rollback into it). When
+    the session is genuinely missing (``operator_sub == "<unknown>"``
+    sentinel), the function skips the revoke step (no row to
+    revoke) and writes the audit row only.
+    """
+    sessionmaker = get_sessionmaker()
+    audit_row = _build_replay_audit_row(
+        session_id=session_id,
+        operator_sub=operator_sub,
+        tenant_id=tenant_id,
+        reason=reason,
+        now=now,
+    )
+    async with sessionmaker() as dedicated, dedicated.begin():
+        # Revoke step: a missing-row reason has nothing to revoke,
+        # but the other three reasons all reference a row that
+        # exists in the session-store and may need its
+        # ``revoked_at`` flipped to ``now``. We re-fetch by id
+        # under the dedicated session so the row is attached to
+        # the transaction we are about to commit.
+        if reason != "missing_session":
+            existing = await dedicated.get(WebSession, session_id)
+            if existing is not None and existing.revoked_at is None:
+                existing.revoked_at = now
+        dedicated.add(audit_row)
+    return audit_row.id

--- a/backend/src/meho_backplane/ui/auth/session_store.py
+++ b/backend/src/meho_backplane/ui/auth/session_store.py
@@ -100,6 +100,7 @@ from decimal import Decimal
 from typing import Final
 
 from cryptography.fernet import Fernet
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.db.engine import get_sessionmaker
@@ -548,7 +549,32 @@ async def rotate_refresh(
         **independently of the caller's transaction** before the
         exception propagates.
     """
-    row = await session.get(WebSession, cookie_id)
+    # RFC 9700 § 4.14 demands single-use refresh tokens, which means
+    # two concurrent requests presenting the same valid refresh value
+    # must not BOTH pass the mismatch / revoked / expired gate and
+    # both successfully rotate. A naive ``session.get`` is a
+    # non-locking read; two transactions could each load the row,
+    # each check ``refresh_token == stored``, and each write a new
+    # ciphertext on top -- the second-writer wins but the
+    # second-presenter still received a "rotation OK" response,
+    # which is exactly the one-time-use breach the RFC closes.
+    #
+    # ``SELECT ... FOR UPDATE`` row-locks the session row for the
+    # duration of the caller's transaction. The second concurrent
+    # rotation blocks until the first commits; when it unblocks and
+    # re-reads, the stored refresh value has already rotated, so
+    # ``presented_refresh != stored_refresh`` and the replay branch
+    # fires -- exactly the one-time-use property the RFC mandates.
+    #
+    # SQLite caveat: aiosqlite's locking is database-level rather
+    # than row-level, so on the dev/test path the serialization
+    # comes from the connection-level write lock rather than a true
+    # row lock. The behavioural contract (exactly one rotation
+    # wins; the other surfaces as replay) holds on both engines.
+    result = await session.execute(
+        select(WebSession).where(WebSession.id == cookie_id).with_for_update()
+    )
+    row = result.scalar_one_or_none()
     now = datetime.now(UTC)
 
     if row is None:

--- a/backend/tests/test_migration_0011_backfill_when_to_use.py
+++ b/backend/tests/test_migration_0011_backfill_when_to_use.py
@@ -443,11 +443,11 @@ def test_re_running_migration_is_idempotent(
     #
     # Pinning the target to ``0011`` (not ``head``) keeps the replay
     # scoped to the migration under test -- downstream schema
-    # migrations (e.g. 0012's ``CREATE TABLE graph_*_history``) are
-    # not idempotent by design (Alembic gates them on
-    # ``alembic_version`` in production) and would raise
-    # ``table already exists`` if the second ``upgrade`` walked past
-    # 0011.
+    # migrations (e.g. 0012's ``CREATE TABLE graph_*_history`` and
+    # 0013's ``CREATE TABLE web_session``) are not idempotent by
+    # design (Alembic gates them on ``alembic_version`` in
+    # production) and would raise ``table already exists`` if the
+    # second ``upgrade`` walked past 0011.
     command.stamp(cfg, "0010")
     command.upgrade(cfg, "0011")
 

--- a/backend/tests/test_ui_session_store.py
+++ b/backend/tests/test_ui_session_store.py
@@ -388,6 +388,114 @@ async def test_rotate_refresh_missing_session_writes_audit(
 
 
 # ---------------------------------------------------------------------------
+# Concurrent rotation: row-lock serializes (RFC 9700 § 4.14 single-use)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rotate_refresh_emits_select_for_update_against_session_row(
+    session: AsyncSession,
+) -> None:
+    """``rotate_refresh`` must read the session row with ``FOR UPDATE``.
+
+    Regression for the RFC 9700 § 4.14 single-use refresh-token
+    property. Before the fix, ``rotate_refresh`` did a non-locking
+    ``await session.get(WebSession, cookie_id)`` -- two concurrent
+    presenters with the same valid refresh value could both pass
+    the mismatch / revoked / expired gate and both successfully
+    rotate, breaking single-use.
+
+    The fix replaces the read with
+    ``select(WebSession).where(WebSession.id == cookie_id).with_for_update()``
+    so the row is row-level-locked for the rotating transaction on
+    PostgreSQL (production); the second concurrent caller blocks,
+    re-reads after the first commits, and falls into the
+    value_mismatch branch -- exactly the one-time-use shape the
+    RFC mandates.
+
+    SQLite caveat (per the punch-list): the test suite's dev/test
+    engine is aiosqlite, whose locking is database-level rather
+    than row-level -- ``FOR UPDATE`` is parsed but does not
+    actually serialise concurrent transactions the way PG's does.
+    A behavioural ``asyncio.gather`` test against two concurrent
+    ``rotate_refresh`` calls therefore cannot prove the fix on
+    SQLite: both attempts may legitimately succeed when the lock
+    is a no-op. The behavioural Postgres-flavour proof would
+    require a testcontainers-PG fixture (the
+    ``backend/tests/integration/`` precedent); the unit suite
+    instead asserts the SQL that goes onto the wire -- the
+    deterministic, dialect-portable signal that the fix is in
+    place. If a future refactor reverts to ``session.get`` (or to
+    a plain ``select`` without ``.with_for_update()``), this
+    assertion fails immediately even on SQLite, surfacing the
+    regression before it ships.
+    """
+    tenant_id = uuid.uuid4()
+    original_refresh = "rt-original-CCCCCCCCCCCCCCCCCCCC"
+
+    async with session.begin():
+        created = await create_session(
+            session,
+            operator_sub="op-alice",
+            tenant_id=tenant_id,
+            access_token="at-initial",
+            refresh_token=original_refresh,
+            lifetime=timedelta(minutes=10),
+        )
+
+    # Spy on the rotation session's ``execute`` so we can inspect
+    # the actual ``Select`` object handed to SQLAlchemy. SQLite's
+    # dialect omits the ``FOR UPDATE`` clause from rendered SQL
+    # entirely (it parses but no-ops the lock), so capturing the
+    # text-on-the-wire is not portable -- the dialect-portable
+    # signal is the ``_for_update_arg`` attribute on the
+    # ``Select`` itself, which ``with_for_update()`` sets and the
+    # plain ``session.get`` / unlocked ``select`` path leaves
+    # ``None``. Both engines compile the same statement object;
+    # only the rendered output differs.
+    from sqlalchemy import Select
+
+    sessionmaker = get_sessionmaker()
+    captured_selects: list[Select[tuple[WebSession]]] = []
+
+    async with sessionmaker() as rotation_session, rotation_session.begin():
+        original_execute = rotation_session.execute
+
+        async def _spy_execute(stmt, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if isinstance(stmt, Select):
+                froms = {t.name for t in stmt.get_final_froms() if hasattr(t, "name")}
+                if "web_session" in froms:
+                    captured_selects.append(stmt)
+            return await original_execute(stmt, *args, **kwargs)
+
+        rotation_session.execute = _spy_execute  # type: ignore[method-assign]
+        await rotate_refresh(
+            rotation_session,
+            created.id,
+            presented_refresh=original_refresh,
+            new_access_token="at-new-EEEEEEEEEEEEEEEEEEE",
+            new_refresh_token="rt-new-FFFFFFFFFFFFFFFFFFFFFFF",
+        )
+
+    assert captured_selects, (
+        "rotate_refresh must execute a Select against web_session; "
+        "if it reverted to session.get, this captures zero Select objects"
+    )
+    # ``with_for_update()`` sets ``_for_update_arg`` on the Select;
+    # the unlocked path leaves it ``None``. Cross-dialect signal,
+    # observable on SQLite even though SQLite renders no FOR UPDATE
+    # clause and applies no row lock at runtime.
+    lock_bearing = [s for s in captured_selects if s._for_update_arg is not None]
+    assert lock_bearing, (
+        "rotate_refresh's SELECT against web_session must call "
+        "`.with_for_update()` to satisfy RFC 9700 § 4.14 single-use "
+        "refresh-token rotation on PostgreSQL; the unlocked read "
+        "regression is back if no captured Select has "
+        "_for_update_arg set"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Expired session returns None (AC 4)
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_ui_session_store.py
+++ b/backend/tests/test_ui_session_store.py
@@ -1,0 +1,545 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the BFF session-store (Task #864).
+
+The tests exercise the four entry points the
+:mod:`meho_backplane.ui.auth.session_store` module exposes
+(:func:`create_session`, :func:`load_session`, :func:`revoke_session`,
+:func:`rotate_refresh`) plus the migration round-trip for the
+``web_session`` table.
+
+Coverage matrix (Task #864 acceptance criteria):
+
+* ``alembic upgrade head`` / ``alembic downgrade -1`` round-trips
+  the ``web_session`` table cleanly (migration ``0012``).
+* :func:`create_session` -> :func:`load_session` -> :func:`revoke_session`
+  round-trips work; the DB columns hold encrypted bytes, never the
+  plaintext tokens.
+* Refresh rotation succeeds when the presented value matches; the
+  prior refresh token is single-use (a second :func:`rotate_refresh`
+  with the old value triggers replay revocation + audit row).
+* :func:`load_session` returns ``None`` when ``expires_at`` is in the
+  past.
+
+The autouse fixtures in :mod:`backend.tests.conftest`
+(``_default_database_url`` + ``_schema_template_db``) provide a fresh
+file-backed SQLite DB migrated to head before every test, so the
+``web_session`` table is present without any per-test
+``alembic upgrade head`` replay (per PR #898's per-worker template
+pattern).
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.engine import (
+    get_sessionmaker,
+    reset_engine_for_testing,
+)
+from meho_backplane.db.models import AuditLog, WebSession
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth.session_store import (
+    REFRESH_REPLAY_AUDIT_METHOD,
+    REFRESH_REPLAY_AUDIT_PATH,
+    DecryptedSession,
+    EncryptionKeyMissingError,
+    RefreshReplayError,
+    create_session,
+    load_session,
+    reset_fernet_cache_for_testing,
+    revoke_session,
+    rotate_refresh,
+)
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars + a session-store Fernet key for every test.
+
+    The chassis-wide :class:`Settings` requires ``KEYCLOAK_ISSUER_URL``
+    / ``KEYCLOAK_AUDIENCE`` / ``VAULT_ADDR`` (see the per-test pattern
+    in :mod:`backend.tests.test_audit_query_handler`); the session-store
+    additionally needs a Fernet key.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """One :class:`AsyncSession` per test, scoped to a single ``async with``."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+# ---------------------------------------------------------------------------
+# Alembic round-trip (acceptance criterion 1)
+# ---------------------------------------------------------------------------
+
+
+def test_alembic_round_trip_web_session_table(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``alembic upgrade head`` then ``downgrade -1`` round-trips cleanly.
+
+    Exercises the reversibility contract documented on
+    ``0012_create_web_session``: ``upgrade`` creates the table + two
+    indexes; ``downgrade`` drops them in inverse order.
+
+    The test function is **sync** (not ``async def``) because
+    :func:`alembic.command.upgrade` invokes :func:`asyncio.run`
+    internally via the env.py async cookbook, and that conflicts
+    with a running pytest-asyncio event loop. Mirrors the pattern in
+    :mod:`tests.test_migration_0011_backfill_when_to_use`.
+
+    Inspecting tables uses a parallel sync engine bound to the same
+    DB file; the migration runner used the async engine.
+    """
+    from alembic import command
+    from sqlalchemy import create_engine as sa_create_engine
+    from sqlalchemy import inspect as sa_inspect
+
+    from meho_backplane.db.migrations import alembic_config
+
+    db_path = tmp_path / "migration_round_trip.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+
+    def _table_names_and_indexes() -> tuple[set[str], set[str]]:
+        sync_eng = sa_create_engine(sync_url)
+        try:
+            inspector = sa_inspect(sync_eng)
+            table_names = set(inspector.get_table_names())
+            index_names: set[str] = set()
+            if "web_session" in table_names:
+                index_names = {ix["name"] for ix in inspector.get_indexes("web_session")}
+            return table_names, index_names
+        finally:
+            sync_eng.dispose()
+
+    # Step 1 -- upgrade only up to 0011 so the table does not yet exist.
+    command.upgrade(cfg, "0011")
+    pre_tables, _pre_indexes = _table_names_and_indexes()
+    assert "web_session" not in pre_tables
+
+    # Step 2 -- upgrade to head creates the table + both indexes.
+    command.upgrade(cfg, "head")
+    up_tables, up_indexes = _table_names_and_indexes()
+    assert "web_session" in up_tables
+    assert "web_session_operator_sub_idx" in up_indexes
+    assert "web_session_expires_at_idx" in up_indexes
+
+    # Step 3 -- downgrade -1 drops the table.
+    command.downgrade(cfg, "-1")
+    down_tables, _down_indexes = _table_names_and_indexes()
+    assert "web_session" not in down_tables
+
+
+# ---------------------------------------------------------------------------
+# create / load / revoke round-trip + ciphertext-at-rest assertion (AC 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_then_load_then_revoke_round_trips(
+    session: AsyncSession,
+) -> None:
+    """A freshly-created session loads, then revokes, then no-longer-loads."""
+    tenant_id = uuid.uuid4()
+    operator_sub = "op-alice"
+    access_plaintext = "at-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    refresh_plaintext = "rt-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+    async with session.begin():
+        created = await create_session(
+            session,
+            operator_sub=operator_sub,
+            tenant_id=tenant_id,
+            access_token=access_plaintext,
+            refresh_token=refresh_plaintext,
+            lifetime=timedelta(minutes=10),
+        )
+    assert isinstance(created, DecryptedSession)
+    assert created.operator_sub == operator_sub
+    assert created.tenant_id == tenant_id
+    assert created.access_token == access_plaintext
+    assert created.refresh_token == refresh_plaintext
+    assert created.expires_at > datetime.now(UTC)
+
+    # Load round-trips the same plaintexts.
+    async with session.begin():
+        loaded = await load_session(session, created.id)
+    assert loaded is not None
+    assert loaded.id == created.id
+    assert loaded.operator_sub == operator_sub
+    assert loaded.access_token == access_plaintext
+    assert loaded.refresh_token == refresh_plaintext
+
+    # Revoke + reload returns None.
+    async with session.begin():
+        await revoke_session(session, created.id)
+    async with session.begin():
+        post_revoke = await load_session(session, created.id)
+    assert post_revoke is None
+
+
+@pytest.mark.asyncio
+async def test_db_columns_are_ciphertext_not_plaintext(
+    session: AsyncSession,
+) -> None:
+    """AC: the access/refresh DB columns must never hold plaintext bytes."""
+    tenant_id = uuid.uuid4()
+    access_plaintext = "at-distinctive-AAA-marker-zzz"
+    refresh_plaintext = "rt-distinctive-BBB-marker-zzz"
+
+    async with session.begin():
+        created = await create_session(
+            session,
+            operator_sub="op-alice",
+            tenant_id=tenant_id,
+            access_token=access_plaintext,
+            refresh_token=refresh_plaintext,
+            lifetime=timedelta(minutes=10),
+        )
+
+    # Read the row back via the ORM and inspect the bytes directly.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as inspect_session:
+        row = await inspect_session.get(WebSession, created.id)
+    assert row is not None
+    assert isinstance(row.access_token, bytes)
+    assert isinstance(row.refresh_token, bytes)
+    # The distinctive plaintext marker must NOT appear in either
+    # column's bytes -- if it did, we'd have stored plaintext.
+    assert access_plaintext.encode("utf-8") not in row.access_token
+    assert refresh_plaintext.encode("utf-8") not in row.refresh_token
+    # Fernet ciphertext is URL-safe-base64 (the `gAAAA...` prefix is
+    # the version byte + timestamp encoded). A successful encrypt
+    # produces non-empty bytes.
+    assert len(row.access_token) > 0
+    assert len(row.refresh_token) > 0
+
+
+# ---------------------------------------------------------------------------
+# Refresh rotation: happy path + replay revokes + audit row (AC 3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rotate_refresh_happy_path_replaces_both_tokens(
+    session: AsyncSession,
+) -> None:
+    """Presenting the current refresh value rotates both tokens in place."""
+    tenant_id = uuid.uuid4()
+    original_access = "at-old-AAAAAAAAAAAAAAAAAAAAAAAAAA"
+    original_refresh = "rt-old-BBBBBBBBBBBBBBBBBBBBBBBBBB"
+    new_access = "at-new-CCCCCCCCCCCCCCCCCCCCCCCCCC"
+    new_refresh = "rt-new-DDDDDDDDDDDDDDDDDDDDDDDDDD"
+
+    async with session.begin():
+        created = await create_session(
+            session,
+            operator_sub="op-alice",
+            tenant_id=tenant_id,
+            access_token=original_access,
+            refresh_token=original_refresh,
+            lifetime=timedelta(minutes=10),
+        )
+
+    async with session.begin():
+        rotated = await rotate_refresh(
+            session,
+            created.id,
+            presented_refresh=original_refresh,
+            new_access_token=new_access,
+            new_refresh_token=new_refresh,
+        )
+
+    assert rotated.id == created.id
+    assert rotated.access_token == new_access
+    assert rotated.refresh_token == new_refresh
+
+    # Re-load via the public API and confirm the new tokens land.
+    async with session.begin():
+        loaded = await load_session(session, created.id)
+    assert loaded is not None
+    assert loaded.access_token == new_access
+    assert loaded.refresh_token == new_refresh
+
+
+@pytest.mark.asyncio
+async def test_rotate_refresh_replay_revokes_and_writes_audit(
+    session: AsyncSession,
+) -> None:
+    """AC: presenting an already-rotated refresh value revokes + audits."""
+    tenant_id = uuid.uuid4()
+    original_refresh = "rt-original-AAAAAAAAAAAAAAAAAAA"
+    new_refresh = "rt-rotated-BBBBBBBBBBBBBBBBBBBB"
+
+    async with session.begin():
+        created = await create_session(
+            session,
+            operator_sub="op-alice",
+            tenant_id=tenant_id,
+            access_token="at-initial",
+            refresh_token=original_refresh,
+            lifetime=timedelta(minutes=10),
+        )
+
+    # First rotation succeeds.
+    async with session.begin():
+        await rotate_refresh(
+            session,
+            created.id,
+            presented_refresh=original_refresh,
+            new_access_token="at-second",
+            new_refresh_token=new_refresh,
+        )
+
+    # Second rotation with the OLD refresh value must raise + revoke
+    # + write an audit row.
+    with pytest.raises(RefreshReplayError) as excinfo:
+        async with session.begin():
+            await rotate_refresh(
+                session,
+                created.id,
+                presented_refresh=original_refresh,
+                new_access_token="at-replay",
+                new_refresh_token="rt-replay",
+            )
+    assert excinfo.value.session_id == created.id
+    audit_id = excinfo.value.audit_id
+
+    # The session is now revoked -- ``load_session`` returns None.
+    async with session.begin():
+        loaded = await load_session(session, created.id)
+    assert loaded is None
+
+    # The audit row + revoke commit on a dedicated session inside
+    # ``rotate_refresh`` (see ``_commit_replay_side_effects``), so
+    # they survive the caller's ``async with session.begin()`` block
+    # rolling back on the propagating ``RefreshReplayError``. A fresh
+    # session here observes both effects.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as inspect_session:
+        row = await inspect_session.get(AuditLog, audit_id)
+    assert row is not None, (
+        "the rotate_refresh replay branch must commit the "
+        "audit row and the revoke independently of the caller's "
+        "transaction"
+    )
+    assert row.method == REFRESH_REPLAY_AUDIT_METHOD
+    assert row.path == REFRESH_REPLAY_AUDIT_PATH
+    assert row.status_code == 401
+    assert row.operator_sub == "op-alice"
+    assert row.tenant_id == tenant_id
+    assert row.payload["session_id"] == str(created.id)
+
+
+@pytest.mark.asyncio
+async def test_rotate_refresh_missing_session_writes_audit(
+    session: AsyncSession,
+) -> None:
+    """A presented cookie with no row triggers the replay-audit branch."""
+    bogus_id = uuid.uuid4()
+    with pytest.raises(RefreshReplayError) as excinfo:
+        async with session.begin():
+            await rotate_refresh(
+                session,
+                bogus_id,
+                presented_refresh="rt-anything",
+                new_access_token="at-x",
+                new_refresh_token="rt-x",
+            )
+    assert excinfo.value.session_id == bogus_id
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as inspect_session:
+        row = await inspect_session.get(AuditLog, excinfo.value.audit_id)
+    assert row is not None
+    assert row.payload["session_id"] == str(bogus_id)
+    assert row.payload["reason"] == "missing_session"
+
+
+# ---------------------------------------------------------------------------
+# Expired session returns None (AC 4)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_session_returns_none_when_expired(
+    session: AsyncSession,
+) -> None:
+    """``expires_at`` in the past -> ``load_session`` returns None."""
+    tenant_id = uuid.uuid4()
+    async with session.begin():
+        created = await create_session(
+            session,
+            operator_sub="op-alice",
+            tenant_id=tenant_id,
+            access_token="at-doomed",
+            refresh_token="rt-doomed",
+            lifetime=timedelta(minutes=10),
+        )
+
+    # Force the row's expires_at into the past via the ORM. Keep the
+    # update inside a single transaction so the load below sees the
+    # committed value.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as patch_session, patch_session.begin():
+        row = await patch_session.get(WebSession, created.id)
+        assert row is not None
+        row.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+
+    async with session.begin():
+        loaded = await load_session(session, created.id)
+    assert loaded is None
+
+
+# ---------------------------------------------------------------------------
+# Misc: missing key error + reset-fernet-cache plumbing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_encryption_key_raises_explicit_error(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``UI_SESSION_ENCRYPTION_KEY`` unset -> :class:`EncryptionKeyMissingError`."""
+    monkeypatch.delenv("UI_SESSION_ENCRYPTION_KEY", raising=False)
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+
+    with pytest.raises(EncryptionKeyMissingError):
+        async with session.begin():
+            await create_session(
+                session,
+                operator_sub="op-alice",
+                tenant_id=uuid.uuid4(),
+                access_token="at",
+                refresh_token="rt",
+                lifetime=timedelta(minutes=10),
+            )
+
+
+@pytest.mark.asyncio
+async def test_revoke_then_load_returns_none_when_active_session_exists(
+    session: AsyncSession,
+) -> None:
+    """``revoke_session`` is idempotent and ``load_session`` skips revoked."""
+    tenant_id = uuid.uuid4()
+    async with session.begin():
+        created = await create_session(
+            session,
+            operator_sub="op-alice",
+            tenant_id=tenant_id,
+            access_token="at",
+            refresh_token="rt",
+            lifetime=timedelta(minutes=10),
+        )
+
+    # First revoke marks the row.
+    async with session.begin():
+        await revoke_session(session, created.id)
+
+    # Second revoke is idempotent (does not error, does not bump the
+    # revoked_at timestamp again -- contract is "first-call wins").
+    async with session.begin():
+        await revoke_session(session, created.id)
+
+    async with session.begin():
+        loaded = await load_session(session, created.id)
+    assert loaded is None
+
+
+@pytest.mark.asyncio
+async def test_revoke_missing_session_is_noop(session: AsyncSession) -> None:
+    """``revoke_session`` on a nonexistent id silently no-ops."""
+    bogus = uuid.uuid4()
+    async with session.begin():
+        await revoke_session(session, bogus)
+    # No assertion needed beyond "did not raise". A query confirms
+    # nothing was created.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as inspect_session:
+        rows = (await inspect_session.execute(select(WebSession))).scalars().all()
+    assert all(row.id != bogus for row in rows)
+
+
+@pytest.mark.asyncio
+async def test_load_session_updates_last_seen_at(
+    session: AsyncSession,
+) -> None:
+    """Successful ``load_session`` refreshes ``last_seen_at``."""
+    tenant_id = uuid.uuid4()
+    async with session.begin():
+        created = await create_session(
+            session,
+            operator_sub="op-alice",
+            tenant_id=tenant_id,
+            access_token="at",
+            refresh_token="rt",
+            lifetime=timedelta(minutes=10),
+        )
+
+    # Capture the create-time last_seen_at via direct ORM read.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as pre_session:
+        pre_row = await pre_session.get(WebSession, created.id)
+    assert pre_row is not None
+    initial_last_seen = pre_row.last_seen_at
+
+    # Sleep is overkill; the fixture's monotonic clock advances
+    # between flush() calls. Just call load_session and assert
+    # the timestamp moved forward (or stayed equal in the rare
+    # same-microsecond case -- treat >= initial as the contract).
+    async with session.begin():
+        loaded = await load_session(session, created.id)
+    assert loaded is not None
+
+    async with sessionmaker() as post_session:
+        post_row = await post_session.get(WebSession, created.id)
+    assert post_row is not None
+    assert post_row.last_seen_at >= initial_last_seen
+
+
+# ---------------------------------------------------------------------------
+# Static guard: the test conftest pins a generated key (not a literal)
+# so the test process does not embed a constant key value. This is a
+# defence against accidentally publishing the key in CI logs.
+# ---------------------------------------------------------------------------
+
+
+def test_required_env_pins_unique_fernet_key() -> None:
+    """The autouse env fixture must inject a real Fernet key."""
+    key = os.environ.get("UI_SESSION_ENCRYPTION_KEY")
+    assert key, "fixture must set UI_SESSION_ENCRYPTION_KEY"
+    # ``Fernet`` raises if the key is not URL-safe-base64 32 bytes.
+    Fernet(key.encode("ascii"))

--- a/backend/tests/test_ui_session_store.py
+++ b/backend/tests/test_ui_session_store.py
@@ -103,7 +103,7 @@ def test_alembic_round_trip_web_session_table(
     """``alembic upgrade head`` then ``downgrade -1`` round-trips cleanly.
 
     Exercises the reversibility contract documented on
-    ``0012_create_web_session``: ``upgrade`` creates the table + two
+    ``0013_create_web_session``: ``upgrade`` creates the table + two
     indexes; ``downgrade`` drops them in inverse order.
 
     The test function is **sync** (not ``async def``) because

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -5,9 +5,11 @@ Frontend chassis) introduces a server-rendered web UI inside the
 backplane FastAPI process at `/ui/*`. This doc covers the **chassis**
 that Task [#863](https://github.com/evoila/meho/issues/863) (G10.0-T2)
 landed — module layout, template-rendering shape, Tailwind 4 build
-pipeline, vendored JS assets. Subsequent Tasks fill in the missing
-pieces (`#864` session storage, `#865` auth flow, `#866` FastAPI
-mount + dashboard + smoke test); this doc grows with each Task.
+pipeline, vendored JS assets — plus the **session storage** that Task
+[#864](https://github.com/evoila/meho/issues/864) (G10.0-T3) layered on
+top. Subsequent Tasks fill in the remaining pieces (`#865` auth
+flow, `#866` FastAPI mount + dashboard + smoke test); this doc grows
+with each Task.
 
 ## Overview
 
@@ -39,7 +41,8 @@ Locked decisions:
 | `meho_backplane.ui.paths` | Resolves `templates/`, `static/src/`, `static/dist/` directories at runtime. Source-tree dev and image deploy both work via `Path(__file__).resolve().parent`. |
 | `meho_backplane.ui.templating` | Jinja2 `Environment` factory with `FileSystemLoader`, `select_autoescape`, `StrictUndefined`, and the `app_version` global pre-bound from `meho_backplane.__version__`. |
 | `meho_backplane.ui.routes` | Stub package for chassis Task. T5 (#866) lands the `APIRouter` instance + dashboard view + the five surface stub routes. |
-| `meho_backplane.ui.auth` | Stub package for chassis Task. T3 (#864) lands `web_session` ORM + encrypted token custody; T4 (#865) lands `/ui/auth/{login,callback,logout}` + session middleware. |
+| `meho_backplane.ui.auth` | BFF auth subpackage. T3 (#864) landed `session_store` (encrypted token custody + RFC 9700 refresh-token rotation); T4 (#865) lands `/ui/auth/{login,callback,logout}` + session middleware. |
+| `meho_backplane.ui.auth.session_store` | Fernet-encrypted server-side session storage. `create_session`, `load_session`, `revoke_session`, `rotate_refresh` against the `web_session` Postgres table. Replay of a used refresh token revokes the session and writes a `ui.session.refresh_replay` audit row on a dedicated transaction so the security signal survives caller rollback. |
 
 The Jinja2 `Environment` is a module-level singleton (constructed on
 first `get_jinja_env()` call); the template cache it holds is keyed
@@ -98,6 +101,51 @@ cd backend && uv run uvicorn meho_backplane.main:app --reload
 The watcher writes to the same `static/dist/` path the image build
 populates; no `npm` / `pnpm` / `node` enters this loop. The Tailwind
 download (~38 MB binary) is the one-time cost.
+
+## Session storage (Task #864)
+
+The BFF (Backend-for-Frontend) shape locked by
+[decision #11](../planning/v0.2-decisions.md) keeps tokens
+server-side. Task #864 ships the storage substrate the
+upcoming T4 login flow writes to:
+
+- **`web_session` Postgres table** — migration
+  [`0012_create_web_session.py`](../../backend/alembic/versions/0012_create_web_session.py).
+  Columns: `id` (UUID PK, the cookie value the browser holds),
+  `operator_sub` (Keycloak `sub` claim), `tenant_id`,
+  `created_at`, `expires_at`, `access_token` (bytea, Fernet
+  ciphertext), `refresh_token` (bytea, Fernet ciphertext),
+  `last_seen_at`, `revoked_at` (nullable; non-null = soft-deleted).
+  Indexes on `operator_sub` and `expires_at` (future
+  bulk-revoke / idle-sweep surfaces).
+- **ORM model** — [`WebSession` in
+  `db/models.py`](../../backend/src/meho_backplane/db/models.py).
+  Mirrors the column shape; no helper methods (write-once /
+  read-mostly).
+- **Encryption** — every token write goes through one
+  [`cryptography.fernet.Fernet`](https://cryptography.io/en/latest/fernet/)
+  instance constructed from `UI_SESSION_ENCRYPTION_KEY` (URL-safe
+  base64-encoded 32-byte key). Production deploys render this from
+  Vault into the pod environment by the same chain that lands
+  `DATABASE_URL` / Keycloak client secrets. Empty value =
+  fail-fast: any session-store call raises
+  `EncryptionKeyMissingError`. The key is process-wide
+  (one-key-per-deploy in v0.2); rotation is a future Initiative
+  (every active session becomes un-decryptable on rotation).
+- **Refresh-token rotation** — `rotate_refresh` implements the
+  [RFC 9700 § 4.14](https://datatracker.ietf.org/doc/rfc9700/)
+  one-time-use contract. The happy path swaps both columns to
+  fresh ciphertext on the caller's session; the replay path
+  (mismatched / already-revoked / expired / missing session)
+  revokes the row and writes a `ui.session.refresh_replay`
+  `audit_log` row on a **dedicated session** so the security
+  signal commits independently of the caller's transaction. The
+  raised `RefreshReplayError` carries the revoked session id +
+  the freshly-written audit row id so the caller (T4 refresh
+  handler) can map both into the 401 + cookie-clear response.
+
+T4 (#865) builds the login / callback / logout flow + the BFF
+middleware on top of this substrate; T3 ships storage only.
 
 ## Vendored asset versions
 
@@ -158,9 +206,12 @@ Initiatives fill the routes in.
 
 - **`jinja2 >= 3.1.6`** — already a backplane dependency; no
   pyproject change.
-- **No new Python deps** for the chassis. T3 (#864) adds `cryptography`
-  (already a dev dep) to runtime; T4 (#865) leans on the existing
-  `authlib` dependency.
+- **`cryptography >= 42`** — already a backplane dependency (vendored
+  for Vault TLS + JWT). T3 (#864) uses
+  `cryptography.fernet.Fernet` for at-rest session-token
+  encryption.
+- **No new Python deps** for the chassis. T4 (#865) leans on the
+  existing `authlib` dependency.
 - **Tailwind standalone CLI** — runtime-of-image-build dependency
   only; never enters the running container or the wheel.
 

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -110,7 +110,7 @@ server-side. Task #864 ships the storage substrate the
 upcoming T4 login flow writes to:
 
 - **`web_session` Postgres table** — migration
-  [`0012_create_web_session.py`](../../backend/alembic/versions/0012_create_web_session.py).
+  [`0013_create_web_session.py`](../../backend/alembic/versions/0013_create_web_session.py).
   Columns: `id` (UUID PK, the cookie value the browser holds),
   `operator_sub` (Keycloak `sub` claim), `tenant_id`,
   `created_at`, `expires_at`, `access_token` (bytea, Fernet


### PR DESCRIPTION
## Summary

- Lands the BFF (Backend-for-Frontend) session-storage substrate for the operator console — Initiative #337 (G10.0), Task #864.
- Decision #11 keeps OAuth tokens server-side; the browser holds nothing but the `meho_session` cookie (a UUID). This PR ships the Postgres `web_session` table, the encrypted-at-rest token custody (Fernet via `cryptography`), and the RFC 9700 §4.14 one-time-use refresh-token rotation contract.
- T4 (#865) builds the login / callback / middleware flow on top of this substrate; T5 (#866) wires it into the FastAPI app + dashboard.

## What ships

- **Migration `0012_create_web_session.py`** — reversible, two-index table. Columns: `id` (UUID PK = cookie value, `gen_random_uuid()` on PG), `operator_sub`, `tenant_id`, `created_at` / `expires_at` / `last_seen_at`, encrypted `access_token` / `refresh_token` (bytea on PG, BLOB on SQLite), soft-delete `revoked_at`. Soft-FK discipline on `tenant_id` matches `audit_log.tenant_id` precedent. Renumbered to 0012 because `0011_backfill_operation_group_when_to_use` already occupied 0011.
- **`WebSession` ORM model** (`backend/src/meho_backplane/db/models.py`) — `Mapped[bytes]` typed columns for the encrypted blobs; no helper methods (write-once / read-mostly).
- **`meho_backplane.ui.auth.session_store`** — `create_session`, `load_session`, `revoke_session`, `rotate_refresh`. All tokens are Fernet-encrypted before insert and decrypted on read; the `bytes` form of the Fernet token is stored (not the URL-safe-base64 string) so text-search tooling never surfaces what looks like a credential in stable storage. The replay branch of `rotate_refresh` revokes the row + writes a `ui.session.refresh_replay` audit row on a **dedicated** session so the security signal commits independently of the caller's transaction.
- **`Settings.ui_session_encryption_key`** mapped to `UI_SESSION_ENCRYPTION_KEY`. Empty value fails fast with `EncryptionKeyMissingError` on first session-store call; production deploys render the key from a Vault-managed secret into the pod env by the same chain that lands `DATABASE_URL`.
- **`docs/codebase/ui.md`** extended with the Session storage section + `session_store` Key-types row.

## Test plan

- [x] `ruff check src/ tests/ alembic/` — clean
- [x] `ruff format --check src/ tests/ alembic/` — clean
- [x] `mypy src/` — 226 files, no issues
- [x] `pytest -n auto backend/tests/test_ui_session_store.py` — 12 passed
- [x] Full unit suite — 3201 passed / 19 skipped / 0 failed (was 3200 / 19, the +1 is the new file and the previously-failing `test_re_running_migration_is_idempotent` is recovered by the surgical edit below)
- [x] **Acceptance criterion 1** — `alembic upgrade head` / `alembic downgrade -1` round-trips the `web_session` table cleanly: `tests/test_ui_session_store.py::test_alembic_round_trip_web_session_table`
- [x] **Acceptance criterion 2** — create/load/revoke round-trip with encrypted columns: `tests/test_ui_session_store.py::test_create_then_load_then_revoke_round_trips` + `test_db_columns_are_ciphertext_not_plaintext` (asserts the plaintext marker bytes are NOT present in the stored bytea columns)
- [x] **Acceptance criterion 3** — refresh rotation: re-use revokes + audit row: `tests/test_ui_session_store.py::test_rotate_refresh_happy_path_replaces_both_tokens` + `test_rotate_refresh_replay_revokes_and_writes_audit` + `test_rotate_refresh_missing_session_writes_audit`
- [x] **Acceptance criterion 4** — expired session returns None: `tests/test_ui_session_store.py::test_load_session_returns_none_when_expired`

## Out of scope (covered by sibling Tasks)

- `/ui/auth/login`, `/callback`, `/logout` handlers + session-cookie middleware — **T4 (#865)**.
- `meho-web` Keycloak client + Vault-stored client secret + cross-repo doc — **T4 (#865)**.
- FastAPI `/ui/*` route mount, dashboard view, CSRF, smoke test — **T5 (#866)**.

## Notes on the one touched-but-unrelated test

`tests/test_migration_0011_backfill_when_to_use.py::test_re_running_migration_is_idempotent` stamps the DB back to `0010` and re-runs `command.upgrade(cfg, "head")` to exercise 0011's filter-shaped idempotence. With 0012 landing, `head` now re-runs both — and 0012's `CREATE TABLE` legitimately fails on the second pass. The surgical fix is to upgrade explicitly to `0011` (not `head`) on the replay step; the test's intent is 0011's idempotence, and 0012 doesn't need to (and shouldn't) be designed for stamp-back replay. One-line change with an inline comment explaining why.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #864


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Encrypted server-side session storage with create, load, and revoke operations.
  * Refresh token rotation with replay detection and automatic session revocation.
  * Session expiration support based on configurable lifetime.

* **Tests**
  * Added comprehensive test suite for session operations and security properties.

* **Documentation**
  * Updated architecture documentation with session storage details and configuration requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/903?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->