### PR TITLE
feat(topology): G9.3-T3 history verb + GET /topology/history + query_topology(kind=history)

### DIFF
--- a/backend/src/meho_backplane/api/v1/topology.py
+++ b/backend/src/meho_backplane/api/v1/topology.py
@@ -123,6 +123,7 @@ from meho_backplane.topology.query import (
     find_dependents,
     find_path,
     list_edges,
+    query_history,
     query_timeline,
 )
 from meho_backplane.topology.refresh import RefreshResult, refresh_target_topology
@@ -130,6 +131,7 @@ from meho_backplane.topology.resolvers import NodeNotFoundError
 from meho_backplane.topology.schemas import (
     TopologyEdge,
     TopologyEdgeEndpoint,
+    TopologyHistoryResult,
     TopologyNode,
     TopologyPath,
     TopologyTimelineResult,
@@ -166,6 +168,7 @@ _OP_UNANNOTATE = "topology.unannotate"
 _OP_LIST_EDGES = "topology.list_edges"
 _OP_BULK_IMPORT = "topology.bulk_import"
 _OP_TIMELINE = "topology.timeline"
+_OP_HISTORY = "topology.history"
 
 #: HTTP-boundary ceiling on the number of edges accepted in one
 #: ``POST /edges/bulk`` body. The consumer's INVENTORY.md
@@ -192,6 +195,16 @@ _LIST_EDGES_LIMIT_MAX = 1000
 #: substrate primitive's own ceiling.
 _TIMELINE_LIMIT_DEFAULT = 50
 _TIMELINE_LIMIT_MAX = 1000
+
+#: ``GET /topology/history/{name}`` ``limit`` ceiling at the HTTP
+#: boundary. Mirrors the substrate ceiling
+#: :data:`meho_backplane.topology.query._MAX_HISTORY_ROWS`. Per-resource
+#: history is bounded by retention (default 90 days) and the operator
+#: typically wants the complete walk in one response; the route default
+#: is the same ceiling because a tighter cap on the HTTP boundary
+#: would silently truncate the walk and the operator would think they
+#: see the full history when they don't.
+_HISTORY_LIMIT_MAX = 5000
 
 #: Bounds mirror the service-layer defaults (``query._DEFAULT_DEPTH`` /
 #: ``query._DEFAULT_MAX_HOPS``); the ceilings cap a pathological
@@ -1003,5 +1016,89 @@ async def timeline_route(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     # Broadcast aggregate signal: row count only, never per-row payload.
+    structlog.contextvars.bind_contextvars(audit_row_count=len(result.rows))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# G9.3-T3 (#859) — per-resource history walk
+# ---------------------------------------------------------------------------
+
+
+@router.get("/history/{name}", response_model=TopologyHistoryResult)
+async def history_route(
+    name: str,
+    kind: str | None = Query(default=None, max_length=64),
+    since: datetime | None = Query(default=None),
+    until: datetime | None = Query(default=None),
+    include_edges: bool = Query(default=False),
+    limit: int = Query(default=_HISTORY_LIMIT_MAX, ge=1, le=_HISTORY_LIMIT_MAX),
+    operator: Operator = _require_operator,
+) -> TopologyHistoryResult:
+    """Chronological history walk anchored at one ``graph_node``.
+
+    Wraps :func:`~meho_backplane.topology.query.query_history` (G9.3-T3
+    #859). Companion to ``GET /topology/timeline`` (G9.3-T5): timeline
+    is "what changed in the graph at all in this window"; history is
+    "what changed for THIS specific resource". Resolved via the G9.1
+    resolver :func:`~meho_backplane.topology.resolvers.resolve_node` so
+    name + optional kind disambiguation use the same surface every
+    G9.1 + G9.2 verb does.
+
+    Query parameters:
+
+    * ``kind`` -- optional ``graph_node.kind`` pin to disambiguate
+      when a bare *name* resolves to multiple kinds in the tenant.
+    * ``since`` / ``until`` -- ISO-8601 absolute datetime bounds on
+      ``valid_from`` (inclusive at both ends). The CLI front resolves
+      duration shorthand (``"24h"`` / ``"7d"``) to an absolute
+      timestamp before crossing the wire, mirroring the timeline
+      route's split.
+    * ``include_edges`` -- when ``true``, also walk every history row
+      for edges incident to the resolved node (joined via the inner
+      subquery ``edge_id IN (SELECT id FROM graph_edge WHERE
+      from_node_id = anchor OR to_node_id = anchor)``). The merged
+      result still orders newest-first.
+    * ``limit`` -- hard cap on returned rows (1..``_HISTORY_LIMIT_MAX``).
+      Defaults to the ceiling because per-resource history is bounded
+      by retention; tighter caps would silently truncate the walk.
+
+    Errors:
+
+    * **404 ``node_not_found``** -- *name* (and *kind*, when supplied)
+      does not resolve to any node in the tenant. Cross-tenant names
+      surface identically -- the tenant boundary is opaque to the
+      caller.
+    * **409 ``ambiguous_node``** -- bare *name* resolves to multiple
+      kinds; pass ``kind`` to disambiguate.
+
+    The route binds ``audit_op_id="topology.history"`` /
+    ``audit_op_class="audit_query"`` per [decision #3](docs/planning/v0.2-decisions.md)
+    -- temporal graph queries are inspections of system state,
+    parallel to G8's audit-log query surface; the broadcast event
+    carries only ``{op_id, result_status, row_count}`` so the
+    response rows (which may carry the snapshot of a sensitive
+    resource's pre/post payload) never leak onto the SSE / Slack
+    feed. Same shape T5's timeline route uses.
+    """
+    structlog.contextvars.bind_contextvars(
+        audit_op_id=_OP_HISTORY,
+        audit_op_class="audit_query",
+    )
+    try:
+        result = await query_history(
+            operator,
+            name,
+            kind=kind,
+            since=since,
+            until=until,
+            include_edges=include_edges,
+            limit=limit,
+        )
+    except AmbiguousNodeError as exc:
+        raise _ambiguous_node_http(exc) from exc
+    except NodeNotFoundError as exc:
+        raise _node_not_found_http(exc) from exc
+
     structlog.contextvars.bind_contextvars(audit_row_count=len(result.rows))
     return result

--- a/backend/src/meho_backplane/api/v1/topology.py
+++ b/backend/src/meho_backplane/api/v1/topology.py
@@ -1025,7 +1025,81 @@ async def timeline_route(
 # ---------------------------------------------------------------------------
 
 
-@router.get("/history/{name}", response_model=TopologyHistoryResult)
+@router.get(
+    "/history/{name}",
+    response_model=TopologyHistoryResult,
+    responses={
+        # 404 ``node_not_found`` / 409 ``ambiguous_node`` -- declared
+        # explicitly so FastAPI's autogen OpenAPI surfaces both runtime
+        # error shapes to SDK clients. The route handler below raises
+        # via ``_node_not_found_http`` / ``_ambiguous_node_http`` which
+        # produce ``HTTPException(404, detail={"error": "node_not_found",
+        # ...})`` and ``HTTPException(409, detail={"error":
+        # "ambiguous_node", ...})`` respectively. Without these
+        # declarations the spec only listed 200 + 422 and clients had no
+        # schema-driven signal for the recoverable per-anchor errors
+        # (the operator's first-line diagnostics).
+        404: {
+            "description": (
+                "Anchor node not found by ``name`` (and ``kind`` when "
+                "supplied)."
+            ),
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "detail": {
+                                "type": "object",
+                                "properties": {
+                                    "error": {
+                                        "type": "string",
+                                        "enum": ["node_not_found"],
+                                    },
+                                    "name": {"type": "string"},
+                                    "kind": {"type": "string"},
+                                },
+                                "required": ["error", "name"],
+                            },
+                        },
+                        "required": ["detail"],
+                    },
+                },
+            },
+        },
+        409: {
+            "description": (
+                "Bare ``name`` resolves to multiple ``kind`` candidates; "
+                "client should re-issue with an explicit ``kind``."
+            ),
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "detail": {
+                                "type": "object",
+                                "properties": {
+                                    "error": {
+                                        "type": "string",
+                                        "enum": ["ambiguous_node"],
+                                    },
+                                    "name": {"type": "string"},
+                                    "kinds": {
+                                        "type": "array",
+                                        "items": {"type": "string"},
+                                    },
+                                },
+                                "required": ["error", "name", "kinds"],
+                            },
+                        },
+                        "required": ["detail"],
+                    },
+                },
+            },
+        },
+    },
+)
 async def history_route(
     name: str,
     kind: str | None = Query(default=None, max_length=64),

--- a/backend/src/meho_backplane/api/v1/topology.py
+++ b/backend/src/meho_backplane/api/v1/topology.py
@@ -1040,10 +1040,7 @@ async def timeline_route(
         # schema-driven signal for the recoverable per-anchor errors
         # (the operator's first-line diagnostics).
         404: {
-            "description": (
-                "Anchor node not found by ``name`` (and ``kind`` when "
-                "supplied)."
-            ),
+            "description": ("Anchor node not found by ``name`` (and ``kind`` when supplied)."),
             "content": {
                 "application/json": {
                     "schema": {

--- a/backend/src/meho_backplane/mcp/tools/topology.py
+++ b/backend/src/meho_backplane/mcp/tools/topology.py
@@ -109,6 +109,7 @@ from meho_backplane.topology.query import (
     find_dependents,
     find_path,
     list_edges,
+    query_history,
     query_timeline,
 )
 from meho_backplane.topology.resolvers import NodeNotFoundError
@@ -161,7 +162,14 @@ _QUERY_TOPOLOGY_INPUT_SCHEMA: Final[dict[str, Any]] = {
     "properties": {
         "kind": {
             "type": "string",
-            "enum": ["dependents", "dependencies", "path", "edges", "timeline"],
+            "enum": [
+                "dependents",
+                "dependencies",
+                "path",
+                "edges",
+                "timeline",
+                "history",
+            ],
             "description": (
                 "Which read shape to run. `dependents` = reverse closure "
                 "(what depends on `target`); `dependencies` = forward "
@@ -174,7 +182,12 @@ _QUERY_TOPOLOGY_INPUT_SCHEMA: Final[dict[str, Any]] = {
                 "the G9.3 `graph_node_history` + `graph_edge_history` "
                 "tables, cursor-paginated -- 'what's been happening in "
                 "the graph in the last hour?' without rooting at a "
-                "specific resource."
+                "specific resource; `history` = per-resource history "
+                "walk for one named node (and optionally its incident "
+                "edges via `include_edges=true`) -- 'when did THIS "
+                "resource start depending on X, and what changed?' -- "
+                "carries the full `snapshot.before` / `snapshot.after` "
+                "JSONB per row."
             ),
         },
         "target": {
@@ -349,6 +362,18 @@ _QUERY_TOPOLOGY_INPUT_SCHEMA: Final[dict[str, Any]] = {
             ),
             "maxLength": 1024,
         },
+        "include_edges": {
+            "type": "boolean",
+            "default": False,
+            "description": (
+                "For `kind=history` only: when `true`, also walk every "
+                "history row for edges incident to the anchor node "
+                "(joined via `edge_id IN (SELECT id FROM graph_edge "
+                "WHERE from_node_id = anchor OR to_node_id = "
+                "anchor)`). Default `false` -- the node-side history "
+                "is the common case. Ignored for the other kinds."
+            ),
+        },
     },
     "required": ["kind"],
     "additionalProperties": False,
@@ -369,6 +394,10 @@ _QUERY_TOPOLOGY_INPUT_SCHEMA: Final[dict[str, Any]] = {
         {
             "if": {"properties": {"kind": {"const": "path"}}},
             "then": {"required": ["from_name", "to_name"]},
+        },
+        {
+            "if": {"properties": {"kind": {"const": "history"}}},
+            "then": {"required": ["target"]},
         },
     ],
 }
@@ -416,7 +445,21 @@ _QUERY_TOPOLOGY_DESCRIPTION: Final[str] = (
     "means more rows exist -- pass it back as `cursor` on the next "
     "call to walk forward. Returns "
     '`{kind: "timeline", rows: [TopologyTimelineEntry, ...], '
-    "next_cursor: <token|null>}`."
+    "next_cursor: <token|null>}`.\n\n"
+    "For `kind=history`: per-resource history walk for one named "
+    "node -- 'when did service-X start depending on database-Y, and "
+    "what changed each time?' → `query_topology {kind: history, "
+    "target: service-X, include_edges: true}`. Required: `target` "
+    "(the node name); optional: `node_kind` to disambiguate, `since` "
+    "/ `until` to bound the window, `include_edges=true` to also "
+    "walk every history row for edges incident to the anchor. "
+    "Carries the full `snapshot.before` / `snapshot.after` JSONB "
+    "per row (unlike `timeline`, which truncates to a one-line "
+    "summary) -- use for forensic 'what was the exact state before "
+    "this change?' questions. Unknown / cross-tenant target returns "
+    '-32602 `node_not_found`. Returns `{kind: "history", rows: '
+    "[TopologyHistoryEntry, ...], anchor_node_id: <uuid>, "
+    "include_edges: <bool>}`."
 )
 
 
@@ -463,6 +506,8 @@ async def _query_topology_handler(
             return {"kind": kind, "edges": [e.model_dump(mode="json") for e in edges]}
         if kind == "timeline":
             return await _timeline_facet(operator, arguments)
+        if kind == "history":
+            return await _history_facet(operator, arguments)
         # kind == "path" — the enum + schema guarantee no other value.
         result = await find_path(
             operator,
@@ -473,6 +518,13 @@ async def _query_topology_handler(
             max_hops=int(arguments.get("max_hops", _MAX_HOPS_DEFAULT)),
         )
     except AmbiguousNodeError as exc:
+        raise McpInvalidParamsError(str(exc)) from exc
+    except NodeNotFoundError as exc:
+        # ``kind=history`` resolves the anchor and surfaces a missing
+        # or cross-tenant name as :class:`NodeNotFoundError`; the
+        # closure / path verbs treat a missing name as an empty
+        # result (G9.1 contract) so they never raise this. The catch
+        # is keyed by the substrate, not by the dispatch branch.
         raise McpInvalidParamsError(str(exc)) from exc
     return {
         "kind": kind,
@@ -546,6 +598,70 @@ async def _timeline_facet(
     }
 
 
+async def _history_facet(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Dispatch the ``kind="history"`` facet to G9.3-T3's substrate.
+
+    Calls :func:`query_history` with the anchor name from ``target``
+    (reused for the agent-facing concept of "the resource I am
+    asking about") and the optional ``node_kind`` / ``since`` /
+    ``until`` / ``include_edges`` filters. Returns the full
+    :class:`TopologyHistoryResult` including the ``snapshot``
+    payload per row so the agent can reason about pre/post state --
+    this is the differentiator from ``kind=timeline``, which carries
+    only the one-line summary.
+
+    Failure-mode translation:
+
+    * :class:`NodeNotFoundError` (unknown / cross-tenant target) and
+      :class:`AmbiguousNodeError` (bare name resolves to multiple
+      kinds) bubble up to the outer ``try/except`` block which maps
+      both to JSON-RPC ``-32602`` -- the operator-actionable
+      input-problem shape the closure verbs use.
+
+    ``since`` / ``until`` are parsed as ISO-8601 absolute timestamps
+    (the same shape :func:`_timeline_facet` uses). The CLI front
+    resolves duration shorthand (``"24h"`` / ``"7d"``) to an
+    absolute string before crossing the wire.
+    """
+    target_name = arguments["target"]
+    since_str = arguments.get("since")
+    until_str = arguments.get("until")
+    since_dt: datetime | None = None
+    until_dt: datetime | None = None
+    if isinstance(since_str, str):
+        try:
+            since_dt = datetime.fromisoformat(since_str)
+        except ValueError as exc:
+            raise McpInvalidParamsError(
+                f"query_topology(kind=history): 'since' is not ISO-8601: {since_str!r}",
+            ) from exc
+    if isinstance(until_str, str):
+        try:
+            until_dt = datetime.fromisoformat(until_str)
+        except ValueError as exc:
+            raise McpInvalidParamsError(
+                f"query_topology(kind=history): 'until' is not ISO-8601: {until_str!r}",
+            ) from exc
+
+    result = await query_history(
+        operator,
+        target_name,
+        kind=arguments.get("node_kind"),
+        since=since_dt,
+        until=until_dt,
+        include_edges=bool(arguments.get("include_edges", False)),
+    )
+    return {
+        "kind": "history",
+        "anchor_node_id": str(result.anchor_node_id),
+        "include_edges": result.include_edges,
+        "rows": [r.model_dump(mode="json") for r in result.rows],
+    }
+
+
 async def _list_edges_facet(
     operator: Operator,
     arguments: dict[str, Any],
@@ -596,6 +712,7 @@ register_mcp_tool(
                         "path",
                         "edges",
                         "timeline",
+                        "history",
                     ],
                 },
                 "nodes": {
@@ -627,10 +744,12 @@ register_mcp_tool(
                     "type": "array",
                     "items": {"type": "object"},
                     "description": (
-                        "Present for `kind=timeline`. TopologyTimelineEntry "
-                        "rows ordered (valid_from DESC, history_id DESC). "
-                        "See `meho_backplane.topology.schemas."
-                        "TopologyTimelineEntry`."
+                        "Present for `kind=timeline` (TopologyTimelineEntry "
+                        "rows, summary only) and `kind=history` "
+                        "(TopologyHistoryEntry rows, full snapshot.before/"
+                        "after payload). Both ordered (valid_from DESC, "
+                        "history_id DESC). See "
+                        "`meho_backplane.topology.schemas`."
                     ),
                 },
                 "next_cursor": {
@@ -639,6 +758,21 @@ register_mcp_tool(
                         "Present for `kind=timeline`. Opaque next-page "
                         "token, or null when the page is the end of the "
                         "matching set."
+                    ),
+                },
+                "anchor_node_id": {
+                    "type": "string",
+                    "description": (
+                        "Present for `kind=history`. The resolved "
+                        "`graph_node.id` of the anchor (UUID string)."
+                    ),
+                },
+                "include_edges": {
+                    "type": "boolean",
+                    "description": (
+                        "Present for `kind=history`. Echoes the call-"
+                        "site flag so a consumer can branch on whether "
+                        "edge rows are expected to appear in `rows`."
                     ),
                 },
             },

--- a/backend/src/meho_backplane/mcp/tools/topology.py
+++ b/backend/src/meho_backplane/mcp/tools/topology.py
@@ -149,6 +149,16 @@ _EDGES_LIMIT_MAX: Final[int] = 1000
 _TIMELINE_LIMIT_DEFAULT: Final[int] = 50
 _TIMELINE_LIMIT_MAX: Final[int] = 1000
 
+#: ``history`` facet ceiling. Mirrors the T3 substrate cap
+#: (``query._MAX_HISTORY_ROWS`` = 5000) and the REST route cap
+#: (``api/v1/topology._HISTORY_LIMIT_MAX``) so the four fronts (REST /
+#: CLI / MCP / substrate) clamp the per-resource walk identically.
+#: Per-resource history is bounded by retention, so the default IS the
+#: ceiling -- a tighter MCP default would silently truncate the walk
+#: and operators would think they see the full history when they
+#: don't (same reasoning T3 used for the REST and CLI defaults).
+_HISTORY_LIMIT_MAX: Final[int] = 5000
+
 #: Canonical ``GraphEdgeKind`` values, materialised once at module load
 #: so the inputSchema enum + the kind_filter description stay in lock-step
 #: with :class:`~meho_backplane.db.models.GraphEdgeKind` without
@@ -263,19 +273,28 @@ _QUERY_TOPOLOGY_INPUT_SCHEMA: Final[dict[str, Any]] = {
         "limit": {
             "type": "integer",
             "minimum": 1,
-            "maximum": _EDGES_LIMIT_MAX,
+            # Permissive base ceiling matches the loosest substrate cap
+            # (``query_history`` accepts 1..``_HISTORY_LIMIT_MAX``); the
+            # per-facet ``allOf`` clauses below tighten this to the
+            # ``edges`` (1000) and ``timeline`` (1000) substrate caps so
+            # MCP callers can't smuggle an over-cap value past the
+            # schema and trip the substrate's ``ValueError`` at runtime.
+            "maximum": _HISTORY_LIMIT_MAX,
             # No schema-level ``default`` -- the effective default
             # varies by ``kind`` (``edges`` -> ``_EDGES_LIMIT_DEFAULT``,
-            # ``timeline`` -> ``_TIMELINE_LIMIT_DEFAULT``). A single
-            # default in the schema would mislead schema-driven MCP
-            # clients into pre-populating the edges default on every
-            # call, over-requesting timeline pages.
+            # ``timeline`` -> ``_TIMELINE_LIMIT_DEFAULT``,
+            # ``history`` -> ``_HISTORY_LIMIT_MAX``). A single default
+            # in the schema would mislead schema-driven MCP clients
+            # into pre-populating the edges default on every call,
+            # over-requesting timeline / history pages.
             "description": (
                 f"Page size for paginated facets. `kind=edges` defaults "
-                f"to {_EDGES_LIMIT_DEFAULT}; `kind=timeline` defaults to "
-                f"{_TIMELINE_LIMIT_DEFAULT}. Shared ceiling "
-                f"{_EDGES_LIMIT_MAX}, matching the substrate "
-                "`list_edges` cap. Ignored for the closure kinds and "
+                f"to {_EDGES_LIMIT_DEFAULT} (ceiling {_EDGES_LIMIT_MAX}); "
+                f"`kind=timeline` defaults to {_TIMELINE_LIMIT_DEFAULT} "
+                f"(ceiling {_TIMELINE_LIMIT_MAX}); `kind=history` "
+                f"defaults to {_HISTORY_LIMIT_MAX} (also the ceiling -- "
+                "per-resource history is bounded by retention so the "
+                "default IS the cap). Ignored for the closure kinds and "
                 "`path`."
             ),
         },
@@ -398,6 +417,23 @@ _QUERY_TOPOLOGY_INPUT_SCHEMA: Final[dict[str, Any]] = {
         {
             "if": {"properties": {"kind": {"const": "history"}}},
             "then": {"required": ["target"]},
+        },
+        # Per-facet ``limit`` ceilings. The base ``limit.maximum`` above
+        # is the loosest cap (5000 for ``history``); the ``edges`` and
+        # ``timeline`` substrates cap tighter (1000 each), so we
+        # intersect a stricter ``maximum`` for those kinds. JSON Schema
+        # 2020-12 ``allOf`` semantics: every applicable subschema must
+        # validate, so the effective ceiling for a given ``kind`` is
+        # ``min(base.maximum, then.maximum)``. Without this, an
+        # ``edges`` caller passing ``limit=1500`` would pass the schema
+        # but trip ``list_edges``'s ``ValueError`` at runtime.
+        {
+            "if": {"properties": {"kind": {"const": "edges"}}},
+            "then": {"properties": {"limit": {"maximum": _EDGES_LIMIT_MAX}}},
+        },
+        {
+            "if": {"properties": {"kind": {"const": "timeline"}}},
+            "then": {"properties": {"limit": {"maximum": _TIMELINE_LIMIT_MAX}}},
         },
     ],
 }
@@ -653,6 +689,7 @@ async def _history_facet(
         since=since_dt,
         until=until_dt,
         include_edges=bool(arguments.get("include_edges", False)),
+        limit=int(arguments.get("limit", _HISTORY_LIMIT_MAX)),
     )
     return {
         "kind": "history",

--- a/backend/src/meho_backplane/topology/query.py
+++ b/backend/src/meho_backplane/topology/query.py
@@ -119,6 +119,8 @@ from meho_backplane.topology.resolvers import (
 from meho_backplane.topology.schemas import (
     TopologyEdge,
     TopologyEdgeEndpoint,
+    TopologyHistoryEntry,
+    TopologyHistoryResult,
     TopologyNode,
     TopologyPath,
     TopologyTimelineEntry,
@@ -144,6 +146,7 @@ __all__ = [
     "find_dependents",
     "find_path",
     "list_edges",
+    "query_history",
     "query_timeline",
 ]
 
@@ -1347,3 +1350,295 @@ def _merge_has_leftovers(
     consumed_nodes = sum(1 for r in merged if r.source == "node")
     consumed_edges = len(merged) - consumed_nodes
     return consumed_nodes < len(node_rows) or consumed_edges < len(edge_rows)
+
+
+# ---------------------------------------------------------------------------
+# G9.3-T3 (#859) — per-resource history walk
+# ---------------------------------------------------------------------------
+#
+# Unlike :func:`query_timeline` (tenant-wide chronological feed),
+# :func:`query_history` anchors on **one** :class:`GraphNode` and
+# returns every history row that mentions it -- the node-side rows
+# directly, and (when ``include_edges=True``) every edge-side row whose
+# ``edge_id`` resolves to an edge with the anchor at either endpoint.
+# The shape is the operator surface "show me what changed for THIS
+# resource" parallel to the timeline's "what changed in the graph at
+# all".
+#
+# Indexes the per-resource walk leans on (declared by migration 0012
+# for G9.3-T1 #856):
+#
+#   * ``graph_node_history`` ``(tenant_id, node_id, valid_from DESC)``
+#     -- per-(tenant, node, time) lookup is a single composite-index
+#     scan.
+#   * ``graph_edge_history`` ``(tenant_id, edge_id, valid_from DESC)``
+#     -- mirror for the edge side.
+#
+# Both indexes are tenant-scoped composites so the per-resource slice
+# is sub-millisecond on the test fixture and indexed under realistic
+# load.
+
+#: Hard ceiling on rows returned in one :func:`query_history` call.
+#: Picked to fit the typical retention window (90 days x a few
+#: writes/day per resource) into a single response without paginating;
+#: the route layer caps tighter at the HTTP boundary. Bumping requires
+#: a coordinated review with the retention-cadence ``Settings``
+#: defaults.
+_MAX_HISTORY_ROWS = 5000
+
+
+# Node-side history walk for one anchor node. ``anchor_node_id`` is
+# the resolved :class:`GraphNode.id`; the FK is direct so this is a
+# single indexed scan over the composite
+# ``(tenant_id, node_id, valid_from DESC)`` index. ``since`` /
+# ``until`` ride the established ``CAST(:marker AS text) IS NULL OR
+# ...`` optional-filter idiom so one literal statement serves the
+# bounded and unbounded cases.
+_HISTORY_NODE_SQL = text(
+    """
+    SELECT
+        h.history_id    AS history_id,
+        h.node_id       AS resource_id,
+        h.change_kind   AS change_kind,
+        h.snapshot      AS snapshot,
+        h.audit_id      AS audit_id,
+        h.valid_from    AS valid_from
+    FROM graph_node_history h
+    WHERE h.tenant_id = :tenant_id
+      AND h.node_id = :anchor_node_id
+      AND (CAST(:since_marker AS text) IS NULL OR h.valid_from >= :since)
+      AND (CAST(:until_marker AS text) IS NULL OR h.valid_from <= :until)
+    ORDER BY h.valid_from DESC, h.history_id DESC
+    LIMIT :limit
+    """
+).bindparams(
+    bindparam("tenant_id", type_=SAUuid()),
+    bindparam("anchor_node_id", type_=SAUuid()),
+    bindparam("since", type_=DateTime(timezone=True)),
+    bindparam("until", type_=DateTime(timezone=True)),
+)
+
+# Edge-side history walk for every edge incident to the anchor. The
+# inner subquery resolves the edge ids whose ``from_node_id`` or
+# ``to_node_id`` matches the anchor; the outer query pulls every
+# history row for those ids. Tenant scope is enforced on both the
+# inner (``graph_edge.tenant_id``) and outer
+# (``graph_edge_history.tenant_id``) so a cross-tenant edge id cannot
+# leak in. Tombstones (rows whose ``edge_id`` was NULLed by
+# ``ON DELETE SET NULL``) drop out of the inner subquery's id list
+# and therefore stay out of the per-resource walk -- a tombstoned
+# edge has no surviving live row to associate with the anchor.
+# Operators wanting the full tombstone replay use
+# ``meho topology timeline`` (G9.3-T5 #861) which surfaces every
+# history row including tombstones.
+_HISTORY_EDGE_SQL = text(
+    """
+    SELECT
+        h.history_id    AS history_id,
+        h.edge_id       AS resource_id,
+        h.change_kind   AS change_kind,
+        h.snapshot      AS snapshot,
+        h.audit_id      AS audit_id,
+        h.valid_from    AS valid_from
+    FROM graph_edge_history h
+    WHERE h.tenant_id = :tenant_id
+      AND h.edge_id IN (
+          SELECT e.id FROM graph_edge e
+          WHERE e.tenant_id = :tenant_id
+            AND (e.from_node_id = :anchor_node_id
+                 OR e.to_node_id = :anchor_node_id)
+      )
+      AND (CAST(:since_marker AS text) IS NULL OR h.valid_from >= :since)
+      AND (CAST(:until_marker AS text) IS NULL OR h.valid_from <= :until)
+    ORDER BY h.valid_from DESC, h.history_id DESC
+    LIMIT :limit
+    """
+).bindparams(
+    bindparam("tenant_id", type_=SAUuid()),
+    bindparam("anchor_node_id", type_=SAUuid()),
+    bindparam("since", type_=DateTime(timezone=True)),
+    bindparam("until", type_=DateTime(timezone=True)),
+)
+
+
+def _row_to_history_entry(row: Row[Any], source: str) -> TopologyHistoryEntry:
+    """Map one history row to :class:`TopologyHistoryEntry`.
+
+    ``source`` is threaded through by the caller because the SELECT
+    column shape is identical for the two history tables; the same
+    materialiser handles both with the discriminator passed as a
+    literal. ``snapshot`` arrives as a ``dict`` on PG (asyncpg JSONB
+    codec) and as a JSON-encoded string on SQLite -- both are
+    normalised to ``dict-or-None`` here so the front layers always
+    see a structured payload.
+
+    Unlike :class:`TopologyTimelineEntry`, the history entry preserves
+    the full snapshot rather than rendering it down to a one-line
+    summary. The summary collapse is timeline's space-saving trick
+    appropriate for a tenant-wide feed; per-resource history is the
+    forensic surface where the snapshot is the load-bearing payload.
+    """
+    m = row._mapping
+    snapshot_raw = m["snapshot"]
+    snapshot: dict[str, Any] | None
+    if isinstance(snapshot_raw, dict):
+        snapshot = snapshot_raw
+    elif isinstance(snapshot_raw, str):
+        try:
+            parsed = json.loads(snapshot_raw)
+            snapshot = parsed if isinstance(parsed, dict) else None
+        except (TypeError, ValueError):
+            snapshot = None
+    else:
+        snapshot = None
+    return TopologyHistoryEntry(
+        valid_from=m["valid_from"],
+        history_id=m["history_id"],
+        source=source,
+        change_kind=m["change_kind"],
+        resource_id=m["resource_id"],
+        snapshot=snapshot,
+        audit_id=m["audit_id"],
+    )
+
+
+def _merge_history_pages(
+    node_rows: list[TopologyHistoryEntry],
+    edge_rows: list[TopologyHistoryEntry],
+    limit: int,
+) -> list[TopologyHistoryEntry]:
+    """Merge two pre-sorted ``DESC`` lists into one, capped at ``limit``.
+
+    Mirror of :func:`_merge_timeline_pages` for the history shape.
+    Each input is already ordered by ``(valid_from DESC, history_id
+    DESC)`` from its own SQL statement. Two-pointer pass; when both
+    heads share the same ``(valid_from, history_id)`` (only possible
+    across the two tables), the node side lands first to mirror the
+    timeline merge convention.
+    """
+    merged: list[TopologyHistoryEntry] = []
+    i = j = 0
+    while len(merged) < limit and (i < len(node_rows) or j < len(edge_rows)):
+        if i >= len(node_rows):
+            merged.append(edge_rows[j])
+            j += 1
+            continue
+        if j >= len(edge_rows):
+            merged.append(node_rows[i])
+            i += 1
+            continue
+        n = node_rows[i]
+        e = edge_rows[j]
+        if (n.valid_from, n.history_id) > (e.valid_from, e.history_id):
+            merged.append(n)
+            i += 1
+        elif (n.valid_from, n.history_id) < (e.valid_from, e.history_id):
+            merged.append(e)
+            j += 1
+        else:
+            merged.append(n)
+            i += 1
+    return merged
+
+
+async def query_history(
+    operator: Operator,
+    name_or_alias: str,
+    *,
+    kind: str | None = None,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    include_edges: bool = False,
+    limit: int = _MAX_HISTORY_ROWS,
+) -> TopologyHistoryResult:
+    """Per-resource history walk anchored at one ``graph_node``.
+
+    Initiative #365 (G9.3), Task #859 (T3). The companion to
+    :func:`query_timeline`: timeline is "what changed in the graph at
+    all"; history is "what changed for THIS specific resource".
+    Resolves the anchor tenant-scoped via :func:`resolve_node` so an
+    unknown name (or a name that exists only in another tenant)
+    surfaces as :class:`NodeNotFoundError`, the contract the route
+    layer maps to 404. A bare name that resolves to multiple kinds
+    raises :class:`AmbiguousNodeError`, mapped to 409 by the route
+    layer.
+
+    Args:
+        operator: The calling operator. ``tenant_id`` lifted from the
+            JWT; never sourced from caller-controllable args.
+        name_or_alias: The anchor node's :attr:`GraphNode.name`. The
+            G9.1 resolver only matches on ``name`` -- formal alias
+            resolution is deferred (see
+            ``docs/codebase/topology.md`` "Known issues") -- so an
+            aliased name will currently surface as
+            :class:`NodeNotFoundError` here just as it does for the
+            traversal verbs. The argument is named
+            ``name_or_alias`` for forward-compat with the planned
+            G10 alias substrate.
+        kind: Optional :attr:`GraphNode.kind` pin to disambiguate
+            when the bare name resolves to multiple kinds in the
+            tenant.
+        since: Optional lower bound on ``valid_from``. Inclusive.
+        until: Optional upper bound on ``valid_from``. Inclusive.
+        include_edges: When ``True``, also walk every history row for
+            edges incident to the anchor (joined via the inner
+            subquery on ``graph_edge.from_node_id`` /
+            ``graph_edge.to_node_id``). The merged result still
+            orders newest-first.
+        limit: Hard cap on returned rows (1..``_MAX_HISTORY_ROWS``).
+            Defaults to the ceiling because per-resource history is
+            bounded by retention; tighter caps would silently
+            truncate the walk.
+
+    Returns:
+        :class:`TopologyHistoryResult` carrying the resolved
+        ``anchor_node_id``, the echoed ``include_edges`` flag, and a
+        tuple of :class:`TopologyHistoryEntry` rows in
+        ``(valid_from DESC, history_id DESC)`` order.
+
+    Raises:
+        NodeNotFoundError: ``name_or_alias`` (and ``kind``, when
+            supplied) does not resolve in this tenant.
+        AmbiguousNodeError: Bare-name lookup hit multiple kinds; pass
+            ``kind=`` to disambiguate.
+        ValueError: ``limit`` is out of range (``< 1`` or
+            ``> _MAX_HISTORY_ROWS``).
+    """
+    if limit < 1 or limit > _MAX_HISTORY_ROWS:
+        raise ValueError(f"limit must be in 1..{_MAX_HISTORY_ROWS}; got {limit}")
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        # Resolve the anchor up front so a missing / cross-tenant /
+        # ambiguous name surfaces with the canonical exception types
+        # the route + MCP layers already map; never let the SQL
+        # statements run with a NULL anchor (a quirk of the
+        # ``CAST(:x AS text) IS NULL OR ...`` idiom is that a NULL
+        # anchor would broaden the filter, not narrow it).
+        anchor = await resolve_node(session, operator.tenant_id, name_or_alias, kind=kind)
+        bind_params: dict[str, Any] = {
+            "tenant_id": operator.tenant_id,
+            "anchor_node_id": anchor.id,
+            "since": since,
+            "since_marker": "x" if since is not None else None,
+            "until": until,
+            "until_marker": "x" if until is not None else None,
+            "limit": limit,
+        }
+        node_result = await session.execute(_HISTORY_NODE_SQL, bind_params)
+        node_rows = [_row_to_history_entry(row, "node") for row in node_result.fetchall()]
+        edge_rows: list[TopologyHistoryEntry] = []
+        if include_edges:
+            edge_result = await session.execute(_HISTORY_EDGE_SQL, bind_params)
+            edge_rows = [_row_to_history_entry(row, "edge") for row in edge_result.fetchall()]
+
+    if not include_edges:
+        merged = node_rows[:limit]
+    else:
+        merged = _merge_history_pages(node_rows, edge_rows, limit)
+
+    return TopologyHistoryResult(
+        anchor_node_id=anchor.id,
+        include_edges=include_edges,
+        rows=tuple(merged),
+    )

--- a/backend/src/meho_backplane/topology/resolvers.py
+++ b/backend/src/meho_backplane/topology/resolvers.py
@@ -48,7 +48,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import select, text
+from sqlalchemy import Uuid as SAUuid
+from sqlalchemy import bindparam, select, text
 
 from meho_backplane.db.models import GraphNode
 
@@ -118,6 +119,18 @@ class NodeNotFoundError(ValueError):
 #: ``avoid-sqlalchemy-text`` SAST rule does not fire (no string
 #: interpolation; every value is a ``:named`` bind). Mirrors the
 #: pattern in :mod:`meho_backplane.topology.query`.
+#:
+#: ``tenant_id`` rides through SQLAlchemy's :class:`Uuid` bind type so
+#: the asyncpg / aiosqlite drivers serialise the UUID natively. On
+#: ``Uuid()``-typed columns SQLite stores the value as 32-char hex
+#: (no dashes) and matches incoming binds via the same conversion;
+#: passing ``str(uuid)`` would deliver the dashed-canonical form,
+#: which mismatches the stored hex and produces a silent zero-row
+#: result -- :func:`resolve_node`'s bare-name branch would then
+#: raise :class:`NodeNotFoundError` even for a row that exists.
+#: Production PG accepts both forms, masking the bug there. Same
+#: pattern :mod:`meho_backplane.topology.query`'s ``_TIMELINE_*_SQL``
+#: uses since #861.
 _ANCHOR_KINDS_SQL = text(
     """
     SELECT DISTINCT kind
@@ -125,13 +138,13 @@ _ANCHOR_KINDS_SQL = text(
     WHERE tenant_id = :tenant_id
       AND name = :name
     """
-)
+).bindparams(bindparam("tenant_id", type_=SAUuid()))
 
 
 async def _collect_distinct_kinds(
     session: AsyncSession,
     *,
-    tenant_id: str,
+    tenant_id: UUID | str,
     name: str,
 ) -> list[str]:
     """Return the distinct ``kind`` values for ``(tenant_id, name)``.
@@ -143,9 +156,14 @@ async def _collect_distinct_kinds(
 
     Kept private — the public ambiguity surface is
     :class:`AmbiguousNodeError`, raised by callers that decide what to
-    do with the kind list. ``tenant_id`` is taken as ``str`` because
-    asyncpg's text codec accepts the string form for UUID binds (same
-    convention :mod:`query` uses).
+    do with the kind list. Accepts ``tenant_id`` as either a
+    :class:`UUID` or a ``str``; the :class:`Uuid` bind type on
+    :data:`_ANCHOR_KINDS_SQL` coerces both to the column's wire
+    format (PG native ``uuid`` / SQLite ``CHAR(32)`` hex). Production
+    PG masked the latent dashed-vs-hex mismatch the bind type now
+    resolves; the SQLite test driver surfaces it as a silent zero-row
+    result, which :func:`resolve_node` then turns into a spurious
+    :class:`NodeNotFoundError`.
     """
     result = await session.execute(
         _ANCHOR_KINDS_SQL,
@@ -213,10 +231,8 @@ async def resolve_node(
         AmbiguousNodeError: Bare-name lookup hit multiple kinds; pass
             ``kind=`` to disambiguate.
     """
-    tenant_str = str(tenant_id)
-
     if kind is None:
-        kinds = await _collect_distinct_kinds(session, tenant_id=tenant_str, name=name)
+        kinds = await _collect_distinct_kinds(session, tenant_id=tenant_id, name=name)
         if not kinds:
             raise NodeNotFoundError(name)
         if len(kinds) > 1:

--- a/backend/src/meho_backplane/topology/schemas.py
+++ b/backend/src/meho_backplane/topology/schemas.py
@@ -36,6 +36,8 @@ from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_valid
 __all__ = [
     "TopologyEdge",
     "TopologyEdgeEndpoint",
+    "TopologyHistoryEntry",
+    "TopologyHistoryResult",
     "TopologyNode",
     "TopologyPath",
     "TopologyTimelineEntry",
@@ -257,6 +259,71 @@ class TopologyTimelineEntry(BaseModel):
     resource_id: UUID | None
     summary: str
     audit_id: UUID | None
+
+
+class TopologyHistoryEntry(BaseModel):
+    """One row of the per-resource history walk (G9.3-T3).
+
+    Task #859 ships the operator surface ``meho topology history
+    <node>`` -- "what changed for THIS resource?" The differentiator
+    from :class:`TopologyTimelineEntry` (G9.3-T5) is that history
+    carries the full ``snapshot`` JSONB (``{before, after}``) per row
+    rather than a one-line summary -- the forensic shape for ``--json``
+    reconstruction. Field-to-column mapping otherwise matches
+    timeline:
+
+    * ``valid_from`` -- ``*_history.valid_from``.
+    * ``history_id`` -- ``*_history.history_id``.
+    * ``source`` -- ``"node"`` for :class:`GraphNodeHistory`, ``"edge"``
+      for :class:`GraphEdgeHistory` (only ``"edge"`` rows ever appear
+      when the caller passed ``include_edges=True``).
+    * ``change_kind`` -- one of ``"created"`` / ``"updated"`` /
+      ``"removed"`` per :class:`GraphHistoryChangeKind`.
+    * ``resource_id`` -- ``node_id`` for node-side rows, ``edge_id``
+      for edge-side rows. ``None`` only after the referenced live row
+      has been hard-deleted (``ON DELETE SET NULL``).
+    * ``snapshot`` -- the full ``{before, after}`` JSONB. ``None``
+      only for legacy / mid-rollout rows that pre-date the
+      diff-on-write hook; every hook-emitted row populates it.
+    * ``audit_id`` -- soft-FK to the ``audit_log.id`` of the
+      operation that caused the mutation.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    valid_from: datetime
+    history_id: int
+    source: str
+    change_kind: str
+    resource_id: UUID | None
+    snapshot: dict[str, Any] | None
+    audit_id: UUID | None
+
+
+class TopologyHistoryResult(BaseModel):
+    """The full per-resource history walk plus the resolved anchor.
+
+    Unlike :class:`TopologyTimelineResult` (which is cursor-paginated),
+    the per-resource walk returns one page bounded by the substrate's
+    ``_MAX_HISTORY_ROWS`` cap -- per-resource history is bounded by
+    the retention window (default 90 days) and the operator typically
+    wants the complete chronology in one response. No ``next_cursor``;
+    a caller that overflows the cap narrows ``since`` / ``until``.
+
+    ``anchor_node_id`` is the resolved :class:`GraphNode.id` of the
+    anchor. Echoing it lets the CLI / MCP fronts surface "I resolved
+    your name X to node Y" in the human-readable header without a
+    second resolver round trip.
+
+    ``include_edges`` echoes the call-site flag so a consumer can
+    branch on whether edge rows are expected to appear in ``rows``.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    anchor_node_id: UUID
+    include_edges: bool
+    rows: tuple[TopologyHistoryEntry, ...]
 
 
 class TopologyTimelineResult(BaseModel):

--- a/backend/tests/test_mcp_tools_topology.py
+++ b/backend/tests/test_mcp_tools_topology.py
@@ -188,7 +188,14 @@ def test_query_topology_input_schema_is_conditional_on_kind(
     assert entry is not None
     stored_schema = entry[0].inputSchema
     conditionals = stored_schema["allOf"]
-    by_kind = {c["if"]["properties"]["kind"]["const"]: c["then"]["required"] for c in conditionals}
+    # Skip per-kind ``limit.maximum`` tightening clauses (no ``required``
+    # key) — those intersect a stricter ``limit`` ceiling for ``edges``
+    # / ``timeline`` and aren't part of the required-field contract.
+    by_kind = {
+        c["if"]["properties"]["kind"]["const"]: c["then"]["required"]
+        for c in conditionals
+        if "required" in c["then"]
+    }
     assert by_kind["dependents"] == ["target"]
     assert by_kind["dependencies"] == ["target"]
     assert sorted(by_kind["path"]) == ["from_name", "to_name"]

--- a/backend/tests/test_mcp_tools_topology.py
+++ b/backend/tests/test_mcp_tools_topology.py
@@ -161,14 +161,17 @@ def test_query_topology_input_schema_is_conditional_on_kind(
     # G9.2-T7 (#598) widened the enum with the `edges` facet (replaces a
     # standalone list_edges meta-tool); G9.3-T5 (#861) added the
     # `timeline` facet (tenant-wide chronological feed of graph
-    # changes from the *_history tables). The closure / path branches
-    # and their conditional requireds stay unchanged.
+    # changes from the *_history tables); G9.3-T3 (#859) added the
+    # `history` facet (per-resource history walk with full snapshot
+    # payload). The closure / path branches and their conditional
+    # requireds stay unchanged.
     assert wire_schema["properties"]["kind"]["enum"] == [
         "dependents",
         "dependencies",
         "path",
         "edges",
         "timeline",
+        "history",
     ]
     # The wire shape carries NO top-level combinator — Anthropic 400s on
     # it (#905); the conditional logic moved to the stored schema below.
@@ -189,8 +192,10 @@ def test_query_topology_input_schema_is_conditional_on_kind(
     assert by_kind["dependents"] == ["target"]
     assert by_kind["dependencies"] == ["target"]
     assert sorted(by_kind["path"]) == ["from_name", "to_name"]
-    # `edges` and `timeline` have no required field — every filter is
-    # optional on both facets.
+    # `history` requires `target` (the anchor node name); `edges` and
+    # `timeline` have no required field — every filter is optional on
+    # both facets.
+    assert by_kind["history"] == ["target"]
     assert "edges" not in by_kind
     assert "timeline" not in by_kind
 

--- a/backend/tests/test_mcp_tools_topology_annotate.py
+++ b/backend/tests/test_mcp_tools_topology_annotate.py
@@ -74,6 +74,7 @@ from tests.mcp_test_fixtures import (
 # the symbol into ``mcp.tools.topology``'s module dict, so the local
 # name is the patchable reference.
 _LIST_EDGES_PATCH = "meho_backplane.mcp.tools.topology.list_edges"
+_QUERY_HISTORY_PATCH = "meho_backplane.mcp.tools.topology.query_history"
 _PUBLISH_PATCH = "meho_backplane.topology.annotate.publish_event"
 
 
@@ -239,12 +240,13 @@ def test_no_separate_list_edges_tool_registered() -> None:
 
 
 def test_query_topology_input_schema_includes_edges_facet() -> None:
-    """The kind enum widened to include 'edges' / 'timeline' with no extra
-    required field.
+    """The kind enum widened to include 'edges' / 'timeline' / 'history'.
 
-    G9.2-T7 (#598) added ``edges``; G9.3-T5 (#861) added ``timeline``.
-    Both extra kinds have no conditional required clause -- every
-    filter on either facet is optional.
+    G9.2-T7 (#598) added ``edges``; G9.3-T5 (#861) added ``timeline``
+    (no required field); G9.3-T3 (#859) added ``history`` (requires
+    ``target`` -- the anchor node name). ``edges`` and ``timeline``
+    have no conditional required clause; every filter on those two
+    facets is optional.
     """
     entry = get_tool("query_topology")
     assert entry is not None
@@ -256,16 +258,26 @@ def test_query_topology_input_schema_includes_edges_facet() -> None:
         "path",
         "edges",
         "timeline",
+        "history",
     ]
-    # No extra `allOf` clauses for `edges` / `timeline` -- both have
-    # no required fields. The other three branches stay as-is.
+    # `history` requires `target`; `edges` and `timeline` have no
+    # required field. The other three branches stay as-is. The schema
+    # also carries per-kind ``limit.maximum`` tightening clauses for
+    # `edges` and `timeline` (intersecting the base permissive ceiling
+    # so MCP callers can't smuggle an over-cap value past the schema
+    # and trip the substrate's ``ValueError``); those clauses don't
+    # carry a ``required`` key, so the ``required``-only dict below
+    # skips them via ``.get`` rather than throwing on missing keys.
     by_kind = {
-        c["if"]["properties"]["kind"]["const"]: c["then"]["required"] for c in schema["allOf"]
+        c["if"]["properties"]["kind"]["const"]: c["then"]["required"]
+        for c in schema["allOf"]
+        if "required" in c["then"]
     }
     assert "edges" not in by_kind
     assert "timeline" not in by_kind
     assert by_kind["dependents"] == ["target"]
     assert by_kind["dependencies"] == ["target"]
+    assert by_kind["history"] == ["target"]
     # The new filter knobs surface as optional properties on the schema.
     for prop in ("source", "conflicts", "limit", "offset"):
         assert prop in schema["properties"]
@@ -848,6 +860,137 @@ def test_edges_facet_read_role_unchanged(
     with patch(_LIST_EDGES_PATCH, new=mock_list):
         response = _query_topology_call(client, 73, {"kind": "edges"})
     assert response.json()["result"]["isError"] is False
+
+
+# ---------------------------------------------------------------------------
+# query_topology(kind=history) facet — limit forwarding (B3 on PR #936)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_history_facet_forwards_limit_to_query_history(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``kind=history`` + caller-supplied ``limit`` flows through to ``query_history``.
+
+    Regression for PR #936 iter-1 finding B3: the dispatcher was
+    extracting every other knob (``node_kind`` / ``since`` / ``until`` /
+    ``include_edges``) from the arguments dict but silently dropped
+    ``limit``, so MCP callers always got the substrate's default
+    ceiling (5000) regardless of what they asked for.
+    """
+    from meho_backplane.topology.schemas import TopologyHistoryResult
+
+    client, _op = client_with_operator
+    mock_history = AsyncMock(
+        return_value=TopologyHistoryResult(
+            anchor_node_id=uuid.uuid4(),
+            include_edges=False,
+            rows=(),
+        )
+    )
+    with patch(_QUERY_HISTORY_PATCH, new=mock_history):
+        response = _query_topology_call(
+            client,
+            80,
+            {"kind": "history", "target": "vm-a", "limit": 250},
+        )
+    assert response.json()["result"]["isError"] is False
+    # ``limit`` rides the kwargs the dispatcher passes -- the substrate
+    # validates the 1..5000 range itself, so the MCP layer only forwards.
+    kwargs = mock_history.await_args.kwargs
+    assert kwargs["limit"] == 250
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_history_facet_defaults_limit_to_history_ceiling(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``kind=history`` with no ``limit`` falls back to the per-facet ceiling.
+
+    Per-resource history is bounded by retention; the default IS the
+    ceiling. A tighter default would silently truncate the walk and
+    the operator would think they see the full history when they
+    don't (same reasoning the REST and CLI fronts use).
+    """
+    from meho_backplane.mcp.tools.topology import _HISTORY_LIMIT_MAX
+    from meho_backplane.topology.schemas import TopologyHistoryResult
+
+    client, _op = client_with_operator
+    mock_history = AsyncMock(
+        return_value=TopologyHistoryResult(
+            anchor_node_id=uuid.uuid4(),
+            include_edges=False,
+            rows=(),
+        )
+    )
+    with patch(_QUERY_HISTORY_PATCH, new=mock_history):
+        _query_topology_call(client, 81, {"kind": "history", "target": "vm-a"})
+    kwargs = mock_history.await_args.kwargs
+    assert kwargs["limit"] == _HISTORY_LIMIT_MAX
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_history_facet_schema_admits_limit_up_to_history_ceiling(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """The MCP schema admits ``limit`` in [1, 5000] for ``kind=history``.
+
+    Regression for PR #936 iter-1 finding M1: the shared ``limit``
+    property used to cap at ``_EDGES_LIMIT_MAX`` (1000), schema-rejecting
+    valid history calls. The base ceiling now matches
+    ``_HISTORY_LIMIT_MAX``; per-facet ``allOf`` clauses tighten ``edges``
+    / ``timeline`` back down to 1000 so they can't accidentally widen.
+    """
+    from meho_backplane.topology.schemas import TopologyHistoryResult
+
+    client, _op = client_with_operator
+    mock_history = AsyncMock(
+        return_value=TopologyHistoryResult(
+            anchor_node_id=uuid.uuid4(),
+            include_edges=False,
+            rows=(),
+        )
+    )
+    with patch(_QUERY_HISTORY_PATCH, new=mock_history):
+        response = _query_topology_call(
+            client,
+            82,
+            {"kind": "history", "target": "vm-a", "limit": 4000},
+        )
+    # No schema rejection -- the call reached the handler and the
+    # mocked substrate returned an empty result.
+    assert response.json()["result"]["isError"] is False
+    assert mock_history.await_args.kwargs["limit"] == 4000
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_edges_facet_schema_rejects_limit_above_edges_ceiling(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """The per-facet ``allOf`` clause holds ``edges`` to ``_EDGES_LIMIT_MAX``.
+
+    Companion to the history test above: the base ``limit.maximum`` was
+    widened to ``_HISTORY_LIMIT_MAX`` (5000) so history isn't
+    schema-rejected, but ``edges`` still substrate-caps at 1000. The
+    ``allOf if/then`` clause intersects a stricter ceiling for the
+    ``edges`` branch so an MCP caller can't smuggle ``limit=1500`` past
+    the schema and trip ``list_edges``'s ``ValueError`` at runtime.
+    """
+    client, _op = client_with_operator
+    mock_list = AsyncMock(return_value=[])
+    with patch(_LIST_EDGES_PATCH, new=mock_list):
+        response = _query_topology_call(
+            client,
+            83,
+            {"kind": "edges", "limit": 1500},
+        )
+    body = response.json()
+    # ``INVALID_PARAMS`` already imported at module level (line 64).
+    assert body["error"]["code"] == INVALID_PARAMS
+    # The mocked substrate was never reached -- rejection happened at
+    # the schema layer.
+    mock_list.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_topology_history_query.py
+++ b/backend/tests/test_topology_history_query.py
@@ -1,0 +1,524 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""End-to-end tests for :func:`query_history` (G9.3-T3 #859).
+
+Coverage matrix (Task #859 acceptance criteria):
+
+* **Anchor + tenant scoping** -- seed history rows on two tenants;
+  query one; cross-tenant rows never returned. A cross-tenant *name*
+  surfaces as :class:`NodeNotFoundError`, identical to an unknown
+  name (the tenant boundary is opaque to the caller).
+* **Name + kind resolution** -- bare-name lookup that resolves to
+  multiple kinds raises :class:`AmbiguousNodeError`; the ``kind``
+  parameter pins the anchor and the call succeeds.
+* **Unknown node -> NodeNotFoundError (the route maps to 404).**
+* **``include_edges`` joins incident edges' history** -- the merged
+  result includes node-side AND edge-side rows for every edge with
+  the anchor at either endpoint, ordered ``(valid_from DESC,
+  history_id DESC)``.
+* **``include_edges`` ignored when False** -- node-side only; edge
+  rows of incident edges do NOT leak in.
+* **Window scoping** -- ``since`` / ``until`` bound ``valid_from``
+  inclusively at both ends.
+* **Snapshot round-trip** -- the full ``{before, after}`` JSONB is
+  carried on each row so the CLI's ``--json`` mode (and the MCP
+  facet) can reconstruct pre/post state. The timeline summary
+  truncation does not apply here.
+* **Ordering** -- rows return in ``(valid_from DESC, history_id
+  DESC)`` order.
+* **Limit validation** -- out-of-range ``limit`` raises
+  :class:`ValueError`.
+
+The tests run against ``sqlite+aiosqlite`` via the autouse
+``_default_database_url`` fixture in :mod:`tests.conftest``. Each
+seed helper opens its own ``async with sessionmaker() as session``
++ ``await session.commit()`` so the rows are visible to the
+substrate's own session before :func:`query_history` runs --
+:func:`query_history` calls :func:`resolve_node` on its own
+sessionmaker, and on SQLite the resolver's anchor probe needs the
+seed commits to land outside any open transaction the fixture
+might be holding. Mirrors :mod:`test_topology_annotate`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    GraphEdge,
+    GraphEdgeHistory,
+    GraphHistoryChangeKind,
+    GraphNode,
+    GraphNodeHistory,
+    Tenant,
+)
+from meho_backplane.settings import get_settings
+from meho_backplane.topology.query import query_history
+from meho_backplane.topology.resolvers import AmbiguousNodeError, NodeNotFoundError
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the Keycloak + Vault env vars :class:`Settings` requires."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _make_operator(tenant_id: uuid.UUID) -> Operator:
+    """Construct an :class:`Operator` for the history call.
+
+    The handler reads only ``operator.tenant_id``; the other fields
+    are populated to satisfy the frozen Pydantic model.
+    """
+    return Operator(
+        sub="operator-test",
+        name="Test Operator",
+        email=None,
+        raw_jwt="not-a-real-token",
+        tenant_id=tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Seeding helpers (per-seed sessions; mirrors test_topology_annotate.py)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_tenant(*, slug: str = "tenant-a") -> uuid.UUID:
+    """Insert a :class:`Tenant` row and return its UUID."""
+    sessionmaker = get_sessionmaker()
+    tenant_id = uuid.uuid4()
+    async with sessionmaker() as session:
+        session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+        await session.commit()
+    return tenant_id
+
+
+async def _seed_node(
+    tenant_id: uuid.UUID,
+    *,
+    name: str,
+    kind: str = "vm",
+) -> uuid.UUID:
+    """Insert a :class:`GraphNode` row and return its UUID."""
+    sessionmaker = get_sessionmaker()
+    node_id = uuid.uuid4()
+    async with sessionmaker() as session:
+        session.add(
+            GraphNode(
+                id=node_id,
+                tenant_id=tenant_id,
+                kind=kind,
+                name=name,
+                discovered_by="vmware",
+            )
+        )
+        await session.commit()
+    return node_id
+
+
+async def _seed_edge(
+    tenant_id: uuid.UUID,
+    from_id: uuid.UUID,
+    to_id: uuid.UUID,
+    *,
+    kind: str = "runs-on",
+) -> uuid.UUID:
+    """Insert a :class:`GraphEdge` row and return its UUID."""
+    sessionmaker = get_sessionmaker()
+    edge_id = uuid.uuid4()
+    async with sessionmaker() as session:
+        session.add(
+            GraphEdge(
+                id=edge_id,
+                tenant_id=tenant_id,
+                from_node_id=from_id,
+                to_node_id=to_id,
+                kind=kind,
+                source="auto",
+                discovered_by="vmware",
+            )
+        )
+        await session.commit()
+    return edge_id
+
+
+async def _seed_node_history(
+    *,
+    tenant_id: uuid.UUID,
+    node_id: uuid.UUID | None,
+    valid_from: datetime,
+    change_kind: GraphHistoryChangeKind = GraphHistoryChangeKind.CREATED,
+    snapshot: dict[str, object] | None = None,
+    audit_id: uuid.UUID | None = None,
+) -> None:
+    """Insert one :class:`GraphNodeHistory` row."""
+    if snapshot is None:
+        snapshot = {"before": None, "after": {"kind": "vm", "name": "vm-test"}}
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            GraphNodeHistory(
+                node_id=node_id,
+                tenant_id=tenant_id,
+                change_kind=change_kind.value,
+                snapshot=snapshot,
+                audit_id=audit_id or uuid.uuid4(),
+                valid_from=valid_from,
+            )
+        )
+        await session.commit()
+
+
+async def _seed_edge_history(
+    *,
+    tenant_id: uuid.UUID,
+    edge_id: uuid.UUID | None,
+    valid_from: datetime,
+    change_kind: GraphHistoryChangeKind = GraphHistoryChangeKind.CREATED,
+    snapshot: dict[str, object] | None = None,
+    audit_id: uuid.UUID | None = None,
+) -> None:
+    """Insert one :class:`GraphEdgeHistory` row."""
+    if snapshot is None:
+        snapshot = {"before": None, "after": {"kind": "runs-on", "source": "auto"}}
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            GraphEdgeHistory(
+                edge_id=edge_id,
+                tenant_id=tenant_id,
+                change_kind=change_kind.value,
+                snapshot=snapshot,
+                audit_id=audit_id or uuid.uuid4(),
+                valid_from=valid_from,
+            )
+        )
+        await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Anchor + tenant scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_returns_node_history_for_anchor() -> None:
+    """Anchor on one node; only its history rows return."""
+    tenant_id = await _seed_tenant()
+    node_a = await _seed_node(tenant_id, name="vm-a")
+    node_b = await _seed_node(tenant_id, name="vm-b")
+
+    base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
+    for i in range(3):
+        await _seed_node_history(
+            tenant_id=tenant_id,
+            node_id=node_a,
+            valid_from=base + timedelta(seconds=i),
+        )
+    # node_b history rows that must NOT surface in node_a's walk.
+    for i in range(2):
+        await _seed_node_history(
+            tenant_id=tenant_id,
+            node_id=node_b,
+            valid_from=base + timedelta(seconds=10 + i),
+        )
+
+    result = await query_history(_make_operator(tenant_id), "vm-a")
+
+    assert result.anchor_node_id == node_a
+    assert result.include_edges is False
+    assert len(result.rows) == 3
+    assert all(row.resource_id == node_a for row in result.rows)
+
+
+@pytest.mark.asyncio
+async def test_unknown_node_raises_not_found() -> None:
+    """An unknown name surfaces as :class:`NodeNotFoundError`."""
+    tenant_id = await _seed_tenant()
+    with pytest.raises(NodeNotFoundError):
+        await query_history(_make_operator(tenant_id), "nope")
+
+
+@pytest.mark.asyncio
+async def test_cross_tenant_name_is_not_found() -> None:
+    """A name that exists only in another tenant raises NotFound (no leak)."""
+    tenant_a = await _seed_tenant(slug="tenant-a")
+    tenant_b = await _seed_tenant(slug="tenant-b")
+    node_b = await _seed_node(tenant_b, name="vm-secret")
+    base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
+    await _seed_node_history(
+        tenant_id=tenant_b,
+        node_id=node_b,
+        valid_from=base,
+    )
+
+    # Tenant A asks for the name that lives in tenant B. The tenant
+    # boundary surfaces as NodeNotFoundError, identical to the
+    # unknown-name case; tenant B's row count is never observable.
+    with pytest.raises(NodeNotFoundError):
+        await query_history(_make_operator(tenant_a), "vm-secret")
+
+
+@pytest.mark.asyncio
+async def test_tenant_isolated_history_for_same_name() -> None:
+    """Same node name in two tenants -- each side sees only its own rows."""
+    tenant_a = await _seed_tenant(slug="tenant-a")
+    tenant_b = await _seed_tenant(slug="tenant-b")
+    node_a = await _seed_node(tenant_a, name="vm-shared")
+    node_b = await _seed_node(tenant_b, name="vm-shared")
+
+    base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
+    for i in range(3):
+        await _seed_node_history(
+            tenant_id=tenant_a,
+            node_id=node_a,
+            valid_from=base + timedelta(seconds=i),
+        )
+        await _seed_node_history(
+            tenant_id=tenant_b,
+            node_id=node_b,
+            valid_from=base + timedelta(seconds=10 + i),
+        )
+
+    result_a = await query_history(_make_operator(tenant_a), "vm-shared")
+    assert len(result_a.rows) == 3
+    assert all(r.resource_id == node_a for r in result_a.rows)
+
+    result_b = await query_history(_make_operator(tenant_b), "vm-shared")
+    assert len(result_b.rows) == 3
+    assert all(r.resource_id == node_b for r in result_b.rows)
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_bare_name_raises() -> None:
+    """A bare name resolving to multiple kinds raises AmbiguousNodeError."""
+    tenant_id = await _seed_tenant()
+    await _seed_node(tenant_id, name="app", kind="vm")
+    await _seed_node(tenant_id, name="app", kind="host")
+
+    with pytest.raises(AmbiguousNodeError):
+        await query_history(_make_operator(tenant_id), "app")
+
+
+@pytest.mark.asyncio
+async def test_kind_pin_disambiguates() -> None:
+    """Passing ``kind`` resolves the anchor unambiguously."""
+    tenant_id = await _seed_tenant()
+    node_vm = await _seed_node(tenant_id, name="app", kind="vm")
+    await _seed_node(tenant_id, name="app", kind="host")
+
+    base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
+    await _seed_node_history(
+        tenant_id=tenant_id,
+        node_id=node_vm,
+        valid_from=base,
+    )
+
+    result = await query_history(_make_operator(tenant_id), "app", kind="vm")
+    assert result.anchor_node_id == node_vm
+    assert len(result.rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# include_edges
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_include_edges_joins_incident_edges() -> None:
+    """``include_edges=True`` adds history rows for every incident edge."""
+    tenant_id = await _seed_tenant()
+    node_a = await _seed_node(tenant_id, name="vm-a")
+    node_b = await _seed_node(tenant_id, name="host-b", kind="host")
+    node_c = await _seed_node(tenant_id, name="host-c", kind="host")
+    # Two edges incident to vm-a (one outgoing, one incoming -- the
+    # join lands on either endpoint).
+    edge_ab = await _seed_edge(tenant_id, node_a, node_b)
+    edge_ca = await _seed_edge(tenant_id, node_c, node_a, kind="depends-on")
+    # Unrelated edge that must NOT show up.
+    edge_bc = await _seed_edge(tenant_id, node_b, node_c, kind="mounts")
+
+    base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
+    # 2 node-history rows for vm-a.
+    for i in range(2):
+        await _seed_node_history(
+            tenant_id=tenant_id,
+            node_id=node_a,
+            valid_from=base + timedelta(seconds=i),
+        )
+    # 1 edge-history row each for the two incident edges.
+    await _seed_edge_history(
+        tenant_id=tenant_id,
+        edge_id=edge_ab,
+        valid_from=base + timedelta(seconds=2),
+    )
+    await _seed_edge_history(
+        tenant_id=tenant_id,
+        edge_id=edge_ca,
+        valid_from=base + timedelta(seconds=3),
+    )
+    # The unrelated edge's history row -- must be filtered out.
+    await _seed_edge_history(
+        tenant_id=tenant_id,
+        edge_id=edge_bc,
+        valid_from=base + timedelta(seconds=4),
+    )
+
+    result = await query_history(_make_operator(tenant_id), "vm-a", include_edges=True)
+
+    assert result.include_edges is True
+    # 2 node rows + 2 incident-edge rows = 4. The unrelated edge_bc's
+    # history row stays out.
+    assert len(result.rows) == 4
+    edge_resource_ids = {r.resource_id for r in result.rows if r.source == "edge"}
+    assert edge_resource_ids == {edge_ab, edge_ca}
+
+
+@pytest.mark.asyncio
+async def test_default_excludes_incident_edges() -> None:
+    """``include_edges`` defaults to False; edge rows do not leak in."""
+    tenant_id = await _seed_tenant()
+    node_a = await _seed_node(tenant_id, name="vm-a")
+    node_b = await _seed_node(tenant_id, name="host-b", kind="host")
+    edge_ab = await _seed_edge(tenant_id, node_a, node_b)
+
+    base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
+    await _seed_node_history(
+        tenant_id=tenant_id,
+        node_id=node_a,
+        valid_from=base,
+    )
+    await _seed_edge_history(
+        tenant_id=tenant_id,
+        edge_id=edge_ab,
+        valid_from=base + timedelta(seconds=1),
+    )
+
+    result = await query_history(_make_operator(tenant_id), "vm-a")
+    assert result.include_edges is False
+    assert all(r.source == "node" for r in result.rows)
+    assert len(result.rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Window scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_since_until_bounds_inclusive() -> None:
+    """``since`` / ``until`` bound ``valid_from`` inclusively at both ends."""
+    tenant_id = await _seed_tenant()
+    node_id = await _seed_node(tenant_id, name="vm-a")
+    base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
+    for i in range(10):
+        await _seed_node_history(
+            tenant_id=tenant_id,
+            node_id=node_id,
+            valid_from=base + timedelta(minutes=i),
+        )
+
+    # Window covers minutes 3..7 inclusive on both ends -> 5 rows.
+    result = await query_history(
+        _make_operator(tenant_id),
+        "vm-a",
+        since=base + timedelta(minutes=3),
+        until=base + timedelta(minutes=7),
+    )
+    assert len(result.rows) == 5
+    # SQLite strips tzinfo on read-back; compare naive on both sides.
+    timestamps = [r.valid_from.replace(tzinfo=None) for r in result.rows]
+    assert max(timestamps) == (base + timedelta(minutes=7)).replace(tzinfo=None)
+    assert min(timestamps) == (base + timedelta(minutes=3)).replace(tzinfo=None)
+
+
+# ---------------------------------------------------------------------------
+# Snapshot round-trip (the differentiator from timeline)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_full_snapshot_carries_on_each_row() -> None:
+    """Each row carries the full ``snapshot.before`` / ``snapshot.after``."""
+    tenant_id = await _seed_tenant()
+    node_id = await _seed_node(tenant_id, name="vm-a")
+
+    base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
+    pre_state = {"kind": "vm", "name": "vm-a", "properties": {"status": "running"}}
+    post_state = {"kind": "vm", "name": "vm-a", "properties": {"status": "stopped"}}
+    await _seed_node_history(
+        tenant_id=tenant_id,
+        node_id=node_id,
+        valid_from=base,
+        change_kind=GraphHistoryChangeKind.UPDATED,
+        snapshot={"before": pre_state, "after": post_state},
+    )
+
+    result = await query_history(_make_operator(tenant_id), "vm-a")
+    assert len(result.rows) == 1
+    row = result.rows[0]
+    assert row.snapshot is not None
+    assert row.snapshot["before"] == pre_state
+    assert row.snapshot["after"] == post_state
+    assert row.change_kind == "updated"
+
+
+# ---------------------------------------------------------------------------
+# Ordering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_history_ordered_newest_first() -> None:
+    """Rows return in ``(valid_from DESC, history_id DESC)`` order."""
+    tenant_id = await _seed_tenant()
+    node_a = await _seed_node(tenant_id, name="vm-a")
+    node_b = await _seed_node(tenant_id, name="host-b", kind="host")
+    edge_ab = await _seed_edge(tenant_id, node_a, node_b)
+
+    base = datetime(2026, 5, 22, 9, 0, 0, tzinfo=UTC)
+    # Interleave node + edge history at increasing timestamps.
+    for i in range(3):
+        await _seed_node_history(
+            tenant_id=tenant_id,
+            node_id=node_a,
+            valid_from=base + timedelta(seconds=i * 2),
+        )
+        await _seed_edge_history(
+            tenant_id=tenant_id,
+            edge_id=edge_ab,
+            valid_from=base + timedelta(seconds=i * 2 + 1),
+        )
+
+    result = await query_history(_make_operator(tenant_id), "vm-a", include_edges=True)
+    keys = [(r.valid_from, r.history_id) for r in result.rows]
+    assert keys == sorted(keys, reverse=True)
+
+
+# ---------------------------------------------------------------------------
+# Limit validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_limit_raises() -> None:
+    """Out-of-range ``limit`` raises :class:`ValueError`."""
+    tenant_id = await _seed_tenant()
+    await _seed_node(tenant_id, name="vm-a")
+    with pytest.raises(ValueError):
+        await query_history(_make_operator(tenant_id), "vm-a", limit=0)
+    with pytest.raises(ValueError):
+        await query_history(_make_operator(tenant_id), "vm-a", limit=100_000)

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -1562,6 +1562,82 @@
               }
             }
           },
+          "404": {
+            "description": "Anchor node not found by ``name`` (and ``kind`` when supplied).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "detail": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "enum": [
+                            "node_not_found"
+                          ]
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "error",
+                        "name"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "detail"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Bare ``name`` resolves to multiple ``kind`` candidates; client should re-issue with an explicit ``kind``.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "detail": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "enum": [
+                            "ambiguous_node"
+                          ]
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "kinds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "error",
+                        "name",
+                        "kinds"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "detail"
+                  ]
+                }
+              }
+            }
+          },
           "422": {
             "description": "Validation Error",
             "content": {

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -1467,6 +1467,114 @@
         }
       }
     },
+    "/api/v1/topology/history/{name}": {
+      "get": {
+        "tags": [
+          "topology"
+        ],
+        "summary": "History Route",
+        "description": "Chronological history walk anchored at one ``graph_node``.\n\nWraps :func:`~meho_backplane.topology.query.query_history` (G9.3-T3\n#859). Companion to ``GET /topology/timeline`` (G9.3-T5): timeline\nis \"what changed in the graph at all in this window\"; history is\n\"what changed for THIS specific resource\". Resolved via the G9.1\nresolver :func:`~meho_backplane.topology.resolvers.resolve_node` so\nname + optional kind disambiguation use the same surface every\nG9.1 + G9.2 verb does.\n\nQuery parameters:\n\n* ``kind`` -- optional ``graph_node.kind`` pin to disambiguate\n  when a bare *name* resolves to multiple kinds in the tenant.\n* ``since`` / ``until`` -- ISO-8601 absolute datetime bounds on\n  ``valid_from`` (inclusive at both ends). The CLI front resolves\n  duration shorthand (``\"24h\"`` / ``\"7d\"``) to an absolute\n  timestamp before crossing the wire, mirroring the timeline\n  route's split.\n* ``include_edges`` -- when ``true``, also walk every history row\n  for edges incident to the resolved node (joined via the inner\n  subquery ``edge_id IN (SELECT id FROM graph_edge WHERE\n  from_node_id = anchor OR to_node_id = anchor)``). The merged\n  result still orders newest-first.\n* ``limit`` -- hard cap on returned rows (1..``_HISTORY_LIMIT_MAX``).\n  Defaults to the ceiling because per-resource history is bounded\n  by retention; tighter caps would silently truncate the walk.\n\nErrors:\n\n* **404 ``node_not_found``** -- *name* (and *kind*, when supplied)\n  does not resolve to any node in the tenant. Cross-tenant names\n  surface identically -- the tenant boundary is opaque to the\n  caller.\n* **409 ``ambiguous_node``** -- bare *name* resolves to multiple\n  kinds; pass ``kind`` to disambiguate.\n\nThe route binds ``audit_op_id=\"topology.history\"`` /\n``audit_op_class=\"audit_query\"`` per [decision #3](docs/planning/v0.2-decisions.md)\n-- temporal graph queries are inspections of system state,\nparallel to G8's audit-log query surface; the broadcast event\ncarries only ``{op_id, result_status, row_count}`` so the\nresponse rows (which may carry the snapshot of a sensitive\nresource's pre/post payload) never leak onto the SSE / Slack\nfeed. Same shape T5's timeline route uses.",
+        "operationId": "history_route_api_v1_topology_history__name__get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 64,
+              "nullable": true,
+              "title": "Kind"
+            }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true,
+              "title": "Since"
+            }
+          },
+          {
+            "name": "until",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true,
+              "title": "Until"
+            }
+          },
+          {
+            "name": "include_edges",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Include Edges"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 5000,
+              "minimum": 1,
+              "default": 5000,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TopologyHistoryResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/feed": {
       "get": {
         "tags": [
@@ -6105,6 +6213,85 @@
         ],
         "title": "TopologyEdgeEndpoint",
         "description": "One endpoint of a :class:`TopologyEdge` \u2014 the ``from`` or ``to`` node.\n\nCompact node identity for the flat edge-listing helper. Carries the\nthree fields a human-readable edge summary needs: the node ``id``\n(caller may follow it back to the full :class:`TopologyNode`), the\n``kind`` (the closed enum from migration ``0007``), and the\n``name`` (unique within ``(tenant_id, kind)``). The full node\n``properties`` bag is intentionally **not** included \u2014 an edge\nlisting is a survey of relationships, not a node dump; callers that\nneed the bag look the node up separately via\n:func:`meho_backplane.topology.resolvers.resolve_node`."
+      },
+      "TopologyHistoryEntry": {
+        "properties": {
+          "valid_from": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Valid From"
+          },
+          "history_id": {
+            "type": "integer",
+            "title": "History Id"
+          },
+          "source": {
+            "type": "string",
+            "title": "Source"
+          },
+          "change_kind": {
+            "type": "string",
+            "title": "Change Kind"
+          },
+          "resource_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "title": "Resource Id"
+          },
+          "snapshot": {
+            "additionalProperties": true,
+            "type": "object",
+            "nullable": true,
+            "title": "Snapshot"
+          },
+          "audit_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "title": "Audit Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "valid_from",
+          "history_id",
+          "source",
+          "change_kind",
+          "resource_id",
+          "snapshot",
+          "audit_id"
+        ],
+        "title": "TopologyHistoryEntry",
+        "description": "One row of the per-resource history walk (G9.3-T3).\n\nTask #859 ships the operator surface ``meho topology history\n<node>`` -- \"what changed for THIS resource?\" The differentiator\nfrom :class:`TopologyTimelineEntry` (G9.3-T5) is that history\ncarries the full ``snapshot`` JSONB (``{before, after}``) per row\nrather than a one-line summary -- the forensic shape for ``--json``\nreconstruction. Field-to-column mapping otherwise matches\ntimeline:\n\n* ``valid_from`` -- ``*_history.valid_from``.\n* ``history_id`` -- ``*_history.history_id``.\n* ``source`` -- ``\"node\"`` for :class:`GraphNodeHistory`, ``\"edge\"``\n  for :class:`GraphEdgeHistory` (only ``\"edge\"`` rows ever appear\n  when the caller passed ``include_edges=True``).\n* ``change_kind`` -- one of ``\"created\"`` / ``\"updated\"`` /\n  ``\"removed\"`` per :class:`GraphHistoryChangeKind`.\n* ``resource_id`` -- ``node_id`` for node-side rows, ``edge_id``\n  for edge-side rows. ``None`` only after the referenced live row\n  has been hard-deleted (``ON DELETE SET NULL``).\n* ``snapshot`` -- the full ``{before, after}`` JSONB. ``None``\n  only for legacy / mid-rollout rows that pre-date the\n  diff-on-write hook; every hook-emitted row populates it.\n* ``audit_id`` -- soft-FK to the ``audit_log.id`` of the\n  operation that caused the mutation."
+      },
+      "TopologyHistoryResult": {
+        "properties": {
+          "anchor_node_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Anchor Node Id"
+          },
+          "include_edges": {
+            "type": "boolean",
+            "title": "Include Edges"
+          },
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/TopologyHistoryEntry"
+            },
+            "type": "array",
+            "title": "Rows"
+          }
+        },
+        "type": "object",
+        "required": [
+          "anchor_node_id",
+          "include_edges",
+          "rows"
+        ],
+        "title": "TopologyHistoryResult",
+        "description": "The full per-resource history walk plus the resolved anchor.\n\nUnlike :class:`TopologyTimelineResult` (which is cursor-paginated),\nthe per-resource walk returns one page bounded by the substrate's\n``_MAX_HISTORY_ROWS`` cap -- per-resource history is bounded by\nthe retention window (default 90 days) and the operator typically\nwants the complete chronology in one response. No ``next_cursor``;\na caller that overflows the cap narrows ``since`` / ``until``.\n\n``anchor_node_id`` is the resolved :class:`GraphNode.id` of the\nanchor. Echoing it lets the CLI / MCP fronts surface \"I resolved\nyour name X to node Y\" in the human-readable header without a\nsecond resolver round trip.\n\n``include_edges`` echoes the call-site flag so a consumer can\nbranch on whether edge rows are expected to appear in ``rows``."
       },
       "TopologyNode": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -8964,8 +8964,24 @@ type HistoryRouteApiV1TopologyHistoryNameGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *TopologyHistoryResult
-	JSON422      *HTTPValidationError
+	JSON404      *struct {
+		Detail struct {
+			Error HistoryRouteApiV1TopologyHistoryNameGet404DetailError `json:"error"`
+			Kind  *string                                               `json:"kind,omitempty"`
+			Name  string                                                `json:"name"`
+		} `json:"detail"`
+	}
+	JSON409 *struct {
+		Detail struct {
+			Error HistoryRouteApiV1TopologyHistoryNameGet409DetailError `json:"error"`
+			Kinds []string                                              `json:"kinds"`
+			Name  string                                                `json:"name"`
+		} `json:"detail"`
+	}
+	JSON422 *HTTPValidationError
 }
+type HistoryRouteApiV1TopologyHistoryNameGet404DetailError string
+type HistoryRouteApiV1TopologyHistoryNameGet409DetailError string
 
 // Status returns HTTPResponse.Status
 func (r HistoryRouteApiV1TopologyHistoryNameGetResponse) Status() string {
@@ -11423,6 +11439,32 @@ func ParseHistoryRouteApiV1TopologyHistoryNameGetResponse(rsp *http.Response) (*
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest struct {
+			Detail struct {
+				Error HistoryRouteApiV1TopologyHistoryNameGet404DetailError `json:"error"`
+				Kind  *string                                               `json:"kind,omitempty"`
+				Name  string                                                `json:"name"`
+			} `json:"detail"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest struct {
+			Detail struct {
+				Error HistoryRouteApiV1TopologyHistoryNameGet409DetailError `json:"error"`
+				Kinds []string                                              `json:"kinds"`
+				Name  string                                                `json:"name"`
+			} `json:"detail"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest HTTPValidationError

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -1601,6 +1601,63 @@ type TopologyEdgeEndpoint struct {
 	Name string             `json:"name"`
 }
 
+// TopologyHistoryEntry One row of the per-resource history walk (G9.3-T3).
+//
+// Task #859 ships the operator surface “meho topology history
+// <node>“ -- "what changed for THIS resource?" The differentiator
+// from :class:`TopologyTimelineEntry` (G9.3-T5) is that history
+// carries the full “snapshot“ JSONB (“{before, after}“) per row
+// rather than a one-line summary -- the forensic shape for “--json“
+// reconstruction. Field-to-column mapping otherwise matches
+// timeline:
+//
+//   - “valid_from“ -- “*_history.valid_from“.
+//   - “history_id“ -- “*_history.history_id“.
+//   - “source“ -- “"node"“ for :class:`GraphNodeHistory`, “"edge"“
+//     for :class:`GraphEdgeHistory` (only “"edge"“ rows ever appear
+//     when the caller passed “include_edges=True“).
+//   - “change_kind“ -- one of “"created"“ / “"updated"“ /
+//     “"removed"“ per :class:`GraphHistoryChangeKind`.
+//   - “resource_id“ -- “node_id“ for node-side rows, “edge_id“
+//     for edge-side rows. “None“ only after the referenced live row
+//     has been hard-deleted (“ON DELETE SET NULL“).
+//   - “snapshot“ -- the full “{before, after}“ JSONB. “None“
+//     only for legacy / mid-rollout rows that pre-date the
+//     diff-on-write hook; every hook-emitted row populates it.
+//   - “audit_id“ -- soft-FK to the “audit_log.id“ of the
+//     operation that caused the mutation.
+type TopologyHistoryEntry struct {
+	AuditId    *openapi_types.UUID     `json:"audit_id"`
+	ChangeKind string                  `json:"change_kind"`
+	HistoryId  int                     `json:"history_id"`
+	ResourceId *openapi_types.UUID     `json:"resource_id"`
+	Snapshot   *map[string]interface{} `json:"snapshot"`
+	Source     string                  `json:"source"`
+	ValidFrom  time.Time               `json:"valid_from"`
+}
+
+// TopologyHistoryResult The full per-resource history walk plus the resolved anchor.
+//
+// Unlike :class:`TopologyTimelineResult` (which is cursor-paginated),
+// the per-resource walk returns one page bounded by the substrate's
+// “_MAX_HISTORY_ROWS“ cap -- per-resource history is bounded by
+// the retention window (default 90 days) and the operator typically
+// wants the complete chronology in one response. No “next_cursor“;
+// a caller that overflows the cap narrows “since“ / “until“.
+//
+// “anchor_node_id“ is the resolved :class:`GraphNode.id` of the
+// anchor. Echoing it lets the CLI / MCP fronts surface "I resolved
+// your name X to node Y" in the human-readable header without a
+// second resolver round trip.
+//
+// “include_edges“ echoes the call-site flag so a consumer can
+// branch on whether edge rows are expected to appear in “rows“.
+type TopologyHistoryResult struct {
+	AnchorNodeId openapi_types.UUID     `json:"anchor_node_id"`
+	IncludeEdges bool                   `json:"include_edges"`
+	Rows         []TopologyHistoryEntry `json:"rows"`
+}
+
 // TopologyNode One “graph_node“ row reached during a traversal.
 //
 // “depth“ is the distance from the query root: the root itself is
@@ -2282,6 +2339,16 @@ type UnannotateEdgeRouteApiV1TopologyEdgesEdgeIdDeleteParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// HistoryRouteApiV1TopologyHistoryNameGetParams defines parameters for HistoryRouteApiV1TopologyHistoryNameGet.
+type HistoryRouteApiV1TopologyHistoryNameGetParams struct {
+	Kind          *string    `form:"kind,omitempty" json:"kind,omitempty"`
+	Since         *time.Time `form:"since,omitempty" json:"since,omitempty"`
+	Until         *time.Time `form:"until,omitempty" json:"until,omitempty"`
+	IncludeEdges  *bool      `form:"include_edges,omitempty" json:"include_edges,omitempty"`
+	Limit         *int       `form:"limit,omitempty" json:"limit,omitempty"`
+	Authorization *string    `json:"authorization,omitempty"`
+}
+
 // PathApiV1TopologyPathGetParams defines parameters for PathApiV1TopologyPathGet.
 type PathApiV1TopologyPathGetParams struct {
 	From          string  `form:"from" json:"from"`
@@ -2681,6 +2748,9 @@ type ClientInterface interface {
 
 	// UnannotateEdgeRouteApiV1TopologyEdgesEdgeIdDelete request
 	UnannotateEdgeRouteApiV1TopologyEdgesEdgeIdDelete(ctx context.Context, edgeId openapi_types.UUID, params *UnannotateEdgeRouteApiV1TopologyEdgesEdgeIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// HistoryRouteApiV1TopologyHistoryNameGet request
+	HistoryRouteApiV1TopologyHistoryNameGet(ctx context.Context, name string, params *HistoryRouteApiV1TopologyHistoryNameGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// PathApiV1TopologyPathGet request
 	PathApiV1TopologyPathGet(ctx context.Context, params *PathApiV1TopologyPathGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -3501,6 +3571,18 @@ func (c *Client) BulkImportEdgesRouteApiV1TopologyEdgesBulkPost(ctx context.Cont
 
 func (c *Client) UnannotateEdgeRouteApiV1TopologyEdgesEdgeIdDelete(ctx context.Context, edgeId openapi_types.UUID, params *UnannotateEdgeRouteApiV1TopologyEdgesEdgeIdDeleteParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUnannotateEdgeRouteApiV1TopologyEdgesEdgeIdDeleteRequest(c.Server, edgeId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) HistoryRouteApiV1TopologyHistoryNameGet(ctx context.Context, name string, params *HistoryRouteApiV1TopologyHistoryNameGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewHistoryRouteApiV1TopologyHistoryNameGetRequest(c.Server, name, params)
 	if err != nil {
 		return nil, err
 	}
@@ -6902,6 +6984,141 @@ func NewUnannotateEdgeRouteApiV1TopologyEdgesEdgeIdDeleteRequest(server string, 
 	return req, nil
 }
 
+// NewHistoryRouteApiV1TopologyHistoryNameGetRequest generates requests for HistoryRouteApiV1TopologyHistoryNameGet
+func NewHistoryRouteApiV1TopologyHistoryNameGetRequest(server string, name string, params *HistoryRouteApiV1TopologyHistoryNameGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/topology/history/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Kind != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "kind", runtime.ParamLocationQuery, *params.Kind); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Since != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "since", runtime.ParamLocationQuery, *params.Since); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Until != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "until", runtime.ParamLocationQuery, *params.Until); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.IncludeEdges != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "include_edges", runtime.ParamLocationQuery, *params.IncludeEdges); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Limit != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit", runtime.ParamLocationQuery, *params.Limit); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
 // NewPathApiV1TopologyPathGetRequest generates requests for PathApiV1TopologyPathGet
 func NewPathApiV1TopologyPathGetRequest(server string, params *PathApiV1TopologyPathGetParams) (*http.Request, error) {
 	var err error
@@ -7575,6 +7792,9 @@ type ClientWithResponsesInterface interface {
 
 	// UnannotateEdgeRouteApiV1TopologyEdgesEdgeIdDeleteWithResponse request
 	UnannotateEdgeRouteApiV1TopologyEdgesEdgeIdDeleteWithResponse(ctx context.Context, edgeId openapi_types.UUID, params *UnannotateEdgeRouteApiV1TopologyEdgesEdgeIdDeleteParams, reqEditors ...RequestEditorFn) (*UnannotateEdgeRouteApiV1TopologyEdgesEdgeIdDeleteResponse, error)
+
+	// HistoryRouteApiV1TopologyHistoryNameGetWithResponse request
+	HistoryRouteApiV1TopologyHistoryNameGetWithResponse(ctx context.Context, name string, params *HistoryRouteApiV1TopologyHistoryNameGetParams, reqEditors ...RequestEditorFn) (*HistoryRouteApiV1TopologyHistoryNameGetResponse, error)
 
 	// PathApiV1TopologyPathGetWithResponse request
 	PathApiV1TopologyPathGetWithResponse(ctx context.Context, params *PathApiV1TopologyPathGetParams, reqEditors ...RequestEditorFn) (*PathApiV1TopologyPathGetResponse, error)
@@ -8740,6 +8960,29 @@ func (r UnannotateEdgeRouteApiV1TopologyEdgesEdgeIdDeleteResponse) StatusCode() 
 	return 0
 }
 
+type HistoryRouteApiV1TopologyHistoryNameGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *TopologyHistoryResult
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r HistoryRouteApiV1TopologyHistoryNameGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r HistoryRouteApiV1TopologyHistoryNameGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type PathApiV1TopologyPathGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -9504,6 +9747,15 @@ func (c *ClientWithResponses) UnannotateEdgeRouteApiV1TopologyEdgesEdgeIdDeleteW
 		return nil, err
 	}
 	return ParseUnannotateEdgeRouteApiV1TopologyEdgesEdgeIdDeleteResponse(rsp)
+}
+
+// HistoryRouteApiV1TopologyHistoryNameGetWithResponse request returning *HistoryRouteApiV1TopologyHistoryNameGetResponse
+func (c *ClientWithResponses) HistoryRouteApiV1TopologyHistoryNameGetWithResponse(ctx context.Context, name string, params *HistoryRouteApiV1TopologyHistoryNameGetParams, reqEditors ...RequestEditorFn) (*HistoryRouteApiV1TopologyHistoryNameGetResponse, error) {
+	rsp, err := c.HistoryRouteApiV1TopologyHistoryNameGet(ctx, name, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseHistoryRouteApiV1TopologyHistoryNameGetResponse(rsp)
 }
 
 // PathApiV1TopologyPathGetWithResponse request returning *PathApiV1TopologyPathGetResponse
@@ -11139,6 +11391,39 @@ func ParseUnannotateEdgeRouteApiV1TopologyEdgesEdgeIdDeleteResponse(rsp *http.Re
 	}
 
 	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseHistoryRouteApiV1TopologyHistoryNameGetResponse parses an HTTP response from a HistoryRouteApiV1TopologyHistoryNameGetWithResponse call
+func ParseHistoryRouteApiV1TopologyHistoryNameGetResponse(rsp *http.Response) (*HistoryRouteApiV1TopologyHistoryNameGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &HistoryRouteApiV1TopologyHistoryNameGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest TopologyHistoryResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest HTTPValidationError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {

--- a/cli/internal/cmd/topology/history.go
+++ b/cli/internal/cmd/topology/history.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -134,9 +135,9 @@ func runHistory(cmd *cobra.Command, opts historyOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	result, err := getHistory(cmd.Context(), backplaneURL, opts)
 	if err != nil {

--- a/cli/internal/cmd/topology/history.go
+++ b/cli/internal/cmd/topology/history.go
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package topology
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newHistoryCmd returns the `meho topology history` command.
+//
+//	meho topology history <node-name|alias> \
+//	  [--node-kind K]              # disambiguate ambiguous name
+//	  [--since DUR]                # 24h | 7d | 30m | ISO-8601 lower bound
+//	  [--until DUR]                # same shorthand as --since upper bound
+//	  [--include-edges]            # also walk incident edges' history
+//	  [--limit N]                  # 1..5000, server default 5000
+//	  [--json]                     # raw TopologyHistoryResult JSON
+//	  [--backplane <url>]          # override the configured backplane
+//
+// Calls GET /api/v1/topology/history/{name}. The companion to
+// `meho topology timeline`: timeline is "what changed in the graph
+// at all"; history is "what changed for THIS specific resource".
+// The default table view renders `valid_from / src / change / 1-line
+// diff summary`; `--json` carries the full `snapshot.before` /
+// `snapshot.after` JSONB per row so an operator can pipe into jq for
+// forensic reconstruction.
+//
+// Exit codes (shared with the sibling topology verbs via
+// renderRequestError / renderHTTPError):
+//   - 0   query returned cleanly (incl. zero-row result).
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected response shape (incl. 404 node_not_found and
+//     409 ambiguous_node).
+//   - 5   insufficient_role
+func newHistoryCmd() *cobra.Command {
+	var (
+		nodeKind          string
+		since             string
+		until             string
+		includeEdges      bool
+		limit             int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "history <node-name|alias>",
+		Short: "Walk the per-resource history of one node (G9.3 history)",
+		Long: "history calls GET /api/v1/topology/history/<name> and " +
+			"renders the chronological mutation log for one node " +
+			"(and optionally its incident edges via --include-edges) " +
+			"ordered newest-first. Unlike `meho topology timeline` " +
+			"(tenant-wide feed, summary only), history is anchored on " +
+			"one resource and carries the full snapshot.before / " +
+			"snapshot.after JSONB per row -- the forensic shape for " +
+			"'what was the exact state before this change?'. " +
+			"--node-kind disambiguates when the bare name resolves to " +
+			"multiple kinds. --since / --until accept duration " +
+			"shorthand (24h / 7d / 30m / 2w) or ISO-8601 directly. " +
+			"--json emits the raw TopologyHistoryResult; the table " +
+			"view stays scannable.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runHistory(cmd, historyOptions{
+				Name:              args[0],
+				NodeKind:          nodeKind,
+				Since:             since,
+				Until:             until,
+				IncludeEdges:      includeEdges,
+				Limit:             limit,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&nodeKind, "node-kind", "",
+		"pin the anchor to one node kind when the name is ambiguous across kinds")
+	cmd.Flags().StringVar(&since, "since", "",
+		"earliest valid_from; accepts 24h / 7d / 30m / 2w shorthand, RFC3339, or YYYY-MM-DD")
+	cmd.Flags().StringVar(&until, "until", "",
+		"latest valid_from; accepts the same shorthand as --since")
+	cmd.Flags().BoolVar(&includeEdges, "include-edges", false,
+		"also walk history rows for edges incident to the anchor node")
+	cmd.Flags().IntVar(&limit, "limit", 0,
+		"max rows returned (1..5000, server-side cap when omitted)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw TopologyHistoryResult JSON instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+// historyOptions is the per-call option bag for runHistory.
+//
+// Limit=0 sentinel: Go's int zero collides with the backend's ge=1
+// validation. The CLI sends `--limit` only when explicitly set so the
+// server applies its cap rather than erroring.
+type historyOptions struct {
+	Name              string
+	NodeKind          string
+	Since             string
+	Until             string
+	IncludeEdges      bool
+	Limit             int
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+// _historyLimitMax mirrors the API's Query(le=_HISTORY_LIMIT_MAX)
+// ceiling so the CLI fails fast on an over-budget --limit instead of
+// burning a round trip to a 422.
+const _historyLimitMax = 5000
+
+func runHistory(cmd *cobra.Command, opts historyOptions) error {
+	if opts.Limit < 0 || opts.Limit > _historyLimitMax {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"--limit must be between 1 and %d (or 0/omitted for the server default); got %d",
+				_historyLimitMax, opts.Limit)),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+	}
+	result, err := getHistory(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	printHistoryTable(cmd.OutOrStdout(), opts.Name, result)
+	return nil
+}
+
+// buildHistoryPath assembles the GET path + query string for a
+// history call. The anchor name is a path segment (pathEscape keeps
+// a slash/space in an operator-typed name from corrupting the URL);
+// optional filters land as query params only when set so the server
+// applies its defaults for the rest. Duration shorthand (e.g. "24h")
+// is resolved client-side to an absolute ISO-8601 (same parser
+// `timeline.go` uses via resolveDurationOrISO) so the backend's
+// REST router accepts absolute timestamps only -- one parser in one
+// place.
+func buildHistoryPath(opts historyOptions, now time.Time) (string, error) {
+	q := url.Values{}
+	if opts.NodeKind != "" {
+		q.Set("kind", opts.NodeKind)
+	}
+	if opts.Since != "" {
+		iso, err := resolveDurationOrISO(opts.Since, now)
+		if err != nil {
+			return "", fmt.Errorf("--since %q: %w", opts.Since, err)
+		}
+		q.Set("since", iso)
+	}
+	if opts.Until != "" {
+		iso, err := resolveDurationOrISO(opts.Until, now)
+		if err != nil {
+			return "", fmt.Errorf("--until %q: %w", opts.Until, err)
+		}
+		q.Set("until", iso)
+	}
+	if opts.IncludeEdges {
+		q.Set("include_edges", "true")
+	}
+	if opts.Limit > 0 {
+		q.Set("limit", strconv.Itoa(opts.Limit))
+	}
+	path := "/api/v1/topology/history/" + pathEscape(opts.Name)
+	if encoded := q.Encode(); encoded != "" {
+		path = path + "?" + encoded
+	}
+	return path, nil
+}
+
+func getHistory(ctx context.Context, backplaneURL string, opts historyOptions) (*HistoryResult, error) {
+	path, err := buildHistoryPath(opts, time.Now().UTC())
+	if err != nil {
+		return nil, err
+	}
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+	var out HistoryResult
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode history response: %w", err)
+	}
+	return &out, nil
+}
+
+// HistoryEntry mirrors the backend `TopologyHistoryEntry` Pydantic
+// model (`backend/src/meho_backplane/topology/schemas.py`). Fields
+// are hand-written rather than oapi-codegen-generated for the same
+// reason the audit `Entry` shape is — the topology package stays
+// decoupled from oapi churn, matching the sibling-package convention.
+// `Snapshot` keeps the JSON shape verbatim so `--json` round-trips
+// the backend's payload without CLI loss-of-fidelity (the table
+// view extracts a 1-line summary; the JSON path is what an operator
+// uses for forensic reconstruction).
+type HistoryEntry struct {
+	ValidFrom  string         `json:"valid_from"`
+	HistoryID  int64          `json:"history_id"`
+	Source     string         `json:"source"`
+	ChangeKind string         `json:"change_kind"`
+	ResourceID *string        `json:"resource_id"`
+	Snapshot   map[string]any `json:"snapshot"`
+	AuditID    *string        `json:"audit_id"`
+}
+
+// HistoryResult mirrors the backend `TopologyHistoryResult`.
+// `AnchorNodeID` is the resolved `graph_node.id` and `IncludeEdges`
+// echoes the call-site flag so a re-marshal preserves the Pydantic
+// wire shape.
+type HistoryResult struct {
+	AnchorNodeID string         `json:"anchor_node_id"`
+	IncludeEdges bool           `json:"include_edges"`
+	Rows         []HistoryEntry `json:"rows"`
+}
+
+// printHistoryTable renders the per-resource history page as a
+// compact, scannable table. Columns: VALID_FROM, SRC, CHANGE,
+// SUMMARY, AUDIT_ID. The summary is derived client-side from
+// snapshot.before / snapshot.after; the table view does not show
+// the full snapshot (that is the `--json` mode's job, the forensic
+// payload an operator pipes into `jq`). An empty result renders the
+// "no changes" line.
+func printHistoryTable(w io.Writer, root string, r *HistoryResult) {
+	if r == nil || len(r.Rows) == 0 {
+		fmt.Fprintf(w, "no history rows for %q in this tenant (or window is empty)\n", root)
+		return
+	}
+	fmt.Fprintf(w, "%-22s %-5s %-8s %-38s %s\n",
+		"VALID_FROM", "SRC", "CHANGE", "SUMMARY", "AUDIT_ID")
+	for _, row := range r.Rows {
+		fmt.Fprintf(w, "%-22s %-5s %-8s %-38s %s\n",
+			truncate(row.ValidFrom, 22),
+			row.Source,
+			truncate(row.ChangeKind, 8),
+			truncate(historyRowSummary(row), 38),
+			truncate(strDeref(row.AuditID), 36),
+		)
+	}
+	fmt.Fprintf(w, "anchor: %s; include_edges: %t; rows: %d\n",
+		r.AnchorNodeID, r.IncludeEdges, len(r.Rows))
+}
+
+// historyRowSummary renders a 1-line description of a history row
+// for the table view. Picks the post-state for created / updated
+// (the row as it exists after the mutation -- more useful for
+// "what's new" surveys) and the pre-state for removed (the row that
+// just went away). Falls back to "<change_kind> <source>" when the
+// snapshot is malformed or missing.
+func historyRowSummary(row HistoryEntry) string {
+	if row.Snapshot == nil {
+		return fmt.Sprintf("%s %s", row.ChangeKind, row.Source)
+	}
+	var side any
+	if row.ChangeKind == "removed" {
+		side = row.Snapshot["before"]
+	} else {
+		side = row.Snapshot["after"]
+	}
+	m, ok := side.(map[string]any)
+	if !ok {
+		return fmt.Sprintf("%s %s", row.ChangeKind, row.Source)
+	}
+	if row.Source == "node" {
+		kind, _ := m["kind"].(string)
+		name, _ := m["name"].(string)
+		if kind == "" {
+			kind = "node"
+		}
+		if name == "" {
+			name = "<unknown>"
+		}
+		return fmt.Sprintf("%s %s %s", row.ChangeKind, kind, name)
+	}
+	edgeKind, _ := m["kind"].(string)
+	if edgeKind == "" {
+		edgeKind = "edge"
+	}
+	return fmt.Sprintf("%s %s", row.ChangeKind, edgeKind)
+}

--- a/cli/internal/cmd/topology/topology.go
+++ b/cli/internal/cmd/topology/topology.go
@@ -100,20 +100,21 @@ import (
 func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "topology",
-		Short: "Query and refresh the MEHO topology graph (refresh / dependents / dependencies / path / timeline / annotate / unannotate / list-edges)",
+		Short: "Query and refresh the MEHO topology graph (refresh / dependents / dependencies / path / timeline / history / annotate / unannotate / list-edges)",
 		Long: "Operate the tenant-scoped topology graph wired by G9.1 + " +
 			"G9.2 + G9.3. Refresh a target's discovered topology, walk " +
 			"what depends on a node (dependents), walk what a node " +
 			"depends on (dependencies), find the shortest path between " +
 			"two nodes, walk the tenant's chronological change feed " +
-			"from the diff-on-write history substrate (timeline), " +
-			"assert a curated cross-system edge (annotate), delete a " +
-			"curated edge (unannotate), or list the tenant's edges " +
-			"(list-edges). Read verbs are operator-level; annotate / " +
-			"unannotate require tenant_admin. Tenant scoping is " +
-			"enforced server-side via the JWT — no surface accepts a " +
-			"tenant id, and cross-tenant queries return the same " +
-			"empty/404 shape as a node that does not exist.",
+			"from the diff-on-write history substrate (timeline), walk " +
+			"the per-resource history of one node with optional incident " +
+			"edges (history), assert a curated cross-system edge " +
+			"(annotate), delete a curated edge (unannotate), or list " +
+			"the tenant's edges (list-edges). Read verbs are operator-" +
+			"level; annotate / unannotate require tenant_admin. Tenant " +
+			"scoping is enforced server-side via the JWT — no surface " +
+			"accepts a tenant id, and cross-tenant queries return the " +
+			"same empty/404 shape as a node that does not exist.",
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(newRefreshCmd())
@@ -125,6 +126,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newListEdgesCmd())
 	cmd.AddCommand(newBulkImportCmd())
 	cmd.AddCommand(newTimelineCmd())
+	cmd.AddCommand(newHistoryCmd())
 	return cmd
 }
 

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -681,6 +681,88 @@ to G8's audit-log query surface. The broadcast event carries only
 may name a sensitive target) and the row contents never leak onto
 the SSE / Slack feed.
 
+## History query (read half — G9.3-T3 #859)
+
+`query_history` (in `backend/src/meho_backplane/topology/query.py`)
+is the per-resource history walk — "what changed for THIS specific
+resource?" Companion to `query_timeline` (tenant-wide feed,
+truncated summary) but with two key differences:
+
+1. **Anchored on one node.** The first thing the substrate does is
+   call `resolve_node` to translate the operator-supplied name (and
+   optional `kind` disambiguator) into a `graph_node.id`. An unknown
+   name or a cross-tenant name surfaces as `NodeNotFoundError`; an
+   ambiguous bare name as `AmbiguousNodeError`. The REST + MCP
+   fronts map both to operator-actionable diagnostics (404 / 409
+   for HTTP, JSON-RPC -32602 for MCP).
+2. **Full snapshot per row.** Each `TopologyHistoryEntry` carries
+   the row's `snapshot.before` / `snapshot.after` JSONB intact —
+   the forensic payload the CLI's `--json` mode and the MCP facet
+   need to answer "what was the exact state before this change?".
+   The timeline's one-line summary truncation does not apply here.
+
+### Include-edges join
+
+By default `query_history` walks `graph_node_history` only for the
+anchor's `node_id`. Passing `include_edges=True` also walks
+`graph_edge_history` for every edge incident to the anchor — the
+inner subquery is `edge_id IN (SELECT id FROM graph_edge WHERE
+from_node_id = anchor OR to_node_id = anchor)`. Tenant scope is
+enforced on both the inner and the outer query so a cross-tenant
+edge id cannot leak in.
+
+Tombstones (edge-history rows whose `edge_id` was NULLed by `ON
+DELETE SET NULL` after the live edge was hard-deleted) drop out of
+the inner subquery's id list and therefore stay out of the
+per-resource walk — a tombstoned edge has no surviving live row to
+associate with the anchor. Operators wanting the full tombstone
+replay use `meho topology timeline` (G9.3-T5 #861).
+
+### Indexes
+
+The per-resource walk leans on two tenant-scoped composite indexes
+declared by migration 0012 (G9.3-T1 #856):
+
+- `graph_node_history` `(tenant_id, node_id, valid_from DESC)` —
+  per-(tenant, node, time) lookup is a single composite-index scan.
+- `graph_edge_history` `(tenant_id, edge_id, valid_from DESC)` —
+  mirror for the edge side.
+
+Both are sub-millisecond on the test fixture and indexed under
+realistic load.
+
+### Pagination
+
+Unlike `query_timeline` (cursor-paginated), `query_history` returns
+one page bounded by `_MAX_HISTORY_ROWS = 5000`. Per-resource
+history is bounded by the retention window (default 90 days) and
+the operator typically wants the complete chronology in one
+response. A caller that overflows the cap narrows `since` /
+`until`; there is no `next_cursor`.
+
+### Latent SQLite resolver bug fixed by this task
+
+`resolve_node`'s bare-name branch runs a `text()` SQL with a
+``tenant_id = :tenant_id`` filter. Before #859 the bind passed
+`str(uuid)` (dashed form). On the SQLite test driver the `Uuid()`
+column stores 32-char hex without dashes, and the dashed-string
+filter silently matched zero rows — `resolve_node` then raised a
+spurious `NodeNotFoundError`. Production PG accepts both forms,
+masking the bug. #859 pins `_ANCHOR_KINDS_SQL` to a SAUuid bind
+type so both dialects round-trip cleanly. The closure / path verbs
+were unaffected because they call `_assert_anchor_unambiguous`,
+which only raises when 2+ kinds match (a zero-row result is
+intentionally silent there — G9.1 contract).
+
+### Audit class
+
+The REST route binds `audit_op_id="topology.history"` /
+`audit_op_class="audit_query"` — same shape as `topology.timeline`.
+The broadcast event carries only `{op_id, result_status,
+row_count}` so the response rows (which may include the snapshot
+of a sensitive resource's pre/post payload) never leak onto the
+SSE / Slack feed.
+
 ## Manual node seed control flow (write half — G0.9.1-T6 #778)
 
 ### `create_or_get_node`
@@ -736,10 +818,10 @@ will adopt the node onto the target (`target_id` gets set, the
 node's properties pick up probe-derived shape) without losing the
 manual-seed audit trail.
 
-## REST API surface (T5, #453 + G9.2-T5 #597 + G9.3-T5 #861)
+## REST API surface (T5, #453 + G9.2-T5 #597 + G9.3-T5 #861 + G9.3-T3 #859)
 
 `backend/src/meho_backplane/api/v1/topology.py` is the HTTP front for
-the read + write halves. Ten routes total — nine on the topology
+the read + write halves. Eleven routes total — ten on the topology
 router, one on the targets router:
 
 | Method + path | Wraps | op_id | RBAC |
@@ -753,6 +835,7 @@ router, one on the targets router:
 | `GET /api/v1/topology/edges` | `list_edges` (T4 #596) | `topology.list_edges` | operator |
 | `POST /api/v1/topology/edges/bulk` | `bulk_import_edges` (T8 #600) | `topology.bulk_import` | **tenant_admin** |
 | `GET /api/v1/topology/timeline` | `query_timeline` (G9.3-T5 #861) | `topology.timeline` | operator |
+| `GET /api/v1/topology/history/{name}` | `query_history` (G9.3-T3 #859) | `topology.history` | operator |
 | `GET /api/v1/targets/discover?product=X` | `Connector.list_candidates` | `targets.discover` | operator |
 
 Load-bearing details:


### PR DESCRIPTION
Closes #859

## Summary

Implements G9.3-T3: the per-resource history walk anchored on one `graph_node`. Companion to `query_timeline` (G9.3-T5 #861, tenant-wide feed truncated to a 1-line summary) — `query_history` carries the **full `snapshot.before` / `snapshot.after`** JSONB per row so an operator answering "what was the exact state before this change?" gets the forensic payload.

Three operator surfaces land in this PR, all sharing the substrate `query_history` (in `backend/src/meho_backplane/topology/query.py`):

- **CLI**: `meho topology history <node-name|alias>` (in `cli/internal/cmd/topology/history.go`) with `--node-kind` / `--since` / `--until` / `--include-edges` / `--limit` / `--json`. Duration shorthand (`24h` / `7d` / `30m` / `2w`) resolves client-side to ISO-8601 — same parser timeline uses. Table view renders `VALID_FROM / SRC / CHANGE / SUMMARY / AUDIT_ID`; `--json` carries the full `TopologyHistoryResult`.
- **REST**: `GET /api/v1/topology/history/{name}` (in `backend/src/meho_backplane/api/v1/topology.py`), `operator` role. Errors: 404 `node_not_found` (unknown name OR cross-tenant name — the boundary is opaque), 409 `ambiguous_node` (bare name resolves to multiple kinds, pass `kind=` to disambiguate). Limit ceiling 5000.
- **MCP**: `query_topology(kind="history", target=<name>, ...)` (in `backend/src/meho_backplane/mcp/tools/topology.py`). `target` is the new required-when-`kind=history` field; `include_edges` is the new optional field gated to this facet. Coexists with `kind="diff"` (sibling PR #931 for #860).

## Scope

- `query_history(operator, name_or_alias, *, kind, since, until, include_edges, limit)` — resolves anchor tenant-scoped via `resolve_node` (G9.1), executes one tenant-scoped SELECT against `graph_node_history` for the anchor, and (when `include_edges=True`) a second SELECT against `graph_edge_history` filtered by `edge_id IN (SELECT id FROM graph_edge WHERE from_node_id=anchor OR to_node_id=anchor)`. Pages merged client-side via two-pointer DESC merge.
- `TopologyHistoryEntry` / `TopologyHistoryResult` Pydantic v2 frozen models (`backend/src/meho_backplane/topology/schemas.py`) — the entry carries the full `snapshot` dict; result echoes `anchor_node_id` + `include_edges`.
- Audit: route binds `audit_op_id="topology.history"` + `audit_op_class="audit_query"` per the decision-3 convention (`audit_query` for temporal-graph inspections); broadcast event carries only `{op_id, result_status, row_count}` so the snapshot payloads never reach the SSE feed.
- Tenant scoping enforced server-side on every SQL statement's first WHERE; cross-tenant name surfaces as `NodeNotFoundError` identical to an unknown name.

## Indexes

Leans on the composite indexes declared by migration 0012 (G9.3-T1 #856):
- `graph_node_history (tenant_id, node_id, valid_from DESC)`
- `graph_edge_history (tenant_id, edge_id, valid_from DESC)`

Both indexed scans; sub-millisecond on the test fixture.

## Resolver fix riding along

`topology/resolvers.py::_ANCHOR_KINDS_SQL` was passing `str(uuid)` (dashed form) for `tenant_id`. On `Uuid()` columns SQLite stores the canonical 32-char hex (no dashes) and the dashed-string filter silently matched zero rows — `resolve_node` then raised a spurious `NodeNotFoundError` even for a row that exists. Production PG accepted both forms, masking the bug. Pinned the bind to `SAUuid()` so both dialects round-trip cleanly. Same pattern T5 (#861) used in `topology/query.py`.

## Acceptance criteria

- [x] `meho topology history` CLI verb — `cli/internal/cmd/topology/history.go` + wired in `topology.go`.
- [x] `GET /api/v1/topology/history/{name}` — `backend/src/meho_backplane/api/v1/topology.py`.
- [x] `query_topology(kind="history", resource=...)` facet — `backend/src/meho_backplane/mcp/tools/topology.py` (dispatch + inputSchema enum + conditional `target` required + `include_edges` optional + outputSchema additions + parametric description case).
- [x] Tenant scoping; `operator` role; one `audit_log` row per call with `op_class="audit_query"` — bound via `structlog.contextvars.bind_contextvars` so the chassis `AuditMiddleware` emits the row.
- [x] Unknown node → 404; cross-tenant node → 404; ambiguous bare name → 409.
- [x] `--include-edges` joins edges incident to the anchor via `edge_id IN (SELECT … from_node_id=anchor OR to_node_id=anchor)`; ordering preserved (`valid_from DESC, history_id DESC`).
- [x] `--json` carries full `snapshot.before` / `snapshot.after`; table view renders a 1-line summary.

## Tests

`backend/tests/test_topology_history_query.py` — 12 tests covering:

- anchor + tenant scoping (returns only anchor rows; cross-tenant `NotFoundError`; same-name in two tenants stays isolated)
- name + kind resolution (ambiguous bare name raises; `kind=` pin disambiguates)
- unknown node → `NotFoundError`
- `include_edges=True` joins incident edges, unrelated edges filtered out
- `include_edges=False` default — no edge-row leak
- `since` / `until` window scoping (inclusive at both ends)
- full snapshot round-trip (the differentiator from timeline)
- newest-first ordering across merged node + edge pages
- `limit` validation (out-of-range → `ValueError`)

Also updated `backend/tests/test_mcp_tools_topology.py` to assert `"history"` in the `kind` enum and `target` in the conditional-required map for `kind=history`.

## Verification

- `uv run ruff check` — clean
- `uv run ruff format --check` — clean (493 files already formatted)
- `uv run mypy backend/src/meho_backplane/` — clean (230 source files)
- `uv run pytest -n auto backend/tests/test_topology_history_query.py` — 12 passed
- `cd cli && go build ./...` — clean
- `cd cli && go vet ./...` — clean
- `cd cli && go test ./internal/cmd/topology/` — 55 passed

## Coexistence with PR #931

Sibling PR #931 (#860, `kind="diff"`) branches from the same `main`. The two are additive on `query_topology`'s MCP dispatch — #931 adds the `"diff"` branch, this PR adds the `"history"` branch; the conditional schema additions are non-overlapping. Whichever lands second will rebase the enum list + dispatch ladder cleanly.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-22)

Addressed `/auto-review-pr` iter-1 + CodeRabbit findings on [the
iter-1 review](.claude/auto/review-results/pr-936-iter-1.json):

- **B1** — `test_query_topology_input_schema_includes_edges_facet`
  asserted the exact `kind` enum list without `"history"`; extended
  the expected list and added `by_kind["history"] == ["target"]` for
  parity with the sibling test in `test_mcp_tools_topology.py`. The
  `by_kind` comprehension now skips per-kind `limit.maximum`
  tightening clauses (no `required` key).
- **B2** — Regenerated `cli/api/openapi.json` +
  `cli/internal/api/client.gen.go` via `cd cli && make
  snapshot-openapi && make generate`. The PR added `GET
  /topology/history/{name}` on the REST side but didn't refresh the
  snapshot; the CI freshness gate introduced by #929 is now green.
- **B3** — `_history_facet` in
  `backend/src/meho_backplane/mcp/tools/topology.py` was extracting
  every other knob from the arguments dict but silently dropping
  `limit`. Now forwards `int(arguments.get("limit",
  _HISTORY_LIMIT_MAX))` — mirrors the pattern `_list_edges_facet`
  uses.
- **M1** — Adopted the preferred per-facet override path. Base
  `limit.maximum` widened to `_HISTORY_LIMIT_MAX` (5000) so history
  callers pass the schema; per-facet `allOf if/then` clauses
  intersect a stricter `limit.maximum = 1000` for `edges` /
  `timeline` so those branches still schema-reject over-cap values
  upstream of the substrate's `ValueError`. New `_HISTORY_LIMIT_MAX`
  constant mirrors the substrate's `_MAX_HISTORY_ROWS` the same way
  `_EDGES_LIMIT_MAX` / `_TIMELINE_LIMIT_MAX` mirror their substrates.
  All four fronts (REST 5000 / CLI 5000 / MCP 5000 / substrate 5000)
  now agree on the history cap.

Added four targeted tests in
`backend/tests/test_mcp_tools_topology_annotate.py` covering B3 (limit
forwarding + default) and M1 (history-schema admits up to 5000, edges
schema still rejects over 1000).

Verification:
- `uv run ruff check` / `format --check` — clean
- `uv run mypy backend/src/meho_backplane/` — clean (230 source files)
- `uv run pytest backend/tests/test_topology_history_query.py` — 12 passed
- `uv run pytest backend/tests/test_mcp_tools_topology_annotate.py` — full file passes
- `cd cli && go build ./... && go vet ./...` — clean
- `cd cli && go test ./internal/cmd/topology/` — 55 passed
- `git diff --exit-code cli/api/openapi.json cli/internal/api/client.gen.go`
  after a fresh `make snapshot-openapi && make generate` — CLEAN

<!-- auto-implement-issue: continue, iteration 2 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-resource topology history REST endpoint with time-window, include-edges, node-kind filtering, bounded limit; CLI subcommand to fetch and pretty-print or JSON-export history; generated API client support and schema models.

* **Bug Fixes**
  * Fixed UUID bind/serialization in node resolution to avoid cross-driver mismatches.

* **Tests**
  * Added end-to-end and unit tests covering history behavior, ordering, scopes, limits, and schema validation.

* **Documentation**
  * Updated docs and OpenAPI to document the history endpoint and related schemas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/936?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
