### PR TITLE
refactor(cli): extract backplane URL-resolve + error-classify helpers (Cluster A subset of #923)

### DIFF
--- a/cli/internal/backplane/backplane.go
+++ b/cli/internal/backplane/backplane.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package backplane holds the backplane-URL resolution + error
+// classification helpers shared by every cmd/* command package. Before
+// it, each package carried a byte-identical resolveBackplane /
+// classifyBackplaneError / normaliseURL / errNoBackplaneConfigured —
+// duplicated only because sibling cmd/* packages can't import one
+// another without an import cycle (cmd/root.go grafts each onto the
+// tree). The per-package transport (doAuthedRequest) and error-render
+// (renderRequestError) helpers stay put: they have genuine per-connector
+// variants (response-size caps, overflow handling) that aren't safe to
+// merge mechanically.
+package backplane
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// NotConfiguredError wraps auth.ErrConfigNotFound so callers can
+// distinguish "operator never logged in" (→ auth_expired exit code 2 —
+// the fix is `meho login`) from URL-parse failures (→ unexpected exit
+// code 4 — the fix is correcting argv).
+type NotConfiguredError struct{ Inner error }
+
+func (e *NotConfiguredError) Error() string {
+	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
+}
+
+func (e *NotConfiguredError) Unwrap() error { return e.Inner }
+
+// Resolve returns the backplane URL: the --backplane override when set,
+// otherwise the URL recorded by the most recent `meho login`. A missing
+// config surfaces as *NotConfiguredError so ClassifyError can route it
+// to auth_expired.
+func Resolve(override string) (string, error) {
+	if override != "" {
+		return NormaliseURL(override)
+	}
+	cfg, err := auth.LoadConfig()
+	if err != nil {
+		if errors.Is(err, auth.ErrConfigNotFound) {
+			return "", &NotConfiguredError{Inner: err}
+		}
+		return "", err
+	}
+	return NormaliseURL(cfg.BackplaneURL)
+}
+
+// ClassifyError maps a Resolve error to the right output.StructuredError
+// category: missing-config → auth_expired; everything else (parse / fs
+// errors) → unexpected.
+func ClassifyError(err error) *output.StructuredError {
+	if errors.Is(err, auth.ErrConfigNotFound) {
+		return output.AuthExpired(err.Error())
+	}
+	return output.Unexpected(err.Error())
+}
+
+// NormaliseURL strips trailing slashes + parses the URL to fail fast on
+// garbage input.
+func NormaliseURL(s string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
+	if trimmed == "" {
+		return "", errors.New("backplane URL is empty")
+	}
+	u, err := url.ParseRequestURI(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("backplane URL %q has no host", s)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}

--- a/cli/internal/backplane/backplane_test.go
+++ b/cli/internal/backplane/backplane_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package backplane
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+func TestNormaliseURLTrimsAndValidates(t *testing.T) {
+	got, err := NormaliseURL("https://meho.test/")
+	if err != nil || got != "https://meho.test" {
+		t.Fatalf("NormaliseURL: got %q, err %v", got, err)
+	}
+	if _, err := NormaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("blank URL should error 'empty', got %v", err)
+	}
+	if _, err := NormaliseURL("notaurl"); err == nil {
+		t.Fatalf("malformed URL should error")
+	}
+}
+
+func TestResolveOverrideWins(t *testing.T) {
+	got, err := Resolve("https://override.test/")
+	if err != nil || got != "https://override.test" {
+		t.Fatalf("Resolve(override): got %q, err %v", got, err)
+	}
+}
+
+func TestClassifyError(t *testing.T) {
+	notConfigured := &NotConfiguredError{Inner: auth.ErrConfigNotFound}
+	if se := ClassifyError(notConfigured); se == nil || se.Code != "auth_expired" {
+		t.Fatalf("not-configured should classify as auth_expired, got %+v", se)
+	}
+	if se := ClassifyError(errors.New("parse boom")); se == nil || se.Code != "unexpected_response" {
+		t.Fatalf("arbitrary error should classify as unexpected_response, got %+v", se)
+	}
+}
+
+func TestNotConfiguredErrorUnwrapsToConfigNotFound(t *testing.T) {
+	err := &NotConfiguredError{Inner: auth.ErrConfigNotFound}
+	if !errors.Is(err, auth.ErrConfigNotFound) {
+		t.Fatalf("NotConfiguredError should unwrap to auth.ErrConfigNotFound")
+	}
+	if !strings.Contains(err.Error(), "meho login") {
+		t.Fatalf("error message should hint `meho login`, got %q", err.Error())
+	}
+}

--- a/cli/internal/cmd/audit/audit.go
+++ b/cli/internal/cmd/audit/audit.go
@@ -45,7 +45,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -115,65 +114,6 @@ type Entry struct {
 type QueryResult struct {
 	Rows       []Entry `json:"rows"`
 	NextCursor *string `json:"next_cursor"`
-}
-
-// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers
-// can distinguish "operator never logged in" from a generic resolver
-// failure. Same shape as the helpers in
-// cli/internal/cmd/targets/targets.go and operation/operation.go;
-// kept independent because importing those packages here would
-// create cycles via cmd/root.go.
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
-// resolveBackplane resolves the backplane URL from either the
-// `--backplane` override or the `meho login` config file. Same shape
-// as the targets / operation package helpers — duplicated to avoid
-// the import cycle the cmd → cmd/audit → cmd path would create.
-func resolveBackplane(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
-	}
-	cfg, err := auth.LoadConfig()
-	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
-	}
-	return normaliseURL(cfg.BackplaneURL)
-}
-
-// classifyBackplaneError maps a resolveBackplane error to the right
-// output.StructuredError category.
-func classifyBackplaneError(err error) *output.StructuredError {
-	if errors.Is(err, auth.ErrConfigNotFound) {
-		return output.AuthExpired(err.Error())
-	}
-	return output.Unexpected(err.Error())
-}
-
-// normaliseURL strips trailing slashes and parses the URL to fail
-// fast on garbage input. Mirrors normaliseURL in
-// targets/targets.go and operation/operation.go.
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
-	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
 }
 
 // renderRequestError translates an error from one of the per-verb

--- a/cli/internal/cmd/audit/audit_test.go
+++ b/cli/internal/cmd/audit/audit_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 )
 
 // seedXDGAndToken seeds a per-test config dir + token store that
@@ -98,7 +99,7 @@ func TestNewRootCmdRegistersAllFiveVerbs(t *testing.T) {
 // targets / operation helpers; the trailing slash invariant is
 // load-bearing for the request paths assembled on top.
 func TestNormaliseURLStripsTrailingSlash(t *testing.T) {
-	got, err := normaliseURL("https://meho.example/")
+	got, err := backplane.NormaliseURL("https://meho.example/")
 	if err != nil {
 		t.Fatalf("normaliseURL: %v", err)
 	}
@@ -110,7 +111,7 @@ func TestNormaliseURLStripsTrailingSlash(t *testing.T) {
 // TestNormaliseURLRejectsHostlessInput — bare paths fail fast rather
 // than producing a request against the local filesystem.
 func TestNormaliseURLRejectsHostlessInput(t *testing.T) {
-	if _, err := normaliseURL("/just/a/path"); err == nil {
+	if _, err := backplane.NormaliseURL("/just/a/path"); err == nil {
 		t.Errorf("expected error for hostless URL")
 	}
 }
@@ -118,7 +119,7 @@ func TestNormaliseURLRejectsHostlessInput(t *testing.T) {
 // TestNormaliseURLRejectsGarbage — a fundamentally unparseable URL
 // surfaces the parse error rather than the silently-empty resolver.
 func TestNormaliseURLRejectsGarbage(t *testing.T) {
-	if _, err := normaliseURL("h ttp://broken"); err == nil {
+	if _, err := backplane.NormaliseURL("h ttp://broken"); err == nil {
 		t.Errorf("expected error for malformed URL")
 	}
 }
@@ -126,7 +127,7 @@ func TestNormaliseURLRejectsGarbage(t *testing.T) {
 // TestNormaliseURLRejectsEmpty — empty config slot must reach the
 // caller as an error rather than producing a zero-host request.
 func TestNormaliseURLRejectsEmpty(t *testing.T) {
-	if _, err := normaliseURL("   "); err == nil {
+	if _, err := backplane.NormaliseURL("   "); err == nil {
 		t.Errorf("expected error for empty URL")
 	}
 }

--- a/cli/internal/cmd/audit/my_recent.go
+++ b/cli/internal/cmd/audit/my_recent.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -82,9 +83,9 @@ func runMyRecent(cmd *cobra.Command, opts myRecentOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	result, err := getMyRecent(cmd.Context(), backplaneURL, opts)
 	if err != nil {

--- a/cli/internal/cmd/audit/query.go
+++ b/cli/internal/cmd/audit/query.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -163,9 +164,9 @@ func runQuery(cmd *cobra.Command, opts queryOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	result, err := postQuery(cmd.Context(), backplaneURL, opts)
 	if err != nil {

--- a/cli/internal/cmd/audit/show.go
+++ b/cli/internal/cmd/audit/show.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -82,9 +83,9 @@ func runShow(cmd *cobra.Command, opts showOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	entry, err := getEntry(cmd.Context(), backplaneURL, opts.AuditID)
 	if err != nil {

--- a/cli/internal/cmd/audit/who_touched.go
+++ b/cli/internal/cmd/audit/who_touched.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -94,9 +95,9 @@ func runWhoTouched(cmd *cobra.Command, opts whoTouchedOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	result, err := getWhoTouched(cmd.Context(), backplaneURL, opts)
 	if err != nil {

--- a/cli/internal/cmd/bind9/about.go
+++ b/cli/internal/cmd/bind9/about.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -75,9 +76,9 @@ func newAboutCmd() *cobra.Command {
 }
 
 func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "bind9.about", targetName, nil)
 	if err != nil {

--- a/cli/internal/cmd/bind9/bind9.go
+++ b/cli/internal/cmd/bind9/bind9.go
@@ -45,14 +45,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -108,69 +106,6 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newRecordCmd())
 	cmd.AddCommand(newConfigCmd())
 	return cmd
-}
-
-// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers
-// can distinguish "operator never logged in" (→ auth_expired exit
-// code 2 — the right fix is `meho login`) from URL-parse failures
-// (→ unexpected exit code 4 — the right fix is correcting argv).
-// Same shape as the vmware / vault siblings; kept independent
-// because cmd/{operation,connector,kb,vmware,vault,bind9} can't
-// import each other without an import cycle (cmd/root.go grafts each
-// onto the tree).
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
-// resolveBackplane mirrors the vmware / vault sibling helpers:
-// --backplane override flag wins; otherwise read the URL the most
-// recent `meho login` wrote to config.json. Missing config surfaces
-// as errNoBackplaneConfigured so classifyBackplaneError can route
-// it to auth_expired.
-func resolveBackplane(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
-	}
-	cfg, err := auth.LoadConfig()
-	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
-	}
-	return normaliseURL(cfg.BackplaneURL)
-}
-
-// classifyBackplaneError maps a resolveBackplane error to the right
-// output.StructuredError category. Identical routing to the vmware /
-// vault siblings: missing-config → auth_expired; everything else
-// (parse errors, fs errors) → unexpected.
-func classifyBackplaneError(err error) *output.StructuredError {
-	if errors.Is(err, auth.ErrConfigNotFound) {
-		return output.AuthExpired(err.Error())
-	}
-	return output.Unexpected(err.Error())
-}
-
-// normaliseURL strips trailing slashes + parses the URL to fail fast
-// on garbage input. Mirrors the vmware / vault siblings.
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
-	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
 }
 
 // renderRequestError translates an error from doAuthedRequest into

--- a/cli/internal/cmd/bind9/bind9_test.go
+++ b/cli/internal/cmd/bind9/bind9_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 )
 
 // ---------- helper tests (pure-function) ----------
@@ -56,14 +57,14 @@ func TestTruncatePassthroughAndCut(t *testing.T) {
 // TestNormaliseURLBasic mirrors the vmware sibling — trailing-slash
 // trimming + reject-empty are the load-bearing properties.
 func TestNormaliseURLBasic(t *testing.T) {
-	got, err := normaliseURL("https://meho.test/")
+	got, err := backplane.NormaliseURL("https://meho.test/")
 	if err != nil {
 		t.Fatalf("normaliseURL: %v", err)
 	}
 	if got != "https://meho.test" {
 		t.Fatalf("expected trailing slash stripped; got %q", got)
 	}
-	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+	if _, err := backplane.NormaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
 		t.Fatalf("empty should reject; got %v", err)
 	}
 }
@@ -72,12 +73,12 @@ func TestNormaliseURLBasic(t *testing.T) {
 // any wrapping error) maps to AuthExpired; everything else maps
 // to Unexpected.
 func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
-	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
-	se := classifyBackplaneError(wrapped)
+	wrapped := &backplane.NotConfiguredError{Inner: auth.ErrConfigNotFound}
+	se := backplane.ClassifyError(wrapped)
 	if se == nil || se.Code != "auth_expired" {
 		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
 	}
-	se = classifyBackplaneError(errors.New("parse failure"))
+	se = backplane.ClassifyError(errors.New("parse failure"))
 	if se == nil || se.Code != "unexpected_response" {
 		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
 	}

--- a/cli/internal/cmd/bind9/config.go
+++ b/cli/internal/cmd/bind9/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -70,9 +71,9 @@ func newConfigShowCmd() *cobra.Command {
 }
 
 func runConfigShow(cmd *cobra.Command, path, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params := map[string]any{"path": path}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "bind9.config.show", targetName, params)
@@ -169,9 +170,9 @@ func runConfigApplyViews(
 	viewsConfPath, zonesDir, primaryPath, verifyFQDN, targetName string,
 	jsonOut bool, backplaneOverride string,
 ) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	files, err := assembleViewsBundle(viewsConfPath, zonesDir)
 	if err != nil {
@@ -320,9 +321,9 @@ func newConfigApplyFileCmd() *cobra.Command {
 }
 
 func runConfigApplyFile(cmd *cobra.Command, name, localSrc, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	content, err := readLocalFile(localSrc)
 	if err != nil {
@@ -381,9 +382,9 @@ func newConfigBackupCmd() *cobra.Command {
 }
 
 func runConfigBackup(cmd *cobra.Command, tag, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params := map[string]any{}
 	if tag != "" {
@@ -472,9 +473,9 @@ func newConfigReloadCmd() *cobra.Command {
 }
 
 func runConfigReload(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "bind9.config.reload", targetName, nil)
 	if err != nil {

--- a/cli/internal/cmd/bind9/record.go
+++ b/cli/internal/cmd/bind9/record.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -71,9 +72,9 @@ func newRecordGetCmd() *cobra.Command {
 }
 
 func runRecordGet(cmd *cobra.Command, fqdn, recordType, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params := map[string]any{"fqdn": fqdn}
 	if recordType != "" {
@@ -185,9 +186,9 @@ func newRecordAddCmd() *cobra.Command {
 }
 
 func runRecordAdd(cmd *cobra.Command, fqdn, ip, zone, recordType, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params := map[string]any{
 		"fqdn": fqdn,
@@ -246,9 +247,9 @@ func newRecordRemoveCmd() *cobra.Command {
 }
 
 func runRecordRemove(cmd *cobra.Command, fqdn, zone, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params := map[string]any{"fqdn": fqdn}
 	if zone != "" {

--- a/cli/internal/cmd/bind9/zone.go
+++ b/cli/internal/cmd/bind9/zone.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -61,9 +62,9 @@ func newZoneListCmd() *cobra.Command {
 }
 
 func runZoneList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "bind9.zone.list", targetName, nil)
 	if err != nil {
@@ -139,9 +140,9 @@ func newZoneReadCmd() *cobra.Command {
 }
 
 func runZoneRead(cmd *cobra.Command, zone, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params := map[string]any{"zone": zone}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "bind9.zone.read", targetName, params)

--- a/cli/internal/cmd/harbor/about.go
+++ b/cli/internal/cmd/harbor/about.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -48,9 +49,9 @@ func newAboutCmd() *cobra.Command {
 }
 
 func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v2.0/systeminfo", targetName, nil)
 	if err != nil {
@@ -128,9 +129,9 @@ func newHealthCmd() *cobra.Command {
 }
 
 func runHealth(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v2.0/health", targetName, nil)
 	if err != nil {

--- a/cli/internal/cmd/harbor/artifact.go
+++ b/cli/internal/cmd/harbor/artifact.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -53,9 +54,9 @@ func newArtifactListCmd() *cobra.Command {
 }
 
 func runArtifactList(cmd *cobra.Command, projectName, repoName, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	opID := "GET:/api/v2.0/projects/{project_name}/repositories/{repository_name}/artifacts"
 	params := map[string]any{
@@ -140,9 +141,9 @@ func newArtifactInfoCmd() *cobra.Command {
 }
 
 func runArtifactInfo(cmd *cobra.Command, projectName, repoName, reference, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	opID := "GET:/api/v2.0/projects/{project_name}/repositories/{repository_name}/artifacts/{reference}"
 	params := map[string]any{

--- a/cli/internal/cmd/harbor/harbor.go
+++ b/cli/internal/cmd/harbor/harbor.go
@@ -35,14 +35,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -74,50 +72,6 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newRobotCmd())
 	cmd.AddCommand(newOperationCmd())
 	return cmd
-}
-
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
-func resolveBackplane(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
-	}
-	cfg, err := auth.LoadConfig()
-	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
-	}
-	return normaliseURL(cfg.BackplaneURL)
-}
-
-func classifyBackplaneError(err error) *output.StructuredError {
-	if errors.Is(err, auth.ErrConfigNotFound) {
-		return output.AuthExpired(err.Error())
-	}
-	return output.Unexpected(err.Error())
-}
-
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
-	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
 }
 
 func renderRequestError(

--- a/cli/internal/cmd/harbor/harbor_test.go
+++ b/cli/internal/cmd/harbor/harbor_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 )
 
 // ---------- helper tests ----------
@@ -40,25 +41,25 @@ func TestTruncatePassthroughAndCut(t *testing.T) {
 }
 
 func TestNormaliseURLBasic(t *testing.T) {
-	got, err := normaliseURL("https://meho.test/")
+	got, err := backplane.NormaliseURL("https://meho.test/")
 	if err != nil {
 		t.Fatalf("normaliseURL: %v", err)
 	}
 	if got != "https://meho.test" {
 		t.Fatalf("expected trailing slash stripped; got %q", got)
 	}
-	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+	if _, err := backplane.NormaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
 		t.Fatalf("empty should reject; got %v", err)
 	}
 }
 
 func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
-	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
-	se := classifyBackplaneError(wrapped)
+	wrapped := &backplane.NotConfiguredError{Inner: auth.ErrConfigNotFound}
+	se := backplane.ClassifyError(wrapped)
 	if se == nil || se.Code != "auth_expired" {
 		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
 	}
-	se = classifyBackplaneError(errors.New("parse failure"))
+	se = backplane.ClassifyError(errors.New("parse failure"))
 	if se == nil || se.Code != "unexpected_response" {
 		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
 	}

--- a/cli/internal/cmd/harbor/operation.go
+++ b/cli/internal/cmd/harbor/operation.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -83,9 +84,9 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 			output.Unexpected(fmt.Sprintf("--limit must be >= 1; got %d", limit)),
 			jsonOut)
 	}
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
 	if err != nil {
@@ -168,9 +169,9 @@ func newOperationCallCmd() *cobra.Command {
 }
 
 func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params, err := loadParamsFlag(paramsFlag)
 	if err != nil {

--- a/cli/internal/cmd/harbor/project.go
+++ b/cli/internal/cmd/harbor/project.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -53,9 +54,9 @@ func newProjectListCmd() *cobra.Command {
 }
 
 func runProjectList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v2.0/projects", targetName, nil)
 	if err != nil {
@@ -128,9 +129,9 @@ func newProjectInfoCmd() *cobra.Command {
 }
 
 func runProjectInfo(cmd *cobra.Command, projectName, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	opID := "GET:/api/v2.0/projects/{project_name}"
 	params := map[string]any{"project_name": projectName}

--- a/cli/internal/cmd/harbor/repository.go
+++ b/cli/internal/cmd/harbor/repository.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -54,9 +55,9 @@ func newRepositoryListCmd() *cobra.Command {
 }
 
 func runRepositoryList(cmd *cobra.Command, projectName, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	opID := "GET:/api/v2.0/projects/{project_name}/repositories"
 	params := map[string]any{"project_name": projectName}
@@ -127,9 +128,9 @@ func newRepositoryInfoCmd() *cobra.Command {
 }
 
 func runRepositoryInfo(cmd *cobra.Command, projectName, repoName, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	opID := "GET:/api/v2.0/projects/{project_name}/repositories/{repository_name}"
 	params := map[string]any{

--- a/cli/internal/cmd/harbor/robot.go
+++ b/cli/internal/cmd/harbor/robot.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -56,9 +57,9 @@ func newRobotListCmd() *cobra.Command {
 }
 
 func runRobotList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v2.0/robots", targetName, nil)
 	if err != nil {
@@ -147,9 +148,9 @@ func newRobotCreateCmd() *cobra.Command {
 }
 
 func runRobotCreate(cmd *cobra.Command, robotName, projectName string, duration int, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params := map[string]any{
 		"name":     robotName,
@@ -225,9 +226,9 @@ func newRobotDeleteCmd() *cobra.Command {
 }
 
 func runRobotDelete(cmd *cobra.Command, projectName string, robotID int, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params := map[string]any{
 		"project": projectName,

--- a/cli/internal/cmd/k8s/dispatch.go
+++ b/cli/internal/cmd/k8s/dispatch.go
@@ -6,6 +6,7 @@ package k8s
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -52,9 +53,9 @@ func bindK8sAddrFlags(cmd *cobra.Command) *k8sAddrFlags {
 // every K8s verb shares. opID + params come from the verb; the shared
 // address flags carry target / json / backplane.
 func dispatchVerb(cmd *cobra.Command, f *k8sAddrFlags, opID string, params map[string]any) error {
-	backplaneURL, err := resolveBackplane(f.backplaneOverride)
+	backplaneURL, err := backplane.Resolve(f.backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), f.jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), f.jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, opID, f.targetName, params)
 	if err != nil {

--- a/cli/internal/cmd/k8s/k8s.go
+++ b/cli/internal/cmd/k8s/k8s.go
@@ -52,14 +52,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -123,66 +121,6 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newEventCmd())
 	cmd.AddCommand(newLogsCmd())
 	return cmd
-}
-
-// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers can
-// distinguish "operator never logged in" (→ auth_expired exit code 2)
-// from URL-parse failures (→ unexpected exit code 4). Same shape as
-// the vault / vmware siblings; kept independent because the cmd
-// packages can't import each other without an import cycle (cmd/root.go
-// grafts each onto the tree).
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
-// resolveBackplane mirrors the vault sibling helper: --backplane
-// override flag wins; otherwise read the URL the most recent
-// `meho login` wrote to config.json. Missing config surfaces as
-// errNoBackplaneConfigured so classifyBackplaneError can route it to
-// auth_expired.
-func resolveBackplane(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
-	}
-	cfg, err := auth.LoadConfig()
-	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
-	}
-	return normaliseURL(cfg.BackplaneURL)
-}
-
-// classifyBackplaneError maps a resolveBackplane error to the right
-// output.StructuredError category. Same routing as the vault sibling:
-// missing-config → auth_expired; everything else → unexpected.
-func classifyBackplaneError(err error) *output.StructuredError {
-	if errors.Is(err, auth.ErrConfigNotFound) {
-		return output.AuthExpired(err.Error())
-	}
-	return output.Unexpected(err.Error())
-}
-
-// normaliseURL strips trailing slashes + parses the URL to fail fast
-// on garbage input. Mirrors the vault sibling.
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
-	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
 }
 
 // renderRequestError translates an error from doAuthedRequest into the

--- a/cli/internal/cmd/k8s/k8s_test.go
+++ b/cli/internal/cmd/k8s/k8s_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 )
 
 // ---------- pure-function helpers ----------
@@ -43,14 +44,14 @@ func TestTruncatePassthroughAndCut(t *testing.T) {
 
 // TestNormaliseURLBasic — trailing-slash trimming + reject-empty.
 func TestNormaliseURLBasic(t *testing.T) {
-	got, err := normaliseURL("https://meho.test/")
+	got, err := backplane.NormaliseURL("https://meho.test/")
 	if err != nil {
 		t.Fatalf("normaliseURL: %v", err)
 	}
 	if got != "https://meho.test" {
 		t.Fatalf("expected trailing slash stripped; got %q", got)
 	}
-	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+	if _, err := backplane.NormaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
 		t.Fatalf("empty should reject; got %v", err)
 	}
 }
@@ -58,12 +59,12 @@ func TestNormaliseURLBasic(t *testing.T) {
 // TestClassifyBackplaneErrorRoutesByCause — ErrConfigNotFound (or any
 // wrapping error) maps to AuthExpired; everything else to Unexpected.
 func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
-	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
-	se := classifyBackplaneError(wrapped)
+	wrapped := &backplane.NotConfiguredError{Inner: auth.ErrConfigNotFound}
+	se := backplane.ClassifyError(wrapped)
 	if se == nil || se.Code != "auth_expired" {
 		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
 	}
-	se = classifyBackplaneError(errors.New("parse failure"))
+	se = backplane.ClassifyError(errors.New("parse failure"))
 	if se == nil || se.Code != "unexpected_response" {
 		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
 	}

--- a/cli/internal/cmd/kb/add.go
+++ b/cli/internal/cmd/kb/add.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -133,9 +134,9 @@ func runAdd(cmd *cobra.Command, opts addOptions) error {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(err.Error()), opts.JSONOut)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	entry, err := postAdd(cmd.Context(), backplaneURL, opts.Slug, body, metadata)
 	if err != nil {

--- a/cli/internal/cmd/kb/delete.go
+++ b/cli/internal/cmd/kb/delete.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -121,9 +122,9 @@ func runDelete(cmd *cobra.Command, opts deleteOptions) error {
 			return nil
 		}
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	if err := callDelete(cmd.Context(), backplaneURL, opts.Slug); err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)

--- a/cli/internal/cmd/kb/ingest.go
+++ b/cli/internal/cmd/kb/ingest.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -113,9 +114,9 @@ func runIngest(cmd *cobra.Command, opts ingestOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	result, err := postIngest(cmd.Context(), backplaneURL, opts)
 	if err != nil {

--- a/cli/internal/cmd/kb/kb.go
+++ b/cli/internal/cmd/kb/kb.go
@@ -59,7 +59,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -168,20 +167,6 @@ type RetrieveResponse struct {
 	QueryDurationMS float64        `json:"query_duration_ms"`
 }
 
-// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers
-// can distinguish "operator never logged in" (→ auth_expired exit
-// code 2 — the right fix is `meho login`) from URL-parse failures
-// (→ unexpected exit code 4 — the right fix is correcting argv).
-// Same shape as the helper in cli/internal/cmd/audit/audit.go;
-// kept independent because importing those packages would create
-// cycles via cmd/root.go.
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
 // errMissingAccessToken is the sentinel doAuthedRequest returns
 // when the stored token row exists but its `access_token` field is
 // empty. It's a credential-state failure rather than a transport
@@ -191,54 +176,6 @@ func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
 // here that falls through to unreachable; the local fix here is
 // scoped to the kb package (m3 in the review punch list).
 var errMissingAccessToken = errors.New("meho: stored token has no access_token")
-
-// resolveBackplane resolves the backplane URL from either the
-// `--backplane` override or the `meho login` config file. Same shape
-// as the audit / targets / operation package helpers — duplicated
-// to avoid the import cycle the cmd → cmd/kb → cmd path would
-// create.
-func resolveBackplane(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
-	}
-	cfg, err := auth.LoadConfig()
-	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
-	}
-	return normaliseURL(cfg.BackplaneURL)
-}
-
-// classifyBackplaneError maps a resolveBackplane error to the right
-// output.StructuredError category. Identical contract to the
-// audit / targets sibling.
-func classifyBackplaneError(err error) *output.StructuredError {
-	if errors.Is(err, auth.ErrConfigNotFound) {
-		return output.AuthExpired(err.Error())
-	}
-	return output.Unexpected(err.Error())
-}
-
-// normaliseURL strips trailing slashes and parses the URL to fail
-// fast on garbage input. Mirrors normaliseURL in audit/audit.go and
-// targets/targets.go.
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
-	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
-}
 
 // renderRequestError translates an error from one of the per-verb
 // request helpers into the right output.StructuredError category.

--- a/cli/internal/cmd/kb/kb_test.go
+++ b/cli/internal/cmd/kb/kb_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 )
 
 // seedXDGAndToken seeds a per-test config dir + token store that
@@ -114,7 +115,7 @@ func TestRootCmdHelpListsAllVerbs(t *testing.T) {
 // TestNormaliseURLStripsTrailingSlash — the resolver mirrors the
 // sibling packages; trailing-slash trimming is the v0.2 convention.
 func TestNormaliseURLStripsTrailingSlash(t *testing.T) {
-	got, err := normaliseURL("https://meho.test/")
+	got, err := backplane.NormaliseURL("https://meho.test/")
 	if err != nil {
 		t.Fatalf("normaliseURL: %v", err)
 	}
@@ -126,7 +127,7 @@ func TestNormaliseURLStripsTrailingSlash(t *testing.T) {
 // TestNormaliseURLRejectsHostless — bare paths fail fast rather
 // than producing a request against the local filesystem.
 func TestNormaliseURLRejectsHostless(t *testing.T) {
-	if _, err := normaliseURL("/just/a/path"); err == nil {
+	if _, err := backplane.NormaliseURL("/just/a/path"); err == nil {
 		t.Errorf("expected error for hostless URL")
 	}
 }
@@ -134,7 +135,7 @@ func TestNormaliseURLRejectsHostless(t *testing.T) {
 // TestNormaliseURLRejectsEmpty — empty input returns the "empty"
 // error string callers depend on.
 func TestNormaliseURLRejectsEmpty(t *testing.T) {
-	if _, err := normaliseURL("   "); err == nil {
+	if _, err := backplane.NormaliseURL("   "); err == nil {
 		t.Errorf("expected error for empty URL")
 	}
 }
@@ -144,13 +145,13 @@ func TestNormaliseURLRejectsEmpty(t *testing.T) {
 // to Unexpected. Same routing ladder as the audit / targets
 // siblings.
 func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
-	wrappedNotFound := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
-	se := classifyBackplaneError(wrappedNotFound)
+	wrappedNotFound := &backplane.NotConfiguredError{Inner: auth.ErrConfigNotFound}
+	se := backplane.ClassifyError(wrappedNotFound)
 	if se == nil || se.Code != "auth_expired" {
 		t.Fatalf("ErrConfigNotFound wrapper should classify as auth_expired; got %+v", se)
 	}
 	parseFailure := errors.New("invalid URL")
-	se = classifyBackplaneError(parseFailure)
+	se = backplane.ClassifyError(parseFailure)
 	if se == nil || se.Code != "unexpected_response" {
 		t.Fatalf("parse failure should classify as unexpected; got %+v", se)
 	}

--- a/cli/internal/cmd/kb/list.go
+++ b/cli/internal/cmd/kb/list.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -104,9 +105,9 @@ func runList(cmd *cobra.Command, opts listOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	resp, err := getList(cmd.Context(), backplaneURL, opts)
 	if err != nil {

--- a/cli/internal/cmd/kb/search.go
+++ b/cli/internal/cmd/kb/search.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -113,9 +114,9 @@ func runSearch(cmd *cobra.Command, opts searchOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	resp, err := postSearch(cmd.Context(), backplaneURL, opts)
 	if err != nil {

--- a/cli/internal/cmd/kb/show.go
+++ b/cli/internal/cmd/kb/show.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -89,9 +90,9 @@ func runShow(cmd *cobra.Command, opts showOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	entry, err := getEntry(cmd.Context(), backplaneURL, opts.Slug)
 	if err != nil {

--- a/cli/internal/cmd/memory/forget.go
+++ b/cli/internal/cmd/memory/forget.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -145,10 +146,10 @@ func runForget(cmd *cobra.Command, opts forgetOptions) error {
 			return nil
 		}
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(),
-			classifyBackplaneError(err), opts.JSONOut)
+			backplane.ClassifyError(err), opts.JSONOut)
 	}
 	if err := callForget(cmd.Context(), backplaneURL, scope, slug, opts.TargetArg); err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)

--- a/cli/internal/cmd/memory/list.go
+++ b/cli/internal/cmd/memory/list.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -141,10 +142,10 @@ func runList(cmd *cobra.Command, opts listOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(),
-			classifyBackplaneError(err), opts.JSONOut)
+			backplane.ClassifyError(err), opts.JSONOut)
 	}
 	resp, err := getList(cmd.Context(), backplaneURL, opts)
 	if err != nil {

--- a/cli/internal/cmd/memory/memory.go
+++ b/cli/internal/cmd/memory/memory.go
@@ -55,7 +55,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -264,21 +263,6 @@ type retrieveRequest struct {
 	Limit  int    `json:"limit,omitempty"`
 }
 
-// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers
-// can distinguish "operator never logged in" (→ auth_expired exit
-// code 2 — fix is `meho login`) from URL-parse failures (→
-// unexpected exit code 4 — fix is correcting argv). Same shape as
-// the audit / kb / targets / connector siblings; duplicated here
-// because importing those packages would create cycles via
-// cmd/root.go (this package is registered onto the root the same
-// way they are).
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
 // errMissingAccessToken is the sentinel doAuthedRequest returns
 // when the stored token row exists but its access_token field is
 // empty. Routed to auth_expired (exit 2) with a `meho login` hint
@@ -302,52 +286,6 @@ const responseBodyCap int64 = 1 << 20
 // bodies are expected to be hand-written notes, not megabyte
 // blobs.
 const loadBodyStdinCap int64 = 1 << 20
-
-// resolveBackplane mirrors the kb / audit / targets sibling helper.
-// Returns the backplane URL from the --backplane override or the
-// `meho login` config; wraps auth.ErrConfigNotFound so an absent
-// config maps to auth_expired (exit 2), not unexpected (exit 4).
-func resolveBackplane(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
-	}
-	cfg, err := auth.LoadConfig()
-	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
-	}
-	return normaliseURL(cfg.BackplaneURL)
-}
-
-// classifyBackplaneError maps a resolveBackplane error to the right
-// output.StructuredError category. Identical contract to the kb /
-// audit / targets siblings.
-func classifyBackplaneError(err error) *output.StructuredError {
-	if errors.Is(err, auth.ErrConfigNotFound) {
-		return output.AuthExpired(err.Error())
-	}
-	return output.Unexpected(err.Error())
-}
-
-// normaliseURL strips trailing slashes and parses the URL to fail
-// fast on garbage input. Mirrors the sibling-package helpers.
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
-	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
-}
 
 // httpError carries a non-2xx response so per-verb runners can
 // render the right category. Same shape as the kb sibling.

--- a/cli/internal/cmd/memory/memory_test.go
+++ b/cli/internal/cmd/memory/memory_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 )
 
 // seedXDGAndToken seeds a per-test config dir + token store the way
@@ -256,7 +257,7 @@ func TestRequireTargetForScopeBlocks(t *testing.T) {
 }
 
 func TestNormaliseURLHappy(t *testing.T) {
-	got, err := normaliseURL("https://meho.test/")
+	got, err := backplane.NormaliseURL("https://meho.test/")
 	if err != nil {
 		t.Fatalf("normaliseURL: %v", err)
 	}
@@ -266,25 +267,25 @@ func TestNormaliseURLHappy(t *testing.T) {
 }
 
 func TestNormaliseURLRejectsHostless(t *testing.T) {
-	if _, err := normaliseURL("/just/a/path"); err == nil {
+	if _, err := backplane.NormaliseURL("/just/a/path"); err == nil {
 		t.Errorf("expected error for hostless URL")
 	}
 }
 
 func TestNormaliseURLRejectsEmpty(t *testing.T) {
-	if _, err := normaliseURL("   "); err == nil {
+	if _, err := backplane.NormaliseURL("   "); err == nil {
 		t.Errorf("expected error for empty URL")
 	}
 }
 
 func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
-	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
-	se := classifyBackplaneError(wrapped)
+	wrapped := &backplane.NotConfiguredError{Inner: auth.ErrConfigNotFound}
+	se := backplane.ClassifyError(wrapped)
 	if se == nil || se.Code != "auth_expired" {
 		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
 	}
 	other := errors.New("invalid URL")
-	se = classifyBackplaneError(other)
+	se = backplane.ClassifyError(other)
 	if se == nil || se.Code != "unexpected_response" {
 		t.Fatalf("other errors should classify as unexpected; got %+v", se)
 	}

--- a/cli/internal/cmd/memory/promote.go
+++ b/cli/internal/cmd/memory/promote.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -165,10 +166,10 @@ func runPromote(cmd *cobra.Command, opts promoteOptions) error {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(err.Error()), opts.JSONOut)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(),
-			classifyBackplaneError(err), opts.JSONOut)
+			backplane.ClassifyError(err), opts.JSONOut)
 	}
 	req := promoteRequest{
 		To:   targetScope,

--- a/cli/internal/cmd/memory/recall.go
+++ b/cli/internal/cmd/memory/recall.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -140,10 +141,10 @@ func runRecall(cmd *cobra.Command, opts recallOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(),
-			classifyBackplaneError(err), opts.JSONOut)
+			backplane.ClassifyError(err), opts.JSONOut)
 	}
 	if hasArg {
 		return runRecallByKey(cmd, backplaneURL, opts)

--- a/cli/internal/cmd/memory/remember.go
+++ b/cli/internal/cmd/memory/remember.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -179,10 +180,10 @@ func runRemember(cmd *cobra.Command, opts rememberOptions) error {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(err.Error()), opts.JSONOut)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(),
-			classifyBackplaneError(err), opts.JSONOut)
+			backplane.ClassifyError(err), opts.JSONOut)
 	}
 	req := rememberRequest{
 		Scope:      scope,

--- a/cli/internal/cmd/nsx/about.go
+++ b/cli/internal/cmd/nsx/about.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -51,9 +52,9 @@ func newAboutCmd() *cobra.Command {
 }
 
 func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v1/node", targetName, nil)
 	if err != nil {

--- a/cli/internal/cmd/nsx/cluster.go
+++ b/cli/internal/cmd/nsx/cluster.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -54,9 +55,9 @@ func newClusterStatusCmd() *cobra.Command {
 }
 
 func runClusterStatus(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v1/cluster/status", targetName, nil)
 	if err != nil {

--- a/cli/internal/cmd/nsx/firewall.go
+++ b/cli/internal/cmd/nsx/firewall.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -76,9 +77,9 @@ func newFirewallPolicyListCmd() *cobra.Command {
 }
 
 func runFirewallPolicyList(cmd *cobra.Command, scope, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	if scope == "" {
 		scope = "default"
@@ -170,9 +171,9 @@ func newFirewallRuleListCmd() *cobra.Command {
 }
 
 func runFirewallRuleList(cmd *cobra.Command, policyID, scope, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	if scope == "" {
 		scope = "default"

--- a/cli/internal/cmd/nsx/node.go
+++ b/cli/internal/cmd/nsx/node.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -54,9 +55,9 @@ func newNodeListCmd() *cobra.Command {
 }
 
 func runNodeList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v1/transport-nodes", targetName, nil)
 	if err != nil {

--- a/cli/internal/cmd/nsx/nsx.go
+++ b/cli/internal/cmd/nsx/nsx.go
@@ -32,14 +32,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -140,50 +138,6 @@ func printErrorTrailer(w io.Writer, r *CallResult) {
 			fmt.Fprintln(w, string(r.Extras))
 		}
 	}
-}
-
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
-func resolveBackplane(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
-	}
-	cfg, err := auth.LoadConfig()
-	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
-	}
-	return normaliseURL(cfg.BackplaneURL)
-}
-
-func classifyBackplaneError(err error) *output.StructuredError {
-	if errors.Is(err, auth.ErrConfigNotFound) {
-		return output.AuthExpired(err.Error())
-	}
-	return output.Unexpected(err.Error())
-}
-
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
-	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
 }
 
 func renderRequestError(

--- a/cli/internal/cmd/nsx/nsx_test.go
+++ b/cli/internal/cmd/nsx/nsx_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 )
 
 // ---------- helper tests ----------
@@ -40,25 +41,25 @@ func TestTruncatePassthroughAndCut(t *testing.T) {
 }
 
 func TestNormaliseURLBasic(t *testing.T) {
-	got, err := normaliseURL("https://meho.test/")
+	got, err := backplane.NormaliseURL("https://meho.test/")
 	if err != nil {
 		t.Fatalf("normaliseURL: %v", err)
 	}
 	if got != "https://meho.test" {
 		t.Fatalf("expected trailing slash stripped; got %q", got)
 	}
-	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+	if _, err := backplane.NormaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
 		t.Fatalf("empty should reject; got %v", err)
 	}
 }
 
 func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
-	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
-	se := classifyBackplaneError(wrapped)
+	wrapped := &backplane.NotConfiguredError{Inner: auth.ErrConfigNotFound}
+	se := backplane.ClassifyError(wrapped)
 	if se == nil || se.Code != "auth_expired" {
 		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
 	}
-	se = classifyBackplaneError(errors.New("parse failure"))
+	se = backplane.ClassifyError(errors.New("parse failure"))
 	if se == nil || se.Code != "unexpected_response" {
 		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
 	}

--- a/cli/internal/cmd/nsx/operation.go
+++ b/cli/internal/cmd/nsx/operation.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -83,9 +84,9 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 			output.Unexpected(fmt.Sprintf("--limit must be >= 1; got %d", limit)),
 			jsonOut)
 	}
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
 	if err != nil {
@@ -175,9 +176,9 @@ func newOperationCallCmd() *cobra.Command {
 }
 
 func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params, err := loadParamsFlag(paramsFlag)
 	if err != nil {

--- a/cli/internal/cmd/nsx/segment.go
+++ b/cli/internal/cmd/nsx/segment.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -54,9 +55,9 @@ func newSegmentListCmd() *cobra.Command {
 }
 
 func runSegmentList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	const opID = "GET:/policy/api/v1/infra/segments"
 	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, nil)

--- a/cli/internal/cmd/nsx/tier0.go
+++ b/cli/internal/cmd/nsx/tier0.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -54,9 +55,9 @@ func newTier0ListCmd() *cobra.Command {
 }
 
 func runTier0List(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	const opID = "GET:/policy/api/v1/infra/tier-0s"
 	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, nil)

--- a/cli/internal/cmd/nsx/tier1.go
+++ b/cli/internal/cmd/nsx/tier1.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -54,9 +55,9 @@ func newTier1ListCmd() *cobra.Command {
 }
 
 func runTier1List(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	const opID = "GET:/policy/api/v1/infra/tier-1s"
 	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, nil)

--- a/cli/internal/cmd/nsx/transportzone.go
+++ b/cli/internal/cmd/nsx/transportzone.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -57,9 +58,9 @@ func newTransportZoneListCmd() *cobra.Command {
 }
 
 func runTransportZoneList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, tzOpID, targetName, nil)
 	if err != nil {

--- a/cli/internal/cmd/operation/call.go
+++ b/cli/internal/cmd/operation/call.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -123,9 +124,9 @@ type callOptions struct {
 }
 
 func runCall(cmd *cobra.Command, opts callOptions) error {
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	params, err := loadParamsFlag(opts.ParamsFlag)
 	if err != nil {

--- a/cli/internal/cmd/operation/groups.go
+++ b/cli/internal/cmd/operation/groups.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -77,9 +78,9 @@ func newGroupsCmd() *cobra.Command {
 }
 
 func runGroups(cmd *cobra.Command, connectorID string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	result, err := getGroups(cmd.Context(), backplaneURL, connectorID)
 	if err != nil {

--- a/cli/internal/cmd/operation/operation.go
+++ b/cli/internal/cmd/operation/operation.go
@@ -32,14 +32,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -58,71 +56,6 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newSearchCmd())
 	cmd.AddCommand(newCallCmd())
 	return cmd
-}
-
-// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers
-// can distinguish "operator never logged in" (→ auth_expired exit
-// code 2 — the right fix is `meho login`) from URL-parse failures
-// (→ unexpected exit code 4 — the right fix is correcting argv).
-// Same shape as the helper in cli/internal/cmd/retrieval/eval.go;
-// kept independent because the cmd/retrieval package can't be
-// imported here without an import cycle (cmd/root.go grafts both
-// packages onto the tree).
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
-// resolveBackplane re-implements the host-trimming + parsing rules
-// the cmd package's resolveBackplaneURL applies. We can't import
-// cmd from a subpackage without an import cycle (cmd/root.go grafts
-// this package onto the tree), so the resolution shape is mirrored
-// here — same shape as retrieval/eval.go's helper.
-func resolveBackplane(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
-	}
-	cfg, err := auth.LoadConfig()
-	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
-	}
-	return normaliseURL(cfg.BackplaneURL)
-}
-
-// classifyBackplaneError maps a resolveBackplane error to the right
-// output.StructuredError category. Identical contract to the
-// retrieval/eval.go sibling: missing-config → auth_expired; everything
-// else (parse errors, fs errors) → unexpected.
-func classifyBackplaneError(err error) *output.StructuredError {
-	if errors.Is(err, auth.ErrConfigNotFound) {
-		return output.AuthExpired(err.Error())
-	}
-	return output.Unexpected(err.Error())
-}
-
-// normaliseURL strips trailing slashes + parses the URL to fail
-// fast on garbage input. Mirrors normalizeBackplaneURL in
-// cmd/status.go (kept independent because of the import-cycle
-// concern noted on resolveBackplane).
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
-	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
 }
 
 // renderRequestError translates an error from one of the per-verb

--- a/cli/internal/cmd/operation/operation_test.go
+++ b/cli/internal/cmd/operation/operation_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 )
 
 // TestTruncateAsciiNoTrim — string within budget passes through.
@@ -261,7 +262,7 @@ func TestLoadParamsFlagMissingFileReportsError(t *testing.T) {
 // TestNormaliseURLStripsTrailingSlash — same contract as the
 // retrieval sibling; trailing-slash trimming is the v0.2 convention.
 func TestNormaliseURLStripsTrailingSlash(t *testing.T) {
-	got, err := normaliseURL("https://meho.test/")
+	got, err := backplane.NormaliseURL("https://meho.test/")
 	if err != nil {
 		t.Fatalf("normaliseURL: %v", err)
 	}
@@ -273,7 +274,7 @@ func TestNormaliseURLStripsTrailingSlash(t *testing.T) {
 // TestNormaliseURLRejectsEmpty — empty input returns the "empty"
 // error string callers depend on.
 func TestNormaliseURLRejectsEmpty(t *testing.T) {
-	_, err := normaliseURL("   ")
+	_, err := backplane.NormaliseURL("   ")
 	if err == nil || !strings.Contains(err.Error(), "empty") {
 		t.Fatalf("expected 'empty' error; got %v", err)
 	}
@@ -283,13 +284,13 @@ func TestNormaliseURLRejectsEmpty(t *testing.T) {
 // any error wrapping it) maps to AuthExpired; everything else maps
 // to Unexpected. Same routing ladder as the retrieval sibling.
 func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
-	wrappedNotFound := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
-	se := classifyBackplaneError(wrappedNotFound)
+	wrappedNotFound := &backplane.NotConfiguredError{Inner: auth.ErrConfigNotFound}
+	se := backplane.ClassifyError(wrappedNotFound)
 	if se == nil || se.Code != "auth_expired" {
 		t.Fatalf("ErrConfigNotFound wrapper should classify as auth_expired; got %+v", se)
 	}
 	parseFailure := errors.New("invalid backplane URL")
-	se = classifyBackplaneError(parseFailure)
+	se = backplane.ClassifyError(parseFailure)
 	if se == nil || se.Code != "unexpected_response" {
 		t.Fatalf("parse failure should classify as unexpected; got %+v", se)
 	}

--- a/cli/internal/cmd/operation/search.go
+++ b/cli/internal/cmd/operation/search.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -114,9 +115,9 @@ func runSearch(cmd *cobra.Command, opts searchOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	result, err := getSearch(cmd.Context(), backplaneURL, opts)
 	if err != nil {

--- a/cli/internal/cmd/retrieval/eval.go
+++ b/cli/internal/cmd/retrieval/eval.go
@@ -11,14 +11,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -161,11 +160,11 @@ type evalOptions struct {
 // flag-parsing boilerplate stays in newEvalCmd and the request-
 // response logic stays testable in isolation.
 func runEval(cmd *cobra.Command, opts evalOptions) error {
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
 		return output.RenderError(
 			cmd.ErrOrStderr(),
-			classifyBackplaneError(err),
+			backplane.ClassifyError(err),
 			opts.JSONOut,
 		)
 	}
@@ -288,77 +287,6 @@ func postEvalWithBearer(
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	return client.Do(req)
-}
-
-// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers
-// can distinguish "operator never logged in" (→ auth_expired exit
-// code 2 — the right fix is `meho login`) from URL-parse failures
-// (→ unexpected exit code 4 — the right fix is correcting argv).
-// Wrapped via %w so errors.Is(err, auth.ErrConfigNotFound) still
-// matches; the user-facing message points at the actionable fix.
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
-// resolveBackplane re-implements the host-trimming + parsing rules
-// the cmd package's resolveBackplaneURL applies. We can't import
-// cmd from a subpackage without an import cycle (cmd/root.go grafts
-// this package onto the tree), so the resolution shape is mirrored
-// here.
-func resolveBackplane(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
-	}
-	cfg, err := auth.LoadConfig()
-	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
-	}
-	return normaliseURL(cfg.BackplaneURL)
-}
-
-// classifyBackplaneError maps a resolveBackplane error to the right
-// output.StructuredError category. The documented exit codes (see
-// runEval header) name 2 = auth_expired vs 3 = unreachable vs 4 =
-// unexpected; collapsing every error to auth_expired (the previous
-// shape) sends operators down the `meho login` path when the actual
-// cause was a typo in --backplane or a stale config file. Classify:
-//
-//   - ErrConfigNotFound (or our wrapper) → auth_expired: operator
-//     hasn't run `meho login` yet, that's exactly the fix.
-//   - everything else (parse errors, file-system errors from
-//     LoadConfig) → unexpected: the cause is operator argv or a
-//     corrupt config, not an expired token.
-func classifyBackplaneError(err error) *output.StructuredError {
-	if errors.Is(err, auth.ErrConfigNotFound) {
-		return output.AuthExpired(err.Error())
-	}
-	return output.Unexpected(err.Error())
-}
-
-// normaliseURL strips trailing slashes + parses the URL to fail
-// fast on garbage input. Mirrors normalizeBackplaneURL in
-// cmd/status.go (kept independent because of the import-cycle
-// concern noted on resolveBackplane).
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
-	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
 }
 
 // renderRequestError translates an error from postEval into the

--- a/cli/internal/cmd/retrieval/eval_test.go
+++ b/cli/internal/cmd/retrieval/eval_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 )
 
 // TestDiffEvalResultsNoRegression — identical metrics on every
@@ -178,7 +179,7 @@ func TestMaybeCompareBaselineMissingFileReturnsError(t *testing.T) {
 // TestNormaliseURLStripsTrailingSlash — backplane URLs are
 // canonicalised so the same URL maps to the same store key.
 func TestNormaliseURLStripsTrailingSlash(t *testing.T) {
-	got, err := normaliseURL("https://meho.test/")
+	got, err := backplane.NormaliseURL("https://meho.test/")
 	if err != nil {
 		t.Fatalf("normaliseURL: %v", err)
 	}
@@ -190,7 +191,7 @@ func TestNormaliseURLStripsTrailingSlash(t *testing.T) {
 // TestNormaliseURLRejectsEmpty — empty URL returns an error
 // (operator forgot to pass --backplane).
 func TestNormaliseURLRejectsEmpty(t *testing.T) {
-	_, err := normaliseURL("   ")
+	_, err := backplane.NormaliseURL("   ")
 	if err == nil || !strings.Contains(err.Error(), "empty") {
 		t.Fatalf("expected 'empty' error; got %v", err)
 	}
@@ -199,7 +200,7 @@ func TestNormaliseURLRejectsEmpty(t *testing.T) {
 // TestNormaliseURLRejectsHostless — URL without a host (e.g. just a
 // path) is rejected at the boundary.
 func TestNormaliseURLRejectsHostless(t *testing.T) {
-	_, err := normaliseURL("/no-host")
+	_, err := backplane.NormaliseURL("/no-host")
 	if err == nil {
 		t.Fatalf("expected error for hostless URL; got nil")
 	}
@@ -224,14 +225,14 @@ func TestErrEvalGateIsSentinel(t *testing.T) {
 // operators down the `meho login` path even for a typo in
 // `--backplane http:/example`.
 func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
-	wrappedNotFound := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
-	se := classifyBackplaneError(wrappedNotFound)
+	wrappedNotFound := &backplane.NotConfiguredError{Inner: auth.ErrConfigNotFound}
+	se := backplane.ClassifyError(wrappedNotFound)
 	if se == nil || se.Code != "auth_expired" {
 		t.Fatalf("ErrConfigNotFound wrapper should classify as auth_expired; got %+v", se)
 	}
 
 	parseFailure := errors.New("invalid backplane URL")
-	se = classifyBackplaneError(parseFailure)
+	se = backplane.ClassifyError(parseFailure)
 	if se == nil || se.Code != "unexpected_response" {
 		t.Fatalf("parse failure should classify as unexpected; got %+v", se)
 	}

--- a/cli/internal/cmd/retrieval/retire_checklist.go
+++ b/cli/internal/cmd/retrieval/retire_checklist.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -254,11 +255,11 @@ type retireOptions struct {
 // the request, render the response. Each error class is mapped to its
 // structured-error category so main() picks the right exit code.
 func runRetireChecklist(cmd *cobra.Command, opts retireOptions) error {
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
 		return output.RenderError(
 			cmd.ErrOrStderr(),
-			classifyBackplaneError(err),
+			backplane.ClassifyError(err),
 			opts.JSONOut,
 		)
 	}

--- a/cli/internal/cmd/retrieval/usage.go
+++ b/cli/internal/cmd/retrieval/usage.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -167,10 +168,10 @@ func runUsage(cmd *cobra.Command, opts usageOptions) error {
 		)
 	}
 
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(),
-			classifyBackplaneError(err), opts.JSONOut)
+			backplane.ClassifyError(err), opts.JSONOut)
 	}
 
 	report, err := getUsage(cmd.Context(), backplaneURL, opts)

--- a/cli/internal/cmd/sddc-manager/about.go
+++ b/cli/internal/cmd/sddc-manager/about.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -44,9 +45,9 @@ func newAboutCmd() *cobra.Command {
 }
 
 func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/v1/releases/system", targetName, nil)
 	if err != nil {

--- a/cli/internal/cmd/sddc-manager/bundle.go
+++ b/cli/internal/cmd/sddc-manager/bundle.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -51,9 +52,9 @@ func newBundleListCmd() *cobra.Command {
 }
 
 func runBundleList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/v1/bundles", targetName, nil)
 	if err != nil {

--- a/cli/internal/cmd/sddc-manager/cluster.go
+++ b/cli/internal/cmd/sddc-manager/cluster.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -54,9 +55,9 @@ func newClusterListCmd() *cobra.Command {
 }
 
 func runClusterList(cmd *cobra.Command, targetName, domainID string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	var params map[string]any
 	if domainID != "" {

--- a/cli/internal/cmd/sddc-manager/domain.go
+++ b/cli/internal/cmd/sddc-manager/domain.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -51,9 +52,9 @@ func newDomainListCmd() *cobra.Command {
 }
 
 func runDomainList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/v1/domains", targetName, nil)
 	if err != nil {
@@ -111,9 +112,9 @@ func newDomainInfoCmd() *cobra.Command {
 }
 
 func runDomainInfo(cmd *cobra.Command, domainID, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params := map[string]any{"id": domainID}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/v1/domains/{id}", targetName, params)

--- a/cli/internal/cmd/sddc-manager/host.go
+++ b/cli/internal/cmd/sddc-manager/host.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -57,9 +58,9 @@ func newHostListCmd() *cobra.Command {
 }
 
 func runHostList(cmd *cobra.Command, targetName, domainID, clusterID string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	var params map[string]any
 	if domainID != "" || clusterID != "" {

--- a/cli/internal/cmd/sddc-manager/manager.go
+++ b/cli/internal/cmd/sddc-manager/manager.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -51,9 +52,9 @@ func newManagerListCmd() *cobra.Command {
 }
 
 func runManagerList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/v1/sddc-managers", targetName, nil)
 	if err != nil {

--- a/cli/internal/cmd/sddc-manager/network_pool.go
+++ b/cli/internal/cmd/sddc-manager/network_pool.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -50,9 +51,9 @@ func newNetworkPoolListCmd() *cobra.Command {
 }
 
 func runNetworkPoolList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/v1/network-pools", targetName, nil)
 	if err != nil {

--- a/cli/internal/cmd/sddc-manager/operation.go
+++ b/cli/internal/cmd/sddc-manager/operation.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -82,9 +83,9 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 			output.Unexpected(fmt.Sprintf("--limit must be >= 1; got %d", limit)),
 			jsonOut)
 	}
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
 	if err != nil {
@@ -167,9 +168,9 @@ func newOperationCallCmd() *cobra.Command {
 }
 
 func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params, err := loadParamsFlag(paramsFlag)
 	if err != nil {

--- a/cli/internal/cmd/sddc-manager/sddc_manager.go
+++ b/cli/internal/cmd/sddc-manager/sddc_manager.go
@@ -32,14 +32,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -137,50 +135,6 @@ func printErrorTrailer(w io.Writer, r *CallResult) {
 			fmt.Fprintln(w, string(r.Extras))
 		}
 	}
-}
-
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
-func resolveBackplane(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
-	}
-	cfg, err := auth.LoadConfig()
-	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
-	}
-	return normaliseURL(cfg.BackplaneURL)
-}
-
-func classifyBackplaneError(err error) *output.StructuredError {
-	if errors.Is(err, auth.ErrConfigNotFound) {
-		return output.AuthExpired(err.Error())
-	}
-	return output.Unexpected(err.Error())
-}
-
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
-	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
 }
 
 func renderRequestError(

--- a/cli/internal/cmd/sddc-manager/sddc_manager_test.go
+++ b/cli/internal/cmd/sddc-manager/sddc_manager_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 )
 
 // ---------- helper tests ----------
@@ -40,25 +41,25 @@ func TestTruncatePassthroughAndCut(t *testing.T) {
 }
 
 func TestNormaliseURLBasic(t *testing.T) {
-	got, err := normaliseURL("https://meho.test/")
+	got, err := backplane.NormaliseURL("https://meho.test/")
 	if err != nil {
 		t.Fatalf("normaliseURL: %v", err)
 	}
 	if got != "https://meho.test" {
 		t.Fatalf("expected trailing slash stripped; got %q", got)
 	}
-	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+	if _, err := backplane.NormaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
 		t.Fatalf("empty should reject; got %v", err)
 	}
 }
 
 func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
-	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
-	se := classifyBackplaneError(wrapped)
+	wrapped := &backplane.NotConfiguredError{Inner: auth.ErrConfigNotFound}
+	se := backplane.ClassifyError(wrapped)
 	if se == nil || se.Code != "auth_expired" {
 		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
 	}
-	se = classifyBackplaneError(errors.New("parse failure"))
+	se = backplane.ClassifyError(errors.New("parse failure"))
 	if se == nil || se.Code != "unexpected_response" {
 		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
 	}

--- a/cli/internal/cmd/sddc-manager/workflow.go
+++ b/cli/internal/cmd/sddc-manager/workflow.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -55,9 +56,9 @@ func newWorkflowListCmd() *cobra.Command {
 }
 
 func runWorkflowList(cmd *cobra.Command, targetName, statusFilter string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	var params map[string]any
 	if statusFilter != "" {

--- a/cli/internal/cmd/targets/describe.go
+++ b/cli/internal/cmd/targets/describe.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -115,9 +116,9 @@ func runDescribe(cmd *cobra.Command, opts describeOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	t, err := getTarget(cmd.Context(), backplaneURL, opts.Query)
 	if err != nil {

--- a/cli/internal/cmd/targets/discover.go
+++ b/cli/internal/cmd/targets/discover.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -129,9 +130,9 @@ type discoverOptions struct {
 }
 
 func runDiscover(cmd *cobra.Command, opts discoverOptions) error {
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	result, err := getDiscover(cmd.Context(), backplaneURL, opts)
 	if err != nil {

--- a/cli/internal/cmd/targets/import.go
+++ b/cli/internal/cmd/targets/import.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -236,9 +237,9 @@ func runImport(cmd *cobra.Command, opts importOptions) error {
 		return renderPlan(cmd, p, opts.JSONOut)
 	}
 
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	doer := authedDoer(backplaneURL)
 

--- a/cli/internal/cmd/targets/list.go
+++ b/cli/internal/cmd/targets/list.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -112,9 +113,9 @@ func runList(cmd *cobra.Command, opts listOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	summaries, err := getTargets(cmd.Context(), backplaneURL, opts)
 	if err != nil {

--- a/cli/internal/cmd/targets/probe.go
+++ b/cli/internal/cmd/targets/probe.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -115,9 +116,9 @@ func runProbe(cmd *cobra.Command, opts probeOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	fp, err := postProbe(cmd.Context(), backplaneURL, opts.Query)
 	if err != nil {

--- a/cli/internal/cmd/targets/targets.go
+++ b/cli/internal/cmd/targets/targets.go
@@ -60,7 +60,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -82,67 +81,6 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newImportCmd())
 	cmd.AddCommand(newDiscoverCmd())
 	return cmd
-}
-
-// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers
-// can distinguish "operator never logged in" (→ auth_expired exit
-// code 2 — the right fix is `meho login`) from URL-parse failures
-// (→ unexpected exit code 4 — the right fix is correcting argv).
-// Same shape as the helper in cli/internal/cmd/operation/operation.go;
-// kept independent because the cmd/operation package can't be
-// imported here without an import cycle.
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
-// resolveBackplane re-implements the host-trimming + parsing rules
-// the cmd package's resolveBackplaneURL applies. We can't import cmd
-// from a subpackage without an import cycle (cmd/root.go grafts this
-// package onto the tree), so the resolution shape is mirrored here —
-// same shape as operation/operation.go's helper.
-func resolveBackplane(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
-	}
-	cfg, err := auth.LoadConfig()
-	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
-	}
-	return normaliseURL(cfg.BackplaneURL)
-}
-
-// classifyBackplaneError maps a resolveBackplane error to the right
-// output.StructuredError category. Identical contract to the
-// operation/operation.go sibling.
-func classifyBackplaneError(err error) *output.StructuredError {
-	if errors.Is(err, auth.ErrConfigNotFound) {
-		return output.AuthExpired(err.Error())
-	}
-	return output.Unexpected(err.Error())
-}
-
-// normaliseURL strips trailing slashes + parses the URL to fail
-// fast on garbage input. Mirrors normaliseURL in operation/operation.go.
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
-	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
 }
 
 // renderRequestError translates an error from one of the per-verb

--- a/cli/internal/cmd/targets/targets_test.go
+++ b/cli/internal/cmd/targets/targets_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 )
 
 // TestRootCmdLists3Verbs pins the v0.2 verb set so a future split
@@ -54,7 +55,7 @@ func TestRootCmdHelpListsAllVerbs(t *testing.T) {
 // sibling operation/retrieval packages enforce; trailing-slash
 // trimming is the v0.2 convention.
 func TestNormaliseURLStripsTrailingSlash(t *testing.T) {
-	got, err := normaliseURL("https://meho.test/")
+	got, err := backplane.NormaliseURL("https://meho.test/")
 	if err != nil {
 		t.Fatalf("normaliseURL: %v", err)
 	}
@@ -66,7 +67,7 @@ func TestNormaliseURLStripsTrailingSlash(t *testing.T) {
 // TestNormaliseURLRejectsEmpty — empty input returns the "empty"
 // error string callers depend on.
 func TestNormaliseURLRejectsEmpty(t *testing.T) {
-	_, err := normaliseURL("   ")
+	_, err := backplane.NormaliseURL("   ")
 	if err == nil || !strings.Contains(err.Error(), "empty") {
 		t.Fatalf("expected 'empty' error; got %v", err)
 	}
@@ -76,13 +77,13 @@ func TestNormaliseURLRejectsEmpty(t *testing.T) {
 // any error wrapping it) maps to AuthExpired; everything else maps
 // to Unexpected. Same routing ladder as the operation sibling.
 func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
-	wrappedNotFound := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
-	se := classifyBackplaneError(wrappedNotFound)
+	wrappedNotFound := &backplane.NotConfiguredError{Inner: auth.ErrConfigNotFound}
+	se := backplane.ClassifyError(wrappedNotFound)
 	if se == nil || se.Code != "auth_expired" {
 		t.Fatalf("ErrConfigNotFound wrapper should classify as auth_expired; got %+v", se)
 	}
 	parseFailure := errors.New("invalid backplane URL")
-	se = classifyBackplaneError(parseFailure)
+	se = backplane.ClassifyError(parseFailure)
 	if se == nil || se.Code != "unexpected_response" {
 		t.Fatalf("parse failure should classify as unexpected; got %+v", se)
 	}

--- a/cli/internal/cmd/topology/annotate.go
+++ b/cli/internal/cmd/topology/annotate.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -158,9 +159,9 @@ type annotateRequestEndpoint struct {
 }
 
 func runAnnotate(cmd *cobra.Command, opts annotateOptions) error {
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	body := annotateRequestBody{
 		From:        annotateRequestEndpoint{Name: opts.From, Kind: opts.FromKind},

--- a/cli/internal/cmd/topology/bulk_import.go
+++ b/cli/internal/cmd/topology/bulk_import.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -222,10 +223,10 @@ func runBulkImport(cmd *cobra.Command, opts bulkImportOptions) error {
 			output.Unexpected("file contains no edges (the `edges:` list is missing or empty)"),
 			opts.JSONOut)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(),
-			classifyBackplaneError(err), opts.JSONOut)
+			backplane.ClassifyError(err), opts.JSONOut)
 	}
 	body, err := json.Marshal(bulkImportRequest{
 		Edges:  doc.Edges,

--- a/cli/internal/cmd/topology/closure.go
+++ b/cli/internal/cmd/topology/closure.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -62,9 +63,9 @@ func runClosure(cmd *cobra.Command, opts closureOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	nodes, err := getClosure(cmd.Context(), backplaneURL, opts)
 	if err != nil {

--- a/cli/internal/cmd/topology/list_edges.go
+++ b/cli/internal/cmd/topology/list_edges.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -152,9 +153,9 @@ func runListEdges(cmd *cobra.Command, opts listEdgesOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	edges, err := getEdges(cmd.Context(), backplaneURL, opts)
 	if err != nil {

--- a/cli/internal/cmd/topology/path.go
+++ b/cli/internal/cmd/topology/path.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -110,9 +111,9 @@ func runPath(cmd *cobra.Command, opts pathOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	path, err := getPath(cmd.Context(), backplaneURL, opts)
 	if err != nil {

--- a/cli/internal/cmd/topology/refresh.go
+++ b/cli/internal/cmd/topology/refresh.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -88,9 +89,9 @@ type refreshOptions struct {
 }
 
 func runRefresh(cmd *cobra.Command, opts refreshOptions) error {
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	result, err := postRefresh(cmd.Context(), backplaneURL, opts.Target)
 	if err != nil {

--- a/cli/internal/cmd/topology/timeline.go
+++ b/cli/internal/cmd/topology/timeline.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -132,9 +133,9 @@ func runTimeline(cmd *cobra.Command, opts timelineOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	result, err := getTimeline(cmd.Context(), backplaneURL, opts)
 	if err != nil {

--- a/cli/internal/cmd/topology/topology.go
+++ b/cli/internal/cmd/topology/topology.go
@@ -89,7 +89,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -127,67 +126,6 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newBulkImportCmd())
 	cmd.AddCommand(newTimelineCmd())
 	return cmd
-}
-
-// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers
-// can distinguish "operator never logged in" (→ auth_expired exit
-// code 2 — the right fix is `meho login`) from URL-parse failures
-// (→ unexpected exit code 4 — the right fix is correcting argv).
-// Same shape as the helper in cli/internal/cmd/targets/targets.go;
-// kept independent because the cmd/targets package can't be imported
-// here without an import cycle.
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
-// resolveBackplane re-implements the host-trimming + parsing rules
-// the cmd package's resolveBackplaneURL applies. We can't import cmd
-// from a subpackage without an import cycle (cmd/root.go grafts this
-// package onto the tree), so the resolution shape is mirrored here —
-// same shape as targets/targets.go's helper.
-func resolveBackplane(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
-	}
-	cfg, err := auth.LoadConfig()
-	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
-	}
-	return normaliseURL(cfg.BackplaneURL)
-}
-
-// classifyBackplaneError maps a resolveBackplane error to the right
-// output.StructuredError category. Identical contract to the
-// targets/targets.go sibling.
-func classifyBackplaneError(err error) *output.StructuredError {
-	if errors.Is(err, auth.ErrConfigNotFound) {
-		return output.AuthExpired(err.Error())
-	}
-	return output.Unexpected(err.Error())
-}
-
-// normaliseURL strips trailing slashes + parses the URL to fail fast
-// on garbage input. Mirrors normaliseURL in targets/targets.go.
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
-	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
 }
 
 // renderRequestError translates an error from one of the per-verb

--- a/cli/internal/cmd/topology/unannotate.go
+++ b/cli/internal/cmd/topology/unannotate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -115,9 +116,9 @@ type unannotateOptions struct {
 }
 
 func runUnannotate(cmd *cobra.Command, opts unannotateOptions) error {
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 
 	edgeID := opts.EdgeID

--- a/cli/internal/cmd/vault/auth.go
+++ b/cli/internal/cmd/vault/auth.go
@@ -6,6 +6,7 @@ package vault
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -89,9 +90,9 @@ func bindAuthAddrFlags(cmd *cobra.Command) *authAddrFlags {
 // dispatchAuth runs the resolve → dispatch → render pipeline shared by
 // every auth verb. params is nil for the list verbs.
 func dispatchAuth(cmd *cobra.Command, f *authAddrFlags, opID string, params map[string]any) error {
-	backplaneURL, err := resolveBackplane(f.backplaneOverride)
+	backplaneURL, err := backplane.Resolve(f.backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), f.jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), f.jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, opID, f.targetName, params)
 	if err != nil {

--- a/cli/internal/cmd/vault/kv.go
+++ b/cli/internal/cmd/vault/kv.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -73,9 +74,9 @@ func bindKVAddrFlags(cmd *cobra.Command) *kvAddrFlags {
 // (kv list) arrive already reduced to the JSONFlux sample + handle by
 // the dispatcher.
 func dispatchKV(cmd *cobra.Command, f *kvAddrFlags, opID string, params map[string]any) error {
-	backplaneURL, err := resolveBackplane(f.backplaneOverride)
+	backplaneURL, err := backplane.Resolve(f.backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), f.jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), f.jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, opID, f.targetName, params)
 	if err != nil {

--- a/cli/internal/cmd/vault/sys.go
+++ b/cli/internal/cmd/vault/sys.go
@@ -6,6 +6,7 @@ package vault
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -82,9 +83,9 @@ func newSysVerbCmd(use, opID, short, long, example string) *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			backplaneURL, err := resolveBackplane(backplaneOverride)
+			backplaneURL, err := backplane.Resolve(backplaneOverride)
 			if err != nil {
-				return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+				return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 			}
 			r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, nil)
 			if err != nil {

--- a/cli/internal/cmd/vault/vault.go
+++ b/cli/internal/cmd/vault/vault.go
@@ -43,14 +43,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -97,68 +95,6 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newSysCmd())
 	cmd.AddCommand(newAuthCmd())
 	return cmd
-}
-
-// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers can
-// distinguish "operator never logged in" (→ auth_expired exit code 2 —
-// the right fix is `meho login`) from URL-parse failures (→ unexpected
-// exit code 4 — the right fix is correcting argv). Same shape as the
-// operation / connector / vmware siblings; kept independent because
-// cmd/{operation,connector,kb,vmware,vault} can't import each other
-// without an import cycle (cmd/root.go grafts each onto the tree).
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
-// resolveBackplane mirrors the vmware sibling helper: --backplane
-// override flag wins; otherwise read the URL the most recent
-// `meho login` wrote to config.json. Missing config surfaces as
-// errNoBackplaneConfigured so classifyBackplaneError can route it to
-// auth_expired.
-func resolveBackplane(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
-	}
-	cfg, err := auth.LoadConfig()
-	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
-	}
-	return normaliseURL(cfg.BackplaneURL)
-}
-
-// classifyBackplaneError maps a resolveBackplane error to the right
-// output.StructuredError category. Identical routing to the vmware
-// sibling: missing-config → auth_expired; everything else (parse
-// errors, fs errors) → unexpected.
-func classifyBackplaneError(err error) *output.StructuredError {
-	if errors.Is(err, auth.ErrConfigNotFound) {
-		return output.AuthExpired(err.Error())
-	}
-	return output.Unexpected(err.Error())
-}
-
-// normaliseURL strips trailing slashes + parses the URL to fail fast
-// on garbage input. Mirrors the vmware sibling.
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
-	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
 }
 
 // renderRequestError translates an error from doAuthedRequest into the

--- a/cli/internal/cmd/vault/vault_test.go
+++ b/cli/internal/cmd/vault/vault_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 )
 
 // ---------- pure-function helpers ----------
@@ -46,14 +47,14 @@ func TestTruncatePassthroughAndCut(t *testing.T) {
 // TestNormaliseURLBasic — trailing-slash trimming + reject-empty are
 // the load-bearing properties.
 func TestNormaliseURLBasic(t *testing.T) {
-	got, err := normaliseURL("https://meho.test/")
+	got, err := backplane.NormaliseURL("https://meho.test/")
 	if err != nil {
 		t.Fatalf("normaliseURL: %v", err)
 	}
 	if got != "https://meho.test" {
 		t.Fatalf("expected trailing slash stripped; got %q", got)
 	}
-	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+	if _, err := backplane.NormaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
 		t.Fatalf("empty should reject; got %v", err)
 	}
 }
@@ -61,12 +62,12 @@ func TestNormaliseURLBasic(t *testing.T) {
 // TestClassifyBackplaneErrorRoutesByCause — ErrConfigNotFound (or any
 // wrapping error) maps to AuthExpired; everything else to Unexpected.
 func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
-	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
-	se := classifyBackplaneError(wrapped)
+	wrapped := &backplane.NotConfiguredError{Inner: auth.ErrConfigNotFound}
+	se := backplane.ClassifyError(wrapped)
 	if se == nil || se.Code != "auth_expired" {
 		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
 	}
-	se = classifyBackplaneError(errors.New("parse failure"))
+	se = backplane.ClassifyError(errors.New("parse failure"))
 	if se == nil || se.Code != "unexpected_response" {
 		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
 	}

--- a/cli/internal/cmd/vcf-automation/about.go
+++ b/cli/internal/cmd/vcf-automation/about.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -62,9 +63,9 @@ func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOver
 	if se := requirePlane(plane); se != nil {
 		return output.RenderError(cmd.ErrOrStderr(), se, jsonOut)
 	}
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	opID := aboutOpForPlane(plane)
 	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, readFqdn(cmd), nil)

--- a/cli/internal/cmd/vcf-automation/operation.go
+++ b/cli/internal/cmd/vcf-automation/operation.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -88,9 +89,9 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 			output.Unexpected(fmt.Sprintf("--limit must be >= 1; got %d", limit)),
 			jsonOut)
 	}
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
 	if err != nil {
@@ -182,9 +183,9 @@ func newOperationCallCmd() *cobra.Command {
 }
 
 func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params, err := loadParamsFlag(paramsFlag)
 	if err != nil {

--- a/cli/internal/cmd/vcf-automation/org.go
+++ b/cli/internal/cmd/vcf-automation/org.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -170,9 +171,9 @@ func runProviderListVerb(
 	if se := validatePlane(readPlane(cmd), PlaneProvider); se != nil {
 		return output.RenderError(cmd.ErrOrStderr(), se, jsonOut)
 	}
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, readFqdn(cmd), nil)
 	if err != nil {
@@ -195,9 +196,9 @@ func runProviderGetVerb(
 	if se := validatePlane(readPlane(cmd), PlaneProvider); se != nil {
 		return output.RenderError(cmd.ErrOrStderr(), se, jsonOut)
 	}
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params := map[string]any{paramName: paramValue}
 	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, readFqdn(cmd), params)

--- a/cli/internal/cmd/vcf-automation/project.go
+++ b/cli/internal/cmd/vcf-automation/project.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -88,9 +89,9 @@ func runTenantListVerb(
 	if se := validatePlane(readPlane(cmd), PlaneTenant); se != nil {
 		return output.RenderError(cmd.ErrOrStderr(), se, jsonOut)
 	}
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, readFqdn(cmd), nil)
 	if err != nil {
@@ -111,9 +112,9 @@ func runTenantGetVerb(
 	if se := validatePlane(readPlane(cmd), PlaneTenant); se != nil {
 		return output.RenderError(cmd.ErrOrStderr(), se, jsonOut)
 	}
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params := map[string]any{paramName: paramValue}
 	r, err := dispatchOp(cmd.Context(), backplaneURL, opID, targetName, readFqdn(cmd), params)

--- a/cli/internal/cmd/vcf-automation/vcfa.go
+++ b/cli/internal/cmd/vcf-automation/vcfa.go
@@ -50,14 +50,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -273,50 +271,6 @@ func printErrorTrailer(w io.Writer, r *CallResult) {
 			fmt.Fprintln(w, string(r.Extras))
 		}
 	}
-}
-
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
-func resolveBackplane(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
-	}
-	cfg, err := auth.LoadConfig()
-	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
-	}
-	return normaliseURL(cfg.BackplaneURL)
-}
-
-func classifyBackplaneError(err error) *output.StructuredError {
-	if errors.Is(err, auth.ErrConfigNotFound) {
-		return output.AuthExpired(err.Error())
-	}
-	return output.Unexpected(err.Error())
-}
-
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
-	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
 }
 
 func renderRequestError(

--- a/cli/internal/cmd/vcf-automation/vcfa_test.go
+++ b/cli/internal/cmd/vcf-automation/vcfa_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 )
 
 // ---------- helper tests ----------
@@ -40,25 +41,25 @@ func TestTruncatePassthroughAndCut(t *testing.T) {
 }
 
 func TestNormaliseURLBasic(t *testing.T) {
-	got, err := normaliseURL("https://meho.test/")
+	got, err := backplane.NormaliseURL("https://meho.test/")
 	if err != nil {
 		t.Fatalf("normaliseURL: %v", err)
 	}
 	if got != "https://meho.test" {
 		t.Fatalf("expected trailing slash stripped; got %q", got)
 	}
-	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+	if _, err := backplane.NormaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
 		t.Fatalf("empty should reject; got %v", err)
 	}
 }
 
 func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
-	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
-	se := classifyBackplaneError(wrapped)
+	wrapped := &backplane.NotConfiguredError{Inner: auth.ErrConfigNotFound}
+	se := backplane.ClassifyError(wrapped)
 	if se == nil || se.Code != "auth_expired" {
 		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
 	}
-	se = classifyBackplaneError(errors.New("parse failure"))
+	se = backplane.ClassifyError(errors.New("parse failure"))
 	if se == nil || se.Code != "unexpected_response" {
 		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
 	}

--- a/cli/internal/cmd/vcf-fleet/about.go
+++ b/cli/internal/cmd/vcf-fleet/about.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -56,9 +57,9 @@ func newAboutCmd() *cobra.Command {
 }
 
 func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, aboutOpID, targetName, nil)
 	if err != nil {

--- a/cli/internal/cmd/vcf-fleet/datacenter.go
+++ b/cli/internal/cmd/vcf-fleet/datacenter.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -57,9 +58,9 @@ func newDatacenterListCmd() *cobra.Command {
 }
 
 func runDatacenterList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, datacenterListOpID, targetName, nil)
 	if err != nil {

--- a/cli/internal/cmd/vcf-fleet/environment.go
+++ b/cli/internal/cmd/vcf-fleet/environment.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -61,9 +62,9 @@ func newEnvironmentListCmd() *cobra.Command {
 }
 
 func runEnvironmentList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, environmentListOpID, targetName, nil)
 	if err != nil {
@@ -127,9 +128,9 @@ func newEnvironmentInfoCmd() *cobra.Command {
 }
 
 func runEnvironmentInfo(cmd *cobra.Command, environmentID, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params := map[string]any{"environmentId": environmentID}
 	r, err := conn.Call(cmd.Context(), backplaneURL, environmentGetOpID, targetName, params)

--- a/cli/internal/cmd/vcf-fleet/operation.go
+++ b/cli/internal/cmd/vcf-fleet/operation.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -82,9 +83,9 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 			output.Unexpected(fmt.Sprintf("--limit must be >= 1; got %d", limit)),
 			jsonOut)
 	}
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
 	if err != nil {
@@ -168,9 +169,9 @@ func newOperationCallCmd() *cobra.Command {
 }
 
 func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params, err := loadParamsFlag(paramsFlag)
 	if err != nil {

--- a/cli/internal/cmd/vcf-fleet/product.go
+++ b/cli/internal/cmd/vcf-fleet/product.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -56,9 +57,9 @@ func newProductListCmd() *cobra.Command {
 }
 
 func runProductList(cmd *cobra.Command, environmentID, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params := map[string]any{"environmentId": environmentID}
 	r, err := conn.Call(cmd.Context(), backplaneURL, productListOpID, targetName, params)

--- a/cli/internal/cmd/vcf-fleet/request.go
+++ b/cli/internal/cmd/vcf-fleet/request.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -62,9 +63,9 @@ func newRequestListCmd() *cobra.Command {
 }
 
 func runRequestList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, requestListOpID, targetName, nil)
 	if err != nil {
@@ -130,9 +131,9 @@ func newRequestInfoCmd() *cobra.Command {
 }
 
 func runRequestInfo(cmd *cobra.Command, requestID, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params := map[string]any{"requestId": requestID}
 	r, err := conn.Call(cmd.Context(), backplaneURL, requestGetOpID, targetName, params)

--- a/cli/internal/cmd/vcf-fleet/vcenter.go
+++ b/cli/internal/cmd/vcf-fleet/vcenter.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -55,9 +56,9 @@ func newVcenterListCmd() *cobra.Command {
 }
 
 func runVcenterList(cmd *cobra.Command, datacenterVmid, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params := map[string]any{"dataCenterVmid": datacenterVmid}
 	r, err := conn.Call(cmd.Context(), backplaneURL, vcenterListOpID, targetName, params)

--- a/cli/internal/cmd/vcf-fleet/vcf_fleet.go
+++ b/cli/internal/cmd/vcf-fleet/vcf_fleet.go
@@ -36,14 +36,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -141,50 +139,6 @@ func printErrorTrailer(w io.Writer, r *CallResult) {
 			fmt.Fprintln(w, string(r.Extras))
 		}
 	}
-}
-
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
-func resolveBackplane(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
-	}
-	cfg, err := auth.LoadConfig()
-	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
-	}
-	return normaliseURL(cfg.BackplaneURL)
-}
-
-func classifyBackplaneError(err error) *output.StructuredError {
-	if errors.Is(err, auth.ErrConfigNotFound) {
-		return output.AuthExpired(err.Error())
-	}
-	return output.Unexpected(err.Error())
-}
-
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
-	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
 }
 
 func renderRequestError(

--- a/cli/internal/cmd/vcf-fleet/vcf_fleet_test.go
+++ b/cli/internal/cmd/vcf-fleet/vcf_fleet_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 )
 
 // ---------- helper tests ----------
@@ -40,25 +41,25 @@ func TestTruncatePassthroughAndCut(t *testing.T) {
 }
 
 func TestNormaliseURLBasic(t *testing.T) {
-	got, err := normaliseURL("https://meho.test/")
+	got, err := backplane.NormaliseURL("https://meho.test/")
 	if err != nil {
 		t.Fatalf("normaliseURL: %v", err)
 	}
 	if got != "https://meho.test" {
 		t.Fatalf("expected trailing slash stripped; got %q", got)
 	}
-	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+	if _, err := backplane.NormaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
 		t.Fatalf("empty should reject; got %v", err)
 	}
 }
 
 func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
-	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
-	se := classifyBackplaneError(wrapped)
+	wrapped := &backplane.NotConfiguredError{Inner: auth.ErrConfigNotFound}
+	se := backplane.ClassifyError(wrapped)
 	if se == nil || se.Code != "auth_expired" {
 		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
 	}
-	se = classifyBackplaneError(errors.New("parse failure"))
+	se = backplane.ClassifyError(errors.New("parse failure"))
 	if se == nil || se.Code != "unexpected_response" {
 		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
 	}

--- a/cli/internal/cmd/vcf-logs/about.go
+++ b/cli/internal/cmd/vcf-logs/about.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -46,9 +47,9 @@ func newAboutCmd() *cobra.Command {
 }
 
 func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v2/version", targetName, nil)
 	if err != nil {

--- a/cli/internal/cmd/vcf-logs/aggregated.go
+++ b/cli/internal/cmd/vcf-logs/aggregated.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -65,9 +66,9 @@ func runAggregated(
 	jsonOut bool,
 	backplaneOverride string,
 ) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params := map[string]any{"constraints": constraints}
 	if timeRange != "" {

--- a/cli/internal/cmd/vcf-logs/alert.go
+++ b/cli/internal/cmd/vcf-logs/alert.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -54,9 +55,9 @@ func newAlertListCmd() *cobra.Command {
 }
 
 func runAlertList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v2/alerts", targetName, nil)
 	if err != nil {

--- a/cli/internal/cmd/vcf-logs/content_pack.go
+++ b/cli/internal/cmd/vcf-logs/content_pack.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -54,9 +55,9 @@ func newContentPackListCmd() *cobra.Command {
 }
 
 func runContentPackList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	const opID = "GET:/api/v2/content/contentpack/list"
 	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, nil)

--- a/cli/internal/cmd/vcf-logs/field.go
+++ b/cli/internal/cmd/vcf-logs/field.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -53,9 +54,9 @@ func newFieldListCmd() *cobra.Command {
 }
 
 func runFieldList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v2/fields", targetName, nil)
 	if err != nil {

--- a/cli/internal/cmd/vcf-logs/host.go
+++ b/cli/internal/cmd/vcf-logs/host.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -53,9 +54,9 @@ func newHostListCmd() *cobra.Command {
 }
 
 func runHostList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/v2/hosts", targetName, nil)
 	if err != nil {

--- a/cli/internal/cmd/vcf-logs/operation.go
+++ b/cli/internal/cmd/vcf-logs/operation.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -83,9 +84,9 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 			output.Unexpected(fmt.Sprintf("--limit must be >= 1; got %d", limit)),
 			jsonOut)
 	}
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
 	if err != nil {
@@ -175,9 +176,9 @@ func newOperationCallCmd() *cobra.Command {
 }
 
 func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params, err := loadParamsFlag(paramsFlag)
 	if err != nil {

--- a/cli/internal/cmd/vcf-logs/query.go
+++ b/cli/internal/cmd/vcf-logs/query.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -88,9 +89,9 @@ func runQuery(
 			output.Unexpected(fmt.Sprintf("--limit must be >= 0; got %d", limit)),
 			jsonOut)
 	}
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params := map[string]any{}
 	// Constraints is path-template substitution; the dispatcher's

--- a/cli/internal/cmd/vcf-logs/vcf_logs.go
+++ b/cli/internal/cmd/vcf-logs/vcf_logs.go
@@ -37,14 +37,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -164,50 +162,6 @@ func printErrorTrailer(w io.Writer, r *CallResult) {
 			fmt.Fprintln(w, string(r.Extras))
 		}
 	}
-}
-
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
-func resolveBackplane(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
-	}
-	cfg, err := auth.LoadConfig()
-	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
-	}
-	return normaliseURL(cfg.BackplaneURL)
-}
-
-func classifyBackplaneError(err error) *output.StructuredError {
-	if errors.Is(err, auth.ErrConfigNotFound) {
-		return output.AuthExpired(err.Error())
-	}
-	return output.Unexpected(err.Error())
-}
-
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
-	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
 }
 
 func renderRequestError(

--- a/cli/internal/cmd/vcf-logs/vcf_logs_test.go
+++ b/cli/internal/cmd/vcf-logs/vcf_logs_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 )
 
 // ---------- helper tests ----------
@@ -48,25 +49,25 @@ func TestTruncatePassthroughAndCut(t *testing.T) {
 }
 
 func TestNormaliseURLBasic(t *testing.T) {
-	got, err := normaliseURL("https://meho.test/")
+	got, err := backplane.NormaliseURL("https://meho.test/")
 	if err != nil {
 		t.Fatalf("normaliseURL: %v", err)
 	}
 	if got != "https://meho.test" {
 		t.Fatalf("expected trailing slash stripped; got %q", got)
 	}
-	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+	if _, err := backplane.NormaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
 		t.Fatalf("empty should reject; got %v", err)
 	}
 }
 
 func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
-	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
-	se := classifyBackplaneError(wrapped)
+	wrapped := &backplane.NotConfiguredError{Inner: auth.ErrConfigNotFound}
+	se := backplane.ClassifyError(wrapped)
 	if se == nil || se.Code != "auth_expired" {
 		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
 	}
-	se = classifyBackplaneError(errors.New("parse failure"))
+	se = backplane.ClassifyError(errors.New("parse failure"))
 	if se == nil || se.Code != "unexpected_response" {
 		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
 	}

--- a/cli/internal/cmd/vcf-operations/about.go
+++ b/cli/internal/cmd/vcf-operations/about.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -54,9 +55,9 @@ func newAboutCmd() *cobra.Command {
 }
 
 func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	const opID = "GET:/suite-api/api/versions/current"
 	r, err := conn.Call(cmd.Context(), backplaneURL, opID, targetName, nil)

--- a/cli/internal/cmd/vcf-operations/alert.go
+++ b/cli/internal/cmd/vcf-operations/alert.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -68,9 +69,9 @@ func newAlertListCmd() *cobra.Command {
 }
 
 func runAlertList(cmd *cobra.Command, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params, err := loadParamsFlag(paramsFlag)
 	if err != nil {

--- a/cli/internal/cmd/vcf-operations/alertdefinition.go
+++ b/cli/internal/cmd/vcf-operations/alertdefinition.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -68,9 +69,9 @@ func newAlertDefinitionListCmd() *cobra.Command {
 }
 
 func runAlertDefinitionList(cmd *cobra.Command, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params, err := loadParamsFlag(paramsFlag)
 	if err != nil {

--- a/cli/internal/cmd/vcf-operations/operation.go
+++ b/cli/internal/cmd/vcf-operations/operation.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -83,9 +84,9 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 			output.Unexpected(fmt.Sprintf("--limit must be >= 1; got %d", limit)),
 			jsonOut)
 	}
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
 	if err != nil {
@@ -175,9 +176,9 @@ func newOperationCallCmd() *cobra.Command {
 }
 
 func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params, err := loadParamsFlag(paramsFlag)
 	if err != nil {

--- a/cli/internal/cmd/vcf-operations/recommendation.go
+++ b/cli/internal/cmd/vcf-operations/recommendation.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -65,9 +66,9 @@ func newRecommendationListCmd() *cobra.Command {
 }
 
 func runRecommendationList(cmd *cobra.Command, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params, err := loadParamsFlag(paramsFlag)
 	if err != nil {

--- a/cli/internal/cmd/vcf-operations/resource.go
+++ b/cli/internal/cmd/vcf-operations/resource.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -71,9 +72,9 @@ func newResourceListCmd() *cobra.Command {
 }
 
 func runResourceList(cmd *cobra.Command, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params, err := loadParamsFlag(paramsFlag)
 	if err != nil {
@@ -152,9 +153,9 @@ func newResourceGetCmd() *cobra.Command {
 }
 
 func runResourceGet(cmd *cobra.Command, id, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	const opID = "GET:/suite-api/api/resources/{id}"
 	params := map[string]any{"id": id}

--- a/cli/internal/cmd/vcf-operations/supermetric.go
+++ b/cli/internal/cmd/vcf-operations/supermetric.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -64,9 +65,9 @@ func newSupermetricListCmd() *cobra.Command {
 }
 
 func runSupermetricList(cmd *cobra.Command, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params, err := loadParamsFlag(paramsFlag)
 	if err != nil {

--- a/cli/internal/cmd/vcf-operations/symptom.go
+++ b/cli/internal/cmd/vcf-operations/symptom.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -66,9 +67,9 @@ func newSymptomListCmd() *cobra.Command {
 }
 
 func runSymptomList(cmd *cobra.Command, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params, err := loadParamsFlag(paramsFlag)
 	if err != nil {

--- a/cli/internal/cmd/vcf-operations/vcf_operations.go
+++ b/cli/internal/cmd/vcf-operations/vcf_operations.go
@@ -41,14 +41,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -209,50 +207,6 @@ func printErrorTrailer(w io.Writer, r *CallResult) {
 			fmt.Fprintln(w, string(r.Extras))
 		}
 	}
-}
-
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
-func resolveBackplane(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
-	}
-	cfg, err := auth.LoadConfig()
-	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
-	}
-	return normaliseURL(cfg.BackplaneURL)
-}
-
-func classifyBackplaneError(err error) *output.StructuredError {
-	if errors.Is(err, auth.ErrConfigNotFound) {
-		return output.AuthExpired(err.Error())
-	}
-	return output.Unexpected(err.Error())
-}
-
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
-	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
 }
 
 func renderRequestError(

--- a/cli/internal/cmd/vcf-operations/vcf_operations_test.go
+++ b/cli/internal/cmd/vcf-operations/vcf_operations_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 )
 
 // ---------- helper tests ----------
@@ -40,25 +41,25 @@ func TestTruncatePassthroughAndCut(t *testing.T) {
 }
 
 func TestNormaliseURLBasic(t *testing.T) {
-	got, err := normaliseURL("https://meho.test/")
+	got, err := backplane.NormaliseURL("https://meho.test/")
 	if err != nil {
 		t.Fatalf("normaliseURL: %v", err)
 	}
 	if got != "https://meho.test" {
 		t.Fatalf("expected trailing slash stripped; got %q", got)
 	}
-	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+	if _, err := backplane.NormaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
 		t.Fatalf("empty should reject; got %v", err)
 	}
 }
 
 func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
-	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
-	se := classifyBackplaneError(wrapped)
+	wrapped := &backplane.NotConfiguredError{Inner: auth.ErrConfigNotFound}
+	se := backplane.ClassifyError(wrapped)
 	if se == nil || se.Code != "auth_expired" {
 		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
 	}
-	se = classifyBackplaneError(errors.New("parse failure"))
+	se = backplane.ClassifyError(errors.New("parse failure"))
 	if se == nil || se.Code != "unexpected_response" {
 		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
 	}

--- a/cli/internal/cmd/vmware/about.go
+++ b/cli/internal/cmd/vmware/about.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -75,9 +76,9 @@ func newAboutCmd() *cobra.Command {
 }
 
 func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/api/about", targetName, nil)
 	if err != nil {

--- a/cli/internal/cmd/vmware/cluster.go
+++ b/cli/internal/cmd/vmware/cluster.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -58,9 +59,9 @@ func newClusterListCmd() *cobra.Command {
 }
 
 func runClusterList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/vcenter/cluster", targetName, nil)
 	if err != nil {
@@ -137,9 +138,9 @@ func newClusterPatchCmd() *cobra.Command {
 }
 
 func runClusterPatch(cmd *cobra.Command, nameOrID, targetName, specFlag string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	moid, err := resolveName(cmd.Context(), backplaneURL, targetName, "cluster", nameOrID)
 	if err != nil {

--- a/cli/internal/cmd/vmware/host.go
+++ b/cli/internal/cmd/vmware/host.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -58,9 +59,9 @@ func newHostListCmd() *cobra.Command {
 }
 
 func runHostList(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, "GET:/vcenter/host", targetName, nil)
 	if err != nil {
@@ -134,9 +135,9 @@ func newHostEvacuateCmd() *cobra.Command {
 }
 
 func runHostEvacuate(cmd *cobra.Command, nameOrID, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	moid, err := resolveName(cmd.Context(), backplaneURL, targetName, "host", nameOrID)
 	if err != nil {

--- a/cli/internal/cmd/vmware/listverbs.go
+++ b/cli/internal/cmd/vmware/listverbs.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -57,9 +58,9 @@ func newSimpleListCmd(spec simpleListSpec) *cobra.Command {
 }
 
 func runSimpleList(cmd *cobra.Command, spec simpleListSpec, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	r, err := conn.Call(cmd.Context(), backplaneURL, spec.opID, targetName, nil)
 	if err != nil {

--- a/cli/internal/cmd/vmware/operation.go
+++ b/cli/internal/cmd/vmware/operation.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -110,9 +111,9 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 			output.Unexpected(fmt.Sprintf("--limit must be >= 1; got %d", limit)),
 			jsonOut)
 	}
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
 	if err != nil {
@@ -228,9 +229,9 @@ func newOperationCallCmd() *cobra.Command {
 }
 
 func runOperationCall(cmd *cobra.Command, opID, targetName, paramsFlag string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params, err := loadParamsFlag(paramsFlag)
 	if err != nil {

--- a/cli/internal/cmd/vmware/vm.go
+++ b/cli/internal/cmd/vmware/vm.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -98,9 +99,9 @@ type vmListOpts struct {
 }
 
 func runVMList(cmd *cobra.Command, opts vmListOpts) error {
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	params, perr := buildListParams(opts.FilterNames, opts.FilterPowerStates, opts.FilterRaw)
 	if perr != nil {
@@ -280,9 +281,9 @@ func newVMInfoCmd() *cobra.Command {
 }
 
 func runVMInfo(cmd *cobra.Command, nameOrID, targetName string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	moid, err := resolveName(cmd.Context(), backplaneURL, targetName, "vm", nameOrID)
 	if err != nil {
@@ -397,9 +398,9 @@ func newVMCreateCmd() *cobra.Command {
 }
 
 func runVMCreate(cmd *cobra.Command, targetName, specFlag string, jsonOut bool, backplaneOverride string) error {
-	backplaneURL, err := resolveBackplane(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
 	params, err := loadParamsFlag(specFlag)
 	if err != nil {

--- a/cli/internal/cmd/vmware/vmware.go
+++ b/cli/internal/cmd/vmware/vmware.go
@@ -47,14 +47,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -110,69 +108,6 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newNetworkCmd())
 	cmd.AddCommand(newOperationCmd())
 	return cmd
-}
-
-// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers
-// can distinguish "operator never logged in" (→ auth_expired exit
-// code 2 — the right fix is `meho login`) from URL-parse failures
-// (→ unexpected exit code 4 — the right fix is correcting argv).
-// Same shape as the operation / connector / kb siblings; kept
-// independent because cmd/{operation,connector,kb,vmware} can't
-// import each other without an import cycle (cmd/root.go grafts each
-// onto the tree).
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
-// resolveBackplane mirrors the operation / connector sibling
-// helpers: --backplane override flag wins; otherwise read the URL
-// the most recent `meho login` wrote to config.json. Missing config
-// surfaces as errNoBackplaneConfigured so classifyBackplaneError
-// can route it to auth_expired.
-func resolveBackplane(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
-	}
-	cfg, err := auth.LoadConfig()
-	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
-	}
-	return normaliseURL(cfg.BackplaneURL)
-}
-
-// classifyBackplaneError maps a resolveBackplane error to the right
-// output.StructuredError category. Identical routing to the operation
-// sibling: missing-config → auth_expired; everything else (parse
-// errors, fs errors) → unexpected.
-func classifyBackplaneError(err error) *output.StructuredError {
-	if errors.Is(err, auth.ErrConfigNotFound) {
-		return output.AuthExpired(err.Error())
-	}
-	return output.Unexpected(err.Error())
-}
-
-// normaliseURL strips trailing slashes + parses the URL to fail fast
-// on garbage input. Mirrors the operation / connector siblings.
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
-	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
 }
 
 // renderRequestError translates an error from doAuthedRequest into

--- a/cli/internal/cmd/vmware/vmware_test.go
+++ b/cli/internal/cmd/vmware/vmware_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 )
 
 // ---------- helper tests (pure-function) ----------
@@ -47,14 +48,14 @@ func TestTruncatePassthroughAndCut(t *testing.T) {
 // trailing-slash trimming + reject-empty are the load-bearing
 // properties.
 func TestNormaliseURLBasic(t *testing.T) {
-	got, err := normaliseURL("https://meho.test/")
+	got, err := backplane.NormaliseURL("https://meho.test/")
 	if err != nil {
 		t.Fatalf("normaliseURL: %v", err)
 	}
 	if got != "https://meho.test" {
 		t.Fatalf("expected trailing slash stripped; got %q", got)
 	}
-	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+	if _, err := backplane.NormaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
 		t.Fatalf("empty should reject; got %v", err)
 	}
 }
@@ -63,12 +64,12 @@ func TestNormaliseURLBasic(t *testing.T) {
 // any wrapping error) maps to AuthExpired; everything else maps
 // to Unexpected.
 func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
-	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
-	se := classifyBackplaneError(wrapped)
+	wrapped := &backplane.NotConfiguredError{Inner: auth.ErrConfigNotFound}
+	se := backplane.ClassifyError(wrapped)
 	if se == nil || se.Code != "auth_expired" {
 		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
 	}
-	se = classifyBackplaneError(errors.New("parse failure"))
+	se = backplane.ClassifyError(errors.New("parse failure"))
 	if se == nil || se.Code != "unexpected_response" {
 		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
 	}


### PR DESCRIPTION
## Why

Cluster A of #923 — the backplane transport/error helpers were copied across ~20 `cmd/*` packages (duplicated only to avoid an import cycle). Per the agreed scope, this PR extracts the **byte-uniform, behavior-safe subset**; the genuinely-variant pieces are deliberately left alone.

## What

New leaf package `cli/internal/backplane`:
- `Resolve` (was `resolveBackplane`), `ClassifyError` (was `classifyBackplaneError`), `NormaliseURL` (was `normaliseURL`), `NotConfiguredError` (was `errNoBackplaneConfigured`)

**18 packages** now call `backplane.*` directly; their copies are deleted. **Net −777 lines** (599 added, 1,376 deleted).

## Deliberately NOT merged (real variants, not safe to force-unify)

| | Why kept per-package |
|---|---|
| `doAuthedRequest` / `sendRequest` / `renderRequestError` | 16 / 2 / 6 distinct bodies — differ by response-size cap and **silent-truncate vs error-on-overflow**. Merging would change behavior. |
| `cmd/connector` | stricter `normaliseURL` that rejects non-HTTP schemes (`ftp`/`ssh`/`file`) — asserted by its tests. |
| `cmd/broadcast` | different `errNoBackplaneConfigured` message (user-facing text). |
| `cmd/migrate`, `status.go` | separately-named `resolveBackplaneURL`. |

This is the discipline from the design checkpoint: dedup the uniform helpers, leave the behavioral variants explicit rather than steamrolling them.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt -l` (clean)
- `go test ./...` — **30 packages ok, 0 failures** (the 18 packages' tests exercise the shared helpers via the rewritten call sites)
- `golangci-lint run` — **0 issues**
- New `backplane_test.go` (69.6%)

Refs #923. With this + #937 (Cluster B), the CLI dispatch/transport duplication that SonarCloud flagged is substantially resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized backplane URL resolution and error classification logic into a shared internal package for consistency across CLI commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/938?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->