### PR TITLE
ci(sonar): resolve coverage paths via backend/ source root (fixes 0% import)

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -63,6 +63,23 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         continue-on-error: true  # missing artifact degrades to "no coverage", never blocks
 
+      - name: Point coverage report at the backend/ source root
+        # coverage.py (relative_files=true) writes an empty <source></source>
+        # and filenames like `src/meho_backplane/...` relative to backend/.
+        # SonarCloud resolves coverage paths from the repo root, so without
+        # the `backend/` prefix every file fails with "Cannot resolve the
+        # file path ... the file does not exist in all 'source'" and coverage
+        # imports as 0% (observed on the #920 merge run). Injecting the
+        # source root makes paths resolve to backend/src/meho_backplane/...
+        # Guarded on the file existing so a missing coverage artifact is a no-op.
+        if: hashFiles('backend/coverage.xml') != ''
+        run: |
+          set -euo pipefail
+          sed -i 's#<source></source>#<source>backend</source>#' backend/coverage.xml
+          grep -q '<source>backend</source>' backend/coverage.xml \
+            && echo "coverage source root set to backend/" \
+            || echo "::warning::coverage <source> not rewritten — sonar may report 0% coverage"
+
       - name: Ensure dirmngr is available (for sonar-scanner GPG verify)
         run: |
           set -euo pipefail

--- a/docs/codebase/sonarcloud.md
+++ b/docs/codebase/sonarcloud.md
@@ -26,7 +26,7 @@ push / PR ──► CI workflow ──► uploads python-coverage artifact (back
 | Project + scope config | [`sonar-project.properties`](../../sonar-project.properties) |
 | Scan trigger + coverage handoff | [`.github/workflows/quality-gate.yml`](../../.github/workflows/quality-gate.yml) |
 | Coverage production | [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) — `Pytest (unit + coverage)` |
-| Coverage path portability | `[tool.coverage.run] relative_files` in [`backend/pyproject.toml`](../../backend/pyproject.toml) |
+| Coverage path portability | `[tool.coverage.run] relative_files` ([`backend/pyproject.toml`](../../backend/pyproject.toml)) + quality-gate.yml's `Point coverage report at the backend/ source root` step (injects `<source>backend</source>` so paths resolve from the repo root) |
 | Auth | `SONAR_TOKEN` repo secret (write/scan only) |
 
 Coverage is the **unit sweep only** (`--cov=meho_backplane`); integration tests

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -62,13 +62,14 @@ sonar.cpd.exclusions=backend/tests/**,**/*_test.go,**/*.gen.go
 # uploaded as the `python-coverage` artifact, and downloaded back into
 # backend/ by quality-gate.yml before this scan runs. `relative_files`
 # (backend/pyproject.toml [tool.coverage.run]) keeps the report paths
-# portable across the two jobs so SonarCloud can resolve them.
+# portable across the two jobs.
 #
-# NOTE: path resolution must be confirmed on the first post-merge Quality
-# Gate run — watch the scan log for "Could not resolve the file path ...
-# in coverage report". It is non-blocking (quality-gate.yml is
-# continue-on-error), so a mismatch degrades to "no coverage" rather than
-# failing the build; adjust reportPaths if the warning appears.
+# coverage.py emits an empty <source></source> with filenames relative to
+# backend/ (e.g. `src/meho_backplane/...`); SonarCloud resolves from the
+# repo root, so quality-gate.yml's "Point coverage report at the backend/
+# source root" step injects <source>backend</source> before the scan,
+# making paths resolve to backend/src/meho_backplane/... (the #920 merge
+# run imported 0% without it). Non-blocking either way (continue-on-error).
 sonar.python.version=3.12, 3.13
 sonar.python.coverage.reportPaths=backend/coverage.xml
 # sonar.javascript.lcov.reportPaths=meho_frontend/coverage/lcov.info


### PR DESCRIPTION
## Why

#920 fixed test-scoping (reliability **E→A**, bugs 51→0, hotspots 28→3) but **coverage still imported as 0%**. The Quality Gate log on the #920 merge run shows why:

```
ERROR Cannot resolve the file path 'src/meho_backplane/__init__.py' of the coverage report, the file does not exist in all 'source'.
ERROR Cannot resolve 229 file paths, ignoring coverage measures for those files
```

`coverage.py` (`relative_files=true`) emits an empty `<source></source>` with filenames relative to `backend/` (e.g. `src/meho_backplane/...`). SonarCloud resolves coverage paths from the **repo root**, so it looks for `<root>/src/...` instead of `<root>/backend/src/...` — off by the `backend/` prefix, and all 229 files fail.

## What

A guarded step in `quality-gate.yml` injects `<source>backend</source>` into the downloaded `coverage.xml` before the scan, so paths resolve to `backend/src/meho_backplane/...`. Validated against the actual artifact from the #920 run.

The coverage data itself is **~95% line coverage** (`13217/13905`), so this unlocks the real number and the `new_coverage ≥ 80` gate condition.

## Risk

Low. The step is `if: hashFiles('backend/coverage.xml') != ''` guarded and the scan stays `continue-on-error`, so a missing artifact is a no-op and nothing here can block CI.

Refs #921.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SonarCloud runbook with clarified coverage path resolution mechanism.

* **Chores**
  * Enhanced quality gate workflow with improved coverage file path handling to ensure SonarCloud correctly resolves coverage reports from the repository root.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/927?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->