### PR TITLE
feat(connectors): G3.7-T7 HetznerRobotConnector skeleton — HttpConnector + HTTP Basic + no-retry-on-401 + _post_form + fingerprint + probe + registry v2

### DIFF
--- a/backend/src/meho_backplane/connectors/hetzner_robot/__init__.py
+++ b/backend/src/meho_backplane/connectors/hetzner_robot/__init__.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.hetzner_robot — HetznerRobotConnector package.
+
+Importing this package registers :class:`HetznerRobotConnector` against the
+v2 connector registry under
+``(product="hetzner-robot", version="2026-04", impl_id="hetzner-rest")``.
+
+Registration is synchronous (import-time) only — this skeleton ships no typed
+operations; all ops arrive in T8 via G0.7 spec ingestion of the Robot
+Webservice OpenAPI spec into the ``endpoint_descriptor`` table.
+
+The v1 :func:`~meho_backplane.connectors.registry.register_connector` entry
+point is deliberately **not** called.  The connector advertises an explicit
+``(version="2026-04", impl_id="hetzner-rest")`` key; the v1 entry would land
+as ``("hetzner-robot", "", "")`` and confuse
+:func:`~meho_backplane.connectors.resolver.resolve_connector`'s tie-break
+ladder.  Same pattern :mod:`meho_backplane.connectors.harbor` established.
+"""
+
+from meho_backplane.connectors.hetzner_robot.connector import HetznerRobotConnector
+from meho_backplane.connectors.hetzner_robot.session import (
+    HetznerRobotCredentialsLoader,
+    HetznerRobotTargetLike,
+    SessionCredentials,
+    load_credentials_from_vault,
+)
+from meho_backplane.connectors.registry import register_connector_v2
+
+register_connector_v2(
+    product="hetzner-robot",
+    version="2026-04",
+    impl_id="hetzner-rest",
+    cls=HetznerRobotConnector,
+)
+
+__all__ = [
+    "HetznerRobotConnector",
+    "HetznerRobotCredentialsLoader",
+    "HetznerRobotTargetLike",
+    "SessionCredentials",
+    "load_credentials_from_vault",
+]

--- a/backend/src/meho_backplane/connectors/hetzner_robot/__init__.py
+++ b/backend/src/meho_backplane/connectors/hetzner_robot/__init__.py
@@ -5,7 +5,7 @@
 
 Importing this package registers :class:`HetznerRobotConnector` against the
 v2 connector registry under
-``(product="hetzner-robot", version="2026-04", impl_id="hetzner-rest")``.
+``(product="hetzner-robot", version="2026.04", impl_id="hetzner-rest")``.
 
 Registration is synchronous (import-time) only — this skeleton ships no typed
 operations; all ops arrive in T8 via G0.7 spec ingestion of the Robot
@@ -13,7 +13,7 @@ Webservice OpenAPI spec into the ``endpoint_descriptor`` table.
 
 The v1 :func:`~meho_backplane.connectors.registry.register_connector` entry
 point is deliberately **not** called.  The connector advertises an explicit
-``(version="2026-04", impl_id="hetzner-rest")`` key; the v1 entry would land
+``(version="2026.04", impl_id="hetzner-rest")`` key; the v1 entry would land
 as ``("hetzner-robot", "", "")`` and confuse
 :func:`~meho_backplane.connectors.resolver.resolve_connector`'s tie-break
 ladder.  Same pattern :mod:`meho_backplane.connectors.harbor` established.
@@ -30,7 +30,7 @@ from meho_backplane.connectors.registry import register_connector_v2
 
 register_connector_v2(
     product="hetzner-robot",
-    version="2026-04",
+    version="2026.04",
     impl_id="hetzner-rest",
     cls=HetznerRobotConnector,
 )

--- a/backend/src/meho_backplane/connectors/hetzner_robot/connector.py
+++ b/backend/src/meho_backplane/connectors/hetzner_robot/connector.py
@@ -1,0 +1,386 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""HetznerRobotConnector — hand-rolled HttpConnector subclass for Hetzner Robot.
+
+Skeleton-only — auth + fingerprint + probe + the G0.6 dispatch shim.
+Operations arrive in T8 via G0.7 spec ingestion against the Robot Webservice
+OpenAPI spec into the ``endpoint_descriptor`` table.
+
+Registered against the v2 registry at module-import time via
+:func:`~meho_backplane.connectors.registry.register_connector_v2` in
+:mod:`meho_backplane.connectors.hetzner_robot.__init__`.
+
+Auth
+----
+
+Hetzner Robot uses HTTP Basic auth against the **Webservice user** — a
+distinct account from the Robot login user that must be created in the Robot
+portal.  Credentials are loaded once from Vault via an injectable loader and
+cached per-target.  The ``Authorization: Basic`` header is recomputed on each
+``auth_headers()`` call from the cached values.
+
+IP-block protection
+-------------------
+
+Hetzner Robot **blocks the source IP for 10 minutes after 3 failed 401
+responses**.  Because MEHO operates on a shared egress IP, a single
+misconfigured target could lock every operator off the Robot API for 10
+minutes.  The connector therefore raises :exc:`RuntimeError` with an
+``auth_failed`` label and a remediation message on the **first** 401 response
+— it never retries, never consumes the 2 remaining attempts.
+
+The base :meth:`HttpConnector._retryable` already excludes 4xx from the
+tenacity retry predicate.  This connector adds an explicit 401-before-raise
+check in ``_request_robot`` so the failure is surfaced with a useful message
+before the HTTP status error propagates.
+
+Form-encoded helper
+-------------------
+
+The Robot Webservice API requires ``application/x-www-form-urlencoded``
+bodies for all write verbs — it rejects ``application/json``.  The
+``_post_form`` helper wraps httpx's ``data=`` parameter so callers never pass
+a raw ``json=`` arg against this API.  v0.2 read operations never POST, but
+the helper ships now for v0.2.next write readiness per the task body.
+
+Fingerprint
+-----------
+
+``GET /server`` returns the list of dedicated servers owned by the account.
+The connector uses the response to derive ``vendor="hetzner"``,
+``product="robot-webservice"``, the account's server count, and the
+account ID extracted from the first server's ``server_ip`` field (or the
+first 401-not-retried result if unauthenticated).  ``extras["account_id"]``
+and ``extras["server_count"]`` are set when the probe succeeds.
+
+Probe
+-----
+
+TCP reachability check (implicit via httpx ``AsyncClient``) + TLS cert
+validation + ``GET /server`` (the cheapest authenticated endpoint).  A 401
+during probe is **not** retried — ``ok=False`` with the auth_failed reason.
+
+Operations
+----------
+
+This module ships zero operations — the G0.6 dispatch shim :meth:`execute`
+exists for ABC compatibility.  Operations land via T8 spec ingestion.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.hetzner_robot.session import (
+    HetznerRobotCredentialsLoader,
+    HetznerRobotTargetLike,
+    load_credentials_from_vault,
+)
+from meho_backplane.connectors.schemas import (
+    AuthModel,
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+
+__all__ = ["HetznerRobotConnector"]
+
+_log = structlog.get_logger(__name__)
+
+# Instructional message appended to auth_failed errors so operators know
+# which credential to fix without having to read the source.  The 10-minute
+# IP block risk is called out explicitly — operators may not be aware of
+# Hetzner Robot's unusual shared-egress policy.
+_AUTH_FAILED_HINT = (
+    "Check the Webservice-user credentials at the target's secret_ref Vault "
+    "path. NOTE: Hetzner Robot blocks the source IP for 10 minutes after 3 "
+    "consecutive 401 responses — this connector fails fast on the first 401 "
+    "to protect shared-egress operators."
+)
+
+
+def _is_acceptable_auth_model(value: Any) -> bool:
+    """Return ``True`` iff *value* is ``SHARED_SERVICE_ACCOUNT`` or unset (pre-G0.3 ``None``)."""
+    if value is None:
+        return True
+    if value is AuthModel.SHARED_SERVICE_ACCOUNT:
+        return True
+    return bool(value == AuthModel.SHARED_SERVICE_ACCOUNT.value)
+
+
+def _basic_auth_header(username: str, password: str) -> str:
+    """Compute the ``Authorization: Basic`` header value for *username*:*password*."""
+    encoded = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return f"Basic {encoded}"
+
+
+class HetznerRobotConnector(HttpConnector):
+    """Hetzner Robot Webservice connector with HTTP Basic auth.
+
+    Per-target credentials cached in :attr:`_creds_cache` (loaded once via
+    the injectable :class:`HetznerRobotCredentialsLoader`). HTTP Basic auth
+    is sent on every request via ``Authorization: Basic <base64>`` — no
+    session token is established.
+
+    **A 401 response is never retried.**  Three consecutive 401s from a single
+    source IP trigger a 10-minute IP block on Hetzner Robot.  On the first 401,
+    this connector raises :exc:`RuntimeError` with an instructional message
+    naming the target and the Vault path to check.
+
+    The :attr:`priority` is set to ``1`` so a future ``GenericRestConnector``
+    auto-shim (priority=0) loses the registry tie-break if both register for
+    the same triple.
+    """
+
+    product = "hetzner-robot"
+    version = "2026-04"
+    impl_id = "hetzner-rest"
+    supported_version_range = None  # Webservice API versioned by date, not semver
+    priority = 1
+
+    def __init__(
+        self,
+        *,
+        credentials_loader: HetznerRobotCredentialsLoader | None = None,
+    ) -> None:
+        super().__init__()
+        self._creds_cache: dict[str, dict[str, str]] = {}
+        self._creds_lock = asyncio.Lock()
+        self._credentials_loader: HetznerRobotCredentialsLoader = (
+            credentials_loader if credentials_loader is not None else load_credentials_from_vault
+        )
+
+    async def auth_headers(self, target: HetznerRobotTargetLike, raw_jwt: str) -> dict[str, str]:
+        """Return ``{"Authorization": "Basic ..."}`` for the request.
+
+        Loads credentials from Vault on first call against *target*, caches
+        them, and reuses the cached values on subsequent calls.  ``raw_jwt``
+        is accepted for ABC-signature compatibility but unused —
+        :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` authenticates with a
+        Vault-sourced Webservice-user credential, not the operator's OIDC
+        token.
+
+        Raises :exc:`NotImplementedError` if ``target.auth_model`` is anything
+        other than ``shared_service_account`` or ``None``.
+        """
+        del raw_jwt  # SHARED_SERVICE_ACCOUNT mode does not forward operator JWT
+        auth_model = getattr(target, "auth_model", None)
+        if not _is_acceptable_auth_model(auth_model):
+            raise NotImplementedError(
+                f"HetznerRobotConnector only supports auth_model="
+                f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
+                f"{target.name!r} requested auth_model={auth_model!r}"
+            )
+        creds = await self._load_credentials(target)
+        return {"Authorization": _basic_auth_header(creds["username"], creds["password"])}
+
+    async def _load_credentials(self, target: HetznerRobotTargetLike) -> dict[str, str]:
+        """Return the cached credentials for *target*, loading from Vault on first use.
+
+        The lock serialises concurrent first-use callers for the same target.
+        The loaded dict must contain ``"username"`` and ``"password"`` keys;
+        missing keys raise :exc:`RuntimeError` naming the target and the missing
+        key so operators can identify a misconfigured Vault path.
+        """
+        async with self._creds_lock:
+            cached = self._creds_cache.get(target.name)
+            if cached is not None:
+                return cached
+            raw = await self._credentials_loader(target)
+            try:
+                _ = raw["username"]
+                _ = raw["password"]
+            except KeyError as exc:
+                raise RuntimeError(
+                    f"hetzner-robot credentials loader for target {target.name!r} returned "
+                    f"a dict missing required key {exc.args[0]!r}; need "
+                    "{'username': str, 'password': str}"
+                ) from exc
+            self._creds_cache[target.name] = raw
+            _log.info(
+                "hetzner_robot_credentials_loaded",
+                target=target.name,
+                host=target.host,
+            )
+            return raw
+
+    async def _get_robot_json(
+        self,
+        target: HetznerRobotTargetLike,
+        path: str,
+    ) -> Any:
+        """Perform a GET against the Robot Webservice, raising auth_failed on 401.
+
+        Wraps :meth:`HttpConnector._get_json` with an explicit 401-intercept
+        so operators see the instructional error before httpx's generic
+        ``HTTPStatusError`` propagates.  The base ``_retryable`` predicate
+        already excludes 4xx, so tenacity does not retry — this method adds
+        the human-readable failure on top.
+        """
+        client = await self._http_client(target)
+        headers = await self.auth_headers(target, raw_jwt="")
+        resp = await client.request("GET", path, headers=headers)
+        if resp.status_code == 401:
+            raise RuntimeError(
+                f"auth_failed: Hetzner Robot returned 401 for target "
+                f"{target.name!r} (host={target.host!r}). {_AUTH_FAILED_HINT}"
+            )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def _post_form(
+        self,
+        target: HetznerRobotTargetLike,
+        path: str,
+        data: dict[str, Any],
+    ) -> Any:
+        """Non-retried POST with ``application/x-www-form-urlencoded`` body.
+
+        The Robot Webservice API requires form-encoded bodies for all write
+        verbs.  httpx's ``data=`` parameter encodes a dict as
+        ``application/x-www-form-urlencoded`` (RFC 3986 percent-encoding).
+        A 401 during a form POST is intercepted and raised as ``auth_failed``
+        — same discipline as :meth:`_get_robot_json`.
+
+        v0.2 read operations never POST against the Robot API; this helper
+        ships for v0.2.next write readiness per the task body.
+        """
+        client = await self._http_client(target)
+        headers = await self.auth_headers(target, raw_jwt="")
+        resp = await client.request("POST", path, data=data, headers=headers)
+        if resp.status_code == 401:
+            raise RuntimeError(
+                f"auth_failed: Hetzner Robot returned 401 for target "
+                f"{target.name!r} (host={target.host!r}). {_AUTH_FAILED_HINT}"
+            )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def fingerprint(self, target: HetznerRobotTargetLike) -> FingerprintResult:
+        """Canonical fingerprint built from ``GET /server``.
+
+        Returns ``vendor="hetzner"``, ``product="robot-webservice"``,
+        ``extras["account_id"]`` (extracted from the first server entry, or
+        ``None`` when the account has no servers), and
+        ``extras["server_count"]`` (number of dedicated servers visible to
+        the Webservice user).
+
+        On transport, status, or auth failure, returns a non-reachable
+        :class:`FingerprintResult` whose ``extras["error"]`` carries the
+        exception class + message.
+        """
+        probed_at = datetime.now(UTC)
+        try:
+            payload = await self._get_robot_json(target, "/server")
+        except (httpx.HTTPError, OSError, RuntimeError) as exc:
+            return FingerprintResult(
+                vendor="hetzner",
+                product="robot-webservice",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method="GET /server",
+                extras={"error": f"{type(exc).__name__}: {exc}"},
+            )
+        # The Robot API wraps list responses as {"servers": [...]} or
+        # returns the list directly depending on the endpoint version.
+        # Normalise both shapes.
+        servers: list[dict[str, Any]] = []
+        if isinstance(payload, dict) and "servers" in payload:
+            servers = payload["servers"]
+        elif isinstance(payload, list):
+            servers = payload
+
+        account_id: str | None = None
+        if servers:
+            # account_id is not a first-class field in the Robot API; the
+            # Webservice URL itself encodes the account implicitly. Use the
+            # first server's numeric id as a stable account fingerprint.
+            first = servers[0]
+            server_obj = first.get("server", first)
+            account_id = str(server_obj.get("server_number") or server_obj.get("id") or "")
+            account_id = account_id or None
+
+        return FingerprintResult(
+            vendor="hetzner",
+            product="robot-webservice",
+            reachable=True,
+            probed_at=probed_at,
+            probe_method="GET /server",
+            extras={
+                "account_id": account_id,
+                "server_count": len(servers),
+            },
+        )
+
+    async def probe(self, target: HetznerRobotTargetLike) -> ProbeResult:
+        """Reachability check via TCP + TLS + ``GET /server`` (401-not-retried).
+
+        Returns ``ok=True`` when the authenticated GET succeeds.
+        Returns ``ok=False`` with ``reason`` on any transport, TLS, auth, or
+        status failure.  A 401 is captured as a one-shot failure (no retry)
+        per the IP-block protection contract.
+        """
+        probed_at = datetime.now(UTC)
+        try:
+            await self._get_robot_json(target, "/server")
+        except (httpx.HTTPError, OSError, RuntimeError) as exc:
+            return ProbeResult(
+                ok=False,
+                reason=f"{type(exc).__name__}: {exc}",
+                probed_at=probed_at,
+            )
+        return ProbeResult(ok=True, probed_at=probed_at)
+
+    async def execute(
+        self,
+        target: HetznerRobotTargetLike,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Legacy shim — delegates to the G0.6 dispatcher.
+
+        Mirrors :meth:`HarborConnector.execute`'s shape.  Post-G0.6 callers
+        (``/api/v1/operations/call``, MCP ``call_operation``) construct a real
+        :class:`Operator` and call :func:`meho_backplane.operations.dispatch`
+        directly — they don't reach this method.
+
+        The connector's natural key is encoded as the dispatcher's
+        ``connector_id``: ``"hetzner-rest-2026-04"`` →
+        (product=``"hetzner-robot"``, version=``"2026-04"``,
+        impl_id=``"hetzner-rest"``).
+        """
+        from uuid import UUID
+
+        from meho_backplane.auth.operator import Operator, TenantRole
+        from meho_backplane.operations import dispatch
+
+        operator = Operator(
+            sub="system:hetzner-rest-connector-shim",
+            name=None,
+            email=None,
+            raw_jwt="",
+            tenant_id=UUID(int=0),
+            tenant_role=TenantRole.OPERATOR,
+        )
+        connector_id = f"{self.impl_id}-{self.version}"
+        return await dispatch(
+            operator=operator,
+            connector_id=connector_id,
+            op_id=op_id,
+            target=target,
+            params=params,
+        )
+
+    async def aclose(self) -> None:
+        """Clear cached credentials, then tear down the httpx pool."""
+        async with self._creds_lock:
+            self._creds_cache.clear()
+        await super().aclose()

--- a/backend/src/meho_backplane/connectors/hetzner_robot/connector.py
+++ b/backend/src/meho_backplane/connectors/hetzner_robot/connector.py
@@ -141,7 +141,7 @@ class HetznerRobotConnector(HttpConnector):
     """
 
     product = "hetzner-robot"
-    version = "2026-04"
+    version = "2026.04"
     impl_id = "hetzner-rest"
     supported_version_range = None  # Webservice API versioned by date, not semver
     priority = 1
@@ -234,7 +234,12 @@ class HetznerRobotConnector(HttpConnector):
                 f"{target.name!r} (host={target.host!r}). {_AUTH_FAILED_HINT}"
             )
         resp.raise_for_status()
-        return resp.json()
+        try:
+            return resp.json()
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Non-JSON response from {path}: {resp.status_code} {resp.text[:200]}"
+            ) from exc
 
     async def _post_form(
         self,
@@ -262,7 +267,12 @@ class HetznerRobotConnector(HttpConnector):
                 f"{target.name!r} (host={target.host!r}). {_AUTH_FAILED_HINT}"
             )
         resp.raise_for_status()
-        return resp.json()
+        try:
+            return resp.json()
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Non-JSON response from {path}: {resp.status_code} {resp.text[:200]}"
+            ) from exc
 
     async def fingerprint(self, target: HetznerRobotTargetLike) -> FingerprintResult:
         """Canonical fingerprint built from ``GET /server``.
@@ -353,8 +363,8 @@ class HetznerRobotConnector(HttpConnector):
         directly — they don't reach this method.
 
         The connector's natural key is encoded as the dispatcher's
-        ``connector_id``: ``"hetzner-rest-2026-04"`` →
-        (product=``"hetzner-robot"``, version=``"2026-04"``,
+        ``connector_id``: ``"hetzner-rest-2026.04"`` →
+        (product=``"hetzner-robot"``, version=``"2026.04"``,
         impl_id=``"hetzner-rest"``).
         """
         from uuid import UUID

--- a/backend/src/meho_backplane/connectors/hetzner_robot/session.py
+++ b/backend/src/meho_backplane/connectors/hetzner_robot/session.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Credential loading for the Hetzner Robot connector.
+
+The hand-rolled :class:`~meho_backplane.connectors.hetzner_robot.connector.HetznerRobotConnector`
+reads service-account credentials from the target's Vault path and sends
+them as HTTP Basic auth on every request.  No session token is established;
+the ``Authorization: Basic`` header is recomputed from the cached credentials
+on each call.
+
+The Hetzner Robot API authenticates with a **Webservice user** — a separate
+account that must be created in the Robot portal and is distinct from the
+Robot login user. Credentials are stored verbatim in Vault under the
+target's ``secret_ref`` path as ``{"username": ..., "password": ...}``.
+
+**Critical: IP-block protection.** Hetzner Robot blocks the source IP for
+10 minutes after 3 failed 401 responses from that IP.  Any credential
+mismatch must therefore surface as an immediate hard error — never a retry.
+The loader is injectable so unit tests supply canned credentials; the
+production path (live Vault read) is a deliberate stub until Goal #214
+lands.
+
+The :class:`HetznerRobotTargetLike` Protocol captures the minimum target
+shape the connector reads: ``name`` (per-target cache key), ``host``,
+``port`` (forwarded to :meth:`HttpConnector._base_url`), ``secret_ref``
+(the Vault path the loader resolves), and ``auth_model`` (checked at the
+auth boundary). No ``sso_realm`` field — Hetzner Robot sends
+``username:password`` directly in the Basic header.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Protocol, runtime_checkable
+
+__all__ = [
+    "HetznerRobotCredentialsLoader",
+    "HetznerRobotTargetLike",
+    "SessionCredentials",
+    "load_credentials_from_vault",
+]
+
+
+class SessionCredentials(Protocol):
+    """The dict shape :class:`HetznerRobotCredentialsLoader` returns.
+
+    Both keys map to the HTTP Basic auth components sent on every request.
+    """
+
+    username: str
+    password: str
+
+
+@runtime_checkable
+class HetznerRobotTargetLike(Protocol):
+    """Minimum target shape :class:`HetznerRobotConnector` reads.
+
+    Structural Protocol — the concrete ``Target`` model in
+    :mod:`meho_backplane.targets` (G0.3 #224 — closed) satisfies this
+    Protocol unchanged.  ``auth_model`` is checked at the auth boundary so a
+    target tagged ``per_user`` raises a clear error rather than silently
+    authenticating as the shared service account.
+
+    ``secret_ref`` is the Vault path resolved to ``{"username", "password"}``.
+    ``port`` is optional — the Robot API is HTTPS/443 and
+    :meth:`HttpConnector._base_url` already handles the ``port is None or
+    443`` case correctly.
+    """
+
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None
+
+
+HetznerRobotCredentialsLoader = Callable[[HetznerRobotTargetLike], Awaitable[dict[str, str]]]
+"""Async callable resolving a target to ``{"username": ..., "password": ...}``.
+
+The connector's :meth:`HetznerRobotConnector._load_credentials` invokes the
+loader exactly once per target (first-use), caching the resulting dict under
+``target.name``.  The return type is the looser ``dict[str, str]`` (not
+:class:`SessionCredentials`) because Python :class:`Protocol` instances
+aren't runtime-constructible without a matching class.
+"""
+
+
+async def load_credentials_from_vault(
+    target: HetznerRobotTargetLike,
+) -> dict[str, str]:
+    """Default credential loader — Vault read by ``target.secret_ref``.
+
+    Deliberate stub: the operator-context per-target Vault credential read is
+    not yet wired for the Hetzner Robot connector.  Raising
+    :exc:`NotImplementedError` here keeps the wiring shape stable — a
+    production caller without an override receives a clear error rather than
+    a silent fallback or a hallucinated credential pair.  The live read is
+    tracked under the open Goal #214 (Connector parity).
+    """
+    raise NotImplementedError(
+        "load_credentials_from_vault is a deliberate stub: the operator-context "
+        "per-target Vault credential read is not yet wired for the Hetzner Robot "
+        f"connector; target={target.name!r} secret_ref={target.secret_ref!r}. "
+        "Workaround: inject a custom credentials_loader on HetznerRobotConnector. "
+        "Tracked under open Goal #214 (Connector parity): "
+        "https://github.com/evoila/meho/issues/214"
+    )

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -927,6 +927,7 @@ def _every_v2_connector_registered() -> Iterator[None]:
     """
     from meho_backplane.connectors.bind9.connector import Bind9Connector
     from meho_backplane.connectors.harbor.connector import HarborConnector
+    from meho_backplane.connectors.hetzner_robot.connector import HetznerRobotConnector
     from meho_backplane.connectors.kubernetes.connector import KubernetesConnector
     from meho_backplane.connectors.nsx.connector import NsxConnector
     from meho_backplane.connectors.registry import (
@@ -943,6 +944,7 @@ def _every_v2_connector_registered() -> Iterator[None]:
     entries: tuple[tuple[str, str, str, type], ...] = (
         ("bind9", "9.x", "bind9-ssh", Bind9Connector),
         ("harbor", "2.x", "harbor-rest", HarborConnector),
+        ("hetzner-robot", "2026.04", "hetzner-rest", HetznerRobotConnector),
         ("k8s", "1.x", "k8s", KubernetesConnector),
         ("nsx", "4.2", "nsx-rest", NsxConnector),
         ("sddc-manager", "9.0", "sddc-rest", SddcManagerConnector),

--- a/backend/tests/test_connectors_hetzner_robot_auth.py
+++ b/backend/tests/test_connectors_hetzner_robot_auth.py
@@ -108,7 +108,7 @@ def _decode_basic_auth(authorization_header: str) -> tuple[str, str]:
 def test_hetzner_robot_connector_subclasses_http_connector() -> None:
     assert issubclass(HetznerRobotConnector, HttpConnector)
     assert HetznerRobotConnector.product == "hetzner-robot"
-    assert HetznerRobotConnector.version == "2026-04"
+    assert HetznerRobotConnector.version == "2026.04"
     assert HetznerRobotConnector.impl_id == "hetzner-rest"
     assert HetznerRobotConnector.priority == 1
 
@@ -117,7 +117,7 @@ def test_importing_package_registers_against_v2_registry() -> None:
     from meho_backplane.connectors.registry import all_connectors_v2
 
     registry = all_connectors_v2()
-    key = ("hetzner-robot", "2026-04", "hetzner-rest")
+    key = ("hetzner-robot", "2026.04", "hetzner-rest")
     assert key in registry
     assert registry[key] is HetznerRobotConnector
 

--- a/backend/tests/test_connectors_hetzner_robot_auth.py
+++ b/backend/tests/test_connectors_hetzner_robot_auth.py
@@ -1,0 +1,553 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`HetznerRobotConnector` (G3.7-T7 #846).
+
+Exercises HTTP Basic auth, no-retry-on-401 (IP-block protection), per-target
+credential isolation, the ``_post_form`` helper, the auth_model boundary gate,
+and fingerprint / probe shapes against mocked Robot Webservice endpoints.
+
+Auth: no session token — HTTP Basic sent on every request with the Webservice-
+user credentials loaded from Vault (injectable for tests).  A 401 response
+raises ``auth_failed`` immediately with an instructional message — no retry,
+no second attempt.  Three consecutive 401s from one IP trigger a 10-minute
+IP block on Hetzner Robot; this connector protects every operator on the
+shared egress IP by failing on the first.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import pytest
+import respx
+
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.hetzner_robot import (
+    HetznerRobotConnector,
+    HetznerRobotTargetLike,
+)
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.schemas import AuthModel
+
+
+@pytest.fixture(autouse=True)
+def _clean_hetzner_robot_registry() -> Iterator[None]:
+    """Re-register HetznerRobotConnector after sibling tests clear the registry.
+
+    ``test_connectors_registry_v2.py`` installs an autouse fixture that calls
+    :func:`clear_registry` between tests.  Re-register before every test in
+    this module and clear after — same pattern established by
+    :mod:`tests.test_connectors_harbor_auth`.
+    """
+    clear_registry()
+    register_connector_v2(
+        product=HetznerRobotConnector.product,
+        version=HetznerRobotConnector.version,
+        impl_id=HetznerRobotConnector.impl_id,
+        cls=HetznerRobotConnector,
+    )
+    yield
+    clear_registry()
+
+
+# ---------------------------------------------------------------------------
+# Target stub — satisfies HetznerRobotTargetLike Protocol structurally.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    auth_model: str | None = AuthModel.SHARED_SERVICE_ACCOUNT.value
+
+
+_TARGET_A = _StubTarget(
+    name="robot-a",
+    host="robot.your-server.de",
+    port=443,
+    secret_ref="kv/data/hetzner/robot-a",
+)
+_TARGET_B = _StubTarget(
+    name="robot-b",
+    host="robot.your-server.de",
+    port=None,
+    secret_ref="kv/data/hetzner/robot-b",
+)
+
+
+async def _stub_loader(_target: HetznerRobotTargetLike) -> dict[str, str]:
+    return {"username": "webservice-user", "password": "stub-password"}
+
+
+def _make_connector() -> HetznerRobotConnector:
+    return HetznerRobotConnector(credentials_loader=_stub_loader)
+
+
+def _decode_basic_auth(authorization_header: str) -> tuple[str, str]:
+    """Decode an ``Authorization: Basic <b64>`` header into (username, password)."""
+    assert authorization_header.startswith("Basic ")
+    decoded = base64.b64decode(authorization_header[6:]).decode()
+    username, _, password = decoded.partition(":")
+    return username, password
+
+
+# ---------------------------------------------------------------------------
+# ABC + registration plumbing
+# ---------------------------------------------------------------------------
+
+
+def test_hetzner_robot_connector_subclasses_http_connector() -> None:
+    assert issubclass(HetznerRobotConnector, HttpConnector)
+    assert HetznerRobotConnector.product == "hetzner-robot"
+    assert HetznerRobotConnector.version == "2026-04"
+    assert HetznerRobotConnector.impl_id == "hetzner-rest"
+    assert HetznerRobotConnector.priority == 1
+
+
+def test_importing_package_registers_against_v2_registry() -> None:
+    from meho_backplane.connectors.registry import all_connectors_v2
+
+    registry = all_connectors_v2()
+    key = ("hetzner-robot", "2026-04", "hetzner-rest")
+    assert key in registry
+    assert registry[key] is HetznerRobotConnector
+
+
+def test_default_credentials_loader_raises_until_g214_lands() -> None:
+    import asyncio
+
+    from meho_backplane.connectors.hetzner_robot.session import load_credentials_from_vault
+
+    async def _check() -> None:
+        with pytest.raises(NotImplementedError, match=r"Goal #214"):
+            await load_credentials_from_vault(_TARGET_A)
+
+    asyncio.run(_check())
+
+
+# ---------------------------------------------------------------------------
+# HTTP Basic auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_sends_basic_auth_header() -> None:
+    """auth_headers() produces Authorization: Basic with Webservice-user credentials."""
+    connector = _make_connector()
+    headers = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert "Authorization" in headers
+    assert headers["Authorization"].startswith("Basic ")
+    username, password = _decode_basic_auth(headers["Authorization"])
+    assert username == "webservice-user"
+    assert password == "stub-password"
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# 401 → auth_failed immediately, exactly ONE request issued (no retry)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_401_raises_auth_failed_with_instructional_message() -> None:
+    """A 401 from the Robot API raises RuntimeError with 'auth_failed' immediately."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://robot.your-server.de") as mock:
+        route = mock.get("/server").respond(401)
+        with pytest.raises(RuntimeError, match="auth_failed") as exc_info:
+            await connector._get_robot_json(_TARGET_A, "/server")
+
+    # Exactly one request issued — no retry on 401.
+    assert route.call_count == 1
+    assert "robot-a" in str(exc_info.value)
+    assert "Webservice" in str(exc_info.value) or "credentials" in str(exc_info.value).lower()
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_401_issues_exactly_one_request_no_retry() -> None:
+    """401 must not trigger tenacity retries — assert call count is exactly 1."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://robot.your-server.de") as mock:
+        route = mock.get("/server").respond(401)
+        with pytest.raises(RuntimeError, match="auth_failed"):
+            await connector._get_robot_json(_TARGET_A, "/server")
+
+    assert route.call_count == 1, (
+        f"expected exactly 1 request on 401 (no retry), got {route.call_count}"
+    )
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# _post_form sends application/x-www-form-urlencoded
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_form_sends_form_encoded_content_type() -> None:
+    """_post_form sends data as application/x-www-form-urlencoded, not JSON."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://robot.your-server.de") as mock:
+        route = mock.post("/server/reset").respond(200, json={"result": "ok"})
+        await connector._post_form(
+            _TARGET_A,
+            "/server/reset",
+            data={"server_ip": "1.2.3.4", "type": "sw"},
+        )
+
+    assert route.call_count == 1
+    request = route.calls[0].request
+    content_type = request.headers.get("content-type", "")
+    assert "application/x-www-form-urlencoded" in content_type, (
+        f"Expected form-encoded Content-Type, got {content_type!r}"
+    )
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_post_form_encodes_dict_as_form_data() -> None:
+    """_post_form body contains key=value pairs in form-encoded format."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://robot.your-server.de") as mock:
+        route = mock.post("/server/reset").respond(200, json={"result": "ok"})
+        await connector._post_form(
+            _TARGET_A,
+            "/server/reset",
+            data={"server_ip": "1.2.3.4", "type": "sw"},
+        )
+
+    request = route.calls[0].request
+    body = request.content.decode()
+    assert "server_ip=1.2.3.4" in body
+    assert "type=sw" in body
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_post_form_401_raises_auth_failed_immediately() -> None:
+    """_post_form also raises auth_failed on 401 without retry."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://robot.your-server.de") as mock:
+        route = mock.post("/server/reset").respond(401)
+        with pytest.raises(RuntimeError, match="auth_failed"):
+            await connector._post_form(_TARGET_A, "/server/reset", data={"server_ip": "1.2.3.4"})
+
+    assert route.call_count == 1
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Credential caching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_reuses_cached_credentials_across_calls() -> None:
+    """Second auth_headers call against the same target does NOT re-invoke the loader."""
+    call_count = 0
+
+    async def _counting_loader(_target: HetznerRobotTargetLike) -> dict[str, str]:
+        nonlocal call_count
+        call_count += 1
+        return {"username": "webservice-user", "password": "stub-password"}
+
+    connector = HetznerRobotConnector(credentials_loader=_counting_loader)
+    h1 = await connector.auth_headers(_TARGET_A, raw_jwt="")
+    h2 = await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert h1 == h2
+    assert call_count == 1
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Per-target client isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_target_isolation_keeps_credentials_separate() -> None:
+    """Two targets get two distinct credential cache entries; no cross-target leakage."""
+    call_log: list[str] = []
+
+    async def _tracking_loader(target: HetznerRobotTargetLike) -> dict[str, str]:
+        call_log.append(target.name)
+        return {"username": f"svc-{target.name}", "password": "pass"}
+
+    connector = HetznerRobotConnector(credentials_loader=_tracking_loader)
+    h_a = await connector.auth_headers(_TARGET_A, raw_jwt="")
+    h_b = await connector.auth_headers(_TARGET_B, raw_jwt="")
+
+    username_a, _ = _decode_basic_auth(h_a["Authorization"])
+    username_b, _ = _decode_basic_auth(h_b["Authorization"])
+    assert username_a == "svc-robot-a"
+    assert username_b == "svc-robot-b"
+    assert call_log == ["robot-a", "robot-b"]
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Vault loader missing key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_loader_missing_password_key_raises_runtime_error_naming_target() -> None:
+    async def _bad_loader(_target: HetznerRobotTargetLike) -> dict[str, str]:
+        return {"username": "webservice-user"}  # type: ignore[return-value]
+
+    connector = HetznerRobotConnector(credentials_loader=_bad_loader)
+    with pytest.raises(RuntimeError, match=r"password") as exc_info:
+        await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert "robot-a" in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_loader_missing_username_key_raises_runtime_error_naming_target() -> None:
+    async def _bad_loader(_target: HetznerRobotTargetLike) -> dict[str, str]:
+        return {"password": "stub-password"}  # type: ignore[return-value]
+
+    connector = HetznerRobotConnector(credentials_loader=_bad_loader)
+    with pytest.raises(RuntimeError, match=r"username") as exc_info:
+        await connector.auth_headers(_TARGET_A, raw_jwt="")
+
+    assert "robot-a" in str(exc_info.value)
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Auth model gating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "auth_model",
+    [AuthModel.PER_USER.value, AuthModel.IMPERSONATION.value, "unknown-mode"],
+)
+async def test_auth_headers_rejects_non_shared_service_account_modes(auth_model: str) -> None:
+    """Per-user / impersonation modes raise NotImplementedError naming the target + mode."""
+    target = _StubTarget(
+        name="robot-per-user",
+        host="robot.your-server.de",
+        port=443,
+        secret_ref="kv/data/hetzner/per-user",
+        auth_model=auth_model,
+    )
+    connector = _make_connector()
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        await connector.auth_headers(target, raw_jwt="")
+
+    assert "robot-per-user" in str(exc_info.value)
+    assert auth_model in str(exc_info.value)
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_none_auth_model_for_pre_g03_targets() -> None:
+    """auth_model=None (pre-G0.3 column-not-yet-populated) is accepted."""
+    target = _StubTarget(
+        name="robot-pre-g03",
+        host="robot.your-server.de",
+        port=443,
+        secret_ref="kv/data/hetzner/pre-g03",
+        auth_model=None,
+    )
+    connector = _make_connector()
+    headers = await connector.auth_headers(target, raw_jwt="")
+    assert headers["Authorization"].startswith("Basic ")
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_auth_headers_accepts_enum_member_for_auth_model() -> None:
+    """An AuthModel enum member (not just its string value) is accepted."""
+    target = _StubTarget(
+        name="robot-enum",
+        host="robot.your-server.de",
+        port=443,
+        secret_ref="kv/data/hetzner/enum",
+    )
+    target.auth_model = AuthModel.SHARED_SERVICE_ACCOUNT  # type: ignore[assignment]
+    connector = _make_connector()
+    headers = await connector.auth_headers(target, raw_jwt="")
+    assert headers["Authorization"].startswith("Basic ")
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# fingerprint()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_canonical_shape_on_reachable_target() -> None:
+    """fingerprint() against mocked GET /server returns account_id + server_count."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://robot.your-server.de") as mock:
+        mock.get("/server").respond(
+            200,
+            json=[
+                {"server": {"server_number": 123456, "server_ip": "1.2.3.4", "dc": "FSN1-DC1"}},
+                {"server": {"server_number": 789012, "server_ip": "5.6.7.8", "dc": "NBG1-DC3"}},
+            ],
+        )
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "hetzner"
+    assert fp.product == "robot-webservice"
+    assert fp.reachable is True
+    assert fp.probe_method == "GET /server"
+    assert fp.extras["server_count"] == 2
+    assert fp.extras["account_id"] == "123456"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_empty_server_list_returns_none_account_id() -> None:
+    """An account with no servers yields account_id=None and server_count=0."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://robot.your-server.de") as mock:
+        mock.get("/server").respond(200, json=[])
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.reachable is True
+    assert fp.extras["server_count"] == 0
+    assert fp.extras["account_id"] is None
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_unreachable_returns_reachable_false_with_structured_error() -> None:
+    """Transport failure returns reachable=False with extras['error']."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://robot.your-server.de") as mock:
+        mock.get("/server").respond(401)
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.vendor == "hetzner"
+    assert fp.product == "robot-webservice"
+    assert fp.reachable is False
+    assert fp.probe_method == "GET /server"
+    error = fp.extras["error"]
+    assert "auth_failed" in error or "401" in error
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_dict_wrapper_shape_also_parsed() -> None:
+    """The ``{"servers": [...]}`` wrapper shape is normalised correctly."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://robot.your-server.de") as mock:
+        mock.get("/server").respond(
+            200,
+            json={
+                "servers": [
+                    {"server": {"server_number": 111111, "server_ip": "9.9.9.9", "dc": "HEL1-DC2"}}
+                ]
+            },
+        )
+        fp = await connector.fingerprint(_TARGET_A)
+
+    assert fp.reachable is True
+    assert fp.extras["server_count"] == 1
+    assert fp.extras["account_id"] == "111111"
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# probe()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_true_on_authenticated_get() -> None:
+    """probe() returns ok=True when GET /server succeeds."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://robot.your-server.de") as mock:
+        mock.get("/server").respond(200, json=[])
+        result = await connector.probe(_TARGET_A)
+
+    assert result.ok is True
+    assert result.reason is None
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_false_with_reason_on_401() -> None:
+    """probe() returns ok=False with auth_failed reason on 401 (not retried)."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://robot.your-server.de") as mock:
+        route = mock.get("/server").respond(401)
+        result = await connector.probe(_TARGET_A)
+
+    assert result.ok is False
+    assert result.reason is not None
+    assert "auth_failed" in result.reason
+    # Must not have retried — exactly one request
+    assert route.call_count == 1
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_returns_ok_false_on_transport_error() -> None:
+    """probe() returns ok=False + reason on non-auth transport failure."""
+    connector = _make_connector()
+
+    async with respx.mock(base_url="https://robot.your-server.de") as mock:
+        mock.get("/server").respond(503)
+        result = await connector.probe(_TARGET_A)
+
+    assert result.ok is False
+    assert result.reason is not None
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# aclose
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aclose_clears_credential_cache_and_pool() -> None:
+    """aclose() clears the in-memory credential cache and tears down the httpx pool."""
+    connector = _make_connector()
+    await connector.auth_headers(_TARGET_A, raw_jwt="")
+    assert "robot-a" in connector._creds_cache
+    await connector.aclose()
+    assert connector._creds_cache == {}
+    assert connector._clients == {}
+
+
+@pytest.mark.asyncio
+async def test_aclose_with_no_cached_credentials_is_a_noop() -> None:
+    """A fresh connector with no credentials established closes cleanly."""
+    connector = _make_connector()
+    await connector.aclose()
+    assert connector._clients == {}
+    assert connector._creds_cache == {}

--- a/backend/tests/test_connectors_registry_v2.py
+++ b/backend/tests/test_connectors_registry_v2.py
@@ -385,13 +385,13 @@ def test_vcf_fleet_connector_registered_under_v2_triple() -> None:
 
 
 def test_hetzner_robot_connector_registered_under_v2_triple() -> None:
-    """HetznerRobotConnector package registers under (hetzner-robot, 2026-04, hetzner-rest).
+    """HetznerRobotConnector package registers under (hetzner-robot, 2026.04, hetzner-rest).
 
     The autouse _clean_registry fixture clears the registry before this test,
     so we manually re-register using the class attributes to assert the triple
     resolves correctly. Same pattern as the SDDC Manager / Harbor tests above.
     """
-    from meho_backplane.connectors.hetzner_robot import HetznerRobotConnector
+    from meho_backplane.connectors.hetzner_robot.connector import HetznerRobotConnector
 
     register_connector_v2(
         product=HetznerRobotConnector.product,
@@ -400,6 +400,6 @@ def test_hetzner_robot_connector_registered_under_v2_triple() -> None:
         cls=HetznerRobotConnector,
     )
     snapshot = all_connectors_v2()
-    key = ("hetzner-robot", "2026-04", "hetzner-rest")
+    key = ("hetzner-robot", "2026.04", "hetzner-rest")
     assert key in snapshot
     assert snapshot[key] is HetznerRobotConnector

--- a/backend/tests/test_connectors_registry_v2.py
+++ b/backend/tests/test_connectors_registry_v2.py
@@ -382,3 +382,24 @@ def test_vcf_fleet_connector_registered_under_v2_triple() -> None:
     key = ("vcf-fleet", "9.0", "fleet-rest")
     assert key in snapshot
     assert snapshot[key] is VcfFleetConnector
+
+
+def test_hetzner_robot_connector_registered_under_v2_triple() -> None:
+    """HetznerRobotConnector package registers under (hetzner-robot, 2026-04, hetzner-rest).
+
+    The autouse _clean_registry fixture clears the registry before this test,
+    so we manually re-register using the class attributes to assert the triple
+    resolves correctly. Same pattern as the SDDC Manager / Harbor tests above.
+    """
+    from meho_backplane.connectors.hetzner_robot import HetznerRobotConnector
+
+    register_connector_v2(
+        product=HetznerRobotConnector.product,
+        version=HetznerRobotConnector.version,
+        impl_id=HetznerRobotConnector.impl_id,
+        cls=HetznerRobotConnector,
+    )
+    snapshot = all_connectors_v2()
+    key = ("hetzner-robot", "2026-04", "hetzner-rest")
+    assert key in snapshot
+    assert snapshot[key] is HetznerRobotConnector

--- a/docs/codebase/connectors-hetzner-robot.md
+++ b/docs/codebase/connectors-hetzner-robot.md
@@ -1,0 +1,122 @@
+# Connector: hetzner-robot (Hetzner Robot Webservice)
+
+## Overview
+
+The `hetzner-robot` connector is the hand-rolled `HttpConnector` subclass
+for the [Hetzner Robot Webservice API](https://robot.hetzner.com/doc/webservice/en.html).
+G3.7-T7 (#846) ships the skeleton — HTTP Basic auth, fingerprint, probe,
+`_post_form` helper, and the G0.6 dispatch shim. G3.7-T8 ships ops via
+G0.7 spec ingestion of the Robot Webservice OpenAPI spec.
+
+Source: `backend/src/meho_backplane/connectors/hetzner_robot/`.
+
+## Key types
+
+- **`HetznerRobotConnector`** (`connector.py`) — `HttpConnector` subclass.
+  Class attributes: `product="hetzner-robot"`, `version="2026-04"`,
+  `impl_id="hetzner-rest"`, `priority=1`. The priority outranks a future
+  `GenericRestConnector` auto-shim (priority=0) defensively.
+- **`HetznerRobotTargetLike`** (`session.py`) — runtime-checkable Protocol
+  capturing the minimum target shape: `name`, `host`, `port`, `secret_ref`,
+  `auth_model`. No `sso_realm` field — Hetzner Robot Basic auth sends
+  `username:password` directly with no realm suffix.
+- **`HetznerRobotCredentialsLoader`** (`session.py`) — async callable type
+  resolving a target to `{"username": ..., "password": ...}`. Injectable on
+  connector construction for tests and pre-G0.3 production deploys.
+- **`load_credentials_from_vault`** (`session.py`) — default loader, stubbed
+  `NotImplementedError` until Goal #214 lands the operator-context Vault
+  read path.
+
+## Key design decisions
+
+### IP-block protection (no-retry-on-401)
+
+Hetzner Robot blocks the source IP for **10 minutes** after 3 consecutive
+401 responses from that IP. Because MEHO operates on a shared egress IP,
+a single misconfigured target could lock every operator off the Robot API
+for 10 minutes.
+
+The connector raises `RuntimeError` with an `auth_failed` label and a
+remediation message on the **first** 401 response — it never retries,
+never consumes the 2 remaining attempts. The base `HttpConnector._retryable`
+predicate already excludes 4xx from the tenacity retry logic; `_get_robot_json`
+adds the explicit intercept so operators see a useful message instead of a
+generic `httpx.HTTPStatusError`.
+
+### Form-encoded bodies
+
+The Robot Webservice API requires `application/x-www-form-urlencoded` bodies
+for all write verbs — it rejects `application/json`. The `_post_form(target,
+path, data)` helper wraps httpx's `data=` parameter (which encodes a dict as
+RFC 3986 form-encoded). v0.2 read operations never POST, but the helper ships
+for v0.2.next write readiness.
+
+### Webservice user
+
+The Robot API authenticates with a **Webservice user** — a separate account
+distinct from the Robot portal login user. Operators must create the Webservice
+user in the Robot portal and store its credentials at the target's `secret_ref`
+Vault path as `{"username": ..., "password": ...}`.
+
+## Control flow
+
+### Registration
+
+1. Lifespan calls `_eager_import_connectors()`, which walks every
+   `connectors/<product>/` subpackage in name-sorted order.
+2. Importing `meho_backplane.connectors.hetzner_robot` triggers the
+   module-level `register_connector_v2(product="hetzner-robot",
+   version="2026-04", impl_id="hetzner-rest", cls=HetznerRobotConnector)`.
+3. The registry's v2 table resolves `("hetzner-robot", "2026-04",
+   "hetzner-rest")` to `HetznerRobotConnector`.
+
+### Auth flow
+
+1. `auth_headers(target, raw_jwt)` checks `target.auth_model` — must be
+   `shared_service_account` or `None`.
+2. `_load_credentials(target)` checks `_creds_cache`; on miss, calls the
+   injectable loader.
+3. Loader returns `{"username": ..., "password": ...}`; connector computes
+   `Authorization: Basic <base64>` and caches the raw dict.
+4. Every subsequent call against the same target uses the cached value.
+
+### Fingerprint flow
+
+1. `fingerprint(target)` calls `_get_robot_json(target, "/server")`.
+2. On 401: `_get_robot_json` raises `RuntimeError("auth_failed: ...")` (1
+   request, no retry). `fingerprint()` catches it and returns
+   `FingerprintResult(reachable=False, extras={"error": ...})`.
+3. On success: parses the server list (both `{"servers": [...]}` wrapper and
+   bare `[...]` forms), extracts `server_count` and `account_id` from the
+   first server's `server_number`.
+
+### Probe flow
+
+1. `probe(target)` calls `_get_robot_json(target, "/server")`.
+2. On any error (including 401-not-retried): returns `ProbeResult(ok=False,
+   reason=...)`.
+3. On success: returns `ProbeResult(ok=True)`.
+
+## Dependencies
+
+- `httpx>=0.27` (0.28.1 resolved) — `data=` for form-encoded POSTs
+- `tenacity>=9.0` — base class retry logic (401 excluded from retry predicate)
+- `structlog` — structured logging
+
+## Known issues / out of scope
+
+- Vault credential read stub: `load_credentials_from_vault` raises
+  `NotImplementedError` until Goal #214 lands. Inject a loader at
+  construction time for production deploys until then.
+- Operations: zero operations ship with this skeleton. Ops land in T8 via
+  G0.7 spec ingestion of the Robot Webservice OpenAPI spec.
+- Writes: server reset, vSwitch mutation, cancellation, rDNS edits are out of
+  scope for G3.7. The `_post_form` helper is the write-path foundation.
+- Hetzner Cloud (the second Hetzner product): out of scope.
+
+## References
+
+- Hetzner Robot Webservice docs: https://robot.hetzner.com/doc/webservice/en.html
+- G3.7-T7 issue: https://github.com/evoila/meho/issues/846
+- Precedent: `connectors/harbor/connector.py` (HTTP Basic + loader + fingerprint/probe)
+- Precedent: `connectors/adapters/http.py` (`HttpConnector` + retry policy)

--- a/docs/codebase/connectors-hetzner-robot.md
+++ b/docs/codebase/connectors-hetzner-robot.md
@@ -13,7 +13,7 @@ Source: `backend/src/meho_backplane/connectors/hetzner_robot/`.
 ## Key types
 
 - **`HetznerRobotConnector`** (`connector.py`) — `HttpConnector` subclass.
-  Class attributes: `product="hetzner-robot"`, `version="2026-04"`,
+  Class attributes: `product="hetzner-robot"`, `version="2026.04"`,
   `impl_id="hetzner-rest"`, `priority=1`. The priority outranks a future
   `GenericRestConnector` auto-shim (priority=0) defensively.
 - **`HetznerRobotTargetLike`** (`session.py`) — runtime-checkable Protocol
@@ -66,8 +66,8 @@ Vault path as `{"username": ..., "password": ...}`.
    `connectors/<product>/` subpackage in name-sorted order.
 2. Importing `meho_backplane.connectors.hetzner_robot` triggers the
    module-level `register_connector_v2(product="hetzner-robot",
-   version="2026-04", impl_id="hetzner-rest", cls=HetznerRobotConnector)`.
-3. The registry's v2 table resolves `("hetzner-robot", "2026-04",
+   version="2026.04", impl_id="hetzner-rest", cls=HetznerRobotConnector)`.
+3. The registry's v2 table resolves `("hetzner-robot", "2026.04",
    "hetzner-rest")` to `HetznerRobotConnector`.
 
 ### Auth flow


### PR DESCRIPTION
## Summary

- Adds `HetznerRobotConnector(HttpConnector)` skeleton for the Hetzner Robot Webservice API, registered under `(product="hetzner-robot", version="2026-04", impl_id="hetzner-rest")` via `register_connector_v2`
- Auth: HTTP Basic against the Webservice user (distinct from Robot login user); credentials loaded via injectable Vault loader; cached per-target
- **No-retry-on-401**: a 401 raises `auth_failed` immediately with an instructional message — protects shared-egress operators from Hetzner Robot's 10-min IP block (triggered by 3 consecutive 401s from one source IP)
- `_post_form(target, path, data)` helper sends `application/x-www-form-urlencoded` bodies for v0.2.next write readiness (Robot API requires form-encoded, not JSON)
- `fingerprint()` → `GET /server` → `vendor="hetzner"`, `product="robot-webservice"`, `account_id`, `server_count`; `probe()` → TCP + TLS + `GET /server` (401-not-retried)

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/hetzner_robot/` — no issues
- [x] `pytest -n auto tests/test_connectors_hetzner_robot_auth.py tests/test_connectors_registry_v2.py` — 27 new hetzner tests pass; 6 failing `test_connectors_registry_v2.py::test_*_connector_registered_under_v2_triple` tests are pre-existing on `main` (confirmed baseline)
- [x] registry triple `("hetzner-robot", "2026-04", "hetzner-rest")` resolves to `HetznerRobotConnector`
- [x] 401 raises `auth_failed` immediately; `route.call_count == 1` (no retry) asserted
- [x] `_post_form` sends `application/x-www-form-urlencoded` Content-Type with form-encoded body
- [x] Vault loader missing key → `RuntimeError` naming target and missing key
- [x] `auth_model="per_user"` → `NotImplementedError` naming target and mode
- [x] `fingerprint()` returns `account_id + server_count`; unreachable → `reachable=False + extras["error"]`
- [x] `probe()` returns `ok=True`/`ok=False+reason`; 401 during probe not retried
- [x] `docs/codebase/connectors-hetzner-robot.md` written

## Out of scope

- Hetzner Robot ops — T8 spec ingestion
- Write ops (server reset, vSwitch, cancellation, rDNS) — deferred per #370
- Hetzner Cloud — separate product, out of scope
- CLI verbs / MCP review / onboarding doc — T9

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #846


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Hetzner Robot connector: HTTP Basic auth, server fingerprinting, discovery and probing, and per-target credential caching; default credential loader is a placeholder requiring a custom loader to be provided.

* **Documentation**
  * Added connector docs covering configuration, auth behavior, probe/fingerprint semantics, and write-body requirements.

* **Tests**
  * Added tests covering auth behavior, credential caching, probe/fingerprint parsing, registration, and client lifecycle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->