### PR TITLE
fix(mcp): strip top-level JSON-Schema combinators from published tool inputSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,20 @@ connector-related release-notes line.
 
 ### Fixed
 
+- MCP `tools/list` no longer publishes a top-level `oneOf` / `allOf` /
+  `anyOf` in any tool's `inputSchema`. The Anthropic Messages API
+  rejects a top-level JSON-Schema combinator in a tool's `input_schema`
+  (`400 ... input_schema does not support oneOf, allOf, or anyOf at the
+  top level`), and because it validates the whole `tools` array a single
+  offender 400'd *every* call in a Claude Code session with the MEHO MCP
+  server connected. `query_topology` (top-level `allOf` for its per-`kind`
+  conditional requireds) and `meho.topology.unannotate` (top-level
+  `oneOf` for its XOR selector) both tripped it. `ToolDefinition.to_wire`
+  now strips top-level combinators from the published copy while the full
+  schema stays on `inputSchema`, so server-side jsonschema validation
+  (the `-32602` rejections for bad argument shapes) is unchanged. Found
+  dogfooding from `claude-rdc-hetzner-dc` after its static `.mcp.json`
+  wire-up. (#905)
 - `search_memory` now returns real `created_at` / `updated_at` for
   each hit instead of the `1970-01-01T00:00:00Z` epoch placeholder
   that v0.3.1 surfaced. The retrieval substrate's `RetrievalHit`

--- a/backend/src/meho_backplane/mcp/registry.py
+++ b/backend/src/meho_backplane/mcp/registry.py
@@ -135,6 +135,36 @@ def role_at_least(actual: TenantRole, required: TenantRole) -> bool:
     return _ROLE_RANK.index(actual) >= _ROLE_RANK.index(required)
 
 
+#: JSON-Schema combinator keywords the Anthropic Messages API rejects at
+#: the *top level* of a tool's ``input_schema``. A request carrying one
+#: 400s with ``input_schema does not support oneOf, allOf, or anyOf at
+#: the top level`` — and because the API validates the whole ``tools``
+#: array, a single offender poisons *every* call in that session, not
+#: just its own. MEHO uses top-level ``allOf`` (``query_topology``'s
+#: per-``kind`` conditional required-args) and ``oneOf``
+#: (``meho.topology.unannotate``'s XOR selector) for *server-side*
+#: jsonschema validation in :mod:`~meho_backplane.mcp.handlers`; those
+#: stay on ``inputSchema`` and keep validating. Only the wire copy
+#: published via :meth:`ToolDefinition.to_wire` drops them. Nested
+#: occurrences (inside ``properties`` / ``items`` / ``$defs`` / …) are
+#: legal and preserved — the restriction is top-level only.
+_WIRE_FORBIDDEN_TOPLEVEL_KEYS: tuple[str, ...] = ("oneOf", "allOf", "anyOf")
+
+
+def _wire_safe_input_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Return *schema* with any top-level combinator keyword removed.
+
+    See :data:`_WIRE_FORBIDDEN_TOPLEVEL_KEYS` for why. *schema* is not
+    mutated: when it carries no forbidden top-level key the same object is
+    returned (the common ~15-tool case, no needless copy); otherwise a
+    shallow copy minus those keys is returned. Nested combinators are
+    untouched — the Anthropic restriction is top-level only.
+    """
+    if not any(key in schema for key in _WIRE_FORBIDDEN_TOPLEVEL_KEYS):
+        return schema
+    return {key: value for key, value in schema.items() if key not in _WIRE_FORBIDDEN_TOPLEVEL_KEYS}
+
+
 class ToolDefinition(BaseModel):
     """MCP tool definition + MEHO-internal RBAC metadata.
 
@@ -166,11 +196,20 @@ class ToolDefinition(BaseModel):
         optional ``title`` / ``outputSchema``. MEHO fields dropped:
         ``required_role``, ``op_class``. The drop is deliberate — clients
         don't need server-side RBAC details and shouldn't see them.
+
+        ``inputSchema`` is additionally passed through
+        :func:`_wire_safe_input_schema`, which strips top-level
+        ``oneOf`` / ``allOf`` / ``anyOf`` — the Anthropic Messages API
+        rejects those at the top level of a tool's ``input_schema`` and
+        the rejection poisons the whole session. The full schema (with
+        the combinators) is retained on ``self.inputSchema`` so
+        server-side jsonschema validation in
+        :mod:`~meho_backplane.mcp.handlers` is unaffected.
         """
         out: dict[str, Any] = {
             "name": self.name,
             "description": self.description,
-            "inputSchema": self.inputSchema,
+            "inputSchema": _wire_safe_input_schema(self.inputSchema),
         }
         if self.title is not None:
             out["title"] = self.title

--- a/backend/tests/test_mcp_registry.py
+++ b/backend/tests/test_mcp_registry.py
@@ -43,6 +43,7 @@ from meho_backplane.mcp import (
 from meho_backplane.mcp.auth import verify_mcp_jwt_and_bind
 from meho_backplane.mcp.registry import (
     _match_uri_template,
+    _wire_safe_input_schema,
     all_resource_templates_for,
     all_tools_for,
     clear_registries,
@@ -155,6 +156,70 @@ def test_register_mcp_tool_makes_it_callable_via_get_tool() -> None:
     stored_defn, stored_handler = entry
     assert stored_defn.name == "test.tool"
     assert stored_handler is _stub
+
+
+def test_to_wire_strips_top_level_combinators_but_keeps_them_on_input_schema() -> None:
+    """``to_wire`` drops top-level oneOf/allOf/anyOf; the stored schema retains them.
+
+    The Anthropic Messages API rejects a top-level JSON-Schema combinator
+    in a tool's ``input_schema`` and 400s the whole session (#905). MEHO
+    keeps the combinator on ``inputSchema`` — server-side jsonschema
+    validation in :mod:`~meho_backplane.mcp.handlers` needs it — and strips
+    it only from the published wire copy. A NESTED combinator (inside
+    ``properties``) is untouched: the restriction is top-level only.
+    """
+    nested_combinator = {"anyOf": [{"type": "string"}, {"type": "null"}]}
+    schema = {
+        "type": "object",
+        "properties": {
+            "kind": {"type": "string"},
+            "opt": nested_combinator,
+        },
+        "required": ["kind"],
+        "additionalProperties": False,
+        "allOf": [
+            {
+                "if": {"properties": {"kind": {"const": "x"}}},
+                "then": {"required": ["opt"]},
+            },
+        ],
+        "oneOf": [{"required": ["kind"]}],
+        "anyOf": [{"required": ["kind"]}],
+    }
+    defn = ToolDefinition(
+        name="test.combinator",
+        description="A tool whose schema carries top-level combinators",
+        inputSchema=schema,
+    )
+
+    wire = defn.to_wire()["inputSchema"]
+    # Top-level combinators gone from the wire shape ...
+    assert "allOf" not in wire
+    assert "oneOf" not in wire
+    assert "anyOf" not in wire
+    # ... the non-combinator keys survive untouched ...
+    assert wire["type"] == "object"
+    assert wire["required"] == ["kind"]
+    assert wire["additionalProperties"] is False
+    # ... and a nested combinator (inside properties) is preserved.
+    assert wire["properties"]["opt"] == nested_combinator
+
+    # The stored schema is unchanged — server-side validation still sees
+    # the combinators by value.
+    assert defn.inputSchema["allOf"] == schema["allOf"]
+    assert defn.inputSchema["oneOf"] == schema["oneOf"]
+    assert defn.inputSchema["anyOf"] == schema["anyOf"]
+
+
+def test_wire_safe_input_schema_returns_same_object_when_nothing_to_strip() -> None:
+    """A combinator-free schema passes through unchanged (no-copy fast path).
+
+    The common case (~15 of MEHO's tools) has no top-level combinator;
+    :func:`_wire_safe_input_schema` returns the same object identity rather
+    than building a needless copy.
+    """
+    schema = {"type": "object", "properties": {"a": {"type": "string"}}}
+    assert _wire_safe_input_schema(schema) is schema
 
 
 def test_register_mcp_tool_rejects_duplicate() -> None:

--- a/backend/tests/test_mcp_tools_topology.py
+++ b/backend/tests/test_mcp_tools_topology.py
@@ -44,11 +44,12 @@ from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.db.models import Tenant
-from meho_backplane.mcp.registry import get_tool
+from meho_backplane.mcp.registry import all_tools_for, get_tool
 from meho_backplane.mcp.schemas import INVALID_PARAMS
 from meho_backplane.topology.schemas import TopologyNode, TopologyPath
 from tests.mcp_test_fixtures import (
     OPERATOR_TENANT_ID,
+    build_operator,
     client_with_operator,  # noqa: F401 — pytest-discovered fixture
     isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
     required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
@@ -136,35 +137,83 @@ def test_query_topology_description_names_blast_radius_verbatim(
 def test_query_topology_input_schema_is_conditional_on_kind(
     client_with_operator: tuple[TestClient, Operator],  # noqa: F811
 ) -> None:
-    """inputSchema encodes the per-kind required fields via allOf/if/then."""
+    """Per-kind required fields are enforced via allOf/if/then on the STORED schema.
+
+    The conditional ``allOf`` lives on the *stored* ``inputSchema`` (what
+    the dispatcher jsonschema-validates ``tools/call.arguments`` against),
+    NOT on the wire shape: the Anthropic Messages API rejects a top-level
+    ``allOf`` / ``oneOf`` / ``anyOf`` in a tool's ``input_schema`` and the
+    rejection 400s the whole session (#905), so
+    :meth:`ToolDefinition.to_wire` strips it from the published copy. This
+    test pins both halves of that split — the wire shape carries no
+    combinator, the stored schema still does (its live effect is proven by
+    the two ``-32602`` tests below).
+    """
     client, _op = client_with_operator
     response = client.post(
         "/mcp",
         json={"jsonrpc": "2.0", "id": 3, "method": "tools/list"},
     )
     tools = {t["name"]: t for t in response.json()["result"]["tools"]}
-    schema = tools["query_topology"]["inputSchema"]
-    assert schema["required"] == ["kind"]
-    assert schema["additionalProperties"] is False
+    wire_schema = tools["query_topology"]["inputSchema"]
+    assert wire_schema["required"] == ["kind"]
+    assert wire_schema["additionalProperties"] is False
     # G9.2-T7 (#598) widened the enum with the `edges` facet (replaces a
     # standalone list_edges meta-tool); the closure / path branches and
     # their conditional requireds stay unchanged.
-    assert schema["properties"]["kind"]["enum"] == [
+    assert wire_schema["properties"]["kind"]["enum"] == [
         "dependents",
         "dependencies",
         "path",
         "edges",
     ]
-    conditionals = schema["allOf"]
+    # The wire shape carries NO top-level combinator — Anthropic 400s on
+    # it (#905); the conditional logic moved to the stored schema below.
+    assert "allOf" not in wire_schema
+    assert "oneOf" not in wire_schema
+    assert "anyOf" not in wire_schema
+    # MEHO-internal fields stripped from the wire shape.
+    assert "required_role" not in tools["query_topology"]
+    assert "op_class" not in tools["query_topology"]
+
+    # The conditional requireds survive on the stored schema (the one the
+    # dispatcher validates against).
+    entry = get_tool("query_topology")
+    assert entry is not None
+    stored_schema = entry[0].inputSchema
+    conditionals = stored_schema["allOf"]
     by_kind = {c["if"]["properties"]["kind"]["const"]: c["then"]["required"] for c in conditionals}
     assert by_kind["dependents"] == ["target"]
     assert by_kind["dependencies"] == ["target"]
     assert sorted(by_kind["path"]) == ["from_name", "to_name"]
     # `edges` has no required field — all filters are optional.
     assert "edges" not in by_kind
-    # MEHO-internal fields stripped from the wire shape.
-    assert "required_role" not in tools["query_topology"]
-    assert "op_class" not in tools["query_topology"]
+
+
+def test_no_published_tool_wire_schema_has_top_level_combinator() -> None:
+    """Registry-wide invariant: no tool's wire ``inputSchema`` has a top-level combinator.
+
+    The guard for #905 at the level it actually bites: every tool the
+    backplane publishes via ``tools/list`` is forwarded verbatim by MCP
+    clients (Claude Code) as a custom tool's ``input_schema``, and the
+    Anthropic Messages API 400s the *entire* request if any one of them
+    carries ``oneOf`` / ``allOf`` / ``anyOf`` at the top level. This walks
+    the full registered tool set (tenant_admin sees every tool) and
+    asserts each :meth:`ToolDefinition.to_wire` output is API-legal. It
+    would have caught both ``query_topology`` (allOf) and
+    ``meho.topology.unannotate`` (oneOf), and catches any future tool that
+    reintroduces the pattern at the source rather than at first 400.
+    """
+    forbidden = ("oneOf", "allOf", "anyOf")
+    offenders = {
+        defn.name: [k for k in forbidden if k in defn.to_wire()["inputSchema"]]
+        for defn in all_tools_for(build_operator(TenantRole.TENANT_ADMIN))
+        if any(k in defn.to_wire()["inputSchema"] for k in forbidden)
+    }
+    assert offenders == {}, (
+        "tools publish a top-level JSON-Schema combinator in their wire "
+        f"inputSchema (Anthropic Messages API rejects these): {offenders}"
+    )
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -81,7 +81,7 @@ class ToolDefinition(BaseModel):
     op_class: str              # "read" | "write" | "credential_read" | "audit_query"
 ```
 
-Wire shape (returned via `tools/list`) drops `required_role` and `op_class` — clients shouldn't see server-side policy.
+Wire shape (returned via `tools/list`) drops `required_role` and `op_class` — clients shouldn't see server-side policy. It also strips any top-level `oneOf` / `allOf` / `anyOf` from `inputSchema`: the Anthropic Messages API rejects a top-level JSON-Schema combinator in a tool's `input_schema` and 400s the whole `tools` array (so one offender breaks every call in the session), hence the published copy must be combinator-free. The full schema — combinators retained — stays on `inputSchema` for server-side `jsonschema` validation, so the `-32602` rejections for bad argument shapes are unaffected. See `_wire_safe_input_schema` in [`mcp/registry.py`](../../backend/src/meho_backplane/mcp/registry.py). (#905)
 
 ### `ResourceTemplateDefinition` + handler
 


### PR DESCRIPTION
Closes #905

A Claude Code session with the MEHO MCP server connected was 400ing every request with `input_schema does not support oneOf, allOf, or anyOf at the top level`. The Anthropic Messages API validates the whole `tools` array, so one bad schema poisons the entire session, not just calls to the offending tool.

Two tools published a top-level combinator in their `inputSchema`: `query_topology` (top-level `allOf` for its per-`kind` conditional requireds) and `meho.topology.unannotate` (top-level `oneOf` for its `edge_id`-vs-triple XOR selector). That schema is correct and load-bearing for the *server-side* `jsonschema.Draft202012Validator` in `handlers.py` — it's just illegal on the wire.

The fix strips top-level `oneOf`/`allOf`/`anyOf` in `ToolDefinition.to_wire()` (the single MCP wire chokepoint that already drops the MEHO-internal fields). The full schema stays on `inputSchema`, so server-side validation — the `-32602` rejections for bad argument shapes — is unchanged. One change covers both tools and any future one. Both tools already spell out their parametric/XOR shape in their `description`, and a bad call still gets a clear `-32602`, so the agent loses nothing actionable.

### Tests
- New registry-wide regression test: no tool in the live registry publishes a wire schema with a top-level combinator (would have caught both offenders, and catches future ones at source instead of at first 400).
- New focused unit test on `to_wire()` / `_wire_safe_input_schema`: top-level strip + retention on the stored schema + nested-combinator preservation.
- Updated the existing wire-shape test to assert the new split (wire stripped, stored retained); the two `-32602` schema-layer tests are untouched and prove server-side validation still bites.

`test_mcp_registry.py` passes locally (28/28). The topology suite was green up to an unrelated local HuggingFace-Hub online-check stall on the embedding model — CI is the real gate there.

Found dogfooding from `claude-rdc-hetzner-dc` after its static `.mcp.json` MCP wire-up (#686). Backplane-internal wire-shape fix — no consumer-side manifest change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented published tool schemas from including top-level JSON Schema combinators (oneOf/allOf/anyOf), fixing API errors that broke Claude Code sessions while preserving server-side validation.

* **Documentation**
  * Clarified how published vs. internal tool schemas differ and why top-level combinators are removed.

* **Tests**
  * Added coverage ensuring published schemas omit top-level combinators while stored schemas remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->