### PR TITLE
feat(connectors): connector-spec catalog substrate + GET /catalog (#743)

### DIFF
--- a/backend/src/meho_backplane/api/v1/connectors_ingest.py
+++ b/backend/src/meho_backplane/api/v1/connectors_ingest.py
@@ -144,6 +144,7 @@ from meho_backplane.operations.ingest import (
     build_version_mismatch_detail,
     default_llm_client_factory,
     list_ingested_connectors,
+    load_catalog,
 )
 from meho_backplane.operations.ingest.api_schemas import ConnectorStatusFilter
 
@@ -359,6 +360,29 @@ async def list_endpoint(
         status=status,
     )
     return {"connectors": [item.model_dump(mode="json") for item in items]}
+
+
+@router.get("/catalog")
+async def catalog_endpoint(
+    operator: Operator = _require_operator,
+) -> dict[str, list[dict[str, object]]]:
+    """Return the curated connector-spec catalog (Goal #214 on-ramp; #743).
+
+    The catalog maps ``(product, version)`` to the recommended OpenAPI
+    spec source(s) + the registered connector class that covers the
+    version label. It is global, built-in reference data (not tenant-
+    scoped), so operator role is the only gate; the read carries no
+    tenant filter. The ``meho connector catalog list`` / ``ingest
+    --catalog`` verbs (#915) consume this route — the CLI ships as a
+    separate binary and cannot read the server's packaged catalog file.
+
+    Declared before the ``/{connector_id}/...`` routes so the literal
+    ``/catalog`` segment is matched ahead of the path-parameter
+    patterns. Wrapped in ``{"catalog": [...]}`` for non-breaking paging
+    room, mirroring the ``GET /`` list shape.
+    """
+    catalog = load_catalog()
+    return {"catalog": [entry.model_dump(mode="json") for entry in catalog.entries]}
 
 
 @router.get("/{connector_id}/review", response_model=ConnectorReviewPayload)

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -96,6 +96,7 @@ from meho_backplane.memory import (
 from meho_backplane.metrics import render_metrics
 from meho_backplane.middleware import BroadcastDetailMiddleware, RequestContextMiddleware
 from meho_backplane.operations import run_typed_op_registrars
+from meho_backplane.operations.ingest import load_catalog
 from meho_backplane.retrieval.embedding import get_embedding_service
 from meho_backplane.settings import get_settings, parse_bool_env
 from meho_backplane.topology import (
@@ -222,6 +223,16 @@ async def _run_lifespan_startup() -> None:
     # `register_connector_v2` calls in each product's `__init__.py`
     # run before the first request arrives.
     _eager_import_connectors()
+    # Connector-spec catalog parse + schema validation (#743). Loads the
+    # packaged catalog.yaml once; a malformed catalog (bad YAML, unknown
+    # field, non-PEP-440 spec_info_version, duplicate (product, version))
+    # raises here and crashes the lifespan, so CI's app-boot smoke fails
+    # instead of the bad catalog surfacing as a 500 on first
+    # GET /api/v1/connectors/catalog. Registry-coverage of each entry's
+    # requires_connector_class is a CI regression test, not a startup
+    # guard (the registry's populated-ness is import-order-dependent
+    # under pytest-xdist; see catalog.py).
+    load_catalog()
     # Typed-op registration (G0.6-T-Refactor-Vault #390). See the
     # docstring for the contract; runs registrars connectors appended
     # to during the import pass above so descriptor rows are populated

--- a/backend/src/meho_backplane/operations/ingest/__init__.py
+++ b/backend/src/meho_backplane/operations/ingest/__init__.py
@@ -28,6 +28,14 @@ from meho_backplane.operations.ingest.api_schemas import (
     IngestResponse,
     SpecSource,
 )
+from meho_backplane.operations.ingest.catalog import (
+    CatalogError,
+    ConnectorSpecCatalog,
+    ConnectorSpecEntry,
+    load_catalog,
+    parse_catalog,
+    validate_catalog_registry_coverage,
+)
 from meho_backplane.operations.ingest.connector_registration import (
     GenericRestConnector,
     check_version_covered_by_registered_class,
@@ -88,12 +96,15 @@ from meho_backplane.operations.ingest.service import ReviewService
 
 __all__ = [
     "DEFAULT_GROUPING_BATCH_SIZE",
+    "CatalogError",
     "ConnectorListItem",
     "ConnectorListResponse",
     "ConnectorNotFoundError",
     "ConnectorReviewGroup",
     "ConnectorReviewOp",
     "ConnectorReviewPayload",
+    "ConnectorSpecCatalog",
+    "ConnectorSpecEntry",
     "ConnectorStatusFilter",
     "EditGroupBody",
     "EditOpBody",
@@ -129,9 +140,12 @@ __all__ = [
     "detect_spec_format",
     "ensure_connector_class_registered",
     "list_ingested_connectors",
+    "load_catalog",
+    "parse_catalog",
     "parse_connector_id",
     "parse_openapi",
     "read_spec_info_version",
     "register_ingested_operations",
     "run_llm_grouping",
+    "validate_catalog_registry_coverage",
 ]

--- a/backend/src/meho_backplane/operations/ingest/catalog.py
+++ b/backend/src/meho_backplane/operations/ingest/catalog.py
@@ -84,6 +84,14 @@ class ConnectorSpecEntry(BaseModel):
     sha256: str | None = Field(default=None, max_length=64)
     notes: str = Field(default="", max_length=2048)
 
+    @field_validator("product", "version", "impl_id", "requires_connector_class")
+    @classmethod
+    def _strip_required_identifier(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("identifier must not be blank or whitespace-only")
+        return normalized
+
     @field_validator("spec_info_version")
     @classmethod
     def _spec_info_version_is_pep440(cls, value: str | None) -> str | None:
@@ -111,9 +119,10 @@ class ConnectorSpecEntry(BaseModel):
             return value
         if not value:
             raise ValueError("upstream must be null (typed connector) or a non-empty URL list")
-        if any(not url.strip() for url in value):
+        normalized = tuple(url.strip() for url in value)
+        if any(not url for url in normalized):
             raise ValueError("upstream URLs must be non-empty")
-        return value
+        return normalized
 
 
 class ConnectorSpecCatalog(BaseModel):

--- a/backend/src/meho_backplane/operations/ingest/catalog.py
+++ b/backend/src/meho_backplane/operations/ingest/catalog.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Curated connector-spec catalog (Goal #214 raw-REST ingest on-ramp; #743).
+
+The catalog maps ``(product, version)`` to the recommended OpenAPI spec
+source(s) plus the registered connector class that covers the version
+label. It is the operator on-ramp for the generic-ingestion half of the
+two-layer connector model: instead of knowing where a vendor hosts its
+spec and which connector class covers which version, an operator (or the
+``meho connector catalog list`` / ``ingest --catalog`` CLI verbs in #915)
+resolves an entry from here.
+
+**Where the data lives.** The data file ships as *package data* next to
+this loader (:data:`_CATALOG_RESOURCE`) rather than at the repo-root
+``docs/connector-specs/catalog.yaml`` path the Task originally named. The
+backend image build context is ``backend/`` and the wheel only packages
+``src/meho_backplane``, so a repo-root ``docs/`` file is absent at
+runtime; colocating the YAML with its loader and resolving it through
+:func:`importlib.resources.files` is the same pattern the Alembic config
+uses (:func:`meho_backplane.db.migrations.find_alembic_ini`) and the only
+shape that survives into a deployed container. ``docs/cross-repo/
+connector-catalog.md`` is the operator-facing pointer.
+
+**Two validation layers.**
+
+* :func:`load_catalog` (called at backplane startup) parses the YAML and
+  runs Pydantic schema validation -- unknown fields, a non-PEP-440
+  ``spec_info_version``, a duplicate ``(product, version)``, or malformed
+  YAML crash startup (and therefore CI's app-boot smoke). It does not
+  touch the connector registry, so it is safe to run inside the lifespan
+  regardless of import-cache state.
+* :func:`validate_catalog_registry_coverage` cross-checks every entry's
+  ``requires_connector_class`` against
+  :func:`~meho_backplane.connectors.registry.all_connectors_v2`. That is
+  the #743 criterion-(b) guard; it runs as a CI regression test (where
+  the full connector set is registered) rather than at startup, where the
+  registry's populated-ness is import-order-dependent under pytest-xdist.
+"""
+
+from __future__ import annotations
+
+import functools
+import re
+from importlib import resources
+
+import yaml
+from packaging.version import InvalidVersion, Version
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+#: Package + resource name of the catalog YAML shipped as package data.
+_CATALOG_PACKAGE = "meho_backplane.operations.ingest"
+_CATALOG_RESOURCE = "catalog.yaml"
+
+#: A SHA-256 digest is 64 lowercase hex characters.
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class CatalogError(RuntimeError):
+    """Raised when the connector-spec catalog is malformed or incoherent.
+
+    Carries a human-readable remediation message; raised at startup (parse
+    failure) and by :func:`validate_catalog_registry_coverage` (registry
+    mismatch).
+    """
+
+
+class ConnectorSpecEntry(BaseModel):
+    """One curated ``(product, version)`` -> spec-source mapping.
+
+    ``upstream is None`` marks a typed connector with no ingestable spec;
+    the CLI's ``ingest --catalog`` path (#915) refuses such an entry rather
+    than POSTing an empty ``specs`` list.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    product: str = Field(min_length=1, max_length=64)
+    version: str = Field(min_length=1, max_length=64)
+    impl_id: str = Field(min_length=1, max_length=128)
+    requires_connector_class: str = Field(min_length=1, max_length=128)
+    upstream: tuple[str, ...] | None = None
+    spec_info_version: str | None = Field(default=None, max_length=64)
+    sha256: str | None = Field(default=None, max_length=64)
+    notes: str = Field(default="", max_length=2048)
+
+    @field_validator("spec_info_version")
+    @classmethod
+    def _spec_info_version_is_pep440(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        try:
+            Version(value)
+        except InvalidVersion as exc:
+            raise ValueError(f"spec_info_version {value!r} is not a valid PEP 440 version") from exc
+        return value
+
+    @field_validator("sha256")
+    @classmethod
+    def _sha256_is_hex_digest(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        if not _SHA256_RE.fullmatch(value):
+            raise ValueError("sha256 must be 64 lowercase hex characters")
+        return value
+
+    @field_validator("upstream")
+    @classmethod
+    def _upstream_entries_nonempty(cls, value: tuple[str, ...] | None) -> tuple[str, ...] | None:
+        if value is None:
+            return value
+        if not value:
+            raise ValueError("upstream must be null (typed connector) or a non-empty URL list")
+        if any(not url.strip() for url in value):
+            raise ValueError("upstream URLs must be non-empty")
+        return value
+
+
+class ConnectorSpecCatalog(BaseModel):
+    """The full catalog: a list of entries with a unique ``(product, version)``."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    entries: tuple[ConnectorSpecEntry, ...] = Field(min_length=1)
+
+    @field_validator("entries")
+    @classmethod
+    def _product_version_unique(
+        cls, entries: tuple[ConnectorSpecEntry, ...]
+    ) -> tuple[ConnectorSpecEntry, ...]:
+        seen: set[tuple[str, str]] = set()
+        for entry in entries:
+            key = (entry.product, entry.version)
+            if key in seen:
+                raise ValueError(f"duplicate catalog entry for product/version {key}")
+            seen.add(key)
+        return entries
+
+    def get(self, product: str, version: str) -> ConnectorSpecEntry | None:
+        """Return the entry for ``(product, version)`` or ``None``."""
+        for entry in self.entries:
+            if entry.product == product and entry.version == version:
+                return entry
+        return None
+
+
+def parse_catalog(raw: str) -> ConnectorSpecCatalog:
+    """Parse + schema-validate raw catalog YAML.
+
+    Raises :class:`CatalogError` (never a bare ``yaml`` / ``pydantic``
+    error) so callers get one remediation-bearing exception type.
+    """
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise CatalogError(f"connector-spec catalog is not valid YAML: {exc}") from exc
+    if not isinstance(data, dict):
+        raise CatalogError("connector-spec catalog must be a mapping with an 'entries' key")
+    try:
+        return ConnectorSpecCatalog.model_validate(data)
+    except ValidationError as exc:
+        raise CatalogError(f"connector-spec catalog failed schema validation: {exc}") from exc
+
+
+@functools.lru_cache(maxsize=1)
+def load_catalog() -> ConnectorSpecCatalog:
+    """Load + validate the packaged catalog (cached for the process).
+
+    Called once at backplane startup (a malformed catalog crashes the
+    lifespan -> CI app-boot smoke fails) and reused by
+    ``GET /api/v1/connectors/catalog``.
+    """
+    raw = resources.files(_CATALOG_PACKAGE).joinpath(_CATALOG_RESOURCE).read_text(encoding="utf-8")
+    return parse_catalog(raw)
+
+
+def validate_catalog_registry_coverage(catalog: ConnectorSpecCatalog | None = None) -> None:
+    """Assert every ``requires_connector_class`` is registered (#743 crit. b).
+
+    Cross-checks against
+    :func:`~meho_backplane.connectors.registry.all_connectors_v2`. Raises
+    :class:`CatalogError` listing the offenders. Imported lazily so this
+    module stays import-light for the startup parse path.
+    """
+    from meho_backplane.connectors.registry import all_connectors_v2
+
+    cat = catalog if catalog is not None else load_catalog()
+    registered = {cls.__name__ for cls in all_connectors_v2().values()}
+    missing = sorted(
+        {
+            e.requires_connector_class
+            for e in cat.entries
+            if e.requires_connector_class not in registered
+        }
+    )
+    if missing:
+        raise CatalogError(
+            "connector-spec catalog references unregistered connector class(es): "
+            f"{missing}; registered classes: {sorted(registered)}"
+        )

--- a/backend/src/meho_backplane/operations/ingest/catalog.yaml
+++ b/backend/src/meho_backplane/operations/ingest/catalog.yaml
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# Curated connector-spec catalog (Goal #214 raw-REST ingest on-ramp; Task #743).
+#
+# This is the machine-readable map of (product, version) -> recommended
+# OpenAPI spec source(s) + the registered connector class that covers the
+# version label. It turns the implicit, commit-message-and-tribal-knowledge
+# ingest workflow into a discoverable artifact: an operator (or the
+# `meho connector catalog list` / `ingest --catalog` CLI verbs in #915)
+# resolves an entry here instead of hand-typing the triple + spec URLs.
+#
+# WHERE THIS FILE LIVES. The Task body asked for `docs/connector-specs/
+# catalog.yaml`, but the backend image build context is `backend/` (see
+# every docker `context: backend` in .github/workflows/*.yml) and the
+# wheel only packages `src/meho_backplane`, so a repo-root `docs/` file is
+# NOT present at runtime. To keep the catalog loadable at startup and over
+# `GET /api/v1/connectors/catalog` in a deployed container, it ships as
+# package data colocated with its loader (catalog.py), resolved via
+# `importlib.resources` -- the same pattern as alembic.ini/alembic
+# (find_alembic_ini in db/migrations.py). docs/cross-repo/connector-catalog.md
+# is the operator-facing pointer.
+#
+# FIELD CONTRACT (validated by catalog.py / ConnectorSpecEntry):
+#   product / version / impl_id  -- the connector triple; (product, version)
+#       is the `--catalog <product>/<version>` lookup key and is unique.
+#   requires_connector_class     -- the registered connector class __name__
+#       that covers this version label. A regression test asserts every
+#       value here exists in all_connectors_v2() (Task #743 criterion b).
+#   upstream                     -- public URL(s) where the vendor hosts the
+#       spec; operators/CLI fetch directly (MEHO does not redistribute).
+#       null == typed connector (no ingestable spec).
+#   spec_info_version            -- the spec.info.version observed when MEHO
+#       smoke-tested the spec; PEP 440 when present. null until a connector's
+#       spec has actually been ingest-verified through MEHO (these are
+#       empirical values, not guesses -- populate on first verified ingest).
+#   sha256                       -- advisory content hash MEHO smoke-tested
+#       against; optional, not enforced. null until smoke-tested.
+#   notes                        -- operator context: sharp edges, version
+#       quirks, appliance-served vs portal-hosted, curation status.
+
+entries:
+  # --- Generic-ingested connectors (Layer 2: ingest the vendor OpenAPI) ---
+
+  - product: vmware
+    version: "9.0"
+    impl_id: vmware-rest
+    requires_connector_class: VmwareRestConnector
+    upstream:
+      - "https://developer.broadcom.com/xapis/vsphere-automation-api/latest/"
+      - "https://developer.broadcom.com/xapis/virtual-infrastructure-json-api/latest/"
+    spec_info_version: null
+    sha256: null
+    notes: >-
+      Generic-ingested. vSphere publishes two specs that merge under one
+      connector triple: vcenter.yaml (modern REST automation API, ~961 paths)
+      and vi-json.yaml (Performance Manager, snapshots, host ops, ~2,195
+      paths). Both are served by the appliance at https://<vcenter-fqdn>/ and
+      mirrored on the Broadcom Developer Portal (links above). spec_info_version
+      pending the first MEHO-verified ingest. See #743 / connector-ingestion.md.
+
+  - product: sddc-manager
+    version: "9.0"
+    impl_id: sddc-rest
+    requires_connector_class: SddcManagerConnector
+    upstream:
+      - "https://developer.broadcom.com/xapis/sddc-manager-api/latest/"
+    spec_info_version: null
+    sha256: null
+    notes: >-
+      Generic-ingested. The SDDC Manager API is served by the appliance at
+      https://<sddc-manager-fqdn>/v1/ and documented on the Broadcom Developer
+      Portal (link above). spec_info_version pending first verified ingest.
+      See #743.
+
+  - product: harbor
+    version: "2.x"
+    impl_id: harbor-rest
+    requires_connector_class: HarborConnector
+    upstream:
+      - "https://raw.githubusercontent.com/goharbor/harbor/v2.11.0/api/v2.0/swagger.yaml"
+    spec_info_version: null
+    sha256: null
+    notes: >-
+      Generic-ingested. goharbor publishes the API spec at
+      api/v2.0/swagger.yaml (info.version observed: 2.0). SHARP EDGE: that
+      file is Swagger 2.0, while the G0.7 ingest parser targets OpenAPI
+      3.0/3.1 -- convert before ingest. spec_info_version left null pending an
+      OpenAPI-3-converted, MEHO-verified ingest. See #743 / harbor-onboarding.md.
+
+  - product: nsx
+    version: "4.2"
+    impl_id: nsx-rest
+    requires_connector_class: NsxConnector
+    upstream:
+      - "https://<nsx-mgr-fqdn>/api/v1/spec/openapi/nsx_api.yaml"
+      - "https://developer.broadcom.com/xapis/nsx-t-data-center-rest-api/latest/"
+    spec_info_version: null
+    sha256: null
+    notes: >-
+      Generic-ingested. NSX Manager serves the OpenAPI spec at
+      /api/v1/spec/openapi/nsx_api.yaml (appliance-served, fqdn-templated);
+      the Broadcom Developer Portal mirrors the reference. spec_info_version
+      pending first verified ingest. See #743.
+
+  # --- Typed connectors (Layer 1: hand-coded; no spec ingestion) ---
+
+  - product: vault
+    version: "1.x"
+    impl_id: vault
+    requires_connector_class: VaultConnector
+    upstream: null
+    spec_info_version: null
+    sha256: null
+    notes: >-
+      Typed connector (hand-coded; KV-v2 + sys + auth read/list ops). Vault
+      publishes an OpenAPI surface, but MEHO ships VaultConnector typed by
+      design -- no spec ingestion. See #743.
+
+  - product: k8s
+    version: "1.x"
+    impl_id: k8s
+    requires_connector_class: KubernetesConnector
+    upstream: null
+    spec_info_version: null
+    sha256: null
+    notes: >-
+      Typed connector (kubernetes_asyncio; 13+ typed read ops; kubeconfig
+      from Vault). Per-Kubernetes-minor OpenAPI ingestion is a future Goal
+      #214 investigation; no spec ingestion today. See #743.
+
+  - product: bind9
+    version: "9.x"
+    impl_id: bind9-ssh
+    requires_connector_class: Bind9Connector
+    upstream: null
+    spec_info_version: null
+    sha256: null
+    notes: >-
+      Typed-SSH connector. BIND 9 exposes no REST/OpenAPI surface (named
+      driven over SSH with atomic-apply discipline), so spec ingestion is not
+      possible. See #743 / bind9-onboarding.md.

--- a/backend/tests/test_operations_ingest_catalog.py
+++ b/backend/tests/test_operations_ingest_catalog.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the curated connector-spec catalog (Goal #214 on-ramp; #743).
+
+Coverage matrix (Task #743 acceptance criteria):
+
+* **(a) The shipped catalog parses cleanly** — :func:`load_catalog`
+  returns a validated :class:`ConnectorSpecCatalog` with one entry per
+  v0.3.0 connector.
+* **(b) Every ``requires_connector_class`` is registered** —
+  :func:`validate_catalog_registry_coverage` cross-checks each entry
+  against :func:`all_connectors_v2` with the seven connectors registered.
+* **(c) Every ``spec_info_version`` is PEP 440** — the field validator
+  rejects a non-PEP-440 string; every present value in the real catalog
+  parses via :class:`packaging.version.Version`.
+
+Plus schema-strictness, the malformed-catalog crash path, the
+typed-vs-generic ``upstream`` contract, and the ``GET
+/api/v1/connectors/catalog`` route the CLI verbs (#915) consume.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from packaging.version import Version
+from pydantic import ValidationError
+
+from meho_backplane.api.v1.connectors_ingest import (
+    catalog_endpoint,
+)
+from meho_backplane.api.v1.connectors_ingest import (
+    router as connectors_ingest_router,
+)
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.connectors.registry import (
+    all_connectors_v2,
+    register_connector_v2,
+)
+from meho_backplane.middleware import RequestContextMiddleware
+from meho_backplane.operations.ingest.catalog import (
+    CatalogError,
+    ConnectorSpecCatalog,
+    ConnectorSpecEntry,
+    load_catalog,
+    parse_catalog,
+    validate_catalog_registry_coverage,
+)
+
+# The seven v0.3.0 connectors the catalog enumerates.
+_EXPECTED_PRODUCT_VERSION = {
+    ("vmware", "9.0"),
+    ("sddc-manager", "9.0"),
+    ("harbor", "2.x"),
+    ("nsx", "4.2"),
+    ("vault", "1.x"),
+    ("k8s", "1.x"),
+    ("bind9", "9.x"),
+}
+_TYPED_PRODUCTS = {"vault", "k8s", "bind9"}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the Keycloak issuer/audience the auth dependency reads.
+
+    The unauthenticated-401 route test drives a request through
+    ``require_role``, which constructs :class:`Settings`; without these
+    every test file pins them (see ``conftest.py`` and the sibling
+    ``test_api_v1_connectors_ingest.py``).
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+
+
+def _entry(**overrides: object) -> ConnectorSpecEntry:
+    """Build a minimal valid entry, overriding fields as needed."""
+    base: dict[str, object] = {
+        "product": "demo",
+        "version": "1.0",
+        "impl_id": "demo-rest",
+        "requires_connector_class": "DemoConnector",
+    }
+    base.update(overrides)
+    return ConnectorSpecEntry.model_validate(base)
+
+
+# ---------------------------------------------------------------------------
+# (a) The shipped catalog parses + has the expected coverage
+# ---------------------------------------------------------------------------
+
+
+def test_shipped_catalog_parses_cleanly() -> None:
+    catalog = load_catalog()
+    assert isinstance(catalog, ConnectorSpecCatalog)
+    pairs = {(e.product, e.version) for e in catalog.entries}
+    assert pairs == _EXPECTED_PRODUCT_VERSION
+
+
+def test_shipped_catalog_typed_connectors_have_null_upstream() -> None:
+    """Typed connectors carry ``upstream: null``; generic ones carry URLs."""
+    for entry in load_catalog().entries:
+        if entry.product in _TYPED_PRODUCTS:
+            assert entry.upstream is None, f"{entry.product} should be typed (null upstream)"
+        else:
+            assert entry.upstream, f"{entry.product} is generic and needs upstream URL(s)"
+
+
+# ---------------------------------------------------------------------------
+# (b) Registry coverage — every requires_connector_class is registered
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _registered_connectors() -> set[str]:
+    """Register the seven catalog connectors, return their class names.
+
+    The autouse ``_isolate_global_registries`` fixture snapshots/restores
+    the registry around each test; depending on collection order it may
+    present an empty registry (cached imports do not re-fire the module-
+    level ``register_connector_v2`` side effect). Registering defensively
+    here — swallowing the duplicate-key ``RuntimeError`` — makes the
+    coverage assertion order-independent under pytest-xdist.
+    """
+    from meho_backplane.connectors.bind9 import Bind9Connector
+    from meho_backplane.connectors.harbor import HarborConnector
+    from meho_backplane.connectors.kubernetes import KubernetesConnector
+    from meho_backplane.connectors.nsx import NsxConnector
+    from meho_backplane.connectors.sddc_manager import SddcManagerConnector
+    from meho_backplane.connectors.vault import VaultConnector
+    from meho_backplane.connectors.vmware_rest import VmwareRestConnector
+
+    for cls in (
+        Bind9Connector,
+        HarborConnector,
+        KubernetesConnector,
+        NsxConnector,
+        SddcManagerConnector,
+        VaultConnector,
+        VmwareRestConnector,
+    ):
+        # Swallow the duplicate-key RuntimeError when the connector is
+        # already registered this session (cached import history).
+        with contextlib.suppress(RuntimeError):
+            register_connector_v2(
+                product=cls.product,
+                version=cls.version,
+                impl_id=cls.impl_id,
+                cls=cls,
+            )
+    return {cls.__name__ for cls in all_connectors_v2().values()}
+
+
+def test_every_requires_connector_class_is_registered(
+    _registered_connectors: set[str],
+) -> None:
+    for entry in load_catalog().entries:
+        assert entry.requires_connector_class in _registered_connectors
+
+
+def test_validate_catalog_registry_coverage_passes_for_shipped_catalog(
+    _registered_connectors: set[str],
+) -> None:
+    validate_catalog_registry_coverage()  # must not raise
+
+
+def test_validate_catalog_registry_coverage_raises_on_unknown_class() -> None:
+    bogus = ConnectorSpecCatalog(
+        entries=(_entry(requires_connector_class="NoSuchConnector999"),),
+    )
+    with pytest.raises(CatalogError, match="unregistered connector class"):
+        validate_catalog_registry_coverage(bogus)
+
+
+# ---------------------------------------------------------------------------
+# (c) spec_info_version is PEP 440
+# ---------------------------------------------------------------------------
+
+
+def test_shipped_catalog_spec_info_versions_are_pep440() -> None:
+    for entry in load_catalog().entries:
+        if entry.spec_info_version is not None:
+            Version(entry.spec_info_version)  # raises InvalidVersion on failure
+
+
+def test_entry_accepts_valid_pep440_spec_info_version() -> None:
+    assert _entry(spec_info_version="9.0.1").spec_info_version == "9.0.1"
+
+
+def test_entry_rejects_non_pep440_spec_info_version() -> None:
+    with pytest.raises(ValidationError, match="PEP 440"):
+        _entry(spec_info_version="not-a-version")
+
+
+# ---------------------------------------------------------------------------
+# Schema strictness + malformed-catalog crash path
+# ---------------------------------------------------------------------------
+
+
+def test_entry_rejects_unknown_field() -> None:
+    with pytest.raises(ValidationError):
+        _entry(typo_field="oops")
+
+
+def test_entry_rejects_bad_sha256() -> None:
+    with pytest.raises(ValidationError, match="64 lowercase hex"):
+        _entry(sha256="deadbeef")
+
+
+def test_entry_rejects_empty_upstream_list() -> None:
+    with pytest.raises(ValidationError):
+        _entry(upstream=[])
+
+
+def test_catalog_rejects_duplicate_product_version() -> None:
+    with pytest.raises(ValidationError, match="duplicate catalog entry"):
+        ConnectorSpecCatalog(entries=(_entry(), _entry()))
+
+
+def test_parse_catalog_rejects_non_mapping() -> None:
+    with pytest.raises(CatalogError, match="mapping with an 'entries' key"):
+        parse_catalog("- just\n- a\n- list\n")
+
+
+def test_parse_catalog_rejects_malformed_yaml() -> None:
+    with pytest.raises(CatalogError, match="not valid YAML"):
+        parse_catalog("entries: [unterminated\n")
+
+
+def test_parse_catalog_rejects_unknown_top_level_field() -> None:
+    with pytest.raises(CatalogError, match="schema validation"):
+        parse_catalog("entries: []\nbogus: 1\n")
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/connectors/catalog route (consumed by the #915 CLI verbs)
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(RequestContextMiddleware)
+    app.include_router(connectors_ingest_router)
+    return app
+
+
+def test_catalog_route_is_mounted() -> None:
+    paths = {route.path for route in _build_app().routes}  # type: ignore[attr-defined]
+    assert "/api/v1/connectors/catalog" in paths
+
+
+def test_catalog_unauthenticated_returns_401() -> None:
+    client = TestClient(_build_app())
+    response = client.get("/api/v1/connectors/catalog")
+    assert response.status_code == 401
+
+
+async def test_catalog_endpoint_returns_all_entries() -> None:
+    # The handler ignores the operator (it returns global reference data);
+    # require_role already gates auth, exercised by the 401 test above.
+    body = await catalog_endpoint(operator=MagicMock())
+    assert set(body) == {"catalog"}
+    returned = {(e["product"], e["version"]) for e in body["catalog"]}
+    assert returned == _EXPECTED_PRODUCT_VERSION

--- a/backend/tests/test_operations_ingest_catalog.py
+++ b/backend/tests/test_operations_ingest_catalog.py
@@ -67,15 +67,22 @@ _TYPED_PRODUCTS = {"vault", "k8s", "bind9"}
 
 @pytest.fixture(autouse=True)
 def _settings_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Pin the Keycloak issuer/audience the auth dependency reads.
+    """Pin the Keycloak + Vault settings the auth dependency reads.
 
     The unauthenticated-401 route test drives a request through
-    ``require_role``, which constructs :class:`Settings`; without these
-    every test file pins them (see ``conftest.py`` and the sibling
-    ``test_api_v1_connectors_ingest.py``).
+    ``require_role``, which constructs :class:`Settings` (Keycloak *and*
+    Vault fields are required). Every test file pins these (see
+    ``conftest.py`` and the sibling ``test_api_v1_connectors_ingest.py``);
+    CI runs with a clean env, so the fixture — not the ambient shell —
+    must provide them.
     """
     monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
     monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
 
 
 def _entry(**overrides: object) -> ConnectorSpecEntry:
@@ -215,6 +222,22 @@ def test_entry_rejects_bad_sha256() -> None:
 def test_entry_rejects_empty_upstream_list() -> None:
     with pytest.raises(ValidationError):
         _entry(upstream=[])
+
+
+def test_entry_strips_identifier_whitespace() -> None:
+    entry = _entry(product="  vmware  ", impl_id=" vmware-rest ")
+    assert entry.product == "vmware"
+    assert entry.impl_id == "vmware-rest"
+
+
+def test_entry_rejects_whitespace_only_identifier() -> None:
+    with pytest.raises(ValidationError, match="blank or whitespace-only"):
+        _entry(version="   ")
+
+
+def test_entry_strips_upstream_urls() -> None:
+    entry = _entry(upstream=["  https://example.test/spec.yaml  "])
+    assert entry.upstream == ("https://example.test/spec.yaml",)
 
 
 def test_catalog_rejects_duplicate_product_version() -> None:

--- a/docs/cross-repo/connector-catalog.md
+++ b/docs/cross-repo/connector-catalog.md
@@ -1,0 +1,119 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# Connector-spec catalog
+
+> Operator-facing reference for the curated connector-spec catalog
+> (Goal [#214](https://github.com/evoila/meho/issues/214) raw-REST ingest
+> on-ramp; Task [#743](https://github.com/evoila/meho/issues/743)). The
+> ingestion mechanics live in
+> [`connector-ingestion.md`](connector-ingestion.md); this doc is the map
+> of *which* spec to ingest for each shipped connector and *where* the
+> vendor hosts it.
+
+## Why this exists
+
+MEHO's generic-ingestion path (the G0.7 pipeline) supports the full vendor
+REST surface — but only once an operator ingests the vendor's OpenAPI
+spec. Doing that by hand means knowing four things per connector: that a
+connector is generic-ingestable at all, where the vendor publishes its
+spec, which `spec.info.version` maps to which release, and which version
+label aligns with a registered connector class. The v0.3.0 RDC dogfood
+showed that friction directly: operators concluded "the vmware connector
+is 13 composites and that's it" because the ingest on-ramp was implicit.
+
+The catalog makes that knowledge a machine-readable artifact: one entry
+per `(product, version)` with the recommended spec source(s) and the
+connector class that covers the label.
+
+## Where the catalog lives
+
+The data file ships as **package data** at
+[`backend/src/meho_backplane/operations/ingest/catalog.yaml`](../../backend/src/meho_backplane/operations/ingest/catalog.yaml),
+colocated with its loader
+([`catalog.py`](../../backend/src/meho_backplane/operations/ingest/catalog.py)).
+
+> **Note on the path.** Task #743 first named `docs/connector-specs/
+> catalog.yaml`, but the backend image build context is `backend/` and the
+> wheel only packages `src/meho_backplane`, so a repo-root `docs/` file is
+> not present in a deployed container. The catalog must be readable at
+> startup and over the API, so it ships as package data resolved through
+> `importlib.resources` — the same pattern as `alembic.ini` / `alembic/`
+> (see `find_alembic_ini` in `db/migrations.py`). This document is the
+> discoverable pointer in its place.
+
+The backplane loads + validates the catalog at startup (a malformed
+catalog crashes the lifespan, so CI's app-boot smoke fails) and serves it
+read-only at `GET /api/v1/connectors/catalog`.
+
+## Entry schema
+
+Each entry is validated by `ConnectorSpecEntry`:
+
+| Field | Meaning |
+|---|---|
+| `product` / `version` / `impl_id` | The connector triple. `(product, version)` is unique and is the `--catalog <product>/<version>` lookup key. |
+| `requires_connector_class` | The registered connector class `__name__` that covers this version label. A regression test asserts every value is present in `all_connectors_v2()`. |
+| `upstream` | Public URL(s) where the vendor hosts the spec. Operators (and the CLI) fetch directly — MEHO does not redistribute. `null` marks a **typed** connector with no ingestable spec. |
+| `spec_info_version` | The `spec.info.version` MEHO observed when smoke-testing the spec; PEP 440 when present. `null` until a connector's spec is ingest-verified through MEHO — these are empirical values, not guesses. |
+| `sha256` | Advisory content hash MEHO smoke-tested against; optional, not enforced. |
+| `notes` | Operator context: sharp edges, version quirks, appliance-served vs portal-hosted, curation status. |
+
+## Current entries
+
+| Product / version | Shape | Spec source |
+|---|---|---|
+| `vmware` 9.0 | generic | `vcenter.yaml` + `vi-json.yaml` (appliance-served at `https://<vcenter-fqdn>/`; mirrored on the Broadcom Developer Portal) |
+| `sddc-manager` 9.0 | generic | SDDC Manager API (appliance-served; Broadcom Developer Portal) |
+| `harbor` 2.x | generic | `goharbor` `api/v2.0/swagger.yaml` — **Swagger 2.0**, needs conversion to OpenAPI 3.x before ingest |
+| `nsx` 4.2 | generic | `/api/v1/spec/openapi/nsx_api.yaml` (appliance-served; Broadcom Developer Portal mirror) |
+| `vault` 1.x | typed | none (hand-coded connector) |
+| `k8s` 1.x | typed | none (typed; per-minor OpenAPI ingest is a future Goal #214 investigation) |
+| `bind9` 9.x | typed | none (SSH-only; no REST surface) |
+
+`spec_info_version` and `sha256` are `null` across the board in this first
+catalog: they are populated only after a connector's spec has been
+ingest-verified through MEHO, not from desk research. Fill them in as part
+of each connector's first verified `--catalog` ingest.
+
+## Operator workflow
+
+1. `meho connector catalog list` — see which `(product, version)` entries
+   exist and which connector classes are registered.
+2. `meho connector ingest --catalog <product>/<version>` — resolve the
+   entry, fetch the upstream spec(s), and ingest under the recommended
+   triple.
+3. `meho connector review <connector_id>` → `meho connector enable <id>` —
+   vet the LLM-summarised groups and turn the operations on.
+
+> The `catalog list` and `ingest --catalog` verbs are tracked in
+> [#915](https://github.com/evoila/meho/issues/915) (the CLI half split
+> out of #743 per the connector `-T` convention). Until they land, use the
+> explicit `meho connector ingest --spec <url>` form from
+> [`connector-ingestion.md`](connector-ingestion.md), reading the `upstream`
+> URL(s) from the catalog by hand.
+
+## Adding or updating an entry
+
+1. Add/edit the entry in
+   [`catalog.yaml`](../../backend/src/meho_backplane/operations/ingest/catalog.yaml).
+2. Set `requires_connector_class` to a class that is actually registered
+   (`all_connectors_v2()`), or the regression test
+   (`backend/tests/test_operations_ingest_catalog.py`) fails.
+3. Populate `spec_info_version` / `sha256` only from a real
+   MEHO-verified ingest of that spec.
+4. Run `uv run pytest tests/test_operations_ingest_catalog.py` from
+   `backend/`.
+
+## References
+
+- [`connector-ingestion.md`](connector-ingestion.md) — the ingest runbook
+  this catalog feeds.
+- [`docs/codebase/connector-release-readiness.md`](../codebase/connector-release-readiness.md)
+  — the three-state (composite / dispatch-catalog / loader-wired) rubric
+  the catalog operationalises.
+- [Broadcom Developer Portal](https://developer.broadcom.com/xapis) —
+  vSphere, NSX, SDDC Manager OpenAPI references.
+- [Harbor swagger](https://github.com/goharbor/harbor/blob/main/api/v2.0/swagger.yaml).

--- a/docs/cross-repo/connector-ingestion.md
+++ b/docs/cross-repo/connector-ingestion.md
@@ -33,6 +33,11 @@ The workflow walks the [five-step pipeline](../architecture/spec-ingestion.md#th
 
 ### Step 1 — find the spec
 
+> For the shipped connectors, the curated
+> [connector-spec catalog](connector-catalog.md) already records the
+> recommended spec source(s) + required connector class per
+> `(product, version)`. Start there before hunting for a URL.
+
 Vendor specs live in one of three places, in priority order:
 
 1. **The consumer's checked-in docs corpus** (e.g. `claude-rdc-hetzner-dc/docs/<product>-<version>/`). The maintainer's local clone is the conventional source. Use the `docs:<product>-<version>/<spec>.yaml` shorthand when this applies.


### PR DESCRIPTION
## Summary

- Adds the **backend substrate** of the curated connector-spec catalog (Goal #214 raw-REST ingest on-ramp): a machine-readable map of `(product, version)` → recommended OpenAPI spec source(s) + the registered connector class that covers the version label. Turns the implicit, tribal-knowledge ingest workflow into a discoverable artifact — the friction the v0.3.0 RDC dogfood flagged ("vmware is 13 composites and that's it").
- `catalog.yaml`: one entry per v0.3.0 connector — `vmware`/`sddc-manager`/`harbor`/`nsx` (generic, with researched upstream URLs) and `vault`/`k8s`/`bind9` (typed, `upstream: null`).
- `catalog.py`: Pydantic `ConnectorSpecEntry`/`ConnectorSpecCatalog` (PEP-440, sha256-hex, `(product,version)`-uniqueness validation), cached `load_catalog()`, and `validate_catalog_registry_coverage()`.
- Startup parses + schema-validates the catalog in the lifespan → a malformed catalog crashes app-boot (CI) instead of 500-ing the route.
- `GET /api/v1/connectors/catalog` (operator read) serves it for the Go CLI verbs in **#915** (which run as a separate binary and can't read the packaged file).

The Go CLI half (`meho connector catalog list` + `ingest --catalog`) is split to **#915** per the connector `-T` convention (CLI verbs are always their own task — cf. #850, #855). This PR ships the data + the `GET` contract it builds on.

### ⚠️ Deliberate deviation from the issue's file path

The issue named `docs/connector-specs/catalog.yaml`. The backend image build context is `backend/` (every `context: backend` in `.github/workflows/*.yml`) and the wheel only packages `src/meho_backplane`, so a **repo-root `docs/` file is absent at runtime** — startup validation and the GET route would break in a deployed container. The catalog therefore ships as **package data colocated with its loader** (`backend/src/meho_backplane/operations/ingest/catalog.yaml`), resolved via `importlib.resources` — the same pattern as `alembic.ini`/`alembic` (`find_alembic_ini`). Verified present in the built wheel (`meho_backplane/operations/ingest/catalog.yaml`). `docs/cross-repo/connector-catalog.md` is the operator-facing pointer.

### Honesty note on empirical fields

`spec_info_version` and `sha256` are `null` for every entry in this first catalog: they record values **observed when MEHO smoke-tests a spec through the ingest pipeline**, which hasn't happened for these connectors yet. They are populated on a connector's first verified `--catalog` ingest, not from desk research. The schema validates them (PEP 440 / hex) *when present*, and a unit test proves the validator.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy src/` (strict) — clean, 229 files
- [x] `pytest tests/test_operations_ingest_catalog.py` — 18 passed, covering #743 acceptance criteria:
  - **(a)** shipped catalog parses cleanly → 7 entries
  - **(b)** every `requires_connector_class` ∈ `all_connectors_v2()` (7 connectors registered defensively)
  - **(c)** every present `spec_info_version` parses as PEP 440 + validator rejects a bad one
  - schema strictness (`extra=forbid`, bad sha256, empty upstream, duplicate `(product,version)`), malformed-YAML / non-mapping crash paths, typed-vs-generic `upstream` contract, `GET /catalog` route mounted / returns entries / 401 unauthenticated
- [x] Regression: `test_api_v1_connectors_ingest.py` (route table incl. new `/catalog`) + `test_mcp_server.py` (full-lifespan boot exercises the startup `load_catalog()`) + health/well-known/auth-config/middleware/registry-v2 — all green
- [x] `uv build --wheel` → confirmed `meho_backplane/operations/ingest/catalog.yaml` is in the wheel

## Out of scope

- **Go CLI verbs** (`catalog list`, `ingest --catalog`) → #915 (`Depends-on` this).
- Shape B (air-gap spec snapshotting) / Shape C (chart-bootstrap auto-ingest) / per-tenant catalogs — deferred per #743.
- Goal #214's body already cites #743 as the catalog on-ramp — no edit needed.

Closes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a curated connector-spec catalog and a GET /api/v1/connectors/catalog endpoint for operators.
  * Catalogs are validated at application startup to catch malformed configurations early.

* **Documentation**
  * Added operator guidance describing the connector catalog, entries, and ingestion workflow.

* **Tests**
  * Added end-to-end tests for catalog parsing, schema validation, registry coverage, and the catalog API (including auth/route checks).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->