### PR TITLE
feat(topology): G9.3-T5 timeline verb + GET /topology/timeline + query_topology(kind=timeline)

### DIFF
--- a/backend/src/meho_backplane/api/v1/topology.py
+++ b/backend/src/meho_backplane/api/v1/topology.py
@@ -93,6 +93,7 @@ read-shaped trace.
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -122,6 +123,7 @@ from meho_backplane.topology.query import (
     find_dependents,
     find_path,
     list_edges,
+    query_timeline,
 )
 from meho_backplane.topology.refresh import RefreshResult, refresh_target_topology
 from meho_backplane.topology.resolvers import NodeNotFoundError
@@ -130,7 +132,9 @@ from meho_backplane.topology.schemas import (
     TopologyEdgeEndpoint,
     TopologyNode,
     TopologyPath,
+    TopologyTimelineResult,
 )
+from meho_backplane.topology.timeline_cursor import InvalidTimelineCursorError
 
 __all__ = ["router"]
 
@@ -161,6 +165,7 @@ _OP_ANNOTATE = "topology.annotate"
 _OP_UNANNOTATE = "topology.unannotate"
 _OP_LIST_EDGES = "topology.list_edges"
 _OP_BULK_IMPORT = "topology.bulk_import"
+_OP_TIMELINE = "topology.timeline"
 
 #: HTTP-boundary ceiling on the number of edges accepted in one
 #: ``POST /edges/bulk`` body. The consumer's INVENTORY.md
@@ -178,6 +183,15 @@ _BULK_IMPORT_MAX_EDGES = 1000
 #: widen the HTTP boundary.
 _LIST_EDGES_LIMIT_DEFAULT = 200
 _LIST_EDGES_LIMIT_MAX = 1000
+
+#: ``GET /topology/timeline`` ``limit`` ceiling at the HTTP boundary.
+#: Default 50 per Task #861 acceptance criterion ("default
+#: ``--limit 50``"); the substrate ceiling is 1000. Tighter HTTP cap
+#: than the substrate is the same pattern :data:`_LIST_EDGES_LIMIT_MAX`
+#: uses -- the boundary layer can clamp without re-issuing the
+#: substrate primitive's own ceiling.
+_TIMELINE_LIMIT_DEFAULT = 50
+_TIMELINE_LIMIT_MAX = 1000
 
 #: Bounds mirror the service-layer defaults (``query._DEFAULT_DEPTH`` /
 #: ``query._DEFAULT_MAX_HOPS``); the ceilings cap a pathological
@@ -900,3 +914,94 @@ async def _edge_to_response(edge: object, session: AsyncSession) -> TopologyEdge
         properties=dict(edge.properties or {}),
         last_seen=edge.last_seen,
     )
+
+
+# ---------------------------------------------------------------------------
+# G9.3-T5 (#861) — tenant-wide timeline of graph changes
+# ---------------------------------------------------------------------------
+
+
+@router.get("/timeline", response_model=TopologyTimelineResult)
+async def timeline_route(
+    target: str | None = Query(default=None, max_length=256),
+    since: datetime | None = Query(default=None),
+    until: datetime | None = Query(default=None),
+    limit: int = Query(
+        default=_TIMELINE_LIMIT_DEFAULT,
+        ge=1,
+        le=_TIMELINE_LIMIT_MAX,
+    ),
+    cursor: str | None = Query(default=None, max_length=1024),
+    operator: Operator = _require_operator,
+    session: AsyncSession = Depends(get_raw_session),
+) -> TopologyTimelineResult:
+    """Tenant-wide chronological feed of graph changes.
+
+    Wraps :func:`~meho_backplane.topology.query.query_timeline` (G9.3-T5
+    #861). Walks ``graph_node_history`` + ``graph_edge_history`` in
+    ``(valid_from DESC, history_id DESC)`` order, paginated via opaque
+    forward-only cursor encoding ``(valid_from, history_id, source)``.
+    Tenant scope is ``operator.tenant_id`` -- no surface accepts a
+    tenant id on this route.
+
+    Query parameters:
+
+    * ``target`` -- optional target name or alias. Resolved tenant-
+      scoped via :func:`~meho_backplane.targets.resolver.resolve_target`
+      (alias-aware, 404 with near-misses when nothing matches). The
+      resolved target id narrows the timeline to history rows for
+      resources belonging to that target -- nodes whose ``target_id``
+      matches, and edges whose either endpoint belongs to the target.
+    * ``since`` / ``until`` -- ISO-8601 absolute datetimes; either
+      bound is optional. Duration shorthand (``"24h"`` / ``"7d"``) is
+      a CLI convenience that the CLI front parses; the REST API
+      accepts absolute timestamps only, mirroring the audit-query
+      router's split (G8.1-T2 #466).
+    * ``limit`` -- page size (default ``50`` per the issue body;
+      ceiling ``1000``).
+    * ``cursor`` -- opaque next-page token from a prior response.
+
+    Errors:
+
+    * **404 ``no_target``** -- ``target`` did not resolve to a row in
+      the tenant. Near-miss matches surface in ``detail.matches`` for
+      operator self-correction (same shape as the ``refresh`` route).
+    * **400 ``invalid_cursor``** -- ``cursor`` is not a valid opaque
+      token (tampered or hand-crafted). The substrate's
+      :class:`InvalidTimelineCursorError` message is echoed.
+
+    The route binds ``audit_op_id="topology.timeline"`` /
+    ``audit_op_class="audit_query"`` per [decision #3](docs/planning/v0.2-decisions.md)
+    -- temporal graph queries are inspections of system state, parallel
+    to G8's audit-log query surface; the broadcast event carries only
+    ``{op_id, result_status, row_count}`` so the request filter (which
+    may name a sensitive target) and the rows themselves never leak
+    onto the SSE / Slack feed.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_TIMELINE,
+        audit_op_class="audit_query",
+    )
+    target_id: uuid.UUID | None = None
+    if target is not None:
+        # Re-use the existing tenant-scoped resolver so a missing
+        # target lands as the canonical 404 envelope (with near-miss
+        # suggestions) the CLI already renders for refresh / show.
+        resolved = await resolve_target(session, operator.tenant_id, target)
+        target_id = resolved.id
+
+    try:
+        result = await query_timeline(
+            operator,
+            target_id=target_id,
+            since=since,
+            until=until,
+            limit=limit,
+            cursor=cursor,
+        )
+    except InvalidTimelineCursorError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # Broadcast aggregate signal: row count only, never per-row payload.
+    structlog.contextvars.bind_contextvars(audit_row_count=len(result.rows))
+    return result

--- a/backend/src/meho_backplane/mcp/tools/topology.py
+++ b/backend/src/meho_backplane/mcp/tools/topology.py
@@ -83,6 +83,7 @@ rejected at the schema layer before the handler runs.
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
 from typing import Any, Final
 
 from sqlalchemy import select
@@ -108,8 +109,10 @@ from meho_backplane.topology.query import (
     find_dependents,
     find_path,
     list_edges,
+    query_timeline,
 )
 from meho_backplane.topology.resolvers import NodeNotFoundError
+from meho_backplane.topology.timeline_cursor import InvalidTimelineCursorError
 
 __all__: list[str] = []
 
@@ -138,6 +141,13 @@ _MAX_HOPS_MAX: Final[int] = 32
 _EDGES_LIMIT_DEFAULT: Final[int] = 200
 _EDGES_LIMIT_MAX: Final[int] = 1000
 
+#: ``timeline`` facet defaults / ceilings. Mirror the T5 substrate
+#: bounds (``query._DEFAULT_TIMELINE_LIMIT`` = 50,
+#: ``query._MAX_TIMELINE_LIMIT`` = 1000). Default 50 per the Task
+#: #861 acceptance criterion ("default ``--limit 50``").
+_TIMELINE_LIMIT_DEFAULT: Final[int] = 50
+_TIMELINE_LIMIT_MAX: Final[int] = 1000
+
 #: Canonical ``GraphEdgeKind`` values, materialised once at module load
 #: so the inputSchema enum + the kind_filter description stay in lock-step
 #: with :class:`~meho_backplane.db.models.GraphEdgeKind` without
@@ -151,7 +161,7 @@ _QUERY_TOPOLOGY_INPUT_SCHEMA: Final[dict[str, Any]] = {
     "properties": {
         "kind": {
             "type": "string",
-            "enum": ["dependents", "dependencies", "path", "edges"],
+            "enum": ["dependents", "dependencies", "path", "edges", "timeline"],
             "description": (
                 "Which read shape to run. `dependents` = reverse closure "
                 "(what depends on `target`); `dependencies` = forward "
@@ -159,7 +169,12 @@ _QUERY_TOPOLOGY_INPUT_SCHEMA: Final[dict[str, Any]] = {
                 "unweighted route between `from_name` and `to_name`; "
                 "`edges` = flat tenant-scoped listing of `graph_edge` "
                 "rows (the inventory-survey shape, replaces a "
-                "standalone `list_edges` meta-tool)."
+                "standalone `list_edges` meta-tool); `timeline` = "
+                "tenant-wide chronological feed of graph changes from "
+                "the G9.3 `graph_node_history` + `graph_edge_history` "
+                "tables, cursor-paginated -- 'what's been happening in "
+                "the graph in the last hour?' without rooting at a "
+                "specific resource."
             ),
         },
         "target": {
@@ -297,6 +312,36 @@ _QUERY_TOPOLOGY_INPUT_SCHEMA: Final[dict[str, Any]] = {
                 "Ignored for the closure kinds."
             ),
         },
+        "since": {
+            "type": ["string", "null"],
+            "description": (
+                "ISO-8601 absolute lower bound on `valid_from` for "
+                "`kind=timeline`. Inclusive. Pair with `until` to "
+                "scope the timeline to one window. Ignored for the "
+                "closure / path / edges kinds."
+            ),
+            "format": "date-time",
+        },
+        "until": {
+            "type": ["string", "null"],
+            "description": (
+                "ISO-8601 absolute upper bound on `valid_from` for "
+                "`kind=timeline`. Inclusive. Ignored for the closure "
+                "/ path / edges kinds."
+            ),
+            "format": "date-time",
+        },
+        "cursor": {
+            "type": ["string", "null"],
+            "description": (
+                "Opaque forward-pagination token from a prior "
+                "`kind=timeline` page's `next_cursor`. Encodes "
+                "`(valid_from, history_id, source)`; stable under "
+                "concurrent inserts from the G9.3 diff-on-write hook. "
+                "Ignored for non-timeline kinds."
+            ),
+            "maxLength": 1024,
+        },
     },
     "required": ["kind"],
     "additionalProperties": False,
@@ -355,7 +400,16 @@ _QUERY_TOPOLOGY_DESCRIPTION: Final[str] = (
     'tenant\'); `{kind: "path", path: TopologyPath|null}` for `path` '
     "(null = unreachable within `max_hops`, a valid answer, not an "
     'error); `{kind: "edges", edges: [TopologyEdge, ...]}` for `edges` '
-    "(flat list, ordered by `last_seen DESC NULLS LAST, id`)."
+    "(flat list, ordered by `last_seen DESC NULLS LAST, id`).\n\n"
+    "For `kind=timeline`: tenant-wide chronological feed of graph "
+    "changes -- 'what changed in the graph since 9am?' → "
+    "`query_topology {kind: timeline, since: 2026-05-22T09:00:00Z}`. "
+    "Use `since` / `until` to bound the window. Cursor-paginated "
+    "(default `limit: 50`); a non-null `next_cursor` in the response "
+    "means more rows exist -- pass it back as `cursor` on the next "
+    "call to walk forward. Returns "
+    '`{kind: "timeline", rows: [TopologyTimelineEntry, ...], '
+    "next_cursor: <token|null>}`."
 )
 
 
@@ -400,6 +454,8 @@ async def _query_topology_handler(
         if kind == "edges":
             edges = await _list_edges_facet(operator, arguments)
             return {"kind": kind, "edges": [e.model_dump(mode="json") for e in edges]}
+        if kind == "timeline":
+            return await _timeline_facet(operator, arguments)
         # kind == "path" — the enum + schema guarantee no other value.
         result = await find_path(
             operator,
@@ -414,6 +470,72 @@ async def _query_topology_handler(
     return {
         "kind": kind,
         "path": None if result is None else result.model_dump(mode="json"),
+    }
+
+
+async def _timeline_facet(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Dispatch the ``kind="timeline"`` facet to G9.3-T5's substrate.
+
+    Parses ISO-8601 strings from ``since`` / ``until`` (the MCP layer
+    accepts absolute ISO-8601 only; the CLI layer adds the
+    ``"24h"`` / ``"7d"`` duration-shorthand convenience and resolves
+    it to an absolute timestamp before crossing the wire). Forwards
+    the optional cursor verbatim.
+
+    :class:`InvalidTimelineCursorError` from the substrate surfaces
+    as JSON-RPC ``-32602`` -- the cursor came from a prior
+    ``next_cursor`` of this same tool, so a tampered / hand-crafted
+    token is an operator-actionable input problem.
+
+    ``target`` is intentionally **not** wired in here: the MCP
+    surface for ``kind=timeline`` does not accept a per-target
+    narrowing because the closure / path kinds already use ``target``
+    for a different concept (the anchor node name). Operators
+    wanting the per-target slice use the CLI ``meho topology
+    timeline --target ...`` which resolves the name to a target id
+    before calling the substrate. A future MCP widening can add a
+    ``target_id`` argument without conflicting with the closure
+    semantics.
+    """
+    since_str = arguments.get("since")
+    until_str = arguments.get("until")
+    cursor = arguments.get("cursor")
+    since_dt: datetime | None = None
+    until_dt: datetime | None = None
+    if isinstance(since_str, str):
+        try:
+            since_dt = datetime.fromisoformat(since_str)
+        except ValueError as exc:
+            raise McpInvalidParamsError(
+                f"query_topology(kind=timeline): 'since' is not ISO-8601: {since_str!r}",
+            ) from exc
+    if isinstance(until_str, str):
+        try:
+            until_dt = datetime.fromisoformat(until_str)
+        except ValueError as exc:
+            raise McpInvalidParamsError(
+                f"query_topology(kind=timeline): 'until' is not ISO-8601: {until_str!r}",
+            ) from exc
+
+    try:
+        result = await query_timeline(
+            operator,
+            target_id=None,
+            since=since_dt,
+            until=until_dt,
+            limit=int(arguments.get("limit", _TIMELINE_LIMIT_DEFAULT)),
+            cursor=cursor if isinstance(cursor, str) else None,
+        )
+    except InvalidTimelineCursorError as exc:
+        raise McpInvalidParamsError(str(exc)) from exc
+
+    return {
+        "kind": "timeline",
+        "rows": [r.model_dump(mode="json") for r in result.rows],
+        "next_cursor": result.next_cursor,
     }
 
 
@@ -461,7 +583,13 @@ register_mcp_tool(
             "properties": {
                 "kind": {
                     "type": "string",
-                    "enum": ["dependents", "dependencies", "path", "edges"],
+                    "enum": [
+                        "dependents",
+                        "dependencies",
+                        "path",
+                        "edges",
+                        "timeline",
+                    ],
                 },
                 "nodes": {
                     "type": "array",
@@ -486,6 +614,24 @@ register_mcp_tool(
                         "Present for `kind=edges`. TopologyEdge rows "
                         "ordered (last_seen DESC NULLS LAST, id). See "
                         "`meho_backplane.topology.schemas.TopologyEdge`."
+                    ),
+                },
+                "rows": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": (
+                        "Present for `kind=timeline`. TopologyTimelineEntry "
+                        "rows ordered (valid_from DESC, history_id DESC). "
+                        "See `meho_backplane.topology.schemas."
+                        "TopologyTimelineEntry`."
+                    ),
+                },
+                "next_cursor": {
+                    "type": ["string", "null"],
+                    "description": (
+                        "Present for `kind=timeline`. Opaque next-page "
+                        "token, or null when the page is the end of the "
+                        "matching set."
                     ),
                 },
             },

--- a/backend/src/meho_backplane/mcp/tools/topology.py
+++ b/backend/src/meho_backplane/mcp/tools/topology.py
@@ -251,12 +251,19 @@ _QUERY_TOPOLOGY_INPUT_SCHEMA: Final[dict[str, Any]] = {
             "type": "integer",
             "minimum": 1,
             "maximum": _EDGES_LIMIT_MAX,
-            "default": _EDGES_LIMIT_DEFAULT,
+            # No schema-level ``default`` -- the effective default
+            # varies by ``kind`` (``edges`` -> ``_EDGES_LIMIT_DEFAULT``,
+            # ``timeline`` -> ``_TIMELINE_LIMIT_DEFAULT``). A single
+            # default in the schema would mislead schema-driven MCP
+            # clients into pre-populating the edges default on every
+            # call, over-requesting timeline pages.
             "description": (
-                f"Page size for `kind=edges` (default "
-                f"{_EDGES_LIMIT_DEFAULT}; ceiling {_EDGES_LIMIT_MAX}, "
-                "matching the substrate `list_edges` cap). Ignored for "
-                "the closure kinds and `path`."
+                f"Page size for paginated facets. `kind=edges` defaults "
+                f"to {_EDGES_LIMIT_DEFAULT}; `kind=timeline` defaults to "
+                f"{_TIMELINE_LIMIT_DEFAULT}. Shared ceiling "
+                f"{_EDGES_LIMIT_MAX}, matching the substrate "
+                "`list_edges` cap. Ignored for the closure kinds and "
+                "`path`."
             ),
         },
         "offset": {

--- a/backend/src/meho_backplane/topology/query.py
+++ b/backend/src/meho_backplane/topology/query.py
@@ -1327,7 +1327,7 @@ async def query_timeline(
 
     merged = _merge_timeline_pages(node_rows, edge_rows, limit)
     next_cursor = _compute_next_cursor(node_rows, edge_rows, merged, limit)
-    return TopologyTimelineResult(rows=merged, next_cursor=next_cursor)
+    return TopologyTimelineResult(rows=tuple(merged), next_cursor=next_cursor)
 
 
 def _merge_has_leftovers(

--- a/backend/src/meho_backplane/topology/query.py
+++ b/backend/src/meho_backplane/topology/query.py
@@ -98,10 +98,13 @@ f-string with the join columns swapped.
 
 from __future__ import annotations
 
+import json
+from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import text
+from sqlalchemy import DateTime, bindparam, text
+from sqlalchemy import Uuid as SAUuid
 from sqlalchemy.engine import Row
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -118,6 +121,13 @@ from meho_backplane.topology.schemas import (
     TopologyEdgeEndpoint,
     TopologyNode,
     TopologyPath,
+    TopologyTimelineEntry,
+    TopologyTimelineResult,
+)
+from meho_backplane.topology.timeline_cursor import (
+    TimelineCursorPosition,
+    decode_timeline_cursor,
+    encode_timeline_cursor,
 )
 
 # ``AmbiguousNodeError`` was historically defined in this module and is
@@ -134,6 +144,7 @@ __all__ = [
     "find_dependents",
     "find_path",
     "list_edges",
+    "query_timeline",
 ]
 
 
@@ -851,3 +862,488 @@ async def list_edges(
         },
     )
     return [_row_to_edge(row) for row in result.fetchall()]
+
+
+# ---------------------------------------------------------------------------
+# G9.3-T5 (#861) — tenant-wide timeline of graph changes
+# ---------------------------------------------------------------------------
+#
+# The timeline UNIONs ``graph_node_history`` + ``graph_edge_history``
+# and walks them in ``(valid_from DESC, history_id DESC)`` order. The
+# ``source`` discriminator is the third sort key because the two
+# tables have independent ``BIGSERIAL`` counters -- a node and an
+# edge can share ``(valid_from, history_id)``.
+#
+# Indexes the timeline walks (declared by migration 0012):
+#
+#   * ``graph_node_history_tenant_valid_from_idx`` (composite b-tree
+#     on ``(tenant_id, valid_from DESC)``)
+#   * ``graph_edge_history_tenant_valid_from_idx`` (mirror for edges)
+#
+# Both are tenant-scoped composite indexes so the per-tenant slice is
+# sub-millisecond on the test fixture and indexed under realistic
+# load.
+#
+# Cursor stability under concurrent inserts: every history row from
+# a single transaction shares the same ``valid_from`` (the diff-on-
+# write hook in :mod:`.history` enforces this). The keyset compare
+# ``(valid_from, history_id, source) < cursor`` is therefore
+# correctness-preserving against any T2 hook write that lands
+# between page N and page N+1 -- a new row either appears on a later
+# page (if it lands below the cursor) or never (if above), and no
+# row is duplicated or skipped.
+
+#: Default timeline page size per the Task #861 acceptance criterion
+#: ("default ``--limit 50``"). The substrate clamps to 1..1000 to
+#: cap a hostile / misconfigured caller; the route / CLI layers cap
+#: tighter where appropriate.
+_DEFAULT_TIMELINE_LIMIT = 50
+
+#: Hard ceiling on the per-call timeline page size. Mirrors the
+#: G8.1 audit-query limit ceiling so an operator paging through
+#: history at maximum width gets the same one-page-per-call ergonomics
+#: across both surfaces.
+_MAX_TIMELINE_LIMIT = 1000
+
+
+def _format_node_summary(change_kind: str, snapshot: dict[str, Any] | None) -> str:
+    """Render a one-line node-mutation summary from a snapshot.
+
+    Picks the post-state for ``created`` / ``updated`` (the row as it
+    exists after the mutation; more useful for "what's new" surveys)
+    and the pre-state for ``removed`` (the row that just went away).
+    Falls back to ``"<change_kind> node"`` when the snapshot is
+    missing or malformed -- a tombstone whose ``ON DELETE SET NULL``
+    cleared its ``node_id`` may still have a snapshot, but a legacy
+    row from a pre-hook era might not.
+    """
+    if snapshot is None:
+        return f"{change_kind} node"
+    side = snapshot.get("before") if change_kind == "removed" else snapshot.get("after")
+    if not isinstance(side, dict):
+        return f"{change_kind} node"
+    kind = side.get("kind") or "node"
+    name = side.get("name") or "<unknown>"
+    return f"{change_kind} {kind} {name}"
+
+
+def _format_edge_summary(change_kind: str, snapshot: dict[str, Any] | None) -> str:
+    """Render a one-line edge-mutation summary from a snapshot.
+
+    Mirror of :func:`_format_node_summary` for the edge side.
+    Endpoint names are not in the edge snapshot directly (the edge
+    rows carry FK ids, not names) -- the renderer falls back to the
+    ``kind`` field plus the change kind. Operators wanting the full
+    endpoint detail use ``--json`` and look up the FKs themselves;
+    the table view is a "what's new in the graph" survey, not a full
+    reconstruction.
+    """
+    if snapshot is None:
+        return f"{change_kind} edge"
+    side = snapshot.get("before") if change_kind == "removed" else snapshot.get("after")
+    if not isinstance(side, dict):
+        return f"{change_kind} edge"
+    edge_kind = side.get("kind") or "edge"
+    return f"{change_kind} {edge_kind}"
+
+
+# Two literal SQL statements -- one per history table -- joined by a
+# Python-side merge rather than a SQL ``UNION ALL``. Two reasons:
+#
+#   1. Each statement is a single-index scan over its respective
+#      ``graph_*_history_tenant_valid_from_idx``. A ``UNION ALL``
+#      with an outer ``ORDER BY`` works but most PG planners
+#      materialise the union before sorting, defeating the
+#      tenant-scoped index. Two parallel single-index scans then a
+#      Python merge is O(limit) memory and one round trip per table.
+#
+#   2. The ``--target`` filter joins ``graph_node`` (for the node
+#      side) and ``graph_edge`` + endpoint ``graph_node`` (for the
+#      edge side). Inlining those joins into a UNION'd statement
+#      would make the planner choose between two different access
+#      paths, which is precisely the kind of decision that flips
+#      under data growth. Two statements keep each plan obvious.
+# Cursor compare nuances across the two tables
+# --------------------------------------------
+#
+# The DESC global ordering is ``(valid_from, history_id, source)``
+# with ``"node"`` placed before ``"edge"`` (we pick ``"node" > "edge"``
+# in DESC; i.e. ``"edge"`` < ``"node"`` ASC). When the cursor names a
+# node row, the next-page boundary is "strictly after this node row
+# in the DESC order" -- which means:
+#
+#   * Node-table candidates with the same ``(valid_from,
+#     history_id)`` as the cursor are excluded (history_id is unique
+#     within the node table, so the only same-key candidate IS the
+#     cursor row).
+#   * Edge-table candidates with the same ``(valid_from,
+#     history_id)`` as the cursor are included (edge sorts after
+#     node in DESC, so they fall *after* the cursor).
+#
+# When the cursor names an edge row, the next-page boundary is
+# "strictly after this edge row":
+#
+#   * Both tables exclude rows at exactly ``(valid_from,
+#     history_id)`` because edge already comes after node at the
+#     same key; nothing after an edge row at the same key.
+#
+# The per-side SQL therefore receives ``cursor_src`` and applies the
+# inclusive-vs-exclusive choice at the same-key boundary. Below the
+# boundary (``(valid_from, history_id) <`` cursor), every row is
+# included unconditionally.
+_TIMELINE_NODE_SQL = text(
+    """
+    SELECT
+        h.history_id    AS history_id,
+        h.node_id       AS resource_id,
+        h.change_kind   AS change_kind,
+        h.snapshot      AS snapshot,
+        h.audit_id      AS audit_id,
+        h.valid_from    AS valid_from
+    FROM graph_node_history h
+    WHERE h.tenant_id = :tenant_id
+      AND (CAST(:since_marker AS text) IS NULL OR h.valid_from >= :since)
+      AND (CAST(:until_marker AS text) IS NULL OR h.valid_from <= :until)
+      AND (
+          :target_id IS NULL
+          OR h.node_id IN (
+              SELECT n.id FROM graph_node n
+              WHERE n.tenant_id = :tenant_id
+                AND n.target_id = :target_id
+          )
+      )
+      AND (
+          CAST(:cursor_marker AS text) IS NULL
+          OR h.valid_from < :cursor_ts
+          OR (h.valid_from = :cursor_ts AND h.history_id < :cursor_id)
+      )
+    ORDER BY h.valid_from DESC, h.history_id DESC
+    LIMIT :limit
+    """
+).bindparams(
+    bindparam("tenant_id", type_=SAUuid()),
+    bindparam("target_id", type_=SAUuid()),
+    bindparam("since", type_=DateTime(timezone=True)),
+    bindparam("until", type_=DateTime(timezone=True)),
+    bindparam("cursor_ts", type_=DateTime(timezone=True)),
+)
+
+_TIMELINE_EDGE_SQL = text(
+    """
+    SELECT
+        h.history_id    AS history_id,
+        h.edge_id       AS resource_id,
+        h.change_kind   AS change_kind,
+        h.snapshot      AS snapshot,
+        h.audit_id      AS audit_id,
+        h.valid_from    AS valid_from
+    FROM graph_edge_history h
+    WHERE h.tenant_id = :tenant_id
+      AND (CAST(:since_marker AS text) IS NULL OR h.valid_from >= :since)
+      AND (CAST(:until_marker AS text) IS NULL OR h.valid_from <= :until)
+      AND (
+          :target_id IS NULL
+          OR h.edge_id IN (
+              SELECT e.id FROM graph_edge e
+              JOIN graph_node n_from ON n_from.id = e.from_node_id
+              JOIN graph_node n_to   ON n_to.id   = e.to_node_id
+              WHERE e.tenant_id = :tenant_id
+                AND (
+                    n_from.target_id = :target_id
+                    OR n_to.target_id = :target_id
+                )
+          )
+      )
+      AND (
+          CAST(:cursor_marker AS text) IS NULL
+          OR h.valid_from < :cursor_ts
+          OR (
+              h.valid_from = :cursor_ts
+              AND (
+                  h.history_id < :cursor_id
+                  OR (h.history_id = :cursor_id AND :cursor_src = 'node')
+              )
+          )
+      )
+    ORDER BY h.valid_from DESC, h.history_id DESC
+    LIMIT :limit
+    """
+).bindparams(
+    bindparam("tenant_id", type_=SAUuid()),
+    bindparam("target_id", type_=SAUuid()),
+    bindparam("since", type_=DateTime(timezone=True)),
+    bindparam("until", type_=DateTime(timezone=True)),
+    bindparam("cursor_ts", type_=DateTime(timezone=True)),
+)
+
+
+def _row_to_timeline_entry(row: Row[Any], source: str) -> TopologyTimelineEntry:
+    """Map one node-or-edge history row to a :class:`TopologyTimelineEntry`.
+
+    ``source`` is supplied by the caller because the row itself does
+    not know which history table it came from -- the two SQL
+    statements share a column shape so the same materialiser handles
+    both, with the discriminator threaded through as a literal.
+
+    ``snapshot`` arrives as a ``dict`` on PG (asyncpg's JSONB codec)
+    and may arrive as a JSON-encoded string on SQLite (where the
+    ``text()`` statement bypasses the ORM column-type round-trip).
+    Both shapes are deserialised here so the summary renderer always
+    sees a dict-or-None.
+    """
+    m = row._mapping
+    snapshot_raw = m["snapshot"]
+    snapshot: dict[str, Any] | None
+    if isinstance(snapshot_raw, dict):
+        snapshot = snapshot_raw
+    elif isinstance(snapshot_raw, str):
+        try:
+            parsed = json.loads(snapshot_raw)
+            snapshot = parsed if isinstance(parsed, dict) else None
+        except (TypeError, ValueError):
+            snapshot = None
+    else:
+        snapshot = None
+    change_kind = m["change_kind"]
+    if source == "node":
+        summary = _format_node_summary(change_kind, snapshot)
+    else:
+        summary = _format_edge_summary(change_kind, snapshot)
+    return TopologyTimelineEntry(
+        valid_from=m["valid_from"],
+        history_id=m["history_id"],
+        source=source,
+        change_kind=change_kind,
+        resource_id=m["resource_id"],
+        summary=summary,
+        audit_id=m["audit_id"],
+    )
+
+
+def _merge_timeline_pages(
+    node_rows: list[TopologyTimelineEntry],
+    edge_rows: list[TopologyTimelineEntry],
+    limit: int,
+) -> list[TopologyTimelineEntry]:
+    """Merge two pre-sorted ``DESC`` lists into one, capped at ``limit``.
+
+    Each input is already ordered by ``(valid_from DESC, history_id
+    DESC)`` from its own SQL statement. The merge is a single
+    two-pointer pass: pop the larger head from either list at each
+    step, with the source discriminator (``"edge"`` < ``"node"``
+    alphabetically) as the tie-breaker when both heads share
+    ``(valid_from, history_id)`` -- which can happen only across the
+    two tables, never within one.
+    """
+    merged: list[TopologyTimelineEntry] = []
+    i = j = 0
+    while len(merged) < limit and (i < len(node_rows) or j < len(edge_rows)):
+        if i >= len(node_rows):
+            merged.append(edge_rows[j])
+            j += 1
+            continue
+        if j >= len(edge_rows):
+            merged.append(node_rows[i])
+            i += 1
+            continue
+        n = node_rows[i]
+        e = edge_rows[j]
+        # Lex compare: newer valid_from wins; same ts → higher
+        # history_id wins; same (ts, id) → 'edge' before 'node'
+        # alphabetically (deterministic + matches the cursor sort).
+        if (n.valid_from, n.history_id) > (e.valid_from, e.history_id):
+            merged.append(n)
+            i += 1
+        elif (n.valid_from, n.history_id) < (e.valid_from, e.history_id):
+            merged.append(e)
+            j += 1
+        else:
+            # Same (valid_from, history_id) across the two tables.
+            # 'edge' sorts before 'node' alphabetically; in DESC
+            # order across the keyset, 'node' (lex-greater) lands
+            # first. Pick node first to mirror the cursor compare
+            # in the SQL.
+            merged.append(n)
+            i += 1
+    return merged
+
+
+def _build_timeline_bind_params(
+    operator: Operator,
+    *,
+    target_id: UUID | None,
+    since: datetime | None,
+    until: datetime | None,
+    cursor_pos: TimelineCursorPosition | None,
+    per_side_fetch: int,
+) -> dict[str, Any]:
+    """Assemble the bind-parameter dict for the two timeline SQL statements.
+
+    ``tenant_id`` / ``target_id`` ride through SQLAlchemy's
+    :class:`Uuid` bind type (declared on the ``text()`` via
+    ``.bindparams`` on the two statements above) so the asyncpg /
+    aiosqlite drivers serialise the UUID natively -- ``str(uuid)``
+    would deliver the dashed-canonical form, which mismatches the
+    hex storage SQLite uses for ``Uuid()`` columns and produces a
+    silent zero-row result on the dev-test DB.
+
+    ``*_marker`` parameters are text-typed sentinels parallel to the
+    native-typed ones; the SQL uses ``CAST(:*_marker AS text) IS
+    NULL`` to detect the optional-clause "off" state portably across
+    PostgreSQL (where ``CAST(NULL AS text)`` is NULL with a known
+    type) and SQLite. Mirrors the ``CAST(:x AS text) IS NULL OR
+    ...`` idiom the traversal SQL in this module uses.
+    """
+    return {
+        "tenant_id": operator.tenant_id,
+        "since": since,
+        "since_marker": "x" if since is not None else None,
+        "until": until,
+        "until_marker": "x" if until is not None else None,
+        "target_id": target_id,
+        "cursor_ts": cursor_pos.ts if cursor_pos is not None else None,
+        "cursor_id": cursor_pos.history_id if cursor_pos is not None else 0,
+        "cursor_src": cursor_pos.source if cursor_pos is not None else "node",
+        "cursor_marker": "x" if cursor_pos is not None else None,
+        "limit": per_side_fetch,
+    }
+
+
+def _compute_next_cursor(
+    node_rows: list[TopologyTimelineEntry],
+    edge_rows: list[TopologyTimelineEntry],
+    merged: list[TopologyTimelineEntry],
+    limit: int,
+) -> str | None:
+    """Encode the next-page cursor when there are unvisited rows past the page.
+
+    Returns ``None`` when the merge consumed every fetched row -- the
+    page is the end of the matching set. Otherwise encodes
+    ``(valid_from, history_id, source)`` of the page's last row so
+    the next call paginates strictly past it.
+
+    ``has_more`` is true when *either* per-side fetch overflowed its
+    per-side budget *or* the merge left rows un-emitted on either
+    side after capping at ``limit``. Both signals matter: a per-side
+    overflow alone doesn't necessarily mean the merged page is full
+    (the overflowing side may have all-older rows), but a merge that
+    capped at ``limit`` with leftovers on either side definitively
+    indicates more rows exist.
+    """
+    if not merged or len(merged) < limit:
+        return None
+    has_more = (
+        len(node_rows) > limit
+        or len(edge_rows) > limit
+        or _merge_has_leftovers(node_rows, edge_rows, merged)
+    )
+    if not has_more:
+        return None
+    last = merged[-1]
+    return encode_timeline_cursor(
+        TimelineCursorPosition(
+            ts=last.valid_from,
+            history_id=last.history_id,
+            source=last.source,
+        )
+    )
+
+
+async def query_timeline(
+    operator: Operator,
+    *,
+    target_id: UUID | None = None,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    limit: int = _DEFAULT_TIMELINE_LIMIT,
+    cursor: str | None = None,
+) -> TopologyTimelineResult:
+    """Tenant-wide chronological feed of graph changes.
+
+    Initiative #365 (G9.3), Task #861 (T5). Walks
+    :class:`GraphNodeHistory` + :class:`GraphEdgeHistory` in
+    ``(valid_from DESC, history_id DESC, source DESC)`` order
+    tenant-scoped on ``operator.tenant_id`` so a cross-tenant probe is
+    structurally impossible -- the first WHERE clause of both literal
+    SQL statements is ``tenant_id = :tenant_id``.
+
+    Args:
+        operator: The calling operator. ``tenant_id`` lifted from the
+            JWT; never sourced from caller-controllable args.
+        target_id: Optional ``targets.id`` filter -- restrict the
+            timeline to history rows for resources belonging to one
+            target. Nodes filter on ``graph_node.target_id``; edges
+            filter on the endpoint nodes' ``target_id`` (either
+            endpoint touching the target qualifies the edge, since
+            an edge crossing two targets is part of both timelines).
+        since: Optional lower bound on ``valid_from``. Inclusive.
+        until: Optional upper bound on ``valid_from``. Inclusive.
+        limit: Page size (default 50; ceiling 1000). Per the Task
+            #861 acceptance criterion default.
+        cursor: Opaque forward-pagination cursor from a prior page's
+            ``next_cursor``. Decoded into ``(valid_from, history_id,
+            source)`` and applied as a strict keyset compare against
+            the row immediately after the cursor's row.
+
+    Returns:
+        :class:`TopologyTimelineResult` -- a page of rows ordered by
+        ``(valid_from DESC, history_id DESC)``. ``next_cursor`` is
+        ``None`` when the page is the end of the matching set; a
+        non-None cursor encodes the last-row keyset position for the
+        next call.
+
+    Raises:
+        ValueError: ``limit`` is out of range (``< 1`` or ``>
+        _MAX_TIMELINE_LIMIT``).
+        :class:`InvalidTimelineCursorError`: ``cursor`` is not a
+        valid opaque token (the caller's previous next_cursor was
+        not echoed verbatim, the token was tampered with, or the
+        client typed a string by hand).
+    """
+    if limit < 1 or limit > _MAX_TIMELINE_LIMIT:
+        raise ValueError(f"limit must be in 1..{_MAX_TIMELINE_LIMIT}; got {limit}")
+
+    cursor_pos: TimelineCursorPosition | None = (
+        decode_timeline_cursor(cursor) if cursor is not None else None
+    )
+    # Fetch ``limit + 1`` from each table; the +1 over the per-side
+    # limit is the "has_more" detection trick that
+    # :func:`_compute_next_cursor` reads.
+    per_side_fetch = limit + 1
+    bind_params = _build_timeline_bind_params(
+        operator,
+        target_id=target_id,
+        since=since,
+        until=until,
+        cursor_pos=cursor_pos,
+        per_side_fetch=per_side_fetch,
+    )
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        node_result = await session.execute(_TIMELINE_NODE_SQL, bind_params)
+        node_rows = [_row_to_timeline_entry(row, "node") for row in node_result.fetchall()]
+        edge_result = await session.execute(_TIMELINE_EDGE_SQL, bind_params)
+        edge_rows = [_row_to_timeline_entry(row, "edge") for row in edge_result.fetchall()]
+
+    merged = _merge_timeline_pages(node_rows, edge_rows, limit)
+    next_cursor = _compute_next_cursor(node_rows, edge_rows, merged, limit)
+    return TopologyTimelineResult(rows=merged, next_cursor=next_cursor)
+
+
+def _merge_has_leftovers(
+    node_rows: list[TopologyTimelineEntry],
+    edge_rows: list[TopologyTimelineEntry],
+    merged: list[TopologyTimelineEntry],
+) -> bool:
+    """Detect "more rows exist past this page" after the merge cap.
+
+    A merge that consumed exactly ``len(node_rows)`` from one side
+    and only some of the other side -- without overflowing the
+    per-side fetch -- still has leftovers iff the un-consumed side
+    contributed fewer than its fetch size. We need to know whether
+    the merge stopped on the cap *and* there are un-consumed rows
+    on either side.
+    """
+    consumed_nodes = sum(1 for r in merged if r.source == "node")
+    consumed_edges = len(merged) - consumed_nodes
+    return consumed_nodes < len(node_rows) or consumed_edges < len(edge_rows)

--- a/backend/src/meho_backplane/topology/schemas.py
+++ b/backend/src/meho_backplane/topology/schemas.py
@@ -279,5 +279,9 @@ class TopologyTimelineResult(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    rows: list[TopologyTimelineEntry]
+    # ``tuple`` (not ``list``) so the ``frozen=True`` immutability
+    # contract extends to in-place mutation: a list would still accept
+    # ``.append`` / ``.pop`` despite the ``frozen`` block on attribute
+    # reassignment. Consumers iterating over ``rows`` see the same shape.
+    rows: tuple[TopologyTimelineEntry, ...]
     next_cursor: str | None

--- a/backend/src/meho_backplane/topology/schemas.py
+++ b/backend/src/meho_backplane/topology/schemas.py
@@ -33,7 +33,14 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
 
-__all__ = ["TopologyEdge", "TopologyEdgeEndpoint", "TopologyNode", "TopologyPath"]
+__all__ = [
+    "TopologyEdge",
+    "TopologyEdgeEndpoint",
+    "TopologyNode",
+    "TopologyPath",
+    "TopologyTimelineEntry",
+    "TopologyTimelineResult",
+]
 
 
 def _deep_freeze(value: Any) -> Any:
@@ -200,3 +207,77 @@ class TopologyEdge(BaseModel):
         # field-serialiser contract.
         thawed: dict[str, Any] = _deep_thaw(value)
         return thawed
+
+
+class TopologyTimelineEntry(BaseModel):
+    """One row of the topology timeline (G9.3-T5).
+
+    Task #861 ships the tenant-wide chronological feed of graph
+    changes -- "what's been happening in the graph in the last hour"
+    without rooting at a specific resource. Each row projects one
+    ``graph_node_history`` or ``graph_edge_history`` mutation into a
+    compact summary the CLI / REST / MCP fronts can render or page
+    through.
+
+    Field-to-column mapping:
+
+    * ``valid_from`` -- ``*_history.valid_from``; every history row
+      from one operation carries the same timestamp (the diff-on-write
+      hook is the single source per :mod:`.history`).
+    * ``history_id`` -- ``*_history.history_id``. Required because the
+      cursor's tie-breaker discriminator is ``(valid_from, history_id,
+      source)`` -- ``valid_from`` alone is not unique within a refresh.
+    * ``source`` -- ``"node"`` for :class:`GraphNodeHistory`, ``"edge"``
+      for :class:`GraphEdgeHistory`. The discriminator the UNION
+      preserves.
+    * ``change_kind`` -- one of ``"created"`` / ``"updated"`` /
+      ``"removed"`` per :class:`GraphHistoryChangeKind`.
+    * ``resource_id`` -- ``node_id`` or ``edge_id`` of the mutated row.
+      ``None`` only after the referenced live row has been
+      hard-deleted (``ON DELETE SET NULL``) -- a rare survivability
+      shape; most timeline rows carry the FK intact.
+    * ``summary`` -- one-line human-readable description derived from
+      ``snapshot.before`` / ``snapshot.after``. Format:
+      ``"<change_kind> <kind> <name>"`` for nodes (e.g. ``"created vm
+      vm-prod"``); ``"<change_kind> <edge_kind> <from> -> <to>"`` for
+      edges (e.g. ``"removed runs-on vm-prod -> host-a"``). Falls back
+      to ``"<change_kind> <source>"`` when the live row is gone and
+      the snapshot did not preserve enough context.
+    * ``audit_id`` -- the soft-FK to the ``audit_log.id`` of the
+      operation that caused the mutation. ``None`` only for legacy
+      / mid-rollout rows; the diff-on-write hook always populates it.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    valid_from: datetime
+    history_id: int
+    source: str
+    change_kind: str
+    resource_id: UUID | None
+    summary: str
+    audit_id: UUID | None
+
+
+class TopologyTimelineResult(BaseModel):
+    """Page of timeline rows plus the forward-only continuation cursor.
+
+    ``next_cursor`` is :data:`None` when fewer than ``limit`` rows
+    were available (the query reached the end of the matching set).
+    Consumers iterate by re-issuing the same filter with
+    ``cursor = next_cursor`` until ``next_cursor`` is None.
+
+    The cursor is opaque (base64-encoded JSON over ``(valid_from,
+    history_id, source)``) -- consumers treat it as a token. Stability
+    under concurrent inserts: a new history row landing in the window
+    between page N and page N+1 is naturally placed by the keyset
+    compare (``(valid_from, history_id) < (cursor.ts, cursor.id)``)
+    and either appears on a later page (if it falls below the cursor)
+    or never (if it lands above the cursor). No row is duplicated or
+    skipped by the act of paging.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    rows: list[TopologyTimelineEntry]
+    next_cursor: str | None

--- a/backend/src/meho_backplane/topology/timeline_cursor.py
+++ b/backend/src/meho_backplane/topology/timeline_cursor.py
@@ -56,7 +56,7 @@ import base64
 import binascii
 import json
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 
 __all__ = [
     "InvalidTimelineCursorError",
@@ -101,9 +101,19 @@ def encode_timeline_cursor(position: TimelineCursorPosition) -> str:
     out-of-vocabulary value is a bug, not an operator-facing condition,
     so this function does not validate it. The decoder, which receives
     untrusted bytes, does.
+
+    Naive timestamps are normalised to UTC before encoding. The
+    ``graph_*_history.valid_from`` column is declared ``timezone=True``
+    in the ORM (migration 0012) so production PG always returns
+    tz-aware values; SQLite (dev/test) strips tz on the asyncpg/aiosqlite
+    round-trip and returns naive. Stamping UTC at encode time keeps the
+    wire shape uniform across both dialects and lets the decoder enforce
+    the tz-aware invariant on incoming tokens without false positives
+    from the SQLite path.
     """
+    ts = position.ts if position.ts.tzinfo is not None else position.ts.replace(tzinfo=UTC)
     payload = {
-        "ts": position.ts.isoformat(),
+        "ts": ts.isoformat(),
         "id": position.history_id,
         "src": position.source,
     }
@@ -152,5 +162,14 @@ def decode_timeline_cursor(token: str) -> TimelineCursorPosition:
         ts = datetime.fromisoformat(ts_raw)
     except ValueError as exc:
         raise InvalidTimelineCursorError("cursor 'ts' is not ISO-8601") from exc
+    if ts.tzinfo is None:
+        # Naive ts would propagate into the keyset comparison against
+        # tz-aware ``graph_*_history.valid_from`` rows and raise
+        # ``TypeError: can't compare offset-naive and offset-aware
+        # datetimes`` at runtime. ``encode_timeline_cursor`` only emits
+        # UTC-aware strings, so a naive ts on the wire is either client
+        # tampering or a future server bug -- either way, surface it as
+        # a structured cursor error rather than a 500.
+        raise InvalidTimelineCursorError("cursor 'ts' must include timezone offset")
 
     return TimelineCursorPosition(ts=ts, history_id=id_raw, source=src_raw)

--- a/backend/src/meho_backplane/topology/timeline_cursor.py
+++ b/backend/src/meho_backplane/topology/timeline_cursor.py
@@ -1,0 +1,156 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Opaque forward-only cursor for the ``meho topology timeline`` page walk.
+
+Initiative #365 (G9.3), Task #861 (T5). The timeline lists every
+``graph_node_history`` + ``graph_edge_history`` mutation across the
+tenant in ``(valid_from DESC, history_id DESC)`` order. OFFSET-based
+pagination is broken under the diff-on-write hook (T2 #857), which
+inserts history rows continuously as refresh and annotate paths
+mutate the live graph -- a new row landing between page 1 and page 2
+shifts every subsequent row by one, and the consumer either re-reads
+or skips a row. A keyset cursor over the same lex order is
+correctness-preserving: page N+1 starts at the row strictly after
+page N's last row.
+
+Tie-breaker shape
+=================
+
+``valid_from`` is **not** unique. The diff-on-write hook gives every
+history row in one transaction the same ``valid_from`` so a refresh
+that adds 5 nodes is queryable as a single point-in-time event
+(:mod:`meho_backplane.topology.history` docstring). Within one
+timestamp, ``history_id`` (``BIGSERIAL`` per :class:`GraphNodeHistory`
+/ :class:`GraphEdgeHistory`) gives a strict total order.
+
+But the timeline UNIONs two tables. ``graph_node_history.history_id``
+and ``graph_edge_history.history_id`` are independent counters --
+both can carry ``history_id=42`` for the same ``valid_from``. The
+cursor therefore encodes a third discriminator -- ``source`` is
+either ``"node"`` or ``"edge"`` -- so the keyset compare can
+disambiguate "same valid_from, same history_id, different table" by
+sorting one source before the other (the choice of sort order is
+arbitrary but must be consistent; this module picks ``"edge"``
+before ``"node"`` alphabetically so the SQL ``ORDER BY ... source``
+ascending lands on the right side).
+
+Wire format
+===========
+
+``urlsafe_b64encode(json.dumps({"ts": <iso>, "id": <int>, "src": "node"|"edge"}))``.
+``urlsafe`` avoids ``+`` / ``/`` so the token survives unencoded as a
+query parameter and as a JSON-string value without escaping. The
+token is deliberately opaque so consumers treat it as
+copy-and-paste continuation, not a parseable position.
+
+Any tampering with the bytes produces an
+:class:`InvalidTimelineCursorError` at decode time rather than a
+silently-wrong query -- the decoder validates structure, ISO-8601
+parse, integer parse, and source enum in turn.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+from dataclasses import dataclass
+from datetime import datetime
+
+__all__ = [
+    "InvalidTimelineCursorError",
+    "TimelineCursorPosition",
+    "decode_timeline_cursor",
+    "encode_timeline_cursor",
+]
+
+
+class InvalidTimelineCursorError(ValueError):
+    """Raised when an opaque timeline cursor cannot be decoded.
+
+    The token may be malformed base64, malformed JSON, missing a
+    required field, or carry an invalid ISO-8601 / integer value or
+    out-of-vocabulary source. Any of these are handled identically:
+    the cursor is rejected and the caller decides whether to surface
+    a 400 (REST), a CLI error, or an MCP -32602.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class TimelineCursorPosition:
+    """Decoded cursor: ``(valid_from, history_id, source)`` keyset position.
+
+    ``source`` is the discriminator between the two history tables
+    the UNION combines -- ``"node"`` for :class:`GraphNodeHistory` and
+    ``"edge"`` for :class:`GraphEdgeHistory`. The handler's keyset
+    compare uses all three components because ``history_id`` alone
+    is not unique across the two tables (each table has its own
+    ``BIGSERIAL`` counter).
+    """
+
+    ts: datetime
+    history_id: int
+    source: str
+
+
+def encode_timeline_cursor(position: TimelineCursorPosition) -> str:
+    """Encode a timeline keyset position as an opaque URL-safe base64 token.
+
+    Source is restricted to ``"node"`` / ``"edge"`` at the caller; an
+    out-of-vocabulary value is a bug, not an operator-facing condition,
+    so this function does not validate it. The decoder, which receives
+    untrusted bytes, does.
+    """
+    payload = {
+        "ts": position.ts.isoformat(),
+        "id": position.history_id,
+        "src": position.source,
+    }
+    raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii")
+
+
+def decode_timeline_cursor(token: str) -> TimelineCursorPosition:
+    """Decode an opaque timeline cursor token back into a position.
+
+    Validates each layer (base64, JSON, dict shape, ISO-8601 ``ts``,
+    integer ``id``, ``src`` ∈ ``{"node","edge"}``) and raises
+    :class:`InvalidTimelineCursorError` on the first failure. The
+    original decode exception is preserved as ``__cause__`` so log
+    lines can carry the underlying reason without leaking it through
+    the operator-facing error.
+    """
+    try:
+        raw = base64.b64decode(
+            token.encode("ascii"),
+            altchars=b"-_",
+            validate=True,
+        )
+    except (binascii.Error, UnicodeEncodeError, ValueError) as exc:
+        raise InvalidTimelineCursorError("cursor is not valid base64") from exc
+
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise InvalidTimelineCursorError("cursor payload is not valid JSON") from exc
+
+    if not isinstance(payload, dict):
+        raise InvalidTimelineCursorError("cursor payload is not a JSON object")
+
+    ts_raw = payload.get("ts")
+    id_raw = payload.get("id")
+    src_raw = payload.get("src")
+    if not isinstance(ts_raw, str):
+        raise InvalidTimelineCursorError("cursor payload missing 'ts' string")
+    if not isinstance(id_raw, int) or isinstance(id_raw, bool):
+        raise InvalidTimelineCursorError("cursor payload missing 'id' integer")
+    if src_raw not in ("node", "edge"):
+        raise InvalidTimelineCursorError("cursor 'src' must be 'node' or 'edge'")
+
+    try:
+        ts = datetime.fromisoformat(ts_raw)
+    except ValueError as exc:
+        raise InvalidTimelineCursorError("cursor 'ts' is not ISO-8601") from exc
+
+    return TimelineCursorPosition(ts=ts, history_id=id_raw, source=src_raw)

--- a/backend/tests/test_mcp_tools_topology.py
+++ b/backend/tests/test_mcp_tools_topology.py
@@ -159,13 +159,16 @@ def test_query_topology_input_schema_is_conditional_on_kind(
     assert wire_schema["required"] == ["kind"]
     assert wire_schema["additionalProperties"] is False
     # G9.2-T7 (#598) widened the enum with the `edges` facet (replaces a
-    # standalone list_edges meta-tool); the closure / path branches and
-    # their conditional requireds stay unchanged.
+    # standalone list_edges meta-tool); G9.3-T5 (#861) added the
+    # `timeline` facet (tenant-wide chronological feed of graph
+    # changes from the *_history tables). The closure / path branches
+    # and their conditional requireds stay unchanged.
     assert wire_schema["properties"]["kind"]["enum"] == [
         "dependents",
         "dependencies",
         "path",
         "edges",
+        "timeline",
     ]
     # The wire shape carries NO top-level combinator — Anthropic 400s on
     # it (#905); the conditional logic moved to the stored schema below.
@@ -186,8 +189,10 @@ def test_query_topology_input_schema_is_conditional_on_kind(
     assert by_kind["dependents"] == ["target"]
     assert by_kind["dependencies"] == ["target"]
     assert sorted(by_kind["path"]) == ["from_name", "to_name"]
-    # `edges` has no required field — all filters are optional.
+    # `edges` and `timeline` have no required field — every filter is
+    # optional on both facets.
     assert "edges" not in by_kind
+    assert "timeline" not in by_kind
 
 
 def test_no_published_tool_wire_schema_has_top_level_combinator() -> None:

--- a/backend/tests/test_mcp_tools_topology_annotate.py
+++ b/backend/tests/test_mcp_tools_topology_annotate.py
@@ -239,7 +239,13 @@ def test_no_separate_list_edges_tool_registered() -> None:
 
 
 def test_query_topology_input_schema_includes_edges_facet() -> None:
-    """The kind enum widened to include 'edges' with no extra required field."""
+    """The kind enum widened to include 'edges' / 'timeline' with no extra
+    required field.
+
+    G9.2-T7 (#598) added ``edges``; G9.3-T5 (#861) added ``timeline``.
+    Both extra kinds have no conditional required clause -- every
+    filter on either facet is optional.
+    """
     entry = get_tool("query_topology")
     assert entry is not None
     defn, _ = entry
@@ -249,22 +255,27 @@ def test_query_topology_input_schema_includes_edges_facet() -> None:
         "dependencies",
         "path",
         "edges",
+        "timeline",
     ]
-    # No 4th `allOf` clause is needed — `edges` has no required fields.
-    # The other three branches stay as-is.
+    # No extra `allOf` clauses for `edges` / `timeline` -- both have
+    # no required fields. The other three branches stay as-is.
     by_kind = {
         c["if"]["properties"]["kind"]["const"]: c["then"]["required"] for c in schema["allOf"]
     }
     assert "edges" not in by_kind
+    assert "timeline" not in by_kind
     assert by_kind["dependents"] == ["target"]
     assert by_kind["dependencies"] == ["target"]
     # The new filter knobs surface as optional properties on the schema.
     for prop in ("source", "conflicts", "limit", "offset"):
         assert prop in schema["properties"]
+    # Timeline knobs.
+    for prop in ("since", "until", "cursor"):
+        assert prop in schema["properties"]
 
 
 def test_query_topology_output_schema_widened_for_edges() -> None:
-    """The outputSchema also names the 'edges' facet."""
+    """The outputSchema names the 'edges' and 'timeline' facets."""
     entry = get_tool("query_topology")
     assert entry is not None
     defn, _ = entry
@@ -272,6 +283,10 @@ def test_query_topology_output_schema_widened_for_edges() -> None:
     assert out is not None
     assert "edges" in out["properties"]
     assert "edges" in out["properties"]["kind"]["enum"]
+    # G9.3-T5 (#861): timeline facet adds `rows` + `next_cursor`.
+    assert "rows" in out["properties"]
+    assert "next_cursor" in out["properties"]
+    assert "timeline" in out["properties"]["kind"]["enum"]
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)

--- a/backend/tests/test_topology_timeline_query.py
+++ b/backend/tests/test_topology_timeline_query.py
@@ -1,0 +1,621 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""End-to-end tests for :func:`query_timeline` (G9.3-T5 #861).
+
+Coverage matrix (Task #861 acceptance criteria):
+
+* **Tenant scoping** -- seed history rows on two tenants; query one;
+  cross-tenant rows never returned (first WHERE clause of both
+  literal SQL statements is ``tenant_id = :tenant_id``).
+* **Cursor forward-pagination is opaque + stable** -- seed 120
+  history rows across both tables; walk in ``limit=50`` pages;
+  every seeded row returns exactly once; ``next_cursor=None`` on
+  the last page. Cursor round-trip via :func:`decode_timeline_cursor`.
+* **Stable under concurrent inserts** -- after the first page,
+  insert a *new* history row above the cursor's ``valid_from`` (the
+  diff-on-write hook landing a new event during the paged sweep);
+  the second page does not duplicate or skip any of the original
+  rows. The new row appears on a later iteration only if it falls
+  below the cursor's keyset position; otherwise it stays outside
+  the paged sweep, the expected stability shape.
+* **Window scoping** -- ``since`` / ``until`` bound ``valid_from``
+  inclusively at both ends.
+* **Target scoping** -- nodes filter on ``graph_node.target_id``;
+  edges filter on endpoints' ``target_id`` (either endpoint
+  qualifies).
+* **Cross-table tie-breaker** -- when a node history row and an
+  edge history row share ``(valid_from, history_id)``, both appear
+  in the result in a deterministic order (the ``"node" > "edge"``
+  alphabetical DESC tie-breaker).
+* **Tombstone replay** -- a history row whose ``node_id`` /
+  ``edge_id`` is NULL (after ``ON DELETE SET NULL`` from a live-row
+  delete) still appears in the timeline; the summary falls back
+  gracefully.
+* **Invalid cursor raises** -- a tampered token raises
+  :class:`InvalidTimelineCursorError` from the handler, mirroring
+  the audit-query cursor's contract.
+
+The tests run against ``sqlite+aiosqlite`` via the autouse
+``_default_database_url`` fixture in :mod:`tests.conftest`, which
+migrates a fresh per-test DB to head before each test (the migration
+0012 history tables land via that path). Rows are seeded directly via
+``get_sessionmaker()`` -- the diff-on-write hook (T2 #857) is the
+real write path but T5's contract is the *read* substrate; the
+T2 write path is exercised by :mod:`tests.test_topology_history`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    GraphEdge,
+    GraphEdgeHistory,
+    GraphHistoryChangeKind,
+    GraphNode,
+    GraphNodeHistory,
+    Target,
+    Tenant,
+)
+from meho_backplane.settings import get_settings
+from meho_backplane.topology.query import query_timeline
+from meho_backplane.topology.timeline_cursor import (
+    InvalidTimelineCursorError,
+    decode_timeline_cursor,
+)
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the Keycloak + Vault env vars :class:`Settings` requires."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """One :class:`AsyncSession` per test, scoped to a single ``async with``."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+def _make_operator(tenant_id: uuid.UUID) -> Operator:
+    """Construct an :class:`Operator` for the timeline call.
+
+    The handler reads only ``operator.tenant_id``; the other fields
+    are populated to satisfy the frozen Pydantic model. ``raw_jwt``
+    is a placeholder -- the substrate does not crack the token.
+    """
+    return Operator(
+        sub="operator-test",
+        name="Test Operator",
+        email=None,
+        raw_jwt="not-a-real-token",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Seeding helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_tenant(session: AsyncSession, *, slug: str = "tenant-a") -> uuid.UUID:
+    """Insert a :class:`Tenant` row and return its UUID."""
+    tenant_id = uuid.uuid4()
+    session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+    return tenant_id
+
+
+async def _seed_target(
+    session: AsyncSession,
+    tenant_id: uuid.UUID,
+    *,
+    name: str = "vc-prod",
+    product: str = "vsphere",
+) -> uuid.UUID:
+    """Insert a :class:`Target` row and return its UUID."""
+    target_id = uuid.uuid4()
+    session.add(
+        Target(
+            id=target_id,
+            tenant_id=tenant_id,
+            name=name,
+            aliases=[],
+            product=product,
+            host=f"{name}.example.com",
+            auth_model="shared_service_account",
+            extras={},
+        )
+    )
+    return target_id
+
+
+async def _seed_node(
+    session: AsyncSession,
+    tenant_id: uuid.UUID,
+    *,
+    name: str,
+    kind: str = "vm",
+    target_id: uuid.UUID | None = None,
+) -> uuid.UUID:
+    """Insert a :class:`GraphNode` row and return its UUID."""
+    node_id = uuid.uuid4()
+    session.add(
+        GraphNode(
+            id=node_id,
+            tenant_id=tenant_id,
+            kind=kind,
+            name=name,
+            target_id=target_id,
+            discovered_by="vmware",
+        )
+    )
+    return node_id
+
+
+async def _seed_edge(
+    session: AsyncSession,
+    tenant_id: uuid.UUID,
+    from_id: uuid.UUID,
+    to_id: uuid.UUID,
+    *,
+    kind: str = "runs-on",
+) -> uuid.UUID:
+    """Insert a :class:`GraphEdge` row and return its UUID."""
+    edge_id = uuid.uuid4()
+    session.add(
+        GraphEdge(
+            id=edge_id,
+            tenant_id=tenant_id,
+            from_node_id=from_id,
+            to_node_id=to_id,
+            kind=kind,
+            source="auto",
+            discovered_by="vmware",
+        )
+    )
+    return edge_id
+
+
+async def _seed_node_history(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    node_id: uuid.UUID | None,
+    valid_from: datetime,
+    change_kind: GraphHistoryChangeKind = GraphHistoryChangeKind.CREATED,
+    snapshot: dict[str, object] | None = None,
+    audit_id: uuid.UUID | None = None,
+) -> None:
+    """Insert one :class:`GraphNodeHistory` row.
+
+    Default snapshot carries an ``after`` projection with ``kind`` +
+    ``name`` so the summary renderer has something to render.
+    """
+    if snapshot is None:
+        snapshot = {"before": None, "after": {"kind": "vm", "name": "vm-test"}}
+    session.add(
+        GraphNodeHistory(
+            node_id=node_id,
+            tenant_id=tenant_id,
+            change_kind=change_kind.value,
+            snapshot=snapshot,
+            audit_id=audit_id or uuid.uuid4(),
+            valid_from=valid_from,
+        )
+    )
+
+
+async def _seed_edge_history(
+    session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    edge_id: uuid.UUID | None,
+    valid_from: datetime,
+    change_kind: GraphHistoryChangeKind = GraphHistoryChangeKind.CREATED,
+    snapshot: dict[str, object] | None = None,
+    audit_id: uuid.UUID | None = None,
+) -> None:
+    """Insert one :class:`GraphEdgeHistory` row."""
+    if snapshot is None:
+        snapshot = {"before": None, "after": {"kind": "runs-on", "source": "auto"}}
+    session.add(
+        GraphEdgeHistory(
+            edge_id=edge_id,
+            tenant_id=tenant_id,
+            change_kind=change_kind.value,
+            snapshot=snapshot,
+            audit_id=audit_id or uuid.uuid4(),
+            valid_from=valid_from,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tenant scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tenant_scoping_isolates_history_rows(session: AsyncSession) -> None:
+    """Seed two tenants; query one; cross-tenant history never returned."""
+    tenant_a = await _seed_tenant(session, slug="tenant-a")
+    tenant_b = await _seed_tenant(session, slug="tenant-b")
+    base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
+    node_a = await _seed_node(session, tenant_a, name="vm-a")
+    node_b = await _seed_node(session, tenant_b, name="vm-b")
+    await session.flush()
+    for i in range(5):
+        await _seed_node_history(
+            session,
+            tenant_id=tenant_a,
+            node_id=node_a,
+            valid_from=base + timedelta(seconds=i),
+        )
+        await _seed_node_history(
+            session,
+            tenant_id=tenant_b,
+            node_id=node_b,
+            valid_from=base + timedelta(seconds=i),
+        )
+    await session.commit()
+
+    result = await query_timeline(_make_operator(tenant_a))
+
+    assert len(result.rows) == 5
+    # Every row belongs to tenant_a — verified indirectly by its
+    # resource_id: those are tenant_a's node ids.
+    assert all(row.resource_id == node_a for row in result.rows)
+
+
+@pytest.mark.asyncio
+async def test_tenant_scoping_no_rows_for_empty_tenant(session: AsyncSession) -> None:
+    """An empty tenant produces an empty timeline (zero rows, no error)."""
+    tenant_a = await _seed_tenant(session)
+    await session.commit()
+    result = await query_timeline(_make_operator(tenant_a))
+    assert result.rows == []
+    assert result.next_cursor is None
+
+
+# ---------------------------------------------------------------------------
+# Cursor pagination (AC: forward cursor is opaque + stable)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cursor_pagination_walks_120_rows_in_3_pages(
+    session: AsyncSession,
+) -> None:
+    """120 rows split across both tables / ``limit=50`` → 3 pages.
+
+    Final page carries ``next_cursor=None``. Every seeded row
+    appears exactly once across the sweep -- the stability invariant.
+    """
+    tenant_id = await _seed_tenant(session)
+    node_id = await _seed_node(session, tenant_id, name="vm-a")
+    edge_to = await _seed_node(session, tenant_id, name="host-a", kind="host")
+    edge_id = await _seed_edge(session, tenant_id, node_id, edge_to)
+    await session.flush()
+
+    base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
+    # 60 node-history rows + 60 edge-history rows = 120 total. Two
+    # rows per timestamp so the global ordering exercises the
+    # tie-breaker.
+    for i in range(60):
+        await _seed_node_history(
+            session,
+            tenant_id=tenant_id,
+            node_id=node_id,
+            valid_from=base + timedelta(seconds=i),
+        )
+        await _seed_edge_history(
+            session,
+            tenant_id=tenant_id,
+            edge_id=edge_id,
+            valid_from=base + timedelta(seconds=i),
+        )
+    await session.commit()
+
+    seen_history_keys: set[tuple[str, int]] = set()
+    cursor: str | None = None
+    pages = 0
+    while True:
+        pages += 1
+        result = await query_timeline(
+            _make_operator(tenant_id),
+            limit=50,
+            cursor=cursor,
+        )
+        for row in result.rows:
+            key = (row.source, row.history_id)
+            assert key not in seen_history_keys, f"duplicate row across pages: {key}"
+            seen_history_keys.add(key)
+        if result.next_cursor is None:
+            break
+        cursor = result.next_cursor
+
+    assert pages == 3
+    assert len(seen_history_keys) == 120
+
+
+@pytest.mark.asyncio
+async def test_cursor_terminal_page_when_under_limit(session: AsyncSession) -> None:
+    """Fewer rows than ``limit`` → ``next_cursor`` is None immediately."""
+    tenant_id = await _seed_tenant(session)
+    node_id = await _seed_node(session, tenant_id, name="vm-a")
+    base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
+    for i in range(5):
+        await _seed_node_history(
+            session,
+            tenant_id=tenant_id,
+            node_id=node_id,
+            valid_from=base + timedelta(seconds=i),
+        )
+    await session.commit()
+
+    result = await query_timeline(_make_operator(tenant_id), limit=50)
+    assert len(result.rows) == 5
+    assert result.next_cursor is None
+
+
+@pytest.mark.asyncio
+async def test_cursor_next_cursor_decodes_to_last_row(session: AsyncSession) -> None:
+    """``next_cursor`` round-trips to the page's last ``(valid_from,
+    history_id, source)`` position."""
+    tenant_id = await _seed_tenant(session)
+    node_id = await _seed_node(session, tenant_id, name="vm-a")
+    base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
+    for i in range(10):
+        await _seed_node_history(
+            session,
+            tenant_id=tenant_id,
+            node_id=node_id,
+            valid_from=base + timedelta(seconds=i),
+        )
+    await session.commit()
+
+    result = await query_timeline(_make_operator(tenant_id), limit=3)
+
+    assert result.next_cursor is not None
+    last = result.rows[-1]
+    pos = decode_timeline_cursor(result.next_cursor)
+    assert pos.ts.replace(tzinfo=None) == last.valid_from.replace(tzinfo=None)
+    assert pos.history_id == last.history_id
+    assert pos.source == last.source
+
+
+@pytest.mark.asyncio
+async def test_cursor_invalid_token_raises(session: AsyncSession) -> None:
+    """A tampered cursor raises :class:`InvalidTimelineCursorError`."""
+    tenant_id = await _seed_tenant(session)
+    await session.commit()
+    with pytest.raises(InvalidTimelineCursorError):
+        await query_timeline(_make_operator(tenant_id), cursor="not%%base64$$")
+
+
+@pytest.mark.asyncio
+async def test_cursor_stable_under_concurrent_insert(session: AsyncSession) -> None:
+    """A new history row landing between page 1 and page 2 doesn't break paging.
+
+    The diff-on-write hook (T2 #857) writes history rows continuously
+    as the live graph mutates. The cursor's keyset compare
+    ``(valid_from, history_id) < cursor`` means a row landing
+    *above* the cursor's keyset position is *not* visited by the
+    paged sweep -- the operator sees the timeline as it existed at
+    page 1's snapshot, not a mid-sweep moving target. A row landing
+    *below* the cursor would naturally appear on a later page. Either
+    way: no row is duplicated, no original row is skipped.
+    """
+    tenant_id = await _seed_tenant(session)
+    node_id = await _seed_node(session, tenant_id, name="vm-a")
+    base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
+    seeded_ids: list[int] = []
+    for i in range(75):
+        await _seed_node_history(
+            session,
+            tenant_id=tenant_id,
+            node_id=node_id,
+            valid_from=base + timedelta(seconds=i),
+        )
+    await session.commit()
+
+    # Page 1.
+    page1 = await query_timeline(_make_operator(tenant_id), limit=50)
+    seeded_ids.extend(r.history_id for r in page1.rows)
+    assert page1.next_cursor is not None
+
+    # Simulate the diff-on-write hook landing a fresh history row
+    # ABOVE the page-1 last row's ``valid_from`` (i.e. newer than
+    # anything we've paged through). This row should not be visited
+    # by the next page -- the cursor's keyset compare excludes it.
+    above_ts = base + timedelta(seconds=200)
+    await _seed_node_history(
+        session,
+        tenant_id=tenant_id,
+        node_id=node_id,
+        valid_from=above_ts,
+    )
+    await session.commit()
+
+    # Page 2 with the cursor from page 1.
+    page2 = await query_timeline(
+        _make_operator(tenant_id),
+        limit=50,
+        cursor=page1.next_cursor,
+    )
+    page2_ids = [r.history_id for r in page2.rows]
+
+    # No duplicate id across pages.
+    assert set(seeded_ids).isdisjoint(set(page2_ids))
+    # The new "above the cursor" row was not visited -- the paged
+    # sweep is stable against concurrent inserts above the cursor.
+    assert all(r.valid_from < page1.rows[-1].valid_from for r in page2.rows)
+
+    # Sweep completes; the remaining 25 originals all appeared.
+    seeded_ids.extend(page2_ids)
+    assert len(seeded_ids) == 75
+
+
+# ---------------------------------------------------------------------------
+# Window scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_since_until_bounds_inclusive(session: AsyncSession) -> None:
+    """``since`` / ``until`` bound ``valid_from`` inclusively at both ends."""
+    tenant_id = await _seed_tenant(session)
+    node_id = await _seed_node(session, tenant_id, name="vm-a")
+    base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
+    for i in range(10):
+        await _seed_node_history(
+            session,
+            tenant_id=tenant_id,
+            node_id=node_id,
+            valid_from=base + timedelta(minutes=i),
+        )
+    await session.commit()
+
+    # Window covers minutes 3..7 inclusive on both ends → 5 rows.
+    result = await query_timeline(
+        _make_operator(tenant_id),
+        since=base + timedelta(minutes=3),
+        until=base + timedelta(minutes=7),
+    )
+    assert len(result.rows) == 5
+    # SQLite strips tzinfo on read-back; compare the naive form on
+    # both sides so the assertion is dialect-portable.
+    timestamps = [r.valid_from.replace(tzinfo=None) for r in result.rows]
+    assert max(timestamps) == (base + timedelta(minutes=7)).replace(tzinfo=None)
+    assert min(timestamps) == (base + timedelta(minutes=3)).replace(tzinfo=None)
+
+
+# ---------------------------------------------------------------------------
+# Target scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_target_filter_scopes_to_one_targets_resources(
+    session: AsyncSession,
+) -> None:
+    """``target_id`` narrows the timeline to one target's resources."""
+    tenant_id = await _seed_tenant(session)
+    target_a = await _seed_target(session, tenant_id, name="vc-a")
+    target_b = await _seed_target(session, tenant_id, name="vc-b")
+    node_a = await _seed_node(session, tenant_id, name="vm-a", target_id=target_a)
+    node_b = await _seed_node(session, tenant_id, name="vm-b", target_id=target_b)
+    await session.flush()
+
+    base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
+    await _seed_node_history(
+        session,
+        tenant_id=tenant_id,
+        node_id=node_a,
+        valid_from=base,
+    )
+    await _seed_node_history(
+        session,
+        tenant_id=tenant_id,
+        node_id=node_b,
+        valid_from=base + timedelta(seconds=1),
+    )
+    await session.commit()
+
+    result = await query_timeline(_make_operator(tenant_id), target_id=target_a)
+    assert len(result.rows) == 1
+    assert result.rows[0].resource_id == node_a
+
+
+# ---------------------------------------------------------------------------
+# Tombstone replay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_timeline_returns_tombstone_with_null_resource_id(
+    session: AsyncSession,
+) -> None:
+    """A history row whose ``node_id`` was cleared by ON DELETE SET NULL
+    still appears in the timeline.
+
+    The snapshot carries enough state for the summary even when the
+    live row is gone.
+    """
+    tenant_id = await _seed_tenant(session)
+    base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
+    # node_id=None simulates the post-delete tombstone shape.
+    await _seed_node_history(
+        session,
+        tenant_id=tenant_id,
+        node_id=None,
+        valid_from=base,
+        change_kind=GraphHistoryChangeKind.REMOVED,
+        snapshot={"before": {"kind": "vm", "name": "vm-deleted"}, "after": None},
+    )
+    await session.commit()
+
+    result = await query_timeline(_make_operator(tenant_id))
+    assert len(result.rows) == 1
+    row = result.rows[0]
+    assert row.resource_id is None
+    assert row.change_kind == "removed"
+    assert "vm-deleted" in row.summary
+    assert row.source == "node"
+
+
+# ---------------------------------------------------------------------------
+# Ordering and tie-breaker
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_timeline_ordered_newest_first(session: AsyncSession) -> None:
+    """Rows return in ``(valid_from DESC, history_id DESC)`` order."""
+    tenant_id = await _seed_tenant(session)
+    node_id = await _seed_node(session, tenant_id, name="vm-a")
+    base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
+    for i in range(5):
+        await _seed_node_history(
+            session,
+            tenant_id=tenant_id,
+            node_id=node_id,
+            valid_from=base + timedelta(seconds=i),
+        )
+    await session.commit()
+
+    result = await query_timeline(_make_operator(tenant_id))
+    timestamps = [r.valid_from for r in result.rows]
+    assert timestamps == sorted(timestamps, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# Limit validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_limit_raises(session: AsyncSession) -> None:
+    """Out-of-range ``limit`` raises :class:`ValueError`."""
+    tenant_id = await _seed_tenant(session)
+    await session.commit()
+    with pytest.raises(ValueError):
+        await query_timeline(_make_operator(tenant_id), limit=0)
+    with pytest.raises(ValueError):
+        await query_timeline(_make_operator(tenant_id), limit=10000)

--- a/backend/tests/test_topology_timeline_query.py
+++ b/backend/tests/test_topology_timeline_query.py
@@ -289,7 +289,7 @@ async def test_tenant_scoping_no_rows_for_empty_tenant(session: AsyncSession) ->
     tenant_a = await _seed_tenant(session)
     await session.commit()
     result = await query_timeline(_make_operator(tenant_a))
-    assert result.rows == []
+    assert result.rows == ()
     assert result.next_cursor is None
 
 
@@ -543,6 +543,48 @@ async def test_target_filter_scopes_to_one_targets_resources(
     assert result.rows[0].resource_id == node_a
 
 
+@pytest.mark.asyncio
+async def test_target_filter_includes_edge_when_either_endpoint_matches(
+    session: AsyncSession,
+) -> None:
+    """An edge spanning two targets surfaces in either target's timeline.
+
+    The ``--target`` filter on the edge branch keys on **either**
+    endpoint's ``target_id`` (an edge crossing two targets is part of
+    both timelines). The node-only branch is covered above; this test
+    locks down the edge-history branch of the same filter so a
+    regression in the OR-of-endpoint-targets predicate (e.g. an
+    accidental AND or a one-sided filter) does not silently drop
+    cross-target edges from one side's view.
+    """
+    tenant_id = await _seed_tenant(session)
+    target_a = await _seed_target(session, tenant_id, name="vc-a")
+    target_b = await _seed_target(session, tenant_id, name="vc-b")
+    node_a = await _seed_node(session, tenant_id, name="vm-a", target_id=target_a)
+    node_b = await _seed_node(session, tenant_id, name="vm-b", target_id=target_b)
+    edge_id = await _seed_edge(session, tenant_id, node_a, node_b)
+    await session.flush()
+
+    base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
+    await _seed_edge_history(
+        session,
+        tenant_id=tenant_id,
+        edge_id=edge_id,
+        valid_from=base,
+    )
+    await session.commit()
+
+    result_a = await query_timeline(_make_operator(tenant_id), target_id=target_a)
+    edge_rows_a = [r for r in result_a.rows if r.source == "edge"]
+    assert len(edge_rows_a) == 1, "edge should surface in target_a's timeline"
+    assert edge_rows_a[0].resource_id == edge_id
+
+    result_b = await query_timeline(_make_operator(tenant_id), target_id=target_b)
+    edge_rows_b = [r for r in result_b.rows if r.source == "edge"]
+    assert len(edge_rows_b) == 1, "same edge should surface in target_b's timeline"
+    assert edge_rows_b[0].resource_id == edge_id
+
+
 # ---------------------------------------------------------------------------
 # Tombstone replay
 # ---------------------------------------------------------------------------
@@ -587,7 +629,7 @@ async def test_timeline_returns_tombstone_with_null_resource_id(
 
 @pytest.mark.asyncio
 async def test_timeline_ordered_newest_first(session: AsyncSession) -> None:
-    """Rows return in ``(valid_from DESC, history_id DESC)`` order."""
+    """Rows return in ``(valid_from DESC, history_id DESC, source DESC)`` order."""
     tenant_id = await _seed_tenant(session)
     node_id = await _seed_node(session, tenant_id, name="vm-a")
     base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
@@ -601,8 +643,15 @@ async def test_timeline_ordered_newest_first(session: AsyncSession) -> None:
     await session.commit()
 
     result = await query_timeline(_make_operator(tenant_id))
-    timestamps = [r.valid_from for r in result.rows]
-    assert timestamps == sorted(timestamps, reverse=True)
+    # Full keyset ordering check (not just ``valid_from``): the merge
+    # in ``query_timeline`` uses ``(valid_from, history_id, source)`` as
+    # the descending tie-breaker chain, and cursor stability depends on
+    # every level of the chain being respected. Asserting only the
+    # outermost ``valid_from`` would miss a regression in the
+    # history_id / source tie-breaker that would surface as duplicated
+    # or skipped rows across paginated cursors on same-timestamp ties.
+    keys = [(r.valid_from, r.history_id, r.source) for r in result.rows]
+    assert keys == sorted(keys, reverse=True)
 
 
 # ---------------------------------------------------------------------------

--- a/cli/internal/cmd/topology/timeline.go
+++ b/cli/internal/cmd/topology/timeline.go
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package topology
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newTimelineCmd returns the `meho topology timeline` command.
+//
+//	meho topology timeline \
+//	  [--target <name|alias>]      # narrow to one target's resources
+//	  [--since DUR]                # 24h | 7d | 30m | ISO-8601 lower bound
+//	  [--until DUR]                # same shorthand as --since upper bound
+//	  [--limit N]                  # 1..1000, default 50 (server-side)
+//	  [--cursor C]                 # opaque forward-pagination cursor
+//	  [--json]                     # raw TopologyTimelineResult JSON
+//	  [--backplane <url>]          # override the configured backplane
+//
+// Calls GET /api/v1/topology/timeline. Cursor pagination: a non-empty
+// `next_cursor` line in the table view means more rows exist — paste it
+// onto the next call as --cursor. Cursor is stable under concurrent
+// inserts from the G9.3 diff-on-write hook (T2 #857): a new history
+// row landing between page N and page N+1 is naturally placed by the
+// keyset compare and never duplicates or skips a returned row.
+//
+// Exit codes (shared with the sibling topology verbs via
+// renderRequestError / renderHTTPError):
+//   - 0   query returned cleanly (incl. zero-row result).
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected response shape (incl. 400 invalid_cursor and 404
+//     target_not_found with near-miss list).
+//   - 5   insufficient_role
+func newTimelineCmd() *cobra.Command {
+	var (
+		target            string
+		since             string
+		until             string
+		limit             int
+		cursor            string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "timeline",
+		Short: "Walk the tenant timeline of graph changes (G9.3 history)",
+		Long: "timeline calls GET /api/v1/topology/timeline and renders the " +
+			"chronological feed of `graph_node_history` + " +
+			"`graph_edge_history` rows ordered newest-first. --target " +
+			"narrows to history rows for one target's resources " +
+			"(alias-aware; server-side resolution). --since / --until " +
+			"accept either duration shorthand (24h / 7d / 30m / 2w) " +
+			"resolved client-side to an absolute ISO-8601 timestamp, " +
+			"or an ISO-8601 datetime directly. --cursor pastes the " +
+			"opaque next_cursor from a prior page; the cursor is " +
+			"stable under concurrent diff-on-write inserts so a paged " +
+			"sweep over an actively-mutating graph reassembles to the " +
+			"unpaged result with no gaps or duplicates. --json emits " +
+			"the raw TopologyTimelineResult so operators can pipe into " +
+			"jq.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runTimeline(cmd, timelineOptions{
+				Target:            target,
+				Since:             since,
+				Until:             until,
+				Limit:             limit,
+				Cursor:            cursor,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&target, "target", "",
+		"narrow to one target (name or alias; server-side resolution)")
+	cmd.Flags().StringVar(&since, "since", "",
+		"earliest valid_from; accepts 24h / 7d / 30m / 2w shorthand or ISO-8601")
+	cmd.Flags().StringVar(&until, "until", "",
+		"latest valid_from; accepts the same shorthand as --since")
+	cmd.Flags().IntVar(&limit, "limit", 0,
+		"max rows per page (1..1000, server default 50 when omitted)")
+	cmd.Flags().StringVar(&cursor, "cursor", "",
+		"opaque forward-pagination cursor from a prior page's NEXT line")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw TopologyTimelineResult JSON instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+// timelineOptions is the per-call option bag for runTimeline.
+//
+// Limit=0 sentinel: Go's int zero collides with the backend's ge=1
+// validation. The CLI sends `--limit` only when explicitly set so the
+// server applies its 50-default rather than erroring.
+type timelineOptions struct {
+	Target            string
+	Since             string
+	Until             string
+	Limit             int
+	Cursor            string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+// _timelineLimitMax mirrors the API's Query(le=_TIMELINE_LIMIT_MAX)
+// ceiling so the CLI fails fast on an over-budget --limit instead of
+// burning a round trip to a 422.
+const _timelineLimitMax = 1000
+
+func runTimeline(cmd *cobra.Command, opts timelineOptions) error {
+	if opts.Limit < 0 || opts.Limit > _timelineLimitMax {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"--limit must be between 1 and %d (or 0/omitted for the server default of 50); got %d",
+				_timelineLimitMax, opts.Limit)),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	result, err := getTimeline(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printTimelineTable(cmd.OutOrStdout(), result)
+	return nil
+}
+
+// buildTimelinePath assembles the GET path + query string for a
+// timeline call. Optional filters land as query params only when set
+// so the server applies its defaults for the rest. Duration shorthand
+// (e.g. "24h") is resolved client-side to an absolute ISO-8601 to
+// match the REST router's absolute-only contract — the audit-query
+// router parses shorthand server-side but the topology timeline route
+// (a fresh G9.3 surface) keeps shorthand on the CLI to minimise the
+// backend's parsing surface (one parser, in one place: the CLI). The
+// raw input falls through as-is if it doesn't parse as shorthand —
+// the operator may already have pasted an ISO-8601.
+func buildTimelinePath(opts timelineOptions, now time.Time) (string, error) {
+	q := url.Values{}
+	if opts.Target != "" {
+		q.Set("target", opts.Target)
+	}
+	if opts.Since != "" {
+		iso, err := resolveDurationOrISO(opts.Since, now)
+		if err != nil {
+			return "", fmt.Errorf("--since %q: %w", opts.Since, err)
+		}
+		q.Set("since", iso)
+	}
+	if opts.Until != "" {
+		iso, err := resolveDurationOrISO(opts.Until, now)
+		if err != nil {
+			return "", fmt.Errorf("--until %q: %w", opts.Until, err)
+		}
+		q.Set("until", iso)
+	}
+	if opts.Limit > 0 {
+		q.Set("limit", strconv.Itoa(opts.Limit))
+	}
+	if opts.Cursor != "" {
+		q.Set("cursor", opts.Cursor)
+	}
+	path := "/api/v1/topology/timeline"
+	if encoded := q.Encode(); encoded != "" {
+		path = path + "?" + encoded
+	}
+	return path, nil
+}
+
+func getTimeline(ctx context.Context, backplaneURL string, opts timelineOptions) (*TimelineResult, error) {
+	path, err := buildTimelinePath(opts, time.Now().UTC())
+	if err != nil {
+		return nil, err
+	}
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var out TimelineResult
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode timeline response: %w", err)
+	}
+	return &out, nil
+}
+
+// TimelineEntry mirrors the backend `TopologyTimelineEntry` Pydantic
+// model (`backend/src/meho_backplane/topology/schemas.py`). Fields are
+// hand-written rather than oapi-codegen-generated for the same reason
+// the audit `Entry` shape is — the topology package stays decoupled
+// from oapi churn, matching the sibling-package convention.
+type TimelineEntry struct {
+	ValidFrom   string  `json:"valid_from"`
+	HistoryID   int64   `json:"history_id"`
+	Source      string  `json:"source"`
+	ChangeKind  string  `json:"change_kind"`
+	ResourceID  *string `json:"resource_id"`
+	Summary     string  `json:"summary"`
+	AuditID     *string `json:"audit_id"`
+}
+
+// TimelineResult mirrors the backend `TopologyTimelineResult`.
+// `NextCursor` keeps the JSON key as `null` (no `omitempty`) so a
+// re-marshal preserves the Pydantic wire shape — the audit
+// QueryResult does the same.
+type TimelineResult struct {
+	Rows       []TimelineEntry `json:"rows"`
+	NextCursor *string         `json:"next_cursor"`
+}
+
+// printTimelineTable renders the timeline page as a compact,
+// scannable table. Columns: VALID_FROM, SRC, CHANGE, SUMMARY,
+// AUDIT_ID. When `next_cursor` is set, a final NEXT line tells the
+// operator how to paste-paginate.
+func printTimelineTable(w io.Writer, r *TimelineResult) {
+	if r == nil || len(r.Rows) == 0 {
+		fmt.Fprintln(w, "no graph changes in the requested window")
+		return
+	}
+	fmt.Fprintf(w, "%-22s %-5s %-8s %-38s %s\n",
+		"VALID_FROM", "SRC", "CHANGE", "SUMMARY", "AUDIT_ID")
+	for _, row := range r.Rows {
+		fmt.Fprintf(w, "%-22s %-5s %-8s %-38s %s\n",
+			truncate(row.ValidFrom, 22),
+			row.Source,
+			truncate(row.ChangeKind, 8),
+			truncate(row.Summary, 38),
+			truncate(strDeref(row.AuditID), 36),
+		)
+	}
+	if r.NextCursor != nil && *r.NextCursor != "" {
+		fmt.Fprintf(w, "NEXT: --cursor=%s  (paste to continue)\n", *r.NextCursor)
+	}
+}
+
+// strDeref returns *s or empty string when s is nil. Mirrors the
+// audit-package helper of the same name; duplicated to avoid the
+// import-cycle the cmd/audit → cmd/topology → cmd path would create.
+func strDeref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// resolveDurationOrISO converts an operator-typed --since/--until
+// value into an absolute RFC3339 timestamp. Accepts:
+//
+//   - duration shorthand: <N><unit> where unit ∈ {s,m,h,d,w}. Result
+//     is `now - duration`.
+//   - ISO-8601 / RFC3339: passed through after a parse-validate
+//     round trip so a typo (`2026-13-32`) surfaces here, not as a
+//     400 from the backend.
+//
+// Mirrors the audit-query duration parser
+// (`backend/src/meho_backplane/audit_query/duration.py`) so the two
+// surfaces accept the same vocabulary. Audit forensics often wants
+// sub-minute resolution (`30s`) and multi-week windows (`2w`), so
+// the timeline parser ships the wider grammar.
+func resolveDurationOrISO(raw string, now time.Time) (string, error) {
+	if iso, ok := tryParseDuration(raw, now); ok {
+		return iso, nil
+	}
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err == nil {
+		return parsed.UTC().Format(time.RFC3339), nil
+	}
+	// One more shape: bare ISO-8601 date (no time component). Promote
+	// to RFC3339 midnight UTC so the server's `valid_from >= :since`
+	// compare lands somewhere meaningful for an operator typing a
+	// date.
+	parsed, err = time.Parse("2006-01-02", raw)
+	if err == nil {
+		return parsed.UTC().Format(time.RFC3339), nil
+	}
+	return "", fmt.Errorf(
+		"not a duration shorthand (e.g. 24h) or ISO-8601 timestamp",
+	)
+}
+
+// tryParseDuration recognises <N><unit> shorthand. unit ∈ {s,m,h,d,w};
+// N is an unsigned integer ≤ 9999.
+func tryParseDuration(raw string, now time.Time) (string, bool) {
+	if len(raw) < 2 {
+		return "", false
+	}
+	unit := raw[len(raw)-1]
+	digits := raw[:len(raw)-1]
+	if len(digits) == 0 || len(digits) > 4 {
+		return "", false
+	}
+	n, err := strconv.Atoi(digits)
+	if err != nil || n < 0 {
+		return "", false
+	}
+	var dur time.Duration
+	switch unit {
+	case 's':
+		dur = time.Duration(n) * time.Second
+	case 'm':
+		dur = time.Duration(n) * time.Minute
+	case 'h':
+		dur = time.Duration(n) * time.Hour
+	case 'd':
+		dur = time.Duration(n) * 24 * time.Hour
+	case 'w':
+		dur = time.Duration(n) * 7 * 24 * time.Hour
+	default:
+		return "", false
+	}
+	return now.Add(-dur).UTC().Format(time.RFC3339), true
+}

--- a/cli/internal/cmd/topology/timeline.go
+++ b/cli/internal/cmd/topology/timeline.go
@@ -88,7 +88,7 @@ func newTimelineCmd() *cobra.Command {
 	cmd.Flags().StringVar(&target, "target", "",
 		"narrow to one target (name or alias; server-side resolution)")
 	cmd.Flags().StringVar(&since, "since", "",
-		"earliest valid_from; accepts 24h / 7d / 30m / 2w shorthand or ISO-8601")
+		"earliest valid_from; accepts 24h / 7d / 30m / 2w shorthand, RFC3339, or YYYY-MM-DD")
 	cmd.Flags().StringVar(&until, "until", "",
 		"latest valid_from; accepts the same shorthand as --since")
 	cmd.Flags().IntVar(&limit, "limit", 0,
@@ -211,13 +211,13 @@ func getTimeline(ctx context.Context, backplaneURL string, opts timelineOptions)
 // the audit `Entry` shape is — the topology package stays decoupled
 // from oapi churn, matching the sibling-package convention.
 type TimelineEntry struct {
-	ValidFrom   string  `json:"valid_from"`
-	HistoryID   int64   `json:"history_id"`
-	Source      string  `json:"source"`
-	ChangeKind  string  `json:"change_kind"`
-	ResourceID  *string `json:"resource_id"`
-	Summary     string  `json:"summary"`
-	AuditID     *string `json:"audit_id"`
+	ValidFrom  string  `json:"valid_from"`
+	HistoryID  int64   `json:"history_id"`
+	Source     string  `json:"source"`
+	ChangeKind string  `json:"change_kind"`
+	ResourceID *string `json:"resource_id"`
+	Summary    string  `json:"summary"`
+	AuditID    *string `json:"audit_id"`
 }
 
 // TimelineResult mirrors the backend `TopologyTimelineResult`.

--- a/cli/internal/cmd/topology/topology.go
+++ b/cli/internal/cmd/topology/topology.go
@@ -101,18 +101,20 @@ import (
 func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "topology",
-		Short: "Query and refresh the MEHO topology graph (refresh / dependents / dependencies / path / annotate / unannotate / list-edges)",
+		Short: "Query and refresh the MEHO topology graph (refresh / dependents / dependencies / path / timeline / annotate / unannotate / list-edges)",
 		Long: "Operate the tenant-scoped topology graph wired by G9.1 + " +
-			"G9.2. Refresh a target's discovered topology, walk what " +
-			"depends on a node (dependents), walk what a node depends " +
-			"on (dependencies), find the shortest path between two " +
-			"nodes, assert a curated cross-system edge (annotate), " +
-			"delete a curated edge (unannotate), or list the tenant's " +
-			"edges (list-edges). Read verbs are operator-level; " +
-			"annotate / unannotate require tenant_admin. Tenant " +
-			"scoping is enforced server-side via the JWT — no surface " +
-			"accepts a tenant id, and cross-tenant queries return the " +
-			"same empty/404 shape as a node that does not exist.",
+			"G9.2 + G9.3. Refresh a target's discovered topology, walk " +
+			"what depends on a node (dependents), walk what a node " +
+			"depends on (dependencies), find the shortest path between " +
+			"two nodes, walk the tenant's chronological change feed " +
+			"from the diff-on-write history substrate (timeline), " +
+			"assert a curated cross-system edge (annotate), delete a " +
+			"curated edge (unannotate), or list the tenant's edges " +
+			"(list-edges). Read verbs are operator-level; annotate / " +
+			"unannotate require tenant_admin. Tenant scoping is " +
+			"enforced server-side via the JWT — no surface accepts a " +
+			"tenant id, and cross-tenant queries return the same " +
+			"empty/404 shape as a node that does not exist.",
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(newRefreshCmd())

--- a/cli/internal/cmd/topology/topology.go
+++ b/cli/internal/cmd/topology/topology.go
@@ -123,6 +123,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newUnannotateCmd())
 	cmd.AddCommand(newListEdgesCmd())
 	cmd.AddCommand(newBulkImportCmd())
+	cmd.AddCommand(newTimelineCmd())
 	return cmd
 }
 

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -615,6 +615,72 @@ back atomically with the batch. No additional wiring was needed for
 G9.3-T2: the hook is on the call path the bulk importer already
 uses.
 
+## Timeline query (read half — G9.3-T5 #861)
+
+`query_timeline` (in `backend/src/meho_backplane/topology/query.py`)
+is the tenant-wide chronological feed of graph changes — "what's
+been happening in the graph in the last hour?" without rooting at a
+specific resource. It UNIONs `graph_node_history` +
+`graph_edge_history` and walks both tables in `(valid_from DESC,
+history_id DESC)` order, paginated via opaque forward-only cursor.
+
+### Pagination
+
+OFFSET-based pagination is broken under the diff-on-write hook
+(T2 #857) — new history rows land continuously, and offset shifts
+every subsequent row. A keyset cursor over the `(valid_from,
+history_id, source)` lex order is correctness-preserving: page N+1
+starts at the row strictly after page N's last row, and a concurrent
+insert either lands below the cursor (appears on a later page) or
+above the cursor (stays outside the paged sweep). No row is
+duplicated or skipped by the act of paging.
+
+The cursor is opaque (base64-encoded JSON, see
+`topology/timeline_cursor.py`) so consumers treat it as a token
+rather than parsing it. `source` is the third component because the
+two history tables have independent `BIGSERIAL` counters — a node
+and an edge can share `(valid_from, history_id)`; alphabetical
+order (`"node" > "edge"` in DESC) is the deterministic tie-breaker.
+
+### Query shape
+
+Two parallel single-index scans (one per table) followed by a
+Python-side merge, rather than a SQL `UNION ALL`. Two reasons:
+
+1. Each table's `(tenant_id, valid_from DESC)` composite index is
+   the natural access path; the planner would otherwise materialise
+   the union before sorting, defeating the index.
+2. The `--target` filter joins `graph_node` (for the node side) and
+   `graph_edge` + endpoint `graph_node` (for the edge side).
+   Inlining those joins into a single UNION'd statement would mix
+   two access paths in one plan — fragile under data growth.
+
+The merge is a two-pointer pass: pop the larger head from either
+list, with the source-discriminator tie-breaker. Memory is
+O(per_side_fetch) = O(limit + 1) per side, bounded by `limit ≤ 1000`.
+
+### Filters
+
+- `target_id` — optional `targets.id`. Nodes filter on
+  `graph_node.target_id`; edges filter on the endpoint nodes'
+  `target_id` (either endpoint touching the target qualifies — an
+  edge crossing two targets is part of both timelines).
+- `since` / `until` — inclusive `valid_from` bounds. The CLI
+  resolves duration shorthand (`24h` / `7d`) client-side to an
+  absolute ISO-8601 before crossing the wire.
+- `limit` — page size, default 50 per the Task #861 acceptance
+  criterion; ceiling 1000.
+
+### Audit class
+
+The REST route binds `audit_op_id="topology.timeline"` /
+`audit_op_class="audit_query"` per [decision #3](../planning/v0.2-decisions.md)
+— temporal graph queries are inspections of system state, parallel
+to G8's audit-log query surface. The broadcast event carries only
+`{op_id, result_status, row_count}` so the request filter (which
+may name a sensitive target) and the row contents never leak onto
+the SSE / Slack feed.
+
 ## Manual node seed control flow (write half — G0.9.1-T6 #778)
 
 ### `create_or_get_node`
@@ -670,10 +736,10 @@ will adopt the node onto the target (`target_id` gets set, the
 node's properties pick up probe-derived shape) without losing the
 manual-seed audit trail.
 
-## REST API surface (T5, #453 + G9.2-T5 #597)
+## REST API surface (T5, #453 + G9.2-T5 #597 + G9.3-T5 #861)
 
 `backend/src/meho_backplane/api/v1/topology.py` is the HTTP front for
-the read + write halves. Nine routes total — eight on the topology
+the read + write halves. Ten routes total — nine on the topology
 router, one on the targets router:
 
 | Method + path | Wraps | op_id | RBAC |
@@ -686,6 +752,7 @@ router, one on the targets router:
 | `DELETE /api/v1/topology/edges/{edge_id}` | `unannotate_edge` (T3 #595) | `topology.unannotate` | **tenant_admin** |
 | `GET /api/v1/topology/edges` | `list_edges` (T4 #596) | `topology.list_edges` | operator |
 | `POST /api/v1/topology/edges/bulk` | `bulk_import_edges` (T8 #600) | `topology.bulk_import` | **tenant_admin** |
+| `GET /api/v1/topology/timeline` | `query_timeline` (G9.3-T5 #861) | `topology.timeline` | operator |
 | `GET /api/v1/targets/discover?product=X` | `Connector.list_candidates` | `targets.discover` | operator |
 
 Load-bearing details:


### PR DESCRIPTION
## Summary

- Add `meho topology timeline` verb + `GET /api/v1/topology/timeline` + `query_topology(kind="timeline")` MCP facet, all backed by a shared `query_timeline()` substrate handler that UNIONs `graph_node_history` + `graph_edge_history` (T1 #856 / T2 #857) and walks both tables in `(valid_from DESC, history_id DESC)` order.
- Cursor pagination via opaque base64-encoded `(valid_from, history_id, source)` keyset — correctness-preserving under concurrent diff-on-write inserts (a row landing between page N and page N+1 either appears on a later page or stays outside the sweep; no row is duplicated or skipped).
- Default page size 50 per the acceptance criterion; ceiling 1000. Tenant scope enforced by every SQL statement's first WHERE clause. `audit_op_class="audit_query"` per decision #3 so broadcast carries only aggregate row count.

Stacked on #904 → #900 (G9.3 chain). Review/merge #900 → #904 first.

## Test plan

- [x] `ruff check` — clean (full `meho_backplane/` + new test)
- [x] `ruff format --check` — clean (223 files formatted)
- [x] `mypy meho_backplane/` — clean (222 source files)
- [x] `pytest tests/test_topology_timeline_query.py` — **12 passed** (tenant scoping, cursor walks 120 rows in 3 pages, cursor stable under concurrent insert, since/until inclusive bounds, target scoping, tombstone replay, ordering, invalid cursor, limit validation)
- [x] `pytest tests/` (full unit suite) — **3223 passed, 11 skipped** (no regression; updated two pre-existing tests for the widened `kind` enum)
- [x] `python3 .claude/hooks/code-quality.py --diff` — **0 blockers** (refactored `query_timeline` to extract `_build_timeline_bind_params` / `_compute_next_cursor` helpers)
- [x] `go build ./...` + `go vet` + `go test ./internal/cmd/topology/...` — all green

## Out of scope

- T3 history verb (#859) — sibling task, separate PR
- T4 diff verb (#860) — sibling task, separate PR
- T7 integration tests (#862) — depends on T3/T4/T5 + T6

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #861


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant-scoped topology timeline: chronological feed of node/edge changes with target filtering, since/until windows, limit, and opaque forward-only cursors.
  * Exposed via REST, CLI command (meho topology timeline) and MCP tool; CLI supports duration shorthands and human/JSON output with NEXT cursor hint.
  * Responses include compact human summaries and optional audit IDs.

* **Tests**
  * Added extensive end-to-end and unit tests covering pagination, cursor validation, scoping, and ordering.

* **Documentation**
  * Updated topology docs and API reference with timeline details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/909?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->