### PR TITLE
ci(sonar): wire Go coverage to SonarCloud (completes the coverage story)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -496,8 +496,10 @@ jobs:
       - name: Go test (race + coverage)
         # -race catches data races the CLI may hit when the
         # async-token-refresh code (internal/auth) is exercised from
-        # parallel tests. -cover keeps the per-package summary in the
-        # workflow log; we don't enforce a threshold v0.1.
+        # parallel tests. -coverprofile writes a merged profile consumed
+        # by the downstream SonarCloud scan (sonar.go.coverage.reportPaths)
+        # so the Clean-as-You-Code new-code-coverage gate sees Go coverage,
+        # not 0%. -covermode=atomic is required under -race.
         #
         # CGO_ENABLED=1 is required: `go test -race` is implemented in
         # the cgo-based race runtime and refuses to run otherwise
@@ -510,7 +512,21 @@ jobs:
         working-directory: cli
         env:
           CGO_ENABLED: '1'
-        run: go test -race -cover ./...
+        run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
+
+      - name: Upload Go coverage artifact
+        # Consumed by quality-gate.yml (`workflow_run` -> SonarCloud).
+        # Lossy like the Python sibling: a missing upload degrades the
+        # SonarCloud signal to "no Go coverage for this run" but never
+        # invalidates the test outcome. continue-on-error is appropriate
+        # ONLY for this step.
+        if: always() && hashFiles('cli/coverage.out') != ''
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: go-coverage
+          path: cli/coverage.out
+          retention-days: 7
 
   cli-api-snapshot-freshness:
     name: CLI API snapshot freshness

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -80,6 +80,20 @@ jobs:
             && echo "coverage source root set to backend/" \
             || echo "::warning::coverage <source> not rewritten — sonar may report 0% coverage"
 
+      - name: Download Go coverage from CI workflow
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: go-coverage
+          # Extract into cli/ so the file lands at cli/coverage.out, matching
+          # sonar.go.coverage.reportPaths. The Go profile uses module import
+          # paths (github.com/evoila/meho/cli/...), which SonarCloud's Go
+          # sensor resolves via cli/go.mod — no path rewrite needed (unlike
+          # the Python report).
+          path: cli
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true  # missing artifact degrades to "no Go coverage", never blocks
+
       - name: Ensure dirmngr is available (for sonar-scanner GPG verify)
         run: |
           set -euo pipefail

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -74,6 +74,16 @@ sonar.python.version=3.12, 3.13
 sonar.python.coverage.reportPaths=backend/coverage.xml
 # sonar.javascript.lcov.reportPaths=meho_frontend/coverage/lcov.info
 
+# Go coverage is produced by CI's `Go test (race + coverage)` step
+# (`go test -covermode=atomic -coverprofile=coverage.out ./...` -> cli/
+# coverage.out), uploaded as the `go-coverage` artifact, and downloaded
+# back into cli/ by quality-gate.yml. The Go profile uses module import
+# paths (github.com/evoila/meho/cli/...), which SonarCloud's Go sensor
+# resolves via cli/go.mod — so unlike the Python report it needs no path
+# rewrite. Without this the Clean-as-You-Code new-code-coverage gate read
+# Go diffs as 0% (the #937/#938 refactors tripped it).
+sonar.go.coverage.reportPaths=cli/coverage.out
+
 # ---------------------------------------------------------------------------
 # Test-scoped issue suppressions (belt-and-braces with sonar.tests above)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

#927 wired **Python** coverage to SonarCloud; **Go was never wired**. With the new-code baseline fixed (T1), the Clean-as-You-Code gate now scrutinises new code — and the #937/#938 Go refactors tripped its `new_coverage < 80` condition purely because no Go coverage report reached SonarCloud (Go diffs read as 0% covered). This is the missing half of the coverage story.

## What

Mirrors the Python wiring:
- CI `Go test` step writes a merged profile: `go test -race -covermode=atomic -coverprofile=coverage.out ./...`, uploaded as the `go-coverage` artifact.
- `quality-gate.yml` downloads it into `cli/` before the scan.
- `sonar.go.coverage.reportPaths=cli/coverage.out`.

**No path rewrite needed** (unlike Python): the Go profile uses module import paths (`github.com/evoila/meho/cli/...`) that SonarCloud's Go sensor resolves via `cli/go.mod`.

## Verification

- Both workflows: valid YAML.
- Locally confirmed the profile generates as `mode: atomic` with import-path entries; `-covermode=atomic` is required under `-race`.

## Note on the gate

This fixes the `new_coverage` condition. The other red condition — `new_duplicated_lines_density` on the recent refactor's per-package binding boilerplate — is transient and ages out as the new-code window rolls forward; it's `continue-on-error` either way. Absolute health is already green (ratings A/A/A, 0 bugs/vulns/hotspots, duplication 4.8%).

Refs #921.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality tracking by integrating Go test coverage with the SonarCloud quality-gate process. Updated CI workflows to generate and upload coverage reports, and configured the quality gate to consume and analyze Go coverage metrics alongside existing coverage data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/952?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->