### PR TITLE
feat(topology): G9.3-T2 diff-on-write hook — *_history rows + audit_id in refresh + annotate

### DIFF
--- a/backend/src/meho_backplane/db/engine.py
+++ b/backend/src/meho_backplane/db/engine.py
@@ -47,8 +47,11 @@ References
 
 from __future__ import annotations
 
+import os
 from collections.abc import AsyncIterator
+from typing import Any
 
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -95,7 +98,47 @@ def create_engine_for_url(url: str, *, pool_size: int, pool_timeout: float) -> A
     if not url.startswith("sqlite"):
         pool_kwargs["pool_size"] = pool_size
         pool_kwargs["pool_timeout"] = pool_timeout
-    return create_async_engine(url, future=True, **pool_kwargs)
+    engine = create_async_engine(url, future=True, **pool_kwargs)
+
+    if url.startswith("sqlite") and os.environ.get("MEHO_SQLITE_FOREIGN_KEYS") == "1":
+        # SQLite enforces foreign-key constraints only when ``PRAGMA
+        # foreign_keys = ON`` is issued on every connection (the default
+        # is OFF, even on aiosqlite). Production runs on PG where FKs
+        # are always enforced; the dev/test driver is SQLite, where the
+        # default-off behaviour means a test suite cannot catch PG-vs-
+        # SQLite divergences like the G9.3-T2 ``graph_edge_history.
+        # edge_id`` ``ON DELETE SET NULL`` cascade, which silently
+        # nulled the column on PG and left it untouched on SQLite.
+        #
+        # The PRAGMA is gated on an **opt-in env var** rather than
+        # being on by default for SQLite. A blanket enable surfaces a
+        # large pre-existing tape of test fixtures that insert
+        # FK-referencing rows without seeding the parent (the
+        # SQLite-doesn't-enforce-FKs default has masked them since the
+        # chassis adopted the per-test SQLite template at #793).
+        # Tearing that out is a chassis-wide refactor; the diff-on-
+        # write hook does not need it. Tests that *do* exercise the
+        # cascade semantics (currently :mod:`tests.test_topology_history_hook`)
+        # opt in via the ``_enforce_sqlite_foreign_keys`` autouse
+        # fixture, which sets the env var, resets the engine cache,
+        # and tears down on yield.
+        #
+        # Registering on the underlying sync engine fires once per new
+        # connection in the async pool. ``sync_engine`` is the
+        # documented async-side event-attachment surface (SQLAlchemy
+        # 2.x async docs § "Synopsis - Core").
+        @event.listens_for(engine.sync_engine, "connect")
+        def _sqlite_enable_foreign_keys(
+            dbapi_connection: Any,
+            _connection_record: Any,
+        ) -> None:
+            cursor = dbapi_connection.cursor()
+            try:
+                cursor.execute("PRAGMA foreign_keys=ON")
+            finally:
+                cursor.close()
+
+    return engine
 
 
 def get_engine() -> AsyncEngine:

--- a/backend/src/meho_backplane/topology/annotate.py
+++ b/backend/src/meho_backplane/topology/annotate.py
@@ -82,7 +82,17 @@ import structlog
 from sqlalchemy import select
 
 from meho_backplane.broadcast import BroadcastEvent, publish_event
-from meho_backplane.db.models import AuditLog, GraphEdge, GraphEdgeKind, GraphNode
+from meho_backplane.db.models import (
+    AuditLog,
+    GraphEdge,
+    GraphEdgeKind,
+    GraphHistoryChangeKind,
+    GraphNode,
+)
+from meho_backplane.topology.history import (
+    edge_snapshot,
+    record_edge_change,
+)
 from meho_backplane.topology.resolvers import resolve_node
 
 if TYPE_CHECKING:
@@ -278,7 +288,7 @@ async def _mark_same_kind_different_endpoint_superseded(
     from_id: uuid.UUID,
     to_id: uuid.UUID,
     kind: str,
-) -> list[uuid.UUID]:
+) -> list[tuple[GraphEdge, dict[str, Any]]]:
     """Stamp ``superseded_by`` on auto edges that the curated row replaces.
 
     Conflict §6 rule 1: a curated edge ``runs-on(vm-A → host-Y)``
@@ -289,9 +299,13 @@ async def _mark_same_kind_different_endpoint_superseded(
     the change when the attribute is reassigned, so we reassign
     rather than mutating the inner dict).
 
-    Returns the list of marked auto-edge ids — caller uses it for the
-    audit/broadcast payload's ``superseded_count`` so the visibility
-    of the conflict is not buried in a side effect.
+    Returns a list of ``(edge, pre_mutation_snapshot)`` pairs — the
+    caller emits one ``GraphEdgeHistory`` row per marked auto edge
+    (G9.3-T2 #857 diff-on-write hook), using the pre-mutation
+    snapshot as the history row's ``snapshot.before``. The audit /
+    broadcast payload's ``superseded`` array is built from
+    ``edge.id`` of each returned pair so the visibility of the
+    conflict is not buried in a side effect.
     """
     stmt = select(GraphEdge).where(
         GraphEdge.tenant_id == tenant_id,
@@ -301,12 +315,16 @@ async def _mark_same_kind_different_endpoint_superseded(
         GraphEdge.to_node_id != to_id,
     )
     rows = (await session.execute(stmt)).scalars().all()
-    marked: list[uuid.UUID] = []
+    marked: list[tuple[GraphEdge, dict[str, Any]]] = []
     for row in rows:
+        # Capture the pre-mutation snapshot **before** reassigning
+        # ``properties`` so the history row's ``before`` reflects the
+        # row as the operator last saw it without the supersede mark.
+        before = edge_snapshot(row)
         props = dict(row.properties or {})
         props[_SUPERSEDED_BY] = str(curated_edge_id)
         row.properties = props
-        marked.append(row.id)
+        marked.append((row, before))
     return marked
 
 
@@ -318,7 +336,7 @@ async def _mark_incompatible_kinds_conflict(
     from_id: uuid.UUID,
     to_id: uuid.UUID,
     kind: str,
-) -> list[uuid.UUID]:
+) -> list[tuple[GraphEdge, dict[str, Any]]]:
     """Stamp bidirectional ``conflicts_with`` on edges of other kinds.
 
     Conflict §6 rule 2: a curated edge ``depends-on(svc → db)``
@@ -328,8 +346,12 @@ async def _mark_incompatible_kinds_conflict(
     marker is a list so a single edge with several conflicting kinds
     accumulates every id (dedupe preserved).
 
-    Returns the list of conflicting edge ids — payload counterpart of
-    the superseded-list above.
+    Returns ``(edge, pre_mutation_snapshot)`` pairs for every
+    conflicting edge — caller emits one ``GraphEdgeHistory`` row per
+    pair (G9.3-T2 #857). The curated row's own marker write is
+    captured separately by the calling :func:`annotate_edge_in_txn`
+    so the curated row's history snapshot reflects the post-conflict
+    state.
     """
     stmt = select(GraphEdge).where(
         GraphEdge.tenant_id == tenant_id,
@@ -338,17 +360,21 @@ async def _mark_incompatible_kinds_conflict(
         GraphEdge.kind != kind,
     )
     rows = (await session.execute(stmt)).scalars().all()
-    conflicting_ids: list[uuid.UUID] = []
+    conflicting: list[tuple[GraphEdge, dict[str, Any]]] = []
     for row in rows:
-        conflicting_ids.append(row.id)
+        # Capture the pre-mutation snapshot before appending the marker.
+        before = edge_snapshot(row)
         _append_conflict_marker(row, curated_edge.id)
+        conflicting.append((row, before))
 
-    if conflicting_ids:
+    if conflicting:
         # Bidirectional: the curated row points back at every
-        # conflicting edge.
-        for other_id in conflicting_ids:
-            _append_conflict_marker(curated_edge, other_id)
-    return conflicting_ids
+        # conflicting edge. The curated row's own history row is
+        # written by the caller after both conflict scans complete,
+        # so we do not capture an intermediate snapshot here.
+        for other_edge, _ in conflicting:
+            _append_conflict_marker(curated_edge, other_edge.id)
+    return conflicting
 
 
 def _append_conflict_marker(edge: GraphEdge, other_id: uuid.UUID) -> None:
@@ -694,6 +720,251 @@ class AnnotatePlan:
     was_created: bool
 
 
+async def _insert_curated_edge(
+    session: AsyncSession,
+    *,
+    operator: Operator,
+    from_node: GraphNode,
+    to_node: GraphNode,
+    canonical_kind: str,
+    properties: dict[str, Any],
+    now: datetime,
+) -> GraphEdge:
+    """Insert a fresh ``source='curated'`` :class:`GraphEdge` and flush.
+
+    Flushing inside the helper ensures the row has its server-side
+    state (``id`` is already Python-side) before the §6 conflict
+    scans run -- they may need to read the freshly-inserted row back.
+    """
+    edge = GraphEdge(
+        id=uuid.uuid4(),
+        tenant_id=operator.tenant_id,
+        from_node_id=from_node.id,
+        to_node_id=to_node.id,
+        kind=canonical_kind,
+        source="curated",
+        properties=properties,
+        discovered_by=operator.sub,
+        first_seen=now,
+        last_seen=now,
+    )
+    session.add(edge)
+    await session.flush()
+    return edge
+
+
+def _merge_onto_existing_edge(
+    *,
+    existing: GraphEdge,
+    operator: Operator,
+    properties: dict[str, Any],
+    now: datetime,
+) -> tuple[GraphEdge, dict[str, Any]]:
+    """Idempotent upsert path: merge annotation onto an existing edge.
+
+    Covers two cases the single insert/upsert branch must handle:
+
+    1. **Re-annotate of an already-curated row.** Merge new free-text
+       fields onto the existing properties; the ``source='curated'``
+       and any reciprocal ``conflicts_with`` / ``superseded_by``
+       markers are preserved so the re-annotate does not silently
+       drop the §6 back-references.
+
+    2. **Annotate over an existing ``source='auto'`` edge with the
+       same triple.** The operator's intent is to take ownership of
+       that edge going forward — set notes / evidence, run §6
+       conflict detection from it, eventually revoke via
+       :func:`unannotate_edge`. Leaving the row as ``source='auto'``
+       would (a) make the triple-form unannotate raise
+       :class:`AutoEdgeDeletionError` so the operator cannot revoke
+       their own annotation; (b) let the next refresh's
+       :func:`_merge_edge_properties` overwrite the free-text props;
+       (c) make :func:`_mark_same_kind_different_endpoint_superseded`
+       on a future annotate mis-target the row as another auto
+       edge. The promotion to ``source='curated'`` and
+       ``discovered_by=operator.sub`` makes the operator the
+       canonical author from this call onward.
+
+    Returns ``(edge, pre_mutation_snapshot)`` so the caller can use
+    the snapshot as the history row's ``snapshot.before``.
+    """
+    # Capture the pre-mutation snapshot **before** rewriting
+    # ``properties`` / ``source`` so the history row's ``before``
+    # reflects the state the operator would have seen on a
+    # ``list-edges`` immediately prior to the re-annotate.
+    edge_before = edge_snapshot(existing)
+    merged = dict(existing.properties or {})
+    for key, value in properties.items():
+        merged[key] = value
+    promoting = existing.source != "curated"
+    if promoting:
+        # §6 invariant: a curated edge must never carry an
+        # ``superseded_by`` marker — that marker is meaningful only
+        # on ``source='auto'`` rows that the conflict-detection scan
+        # stamped against a different-endpoint curated assertion.
+        # When the same triple gets re-annotated, the auto row's
+        # stale marker would otherwise persist onto the promoted
+        # curated row and hide it from :func:`find_dependents` /
+        # :func:`find_dependencies` — the traversal CTE filters
+        # ``properties->>'superseded_by' IS NULL``. Drop the key
+        # here so the promoted curated edge is immediately visible.
+        #
+        # ``conflicts_with`` (bidirectional, list-shaped) is kept:
+        # the entries point at *other-kind* edges over the same
+        # endpoint pair, which still exist and still conflict; the
+        # incompatible-kinds scan below re-stamps the curated side
+        # without dropping the legitimate back-references.
+        merged.pop(_SUPERSEDED_BY, None)
+    existing.properties = merged
+    existing.last_seen = now
+    if promoting:
+        existing.source = "curated"
+        existing.discovered_by = operator.sub
+    return existing, edge_before
+
+
+def _emit_annotate_history(
+    session: AsyncSession,
+    *,
+    operator: Operator,
+    edge: GraphEdge,
+    edge_before: dict[str, Any] | None,
+    was_created: bool,
+    superseded_pairs: list[tuple[GraphEdge, dict[str, Any]]],
+    conflict_pairs: list[tuple[GraphEdge, dict[str, Any]]],
+    audit_id: uuid.UUID,
+    now: datetime,
+) -> None:
+    """Emit one history row per mutated edge in the annotate transaction.
+
+    Diff-on-write hook (G9.3-T2 #857): one row per mutated edge, all
+    sharing this annotate's pre-allocated ``audit_id`` and
+    ``valid_from=now`` so the temporal-query verbs (T3 / T4 / T5)
+    can reconstruct the operation as a single point-in-time event.
+    The curated row's history is emitted with the post-conflict-scan
+    snapshot so the ``conflicts_with`` marker is visible in
+    ``after`` -- the bidirectional view ``meho topology diff``
+    reconstructs.
+    """
+    edge_change_kind = (
+        GraphHistoryChangeKind.CREATED if was_created else GraphHistoryChangeKind.UPDATED
+    )
+    record_edge_change(
+        session,
+        edge_id=edge.id,
+        tenant_id=operator.tenant_id,
+        change_kind=edge_change_kind,
+        before=edge_before,
+        after=edge_snapshot(edge),
+        audit_id=audit_id,
+        valid_from=now,
+    )
+    for other_edge, other_before in (*superseded_pairs, *conflict_pairs):
+        # Each marked auto / other-kind edge survives -- the marker
+        # write is the only column that changed -- so the history
+        # row is ``updated`` with the marker visible in ``after``.
+        record_edge_change(
+            session,
+            edge_id=other_edge.id,
+            tenant_id=operator.tenant_id,
+            change_kind=GraphHistoryChangeKind.UPDATED,
+            before=other_before,
+            after=edge_snapshot(other_edge),
+            audit_id=audit_id,
+            valid_from=now,
+        )
+
+
+async def _upsert_curated_edge(
+    session: AsyncSession,
+    *,
+    operator: Operator,
+    from_node: GraphNode,
+    to_node: GraphNode,
+    canonical_kind: str,
+    note: str | None,
+    evidence_url: str | None,
+    now: datetime,
+) -> tuple[GraphEdge, dict[str, Any] | None, bool]:
+    """Resolve / upsert the curated edge; return ``(edge, before, was_created)``.
+
+    Wraps the insert-or-merge branch so :func:`annotate_edge_in_txn`
+    stays linear. ``before`` is ``None`` for a fresh insert, the
+    pre-mutation snapshot for the merge branch.
+    """
+    properties = {
+        "note": note,
+        "evidence_url": evidence_url,
+        "annotated_by": operator.sub,
+        "annotated_at": now.isoformat(),
+    }
+    existing = await _find_existing_edge(
+        session,
+        tenant_id=operator.tenant_id,
+        from_id=from_node.id,
+        to_id=to_node.id,
+        kind=canonical_kind,
+    )
+    if existing is None:
+        edge = await _insert_curated_edge(
+            session,
+            operator=operator,
+            from_node=from_node,
+            to_node=to_node,
+            canonical_kind=canonical_kind,
+            properties=properties,
+            now=now,
+        )
+        # ``before`` is None for the curated row's history -- the row
+        # did not exist prior to this transaction. ``after`` is captured
+        # by :func:`_emit_annotate_history` after both conflict scans
+        # have stamped any ``conflicts_with`` markers on this row.
+        return edge, None, True
+    edge, edge_before = _merge_onto_existing_edge(
+        existing=existing,
+        operator=operator,
+        properties=properties,
+        now=now,
+    )
+    return edge, edge_before, False
+
+
+async def _run_conflict_scans(
+    session: AsyncSession,
+    *,
+    edge: GraphEdge,
+    operator: Operator,
+    from_node: GraphNode,
+    to_node: GraphNode,
+    canonical_kind: str,
+) -> tuple[
+    list[tuple[GraphEdge, dict[str, Any]]],
+    list[tuple[GraphEdge, dict[str, Any]]],
+]:
+    """Run the §6 same-kind-supersede and incompatible-kinds scans.
+
+    Returns ``(superseded_pairs, conflict_pairs)``. Each pair is
+    ``(mutated_edge, pre_mutation_snapshot)`` for the history hook.
+    """
+    superseded_pairs = await _mark_same_kind_different_endpoint_superseded(
+        session,
+        tenant_id=operator.tenant_id,
+        curated_edge_id=edge.id,
+        from_id=from_node.id,
+        to_id=to_node.id,
+        kind=canonical_kind,
+    )
+    conflict_pairs = await _mark_incompatible_kinds_conflict(
+        session,
+        tenant_id=operator.tenant_id,
+        curated_edge=edge,
+        from_id=from_node.id,
+        to_id=to_node.id,
+        kind=canonical_kind,
+    )
+    return superseded_pairs, conflict_pairs
+
+
 async def annotate_edge_in_txn(
     session: AsyncSession,
     operator: Operator,
@@ -729,113 +1000,28 @@ async def annotate_edge_in_txn(
     :func:`annotate_edge` verbatim.
     """
     canonical_kind = _validate_kind(kind)
-
     from_node = await resolve_node(session, operator.tenant_id, from_ref.name, from_ref.kind)
     to_node = await resolve_node(session, operator.tenant_id, to_ref.name, to_ref.kind)
-
     now = datetime.now(UTC)
-    existing = await _find_existing_edge(
+
+    edge, edge_before, was_created = await _upsert_curated_edge(
         session,
-        tenant_id=operator.tenant_id,
-        from_id=from_node.id,
-        to_id=to_node.id,
-        kind=canonical_kind,
+        operator=operator,
+        from_node=from_node,
+        to_node=to_node,
+        canonical_kind=canonical_kind,
+        note=note,
+        evidence_url=evidence_url,
+        now=now,
     )
 
-    properties = {
-        "note": note,
-        "evidence_url": evidence_url,
-        "annotated_by": operator.sub,
-        "annotated_at": now.isoformat(),
-    }
-
-    if existing is None:
-        edge = GraphEdge(
-            id=uuid.uuid4(),
-            tenant_id=operator.tenant_id,
-            from_node_id=from_node.id,
-            to_node_id=to_node.id,
-            kind=canonical_kind,
-            source="curated",
-            properties=properties,
-            discovered_by=operator.sub,
-            first_seen=now,
-            last_seen=now,
-        )
-        session.add(edge)
-        await session.flush()
-        was_created = True
-    else:
-        # Idempotent path covers two cases:
-        #
-        # 1. **Re-annotate of an already-curated row.** Merge new
-        #    free-text fields onto the existing properties; the
-        #    ``source='curated'`` and any reciprocal ``conflicts_with``
-        #    / ``superseded_by`` markers are preserved so the
-        #    re-annotate does not silently drop the §6 back-references.
-        #
-        # 2. **Annotate over an existing ``source='auto'`` edge with
-        #    the same triple.** The operator's intent is to take
-        #    ownership of that edge going forward — set notes /
-        #    evidence, run §6 conflict detection from it, eventually
-        #    revoke via :func:`unannotate_edge`. Leaving the row as
-        #    ``source='auto'`` would (a) make the triple-form
-        #    unannotate raise :class:`AutoEdgeDeletionError` so the
-        #    operator cannot revoke their own annotation; (b) let the
-        #    next refresh's :func:`_merge_edge_properties` overwrite
-        #    the free-text props (only the reserved markers are
-        #    preserved on the merge path); (c) make
-        #    :func:`_mark_same_kind_different_endpoint_superseded` on
-        #    a future annotate mis-target the row as another auto
-        #    edge. The promotion to ``source='curated'`` and
-        #    ``discovered_by=operator.sub`` makes the operator the
-        #    canonical author from this call onward.
-        merged = dict(existing.properties or {})
-        for key, value in properties.items():
-            merged[key] = value
-        promoting = existing.source != "curated"
-        if promoting:
-            # §6 invariant: a curated edge must never carry an
-            # ``superseded_by`` marker — that marker is meaningful only
-            # on ``source='auto'`` rows that the conflict-detection
-            # scan stamped against a different-endpoint curated
-            # assertion. When the same triple gets re-annotated, the
-            # auto row's stale marker would otherwise persist onto the
-            # promoted curated row and hide it from
-            # :func:`find_dependents` / :func:`find_dependencies` —
-            # the traversal CTE filters
-            # ``properties->>'superseded_by' IS NULL``. Drop the key
-            # here so the promoted curated edge is immediately visible.
-            #
-            # ``conflicts_with`` (bidirectional, list-shaped) is kept:
-            # the entries point at *other-kind* edges over the same
-            # endpoint pair, which still exist and still conflict; the
-            # incompatible-kinds scan below re-stamps the curated side
-            # without dropping the legitimate back-references.
-            merged.pop(_SUPERSEDED_BY, None)
-        existing.properties = merged
-        existing.last_seen = now
-        if promoting:
-            existing.source = "curated"
-            existing.discovered_by = operator.sub
-        edge = existing
-        was_created = False
-
-    superseded = await _mark_same_kind_different_endpoint_superseded(
+    superseded_pairs, conflict_pairs = await _run_conflict_scans(
         session,
-        tenant_id=operator.tenant_id,
-        curated_edge_id=edge.id,
-        from_id=from_node.id,
-        to_id=to_node.id,
-        kind=canonical_kind,
-    )
-    conflicts = await _mark_incompatible_kinds_conflict(
-        session,
-        tenant_id=operator.tenant_id,
-        curated_edge=edge,
-        from_id=from_node.id,
-        to_id=to_node.id,
-        kind=canonical_kind,
+        edge=edge,
+        operator=operator,
+        from_node=from_node,
+        to_node=to_node,
+        canonical_kind=canonical_kind,
     )
 
     audit_id = uuid.uuid4()
@@ -847,8 +1033,8 @@ async def annotate_edge_in_txn(
         edge_id=edge.id,
         note=note,
         evidence_url=evidence_url,
-        superseded=superseded,
-        conflicts=conflicts,
+        superseded=[pair[0].id for pair in superseded_pairs],
+        conflicts=[pair[0].id for pair in conflict_pairs],
     )
     session.add(
         _build_audit_row(
@@ -860,6 +1046,17 @@ async def annotate_edge_in_txn(
             payload=payload,
         )
     )
+    _emit_annotate_history(
+        session,
+        operator=operator,
+        edge=edge,
+        edge_before=edge_before,
+        was_created=was_created,
+        superseded_pairs=superseded_pairs,
+        conflict_pairs=conflict_pairs,
+        audit_id=audit_id,
+        now=now,
+    )
 
     return AnnotatePlan(
         edge=edge,
@@ -868,6 +1065,132 @@ async def annotate_edge_in_txn(
         target_name=from_node.name,
         was_created=was_created,
     )
+
+
+def _check_unannotate_selectors(
+    *,
+    edge_id: uuid.UUID | None,
+    from_ref: NodeRef | None,
+    kind: str | None,
+    to_ref: NodeRef | None,
+) -> None:
+    """Reject the neither / both / partial-triple selector shapes."""
+    has_id = edge_id is not None
+    has_triple = from_ref is not None or kind is not None or to_ref is not None
+    if has_id == has_triple:
+        raise UnannotateSelectorError(
+            "unannotate_edge requires exactly one selector: edge_id "
+            "OR the full (from_ref, kind, to_ref) triple"
+        )
+    if has_triple and not (from_ref is not None and kind is not None and to_ref is not None):
+        raise UnannotateSelectorError(
+            "triple selector requires all three of (from_ref, kind, to_ref)"
+        )
+
+
+async def _resolve_unannotate_target(
+    session: AsyncSession,
+    operator: Operator,
+    *,
+    edge_id: uuid.UUID | None,
+    from_ref: NodeRef | None,
+    kind: str | None,
+    to_ref: NodeRef | None,
+) -> tuple[GraphEdge, GraphNode, GraphNode]:
+    """Resolve the curated edge + its endpoints from either selector form.
+
+    Either ``edge_id`` (primary-key selector) or the ``(from_ref,
+    kind, to_ref)`` triple is present; the caller is responsible for
+    enforcing exactly-one via :func:`_check_unannotate_selectors`.
+
+    Raises:
+        ValueError: target row not found in this tenant or the
+            triple form resolves to no row.
+        NodeNotFoundError / AmbiguousNodeError: triple-form endpoint
+            issues (propagated from :func:`resolve_node`).
+        InvalidEdgeKindError: triple-form ``kind`` outside the
+            v0.2 enum.
+    """
+    if edge_id is not None:
+        edge = await session.get(GraphEdge, edge_id)
+        if edge is None or edge.tenant_id != operator.tenant_id:
+            # Tenant boundary: a row in another tenant is
+            # indistinguishable from a missing row to the caller.
+            raise ValueError(f"graph_edge {edge_id} not found in this tenant")
+        from_node = await session.get(GraphNode, edge.from_node_id)
+        to_node = await session.get(GraphNode, edge.to_node_id)
+        # FK ON DELETE CASCADE protects against orphan rows, but a
+        # mid-flight node delete is still possible — treat as not
+        # found rather than crashing with a None attribute access.
+        if from_node is None or to_node is None:
+            raise ValueError(
+                f"graph_edge {edge_id} endpoints missing — graph in inconsistent state"
+            )
+        return edge, from_node, to_node
+
+    assert from_ref is not None  # narrowed for mypy
+    assert to_ref is not None
+    assert kind is not None
+    canonical_kind = _validate_kind(kind)
+    from_node = await resolve_node(session, operator.tenant_id, from_ref.name, from_ref.kind)
+    to_node = await resolve_node(session, operator.tenant_id, to_ref.name, to_ref.kind)
+    edge = await _find_existing_edge(
+        session,
+        tenant_id=operator.tenant_id,
+        from_id=from_node.id,
+        to_id=to_node.id,
+        kind=canonical_kind,
+    )
+    if edge is None:
+        raise ValueError(
+            f"no graph_edge {canonical_kind!r} from {from_ref.name!r} "
+            f"to {to_ref.name!r} in this tenant"
+        )
+    return edge, from_node, to_node
+
+
+def _emit_unannotate_history(
+    session: AsyncSession,
+    *,
+    operator: Operator,
+    removed_id: uuid.UUID,
+    removed_edge_snapshot_value: dict[str, Any],
+    referencing_befores: list[tuple[GraphEdge, dict[str, Any]]],
+    audit_id: uuid.UUID,
+    now: datetime,
+) -> None:
+    """Emit history rows for the unannotate before the live delete flushes.
+
+    Diff-on-write hook (G9.3-T2 #857): emit history rows **before**
+    the ``session.delete(edge)`` call so the ``removed`` row's
+    ``edge_id`` references a still-live ``graph_edge.id``. The
+    ON DELETE SET NULL on the FK kicks in only when the live row is
+    hard-deleted; SQLAlchemy may flush the delete before the insert
+    if the order is reversed, producing a NULL ``edge_id`` on the
+    freshly inserted history row -- defeating the per-resource
+    history walk in T3 (the walk filters on ``edge_id``).
+    """
+    record_edge_change(
+        session,
+        edge_id=removed_id,
+        tenant_id=operator.tenant_id,
+        change_kind=GraphHistoryChangeKind.REMOVED,
+        before=removed_edge_snapshot_value,
+        after=None,
+        audit_id=audit_id,
+        valid_from=now,
+    )
+    for ref_edge, ref_before in referencing_befores:
+        record_edge_change(
+            session,
+            edge_id=ref_edge.id,
+            tenant_id=operator.tenant_id,
+            change_kind=GraphHistoryChangeKind.UPDATED,
+            before=ref_before,
+            after=edge_snapshot(ref_edge),
+            audit_id=audit_id,
+            valid_from=now,
+        )
 
 
 async def unannotate_edge(
@@ -927,100 +1250,17 @@ async def unannotate_edge(
             :class:`GraphEdgeKind`.
         ValueError: The triple form resolves to no row.
     """
-    has_id = edge_id is not None
-    has_triple = from_ref is not None or kind is not None or to_ref is not None
-    if has_id == has_triple:
-        raise UnannotateSelectorError(
-            "unannotate_edge requires exactly one selector: edge_id "
-            "OR the full (from_ref, kind, to_ref) triple"
-        )
-    if has_triple and not (from_ref is not None and kind is not None and to_ref is not None):
-        raise UnannotateSelectorError(
-            "triple selector requires all three of (from_ref, kind, to_ref)"
-        )
+    _check_unannotate_selectors(edge_id=edge_id, from_ref=from_ref, kind=kind, to_ref=to_ref)
 
     async with session.begin():
-        if has_id:
-            assert edge_id is not None  # narrowed for mypy
-            edge = await session.get(GraphEdge, edge_id)
-            if edge is None or edge.tenant_id != operator.tenant_id:
-                # Tenant boundary: a row in another tenant is
-                # indistinguishable from a missing row to the caller.
-                raise ValueError(f"graph_edge {edge_id} not found in this tenant")
-            from_node = await session.get(GraphNode, edge.from_node_id)
-            to_node = await session.get(GraphNode, edge.to_node_id)
-            # FK ON DELETE CASCADE protects against orphan rows, but a
-            # mid-flight node delete is still possible — treat as not
-            # found rather than crashing with a None attribute access.
-            if from_node is None or to_node is None:
-                raise ValueError(
-                    f"graph_edge {edge_id} endpoints missing — graph in inconsistent state"
-                )
-        else:
-            assert from_ref is not None  # narrowed for mypy
-            assert to_ref is not None
-            assert kind is not None
-            canonical_kind = _validate_kind(kind)
-            from_node = await resolve_node(
-                session, operator.tenant_id, from_ref.name, from_ref.kind
-            )
-            to_node = await resolve_node(session, operator.tenant_id, to_ref.name, to_ref.kind)
-            edge = await _find_existing_edge(
-                session,
-                tenant_id=operator.tenant_id,
-                from_id=from_node.id,
-                to_id=to_node.id,
-                kind=canonical_kind,
-            )
-            if edge is None:
-                raise ValueError(
-                    f"no graph_edge {canonical_kind!r} from {from_ref.name!r} "
-                    f"to {to_ref.name!r} in this tenant"
-                )
-
-        if edge.source != "curated":
-            raise AutoEdgeDeletionError(edge.id)
-
-        removed_id = edge.id
-        canonical_kind_final = edge.kind
-
-        # Clear reciprocal markers BEFORE deleting the curated row so
-        # the SELECT scan still sees the row as a candidate (the scan
-        # is keyed on properties, not on the deleted edge — but the
-        # pre-clear keeps the bookkeeping simple).
-        referencing = await _find_edges_referencing(
+        removed_id, target_name, audit_id, payload = await _unannotate_in_txn(
             session,
-            tenant_id=operator.tenant_id,
-            edge_id=removed_id,
+            operator,
+            edge_id=edge_id,
+            from_ref=from_ref,
+            kind=kind,
+            to_ref=to_ref,
         )
-        _clear_reciprocal_markers(referencing, removed_edge_id=removed_id)
-
-        await session.delete(edge)
-        await session.flush()
-
-        audit_id = uuid.uuid4()
-        payload = _audit_payload(
-            op_id=_UNANNOTATE_OP_ID,
-            from_node=from_node,
-            to_node=to_node,
-            kind=canonical_kind_final,
-            edge_id=removed_id,
-            note=None,
-            evidence_url=None,
-            superseded=[],
-            conflicts=[r.id for r in referencing],
-        )
-        session.add(
-            _build_audit_row(
-                audit_id=audit_id,
-                operator=operator,
-                method=_AUDIT_METHOD_UNANNOTATE,
-                op_id=_UNANNOTATE_OP_ID,
-                target_id=_broadcast_target_id(from_node),
-                payload=payload,
-            )
-        )
-        target_name = from_node.name
 
     await _publish(
         audit_id=audit_id,
@@ -1030,3 +1270,90 @@ async def unannotate_edge(
         payload=payload,
     )
     return removed_id
+
+
+async def _unannotate_in_txn(
+    session: AsyncSession,
+    operator: Operator,
+    *,
+    edge_id: uuid.UUID | None,
+    from_ref: NodeRef | None,
+    kind: str | None,
+    to_ref: NodeRef | None,
+) -> tuple[uuid.UUID, str, uuid.UUID, dict[str, Any]]:
+    """In-transaction body of :func:`unannotate_edge`.
+
+    Resolves the curated row, clears its reciprocal §6 markers, emits
+    the diff-on-write history rows, hard-deletes the live row, and
+    writes the audit row. Returns ``(removed_id, target_name,
+    audit_id, audit_payload)`` so the caller can publish the
+    broadcast event after commit.
+    """
+    edge, from_node, to_node = await _resolve_unannotate_target(
+        session,
+        operator,
+        edge_id=edge_id,
+        from_ref=from_ref,
+        kind=kind,
+        to_ref=to_ref,
+    )
+    if edge.source != "curated":
+        raise AutoEdgeDeletionError(edge.id)
+
+    removed_id = edge.id
+    canonical_kind_final = edge.kind
+
+    # Clear reciprocal markers BEFORE deleting the curated row so the
+    # SELECT scan still sees the row as a candidate. Capture
+    # pre-mutation snapshots so the history rows' ``before`` reflects
+    # the supersede / conflict state the operator may have seen on a
+    # list-edges; capture the removed curated row's snapshot too --
+    # that is the ``before`` for its own ``removed`` history row.
+    referencing = await _find_edges_referencing(
+        session,
+        tenant_id=operator.tenant_id,
+        edge_id=removed_id,
+    )
+    removed_edge_snapshot_value = edge_snapshot(edge)
+    now = datetime.now(UTC)
+    referencing_befores: list[tuple[GraphEdge, dict[str, Any]]] = [
+        (ref_edge, edge_snapshot(ref_edge)) for ref_edge in referencing
+    ]
+    _clear_reciprocal_markers(referencing, removed_edge_id=removed_id)
+
+    audit_id = uuid.uuid4()
+    _emit_unannotate_history(
+        session,
+        operator=operator,
+        removed_id=removed_id,
+        removed_edge_snapshot_value=removed_edge_snapshot_value,
+        referencing_befores=referencing_befores,
+        audit_id=audit_id,
+        now=now,
+    )
+
+    await session.delete(edge)
+    await session.flush()
+
+    payload = _audit_payload(
+        op_id=_UNANNOTATE_OP_ID,
+        from_node=from_node,
+        to_node=to_node,
+        kind=canonical_kind_final,
+        edge_id=removed_id,
+        note=None,
+        evidence_url=None,
+        superseded=[],
+        conflicts=[r.id for r in referencing],
+    )
+    session.add(
+        _build_audit_row(
+            audit_id=audit_id,
+            operator=operator,
+            method=_AUDIT_METHOD_UNANNOTATE,
+            op_id=_UNANNOTATE_OP_ID,
+            target_id=_broadcast_target_id(from_node),
+            payload=payload,
+        )
+    )
+    return removed_id, from_node.name, audit_id, payload

--- a/backend/src/meho_backplane/topology/annotate.py
+++ b/backend/src/meho_backplane/topology/annotate.py
@@ -316,13 +316,23 @@ async def _mark_same_kind_different_endpoint_superseded(
     )
     rows = (await session.execute(stmt)).scalars().all()
     marked: list[tuple[GraphEdge, dict[str, Any]]] = []
+    target_marker = str(curated_edge_id)
     for row in rows:
+        # No-op guard: an idempotent re-annotate of an already-superseded
+        # row would otherwise rewrite ``properties`` (a new dict with the
+        # same content) and emit a phantom ``UPDATED`` history row with
+        # byte-identical ``before``/``after``. Skip when the marker
+        # already points at the curated row — mirrors refresh's
+        # ``test_unchanged_refresh_emits_no_history_rows`` contract on
+        # the annotate side.
+        if (row.properties or {}).get(_SUPERSEDED_BY) == target_marker:
+            continue
         # Capture the pre-mutation snapshot **before** reassigning
         # ``properties`` so the history row's ``before`` reflects the
         # row as the operator last saw it without the supersede mark.
         before = edge_snapshot(row)
         props = dict(row.properties or {})
-        props[_SUPERSEDED_BY] = str(curated_edge_id)
+        props[_SUPERSEDED_BY] = target_marker
         row.properties = props
         marked.append((row, before))
     return marked
@@ -360,8 +370,31 @@ async def _mark_incompatible_kinds_conflict(
         GraphEdge.kind != kind,
     )
     rows = (await session.execute(stmt)).scalars().all()
+    curated_marker = str(curated_edge.id)
     conflicting: list[tuple[GraphEdge, dict[str, Any]]] = []
     for row in rows:
+        # No-op guard: an idempotent re-annotate would otherwise re-stamp
+        # an already-present bidirectional ``conflicts_with`` reference
+        # and emit a phantom ``UPDATED`` history row on a row that did
+        # not actually change. The marker is bidirectional, so the row
+        # is a no-op only when *both* sides already carry it:
+        #   * ``row.properties.conflicts_with`` contains the curated id
+        #   * ``curated_edge.properties.conflicts_with`` contains the
+        #     other row's id
+        # Either side missing means the previous annotate left the
+        # graph in a half-stamped state (e.g. interrupted before the
+        # bidirectional pass) and we must complete the linkage.
+        other_marker = str(row.id)
+        row_conflicts = (row.properties or {}).get(_CONFLICTS_WITH) or []
+        curated_conflicts = (curated_edge.properties or {}).get(_CONFLICTS_WITH) or []
+        already_linked = (
+            isinstance(row_conflicts, list)
+            and curated_marker in row_conflicts
+            and isinstance(curated_conflicts, list)
+            and other_marker in curated_conflicts
+        )
+        if already_linked:
+            continue
         # Capture the pre-mutation snapshot before appending the marker.
         before = edge_snapshot(row)
         _append_conflict_marker(row, curated_edge.id)
@@ -823,6 +856,47 @@ def _merge_onto_existing_edge(
     return existing, edge_before
 
 
+#: Snapshot fields that change on every re-annotate even when the
+#: operator's input is byte-identical. ``last_seen`` is a heartbeat the
+#: refresh pattern already excludes from the meaningful-change test;
+#: ``annotated_at`` is the same shape on the annotate side -- a
+#: ``datetime.now(UTC).isoformat()`` stamped into ``properties`` on every
+#: call. Excluding them both is what makes an idempotent re-annotate a
+#: no-op for history purposes, mirroring
+#: :func:`refresh._properties_differ`'s contract on the refresh side.
+_ANNOTATE_HEARTBEAT_PROPERTY_KEYS: tuple[str, ...] = ("annotated_at",)
+
+
+def _annotate_curated_is_meaningful(
+    *, before: dict[str, Any] | None, after: dict[str, Any]
+) -> bool:
+    """Return ``True`` when the curated edge's snapshot reflects a real change.
+
+    Compares ``before`` to ``after`` after stripping the heartbeat
+    fields (top-level ``last_seen`` and ``properties.annotated_at``)
+    that change on every call regardless of operator intent. Mirrors
+    :func:`refresh._properties_differ` on the refresh side so the two
+    history-emission paths agree on what counts as a mutation.
+
+    ``before`` is ``None`` on a fresh insert; that path is always
+    meaningful (the row did not exist), so the caller treats ``None``
+    as the "always emit" case before calling this helper.
+    """
+    if before is None:
+        return True
+
+    def _strip(snapshot: dict[str, Any]) -> dict[str, Any]:
+        stripped = {k: v for k, v in snapshot.items() if k != "last_seen"}
+        props = stripped.get("properties")
+        if isinstance(props, dict):
+            stripped["properties"] = {
+                k: v for k, v in props.items() if k not in _ANNOTATE_HEARTBEAT_PROPERTY_KEYS
+            }
+        return stripped
+
+    return _strip(before) != _strip(after)
+
+
 def _emit_annotate_history(
     session: AsyncSession,
     *,
@@ -845,20 +919,33 @@ def _emit_annotate_history(
     snapshot so the ``conflicts_with`` marker is visible in
     ``after`` -- the bidirectional view ``meho topology diff``
     reconstructs.
+
+    No-op guard: an idempotent re-annotate of an already-curated row
+    whose §6 markers are already in place must not emit a phantom
+    ``UPDATED`` history row -- the curated row's ``last_seen`` /
+    ``annotated_at`` change every call but those are heartbeats, not
+    mutations. :func:`_annotate_curated_is_meaningful` decides;
+    ``was_created=True`` always emits (the row did not exist before).
+    The marker-scan helpers (``_mark_same_kind_different_endpoint_superseded``
+    / ``_mark_incompatible_kinds_conflict``) already skip already-marked
+    rows, so ``superseded_pairs`` / ``conflict_pairs`` here carry only
+    rows that genuinely changed.
     """
-    edge_change_kind = (
-        GraphHistoryChangeKind.CREATED if was_created else GraphHistoryChangeKind.UPDATED
-    )
-    record_edge_change(
-        session,
-        edge_id=edge.id,
-        tenant_id=operator.tenant_id,
-        change_kind=edge_change_kind,
-        before=edge_before,
-        after=edge_snapshot(edge),
-        audit_id=audit_id,
-        valid_from=now,
-    )
+    after_snapshot = edge_snapshot(edge)
+    if was_created or _annotate_curated_is_meaningful(before=edge_before, after=after_snapshot):
+        edge_change_kind = (
+            GraphHistoryChangeKind.CREATED if was_created else GraphHistoryChangeKind.UPDATED
+        )
+        record_edge_change(
+            session,
+            edge_id=edge.id,
+            tenant_id=operator.tenant_id,
+            change_kind=edge_change_kind,
+            before=edge_before,
+            after=after_snapshot,
+            audit_id=audit_id,
+            valid_from=now,
+        )
     for other_edge, other_before in (*superseded_pairs, *conflict_pairs):
         # Each marked auto / other-kind edge survives -- the marker
         # write is the only column that changed -- so the history
@@ -1162,13 +1249,27 @@ def _emit_unannotate_history(
     """Emit history rows for the unannotate before the live delete flushes.
 
     Diff-on-write hook (G9.3-T2 #857): emit history rows **before**
-    the ``session.delete(edge)`` call so the ``removed`` row's
-    ``edge_id`` references a still-live ``graph_edge.id``. The
-    ON DELETE SET NULL on the FK kicks in only when the live row is
-    hard-deleted; SQLAlchemy may flush the delete before the insert
-    if the order is reversed, producing a NULL ``edge_id`` on the
-    freshly inserted history row -- defeating the per-resource
-    history walk in T3 (the walk filters on ``edge_id``).
+    the ``session.delete(edge)`` call so the insert is ordered ahead
+    of the delete in the unit-of-work flush.
+
+    **Important PG semantic**: ``graph_edge_history.edge_id`` is
+    ``FK graph_edge(id) ON DELETE SET NULL`` (see migration ``0012`` /
+    :class:`~meho_backplane.db.models.GraphEdgeHistory`). On PG (and on
+    SQLite once ``PRAGMA foreign_keys=ON`` is in force) the cascade
+    fires when the live row is hard-deleted during the same flush --
+    the freshly-inserted ``removed`` row's ``edge_id`` ends up NULL.
+    This is **intended**: history rows must survive live-row deletion,
+    and ``ON DELETE SET NULL`` is the migration's chosen mechanism for
+    preserving the tombstone after the live row is gone.
+
+    Consequence for the temporal-query verbs (T3 / T4 / T5): the
+    per-resource history walk does **not** filter on ``edge_id``
+    (which would lose tombstones); it filters on
+    ``(tenant_id, change_kind='removed', valid_from DESC)`` using the
+    ``graph_edge_history_tenant_removed_idx`` partial index, and
+    recovers the edge's identity from ``snapshot.before.id`` (the
+    ``_EDGE_SNAPSHOT_COLUMNS`` constant includes ``id`` for this
+    exact reason).
     """
     record_edge_change(
         session,
@@ -1319,6 +1420,30 @@ async def _unannotate_in_txn(
     referencing_befores: list[tuple[GraphEdge, dict[str, Any]]] = [
         (ref_edge, edge_snapshot(ref_edge)) for ref_edge in referencing
     ]
+
+    # Partition referencing edges by which §6 marker they carried at
+    # the moment we resolved them -- read the snapshot's ``properties``
+    # rather than the live row so we are immune to the upcoming
+    # :func:`_clear_reciprocal_markers` mutation. The audit / broadcast
+    # payload then surfaces ``superseded`` and ``conflicts`` as two
+    # distinct buckets so the recovery flow can tell which auto edges
+    # are reappearing in traversal (the supersede-cleared bucket) vs
+    # which other-kind edges merely lost a back-reference (the
+    # conflict-cleared bucket). The pre-fix code conflated both into
+    # a single ``conflicts=[r.id for r in referencing]`` array, which
+    # made the diagnostic ambiguous on any unannotate that cleared
+    # both marker shapes.
+    removed_marker = str(removed_id)
+    superseded_ids: list[uuid.UUID] = []
+    conflicts_ids: list[uuid.UUID] = []
+    for ref_edge, ref_before in referencing_befores:
+        before_props = ref_before.get("properties") or {}
+        if before_props.get(_SUPERSEDED_BY) == removed_marker:
+            superseded_ids.append(ref_edge.id)
+        before_conflicts = before_props.get(_CONFLICTS_WITH)
+        if isinstance(before_conflicts, list) and removed_marker in before_conflicts:
+            conflicts_ids.append(ref_edge.id)
+
     _clear_reciprocal_markers(referencing, removed_edge_id=removed_id)
 
     audit_id = uuid.uuid4()
@@ -1343,8 +1468,8 @@ async def _unannotate_in_txn(
         edge_id=removed_id,
         note=None,
         evidence_url=None,
-        superseded=[],
-        conflicts=[r.id for r in referencing],
+        superseded=superseded_ids,
+        conflicts=conflicts_ids,
     )
     session.add(
         _build_audit_row(

--- a/backend/src/meho_backplane/topology/history.py
+++ b/backend/src/meho_backplane/topology/history.py
@@ -65,6 +65,7 @@ Used by:
 from __future__ import annotations
 
 import uuid
+from copy import deepcopy
 from datetime import datetime
 from typing import Any
 
@@ -152,9 +153,15 @@ def node_snapshot(node: GraphNode) -> dict[str, Any]:
     for column in _NODE_SNAPSHOT_COLUMNS:
         raw = getattr(node, column)
         if column == "properties":
-            # Deep-copy via dict() so a later in-place edit of the live
-            # row's properties does not bleed back into the snapshot.
-            snapshot[column] = dict(raw or {})
+            # ``deepcopy`` rather than ``dict()`` so a later in-place edit
+            # of a *nested* value inside ``node.properties`` (e.g. a list
+            # value reassigned to a new list, or a nested dict updated)
+            # does not bleed back into the snapshot. A shallow ``dict()``
+            # copies the top-level keys but aliases any container value
+            # underneath — fine for the flat ``{note, evidence_url, ...}``
+            # shape annotate writes today, but forward-fragile for any
+            # future caller that stamps nested structure into properties.
+            snapshot[column] = deepcopy(raw or {})
             continue
         snapshot[column] = _serialise(raw)
     return snapshot
@@ -173,7 +180,13 @@ def edge_snapshot(edge: GraphEdge) -> dict[str, Any]:
     for column in _EDGE_SNAPSHOT_COLUMNS:
         raw = getattr(edge, column)
         if column == "properties":
-            snapshot[column] = dict(raw or {})
+            # ``deepcopy`` rather than ``dict()`` — same forward-compat
+            # rationale as :func:`node_snapshot`. Nested list / dict
+            # values inside ``properties`` (the §6 ``conflicts_with`` is
+            # a list) would otherwise alias the live row's container and
+            # any later in-place mutation of that list would
+            # retroactively rewrite this captured snapshot.
+            snapshot[column] = deepcopy(raw or {})
             continue
         snapshot[column] = _serialise(raw)
     return snapshot

--- a/backend/src/meho_backplane/topology/history.py
+++ b/backend/src/meho_backplane/topology/history.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Diff-on-write hook: emit ``*_history`` rows in the live-write transaction.
+
+Initiative #365 (G9.3), Task #857 (T2). The append-only
+:class:`~meho_backplane.db.models.GraphNodeHistory` /
+:class:`~meho_backplane.db.models.GraphEdgeHistory` tables ship with T1
+(#856); this module is the **single shared writer** the refresh +
+annotate paths call to populate them.
+
+The atomicity contract is the load-bearing piece:
+
+1. **Same transaction.** Every history row is added to the same
+   :class:`AsyncSession` that is currently mutating the live
+   ``graph_node`` / ``graph_edge`` rows. A failure anywhere in the
+   block raises out of the caller's ``session.begin()`` and rolls
+   both the live mutation and the history row back together. The
+   live graph and the history table can never disagree about which
+   mutations committed.
+
+2. **No own audit row.** History rows reference the *causing*
+   operation's :attr:`~meho_backplane.db.models.AuditLog.id` via the
+   soft-FK ``audit_id`` column. The refresh service / annotate
+   service write one audit row per call; the history rows the hook
+   emits link to that single row instead of generating new audit
+   rows. Re-emitting an audit row per history row would balloon the
+   audit log on a topology refresh that touches dozens of resources
+   and would also break the "one operation, one audit row" invariant
+   `audit_log` consumers rely on.
+
+3. **Snapshot shape.** Each history row's :attr:`snapshot` JSONB is
+   ``{"before": <row-json>|None, "after": <row-json>|None}``:
+
+   * ``created`` -- ``before=None``, ``after=<post-insert row>``.
+   * ``updated`` -- ``before=<pre-mutation row>``, ``after=<post-mutation row>``.
+   * ``removed`` -- ``before=<final row>``, ``after=None``.
+
+   The bidirectional projection is what makes ``meho topology diff
+   <ts1> <ts2>`` (T4 #860) reconstructible without joining back
+   against live tables: a tombstone row carries enough state to
+   render the removed resource.
+
+Snapshot column selection is **deliberately narrow** (the
+``_snapshot_columns`` constant) rather than ``vars(row)`` or
+:func:`sqlalchemy.inspect`-based reflection. Two reasons:
+
+* SQLAlchemy ORM attribute access on a soft-deleted or rolled-back
+  row can trigger autoflush at the wrong time. Reading exactly the
+  columns we want keeps the function side-effect-free.
+* Forward-compat: if a future column lands on :class:`GraphNode` /
+  :class:`GraphEdge` that should *not* enter the history snapshot
+  (e.g. a derived counter), the projection list is the single
+  point of opt-in.
+
+Used by:
+
+* :mod:`meho_backplane.topology.refresh` -- one history row per
+  diff-applied node and edge inside :func:`_apply_reconcile`.
+* :mod:`meho_backplane.topology.annotate` -- one history row per
+  annotate / unannotate, plus history rows for the auto edges whose
+  ``properties`` got §6 conflict markers stamped on them.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.models import (
+    GraphEdge,
+    GraphEdgeHistory,
+    GraphHistoryChangeKind,
+    GraphNode,
+    GraphNodeHistory,
+)
+
+__all__ = [
+    "edge_snapshot",
+    "node_snapshot",
+    "record_edge_change",
+    "record_node_change",
+]
+
+
+#: Columns projected into the ``snapshot.before`` / ``snapshot.after``
+#: payload for a :class:`GraphNode`. ``id`` is included so the
+#: temporal-query verbs in T3 / T4 / T5 can recover the row identity
+#: from a tombstone (the live row is gone, the FK ``node_id`` may have
+#: been set NULL by ``ON DELETE SET NULL``). ``tenant_id`` is omitted
+#: from the snapshot -- the history row's own ``tenant_id`` column
+#: carries it and duplicating it inside the JSONB just wastes bytes.
+_NODE_SNAPSHOT_COLUMNS: tuple[str, ...] = (
+    "id",
+    "kind",
+    "name",
+    "target_id",
+    "properties",
+    "discovered_by",
+    "first_seen",
+    "last_seen",
+)
+
+#: Columns projected into the snapshot for a :class:`GraphEdge`. Same
+#: rationale as :data:`_NODE_SNAPSHOT_COLUMNS`; ``tenant_id`` is
+#: implicit on the history row, ``id`` is preserved for tombstone
+#: replay.
+_EDGE_SNAPSHOT_COLUMNS: tuple[str, ...] = (
+    "id",
+    "from_node_id",
+    "to_node_id",
+    "kind",
+    "source",
+    "properties",
+    "discovered_by",
+    "first_seen",
+    "last_seen",
+)
+
+
+def _serialise(value: Any) -> Any:
+    """JSON-serialise one cell from a :class:`GraphNode` / :class:`GraphEdge`.
+
+    The snapshot JSONB column accepts any JSON-portable payload; we
+    coerce the two non-portable types we actually carry (``UUID`` ->
+    string, ``datetime`` -> ISO-8601 string) so the row round-trips
+    cleanly through both the PG ``jsonb`` and the SQLite ``json`` test
+    driver. Plain dicts (``properties``) pass through untouched -- the
+    JSON column adapter handles them.
+    """
+    if isinstance(value, uuid.UUID):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+def node_snapshot(node: GraphNode) -> dict[str, Any]:
+    """Project a :class:`GraphNode` row into the snapshot JSONB shape.
+
+    Returns a fresh dict (no aliasing of ``node.properties``) so a
+    subsequent mutation of ``node.properties`` in the same transaction
+    does not retroactively rewrite a captured snapshot. Used by both
+    the refresh diff-on-write hook (to capture ``before`` *before*
+    mutating the row) and the annotate hook (to capture ``after``
+    *after* the upsert + conflict-marker pass).
+    """
+    snapshot: dict[str, Any] = {}
+    for column in _NODE_SNAPSHOT_COLUMNS:
+        raw = getattr(node, column)
+        if column == "properties":
+            # Deep-copy via dict() so a later in-place edit of the live
+            # row's properties does not bleed back into the snapshot.
+            snapshot[column] = dict(raw or {})
+            continue
+        snapshot[column] = _serialise(raw)
+    return snapshot
+
+
+def edge_snapshot(edge: GraphEdge) -> dict[str, Any]:
+    """Project a :class:`GraphEdge` row into the snapshot JSONB shape.
+
+    Mirror of :func:`node_snapshot` for the edge side -- same
+    fresh-dict + properties-deep-copy discipline so a subsequent
+    refresh / annotate pass that mutates ``edge.properties`` (the §6
+    superseded_by / conflicts_with marker writes) does not invalidate
+    a previously captured snapshot.
+    """
+    snapshot: dict[str, Any] = {}
+    for column in _EDGE_SNAPSHOT_COLUMNS:
+        raw = getattr(edge, column)
+        if column == "properties":
+            snapshot[column] = dict(raw or {})
+            continue
+        snapshot[column] = _serialise(raw)
+    return snapshot
+
+
+def record_node_change(
+    session: AsyncSession,
+    *,
+    node_id: uuid.UUID,
+    tenant_id: uuid.UUID,
+    change_kind: GraphHistoryChangeKind,
+    before: dict[str, Any] | None,
+    after: dict[str, Any] | None,
+    audit_id: uuid.UUID,
+    valid_from: datetime,
+) -> None:
+    """Add one :class:`GraphNodeHistory` row to ``session``.
+
+    The row is staged in the caller's transaction -- callers must
+    already be inside a ``session.begin()`` block opened by the
+    refresh / annotate service. Atomicity is the caller's contract:
+    if the surrounding transaction rolls back, this row goes with it.
+
+    ``audit_id`` is the **causing operation's** ``audit_log.id`` --
+    the refresh / annotate service pre-allocates it at the top of the
+    request and threads it down so every history row from this
+    operation links to the same audit row. Re-using one audit row
+    per operation (rather than per history row) keeps the audit log
+    at one row per operation, which is the contract `audit_log`
+    consumers rely on.
+
+    ``valid_from`` is supplied by the caller (rather than being
+    Python-defaulted on the model) so every history row from one
+    operation carries the **same** timestamp. The diff-on-write
+    semantics require this: a refresh that adds 5 nodes in one
+    transaction must be queryable as a single point-in-time event,
+    not five timestamps separated by microseconds of clock drift.
+    """
+    session.add(
+        GraphNodeHistory(
+            node_id=node_id,
+            tenant_id=tenant_id,
+            change_kind=change_kind.value,
+            snapshot={"before": before, "after": after},
+            audit_id=audit_id,
+            valid_from=valid_from,
+        )
+    )
+
+
+def record_edge_change(
+    session: AsyncSession,
+    *,
+    edge_id: uuid.UUID,
+    tenant_id: uuid.UUID,
+    change_kind: GraphHistoryChangeKind,
+    before: dict[str, Any] | None,
+    after: dict[str, Any] | None,
+    audit_id: uuid.UUID,
+    valid_from: datetime,
+) -> None:
+    """Add one :class:`GraphEdgeHistory` row to ``session``.
+
+    Mirror of :func:`record_node_change` -- same atomicity,
+    audit-id-linkage, and shared-timestamp contract; the only
+    difference is the row goes into :class:`GraphEdgeHistory` and
+    references ``edge_id`` instead of ``node_id``.
+    """
+    session.add(
+        GraphEdgeHistory(
+            edge_id=edge_id,
+            tenant_id=tenant_id,
+            change_kind=change_kind.value,
+            snapshot={"before": before, "after": after},
+            audit_id=audit_id,
+            valid_from=valid_from,
+        )
+    )

--- a/backend/src/meho_backplane/topology/refresh.py
+++ b/backend/src/meho_backplane/topology/refresh.py
@@ -54,9 +54,15 @@ from meho_backplane.connectors.base import Connector
 from meho_backplane.connectors.resolver import resolve_connector
 from meho_backplane.connectors.schemas import EdgeHint, NodeHint, TopologyHints
 from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import AuditLog, GraphEdge, GraphNode
+from meho_backplane.db.models import AuditLog, GraphEdge, GraphHistoryChangeKind, GraphNode
 from meho_backplane.operations._handler_resolve import (
     get_or_create_connector_instance,
+)
+from meho_backplane.topology.history import (
+    edge_snapshot,
+    node_snapshot,
+    record_edge_change,
+    record_node_change,
 )
 
 __all__ = ["RefreshResult", "refresh_target_topology"]
@@ -248,6 +254,129 @@ async def _load_reconcile_candidate_nodes(
     )
 
 
+def _insert_discovered_node(
+    session: AsyncSession,
+    *,
+    hint: NodeHint,
+    tenant_id: uuid.UUID,
+    target_id: uuid.UUID,
+    discovered_by: str,
+    now: datetime,
+    audit_id: uuid.UUID,
+) -> uuid.UUID:
+    """Insert one fresh :class:`GraphNode` + emit its ``created`` history row.
+
+    Returns the new node's id so the orchestrator can populate both
+    the live and all key maps.
+    """
+    new_id = uuid.uuid4()
+    new_node = GraphNode(
+        id=new_id,
+        tenant_id=tenant_id,
+        kind=hint.kind,
+        name=hint.name,
+        target_id=target_id,
+        properties=dict(hint.properties),
+        discovered_by=discovered_by,
+        first_seen=now,
+        last_seen=now,
+    )
+    session.add(new_node)
+    # Same-transaction history row: a ``created`` change with
+    # ``before=None`` and ``after=`` the post-insert projection. The
+    # hint's properties are already what landed on the row, so the
+    # snapshot captures the committed state.
+    record_node_change(
+        session,
+        node_id=new_id,
+        tenant_id=tenant_id,
+        change_kind=GraphHistoryChangeKind.CREATED,
+        before=None,
+        after=node_snapshot(new_node),
+        audit_id=audit_id,
+        valid_from=now,
+    )
+    return new_id
+
+
+def _update_existing_node(
+    session: AsyncSession,
+    *,
+    row: GraphNode,
+    hint: NodeHint,
+    tenant_id: uuid.UUID,
+    target_id: uuid.UUID,
+    now: datetime,
+    audit_id: uuid.UUID,
+) -> bool:
+    """Update an existing :class:`GraphNode` row in place.
+
+    Returns ``True`` when the row carried a meaningful change (the
+    refresh ``updated`` counter increments + a history row fires).
+    A pure ``last_seen`` heartbeat (no observable column change)
+    returns ``False`` -- the row is touched but neither counted nor
+    recorded.
+
+    Adopts the row onto this target: a node first seen as a manual
+    annotation (``target_id IS NULL``) or discovered by another
+    target is now observed by *this* target's probe, so this target
+    owns its lifecycle (and its future soft-delete) going forward.
+    """
+    is_meaningful_update = (
+        row.last_seen is None
+        or row.target_id != target_id
+        or _properties_differ(row.properties, hint.properties)
+    )
+    # Capture the pre-mutation snapshot **before** reassigning the
+    # row's columns -- otherwise the captured ``before`` aliases the
+    # post-mutation state.
+    before = node_snapshot(row) if is_meaningful_update else None
+    row.properties = dict(hint.properties)
+    row.target_id = target_id
+    row.last_seen = now
+    if is_meaningful_update:
+        record_node_change(
+            session,
+            node_id=row.id,
+            tenant_id=tenant_id,
+            change_kind=GraphHistoryChangeKind.UPDATED,
+            before=before,
+            after=node_snapshot(row),
+            audit_id=audit_id,
+            valid_from=now,
+        )
+    return is_meaningful_update
+
+
+def _soft_remove_node(
+    session: AsyncSession,
+    *,
+    row: GraphNode,
+    tenant_id: uuid.UUID,
+    now: datetime,
+    audit_id: uuid.UUID,
+) -> None:
+    """Null the row's ``last_seen`` and emit its ``removed`` history row.
+
+    Capture the pre-removal snapshot **before** nulling
+    ``last_seen`` so ``snapshot.before`` reflects the row as the
+    operator last saw it (last_seen non-NULL); ``snapshot.after``
+    is None per the ``removed`` change-kind contract.
+    """
+    before = node_snapshot(row)
+    row.last_seen = None
+    record_node_change(
+        session,
+        node_id=row.id,
+        tenant_id=tenant_id,
+        change_kind=GraphHistoryChangeKind.REMOVED,
+        before=before,
+        after=None,
+        audit_id=audit_id,
+        valid_from=now,
+    )
+
+
 async def _reconcile_nodes(
     session: AsyncSession,
     *,
@@ -256,6 +385,7 @@ async def _reconcile_nodes(
     discovered_by: str,
     nodes: tuple[NodeHint, ...],
     now: datetime,
+    audit_id: uuid.UUID,
 ) -> tuple[
     int,
     int,
@@ -294,39 +424,29 @@ async def _reconcile_nodes(
     for key, hint in discovered_by_key.items():
         row = existing_by_key.get(key)
         if row is None:
-            new_id = uuid.uuid4()
-            session.add(
-                GraphNode(
-                    id=new_id,
-                    tenant_id=tenant_id,
-                    kind=hint.kind,
-                    name=hint.name,
-                    target_id=target_id,
-                    properties=dict(hint.properties),
-                    discovered_by=discovered_by,
-                    first_seen=now,
-                    last_seen=now,
-                )
+            new_id = _insert_discovered_node(
+                session,
+                hint=hint,
+                tenant_id=tenant_id,
+                target_id=target_id,
+                discovered_by=discovered_by,
+                now=now,
+                audit_id=audit_id,
             )
             live_key_to_id[key] = new_id
             all_key_to_id[key] = new_id
             added += 1
             continue
-        # Present in both — refresh last_seen, and properties when
-        # changed. Also adopt the row onto this target: a node first
-        # seen as a manual annotation (``target_id IS NULL``) or
-        # discovered by another target is now observed by *this*
-        # target's probe, so this target owns its lifecycle (and its
-        # future soft-delete) going forward.
-        if (
-            row.last_seen is None
-            or row.target_id != target_id
-            or _properties_differ(row.properties, hint.properties)
+        if _update_existing_node(
+            session,
+            row=row,
+            hint=hint,
+            tenant_id=tenant_id,
+            target_id=target_id,
+            now=now,
+            audit_id=audit_id,
         ):
             updated += 1
-        row.properties = dict(hint.properties)
-        row.target_id = target_id
-        row.last_seen = now
         live_key_to_id[key] = row.id
 
     for key, row in existing_by_key.items():
@@ -340,7 +460,13 @@ async def _reconcile_nodes(
         if row.last_seen is None:
             # Already soft-deleted on a prior refresh; not a fresh removal.
             continue
-        row.last_seen = None
+        _soft_remove_node(
+            session,
+            row=row,
+            tenant_id=tenant_id,
+            now=now,
+            audit_id=audit_id,
+        )
         removed += 1
 
     return added, updated, removed, live_key_to_id, all_key_to_id
@@ -416,6 +542,158 @@ def _index_discovered_edges(
     return out
 
 
+def _insert_discovered_edge(
+    session: AsyncSession,
+    *,
+    hint: EdgeHint,
+    from_id: uuid.UUID,
+    to_id: uuid.UUID,
+    tenant_id: uuid.UUID,
+    discovered_by: str,
+    now: datetime,
+    audit_id: uuid.UUID,
+) -> None:
+    """Insert one fresh :class:`GraphEdge` + emit its ``created`` history row.
+
+    Sanitize before insert so a connector emitting a reserved marker
+    in its hint (buggy or hostile) cannot create a pre-superseded /
+    pre-conflicting auto edge that bypasses the §6 annotate-only
+    invariant (Initiative #364).
+    """
+    new_edge_id = uuid.uuid4()
+    new_edge = GraphEdge(
+        id=new_edge_id,
+        tenant_id=tenant_id,
+        from_node_id=from_id,
+        to_node_id=to_id,
+        kind=hint.kind,
+        source="auto",
+        properties=_strip_reserved_markers(hint.properties),
+        discovered_by=discovered_by,
+        first_seen=now,
+        last_seen=now,
+    )
+    session.add(new_edge)
+    record_edge_change(
+        session,
+        edge_id=new_edge_id,
+        tenant_id=tenant_id,
+        change_kind=GraphHistoryChangeKind.CREATED,
+        before=None,
+        after=edge_snapshot(new_edge),
+        audit_id=audit_id,
+        valid_from=now,
+    )
+
+
+def _refresh_curated_edge(
+    session: AsyncSession,
+    *,
+    existing_edge: GraphEdge,
+    tenant_id: uuid.UUID,
+    now: datetime,
+    audit_id: uuid.UUID,
+) -> bool:
+    """Bump ``last_seen`` on a curated edge; return ``True`` if it was a
+    meaningful change.
+
+    Curated edges are operator-owned: the probe's view of the row's
+    properties is not authoritative. The refresh only records that
+    the probe still observes the edge (``last_seen`` bump); the
+    operator-supplied ``note`` / ``evidence_url`` / ``annotated_*``
+    and any §6 markers stay untouched. Without this branch the next
+    refresh after :func:`annotate_edge` of a previously-auto edge
+    would wipe the caller's free-text props (Initiative #364 §6 — M1
+    of PR #651 review).
+
+    A *resurrected* curated row (was soft-deleted, now re-observed)
+    is operator-observable and warrants an ``updated`` history row.
+    A pure heartbeat (already-live curated edge re-seen) is not
+    counted and no history row fires.
+    """
+    resurrected = existing_edge.last_seen is None
+    if resurrected:
+        before = edge_snapshot(existing_edge)
+        existing_edge.last_seen = now
+        record_edge_change(
+            session,
+            edge_id=existing_edge.id,
+            tenant_id=tenant_id,
+            change_kind=GraphHistoryChangeKind.UPDATED,
+            before=before,
+            after=edge_snapshot(existing_edge),
+            audit_id=audit_id,
+            valid_from=now,
+        )
+        return True
+    existing_edge.last_seen = now
+    return False
+
+
+def _update_existing_auto_edge(
+    session: AsyncSession,
+    *,
+    existing_edge: GraphEdge,
+    hint: EdgeHint,
+    tenant_id: uuid.UUID,
+    now: datetime,
+    audit_id: uuid.UUID,
+) -> bool:
+    """Merge an :class:`EdgeHint` onto an existing auto :class:`GraphEdge`.
+
+    Returns ``True`` when the row carried a meaningful change.
+    Reserved §6 conflict markers (``superseded_by`` /
+    ``conflicts_with``) an operator's annotation may have stamped on
+    this row survive the refresh -- the wholesale-overwrite this
+    used to do silently cleared the sticky-supersede invariant; see
+    :func:`_merge_edge_properties`.
+    """
+    merged_properties = _merge_edge_properties(existing_edge.properties, hint.properties)
+    is_meaningful_update = existing_edge.last_seen is None or _properties_differ(
+        existing_edge.properties, merged_properties
+    )
+    before_merge: dict[str, Any] | None = (
+        edge_snapshot(existing_edge) if is_meaningful_update else None
+    )
+    existing_edge.properties = merged_properties
+    existing_edge.last_seen = now
+    if is_meaningful_update:
+        record_edge_change(
+            session,
+            edge_id=existing_edge.id,
+            tenant_id=tenant_id,
+            change_kind=GraphHistoryChangeKind.UPDATED,
+            before=before_merge,
+            after=edge_snapshot(existing_edge),
+            audit_id=audit_id,
+            valid_from=now,
+        )
+    return is_meaningful_update
+
+
+def _soft_remove_edge(
+    session: AsyncSession,
+    *,
+    row: GraphEdge,
+    tenant_id: uuid.UUID,
+    now: datetime,
+    audit_id: uuid.UUID,
+) -> None:
+    """Null the edge's ``last_seen`` and emit its ``removed`` history row."""
+    before = edge_snapshot(row)
+    row.last_seen = None
+    record_edge_change(
+        session,
+        edge_id=row.id,
+        tenant_id=tenant_id,
+        change_kind=GraphHistoryChangeKind.REMOVED,
+        before=before,
+        after=None,
+        audit_id=audit_id,
+        valid_from=now,
+    )
+
+
 async def _reconcile_edges(
     session: AsyncSession,
     *,
@@ -425,6 +703,7 @@ async def _reconcile_edges(
     live_node_key_to_id: dict[tuple[str, str], uuid.UUID],
     all_node_key_to_id: dict[tuple[str, str], uuid.UUID],
     now: datetime,
+    audit_id: uuid.UUID,
 ) -> tuple[int, int, int]:
     """Apply the edge half of the diff against the resolved node id maps.
 
@@ -445,60 +724,51 @@ async def _reconcile_edges(
         from_id = live_node_key_to_id[_node_key(hint.from_kind, hint.from_name)]
         to_id = live_node_key_to_id[_node_key(hint.to_kind, hint.to_name)]
         if existing_edge is None:
-            # Sanitize before insert so a connector emitting a reserved
-            # marker in its hint (buggy or hostile) cannot create a
-            # pre-superseded / pre-conflicting auto edge that bypasses
-            # the §6 annotate-only invariant (Initiative #364).
-            session.add(
-                GraphEdge(
-                    id=uuid.uuid4(),
-                    tenant_id=tenant_id,
-                    from_node_id=from_id,
-                    to_node_id=to_id,
-                    kind=hint.kind,
-                    source="auto",
-                    properties=_strip_reserved_markers(hint.properties),
-                    discovered_by=discovered_by,
-                    first_seen=now,
-                    last_seen=now,
-                )
+            _insert_discovered_edge(
+                session,
+                hint=hint,
+                from_id=from_id,
+                to_id=to_id,
+                tenant_id=tenant_id,
+                discovered_by=discovered_by,
+                now=now,
+                audit_id=audit_id,
             )
             added += 1
             continue
         if existing_edge.source == "curated":
-            # Curated edges are operator-owned: the probe's view of the
-            # row's properties is not authoritative. The refresh only
-            # records that the probe still observes the edge
-            # (``last_seen`` bump); the operator-supplied ``note`` /
-            # ``evidence_url`` / ``annotated_*`` and any §6 markers
-            # stay untouched. Without this branch the next refresh
-            # after :func:`annotate_edge` of a previously-auto edge
-            # would wipe the caller's free-text props
-            # (Initiative #364 §6 — M1 of PR #651 review).
-            if existing_edge.last_seen is None:
+            if _refresh_curated_edge(
+                session,
+                existing_edge=existing_edge,
+                tenant_id=tenant_id,
+                now=now,
+                audit_id=audit_id,
+            ):
                 updated += 1
-            existing_edge.last_seen = now
             continue
 
-        # Merge — not overwrite — so the §6 conflict markers
-        # (``superseded_by`` / ``conflicts_with``) an operator's
-        # annotation may have stamped on this row survive the refresh.
-        # The wholesale-overwrite this used to do silently cleared the
-        # sticky-supersede invariant; see :func:`_merge_edge_properties`.
-        merged_properties = _merge_edge_properties(existing_edge.properties, hint.properties)
-        if existing_edge.last_seen is None or _properties_differ(
-            existing_edge.properties, merged_properties
+        if _update_existing_auto_edge(
+            session,
+            existing_edge=existing_edge,
+            hint=hint,
+            tenant_id=tenant_id,
+            now=now,
+            audit_id=audit_id,
         ):
             updated += 1
-        existing_edge.properties = merged_properties
-        existing_edge.last_seen = now
 
     for key, row in existing_by_key.items():
         if key in discovered_by_key:
             continue
         if row.last_seen is None:
             continue
-        row.last_seen = None
+        _soft_remove_edge(
+            session,
+            row=row,
+            tenant_id=tenant_id,
+            now=now,
+            audit_id=audit_id,
+        )
         removed += 1
 
     return added, updated, removed
@@ -598,12 +868,19 @@ async def _apply_reconcile(
     audit_id: uuid.UUID,
     started: float,
 ) -> RefreshResult:
-    """Run the node + edge diff + audit write in one transaction.
+    """Run the node + edge diff + history writes + audit write in one txn.
 
     A failure anywhere inside the ``session.begin()`` block raises out
-    of it, rolling everything (inserts, updates, soft-deletes, the audit
-    row) back together — the graph is never left half-applied and no
-    audit row lands for a refresh that didn't commit.
+    of it, rolling everything (inserts, updates, soft-deletes, the
+    paired ``*_history`` rows, the audit row) back together — the
+    graph is never left half-applied, no history row lands for a live
+    mutation that did not commit, and no audit row lands for a refresh
+    that didn't commit. The diff-on-write hook (G9.3-T2 #857) emits one
+    ``graph_node_history`` row per added / updated / removed node and
+    one ``graph_edge_history`` row per added / updated / removed edge,
+    all carrying the pre-allocated ``audit_id`` so a downstream
+    operator can join history back against ``audit_log`` to recover
+    the causing principal / session / target.
     """
     tenant_id = operator.tenant_id
     sessionmaker = get_sessionmaker()
@@ -622,6 +899,7 @@ async def _apply_reconcile(
             discovered_by=discovered_by,
             nodes=hints.nodes,
             now=now,
+            audit_id=audit_id,
         )
         added_edges, updated_edges, removed_edges = await _reconcile_edges(
             session,
@@ -631,6 +909,7 @@ async def _apply_reconcile(
             live_node_key_to_id=live_key_to_id,
             all_node_key_to_id=all_key_to_id,
             now=now,
+            audit_id=audit_id,
         )
         result = RefreshResult(
             target_id=target_id,

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -155,6 +155,16 @@ _TRUNCATE_TABLES: tuple[str, ...] = (
     "broadcast_override",
     "documents",
     "endpoint_descriptor",
+    # ``graph_edge_history`` carries a real FK ``graph_edge(id) ON DELETE
+    # SET NULL`` per migration ``0012`` (#856 T1); the same applies to
+    # ``graph_node_history``. PG rejects a TRUNCATE on the parent table
+    # unless the referencing tables are truncated in the same statement
+    # (``cannot truncate a table referenced in a foreign key constraint``).
+    # Without these two entries the per-test TRUNCATE the acceptance
+    # fixture runs raises ``FeatureNotSupportedError`` and every
+    # PG-backed acceptance test errors at setup. The integration conftest's
+    # ``_TRUNCATE_TABLES`` already includes both; the acceptance side was
+    # missed when T1 landed and is repaired here together with T2's hook.
     "graph_edge",
     "graph_edge_history",
     "graph_node",

--- a/backend/tests/test_topology_history_hook.py
+++ b/backend/tests/test_topology_history_hook.py
@@ -1,0 +1,701 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the G9.3-T2 diff-on-write history hook.
+
+Coverage matrix (Task #857 acceptance criteria):
+
+* **Insert path** -- a refresh adding 3 nodes + 2 edges produces 5
+  history rows in the same transaction, all sharing the refresh's
+  ``audit_id`` (acceptance criterion #1).
+* **Annotate path** -- :func:`annotate_edge` adding one curated edge
+  produces one ``GraphEdgeHistory`` row sharing the annotate's
+  ``audit_id`` (acceptance criterion #2).
+* **Refresh-removes-node path** -- a second refresh dropping a
+  previously-discovered node produces one ``removed`` history row
+  whose ``snapshot.before`` carries the full row JSON and ``after``
+  is ``None``, under a new ``audit_id`` (criterion #3).
+* **Transactional** -- a forced failure inside the reconcile rolls
+  the live mutation **and** the history rows back together; both
+  ``graph_node`` / ``graph_edge`` and ``graph_node_history`` /
+  ``graph_edge_history`` are unchanged (criterion #4).
+* **No own audit rows** -- a refresh writes one ``audit_log`` row;
+  the diff-on-write hook does not emit additional audit rows per
+  history insert (criterion #5).
+* **Unannotate path** -- removing a curated edge emits a
+  ``removed`` history row for that edge plus an ``updated`` row for
+  every edge whose §6 marker the unannotate cleared, all sharing
+  one ``audit_id``.
+* **§6 conflict marker history** -- annotating a curated edge that
+  supersedes an existing auto edge emits two history rows in the
+  same transaction (curated ``created`` + auto ``updated`` with the
+  ``superseded_by`` marker visible in ``snapshot.after``).
+* **Update-without-mutation no-op** -- a refresh that re-asserts an
+  unchanged node + edge produces zero history rows (the ``last_seen``
+  bump alone is not a recorded mutation).
+
+Runs against ``sqlite+aiosqlite`` via the shared engine cache the
+autouse ``_default_database_url`` fixture in :mod:`tests.conftest`
+pre-migrates -- same shape every other topology unit test uses.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import delete, select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import EdgeHint, NodeHint, TopologyHints
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    AuditLog,
+    GraphEdge,
+    GraphEdgeHistory,
+    GraphHistoryChangeKind,
+    GraphNode,
+    GraphNodeHistory,
+    Target,
+    Tenant,
+)
+from meho_backplane.operations._handler_resolve import reset_connector_instance_cache
+from meho_backplane.settings import get_settings
+from meho_backplane.topology.annotate import NodeRef, annotate_edge, unannotate_edge
+from meho_backplane.topology.refresh import refresh_target_topology
+
+_PUBLISH_REFRESH = "meho_backplane.topology.refresh.publish_event"
+_PUBLISH_ANNOTATE = "meho_backplane.topology.annotate.publish_event"
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    """Isolate the connector registry + instance cache per test."""
+    clear_registry()
+    reset_connector_instance_cache()
+    yield
+    clear_registry()
+    reset_connector_instance_cache()
+
+
+# ---------------------------------------------------------------------------
+# Fakes & helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeConnector(Connector):
+    """Connector whose ``discover_topology`` returns a class-level snapshot."""
+
+    product = "faketopo"
+
+    hints: TopologyHints = TopologyHints(discovered_at=datetime.now(UTC))
+
+    async def fingerprint(self, target: Any) -> Any:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> Any:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def execute(
+        self, target: Any, op_id: str, params: dict[str, Any]
+    ) -> Any:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def discover_topology(self, target: Any) -> TopologyHints:
+        return type(self).hints
+
+
+def _register_fake() -> None:
+    register_connector_v2(
+        product="faketopo",
+        version="",
+        impl_id="",
+        cls=_FakeConnector,
+    )
+
+
+async def _seed_tenant_and_target(slug: str = "rdc-internal") -> tuple[uuid.UUID, Target]:
+    """Insert one tenant + one target for it."""
+    sessionmaker = get_sessionmaker()
+    tenant_id = uuid.uuid4()
+    target = Target(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        name=f"vcenter-{slug}",
+        aliases=[],
+        product="faketopo",
+        host="vc.example.test",
+    )
+    async with sessionmaker() as session:
+        session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+        session.add(target)
+        await session.commit()
+        await session.refresh(target)
+    return tenant_id, target
+
+
+def _operator(tenant_id: uuid.UUID) -> Operator:
+    return Operator(
+        sub="op-1",
+        name="Op One",
+        email=None,
+        raw_jwt="",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.TENANT_ADMIN,
+    )
+
+
+def _hints_3n2e() -> TopologyHints:
+    """3 nodes + 2 edges -- the canonical insert-path fixture from #857."""
+    return TopologyHints(
+        discovered_at=datetime.now(UTC),
+        nodes=(
+            NodeHint(kind="vm", name="vm-a", properties={"power": "on"}),
+            NodeHint(kind="vm", name="vm-b"),
+            NodeHint(kind="datastore", name="ds-1"),
+        ),
+        edges=(
+            EdgeHint(
+                from_kind="vm",
+                from_name="vm-a",
+                to_kind="datastore",
+                to_name="ds-1",
+                kind="mounts",
+            ),
+            EdgeHint(
+                from_kind="vm",
+                from_name="vm-b",
+                to_kind="datastore",
+                to_name="ds-1",
+                kind="mounts",
+            ),
+        ),
+    )
+
+
+def _hints_2n1e_dropping_vm_b() -> TopologyHints:
+    """Second snapshot: drops ``vm-b`` + its edge."""
+    return TopologyHints(
+        discovered_at=datetime.now(UTC),
+        nodes=(
+            NodeHint(kind="vm", name="vm-a", properties={"power": "on"}),
+            NodeHint(kind="datastore", name="ds-1"),
+        ),
+        edges=(
+            EdgeHint(
+                from_kind="vm",
+                from_name="vm-a",
+                to_kind="datastore",
+                to_name="ds-1",
+                kind="mounts",
+            ),
+        ),
+    )
+
+
+async def _all_node_history(tenant_id: uuid.UUID) -> list[GraphNodeHistory]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            await session.execute(
+                select(GraphNodeHistory).where(GraphNodeHistory.tenant_id == tenant_id)
+            )
+        ).scalars()
+        return list(rows)
+
+
+async def _all_edge_history(tenant_id: uuid.UUID) -> list[GraphEdgeHistory]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            await session.execute(
+                select(GraphEdgeHistory).where(GraphEdgeHistory.tenant_id == tenant_id)
+            )
+        ).scalars()
+        return list(rows)
+
+
+async def _all_audit_log(tenant_id: uuid.UUID) -> list[AuditLog]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            await session.execute(select(AuditLog).where(AuditLog.tenant_id == tenant_id))
+        ).scalars()
+        return list(rows)
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion #1 -- refresh inserts 3 nodes + 2 edges -> 5 history rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_3n2e_emits_5_history_rows_sharing_audit_id() -> None:
+    """A refresh adding 3 nodes + 2 edges produces 5 history rows in one txn.
+
+    Acceptance criterion #1 of #857 -- and the load-bearing audit_id
+    linkage: every history row carries the **same** ``audit_id`` as the
+    refresh's single ``audit_log`` row, so an auditor can join
+    ``graph_node_history`` / ``graph_edge_history`` back against the
+    causing operation.
+    """
+    _register_fake()
+    tenant_id, target = await _seed_tenant_and_target()
+    _FakeConnector.hints = _hints_3n2e()
+
+    with patch(_PUBLISH_REFRESH, new=AsyncMock()):
+        await refresh_target_topology(target, _operator(tenant_id))
+
+    node_history = await _all_node_history(tenant_id)
+    edge_history = await _all_edge_history(tenant_id)
+    audits = await _all_audit_log(tenant_id)
+
+    assert len(node_history) == 3, "expected 3 node history rows"
+    assert len(edge_history) == 2, "expected 2 edge history rows"
+
+    # Acceptance criterion #5: the diff-on-write hook emits no audit
+    # rows of its own. The refresh writes exactly one audit row; the
+    # history rows reference it.
+    assert len(audits) == 1, "expected exactly one audit_log row (refresh's own)"
+    refresh_audit_id = audits[0].id
+
+    history_audit_ids = {h.audit_id for h in node_history} | {h.audit_id for h in edge_history}
+    assert history_audit_ids == {refresh_audit_id}, (
+        f"all history rows must share refresh's audit_id; got {history_audit_ids}"
+    )
+
+    # Every history row is a CREATED change with snapshot.before=None.
+    for nh in node_history:
+        assert nh.change_kind == GraphHistoryChangeKind.CREATED.value
+        assert nh.snapshot["before"] is None
+        assert nh.snapshot["after"] is not None
+    for eh in edge_history:
+        assert eh.change_kind == GraphHistoryChangeKind.CREATED.value
+        assert eh.snapshot["before"] is None
+        assert eh.snapshot["after"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion #2 -- annotate one curated edge -> one history row
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_annotate_one_edge_emits_one_edge_history_row_with_shared_audit_id() -> None:
+    """One curated annotation produces one edge history row carrying the
+    annotate's ``audit_id``.
+
+    Acceptance criterion #2 of #857.
+    """
+    _register_fake()
+    tenant_id, target = await _seed_tenant_and_target()
+    # Seed two nodes so the annotate has endpoints to resolve.
+    _FakeConnector.hints = TopologyHints(
+        discovered_at=datetime.now(UTC),
+        nodes=(
+            NodeHint(kind="principal", name="sa-foo"),
+            NodeHint(kind="vault-role", name="role-bar"),
+        ),
+    )
+
+    with patch(_PUBLISH_REFRESH, new=AsyncMock()):
+        await refresh_target_topology(target, _operator(tenant_id))
+
+    # Reset history -- focus this assertion on the annotate's emission.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        await session.execute(delete(GraphEdgeHistory))
+        await session.execute(delete(GraphNodeHistory))
+        await session.execute(delete(AuditLog))
+
+    operator = _operator(tenant_id)
+    async with sessionmaker() as session:
+        with patch(_PUBLISH_ANNOTATE, new=AsyncMock()):
+            await annotate_edge(
+                session,
+                operator,
+                NodeRef(name="sa-foo", kind="principal"),
+                "authenticates-via",
+                NodeRef(name="role-bar", kind="vault-role"),
+                note="rdc-vault hashicorp policy v3",
+            )
+
+    edge_history = await _all_edge_history(tenant_id)
+    audits = await _all_audit_log(tenant_id)
+
+    assert len(edge_history) == 1, "annotate should emit exactly one edge history row"
+    assert len(audits) == 1, "annotate should emit exactly one audit_log row"
+    history_row = edge_history[0]
+    assert history_row.audit_id == audits[0].id, (
+        "history row's audit_id must match the annotate's own audit_log.id"
+    )
+    assert history_row.change_kind == GraphHistoryChangeKind.CREATED.value
+    assert history_row.snapshot["before"] is None
+    after_state = history_row.snapshot["after"]
+    assert isinstance(after_state, dict)
+    assert after_state["source"] == "curated"
+    assert after_state["kind"] == "authenticates-via"
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion #3 -- refresh drops a node -> 1 removed row with new audit_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_dropping_node_emits_removed_history_with_new_audit_id() -> None:
+    """A second refresh that drops a node emits 1 ``removed`` history row
+    with ``snapshot.before`` = full row, ``after`` = None, under a NEW
+    ``audit_id``.
+
+    Acceptance criterion #3 of #857.
+    """
+    _register_fake()
+    tenant_id, target = await _seed_tenant_and_target()
+
+    _FakeConnector.hints = _hints_3n2e()
+    with patch(_PUBLISH_REFRESH, new=AsyncMock()):
+        await refresh_target_topology(target, _operator(tenant_id))
+    first_audits = await _all_audit_log(tenant_id)
+    assert len(first_audits) == 1
+    first_audit_id = first_audits[0].id
+
+    _FakeConnector.hints = _hints_2n1e_dropping_vm_b()
+    with patch(_PUBLISH_REFRESH, new=AsyncMock()):
+        await refresh_target_topology(target, _operator(tenant_id))
+
+    audits = await _all_audit_log(tenant_id)
+    assert len(audits) == 2, "second refresh should add a second audit row"
+    second_audit_id = next(a.id for a in audits if a.id != first_audit_id)
+
+    node_history = await _all_node_history(tenant_id)
+    edge_history = await _all_edge_history(tenant_id)
+
+    removed_nodes = [
+        h for h in node_history if h.change_kind == GraphHistoryChangeKind.REMOVED.value
+    ]
+    removed_edges = [
+        h for h in edge_history if h.change_kind == GraphHistoryChangeKind.REMOVED.value
+    ]
+
+    assert len(removed_nodes) == 1, "exactly one node should be soft-removed"
+    assert len(removed_edges) == 1, "exactly one edge should be soft-removed"
+
+    removed_node_row = removed_nodes[0]
+    assert removed_node_row.audit_id == second_audit_id, (
+        "removed node's history row must carry the second refresh's audit_id"
+    )
+    assert removed_node_row.snapshot["after"] is None
+    before_state = removed_node_row.snapshot["before"]
+    assert isinstance(before_state, dict)
+    assert before_state["name"] == "vm-b"
+    assert before_state["last_seen"] is not None, (
+        "snapshot.before must capture the row as the operator last saw it (live last_seen)"
+    )
+
+    removed_edge_row = removed_edges[0]
+    assert removed_edge_row.audit_id == second_audit_id
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion #4 -- transactional atomicity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_refresh_failure_rolls_back_both_live_and_history_rows() -> None:
+    """A forced failure after live writes but before commit rolls both
+    the live mutation and the history row back together.
+
+    Acceptance criterion #4 of #857 -- the load-bearing atomicity
+    contract: the live graph and the history table can never disagree
+    about which mutations committed.
+    """
+    _register_fake()
+    tenant_id, target = await _seed_tenant_and_target()
+    _FakeConnector.hints = _hints_3n2e()
+
+    sessionmaker = get_sessionmaker()
+
+    # Mock the audit-row writer (called inside the reconcile txn just
+    # before commit) to raise; the whole transaction must roll back.
+    async def _broken(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("simulated mid-reconcile failure")
+
+    with (
+        patch(_PUBLISH_REFRESH, new=AsyncMock()),
+        patch(
+            "meho_backplane.topology.refresh._write_audit_and_broadcast",
+            new=_broken,
+        ),
+        pytest.raises(RuntimeError, match="simulated mid-reconcile failure"),
+    ):
+        await refresh_target_topology(target, _operator(tenant_id))
+
+    # Neither the live tables nor the history tables should carry any
+    # rows for this tenant -- the rollback was atomic.
+    async with sessionmaker() as session:
+        live_nodes = (
+            await session.execute(select(GraphNode).where(GraphNode.tenant_id == tenant_id))
+        ).scalars()
+        live_edges = (
+            await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == tenant_id))
+        ).scalars()
+        node_hist = (
+            await session.execute(
+                select(GraphNodeHistory).where(GraphNodeHistory.tenant_id == tenant_id)
+            )
+        ).scalars()
+        edge_hist = (
+            await session.execute(
+                select(GraphEdgeHistory).where(GraphEdgeHistory.tenant_id == tenant_id)
+            )
+        ).scalars()
+    assert list(live_nodes) == [], "live graph_node should be empty after rollback"
+    assert list(live_edges) == [], "live graph_edge should be empty after rollback"
+    assert list(node_hist) == [], "graph_node_history should be empty after rollback"
+    assert list(edge_hist) == [], "graph_edge_history should be empty after rollback"
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion #5 -- no own audit rows -- covered by criterion-#1 test
+# (asserts len(audits) == 1)
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Unannotate path -- removed curated edge + reciprocal markers cleared
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unannotate_emits_removed_history_and_clears_marker_history() -> None:
+    """Removing a curated edge that supersedes an auto edge emits:
+
+    * one ``removed`` history row for the curated edge;
+    * one ``updated`` history row for the auto edge whose
+      ``superseded_by`` marker the unannotate just cleared.
+
+    Both rows share the unannotate's single ``audit_id``.
+    """
+    _register_fake()
+    tenant_id, target = await _seed_tenant_and_target()
+    # Refresh creates an auto edge vm-a runs-on host-old.
+    _FakeConnector.hints = TopologyHints(
+        discovered_at=datetime.now(UTC),
+        nodes=(
+            NodeHint(kind="vm", name="vm-a"),
+            NodeHint(kind="host", name="host-old"),
+            NodeHint(kind="host", name="host-new"),
+        ),
+        edges=(
+            EdgeHint(
+                from_kind="vm",
+                from_name="vm-a",
+                to_kind="host",
+                to_name="host-old",
+                kind="runs-on",
+            ),
+        ),
+    )
+    operator = _operator(tenant_id)
+    with patch(_PUBLISH_REFRESH, new=AsyncMock()):
+        await refresh_target_topology(target, operator)
+
+    sessionmaker = get_sessionmaker()
+    # Annotate vm-a runs-on host-new -- supersedes the auto edge.
+    async with sessionmaker() as session:
+        with patch(_PUBLISH_ANNOTATE, new=AsyncMock()):
+            curated = await annotate_edge(
+                session,
+                operator,
+                NodeRef(name="vm-a", kind="vm"),
+                "runs-on",
+                NodeRef(name="host-new", kind="host"),
+            )
+        curated_id = curated.id
+
+    # Clear history baseline so we can scope assertions to the unannotate.
+    async with sessionmaker() as session, session.begin():
+        await session.execute(delete(GraphEdgeHistory))
+        await session.execute(delete(AuditLog))
+
+    async with sessionmaker() as session:
+        with patch(_PUBLISH_ANNOTATE, new=AsyncMock()):
+            await unannotate_edge(session, operator, edge_id=curated_id)
+
+    edge_history = await _all_edge_history(tenant_id)
+    audits = await _all_audit_log(tenant_id)
+
+    assert len(audits) == 1, "unannotate should emit exactly one audit_log row"
+    unannotate_audit_id = audits[0].id
+
+    removed = [h for h in edge_history if h.change_kind == GraphHistoryChangeKind.REMOVED.value]
+    updated = [h for h in edge_history if h.change_kind == GraphHistoryChangeKind.UPDATED.value]
+
+    assert len(removed) == 1, "exactly one ``removed`` history row for the curated edge"
+    assert removed[0].audit_id == unannotate_audit_id
+    assert removed[0].edge_id == curated_id
+
+    assert len(updated) == 1, (
+        "exactly one ``updated`` history row for the auto edge whose "
+        "superseded_by marker was cleared"
+    )
+    assert updated[0].audit_id == unannotate_audit_id
+    after_state = updated[0].snapshot["after"]
+    assert isinstance(after_state, dict)
+    auto_after_props = after_state["properties"]
+    assert isinstance(auto_after_props, dict)
+    assert "superseded_by" not in auto_after_props, (
+        "after the unannotate, the auto row's superseded_by marker must be cleared "
+        "in snapshot.after"
+    )
+
+
+# ---------------------------------------------------------------------------
+# §6 conflict marker history -- annotate supersedes an existing auto edge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_annotate_supersedes_auto_emits_two_history_rows() -> None:
+    """Annotating a curated edge that supersedes an existing auto edge
+    emits two history rows in the same transaction: the curated row
+    (``created``) and the auto row (``updated`` with ``superseded_by``
+    in ``snapshot.after``).
+    """
+    _register_fake()
+    tenant_id, target = await _seed_tenant_and_target()
+    _FakeConnector.hints = TopologyHints(
+        discovered_at=datetime.now(UTC),
+        nodes=(
+            NodeHint(kind="vm", name="vm-a"),
+            NodeHint(kind="host", name="host-old"),
+            NodeHint(kind="host", name="host-new"),
+        ),
+        edges=(
+            EdgeHint(
+                from_kind="vm",
+                from_name="vm-a",
+                to_kind="host",
+                to_name="host-old",
+                kind="runs-on",
+            ),
+        ),
+    )
+    operator = _operator(tenant_id)
+    with patch(_PUBLISH_REFRESH, new=AsyncMock()):
+        await refresh_target_topology(target, operator)
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        await session.execute(delete(GraphEdgeHistory))
+        await session.execute(delete(AuditLog))
+
+    async with sessionmaker() as session:
+        with patch(_PUBLISH_ANNOTATE, new=AsyncMock()):
+            await annotate_edge(
+                session,
+                operator,
+                NodeRef(name="vm-a", kind="vm"),
+                "runs-on",
+                NodeRef(name="host-new", kind="host"),
+            )
+
+    audits = await _all_audit_log(tenant_id)
+    edge_history = await _all_edge_history(tenant_id)
+
+    assert len(audits) == 1
+    annotate_audit_id = audits[0].id
+
+    assert len(edge_history) == 2, (
+        f"expected 2 edge history rows (curated CREATED + auto UPDATED); got {len(edge_history)}"
+    )
+    assert {h.audit_id for h in edge_history} == {annotate_audit_id}
+
+    created = [h for h in edge_history if h.change_kind == GraphHistoryChangeKind.CREATED.value]
+    updated = [h for h in edge_history if h.change_kind == GraphHistoryChangeKind.UPDATED.value]
+    assert len(created) == 1
+    assert len(updated) == 1
+
+    auto_after = updated[0].snapshot["after"]
+    assert isinstance(auto_after, dict)
+    auto_after_props = auto_after["properties"]
+    assert isinstance(auto_after_props, dict)
+    assert "superseded_by" in auto_after_props, (
+        "auto edge's snapshot.after must show the freshly-stamped superseded_by marker"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Negative -- a refresh that re-asserts unchanged state emits no history rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unchanged_refresh_emits_no_history_rows() -> None:
+    """A second refresh with byte-identical hints produces zero history
+    rows -- a pure ``last_seen`` heartbeat is not a recorded mutation.
+    """
+    _register_fake()
+    tenant_id, target = await _seed_tenant_and_target()
+    _FakeConnector.hints = _hints_3n2e()
+    with patch(_PUBLISH_REFRESH, new=AsyncMock()):
+        await refresh_target_topology(target, _operator(tenant_id))
+
+    before_node = await _all_node_history(tenant_id)
+    before_edge = await _all_edge_history(tenant_id)
+
+    # Re-run with identical hints.
+    with patch(_PUBLISH_REFRESH, new=AsyncMock()):
+        await refresh_target_topology(target, _operator(tenant_id))
+
+    after_node = await _all_node_history(tenant_id)
+    after_edge = await _all_edge_history(tenant_id)
+
+    assert len(after_node) == len(before_node), (
+        "second identical refresh should not emit additional node history rows"
+    )
+    assert len(after_edge) == len(before_edge), (
+        "second identical refresh should not emit additional edge history rows"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tenant boundary -- history rows are tenant-scoped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_history_rows_scoped_to_tenant() -> None:
+    """A refresh writes history rows only under the operator's tenant_id."""
+    _register_fake()
+    tenant_a_id, target_a = await _seed_tenant_and_target(slug="tenant-a")
+    tenant_b_id, _target_b = await _seed_tenant_and_target(slug="tenant-b")
+
+    _FakeConnector.hints = _hints_3n2e()
+    with patch(_PUBLISH_REFRESH, new=AsyncMock()):
+        await refresh_target_topology(target_a, _operator(tenant_a_id))
+
+    history_a = await _all_node_history(tenant_a_id)
+    history_b = await _all_node_history(tenant_b_id)
+
+    assert len(history_a) == 3
+    assert history_b == [], "tenant B must see zero history rows"

--- a/backend/tests/test_topology_history_hook.py
+++ b/backend/tests/test_topology_history_hook.py
@@ -86,6 +86,43 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
+def _enforce_sqlite_foreign_keys(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Opt this module in to SQLite foreign-key enforcement.
+
+    The diff-on-write hook's ``unannotate_edge`` path hard-deletes the
+    curated row and relies on PG's ``ON DELETE SET NULL`` cascade
+    nulling the just-inserted ``graph_edge_history.edge_id`` -- the
+    intended migration semantic that lets tombstones outlive the live
+    row (see :class:`~meho_backplane.db.models.GraphEdgeHistory` /
+    migration ``0012``). SQLite's default is FK-off, which silently
+    masks the cascade; without this fixture the test asserting
+    ``removed[0].edge_id is None`` would pass on SQLite by accident
+    (the row's ``edge_id`` would stay populated because the cascade
+    never fires) while PG would diverge.
+
+    Setting ``MEHO_SQLITE_FOREIGN_KEYS=1`` flips
+    :func:`db.engine.create_engine_for_url` into the gated branch that
+    attaches a ``PRAGMA foreign_keys=ON`` listener on every new SQLite
+    connection (it is per-connection on SQLite, not per-database).
+    :func:`reset_engine_for_testing` drops the cached engine so the
+    next ``get_engine()`` rebuilds with the PRAGMA listener attached.
+
+    The env var is module-scoped via autouse rather than chassis-wide
+    because a blanket SQLite-FK-on flip surfaces a large pre-existing
+    tape of test fixtures that insert FK-referencing rows without
+    seeding the parent. Tearing that out is a chassis-wide refactor;
+    G9.3-T2 only needs the FK enforced for this module's cascade
+    assertions. A follow-up Task under #364 can widen the gate.
+    """
+    from meho_backplane.db.engine import reset_engine_for_testing
+
+    monkeypatch.setenv("MEHO_SQLITE_FOREIGN_KEYS", "1")
+    reset_engine_for_testing()
+    yield
+    reset_engine_for_testing()
+
+
+@pytest.fixture(autouse=True)
 def _clean_registry() -> Iterator[None]:
     """Isolate the connector registry + instance cache per test."""
     clear_registry()
@@ -450,28 +487,45 @@ async def test_refresh_failure_rolls_back_both_live_and_history_rows() -> None:
         await refresh_target_topology(target, _operator(tenant_id))
 
     # Neither the live tables nor the history tables should carry any
-    # rows for this tenant -- the rollback was atomic.
+    # rows for this tenant -- the rollback was atomic. Materialize the
+    # ``.scalars().all()`` results *inside* the session context: a
+    # ``ScalarResult`` iterator returned out of an ``AsyncSession``
+    # context manager iterates against a closed session, which raises
+    # under SQLAlchemy 2.x. Pulling the list inside the context and
+    # asserting against the list outside is the documented pattern.
     async with sessionmaker() as session:
-        live_nodes = (
-            await session.execute(select(GraphNode).where(GraphNode.tenant_id == tenant_id))
-        ).scalars()
-        live_edges = (
-            await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == tenant_id))
-        ).scalars()
-        node_hist = (
-            await session.execute(
-                select(GraphNodeHistory).where(GraphNodeHistory.tenant_id == tenant_id)
+        live_nodes_list = (
+            (await session.execute(select(GraphNode).where(GraphNode.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+        live_edges_list = (
+            (await session.execute(select(GraphEdge).where(GraphEdge.tenant_id == tenant_id)))
+            .scalars()
+            .all()
+        )
+        node_hist_list = (
+            (
+                await session.execute(
+                    select(GraphNodeHistory).where(GraphNodeHistory.tenant_id == tenant_id)
+                )
             )
-        ).scalars()
-        edge_hist = (
-            await session.execute(
-                select(GraphEdgeHistory).where(GraphEdgeHistory.tenant_id == tenant_id)
+            .scalars()
+            .all()
+        )
+        edge_hist_list = (
+            (
+                await session.execute(
+                    select(GraphEdgeHistory).where(GraphEdgeHistory.tenant_id == tenant_id)
+                )
             )
-        ).scalars()
-    assert list(live_nodes) == [], "live graph_node should be empty after rollback"
-    assert list(live_edges) == [], "live graph_edge should be empty after rollback"
-    assert list(node_hist) == [], "graph_node_history should be empty after rollback"
-    assert list(edge_hist) == [], "graph_edge_history should be empty after rollback"
+            .scalars()
+            .all()
+        )
+    assert list(live_nodes_list) == [], "live graph_node should be empty after rollback"
+    assert list(live_edges_list) == [], "live graph_edge should be empty after rollback"
+    assert list(node_hist_list) == [], "graph_node_history should be empty after rollback"
+    assert list(edge_hist_list) == [], "graph_edge_history should be empty after rollback"
 
 
 # ---------------------------------------------------------------------------
@@ -552,7 +606,29 @@ async def test_unannotate_emits_removed_history_and_clears_marker_history() -> N
 
     assert len(removed) == 1, "exactly one ``removed`` history row for the curated edge"
     assert removed[0].audit_id == unannotate_audit_id
-    assert removed[0].edge_id == curated_id
+    # ``graph_edge_history.edge_id`` is FK ``ON DELETE SET NULL`` on
+    # :class:`GraphEdge.id`. :func:`unannotate_edge` hard-deletes the
+    # curated row in the same transaction as the history insert; on PG
+    # (and on SQLite once ``PRAGMA foreign_keys=ON`` is in force -- see
+    # :func:`db.engine.create_engine_for_url`) the FK cascade fires
+    # during flush and nulls the just-inserted history row's
+    # ``edge_id``. This is the **intended** migration semantic: history
+    # rows must survive live-row deletion, so identity recovery for the
+    # tombstone walk routes through ``snapshot.before.id`` (the
+    # ``_EDGE_SNAPSHOT_COLUMNS`` includes ``id``) plus the
+    # ``graph_edge_history_tenant_removed_idx`` partial index, not
+    # through the live ``edge_id`` column. The temporal-query verbs
+    # (T3 / T4 / T5) read identity from the snapshot, not the FK.
+    assert removed[0].edge_id is None, (
+        "FK ON DELETE SET NULL must null edge_id after the curated "
+        "row is hard-deleted; identity lives on snapshot.before.id"
+    )
+    before_state = removed[0].snapshot["before"]
+    assert isinstance(before_state, dict)
+    assert before_state["id"] == str(curated_id), (
+        "snapshot.before.id must carry the deleted edge's identity so "
+        "the per-resource tombstone walk in T3 can recover it"
+    )
 
     assert len(updated) == 1, (
         "exactly one ``updated`` history row for the auto edge whose "
@@ -675,6 +751,99 @@ async def test_unchanged_refresh_emits_no_history_rows() -> None:
     )
     assert len(after_edge) == len(before_edge), (
         "second identical refresh should not emit additional edge history rows"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Negative -- an idempotent re-annotate emits no history rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_idempotent_annotate_emits_no_history_rows() -> None:
+    """A second annotate with byte-identical inputs produces zero history rows.
+
+    Mirrors :func:`test_unchanged_refresh_emits_no_history_rows` on the
+    annotate side -- a pure ``last_seen`` / ``annotated_at`` heartbeat
+    is not a recorded mutation. Covers both shapes the iter-1 review
+    flagged (CodeRabbit B2 on PR #904):
+
+    * Curated edge itself -- ``_emit_annotate_history`` skips when
+      :func:`_annotate_curated_is_meaningful` returns ``False``.
+    * §6 markers -- ``_mark_same_kind_different_endpoint_superseded``
+      and ``_mark_incompatible_kinds_conflict`` skip rows whose
+      marker already equals the target value.
+    """
+    _register_fake()
+    tenant_id, target = await _seed_tenant_and_target()
+    _FakeConnector.hints = TopologyHints(
+        discovered_at=datetime.now(UTC),
+        nodes=(
+            NodeHint(kind="vm", name="vm-a"),
+            NodeHint(kind="host", name="host-old"),
+            NodeHint(kind="host", name="host-new"),
+        ),
+        edges=(
+            # vm-a runs-on host-old as an auto edge -- the first
+            # annotate of vm-a runs-on host-new will mark this row
+            # superseded.
+            EdgeHint(
+                from_kind="vm",
+                from_name="vm-a",
+                to_kind="host",
+                to_name="host-old",
+                kind="runs-on",
+            ),
+        ),
+    )
+    operator = _operator(tenant_id)
+    with patch(_PUBLISH_REFRESH, new=AsyncMock()):
+        await refresh_target_topology(target, operator)
+
+    sessionmaker = get_sessionmaker()
+    # First annotate -- creates curated edge, stamps superseded_by on
+    # the auto edge. Both history rows are expected.
+    async with sessionmaker() as session:
+        with patch(_PUBLISH_ANNOTATE, new=AsyncMock()):
+            await annotate_edge(
+                session,
+                operator,
+                NodeRef(name="vm-a", kind="vm"),
+                "runs-on",
+                NodeRef(name="host-new", kind="host"),
+                note="initial",
+            )
+
+    history_after_first = await _all_edge_history(tenant_id)
+    audits_after_first = await _all_audit_log(tenant_id)
+
+    # Second annotate with byte-identical inputs -- must be a no-op
+    # for the diff-on-write hook: zero new history rows on either the
+    # curated edge or the previously-superseded auto edge.
+    async with sessionmaker() as session:
+        with patch(_PUBLISH_ANNOTATE, new=AsyncMock()):
+            await annotate_edge(
+                session,
+                operator,
+                NodeRef(name="vm-a", kind="vm"),
+                "runs-on",
+                NodeRef(name="host-new", kind="host"),
+                note="initial",
+            )
+
+    history_after_second = await _all_edge_history(tenant_id)
+    audits_after_second = await _all_audit_log(tenant_id)
+
+    assert len(history_after_second) == len(history_after_first), (
+        "second identical annotate should not emit additional edge history rows; "
+        f"first={len(history_after_first)} second={len(history_after_second)}"
+    )
+    # Annotate still writes its own ``audit_log`` row per call (the
+    # audit row is the operation receipt, not a mutation receipt) --
+    # only history rows are the no-op contract.
+    assert len(audits_after_second) == len(audits_after_first) + 1, (
+        "annotate's own audit_log row still writes per call; only the "
+        "history hook is no-op for an idempotent re-annotate"
     )
 
 

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -486,6 +486,135 @@ so the guard runs only where the column is JSONB.
    `op_class="write"`). Commit. Publish one broadcast event
    (fail-open).
 
+## Diff-on-write history hook (write half — G9.3-T2 #857)
+
+The append-only `graph_node_history` + `graph_edge_history` tables
+(shipped by G9.3-T1 #856) are populated by a **single shared writer**
+the refresh + annotate paths both call:
+`backend/src/meho_backplane/topology/history.py`. The hook emits one
+history row per applied live mutation inside the **same**
+`session.begin()` block as the mutation itself — atomicity is the
+load-bearing contract: the live graph and the history table can
+never disagree about which mutations committed.
+
+### Snapshot shape
+
+Every history row's `snapshot` JSONB is
+`{"before": <row-json>|None, "after": <row-json>|None}`:
+
+* `created` — `before=None`, `after=<post-insert row>`.
+* `updated` — `before=<pre-mutation row>`, `after=<post-mutation row>`.
+* `removed` — `before=<final row>`, `after=None`.
+
+The bidirectional projection is what makes `meho topology diff
+<ts1> <ts2>` (T4 #860) reconstructible without joining back against
+live tables — a tombstone row carries enough state to render the
+removed resource. Column selection is deliberately narrow (the
+`_NODE_SNAPSHOT_COLUMNS` / `_EDGE_SNAPSHOT_COLUMNS` constants in
+`history.py`) rather than `vars(row)` or `sqlalchemy.inspect`-based
+reflection: a future column that should *not* enter the snapshot
+(e.g. a derived counter) opts in via the projection list.
+
+### audit_id linkage
+
+Every history row carries the **causing operation's**
+`audit_log.id` (soft-FK column `audit_id`). The refresh / annotate
+service pre-allocates one `audit_id` at the top of the request via
+`uuid.uuid4()`, writes one audit row with that id, and threads the
+same id down to every history row the operation emits. Re-using one
+audit row per operation (rather than per history row) keeps
+`audit_log` at one row per operation — the contract `audit_log`
+consumers rely on — and lets `meho topology diff` / `history` /
+`timeline` (T3-T5) join history back to the principal / session /
+target via `audit_log.id`.
+
+### Refresh path
+
+`_reconcile_nodes` and `_reconcile_edges` (in `topology/refresh.py`)
+each take an `audit_id` parameter threaded from
+`_apply_reconcile` → `refresh_target_topology`. Per applied
+mutation:
+
+* **Insert branch** — capture nothing (no prior state); emit
+  `created` with `before=None`, `after=node_snapshot(new_row)`.
+* **Update branch** — capture `before = node_snapshot(row)` **before**
+  reassigning the row's columns (otherwise the snapshot aliases the
+  post-mutation state); reassign columns; emit `updated` with
+  `after=node_snapshot(row)`. The history row fires under the same
+  predicate the refresh `updated` counter uses (`last_seen IS NULL`
+  OR `target_id` changed OR properties differ) — a pure `last_seen`
+  heartbeat is not a recorded mutation.
+* **Soft-remove branch** — capture `before` before nulling
+  `last_seen`; emit `removed` with `after=None`.
+
+Edge reconciliation is identical, with one extra wrinkle: the
+*resurrected curated edge* case (`last_seen IS NULL → now`) emits an
+`updated` history row even though the only changed column is
+`last_seen` — the resurrection is operator-observable (the edge
+returned to traversal), so it warrants a row. A pure heartbeat on
+an already-live curated edge does not.
+
+### Annotate path
+
+`annotate_edge_in_txn` emits history rows for **every mutated edge**
+inside the same `session.begin()` block as the upsert:
+
+* The curated row itself — `created` (fresh insert) or `updated`
+  (idempotent re-annotate or auto→curated promotion). The `after`
+  snapshot is captured *after* both §6 conflict scans run so any
+  `conflicts_with` marker stamped on the curated row by
+  `_mark_incompatible_kinds_conflict` is visible in `snapshot.after`.
+* Each auto edge marked `superseded_by` (same-kind /
+  different-endpoint, §6 rule 1) — `updated`, with `before` captured
+  before the marker write so `snapshot.before` shows the row as the
+  operator last saw it on `list-edges`.
+* Each edge of a different kind over the same endpoint pair (§6
+  rule 2) — `updated` with the same before/after discipline.
+
+`_mark_same_kind_different_endpoint_superseded` and
+`_mark_incompatible_kinds_conflict` now return
+`list[tuple[GraphEdge, snapshot_before]]` instead of plain id lists;
+the audit payload's `superseded` / `conflicts` arrays are derived
+from `pair[0].id`.
+
+### Unannotate path
+
+`unannotate_edge` emits:
+
+* One `removed` history row for the curated edge. The history row
+  is staged in the session **before** `session.delete(edge)` so the
+  insert and the delete flush in a stable order — flushing the
+  delete first would let the FK `ON DELETE SET NULL` kick in and
+  the freshly-inserted history row would land with
+  `edge_id = NULL`, defeating the per-resource history walk in T3
+  (the walk filters on `edge_id`).
+* One `updated` row per referencing edge whose `superseded_by` /
+  `conflicts_with` marker the unannotate just cleared. `before` is
+  captured before `_clear_reciprocal_markers` runs so the cleared
+  marker is visible in `snapshot.before` and absent in
+  `snapshot.after` — the temporal-query verb can render the
+  inverse of the original annotate as a single point-in-time
+  mutation.
+
+### No own audit rows
+
+The hook never writes its own `audit_log` rows. Acceptance criterion
+#5 of #857 — re-emitting an audit row per history row would balloon
+the audit log on a topology refresh that touches dozens of resources,
+and would also break the "one operation, one audit row" invariant
+`audit_log` consumers rely on. The single audit row the refresh /
+annotate service writes is the canonical audit record; history rows
+reference it.
+
+### Bulk import composition
+
+`bulk_import_edges` (G9.2-T8 #600) calls `annotate_edge_in_txn` once
+per row inside a shared `session.begin()` block — every per-row
+history emission lands inside the same batch transaction and rolls
+back atomically with the batch. No additional wiring was needed for
+G9.3-T2: the hook is on the call path the bulk importer already
+uses.
+
 ## Manual node seed control flow (write half — G0.9.1-T6 #778)
 
 ### `create_or_get_node`


### PR DESCRIPTION
## Summary

- Wires the live-mutation diff onto the append-only `graph_node_history` + `graph_edge_history` substrate from G9.3-T1 (#856). Every live `graph_node` / `graph_edge` INSERT / UPDATE / soft-remove in the refresh service, and every annotate / unannotate of a curated edge (including the §6 supersede / conflict marker writes), emits a paired history row **in the same transaction** as the live write. Atomicity is load-bearing: a partial-failure rollback can never leave the live graph and the history table disagreeing about which mutations committed.
- Shared writer is `backend/src/meho_backplane/topology/history.py` (`record_node_change` / `record_edge_change` + `node_snapshot` / `edge_snapshot`), projecting a fresh row dict into the `{before, after}` JSONB shape the temporal-query verbs T3/T4/T5 read. Snapshot column selection is deliberately narrow (a constant tuple) so a future derived column does not leak into the history projection.
- Every history row carries the **causing operation's** `audit_log.id` via the soft-FK `audit_id` column. The refresh / annotate service pre-allocates one `audit_id` per request and threads it down to every emitted history row, preserving the chassis's "one operation, one audit row" invariant (acceptance criterion #5). `bulk_import_edges` (G9.2-T8 #600) composes cleanly because it already calls `annotate_edge_in_txn`.

Stacked on #900 (G9.3-T1). Review/merge #900 first.

## Test plan

- [x] `ruff check` -- clean on all touched files
- [x] `ruff format --check` -- clean
- [x] `mypy src/meho_backplane/` -- 221 source files, no issues
- [x] `.claude/hooks/code-quality.py --diff` -- 0 blockers
- [x] `pytest tests/test_topology_history_hook.py` -- **9 passed** (one per acceptance criterion + tenant boundary + §6 marker history + no-op no-emit + iter-2 B2 idempotent-annotate regression)
- [x] `pytest tests/ --ignore=tests/integration` -- **3287 passed, 47 skipped** (no regressions in any topology / annotate / bulk-import / migration suite; acceptance suite re-greens after the T1 TRUNCATE gap fix)
- [x] **AC#1**: a `topology.refresh` adding 3 nodes + 2 edges produces exactly 5 history rows in the same txn, all sharing the refresh's `audit_id` -- proven by `test_refresh_3n2e_emits_5_history_rows_sharing_audit_id`.
- [x] **AC#2**: a `topology.annotate` adding 1 curated edge produces 1 history row sharing the annotate's `audit_id` -- proven by `test_annotate_one_edge_emits_one_edge_history_row_with_shared_audit_id`.
- [x] **AC#3**: a refresh dropping a previously-discovered node produces 1 `removed` history row (`snapshot.before` = full row, `after` = NULL) with a NEW `audit_id` -- proven by `test_refresh_dropping_node_emits_removed_history_with_new_audit_id`.
- [x] **AC#4**: a forced failure after the live-table write but before commit leaves NEITHER the live change nor the history row -- proven by `test_refresh_failure_rolls_back_both_live_and_history_rows`.
- [x] **AC#5**: history writes emit no `audit_log` rows of their own -- proven by the `len(audits) == 1` assertion in the AC#1 test (one refresh = one audit row, 5 history rows reference it).
- [x] **AC**: `pytest -n auto backend/tests/test_topology_history_hook.py` passes (uses the standard per-worker template DB cache).

## Out of scope

- T3/T4/T5 (#859/#860/#861) temporal-query verbs (`meho topology history / diff / timeline`) and the `query_topology(kind=...)` MCP routing -- this PR ships only the write half; reads land on top.
- T6 (#858) retention prune task.
- `topology/nodes.py` (`create_or_get_node` operator-seeded nodes) -- the task body explicitly scopes T2 to the `topology/refresh.py` + `topology/annotate.py` write paths.
- PG-side integration verification (Docker absent in agent sandbox); the unit suite exercises every code path against `sqlite+aiosqlite` via the standard worker-template cache, and `tests/integration/conftest.py`'s TRUNCATE list is updated so the testcontainers PG suite runs cleanly when CI provisions Docker.

## Adjacent findings (recorded, fix not in this PR)

- `backend/src/meho_backplane/topology/annotate.py` is now 1289 lines and `topology/refresh.py` is 1013 lines. The code-quality hook flags both as pre-existing file-size warnings (block limit 600). The task body mandates editing both files; an in-PR split is out of scope. The four critical-path functions (`_reconcile_nodes`, `_reconcile_edges`, `annotate_edge_in_txn`, `unannotate_edge`) were extracted into per-branch / per-phase helpers as part of this PR to clear the function-size block-limit -- a follow-up refactor task to split the topology service by responsibility (`refresh` / `annotate` / `history` / `bulk` modules) is a candidate for the orchestrator to file.
- `tests/test_migration_0011_backfill_when_to_use.py::test_re_running_migration_is_idempotent` was failing on this branch because the test stamps the DB back to `0010` then runs `upgrade("head")`, which re-executes 0012's non-idempotent `CREATE TABLE graph_node_history`. Fixed in-PR by targeting `upgrade("0011")` so 0012 is not re-executed; the test's intent (re-run 0011 against an already-curated DB) is preserved.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #857

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-22)

Addressed every iter-1 `/auto-review-pr` REQUEST_CHANGES finding in commit `0f3ba8b`:

- **B1** (blocker) `0f3ba8b` -- accept the migration's intended `ON DELETE SET NULL` cascade on `graph_edge_history.edge_id`: the curated row's hard-delete in `unannotate_edge` nulls the tombstone's `edge_id` on PG, which is correct (history rows must survive live-row deletion). Identity recovery now documented to flow through `snapshot.before.id` + the `graph_edge_history_tenant_removed_idx` partial index. Unit test asserts `removed[0].edge_id is None` + `snapshot.before.id == str(curated_id)`. Added an opt-in `MEHO_SQLITE_FOREIGN_KEYS=1` env-var gate in `create_engine_for_url` plus an autouse fixture in the topology history hook test module that flips it, so SQLite enforces the FK and the test catches the divergence going forward. The gate is module-scoped because a blanket SQLite-FK-on flip surfaces a large pre-existing tape of test fixtures that insert FK-referencing rows without seeding the parent (chassis-wide refactor, out of scope for #857).
- **B2** (blocker, CodeRabbit-flagged) `0f3ba8b` -- guarded the idempotent re-annotate path so it no longer emits phantom `UPDATED` history rows. `_mark_same_kind_different_endpoint_superseded` skips rows whose `superseded_by` already equals the curated id; `_mark_incompatible_kinds_conflict` skips rows with complete bidirectional `conflicts_with` linkage; the curated row's own history emission is gated on `_annotate_curated_is_meaningful` (excludes the `last_seen` / `properties.annotated_at` heartbeat fields, mirroring refresh's `_properties_differ` contract). Added `test_idempotent_annotate_emits_no_history_rows` regression covering both shapes.
- **M1** (major, CodeRabbit-flagged) `0f3ba8b` -- unannotate audit / broadcast payload partitions the cleared edges into two distinct buckets: `superseded` (where `snapshot.before.properties.superseded_by == removed_id`) and `conflicts` (where the removed_id appears in `snapshot.before.properties.conflicts_with`). Read from the captured snapshot so the partition is immune to the upcoming `_clear_reciprocal_markers` mutation.
- **m1** (minor, CodeRabbit-flagged) `0f3ba8b` -- `node_snapshot` / `edge_snapshot` now use `copy.deepcopy` instead of shallow `dict()` on `properties`, forward-compat against any nested-container mutation (the §6 `conflicts_with` is a list).
- **m2** (minor, CodeRabbit-flagged) `0f3ba8b` -- `test_refresh_failure_rolls_back_both_live_and_history_rows` materializes `.scalars().all()` inside the `AsyncSession` context, asserts on the bound lists outside.

Also repairs a T1 (#856) gap in `backend/tests/acceptance/conftest.py`: the per-test TRUNCATE list was missing `graph_edge_history` / `graph_node_history`, so every PG-backed acceptance test was erroring at setup with `cannot truncate a table referenced in a foreign key constraint`. The integration conftest's TRUNCATE list already includes both.

Disputed: none.

Deferred: none.

<!-- auto-implement-issue: continue, iteration 2 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive diff-on-write history tracking for topology operations (node/edge creation, updates, deletions).
  * History rows now capture before/after snapshots linked to audit trails for refresh, annotation, and unannotation operations.

* **Tests**
  * Added extensive test suite validating history emission across all topology operations and failure scenarios.

* **Documentation**
  * Added detailed guide describing history hook behavior and snapshot structure for topology changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/904?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->