### PR TITLE
docs(changelog): roll [Unreleased] into [0.5.0] + backfill missing bullets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,39 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed
+
+- MCP `tools/list` no longer publishes a top-level `oneOf` / `allOf` /
+  `anyOf` in any tool's `inputSchema`. The Anthropic Messages API
+  rejects a top-level JSON-Schema combinator in a tool's `input_schema`
+  (`400 ... input_schema does not support oneOf, allOf, or anyOf at the
+  top level`), and because it validates the whole `tools` array a single
+  offender 400'd *every* call in a Claude Code session with the MEHO MCP
+  server connected. `query_topology` (top-level `allOf` for its per-`kind`
+  conditional requireds) and `meho.topology.unannotate` (top-level
+  `oneOf` for its XOR selector) both tripped it. `ToolDefinition.to_wire`
+  now strips top-level combinators from the published copy while the full
+  schema stays on `inputSchema`, so server-side jsonschema validation
+  (the `-32602` rejections for bad argument shapes) is unchanged. Found
+  dogfooding from `claude-rdc-hetzner-dc` after its static `.mcp.json`
+  wire-up. (#905)
+
+## [0.5.0] - 2026-05-22
+
+**VMware Cloud Foundation connector wave + second-cycle dogfood
+hardening.** This minor release lands the G3.6 VCF connector fleet
+(VCF Operations / vROps, VCF Logs / vRLI, VCF Fleet, VCF Automation,
+plus a shared `vcf_auth` substrate), the G5.2 memory-promotion verbs,
+harbor operator CLI verbs, and the G0.9.1 hardening of every surface
+the 2026-05-21/22 RDC second-cycle dogfood drove against the v0.3.1
+deploy — the catalog↔dispatch regression, the `when_to_use`
+backfill-on-upgrade gap, memory / ingest / topology polish, and the
+full CLI + MCP first-login auth onramp (`auth-config`, the deployer
+recipe, the `bootstrap-clients` verb, claim-specific token errors, and
+the macOS keyring + device-flow login fixes). CI test-suite performance
+was hardened in parallel to keep the unit job under budget as the op
+count grew.
+
 ### Breaking changes
 
 - **MCP `add_to_memory` argument renamed `content` → `body`**
@@ -229,6 +262,59 @@ connector-related release-notes line.
   is also the canonical path for curated inner-graph nodes the probes
   cannot derive (vault-role, keycloak-realm, externally-managed
   principals) ([#778](https://github.com/evoila/meho/issues/778)).
+- **VCF Fleet spec-ingest + 8-op read core** (G3.6-T8
+  [#890](https://github.com/evoila/meho/issues/890)) — enables the
+  `VcfFleetConnector` (#886) for agent dispatch by ingesting the Fleet
+  spec via the G0.7 pipeline and curating an 8-op read core that
+  `search_operations` / `call_operation` surface. **Dispatch + catalog**
+  state; production execution against per-target Vault credentials is
+  tracked under [#214](https://github.com/evoila/meho/issues/214). Write
+  ops stay `is_enabled=False` per Initiative #369.
+- **VCF Automation dual-plane spec ingestion + 11-op read core**
+  (G3.6-T11 [#892](https://github.com/evoila/meho/issues/892)) — enables
+  the `VcfAutomationConnector` (#885) for agent dispatch across both VCFA
+  planes; 11 read ops curated and surfaced by `search_operations` /
+  `call_operation`. **Dispatch + catalog** state; loader wiring tracked
+  under [#214](https://github.com/evoila/meho/issues/214).
+- **Three more VCF connector skeletons registered** — `HttpConnector`
+  subclasses with `fingerprint()` + `probe()` but **no dispatchable ops
+  until their curation Tasks land** (registered-not-ingested state):
+  - **VcfLogsConnector** `vrli-rest-9.0` — session-token auth +
+    401-retry-once (G3.6-T4,
+    [#887](https://github.com/evoila/meho/issues/887)); ops via the vRLI
+    read core (#834).
+  - **VcfFleetConnector** — HTTP Basic (`admin@local`, no SSO) +
+    wrapper-verified probe (G3.6-T7,
+    [#886](https://github.com/evoila/meho/issues/886)); ops via #890.
+  - **VcfAutomationConnector** — dual-plane auth + vhost routing
+    (G3.6-T10, [#885](https://github.com/evoila/meho/issues/885)); ops
+    via #892.
+- **Shared `connectors/_shared/vcf_auth.py` substrate + recorded-fixture
+  refresh tool** (G3.6-T13 [#841](https://github.com/evoila/meho/issues/841)
+  / #884) — common Basic / session auth scaffolding, auth-model
+  predicate, credentials cache, and Vault loader stub shared across the
+  VCF connector skeletons, plus the tool that refreshes the recorded
+  HTTP fixtures the connector E2E suites replay.
+- **Operator CLI alias verbs for three more connectors** — pure
+  Cobra-over-HTTP wrappers that pre-bake the `connector_id` and POST to
+  `/api/v1/operations/call` (the same dispatcher route the agent uses;
+  vendor logic stays out of the CLI per CLAUDE.md postulate 5), each
+  with a recorded-fixture E2E and an onboarding doc:
+  - **`meho vrli`** over the vRLI read core (G3.6-T6,
+    [#896](https://github.com/evoila/meho/issues/896)).
+  - **`meho fleet`** over the Fleet read core (G3.6-T9,
+    [#894](https://github.com/evoila/meho/issues/894)).
+  - **`meho vcf-automation`** over the VCFA dual-plane core, with
+    `--fqdn` plane selection (G3.6-T12,
+    [#895](https://github.com/evoila/meho/issues/895)).
+- **`meho harbor` operator CLI alias verbs** over the `harbor-rest-2.x`
+  op surface, with container E2E + onboarding doc (G3.5-T10
+  [#622](https://github.com/evoila/meho/issues/622) / #768).
+- **Memory promotion** — `POST /api/v1/memory/{scope}/{slug}/promote`
+  (idempotent) + the `meho.memory.promote` admin meta-tool (G5.2-T4
+  [#626](https://github.com/evoila/meho/issues/626) / #764), and the
+  `meho promote` CLI verb with exit-code mapping + E2E smoke (G5.2-T5
+  [#627](https://github.com/evoila/meho/issues/627) / #784).
 
 ### Changed
 
@@ -252,20 +338,6 @@ connector-related release-notes line.
 
 ### Fixed
 
-- MCP `tools/list` no longer publishes a top-level `oneOf` / `allOf` /
-  `anyOf` in any tool's `inputSchema`. The Anthropic Messages API
-  rejects a top-level JSON-Schema combinator in a tool's `input_schema`
-  (`400 ... input_schema does not support oneOf, allOf, or anyOf at the
-  top level`), and because it validates the whole `tools` array a single
-  offender 400'd *every* call in a Claude Code session with the MEHO MCP
-  server connected. `query_topology` (top-level `allOf` for its per-`kind`
-  conditional requireds) and `meho.topology.unannotate` (top-level
-  `oneOf` for its XOR selector) both tripped it. `ToolDefinition.to_wire`
-  now strips top-level combinators from the published copy while the full
-  schema stays on `inputSchema`, so server-side jsonschema validation
-  (the `-32602` rejections for bad argument shapes) is unchanged. Found
-  dogfooding from `claude-rdc-hetzner-dc` after its static `.mcp.json`
-  wire-up. (#905)
 - `search_memory` now returns real `created_at` / `updated_at` for
   each hit instead of the `1970-01-01T00:00:00Z` epoch placeholder
   that v0.3.1 surfaced. The retrieval substrate's `RetrievalHit`
@@ -311,6 +383,42 @@ connector-related release-notes line.
   G0.9.1-T9 under [#772](https://github.com/evoila/meho/issues/772)).
   Auto-provisioning the public client at install time is tracked under
   [#791](https://github.com/evoila/meho/issues/791) (T11).
+- Backfill curated per-group `when_to_use` text onto existing
+  `operation_group` rows on upgrade (Alembic `0011`), closing the
+  Signal #5 gap where #731/#732's curation never replaced the
+  v0.3.0-era auto-derived templates already written to the DB. The
+  migration rewrites only rows still holding the template prefix —
+  operator edits via `meho.connector.edit_group` and tenant-scoped rows
+  are preserved — and is idempotent; Harbor's placeholder group text is
+  curated in the same pass. Signal #5 (refined: backfill-on-upgrade,
+  not curate-existing) ([#774](https://github.com/evoila/meho/issues/774)
+  / #783).
+- MCP `add_to_memory` now injects the default user-scope TTL when `ttl`
+  is omitted, matching the REST path — a shared resolver distinguishes
+  "omitted" (apply `MEMORY_USER_DEFAULT_TTL_DAYS`) from explicit
+  `ttl: null` (the `--persist` opt-out, persist forever). The v0.3.1 MCP
+  path silently bypassed the default and stored `expires_at = null`.
+  Signal #10 ([#775](https://github.com/evoila/meho/issues/775) / #781).
+- The token validator returns a specific code at the decode stage —
+  `invalid_audience` / `invalid_issuer` / `missing_sub` /
+  `token_expired` / `signature_verification_failed` / … — instead of a
+  bare `invalid_token`, so a deployer sees which claim failed. Per
+  RFC 6750 the response body stays terse and the full
+  expected-vs-received diagnostic goes to the structured log. Addendum II
+  Ask #1 (Walls #2/#3) ([#797](https://github.com/evoila/meho/issues/797)
+  / #842).
+- `meho login`'s device-code poll no longer dies with `context deadline
+  exceeded` under wrapped / non-interactive invocation (CI, an agent's
+  shell tool): the device-flow wait is detached from the ambient parent
+  context and bounded by its own deadline matching Keycloak's device-code
+  TTL. Addendum II Wall #4
+  ([#798](https://github.com/evoila/meho/issues/798) / #821).
+- `meho login` on macOS now falls back to the `0600` credentials file
+  store when the system keyring rejects the token bundle with a size
+  error (`go-keyring` hitting the legacy `kSecValueData` ~4 KB limit),
+  instead of failing the whole login; `MEHO_KEYRING_DISABLE` is now
+  surfaced in `--help` to force the file store. Addendum II Wall #5
+  ([#876](https://github.com/evoila/meho/issues/876)).
 
 ### Documentation
 
@@ -367,6 +475,21 @@ connector-related release-notes line.
   [#797](https://github.com/evoila/meho/issues/797) (T12); the
   `meho login` device-flow deadline fix is
   [#798](https://github.com/evoila/meho/issues/798) (T13).
+
+### Performance (internal — CI / test-suite, no operator-facing change)
+
+- Unit-job CI time brought back under budget as the G3.6 op count grew:
+  skip the per-test typed-descriptor re-embed in the unit suite
+  ([#771](https://github.com/evoila/meho/issues/771) / #799),
+  session-scope the fastembed model cache dir to kill per-test model
+  re-fetch (#786), amortize per-test DB schema via a per-worker template
+  (#898), run `python-lint-test` on `meho-runners-ci-heavy` at `-n 6`
+  ([#761](https://github.com/evoila/meho/issues/761) / #765), and restore
+  `--cov` on PRs while lowering the job timeout 50→20 min (#814). An
+  opt-in real-embedding guard + CI-perf timing instrumentation (#827)
+  backs the measurement.
+- Test correctness: the G8.1 audit acceptance test asserts `422` for a
+  body-level `tenant_id` (the `extra="forbid"` contract) (#767).
 
 ## [0.3.1] - 2026-05-21
 


### PR DESCRIPTION
## What

Roll the CHANGELOG `[Unreleased]` section into `## [0.5.0] - 2026-05-22` and backfill the bullets that were never written.

## Why

`v0.5.0` was tagged (the project jumped `v0.3.1 → v0.5.0`) **without rolling the changelog**. As a result:

- the `[Unreleased]` bullets were never moved under a versioned heading, so `cli-release.yml`'s notes extraction had nothing to publish for `v0.5.0` — the GitHub release body omits the work; and
- **~24 PRs that shipped in `v0.5.0` had no bullet at all** (most of the G3.6 VCF connector wave, G5.2 memory promote, harbor CLI, several G0.9.1 auth/dogfood fixes, and all the CI-perf work).

This PR fixes the `v0.5.0` record. The systemic cause — no enforced "roll the changelog in the release-cutting PR" step — is being addressed separately by a `docs/RELEASING.md` runbook + a `/release` skill.

## What's in `[0.5.0]` now

- **Rolled** (was already in `[Unreleased]`): `add_to_memory content→body` breaking change; vROps/vRLI cores + `meho vcf-operations` CLI + VcfOperations skeleton; `bootstrap-clients`; `topology.create_node`; schema symmetry; search_memory / ingest / connector-reconcile / auth-config fixes; target-shape + slug + auth-onramp docs.
- **Backfilled (newly authored):**
  - **Added** — Fleet (#890) & VCFA (#892) cores (*dispatch + catalog*, loader wiring under #214); the three skeletons #885/#886/#887 (*registered, no dispatchable ops yet*); shared `vcf_auth` (#884); `meho vrli`/`fleet`/`vcf-automation` CLI verbs (#896/#894/#895); `meho harbor` CLI (#768); G5.2 memory-promote (#764/#784).
  - **Fixed** — the five that had no own bullet: when_to_use backfill / Alembic 0011 (#774), MCP default-TTL (#781), token-validator codes (#797), device-flow deadline (#798), macOS keyring fallback (#876).
  - **Performance** — new section folding the CI-perf PRs (#771/#786/#898/#761/#814/#827) + the audit test fix (#767).

## Judgment calls to eyeball

1. **Connector ship-states** applied per [`docs/codebase/connector-release-readiness.md`](docs/codebase/connector-release-readiness.md): Fleet/VCFA cores = *dispatch + catalog* (not production; loader under #214); the three skeletons = *registered, no dispatchable ops yet*.
2. **`### Performance (internal …)`** is a non-standard (non-Keep-a-Changelog) category; included for completeness, flagged as not operator-facing.
3. **CI-perf PRs grouped into 2 bullets** rather than one-per-PR (all PR numbers preserved for traceability).

## Scope notes

- The post-`v0.5.0` `#910` MCP top-level-combinator fix stays in `[Unreleased]` (it's not in the `v0.5.0` tag).
- **Still undocumented:** six other post-`v0.5.0` commits (G10.0 UI #897/#903, G9.3 topology history #900/#904, CI #770/#899) have no `[Unreleased]` bullet yet. Out of scope here; the next release-cut (following the new runbook) should backfill them.

Purely additive to released history; no operator-facing behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved MCP tool schema validation errors preventing API calls
  * Fixed authentication client discovery and login behavior
  * Improved macOS keyring handling
  * Corrected memory search and error handling

* **New Features**
  * Added VCF (vCloud Foundation) capabilities and new connectors
  * Introduced Fleet and Automation spec integration
  * Expanded operator CLI support for additional connectors
  * Added memory promotion endpoints and CLI commands

* **Performance**
  * Reduced CI and test suite execution time

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/913?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->