### PR TITLE
fix(chart): add ephemeral-storage limits to backplane/broadcast/migration (kubernetes:S6870)

### DIFF
--- a/deploy/charts/meho/charts/broadcast/values.yaml
+++ b/deploy/charts/meho/charts/broadcast/values.yaml
@@ -55,9 +55,14 @@ resources:
   limits:
     cpu: 500m
     memory: 512Mi
+    # -- Node-pressure guard for the ephemeral streams data emptyDir +
+    # logs (kubernetes:S6870). Subchart default; the parent chart's
+    # `broadcast.resources` mirrors it.
+    ephemeral-storage: 512Mi
   requests:
     cpu: 50m
     memory: 128Mi
+    ephemeral-storage: 128Mi
 
 service:
   # -- Service type. ClusterIP is the only sensible choice for v0.1 — the

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -723,6 +723,10 @@
         "memory": {
           "type": "string",
           "pattern": "^[0-9]+(\\.[0-9]+)?(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$"
+        },
+        "ephemeral-storage": {
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?(E|P|T|G|M|K|Ei|Pi|Ti|Gi|Mi|Ki)?$"
         }
       }
     }

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -155,9 +155,15 @@ resources:
   limits:
     cpu: 1000m
     memory: 1Gi
+    # -- Bounds writable-layer + emptyDir (tmp, fastembed-cache) + log
+    # growth so a runaway write can't trigger node-pressure eviction of
+    # co-located pods (kubernetes:S6870). The default model is baked into
+    # the image layer, not ephemeral storage.
+    ephemeral-storage: 1Gi
   requests:
     cpu: 100m
     memory: 256Mi
+    ephemeral-storage: 256Mi
 
 # -- ConfigMap-sourced environment variables (non-secret).
 # These map 1:1 to `backend/src/meho_backplane/settings.py` env-var contract.
@@ -398,9 +404,13 @@ broadcast:
     limits:
       cpu: 500m
       memory: 512Mi
+      # -- Node-pressure guard for the broadcast container's ephemeral
+      # data emptyDir + logs (kubernetes:S6870).
+      ephemeral-storage: 512Mi
     requests:
       cpu: 50m
       memory: 128Mi
+      ephemeral-storage: 128Mi
   service:
     type: ClusterIP
     port: 6379
@@ -430,9 +440,13 @@ migrationJob:
     limits:
       cpu: 500m
       memory: 512Mi
+      # -- Short-lived migration runner; small ephemeral footprint
+      # (kubernetes:S6870).
+      ephemeral-storage: 256Mi
     requests:
       cpu: 50m
       memory: 256Mi
+      ephemeral-storage: 64Mi
 
 connectors:
   # -- v0.1 ships the chassis with no connectors enabled. The connector


### PR DESCRIPTION
## Why

SonarCloud `kubernetes:S6870` ("Specify a storage limit for this container") flagged the three main chart containers for lacking an `ephemeral-storage` bound. Without one, a container that exhausts the node's ephemeral storage (writable layer, `emptyDir` volumes — `tmp` / `fastembed-cache` / broadcast streams — and logs) can trigger **node-pressure eviction of co-located pods**.

Closes the T3 item of Initiative #921. Refs #924.

## What

All three resource blocks are values-driven (`{{- toYaml .Values... }}`), so the fix lives in values, not templates:

| Container | requests | limits |
|---|---|---|
| backplane | ephemeral-storage: 256Mi | 1Gi |
| broadcast | 128Mi | 512Mi |
| migration job | 64Mi | 256Mi |

- `deploy/charts/meho/values.yaml` — `resources`, `broadcast.resources`, `migrationJob.resources`
- `deploy/charts/meho/charts/broadcast/values.yaml` — subchart `resources` default (so SonarCloud resolves the subchart template, and the parent override is mirrored)
- `deploy/charts/meho/values.schema.json` — the shared `resourceQuantities` definition (`additionalProperties: false`) is extended to permit `ephemeral-storage` (same quantity pattern as `memory`); one edit covers all three blocks.

## Verification

- `helm lint` → **0 failures**.
- `helm template` → all three containers render `ephemeral-storage` under both `requests` and `limits` (6 occurrences).

Because the limits are injected via `toYaml .Values.resources`, if SonarCloud's Helm analyzer can't resolve that indirection statically, S6870 may need to be marked **Accepted** — the rendered manifests demonstrably carry the limits.

## Out of scope

A postgres-readiness initContainer also lacks an ephemeral-storage limit but was **not** flagged by S6870 (the rule's selector skips initContainers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Helm chart configurations to include ephemeral storage resource specifications across deployment containers. Added ephemeral storage limits of 512Mi and requests of 128Mi for primary components. Updated the Helm schema definitions to validate and support the new ephemeral storage resource parameters in deployment configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/932?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->