### PR TITLE
ci(sonar): scope tests, wire coverage, document new-code baseline fix

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -3,15 +3,18 @@
 
 # SonarCloud quality gate.
 #
-# Triggers via workflow_run after CI succeeds. Downloads Python coverage
-# from CI's artifacts (when CI starts producing them), then runs the
-# SonarCloud scan. The "Clean as You Code" model applies the gate to
-# new code only — existing issues don't block PRs.
+# Triggers via workflow_run after CI succeeds. Downloads the Python
+# coverage artifact CI produces, then runs the SonarCloud scan. The
+# "Clean as You Code" model is meant to gate new code only — existing
+# issues don't block PRs.
 #
-# After the orphan-commit reset, SonarCloud sees a fresh single-commit
-# history. The project (evoila_meho on org evoila) persists across the
-# reset — it's external state keyed by repo identifier — so the same
-# project picks up the new commits and resets the baseline naturally.
+# NEW-CODE BASELINE: the orphan-commit reset left SonarCloud with a
+# baseline that predates *all* commits, so the entire repo is scored as
+# "new code" (every new_* metric equals its all-time twin and the gate
+# fails on the whole codebase, not the diff). It does NOT reset itself.
+# Fix is a one-time project setting — New Code = "Reference branch: main"
+# — documented in docs/codebase/sonarcloud.md. continue-on-error below
+# keeps the (currently meaningless) gate advisory until that lands.
 #
 # Prerequisite: SONAR_TOKEN repo secret. Verified present pre-merge.
 #
@@ -51,9 +54,14 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: python-coverage
+          # Extract into backend/ so the file lands at backend/coverage.xml,
+          # matching sonar.python.coverage.reportPaths in
+          # sonar-project.properties. The artifact stores the bare
+          # `coverage.xml` basename (uploaded from backend/coverage.xml).
+          path: backend
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true  # coverage artifact may not exist yet (no tests)
+        continue-on-error: true  # missing artifact degrades to "no coverage", never blocks
 
       - name: Ensure dirmngr is available (for sonar-scanner GPG verify)
         run: |
@@ -65,5 +73,10 @@ jobs:
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@7006c4492b2e0ee0f816d36501671557c97f5995  # v8.1.0
+        with:
+          # Stamp each analysis with the analysed commit so SonarCloud's
+          # history is navigable (the project version was "not provided").
+          args: >-
+            -Dsonar.projectVersion=${{ github.event.workflow_run.head_sha }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -258,3 +258,12 @@ markers = [
 # warning is intentional — it's the only signal the test run carries
 # of the v0.2 ``joserfc`` migration backlog item, and silencing it
 # would risk obscuring future authlib deprecations.
+
+[tool.coverage.run]
+# Store file paths in coverage.xml *relative* to the project root rather
+# than as absolute runner paths. The unit-test + coverage step (CI's
+# `Pytest (unit + coverage)`) and the SonarCloud scan (quality-gate.yml)
+# run in separate jobs on separate runners, so absolute paths captured by
+# the first never resolve in the second. Relative paths make the report
+# portable so SonarCloud can map coverage onto the analysed sources.
+relative_files = true

--- a/docs/codebase/sonarcloud.md
+++ b/docs/codebase/sonarcloud.md
@@ -1,0 +1,106 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# SonarCloud — how it's wired, how to read it, how to keep it honest
+
+MEHO is analysed by [SonarCloud](https://sonarcloud.io/project/overview?id=evoila_meho)
+(project `evoila_meho`, organisation `evoila`, **public** project — read APIs
+need no token). This doc is the operator runbook: what the analysis covers, the
+one project setting that currently makes the dashboard misleading, and how to
+triage results without drowning in false positives.
+
+## How analysis runs
+
+```
+push / PR ──► CI workflow ──► uploads python-coverage artifact (backend/coverage.xml)
+                  │
+                  └─ on success ──► Quality Gate workflow (workflow_run)
+                                       ├─ downloads python-coverage into backend/
+                                       └─ SonarSource/sonarqube-scan-action  ──► SonarCloud
+```
+
+| Concern | Where |
+|---|---|
+| Project + scope config | [`sonar-project.properties`](../../sonar-project.properties) |
+| Scan trigger + coverage handoff | [`.github/workflows/quality-gate.yml`](../../.github/workflows/quality-gate.yml) |
+| Coverage production | [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) — `Pytest (unit + coverage)` |
+| Coverage path portability | `[tool.coverage.run] relative_files` in [`backend/pyproject.toml`](../../backend/pyproject.toml) |
+| Auth | `SONAR_TOKEN` repo secret (write/scan only) |
+
+Coverage is the **unit sweep only** (`--cov=meho_backplane`); integration tests
+run in a separate job without `--cov`. The gate is `continue-on-error: true` — it
+is **advisory**, never blocks merges, until the baseline below is fixed.
+
+## ⚠️ The new-code baseline is broken — fix it once
+
+SonarCloud's "Clean as You Code" model is supposed to gate only **changed** code.
+Right now it gates the **entire 186k-line repo** because the orphan-commit history
+reset left the new-code baseline predating every commit. The tell:
+
+- `new_lines` (~296k) **exceeds** total `ncloc` (~187k), and
+- every `new_*` metric exactly equals its all-time twin (`new_bugs == bugs`, etc.).
+
+Until this is fixed the Quality Gate verdict is **meaningless** (it fails the whole
+codebase as if it were one giant PR), which is why it's kept advisory.
+
+**Fix (one-time, requires project admin — it is a SonarCloud setting, not a file):**
+
+1. UI: **Project → Administration → New Code → Reference branch → `main`**, *or*
+2. API:
+   ```bash
+   curl -s -u "$SONAR_TOKEN:" -X POST \
+     "https://sonarcloud.io/api/new_code_periods/set" \
+     -d project=evoila_meho -d type=REFERENCE_BRANCH -d value=main
+   ```
+
+After this, PRs are diffed against `main` and the gate scores only the real diff.
+Coverage/duplication/ratings on new code then become trustworthy signals.
+
+## Reading the dashboard without drowning
+
+The single most useful triage axis is **test code vs. production code**. After the
+`sonar.tests` split in `sonar-project.properties`, test fixtures no longer inflate
+the ratings, but when reading raw issues remember:
+
+- **Bugs**: historically *all* were in `backend/tests/**` (float `==` asserts).
+  Production bug count was zero. Reliability E was 100% test noise.
+- **Vulnerabilities**: ~87% were test fixtures (fake tokens, `/tmp`). The handful
+  in production are reviewed below.
+- **Maintainability** is genuinely **A** (debt ratio ~0.1%). Trust it.
+- **Duplication** is concentrated in the Go per-vendor CLI command files
+  (`cli/internal/cmd/<vendor>/<vendor>.go`, 44–74% each) — real, structural,
+  tracked as the dispatch-boilerplate refactor.
+
+The only smell bucket worth actively chasing is **`S3776` cognitive complexity**
+(~45 functions, Python + Go); the high-volume buckets (`S7503` async-without-await,
+`S1313` hard-coded IPs, `S8410` type-hints) are mostly intentional or test-only.
+
+## Security hotspots — accepted false positives
+
+28 hotspots; 25 are `S5332` clear-text-HTTP in **test** fixtures (bulk-mark *Safe*).
+The three that touch production are all reviewed and **accepted**:
+
+| Finding | Verdict |
+|---|---|
+| `go:S4036` PATH-exec of `gh` — `cli/internal/cmd/retrieval/retire_checklist.go` | **Safe.** Bounded-context `gh` invocation, already `//nolint:gosec`. You can't hardcode the path to `gh`. |
+| `python:S5852` ReDoS — `backend/src/meho_backplane/operations/ingest/_llm_grouping_internals.py` | **Low risk.** ```` ```json ```` fence-stripper over bounded LLM output, not adversarial input. |
+| `docker:S6504` group-write — `backend/Dockerfile` (`chmod -R g=u /opt/meho`) | **Safe.** Deliberate OpenShift / arbitrary-UID pattern: the container runs as any UID in group 0, and fastembed must *write* the model cache at runtime. Required, not gratuitous. |
+
+Other accepted issue-level false positives: `go:S4830`/`S5527` on
+`cli/internal/cmd/admin/keycloak/tls.go` (flag-gated `InsecureSkipVerify`, already
+`//nolint:gosec`); `go:S2068` on the `keycloak.go` `--help` example string;
+`python:S5443` on `bind9/_atomic.py` (CSPRNG-random `/tmp` name, runs as a remote
+shell script). Mark these *Accepted* / *Won't fix* in SonarCloud with the rationale
+above so the ratings reflect real risk.
+
+## Real backlog (not noise)
+
+- **Go CLI dispatch boilerplate** — extract a shared `CallOperation` helper so the
+  ~18 per-vendor command files stop re-implementing the HTTP-to-`/operations/call`
+  plumbing. Compatible with CLAUDE.md postulate 5 (transport DRYing ≠ thin wrapper).
+- **K8s resource requests/limits** (`kubernetes:S6870`) on the chart deployments +
+  migration job.
+- **Dockerfile hardening** (`docker:S8541`).
+- *(optional)* **`S3776` cognitive-complexity** pass on the worst offenders.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,17 @@ sonar.projectKey=evoila_meho
 sonar.organization=evoila
 sonar.host.url=https://sonarcloud.io
 
-sonar.sources=.
+# Production source roots vs. test code. Test code is declared via
+# `sonar.tests` so it is scored under the lighter test rule profile
+# instead of as production source. Without this split, test fixtures
+# (fake tokens/passwords, /tmp paths, float-equality asserts) dominate
+# the reliability + security ratings with false positives — they are
+# the entire reason both ratings sit at E. Python tests live in a clean
+# `backend/tests/**` tree (declared below); Go `*_test.go` files are
+# co-located with their package and stay under `sonar.sources` (their
+# duplication is carved out via `sonar.cpd.exclusions`).
+sonar.sources=backend/src,backend/Dockerfile,cli,deploy,scripts
+sonar.tests=backend/tests
 
 # Paths excluded from analysis entirely. Generated code and vendored
 # trees never warrant code-quality scoring — the file is not authored
@@ -35,9 +45,53 @@ sonar.exclusions=.github/**,**/node_modules/**,**/dist/**,**/build/**,**/*.gen.g
 # for CPD but honours `sonar.cpd.exclusions`. Standard SonarSource
 # pattern — see
 # https://docs.sonarsource.com/sonarqube/latest/project-administration/analysis-scope/.
-sonar.cpd.exclusions=backend/tests/**,**/*.gen.go
+#
+# `**/*_test.go` is excluded too: Go table-driven command tests re-declare
+# near-identical request/response scaffolding per verb (the CLI command
+# suites run 44–57% duplicated by design). Production Go duplication still
+# scores because the non-test command files are NOT excluded — that real
+# signal is tracked separately (the per-vendor dispatch-boilerplate
+# refactor).
+sonar.cpd.exclusions=backend/tests/**,**/*_test.go,**/*.gen.go
 
-# Language-specific blocks — ready to populate when code lands.
-# sonar.python.version=3.13
-# sonar.python.coverage.reportPaths=coverage.xml
+# ---------------------------------------------------------------------------
+# Coverage
+# ---------------------------------------------------------------------------
+# Python coverage is produced by CI's `Pytest (unit + coverage)` step
+# (`--cov=meho_backplane --cov-report=xml` -> backend/coverage.xml),
+# uploaded as the `python-coverage` artifact, and downloaded back into
+# backend/ by quality-gate.yml before this scan runs. `relative_files`
+# (backend/pyproject.toml [tool.coverage.run]) keeps the report paths
+# portable across the two jobs so SonarCloud can resolve them.
+#
+# NOTE: path resolution must be confirmed on the first post-merge Quality
+# Gate run — watch the scan log for "Could not resolve the file path ...
+# in coverage report". It is non-blocking (quality-gate.yml is
+# continue-on-error), so a mismatch degrades to "no coverage" rather than
+# failing the build; adjust reportPaths if the warning appears.
+sonar.python.version=3.12, 3.13
+sonar.python.coverage.reportPaths=backend/coverage.xml
 # sonar.javascript.lcov.reportPaths=meho_frontend/coverage/lcov.info
+
+# ---------------------------------------------------------------------------
+# Test-scoped issue suppressions (belt-and-braces with sonar.tests above)
+# ---------------------------------------------------------------------------
+# These rules are pure false positives *in test code* and would otherwise
+# keep the security/reliability ratings pinned at E:
+#   S2068 / S6418 — "hard-coded secret" on fake fixture tokens/passwords
+#   S5443         — "publicly writable directory" on /tmp paths in tests
+#   S1244         — float `==` in test asserts (intentional fixture
+#                   comparisons). Scoped to backend/tests/** so production
+#                   float-equality bugs are STILL flagged.
+# Every pattern is path-scoped to backend/tests/** — production code is
+# untouched. S930 ("wrong arguments") is deliberately NOT suppressed: the
+# two test hits may be real call-site bugs worth fixing.
+sonar.issue.ignore.multicriteria=t_creds,t_secret,t_tmpdir,t_float
+sonar.issue.ignore.multicriteria.t_creds.ruleKey=python:S2068
+sonar.issue.ignore.multicriteria.t_creds.resourceKey=backend/tests/**
+sonar.issue.ignore.multicriteria.t_secret.ruleKey=python:S6418
+sonar.issue.ignore.multicriteria.t_secret.resourceKey=backend/tests/**
+sonar.issue.ignore.multicriteria.t_tmpdir.ruleKey=python:S5443
+sonar.issue.ignore.multicriteria.t_tmpdir.resourceKey=backend/tests/**
+sonar.issue.ignore.multicriteria.t_float.ruleKey=python:S1244
+sonar.issue.ignore.multicriteria.t_float.resourceKey=backend/tests/**


### PR DESCRIPTION
## Why

SonarCloud was wired during the orphan-commit reset but the last-mile config was left as commented TODOs. The result looks alarming but is mostly **measurement artifacts**, not code quality: reliability + security both **E**, **0%** coverage, and the Quality Gate failing on the **whole 187k-line repo** (because the new-code baseline predates every commit). Maintainability is genuinely **A** (debt ratio ~0.1%) and there are **no unaddressed production security findings** — the E ratings are driven by test fixtures.

This PR fixes the config so the dashboard reflects reality. **Config + docs only — no product code touched.**

## What

| Change | File |
|---|---|
| Split `sonar.sources` (prod) vs `sonar.tests=backend/tests` so test fixtures stop inflating ratings | `sonar-project.properties` |
| Test-scoped issue-ignores for `S2068`/`S6418`/`S5443`/`S1244` (path-scoped to `backend/tests/**`; prod untouched) | `sonar-project.properties` |
| Wire Python coverage: `reportPaths=backend/coverage.xml` + extract artifact into `backend/` + `relative_files` | `sonar-project.properties`, `quality-gate.yml`, `backend/pyproject.toml` |
| Exclude Go `*_test.go` from CPD (duplicative by design; prod Go dup still scores) | `sonar-project.properties` |
| Stamp `projectVersion` from the analysed commit (was `not provided`) | `quality-gate.yml` |
| Correct the misleading "baseline resets naturally" comment | `quality-gate.yml` |
| New operator runbook (triage, accepted FPs, baseline fix) | `docs/codebase/sonarcloud.md` |

## ⚠️ Two manual follow-ups (cannot ship in a PR)

1. **New-code baseline** — set **New Code = Reference branch `main`** in SonarCloud project admin (a project setting, not a file). Until then the gate scores the whole repo as "new code" and stays meaningless. Steps in `docs/codebase/sonarcloud.md`.
2. **Coverage path resolution** — can't be verified locally (no scanner + needs a real CI `coverage.xml`). Watch the **first post-merge** Quality Gate log for `Could not resolve the file path ... in coverage report`. It's `continue-on-error`, so a mismatch degrades to "no coverage", never a failed build.

## Risk

Low. `quality-gate.yml` is `continue-on-error: true`, so even a misconfigured scan can't block CI. No production code, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality analysis configuration with improved test and production code separation for more accurate scans.
  * Updated CI coverage reporting paths to ensure proper baseline alignment.
  * Refined SonarCloud analysis scope and quality-gate baselines.

* **Documentation**
  * Added operator runbook for SonarCloud maintenance, quality-gate interpretation, and known issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/920?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->