### PR TITLE
docs: G3.9 connector-auth design + research + 2026-05-22 roadmap replan

### DIFF
--- a/docs/architecture/connector-auth.md
+++ b/docs/architecture/connector-auth.md
@@ -1,0 +1,159 @@
+# Connector auth — the per-target credential read identity (decision)
+
+**Status:** proposed (gates Goal [#214](https://github.com/evoila/meho/issues/214) execution)
+**Date:** 2026-05-22
+**Context doc:** [docs/research/214-connector-credential-broker.md](../research/214-connector-credential-broker.md)
+
+## The decision this resolves
+
+Every MEHO REST/k8s connector resolves a per-target credential from Vault before
+it can call the vendor API. The loader that does this is a deliberate
+`NotImplementedError` stub today (see the research doc §1). Before any loader is
+implemented, one architectural question must be answered because it shapes the
+loader signature, the RBAC model, and the audit trail:
+
+> **What identity performs the per-target Vault read — the operator's, or the
+> backplane's own service identity?**
+
+## Options
+
+### Option A — Operator-context (forward the operator's JWT) ✅ recommended
+
+The loader calls the already-built
+[`vault_client_for_operator(operator)`](../../backend/src/meho_backplane/auth/vault.py#L198),
+which forwards the operator's validated Keycloak JWT to Vault's JWT/OIDC auth
+method (the existing `meho-mcp` role) and reads `target.secret_ref` as a KV-v2
+secret under the operator's identity. This is exactly what the `vault-1.x`
+connector already does for every op
+([vault/ops.py:294](../../backend/src/meho_backplane/connectors/vault/ops.py#L294)).
+
+- **RBAC:** the operator's Vault policy. A single role enforces *per-operator*
+  path scoping via **ACL policy templating** —
+  `path "secret/data/targets/{{identity.entity.aliases.<accessor>.name}}/*"`
+  scopes each operator to their own target secrets without per-operator roles.
+  ([Vault policy templating](https://developer.hashicorp.com/vault/docs/concepts/policies))
+- **Audit:** Vault's own audit log attributes every read to the operator's
+  Identity entity (the JWT `user_claim`), HMAC-hashing the values. MEHO's audit
+  row already records the operator + `target_id`. Dual attribution, for free.
+- **Secret-zero:** none — JWT/OIDC trusts Keycloak as a third party; no AppRole
+  `secret_id` to bootstrap.
+- **Blast radius:** a per-request Vault token, scoped to the operator's policy,
+  revoked on context exit. A compromised backplane cannot read more than the
+  *currently-acting operator* could.
+- **RFC 8693 framing:** impersonation-flavoured (Vault sees the operator).
+
+### Option B — Backplane-service-identity (AppRole)
+
+The backplane authenticates to Vault as itself (AppRole `role_id`+`secret_id`)
+and reads target secrets under one broad backplane policy.
+
+- **RBAC:** the backplane's policy (necessarily broad — it must read every
+  target's secret). No per-operator scoping at Vault.
+- **Audit:** Vault attributes every read to the backplane; per-operator
+  attribution exists only in MEHO's own audit log.
+- **Secret-zero:** reintroduced — the `secret_id` must be delivered securely
+  (response-wrapping / Vault Agent). ([AppRole pattern](https://developer.hashicorp.com/vault/docs/auth/approle/approle-pattern))
+- **Blast radius:** a compromised backplane holds a token that can read *every*
+  target's credential.
+- **RFC 8693 framing:** delegation-flavoured, but without token exchange the
+  `act`/`may_act` linkage never reaches Vault.
+
+## Recommendation: Option A (operator-context)
+
+Four reasons, in priority order:
+
+1. **The primitive already exists and is proven in production.**
+   `vault_client_for_operator` + the KV-v2 read is the live `vault-1.x` path
+   (rubric State 3). Option A reuses it; Option B builds a parallel auth path
+   MEHO does not currently have.
+2. **It is the stubs' stated intent.** Every stub's docstring and error message
+   says "the *operator-context* per-target Vault credential read is not yet
+   wired" ([vmware_rest/session.py:99](../../backend/src/meho_backplane/connectors/vmware_rest/session.py#L99),
+   [_shared/vcf_auth.py:182](../../backend/src/meho_backplane/connectors/_shared/vcf_auth.py#L182),
+   [kubernetes/kubeconfig.py:86](../../backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py#L86)).
+3. **Per-operator RBAC *and* audit through one role**, via templated policy — the
+   research-doc §2 finding. Option B can't match the attribution without extra
+   machinery (token exchange).
+4. **Smaller blast radius + no secret-zero.** Aligns with the comparable-systems
+   synthesis (Boundary "inject, never broker"; secret-zero-free).
+
+This is also the lowest-friction default: it is less new code than Option B, not
+more.
+
+### The one carve-out: system-initiated calls have no operator JWT
+
+Background/scheduled work (e.g. the topology scheduler) runs as a synthesised
+system operator with `raw_jwt=""`
+([connectors/vault/connector.py:311](../../backend/src/meho_backplane/connectors/vault/connector.py#L311)).
+Such a call **cannot** perform an operator-context Vault read. For v0.x this is
+acceptable and explicit: **system-initiated calls that need a vendor credential
+are out of scope** — today the only system caller (the readiness probe) hits
+Vault's *unauthenticated* health endpoint and forwards no token. A loader that
+receives an operator with empty `raw_jwt` MUST fail closed with a clear error
+("operator-context credential read requires an authenticated operator;
+target=…"), never silently fall back. A backplane-AppRole fallback for
+system-initiated connector calls is a **later, additive** option to file only
+when a concrete need exists — not built speculatively now.
+
+## Blast radius of implementing Option A (signature changes)
+
+The change is mechanical and bounded; `operator.raw_jwt` already reaches
+`auth_headers`, it is just dropped:
+
+1. **Loader type aliases** gain an `Operator` parameter:
+   - `VsphereSessionLoader = Callable[[VsphereTargetLike], Awaitable[dict]]` →
+     `Callable[[VsphereTargetLike, Operator], Awaitable[dict]]`
+     ([vmware_rest/session.py:86](../../backend/src/meho_backplane/connectors/vmware_rest/session.py#L86))
+   - `VcfCredentialsLoader` ([_shared/vcf_auth.py:165](../../backend/src/meho_backplane/connectors/_shared/vcf_auth.py#L165))
+   - `KubeconfigLoader` ([kubernetes/kubeconfig.py:53](../../backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py#L53))
+
+   **Pass the full `Operator`, not just `raw_jwt`** — `vault_client_for_operator`
+   takes an `Operator`, and the future `per_user` model needs `operator.sub` to
+   key the secret path. `Operator` is frozen, so there's no confused-deputy risk.
+
+2. **`auth_headers` stops discarding `raw_jwt`** and threads the operator down to
+   the loader. Today `auth_headers(target, raw_jwt)` does `del raw_jwt`
+   ([vmware_rest/connector.py:270](../../backend/src/meho_backplane/connectors/vmware_rest/connector.py#L270)).
+   Cleanest fix: the dispatcher already has the full `Operator`; thread the
+   `Operator` (not just `raw_jwt`) from `dispatch_ingested`
+   ([_branches.py:167](../../backend/src/meho_backplane/operations/_branches.py#L167))
+   → `_request_json`/`_post_json` → `auth_headers` → `_session_token` → loader.
+   This is an `HttpConnector` ABC-surface change
+   ([adapters/http.py:103,119,159](../../backend/src/meho_backplane/connectors/adapters/http.py#L103))
+   affecting every HTTP connector — do it once in the base + vmware as the canary,
+   then fan out. `CredentialsCache.get(target)` →
+   `get(target, operator)` ([_shared/vcf_auth.py:251](../../backend/src/meho_backplane/connectors/_shared/vcf_auth.py#L251)).
+
+3. **The loader body** becomes: `async with vault_client_for_operator(operator)
+   as client: read KV-v2 at target.secret_ref → return {"username","password"}`
+   (or kubeconfig YAML for k8s). Mirror the `vault/ops.py` unwrap +
+   error-class contract.
+
+4. **Tests** keep injecting fake loaders; the new loaders' own tests exercise the
+   live read against a Vault dev-mode harness (rubric State-2 bar).
+
+### What does NOT change
+
+The dispatch chain, resolver, target model, audit, policy gate, JSONFlux hook,
+catalog, and the agent surface are untouched — this is purely the
+credential-read leaf of the chain.
+
+## Consequences
+
+- Connectors move from rubric **State 1 → State 2** (`shared_service_account`
+  live) one at a time, reusing one shared Vault-read helper.
+- `per_user` / `impersonation` auth models stay deferred (they raise a clear
+  boundary error today); Option A's "pass the full `Operator`" choice keeps
+  `per_user` cheap to add later.
+- A **deploy-time prerequisite** is created: the Vault `meho-mcp` role's policy
+  must grant operators read on their target secret paths (templated policy), and
+  the operator's Keycloak→Vault Identity entity must exist. This is an operator
+  onboarding/runbook item, not code — call it out in the first Initiative.
+
+## Open question for the human (approval gate)
+
+Confirm **Option A (operator-context)**. If per-operator Vault policy
+administration is judged too heavy for the dogfood phase and a single broad
+backplane policy is preferred short-term, say so — that selects Option B and
+changes the first Initiative's RBAC/runbook tasks (but not the loader call
+sites, which still receive the `Operator`).

--- a/docs/planning/mvp-roadmap.md
+++ b/docs/planning/mvp-roadmap.md
@@ -1,6 +1,6 @@
 # MEHO MVP roadmap — versioned deploys
 
-Maps the seven MVPs to release versions, names what ships in each, and links the
+Maps the MVP sequence to release versions, names what ships in each, and links the
 GitHub Initiatives that close each MVP.
 
 **Relationship to [v0.2-decisions.md](v0.2-decisions.md):** v0.2-decisions remains
@@ -20,8 +20,42 @@ v0.2" framing on the board.
 | **v0.4** | **MVP3** | NSX + SDDC + Harbor + agent memory | partially filed |
 | **v0.5** | **MVP4** | VCF mgmt plane + broadcast *complete* (live SSE + historical query) | partially filed |
 | **v0.6** | **MVP5** | pfSense + gcloud + Hetzner Robot + tenant conventions | partially filed |
-| **v0.7** | **MVP6** | Holodeck + operator web UI (broadcast / KB / connectors / memory / topology) | unfiled |
-| **v0.8** | **MVP7** | Audit replay (forensic session traversal) | unfiled |
+| **v0.7** | **MVP6** | **Agent runtime — floor** (G11.1 runtime + G11.2 identity/RBAC/approval + G11.3 scheduler) | filed (17 tasks); unstaffed |
+| **v0.8** | **MVP7** | **Agent runtime — hardening** (G11.4 sanitization + G11.5 providers/budgets + G11.6 reference patterns) | initiatives filed; child tasks unfiled |
+| **v0.9** | **MVP8** | Operator web UI (broadcast / KB / connectors / memory / topology) + topology time-travel | filed |
+| **v0.10** | **MVP9** | Audit replay (forensic session traversal) | initiative filed; tasks unfiled |
+| **v0.11** | **MVP10** | Holodeck connector — closes the G3 wrapper-retirement story (deferred; unblocked, ready now) | filed (3 tasks) |
+
+---
+
+## Capability-first overlay (added 2026-05-22)
+
+**Read [release-plan.md](release-plan.md) alongside this table.** A full-board +
+code audit on 2026-05-22 found that the version status above measures
+*initiative closure*, not *usable capability*: v0.2–v0.5 read as shipped while
+**no REST connector can execute against a real target** and **set-shaped
+responses are not reduced**. Two cross-cutting gates — invisible because they
+are not connector-tier line items — block usability across those versions:
+
+| Gate | Initiative | Status | Blocks |
+|---|---|---|---|
+| **JSONFlux reducer** (real reduction, not pass-through; [postulate 6](../../CLAUDE.md)) | [G0.6.1 #750](https://github.com/evoila/meho/issues/750) | open, 0/5, **was off-map** | safe output for *every* connector at scale |
+| **Connector credential broker** (operator-context Vault read) — vmware vertical slice | [G3.9 #939](https://github.com/evoila/meho/issues/939) | open, 0/4, **new** | v0.2 vSphere actually executing |
+| **Credential-loader fan-out** (nsx/sddc/harbor, VCF, k8s) | [G3.10 #944](https://github.com/evoila/meho/issues/944) | open, 0/4, **new** | v0.3/v0.4/v0.5 connectors executing |
+
+**Connector versions ship at [State 1–3](../codebase/connector-release-readiness.md), not binary "done":**
+
+- **v0.2** vSphere, **v0.3** k8s, **v0.4** nsx/sddc/harbor, **v0.5** VCF — all
+  shipped/planned at **State 1 (cataloged)**. They reach **State 2 (executes)**
+  only when #750 + #939 (v0.2) and #944 (v0.3–v0.5) land. Slot #939 into
+  **v0.2.1**; #944 spans **v0.3/v0.4/v0.5**; #750 into **v0.2.1**.
+- Release notes cite the connector's state + live auth models, never "shipped"
+  for a cataloged-only connector (the convention from
+  [connector-release-readiness.md](../codebase/connector-release-readiness.md)).
+
+The capability-first sequencing (R1 gates → R2 fan-out → R3 UI/replay → R4
+runtime) lives in [release-plan.md](release-plan.md); it re-orders *delivery*
+without renumbering the versions here.
 
 ---
 
@@ -162,10 +196,18 @@ so G0.8 corrects it before v0.3 work proceeds.
 | Initiative | # |
 |---|---|
 | [G0.8 v0.2 dogfood hardening](https://github.com/evoila/meho/issues/634) | #634 |
+| [G0.6.1 Real JSONFlux reducer (execution gate)](https://github.com/evoila/meho/issues/750) | #750 |
+| [G3.9 Connector credential broker + vmware vertical slice (execution gate)](https://github.com/evoila/meho/issues/939) | #939 |
 
 Parent goal G0 [#221](https://github.com/evoila/meho/issues/221). All 8
-child Tasks (#628 #583 #629 #633 #630 #632 #631 #668) closed; the three
+G0.8 child Tasks (#628 #583 #629 #633 #630 #632 #631 #668) closed; the three
 hard blockers (#628 / #583 / #629) cleared, lifting the v0.3/v0.4 freeze.
+
+**Execution gates added 2026-05-22 (see [release-plan.md](release-plan.md)).**
+v0.2 shipped vSphere at **State 1 (cataloged)**. It reaches **State 2
+(executes against a real target)** only when #750 (safe reduction) and #939
+(operator-context credential read) land — both folded into v0.2.1 because the
+hardening theme is "make the shipped v0.2 actually usable."
 
 > **`/meho-status` `VERSION_MAP` drift (surfaced, not silently
 > reconciled):** the `meho-status` skill's hardcoded `VERSION_MAP` does
@@ -199,11 +241,18 @@ hard blockers (#628 / #583 / #629) cleared, lifting the v0.3/v0.4 freeze.
 | [G3.4 bind9-9.x typed-SSH](https://github.com/evoila/meho/issues/367) | #367 |
 | [G9.1 Graph schema + auto-discovery + verbs](https://github.com/evoila/meho/issues/363) | #363 |
 | [G9.2 Curated cross-system edges](https://github.com/evoila/meho/issues/364) | #364 |
+| [G3.10 Credential-loader fan-out (execution gate; spans v0.3–v0.5 connectors)](https://github.com/evoila/meho/issues/944) | #944 |
 
-**Open scoping question:** [G9.3 Discovery history](https://github.com/evoila/meho/issues/365)
-(topology time-travel queries) is filed under G9 but unstaffed. This roadmap
-pushes it to **v0.7** where the Topology UI gives time-travel real reach.
-Decision needed before locking v0.3.
+**Execution gate:** [G3.10 #944](https://github.com/evoila/meho/issues/944) is
+one initiative that takes the v0.3 (k8s), v0.4 (nsx/sddc/harbor) and v0.5 (VCF)
+connectors from **State 1 → State 2**. It is mapped here at v0.3 as its earliest
+gated version; depends on [#939](https://github.com/evoila/meho/issues/939). See
+[release-plan.md](release-plan.md) R2.
+
+**Resolved:** [G9.3 Discovery history](https://github.com/evoila/meho/issues/365)
+(topology time-travel queries) ships in **v0.9** alongside the operator web UI,
+where the Topology UI gives time-travel real reach. (Originally floated for
+v0.7; moved with the UI in the 2026-05-22 replan — see Cross-cutting.)
 
 ---
 
@@ -300,12 +349,88 @@ subscriber externally; the backplane doesn't ship one.
 
 ---
 
-## v0.7 — MVP6 — Holodeck + operator web UI
+## v0.7 — MVP6 — Agent runtime — floor (G11 wave 1)
+
+**Reprioritised 2026-05-22:** agent runtime (Goal G11) moves ahead of the
+operator web UI and Holodeck. MEHO becomes a first-class **agent host** —
+long-running LLM agents that observe, reason, and (under governance) act,
+running *inside* MEHO's process boundary on the same identity + RBAC + audit +
+dispatch machinery as human operators. G11 is UI-independent by design (its own
+scope note: "agent surfaces in G10's UI are a later G10.x slice"), so it can
+lead while the UI waits. See [Goal #800](https://github.com/evoila/meho/issues/800).
 
 ### What ships
 
-- **Holodeck** (typed-SSH; PowerShell-over-SSH) — closes the
-  wrapper-retirement story
+The **runtime floor** — the three primitives that make MEHO an agent host:
+
+- **P1 — Agent runtime (G11.1)** — in-process Pydantic AI tool-use loop behind
+  an `AgentRun` seam; sync + async (handle/SSE) invocation; agent-invokes-agent.
+  Every tool call routes through the normal dispatch + RBAC + audit path.
+- **P3 — Agent identity + RBAC + approval (G11.2)** — agents as Keycloak
+  principals; RFC 8693 delegation (`sub`=user, `act`=agent); the v0.2
+  `requires_approval` hard-deny becomes the durable per-(principal, op, target)
+  approval queue (auto-execute | needs-approval | deny) it always foresaw.
+- **P2 — Scheduler (G11.3)** — durable cron + one-off + event(outbox) triggers
+  firing agent runs; the floor of 24/7 operation. Roll-our-own vs DBOS settled
+  by a spike task.
+
+Builds only on shipped substrate (G0 identity/audit/dispatch, G4 knowledge,
+G5 memory). Surfaced via CLI + MCP per v0.1 — no web-UI dependency.
+
+### Initiatives
+
+| Initiative | # | Tasks |
+|---|---|---|
+| [G11.1 Agent runtime (P1)](https://github.com/evoila/meho/issues/802) | #802 | #808–#813 (6) |
+| [G11.2 Agent identity + RBAC + approval (P3)](https://github.com/evoila/meho/issues/803) | #803 | #815–#820 (6) |
+| [G11.3 Scheduler (P2)](https://github.com/evoila/meho/issues/804) | #804 | #822–#826 (5) |
+
+---
+
+## v0.8 — MVP7 — Agent runtime — hardening (G11 waves 2–4)
+
+### What ships
+
+Completes the agent-runtime capability. The floor (v0.7) is not
+production-safe until sanitization lands, so these ship as the immediate
+follow-on, ahead of the UI:
+
+- **C1+C2 — Safety (G11.4)** — sanitization middleware (declarative regex hot
+  path + Presidio for free-text) on *every* connector response, "store raw in
+  audit, show redacted to caller"; plus the agent audit/replay extension
+  (`agent_session_id` lineage, raw+redacted side-by-side, redaction manifest).
+  This is what satisfies the consumer's "zero raw credentials in any LLM
+  prompt" bar.
+- **C4+C3 — Portability + cost (G11.5)** — LLM-provider abstraction (Anthropic
+  + Bedrock + OpenAI + on-prem vLLM/Ollama + **VCF Private AI Foundation**) so
+  the same agents ship to SaaS-OK and air-gapped tenants; plus per-identity
+  token budgets (the cost kill switch).
+- **R1–R4 — Reference patterns (G11.6)** — runnable sample agents + docs in
+  `examples/` (tiered triage, operator-approval gate, kb write-back,
+  local-Claude-as-triage). Not MEHO surface — composition examples on the
+  primitives.
+
+### Initiatives
+
+| Initiative | # |
+|---|---|
+| [G11.4 Safety — sanitization + audit/replay](https://github.com/evoila/meho/issues/805) | #805 |
+| [G11.5 Portability + cost — providers + budgets](https://github.com/evoila/meho/issues/806) | #806 |
+| [G11.6 Reference patterns (R1–R4)](https://github.com/evoila/meho/issues/807) | #807 |
+
+*Child tasks for #805 / #806 / #807 are outlined in each Initiative body but
+not yet filed as issues — file them before this version locks.*
+
+---
+
+## v0.9 — MVP8 — operator web UI + topology time-travel
+
+**Pushed back from v0.7** by the 2026-05-22 agent-runtime reprioritisation.
+Content is unchanged — the operator console, plus G9.3 topology time-travel
+which travels with it (its value is gated by the Topology UI).
+
+### What ships
+
 - **Operator console** at `/ui/*` — HTMX 2 + Jinja2 + Tailwind 4 + DaisyUI 5
   + Alpine.js + Cytoscape.js island
   - Frontend chassis (G10.0)
@@ -314,6 +439,8 @@ subscriber externally; the backplane doesn't ship one.
   - Connectors + Targets UI (G10.3) — table + per-target detail + ops matrix
   - Memory UI (G10.4) — 5-scope filtered list + scope-promotion + expiry viz
   - Topology UI (G10.5) — tabular + Cytoscape.js graph + dependents/dependencies/path
+  - **Agent surfaces** (run / inspect / approve) land here as a G10.x slice now
+    that the agent runtime (G11) ships first
 - **Discovery history (G9.3)** — pulled from v0.3 so the Topology UI can show
   time-travel topology meaningfully
 
@@ -321,25 +448,28 @@ subscriber externally; the backplane doesn't ship one.
 
 | Initiative | # |
 |---|---|
-| [G3.8 Holodeck typed-SSH](https://github.com/evoila/meho/issues/371) | #371 |
-| [G9.3 Discovery history](https://github.com/evoila/meho/issues/365) | #365 *(moved from v0.3)* |
 | [G10.0 Frontend chassis](https://github.com/evoila/meho/issues/337) | #337 |
 | [G10.1 Broadcast UI](https://github.com/evoila/meho/issues/338) | #338 |
 | [G10.2 KB UI](https://github.com/evoila/meho/issues/339) | #339 |
 | [G10.3 Connectors + Targets UI](https://github.com/evoila/meho/issues/340) | #340 |
 | [G10.4 Memory UI](https://github.com/evoila/meho/issues/341) | #341 |
 | [G10.5 Topology UI](https://github.com/evoila/meho/issues/342) | #342 |
+| [G9.3 Discovery history](https://github.com/evoila/meho/issues/365) | #365 *(moved from v0.3)* |
 
 ---
 
-## v0.8 — MVP7 — audit replay (post-MVP forensics)
+## v0.10 — MVP9 — audit replay (post-MVP forensics)
+
+**Pushed back from v0.8** by the agent-runtime reprioritisation; content
+unchanged.
 
 ### What ships
 
 - **Audit replay** — `meho audit replay <session-id>` reconstructs the full
   forensic trace of one agent session as a chronologically-ordered,
   parent/child tree of every operation. Recursive-CTE traversal over
-  `audit_log.parent_audit_id`. Closes the third leg of G8.
+  `audit_log.parent_audit_id`. Closes the third leg of G8. (Now also traverses
+  the `agent_session_id` lineage added in v0.8 / G11.4.)
 
 ### Initiatives
 
@@ -349,6 +479,31 @@ subscriber externally; the backplane doesn't ship one.
 
 *Audit query core (G8.1) shipped in v0.5. Only the replay/graph-traversal
 half remains.*
+
+---
+
+## v0.11 — MVP10 — Holodeck connector (G3 closer)
+
+**Deferred from v0.7** in the 2026-05-22 replan — lowest scheduled priority,
+but **unblocked and ready now**: it inherits the shipped `SshConnector`, and
+its tasks (#853–#855) are filed and ready for
+`/auto-implement-initiative #371`. It blocks nothing and nothing blocks it, so
+any contributor can pull it forward opportunistically; it sits at the tail only
+because agent runtime + UI + audit replay outrank it.
+
+### What ships
+
+- **Holodeck** (typed-SSH; PowerShell-over-SSH) — ~8 read-only inspection ops
+  against the VMware Holodeck nested-VCF-lab appliance (HoloRouter has no REST
+  API). Closes the G3 wrapper-retirement story — every consumer `scripts/*.sh`
+  wrapper now has a MEHO parallel. Pod-clone provisioning stays a future Runbook
+  under G11. See [#371](https://github.com/evoila/meho/issues/371).
+
+### Initiatives
+
+| Initiative | # |
+|---|---|
+| [G3.8 Holodeck typed-SSH](https://github.com/evoila/meho/issues/371) | #371 |
 
 ---
 
@@ -371,7 +526,7 @@ Tier is fixed by operator value, not architectural dependency:
 | 3 | pfSense | typed-SSH | v0.6 |
 | 3 | gcloud | transport TBD | v0.6 |
 | 3 | Hetzner Robot | generic-ingested | v0.6 |
-| — | Holodeck | typed-SSH | v0.7 |
+| — | Holodeck | typed-SSH | v0.11 *(deferred 2026-05-22; ready now)* |
 
 ### Items dropped from scope
 
@@ -379,14 +534,31 @@ Tier is fixed by operator value, not architectural dependency:
 
 ### Items pulled forward
 
+- **Agent runtime (Goal G11) — off-roadmap → v0.7 + v0.8.** Pulled in and
+  prioritised ahead of the operator UI in the 2026-05-22 replan: MEHO-as-agent-
+  host (P1 runtime + P2 scheduler + P3 identity/RBAC/approval in v0.7; then
+  C1–C4 + reference patterns in v0.8). Builds on already-shipped substrate and
+  is UI-independent by design. This **redefines MVP6/MVP7** (previously
+  Holodeck + UI / audit replay) — see TL;DR and the per-version sections.
 - **G8.1 Audit query core** — moved v0.8 → v0.5. Reason: it's what gives
   agents "what happened in the past X days," which is half of the broadcast
   contract.
 
 ### Items pushed back
 
-- **G9.3 Discovery history (topology time-travel)** — moved v0.3 → v0.7.
-  Reason: value is gated by the Topology UI.
+*All four below are consequences of the 2026-05-22 agent-runtime
+reprioritisation; none changed in content, only in sequence.*
+
+- **Operator web UI (G10.0–G10.5)** — moved v0.7 → **v0.9**. Reason: agent
+  runtime (G11) reprioritised ahead of it. Ships one release later, unchanged.
+- **Audit replay (G8.2)** — moved v0.8 → **v0.10**, displaced by the two
+  agent-runtime releases. Content unchanged.
+- **Holodeck (G3.8)** — moved v0.7 → **v0.11** (tail). Reason: tier-4,
+  event-shaped, lowest operator-frequency connector; deferred so agent runtime
+  leads. Unblocked and ready — can be pulled forward opportunistically.
+- **G9.3 Discovery history (topology time-travel)** — moved v0.3 → **v0.9**
+  (was floated for v0.7). Reason: value is gated by the Topology UI, so it
+  travels with the UI wherever the UI lands.
 
 ### Ownership today — the structural risk
 
@@ -397,8 +569,11 @@ Tier is fixed by operator value, not architectural dependency:
 | v0.4 | — | all | UNSTAFFED |
 | v0.5 | — | all | UNSTAFFED |
 | v0.6 | — | all | UNSTAFFED |
-| v0.7 | — | all | UNSTAFFED |
-| v0.8 | — | all | UNSTAFFED |
+| v0.7 | — | G11.1, G11.2, G11.3 (all) | **HIGH** — new lead release; the agent-runtime floor has no named owner |
+| v0.8 | — | G11.4, G11.5, G11.6 (all; child tasks unfiled) | UNSTAFFED |
+| v0.9 | G10.0–G10.4 (`@damir-topic`), G10.5 + G9.3 (`@zdamir`) | — | staffed |
+| v0.10 | — | G8.2 | UNSTAFFED |
+| v0.11 | G3.8 (`@kr3s0`) | — | staffed; ready to auto-implement |
 
 **Owner assignment is the single largest unmitigated risk to this roadmap.**
 Even MVP1 — partially merged, in flight — has zero named owners on four of its

--- a/docs/planning/release-plan.md
+++ b/docs/planning/release-plan.md
@@ -1,0 +1,154 @@
+# MEHO release plan — ship *usable* capability, not parts
+
+Companion to [mvp-roadmap.md](mvp-roadmap.md). The roadmap sequences *what gets
+built*; this document sequences *what becomes usable*, because the two had
+silently diverged: by initiative-closure the board read v0.2–v0.5 as `✓ ready`,
+while **not one REST connector could execute against a real target.** This plan
+fixes the measurement and the sequence.
+
+Authored 2026-05-22 after a full-board + code audit. Depth-first, with CLI⇄MCP
+parity held as a hard constraint every release.
+
+## The one principle
+
+> **A release ships only when it passes a demo test: a named workflow an
+> operator *and* an agent can complete end-to-end through MEHO.**
+> "Done" means "works against a real target," not "the initiative merged."
+
+Two corollaries:
+
+- **State, not closure.** Every connector is described by the [3-state
+  rubric](../codebase/connector-release-readiness.md): State 1 (cataloged) /
+  State 2 (one auth model executes) / State 3 (production). Release notes cite
+  the state. "Cataloged" is never reported as "shipped."
+- **Dual-surface parity.** Each demo test must pass via **both** the `meho`
+  CLI and the MCP meta-tools (`call_operation`, etc.). They share one dispatch
+  path; the constraint keeps them from drifting.
+
+## Honest capability ledger (2026-05-22)
+
+| Aspect | Goal | Real state | Usable E2E? |
+|---|---|---|---|
+| Substrate (dispatch / registry / audit / policy / resolver) | G0 | 89/94 tasks; **JSONFlux reducer stubbed** ([#750](https://github.com/evoila/meho/issues/750), pass-through) | ⚠️ small responses only |
+| Knowledge base | G4 | 3/3 inis, 14/14 tasks | ✅ |
+| Memory | G5 | 3/3, 16/16 | ✅ |
+| Broadcast (live SSE feed) | G6 | 3/3, 16/17 | ✅ |
+| Audit **query** | G8.1 | done | ✅ |
+| Topology / targets-as-data | G9 | 23/26; G9.3 in progress | ✅ mostly |
+| Connectors — **discovery** (search + catalog) | G3 | vmware/k8s/nsx/sddc/harbor/VCF cataloged | ✅ |
+| Connectors — **execution** (real vendor calls) | G3 | **only `vault-1.x` truly executes**; bind9 caveated; all REST loaders stubbed ([#939](https://github.com/evoila/meho/issues/939)/[#944](https://github.com/evoila/meho/issues/944)) | ❌ |
+| Tenant conventions | G7 | 0/1, 0/6 ([#229](https://github.com/evoila/meho/issues/229)) | ❌ not started |
+| Audit **replay** | G8.2 | filed, 0 tasks ([#377](https://github.com/evoila/meho/issues/377)) | ❌ not started |
+| Operator web UI | G10 | 0/6, 3/20 | ❌ barely started |
+| Agentic runtime | G11 | 0/6, 0/17 | ❌ not started |
+
+**Headline:** MEHO today is a working *knowledge / memory / broadcast / audit /
+topology backplane with a connector search surface* — but it cannot execute a
+vendor REST call against a real target, nor safely reduce a large response.
+Both are downstream of two cross-cutting gates.
+
+## The two gates that unlock everything
+
+Neither is a connector-tier line item, which is exactly why they were invisible.
+Both gate *usability* across multiple releases.
+
+1. **JSONFlux reducer** — [#750](https://github.com/evoila/meho/issues/750)
+   (G0.6.1), open, 0/5, off the version map. [CLAUDE.md postulate
+   6](../../CLAUDE.md) calls set-shaped reduction "non-negotiable"; the
+   dispatcher ships `PassThroughReducer` today, so a large vCenter list dumps
+   raw into the agent context — the precise failure MEHO exists to prevent.
+2. **Credential execution** — [#939](https://github.com/evoila/meho/issues/939)
+   + [#944](https://github.com/evoila/meho/issues/944). Decision:
+   operator-context Vault read ([connector-auth.md](../architecture/connector-auth.md)).
+   Without it, no REST connector authenticates.
+
+Land both and the dozens of already-cataloged connector ops become usable at
+once. **This is the highest-leverage work on the board.**
+
+## Releases (capability-themed, depth-first)
+
+Each maps onto the existing version numbers in [mvp-roadmap.md](mvp-roadmap.md);
+the change is the *ordering* (gates first) and the *done-when* (demo test).
+
+### R1 — "Execute one thing, safely" → folds into v0.2.1 / v0.3
+
+**Demo test:** an operator runs `meho vmware vm list --target rdc-vcenter`
+*and* an agent calls `call_operation("vmware-rest-9.0", <vm list op>, target)`;
+both return a **reduced, handle-backed, audited** result from a **real** vCenter.
+
+| Pulls in | Why |
+|---|---|
+| [#750](https://github.com/evoila/meho/issues/750) JSONFlux reducer | so the result is safe at scale (postulate 6) |
+| [#939](https://github.com/evoila/meho/issues/939) credential broker + vmware slice (#940 threading, #941 helper, #942 vmware loader + lab E2E, #943 Vault-policy runbook) | so the call authenticates as the operator |
+
+**Done-when:** vmware-rest at **State 2**; demo test green via CLI + MCP; lab
+E2E (env-gated) passes; no secret in logs/results; release notes say "executes
+(shared_service_account); reduced output."
+**Lane:** @ikaric / @zdamir (JSONFlux — retrieval/backplane) ∥ @kr3s0 (credential slice).
+
+### R2 — "Execute the working set" → v0.3 / v0.4 / v0.5
+
+**Demo test:** an RDC operator retires `scripts/*.sh` for tier-1/2/3 ops for ≥2
+weeks (Goal [#214](https://github.com/evoila/meho/issues/214) done-when), with
+per-tenant standing instructions auto-loading.
+
+| Pulls in | |
+|---|---|
+| [#944](https://github.com/evoila/meho/issues/944) fan-out: nsx/harbor/sddc (#945), vROps/vRLI/Fleet (#946), vcf-automation (#947), k8s (#948) | every REST + k8s connector → State 2 |
+| [#229](https://github.com/evoila/meho/issues/229) G7.1 tenant conventions | standing instructions per tenant |
+
+**Done-when:** each connector at State 2 with a recorded-fixture E2E; conventions
+load at session preamble (CLI + MCP); Goal #214 done-when met.
+**Lane:** @kr3s0 (connectors) ∥ @zdamir (conventions/backplane).
+
+### R3 — "See it" → v0.9 / v0.10
+
+**Demo test:** an operator uses a web console to browse broadcast / KB /
+connectors / memory / topology, and replays a past agent session forensically.
+
+| Pulls in | |
+|---|---|
+| G10 ([#336](https://github.com/evoila/meho/issues/336)) operator web UI | surfaces the already-working substrate that's API/MCP-only today |
+| [#377](https://github.com/evoila/meho/issues/377) G8.2 audit replay | forensic session traversal |
+
+**Done-when:** each console reads live data; replay reconstructs a session from
+`audit_log`. **Lane:** @damir-topic (UI) ∥ @zdamir (replay/audit).
+
+### R4 — "Run it unattended" → v0.7 / v0.8
+
+**Demo test:** an agent completes a governed multi-step op (approval-gated, scheduled,
+sanitized) end-to-end, including a safe store-to-store secret move it never observes.
+
+| Pulls in | |
+|---|---|
+| G11 ([#800](https://github.com/evoila/meho/issues/800)) agentic runtime (G11.1 runtime, G11.2 identity/RBAC/approval, G11.3 scheduler, G11.4-6 hardening) | the autonomous spine |
+| [#581](https://github.com/evoila/meho/issues/581) secret broker | unattended credential moves, agent-blind |
+
+**Done-when:** an unattended agent run passes with approval + audit + scheduling.
+**Lane:** @zdamir / @ikaric (runtime + MCP) ∥ @kr3s0 (connector ops).
+
+## Why this ordering
+
+- **Depth-first:** R1 proves *one* connector works end-to-end before fanning out.
+  The fastest credible "it executes" moment; de-risks the credential + JSONFlux
+  design once, on vSphere, before it's repeated 8×.
+- **Already-done aspects aren't re-litigated** — KB/memory/broadcast/audit-query/
+  topology work now; R3 *surfaces* them (UI) rather than rebuilding them. "Covers
+  all aspects" is satisfied by scheduling the not-started ones (conventions in R2,
+  replay + UI in R3, runtime in R4), not by spreading R1 thin.
+- **The gates lead.** #750 + #939 before #944, because fan-out to inert
+  connectors ships more parts that still don't work.
+
+## What changed vs the old roadmap
+
+1. Two gates promoted to first-class, release-leading work: #750, #939/#944.
+2. Release "done" redefined as the demo test (State 2/3), not initiative merge.
+3. CLI⇄MCP parity made an explicit per-release constraint.
+4. Goal-label gap fixed (G2–G9 were unlabeled and invisible to rollups).
+
+## See also
+
+- [mvp-roadmap.md](mvp-roadmap.md) — version→initiative mapping (now annotated with the gates).
+- [connector-release-readiness.md](../codebase/connector-release-readiness.md) — the State 1/2/3 rubric.
+- [architecture/connector-auth.md](../architecture/connector-auth.md) — the credential-read decision.
+- [research/214-connector-credential-broker.md](../research/214-connector-credential-broker.md) — the credential-broker research.

--- a/docs/research/214-connector-credential-broker.md
+++ b/docs/research/214-connector-credential-broker.md
@@ -1,0 +1,395 @@
+# Connector credential brokering — research + execution-gap map (Goal #214)
+
+Research artifact for Goal [#214](https://github.com/evoila/meho/issues/214)
+(connector parity). Answers one question: **what has to land for a MEHO REST
+connector to execute against a real vendor target, and how should the
+per-target credential read be designed** so the agent/operator never handles
+the secret value, with per-operator RBAC + audit.
+
+Two halves:
+
+1. **§1 Execution-gap map** — what is wired vs stubbed in the dispatch chain
+   today, with `file:line` evidence (re-derived from the tree on 2026-05-22,
+   not from prior session notes).
+2. **§2–§7 Research** — industry patterns + standards for secrets brokering,
+   operator- vs workload-scoped access, multi-vendor session lifecycle,
+   comparable systems, audit/least-privilege, and testing without real
+   secrets.
+
+The gating architecture decision this research feeds is written up separately
+in [docs/architecture/connector-auth.md](../architecture/connector-auth.md).
+
+---
+
+## §1 — Execution-gap map: wired vs stubbed
+
+**Finding (verified):** the dispatch substrate is fully wired end-to-end. The
+production gap is the **per-target credential read** in each REST/k8s
+connector's loader, plus the **operator-identity threading** that would let
+that loader read Vault under the operator's identity. One connector
+(`vault-1.x`) already does the operator-context Vault read and is the working
+reference; `bind9-ssh-9.x` executes but via a *different* (embedded-credential)
+path that does not generalise (see the bind9 note below).
+
+### The dispatch chain (operator → vendor API)
+
+| Stage | Status | Evidence |
+|---|---|---|
+| Agent/CLI/REST entry → `call_operation` | ✅ wired | [operations/meta_tools.py:455](../../backend/src/meho_backplane/operations/meta_tools.py#L455) — resolves target via `resolve_target`, binds `audit_target_id`, calls `dispatch` |
+| Target resolution (name/alias → DB row) | ✅ wired | [targets/resolver.py](../../backend/src/meho_backplane/targets/resolver.py); `call_operation` calls it at [meta_tools.py:491](../../backend/src/meho_backplane/operations/meta_tools.py#L491) |
+| `dispatch(...)` — lookup → validate → policy → resolve → branch → reduce → audit | ✅ wired | [operations/dispatcher.py:469](../../backend/src/meho_backplane/operations/dispatcher.py#L469) (8-phase flow) |
+| Connector resolution by fingerprint | ✅ wired | [connectors/resolver.py](../../backend/src/meho_backplane/connectors/resolver.py); called from [dispatcher.py:525](../../backend/src/meho_backplane/operations/dispatcher.py#L525) via `_resolve_connector_instance` |
+| Source-kind branches (`ingested`/`typed`/`composite`) | ✅ wired | [operations/_branches.py:119](../../backend/src/meho_backplane/operations/_branches.py#L119) |
+| `operator.raw_jwt` carried to connector transport | ✅ wired | `dispatch_ingested` reads `raw_jwt = operator.raw_jwt` and forwards it to `_request_json`/`_post_json` — [_branches.py:167](../../backend/src/meho_backplane/operations/_branches.py#L167) |
+| HTTP transport injects auth via `auth_headers(target, raw_jwt)` | ✅ wired | [adapters/http.py:143](../../backend/src/meho_backplane/connectors/adapters/http.py#L143) calls `await self.auth_headers(target, raw_jwt)` |
+| **REST connector `auth_headers` uses `raw_jwt`** | ❌ **discards it** | `vmware_rest` does `del raw_jwt` then `self._session_token(target)` — [vmware_rest/connector.py:270](../../backend/src/meho_backplane/connectors/vmware_rest/connector.py#L270) |
+| **Loader receives operator identity** | ❌ **signature is `loader(target)`** | `VsphereSessionLoader = Callable[[VsphereTargetLike], Awaitable[dict[str,str]]]` — [vmware_rest/session.py:86](../../backend/src/meho_backplane/connectors/vmware_rest/session.py#L86). No `operator`/`raw_jwt` parameter. |
+| **Default loader does the Vault read** | ❌ **`NotImplementedError` stub** | [vmware_rest/session.py:99](../../backend/src/meho_backplane/connectors/vmware_rest/session.py#L99); shared VCF stub [_shared/vcf_auth.py:182](../../backend/src/meho_backplane/connectors/_shared/vcf_auth.py#L182); k8s [kubernetes/kubeconfig.py:86](../../backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py#L86) |
+| Operator-context Vault read primitive | ✅ **exists, proven** | `vault_client_for_operator(operator)` JWT/OIDC-logs-in with `operator.raw_jwt`, yields an authed hvac client, revokes on exit — [auth/vault.py:198](../../backend/src/meho_backplane/auth/vault.py#L198) |
+| KV-v2 read under operator identity | ✅ **exists, proven** | Vault connector op: `async with vault_client_for_operator(operator) as client: client.secrets.kv.v2.read_secret_version(path=..., mount_point=...)` — [vault/ops.py:294](../../backend/src/meho_backplane/connectors/vault/ops.py#L294) |
+
+### The precise gap, in one sentence
+
+`operator.raw_jwt` already reaches the connector's `auth_headers(target, raw_jwt)`,
+but every REST connector **drops it** and every credential loader's signature is
+`loader(target)` — so the loader cannot reach the already-built
+`vault_client_for_operator(operator)` primitive to perform the per-target Vault
+read. Closing the gap = (a) thread the operator (or `raw_jwt`) from
+`auth_headers`/`_session_token` into the loader, and (b) implement the loader as
+a KV-v2 read of `target.secret_ref` under `vault_client_for_operator`.
+
+### Connector-by-connector state (against the 3-state rubric)
+
+Per [docs/codebase/connector-release-readiness.md](../codebase/connector-release-readiness.md):
+
+| Connector | Loader | State | Executes against a real DB-backed target? |
+|---|---|---|---|
+| `vault-1.x` | operator-context KV-v2 read, live ([vault/ops.py:294](../../backend/src/meho_backplane/connectors/vault/ops.py#L294)) | **3** | ✅ — the reference chain |
+| `bind9-ssh-9.x` | reads `target.secret_ref` as a **dict** (`secret_ref.get("password")`) — [bind9/ops_record.py:912](../../backend/src/meho_backplane/connectors/bind9/ops_record.py#L912) | **2 (with caveat)** | ⚠️ see note |
+| `vmware-rest-9.0` | `load_session_credentials_from_vault` — `NotImplementedError` | **1** | ❌ (mock loader in tests only) |
+| `nsx-4.2`, `harbor-2.x`, `sddc-manager-9.0` | per-connector `session.py` stub | **0.5–1** | ❌ |
+| `vcf-operations/logs/fleet/automation-9.0` | shared `_shared/vcf_auth.py` stub | **0.5–1** | ❌ |
+| `k8s-1.x` | `load_kubeconfig_from_vault` — `NotImplementedError` | **1** | ❌ (mock loader in tests only) |
+
+**bind9 caveat (correction to the "bind9 works end-to-end" claim).** bind9's
+credential read is `_sudo_password_from_target(target)`, which requires
+`target.secret_ref` to be a **dict** and reads `secret_ref.get("sudo_password")
+or secret_ref.get("password")`
+([ops_record.py:912-934](../../backend/src/meho_backplane/connectors/bind9/), same in
+[ops_config.py:430](../../backend/src/meho_backplane/connectors/bind9/)). But the
+persisted `targets.secret_ref` column is **`Text` (a string)**
+([alembic/versions/0004_create_targets_and_audit_target_id.py:139](../../backend/alembic/versions/0004_create_targets_and_audit_target_id.py#L139)),
+and the `Target` Pydantic schema declares `secret_ref: str | None`
+([targets/schemas.py:104](../../backend/src/meho_backplane/targets/schemas.py#L104)).
+So bind9's loader proves **dispatch + SSH transport + atomic-apply**, but its
+credential model (embedded dict) is *inconsistent with the persisted target
+shape* and is **not** the Vault-broker model the REST connectors need. bind9 is
+not a usable template for this Goal; the `vault-1.x` op path is.
+
+### Proof the only gap is the production loader
+
+Every connector's E2E/auth test passes by **injecting a fake loader**, which is
+exactly what isolates the production loader as the single missing piece:
+
+- vmware: `VmwareRestConnector(session_loader=_stub_loader)` and an explicit
+  test asserting the default raises (`pytest.raises(NotImplementedError,
+  match=r"deliberate stub.*#214")`) —
+  [tests/test_connectors_vmware_rest_auth.py:106,143](../../backend/tests/test_connectors_vmware_rest_auth.py)
+- nsx: `instance._session_loader = _nsx_session_loader  # bypass Vault` —
+  [tests/test_connectors_nsx_e2e.py:223](../../backend/tests/test_connectors_nsx_e2e.py#L223)
+- vcf-*/sddc/harbor: same injected-loader shape in their `_e2e` / `_auth` tests.
+
+### vcsim is NOT a real-vCenter E2E (scoping consequence)
+
+The vmware integration test is **respx-mocked**, not a live `vmware/vcsim`
+container — because govmomi's vcsim does not serve the modern `/api/about`
+endpoint `fingerprint()` calls (it 404s):
+[tests/integration/test_connectors_vmware_rest_vcsim.py:4-16](../../backend/tests/integration/test_connectors_vmware_rest_vcsim.py).
+**Consequence for Goal #214:** the "one real call" proof cannot be vcsim for the
+modern REST surface. It must be either (a) a recorded-fixture E2E (respx replay
+of a captured real-vCenter exchange) for CI, plus (b) an opt-in smoke against a
+lab vCenter, gated behind an env-marker so secret-free CI stays green.
+
+---
+
+## §2 — Secrets brokering: "the operator/agent never sees the value"
+
+The load-bearing requirement (CLAUDE.md postulate; v0.1-spec §6/§7; secret-broker
+issue [#581](https://github.com/evoila/meho/issues/581)) is that the credential
+value never enters the agent's context, the operator's shell, or any transcript.
+The backplane is the credentialed intermediary; the operator submits *intent*
+(`call_operation(..., target)`), and the backplane resolves the secret
+server-side.
+
+### Static (KV v2) vs dynamic secrets
+
+- **KV v2** stores an operator-managed static secret (username/password,
+  kubeconfig, API key). Use only for secrets that *must* be static — vendor
+  service accounts that the backplane cannot mint. KV v2 adds versioning + soft
+  delete vs v1. ([Understand static and dynamic secrets](https://developer.hashicorp.com/vault/tutorials/get-started/understand-static-dynamic-secrets))
+- **Dynamic secrets** are generated on demand with a short TTL and auto-expire;
+  prefer them whenever the backend supports a Vault secrets engine (databases,
+  cloud IAM, SSH, PKI). A 1-hour TTL means a leaked credential is useless within
+  the hour. ([Manage dynamic credential leases](https://developer.hashicorp.com/vault/tutorials/db-credentials/manage-dynamic-leases), [Tune the lease TTL](https://developer.hashicorp.com/vault/docs/troubleshoot/tune-lease-ttl))
+
+**MEHO fit:** vCenter/NSX/SDDC/Harbor/VCF service accounts are *vendor-owned*
+static credentials — KV v2 is the correct day-1 store (matches the consumer's
+`targets.yaml` `secret_ref` convention). Dynamic secrets are a later option only
+where a vendor has a Vault secrets engine (e.g. a future LDAP/AD-backed account).
+Design the loader so a dynamic-secret backend is a *different loader*, not a
+different call site.
+
+### Vault auth method: JWT/OIDC vs AppRole
+
+- **JWT/OIDC.** Vault treats the IdP (Keycloak) as a trusted third party and
+  needs no pre-deployed secret. The `user_claim` becomes the Identity entity
+  alias; `groups_claim` maps to group aliases — both available for policy
+  scoping. ([JWT/OIDC auth](https://developer.hashicorp.com/vault/docs/auth/jwt))
+- **AppRole.** A workload (the backplane) authenticates with a `role_id` +
+  `secret_id`. This re-introduces the **secret-zero problem** — how to deliver
+  the first secret securely — solved with response-wrapping the `secret_id` via
+  `-wrap-ttl`. ([AppRole best practices](https://developer.hashicorp.com/vault/docs/auth/approle/approle-pattern), [Response wrapping](https://developer.hashicorp.com/vault/docs/concepts/response-wrapping))
+
+**MEHO already uses JWT/OIDC** for the Vault connector
+([auth/vault.py:198](../../backend/src/meho_backplane/auth/vault.py#L198)),
+forwarding the operator's *own* validated Keycloak JWT to Vault's JWT auth
+method. This is the secret-zero–free path and is the existing, proven primitive.
+
+### Per-operator RBAC through a single role: ACL policy templating
+
+A single Vault role (the existing `meho-mcp` role) can still enforce
+**per-operator** path scoping via **templated ACL policies**. Vault renders
+identity attributes into policy paths at evaluation time:
+
+- `{{identity.entity.aliases.<mount accessor>.name}}` — the operator's
+  `user_claim` (their identity).
+- `{{identity.entity.metadata.<key>}}`, `{{identity.groups.names.<name>.id}}`,
+  etc. ([Policy templating](https://developer.hashicorp.com/vault/docs/concepts/policies))
+
+Example: `path "secret/data/targets/{{identity.entity.aliases.<accessor>.name}}/*"`
+scopes each operator to their own target secrets through one role. Wildcards/globs
+are not permitted in a template's rendered output (prevents injection).
+
+**Consequence for the gating decision:** operator-context JWT login yields
+per-operator **RBAC** (via templated policy) *and* per-operator **audit** (Vault
+logs the operator's entity), through the single role MEHO already configured —
+not just weaker attribution. This is the decisive point in
+[connector-auth.md](../architecture/connector-auth.md).
+
+### Response wrapping, namespaces, secret-zero
+
+- **Response wrapping** (cubbyhole single-use token, short TTL, unwrap-once,
+  tamper-evident) is the right primitive for the [#581](https://github.com/evoila/meho/issues/581)
+  store-to-store *secret move* (the agent gets a wrapping token / hash, never the
+  value), but is **not needed** for the per-target read on this Goal — the
+  backplane reads and *uses* the credential server-side without ever returning it.
+  ([Response wrapping](https://developer.hashicorp.com/vault/docs/concepts/response-wrapping))
+- **Namespaces** (Vault Enterprise/HCP) isolate tenants; relevant if MEHO's
+  multi-tenancy ever maps tenants to Vault namespaces. Out of scope for v0.x
+  (OSS Vault; `vault_namespace` setting already plumbed in `_build_client`).
+
+---
+
+## §3 — Operator-scoped vs workload-scoped credential access
+
+Two identities could perform the per-target Vault read:
+
+1. **Operator-context** — forward the operator's Keycloak JWT to Vault
+   (`vault_client_for_operator(operator)`). RBAC = operator's templated Vault
+   policy; Vault's audit log attributes the read to the operator's entity. This
+   is RFC 8693 **impersonation** in spirit: the backplane presents the
+   operator's own token, so Vault sees the operator.
+   ([RFC 8693 §1.1](https://datatracker.ietf.org/doc/html/rfc8693))
+2. **Workload-context** — the backplane authenticates as itself (AppRole) and
+   reads under its own broad policy. Attribution to the operator exists only in
+   MEHO's *own* audit log, not in Vault's. This is RFC 8693 **delegation** in
+   spirit (the backplane acts on behalf of the operator, recording the actor
+   separately) — but without token exchange, the `act`/`may_act` linkage is not
+   carried into Vault. ([RFC 8693 impersonation vs delegation](https://datatracker.ietf.org/doc/html/rfc8693))
+
+**RFC 8693 token exchange** formalises the on-behalf-of pattern: a service
+exchanges a `subject_token` (the user) — optionally with an `actor_token` (the
+service) — at an STS for a token suited to the downstream call, and the `act` /
+`may_act` claims preserve the delegation chain for attribution. MEHO does not
+need a full STS today; the operator-JWT-forward already gives per-operator
+attribution at Vault for free. Token exchange becomes relevant only if MEHO later
+needs *vendor-side* per-operator identity (impersonation auth model, §4).
+
+**Short-lived credentials / workload identity** (the SPIFFE/SPIRE direction) are
+the principled long-term answer where a downstream supports it: the workload
+proves identity and receives an ephemeral credential, eliminating long-lived
+shared secrets. For vendor APIs that only accept a static service account
+(vCenter/NSX/etc.), the static-KV + operator-context-read pattern is the
+pragmatic floor; the loader abstraction must not preclude a future
+short-lived/dynamic loader.
+
+---
+
+## §4 — Multi-vendor session lifecycle + the auth-model taxonomy
+
+### Session establishment + caching (already implemented, just credential-blocked)
+
+The REST connectors already implement per-target session lifecycle correctly;
+they are only missing the credential the session-establish call needs:
+
+- **vSphere REST:** `POST /api/session` (modern) with HTTP Basic → returns a
+  `vmware-api-session-id` token reused on subsequent calls; falls back to legacy
+  `POST /rest/com/vmware/cis/session` on 404 (vcsim/older vCenter). Token cached
+  per `target.name` under an `asyncio.Lock`; revoked via `DELETE` on `aclose()`.
+  ([vmware_rest/connector.py:309](../../backend/src/meho_backplane/connectors/vmware_rest/connector.py#L309); confirmed against [VMware vSphere Automation REST API Programming Guide 8.0](https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere-sdks-tools/8-0/vmware-vsphere-automation-rest-programming-guide-8-0.html))
+- **vRLI / NSX / VCF:** session-login POST → token, with single-retry-on-401
+  around downstream calls; the shared round-trip is `vcf_session_login`
+  ([_shared/vcf_auth.py:354](../../backend/src/meho_backplane/connectors/_shared/vcf_auth.py#L354)).
+- **Credential caching:** `CredentialsCache` loads `{username, password}`
+  once-per-target with a lock + missing-key error contract
+  ([_shared/vcf_auth.py:212](../../backend/src/meho_backplane/connectors/_shared/vcf_auth.py#L212)).
+
+**Expiry handling:** the connectors deliberately do *not* proactively refresh on
+the ~5-min vSphere idle timeout; a 401 surfaces to the caller as a clean retry.
+Explicit 401-driven re-login is deferred. The credential read happening
+per-session-establish (not per-request) means an operator-context read only fires
+on first use / re-login — important for the per-operator-JWT path (the operator's
+JWT must be live at session-establish time).
+
+### Auth-model taxonomy (only one mode wired)
+
+`AuthModel` enum: `shared_service_account` / `per_user` / `impersonation`
+([targets/schemas.py](../../backend/src/meho_backplane/targets/schemas.py),
+`AuthModel` re-exported from `connectors/schemas.py`). Every REST connector's
+`auth_headers` accepts only `shared_service_account` (or `None`) and raises
+`NotImplementedError` naming the target + mode for the others
+([vmware_rest/connector.py:271-277](../../backend/src/meho_backplane/connectors/vmware_rest/connector.py#L271)).
+
+- **shared_service_account** — one vendor service account per target, stored in
+  Vault, read by the backplane. The day-1 model; what this Goal wires.
+- **per_user** — each operator has their own vendor credential. Needs a
+  per-operator secret path (templated policy does the scoping) and a loader that
+  keys on operator identity, not just target.
+- **impersonation** — the backplane authenticates as a privileged account and
+  asks the vendor to act *as* the operator (vendor-side impersonation; e.g.
+  vCenter SSO delegation). Needs vendor-specific support and likely RFC 8693–style
+  token exchange. Defer until a concrete consumer need exists (no speculative
+  build).
+
+---
+
+## §5 — Comparable systems
+
+How other "broker between operators and many backends" systems handle the
+credential, who the downstream identity is, and how attribution is kept.
+
+- **HashiCorp Boundary** — holds per-target credentials in *credential stores*
+  (static, or a Vault store backed by dynamic secrets). Two modes: *brokering*
+  returns the secret to the user; **credential injection** does not — "the user
+  never sees the credential required to authenticate to the target." The
+  **worker** (proxy) authenticates to the target on the user's behalf using the
+  *target's* credential; the operator's Boundary identity gates the session and
+  is what audit attributes. ([credential management](https://developer.hashicorp.com/boundary/docs/concepts/credential-management), [Vault store](https://developer.hashicorp.com/boundary/docs/vault), [auditing](https://developer.hashicorp.com/boundary/docs/concepts/auditing)) — **the closest 1:1 analogue to MEHO's narrow waist; "injection, never broker" is the default to copy.**
+- **Teleport** — a central CA issues short-lived, **identity-bound** certs
+  instead of holding shared target secrets; there is no reusable secret to see,
+  "any connection and action can be traced back to a user or a service," and
+  time-based expiry replaces revocation. ([architecture](https://goteleport.com/docs/reference/architecture/authentication/)) — pushes attribution all the way to the target; relevant only for backends that accept identity certs (not vCenter today).
+- **Steampipe** — per-connection static creds, **in plaintext in `.spc` config**;
+  no server-side broker; attribution is whatever the cloud account logs. ([connection config](https://steampipe.io/docs/reference/config-files/connection)) — the **anti-pattern**: it's exactly the embedded-credential shape (cf. bind9's dict `secret_ref`) that Vault-backed brokering should replace. The one reusable idea is its clean "one connection = one target scope" abstraction.
+- **Terraform/Pulumi providers** — modern pattern is **ephemeral resources**
+  (TF v1.10+): fetch a credential from Vault at apply time, feed it to another
+  provider, and it is **not persisted to state/plan**. ([ephemeral resources](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/guides/using_ephemeral_resources), [TF 1.10 ephemeral values](https://www.hashicorp.com/en/blog/terraform-1-10-improves-handling-secrets-in-state-with-ephemeral-values)) — the discipline "the secret is a transient in-memory value, never written to a durable artifact" maps directly onto MEHO's loader (never log it, never put it in `OperationResult`/audit).
+- **Backstage** — plugins choose, **per call**, between forwarding the user
+  principal (`auth.getPluginRequestToken({ onBehalfOf })`) and acting as their
+  own service identity (`auth.getOwnServiceCredentials()`). ([service-to-service auth](https://backstage.io/docs/auth/service-to-service-auth/), [proxy modes](https://backstage.io/docs/plugins/proxying/)) — **"as operator vs as broker" should be a first-class, explicit choice, not an implicit default** (informs the auth-model axis).
+- **SPIFFE/SPIRE** — workloads get short-lived auto-rotated **SVIDs** via the
+  Workload API with **no bootstrap secret**: two-level attestation (node + workload)
+  *is* the proof of identity. ([SPIFFE concepts](https://spiffe.io/docs/latest/spiffe-about/spiffe-concepts/), [SPIRE concepts](https://spiffe.io/docs/latest/spire-about/spire-concepts/)) — the principled answer to "secret zero" if MEHO ever needs the backplane to authenticate to Vault without a planted credential (attestation instead of AppRole `secret_id`).
+- **API gateways (Kong / Apigee)** — config holds a **secret reference**
+  (`vault://…` / encrypted KVM key), resolved + injected at request time with a
+  TTL/refresh; the operator and the config repo never hold cleartext. ([Kong secrets mgmt](https://developer.konghq.com/gateway/secrets-management/), [Kong Vault refs](https://developer.konghq.com/gateway/entities/vault/), [Apigee KVM](https://docs.apigee.com/api-platform/cache/key-value-maps)) — validates MEHO's `target.secret_ref` = a Vault reference resolved at dispatch (not embedded value).
+
+### Synthesis — patterns reusable for MEHO's Vault-backed waist
+
+1. **Inject, never broker, by default** (Boundary): the dispatch tier reads the
+   per-target credential from Vault and *uses* it server-side; the agent/operator
+   never sees cleartext. Reserve returning a value for the explicit [#581](https://github.com/evoila/meho/issues/581) break-glass move.
+2. **Treat the resolved secret as ephemeral state** (Terraform): never in logs,
+   audit rows, result handles, or any durable artifact.
+3. **Config holds references, not values** (Kong/Apigee): `target.secret_ref` is a
+   Vault path resolved at dispatch — *not* an embedded dict (the bind9 / Steampipe
+   shape to avoid).
+4. **Make "as operator vs as broker" explicit** (Backstage): the auth-model on the
+   target is a first-class choice, never an implicit default — which is exactly the
+   `AuthModel` enum's job.
+5. **Prefer short-lived/dynamic where the backend supports it** (Boundary/TF):
+   keep the loader abstraction open to a dynamic-secret loader; don't hard-wire
+   static KV as the only path.
+6. **Solve secret-zero with attestation if a workload identity is ever needed**
+   (SPIFFE/SPIRE) rather than planting an AppRole `secret_id`.
+7. **Use RFC 8693 delegation (not impersonation) for OAuth-speaking vendors** if
+   vendor-side per-operator identity is ever required — `subject_token` (operator)
+   + `actor_token` (broker) keeps dual attribution. ([RFC 8693 §1.1](https://datatracker.ietf.org/doc/html/rfc8693#section-1.1))
+
+---
+
+## §6 — Audit + least privilege for credential USE
+
+- **Audit the use, never the value.** MEHO's dispatcher already writes a
+  synchronous, append-only audit row per op with `params_hash` (never raw
+  params) and the resolved `target_id`
+  ([dispatcher.py `_execute_and_audit`](../../backend/src/meho_backplane/operations/dispatcher.py#L329);
+  `compute_params_hash` in `operations/_validate.py`). The credential value is
+  never an op param, so it is never in the audit row.
+- **Vault-side audit.** Vault audit devices HMAC-SHA256 all string
+  request/response fields with a per-device salt, so secret values are not in
+  plaintext in Vault's own logs; operators can still match a known value via
+  `/sys/audit-hash`. Never disable HMAC in production.
+  ([Audit devices](https://developer.hashicorp.com/vault/docs/audit))
+- **No-secret-in-logs in MEHO.** `Operator.raw_jwt` is `Field(repr=False)` so it
+  cannot leak via structlog's `repr()` of bound values
+  ([auth/operator.py:88](../../backend/src/meho_backplane/auth/operator.py#L88));
+  bind9's safe-sudo primitive streams the password via stdin, never argv/history/
+  logs ([bind9/connector.py:266](../../backend/src/meho_backplane/connectors/bind9/connector.py#L266)).
+  Any new loader MUST keep `{username,password}`/kubeconfig out of every log
+  event and every `OperationResult` — the existing `CredentialsCache` logs only
+  `target`/`host`, never the dict.
+- **Least privilege.** Per-operator templated policy (§2) scopes each operator's
+  Vault reads to their own target secrets through one role; the backplane never
+  needs a god-mode Vault token under the operator-context model.
+- **Rotation.** `CredentialsCache.invalidate(target)` already exists for
+  post-rotation cache busting ([_shared/vcf_auth.py:280](../../backend/src/meho_backplane/connectors/_shared/vcf_auth.py#L280));
+  a rotation event must invalidate the cached credential *and* drop the cached
+  session token (the connectors hold both). Automatic rotation is out of scope for
+  this Goal. ([Secret rotation](https://developer.hashicorp.com/vault/tutorials/db-credentials/database-creds-rotation))
+
+---
+
+## §7 — Testing without real secrets
+
+- **Recorded fixtures (respx replay).** The vmware integration test already
+  replays a captured vCenter exchange via respx instead of a live appliance —
+  the pattern to extend: capture once against a lab vCenter, scrub secrets,
+  replay in CI. ([test_connectors_vmware_rest_vcsim.py](../../backend/tests/integration/test_connectors_vmware_rest_vcsim.py))
+- **Injected loader = secret-free unit/E2E gate.** All connector tests inject a
+  fake loader (§1). Keep that: the production loader's *own* test exercises the
+  Vault read against a **Vault dev-mode harness** (the rubric's State-2 bar),
+  not a recorded fixture, so the live KV-v2 path is actually proven.
+- **vcsim limits.** vcsim does not serve modern `/api`; it is usable only for
+  legacy `/rest` paths and govmomi-backed inventory, not the REST `fingerprint`
+  path. Do not gate the "real call" proof on vcsim. (§1)
+- **Lab-vCenter smoke, opt-in.** A real end-to-end run belongs behind an
+  env-gated marker (`MEHO_LAB_VCENTER=…`) so default CI needs no secret and the
+  secret-free gate stays green; the consumer's lab vCenter is the target.
+- **Contract tests.** Pin the loader's I/O contract (`secret_ref` → KV-v2 path →
+  `{username,password}`) and the auth-model boundary (`per_user`/`impersonation`
+  raise) as fast unit tests independent of any network.
+
+---
+
+## Sources
+
+- HashiCorp Vault — [JWT/OIDC auth method](https://developer.hashicorp.com/vault/docs/auth/jwt)
+- HashiCorp Vault — [ACL policy templating](https://developer.hashicorp.com/vault/docs/concepts/policies)
+- HashiCorp Vault — [Static vs dynamic secrets](https://developer.hashicorp.com/vault/tutorials/get-started/understand-static-dynamic-secrets)
+- HashiCorp Vault — [Manage dynamic credential leases](https://developer.hashicorp.com/vault/tutorials/db-credentials/manage-dynamic-leases) · [Tune lease TTL](https://developer.hashicorp.com/vault/docs/troubleshoot/tune-lease-ttl)
+- HashiCorp Vault — [AppRole best practices](https://developer.hashicorp.com/vault/docs/auth/approle/approle-pattern) · [Response wrapping](https://developer.hashicorp.com/vault/docs/concepts/response-wrapping)
+- HashiCorp Vault — [Audit devices](https://developer.hashicorp.com/vault/docs/audit)
+- IETF — [RFC 8693 OAuth 2.0 Token Exchange](https://datatracker.ietf.org/doc/html/rfc8693)
+- Broadcom/VMware — [vSphere Automation REST API Programming Guide 8.0](https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere-sdks-tools/8-0/vmware-vsphere-automation-rest-programming-guide-8-0.html)
+- (Comparable systems: Boundary, Teleport, Steampipe, Terraform/Pulumi, Backstage, SPIFFE/SPIRE, Kong/Apigee — see §5, sourced inline.)


### PR DESCRIPTION
## What

Lands the four uncommitted docs from the 2026-05-22 planning/design session — a precursor that **unblocks autonomous execution of Initiative #939** (G3.9 connector credential broker). #939's tasks (#940/#942/#943) reference two of these docs as committed repo paths; without them on `main`, sub-agent worktrees can't resolve the references.

### Files

**G3.9 design docs** (referenced by the Initiative + tasks):
- `docs/architecture/connector-auth.md` — locked operator-context Vault read decision (gates Goal #214)
- `docs/research/214-connector-credential-broker.md` — execution-gap map + secrets-brokering research

**Board-wide 2026-05-22 replan** (the planning context the design sits within):
- `docs/planning/mvp-roadmap.md` — capability-first overlay; version renumber v0.7→v0.11; agent-runtime (G11) reprioritisation
- `docs/planning/release-plan.md` — capability-first delivery sequencing (R1 gates → R2 fan-out → R3 UI/replay → R4 runtime)

## Why now

The autonomous run for #939 aborted at preflight (`BLOCKED-dirty-tree`): these were uncommitted in the working tree, and untracked files don't propagate into the implementer worktrees. Landing them on `main` clears both the dirty-tree gate and the dangling references.

## Scope

Docs only — no code, no behavior change. `Refs #939 #214` (does **not** close the Initiative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architecture decision document for connector credential access and implementation approach.
  * Updated MVP roadmap with capability-first versioning and revised delivery timeline.
  * Added release plan defining gates, demo requirements, and completion criteria for upcoming releases.
  * Added research documentation on credential brokering requirements and comparable industry patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/951?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->