### PR TITLE
refactor(cli): extract shared operation-call dispatch core (Cluster B of #923)

### DIFF
--- a/cli/internal/cmd/bind9/about.go
+++ b/cli/internal/cmd/bind9/about.go
@@ -79,11 +79,11 @@ func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOver
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.about", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "bind9.about", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "bind9.about", r, jsonOut, printAbout)
+	return conn.Render(cmd, "bind9.about", r, jsonOut, printAbout)
 }
 
 // printAbout renders the bind9.about result fields. The handler

--- a/cli/internal/cmd/bind9/bind9_test.go
+++ b/cli/internal/cmd/bind9/bind9_test.go
@@ -484,7 +484,7 @@ func TestDispatchOpBakesConnectorID(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	r, err := dispatchOp(context.Background(), srv.URL, "bind9.about", "vcf-router-bind9", nil)
+	r, err := conn.Call(context.Background(), srv.URL, "bind9.about", "vcf-router-bind9", nil)
 	if err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
@@ -515,7 +515,7 @@ func TestDispatchOpTargetSlugWrappedAsName(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	if _, err := dispatchOp(context.Background(), srv.URL, "bind9.about", "vcf-router-bind9", nil); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, "bind9.about", "vcf-router-bind9", nil); err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
 }
@@ -559,7 +559,7 @@ func TestDispatchOpRecordAddSendsExpectedParams(t *testing.T) {
 		"zone": "evba.lab",
 		"type": "A",
 	}
-	if _, err := dispatchOp(context.Background(), srv.URL, "bind9.record.add", "vcf-router-bind9", params); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, "bind9.record.add", "vcf-router-bind9", params); err != nil {
 		t.Fatalf("dispatchOp record.add: %v", err)
 	}
 }

--- a/cli/internal/cmd/bind9/config.go
+++ b/cli/internal/cmd/bind9/config.go
@@ -75,11 +75,11 @@ func runConfigShow(cmd *cobra.Command, path, targetName string, jsonOut bool, ba
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
 	params := map[string]any{"path": path}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.config.show", targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "bind9.config.show", targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "bind9.config.show", r, jsonOut, printConfigShow)
+	return conn.Render(cmd, "bind9.config.show", r, jsonOut, printConfigShow)
 }
 
 // printConfigShow renders `{"file": <abs-path>, "content": <text>}`.
@@ -184,11 +184,11 @@ func runConfigApplyViews(
 	if verifyFQDN != "" {
 		params["verify_fqdn"] = verifyFQDN
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.config.apply_views", targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "bind9.config.apply_views", targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "bind9.config.apply_views", r, jsonOut, printWriteResult)
+	return conn.Render(cmd, "bind9.config.apply_views", r, jsonOut, printWriteResult)
 }
 
 // assembleViewsBundle reads the local views.conf and every regular
@@ -332,11 +332,11 @@ func runConfigApplyFile(cmd *cobra.Command, name, localSrc, targetName string, j
 		"path":    name,
 		"content": content,
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.config.apply_file", targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "bind9.config.apply_file", targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "bind9.config.apply_file", r, jsonOut, printWriteResult)
+	return conn.Render(cmd, "bind9.config.apply_file", r, jsonOut, printWriteResult)
 }
 
 // newConfigBackupCmd returns `meho bind9 config backup [--tag T]`.
@@ -392,11 +392,11 @@ func runConfigBackup(cmd *cobra.Command, tag, targetName string, jsonOut bool, b
 	if len(params) == 0 {
 		params = nil
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.config.backup", targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "bind9.config.backup", targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "bind9.config.backup", r, jsonOut, printConfigBackup)
+	return conn.Render(cmd, "bind9.config.backup", r, jsonOut, printConfigBackup)
 }
 
 // printConfigBackup renders the backup result. Surfaces backup_id +
@@ -476,11 +476,11 @@ func runConfigReload(cmd *cobra.Command, targetName string, jsonOut bool, backpl
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.config.reload", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "bind9.config.reload", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "bind9.config.reload", r, jsonOut, printConfigReload)
+	return conn.Render(cmd, "bind9.config.reload", r, jsonOut, printConfigReload)
 }
 
 // printConfigReload renders the rndc reload result. Surfaces ok +

--- a/cli/internal/cmd/bind9/dispatch.go
+++ b/cli/internal/cmd/bind9/dispatch.go
@@ -4,170 +4,33 @@
 package bind9
 
 import (
-	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 
-	"github.com/spf13/cobra"
-
-	"github.com/evoila/meho/cli/internal/output"
+	"github.com/evoila/meho/cli/internal/dispatch"
 )
 
-// CallResult mirrors the backend OperationResult Pydantic model.
-// Same shape as cmd/vmware/CallResult; duplicated here because
-// cmd/bind9 can't import cmd/vmware without an import cycle
-// (cmd/root.go grafts both onto the tree).
-//
-// Result is left as json.RawMessage because the backend types it as
-// a oneOf(dict, list) union — pretty-printing the raw bytes is the
-// cleanest renderer until a per-shape table specialisation lands.
-// Same approach the vmware sibling takes.
-type CallResult struct {
-	Status     string          `json:"status"`
-	OpID       string          `json:"op_id"`
-	Result     json.RawMessage `json:"result"`
-	Error      *string         `json:"error"`
-	Extras     json.RawMessage `json:"extras,omitempty"`
-	DurationMs float64         `json:"duration_ms"`
-}
+// Aliases + binding to the shared dispatch core (cli/internal/dispatch).
+// The verb files keep referring to the unqualified names; the operation-
+// call logic lives once in the dispatch package. The bind9-specific
+// result decoders + renderers below stay here.
+type (
+	// CallResult is the decoded OperationResult envelope.
+	CallResult = dispatch.CallResult
+	// callRequestBody is the on-the-wire OperationCall body (asserted by tests).
+	callRequestBody = dispatch.CallRequestBody
+)
 
-// callRequestBody mirrors the backend CallOperationBody Pydantic
-// model. Target uses a map[string]any so the empty case serialises
-// as `null` rather than an empty struct; the route layer's resolver
-// short-circuits on the missing-name case (raising 400) for ops
-// that need a target.
-type callRequestBody struct {
-	ConnectorID string         `json:"connector_id"`
-	OpID        string         `json:"op_id"`
-	Target      map[string]any `json:"target"`
-	Params      map[string]any `json:"params,omitempty"`
-}
+// errOpError is the structured-failure sentinel (status error/denied).
+var errOpError = dispatch.ErrOpError
 
-// errOpError is the sentinel returned when the dispatcher reported a
-// structured-failure result (status == "error" or status ==
-// "denied"). main translates non-nil RunE errors into a non-zero
-// exit; SilenceErrors=true on each command keeps cobra from double-
-// printing the error string. Same shape as the vmware sibling's
-// errOpError.
-var errOpError = errors.New("operation status not ok")
+// conn binds this package's pre-baked connector_id + authed transport
+// (doAuthedRequest) to the shared dispatch core.
+var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}
 
-// dispatchOp POSTs an OperationCall to the backplane and returns the
-// decoded CallResult. The pre-baked connector_id ("bind9-ssh-9.x")
-// is baked in; callers pass op_id, an optional target slug (empty
-// string → no target field on the wire), and an optional params map.
-//
-// Centralised here so every verb in the package shares one
-// dispatcher implementation (over a dozen call sites). Renamed from
-// the vmware sibling's postCall to make the call sites self-
-// documenting at the grep level: a grep for `dispatchOp` finds every
-// alias-verb dispatch in the bind9 package.
-func dispatchOp(
-	ctx context.Context,
-	backplaneURL, opID, targetSlug string,
-	params map[string]any,
-) (*CallResult, error) {
-	body := callRequestBody{
-		ConnectorID: ConnectorID,
-		OpID:        opID,
-		Target:      nil,
-	}
-	if targetSlug != "" {
-		body.Target = map[string]any{"name": targetSlug}
-	}
-	if params != nil {
-		body.Params = params
-	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal call request: %w", err)
-	}
-	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
-	if err != nil {
-		return nil, err
-	}
-	var out CallResult
-	if err := json.Unmarshal(respBody, &out); err != nil {
-		return nil, fmt.Errorf("decode call response: %w", err)
-	}
-	return &out, nil
-}
-
-// renderCallResult handles the unified post-dispatch path every verb
-// uses: validate status enum, render the envelope (JSON or human),
-// then translate "error" / "denied" into the errOpError sentinel so
-// main propagates the right non-zero exit. Returns nil on success
-// or one of:
-//   - errOpError (status == "error" / "denied" → exit 1)
-//   - a structured renderer error (unexpected status → exit 4)
-//
-// Pretty-printing is delegated to a per-verb closure so verb files
-// can lay out their domain-specific tables (zone list shows
-// name/type/file columns; record get shows the rdata rows; etc.).
-// When prettyPrinter is nil, the fallback renders the generic
-// envelope shape — handy for verbs whose result envelope is opaque
-// to the CLI today (config.apply_* / config.backup write envelopes).
-func renderCallResult(
-	cmd *cobra.Command,
-	opID string,
-	r *CallResult,
-	jsonOut bool,
-	prettyPrinter func(w io.Writer, r *CallResult),
-) error {
-	switch r.Status {
-	case "ok", "error", "denied":
-		// fall through.
-	default:
-		return output.RenderError(
-			cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf(
-				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
-				r.Status,
-			)),
-			jsonOut,
-		)
-	}
-	if jsonOut {
-		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
-			return err
-		}
-	} else if prettyPrinter != nil {
-		prettyPrinter(cmd.OutOrStdout(), r)
-	} else {
-		printGenericResult(cmd.OutOrStdout(), opID, r)
-	}
-	if r.Status == "ok" {
-		return nil
-	}
-	return errOpError
-}
-
-// printGenericResult renders a CallResult in the same shape the
-// vmware sibling's printGenericResult uses. Used as the fallback
-// pretty-printer for verbs that don't define their own table layout
-// (config.apply_* writes whose result envelope is opaque to the
-// CLI; config.backup whose listing is best read as JSON).
-func printGenericResult(w io.Writer, opID string, r *CallResult) {
-	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
-	if r.Status == "ok" {
-		if len(r.Result) > 0 && string(r.Result) != "null" {
-			pretty, err := prettyJSON(r.Result)
-			if err == nil {
-				fmt.Fprintln(w, pretty)
-				return
-			}
-			fmt.Fprintln(w, string(r.Result))
-		}
-		return
-	}
-	printErrorTrailer(w, r)
-}
-
-// printErrorTrailer surfaces the dispatcher error / extras envelope.
-// Used by every per-verb pretty-printer's error branch so the
-// "status=error" output is consistent across verbs. Same shape as
-// the vmware sibling's helper.
+// printErrorTrailer renders the connector error + extras tail shared by
+// the bind9 per-verb pretty-printers (the success body is verb-specific).
 func printErrorTrailer(w io.Writer, r *CallResult) {
 	if r.Error != nil && *r.Error != "" {
 		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
@@ -176,27 +39,13 @@ func printErrorTrailer(w io.Writer, r *CallResult) {
 	}
 	if len(r.Extras) > 0 && string(r.Extras) != "null" {
 		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
+		pretty, err := dispatch.PrettyJSON(r.Extras)
 		if err == nil {
 			fmt.Fprintln(w, pretty)
 		} else {
 			fmt.Fprintln(w, string(r.Extras))
 		}
 	}
-}
-
-// prettyJSON pretty-prints a json.RawMessage with 2-space indent.
-// Same implementation as the vmware sibling.
-func prettyJSON(raw json.RawMessage) (string, error) {
-	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return "", err
-	}
-	out, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
 }
 
 // decodeRowsResult decodes the canonical `{"rows": [...], "total": N}`
@@ -232,8 +81,7 @@ func decodeFlatResult(raw json.RawMessage) (map[string]any, error) {
 }
 
 // stringField pulls a string field from a row entry, returning empty
-// string when the field is missing or wrong type. Mirrors the vmware
-// sibling's helper.
+// string when the field is missing or wrong type.
 func stringField(e map[string]any, key string) string {
 	v, ok := e[key]
 	if !ok {
@@ -252,7 +100,7 @@ func fallbackResultRender(w io.Writer, r *CallResult) {
 	if len(r.Result) == 0 || string(r.Result) == "null" {
 		return
 	}
-	pretty, err := prettyJSON(r.Result)
+	pretty, err := dispatch.PrettyJSON(r.Result)
 	if err == nil {
 		fmt.Fprintln(w, pretty)
 		return

--- a/cli/internal/cmd/bind9/record.go
+++ b/cli/internal/cmd/bind9/record.go
@@ -79,11 +79,11 @@ func runRecordGet(cmd *cobra.Command, fqdn, recordType, targetName string, jsonO
 	if recordType != "" {
 		params["type"] = recordType
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.record.get", targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "bind9.record.get", targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "bind9.record.get", r, jsonOut, printRecordGet)
+	return conn.Render(cmd, "bind9.record.get", r, jsonOut, printRecordGet)
 }
 
 // printRecordGet renders the record get result. Same row shape as
@@ -199,11 +199,11 @@ func runRecordAdd(cmd *cobra.Command, fqdn, ip, zone, recordType, targetName str
 	if recordType != "" {
 		params["type"] = recordType
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.record.add", targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "bind9.record.add", targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "bind9.record.add", r, jsonOut, printWriteResult)
+	return conn.Render(cmd, "bind9.record.add", r, jsonOut, printWriteResult)
 }
 
 // newRecordRemoveCmd returns `meho bind9 record remove <fqdn>`.
@@ -254,11 +254,11 @@ func runRecordRemove(cmd *cobra.Command, fqdn, zone, targetName string, jsonOut 
 	if zone != "" {
 		params["zone"] = zone
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.record.remove", targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "bind9.record.remove", targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "bind9.record.remove", r, jsonOut, printWriteResult)
+	return conn.Render(cmd, "bind9.record.remove", r, jsonOut, printWriteResult)
 }
 
 // printWriteResult renders the canonical write-op result envelope

--- a/cli/internal/cmd/bind9/zone.go
+++ b/cli/internal/cmd/bind9/zone.go
@@ -65,11 +65,11 @@ func runZoneList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneO
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.zone.list", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "bind9.zone.list", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "bind9.zone.list", r, jsonOut, printZoneList)
+	return conn.Render(cmd, "bind9.zone.list", r, jsonOut, printZoneList)
 }
 
 // printZoneList renders the zone list. Each row carries `{name,
@@ -144,11 +144,11 @@ func runZoneRead(cmd *cobra.Command, zone, targetName string, jsonOut bool, back
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
 	params := map[string]any{"zone": zone}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "bind9.zone.read", targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "bind9.zone.read", targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "bind9.zone.read", r, jsonOut, printZoneRead)
+	return conn.Render(cmd, "bind9.zone.read", r, jsonOut, printZoneRead)
 }
 
 // printZoneRead renders the zone read result. Each row carries

--- a/cli/internal/cmd/harbor/about.go
+++ b/cli/internal/cmd/harbor/about.go
@@ -52,11 +52,11 @@ func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOver
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/api/v2.0/systeminfo", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v2.0/systeminfo", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/api/v2.0/systeminfo", r, jsonOut, printAbout)
+	return conn.Render(cmd, "GET:/api/v2.0/systeminfo", r, jsonOut, printAbout)
 }
 
 func printAbout(w io.Writer, r *CallResult) {
@@ -132,11 +132,11 @@ func runHealth(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOve
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/api/v2.0/health", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v2.0/health", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/api/v2.0/health", r, jsonOut, printHealth)
+	return conn.Render(cmd, "GET:/api/v2.0/health", r, jsonOut, printHealth)
 }
 
 func printHealth(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/harbor/artifact.go
+++ b/cli/internal/cmd/harbor/artifact.go
@@ -62,11 +62,11 @@ func runArtifactList(cmd *cobra.Command, projectName, repoName, targetName strin
 		"project_name":    projectName,
 		"repository_name": repoName,
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printArtifactList)
+	return conn.Render(cmd, opID, r, jsonOut, printArtifactList)
 }
 
 func printArtifactList(w io.Writer, r *CallResult) {
@@ -150,11 +150,11 @@ func runArtifactInfo(cmd *cobra.Command, projectName, repoName, reference, targe
 		"repository_name": repoName,
 		"reference":       reference,
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printArtifactInfo)
+	return conn.Render(cmd, opID, r, jsonOut, printArtifactInfo)
 }
 
 func printArtifactInfo(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/harbor/dispatch.go
+++ b/cli/internal/cmd/harbor/dispatch.go
@@ -4,134 +4,28 @@
 package harbor
 
 import (
-	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 
-	"github.com/spf13/cobra"
-
-	"github.com/evoila/meho/cli/internal/output"
+	"github.com/evoila/meho/cli/internal/dispatch"
 )
 
-// CallResult mirrors the backend OperationResult Pydantic model.
-type CallResult struct {
-	Status     string          `json:"status"`
-	OpID       string          `json:"op_id"`
-	Result     json.RawMessage `json:"result"`
-	Error      *string         `json:"error"`
-	Extras     json.RawMessage `json:"extras,omitempty"`
-	DurationMs float64         `json:"duration_ms"`
-}
+// Aliases + binding to the shared dispatch core (cli/internal/dispatch).
+// The verb files keep referring to the unqualified names; the operation-
+// call logic lives once in the dispatch package.
+type (
+	// CallResult is the decoded OperationResult envelope.
+	CallResult = dispatch.CallResult
+	// callRequestBody is the on-the-wire OperationCall body (asserted by tests).
+	callRequestBody = dispatch.CallRequestBody
+)
 
-// callRequestBody mirrors the backend CallOperationBody Pydantic model.
-type callRequestBody struct {
-	ConnectorID string         `json:"connector_id"`
-	OpID        string         `json:"op_id"`
-	Target      map[string]any `json:"target"`
-	Params      map[string]any `json:"params,omitempty"`
-}
+// errOpError is the structured-failure sentinel (status error/denied).
+var errOpError = dispatch.ErrOpError
 
-var errOpError = errors.New("operation status not ok")
-
-// dispatchOp POSTs an OperationCall to the backplane and returns the
-// decoded CallResult with connector_id="harbor-rest-2.x" pre-baked.
-func dispatchOp(
-	ctx context.Context,
-	backplaneURL, opID, targetSlug string,
-	params map[string]any,
-) (*CallResult, error) {
-	body := callRequestBody{
-		ConnectorID: ConnectorID,
-		OpID:        opID,
-		Target:      nil,
-	}
-	if targetSlug != "" {
-		body.Target = map[string]any{"name": targetSlug}
-	}
-	if params != nil {
-		body.Params = params
-	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal call request: %w", err)
-	}
-	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
-	if err != nil {
-		return nil, err
-	}
-	var out CallResult
-	if err := json.Unmarshal(respBody, &out); err != nil {
-		return nil, fmt.Errorf("decode call response: %w", err)
-	}
-	return &out, nil
-}
-
-// renderCallResult handles the unified post-dispatch rendering path.
-func renderCallResult(
-	cmd *cobra.Command,
-	opID string,
-	r *CallResult,
-	jsonOut bool,
-	prettyPrinter func(w io.Writer, r *CallResult),
-) error {
-	switch r.Status {
-	case "ok", "error", "denied":
-	default:
-		return output.RenderError(
-			cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf(
-				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
-				r.Status,
-			)),
-			jsonOut,
-		)
-	}
-	if jsonOut {
-		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
-			return err
-		}
-	} else if prettyPrinter != nil {
-		prettyPrinter(cmd.OutOrStdout(), r)
-	} else {
-		printGenericResult(cmd.OutOrStdout(), opID, r)
-	}
-	if r.Status == "ok" {
-		return nil
-	}
-	return errOpError
-}
-
-// printGenericResult renders a CallResult in the generic envelope shape.
-func printGenericResult(w io.Writer, opID string, r *CallResult) {
-	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
-	if r.Status == "ok" {
-		if len(r.Result) > 0 && string(r.Result) != "null" {
-			pretty, err := prettyJSON(r.Result)
-			if err == nil {
-				fmt.Fprintln(w, pretty)
-				return
-			}
-			fmt.Fprintln(w, string(r.Result))
-		}
-		return
-	}
-	if r.Error != nil && *r.Error != "" {
-		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
-	} else {
-		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
-	}
-	if len(r.Extras) > 0 && string(r.Extras) != "null" {
-		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
-		if err == nil {
-			fmt.Fprintln(w, pretty)
-		} else {
-			fmt.Fprintln(w, string(r.Extras))
-		}
-	}
-}
+// conn binds this package's pre-baked connector_id + authed transport
+// (doAuthedRequest) to the shared dispatch core.
+var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}
 
 // decodeHarborList decodes the result of a Harbor list op. Harbor
 // list endpoints return a bare JSON array (no "results" wrapper).
@@ -144,16 +38,4 @@ func decodeHarborList(raw json.RawMessage) ([]map[string]any, error) {
 		return nil, fmt.Errorf("decode harbor list: %w", err)
 	}
 	return items, nil
-}
-
-func prettyJSON(raw json.RawMessage) (string, error) {
-	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return "", err
-	}
-	out, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
 }

--- a/cli/internal/cmd/harbor/harbor.go
+++ b/cli/internal/cmd/harbor/harbor.go
@@ -43,6 +43,7 @@ import (
 
 	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -280,7 +281,7 @@ func printErrorTrailer(w io.Writer, r *CallResult) {
 	}
 	if len(r.Extras) > 0 && string(r.Extras) != "null" {
 		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
+		pretty, err := dispatch.PrettyJSON(r.Extras)
 		if err == nil {
 			fmt.Fprintln(w, pretty)
 		} else {
@@ -295,7 +296,7 @@ func fallbackResultRender(w io.Writer, r *CallResult) {
 	if len(r.Result) == 0 || string(r.Result) == "null" {
 		return
 	}
-	pretty, err := prettyJSON(r.Result)
+	pretty, err := dispatch.PrettyJSON(r.Result)
 	if err == nil {
 		fmt.Fprintln(w, pretty)
 		return

--- a/cli/internal/cmd/harbor/harbor_test.go
+++ b/cli/internal/cmd/harbor/harbor_test.go
@@ -380,7 +380,7 @@ func TestDispatchOpBakesConnectorID(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	r, err := dispatchOp(context.Background(), srv.URL, "GET:/api/v2.0/systeminfo", "prod-harbor", nil)
+	r, err := conn.Call(context.Background(), srv.URL, "GET:/api/v2.0/systeminfo", "prod-harbor", nil)
 	if err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
@@ -408,7 +408,7 @@ func TestDispatchOpEmptyTargetSendsNullTarget(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	if _, err := dispatchOp(context.Background(), srv.URL, "GET:/api/v2.0/systeminfo", "", nil); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, "GET:/api/v2.0/systeminfo", "", nil); err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
 }
@@ -435,7 +435,7 @@ func TestDispatchProjectInfoSendsParams(t *testing.T) {
 
 	const opID = "GET:/api/v2.0/projects/{project_name}"
 	params := map[string]any{"project_name": "library"}
-	if _, err := dispatchOp(context.Background(), srv.URL, opID, "prod-harbor", params); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, opID, "prod-harbor", params); err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
 }
@@ -476,7 +476,7 @@ func TestDispatchRobotCreateSendsAllParams(t *testing.T) {
 	primeToken(t, srv.URL)
 
 	params := map[string]any{"name": "ci-push", "project": "myproject", "duration": 90}
-	r, err := dispatchOp(context.Background(), srv.URL, "harbor.robot.create", "prod-harbor", params)
+	r, err := conn.Call(context.Background(), srv.URL, "harbor.robot.create", "prod-harbor", params)
 	if err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}

--- a/cli/internal/cmd/harbor/operation.go
+++ b/cli/internal/cmd/harbor/operation.go
@@ -176,9 +176,9 @@ func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, j
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, nil)
+	return conn.Render(cmd, opID, r, jsonOut, nil)
 }

--- a/cli/internal/cmd/harbor/project.go
+++ b/cli/internal/cmd/harbor/project.go
@@ -57,11 +57,11 @@ func runProjectList(cmd *cobra.Command, targetName string, jsonOut bool, backpla
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/api/v2.0/projects", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v2.0/projects", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/api/v2.0/projects", r, jsonOut, printProjectList)
+	return conn.Render(cmd, "GET:/api/v2.0/projects", r, jsonOut, printProjectList)
 }
 
 func printProjectList(w io.Writer, r *CallResult) {
@@ -134,11 +134,11 @@ func runProjectInfo(cmd *cobra.Command, projectName, targetName string, jsonOut 
 	}
 	opID := "GET:/api/v2.0/projects/{project_name}"
 	params := map[string]any{"project_name": projectName}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printProjectInfo)
+	return conn.Render(cmd, opID, r, jsonOut, printProjectInfo)
 }
 
 func printProjectInfo(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/harbor/repository.go
+++ b/cli/internal/cmd/harbor/repository.go
@@ -60,11 +60,11 @@ func runRepositoryList(cmd *cobra.Command, projectName, targetName string, jsonO
 	}
 	opID := "GET:/api/v2.0/projects/{project_name}/repositories"
 	params := map[string]any{"project_name": projectName}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printRepositoryList)
+	return conn.Render(cmd, opID, r, jsonOut, printRepositoryList)
 }
 
 func printRepositoryList(w io.Writer, r *CallResult) {
@@ -136,11 +136,11 @@ func runRepositoryInfo(cmd *cobra.Command, projectName, repoName, targetName str
 		"project_name":    projectName,
 		"repository_name": repoName,
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printRepositoryInfo)
+	return conn.Render(cmd, opID, r, jsonOut, printRepositoryInfo)
 }
 
 func printRepositoryInfo(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/harbor/robot.go
+++ b/cli/internal/cmd/harbor/robot.go
@@ -60,11 +60,11 @@ func runRobotList(cmd *cobra.Command, targetName string, jsonOut bool, backplane
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/api/v2.0/robots", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v2.0/robots", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/api/v2.0/robots", r, jsonOut, printRobotList)
+	return conn.Render(cmd, "GET:/api/v2.0/robots", r, jsonOut, printRobotList)
 }
 
 func printRobotList(w io.Writer, r *CallResult) {
@@ -156,11 +156,11 @@ func runRobotCreate(cmd *cobra.Command, robotName, projectName string, duration 
 		"project":  projectName,
 		"duration": duration,
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "harbor.robot.create", targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "harbor.robot.create", targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "harbor.robot.create", r, jsonOut, printRobotCreate)
+	return conn.Render(cmd, "harbor.robot.create", r, jsonOut, printRobotCreate)
 }
 
 func printRobotCreate(w io.Writer, r *CallResult) {
@@ -233,11 +233,11 @@ func runRobotDelete(cmd *cobra.Command, projectName string, robotID int, targetN
 		"project": projectName,
 		"id":      robotID,
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "harbor.robot.delete", targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "harbor.robot.delete", targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "harbor.robot.delete", r, jsonOut, printRobotDelete)
+	return conn.Render(cmd, "harbor.robot.delete", r, jsonOut, printRobotDelete)
 }
 
 func printRobotDelete(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/k8s/dispatch.go
+++ b/cli/internal/cmd/k8s/dispatch.go
@@ -4,195 +4,30 @@
 package k8s
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
-// CallResult mirrors the backend OperationResult Pydantic model. Same
-// shape as cmd/vault/CallResult; duplicated here because cmd/k8s
-// can't import cmd/vault without an import cycle.
-//
-// Result is left as json.RawMessage because the backend types it as a
-// oneOf(dict, list) union — pretty-printing the raw bytes is the
-// cleanest renderer. Set-shaped K8s ops (pod.list, deployment.list,
-// service.list, …) return whatever the dispatcher's JSONFlux layer
-// reduced them to (handle envelope + sample when the row count
-// crosses the threshold); the CLI renders that verbatim, consistent
-// with the vault sibling.
-type CallResult struct {
-	Status     string          `json:"status"`
-	OpID       string          `json:"op_id"`
-	Result     json.RawMessage `json:"result"`
-	Error      *string         `json:"error"`
-	Extras     json.RawMessage `json:"extras,omitempty"`
-	DurationMs float64         `json:"duration_ms"`
-}
+// Aliases + binding to the shared dispatch core (cli/internal/dispatch).
+// The verb files keep referring to the unqualified names; the operation-
+// call logic lives once in the dispatch package. The k8s-specific shared
+// flag set + verb pipeline stay here.
+type (
+	// CallResult is the decoded OperationResult envelope.
+	CallResult = dispatch.CallResult
+	// callRequestBody is the on-the-wire OperationCall body (asserted by tests).
+	callRequestBody = dispatch.CallRequestBody
+)
 
-// callRequestBody mirrors the backend CallOperationBody Pydantic
-// model. Target uses a map[string]any so the empty case serialises as
-// `null` rather than an empty struct; every K8s op needs a target so
-// every verb wires --target through.
-type callRequestBody struct {
-	ConnectorID string         `json:"connector_id"`
-	OpID        string         `json:"op_id"`
-	Target      map[string]any `json:"target"`
-	Params      map[string]any `json:"params,omitempty"`
-}
+// errOpError is the structured-failure sentinel (status error/denied).
+var errOpError = dispatch.ErrOpError
 
-// errOpError is the sentinel returned when the dispatcher reported a
-// structured-failure result (status == "error" or status == "denied").
-// main translates non-nil RunE errors into a non-zero exit;
-// SilenceErrors=true on each command keeps cobra from double-printing
-// the error string. Same shape as the vault sibling's errOpError.
-var errOpError = errors.New("operation status not ok")
+// conn binds this package's pre-baked connector_id + authed transport
+// (doAuthedRequest) to the shared dispatch core.
+var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}
 
-// dispatchOp POSTs an OperationCall to the backplane and returns the
-// decoded CallResult. The pre-baked connector_id ("k8s-1.x") is baked
-// in; callers pass op_id, an optional target slug (empty string → no
-// target field on the wire), and an optional params map.
-//
-// Centralised here so every verb in the package shares one dispatcher
-// implementation. A grep for `dispatchOp` finds every alias-verb
-// dispatch in the k8s package.
-func dispatchOp(
-	ctx context.Context,
-	backplaneURL, opID, targetSlug string,
-	params map[string]any,
-) (*CallResult, error) {
-	body := callRequestBody{
-		ConnectorID: ConnectorID,
-		OpID:        opID,
-		Target:      nil,
-	}
-	if targetSlug != "" {
-		body.Target = map[string]any{"name": targetSlug}
-	}
-	if params != nil {
-		body.Params = params
-	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal call request: %w", err)
-	}
-	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
-	if err != nil {
-		return nil, err
-	}
-	var out CallResult
-	if err := json.Unmarshal(respBody, &out); err != nil {
-		return nil, fmt.Errorf("decode call response: %w", err)
-	}
-	return &out, nil
-}
-
-// renderCallResult handles the unified post-dispatch path every verb
-// uses: validate status enum, render the envelope (JSON or human),
-// then translate "error" / "denied" into the errOpError sentinel so
-// main propagates the right non-zero exit. Returns nil on success or
-// one of:
-//   - errOpError (status == "error" / "denied" → exit 1)
-//   - a structured renderer error (unexpected status → exit 4)
-//
-// Pretty-printing is delegated to a per-verb closure so verb files can
-// lay out their domain-specific render. When prettyPrinter is nil, the
-// fallback renders the generic envelope shape the vault sibling uses.
-func renderCallResult(
-	cmd *cobra.Command,
-	opID string,
-	r *CallResult,
-	jsonOut bool,
-	prettyPrinter func(w io.Writer, r *CallResult),
-) error {
-	switch r.Status {
-	case "ok", "error", "denied":
-		// fall through.
-	default:
-		return output.RenderError(
-			cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf(
-				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
-				r.Status,
-			)),
-			jsonOut,
-		)
-	}
-	if jsonOut {
-		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
-			return err
-		}
-	} else if prettyPrinter != nil {
-		prettyPrinter(cmd.OutOrStdout(), r)
-	} else {
-		printGenericResult(cmd.OutOrStdout(), opID, r)
-	}
-	if r.Status == "ok" {
-		return nil
-	}
-	return errOpError
-}
-
-// printGenericResult renders a CallResult in the same shape the vault
-// sibling's printGenericResult uses. Default pretty-printer for every
-// k8s verb: results are nested JSON (rows, pod info, configmap data,
-// logs lines, JSONFlux handle envelopes) that the operator reads as a
-// tree, and a per-shape table buys little over the indented dump while
-// risking contract-drift panics. Set-shaped responses arrive already
-// reduced to the JSONFlux sample + handle envelope by the dispatcher,
-// so they print with the handle hint intact.
-func printGenericResult(w io.Writer, opID string, r *CallResult) {
-	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
-	if r.Status == "ok" {
-		if len(r.Result) > 0 && string(r.Result) != "null" {
-			pretty, err := prettyJSON(r.Result)
-			if err == nil {
-				fmt.Fprintln(w, pretty)
-				return
-			}
-			fmt.Fprintln(w, string(r.Result))
-		}
-		return
-	}
-	if r.Error != nil && *r.Error != "" {
-		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
-	} else {
-		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
-	}
-	if len(r.Extras) > 0 && string(r.Extras) != "null" {
-		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
-		if err == nil {
-			fmt.Fprintln(w, pretty)
-		} else {
-			fmt.Fprintln(w, string(r.Extras))
-		}
-	}
-}
-
-// prettyJSON pretty-prints a json.RawMessage with 2-space indent. Same
-// implementation as the vault sibling.
-func prettyJSON(raw json.RawMessage) (string, error) {
-	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return "", err
-	}
-	out, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
-}
-
-// k8sAddrFlags is the per-verb shared flag block (target slug, --json,
-// --backplane). Every K8s verb embeds it via bindK8sAddrFlags so the
-// resolve-and-dispatch boilerplate stays in one place. Mirrors the
-// kvAddrFlags / sysAddrFlags pattern from the vault sibling.
 type k8sAddrFlags struct {
 	targetName        string
 	jsonOut           bool
@@ -221,9 +56,9 @@ func dispatchVerb(cmd *cobra.Command, f *k8sAddrFlags, opID string, params map[s
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), f.jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, f.targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, f.targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, f.jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, f.jsonOut, nil)
+	return conn.Render(cmd, opID, r, f.jsonOut, nil)
 }

--- a/cli/internal/cmd/k8s/k8s_test.go
+++ b/cli/internal/cmd/k8s/k8s_test.go
@@ -203,7 +203,7 @@ func TestDispatchOpBakesConnectorID(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	r, err := dispatchOp(context.Background(), srv.URL, opAbout, "rke2-meho", nil)
+	r, err := conn.Call(context.Background(), srv.URL, opAbout, "rke2-meho", nil)
 	if err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestDispatchOpTargetSlugWrappedAsName(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	if _, err := dispatchOp(context.Background(), srv.URL, "x", "rke2-meho", nil); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, "x", "rke2-meho", nil); err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
 }

--- a/cli/internal/cmd/nsx/about.go
+++ b/cli/internal/cmd/nsx/about.go
@@ -55,11 +55,11 @@ func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOver
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/api/v1/node", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v1/node", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/api/v1/node", r, jsonOut, printAbout)
+	return conn.Render(cmd, "GET:/api/v1/node", r, jsonOut, printAbout)
 }
 
 func printAbout(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/nsx/cluster.go
+++ b/cli/internal/cmd/nsx/cluster.go
@@ -58,11 +58,11 @@ func runClusterStatus(cmd *cobra.Command, targetName string, jsonOut bool, backp
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/api/v1/cluster/status", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v1/cluster/status", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/api/v1/cluster/status", r, jsonOut, printClusterStatus)
+	return conn.Render(cmd, "GET:/api/v1/cluster/status", r, jsonOut, printClusterStatus)
 }
 
 func printClusterStatus(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/nsx/dispatch.go
+++ b/cli/internal/cmd/nsx/dispatch.go
@@ -3,144 +3,21 @@
 
 package nsx
 
-import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
+import "github.com/evoila/meho/cli/internal/dispatch"
 
-	"github.com/spf13/cobra"
-
-	"github.com/evoila/meho/cli/internal/output"
+// Aliases + binding to the shared dispatch core (cli/internal/dispatch).
+// The verb files in this package keep referring to the unqualified names;
+// the operation-call logic lives once in the dispatch package.
+type (
+	// CallResult is the decoded OperationResult envelope.
+	CallResult = dispatch.CallResult
+	// callRequestBody is the on-the-wire OperationCall body (asserted by tests).
+	callRequestBody = dispatch.CallRequestBody
 )
 
-// CallResult mirrors the backend OperationResult Pydantic model.
-type CallResult struct {
-	Status     string          `json:"status"`
-	OpID       string          `json:"op_id"`
-	Result     json.RawMessage `json:"result"`
-	Error      *string         `json:"error"`
-	Extras     json.RawMessage `json:"extras,omitempty"`
-	DurationMs float64         `json:"duration_ms"`
-}
+// errOpError is the structured-failure sentinel (status error/denied).
+var errOpError = dispatch.ErrOpError
 
-// callRequestBody mirrors the backend CallOperationBody Pydantic model.
-type callRequestBody struct {
-	ConnectorID string         `json:"connector_id"`
-	OpID        string         `json:"op_id"`
-	Target      map[string]any `json:"target"`
-	Params      map[string]any `json:"params,omitempty"`
-}
-
-var errOpError = errors.New("operation status not ok")
-
-// dispatchOp POSTs an OperationCall to the backplane and returns the
-// decoded CallResult with connector_id="nsx-rest-4.2" pre-baked.
-func dispatchOp(
-	ctx context.Context,
-	backplaneURL, opID, targetSlug string,
-	params map[string]any,
-) (*CallResult, error) {
-	body := callRequestBody{
-		ConnectorID: ConnectorID,
-		OpID:        opID,
-		Target:      nil,
-	}
-	if targetSlug != "" {
-		body.Target = map[string]any{"name": targetSlug}
-	}
-	if params != nil {
-		body.Params = params
-	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal call request: %w", err)
-	}
-	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
-	if err != nil {
-		return nil, err
-	}
-	var out CallResult
-	if err := json.Unmarshal(respBody, &out); err != nil {
-		return nil, fmt.Errorf("decode call response: %w", err)
-	}
-	return &out, nil
-}
-
-// renderCallResult handles the unified post-dispatch rendering path.
-func renderCallResult(
-	cmd *cobra.Command,
-	opID string,
-	r *CallResult,
-	jsonOut bool,
-	prettyPrinter func(w io.Writer, r *CallResult),
-) error {
-	switch r.Status {
-	case "ok", "error", "denied":
-	default:
-		return output.RenderError(
-			cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf(
-				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
-				r.Status,
-			)),
-			jsonOut,
-		)
-	}
-	if jsonOut {
-		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
-			return err
-		}
-	} else if prettyPrinter != nil {
-		prettyPrinter(cmd.OutOrStdout(), r)
-	} else {
-		printGenericResult(cmd.OutOrStdout(), opID, r)
-	}
-	if r.Status == "ok" {
-		return nil
-	}
-	return errOpError
-}
-
-// printGenericResult renders a CallResult in the generic envelope shape.
-func printGenericResult(w io.Writer, opID string, r *CallResult) {
-	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
-	if r.Status == "ok" {
-		if len(r.Result) > 0 && string(r.Result) != "null" {
-			pretty, err := prettyJSON(r.Result)
-			if err == nil {
-				fmt.Fprintln(w, pretty)
-				return
-			}
-			fmt.Fprintln(w, string(r.Result))
-		}
-		return
-	}
-	if r.Error != nil && *r.Error != "" {
-		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
-	} else {
-		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
-	}
-	if len(r.Extras) > 0 && string(r.Extras) != "null" {
-		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
-		if err == nil {
-			fmt.Fprintln(w, pretty)
-		} else {
-			fmt.Fprintln(w, string(r.Extras))
-		}
-	}
-}
-
-func prettyJSON(raw json.RawMessage) (string, error) {
-	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return "", err
-	}
-	out, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
-}
+// conn binds this package's pre-baked connector_id + authed transport
+// (doAuthedRequest) to the shared dispatch core.
+var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}

--- a/cli/internal/cmd/nsx/firewall.go
+++ b/cli/internal/cmd/nsx/firewall.go
@@ -85,11 +85,11 @@ func runFirewallPolicyList(cmd *cobra.Command, scope, targetName string, jsonOut
 	}
 	const opID = "GET:/policy/api/v1/infra/domains/{domain-id}/security-policies"
 	params := map[string]any{"domain-id": scope}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printFirewallPolicyList)
+	return conn.Render(cmd, opID, r, jsonOut, printFirewallPolicyList)
 }
 
 func printFirewallPolicyList(w io.Writer, r *CallResult) {
@@ -182,11 +182,11 @@ func runFirewallRuleList(cmd *cobra.Command, policyID, scope, targetName string,
 		"domain-id":          scope,
 		"security-policy-id": policyID,
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printFirewallRuleList)
+	return conn.Render(cmd, opID, r, jsonOut, printFirewallRuleList)
 }
 
 func printFirewallRuleList(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/nsx/node.go
+++ b/cli/internal/cmd/nsx/node.go
@@ -58,11 +58,11 @@ func runNodeList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneO
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/api/v1/transport-nodes", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v1/transport-nodes", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/api/v1/transport-nodes", r, jsonOut, printNodeList)
+	return conn.Render(cmd, "GET:/api/v1/transport-nodes", r, jsonOut, printNodeList)
 }
 
 func printNodeList(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/nsx/nsx.go
+++ b/cli/internal/cmd/nsx/nsx.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -115,7 +116,7 @@ func fallbackResultRender(w io.Writer, r *CallResult) {
 	if len(r.Result) == 0 || string(r.Result) == "null" {
 		return
 	}
-	pretty, err := prettyJSON(r.Result)
+	pretty, err := dispatch.PrettyJSON(r.Result)
 	if err == nil {
 		fmt.Fprintln(w, pretty)
 		return
@@ -132,7 +133,7 @@ func printErrorTrailer(w io.Writer, r *CallResult) {
 	}
 	if len(r.Extras) > 0 && string(r.Extras) != "null" {
 		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
+		pretty, err := dispatch.PrettyJSON(r.Extras)
 		if err == nil {
 			fmt.Fprintln(w, pretty)
 		} else {

--- a/cli/internal/cmd/nsx/nsx_test.go
+++ b/cli/internal/cmd/nsx/nsx_test.go
@@ -373,7 +373,7 @@ func TestDispatchOpBakesConnectorID(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	r, err := dispatchOp(context.Background(), srv.URL, "GET:/api/v1/node", "rdc-nsx", nil)
+	r, err := conn.Call(context.Background(), srv.URL, "GET:/api/v1/node", "rdc-nsx", nil)
 	if err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
@@ -401,7 +401,7 @@ func TestDispatchOpEmptyTargetSendsNullTarget(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	if _, err := dispatchOp(context.Background(), srv.URL, "GET:/api/v1/node", "", nil); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, "GET:/api/v1/node", "", nil); err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
 }
@@ -429,7 +429,7 @@ func TestDispatchFirewallPolicySendsScope(t *testing.T) {
 
 	const opID = "GET:/policy/api/v1/infra/domains/{domain-id}/security-policies"
 	params := map[string]any{"domain-id": "my-domain"}
-	if _, err := dispatchOp(context.Background(), srv.URL, opID, "rdc-nsx", params); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, opID, "rdc-nsx", params); err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
 }
@@ -464,7 +464,7 @@ func TestDispatchFirewallRuleListSendsPolicyAndScope(t *testing.T) {
 		"domain-id":          "default",
 		"security-policy-id": "policy-app-tier",
 	}
-	if _, err := dispatchOp(context.Background(), srv.URL, opID, "rdc-nsx", params); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, opID, "rdc-nsx", params); err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
 }

--- a/cli/internal/cmd/nsx/operation.go
+++ b/cli/internal/cmd/nsx/operation.go
@@ -183,9 +183,9 @@ func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, j
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, nil)
+	return conn.Render(cmd, opID, r, jsonOut, nil)
 }

--- a/cli/internal/cmd/nsx/segment.go
+++ b/cli/internal/cmd/nsx/segment.go
@@ -59,11 +59,11 @@ func runSegmentList(cmd *cobra.Command, targetName string, jsonOut bool, backpla
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
 	const opID = "GET:/policy/api/v1/infra/segments"
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printSegmentList)
+	return conn.Render(cmd, opID, r, jsonOut, printSegmentList)
 }
 
 func printSegmentList(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/nsx/tier0.go
+++ b/cli/internal/cmd/nsx/tier0.go
@@ -59,11 +59,11 @@ func runTier0List(cmd *cobra.Command, targetName string, jsonOut bool, backplane
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
 	const opID = "GET:/policy/api/v1/infra/tier-0s"
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printTier0List)
+	return conn.Render(cmd, opID, r, jsonOut, printTier0List)
 }
 
 func printTier0List(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/nsx/tier1.go
+++ b/cli/internal/cmd/nsx/tier1.go
@@ -59,11 +59,11 @@ func runTier1List(cmd *cobra.Command, targetName string, jsonOut bool, backplane
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
 	const opID = "GET:/policy/api/v1/infra/tier-1s"
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printTier1List)
+	return conn.Render(cmd, opID, r, jsonOut, printTier1List)
 }
 
 func printTier1List(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/nsx/transportzone.go
+++ b/cli/internal/cmd/nsx/transportzone.go
@@ -61,11 +61,11 @@ func runTransportZoneList(cmd *cobra.Command, targetName string, jsonOut bool, b
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, tzOpID, targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, tzOpID, targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, tzOpID, r, jsonOut, printTransportZoneList)
+	return conn.Render(cmd, tzOpID, r, jsonOut, printTransportZoneList)
 }
 
 func printTransportZoneList(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/sddc-manager/about.go
+++ b/cli/internal/cmd/sddc-manager/about.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -47,11 +48,11 @@ func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOver
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/v1/releases/system", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/v1/releases/system", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/v1/releases/system", r, jsonOut, printAbout)
+	return conn.Render(cmd, "GET:/v1/releases/system", r, jsonOut, printAbout)
 }
 
 func printAbout(w io.Writer, r *CallResult) {
@@ -87,7 +88,7 @@ func printAbout(w io.Writer, r *CallResult) {
 		return
 	}
 	if len(r.Result) > 0 && string(r.Result) != "null" {
-		pretty, err := prettyJSON(r.Result)
+		pretty, err := dispatch.PrettyJSON(r.Result)
 		if err == nil {
 			fmt.Fprintln(w, pretty)
 		} else {

--- a/cli/internal/cmd/sddc-manager/bundle.go
+++ b/cli/internal/cmd/sddc-manager/bundle.go
@@ -55,17 +55,17 @@ func runBundleList(cmd *cobra.Command, targetName string, jsonOut bool, backplan
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/v1/bundles", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/v1/bundles", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/v1/bundles", r, jsonOut, printBundleList)
+	return conn.Render(cmd, "GET:/v1/bundles", r, jsonOut, printBundleList)
 }
 
 func printBundleList(w io.Writer, r *CallResult) {
 	entries, err := decodeElementsResult(r.Result)
 	if err != nil || r.Status != "ok" {
-		printGenericResult(w, "GET:/v1/bundles", r)
+		conn.PrintGeneric(w, "GET:/v1/bundles", r)
 		return
 	}
 	fmt.Fprintf(w, "VCF LCM bundles (%d)\n", len(entries))

--- a/cli/internal/cmd/sddc-manager/cluster.go
+++ b/cli/internal/cmd/sddc-manager/cluster.go
@@ -62,17 +62,17 @@ func runClusterList(cmd *cobra.Command, targetName, domainID string, jsonOut boo
 	if domainID != "" {
 		params = map[string]any{"domainId": domainID}
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/v1/clusters", targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/v1/clusters", targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/v1/clusters", r, jsonOut, printClusterList)
+	return conn.Render(cmd, "GET:/v1/clusters", r, jsonOut, printClusterList)
 }
 
 func printClusterList(w io.Writer, r *CallResult) {
 	entries, err := decodeElementsResult(r.Result)
 	if err != nil || r.Status != "ok" {
-		printGenericResult(w, "GET:/v1/clusters", r)
+		conn.PrintGeneric(w, "GET:/v1/clusters", r)
 		return
 	}
 	fmt.Fprintf(w, "VCF clusters (%d)\n", len(entries))

--- a/cli/internal/cmd/sddc-manager/dispatch.go
+++ b/cli/internal/cmd/sddc-manager/dispatch.go
@@ -3,142 +3,21 @@
 
 package sddcmanager
 
-import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
+import "github.com/evoila/meho/cli/internal/dispatch"
 
-	"github.com/spf13/cobra"
-
-	"github.com/evoila/meho/cli/internal/output"
+// Aliases + binding to the shared dispatch core (cli/internal/dispatch).
+// The verb files in this package keep referring to the unqualified names;
+// the operation-call logic lives once in the dispatch package.
+type (
+	// CallResult is the decoded OperationResult envelope.
+	CallResult = dispatch.CallResult
+	// callRequestBody is the on-the-wire OperationCall body (asserted by tests).
+	callRequestBody = dispatch.CallRequestBody
 )
 
-// CallResult mirrors the backend OperationResult Pydantic model.
-type CallResult struct {
-	Status     string          `json:"status"`
-	OpID       string          `json:"op_id"`
-	Result     json.RawMessage `json:"result"`
-	Error      *string         `json:"error"`
-	Extras     json.RawMessage `json:"extras,omitempty"`
-	DurationMs float64         `json:"duration_ms"`
-}
+// errOpError is the structured-failure sentinel (status error/denied).
+var errOpError = dispatch.ErrOpError
 
-// callRequestBody mirrors the backend CallOperationBody Pydantic model.
-type callRequestBody struct {
-	ConnectorID string         `json:"connector_id"`
-	OpID        string         `json:"op_id"`
-	Target      map[string]any `json:"target"`
-	Params      map[string]any `json:"params,omitempty"`
-}
-
-var errOpError = errors.New("operation status not ok")
-
-// dispatchOp POSTs an OperationCall to the backplane with connector_id="sddc-rest-9.0" pre-baked.
-func dispatchOp(
-	ctx context.Context,
-	backplaneURL, opID, targetSlug string,
-	params map[string]any,
-) (*CallResult, error) {
-	body := callRequestBody{
-		ConnectorID: ConnectorID,
-		OpID:        opID,
-		Target:      nil,
-	}
-	if targetSlug != "" {
-		body.Target = map[string]any{"name": targetSlug}
-	}
-	if params != nil {
-		body.Params = params
-	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal call request: %w", err)
-	}
-	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
-	if err != nil {
-		return nil, err
-	}
-	var out CallResult
-	if err := json.Unmarshal(respBody, &out); err != nil {
-		return nil, fmt.Errorf("decode call response: %w", err)
-	}
-	return &out, nil
-}
-
-// renderCallResult handles the unified post-dispatch rendering path.
-func renderCallResult(
-	cmd *cobra.Command,
-	opID string,
-	r *CallResult,
-	jsonOut bool,
-	prettyPrinter func(w io.Writer, r *CallResult),
-) error {
-	switch r.Status {
-	case "ok", "error", "denied":
-	default:
-		return output.RenderError(
-			cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf(
-				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
-				r.Status,
-			)),
-			jsonOut,
-		)
-	}
-	if jsonOut {
-		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
-			return err
-		}
-	} else if prettyPrinter != nil {
-		prettyPrinter(cmd.OutOrStdout(), r)
-	} else {
-		printGenericResult(cmd.OutOrStdout(), opID, r)
-	}
-	if r.Status == "ok" {
-		return nil
-	}
-	return errOpError
-}
-
-func printGenericResult(w io.Writer, opID string, r *CallResult) {
-	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
-	if r.Status == "ok" {
-		if len(r.Result) > 0 && string(r.Result) != "null" {
-			pretty, err := prettyJSON(r.Result)
-			if err == nil {
-				fmt.Fprintln(w, pretty)
-				return
-			}
-			fmt.Fprintln(w, string(r.Result))
-		}
-		return
-	}
-	if r.Error != nil && *r.Error != "" {
-		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
-	} else {
-		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
-	}
-	if len(r.Extras) > 0 && string(r.Extras) != "null" {
-		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
-		if err == nil {
-			fmt.Fprintln(w, pretty)
-		} else {
-			fmt.Fprintln(w, string(r.Extras))
-		}
-	}
-}
-
-func prettyJSON(raw json.RawMessage) (string, error) {
-	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return "", err
-	}
-	out, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
-}
+// conn binds this package's pre-baked connector_id + authed transport
+// (doAuthedRequest) to the shared dispatch core.
+var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}

--- a/cli/internal/cmd/sddc-manager/domain.go
+++ b/cli/internal/cmd/sddc-manager/domain.go
@@ -55,17 +55,17 @@ func runDomainList(cmd *cobra.Command, targetName string, jsonOut bool, backplan
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/v1/domains", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/v1/domains", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/v1/domains", r, jsonOut, printDomainList)
+	return conn.Render(cmd, "GET:/v1/domains", r, jsonOut, printDomainList)
 }
 
 func printDomainList(w io.Writer, r *CallResult) {
 	entries, err := decodeElementsResult(r.Result)
 	if err != nil || r.Status != "ok" {
-		printGenericResult(w, "GET:/v1/domains", r)
+		conn.PrintGeneric(w, "GET:/v1/domains", r)
 		return
 	}
 	fmt.Fprintf(w, "VCF domains (%d)\n", len(entries))
@@ -116,16 +116,16 @@ func runDomainInfo(cmd *cobra.Command, domainID, targetName string, jsonOut bool
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
 	params := map[string]any{"id": domainID}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/v1/domains/{id}", targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/v1/domains/{id}", targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/v1/domains/{id}", r, jsonOut, printDomainInfo)
+	return conn.Render(cmd, "GET:/v1/domains/{id}", r, jsonOut, printDomainInfo)
 }
 
 func printDomainInfo(w io.Writer, r *CallResult) {
 	if r.Status != "ok" {
-		printGenericResult(w, "GET:/v1/domains/{id}", r)
+		conn.PrintGeneric(w, "GET:/v1/domains/{id}", r)
 		return
 	}
 	var d struct {
@@ -148,7 +148,7 @@ func printDomainInfo(w io.Writer, r *CallResult) {
 		SSOName string `json:"ssoName"`
 	}
 	if err := jsonUnmarshalStrict(r.Result, &d); err != nil || d.ID == "" {
-		printGenericResult(w, "GET:/v1/domains/{id}", r)
+		conn.PrintGeneric(w, "GET:/v1/domains/{id}", r)
 		return
 	}
 	fmt.Fprintf(w, "domain:  %s (%s) — type=%s\n", d.Name, d.ID, d.Type)

--- a/cli/internal/cmd/sddc-manager/host.go
+++ b/cli/internal/cmd/sddc-manager/host.go
@@ -71,17 +71,17 @@ func runHostList(cmd *cobra.Command, targetName, domainID, clusterID string, jso
 			params["clusterId"] = clusterID
 		}
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/v1/hosts", targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/v1/hosts", targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/v1/hosts", r, jsonOut, printHostList)
+	return conn.Render(cmd, "GET:/v1/hosts", r, jsonOut, printHostList)
 }
 
 func printHostList(w io.Writer, r *CallResult) {
 	entries, err := decodeElementsResult(r.Result)
 	if err != nil || r.Status != "ok" {
-		printGenericResult(w, "GET:/v1/hosts", r)
+		conn.PrintGeneric(w, "GET:/v1/hosts", r)
 		return
 	}
 	fmt.Fprintf(w, "ESXi hosts (%d)\n", len(entries))

--- a/cli/internal/cmd/sddc-manager/manager.go
+++ b/cli/internal/cmd/sddc-manager/manager.go
@@ -55,17 +55,17 @@ func runManagerList(cmd *cobra.Command, targetName string, jsonOut bool, backpla
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/v1/sddc-managers", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/v1/sddc-managers", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/v1/sddc-managers", r, jsonOut, printManagerList)
+	return conn.Render(cmd, "GET:/v1/sddc-managers", r, jsonOut, printManagerList)
 }
 
 func printManagerList(w io.Writer, r *CallResult) {
 	entries, err := decodeElementsResult(r.Result)
 	if err != nil || r.Status != "ok" {
-		printGenericResult(w, "GET:/v1/sddc-managers", r)
+		conn.PrintGeneric(w, "GET:/v1/sddc-managers", r)
 		return
 	}
 	fmt.Fprintf(w, "sddc-manager appliances (%d)\n", len(entries))

--- a/cli/internal/cmd/sddc-manager/network_pool.go
+++ b/cli/internal/cmd/sddc-manager/network_pool.go
@@ -54,17 +54,17 @@ func runNetworkPoolList(cmd *cobra.Command, targetName string, jsonOut bool, bac
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/v1/network-pools", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/v1/network-pools", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/v1/network-pools", r, jsonOut, printNetworkPoolList)
+	return conn.Render(cmd, "GET:/v1/network-pools", r, jsonOut, printNetworkPoolList)
 }
 
 func printNetworkPoolList(w io.Writer, r *CallResult) {
 	entries, err := decodeElementsResult(r.Result)
 	if err != nil || r.Status != "ok" {
-		printGenericResult(w, "GET:/v1/network-pools", r)
+		conn.PrintGeneric(w, "GET:/v1/network-pools", r)
 		return
 	}
 	fmt.Fprintf(w, "VCF network pools (%d)\n", len(entries))

--- a/cli/internal/cmd/sddc-manager/operation.go
+++ b/cli/internal/cmd/sddc-manager/operation.go
@@ -175,9 +175,9 @@ func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, j
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, nil)
+	return conn.Render(cmd, opID, r, jsonOut, nil)
 }

--- a/cli/internal/cmd/sddc-manager/sddc_manager.go
+++ b/cli/internal/cmd/sddc-manager/sddc_manager.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -129,7 +130,7 @@ func printErrorTrailer(w io.Writer, r *CallResult) {
 	}
 	if len(r.Extras) > 0 && string(r.Extras) != "null" {
 		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
+		pretty, err := dispatch.PrettyJSON(r.Extras)
 		if err == nil {
 			fmt.Fprintln(w, pretty)
 		} else {

--- a/cli/internal/cmd/sddc-manager/sddc_manager_test.go
+++ b/cli/internal/cmd/sddc-manager/sddc_manager_test.go
@@ -452,7 +452,7 @@ func TestDispatchOpBakesConnectorID(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	r, err := dispatchOp(context.Background(), srv.URL, "GET:/v1/releases/system", "rdc-sddc", nil)
+	r, err := conn.Call(context.Background(), srv.URL, "GET:/v1/releases/system", "rdc-sddc", nil)
 	if err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
@@ -480,7 +480,7 @@ func TestDispatchOpEmptyTargetSendsNullTarget(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	if _, err := dispatchOp(context.Background(), srv.URL, "GET:/v1/domains", "", nil); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, "GET:/v1/domains", "", nil); err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
 }
@@ -511,7 +511,7 @@ func TestDispatchDomainInfoSendsIDParam(t *testing.T) {
 	primeToken(t, srv.URL)
 
 	params := map[string]any{"id": "domain-mgmt"}
-	if _, err := dispatchOp(context.Background(), srv.URL, "GET:/v1/domains/{id}", "rdc-sddc", params); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, "GET:/v1/domains/{id}", "rdc-sddc", params); err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
 }
@@ -538,7 +538,7 @@ func TestDispatchWorkflowListSendsStatusFilter(t *testing.T) {
 	primeToken(t, srv.URL)
 
 	params := map[string]any{"status": "In_Progress"}
-	if _, err := dispatchOp(context.Background(), srv.URL, "GET:/v1/tasks", "rdc-sddc", params); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, "GET:/v1/tasks", "rdc-sddc", params); err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
 }

--- a/cli/internal/cmd/sddc-manager/workflow.go
+++ b/cli/internal/cmd/sddc-manager/workflow.go
@@ -63,17 +63,17 @@ func runWorkflowList(cmd *cobra.Command, targetName, statusFilter string, jsonOu
 	if statusFilter != "" {
 		params = map[string]any{"status": statusFilter}
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/v1/tasks", targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/v1/tasks", targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/v1/tasks", r, jsonOut, printWorkflowList)
+	return conn.Render(cmd, "GET:/v1/tasks", r, jsonOut, printWorkflowList)
 }
 
 func printWorkflowList(w io.Writer, r *CallResult) {
 	entries, err := decodeElementsResult(r.Result)
 	if err != nil || r.Status != "ok" {
-		printGenericResult(w, "GET:/v1/tasks", r)
+		conn.PrintGeneric(w, "GET:/v1/tasks", r)
 		return
 	}
 	fmt.Fprintf(w, "VCF workflow tasks (%d)\n", len(entries))

--- a/cli/internal/cmd/vault/auth.go
+++ b/cli/internal/cmd/vault/auth.go
@@ -93,11 +93,11 @@ func dispatchAuth(cmd *cobra.Command, f *authAddrFlags, opID string, params map[
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), f.jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, f.targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, f.targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, f.jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, f.jsonOut, nil)
+	return conn.Render(cmd, opID, r, f.jsonOut, nil)
 }
 
 // newAuthListVerbCmd builds one no-arg, no-param list verb (userpass-

--- a/cli/internal/cmd/vault/dispatch.go
+++ b/cli/internal/cmd/vault/dispatch.go
@@ -3,192 +3,21 @@
 
 package vault
 
-import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
+import "github.com/evoila/meho/cli/internal/dispatch"
 
-	"github.com/spf13/cobra"
-
-	"github.com/evoila/meho/cli/internal/output"
+// Aliases + binding to the shared dispatch core (cli/internal/dispatch).
+// The verb files in this package keep referring to the unqualified names;
+// the operation-call logic lives once in the dispatch package.
+type (
+	// CallResult is the decoded OperationResult envelope.
+	CallResult = dispatch.CallResult
+	// callRequestBody is the on-the-wire OperationCall body (asserted by tests).
+	callRequestBody = dispatch.CallRequestBody
 )
 
-// CallResult mirrors the backend OperationResult Pydantic model. Same
-// shape as cmd/vmware/CallResult; duplicated here because cmd/vault
-// can't import cmd/vmware without an import cycle (cmd/root.go grafts
-// both onto the tree).
-//
-// Result is left as json.RawMessage because the backend types it as a
-// oneOf(dict, list) union — pretty-printing the raw bytes is the
-// cleanest renderer. Set-shaped Vault ops (kv.list, sys.mounts.list,
-// auth.userpass.list, …) return whatever the dispatcher's JSONFlux
-// layer reduced them to (a handle envelope + sample when the row count
-// crosses the threshold); the CLI renders that verbatim, consistent
-// with the vmware sibling.
-type CallResult struct {
-	Status     string          `json:"status"`
-	OpID       string          `json:"op_id"`
-	Result     json.RawMessage `json:"result"`
-	Error      *string         `json:"error"`
-	Extras     json.RawMessage `json:"extras,omitempty"`
-	DurationMs float64         `json:"duration_ms"`
-}
+// errOpError is the structured-failure sentinel (status error/denied).
+var errOpError = dispatch.ErrOpError
 
-// callRequestBody mirrors the backend CallOperationBody Pydantic
-// model. Target uses a map[string]any so the empty case serialises as
-// `null` rather than an empty struct; the route layer's resolver
-// short-circuits on the missing-name case for the ops that need a
-// target. Vault ops resolve a Vault target server-side, so every verb
-// passes the --target slug through here.
-type callRequestBody struct {
-	ConnectorID string         `json:"connector_id"`
-	OpID        string         `json:"op_id"`
-	Target      map[string]any `json:"target"`
-	Params      map[string]any `json:"params,omitempty"`
-}
-
-// errOpError is the sentinel returned when the dispatcher reported a
-// structured-failure result (status == "error" or status == "denied").
-// main translates non-nil RunE errors into a non-zero exit;
-// SilenceErrors=true on each command keeps cobra from double-printing
-// the error string. Same shape as the vmware sibling's errOpError.
-var errOpError = errors.New("operation status not ok")
-
-// dispatchOp POSTs an OperationCall to the backplane and returns the
-// decoded CallResult. The pre-baked connector_id ("vault-1.x") is
-// baked in; callers pass op_id, an optional target slug (empty string
-// → no target field on the wire), and an optional params map.
-//
-// Centralised here so every verb in the package shares one dispatcher
-// implementation. A grep for `dispatchOp` finds every alias-verb
-// dispatch in the vault package.
-func dispatchOp(
-	ctx context.Context,
-	backplaneURL, opID, targetSlug string,
-	params map[string]any,
-) (*CallResult, error) {
-	body := callRequestBody{
-		ConnectorID: ConnectorID,
-		OpID:        opID,
-		Target:      nil,
-	}
-	if targetSlug != "" {
-		body.Target = map[string]any{"name": targetSlug}
-	}
-	if params != nil {
-		body.Params = params
-	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal call request: %w", err)
-	}
-	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
-	if err != nil {
-		return nil, err
-	}
-	var out CallResult
-	if err := json.Unmarshal(respBody, &out); err != nil {
-		return nil, fmt.Errorf("decode call response: %w", err)
-	}
-	return &out, nil
-}
-
-// renderCallResult handles the unified post-dispatch path every verb
-// uses: validate status enum, render the envelope (JSON or human),
-// then translate "error" / "denied" into the errOpError sentinel so
-// main propagates the right non-zero exit. Returns nil on success or
-// one of:
-//   - errOpError (status == "error" / "denied" → exit 1)
-//   - a structured renderer error (unexpected status → exit 4)
-//
-// Pretty-printing is delegated to a per-verb closure so verb files can
-// lay out their domain-specific render. When prettyPrinter is nil, the
-// fallback renders the generic envelope shape the vmware sibling uses.
-func renderCallResult(
-	cmd *cobra.Command,
-	opID string,
-	r *CallResult,
-	jsonOut bool,
-	prettyPrinter func(w io.Writer, r *CallResult),
-) error {
-	switch r.Status {
-	case "ok", "error", "denied":
-		// fall through.
-	default:
-		return output.RenderError(
-			cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf(
-				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
-				r.Status,
-			)),
-			jsonOut,
-		)
-	}
-	if jsonOut {
-		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
-			return err
-		}
-	} else if prettyPrinter != nil {
-		prettyPrinter(cmd.OutOrStdout(), r)
-	} else {
-		printGenericResult(cmd.OutOrStdout(), opID, r)
-	}
-	if r.Status == "ok" {
-		return nil
-	}
-	return errOpError
-}
-
-// printGenericResult renders a CallResult in the same shape the vmware
-// sibling's printGenericResult uses. Used as the default pretty-
-// printer for every vault verb: the Vault op results (secret data,
-// metadata, mount maps, key lists, JSONFlux handle envelopes) are
-// nested JSON the operator reads as a tree, and a per-shape table buys
-// little over the indented dump while risking contract-drift panics.
-// Set-shaped responses arrive already reduced to the JSONFlux
-// sample + handle envelope by the dispatcher, so they print here with
-// the handle hint intact, consistent with the vmware sibling.
-func printGenericResult(w io.Writer, opID string, r *CallResult) {
-	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
-	if r.Status == "ok" {
-		if len(r.Result) > 0 && string(r.Result) != "null" {
-			pretty, err := prettyJSON(r.Result)
-			if err == nil {
-				fmt.Fprintln(w, pretty)
-				return
-			}
-			fmt.Fprintln(w, string(r.Result))
-		}
-		return
-	}
-	if r.Error != nil && *r.Error != "" {
-		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
-	} else {
-		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
-	}
-	if len(r.Extras) > 0 && string(r.Extras) != "null" {
-		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
-		if err == nil {
-			fmt.Fprintln(w, pretty)
-		} else {
-			fmt.Fprintln(w, string(r.Extras))
-		}
-	}
-}
-
-// prettyJSON pretty-prints a json.RawMessage with 2-space indent. Same
-// implementation as the vmware sibling.
-func prettyJSON(raw json.RawMessage) (string, error) {
-	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return "", err
-	}
-	out, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
-}
+// conn binds this package's pre-baked connector_id + authed transport
+// (doAuthedRequest) to the shared dispatch core.
+var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}

--- a/cli/internal/cmd/vault/kv.go
+++ b/cli/internal/cmd/vault/kv.go
@@ -77,11 +77,11 @@ func dispatchKV(cmd *cobra.Command, f *kvAddrFlags, opID string, params map[stri
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), f.jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, f.targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, f.targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, f.jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, f.jsonOut, nil)
+	return conn.Render(cmd, opID, r, f.jsonOut, nil)
 }
 
 // kvPathParams folds the `<mount> <path>` positional pair into the op

--- a/cli/internal/cmd/vault/sys.go
+++ b/cli/internal/cmd/vault/sys.go
@@ -86,11 +86,11 @@ func newSysVerbCmd(use, opID, short, long, example string) *cobra.Command {
 			if err != nil {
 				return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 			}
-			r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, nil)
+			r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, nil)
 			if err != nil {
 				return renderRequestError(cmd, backplaneURL, err, jsonOut)
 			}
-			return renderCallResult(cmd, opID, r, jsonOut, nil)
+			return conn.Render(cmd, opID, r, jsonOut, nil)
 		},
 	}
 	cmd.Flags().StringVar(&targetName, "target", "",

--- a/cli/internal/cmd/vault/vault_test.go
+++ b/cli/internal/cmd/vault/vault_test.go
@@ -272,7 +272,7 @@ func TestDispatchOpBakesConnectorID(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	r, err := dispatchOp(context.Background(), srv.URL, opKVRead, "rdc-vault", nil)
+	r, err := conn.Call(context.Background(), srv.URL, opKVRead, "rdc-vault", nil)
 	if err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
@@ -301,7 +301,7 @@ func TestDispatchOpEmptyTargetSendsNullTarget(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	if _, err := dispatchOp(context.Background(), srv.URL, "x", "", nil); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, "x", "", nil); err != nil {
 		t.Fatalf("dispatchOp empty-target: %v", err)
 	}
 }
@@ -328,7 +328,7 @@ func TestDispatchOpTargetSlugWrappedAsName(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	if _, err := dispatchOp(context.Background(), srv.URL, "x", "rdc-vault", nil); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, "x", "rdc-vault", nil); err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
 }

--- a/cli/internal/cmd/vcf-automation/about.go
+++ b/cli/internal/cmd/vcf-automation/about.go
@@ -72,7 +72,7 @@ func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOver
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
 	printer := func(w io.Writer, res *CallResult) { printAbout(w, plane, res) }
-	return renderCallResult(cmd, opID, r, jsonOut, printer)
+	return conn.Render(cmd, opID, r, jsonOut, printer)
 }
 
 // aboutOpForPlane returns the op_id the `about` verb dispatches for

--- a/cli/internal/cmd/vcf-automation/dispatch.go
+++ b/cli/internal/cmd/vcf-automation/dispatch.go
@@ -6,160 +6,51 @@ package vcfautomation
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
 
-	"github.com/spf13/cobra"
-
-	"github.com/evoila/meho/cli/internal/output"
+	"github.com/evoila/meho/cli/internal/dispatch"
 )
 
-// CallResult mirrors the backend OperationResult Pydantic model.
-type CallResult struct {
-	Status     string          `json:"status"`
-	OpID       string          `json:"op_id"`
-	Result     json.RawMessage `json:"result"`
-	Error      *string         `json:"error"`
-	Extras     json.RawMessage `json:"extras,omitempty"`
-	DurationMs float64         `json:"duration_ms"`
-}
+// Aliases + binding to the shared dispatch core (cli/internal/dispatch).
+// vcf-automation keeps its own dispatchOp wrapper because it threads a
+// per-call "fqdn" vhost override into the target dict (G3.6-T12 #840) —
+// the wrapper delegates to the shared Connector.CallWithTarget.
+type (
+	// CallResult is the decoded OperationResult envelope.
+	CallResult = dispatch.CallResult
+	// callRequestBody is the on-the-wire OperationCall body (asserted by tests).
+	callRequestBody = dispatch.CallRequestBody
+)
 
-// callRequestBody mirrors the backend CallOperationBody Pydantic model.
-type callRequestBody struct {
-	ConnectorID string         `json:"connector_id"`
-	OpID        string         `json:"op_id"`
-	Target      map[string]any `json:"target"`
-	Params      map[string]any `json:"params,omitempty"`
-}
+// errOpError is the structured-failure sentinel (status error/denied).
+var errOpError = dispatch.ErrOpError
 
-var errOpError = errors.New("operation status not ok")
+// conn binds this package's pre-baked connector_id + authed transport
+// (doAuthedRequest) to the shared dispatch core.
+var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}
 
-// dispatchOp POSTs an OperationCall to the backplane and returns the
-// decoded CallResult with connector_id="vcfa-rest-9.0" pre-baked.
-//
-// The optional `fqdn` argument is threaded into the request body's
-// target dict as the `fqdn` field — the backend honours that as a
-// per-call vhost override on the resolved Target row (G3.6-T12 #840;
-// extended `CallOperationBody.target` to read the `fqdn` key in this
-// task). Empty `fqdn` is omitted from the body so the backend reads
-// `target.fqdn` from the registry.
-//
-// When `targetSlug` is empty, the body's `target` field is encoded as
-// JSON null — matches the backend contract for ops that don't act on
-// a target.
+// dispatchOp POSTs an OperationCall with connector_id="vcfa-rest-9.0"
+// pre-baked. The optional fqdn is threaded into the request body's
+// target dict as the "fqdn" field — the backend honours it as a
+// per-call vhost override on the resolved Target row (G3.6-T12 #840).
+// Empty fqdn is omitted so the backend reads target.fqdn from the
+// registry; an empty targetSlug omits the target entirely.
 func dispatchOp(
 	ctx context.Context,
 	backplaneURL, opID, targetSlug, fqdn string,
 	params map[string]any,
 ) (*CallResult, error) {
-	body := callRequestBody{
-		ConnectorID: ConnectorID,
-		OpID:        opID,
-		Target:      nil,
-	}
+	var target map[string]any
 	if targetSlug != "" {
-		t := map[string]any{"name": targetSlug}
+		target = map[string]any{"name": targetSlug}
 		if fqdn != "" {
-			t["fqdn"] = fqdn
+			target["fqdn"] = fqdn
 		}
-		body.Target = t
 	}
-	if params != nil {
-		body.Params = params
-	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal call request: %w", err)
-	}
-	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
-	if err != nil {
-		return nil, err
-	}
-	var out CallResult
-	if err := json.Unmarshal(respBody, &out); err != nil {
-		return nil, fmt.Errorf("decode call response: %w", err)
-	}
-	return &out, nil
+	return conn.CallWithTarget(ctx, backplaneURL, opID, target, params)
 }
 
-// renderCallResult handles the unified post-dispatch rendering path.
-func renderCallResult(
-	cmd *cobra.Command,
-	opID string,
-	r *CallResult,
-	jsonOut bool,
-	prettyPrinter func(w io.Writer, r *CallResult),
-) error {
-	switch r.Status {
-	case "ok", "error", "denied":
-	default:
-		return output.RenderError(
-			cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf(
-				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
-				r.Status,
-			)),
-			jsonOut,
-		)
-	}
-	if jsonOut {
-		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
-			return err
-		}
-	} else if prettyPrinter != nil {
-		prettyPrinter(cmd.OutOrStdout(), r)
-	} else {
-		printGenericResult(cmd.OutOrStdout(), opID, r)
-	}
-	if r.Status == "ok" {
-		return nil
-	}
-	return errOpError
-}
-
-// printGenericResult renders a CallResult in the generic envelope shape.
-func printGenericResult(w io.Writer, opID string, r *CallResult) {
-	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
-	if r.Status == "ok" {
-		if len(r.Result) > 0 && string(r.Result) != "null" {
-			pretty, err := prettyJSON(r.Result)
-			if err == nil {
-				fmt.Fprintln(w, pretty)
-				return
-			}
-			fmt.Fprintln(w, string(r.Result))
-		}
-		return
-	}
-	if r.Error != nil && *r.Error != "" {
-		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
-	} else {
-		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
-	}
-	if len(r.Extras) > 0 && string(r.Extras) != "null" {
-		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
-		if err == nil {
-			fmt.Fprintln(w, pretty)
-		} else {
-			fmt.Fprintln(w, string(r.Extras))
-		}
-	}
-}
-
+// jsonUnmarshalStrict decodes raw into out. Thin wrapper retained so the
+// per-verb decoders read uniformly.
 func jsonUnmarshalStrict(raw []byte, out any) error {
 	return json.Unmarshal(raw, out)
-}
-
-func prettyJSON(raw json.RawMessage) (string, error) {
-	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return "", err
-	}
-	out, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
 }

--- a/cli/internal/cmd/vcf-automation/operation.go
+++ b/cli/internal/cmd/vcf-automation/operation.go
@@ -194,5 +194,5 @@ func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, j
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, nil)
+	return conn.Render(cmd, opID, r, jsonOut, nil)
 }

--- a/cli/internal/cmd/vcf-automation/org.go
+++ b/cli/internal/cmd/vcf-automation/org.go
@@ -178,7 +178,7 @@ func runProviderListVerb(
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printer)
+	return conn.Render(cmd, opID, r, jsonOut, printer)
 }
 
 // runProviderGetVerb is the shared dispatch path for provider-plane
@@ -204,5 +204,5 @@ func runProviderGetVerb(
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printer)
+	return conn.Render(cmd, opID, r, jsonOut, printer)
 }

--- a/cli/internal/cmd/vcf-automation/project.go
+++ b/cli/internal/cmd/vcf-automation/project.go
@@ -96,7 +96,7 @@ func runTenantListVerb(
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printer)
+	return conn.Render(cmd, opID, r, jsonOut, printer)
 }
 
 // runTenantGetVerb dispatches a tenant-plane read-by-id op_id with the
@@ -120,5 +120,5 @@ func runTenantGetVerb(
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printer)
+	return conn.Render(cmd, opID, r, jsonOut, printer)
 }

--- a/cli/internal/cmd/vcf-automation/vcfa.go
+++ b/cli/internal/cmd/vcf-automation/vcfa.go
@@ -58,6 +58,7 @@ import (
 
 	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -248,7 +249,7 @@ func fallbackResultRender(w io.Writer, r *CallResult) {
 	if len(r.Result) == 0 || string(r.Result) == "null" {
 		return
 	}
-	pretty, err := prettyJSON(r.Result)
+	pretty, err := dispatch.PrettyJSON(r.Result)
 	if err == nil {
 		fmt.Fprintln(w, pretty)
 		return
@@ -265,7 +266,7 @@ func printErrorTrailer(w io.Writer, r *CallResult) {
 	}
 	if len(r.Extras) > 0 && string(r.Extras) != "null" {
 		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
+		pretty, err := dispatch.PrettyJSON(r.Extras)
 		if err == nil {
 			fmt.Fprintln(w, pretty)
 		} else {

--- a/cli/internal/cmd/vcf-fleet/about.go
+++ b/cli/internal/cmd/vcf-fleet/about.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -59,11 +60,11 @@ func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOver
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, aboutOpID, targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, aboutOpID, targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, aboutOpID, r, jsonOut, printAbout)
+	return conn.Render(cmd, aboutOpID, r, jsonOut, printAbout)
 }
 
 func printAbout(w io.Writer, r *CallResult) {
@@ -83,7 +84,7 @@ func printAbout(w io.Writer, r *CallResult) {
 	}
 	if err := jsonUnmarshalStrict(r.Result, &payload); err != nil || payload.APIVersion == "" {
 		if len(r.Result) > 0 && string(r.Result) != "null" {
-			pretty, perr := prettyJSON(r.Result)
+			pretty, perr := dispatch.PrettyJSON(r.Result)
 			if perr == nil {
 				fmt.Fprintln(w, pretty)
 				return

--- a/cli/internal/cmd/vcf-fleet/datacenter.go
+++ b/cli/internal/cmd/vcf-fleet/datacenter.go
@@ -61,11 +61,11 @@ func runDatacenterList(cmd *cobra.Command, targetName string, jsonOut bool, back
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, datacenterListOpID, targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, datacenterListOpID, targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, datacenterListOpID, r, jsonOut, printDatacenterList)
+	return conn.Render(cmd, datacenterListOpID, r, jsonOut, printDatacenterList)
 }
 
 func printDatacenterList(w io.Writer, r *CallResult) {
@@ -76,7 +76,7 @@ func printDatacenterList(w io.Writer, r *CallResult) {
 	}
 	entries, err := decodeListResult(r.Result)
 	if err != nil {
-		printGenericResult(w, datacenterListOpID, r)
+		conn.PrintGeneric(w, datacenterListOpID, r)
 		return
 	}
 	if len(entries) == 0 {

--- a/cli/internal/cmd/vcf-fleet/dispatch.go
+++ b/cli/internal/cmd/vcf-fleet/dispatch.go
@@ -3,143 +3,21 @@
 
 package vcffleet
 
-import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
+import "github.com/evoila/meho/cli/internal/dispatch"
 
-	"github.com/spf13/cobra"
-
-	"github.com/evoila/meho/cli/internal/output"
+// Aliases + binding to the shared dispatch core (cli/internal/dispatch).
+// The verb files in this package keep referring to the unqualified names;
+// the operation-call logic lives once in the dispatch package.
+type (
+	// CallResult is the decoded OperationResult envelope.
+	CallResult = dispatch.CallResult
+	// callRequestBody is the on-the-wire OperationCall body (asserted by tests).
+	callRequestBody = dispatch.CallRequestBody
 )
 
-// CallResult mirrors the backend OperationResult Pydantic model.
-type CallResult struct {
-	Status     string          `json:"status"`
-	OpID       string          `json:"op_id"`
-	Result     json.RawMessage `json:"result"`
-	Error      *string         `json:"error"`
-	Extras     json.RawMessage `json:"extras,omitempty"`
-	DurationMs float64         `json:"duration_ms"`
-}
+// errOpError is the structured-failure sentinel (status error/denied).
+var errOpError = dispatch.ErrOpError
 
-// callRequestBody mirrors the backend CallOperationBody Pydantic model.
-type callRequestBody struct {
-	ConnectorID string         `json:"connector_id"`
-	OpID        string         `json:"op_id"`
-	Target      map[string]any `json:"target"`
-	Params      map[string]any `json:"params,omitempty"`
-}
-
-var errOpError = errors.New("operation status not ok")
-
-// dispatchOp POSTs an OperationCall to the backplane with
-// connector_id="fleet-rest-9.0" pre-baked.
-func dispatchOp(
-	ctx context.Context,
-	backplaneURL, opID, targetSlug string,
-	params map[string]any,
-) (*CallResult, error) {
-	body := callRequestBody{
-		ConnectorID: ConnectorID,
-		OpID:        opID,
-		Target:      nil,
-	}
-	if targetSlug != "" {
-		body.Target = map[string]any{"name": targetSlug}
-	}
-	if params != nil {
-		body.Params = params
-	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal call request: %w", err)
-	}
-	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
-	if err != nil {
-		return nil, err
-	}
-	var out CallResult
-	if err := json.Unmarshal(respBody, &out); err != nil {
-		return nil, fmt.Errorf("decode call response: %w", err)
-	}
-	return &out, nil
-}
-
-// renderCallResult handles the unified post-dispatch rendering path.
-func renderCallResult(
-	cmd *cobra.Command,
-	opID string,
-	r *CallResult,
-	jsonOut bool,
-	prettyPrinter func(w io.Writer, r *CallResult),
-) error {
-	switch r.Status {
-	case "ok", "error", "denied":
-	default:
-		return output.RenderError(
-			cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf(
-				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
-				r.Status,
-			)),
-			jsonOut,
-		)
-	}
-	if jsonOut {
-		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
-			return err
-		}
-	} else if prettyPrinter != nil {
-		prettyPrinter(cmd.OutOrStdout(), r)
-	} else {
-		printGenericResult(cmd.OutOrStdout(), opID, r)
-	}
-	if r.Status == "ok" {
-		return nil
-	}
-	return errOpError
-}
-
-func printGenericResult(w io.Writer, opID string, r *CallResult) {
-	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
-	if r.Status == "ok" {
-		if len(r.Result) > 0 && string(r.Result) != "null" {
-			pretty, err := prettyJSON(r.Result)
-			if err == nil {
-				fmt.Fprintln(w, pretty)
-				return
-			}
-			fmt.Fprintln(w, string(r.Result))
-		}
-		return
-	}
-	if r.Error != nil && *r.Error != "" {
-		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
-	} else {
-		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
-	}
-	if len(r.Extras) > 0 && string(r.Extras) != "null" {
-		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
-		if err == nil {
-			fmt.Fprintln(w, pretty)
-		} else {
-			fmt.Fprintln(w, string(r.Extras))
-		}
-	}
-}
-
-func prettyJSON(raw json.RawMessage) (string, error) {
-	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return "", err
-	}
-	out, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
-}
+// conn binds this package's pre-baked connector_id + authed transport
+// (doAuthedRequest) to the shared dispatch core.
+var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}

--- a/cli/internal/cmd/vcf-fleet/environment.go
+++ b/cli/internal/cmd/vcf-fleet/environment.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -64,11 +65,11 @@ func runEnvironmentList(cmd *cobra.Command, targetName string, jsonOut bool, bac
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, environmentListOpID, targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, environmentListOpID, targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, environmentListOpID, r, jsonOut, printEnvironmentList)
+	return conn.Render(cmd, environmentListOpID, r, jsonOut, printEnvironmentList)
 }
 
 func printEnvironmentList(w io.Writer, r *CallResult) {
@@ -79,7 +80,7 @@ func printEnvironmentList(w io.Writer, r *CallResult) {
 	}
 	entries, err := decodeListResult(r.Result)
 	if err != nil {
-		printGenericResult(w, environmentListOpID, r)
+		conn.PrintGeneric(w, environmentListOpID, r)
 		return
 	}
 	if len(entries) == 0 {
@@ -131,11 +132,11 @@ func runEnvironmentInfo(cmd *cobra.Command, environmentID, targetName string, js
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
 	params := map[string]any{"environmentId": environmentID}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, environmentGetOpID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, environmentGetOpID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, environmentGetOpID, r, jsonOut, printEnvironmentInfo)
+	return conn.Render(cmd, environmentGetOpID, r, jsonOut, printEnvironmentInfo)
 }
 
 func printEnvironmentInfo(w io.Writer, r *CallResult) {
@@ -166,7 +167,7 @@ func printEnvironmentInfo(w io.Writer, r *CallResult) {
 		} `json:"products"`
 	}
 	if err := jsonUnmarshalStrict(r.Result, &env); err != nil || env.EnvironmentID == "" {
-		if pretty, perr := prettyJSON(r.Result); perr == nil {
+		if pretty, perr := dispatch.PrettyJSON(r.Result); perr == nil {
 			fmt.Fprintln(w, pretty)
 		} else {
 			fmt.Fprintln(w, string(r.Result))

--- a/cli/internal/cmd/vcf-fleet/operation.go
+++ b/cli/internal/cmd/vcf-fleet/operation.go
@@ -176,9 +176,9 @@ func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, j
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, nil)
+	return conn.Render(cmd, opID, r, jsonOut, nil)
 }

--- a/cli/internal/cmd/vcf-fleet/product.go
+++ b/cli/internal/cmd/vcf-fleet/product.go
@@ -61,11 +61,11 @@ func runProductList(cmd *cobra.Command, environmentID, targetName string, jsonOu
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
 	params := map[string]any{"environmentId": environmentID}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, productListOpID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, productListOpID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, productListOpID, r, jsonOut, printProductList)
+	return conn.Render(cmd, productListOpID, r, jsonOut, printProductList)
 }
 
 func printProductList(w io.Writer, r *CallResult) {
@@ -76,7 +76,7 @@ func printProductList(w io.Writer, r *CallResult) {
 	}
 	entries, err := decodeListResult(r.Result)
 	if err != nil {
-		printGenericResult(w, productListOpID, r)
+		conn.PrintGeneric(w, productListOpID, r)
 		return
 	}
 	if len(entries) == 0 {

--- a/cli/internal/cmd/vcf-fleet/request.go
+++ b/cli/internal/cmd/vcf-fleet/request.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -65,11 +66,11 @@ func runRequestList(cmd *cobra.Command, targetName string, jsonOut bool, backpla
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, requestListOpID, targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, requestListOpID, targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, requestListOpID, r, jsonOut, printRequestList)
+	return conn.Render(cmd, requestListOpID, r, jsonOut, printRequestList)
 }
 
 func printRequestList(w io.Writer, r *CallResult) {
@@ -80,7 +81,7 @@ func printRequestList(w io.Writer, r *CallResult) {
 	}
 	entries, err := decodeListResult(r.Result)
 	if err != nil {
-		printGenericResult(w, requestListOpID, r)
+		conn.PrintGeneric(w, requestListOpID, r)
 		return
 	}
 	if len(entries) == 0 {
@@ -134,11 +135,11 @@ func runRequestInfo(cmd *cobra.Command, requestID, targetName string, jsonOut bo
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
 	params := map[string]any{"requestId": requestID}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, requestGetOpID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, requestGetOpID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, requestGetOpID, r, jsonOut, printRequestInfo)
+	return conn.Render(cmd, requestGetOpID, r, jsonOut, printRequestInfo)
 }
 
 func printRequestInfo(w io.Writer, r *CallResult) {
@@ -162,7 +163,7 @@ func printRequestInfo(w io.Writer, r *CallResult) {
 		LastUpdatedOn   string `json:"lastUpdatedOn"`
 	}
 	if err := jsonUnmarshalStrict(r.Result, &req); err != nil || req.VMID == "" {
-		if pretty, perr := prettyJSON(r.Result); perr == nil {
+		if pretty, perr := dispatch.PrettyJSON(r.Result); perr == nil {
 			fmt.Fprintln(w, pretty)
 		} else {
 			fmt.Fprintln(w, string(r.Result))

--- a/cli/internal/cmd/vcf-fleet/vcenter.go
+++ b/cli/internal/cmd/vcf-fleet/vcenter.go
@@ -60,11 +60,11 @@ func runVcenterList(cmd *cobra.Command, datacenterVmid, targetName string, jsonO
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
 	params := map[string]any{"dataCenterVmid": datacenterVmid}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, vcenterListOpID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, vcenterListOpID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, vcenterListOpID, r, jsonOut, printVcenterList)
+	return conn.Render(cmd, vcenterListOpID, r, jsonOut, printVcenterList)
 }
 
 func printVcenterList(w io.Writer, r *CallResult) {
@@ -75,7 +75,7 @@ func printVcenterList(w io.Writer, r *CallResult) {
 	}
 	entries, err := decodeListResult(r.Result)
 	if err != nil {
-		printGenericResult(w, vcenterListOpID, r)
+		conn.PrintGeneric(w, vcenterListOpID, r)
 		return
 	}
 	if len(entries) == 0 {

--- a/cli/internal/cmd/vcf-fleet/vcf_fleet.go
+++ b/cli/internal/cmd/vcf-fleet/vcf_fleet.go
@@ -44,6 +44,7 @@ import (
 
 	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -133,7 +134,7 @@ func printErrorTrailer(w io.Writer, r *CallResult) {
 	}
 	if len(r.Extras) > 0 && string(r.Extras) != "null" {
 		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
+		pretty, err := dispatch.PrettyJSON(r.Extras)
 		if err == nil {
 			fmt.Fprintln(w, pretty)
 		} else {

--- a/cli/internal/cmd/vcf-fleet/vcf_fleet_test.go
+++ b/cli/internal/cmd/vcf-fleet/vcf_fleet_test.go
@@ -428,7 +428,7 @@ func TestDispatchOpBakesConnectorID(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	r, err := dispatchOp(context.Background(), srv.URL, datacenterListOpID, "rdc-fleet", nil)
+	r, err := conn.Call(context.Background(), srv.URL, datacenterListOpID, "rdc-fleet", nil)
 	if err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
@@ -456,7 +456,7 @@ func TestDispatchOpEmptyTargetSendsNullTarget(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	if _, err := dispatchOp(context.Background(), srv.URL, datacenterListOpID, "", nil); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, datacenterListOpID, "", nil); err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
 }
@@ -486,7 +486,7 @@ func TestDispatchVcenterListSendsDataCenterVmidParam(t *testing.T) {
 	primeToken(t, srv.URL)
 
 	params := map[string]any{"dataCenterVmid": "dc-001"}
-	if _, err := dispatchOp(context.Background(), srv.URL, vcenterListOpID, "rdc-fleet", params); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, vcenterListOpID, "rdc-fleet", params); err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
 }
@@ -515,7 +515,7 @@ func TestDispatchEnvironmentInfoSendsEnvironmentIDParam(t *testing.T) {
 	primeToken(t, srv.URL)
 
 	params := map[string]any{"environmentId": "env-vrops"}
-	if _, err := dispatchOp(context.Background(), srv.URL, environmentGetOpID, "rdc-fleet", params); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, environmentGetOpID, "rdc-fleet", params); err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
 }
@@ -541,7 +541,7 @@ func TestDispatchRequestInfoSendsRequestIDParam(t *testing.T) {
 	primeToken(t, srv.URL)
 
 	params := map[string]any{"requestId": "req-001"}
-	if _, err := dispatchOp(context.Background(), srv.URL, requestGetOpID, "rdc-fleet", params); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, requestGetOpID, "rdc-fleet", params); err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
 }

--- a/cli/internal/cmd/vcf-logs/about.go
+++ b/cli/internal/cmd/vcf-logs/about.go
@@ -50,11 +50,11 @@ func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOver
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/api/v2/version", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v2/version", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/api/v2/version", r, jsonOut, printAbout)
+	return conn.Render(cmd, "GET:/api/v2/version", r, jsonOut, printAbout)
 }
 
 func printAbout(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/vcf-logs/aggregated.go
+++ b/cli/internal/cmd/vcf-logs/aggregated.go
@@ -74,11 +74,11 @@ func runAggregated(
 		params["timestamp_window"] = timeRange
 	}
 	const opID = "GET:/api/v2/aggregated-events/{constraints}"
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printAggregated)
+	return conn.Render(cmd, opID, r, jsonOut, printAggregated)
 }
 
 func printAggregated(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/vcf-logs/alert.go
+++ b/cli/internal/cmd/vcf-logs/alert.go
@@ -58,11 +58,11 @@ func runAlertList(cmd *cobra.Command, targetName string, jsonOut bool, backplane
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/api/v2/alerts", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v2/alerts", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/api/v2/alerts", r, jsonOut, printAlertList)
+	return conn.Render(cmd, "GET:/api/v2/alerts", r, jsonOut, printAlertList)
 }
 
 func printAlertList(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/vcf-logs/content_pack.go
+++ b/cli/internal/cmd/vcf-logs/content_pack.go
@@ -59,11 +59,11 @@ func runContentPackList(cmd *cobra.Command, targetName string, jsonOut bool, bac
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
 	const opID = "GET:/api/v2/content/contentpack/list"
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printContentPackList)
+	return conn.Render(cmd, opID, r, jsonOut, printContentPackList)
 }
 
 func printContentPackList(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/vcf-logs/dispatch.go
+++ b/cli/internal/cmd/vcf-logs/dispatch.go
@@ -3,144 +3,21 @@
 
 package vcflogs
 
-import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
+import "github.com/evoila/meho/cli/internal/dispatch"
 
-	"github.com/spf13/cobra"
-
-	"github.com/evoila/meho/cli/internal/output"
+// Aliases + binding to the shared dispatch core (cli/internal/dispatch).
+// The verb files in this package keep referring to the unqualified names;
+// the operation-call logic lives once in the dispatch package.
+type (
+	// CallResult is the decoded OperationResult envelope.
+	CallResult = dispatch.CallResult
+	// callRequestBody is the on-the-wire OperationCall body (asserted by tests).
+	callRequestBody = dispatch.CallRequestBody
 )
 
-// CallResult mirrors the backend OperationResult Pydantic model.
-type CallResult struct {
-	Status     string          `json:"status"`
-	OpID       string          `json:"op_id"`
-	Result     json.RawMessage `json:"result"`
-	Error      *string         `json:"error"`
-	Extras     json.RawMessage `json:"extras,omitempty"`
-	DurationMs float64         `json:"duration_ms"`
-}
+// errOpError is the structured-failure sentinel (status error/denied).
+var errOpError = dispatch.ErrOpError
 
-// callRequestBody mirrors the backend CallOperationBody Pydantic model.
-type callRequestBody struct {
-	ConnectorID string         `json:"connector_id"`
-	OpID        string         `json:"op_id"`
-	Target      map[string]any `json:"target"`
-	Params      map[string]any `json:"params,omitempty"`
-}
-
-var errOpError = errors.New("operation status not ok")
-
-// dispatchOp POSTs an OperationCall to the backplane and returns the
-// decoded CallResult with connector_id="vrli-rest-9.0" pre-baked.
-func dispatchOp(
-	ctx context.Context,
-	backplaneURL, opID, targetSlug string,
-	params map[string]any,
-) (*CallResult, error) {
-	body := callRequestBody{
-		ConnectorID: ConnectorID,
-		OpID:        opID,
-		Target:      nil,
-	}
-	if targetSlug != "" {
-		body.Target = map[string]any{"name": targetSlug}
-	}
-	if params != nil {
-		body.Params = params
-	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal call request: %w", err)
-	}
-	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
-	if err != nil {
-		return nil, err
-	}
-	var out CallResult
-	if err := json.Unmarshal(respBody, &out); err != nil {
-		return nil, fmt.Errorf("decode call response: %w", err)
-	}
-	return &out, nil
-}
-
-// renderCallResult handles the unified post-dispatch rendering path.
-func renderCallResult(
-	cmd *cobra.Command,
-	opID string,
-	r *CallResult,
-	jsonOut bool,
-	prettyPrinter func(w io.Writer, r *CallResult),
-) error {
-	switch r.Status {
-	case "ok", "error", "denied":
-	default:
-		return output.RenderError(
-			cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf(
-				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
-				r.Status,
-			)),
-			jsonOut,
-		)
-	}
-	if jsonOut {
-		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
-			return err
-		}
-	} else if prettyPrinter != nil {
-		prettyPrinter(cmd.OutOrStdout(), r)
-	} else {
-		printGenericResult(cmd.OutOrStdout(), opID, r)
-	}
-	if r.Status == "ok" {
-		return nil
-	}
-	return errOpError
-}
-
-// printGenericResult renders a CallResult in the generic envelope shape.
-func printGenericResult(w io.Writer, opID string, r *CallResult) {
-	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
-	if r.Status == "ok" {
-		if len(r.Result) > 0 && string(r.Result) != "null" {
-			pretty, err := prettyJSON(r.Result)
-			if err == nil {
-				fmt.Fprintln(w, pretty)
-				return
-			}
-			fmt.Fprintln(w, string(r.Result))
-		}
-		return
-	}
-	if r.Error != nil && *r.Error != "" {
-		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
-	} else {
-		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
-	}
-	if len(r.Extras) > 0 && string(r.Extras) != "null" {
-		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
-		if err == nil {
-			fmt.Fprintln(w, pretty)
-		} else {
-			fmt.Fprintln(w, string(r.Extras))
-		}
-	}
-}
-
-func prettyJSON(raw json.RawMessage) (string, error) {
-	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return "", err
-	}
-	out, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
-}
+// conn binds this package's pre-baked connector_id + authed transport
+// (doAuthedRequest) to the shared dispatch core.
+var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}

--- a/cli/internal/cmd/vcf-logs/field.go
+++ b/cli/internal/cmd/vcf-logs/field.go
@@ -57,11 +57,11 @@ func runFieldList(cmd *cobra.Command, targetName string, jsonOut bool, backplane
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/api/v2/fields", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v2/fields", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/api/v2/fields", r, jsonOut, printFieldList)
+	return conn.Render(cmd, "GET:/api/v2/fields", r, jsonOut, printFieldList)
 }
 
 func printFieldList(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/vcf-logs/host.go
+++ b/cli/internal/cmd/vcf-logs/host.go
@@ -57,11 +57,11 @@ func runHostList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneO
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/api/v2/hosts", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v2/hosts", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/api/v2/hosts", r, jsonOut, printHostList)
+	return conn.Render(cmd, "GET:/api/v2/hosts", r, jsonOut, printHostList)
 }
 
 func printHostList(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/vcf-logs/operation.go
+++ b/cli/internal/cmd/vcf-logs/operation.go
@@ -183,9 +183,9 @@ func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, j
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, nil)
+	return conn.Render(cmd, opID, r, jsonOut, nil)
 }

--- a/cli/internal/cmd/vcf-logs/query.go
+++ b/cli/internal/cmd/vcf-logs/query.go
@@ -105,11 +105,11 @@ func runQuery(
 		params["limit"] = strconv.Itoa(limit)
 	}
 	const opID = "GET:/api/v2/events/{constraints}"
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printQuery)
+	return conn.Render(cmd, opID, r, jsonOut, printQuery)
 }
 
 func printQuery(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/vcf-logs/vcf_logs.go
+++ b/cli/internal/cmd/vcf-logs/vcf_logs.go
@@ -45,6 +45,7 @@ import (
 
 	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -139,7 +140,7 @@ func fallbackResultRender(w io.Writer, r *CallResult) {
 	if len(r.Result) == 0 || string(r.Result) == "null" {
 		return
 	}
-	pretty, err := prettyJSON(r.Result)
+	pretty, err := dispatch.PrettyJSON(r.Result)
 	if err == nil {
 		fmt.Fprintln(w, pretty)
 		return
@@ -156,7 +157,7 @@ func printErrorTrailer(w io.Writer, r *CallResult) {
 	}
 	if len(r.Extras) > 0 && string(r.Extras) != "null" {
 		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
+		pretty, err := dispatch.PrettyJSON(r.Extras)
 		if err == nil {
 			fmt.Fprintln(w, pretty)
 		} else {

--- a/cli/internal/cmd/vcf-logs/vcf_logs_test.go
+++ b/cli/internal/cmd/vcf-logs/vcf_logs_test.go
@@ -410,7 +410,7 @@ func TestDispatchOpBakesConnectorID(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	r, err := dispatchOp(context.Background(), srv.URL, "GET:/api/v2/version", "rdc-vrli", nil)
+	r, err := conn.Call(context.Background(), srv.URL, "GET:/api/v2/version", "rdc-vrli", nil)
 	if err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
@@ -438,7 +438,7 @@ func TestDispatchOpEmptyTargetSendsNullTarget(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	if _, err := dispatchOp(context.Background(), srv.URL, "GET:/api/v2/version", "", nil); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, "GET:/api/v2/version", "", nil); err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
 }

--- a/cli/internal/cmd/vcf-operations/about.go
+++ b/cli/internal/cmd/vcf-operations/about.go
@@ -59,11 +59,11 @@ func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOver
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
 	const opID = "GET:/suite-api/api/versions/current"
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printAbout)
+	return conn.Render(cmd, opID, r, jsonOut, printAbout)
 }
 
 func printAbout(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/vcf-operations/alert.go
+++ b/cli/internal/cmd/vcf-operations/alert.go
@@ -77,11 +77,11 @@ func runAlertList(cmd *cobra.Command, targetName, paramsFlag string, jsonOut boo
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
 	}
 	const opID = "GET:/suite-api/api/alerts"
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printAlertList)
+	return conn.Render(cmd, opID, r, jsonOut, printAlertList)
 }
 
 func printAlertList(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/vcf-operations/alertdefinition.go
+++ b/cli/internal/cmd/vcf-operations/alertdefinition.go
@@ -77,11 +77,11 @@ func runAlertDefinitionList(cmd *cobra.Command, targetName, paramsFlag string, j
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
 	}
 	const opID = "GET:/suite-api/api/alertdefinitions"
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printAlertDefinitionList)
+	return conn.Render(cmd, opID, r, jsonOut, printAlertDefinitionList)
 }
 
 func printAlertDefinitionList(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/vcf-operations/dispatch.go
+++ b/cli/internal/cmd/vcf-operations/dispatch.go
@@ -3,161 +3,21 @@
 
 package vcfoperations
 
-import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
+import "github.com/evoila/meho/cli/internal/dispatch"
 
-	"github.com/spf13/cobra"
-
-	"github.com/evoila/meho/cli/internal/output"
+// Aliases + binding to the shared dispatch core (cli/internal/dispatch).
+// The verb files in this package keep referring to the unqualified names;
+// the operation-call logic lives once in the dispatch package.
+type (
+	// CallResult is the decoded OperationResult envelope.
+	CallResult = dispatch.CallResult
+	// callRequestBody is the on-the-wire OperationCall body (asserted by tests).
+	callRequestBody = dispatch.CallRequestBody
 )
 
-// CallResult mirrors the backend OperationResult Pydantic model.
-type CallResult struct {
-	Status     string          `json:"status"`
-	OpID       string          `json:"op_id"`
-	Result     json.RawMessage `json:"result"`
-	Error      *string         `json:"error"`
-	Extras     json.RawMessage `json:"extras,omitempty"`
-	DurationMs float64         `json:"duration_ms"`
-}
+// errOpError is the structured-failure sentinel (status error/denied).
+var errOpError = dispatch.ErrOpError
 
-// callRequestBody mirrors the backend CallOperationBody Pydantic model.
-type callRequestBody struct {
-	ConnectorID string         `json:"connector_id"`
-	OpID        string         `json:"op_id"`
-	Target      map[string]any `json:"target"`
-	Params      map[string]any `json:"params,omitempty"`
-}
-
-// errOpError is the sentinel returned when the dispatcher reported a
-// structured-failure result (status == "error" or status ==
-// "denied"). main translates non-nil RunE errors into a non-zero
-// exit; SilenceErrors=true on each command keeps cobra from double-
-// printing the error string.
-var errOpError = errors.New("operation status not ok")
-
-// dispatchOp POSTs an OperationCall to the backplane and returns the
-// decoded CallResult with connector_id="vrops-rest-9.0" pre-baked.
-//
-// targetSlug is wrapped as `{"name": <slug>}` when non-empty; the
-// empty case sends `target: null` on the wire so the dispatcher's
-// resolver short-circuits to the no-target branch (no vROps read op
-// in the v0.5 core is target-optional, but keeping the wire shape
-// uniform with the NSX / SDDC Manager siblings simplifies the
-// transport-layer audit).
-func dispatchOp(
-	ctx context.Context,
-	backplaneURL, opID, targetSlug string,
-	params map[string]any,
-) (*CallResult, error) {
-	body := callRequestBody{
-		ConnectorID: ConnectorID,
-		OpID:        opID,
-		Target:      nil,
-	}
-	if targetSlug != "" {
-		body.Target = map[string]any{"name": targetSlug}
-	}
-	if params != nil {
-		body.Params = params
-	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal call request: %w", err)
-	}
-	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
-	if err != nil {
-		return nil, err
-	}
-	var out CallResult
-	if err := json.Unmarshal(respBody, &out); err != nil {
-		return nil, fmt.Errorf("decode call response: %w", err)
-	}
-	return &out, nil
-}
-
-// renderCallResult handles the unified post-dispatch rendering path.
-// Returns nil on success, errOpError on "error" / "denied", or a
-// renderer error on an unexpected status enum value.
-func renderCallResult(
-	cmd *cobra.Command,
-	opID string,
-	r *CallResult,
-	jsonOut bool,
-	prettyPrinter func(w io.Writer, r *CallResult),
-) error {
-	switch r.Status {
-	case "ok", "error", "denied":
-	default:
-		return output.RenderError(
-			cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf(
-				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
-				r.Status,
-			)),
-			jsonOut,
-		)
-	}
-	if jsonOut {
-		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
-			return err
-		}
-	} else if prettyPrinter != nil {
-		prettyPrinter(cmd.OutOrStdout(), r)
-	} else {
-		printGenericResult(cmd.OutOrStdout(), opID, r)
-	}
-	if r.Status == "ok" {
-		return nil
-	}
-	return errOpError
-}
-
-// printGenericResult renders a CallResult in the generic envelope
-// shape. Used as the fallback when no per-verb printer is provided
-// (operation call wrapper).
-func printGenericResult(w io.Writer, opID string, r *CallResult) {
-	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
-	if r.Status == "ok" {
-		if len(r.Result) > 0 && string(r.Result) != "null" {
-			pretty, err := prettyJSON(r.Result)
-			if err == nil {
-				fmt.Fprintln(w, pretty)
-				return
-			}
-			fmt.Fprintln(w, string(r.Result))
-		}
-		return
-	}
-	if r.Error != nil && *r.Error != "" {
-		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
-	} else {
-		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
-	}
-	if len(r.Extras) > 0 && string(r.Extras) != "null" {
-		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
-		if err == nil {
-			fmt.Fprintln(w, pretty)
-		} else {
-			fmt.Fprintln(w, string(r.Extras))
-		}
-	}
-}
-
-// prettyJSON pretty-prints a json.RawMessage with 2-space indent.
-func prettyJSON(raw json.RawMessage) (string, error) {
-	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return "", err
-	}
-	out, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
-}
+// conn binds this package's pre-baked connector_id + authed transport
+// (doAuthedRequest) to the shared dispatch core.
+var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}

--- a/cli/internal/cmd/vcf-operations/operation.go
+++ b/cli/internal/cmd/vcf-operations/operation.go
@@ -183,9 +183,9 @@ func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, j
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, nil)
+	return conn.Render(cmd, opID, r, jsonOut, nil)
 }

--- a/cli/internal/cmd/vcf-operations/recommendation.go
+++ b/cli/internal/cmd/vcf-operations/recommendation.go
@@ -74,11 +74,11 @@ func runRecommendationList(cmd *cobra.Command, targetName, paramsFlag string, js
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
 	}
 	const opID = "GET:/suite-api/api/recommendations"
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printRecommendationList)
+	return conn.Render(cmd, opID, r, jsonOut, printRecommendationList)
 }
 
 func printRecommendationList(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/vcf-operations/resource.go
+++ b/cli/internal/cmd/vcf-operations/resource.go
@@ -80,11 +80,11 @@ func runResourceList(cmd *cobra.Command, targetName, paramsFlag string, jsonOut 
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
 	}
 	const opID = "GET:/suite-api/api/resources"
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printResourceList)
+	return conn.Render(cmd, opID, r, jsonOut, printResourceList)
 }
 
 func printResourceList(w io.Writer, r *CallResult) {
@@ -158,11 +158,11 @@ func runResourceGet(cmd *cobra.Command, id, targetName string, jsonOut bool, bac
 	}
 	const opID = "GET:/suite-api/api/resources/{id}"
 	params := map[string]any{"id": id}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printResourceGet)
+	return conn.Render(cmd, opID, r, jsonOut, printResourceGet)
 }
 
 func printResourceGet(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/vcf-operations/supermetric.go
+++ b/cli/internal/cmd/vcf-operations/supermetric.go
@@ -73,11 +73,11 @@ func runSupermetricList(cmd *cobra.Command, targetName, paramsFlag string, jsonO
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
 	}
 	const opID = "GET:/suite-api/api/supermetrics"
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printSupermetricList)
+	return conn.Render(cmd, opID, r, jsonOut, printSupermetricList)
 }
 
 func printSupermetricList(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/vcf-operations/symptom.go
+++ b/cli/internal/cmd/vcf-operations/symptom.go
@@ -75,11 +75,11 @@ func runSymptomList(cmd *cobra.Command, targetName, paramsFlag string, jsonOut b
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
 	}
 	const opID = "GET:/suite-api/api/symptoms"
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printSymptomList)
+	return conn.Render(cmd, opID, r, jsonOut, printSymptomList)
 }
 
 func printSymptomList(w io.Writer, r *CallResult) {

--- a/cli/internal/cmd/vcf-operations/vcf_operations.go
+++ b/cli/internal/cmd/vcf-operations/vcf_operations.go
@@ -49,6 +49,7 @@ import (
 
 	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -184,7 +185,7 @@ func fallbackResultRender(w io.Writer, r *CallResult) {
 	if len(r.Result) == 0 || string(r.Result) == "null" {
 		return
 	}
-	pretty, err := prettyJSON(r.Result)
+	pretty, err := dispatch.PrettyJSON(r.Result)
 	if err == nil {
 		fmt.Fprintln(w, pretty)
 		return
@@ -201,7 +202,7 @@ func printErrorTrailer(w io.Writer, r *CallResult) {
 	}
 	if len(r.Extras) > 0 && string(r.Extras) != "null" {
 		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
+		pretty, err := dispatch.PrettyJSON(r.Extras)
 		if err == nil {
 			fmt.Fprintln(w, pretty)
 		} else {

--- a/cli/internal/cmd/vcf-operations/vcf_operations_test.go
+++ b/cli/internal/cmd/vcf-operations/vcf_operations_test.go
@@ -524,7 +524,7 @@ func TestDispatchOpBakesConnectorID(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	r, err := dispatchOp(context.Background(), srv.URL, "GET:/suite-api/api/versions/current", "rdc-vrops", nil)
+	r, err := conn.Call(context.Background(), srv.URL, "GET:/suite-api/api/versions/current", "rdc-vrops", nil)
 	if err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
@@ -551,7 +551,7 @@ func TestDispatchOpEmptyTargetSendsNullTarget(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	if _, err := dispatchOp(context.Background(), srv.URL, "x", "", nil); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, "x", "", nil); err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
 }
@@ -575,7 +575,7 @@ func TestDispatchOpTargetSlugWrappedAsName(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	if _, err := dispatchOp(context.Background(), srv.URL, "x", "rdc-vrops", nil); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, "x", "rdc-vrops", nil); err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
 }
@@ -610,7 +610,7 @@ func TestDispatchResourceGetSendsIDParam(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	r, err := dispatchOp(
+	r, err := conn.Call(
 		context.Background(), srv.URL,
 		"GET:/suite-api/api/resources/{id}",
 		"rdc-vrops",
@@ -660,7 +660,7 @@ func TestRenderCallResultUnknownStatus(t *testing.T) {
 	cmd := newOperationCallCmd()
 	cmd.SetErr(&buf)
 	cmd.SetOut(&buf)
-	err := renderCallResult(cmd, "x", r, false, nil)
+	err := conn.Render(cmd, "x", r, false, nil)
 	if err == nil {
 		t.Fatalf("unknown status should surface as error")
 	}

--- a/cli/internal/cmd/vmware/about.go
+++ b/cli/internal/cmd/vmware/about.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -78,11 +79,11 @@ func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOver
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/api/about", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/about", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/api/about", r, jsonOut, printAbout)
+	return conn.Render(cmd, "GET:/api/about", r, jsonOut, printAbout)
 }
 
 // printAbout renders the about endpoint's result fields. The vSphere
@@ -110,7 +111,7 @@ func printAbout(w io.Writer, r *CallResult) {
 		// Fallback to raw JSON dump when the shape doesn't match the
 		// documented /api/about contract. Contract drift surfaces at
 		// the inspection layer rather than as a panic.
-		pretty, perr := prettyJSON(r.Result)
+		pretty, perr := dispatch.PrettyJSON(r.Result)
 		if perr == nil {
 			fmt.Fprintln(w, pretty)
 		} else {
@@ -175,7 +176,7 @@ func printErrorTrailer(w io.Writer, r *CallResult) {
 	}
 	if len(r.Extras) > 0 && string(r.Extras) != "null" {
 		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
+		pretty, err := dispatch.PrettyJSON(r.Extras)
 		if err == nil {
 			fmt.Fprintln(w, pretty)
 		} else {

--- a/cli/internal/cmd/vmware/cluster.go
+++ b/cli/internal/cmd/vmware/cluster.go
@@ -62,11 +62,11 @@ func runClusterList(cmd *cobra.Command, targetName string, jsonOut bool, backpla
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/vcenter/cluster", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/vcenter/cluster", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/vcenter/cluster", r, jsonOut, printClusterList)
+	return conn.Render(cmd, "GET:/vcenter/cluster", r, jsonOut, printClusterList)
 }
 
 func printClusterList(w io.Writer, r *CallResult) {
@@ -156,9 +156,9 @@ func runClusterPatch(cmd *cobra.Command, nameOrID, targetName, specFlag string, 
 	}
 	params["cluster"] = moid
 	opID := "vmware.composite.cluster.patch"
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, nil)
+	return conn.Render(cmd, opID, r, jsonOut, nil)
 }

--- a/cli/internal/cmd/vmware/dispatch.go
+++ b/cli/internal/cmd/vmware/dispatch.go
@@ -3,190 +3,21 @@
 
 package vmware
 
-import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
+import "github.com/evoila/meho/cli/internal/dispatch"
 
-	"github.com/spf13/cobra"
-
-	"github.com/evoila/meho/cli/internal/output"
+// Aliases + binding to the shared dispatch core (cli/internal/dispatch).
+// The verb files in this package keep referring to the unqualified names;
+// the operation-call logic lives once in the dispatch package.
+type (
+	// CallResult is the decoded OperationResult envelope.
+	CallResult = dispatch.CallResult
+	// callRequestBody is the on-the-wire OperationCall body (asserted by tests).
+	callRequestBody = dispatch.CallRequestBody
 )
 
-// CallResult mirrors the backend OperationResult Pydantic model.
-// Same shape as cmd/operation/CallResult; duplicated here because
-// cmd/vmware can't import cmd/operation without an import cycle
-// (cmd/root.go grafts both onto the tree).
-//
-// Result is left as json.RawMessage because the backend types it as
-// a oneOf(dict, list) union — pretty-printing the raw bytes is the
-// cleanest renderer until a per-shape table specialisation lands.
-// Same approach the operation sibling takes.
-type CallResult struct {
-	Status     string          `json:"status"`
-	OpID       string          `json:"op_id"`
-	Result     json.RawMessage `json:"result"`
-	Error      *string         `json:"error"`
-	Extras     json.RawMessage `json:"extras,omitempty"`
-	DurationMs float64         `json:"duration_ms"`
-}
+// errOpError is the structured-failure sentinel (status error/denied).
+var errOpError = dispatch.ErrOpError
 
-// callRequestBody mirrors the backend CallOperationBody Pydantic
-// model. Target uses a map[string]any so the empty case serialises
-// as `null` rather than an empty struct; the route layer's resolver
-// short-circuits on the missing-name case (raising 400) for the few
-// ops that do need a target.
-type callRequestBody struct {
-	ConnectorID string         `json:"connector_id"`
-	OpID        string         `json:"op_id"`
-	Target      map[string]any `json:"target"`
-	Params      map[string]any `json:"params,omitempty"`
-}
-
-// errOpError is the sentinel returned when the dispatcher reported a
-// structured-failure result (status == "error" or status ==
-// "denied"). main translates non-nil RunE errors into a non-zero
-// exit; SilenceErrors=true on each command keeps cobra from double-
-// printing the error string. Same shape as the operation sibling's
-// errOpError.
-var errOpError = errors.New("operation status not ok")
-
-// dispatchOp POSTs an OperationCall to the backplane and returns the
-// decoded CallResult. The pre-baked connector_id ("vmware-rest-9.0")
-// is baked in; callers pass op_id, an optional target slug (empty
-// string → no target field on the wire), and an optional params map.
-//
-// Centralised here so every verb in the package shares one
-// dispatcher implementation (over a dozen call sites). Renamed from
-// the operation sibling's postCall to make the call sites self-
-// documenting at the grep level: a grep for `dispatchOp` finds every
-// alias-verb dispatch in the vmware package.
-func dispatchOp(
-	ctx context.Context,
-	backplaneURL, opID, targetSlug string,
-	params map[string]any,
-) (*CallResult, error) {
-	body := callRequestBody{
-		ConnectorID: ConnectorID,
-		OpID:        opID,
-		Target:      nil,
-	}
-	if targetSlug != "" {
-		body.Target = map[string]any{"name": targetSlug}
-	}
-	if params != nil {
-		body.Params = params
-	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal call request: %w", err)
-	}
-	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
-	if err != nil {
-		return nil, err
-	}
-	var out CallResult
-	if err := json.Unmarshal(respBody, &out); err != nil {
-		return nil, fmt.Errorf("decode call response: %w", err)
-	}
-	return &out, nil
-}
-
-// renderCallResult handles the unified post-dispatch path every verb
-// uses: validate status enum, render the envelope (JSON or human),
-// then translate "error" / "denied" into the errOpError sentinel so
-// main propagates the right non-zero exit. Returns nil on success
-// or one of:
-//   - errOpError (status == "error" / "denied" → exit 1)
-//   - a structured renderer error (unexpected status → exit 4)
-//
-// Pretty-printing is delegated to a per-verb closure so verb files
-// can lay out their domain-specific tables (vm list shows
-// name/power/host/datastore columns; cluster list shows different
-// columns). When prettyPrinter is nil, the fallback renders the
-// generic envelope shape the operation sibling uses — handy for the
-// composite-backed verbs whose output is opaque to the CLI today.
-func renderCallResult(
-	cmd *cobra.Command,
-	opID string,
-	r *CallResult,
-	jsonOut bool,
-	prettyPrinter func(w io.Writer, r *CallResult),
-) error {
-	switch r.Status {
-	case "ok", "error", "denied":
-		// fall through.
-	default:
-		return output.RenderError(
-			cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf(
-				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
-				r.Status,
-			)),
-			jsonOut,
-		)
-	}
-	if jsonOut {
-		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
-			return err
-		}
-	} else if prettyPrinter != nil {
-		prettyPrinter(cmd.OutOrStdout(), r)
-	} else {
-		printGenericResult(cmd.OutOrStdout(), opID, r)
-	}
-	if r.Status == "ok" {
-		return nil
-	}
-	return errOpError
-}
-
-// printGenericResult renders a CallResult in the same shape the
-// operation sibling's printCallResult uses. Used as the fallback
-// pretty-printer for verbs that don't define their own table layout
-// (composite-backed verbs whose result envelope is opaque to the
-// CLI; the operation call wrapper which is a verbatim pass-through).
-func printGenericResult(w io.Writer, opID string, r *CallResult) {
-	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
-	if r.Status == "ok" {
-		if len(r.Result) > 0 && string(r.Result) != "null" {
-			pretty, err := prettyJSON(r.Result)
-			if err == nil {
-				fmt.Fprintln(w, pretty)
-				return
-			}
-			fmt.Fprintln(w, string(r.Result))
-		}
-		return
-	}
-	if r.Error != nil && *r.Error != "" {
-		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
-	} else {
-		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
-	}
-	if len(r.Extras) > 0 && string(r.Extras) != "null" {
-		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
-		if err == nil {
-			fmt.Fprintln(w, pretty)
-		} else {
-			fmt.Fprintln(w, string(r.Extras))
-		}
-	}
-}
-
-// prettyJSON pretty-prints a json.RawMessage with 2-space indent.
-// Same implementation as the operation sibling.
-func prettyJSON(raw json.RawMessage) (string, error) {
-	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return "", err
-	}
-	out, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
-}
+// conn binds this package's pre-baked connector_id + authed transport
+// (doAuthedRequest) to the shared dispatch core.
+var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}

--- a/cli/internal/cmd/vmware/host.go
+++ b/cli/internal/cmd/vmware/host.go
@@ -62,11 +62,11 @@ func runHostList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneO
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/vcenter/host", targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/vcenter/host", targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, "GET:/vcenter/host", r, jsonOut, printHostList)
+	return conn.Render(cmd, "GET:/vcenter/host", r, jsonOut, printHostList)
 }
 
 func printHostList(w io.Writer, r *CallResult) {
@@ -146,9 +146,9 @@ func runHostEvacuate(cmd *cobra.Command, nameOrID, targetName string, jsonOut bo
 	}
 	opID := "vmware.composite.host.evacuate"
 	params := map[string]any{"host": moid}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, nil)
+	return conn.Render(cmd, opID, r, jsonOut, nil)
 }

--- a/cli/internal/cmd/vmware/listverbs.go
+++ b/cli/internal/cmd/vmware/listverbs.go
@@ -61,11 +61,11 @@ func runSimpleList(cmd *cobra.Command, spec simpleListSpec, targetName string, j
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, spec.opID, targetName, nil)
+	r, err := conn.Call(cmd.Context(), backplaneURL, spec.opID, targetName, nil)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, spec.opID, r, jsonOut, makeSimpleListPrinter(spec))
+	return conn.Render(cmd, spec.opID, r, jsonOut, makeSimpleListPrinter(spec))
 }
 
 func makeSimpleListPrinter(spec simpleListSpec) func(io.Writer, *CallResult) {

--- a/cli/internal/cmd/vmware/operation.go
+++ b/cli/internal/cmd/vmware/operation.go
@@ -236,9 +236,9 @@ func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, j
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, nil)
+	return conn.Render(cmd, opID, r, jsonOut, nil)
 }

--- a/cli/internal/cmd/vmware/resolve.go
+++ b/cli/internal/cmd/vmware/resolve.go
@@ -108,7 +108,7 @@ func resolveName(
 	params := map[string]any{
 		"filter.names": name,
 	}
-	r, err := dispatchOp(ctx, backplaneURL, opID, targetSlug, params)
+	r, err := conn.Call(ctx, backplaneURL, opID, targetSlug, params)
 	if err != nil {
 		return "", err
 	}

--- a/cli/internal/cmd/vmware/vm.go
+++ b/cli/internal/cmd/vmware/vm.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -105,11 +106,11 @@ func runVMList(cmd *cobra.Command, opts vmListOpts) error {
 	if perr != nil {
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(perr.Error()), opts.JSONOut)
 	}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, "GET:/vcenter/vm", opts.TargetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/vcenter/vm", opts.TargetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
-	return renderCallResult(cmd, "GET:/vcenter/vm", r, opts.JSONOut, printVMList)
+	return conn.Render(cmd, "GET:/vcenter/vm", r, opts.JSONOut, printVMList)
 }
 
 // printVMList renders a VM list as a table. vSphere's GET /vcenter/vm
@@ -157,7 +158,7 @@ func fallbackResultRender(w io.Writer, r *CallResult) {
 	if len(r.Result) == 0 || string(r.Result) == "null" {
 		return
 	}
-	pretty, err := prettyJSON(r.Result)
+	pretty, err := dispatch.PrettyJSON(r.Result)
 	if err == nil {
 		fmt.Fprintln(w, pretty)
 		return
@@ -299,11 +300,11 @@ func runVMInfo(cmd *cobra.Command, nameOrID, targetName string, jsonOut bool, ba
 	}
 	opID := "GET:/vcenter/vm/{vm}"
 	params := map[string]any{"vm": moid}
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
-	return renderCallResult(cmd, opID, r, jsonOut, printVMInfo)
+	return conn.Render(cmd, opID, r, jsonOut, printVMInfo)
 }
 
 // printVMInfo renders a single-VM detail block. The result body's
@@ -405,12 +406,12 @@ func runVMCreate(cmd *cobra.Command, targetName, specFlag string, jsonOut bool, 
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
 	}
 	opID := "vmware.composite.vm.create"
-	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, params)
+	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
 	// The composite's success shape is opaque to the CLI today
 	// (T6 ships the canonical envelope; CLI consumers read --json).
 	// Use the generic renderer until the shape stabilises.
-	return renderCallResult(cmd, opID, r, jsonOut, nil)
+	return conn.Render(cmd, opID, r, jsonOut, nil)
 }

--- a/cli/internal/cmd/vmware/vmware_test.go
+++ b/cli/internal/cmd/vmware/vmware_test.go
@@ -575,7 +575,7 @@ func TestDispatchOpBakesConnectorID(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	r, err := dispatchOp(context.Background(), srv.URL, "GET:/api/about", "rdc-vcenter", nil)
+	r, err := conn.Call(context.Background(), srv.URL, "GET:/api/about", "rdc-vcenter", nil)
 	if err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
@@ -606,7 +606,7 @@ func TestDispatchOpEmptyTargetSendsNullTarget(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	if _, err := dispatchOp(context.Background(), srv.URL, "x", "", nil); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, "x", "", nil); err != nil {
 		t.Fatalf("dispatchOp empty-target: %v", err)
 	}
 }
@@ -633,7 +633,7 @@ func TestDispatchOpTargetSlugWrappedAsName(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	if _, err := dispatchOp(context.Background(), srv.URL, "x", "rdc-vcenter", nil); err != nil {
+	if _, err := conn.Call(context.Background(), srv.URL, "x", "rdc-vcenter", nil); err != nil {
 		t.Fatalf("dispatchOp: %v", err)
 	}
 }
@@ -804,7 +804,7 @@ func TestRenderCallResultUnknownStatus(t *testing.T) {
 	cmd := newOperationCallCmd()
 	cmd.SetErr(&buf)
 	cmd.SetOut(&buf)
-	err := renderCallResult(cmd, "x", r, false, nil)
+	err := conn.Render(cmd, "x", r, false, nil)
 	if err == nil {
 		t.Fatalf("unknown status should surface as error")
 	}

--- a/cli/internal/dispatch/dispatch.go
+++ b/cli/internal/dispatch/dispatch.go
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package dispatch is the shared operation-call core for the per-vendor
+// CLI command packages (cmd/vault, cmd/harbor, cmd/nsx, ...). Before it,
+// every vendor package carried a byte-identical dispatch.go — CallResult,
+// dispatchOp, renderCallResult, printGenericResult, prettyJSON —
+// duplicated only because sibling cmd/* packages can't import one another
+// without an import cycle (cmd/root.go grafts each onto the tree). This
+// leaf package breaks that cycle: each vendor package binds one
+// Connector{ID, Request} and calls its methods.
+//
+// The authed transport is *injected* (Request) rather than imported here,
+// so the per-package doAuthedRequest helper stays where it is for now;
+// deduplicating that transport cluster is a separate change.
+package dispatch
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// CallResult mirrors the backend OperationResult Pydantic model. Result
+// and Extras stay json.RawMessage because the backend types Result as a
+// oneOf(dict, list) union — pretty-printing the raw bytes is the cleanest
+// renderer. Set-shaped responses arrive already reduced to a JSONFlux
+// handle envelope + sample by the dispatcher, so they render verbatim
+// here with the handle hint intact.
+type CallResult struct {
+	Status     string          `json:"status"`
+	OpID       string          `json:"op_id"`
+	Result     json.RawMessage `json:"result"`
+	Error      *string         `json:"error"`
+	Extras     json.RawMessage `json:"extras,omitempty"`
+	DurationMs float64         `json:"duration_ms"`
+}
+
+// CallRequestBody mirrors the backend CallOperationBody Pydantic model.
+// Target is a map so the empty case serialises as null rather than an
+// empty struct; the route layer's resolver short-circuits the missing-
+// name case for ops that need a target.
+type CallRequestBody struct {
+	ConnectorID string         `json:"connector_id"`
+	OpID        string         `json:"op_id"`
+	Target      map[string]any `json:"target"`
+	Params      map[string]any `json:"params,omitempty"`
+}
+
+// ErrOpError is the sentinel returned when the dispatcher reported a
+// structured failure (status == "error" or "denied"). main translates a
+// non-nil RunE error into a non-zero exit; SilenceErrors=true on each
+// command keeps cobra from double-printing the error string.
+var ErrOpError = errors.New("operation status not ok")
+
+// RequestFunc issues a single authed HTTP request against the backplane
+// and returns the response body. It matches each vendor package's
+// doAuthedRequest verbatim and is injected into a Connector so this
+// package stays transport-agnostic.
+type RequestFunc func(ctx context.Context, backplaneURL, method, path string, body []byte) ([]byte, error)
+
+// Connector binds a pre-baked connector_id and an authed transport so
+// every alias verb in a vendor package shares one dispatch + render
+// implementation.
+type Connector struct {
+	ID      string
+	Request RequestFunc
+}
+
+// Call POSTs an OperationCall to the backplane and returns the decoded
+// CallResult. An empty targetSlug omits the target field on the wire; a
+// nil params omits params.
+func (c Connector) Call(
+	ctx context.Context,
+	backplaneURL, opID, targetSlug string,
+	params map[string]any,
+) (*CallResult, error) {
+	var target map[string]any
+	if targetSlug != "" {
+		target = map[string]any{"name": targetSlug}
+	}
+	return c.CallWithTarget(ctx, backplaneURL, opID, target, params)
+}
+
+// CallWithTarget is Call for connectors that need extra target keys
+// beyond "name" (e.g. cmd/vcf-automation threads a per-call "fqdn"
+// vhost override). target is encoded verbatim — pass nil to omit the
+// target field (JSON null) for ops that don't act on a target.
+func (c Connector) CallWithTarget(
+	ctx context.Context,
+	backplaneURL, opID string,
+	target map[string]any,
+	params map[string]any,
+) (*CallResult, error) {
+	body := CallRequestBody{ConnectorID: c.ID, OpID: opID, Target: target}
+	if params != nil {
+		body.Params = params
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal call request: %w", err)
+	}
+	respBody, err := c.Request(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
+	if err != nil {
+		return nil, err
+	}
+	var out CallResult
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("decode call response: %w", err)
+	}
+	return &out, nil
+}
+
+// Render runs the unified post-dispatch path every verb uses: validate
+// the status enum, render the envelope (JSON or human), then map
+// "error" / "denied" to ErrOpError. When prettyPrinter is nil the generic
+// envelope is used.
+func (c Connector) Render(
+	cmd *cobra.Command,
+	opID string,
+	r *CallResult,
+	jsonOut bool,
+	prettyPrinter func(w io.Writer, r *CallResult),
+) error {
+	switch r.Status {
+	case "ok", "error", "denied":
+		// fall through.
+	default:
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
+				r.Status,
+			)),
+			jsonOut,
+		)
+	}
+	if jsonOut {
+		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
+			return err
+		}
+	} else if prettyPrinter != nil {
+		prettyPrinter(cmd.OutOrStdout(), r)
+	} else {
+		c.PrintGeneric(cmd.OutOrStdout(), opID, r)
+	}
+	if r.Status == "ok" {
+		return nil
+	}
+	return ErrOpError
+}
+
+// PrintGeneric renders a CallResult in the generic envelope shape: a
+// status line, then the pretty-printed Result on success or the connector
+// error + extras on failure. Used as the default pretty-printer when a
+// verb passes none.
+func (c Connector) PrintGeneric(w io.Writer, opID string, r *CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", c.ID, opID, r.Status, r.DurationMs)
+	if r.Status == "ok" {
+		if len(r.Result) > 0 && string(r.Result) != "null" {
+			pretty, err := PrettyJSON(r.Result)
+			if err == nil {
+				fmt.Fprintln(w, pretty)
+				return
+			}
+			fmt.Fprintln(w, string(r.Result))
+		}
+		return
+	}
+	if r.Error != nil && *r.Error != "" {
+		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
+	} else {
+		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
+	}
+	if len(r.Extras) > 0 && string(r.Extras) != "null" {
+		fmt.Fprintln(w, "extras:")
+		pretty, err := PrettyJSON(r.Extras)
+		if err == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Extras))
+		}
+	}
+}
+
+// PrettyJSON pretty-prints a json.RawMessage with 2-space indent.
+func PrettyJSON(raw json.RawMessage) (string, error) {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return "", err
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/cli/internal/dispatch/dispatch_test.go
+++ b/cli/internal/dispatch/dispatch_test.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package dispatch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// capturingConn returns a Connector whose Request records the last
+// marshalled body and replies with a fixed response.
+func capturingConn(id string, reply []byte, replyErr error) (*Connector, *[]byte) {
+	var last []byte
+	c := Connector{
+		ID: id,
+		Request: func(_ context.Context, _, _, _ string, body []byte) ([]byte, error) {
+			last = body
+			return reply, replyErr
+		},
+	}
+	return &c, &last
+}
+
+func TestCallBakesConnectorIDAndTarget(t *testing.T) {
+	c, last := capturingConn("vault-1.x", []byte(`{"status":"ok","op_id":"x","duration_ms":1}`), nil)
+	if _, err := c.Call(context.Background(), "https://bp", "vault.kv.read", "rdc-vault", map[string]any{"path": "p"}); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	var body CallRequestBody
+	if err := json.Unmarshal(*last, &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body.ConnectorID != "vault-1.x" || body.OpID != "vault.kv.read" {
+		t.Fatalf("connector/op not baked: %+v", body)
+	}
+	if body.Target["name"] != "rdc-vault" {
+		t.Fatalf("target name = %v, want rdc-vault", body.Target["name"])
+	}
+	if body.Params["path"] != "p" {
+		t.Fatalf("params not threaded: %+v", body.Params)
+	}
+}
+
+func TestCallEmptyTargetSerialisesNull(t *testing.T) {
+	c, last := capturingConn("c", []byte(`{"status":"ok"}`), nil)
+	if _, err := c.Call(context.Background(), "https://bp", "op", "", nil); err != nil {
+		t.Fatalf("Call: %v", err)
+	}
+	if got := string(*last); !strings.Contains(got, `"target":null`) {
+		t.Fatalf("empty target should serialise null, got %s", got)
+	}
+}
+
+func TestCallWithTargetThreadsExtraKeys(t *testing.T) {
+	c, last := capturingConn("vcfa-rest-9.0", []byte(`{"status":"ok"}`), nil)
+	target := map[string]any{"name": "vcfa", "fqdn": "vra.lab"}
+	if _, err := c.CallWithTarget(context.Background(), "https://bp", "op", target, nil); err != nil {
+		t.Fatalf("CallWithTarget: %v", err)
+	}
+	var body CallRequestBody
+	_ = json.Unmarshal(*last, &body)
+	if body.Target["fqdn"] != "vra.lab" {
+		t.Fatalf("fqdn not threaded into target: %+v", body.Target)
+	}
+}
+
+func TestRenderStatusMapping(t *testing.T) {
+	c := Connector{ID: "c"}
+	cases := []struct {
+		status  string
+		wantErr error
+	}{
+		{"ok", nil},
+		{"error", ErrOpError},
+		{"denied", ErrOpError},
+	}
+	for _, tc := range cases {
+		cmd := &cobra.Command{}
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		r := &CallResult{Status: tc.status, OpID: "op"}
+		err := c.Render(cmd, "op", r, false, nil)
+		if !errors.Is(err, tc.wantErr) {
+			t.Fatalf("status %q: err = %v, want %v", tc.status, err, tc.wantErr)
+		}
+	}
+}
+
+func TestRenderInvalidStatusReturnsRenderError(t *testing.T) {
+	c := Connector{ID: "c"}
+	cmd := &cobra.Command{}
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	err := c.Render(cmd, "op", &CallResult{Status: "weird"}, false, nil)
+	if err == nil || errors.Is(err, ErrOpError) {
+		t.Fatalf("invalid status should yield a non-ErrOpError render error, got %v", err)
+	}
+}
+
+func TestPrintGenericSuccessRendersResult(t *testing.T) {
+	c := Connector{ID: "vault-1.x"}
+	var buf bytes.Buffer
+	c.PrintGeneric(&buf, "vault.kv.read", &CallResult{
+		Status: "ok", Result: json.RawMessage(`{"k":"v"}`), DurationMs: 12,
+	})
+	out := buf.String()
+	if !strings.Contains(out, "vault-1.x vault.kv.read") || !strings.Contains(out, `"k": "v"`) {
+		t.Fatalf("unexpected generic render:\n%s", out)
+	}
+}
+
+func TestPrettyJSON(t *testing.T) {
+	got, err := PrettyJSON(json.RawMessage(`{"b":1,"a":2}`))
+	if err != nil {
+		t.Fatalf("PrettyJSON: %v", err)
+	}
+	if !strings.Contains(got, "\n  ") {
+		t.Fatalf("expected 2-space indent, got %q", got)
+	}
+	if _, err := PrettyJSON(json.RawMessage(`{bad`)); err == nil {
+		t.Fatalf("expected error on malformed JSON")
+	}
+}


### PR DESCRIPTION
## Why

Each per-vendor CLI command package carried a **byte-identical `dispatch.go`** (`CallResult`, `callRequestBody`, `errOpError`, `dispatchOp`, `renderCallResult`, `printGenericResult`, `prettyJSON`) — duplicated only because sibling `cmd/*` packages can't import one another without an import cycle. This is the dominant production duplication SonarCloud reported on `cli/`.

This PR is **Cluster B** of #923 (the 11 `dispatch.go` files). The transport/error helpers (`resolveBackplane`, `doAuthedRequest`, `classifyBackplaneError`, `renderRequestError` — ~20 copies) are **Cluster A**, a deliberate follow-up.

## What

New leaf package `cli/internal/dispatch` holds the logic once, parameterised by a `Connector{ID, Request}`:

- `Call` / `CallWithTarget` — the latter threads extra target keys (e.g. `cmd/vcf-automation`'s per-call `fqdn` vhost override)
- `Render` — status enum → JSON/human render → `ErrOpError` mapping
- `PrintGeneric`, `PrettyJSON`, `CallResult`, `CallRequestBody`, `ErrOpError`

Each vendor package now keeps only a ~23-line `dispatch.go`: a `CallResult`/`callRequestBody` **alias** (so verb files + tests are unchanged), the `errOpError` alias, and `var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}`. Call-sites became `conn.Call(...)` / `conn.Render(...)`. Vendor-specific helpers stay put (harbor `decodeHarborList`; bind9 row/flat decoders + renderers; k8s addr-flags + `dispatchVerb`; vcf-automation fqdn wrapper + `jsonUnmarshalStrict`).

**Net −1,297 lines** (1,940 deleted, 643 added). Per-package `dispatch.go` shrank from 144–261 lines to 23 (or 41–109 where vendor helpers remain).

## Behaviour-preserving

Same wire body, same render output, same exit-code mapping. Compatible with CLAUDE.md **postulate 5** — this DRYs transport plumbing only; per-vendor verbs, operation IDs, and help text stay explicit (CLI is not a thin wrapper).

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` (clean)
- `go test ./...` — **28 packages ok, 0 failures** (the 11 packages' existing tests exercise the shared core through `conn.Call`)
- `golangci-lint run` — **0 issues**
- New `dispatch_test.go` — direct coverage of the shared core (73.6%)

Refs #923.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated operation dispatch and rendering logic across all CLI command packages into a shared central dispatch core for improved code maintainability and consistency across vendor integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->