### PR TITLE
feat(cli): meho connector catalog list + ingest --catalog verbs (#915)

### DIFF
--- a/backend/src/meho_backplane/api/v1/connectors_ingest.py
+++ b/backend/src/meho_backplane/api/v1/connectors_ingest.py
@@ -122,6 +122,7 @@ from fastapi.responses import Response
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
 from meho_backplane.operations.ingest import (
+    CatalogListResponse,
     ConnectorNotFoundError,
     ConnectorReviewPayload,
     EditGroupBody,
@@ -362,10 +363,10 @@ async def list_endpoint(
     return {"connectors": [item.model_dump(mode="json") for item in items]}
 
 
-@router.get("/catalog")
+@router.get("/catalog", response_model=CatalogListResponse)
 async def catalog_endpoint(
     operator: Operator = _require_operator,
-) -> dict[str, list[dict[str, object]]]:
+) -> CatalogListResponse:
     """Return the curated connector-spec catalog (Goal #214 on-ramp; #743).
 
     The catalog maps ``(product, version)`` to the recommended OpenAPI
@@ -379,10 +380,13 @@ async def catalog_endpoint(
     Declared before the ``/{connector_id}/...`` routes so the literal
     ``/catalog`` segment is matched ahead of the path-parameter
     patterns. Wrapped in ``{"catalog": [...]}`` for non-breaking paging
-    room, mirroring the ``GET /`` list shape.
+    room, mirroring the ``GET /`` list shape. Typed via
+    ``response_model=CatalogListResponse`` so the OpenAPI contract for
+    this public route declares the envelope + entry fields explicitly;
+    unlike the ``GET /`` list route it has no per-row UUID-serialisation
+    reason to stay an untyped object map.
     """
-    catalog = load_catalog()
-    return {"catalog": [entry.model_dump(mode="json") for entry in catalog.entries]}
+    return CatalogListResponse(catalog=load_catalog().entries)
 
 
 @router.get("/{connector_id}/review", response_model=ConnectorReviewPayload)

--- a/backend/src/meho_backplane/operations/ingest/__init__.py
+++ b/backend/src/meho_backplane/operations/ingest/__init__.py
@@ -30,6 +30,7 @@ from meho_backplane.operations.ingest.api_schemas import (
 )
 from meho_backplane.operations.ingest.catalog import (
     CatalogError,
+    CatalogListResponse,
     ConnectorSpecCatalog,
     ConnectorSpecEntry,
     load_catalog,
@@ -97,6 +98,7 @@ from meho_backplane.operations.ingest.service import ReviewService
 __all__ = [
     "DEFAULT_GROUPING_BATCH_SIZE",
     "CatalogError",
+    "CatalogListResponse",
     "ConnectorListItem",
     "ConnectorListResponse",
     "ConnectorNotFoundError",

--- a/backend/src/meho_backplane/operations/ingest/catalog.py
+++ b/backend/src/meho_backplane/operations/ingest/catalog.py
@@ -153,6 +153,20 @@ class ConnectorSpecCatalog(BaseModel):
         return None
 
 
+class CatalogListResponse(BaseModel):
+    """Wire envelope for ``GET /api/v1/connectors/catalog``.
+
+    Wrapped in ``catalog`` (not a bare list) so future paging fields can
+    land non-breakingly, mirroring the ``GET /`` list shape. Used as the
+    route's ``response_model`` so the OpenAPI contract explicitly types
+    the envelope + entry fields (rather than a free-form object map).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    catalog: tuple[ConnectorSpecEntry, ...]
+
+
 def parse_catalog(raw: str) -> ConnectorSpecCatalog:
     """Parse + schema-validate raw catalog YAML.
 

--- a/backend/tests/test_operations_ingest_catalog.py
+++ b/backend/tests/test_operations_ingest_catalog.py
@@ -287,7 +287,8 @@ def test_catalog_unauthenticated_returns_401() -> None:
 async def test_catalog_endpoint_returns_all_entries() -> None:
     # The handler ignores the operator (it returns global reference data);
     # require_role already gates auth, exercised by the 401 test above.
-    body = await catalog_endpoint(operator=MagicMock())
-    assert set(body) == {"catalog"}
-    returned = {(e["product"], e["version"]) for e in body["catalog"]}
+    # response_model=CatalogListResponse → the handler returns the typed
+    # model (not a dict).
+    response = await catalog_endpoint(operator=MagicMock())
+    returned = {(e.product, e.version) for e in response.catalog}
     assert returned == _EXPECTED_PRODUCT_VERSION

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -1103,6 +1103,58 @@
         }
       }
     },
+    "/api/v1/connectors/catalog": {
+      "get": {
+        "tags": [
+          "connectors"
+        ],
+        "summary": "Catalog Endpoint",
+        "description": "Return the curated connector-spec catalog (Goal #214 on-ramp; #743).\n\nThe catalog maps ``(product, version)`` to the recommended OpenAPI\nspec source(s) + the registered connector class that covers the\nversion label. It is global, built-in reference data (not tenant-\nscoped), so operator role is the only gate; the read carries no\ntenant filter. The ``meho connector catalog list`` / ``ingest\n--catalog`` verbs (#915) consume this route \u2014 the CLI ships as a\nseparate binary and cannot read the server's packaged catalog file.\n\nDeclared before the ``/{connector_id}/...`` routes so the literal\n``/catalog`` segment is matched ahead of the path-parameter\npatterns. Wrapped in ``{\"catalog\": [...]}`` for non-breaking paging\nroom, mirroring the ``GET /`` list shape.",
+        "operationId": "catalog_endpoint_api_v1_connectors_catalog_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": true
+                    }
+                  },
+                  "title": "Response Catalog Endpoint Api V1 Connectors Catalog Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/connectors/{connector_id}/review": {
       "get": {
         "tags": [

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -1109,7 +1109,7 @@
           "connectors"
         ],
         "summary": "Catalog Endpoint",
-        "description": "Return the curated connector-spec catalog (Goal #214 on-ramp; #743).\n\nThe catalog maps ``(product, version)`` to the recommended OpenAPI\nspec source(s) + the registered connector class that covers the\nversion label. It is global, built-in reference data (not tenant-\nscoped), so operator role is the only gate; the read carries no\ntenant filter. The ``meho connector catalog list`` / ``ingest\n--catalog`` verbs (#915) consume this route \u2014 the CLI ships as a\nseparate binary and cannot read the server's packaged catalog file.\n\nDeclared before the ``/{connector_id}/...`` routes so the literal\n``/catalog`` segment is matched ahead of the path-parameter\npatterns. Wrapped in ``{\"catalog\": [...]}`` for non-breaking paging\nroom, mirroring the ``GET /`` list shape.",
+        "description": "Return the curated connector-spec catalog (Goal #214 on-ramp; #743).\n\nThe catalog maps ``(product, version)`` to the recommended OpenAPI\nspec source(s) + the registered connector class that covers the\nversion label. It is global, built-in reference data (not tenant-\nscoped), so operator role is the only gate; the read carries no\ntenant filter. The ``meho connector catalog list`` / ``ingest\n--catalog`` verbs (#915) consume this route \u2014 the CLI ships as a\nseparate binary and cannot read the server's packaged catalog file.\n\nDeclared before the ``/{connector_id}/...`` routes so the literal\n``/catalog`` segment is matched ahead of the path-parameter\npatterns. Wrapped in ``{\"catalog\": [...]}`` for non-breaking paging\nroom, mirroring the ``GET /`` list shape. Typed via\n``response_model=CatalogListResponse`` so the OpenAPI contract for\nthis public route declares the envelope + entry fields explicitly;\nunlike the ``GET /`` list route it has no per-row UUID-serialisation\nreason to stay an untyped object map.",
         "operationId": "catalog_endpoint_api_v1_connectors_catalog_get",
         "parameters": [
           {
@@ -1129,15 +1129,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "array",
-                    "items": {
-                      "type": "object",
-                      "additionalProperties": true
-                    }
-                  },
-                  "title": "Response Catalog Endpoint Api V1 Connectors Catalog Get"
+                  "$ref": "#/components/schemas/CatalogListResponse"
                 }
               }
             }
@@ -3063,6 +3055,87 @@
         ],
         "title": "VaultStatus",
         "description": "Vault federation-chain status.\n\n``reachable`` is true when the OIDC login succeeded (TCP + TLS +\nJWT forward all worked). ``read_ok`` is true when the test secret\nread succeeded against the resulting Vault token. ``detail`` carries\na short structured string for the CLI to render on failure paths \u2014\nnever an unbounded exception message."
+      },
+      "CatalogListResponse": {
+        "properties": {
+          "catalog": {
+            "items": {
+              "$ref": "#/components/schemas/ConnectorSpecEntry"
+            },
+            "type": "array",
+            "title": "Catalog"
+          }
+        },
+        "type": "object",
+        "required": [
+          "catalog"
+        ],
+        "title": "CatalogListResponse",
+        "description": "Wire envelope for ``GET /api/v1/connectors/catalog``.\n\nWrapped in ``catalog`` (not a bare list) so future paging fields can\nland non-breakingly, mirroring the ``GET /`` list shape. Used as the\nroute's ``response_model`` so the OpenAPI contract explicitly types\nthe envelope + entry fields (rather than a free-form object map)."
+      },
+      "ConnectorSpecEntry": {
+        "properties": {
+          "product": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Product"
+          },
+          "version": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Version"
+          },
+          "impl_id": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Impl Id"
+          },
+          "requires_connector_class": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Requires Connector Class"
+          },
+          "upstream": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "nullable": true,
+            "title": "Upstream"
+          },
+          "spec_info_version": {
+            "type": "string",
+            "maxLength": 64,
+            "nullable": true,
+            "title": "Spec Info Version"
+          },
+          "sha256": {
+            "type": "string",
+            "maxLength": 64,
+            "nullable": true,
+            "title": "Sha256"
+          },
+          "notes": {
+            "type": "string",
+            "maxLength": 2048,
+            "title": "Notes",
+            "default": ""
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "product",
+          "version",
+          "impl_id",
+          "requires_connector_class"
+        ],
+        "title": "ConnectorSpecEntry",
+        "description": "One curated ``(product, version)`` -> spec-source mapping.\n\n``upstream is None`` marks a typed connector with no ingestable spec;\nthe CLI's ``ingest --catalog`` path (#915) refuses such an entry rather\nthan POSTing an empty ``specs`` list."
       }
     }
   }

--- a/cli/internal/cmd/connector/catalog.go
+++ b/cli/internal/cmd/connector/catalog.go
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package connector
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// CatalogEntry mirrors the backend ConnectorSpecEntry
+// (operations/ingest/catalog.py) as served by
+// GET /api/v1/connectors/catalog (Goal #214 raw-REST ingest on-ramp;
+// #743). Upstream is nil for typed connectors (no ingestable spec) —
+// the `ingest --catalog` path refuses those rather than POSTing an
+// empty specs list. SpecInfoVersion / SHA256 are pointers so the JSON
+// null (empirical, not-yet-smoke-tested) round-trips distinctly from
+// an empty string.
+type CatalogEntry struct {
+	Product                string   `json:"product"`
+	Version                string   `json:"version"`
+	ImplID                 string   `json:"impl_id"`
+	RequiresConnectorClass string   `json:"requires_connector_class"`
+	Upstream               []string `json:"upstream"`
+	SpecInfoVersion        *string  `json:"spec_info_version"`
+	SHA256                 *string  `json:"sha256"`
+	Notes                  string   `json:"notes"`
+}
+
+// CatalogResponse is the envelope for GET /api/v1/connectors/catalog.
+// Wrapped in {"catalog": [...]} so future paging fields can land
+// non-breakingly, mirroring the GET / list shape.
+type CatalogResponse struct {
+	Catalog []CatalogEntry `json:"catalog"`
+}
+
+// errCatalogResolve tags the local (non-transport) failures of
+// resolveCatalogEntry — entry-not-found, typed-connector, templated
+// upstream — so the ingest verb renders them as `unexpected` (a clear
+// operator message) rather than routing them through the transport
+// error classifier.
+var errCatalogResolve = errors.New("catalog resolve")
+
+// newCatalogCmd returns the `meho connector catalog` parent command.
+// The catalog is the curated map of (product, version) -> recommended
+// OpenAPI spec source(s) + the registered connector class that covers
+// the version label; it is the operator on-ramp for the generic-
+// ingestion half of the two-layer connector model.
+func newCatalogCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "catalog",
+		Short:        "Curated connector-spec catalog (the raw-REST ingest on-ramp)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newCatalogListCmd())
+	return cmd
+}
+
+// newCatalogListCmd returns the `meho connector catalog list` command.
+//
+// CLI shape:
+//
+//	meho connector catalog list [--json] [--backplane <url>]
+//
+// Hits GET /api/v1/connectors/catalog and renders one row per entry.
+// The `registered` column is a best-effort cross-reference against
+// GET /api/v1/connectors (which unions the class-side registry per T5
+// #733): an entry whose (product, version, impl_id) appears there has
+// its connector class registered. operator role suffices (read-only).
+func newCatalogListCmd() *cobra.Command {
+	var (
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List curated connector-spec catalog entries",
+		Long: "list calls GET /api/v1/connectors/catalog and renders one row\n" +
+			"per curated (product, version) entry: the impl_id, the connector\n" +
+			"class that covers the version label, whether that class is\n" +
+			"registered on this backplane, the observed spec.info.version (when\n" +
+			"a spec has been ingest-verified), and operator notes.\n\n" +
+			"Entries with an empty upstream are typed connectors with no\n" +
+			"ingestable spec; the rest are generic-ingestable via\n" +
+			"`meho connector ingest --catalog <product>/<version>`.\n\n" +
+			"Read-only; operator role suffices.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runCatalogList(cmd, catalogListOptions{
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit machine-readable JSON to stdout instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type catalogListOptions struct {
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runCatalogList(cmd *cobra.Command, opts catalogListOptions) error {
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	catalog, err := getCatalog(cmd.Context(), backplaneURL)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), catalog)
+	}
+	// Best-effort registry cross-reference; a nil map degrades the
+	// `registered` column to "?" rather than failing the listing.
+	registered := registeredTriples(cmd.Context(), backplaneURL)
+	printCatalogTable(cmd.OutOrStdout(), catalog, registered)
+	return nil
+}
+
+func getCatalog(ctx context.Context, backplaneURL string) (*CatalogResponse, error) {
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", "/api/v1/connectors/catalog", nil)
+	if err != nil {
+		return nil, err
+	}
+	var out CatalogResponse
+	if err := decodeJSON(raw, "connector catalog", &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// registeredTriples returns the set of (product, version, impl_id)
+// the backplane reports as registered connectors, keyed via
+// tripleKey. Best-effort: any error yields a nil map so the caller
+// renders registration as unknown rather than failing the listing.
+func registeredTriples(ctx context.Context, backplaneURL string) map[string]bool {
+	list, err := getList(ctx, backplaneURL, "all")
+	if err != nil {
+		return nil
+	}
+	set := make(map[string]bool, len(list.Connectors))
+	for _, c := range list.Connectors {
+		set[tripleKey(c.Product, c.Version, c.ImplID)] = true
+	}
+	return set
+}
+
+// tripleKey joins the connector triple with a NUL separator so
+// distinct (product, version, impl_id) tuples can't collide via
+// string concatenation (e.g. ("a-b","c") vs ("a","b-c")).
+func tripleKey(product, version, implID string) string {
+	return product + "\x00" + version + "\x00" + implID
+}
+
+func printCatalogTable(w io.Writer, c *CatalogResponse, registered map[string]bool) {
+	if len(c.Catalog) == 0 {
+		fmt.Fprintln(w, "0 catalog entries")
+		return
+	}
+	fmt.Fprintf(w, "%d catalog entr%s\n", len(c.Catalog), pluralY(len(c.Catalog)))
+	fmt.Fprintf(w, "%-22s %-13s %-24s %-4s %-9s %s\n",
+		"product/version", "impl_id", "connector_class", "reg", "spec_ver", "notes",
+	)
+	for _, e := range c.Catalog {
+		fmt.Fprintf(w, "%-22s %-13s %-24s %-4s %-9s %s\n",
+			truncate(e.Product+"/"+e.Version, 22),
+			truncate(e.ImplID, 13),
+			truncate(e.RequiresConnectorClass, 24),
+			registeredLabel(registered, e),
+			truncate(specVersionLabel(e), 9),
+			truncate(e.Notes, 60),
+		)
+	}
+}
+
+// registeredLabel renders the registration column: "yes"/"no" when
+// the cross-reference succeeded, "?" when it was unavailable.
+func registeredLabel(registered map[string]bool, e CatalogEntry) string {
+	if registered == nil {
+		return "?"
+	}
+	if registered[tripleKey(e.Product, e.Version, e.ImplID)] {
+		return "yes"
+	}
+	return "no"
+}
+
+// specVersionLabel renders the observed spec.info.version, or "-" when
+// the entry has not been ingest-verified yet (the common case for a
+// fresh catalog).
+func specVersionLabel(e CatalogEntry) string {
+	if e.SpecInfoVersion != nil && *e.SpecInfoVersion != "" {
+		return *e.SpecInfoVersion
+	}
+	return "-"
+}
+
+func pluralY(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
+}
+
+// resolveCatalogEntry fetches the catalog and resolves a
+// "<product>/<version>" reference to its entry, validating that the
+// entry is generic-ingestable. Local (non-transport) failures are
+// wrapped in errCatalogResolve so the caller can render them as
+// `unexpected`; transport/auth errors from the GET propagate
+// unwrapped for renderRequestError.
+func resolveCatalogEntry(ctx context.Context, backplaneURL, ref string) (*CatalogEntry, error) {
+	product, version, err := parseCatalogRef(ref)
+	if err != nil {
+		return nil, err
+	}
+	catalog, err := getCatalog(ctx, backplaneURL)
+	if err != nil {
+		return nil, err // transport/auth — caller routes via renderRequestError
+	}
+	var entry *CatalogEntry
+	available := make([]string, 0, len(catalog.Catalog))
+	for i := range catalog.Catalog {
+		e := catalog.Catalog[i]
+		available = append(available, e.Product+"/"+e.Version)
+		if e.Product == product && e.Version == version {
+			entry = &catalog.Catalog[i]
+		}
+	}
+	if entry == nil {
+		return nil, fmt.Errorf("%w: no catalog entry for %q; available: %s",
+			errCatalogResolve, ref, strings.Join(available, ", "))
+	}
+	if len(entry.Upstream) == 0 {
+		return nil, fmt.Errorf(
+			"%w: %q is a typed connector with no ingestable spec; nothing to ingest",
+			errCatalogResolve, ref)
+	}
+	for _, u := range entry.Upstream {
+		if strings.ContainsAny(u, "<>") {
+			return nil, fmt.Errorf(
+				"%w: %q upstream URL %q is fqdn-templated; supply the concrete spec via "+
+					"`meho connector ingest --product %s --version %s --impl %s --spec <url>`",
+				errCatalogResolve, ref, u, entry.Product, entry.Version, entry.ImplID)
+		}
+	}
+	return entry, nil
+}
+
+// parseCatalogRef splits a "<product>/<version>" reference. Both
+// halves must be non-empty; the version may itself contain no slash.
+func parseCatalogRef(ref string) (product, version string, err error) {
+	parts := strings.SplitN(ref, "/", 2)
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return "", "", fmt.Errorf(
+			"%w: --catalog value %q must be <product>/<version> (e.g. vmware/9.0)",
+			errCatalogResolve, ref)
+	}
+	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), nil
+}
+
+// upstreamSpecs turns a catalog entry's upstream URLs into the
+// SpecSource list the backplane's IngestRequest expects. The backend
+// parser fetches each URL; the CLI does not download.
+func upstreamSpecs(upstream []string) []SpecSource {
+	specs := make([]SpecSource, 0, len(upstream))
+	for _, u := range upstream {
+		specs = append(specs, SpecSource{URI: u})
+	}
+	return specs
+}

--- a/cli/internal/cmd/connector/catalog.go
+++ b/cli/internal/cmd/connector/catalog.go
@@ -238,6 +238,15 @@ func resolveCatalogEntry(ctx context.Context, backplaneURL, ref string) (*Catalo
 		e := catalog.Catalog[i]
 		available = append(available, e.Product+"/"+e.Version)
 		if e.Product == product && e.Version == version {
+			// The backend model enforces (product, version) uniqueness,
+			// but don't trust the response blindly — a second match means
+			// duplicated catalog data, and silently taking the last would
+			// ingest an ambiguous impl_id.
+			if entry != nil {
+				return nil, fmt.Errorf(
+					"%w: catalog has multiple entries for %q; disambiguate catalog data before ingest",
+					errCatalogResolve, ref)
+			}
 			entry = &catalog.Catalog[i]
 		}
 	}
@@ -250,7 +259,13 @@ func resolveCatalogEntry(ctx context.Context, backplaneURL, ref string) (*Catalo
 			"%w: %q is a typed connector with no ingestable spec; nothing to ingest",
 			errCatalogResolve, ref)
 	}
-	for _, u := range entry.Upstream {
+	for i, u := range entry.Upstream {
+		u = strings.TrimSpace(u)
+		if u == "" {
+			return nil, fmt.Errorf("%w: %q has an empty upstream URL entry",
+				errCatalogResolve, ref)
+		}
+		entry.Upstream[i] = u
 		if strings.ContainsAny(u, "<>") {
 			return nil, fmt.Errorf(
 				"%w: %q upstream URL %q is fqdn-templated; supply the concrete spec via "+

--- a/cli/internal/cmd/connector/catalog_test.go
+++ b/cli/internal/cmd/connector/catalog_test.go
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package connector
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func strptr(s string) *string { return &s }
+
+// --- parseCatalogRef -------------------------------------------------------
+
+func TestParseCatalogRefTable(t *testing.T) {
+	cases := []struct {
+		in               string
+		product, version string
+		wantErr          bool
+	}{
+		{"vmware/9.0", "vmware", "9.0", false},
+		{"sddc-manager/9.0", "sddc-manager", "9.0", false},
+		{"  vmware / 9.0  ", "vmware", "9.0", false},
+		{"vmware", "", "", true},
+		{"", "", "", true},
+		{"vmware/", "", "", true},
+		{"/9.0", "", "", true},
+	}
+	for _, c := range cases {
+		p, v, err := parseCatalogRef(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("parseCatalogRef(%q): want error, got (%q,%q)", c.in, p, v)
+			} else if !errors.Is(err, errCatalogResolve) {
+				t.Errorf("parseCatalogRef(%q): error should wrap errCatalogResolve, got %v", c.in, err)
+			}
+			continue
+		}
+		if err != nil || p != c.product || v != c.version {
+			t.Errorf("parseCatalogRef(%q) = (%q,%q,%v); want (%q,%q,nil)",
+				c.in, p, v, err, c.product, c.version)
+		}
+	}
+}
+
+// --- upstreamSpecs ---------------------------------------------------------
+
+func TestUpstreamSpecs(t *testing.T) {
+	got := upstreamSpecs([]string{"https://a/x.yaml", "https://b/y.yaml"})
+	if len(got) != 2 || got[0].URI != "https://a/x.yaml" || got[1].URI != "https://b/y.yaml" {
+		t.Fatalf("upstreamSpecs mapping wrong: %+v", got)
+	}
+	if len(upstreamSpecs(nil)) != 0 {
+		t.Fatalf("upstreamSpecs(nil) should be empty")
+	}
+}
+
+// --- validateIngestMode ----------------------------------------------------
+
+func TestValidateIngestModeTable(t *testing.T) {
+	cases := []struct {
+		name    string
+		opts    ingestOptions
+		wantErr string // substring; "" = no error
+	}{
+		{"catalog only", ingestOptions{Catalog: "vmware/9.0"}, ""},
+		{"manual complete", ingestOptions{
+			Product: "vmware", Version: "9.0", ImplID: "vmware-rest",
+			Specs: []string{"file:///x.yaml"},
+		}, ""},
+		{"catalog + manual", ingestOptions{
+			Catalog: "vmware/9.0", Product: "vmware",
+		}, "cannot be combined"},
+		{"neither", ingestOptions{}, "specify a connector"},
+		{"manual missing impl+spec", ingestOptions{
+			Product: "vmware", Version: "9.0",
+		}, "manual ingest requires --impl, --spec"},
+	}
+	for _, c := range cases {
+		err := validateIngestMode(c.opts)
+		if c.wantErr == "" {
+			if err != nil {
+				t.Errorf("%s: want nil, got %v", c.name, err)
+			}
+			continue
+		}
+		if err == nil || !strings.Contains(err.Error(), c.wantErr) {
+			t.Errorf("%s: want error containing %q, got %v", c.name, c.wantErr, err)
+		}
+	}
+}
+
+// --- getCatalog decode -----------------------------------------------------
+
+func TestGetCatalogDecodesEntries(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"GET /api/v1/connectors/catalog": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 200, CatalogResponse{Catalog: []CatalogEntry{
+				{
+					Product: "vmware", Version: "9.0", ImplID: "vmware-rest",
+					RequiresConnectorClass: "VmwareRestConnector",
+					Upstream:               []string{"https://example.test/vcenter.yaml"},
+					SpecInfoVersion:        strptr("9.0.1"),
+				},
+				{
+					Product: "vault", Version: "1.x", ImplID: "vault",
+					RequiresConnectorClass: "VaultConnector",
+					Upstream:               nil, // typed
+					SpecInfoVersion:        nil,
+				},
+			}})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	got, err := getCatalog(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("getCatalog: %v", err)
+	}
+	if len(got.Catalog) != 2 {
+		t.Fatalf("want 2 entries, got %d", len(got.Catalog))
+	}
+	if got.Catalog[1].Upstream != nil {
+		t.Errorf("typed entry upstream should decode to nil, got %+v", got.Catalog[1].Upstream)
+	}
+	if got.Catalog[1].SpecInfoVersion != nil {
+		t.Errorf("null spec_info_version should decode to nil pointer")
+	}
+	if got.Catalog[0].SpecInfoVersion == nil || *got.Catalog[0].SpecInfoVersion != "9.0.1" {
+		t.Errorf("spec_info_version decode wrong: %+v", got.Catalog[0].SpecInfoVersion)
+	}
+}
+
+// --- resolveCatalogEntry ---------------------------------------------------
+
+func catalogServer(t *testing.T, entries []CatalogEntry) string {
+	t.Helper()
+	srv := mockBackplane(t, map[string]mockHandler{
+		"GET /api/v1/connectors/catalog": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 200, CatalogResponse{Catalog: entries})
+		},
+	})
+	t.Cleanup(srv.Close)
+	primeToken(t, srv.URL)
+	return srv.URL
+}
+
+func TestResolveCatalogEntryHappyPath(t *testing.T) {
+	url := catalogServer(t, []CatalogEntry{{
+		Product: "vmware", Version: "9.0", ImplID: "vmware-rest",
+		RequiresConnectorClass: "VmwareRestConnector",
+		Upstream:               []string{"https://example.test/vcenter.yaml"},
+	}})
+	entry, err := resolveCatalogEntry(context.Background(), url, "vmware/9.0")
+	if err != nil {
+		t.Fatalf("resolveCatalogEntry: %v", err)
+	}
+	if entry.ImplID != "vmware-rest" || len(entry.Upstream) != 1 {
+		t.Fatalf("unexpected entry: %+v", entry)
+	}
+}
+
+func TestResolveCatalogEntryNotFound(t *testing.T) {
+	url := catalogServer(t, []CatalogEntry{{
+		Product: "vmware", Version: "9.0", ImplID: "vmware-rest",
+		Upstream: []string{"https://example.test/x.yaml"},
+	}})
+	_, err := resolveCatalogEntry(context.Background(), url, "nsx/4.2")
+	if err == nil || !errors.Is(err, errCatalogResolve) {
+		t.Fatalf("want errCatalogResolve, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "vmware/9.0") {
+		t.Errorf("not-found error should list available entries; got %v", err)
+	}
+}
+
+func TestResolveCatalogEntryTypedRefused(t *testing.T) {
+	url := catalogServer(t, []CatalogEntry{{
+		Product: "vault", Version: "1.x", ImplID: "vault",
+		RequiresConnectorClass: "VaultConnector",
+		Upstream:               nil,
+	}})
+	_, err := resolveCatalogEntry(context.Background(), url, "vault/1.x")
+	if err == nil || !errors.Is(err, errCatalogResolve) {
+		t.Fatalf("want errCatalogResolve, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "typed connector") {
+		t.Errorf("typed refusal message wrong: %v", err)
+	}
+}
+
+func TestResolveCatalogEntryTemplatedRefused(t *testing.T) {
+	url := catalogServer(t, []CatalogEntry{{
+		Product: "nsx", Version: "4.2", ImplID: "nsx-rest",
+		RequiresConnectorClass: "NsxConnector",
+		Upstream:               []string{"https://<nsx-mgr-fqdn>/api/v1/spec/openapi/nsx_api.yaml"},
+	}})
+	_, err := resolveCatalogEntry(context.Background(), url, "nsx/4.2")
+	if err == nil || !errors.Is(err, errCatalogResolve) {
+		t.Fatalf("want errCatalogResolve, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "templated") {
+		t.Errorf("templated refusal message wrong: %v", err)
+	}
+}
+
+// --- printCatalogTable -----------------------------------------------------
+
+func TestPrintCatalogTableHappyPath(t *testing.T) {
+	var buf bytes.Buffer
+	registered := map[string]bool{tripleKey("vmware", "9.0", "vmware-rest"): true}
+	printCatalogTable(&buf, &CatalogResponse{Catalog: []CatalogEntry{
+		{Product: "vmware", Version: "9.0", ImplID: "vmware-rest",
+			RequiresConnectorClass: "VmwareRestConnector",
+			Upstream:               []string{"https://example.test/x.yaml"},
+			SpecInfoVersion:        strptr("9.0.1"), Notes: "generic"},
+		{Product: "vault", Version: "1.x", ImplID: "vault",
+			RequiresConnectorClass: "VaultConnector", Notes: "typed"},
+	}}, registered)
+	out := buf.String()
+	for _, want := range []string{"vmware/9.0", "VmwareRestConnector", "9.0.1", "yes", "vault/1.x", "no"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("catalog table missing %q\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintCatalogTableUnknownRegistration(t *testing.T) {
+	var buf bytes.Buffer
+	// nil registered map → registration column renders "?".
+	printCatalogTable(&buf, &CatalogResponse{Catalog: []CatalogEntry{
+		{Product: "vmware", Version: "9.0", ImplID: "vmware-rest",
+			RequiresConnectorClass: "VmwareRestConnector",
+			Upstream:               []string{"https://example.test/x.yaml"}},
+	}}, nil)
+	if !strings.Contains(buf.String(), "?") {
+		t.Errorf("nil registration map should render ?\n%s", buf.String())
+	}
+}
+
+func TestPrintCatalogTableEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	printCatalogTable(&buf, &CatalogResponse{}, map[string]bool{})
+	if !strings.Contains(buf.String(), "0 catalog entries") {
+		t.Errorf("empty catalog render wrong: %q", buf.String())
+	}
+}
+
+// --- registeredTriples -----------------------------------------------------
+
+func TestRegisteredTriplesFromMockServer(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"GET /api/v1/connectors": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 200, ListResponse{Connectors: []Summary{
+				{ConnectorID: "vmware-rest-9.0", Product: "vmware", Version: "9.0", ImplID: "vmware-rest"},
+			}})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	set := registeredTriples(context.Background(), srv.URL)
+	if !set[tripleKey("vmware", "9.0", "vmware-rest")] {
+		t.Fatalf("expected vmware triple registered; got %+v", set)
+	}
+	if set[tripleKey("nsx", "4.2", "nsx-rest")] {
+		t.Fatalf("nsx should not be registered")
+	}
+}
+
+// --- runIngest catalog mode (end-to-end through the verb) -------------------
+
+func TestRunIngestCatalogModeRoundTrip(t *testing.T) {
+	var posted IngestRequest
+	srv := mockBackplane(t, map[string]mockHandler{
+		"GET /api/v1/connectors/catalog": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, 200, CatalogResponse{Catalog: []CatalogEntry{{
+				Product: "vmware", Version: "9.0", ImplID: "vmware-rest",
+				RequiresConnectorClass: "VmwareRestConnector",
+				Upstream: []string{
+					"https://example.test/vcenter.yaml",
+					"https://example.test/vi-json.yaml",
+				},
+			}}})
+		},
+		"POST /api/v1/connectors/ingest": func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			if err := json.Unmarshal(body, &posted); err != nil {
+				t.Errorf("decode ingest body: %v", err)
+			}
+			writeJSON(t, w, 200, IngestResponse{
+				Ingestion: IngestionResult{ConnectorID: "vmware-rest-9.0", InsertedCount: 961},
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := runIngest(cmd, ingestOptions{Catalog: "vmware/9.0", BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runIngest catalog mode: %v", err)
+	}
+	if posted.Product != "vmware" || posted.Version != "9.0" || posted.ImplID != "vmware-rest" {
+		t.Fatalf("posted triple wrong: %+v", posted)
+	}
+	if len(posted.Specs) != 2 || posted.Specs[0].URI != "https://example.test/vcenter.yaml" {
+		t.Fatalf("posted specs wrong: %+v", posted.Specs)
+	}
+}

--- a/cli/internal/cmd/connector/catalog_test.go
+++ b/cli/internal/cmd/connector/catalog_test.go
@@ -213,6 +213,36 @@ func TestResolveCatalogEntryTemplatedRefused(t *testing.T) {
 	}
 }
 
+func TestResolveCatalogEntryDuplicateRejected(t *testing.T) {
+	url := catalogServer(t, []CatalogEntry{
+		{Product: "vmware", Version: "9.0", ImplID: "vmware-rest",
+			Upstream: []string{"https://example.test/a.yaml"}},
+		{Product: "vmware", Version: "9.0", ImplID: "vmware-rest-2",
+			Upstream: []string{"https://example.test/b.yaml"}},
+	})
+	_, err := resolveCatalogEntry(context.Background(), url, "vmware/9.0")
+	if err == nil || !errors.Is(err, errCatalogResolve) {
+		t.Fatalf("want errCatalogResolve, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "multiple entries") {
+		t.Errorf("duplicate message wrong: %v", err)
+	}
+}
+
+func TestResolveCatalogEntryEmptyUpstreamRejected(t *testing.T) {
+	url := catalogServer(t, []CatalogEntry{{
+		Product: "vmware", Version: "9.0", ImplID: "vmware-rest",
+		Upstream: []string{"   "},
+	}})
+	_, err := resolveCatalogEntry(context.Background(), url, "vmware/9.0")
+	if err == nil || !errors.Is(err, errCatalogResolve) {
+		t.Fatalf("want errCatalogResolve, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "empty upstream") {
+		t.Errorf("empty-upstream message wrong: %v", err)
+	}
+}
+
 // --- printCatalogTable -----------------------------------------------------
 
 func TestPrintCatalogTableHappyPath(t *testing.T) {

--- a/cli/internal/cmd/connector/connector.go
+++ b/cli/internal/cmd/connector/connector.go
@@ -65,11 +65,12 @@ import (
 func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "connector",
-		Short:        "G0.7 spec-ingestion + review workflow (ingest / list / review / edit / enable / disable)",
+		Short:        "G0.7 spec-ingestion + review workflow (ingest / list / catalog / review / edit / enable / disable)",
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(newIngestCmd())
 	cmd.AddCommand(newListCmd())
+	cmd.AddCommand(newCatalogCmd())
 	cmd.AddCommand(newReviewCmd())
 	cmd.AddCommand(newEditGroupCmd())
 	cmd.AddCommand(newEditOpCmd())

--- a/cli/internal/cmd/connector/ingest.go
+++ b/cli/internal/cmd/connector/ingest.go
@@ -6,8 +6,10 @@ package connector
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -112,6 +114,7 @@ func newIngestCmd() *cobra.Command {
 		versionFlag       string
 		implID            string
 		specs             []string
+		catalog           string
 		dryRun            bool
 		jsonOut           bool
 		backplaneOverride string
@@ -119,20 +122,26 @@ func newIngestCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ingest",
 		Short: "Ingest one or more vendor specs into a new connector (staged state)",
-		Long: "ingest parses each --spec URI, registers the operations into the\n" +
+		Long: "ingest parses each spec, registers the operations into the\n" +
 			"endpoint_descriptor table under one connector_id, and runs the\n" +
 			"LLM-summarised grouping pass. The newly-ingested connector lands\n" +
 			"in review_status=staged — operations are NOT dispatchable until\n" +
 			"an operator runs `meho connector review <id>` + `meho connector\n" +
 			"enable <id>`.\n\n" +
-			"--spec accepts three URI shapes:\n" +
-			"  - file:///abs/path/to/spec.yaml          (local file)\n" +
-			"  - https://example.com/spec.yaml           (HTTP fetch)\n" +
-			"  - docs:<product-version>/<spec.yaml>      (resolves against\n" +
-			"    $CLAUDE_RDC_DOCS when set; otherwise passed through for\n" +
-			"    backplane-side resolution against its own checked-in docs)\n\n" +
-			"Repeat --spec to merge multiple specs under one connector_id\n" +
-			"(vSphere is the canonical case: vcenter.yaml + vi-json.yaml).\n\n" +
+			"Two mutually-exclusive modes:\n\n" +
+			"  Catalog mode: --catalog <product>/<version> resolves the curated\n" +
+			"  catalog entry (see `meho connector catalog list`) and ingests its\n" +
+			"  recommended triple + upstream spec URL(s). Typed-connector and\n" +
+			"  fqdn-templated entries are refused with a hint.\n\n" +
+			"  Manual mode: --product + --version + --impl + one-or-more --spec.\n" +
+			"  --spec accepts three URI shapes:\n" +
+			"    - file:///abs/path/to/spec.yaml          (local file)\n" +
+			"    - https://example.com/spec.yaml           (HTTP fetch)\n" +
+			"    - docs:<product-version>/<spec.yaml>      (resolves against\n" +
+			"      $CLAUDE_RDC_DOCS when set; otherwise passed through for\n" +
+			"      backplane-side resolution against its own checked-in docs)\n" +
+			"  Repeat --spec to merge multiple specs under one connector_id\n" +
+			"  (vSphere is the canonical case: vcenter.yaml + vi-json.yaml).\n\n" +
 			"--dry-run parses + plans without writing to the DB; useful for\n" +
 			"validating a spec before committing. Role: tenant_admin.",
 		Args:          cobra.NoArgs,
@@ -144,6 +153,7 @@ func newIngestCmd() *cobra.Command {
 				Version:           versionFlag,
 				ImplID:            implID,
 				Specs:             specs,
+				Catalog:           catalog,
 				DryRun:            dryRun,
 				JSONOut:           jsonOut,
 				BackplaneOverride: backplaneOverride,
@@ -151,23 +161,22 @@ func newIngestCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&product, "product", "",
-		"product name (e.g. vmware, kubernetes); required")
+		"product name (e.g. vmware, kubernetes); manual mode (required with --version/--impl/--spec)")
 	cmd.Flags().StringVar(&versionFlag, "version", "",
-		"product version (e.g. 9.0, 1.x); required")
+		"product version (e.g. 9.0, 1.x); manual mode")
 	cmd.Flags().StringVar(&implID, "impl", "",
-		"impl identifier (e.g. vmware-rest, k8s-go); required")
+		"impl identifier (e.g. vmware-rest, k8s-go); manual mode")
 	cmd.Flags().StringArrayVar(&specs, "spec", nil,
-		"spec URI; repeat for multi-spec merge under one connector_id (required, at least one)")
+		"spec URI; repeat for multi-spec merge under one connector_id; manual mode")
+	cmd.Flags().StringVar(&catalog, "catalog", "",
+		"catalog mode: ingest the curated entry for <product>/<version> (e.g. vmware/9.0); "+
+			"mutually exclusive with --product/--version/--impl/--spec")
 	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
 		"parse and plan without writing to the DB; the response carries an IngestionResult with counts but no GroupingResult")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
 		"emit machine-readable JSON to stdout instead of the human summary")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
-	_ = cmd.MarkFlagRequired("product")
-	_ = cmd.MarkFlagRequired("version")
-	_ = cmd.MarkFlagRequired("impl")
-	_ = cmd.MarkFlagRequired("spec")
 	return cmd
 }
 
@@ -176,41 +185,57 @@ type ingestOptions struct {
 	Version           string
 	ImplID            string
 	Specs             []string
+	Catalog           string
 	DryRun            bool
 	JSONOut           bool
 	BackplaneOverride string
 }
 
 func runIngest(cmd *cobra.Command, opts ingestOptions) error {
-	// Validate + resolve the spec URIs locally so the operator gets a
-	// fast hint on a typo'd scheme rather than a backplane 422.
-	if len(opts.Specs) == 0 {
-		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected("at least one --spec is required"),
-			opts.JSONOut,
-		)
-	}
-	resolved := make([]SpecSource, 0, len(opts.Specs))
-	for _, raw := range opts.Specs {
-		uri, err := resolveSpecURI(raw)
-		if err != nil {
-			return output.RenderError(cmd.ErrOrStderr(),
-				output.Unexpected(err.Error()),
-				opts.JSONOut,
-			)
-		}
-		resolved = append(resolved, SpecSource{URI: uri})
+	if err := validateIngestMode(opts); err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), opts.JSONOut)
 	}
 
 	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
 	}
+
+	var specs []SpecSource
+	if opts.Catalog != "" {
+		entry, rerr := resolveCatalogEntry(cmd.Context(), backplaneURL, opts.Catalog)
+		if rerr != nil {
+			// Local resolution failures (bad ref, no entry, typed
+			// connector, templated upstream) carry errCatalogResolve and
+			// render as `unexpected`; transport/auth errors from the GET
+			// route through renderRequestError.
+			if errors.Is(rerr, errCatalogResolve) {
+				return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(rerr.Error()), opts.JSONOut)
+			}
+			return renderRequestError(cmd, backplaneURL, rerr, opts.JSONOut)
+		}
+		// Adopt the catalog's recommended triple so the summary + the
+		// posted body carry it (the catalog flag supplies no triple).
+		opts.Product, opts.Version, opts.ImplID = entry.Product, entry.Version, entry.ImplID
+		specs = upstreamSpecs(entry.Upstream)
+	} else {
+		// Manual mode: resolve each --spec URI locally so the operator
+		// gets a fast hint on a typo'd scheme rather than a backplane 422.
+		specs = make([]SpecSource, 0, len(opts.Specs))
+		for _, raw := range opts.Specs {
+			uri, uerr := resolveSpecURI(raw)
+			if uerr != nil {
+				return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(uerr.Error()), opts.JSONOut)
+			}
+			specs = append(specs, SpecSource{URI: uri})
+		}
+	}
+
 	result, err := postIngest(cmd.Context(), backplaneURL, IngestRequest{
 		Product: opts.Product,
 		Version: opts.Version,
 		ImplID:  opts.ImplID,
-		Specs:   resolved,
+		Specs:   specs,
 		DryRun:  opts.DryRun,
 	})
 	if err != nil {
@@ -220,6 +245,45 @@ func runIngest(cmd *cobra.Command, opts ingestOptions) error {
 		return output.PrintJSON(cmd.OutOrStdout(), result)
 	}
 	printIngestSummary(cmd.OutOrStdout(), opts, result)
+	return nil
+}
+
+// validateIngestMode enforces the catalog/manual split: exactly one
+// mode, and manual mode needs the full triple + at least one --spec.
+// Replaces the per-flag MarkFlagRequired wiring (which can't express
+// "required unless --catalog").
+func validateIngestMode(opts ingestOptions) error {
+	manualSet := opts.Product != "" || opts.Version != "" || opts.ImplID != "" || len(opts.Specs) > 0
+	if opts.Catalog != "" {
+		if manualSet {
+			return errors.New(
+				"--catalog cannot be combined with --product/--version/--impl/--spec; " +
+					"use catalog mode OR manual mode, not both")
+		}
+		return nil
+	}
+	if !manualSet {
+		return errors.New(
+			"specify a connector to ingest: --catalog <product>/<version>, " +
+				"or manual mode (--product --version --impl --spec)")
+	}
+	var missing []string
+	if opts.Product == "" {
+		missing = append(missing, "--product")
+	}
+	if opts.Version == "" {
+		missing = append(missing, "--version")
+	}
+	if opts.ImplID == "" {
+		missing = append(missing, "--impl")
+	}
+	if len(opts.Specs) == 0 {
+		missing = append(missing, "--spec")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("manual ingest requires %s (or use --catalog <product>/<version>)",
+			strings.Join(missing, ", "))
+	}
 	return nil
 }
 

--- a/docs/cross-repo/connector-catalog.md
+++ b/docs/cross-repo/connector-catalog.md
@@ -80,20 +80,26 @@ of each connector's first verified `--catalog` ingest.
 
 ## Operator workflow
 
-1. `meho connector catalog list` — see which `(product, version)` entries
-   exist and which connector classes are registered.
+1. `meho connector catalog list` — print the catalog table: each
+   `(product, version)` entry's `impl_id`, the connector class that
+   covers it, whether that class is registered on this backplane (`reg`
+   column), the observed `spec_info_version`, and notes. Read-only;
+   operator role suffices.
 2. `meho connector ingest --catalog <product>/<version>` — resolve the
-   entry, fetch the upstream spec(s), and ingest under the recommended
-   triple.
+   entry and ingest its recommended triple + upstream spec URL(s) (the
+   backplane fetches each URL). Typed-connector entries (`upstream:
+   null`) and fqdn-templated upstream URLs are refused with a hint to
+   use the explicit `--spec` form instead. `--catalog` is mutually
+   exclusive with the manual `--product`/`--version`/`--impl`/`--spec`
+   flags. Add `--dry-run` to validate before committing.
 3. `meho connector review <connector_id>` → `meho connector enable <id>` —
    vet the LLM-summarised groups and turn the operations on.
 
-> The `catalog list` and `ingest --catalog` verbs are tracked in
-> [#915](https://github.com/evoila/meho/issues/915) (the CLI half split
-> out of #743 per the connector `-T` convention). Until they land, use the
-> explicit `meho connector ingest --spec <url>` form from
-> [`connector-ingestion.md`](connector-ingestion.md), reading the `upstream`
-> URL(s) from the catalog by hand.
+For an entry the catalog can't ingest directly (typed, or fqdn-templated
+upstream such as `nsx`), fall back to the explicit `meho connector ingest
+--product … --version … --impl … --spec <url>` form documented in
+[`connector-ingestion.md`](connector-ingestion.md), reading the `upstream`
+URL(s) from `catalog list`.
 
 ## Adding or updating an entry
 


### PR DESCRIPTION
## Summary

- Adds the operator-facing **Go CLI half** of the connector-spec catalog (Goal #214 raw-REST ingest on-ramp). The backend substrate + `GET /api/v1/connectors/catalog` landed in #743; this PR ships the two verbs that consume it (the CLI is a separate binary and can't read the server's packaged catalog file).
- **`meho connector catalog list`** — GETs the catalog and renders a table (`product/version`, `impl_id`, connector class, `reg`, `spec_ver`, notes) or `--json`. The `reg` column best-effort cross-references `GET /connectors` (which unions the class-side registry per #733); on failure it degrades to `?` rather than failing the listing.
- **`meho connector ingest --catalog <product>/<version>`** — resolves the entry and POSTs its recommended triple + upstream spec URLs (the backplane fetches them). Mutually exclusive with the manual `--product`/`--version`/`--impl`/`--spec` flags (validated **before any network call**); typed connectors (`upstream: null`) and fqdn-templated upstream URLs (e.g. `nsx`) are refused with an actionable hint instead of POSTing a bad request.

## Notable decisions

- **`validateIngestMode` replaces `MarkFlagRequired`.** cobra's per-flag required wiring can't express "required *unless* `--catalog`", so the manual-mode completeness + catalog/manual mutual-exclusion is enforced in one validator with clear messages. No existing test couples to the old required-flag behavior (they call the functions directly).
- **OpenAPI snapshot: surgical `/catalog` add, not a full regen.** The committed `cli/api/openapi.json` was **22 routes stale** (27→49 paths); a full `make snapshot-openapi` produced a ~3,700-line diff dominated by unrelated drift. Per surgical-changes discipline, I added **only** the `/catalog` path (self-contained — it refs only the pre-existing `HTTPValidationError`). The broader snapshot drift is a pre-existing maintenance gap left for a dedicated regen task (see Out of scope).

## Test plan

- [x] `cd cli && gofmt -l .` — clean
- [x] `go build ./...` + `go vet ./...` — clean
- [x] `golangci-lint run ./internal/cmd/connector/` — 0 issues
- [x] `go test -race ./...` — all packages pass
- [x] New `catalog_test.go` covers: `parseCatalogRef` table, `upstreamSpecs`, `validateIngestMode` table (catalog-only / manual-complete / both-set / neither / manual-incomplete), `getCatalog` decode (null upstream→nil, null spec_info_version→nil ptr), `resolveCatalogEntry` happy/not-found/typed-refused/templated-refused, `printCatalogTable` (happy / unknown-registration `?` / empty), `registeredTriples`, and an end-to-end `runIngest` catalog-mode round-trip asserting the POSTed triple + specs
- [x] `make snapshot-openapi` confirmed the live `/catalog` shape; spliced surgically into the snapshot (28 paths, +52 lines)

## Out of scope

- **Full OpenAPI snapshot regen** (the 22-route pre-existing drift) — recommend a dedicated `chore(cli): regen openapi.json snapshot` task; mixing it here would bury this feature in ~3,700 unrelated lines.
- `fqdn` templating for appliance-served specs (e.g. `nsx`) — the CLI refuses templated upstream with a hint to use `--spec`; auto-templating is a future enhancement.
- MCP tool surface for the catalog (CLI-only here).

Closes #915

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added connector catalog API endpoint (GET /api/v1/connectors/catalog) returning a typed catalog envelope
  * Added `meho connector catalog list` with registration column and human/JSON output
  * Added `meho connector ingest --catalog <product>/<version>` mode (mutually exclusive with manual flags)

* **Tests**
  * Added comprehensive unit and end-to-end tests for catalog parsing, resolution, rendering, and ingest round‑trip

* **Documentation**
  * Updated operator workflow with catalog behavior, constraints, and fallback guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/926?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->