### PR TITLE
feat(jsonflux): vendor MEHO.X jsonflux tree under meho_backplane (Apache-2.0) (#752)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2,3 +2,16 @@ MEHO
 Copyright 2026 evoila Group
 
 This product includes software developed at evoila Group (https://evoila.com/).
+
+---
+
+This product bundles JSONFlux, located at
+src/meho_backplane/jsonflux/, originally authored by Ilhan Karić
+(@ikaric) and published as ikaric/jsonflux under the MIT License.
+The vendored copy is sourced from the MEHO.X fork
+(meho_app/jsonflux/) at commit fc82cf93, which carries additional
+work by the MEHO team (smart register() with unwrap/append, plus
+mypy/ruff/SonarQube hygiene). With the copyright holder's consent,
+this vendored tree is relicensed to Apache-2.0 to match the rest of
+MEHO; see docs/decisions/jsonflux-license.md for the license-chain
+provenance and signoff of record.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,6 +27,10 @@ dependencies = [
     "packaging>=24.0",
     "python-frontmatter>=1.2.0",
     "jinja2>=3.1.6",
+    "duckdb>=1.4.3",
+    "pyarrow>=21.0.0",
+    "msgspec>=0.20.0",
+    "tabulate>=0.9.0",
 ]
 
 [dependency-groups]
@@ -106,6 +110,28 @@ select = [
 # and then `operator.attrgetter(...)` — that pattern WOULD be confusing.
 "src/meho_backplane/auth/operator.py" = ["A005"]
 "src/meho_backplane/logging.py" = ["A005"]
+# Vendored JSONFlux tree (#752, from MEHO.X meho_app/jsonflux/ at fc82cf93).
+# Kept as a verbatim copy, so the lint carveouts mirror MEHO.X's own and
+# additionally cover the rules MEHO.X never tripped because its ruff config
+# differs from this repo's:
+#   - C901 cognitive complexity, PERF perf-sensitive loops, BLE001 broad
+#     excepts at the SQL/IO boundary, ERA001 commented-out documented
+#     examples, TCH import-time type-checking blocks, S608 SQL-literal
+#     construction on Arrow tables  (the carveouts MEHO.X declares directly).
+#   - A002 (`format` arg shadows a builtin) and N806 (Arrow/SQL-style
+#     CamelCase locals): this repo selects A + N; MEHO.X does not.
+#   - E501 line-too-long and RUF100 unused-noqa: this repo enforces both;
+#     MEHO.X ignores them globally. RUF100 fires here because the verbatim
+#     source carries `# noqa: S608/S311` for the bandit (S) ruleset, which
+#     this repo does not select — the noqa comments are retained for
+#     provenance and to keep the tree byte-identical to upstream.
+# Revisit on the next upstream sync.
+"src/meho_backplane/jsonflux/__init__.py" = ["C901", "PERF", "BLE001", "A002", "RUF100"]
+"src/meho_backplane/jsonflux/core/analyzer.py" = ["C901", "ERA001", "PERF", "TCH", "N806"]
+"src/meho_backplane/jsonflux/core/converter.py" = ["C901"]
+"src/meho_backplane/jsonflux/core/stats.py" = ["C901", "ERA001", "PERF", "E501"]
+"src/meho_backplane/jsonflux/query/engine.py" = ["C901", "PERF", "S608", "TCH", "BLE001", "A002", "E501", "RUF100"]
+"src/meho_backplane/jsonflux/utils/sampling.py" = ["TCH"]
 
 [tool.ruff.lint.flake8-bugbear]
 # FastAPI's standard dependency-injection pattern relies on calling
@@ -225,6 +251,32 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = ["frontmatter.*"]
 ignore_missing_imports = true
+
+# tabulate (used by the vendored JSONFlux query engine, #752) ships no
+# ``py.typed`` marker as of 0.9.x. It is imported lazily inside the
+# ``query_table`` / ``query_print`` rendering paths of
+# :mod:`meho_backplane.jsonflux.query.engine`. Whitelisting the module
+# avoids pulling ``types-tabulate`` into the dev image just for those
+# two call sites. Drop this override if upstream ships stubs.
+[[tool.mypy.overrides]]
+module = ["tabulate.*"]
+ignore_missing_imports = true
+
+# Vendored JSONFlux tree (#752, from MEHO.X meho_app/jsonflux/ at
+# fc82cf93). The tree is mypy-clean under MEHO.X's config, which does
+# not enable two of this repo's ``strict = true`` sub-flags:
+# ``disallow_any_generics`` (bare ``dict``/``list``/``frozenset``
+# annotations -> ``type-arg``) and ``no_implicit_reexport`` (re-exports
+# without ``__all__`` -> ``attr-defined`` on ``from .core.analyzer
+# import ALL_KINDS`` etc.). To keep the tree byte-identical to upstream
+# rather than re-annotate ~3.3k LOC, this override relaxes exactly those
+# two error codes for the vendored package only — the rest of strict
+# mode (untyped-def detection, return-any, etc.) stays in force here,
+# and the whole repo outside ``jsonflux`` is unaffected. Revisit /
+# tighten on the next upstream sync.
+[[tool.mypy.overrides]]
+module = ["meho_backplane.jsonflux.*"]
+disable_error_code = ["type-arg", "attr-defined"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/backend/src/meho_backplane/jsonflux/__init__.py
+++ b/backend/src/meho_backplane/jsonflux/__init__.py
@@ -1,0 +1,550 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+from __future__ import annotations
+
+import os
+import random
+import time
+from pathlib import Path
+from typing import Any
+
+import msgspec
+
+from .core.analyzer import (
+    ALL_KINDS,
+    KIND_ORDER,
+    PRIMITIVE_KINDS,
+    Analyzer,
+    fmt_count,
+    fmt_types,
+    kind_of,
+    render_bracket,
+    render_schema,
+    render_tabs,
+    render_tree,
+    summary_to_schema,
+    summary_to_tree,
+)
+from .core.models import ProfileResult, Summary, TreeNode
+from .core.stats import (
+    FieldStats,
+    StatsResult,
+    collect_stats,
+    estimate_json_size,
+    fmt_bytes,
+    fmt_size,
+    format_stats,
+    format_stats_compact,
+)
+from .query.engine import QueryEngine, QueryResult
+from .utils.sampling import ReservoirSampler
+
+# --------------------------
+# Version
+# --------------------------
+
+__version__ = "0.1.0"
+
+# --------------------------
+# Public API exports
+# --------------------------
+
+__all__ = [
+    "ALL_KINDS",
+    "KIND_ORDER",
+    # Constants
+    "PRIMITIVE_KINDS",
+    # Analyzer components
+    "Analyzer",
+    "FieldStats",
+    # Main class
+    "JsonFlux",
+    "JsonFluxConfig",
+    # Core models
+    "ProfileResult",
+    "QueryEngine",
+    "QueryResult",
+    "ReservoirSampler",
+    "StatsResult",
+    "Summary",
+    "TreeNode",
+    # Version
+    "__version__",
+    "collect_stats",
+    "estimate_json_size",
+    "fmt_bytes",
+    "fmt_count",
+    "fmt_size",
+    "fmt_types",
+    "format_stats",
+    "format_stats_compact",
+    # Utility functions
+    "kind_of",
+    "render_bracket",
+    "render_schema",
+    "render_tabs",
+    "render_tree",
+    # Schema rendering (LLM-friendly)
+    "summary_to_schema",
+    # Tree rendering
+    "summary_to_tree",
+    # Validation
+    "validate",
+]
+
+MSG_NO_DATA_ANALYZED = "No data analyzed yet. Call analyze() first."
+
+
+# --------------------------
+# Configuration (msgspec.Struct for speed)
+# --------------------------
+
+
+class JsonFluxConfig(msgspec.Struct, gc=False):
+    """Configuration for JsonFlux profiler."""
+
+    max_depth: int = 32
+    sample_per_kind: int = 200
+    sort_keys: bool = True
+    max_keys_per_object: int | None = None
+    samples: int = 3
+    sample_seed: int = 12345
+    max_sample_len: int = 60
+
+
+class JsonFlux:
+    """
+    Main entry point for JSON structure analysis and querying.
+
+    Example:
+        flux = JsonFlux(max_depth=20, samples=5)
+        result = flux.analyze(data)
+        print(flux.tree())
+        print(flux.stats())
+    """
+
+    __slots__ = ("_engine", "_last_profile", "analyzer", "config", "data")
+
+    def __init__(
+        self,
+        max_depth: int = 32,
+        sample_per_kind: int = 200,
+        sort_keys: bool = True,
+        max_keys_per_object: int | None = None,
+        samples: int = 3,
+        sample_seed: int = 12345,
+        max_sample_len: int = 60,
+    ) -> None:
+        self.config = JsonFluxConfig(
+            max_depth=max_depth,
+            sample_per_kind=sample_per_kind,
+            sort_keys=sort_keys,
+            max_keys_per_object=max_keys_per_object,
+            samples=samples,
+            sample_seed=sample_seed,
+            max_sample_len=max_sample_len,
+        )
+        self.analyzer = Analyzer(
+            max_depth=max_depth,
+            sample_per_kind=sample_per_kind,
+            sort_keys=sort_keys,
+            max_keys_per_object=max_keys_per_object,
+        )
+        self.data: Any = None
+        self._last_profile: ProfileResult | None = None
+        self._engine: QueryEngine | None = None
+
+    def analyze(self, source: dict | list | str | list[str] | Path) -> JsonFlux:
+        """Load and analyze JSON data using msgspec for fast parsing."""
+        config = self.config
+
+        # Invalidate cached query engine
+        if self._engine is not None:
+            self._engine.close()
+            self._engine = None
+
+        # Parse JSON (timed)
+        t0 = time.perf_counter()
+        data, source_type = self._load_source(source)
+        self.data = data
+        parse_time = time.perf_counter() - t0
+
+        # Build structure summary (timed)
+        t0 = time.perf_counter()
+        summary = self.analyzer.summarize(data, self.analyzer.max_depth)
+        analyze_time = time.perf_counter() - t0
+
+        # Collect samples if enabled (timed)
+        t0 = time.perf_counter()
+        sample_store: dict[tuple[str, ...], ReservoirSampler] = {}
+        if config.samples > 0:
+            rng = random.Random(  # noqa: S311 -- non-cryptographic context, random OK
+                config.sample_seed
+            )
+            self.analyzer.collect_samples(data, sample_store, k=config.samples, rng=rng)
+        sample_time = time.perf_counter() - t0
+
+        self._last_profile = ProfileResult(
+            summary=summary,
+            sample_store=sample_store,
+            source=source_type,
+            parse_time=parse_time,
+            analyze_time=analyze_time,
+            sample_time=sample_time,
+        )
+        return self
+
+    def _load_source(self, source: dict | list | str | list[str] | Path) -> tuple[Any, str]:
+        """Load JSON from various source types using msgspec for speed."""
+        if isinstance(source, dict):
+            return source, "dict"
+        if isinstance(source, Path):
+            with open(source, "rb") as f:
+                return msgspec.json.decode(f.read()), "file"
+        if isinstance(source, list):
+            # Check if list of JSON strings
+            if source and isinstance(source[0], str):
+                return [msgspec.json.decode(s) for s in source], "json_strings"
+            return source, "list"
+        if isinstance(source, str):
+            # Check if it's an existing file first (avoids misinterpreting
+            # filenames like "[config].json" as JSON content)
+            if os.path.exists(source):
+                with open(source, "rb") as f:
+                    return msgspec.json.decode(f.read()), "file"
+            source_stripped = source.strip()
+            if source_stripped.startswith("{") or source_stripped.startswith("["):
+                return msgspec.json.decode(source), "json_string"
+            # Last resort: treat as file path (will raise FileNotFoundError)
+            with open(source, "rb") as f:
+                return msgspec.json.decode(f.read()), "file"
+        raise TypeError(f"Unsupported source type: {type(source)}")
+
+    def tree(
+        self,
+        format: str = "tree",
+        indent: str = "\t",
+        root_label: str = "<root>",
+    ) -> str:
+        """
+        Return a structural report of the JSON data.
+
+        Args:
+            format: Output format:
+                - "tree": Box-drawing connectors (├── └──)
+                - "tabs": Tab-indented (TSV-like)
+                - "bracket": Curly brace nesting
+                - "schema": Compact TypeScript-like (LLM-optimized, token-efficient)
+            indent: Indentation string for tabs/bracket formats (default: tab character)
+            root_label: Label for the root node (not used in schema format)
+
+        Returns:
+            Formatted structure string
+
+        Examples:
+            flux.tree()                    # Box-drawing tree with samples
+            flux.tree(format="tabs")       # Tab-indented
+            flux.tree(format="schema")     # Compact schema for LLMs
+        """
+        if not self._last_profile:
+            raise ValueError(MSG_NO_DATA_ANALYZED)
+
+        # Schema format uses different renderer (works on Summary, not TreeNode)
+        if format == "schema":
+            return render_schema(
+                self._last_profile.summary,
+                sample_store=self._last_profile.sample_store,
+                max_sample_len=self.config.max_sample_len,
+                samples_k=self.config.samples,
+            )
+
+        # Other formats use TreeNode-based rendering
+        root_node = self._build_tree(self._last_profile, root_label)
+
+        if format == "tree":
+            return render_tree(root_node)
+        elif format == "tabs":
+            return render_tabs(root_node, indent)
+        elif format == "bracket":
+            return render_bracket(root_node, indent)
+        else:
+            raise ValueError(
+                f"Unknown format: {format}. Use 'tree', 'tabs', 'bracket', or 'schema'."
+            )
+
+    def stats(self, compact: bool = False, top_n: int = 50, max_unique: int = 100) -> str:
+        """
+        Return a statistical report of the data.
+
+        Args:
+            compact: If True, return compact summary without per-path breakdown
+            top_n: Number of top paths to show (for non-compact mode)
+            max_unique: Maximum unique values to track per field
+
+        Returns:
+            Formatted statistics string
+        """
+        if self.data is None:
+            raise ValueError(MSG_NO_DATA_ANALYZED)
+
+        stats_result = collect_stats(self.data, max_unique=max_unique)
+
+        if compact:
+            return format_stats_compact(stats_result)
+        return format_stats(stats_result, top_n=top_n)
+
+    def stats_result(self, max_unique: int = 100) -> StatsResult:
+        """
+        Return the raw StatsResult object for programmatic access.
+
+        Args:
+            max_unique: Maximum unique values to track per field
+
+        Returns:
+            StatsResult struct with all collected statistics
+        """
+        if self.data is None:
+            raise ValueError(MSG_NO_DATA_ANALYZED)
+        return collect_stats(self.data, max_unique=max_unique)
+
+    def _get_engine(self) -> QueryEngine:
+        """Return the cached QueryEngine, creating it on first use."""
+        if self.data is None:
+            raise ValueError(MSG_NO_DATA_ANALYZED)
+        if self._engine is None:
+            self._engine = QueryEngine()
+            self._engine.register("data", self.data)
+        return self._engine
+
+    def query(self, sql: str) -> list[dict[str, Any]]:
+        """Query the analyzed data using SQL."""
+        return self._get_engine().query(sql)
+
+    def query_table(
+        self,
+        sql: str,
+        format: str = "grid",
+        max_rows: int | None = 20,
+        max_colwidth: int | None = 50,
+    ) -> str:
+        """
+        Execute SQL and return a formatted tabular string.
+
+        Args:
+            sql: SQL query string
+            format: Output format - 'simple', 'grid', 'pipe', 'markdown', 'csv', 'json'
+            max_rows: Limit rows shown (None = all, default 20)
+            max_colwidth: Max column width (None = unlimited, default 50)
+
+        Returns:
+            Formatted string, or an error message prefixed with "ERROR: "
+            if the query fails.
+        """
+        return self._get_engine().format_query(
+            sql, format=format, max_rows=max_rows, max_colwidth=max_colwidth
+        )
+
+    def _build_tree(self, result: ProfileResult, root_label: str) -> TreeNode:
+        """Build TreeNode from ProfileResult using optimized summary_to_tree."""
+        summary = result.summary
+        sample_store = result.sample_store
+        config = self.config
+
+        children: list[TreeNode] = []
+
+        if summary.obj is not None:
+            for key in summary.obj:
+                children.append(
+                    summary_to_tree(
+                        key,
+                        summary.obj[key],
+                        (key,),
+                        sample_store,
+                        config.max_sample_len,
+                        config.samples,
+                    )
+                )
+            if summary.truncated:
+                children.append(TreeNode(label="…", children=[]))
+        else:
+            children.append(
+                summary_to_tree(
+                    "<value>",
+                    summary,
+                    ("<value>",),
+                    sample_store,
+                    config.max_sample_len,
+                    config.samples,
+                )
+            )
+
+        return TreeNode(label=root_label, children=children)
+
+    def profile_result(self) -> ProfileResult | None:
+        """Return the raw ProfileResult for programmatic access."""
+        return self._last_profile
+
+    def timing(self) -> dict[str, float]:
+        """Return timing information from the last analysis."""
+        if not self._last_profile:
+            return {}
+        return {
+            "parse_time": self._last_profile.parse_time,
+            "analyze_time": self._last_profile.analyze_time,
+            "sample_time": self._last_profile.sample_time,
+            "total_time": (
+                self._last_profile.parse_time
+                + self._last_profile.analyze_time
+                + self._last_profile.sample_time
+            ),
+        }
+
+    def close(self) -> None:
+        """Close the cached query engine and release resources."""
+        if self._engine is not None:
+            self._engine.close()
+            self._engine = None
+
+    def __enter__(self) -> JsonFlux:
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        self.close()
+
+
+# --------------------------
+# Validation function
+# --------------------------
+
+
+def validate() -> list[str]:  # NOSONAR (cognitive complexity)
+    """
+    Validate profiler output against known test cases.
+
+    Returns:
+        Empty list if all checks pass, otherwise a list of error strings.
+    """
+    # Test case: comprehensive JSON with all types
+    test_data = {
+        "string_field": "hello",
+        "int_field": 42,
+        "float_field": 3.14,
+        "bool_field": True,
+        "null_field": None,
+        "empty_object": {},
+        "empty_array": [],
+        "nested": {"level2": {"level3": {"deep_value": 999}}},
+        "array_of_ints": [1, 2, 3],
+        "array_of_strings": ["a", "b", "c"],
+        "array_of_objects": [
+            {"id": 1, "name": "one"},
+            {"id": 2, "name": "two"},
+        ],
+        "mixed_array": [1, "two", 3.0, True, None, {}, []],
+        "array_of_arrays": [[1, 2], [3, 4], [5, 6]],
+    }
+
+    flux = JsonFlux(max_depth=32, samples=0)
+    flux.analyze(test_data)
+    result = flux.profile_result()
+
+    if result is None:
+        return ["No profile result"]
+
+    summary = result.summary
+    errors: list[str] = []
+
+    # Check top-level is object
+    obj = summary.obj
+    if obj is None:
+        errors.append("Top-level should be object")
+    else:
+        # Check expected keys exist
+        expected_keys = {
+            "string_field",
+            "int_field",
+            "float_field",
+            "bool_field",
+            "null_field",
+            "empty_object",
+            "empty_array",
+            "nested",
+            "array_of_ints",
+            "array_of_strings",
+            "array_of_objects",
+            "mixed_array",
+            "array_of_arrays",
+        }
+        actual_keys = set(obj.keys())
+        missing = expected_keys - actual_keys
+        if missing:
+            errors.append(f"Missing keys: {missing}")
+
+        # Check primitive types detected correctly
+        def check_primitive(key: str, expected_type: str) -> None:
+            if key not in obj:
+                errors.append(f"Key '{key}' missing")
+                return
+            s = obj[key]
+            if expected_type not in s.primitives:
+                errors.append(f"'{key}' should have type '{expected_type}', got {s.primitives}")
+
+        check_primitive("string_field", "str")
+        check_primitive("int_field", "int")
+        check_primitive("float_field", "float")
+        check_primitive("bool_field", "bool")
+        check_primitive("null_field", "null")
+
+        # Check nested object depth
+        if "nested" in obj:
+            nested = obj["nested"]
+            if nested.obj is None:
+                errors.append("'nested' should be object")
+            elif "level2" not in nested.obj:
+                errors.append("'nested.level2' missing")
+            elif nested.obj["level2"].obj is None:
+                errors.append("'nested.level2' should be object")
+            elif "level3" not in nested.obj["level2"].obj:
+                errors.append("'nested.level2.level3' missing")
+
+        # Check array detection
+        if "array_of_ints" in obj:
+            arr_sum = obj["array_of_ints"].arr
+            if arr_sum is None:
+                errors.append("'array_of_ints' should be array")
+            elif arr_sum.kind_minmax.get("int", (0, 0))[1] != 3:
+                errors.append("'array_of_ints' should have 3 ints")
+
+        # Check mixed array
+        if "mixed_array" in obj:
+            arr_sum = obj["mixed_array"].arr
+            if arr_sum is None:
+                errors.append("'mixed_array' should be array")
+            else:
+                kinds_found = {k for k, (_, mx) in arr_sum.kind_minmax.items() if mx > 0}
+                expected_kinds = {
+                    "int",
+                    "str",
+                    "float",
+                    "bool",
+                    "null",
+                    "object",
+                    "array",
+                }
+                missing_kinds = expected_kinds - kinds_found
+                if missing_kinds:
+                    errors.append(f"'mixed_array' missing kinds: {missing_kinds}")
+
+    # Check render doesn't crash
+    try:
+        for fmt in ["tree", "tabs", "bracket"]:
+            output = flux.tree(format=fmt)
+            if len(output) < 100:
+                errors.append(f"'{fmt}' render output suspiciously short")
+    except Exception as e:
+        errors.append(f"Render crashed: {e}")
+
+    return errors

--- a/backend/src/meho_backplane/jsonflux/core/__init__.py
+++ b/backend/src/meho_backplane/jsonflux/core/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group

--- a/backend/src/meho_backplane/jsonflux/core/analyzer.py
+++ b/backend/src/meho_backplane/jsonflux/core/analyzer.py
@@ -1,0 +1,661 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+from __future__ import annotations
+
+import random
+from functools import lru_cache
+from typing import Any
+
+import msgspec
+
+from ..utils.sampling import ReservoirSampler
+from .models import (
+    ALL_KINDS,
+    KIND_ORDER,
+    PRIMITIVE_KINDS,
+    ArraySummary,
+    Summary,
+    TreeNode,
+    kind_map_get,
+)
+
+ITEMS_PLACEHOLDER = "<items>"
+
+# Local alias for hot path
+_kind_map_get = kind_map_get
+
+
+def kind_of(v: Any) -> str:
+    """Classify a Python value into a JSON kind string."""
+    return _kind_map_get(type(v), "unknown")
+
+
+# --------------------------
+# Cached formatting functions
+# --------------------------
+
+
+@lru_cache(maxsize=32)
+def fmt_types(types: frozenset) -> str:
+    """Cached type formatting."""
+    ordered = [t for t in ("str", "int", "float", "bool", "null") if t in types]
+    return "|".join(ordered) if ordered else "unknown"
+
+
+@lru_cache(maxsize=1024)
+def fmt_count(min_v: int, max_v: int) -> str:
+    return f"[{min_v}]" if min_v == max_v else f"[{min_v}..{max_v}]"
+
+
+def jsonish_sample(v: Any, max_len: int) -> str:
+    """Format a value as JSON-like string, truncating if needed."""
+    if type(v) is str and len(v) > max_len:
+        v = v[:max_len] + "…"
+    return msgspec.json.encode(v).decode("utf-8")
+
+
+def samples_suffix(
+    store: dict[tuple[str, ...], ReservoirSampler],
+    path: tuple[str, ...],
+    max_sample_len: int,
+    samples_k: int,
+) -> str:
+    """Generate sample values suffix for tree labels."""
+    if samples_k <= 0:
+        return ""
+    sampler = store.get(path)
+    vals = sampler.get_exact_k() if sampler else [None] * samples_k
+    rendered = ", ".join(jsonish_sample(x, max_sample_len) for x in vals)
+    return f" samples=[{rendered}]"
+
+
+def merge_summary(a: Summary, b: Summary) -> Summary:  # NOSONAR (cognitive complexity)
+    primitives = a.primitives | b.primitives
+    truncated = a.truncated or b.truncated
+    obj = None
+    arr = None
+
+    if a.obj is not None or b.obj is not None:
+        obj = {}
+        a_obj = a.obj or {}
+        b_obj = b.obj or {}
+        all_keys = set(a_obj.keys()) | set(b_obj.keys())
+        for k in all_keys:
+            a_child = a_obj.get(k)
+            b_child = b_obj.get(k)
+            if a_child and b_child:
+                obj[k] = merge_summary(a_child, b_child)
+            elif a_child:
+                obj[k] = a_child
+            elif b_child:
+                obj[k] = b_child
+
+    if a.arr is not None or b.arr is not None:
+        if a.arr is None:
+            arr = b.arr
+        elif b.arr is None:
+            arr = a.arr
+        else:
+            kind_minmax = {}
+            for kind in ALL_KINDS:
+                a_mm = a.arr.kind_minmax.get(kind, (0, 0))
+                b_mm = b.arr.kind_minmax.get(kind, (0, 0))
+                kind_minmax[kind] = (min(a_mm[0], b_mm[0]), max(a_mm[1], b_mm[1]))
+
+            kind_summaries = {}
+            for kind in ("object", "array"):
+                a_ks = a.arr.kind_summaries.get(kind)
+                b_ks = b.arr.kind_summaries.get(kind)
+                if a_ks and b_ks:
+                    kind_summaries[kind] = merge_summary(a_ks, b_ks)
+                elif a_ks:
+                    kind_summaries[kind] = a_ks
+                elif b_ks:
+                    kind_summaries[kind] = b_ks
+
+            arr = ArraySummary(
+                len_min=min(a.arr.len_min, b.arr.len_min),
+                len_max=max(a.arr.len_max, b.arr.len_max),
+                kind_minmax=kind_minmax,
+                kind_summaries=kind_summaries,
+                truncated=a.arr.truncated or b.arr.truncated,
+            )
+
+    return Summary(primitives=primitives, obj=obj, arr=arr, truncated=truncated)
+
+
+class Analyzer:
+    """Core logic for analyzing JSON structure."""
+
+    __slots__ = ("max_depth", "max_keys_per_object", "sample_per_kind", "sort_keys")
+
+    def __init__(
+        self,
+        max_depth: int = 32,
+        sample_per_kind: int = 200,
+        sort_keys: bool = True,
+        max_keys_per_object: int | None = None,
+    ) -> None:
+        self.max_depth = max_depth
+        self.sample_per_kind = sample_per_kind
+        self.sort_keys = sort_keys
+        self.max_keys_per_object = max_keys_per_object
+
+    def summarize(self, v: Any, depth: int) -> Summary:  # NOSONAR (cognitive complexity)
+        """Summarize a JSON value with local variable caching for speed."""
+        # Local variable caching for hot path
+        _kind_of = kind_of
+        _PRIMITIVE_KINDS = PRIMITIVE_KINDS
+        _ALL_KINDS = ALL_KINDS
+        _merge_summary = merge_summary
+
+        def _summarize(v: Any, depth: int) -> Summary:
+            if depth < 0:
+                return Summary(truncated=True)
+
+            k = _kind_of(v)
+
+            if k in _PRIMITIVE_KINDS:
+                return Summary(primitives=frozenset((k,)))
+
+            if k == "object":
+                if depth == 0:
+                    return Summary(obj={}, truncated=True)
+                keys = list(v.keys())
+                if self.sort_keys:
+                    keys.sort(key=str)
+                truncated = False
+                if self.max_keys_per_object is not None and len(keys) > self.max_keys_per_object:
+                    keys = keys[: self.max_keys_per_object]
+                    truncated = True
+                children = {str(key): _summarize(v[key], depth - 1) for key in keys}
+                return Summary(obj=children, truncated=truncated)
+
+            if k == "array":
+                arr_len = len(v)
+                counts = dict.fromkeys(_ALL_KINDS, 0)
+                obj_samples: list[Any] = []
+                arr_samples: list[Any] = []
+                sample_per_kind = self.sample_per_kind
+
+                for el in v:
+                    ek = _kind_of(el)
+                    counts[ek] = counts.get(ek, 0) + 1
+                    if ek == "object" and len(obj_samples) < sample_per_kind:
+                        obj_samples.append(el)
+                    elif ek == "array" and len(arr_samples) < sample_per_kind:
+                        arr_samples.append(el)
+
+                kind_minmax = {kk: (c, c) for kk, c in counts.items()}
+                if depth == 0:
+                    return Summary(
+                        arr=ArraySummary(
+                            len_min=arr_len,
+                            len_max=arr_len,
+                            kind_minmax=kind_minmax,
+                            truncated=True,
+                        ),
+                        truncated=True,
+                    )
+
+                kind_summaries: dict[str, Summary] = {}
+                if obj_samples:
+                    merged = _summarize(obj_samples[0], depth - 1)
+                    for el in obj_samples[1:]:
+                        merged = _merge_summary(merged, _summarize(el, depth - 1))
+                    kind_summaries["object"] = merged
+                if arr_samples:
+                    merged = _summarize(arr_samples[0], depth - 1)
+                    for el in arr_samples[1:]:
+                        merged = _merge_summary(merged, _summarize(el, depth - 1))
+                    kind_summaries["array"] = merged
+
+                return Summary(
+                    arr=ArraySummary(
+                        len_min=arr_len,
+                        len_max=arr_len,
+                        kind_minmax=kind_minmax,
+                        kind_summaries=kind_summaries,
+                    )
+                )
+
+            return Summary(primitives=frozenset(("unknown",)))
+
+        return _summarize(v, depth)
+
+    def collect_samples(  # NOSONAR (cognitive complexity)
+        self,
+        root: Any,
+        store: dict[tuple[str, ...], ReservoirSampler],
+        k: int,
+        rng: random.Random,
+    ) -> None:
+        """Iterative sample collection using explicit stack with local caching."""
+        if k <= 0:
+            return
+
+        # Local caching for hot path
+        _kind_of = kind_of
+        _PRIMITIVE_KINDS = PRIMITIVE_KINDS
+        store_get = store.get
+
+        # Stack: (value, path_tuple)
+        stack: list[tuple[Any, tuple[str, ...]]] = [(root, ())]
+
+        while stack:
+            v, path = stack.pop()
+            t = _kind_of(v)
+
+            if t in _PRIMITIVE_KINDS:
+                spath = (
+                    (*path[:-1], f"<items:{t}>") if path and path[-1] == ITEMS_PLACEHOLDER else path
+                )
+
+                sampler = store_get(spath)
+                if sampler is None:
+                    sampler = ReservoirSampler(k, rng)
+                    store[spath] = sampler
+                sampler.add(v)
+
+            elif t == "object":
+                # Push children in reverse order so they pop in order
+                items = list(v.items())
+                for key, val in reversed(items):
+                    stack.append((val, (*path, str(key))))
+
+            elif t == "array":
+                items_path = (*path, ITEMS_PLACEHOLDER)
+                for el in reversed(v):
+                    stack.append((el, items_path))
+
+
+# --------------------------
+# Tree building function (optimized)
+# --------------------------
+
+
+def summary_to_tree(  # NOSONAR (cognitive complexity)
+    name: str,
+    s: Summary,
+    path: tuple[str, ...],
+    sample_store: dict[tuple[str, ...], ReservoirSampler],
+    max_sample_len: int,
+    samples_k: int,
+) -> TreeNode:
+    """Build tree node from summary (recursive - tree is usually small)."""
+    s_obj = s.obj
+    s_arr = s.arr
+    has_obj = s_obj is not None
+    has_arr = s_arr is not None
+
+    if not has_obj and not has_arr:
+        label = f"{name}: {fmt_types(s.primitives)}"
+        label += samples_suffix(sample_store, path, max_sample_len, samples_k)
+        return TreeNode(label=label, children=[])
+
+    children: list[TreeNode] = []
+
+    # Primitive types at this level
+    for p in KIND_ORDER:
+        if p in s.primitives:
+            label = p + samples_suffix(sample_store, path, max_sample_len, samples_k)
+            children.append(TreeNode(label=label, children=[]))
+
+    # Object children
+    if s_obj is not None:
+        for key in s_obj:
+            children.append(
+                summary_to_tree(
+                    key,
+                    s_obj[key],
+                    (*path, key),
+                    sample_store,
+                    max_sample_len,
+                    samples_k,
+                )
+            )
+
+    # Array children
+    if s_arr is not None:
+        if s_arr.len_max == 0:
+            children.append(TreeNode(label="<empty> [0]", children=[]))
+        else:
+            for kind in KIND_ORDER:
+                mm = s_arr.kind_minmax.get(kind, (0, 0))
+                if mm[1] == 0:
+                    continue
+
+                child_label = f"{kind} {fmt_count(mm[0], mm[1])}"
+                if kind in PRIMITIVE_KINDS:
+                    child_label += samples_suffix(
+                        sample_store,
+                        (*path, f"<items:{kind}>"),
+                        max_sample_len,
+                        samples_k,
+                    )
+
+                grandchildren: list[TreeNode] = []
+                if kind in s_arr.kind_summaries:
+                    elem_sum = s_arr.kind_summaries[kind]
+                    if kind == "object" and elem_sum.obj is not None:
+                        for k2 in elem_sum.obj:
+                            grandchildren.append(
+                                summary_to_tree(
+                                    k2,
+                                    elem_sum.obj[k2],
+                                    (*path, ITEMS_PLACEHOLDER, k2),
+                                    sample_store,
+                                    max_sample_len,
+                                    samples_k,
+                                )
+                            )
+                        if elem_sum.truncated:
+                            grandchildren.append(TreeNode(label="…", children=[]))
+                    elif kind == "array" and elem_sum.arr is not None:
+                        nested = Summary(arr=elem_sum.arr, truncated=elem_sum.truncated)
+                        grandchildren.append(
+                            summary_to_tree(
+                                ITEMS_PLACEHOLDER,
+                                nested,
+                                (*path, ITEMS_PLACEHOLDER),
+                                sample_store,
+                                max_sample_len,
+                                samples_k,
+                            )
+                        )
+                    elif elem_sum.truncated:
+                        grandchildren.append(TreeNode(label="…", children=[]))
+
+                if s_arr.truncated:
+                    grandchildren.append(TreeNode(label="…", children=[]))
+
+                children.append(TreeNode(label=child_label, children=grandchildren))
+
+    if s.truncated:
+        children.append(TreeNode(label="…", children=[]))
+
+    return TreeNode(label=name, children=children)
+
+
+# --------------------------
+# Renderers (iterative for efficiency)
+# --------------------------
+
+
+def render_tree(root: TreeNode) -> str:
+    """Render with └── ├── box-drawing connectors (iterative)."""
+    lines: list[str] = [root.label]
+
+    # Stack: (node, prefix, is_last)
+    stack: list[tuple[TreeNode, str, bool]] = []
+
+    # Initialize with root's children in reverse
+    root_children = root.children
+    n = len(root_children)
+    for i in range(n - 1, -1, -1):
+        stack.append((root_children[i], "", i == n - 1))
+
+    while stack:
+        node, prefix, is_last = stack.pop()
+        connector = "└── " if is_last else "├── "
+        lines.append(prefix + connector + node.label)
+        next_prefix = prefix + ("    " if is_last else "│   ")
+
+        children = node.children
+        n = len(children)
+        for i in range(n - 1, -1, -1):
+            stack.append((children[i], next_prefix, i == n - 1))
+
+    return "\n".join(lines)
+
+
+def render_tabs(root: TreeNode, indent_str: str = "\t") -> str:
+    """Render with tab indentation (TSV-like, iterative)."""
+    lines: list[str] = [root.label]
+
+    # Stack: (node, level)
+    stack: list[tuple[TreeNode, int]] = []
+    for ch in reversed(root.children):
+        stack.append((ch, 1))
+
+    while stack:
+        node, level = stack.pop()
+        lines.append(indent_str * level + node.label)
+        for ch in reversed(node.children):
+            stack.append((ch, level + 1))
+
+    return "\n".join(lines)
+
+
+# Alias for backward compatibility
+
+
+def render_bracket(root: TreeNode, indent_str: str = "\t") -> str:
+    """Render with curly brace nesting (iterative)."""
+    lines: list[str] = []
+
+    # Stack entries: (node, level, is_close)
+    stack: list[tuple[TreeNode, int, bool]] = [(root, 0, False)]
+
+    while stack:
+        node, level, is_close = stack.pop()
+        pad = indent_str * level
+
+        if is_close:
+            lines.append(f"{pad}}}")
+        elif node.children:
+            lines.append(f"{pad}{node.label} {{")
+            stack.append((node, level, True))  # Push close brace
+            for ch in reversed(node.children):
+                stack.append((ch, level + 1, False))
+        else:
+            lines.append(f"{pad}{node.label}")
+
+    return "\n".join(lines)
+
+
+# --------------------------
+# LLM-friendly schema (compact, TypeScript-like)
+# --------------------------
+
+
+def summary_to_schema(  # NOSONAR (cognitive complexity)
+    s: Summary,
+    path: tuple[str, ...] = (),
+    sample_store: dict[tuple[str, ...], ReservoirSampler] | None = None,
+    max_sample_len: int = 60,
+    samples_k: int = 0,
+    indent: int = 0,
+    inline: bool = False,
+    max_depth: int | None = None,
+) -> str:
+    """
+    Convert Summary to compact TypeScript-like schema for LLM consumption.
+
+    Output format is designed to be:
+    - Token-efficient (minimal syntax)
+    - Clear about types and structure
+    - Easy for LLMs to parse and use for query generation
+
+    Args:
+        s: Summary to convert
+        path: Current path tuple for sample lookup
+        sample_store: Optional sample store for including examples
+        max_sample_len: Max length for sample strings
+        samples_k: Number of samples to include (0 = none)
+        indent: Current indentation level
+        inline: Whether to use compact inline format
+        max_depth: Maximum nesting depth for schema rendering.
+                   Beyond this, objects render as ``{...}`` and arrays as
+                   ``[...]``.  ``None`` means unlimited (the old default).
+
+    Examples:
+        {name: str, age: int}
+        [{id: int, name: str, score: float?}]
+        [int|str]
+        {name: str}  # samples=["Alice", "Bob"]  (with samples)
+    """
+    # Depth guard: truncate deeply nested structures to save tokens
+    if max_depth is not None and indent >= max_depth:
+        has_obj = s.obj is not None and bool(s.obj)
+        has_arr = s.arr is not None
+        prim = [t for t in ("str", "int", "float", "bool", "null") if t in s.primitives]
+        abbr: list[str] = []
+        if has_obj:
+            abbr.append("{...}")
+        if has_arr:
+            abbr.append("[...]")
+        abbr.extend(prim)
+        return " | ".join(abbr) if abbr else "unknown"
+
+    pad = "  " * indent
+    s_obj = s.obj
+    s_arr = s.arr
+    primitives = s.primitives
+
+    parts: list[str] = []
+
+    # Helper to get sample suffix
+    def get_samples(p: tuple[str, ...], kind: str | None = None) -> str:
+        if samples_k <= 0 or sample_store is None:
+            return ""
+        # For array items, use the kind-specific path
+        lookup_path = (*p, f"<items:{kind}>") if kind else p
+        return samples_suffix(sample_store, lookup_path, max_sample_len, samples_k)
+
+    # Collect primitive types
+    prim_types = [t for t in ("str", "int", "float", "bool", "null") if t in primitives]
+
+    # Handle object
+    if s_obj is not None:
+        if not s_obj:  # empty object
+            parts.append("{}")
+        else:
+            fields: list[str] = []
+            for key, child in s_obj.items():
+                child_path = (*path, key)
+                child_schema = summary_to_schema(
+                    child,
+                    child_path,
+                    sample_store,
+                    max_sample_len,
+                    samples_k,
+                    indent + 1,
+                    inline=True,
+                    max_depth=max_depth,
+                )
+                fields.append(f"{key}: {child_schema}")
+
+            if inline and len(fields) <= 3 and all(len(f) < 30 for f in fields):
+                # Compact inline: {a: int, b: str}
+                parts.append("{" + ", ".join(fields) + "}")
+            else:
+                # Multi-line for readability
+                inner_pad = "  " * (indent + 1)
+                field_lines = [f"{inner_pad}{f}" for f in fields]
+                parts.append("{\n" + "\n".join(field_lines) + "\n" + pad + "}")
+
+    # Handle array
+    if s_arr is not None:
+        if s_arr.len_max == 0:
+            parts.append("[]")
+        else:
+            # Collect element types
+            elem_types: list[str] = []
+
+            for kind in KIND_ORDER:
+                mm = s_arr.kind_minmax.get(kind, (0, 0))
+                if mm[1] == 0:
+                    continue
+
+                if kind in PRIMITIVE_KINDS:
+                    sample_str = get_samples(path, kind)
+                    elem_types.append(f"{kind}{sample_str}" if sample_str else kind)
+                elif (kind == "object" and kind in s_arr.kind_summaries) or (
+                    kind == "array" and kind in s_arr.kind_summaries
+                ):
+                    elem_schema = summary_to_schema(
+                        s_arr.kind_summaries[kind],
+                        (*path, ITEMS_PLACEHOLDER),
+                        sample_store,
+                        max_sample_len,
+                        samples_k,
+                        indent,
+                        inline=True,
+                        max_depth=max_depth,
+                    )
+                    elem_types.append(elem_schema)
+                elif kind == "object":
+                    elem_types.append("{...}")
+                elif kind == "array":
+                    elem_types.append("[...]")
+
+            if len(elem_types) == 1:
+                parts.append(f"[{elem_types[0]}]")
+            elif elem_types:
+                parts.append(f"[{' | '.join(elem_types)}]")
+            else:
+                parts.append("[]")
+
+    # Add primitive types with samples
+    if prim_types:
+        if len(prim_types) == 1 and not s_obj and not s_arr:
+            # Single primitive type at leaf - add samples
+            sample_str = get_samples(path)
+            if sample_str:
+                parts.append(f"{prim_types[0]}{sample_str}")
+            else:
+                parts.append(prim_types[0])
+        else:
+            parts.extend(prim_types)
+
+    # Combine all parts
+    if not parts:
+        return "unknown"
+
+    if len(parts) == 1:
+        return parts[0]
+
+    # Multiple types - use union
+    # Simplify: if we have "null" and one other type, use ? suffix
+    if len(parts) == 2 and "null" in parts:
+        other = next(p for p in parts if p != "null")
+        # Only use ? for simple types, not complex objects/arrays
+        if other in ("str", "int", "float", "bool"):
+            return f"{other}?"
+
+    return " | ".join(parts)
+
+
+def render_schema(
+    root_summary: Summary,
+    sample_store: dict[tuple[str, ...], ReservoirSampler] | None = None,
+    max_sample_len: int = 60,
+    samples_k: int = 0,
+    max_depth: int | None = None,
+) -> str:
+    """
+    Render a compact schema from the root Summary.
+
+    This is the main entry point for LLM-friendly schema generation.
+    Returns a TypeScript-like schema string.
+
+    Args:
+        root_summary: The Summary to render
+        sample_store: Optional sample store for including examples
+        max_sample_len: Max length for sample strings
+        samples_k: Number of samples to include (0 = none)
+        max_depth: Maximum nesting depth to render.  Structures deeper
+                   than this are collapsed to ``{...}`` / ``[...]``.
+                   ``None`` means unlimited.
+    """
+    return summary_to_schema(
+        root_summary,
+        path=(),
+        sample_store=sample_store,
+        max_sample_len=max_sample_len,
+        samples_k=samples_k,
+        indent=0,
+        inline=False,
+        max_depth=max_depth,
+    )

--- a/backend/src/meho_backplane/jsonflux/core/converter.py
+++ b/backend/src/meho_backplane/jsonflux/core/converter.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+from typing import Any
+
+import pyarrow as pa
+
+from .models import Summary
+
+
+def summary_to_arrow_type(summary: Summary) -> pa.DataType:  # NOSONAR (cognitive complexity)
+    """
+    Convert a JsonFlux Summary to a PyArrow DataType.
+
+    Strategies for type conflict resolution:
+    - Mixed primitives (int + float) -> float
+    - Mixed primitives (int/float + str) -> string
+    - Mixed complex (object + array) -> string (JSON dump)
+    - Unknown/Null only -> string (safe default)
+    """
+    prims = summary.primitives
+
+    # 1. Complex types (Object/Array) need special handling
+    has_obj = summary.obj is not None
+    has_arr = summary.arr is not None
+
+    if has_obj and has_arr:
+        # Conflict: field is both object and array in different rows
+        return pa.string()
+
+    if has_obj:
+        # If it also has primitives (e.g. obj | null is fine, but obj | int -> string)
+        non_null_prims = [p for p in prims if p != "null"]
+        if non_null_prims:
+            return pa.string()
+
+        # DuckDB does not support zero-field structs.
+        # If the object is empty across all samples, we use string as a fallback.
+        if not summary.obj:
+            return pa.string()
+
+        # Recursive struct construction
+        fields = []
+        # Sort keys for deterministic schema
+        for key in sorted(summary.obj.keys()):
+            child_type = summary_to_arrow_type(summary.obj[key])
+            fields.append(pa.field(key, child_type, nullable=True))
+        return pa.struct(fields)
+
+    if has_arr:
+        non_null_prims = [p for p in prims if p != "null"]
+        if non_null_prims:
+            return pa.string()
+
+        # Determine array item type
+        # We need to merge all "kind_summaries" in the array summary to find a unified type
+        # For now, let's look at what kinds are present in the array
+
+        # ArraySummary has: kind_summaries for 'object' and 'array'
+        # and kind_minmax for primitives.
+
+        # We need to synthesize a single Summary for the items
+        # This is strictly speaking a bit lossy if we don't have a pre-merged item summary
+        # But we can reconstruct it from the ArraySummary parts.
+
+        # Check primitives in array
+        arr_prims = set()
+        if summary.arr is None:
+            return pa.string()
+        for kind in ("str", "int", "float", "bool", "null"):
+            if summary.arr.kind_minmax.get(kind, (0, 0))[1] > 0:
+                arr_prims.add(kind)
+
+        # Check complex in array
+        obj_summary = summary.arr.kind_summaries.get("object")
+        arr_summary = summary.arr.kind_summaries.get("array")
+
+        # If mixed types in array -> string
+        # e.g. [1, "a"] -> list<string>
+        # e.g. [{"a": 1}, 2] -> list<string>
+
+        has_complex_items = (obj_summary is not None) or (arr_summary is not None)
+        has_prim_items = len(arr_prims - {"null"}) > 0
+
+        if has_complex_items and has_prim_items:
+            # Mix of objects and primitives in list -> list<string> (or stringify whole list?)
+            # Usually list<string> is better so we can at least unnest
+            return pa.list_(pa.string())
+
+        if has_complex_items:
+            if obj_summary and arr_summary:
+                return pa.list_(pa.string())
+            if obj_summary:
+                return pa.list_(summary_to_arrow_type(obj_summary))
+            if arr_summary:
+                # List of lists
+                # We need to wrap the inner array summary back into a full Summary to recurse
+                inner_s = Summary(arr=arr_summary.arr, truncated=arr_summary.truncated)
+                return pa.list_(summary_to_arrow_type(inner_s))
+
+        # Only primitives
+        if not arr_prims or arr_prims == {"null"}:
+            return pa.list_(pa.string())  # Empty/Null list
+
+        if "str" in arr_prims:
+            return pa.list_(pa.string())
+        if "float" in arr_prims:
+            return pa.list_(pa.float64())
+        if "int" in arr_prims:
+            return pa.list_(pa.int64())
+        if "bool" in arr_prims:
+            return pa.list_(pa.bool_())
+
+        return pa.list_(pa.string())
+
+    # 2. Primitives only
+    non_null_prims = [p for p in prims if p != "null"]
+
+    if not non_null_prims:
+        return pa.string()  # Default for "null" only or empty
+
+    if "str" in non_null_prims:
+        return pa.string()
+
+    if "float" in non_null_prims:
+        return pa.float64()
+
+    if "int" in non_null_prims:
+        # Check range if we tracked it? For now assume int64
+        return pa.int64()
+
+    if "bool" in non_null_prims:
+        return pa.bool_()
+
+    return pa.string()
+
+
+def summary_to_schema(summary: Summary) -> pa.Schema:
+    """Convert root Summary to PyArrow Schema."""
+    if summary.obj is None:
+        # Root must be object to be a "Table" (or we treat array as 1 col?)
+        # For direct JSON mapping, usually root is struct.
+        # If root is array, we might treat it as a table where each item is a row.
+        raise ValueError("Root summary must be an object to convert to Schema")
+
+    fields = []
+    for key in sorted(summary.obj.keys()):
+        field_type = summary_to_arrow_type(summary.obj[key])
+        fields.append(pa.field(key, field_type, nullable=True))
+
+    return pa.schema(fields)
+
+
+def normalize_data(
+    data: Any, schema: pa.DataType | pa.Schema
+) -> Any:  # NOSONAR (cognitive complexity)
+    """
+    Recursively normalize data to match the Arrow schema.
+
+    Handles:
+    - safely casting primitives to string (if schema expects string)
+    - casting int to float
+    - filtering unknown fields (optional, but good for struct strictness)
+    - handling nulls
+    """
+    if data is None:
+        return None
+
+    # Handle Schema vs DataType
+    if isinstance(schema, pa.Schema):
+        if not isinstance(data, dict):
+            # If root is a list of records, we might need to handle that outside
+            # But usually we normalize a single record or list of records
+            return data
+
+        out = {}
+        for field in schema:
+            val = data.get(field.name)
+            out[field.name] = normalize_data(val, field.type)
+        return out
+
+    # Handle DataTypes
+    if isinstance(schema, pa.StructType):
+        if not isinstance(data, dict):
+            # Fallback if structure mismatches (e.g. schema says struct, data has "foo")
+            return None
+        out = {}
+        for field in schema:
+            val = data.get(field.name)
+            out[field.name] = normalize_data(val, field.type)
+        return out
+
+    if isinstance(schema, pa.ListType):
+        if not isinstance(data, list):
+            return []  # expected list, got something else
+
+        item_type = schema.value_type
+        return [normalize_data(x, item_type) for x in data]
+
+    if pa.types.is_string(schema):
+        if isinstance(data, (dict, list)):
+            import json
+
+            return json.dumps(data)
+        return str(data)
+
+    if pa.types.is_float64(schema):
+        try:
+            return float(data)
+        except (ValueError, TypeError):
+            return None
+
+    if pa.types.is_int64(schema):
+        try:
+            return int(data)
+        except (ValueError, TypeError):
+            # Determine strategy: return None or 0? None is safer
+            return None
+
+    if pa.types.is_boolean(schema):
+        return bool(data)
+
+    return data

--- a/backend/src/meho_backplane/jsonflux/core/models.py
+++ b/backend/src/meho_backplane/jsonflux/core/models.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+from __future__ import annotations
+
+from typing import Any
+
+import msgspec
+
+# --------------------------
+# Shared constants (canonical definitions)
+# --------------------------
+
+ALL_KINDS: tuple[str, ...] = ("object", "array", "str", "int", "float", "bool", "null")
+KIND_ORDER: tuple[str, ...] = ALL_KINDS
+PRIMITIVE_KINDS: frozenset = frozenset(("str", "int", "float", "bool", "null"))
+
+KIND_MAP: dict[type, str] = {
+    type(None): "null",
+    bool: "bool",
+    int: "int",
+    float: "float",
+    str: "str",
+    dict: "object",
+    list: "array",
+}
+kind_map_get = KIND_MAP.get  # Cached lookup for hot paths
+
+
+# --------------------------
+# Data models
+# --------------------------
+
+
+class ArraySummary(msgspec.Struct, gc=False):
+    len_min: int
+    len_max: int
+    kind_minmax: dict[str, tuple[int, int]] = {}
+    kind_summaries: dict[str, Summary] = {}
+    truncated: bool = False
+
+
+class Summary(msgspec.Struct, gc=False):
+    primitives: frozenset = frozenset()
+    obj: dict[str, Summary] | None = None
+    arr: ArraySummary | None = None
+    truncated: bool = False
+
+
+class TreeNode(msgspec.Struct, gc=False):
+    label: str
+    children: list[TreeNode] = []
+
+
+class ProfileResult(msgspec.Struct, gc=False):
+    summary: Summary
+    sample_store: dict[tuple[str, ...], Any]  # Using Any for ReservoirSampler to avoid circularity
+    source: str
+    parse_time: float = 0.0
+    analyze_time: float = 0.0
+    sample_time: float = 0.0

--- a/backend/src/meho_backplane/jsonflux/core/stats.py
+++ b/backend/src/meho_backplane/jsonflux/core/stats.py
@@ -1,0 +1,557 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+from __future__ import annotations
+
+import contextlib
+import time
+from typing import Any
+
+import msgspec
+
+from .models import kind_map_get
+
+# Local alias for hot path
+_kind_map_get = kind_map_get
+
+
+def estimate_json_size(v: Any) -> int:
+    """Estimate JSON-serialized size in bytes (fast approximation)."""
+    t = type(v)
+    if v is None:
+        return 4  # "null"
+    elif t is bool:
+        return 5 if v else 4  # "true" or "false"
+    elif t is int or t is float:
+        return len(str(v))
+    elif isinstance(v, str):
+        # Account for quotes and potential escaping (rough estimate)
+        return len(v) + 2 + v.count('"') + v.count("\\")
+    elif t is list:
+        return 2  # Just brackets, items counted separately
+    elif t is dict:
+        return 2  # Just braces, keys/values counted separately
+    return 0
+
+
+def fmt_size(n: int) -> str:
+    """Format bytes as human-readable string with appropriate unit."""
+    if n < 1024:
+        return f"{n} B"
+    elif n < 1024 * 1024:
+        return f"{n / 1024:.2f} KB"
+    elif n < 1024 * 1024 * 1024:
+        return f"{n / (1024 * 1024):.2f} MB"
+    else:
+        return f"{n / (1024 * 1024 * 1024):.2f} GB"
+
+
+# Alias for backward compatibility
+fmt_bytes = fmt_size
+
+
+class FieldStats:
+    __slots__ = (
+        "arr_count",
+        "arr_empty_count",
+        "arr_max_len",
+        "arr_min_len",
+        "arr_total_len",
+        "bool_false_count",
+        "bool_true_count",
+        "null_count",
+        "num_count",
+        "num_max",
+        "num_min",
+        "num_sum",
+        "obj_count",
+        "obj_empty_count",
+        "obj_key_counts",
+        "path",
+        "size_max",
+        "size_min",
+        "str_count",
+        "str_empty_count",
+        "str_max_len",
+        "str_min_len",
+        "str_total_len",
+        "total_seen",
+        "total_size",
+        "type_counts",
+        "unique_limit",
+        "unique_values",
+    )
+
+    def __init__(self, path: str, unique_limit: int = 100) -> None:
+        self.path = path
+        self.total_seen = 0
+        self.null_count = 0
+        self.type_counts: dict[str, int] = {}
+        self.total_size = 0
+        self.size_min: int | None = None
+        self.size_max: int | None = None
+        self.num_min: float | None = None
+        self.num_max: float | None = None
+        self.num_sum = 0.0
+        self.num_count = 0
+        self.str_min_len: int | None = None
+        self.str_max_len: int | None = None
+        self.str_total_len = 0
+        self.str_count = 0
+        self.str_empty_count = 0
+        self.arr_min_len: int | None = None
+        self.arr_max_len: int | None = None
+        self.arr_total_len = 0
+        self.arr_count = 0
+        self.arr_empty_count = 0
+        self.obj_key_counts: dict[str, int] = {}
+        self.obj_count = 0
+        self.obj_empty_count = 0
+        self.bool_true_count = 0
+        self.bool_false_count = 0
+        self.unique_values: set[Any] = set()
+        self.unique_limit = unique_limit
+
+    def add(self, value: Any) -> None:  # NOSONAR (cognitive complexity)
+        self.total_seen += 1
+        t = type(value)
+        size = estimate_json_size(value)
+        self.total_size += size
+        if self.size_min is None or size < self.size_min:
+            self.size_min = size
+        if self.size_max is None or size > self.size_max:
+            self.size_max = size
+
+        if value is None:
+            self.null_count += 1
+            self.type_counts["null"] = self.type_counts.get("null", 0) + 1
+            return
+
+        type_name = _kind_map_get(t, "unknown")
+        self.type_counts[type_name] = self.type_counts.get(type_name, 0) + 1
+
+        if t is bool:
+            if value:
+                self.bool_true_count += 1
+            else:
+                self.bool_false_count += 1
+            self._track_unique(value)
+        elif t in (int, float):
+            v = float(value)
+            self.num_count += 1
+            self.num_sum += v
+            if self.num_min is None or v < self.num_min:
+                self.num_min = v
+            if self.num_max is None or v > self.num_max:
+                self.num_max = v
+            self._track_unique(value)
+        elif t is str:
+            length = len(value)
+            self.str_count += 1
+            self.str_total_len += length
+            if length == 0:
+                self.str_empty_count += 1
+            if self.str_min_len is None or length < self.str_min_len:
+                self.str_min_len = length
+            if self.str_max_len is None or length > self.str_max_len:
+                self.str_max_len = length
+            if length <= 100:
+                self._track_unique(value)
+        elif t is list:
+            length = len(value)
+            self.arr_count += 1
+            self.arr_total_len += length
+            if length == 0:
+                self.arr_empty_count += 1
+            if self.arr_min_len is None or length < self.arr_min_len:
+                self.arr_min_len = length
+            if self.arr_max_len is None or length > self.arr_max_len:
+                self.arr_max_len = length
+        elif t is dict:
+            self.obj_count += 1
+            if len(value) == 0:
+                self.obj_empty_count += 1
+            for key in value:
+                k = str(key)
+                self.obj_key_counts[k] = self.obj_key_counts.get(k, 0) + 1
+
+    def _track_unique(self, value: Any) -> None:
+        if len(self.unique_values) < self.unique_limit:
+            with contextlib.suppress(TypeError):
+                self.unique_values.add(value)
+
+    def format_report(self) -> str:
+        lines = [
+            f"📍 {self.path}",
+            f"   Count: {self.total_seen:,} | Size: {fmt_size(self.total_size)}",
+        ]
+        if self.null_count > 0:
+            lines.append(
+                f"   Null: {self.null_count} ({self.null_count / self.total_seen * 100:.1f}%)"
+            )
+
+        type_parts = []
+        for t, c in sorted(self.type_counts.items(), key=lambda x: -x[1]):
+            type_parts.append(f"{t}:{c}({c / self.total_seen * 100:.1f}%)")
+        lines.append(f"   Types: {', '.join(type_parts)}")
+
+        if self.num_count > 0:
+            lines.append(
+                f"   Numeric: min={self.num_min}, max={self.num_max}, avg={self.num_sum / self.num_count:.2f}"
+            )
+        if self.str_count > 0:
+            lines.append(
+                f"   String: len={self.str_min_len}..{self.str_max_len}, avg={self.str_total_len / self.str_count:.1f} chars"
+            )
+        if self.arr_count > 0:
+            lines.append(
+                f"   Array: len={self.arr_min_len}..{self.arr_max_len}, avg={self.arr_total_len / self.arr_count:.1f} items"
+            )
+        if self.obj_key_counts:
+            lines.append(f"   Keys: {len(self.obj_key_counts)} unique keys")
+
+        return "\n".join(lines)
+
+
+class StatsResult(msgspec.Struct, gc=False):
+    field_stats: dict[str, FieldStats]
+    total_values: int
+    total_objects: int
+    total_arrays: int
+    total_primitives: int
+    total_size_bytes: int
+    max_depth: int
+    collection_time: float = 0.0
+
+    def __str__(self) -> str:
+        lines = [
+            " " + "=" * 68,
+            " JSON STATISTICS",
+            " " + "=" * 68,
+            f" Total values:     {self.total_values:,}",
+            f"   Objects:        {self.total_objects:,}",
+            f"   Arrays:         {self.total_arrays:,}",
+            f"   Primitives:     {self.total_primitives:,}",
+            f" Estimated size:   {fmt_size(self.total_size_bytes)}",
+            f" Max depth:        {self.max_depth}",
+            f" Unique paths:     {len(self.field_stats):,}",
+            f" Collection time:  {self.collection_time:.3f}s",
+            " " + "-" * 68,
+            "",
+        ]
+        # Show top 20 paths by size
+        sorted_fields = sorted(self.field_stats.values(), key=lambda x: -x.total_size)[:20]
+        for fs in sorted_fields:
+            lines.append(fs.format_report())
+            lines.append("")
+
+        if len(self.field_stats) > 20:
+            lines.append(f"... and {len(self.field_stats) - 20} more paths")
+
+        return "\n".join(lines)
+
+
+# --------------------------
+# Stats formatting functions
+# --------------------------
+
+
+def format_stats_compact(stats: StatsResult) -> str:  # NOSONAR (cognitive complexity)
+    """Format statistics as a compact summary (no per-path breakdown)."""
+    lines: list[str] = []
+    lines.append("=" * 60)
+    lines.append("JSON STATISTICS (COMPACT)")
+    lines.append("=" * 60)
+
+    # Value counts
+    total = stats.total_values
+    lines.append(f"Total values:       {total:,}")
+    lines.append(
+        f"  Objects:          {stats.total_objects:,} ({stats.total_objects / total * 100:.1f}%)"
+    )
+    lines.append(
+        f"  Arrays:           {stats.total_arrays:,} ({stats.total_arrays / total * 100:.1f}%)"
+    )
+    lines.append(
+        f"  Primitives:       {stats.total_primitives:,} ({stats.total_primitives / total * 100:.1f}%)"
+    )
+    lines.append("")
+
+    # Aggregate type distribution across all paths
+    type_totals: dict[str, int] = {}
+    null_total = 0
+    str_total_len = 0
+    str_count = 0
+    num_min: float | None = None
+    num_max: float | None = None
+    num_sum = 0.0
+    num_count = 0
+    bool_true = 0
+    bool_false = 0
+    empty_arrays = 0
+    empty_objects = 0
+    empty_strings = 0
+
+    for fs in stats.field_stats.values():
+        for t, c in fs.type_counts.items():
+            type_totals[t] = type_totals.get(t, 0) + c
+        null_total += fs.null_count
+        str_total_len += fs.str_total_len
+        str_count += fs.str_count
+        empty_strings += fs.str_empty_count
+        if fs.num_count > 0:
+            num_count += fs.num_count
+            num_sum += fs.num_sum
+            if num_min is None or (fs.num_min is not None and fs.num_min < num_min):
+                num_min = fs.num_min
+            if num_max is None or (fs.num_max is not None and fs.num_max > num_max):
+                num_max = fs.num_max
+        bool_true += fs.bool_true_count
+        bool_false += fs.bool_false_count
+        empty_arrays += fs.arr_empty_count
+        empty_objects += fs.obj_empty_count
+
+    # Type distribution
+    lines.append("TYPE DISTRIBUTION:")
+    type_total = sum(type_totals.values())
+    for t in ["object", "array", "str", "int", "float", "bool", "null"]:
+        c = type_totals.get(t, 0)
+        if c > 0:
+            pct = c / type_total * 100
+            lines.append(f"  {t:12} {c:>12,}  ({pct:5.1f}%)")
+    lines.append("")
+
+    # Size info
+    lines.append("SIZE:")
+    lines.append(f"  Estimated total:  {fmt_size(stats.total_size_bytes)}")
+    lines.append(f"  Avg per value:    {fmt_size(stats.total_size_bytes // max(1, total))}")
+    lines.append("")
+
+    # Depth and paths
+    lines.append("STRUCTURE:")
+    lines.append(f"  Max depth:        {stats.max_depth}")
+    lines.append(f"  Unique paths:     {len(stats.field_stats):,}")
+    lines.append("")
+
+    # Null rate
+    if null_total > 0:
+        lines.append("NULL ANALYSIS:")
+        lines.append(f"  Total nulls:      {null_total:,} ({null_total / total * 100:.2f}%)")
+        lines.append("")
+
+    # String stats
+    if str_count > 0:
+        lines.append("STRING STATS:")
+        lines.append(f"  Total strings:    {str_count:,}")
+        lines.append(f"  Avg length:       {str_total_len / str_count:.1f} chars")
+        if empty_strings > 0:
+            lines.append(
+                f"  Empty strings:    {empty_strings:,} ({empty_strings / str_count * 100:.1f}%)"
+            )
+        lines.append("")
+
+    # Numeric stats
+    if num_count > 0:
+        lines.append("NUMERIC STATS:")
+        lines.append(f"  Total numbers:    {num_count:,}")
+        lines.append(f"  Min:              {num_min}")
+        lines.append(f"  Max:              {num_max}")
+        lines.append(f"  Avg:              {num_sum / num_count:.4f}")
+        lines.append("")
+
+    # Boolean stats
+    if bool_true + bool_false > 0:
+        total_bool = bool_true + bool_false
+        lines.append("BOOLEAN STATS:")
+        lines.append(f"  Total booleans:   {total_bool:,}")
+        lines.append(f"  True:             {bool_true:,} ({bool_true / total_bool * 100:.1f}%)")
+        lines.append(f"  False:            {bool_false:,} ({bool_false / total_bool * 100:.1f}%)")
+        lines.append("")
+
+    # Empty collections
+    if empty_arrays > 0 or empty_objects > 0:
+        lines.append("EMPTY COLLECTIONS:")
+        if empty_arrays > 0:
+            lines.append(f"  Empty arrays:     {empty_arrays:,}")
+        if empty_objects > 0:
+            lines.append(f"  Empty objects:    {empty_objects:,}")
+        lines.append("")
+
+    lines.append(f"Collection time:    {stats.collection_time:.3f}s")
+    lines.append("=" * 60)
+
+    return "\n".join(lines)
+
+
+def format_stats(stats: StatsResult, top_n: int = 50) -> str:  # NOSONAR (cognitive complexity)
+    """Format statistics as a readable string with per-path breakdown."""
+    lines: list[str] = []
+    lines.append("=" * 70)
+    lines.append("JSON STATISTICS")
+    lines.append("=" * 70)
+    lines.append(f"Total values:     {stats.total_values:,}")
+    lines.append(f"  Objects:        {stats.total_objects:,}")
+    lines.append(f"  Arrays:         {stats.total_arrays:,}")
+    lines.append(f"  Primitives:     {stats.total_primitives:,}")
+    lines.append(f"Estimated size:   {fmt_size(stats.total_size_bytes)}")
+    lines.append(f"Max depth:        {stats.max_depth}")
+    lines.append(f"Unique paths:     {len(stats.field_stats):,}")
+    lines.append(f"Collection time:  {stats.collection_time:.3f}s")
+    lines.append("-" * 70)
+    lines.append("")
+
+    # Sort by total size (most data first)
+    sorted_stats = sorted(stats.field_stats.values(), key=lambda x: -x.total_size)[:top_n]
+
+    for fs in sorted_stats:
+        lines.append(f"📍 {fs.path}")
+        lines.append(f"   Count: {fs.total_seen:,}  |  Size: {fmt_size(fs.total_size)}")
+
+        # Size breakdown
+        if fs.total_seen > 0:
+            avg_size = fs.total_size / fs.total_seen
+            lines.append(
+                f"   Size/value: min={fmt_size(fs.size_min or 0)}, "
+                f"max={fmt_size(fs.size_max or 0)}, avg={fmt_size(int(avg_size))}"
+            )
+
+        # Type distribution
+        type_parts = []
+        for t, c in sorted(fs.type_counts.items(), key=lambda x: -x[1]):
+            pct = c / fs.total_seen * 100
+            type_parts.append(f"{t}:{c}({pct:.1f}%)")
+        lines.append(f"   Types: {', '.join(type_parts)}")
+
+        # Null rate
+        if fs.null_count > 0:
+            null_pct = fs.null_count / fs.total_seen * 100
+            lines.append(f"   Null: {fs.null_count:,} ({null_pct:.1f}%)")
+
+        # Numeric stats
+        if fs.num_count > 0:
+            avg = fs.num_sum / fs.num_count
+            lines.append(f"   Numeric: min={fs.num_min}, max={fs.num_max}, avg={avg:.2f}")
+
+        # String stats
+        if fs.str_count > 0:
+            avg_len = fs.str_total_len / fs.str_count
+            lines.append(f"   String: len={fs.str_min_len}..{fs.str_max_len}, avg={avg_len:.1f}")
+            if fs.str_empty_count > 0:
+                lines.append(f"   String empty: {fs.str_empty_count:,}")
+
+        # Array stats
+        if fs.arr_count > 0:
+            avg_len = fs.arr_total_len / fs.arr_count
+            lines.append(f"   Array: len={fs.arr_min_len}..{fs.arr_max_len}, avg={avg_len:.1f}")
+            if fs.arr_empty_count > 0:
+                lines.append(f"   Array empty: {fs.arr_empty_count:,}")
+
+        # Boolean stats
+        if fs.bool_true_count + fs.bool_false_count > 0:
+            total_bool = fs.bool_true_count + fs.bool_false_count
+            true_pct = fs.bool_true_count / total_bool * 100
+            lines.append(
+                f"   Boolean: true={fs.bool_true_count} ({true_pct:.1f}%), false={fs.bool_false_count}"
+            )
+
+        # Unique values
+        if fs.unique_values:
+            n = len(fs.unique_values)
+            if n <= 10:
+                vals = sorted(
+                    [v for v in fs.unique_values if v is not None],
+                    key=lambda x: str(x),
+                )[:10]
+                lines.append(f"   Unique({n}): {vals}")
+            else:
+                note = "+" if n >= fs.unique_limit else ""
+                lines.append(f"   Unique: {n}{note} distinct values")
+
+        # Object key presence
+        if fs.obj_count > 0 and fs.obj_key_counts:
+            lines.append(f"   Object keys ({len(fs.obj_key_counts)}):")
+            for k, c in sorted(fs.obj_key_counts.items(), key=lambda x: -x[1])[:10]:
+                pct = c / fs.obj_count * 100
+                lines.append(f"      .{k}: {c} ({pct:.1f}%)")
+
+        lines.append("")
+
+    if len(stats.field_stats) > top_n:
+        lines.append(f"... and {len(stats.field_stats) - top_n} more paths")
+
+    return "\n".join(lines)
+
+
+def collect_stats(  # NOSONAR (cognitive complexity)
+    root: Any,
+    *,
+    max_unique: int = 100,
+) -> StatsResult:
+    """
+    Collect comprehensive statistics about a JSON document.
+    Iterative traversal for speed.
+    """
+    t0 = time.perf_counter()
+
+    field_stats: dict[str, FieldStats] = {}
+    total_values = 0
+    total_objects = 0
+    total_arrays = 0
+    total_primitives = 0
+    total_size_bytes = 0
+    max_depth = 0
+
+    # Stack: (value, path_str, depth)
+    stack: list[tuple[Any, str, int]] = [(root, "$", 0)]
+
+    while stack:
+        v, path, depth = stack.pop()
+        total_values += 1
+        if depth > max_depth:
+            max_depth = depth
+
+        # Track size
+        size = estimate_json_size(v)
+        total_size_bytes += size
+
+        # Get or create field stats
+        fs = field_stats.get(path)
+        if fs is None:
+            fs = FieldStats(path, unique_limit=max_unique)
+            field_stats[path] = fs
+
+        fs.add(v)
+        t = type(v)
+
+        if t is dict:
+            total_objects += 1
+            # Add size for keys and separators
+            for key, val in v.items():
+                total_size_bytes += len(str(key)) + 3  # "key":
+                child_path = f"{path}.{key}"
+                stack.append((val, child_path, depth + 1))
+            if v:
+                total_size_bytes += len(v) - 1  # commas between items
+
+        elif t is list:
+            total_arrays += 1
+            item_path = f"{path}[]"
+            for el in v:
+                stack.append((el, item_path, depth + 1))
+            if v:
+                total_size_bytes += len(v) - 1  # commas between items
+
+        else:
+            total_primitives += 1
+
+    collection_time = time.perf_counter() - t0
+
+    return StatsResult(
+        field_stats=field_stats,
+        total_values=total_values,
+        total_objects=total_objects,
+        total_arrays=total_arrays,
+        total_primitives=total_primitives,
+        total_size_bytes=total_size_bytes,
+        max_depth=max_depth,
+        collection_time=collection_time,
+    )

--- a/backend/src/meho_backplane/jsonflux/query/__init__.py
+++ b/backend/src/meho_backplane/jsonflux/query/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group

--- a/backend/src/meho_backplane/jsonflux/query/engine.py
+++ b/backend/src/meho_backplane/jsonflux/query/engine.py
@@ -1,0 +1,1258 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+from __future__ import annotations
+
+import contextlib
+import random
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import msgspec
+import pyarrow as pa
+
+from ..core.analyzer import Analyzer, render_schema
+from ..core.converter import normalize_data, summary_to_schema
+from ..utils.sampling import ReservoirSampler
+
+SQL_CODE_FENCE = "```sql"
+
+# --------------------------
+# Query result models
+# --------------------------
+
+
+class QueryResult(msgspec.Struct, gc=False):
+    """Structured result from query execution."""
+
+    success: bool
+    """True if the query executed without error."""
+
+    sql: str
+    """The SQL query that was executed."""
+
+    markdown: str
+    """Full result formatted as a markdown table (empty string on error)."""
+
+    error: str | None = None
+    """Error message if success is False, None otherwise."""
+
+    row_count: int = 0
+    """Total number of rows in the result."""
+
+    preview: str | None = None
+    """First N rows as markdown table when split is requested, None otherwise."""
+
+
+def _get_root_obj(summary: Any) -> dict[Any, Any] | None:
+    """Unwrap a root array to get the object field map, or return obj directly."""
+    obj: dict[Any, Any] | None = summary.obj
+    if obj is None and summary.arr:
+        ks = summary.arr.kind_summaries
+        if "object" in ks and ks["object"].obj:
+            obj = ks["object"].obj
+    return obj
+
+
+def _analyze_summary_fields(  # NOSONAR (cognitive complexity)
+    summary: Any,
+) -> tuple[list[tuple[str, str]], list[str], list[tuple[str, str]]]:
+    """
+    Analyze a table summary to categorize fields.
+
+    Returns:
+        (flat_fields, nested_fields, array_fields) where:
+        - flat_fields: list of (name, type_str) for primitive fields
+        - nested_fields: list of field names that are nested objects
+        - array_fields: list of (name, element_kind) for array fields
+    """
+    flat: list[tuple[str, str]] = []
+    nested: list[str] = []
+    arrays: list[tuple[str, str]] = []
+
+    obj = _get_root_obj(summary)
+    if obj is None:
+        return flat, nested, arrays
+
+    for key, child in obj.items():
+        has_prim = bool(child.primitives)
+        has_obj = child.obj is not None and bool(child.obj)
+        has_arr = child.arr is not None
+
+        if has_arr:
+            # Figure out element kind
+            elem = "object"
+            if child.arr.kind_summaries:
+                kinds = list(child.arr.kind_summaries.keys())
+                if kinds:
+                    elem = kinds[0]
+            elif child.arr.kind_minmax:
+                for k, (_, mx) in child.arr.kind_minmax.items():
+                    if mx > 0 and k != "object":
+                        elem = k
+                        break
+            arrays.append((key, elem))
+        elif has_obj:
+            nested.append(key)
+        elif has_prim:
+            # Pick first primitive type
+            for t in ("str", "int", "float", "bool"):
+                if t in child.primitives:
+                    flat.append((key, t))
+                    break
+
+    return flat, nested, arrays
+
+
+def _collect_nested_id_fields(  # NOSONAR (cognitive complexity)
+    summary: Any,
+) -> list[tuple[str, str]]:
+    """
+    Scan one level of nested objects for primitive fields likely to be
+    join keys (ending in ``_id`` or named ``id``).
+
+    Returns a list of ``("parent.child", type_str)`` tuples using
+    dot-notation paths that are valid in DuckDB SQL.
+    """
+    result: list[tuple[str, str]] = []
+    obj = _get_root_obj(summary)
+    if obj is None:
+        return result
+
+    for key, child in obj.items():
+        if child.obj is None or not child.obj:
+            continue
+        # child is a nested object — scan its children
+        for sub_key, sub_child in child.obj.items():
+            sub_lower = sub_key.lower()
+            if not (sub_lower.endswith("_id") or sub_lower == "id"):
+                continue
+            if sub_child.primitives:
+                for t in ("str", "int", "float", "bool"):
+                    if t in sub_child.primitives:
+                        result.append((f"{key}.{sub_key}", t))
+                        break
+    return result
+
+
+class QueryEngine:
+    """
+    SQL query engine for JSON files using DuckDB.
+
+    Supports:
+    - Multiple JSON files as tables
+    - Full SQL: SELECT, JOIN, WHERE, GROUP BY, ORDER BY, etc.
+    - Nested JSON access with dot notation
+    - Array flattening with UNNEST
+
+    Example:
+        engine = QueryEngine()
+        engine.register("products", products_data, path="$.catalog.products")
+        engine.register("orders", orders_data)
+
+        result = engine.query('''
+            SELECT p.name, COUNT(*) as cnt
+            FROM orders o
+            JOIN products p ON o.product_id = p.product_id
+            GROUP BY p.name
+            ORDER BY cnt DESC
+            LIMIT 10
+        ''')
+    """
+
+    __slots__ = ("_closed", "conn", "tables")
+
+    def __init__(self) -> None:
+        self.conn = duckdb.connect(":memory:")
+        self.tables: dict[str, dict[str, Any]] = {}
+        self._closed = False
+
+    def register(  # NOSONAR (cognitive complexity)
+        self,
+        name: str,
+        source: str | Path | dict | list,
+        path: str | None = None,
+        description: str | None = None,
+        unwrap: bool | str = "auto",
+        append: bool = False,
+    ) -> QueryEngine:
+        """
+        Register a JSON source as a queryable table using Arrow for type safety.
+
+        Supports smart response shape detection for dict sources:
+
+        - Flat array ``[{...}, ...]`` -> multi-row table (unchanged)
+        - Wrapped collection ``{"results": [...], "total": N}`` -> unwrap
+          list as main table, scalars/nested objects as ``{name}_meta``
+        - Single flat object ``{"k": "v"}`` -> 1-row table with
+          ``tier_hint="inline"``
+        - Multi-collection ``{"pods": [...], "svcs": [...]}`` -> split into
+          ``{name}_pods``, ``{name}_svcs`` tables
+
+        Args:
+            name: Table name to use in SQL queries
+            source: File path, JSON string, dict, or list
+            path: JSON path to extract (e.g., "$.catalog.products")
+            description: Optional human-readable description of the table.
+                Included in ``describe_tables()`` and ``generate_prompt()``
+                output so LLMs understand the domain context.
+            unwrap: Controls dict unwrapping behavior:
+                - ``'auto'`` (default): heuristic shape detection
+                - ``True``: force unwrap (find first list-of-dicts value)
+                - ``False``: force 1-row table
+            append: When ``True`` and a table with the same name already
+                exists, concatenate new rows with existing data instead of
+                replacing.  Metadata companion tables are always *replaced*
+                (latest page wins).
+
+        Returns:
+            self (for chaining)
+        """
+        # Determine source type and load data
+        if isinstance(source, (dict, list)):
+            data = source
+            source_desc = "memory"
+        elif isinstance(source, (str, Path)):
+            source_str = str(source)
+            if source_str.strip().startswith("{") or source_str.strip().startswith("["):
+                data = msgspec.json.decode(source_str)
+                source_desc = "json_string"
+            else:
+                with open(source_str, "rb") as f:
+                    data = msgspec.json.decode(f.read())
+                source_desc = source_str
+        else:
+            raise TypeError(f"Unsupported source type: {type(source)}")
+
+        if path:
+            data = self._extract_path(data, path)
+
+        if isinstance(data, dict):
+            if unwrap == "auto":
+                tables = self._detect_and_split(name, data, description)
+                for tname, tdata, tdesc, tier_hint in tables:
+                    # Only the main table (same name as requested) gets
+                    # appended; companion tables (_meta, _tags, etc.) are
+                    # always replaced so the latest metadata wins.
+                    should_append = append and tname == name
+                    self._register_table(
+                        tname,
+                        tdata,
+                        tdesc,
+                        append=should_append,
+                        tier_hint=tier_hint,
+                        source_desc=source_desc,
+                        path=path,
+                    )
+                return self
+            elif unwrap is True:
+                # Force unwrap: find first list-of-dicts value
+                for value in data.values():
+                    if isinstance(value, list) and value and isinstance(value[0], dict):
+                        data = value
+                        break
+                else:
+                    data = [data]
+            else:  # unwrap is False
+                data = [data]
+
+        if not isinstance(data, list):
+            raise ValueError(f"Data at path must be array or object, got {type(data)}")
+
+        self._register_table(
+            name,
+            data,
+            description,
+            append=append,
+            tier_hint=None,
+            source_desc=source_desc,
+            path=path,
+        )
+        return self
+
+    # ------------------------------------------------------------------
+    # Shape detection helpers
+    # ------------------------------------------------------------------
+
+    def _detect_and_split(  # NOSONAR (cognitive complexity)
+        self,
+        name: str,
+        data: dict,
+        description: str | None,
+    ) -> list[tuple[str, list[dict], str | None, str | None]]:
+        """Split a dict response into appropriate table registrations.
+
+        Classifies response shape and returns a list of
+        ``(table_name, row_list, description, tier_hint)`` tuples.
+        """
+        list_of_dicts_keys: list[str] = []
+        scalar_keys: dict[str, Any] = {}
+        scalar_list_keys: dict[str, list] = {}
+        nested_obj_keys: dict[str, dict] = {}
+
+        for key, value in data.items():
+            if isinstance(value, list):
+                if not value:
+                    # Empty list -- treat as collection (produces 0-row table)
+                    list_of_dicts_keys.append(key)
+                elif isinstance(value[0], dict):
+                    list_of_dicts_keys.append(key)
+                else:
+                    scalar_list_keys[key] = value
+            elif isinstance(value, dict):
+                nested_obj_keys[key] = value
+            else:
+                scalar_keys[key] = value
+
+        tables: list[tuple[str, list[dict], str | None, str | None]] = []
+
+        if len(list_of_dicts_keys) == 0:
+            # Single flat object -> 1-row table with inline tier hint
+            tables.append((name, [data], description, "inline"))
+
+        elif len(list_of_dicts_keys) == 1:
+            # Wrapped collection -> unwrap main + metadata companion
+            main_key = list_of_dicts_keys[0]
+            tables.append((name, data[main_key], description, None))
+
+            # Scalar lists get their own tables
+            for sk, sv in scalar_list_keys.items():
+                tables.append(
+                    (
+                        f"{name}_{sk}",
+                        [{sk: item} for item in sv],
+                        f"Scalar list from {name}.{sk}",
+                        None,
+                    )
+                )
+
+            # Build metadata companion from scalars + nested objects
+            meta: dict[str, Any] = dict(scalar_keys)
+            for nk, nv in nested_obj_keys.items():
+                meta.update(self._flatten_metadata(nv, prefix=nk))
+            if meta:
+                tables.append((f"{name}_meta", [meta], f"Metadata for {name}", None))
+
+        else:
+            # Multiple collections -> split into {name}_{key} tables
+            for key in list_of_dicts_keys:
+                tables.append(
+                    (
+                        f"{name}_{key}",
+                        data[key],
+                        f"{key} from {name}",
+                        None,
+                    )
+                )
+
+            # Scalar lists get their own tables
+            for sk, sv in scalar_list_keys.items():
+                tables.append(
+                    (
+                        f"{name}_{sk}",
+                        [{sk: item} for item in sv],
+                        f"Scalar list from {name}.{sk}",
+                        None,
+                    )
+                )
+
+            # Remaining scalars + nested objects -> metadata
+            meta = dict(scalar_keys)
+            for nk2, nv2 in nested_obj_keys.items():
+                meta.update(self._flatten_metadata(nv2, prefix=nk2))
+            if meta:
+                tables.append((f"{name}_meta", [meta], f"Metadata for {name}", None))
+
+        return tables
+
+    def _flatten_metadata(
+        self, data: dict, prefix: str = ""
+    ) -> dict[str, Any]:  # NOSONAR (cognitive complexity)
+        """Flatten nested dicts to dot-notation keys.
+
+        Skips list-of-dicts values (those are collections, not metadata).
+        Scalar lists are kept as-is.
+        """
+        flat: dict[str, Any] = {}
+        for key, value in data.items():
+            full_key = f"{prefix}.{key}" if prefix else key
+            if isinstance(value, dict):
+                flat.update(self._flatten_metadata(value, full_key))
+            elif isinstance(value, list) and value and isinstance(value[0], dict):
+                pass  # Skip list-of-dicts (collections, not metadata)
+            else:
+                flat[full_key] = value
+        return flat
+
+    def _register_table(
+        self,
+        name: str,
+        data: list,
+        description: str | None,
+        *,
+        append: bool = False,
+        tier_hint: str | None = None,
+        source_desc: str = "memory",
+        path: str | None = None,
+    ) -> None:
+        """Register a list of dicts as a DuckDB table via Arrow.
+
+        Handles schema analysis, normalization, Arrow table creation,
+        DuckDB registration, and sample collection.  When *append* is
+        ``True`` and the table already exists, new rows are concatenated
+        with the existing table.
+        """
+        from ..core.models import Summary as SummaryModel
+
+        # --- Arrow Content Integration ---
+        analyzer = Analyzer()
+        summary = analyzer.summarize(data, analyzer.max_depth)
+
+        # Convert Summary to Arrow Schema
+        if summary.arr:
+            item_summary = summary.arr.kind_summaries.get("object") or SummaryModel()
+            try:
+                schema = summary_to_schema(item_summary)
+            except ValueError:
+                # Empty array with no schema info -> zero-column table
+                schema = pa.schema([])
+        elif summary.obj:
+            schema = summary_to_schema(summary)
+        else:
+            # Completely empty / no structure -> zero-column table
+            schema = pa.schema([])
+
+        # Normalize data to match schema
+        if schema and len(schema) > 0:
+            norm_data = [normalize_data(row, schema) for row in data]
+            new_table = pa.Table.from_pylist(norm_data, schema=schema)
+        else:
+            # DuckDB requires at least one column.  Create a minimal
+            # placeholder so the table is queryable (0 rows).
+            new_table = pa.table({"_empty": pa.array([], type=pa.int8())})
+
+        if append and name in self.tables:
+            # Append mode: concatenate with existing table
+            # Safe (sqlalchemy-execute-raw-query): DuckDB in-memory query, table name from server-generated operation ID (not user input)
+            result = self.conn.execute(f'SELECT * FROM "{name}"').arrow()
+            # DuckDB may return RecordBatchReader; ensure we have a Table
+            existing = result.read_all() if hasattr(result, "read_all") else result
+            self.conn.unregister(name)
+            combined = pa.concat_tables(
+                [existing, new_table],
+                promote_options="default",
+            )
+            self.conn.register(name, combined)
+            row_count = len(combined)
+        else:
+            # Replace mode (default)
+            if name in self.tables:
+                self.conn.unregister(name)
+            self.conn.register(name, new_table)
+            row_count = len(new_table)
+
+        # Eagerly collect samples so we can discard raw data
+        sample_store: dict[tuple[str, ...], ReservoirSampler] = {}
+        rng = random.Random(12345)  # noqa: S311 -- non-cryptographic context, random OK
+        sample_analyzer = Analyzer()
+        sample_analyzer.collect_samples(data, sample_store, k=3, rng=rng)
+
+        table_info: dict[str, Any] = {
+            "source": source_desc,
+            "path": path,
+            "row_count": row_count,
+            "summary": summary,
+            "sample_store": sample_store,
+            "description": description,
+        }
+        if tier_hint is not None:
+            table_info["tier_hint"] = tier_hint
+
+        self.tables[name] = table_info
+
+    def register_many(
+        self,
+        tables: dict[str, Any | tuple[Any, str | None]],
+    ) -> QueryEngine:
+        """
+        Register multiple tables at once.
+
+        Args:
+            tables: Dict mapping table names to sources.
+                - {"name": data} - direct data (dict or list)
+                - {"name": "file.json"} - file path
+                - {"name": ("file.json", "$.path")} - file with JSON path
+
+        Returns:
+            self (for chaining)
+        """
+        for name, source in tables.items():
+            if isinstance(source, tuple):
+                file_path, json_path = source
+                self.register(name, file_path, path=json_path)
+            else:
+                self.register(name, source)
+        return self
+
+    def _extract_path(self, data: Any, path: str) -> Any:
+        """Extract data at JSON path (simple $ notation)."""
+        # Remove leading $ if present
+        if path.startswith("$."):
+            path = path[2:]
+        elif path.startswith("$"):
+            path = path[1:]
+
+        if not path:
+            return data
+
+        # Navigate path
+        parts = path.split(".")
+        current = data
+        for part in parts:
+            # Handle array notation like items[]
+            if part.endswith("[]"):
+                part = part[:-2]
+            if isinstance(current, dict):
+                current = current.get(part)
+            elif isinstance(current, list) and part.isdigit():
+                current = current[int(part)]
+            else:
+                raise ValueError(f"Cannot navigate to '{part}' in path '{path}'")
+            if current is None:
+                raise ValueError(f"Path '{path}' not found in data")
+        return current
+
+    def query(self, sql: str) -> list[dict[str, Any]]:
+        """Execute SQL query and return results as list of dicts."""
+        result = self.conn.execute(sql)
+        columns = [desc[0] for desc in result.description]
+        return [dict(zip(columns, row, strict=False)) for row in result.fetchall()]
+
+    def query_arrow(self, sql: str) -> Any:
+        """Execute SQL and return as PyArrow Table."""
+        return self.conn.execute(sql).arrow()
+
+    def execute(self, sql: str) -> Any:
+        """Execute SQL and return raw DuckDB result."""
+        return self.conn.execute(sql)
+
+    def explain(self, sql: str) -> str:
+        """Show query execution plan."""
+        # Safe (sqlalchemy-execute-raw-query): DuckDB in-memory EXPLAIN, sql from LLM-generated query (not direct user input)
+        result = self.conn.execute(f"EXPLAIN {sql}").fetchall()
+        return "\n".join(row[0] for row in result)
+
+    def tables_info(self) -> str:
+        """Show registered tables and their info."""
+        lines = ["Registered tables:"]
+        for name, info in self.tables.items():
+            lines.append(f"  {name}:")
+            lines.append(f"    source: {info.get('source', 'unknown')}")
+            if info.get("path"):
+                lines.append(f"    path: {info['path']}")
+            lines.append(f"    rows: {info['row_count']:,}")
+        return "\n".join(lines)
+
+    def schema(self, table: str) -> str:
+        """Show schema of a table."""
+        # Safe (sqlalchemy-execute-raw-query): DuckDB in-memory DESCRIBE, table name from registered tables (not user input)
+        result = self.conn.execute(f"DESCRIBE {table}").fetchall()
+        lines = [f"Schema of '{table}':"]
+        for row in result:
+            lines.append(f"  {row[0]}: {row[1]}")
+        return "\n".join(lines)
+
+    def print_tables(self) -> None:
+        """Print registered tables info."""
+        print(self.tables_info())
+
+    def print_schema(self, table: str) -> None:
+        """Print table schema."""
+        print(self.schema(table))
+
+    def _get_sample_store(
+        self,
+        info: dict[str, Any],
+        samples: int,
+    ) -> dict[tuple[str, ...], ReservoirSampler] | None:
+        """Return pre-collected sample store if samples are requested."""
+        if samples <= 0:
+            return None
+        return info.get("sample_store")
+
+    def describe_tables(
+        self,
+        samples: int | None = 3,
+        max_sample_len: int = 60,
+        max_schema_depth: int | None = 8,
+    ) -> str:
+        """
+        Generate table schemas section for LLM consumption.
+        Uses compact TypeScript-like schema format for maximum token efficiency.
+
+        Args:
+            samples: Number of sample values per field (0 or None = none)
+            max_sample_len: Max length for sample value strings
+            max_schema_depth: Maximum nesting depth to render in schemas.
+                Structures deeper than this are collapsed to ``{...}`` /
+                ``[...]`` to save tokens.  ``None`` means unlimited.
+
+        Returns:
+            Markdown-formatted string describing all registered tables.
+        """
+        samples_k = max(samples, 0) if samples is not None else 0
+
+        lines: list[str] = []
+        lines.append("## Available Tables\n")
+
+        for table_name, info in self.tables.items():
+            row_count = info.get("row_count", 0)
+            description = info.get("description")
+            if description:
+                lines.append(f"### `{table_name}` ({row_count:,} rows) — {description}\n")
+            else:
+                lines.append(f"### `{table_name}` ({row_count:,} rows)\n")
+
+            summary = info.get("summary")
+            if summary:
+                sample_store = self._get_sample_store(info, samples_k)
+                schema_str = render_schema(
+                    summary,
+                    sample_store=sample_store,
+                    max_sample_len=max_sample_len,
+                    samples_k=samples_k,
+                    max_depth=max_schema_depth,
+                )
+                lines.append("```typescript")
+                lines.append(schema_str)
+                lines.append("```")
+            else:
+                # Safe (sqlalchemy-execute-raw-query): DuckDB in-memory DESCRIBE, table_name from registered tables dict
+                schema_raw = self.conn.execute(f"DESCRIBE {table_name}").fetchall()
+                lines.append("| Column | Type |")
+                lines.append("|--------|------|")
+                for row in schema_raw:
+                    lines.append(f"| {row[0]} | {row[1]} |")
+
+            lines.append("")
+
+        return "\n".join(lines)
+
+    def _build_prompt(self, table_descriptions: str) -> str:  # NOSONAR (cognitive complexity)
+        """
+        Build the full system prompt with contextual examples derived from
+        the actual registered table names and field names.
+        """
+        # Analyze all registered tables
+        table_names = list(self.tables.keys())
+        all_flat: dict[str, list[tuple[str, str]]] = {}
+        all_nested: dict[str, list[str]] = {}
+        all_arrays: dict[str, list[tuple[str, str]]] = {}
+
+        for tname, info in self.tables.items():
+            summary = info.get("summary")
+            if summary:
+                flat, nested, arrays = _analyze_summary_fields(summary)
+                all_flat[tname] = flat
+                all_nested[tname] = nested
+                all_arrays[tname] = arrays
+
+        has_nested = any(bool(v) for v in all_nested.values())
+        has_arrays = any(bool(v) for v in all_arrays.values())
+        has_multi = len(table_names) >= 2
+
+        # Build enriched field set for join detection: flat fields +
+        # one-level nested _id fields (e.g. orders.customer.customer_id)
+        joinable: dict[str, list[tuple[str, str]]] = {}
+        for tname, info in self.tables.items():
+            summary = info.get("summary")
+            fields = list(all_flat.get(tname, []))
+            if summary:
+                fields.extend(_collect_nested_id_fields(summary))
+            joinable[tname] = fields
+
+        lines: list[str] = []
+
+        # -- Role & output rules --
+        lines.append(
+            "You are a DuckDB SQL query generator. "
+            "Convert natural language data requests into SQL queries."
+        )
+        lines.append("")
+        lines.append("RULES:")
+        lines.append("- Return ONLY the raw SQL query text.")
+        lines.append("- No explanations, no markdown fences, no code blocks, no comments.")
+        lines.append("- If the request is ambiguous, make a reasonable choice and return the SQL.")
+        lines.append("")
+
+        # -- Schema notation (compact) --
+        lines.append("## Schema Notation\n")
+        lines.append("Schemas below use TypeScript-like notation:")
+        lines.append("- `field: str` = string, `int` = integer, `float` = number, `bool` = boolean")
+        lines.append("- `field: str?` = nullable (may be null)")
+        lines.append("- `[{...}]` = array of objects, `[str]` = array of strings")
+        if has_nested:
+            # Use a real nested field for the dot notation example
+            for tn, nl in all_nested.items():
+                if nl:
+                    summary = self.tables[tn].get("summary")
+                    subs = self._get_nested_subfields(summary, nl[0])
+                    if subs:
+                        lines.append(f"- Nested objects use dot notation: `{tn}.{nl[0]}.{subs[0]}`")
+                    else:
+                        lines.append("- Nested objects use dot notation: `table_name.parent.child`")
+                    break
+        else:
+            lines.append("- Nested objects use dot notation: `table_name.parent.child`")
+        lines.append("")
+
+        # -- Query patterns using REAL table/field names --
+        lines.append("## Query Patterns\n")
+
+        # Pattern: Basic SELECT
+        # Pick first table with flat fields
+        for tname, flat in all_flat.items():
+            if len(flat) >= 2:
+                f1, f2 = flat[0], flat[1]
+                lines.append("### Basic Query")
+                lines.append(SQL_CODE_FENCE)
+                lines.append(f"SELECT {f1[0]}, {f2[0]} FROM {tname} ORDER BY {f1[0]} LIMIT 10")  # noqa: S608 -- static SQL query, no user input
+                lines.append("```\n")
+                break
+
+        # Pattern: Nested objects (dot notation)
+        if has_nested:
+            for tname, nested_list in all_nested.items():
+                if nested_list:
+                    nfield = nested_list[0]
+                    # Try to find sub-fields
+                    summary = self.tables[tname].get("summary")
+                    sub_fields = self._get_nested_subfields(summary, nfield)
+                    if sub_fields:
+                        sf1 = sub_fields[0]
+                        lines.append("### Nested Objects (Dot Notation)")
+                        lines.append("Access nested fields with dots:")
+                        lines.append(SQL_CODE_FENCE)
+                        lines.append(f"SELECT {nfield}.{sf1} FROM {tname}")  # noqa: S608 -- static SQL query, no user input
+                        lines.append("```\n")
+                    break
+
+        # Pattern: UNNEST for arrays (CRITICAL)
+        if has_arrays:
+            for tname, arr_list in all_arrays.items():
+                if arr_list:
+                    arr_name, elem_kind = arr_list[0]
+                    lines.append("### Arrays — CRITICAL")
+                    lines.append(
+                        "Array fields MUST be flattened with UNNEST "
+                        "before grouping or aggregation.\n"
+                    )
+                    if elem_kind == "object":
+                        # Get sub-fields of the array element
+                        summary = self.tables[tname].get("summary")
+                        arr_subfields = self._get_array_subfields(summary, arr_name)
+                        if arr_subfields:
+                            sf = arr_subfields[0]
+                            lines.append(SQL_CODE_FENCE)
+                            lines.append(f"SELECT item.{sf}, COUNT(*) as cnt")
+                            lines.append(f"FROM (SELECT unnest({arr_name}) as item FROM {tname})")  # noqa: S608 -- static SQL query, no user input
+                            lines.append(f"GROUP BY item.{sf}")
+                            lines.append("```\n")
+                        else:
+                            lines.append(SQL_CODE_FENCE)
+                            lines.append(f"SELECT unnest({arr_name}) as item FROM {tname}")  # noqa: S608 -- static SQL query, no user input
+                            lines.append("```\n")
+                    else:
+                        lines.append(SQL_CODE_FENCE)
+                        lines.append(f"SELECT unnest({arr_name}) as val FROM {tname}")  # noqa: S608 -- static SQL query, no user input
+                        lines.append("```\n")
+
+                    # Wrong/right example
+                    lines.append(
+                        "Always unnest first, then aggregate. "
+                        "Never aggregate an array column directly."
+                    )
+                    lines.append("")
+                    break
+
+        # Pattern: JOINs (only if 2+ tables)
+        if has_multi:
+            lines.append("### JOINs")
+            joined = ", ".join(f"`{t}`" for t in table_names)
+            lines.append(f"Tables available for JOIN: {joined}")
+
+            # Detect real FK/PK relationships (includes nested _id fields)
+            join_hints = self._detect_join_keys(joinable)
+            if join_hints:
+                # Parse the first hint to generate a concrete example
+                # Hints are "t1.col1 ↔ t2.col2 (both type)"
+                hint = join_hints[0]
+                left, rest = hint.split(" ↔ ", 1)
+                right = rest.split(" (")[0]
+                lt, lc = left.split(".", 1)
+                rt, rc = right.split(".", 1)
+                lines.append(SQL_CODE_FENCE)
+                lines.append(f"SELECT a.*, b.* FROM {lt} a JOIN {rt} b ON a.{lc} = b.{rc}")  # noqa: S608 -- static SQL query, no user input
+                lines.append("```")
+                if len(join_hints) > 1:
+                    lines.append("\nDetected join keys:")
+                    for h in join_hints:
+                        lines.append(f"- {h}")
+                lines.append("")
+            else:
+                t1, t2 = table_names[0], table_names[1]
+                lines.append("Check the schemas above for matching columns to join on.")
+                lines.append(SQL_CODE_FENCE)
+                lines.append(f"SELECT a.*, b.* FROM {t1} a JOIN {t2} b ON a.<key> = b.<key>")  # noqa: S608 -- static SQL query, no user input
+                lines.append("```\n")
+
+        # Pattern: UNNEST + JOIN (when array elements reference another table)
+        if has_arrays and has_multi:
+            unnest_join_done = False
+            for tname, arr_list in all_arrays.items():
+                if unnest_join_done:
+                    break
+                for arr_name, elem_kind in arr_list:
+                    if elem_kind != "object":
+                        continue
+                    summary = self.tables[tname].get("summary")
+                    arr_subs = self._get_array_subfields(summary, arr_name)
+                    if not arr_subs:
+                        continue
+                    # Check if any array sub-field matches a column in
+                    # another table (e.g. items.product_id ↔ products.product_id)
+                    for other_t, other_cols in joinable.items():
+                        if other_t == tname:
+                            continue
+                        for other_col, _ in other_cols:
+                            other_leaf = other_col.rsplit(".", 1)[-1]
+                            if other_leaf in arr_subs:
+                                # Found: arr_subs field matches other table
+                                # Pick a display field from the other table
+                                # Prefer str fields like name/category over bools
+                                disp = None
+                                str_fields = [
+                                    fc
+                                    for fc, ft in all_flat.get(other_t, [])
+                                    if ft == "str" and not fc.endswith("_id") and fc != "id"
+                                ]
+                                if str_fields:
+                                    disp = str_fields[0]
+                                else:
+                                    for fc, _ in all_flat.get(other_t, []):
+                                        if not fc.endswith("_id") and fc != "id":
+                                            disp = fc
+                                            break
+                                disp = disp or other_leaf
+                                lines.append("### UNNEST + JOIN")
+                                lines.append(
+                                    "When array elements reference another "
+                                    "table, unnest first, then join:\n"
+                                )
+                                lines.append(SQL_CODE_FENCE)
+                                lines.append(f"SELECT b.{disp}, COUNT(*) as cnt")
+                                lines.append(
+                                    f"FROM (SELECT unnest({arr_name}) as item FROM {tname}) sub"  # noqa: S608 -- static SQL query, no user input
+                                )
+                                lines.append(
+                                    f"JOIN {other_t} b ON sub.item.{other_leaf} = b.{other_col}"
+                                )
+                                lines.append(f"GROUP BY b.{disp}")
+                                lines.append("```\n")
+                                unnest_join_done = True
+                                break
+                        if unnest_join_done:
+                            break
+                    if unnest_join_done:
+                        break
+
+        # -- DuckDB functions --
+        lines.append("## DuckDB Functions\n")
+        lines.append("- Aggregation: `SUM()`, `AVG()`, `COUNT()`, `MIN()`, `MAX()`")
+        lines.append("- Strings: `LOWER()`, `UPPER()`, `CONTAINS()`, `LENGTH()`")
+        lines.append("- Arrays: `UNNEST()`, `list_contains()`, `len()`, `array_agg()`")
+        lines.append("- Math: `ROUND()`, `ABS()`, `CEIL()`, `FLOOR()`")
+        lines.append("- Dates: `DATE_TRUNC()`, `EXTRACT()`, `CURRENT_DATE`")
+        lines.append("- Window: `ROW_NUMBER()`, `RANK()`, `LAG()`, `LEAD()`")
+        lines.append("- Conditional: `CASE WHEN ... THEN ... ELSE ... END`, `COALESCE()`")
+        lines.append("")
+
+        # -- Common mistakes (use real names when arrays exist) --
+        lines.append("## Common Mistakes\n")
+        if has_arrays:
+            # Pick a real array field for concrete examples
+            ex_tname = ""
+            ex_arr = ""
+            for tn, al in all_arrays.items():
+                if al:
+                    ex_tname, ex_arr = tn, al[0][0]
+                    break
+            lines.append(
+                f"1. Forgetting UNNEST — array fields like `{ex_arr}` in "  # noqa: S608 -- static SQL query, no user input
+                f"`{ex_tname}` MUST use "
+                f"`SELECT unnest({ex_arr}) as item FROM {ex_tname}`"
+            )
+            lines.append("2. Missing alias after UNNEST — always write `unnest(col) as item`")
+            lines.append("3. Using array indexing like `[0]` — use UNNEST instead")
+        else:
+            lines.append("1. If the data had array fields, they would require UNNEST")
+        lines.append(
+            f"{'4' if has_arrays else '2'}. Wrong dot notation path — check the schema carefully"
+        )
+        lines.append("")
+
+        # -- Table descriptions --
+        lines.append("---\n")
+        lines.append("# YOUR DATA\n")
+        lines.append(table_descriptions)
+
+        return "\n".join(lines)
+
+    def _get_nested_subfields(self, summary: Any, field_name: str) -> list[str]:
+        """Get sub-field names from a nested object field."""
+        obj = summary.obj
+        if obj is None and summary.arr:
+            ks = summary.arr.kind_summaries
+            if "object" in ks and ks["object"].obj:
+                obj = ks["object"].obj
+        if obj is None or field_name not in obj:
+            return []
+        child = obj[field_name]
+        if child.obj:
+            return list(child.obj.keys())
+        return []
+
+    def _get_array_subfields(self, summary: Any, field_name: str) -> list[str]:
+        """Get sub-field names from array-of-objects elements."""
+        obj = summary.obj
+        if obj is None and summary.arr:
+            ks = summary.arr.kind_summaries
+            if "object" in ks and ks["object"].obj:
+                obj = ks["object"].obj
+        if obj is None or field_name not in obj:
+            return []
+        child = obj[field_name]
+        if child.arr and child.arr.kind_summaries:
+            elem_sum = child.arr.kind_summaries.get("object")
+            if elem_sum and elem_sum.obj:
+                return list(elem_sum.obj.keys())
+        return []
+
+    def generate_prompt(
+        self,
+        samples: int | None = 3,
+        max_sample_len: int = 60,
+        max_schema_depth: int | None = 8,
+    ) -> str:
+        """
+        Generate a complete system prompt for LLM SQL generation.
+
+        The prompt is dynamically built from the registered tables: all SQL
+        examples reference real table names and field names so the LLM never
+        sees irrelevant placeholder tables.
+
+        Args:
+            samples: Number of sample values per field (0 or None = none)
+            max_sample_len: Max length for sample value strings
+            max_schema_depth: Maximum nesting depth for schemas (default 8).
+                Deeply nested structures beyond this limit are collapsed to
+                ``{...}`` / ``[...]`` to save tokens.
+
+        Returns:
+            Complete system prompt string ready to pass to an LLM.
+
+        Example:
+            ```python
+            prompt = engine.generate_prompt(samples=3)
+            # Use as system prompt for any LLM
+            ```
+        """
+        table_desc = self.describe_tables(
+            samples=samples,
+            max_sample_len=max_sample_len,
+            max_schema_depth=max_schema_depth,
+        )
+        return self._build_prompt(table_desc)
+
+    def execute_query(
+        self,
+        sql: str,
+        split: int | None = None,
+        max_colwidth: int | None = 50,
+    ) -> QueryResult:
+        """
+        Execute a SQL query and return a structured result.
+
+        Designed for LLM tool workflows: always returns a result object
+        with status, the SQL that was run, and markdown-formatted output.
+
+        Args:
+            sql: SQL query string to execute
+            split: If set, ``preview`` will contain the first N rows as
+                   markdown while ``markdown`` contains the full table.
+                   None or <= 0 means no preview.
+            max_colwidth: Max column width for markdown rendering
+                          (None = unlimited)
+
+        Returns:
+            QueryResult with success/error status, SQL, and markdown tables.
+        """
+        from tabulate import tabulate
+
+        try:
+            result = self.conn.execute(sql)
+            columns = [desc[0] for desc in result.description]
+            rows = result.fetchall()
+        except Exception as e:
+            return QueryResult(
+                success=False,
+                sql=sql,
+                markdown="",
+                error=str(e),
+            )
+
+        row_count = len(rows)
+
+        def _to_markdown(
+            row_data: list[tuple[Any, ...]],
+            cols: list[str],
+        ) -> str:
+            if max_colwidth is not None:
+
+                def truncate(val: Any) -> Any:
+                    if isinstance(val, str) and len(val) > max_colwidth:
+                        return val[: max_colwidth - 1] + "…"
+                    return val
+
+                row_data = [tuple(truncate(v) for v in r) for r in row_data]
+            return str(tabulate(row_data, headers=cols, tablefmt="github"))
+
+        full_md = _to_markdown(rows, columns)
+
+        preview_md: str | None = None
+        if split is not None and split > 0 and row_count > 0:
+            preview_md = _to_markdown(rows[:split], columns)
+
+        return QueryResult(
+            success=True,
+            sql=sql,
+            markdown=full_md,
+            row_count=row_count,
+            preview=preview_md,
+        )
+
+    def _detect_join_keys(
+        self, schemas: dict[str, list[tuple[str, str]]]
+    ) -> list[str]:  # NOSONAR (cognitive complexity)
+        """Detect potential join keys between tables based on column names."""
+        hints: list[str] = []
+        table_names = list(schemas.keys())
+
+        for i, t1 in enumerate(table_names):
+            for t2 in table_names[i + 1 :]:
+                cols1 = dict(schemas[t1])
+                cols2 = dict(schemas[t2])
+
+                # Look for join patterns
+                for col1, dtype1 in cols1.items():
+                    for col2, dtype2 in cols2.items():
+                        if self._columns_might_join(col1, col2, dtype1, dtype2, t1, t2):
+                            hints.append(f"{t1}.{col1} ↔ {t2}.{col2} (both {dtype1})")
+
+        return hints
+
+    def _columns_might_join(
+        self, col1: str, col2: str, dtype1: str, dtype2: str, t1: str, t2: str
+    ) -> bool:
+        """
+        Heuristic to detect if two columns might be joinable.
+
+        Columns may be dot-notation paths (e.g. ``customer.customer_id``).
+        Comparisons use the *leaf* name (part after the last dot).
+
+        Detects:
+        - Same leaf name ending in ``_id`` (e.g. both have ``customer_id``)
+        - FK → PK patterns (e.g. ``products.id`` ↔ ``orders.product_id``)
+        """
+        # Must have compatible types
+        if dtype1 != dtype2:
+            return False
+
+        # Use leaf name for comparison (e.g. "customer.customer_id" -> "customer_id")
+        leaf1 = col1.rsplit(".", 1)[-1].lower()
+        leaf2 = col2.rsplit(".", 1)[-1].lower()
+        t1_lower = t1.lower().rstrip("s")  # "products" -> "product"
+        t2_lower = t2.lower().rstrip("s")
+
+        # Same leaf name ending in _id — very likely a join key
+        # e.g., products.product_id ↔ orders.customer.customer_id is NOT a match,
+        # but orders.customer.customer_id ↔ customers.customer_id IS
+        if leaf1 == leaf2 and leaf1.endswith("_id"):
+            return True
+
+        # Skip other same-leaf matches (e.g. both have "name")
+        if leaf1 == leaf2:
+            return False
+
+        # Pattern: table1.id ↔ table2.table1_id
+        if leaf1 == "id" and leaf2 == f"{t1_lower}_id":
+            return True
+        if leaf2 == "id" and leaf1 == f"{t2_lower}_id":
+            return True
+
+        # Pattern: table1.x_id ↔ table2.id (where x matches table2 name)
+        if leaf1.endswith("_id"):
+            base = leaf1[:-3]
+            if leaf2 == "id" and base == t2_lower:
+                return True
+
+        if leaf2.endswith("_id"):
+            base = leaf2[:-3]
+            if leaf1 == "id" and base == t1_lower:
+                return True
+
+        return False
+
+    def _format_rows(
+        self,
+        columns: list[str],
+        rows: list[tuple[Any, ...]],
+        format: str = "grid",
+        max_rows: int | None = None,
+        max_colwidth: int | None = 50,
+    ) -> str:
+        """
+        Format pre-fetched rows into a string.
+
+        This is the shared formatting logic used by both ``format_query``
+        and ``query_print``.
+        """
+        from tabulate import tabulate
+
+        if max_rows is not None:
+            rows = rows[:max_rows]
+
+        # Truncate long string values if max_colwidth is set
+        if max_colwidth is not None:
+
+            def truncate(val: Any) -> Any:
+                if isinstance(val, str) and len(val) > max_colwidth:
+                    return val[: max_colwidth - 1] + "…"
+                return val
+
+            rows = [tuple(truncate(v) for v in row) for row in rows]
+
+        if format == "csv":
+            import csv
+            import io
+
+            output = io.StringIO()
+            writer = csv.writer(output)
+            writer.writerow(columns)
+            writer.writerows(rows)
+            return output.getvalue()
+        elif format == "json":
+            data = [dict(zip(columns, row, strict=False)) for row in rows]
+            return msgspec.json.encode(data).decode("utf-8")
+        elif format in ("simple", "grid", "pipe", "markdown", "github"):
+            tablefmt = "github" if format == "markdown" else format
+            return str(tabulate(rows, headers=columns, tablefmt=tablefmt))
+        else:
+            raise ValueError(
+                f"Unknown format: {format}. Use: simple, grid, pipe, markdown, csv, json"
+            )
+
+    def format_query(
+        self,
+        sql: str,
+        format: str = "grid",
+        max_rows: int | None = None,
+        max_colwidth: int | None = 50,
+    ) -> str:
+        """
+        Execute SQL and return formatted string.
+
+        Args:
+            sql: SQL query string
+            format: Output format - "simple", "grid", "pipe", "markdown", "csv", "json"
+            max_rows: Limit rows shown (None = all)
+            max_colwidth: Max column width (None = unlimited)
+
+        Returns:
+            Formatted string, or an error message prefixed with "ERROR: "
+            if the query fails.
+        """
+        try:
+            result = self.conn.execute(sql)
+            columns = [desc[0] for desc in result.description]
+            rows = result.fetchall()
+        except Exception as e:
+            return f"ERROR: {e}"
+
+        return self._format_rows(
+            columns, rows, format=format, max_rows=max_rows, max_colwidth=max_colwidth
+        )
+
+    def query_print(
+        self,
+        sql: str,
+        format: str = "grid",
+        max_rows: int | None = 20,
+        max_colwidth: int | None = 50,
+        title: str | None = None,
+    ) -> None:
+        """
+        Execute SQL and print formatted output.
+
+        Args:
+            sql: SQL query string
+            format: Output format (default: "grid")
+            max_rows: Limit rows shown (default 20)
+            max_colwidth: Max column width
+            title: Optional title to print above results
+        """
+        if title:
+            print(f"\n📊 {title}")
+            print("-" * 60)
+
+        try:
+            result = self.conn.execute(sql)
+            columns = [desc[0] for desc in result.description]
+            all_rows = result.fetchall()
+        except Exception as e:
+            print(f"ERROR: {e}")
+            return
+
+        total_rows = len(all_rows)
+        output = self._format_rows(
+            columns,
+            all_rows,
+            format=format,
+            max_rows=max_rows,
+            max_colwidth=max_colwidth,
+        )
+        print(output)
+
+        if max_rows is not None and total_rows > max_rows:
+            print(f"\n... showing {max_rows} of {total_rows} rows")
+
+    def close(self) -> None:
+        """Close the DuckDB connection and release resources."""
+        if not self._closed:
+            self._closed = True
+            self.tables.clear()
+            with contextlib.suppress(Exception):
+                self.conn.close()
+
+    def __enter__(self) -> QueryEngine:
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    def __del__(self) -> None:
+        self.close()
+
+    def __repr__(self) -> str:
+        tables_str = ", ".join(self.tables.keys()) if self.tables else "(none)"
+        return f"QueryEngine(tables=[{tables_str}])"

--- a/backend/src/meho_backplane/jsonflux/utils/__init__.py
+++ b/backend/src/meho_backplane/jsonflux/utils/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group

--- a/backend/src/meho_backplane/jsonflux/utils/sampling.py
+++ b/backend/src/meho_backplane/jsonflux/utils/sampling.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+from __future__ import annotations
+
+import random
+from typing import Any
+
+
+class ReservoirSampler:
+    __slots__ = ("k", "n_seen", "rng", "samples")
+
+    def __init__(self, k: int, rng: random.Random) -> None:
+        self.k = k
+        self.rng = rng
+        self.n_seen = 0
+        self.samples: list[Any] = []
+
+    def add(self, v: Any) -> None:
+        n = self.n_seen = self.n_seen + 1
+        samples = self.samples
+        k = self.k
+        if len(samples) < k:
+            samples.append(v)
+            return
+        j = self.rng.randint(1, n)
+        if j <= k:
+            samples[j - 1] = v
+
+    def get_exact_k(self) -> list[Any]:
+        k = self.k
+        if k <= 0:
+            return []
+        samples = self.samples
+        n_seen = self.n_seen
+        if n_seen <= 0:
+            return [None] * k
+        n_samples = len(samples)
+        if n_samples >= k:
+            return list(samples)
+        out = list(samples)
+        rng_choice = self.rng.choice
+        needed = k - n_samples
+        out.extend(rng_choice(samples) for _ in range(needed))
+        return out

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -603,6 +603,35 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/00/d579dcb2a536b6ea3a2563cdad6844f77d81a9b2d4b22a858097f2468acf/duckdb-1.5.3.tar.gz", hash = "sha256:df39428eb130faa35ae96fd35245bdeae6ecf43936250b116b5fead568eb9f16", size = 18026640, upload-time = "2026-05-20T11:55:31.901Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c4/2e34929b16c8d544ef664fad8f7f3a2a9db05746aae1e7c8c4ee3a8b23e4/duckdb-1.5.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ff11a457258148337ef9a392148a8cdbd1069b6c27c21958816c7b67fe6c542d", size = 32626494, upload-time = "2026-05-20T11:54:33.738Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/53/3af681793d03771365ae3e2215331151c196a3ac8193f613344840694671/duckdb-1.5.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fd25f533cb1b6b2c84cc767a9a9bab7769bb1aa44571a2a0bfc91ac3e4a38ac", size = 17301121, upload-time = "2026-05-20T11:54:36.928Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e2/c80af1eac2ab5d35fc2c372ef0a84668842e549fbbf7799277b3fccf3e39/duckdb-1.5.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:10960400ed60cdf0fe05bab2086fa8eb733889cb0ceca18d07ff9a00c0e0be7b", size = 15449283, upload-time = "2026-05-20T11:54:39.777Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/9a/c63af233c9f761bf5178a5210437e1bc6bcb30fa8a9073de6398cfb12c03/duckdb-1.5.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c5f18e7561403054433706c187589e86629a7af09a7efc23a06a8b308e6acc68", size = 19332762, upload-time = "2026-05-20T11:54:42.51Z" },
+    { url = "https://files.pythonhosted.org/packages/21/cc/2d77af4fff86012f334ef82e6d54a995a86c8745e58074f1218ed7d25171/duckdb-1.5.3-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9fb7516255a8764545e30f7efacea408cc847764a3027b3b0b3e7d1a7bebbc5c", size = 21453290, upload-time = "2026-05-20T11:54:45.272Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/5e/9bc4817a98feb4dab83e56f2245cd3a30d00ee646d4dec7926464e2b3f28/duckdb-1.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:8001eccbc28be244dfd04d708526f34ddd6460b47a8aeb5d0e39d6f7f9e3fe15", size = 13118308, upload-time = "2026-05-20T11:54:48.058Z" },
+    { url = "https://files.pythonhosted.org/packages/81/35/e3f32e4e53e2450ddb1db8312a17d1ce455d60cc4941b6ad2cfc908794b0/duckdb-1.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:6d2835e39bb6af73891f73c0f8d4324f98afe00d0b00c6d34b2a582c2256cbb0", size = 13927187, upload-time = "2026-05-20T11:54:50.584Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/a528eb09d8be51954c485864bd06753e616939a080cbc3dd4417e8c94a57/duckdb-1.5.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e75a6122c12579a99848517f6f00a4e342aebda3590c30fe9b5cc5f39d5e6afc", size = 32626254, upload-time = "2026-05-20T11:54:53.65Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/3c/1534c0a6db347c05eb7d0f6ecfb7aefbe74cbff398e4892a8fd1903a20e8/duckdb-1.5.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:fd3963c1cb9d9567777f4a898a9dbe388a2fe9724681801b1e7d6d93eecf1b76", size = 17300917, upload-time = "2026-05-20T11:54:56.628Z" },
+    { url = "https://files.pythonhosted.org/packages/23/fa/beafb91e6e152d2161c4a9cbc472334c87607eb61ad7104b5a7fa8d8d7b1/duckdb-1.5.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3d5db8c0b55e072cf437948ebb5d7e23d7b9d03d905fa5f9145583e65aa447f7", size = 15449411, upload-time = "2026-05-20T11:54:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/50/0a/49b6fe04e2fcd63729eb607dadd44818dde77342a4f5ce086c6c92f1dd4d/duckdb-1.5.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ce80aed7a538422129a57eaca9141e3afb51f8bf562b1908b1576c9725b5b22", size = 19333120, upload-time = "2026-05-20T11:55:01.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4c/0907c3f76adb9dd90e67610b31e0304a35814e65c4c41a354a262c09b885/duckdb-1.5.3-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:787df63824f07bf18022dbc3b8ca4b2bfab0ebe616464f55c6e8cd0f59ea762e", size = 21453266, upload-time = "2026-05-20T11:55:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/9c/d2f23a7803ddbbd9413f7572ecf66a15120ed5ced7ce5c73e698c1406b76/duckdb-1.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:bb5bb5dcdd09d62ee60f0ddbbef918e71cce304ffe28428b1131949d39ffaabf", size = 13118640, upload-time = "2026-05-20T11:55:07.389Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d5/7ba2316415bcdab6edd765bbbe35c2ca8a3800f2fe695cd70e3cdb997f09/duckdb-1.5.3-cp313-cp313-win_arm64.whl", hash = "sha256:2fa17ecdd5d3db122836cb71bb93601c2106a3be883c17dffddc02fbf3fa7888", size = 13926409, upload-time = "2026-05-20T11:55:10.166Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/c2/d4b6f8a5e4d3bc25773be6da76a99d9661ebbf3552c007c460d2dd59dbf8/duckdb-1.5.3-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4bfa9a4dadf71e83e2c4eaca2f9421c82a54defecc1b0b4c0be95e2389dec4fe", size = 32636685, upload-time = "2026-05-20T11:55:13.158Z" },
+    { url = "https://files.pythonhosted.org/packages/42/58/e835c8298979d29db7a62cb5acc29e9b57aeaca7cdde2fcd3ac980f5cb18/duckdb-1.5.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:aea7baf67ad7e1829ac76f67d7dcbd7fb1f57c3eb179d55ac30952df4709ae30", size = 17308134, upload-time = "2026-05-20T11:55:16.194Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/46/617b51363f5613418c8b224b3cce16b58e6dde80904566bec232579c1d4e/duckdb-1.5.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0b0b4f088a65d77e1217ce5d7eff889e63fedc44281200d899ff47c84d8ff836", size = 15449891, upload-time = "2026-05-20T11:55:18.687Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/72/354146656e8d9ba3853d3a5ee80a481b8c5f70edfc3d5ae80a8c4479c967/duckdb-1.5.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe8d0c1f6a120aa03fa6e0d03897c71a1842e6cf7afd31d181348391f7108fe1", size = 19338499, upload-time = "2026-05-20T11:55:21.34Z" },
+    { url = "https://files.pythonhosted.org/packages/56/8f/65fc623b51448f2bfba1a9ec6ab3debb4664c0876c0113a5e782600b53ac/duckdb-1.5.3-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0405eae18ec6e8210a471c97dbfe87a7e4d605274b7fe572a1f276e92158f13", size = 21455828, upload-time = "2026-05-20T11:55:23.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/db/d0274cbe9f5fe219f77c0bdf900ac77103569e83c102a4225ce04cbc607d/duckdb-1.5.3-cp314-cp314-win_amd64.whl", hash = "sha256:33ae08b3e818d7613d8936744b67718c2062c2f530376895bfd89efb51b81538", size = 13640011, upload-time = "2026-05-20T11:55:26.276Z" },
+    { url = "https://files.pythonhosted.org/packages/07/5d/8f1899b8bef291caf953992fcd6c24df9f29387a35645e58c2504a5ca473/duckdb-1.5.3-cp314-cp314-win_arm64.whl", hash = "sha256:746433e49bbc667b4df283153415fbe37e9083e0eff6c3cd6e54de7536869cd4", size = 14411554, upload-time = "2026-05-20T11:55:29.037Z" },
+]
+
+[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1217,6 +1246,7 @@ dependencies = [
     { name = "asyncpg" },
     { name = "asyncssh" },
     { name = "authlib" },
+    { name = "duckdb" },
     { name = "fastapi" },
     { name = "fastembed" },
     { name = "httpx" },
@@ -1224,14 +1254,17 @@ dependencies = [
     { name = "jinja2" },
     { name = "jsonschema" },
     { name = "kubernetes-asyncio" },
+    { name = "msgspec" },
     { name = "packaging" },
     { name = "pgvector" },
     { name = "prometheus-client" },
+    { name = "pyarrow" },
     { name = "pydantic", extra = ["email"] },
     { name = "python-frontmatter" },
     { name = "redis" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "structlog" },
+    { name = "tabulate" },
     { name = "tenacity" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -1257,6 +1290,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.29" },
     { name = "asyncssh", specifier = ">=2.18,<3.0" },
     { name = "authlib", specifier = ">=1.3" },
+    { name = "duckdb", specifier = ">=1.4.3" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "fastembed", specifier = ">=0.7,<1.0" },
     { name = "httpx", specifier = ">=0.27" },
@@ -1264,14 +1298,17 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "kubernetes-asyncio", specifier = ">=35.0.1,<36" },
+    { name = "msgspec", specifier = ">=0.20.0" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "pgvector", specifier = ">=0.3,<1.0" },
     { name = "prometheus-client", specifier = ">=0.20" },
+    { name = "pyarrow", specifier = ">=21.0.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.13.4" },
     { name = "python-frontmatter", specifier = ">=1.2.0" },
     { name = "redis", specifier = ">=5,<8" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.49" },
     { name = "structlog", specifier = ">=24.1" },
+    { name = "tabulate", specifier = ">=0.9.0" },
     { name = "tenacity", specifier = ">=9.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.47.0" },
 ]
@@ -1371,6 +1408,46 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/21/54/1d71cd143752361c0aebef16ad3f55926a6faf7b112d355745c1f8a25f7f/mmh3-5.2.1-cp314-cp314t-win32.whl", hash = "sha256:29bc3973676ae334412efdd367fcd11d036b7be3efc1ce2407ef8676dabfeb82", size = 41934, upload-time = "2026-03-05T15:55:53.564Z" },
     { url = "https://files.pythonhosted.org/packages/9d/e4/63a2a88f31d93dea03947cccc2a076946857e799ea4f7acdecbf43b324aa/mmh3-5.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:28cfab66577000b9505a0d068c731aee7ca85cd26d4d63881fab17857e0fe1fb", size = 43036, upload-time = "2026-03-05T15:55:55.252Z" },
     { url = "https://files.pythonhosted.org/packages/a0/0f/59204bf136d1201f8d7884cfbaf7498c5b4674e87a4c693f9bde63741ce1/mmh3-5.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:dfd51b4c56b673dfbc43d7d27ef857dd91124801e2806c69bb45585ce0fa019b", size = 40391, upload-time = "2026-03-05T15:55:56.697Z" },
+]
+
+[[package]]
+name = "msgspec"
+version = "0.21.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/60/f79b9b013a16fa3a58350c9295ddc6789f2e335f36ea61ed10a21b215364/msgspec-0.21.1.tar.gz", hash = "sha256:2313508e394b0d208f8f56892ca9b2799e2561329de9763b19619595a6c0f72c", size = 319193, upload-time = "2026-04-12T21:44:50.394Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/cf/317224852c00248c620a9bcf4b26e2e4ab8afd752f18d2a6ef73ebd423b6/msgspec-0.21.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d4248cf0b6129b7d230eacd493c17cc2d4f3989f3bb7f633a928a85b7dcfa251", size = 196188, upload-time = "2026-04-12T21:44:07.181Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/81/074612945c0666078f7366f40000013de9f6ba687491d450df699bceebc9/msgspec-0.21.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5102c7e9b3acff82178449b85006d96310e690291bb1ea0142f1b24bcb8aabcb", size = 188473, upload-time = "2026-04-12T21:44:08.736Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/37/655101799590bcc5fddb2bd3fe0e6194e816c2d1da7c361725f5eb89a910/msgspec-0.21.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:846758412e9518252b2ac9bffd6f0e54d9ff614f5f9488df7749f81ff5c80920", size = 218871, upload-time = "2026-04-12T21:44:09.917Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d1/d4cd9fe89c7d400d7a18f86ccc94daa3f0927f53558846fcb60791dce5d6/msgspec-0.21.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21995e74b5c598c2e004110ad66ec7f1b8c20bf2bcf3b2de8fd9a3094422d3ff", size = 225025, upload-time = "2026-04-12T21:44:11.191Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bf/e20549e602b9edccadeeff98760345a416f9cce846a657e8b18e3396b212/msgspec-0.21.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6129f0cca52992e898fd5344187f7c8127b63d810b2fd73e36fca73b4c6475ee", size = 222672, upload-time = "2026-04-12T21:44:12.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/68/04d7a8f0f786545cf9b8c280c57aa6befb5977af6e884b8b54191cbe44b3/msgspec-0.21.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ef3ec2296248d1f8b9231acb051b6d471dfde8f21819e86c9adaaa9f42918521", size = 227303, upload-time = "2026-04-12T21:44:13.709Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4d/619866af2840875be408047bf9e70ceafbae6ab50660de7134ed1b25eb86/msgspec-0.21.1-cp312-cp312-win_amd64.whl", hash = "sha256:d4ab834a054c6f0cbeef6df9e7e1b33d5f1bc7b86dea1d2fd7cad003873e783d", size = 190017, upload-time = "2026-04-12T21:44:14.977Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2e/a8f9eca8fd00e097d7a9e99ba8a4685db994494448e3d4f0b7f6e9a3c0f7/msgspec-0.21.1-cp312-cp312-win_arm64.whl", hash = "sha256:628aaa35c74950a8c59da330d7e98917e1c7188f983745782027748ee4ca573e", size = 175345, upload-time = "2026-04-12T21:44:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/74/f11ede02839b19ff459f88e3145df5d711626ca84da4e23520cebf819367/msgspec-0.21.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:764173717a01743f007e9f74520ed281f24672c604514f7d76c1c3a10e8edb66", size = 196176, upload-time = "2026-04-12T21:44:17.613Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/40/4476c1bd341418a046c4955aff632ec769315d1e3cb94e6acf86d461f9ed/msgspec-0.21.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:344c7cd0eaed1fb81d7959f99100ef71ec9b536881a376f11b9a6c4803365697", size = 188524, upload-time = "2026-04-12T21:44:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/d9/9e9d7d7e5061b47540d03d640fab9b3965ba7ae49c1b2154861c8f007518/msgspec-0.21.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48943e278b3854c2f89f955ddc6f9f430d3f0784b16e47d10604ee0463cd21f5", size = 218880, upload-time = "2026-04-12T21:44:20.028Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/2bb344f34abb4b57e60c7c9c761994e0417b9718ec1460bf00c296f2a7ea/msgspec-0.21.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9aa659ebb0101b1cbc31461212b87e341d961f0ab0772aaf068a99e001ec4aa", size = 225050, upload-time = "2026-04-12T21:44:21.577Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/84/7c1e412f76092277bf760cef12b7979d03314d259ab5b5cafde5d0c1722d/msgspec-0.21.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7b27d1a8ead2b6f5b0c4f2d07b8be1ccfcc041c8a0e704781edebe3ae13c484", size = 222713, upload-time = "2026-04-12T21:44:22.83Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/27/0bba04b2b4ef05f3d068429410bc71d2cea925f1596a8f41152cccd5edb8/msgspec-0.21.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:38fe93e86b61328fe544cb7fd871fad5a27c8734bfda90f65e5dbe288ae50f61", size = 227259, upload-time = "2026-04-12T21:44:24.11Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/2d/09574b0eea02fed2c2c1383dbaae2c7f79dc16dcd6487a886000afb5d7c4/msgspec-0.21.1-cp313-cp313-win_amd64.whl", hash = "sha256:8bc666331c35fcce05a7cd2d6221adbe0f6058f8e750711413d22793c080ac6a", size = 189857, upload-time = "2026-04-12T21:44:25.359Z" },
+    { url = "https://files.pythonhosted.org/packages/46/34/105b1576ad182879914f0c821f17ee1d13abb165cb060448f96fe2aff078/msgspec-0.21.1-cp313-cp313-win_arm64.whl", hash = "sha256:42bb1241e0750c1a4346f2aa84db26c5ffd99a4eb3a954927d9f149ff2f42898", size = 175403, upload-time = "2026-04-12T21:44:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ad/86954e987d1d6a5c579e2c2e7832b65e0fff194179fdac4f581536086024/msgspec-0.21.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fab48eb45fdbfbdb2c0edfec00ffc53b6b6085beefc6b50b61e01659f9f8757f", size = 196261, upload-time = "2026-04-12T21:44:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a1/c5e46c3e42b866199365e35d11dddfd1fbd8bba4fdb3c52f965b1607ce94/msgspec-0.21.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3cb779ea0c35bc807ff941d415875c1f69ca0be91a2e907ab99a171811d86a9a", size = 188729, upload-time = "2026-04-12T21:44:28.99Z" },
+    { url = "https://files.pythonhosted.org/packages/85/7d/1e29a319d678d6cb962ae5bdf32a6858ebdf38f73bc654c0e9c742a0c2c8/msgspec-0.21.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68604db36b3b4dd9bf160e436e12798a4738848144cea1aca1cb984011eb160f", size = 219866, upload-time = "2026-04-12T21:44:31.104Z" },
+    { url = "https://files.pythonhosted.org/packages/25/1f/cca084ca2572810fff12ea9dbdcbe39eac048f40daf4a9077b49fcbe8cee/msgspec-0.21.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d6b9dc50948eaf65df54d2fd0ff66e6d8c32f116037209ee861810eb9b676cb", size = 224993, upload-time = "2026-04-12T21:44:32.649Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/d2120fc9d419a89a3a7c13e5b7078798c4b392a96a02a6e2b3ce43a8766c/msgspec-0.21.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:52c5e21930942302394429c5a582ce7e6b62c7f983b3760834c2ce107e0dd6df", size = 223535, upload-time = "2026-04-12T21:44:33.839Z" },
+    { url = "https://files.pythonhosted.org/packages/75/17/42418b66a3ad972a89bab73dd78b79cc6282bb488a25e73c853cee7443b9/msgspec-0.21.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:abbb39d65681fa24ed394e01af3d59d869068324f900c61d06062b7fb9980f2f", size = 227222, upload-time = "2026-04-12T21:44:35.093Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/33/265c894268cca88ff67b144ca2b4c522fc8b9a6f1966a3640c70516e78e1/msgspec-0.21.1-cp314-cp314-win_amd64.whl", hash = "sha256:5666b1b560b97b6ec2eb3fca8a502298ebac56e13bbca1f88523538ce83d01ea", size = 193810, upload-time = "2026-04-12T21:44:36.612Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8f/a6d35f25bf1fc63c492fdd88fdce01ba0875ead48c2b91f90f33653b4131/msgspec-0.21.1-cp314-cp314-win_arm64.whl", hash = "sha256:d8b8578e4c83b14ceea4cef0d0b747e31d9330fe4b03b2b2ad4063866a178f93", size = 179125, upload-time = "2026-04-12T21:44:38.198Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/39/74839641e64b99d87da55af0fc472854d42b46e2183b9e2a67fe1bb2a512/msgspec-0.21.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:15f523d51c00ebad412213bfe9f06f0a50ec2b93e0c19e824a2d267cabb48ea2", size = 200171, upload-time = "2026-04-12T21:44:39.414Z" },
+    { url = "https://files.pythonhosted.org/packages/70/9b/ce0cca6d2d87fcd4b6ff97600790494e64f26a2c55d61507cd2755c16193/msgspec-0.21.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e47390360583ba3d5c6cb44cf0a9f61b0a06a899d3c2c00627cedebb2e2884b", size = 192879, upload-time = "2026-04-12T21:44:40.882Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/08/673a7bb05e5702dc787ddd3011195b509f9867927970da59052211929987/msgspec-0.21.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f60800e6299b798142dc40b0644da77ceac5ea0568be58228417eae14135c847", size = 226281, upload-time = "2026-04-12T21:44:42.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/45/86508cf57283e9070b3c447e3ab25b792a7a0855a3ea4e0c6d111ac34c97/msgspec-0.21.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5f8e9dfcd98419cf7568808470c4317a3fb30bef0e3715b568730a2b272a20d7", size = 229863, upload-time = "2026-04-12T21:44:43.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/62/e7c9367cd08d590559faacd711edbae36840342843e669440363f33c7d36/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:92d89dfad13bd1ea640dc3e37e724ed380da1030b272bdf5ecafb983c3ad7c75", size = 230445, upload-time = "2026-04-12T21:44:44.806Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b4/c0f54632103846b658a10930025f4de41c8724b5e4805a5f3b395586cb7e/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0d03867786e5d7ba25d666df4b11320c27170f4aeafcb8e3a8b0a50a4fb742ca", size = 231822, upload-time = "2026-04-12T21:44:46.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/1d/0d85cc79d0ccf5508e9c846cc66552a6a16bf92abd1dbd8362617f7b35cd/msgspec-0.21.1-cp314-cp314t-win_amd64.whl", hash = "sha256:740fbf1c9d59992ca3537d6fbe9ebbf9eaf726a65fbf31448e0ecbc710697a63", size = 206650, upload-time = "2026-04-12T21:44:47.601Z" },
+    { url = "https://files.pythonhosted.org/packages/90/91/56c5d560f20e6c20e9e4f55bd0e458f7f162aa689ee350346c04c48eac0b/msgspec-0.21.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0d2cc73df6058d811a126ac3a8ad63a4dfa210c82f9cf5a004802eaf4712de90", size = 183149, upload-time = "2026-04-12T21:44:48.833Z" },
 ]
 
 [[package]]
@@ -1870,6 +1947,49 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/87/4619c395b325e26048a6e28a365afed754614788ba1f49b2eefb07621a03/py_rust_stemmers-0.1.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:35d32f6e7bdf6fd90e981765e32293a8be74def807147dea9fdc1f65d6ce382f", size = 575582, upload-time = "2025-02-19T13:55:46.436Z" },
     { url = "https://files.pythonhosted.org/packages/98/6e/214f1a889142b7df6d716e7f3fea6c41e87bd6c29046aa57e175d452b104/py_rust_stemmers-0.1.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:191ea8bf922c984631ffa20bf02ef0ad7eec0465baeaed3852779e8f97c7e7a3", size = 493269, upload-time = "2025-02-19T13:55:49.057Z" },
     { url = "https://files.pythonhosted.org/packages/e1/b9/c5185df277576f995ae34418eb2b2ac12f30835412270f9e05c52face521/py_rust_stemmers-0.1.5-cp313-none-win_amd64.whl", hash = "sha256:e564c9efdbe7621704e222b53bac265b0e4fbea788f07c814094f0ec6b80adcf", size = 209397, upload-time = "2025-02-19T13:55:50.853Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654, upload-time = "2026-04-21T10:47:28.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394, upload-time = "2026-04-21T10:47:34.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122, upload-time = "2026-04-21T10:47:42.056Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032, upload-time = "2026-04-21T10:47:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490, upload-time = "2026-04-21T10:47:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660, upload-time = "2026-04-21T10:48:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
 ]
 
 [[package]]
@@ -2394,6 +2514,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ef/52/9ba0f43b686e7f3ddfeaa78ac3af750292662284b3661e91ad5494f21dbc/structlog-25.5.0.tar.gz", hash = "sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98", size = 1460830, upload-time = "2025-10-27T08:28:23.028Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/45/a132b9074aa18e799b891b91ad72133c98d8042c70f6240e4c5f9dabee2f/structlog-25.5.0-py3-none-any.whl", hash = "sha256:a8453e9b9e636ec59bd9e79bbd4a72f025981b3ba0f5837aebf48f02f37a7f9f", size = 72510, upload-time = "2025-10-27T08:28:21.535Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Vendor the MEHO.X `meho_app/jsonflux/` tree (10 files, ~3.3k LOC) into `backend/src/meho_backplane/jsonflux/` as a **verbatim** copy — bodies are byte-identical to source; only the per-file SPDX header changed.
- **Source pin:** MEHO.X commit `fc82cf932f74b7c0657d0b9b3e99d5e74bac5156` (`fc82cf93`) — the SHA named in the merged T1 ADR (`docs/decisions/jsonflux-license.md`) and the latest mypy-clean `meho_app/jsonflux/` state.
- Apply the T1 ADR's **Option B** (relicense to Apache-2.0): every header swapped `AGPL-3.0-only` → `Apache-2.0`; the three bare package `__init__.py` files normalised to the repo's two-line `# Copyright (c) 2026 evoila Group` convention. **No `LICENSES/` carve-out** (that was the unchosen Option C). NOTICE gains a JSONFlux attribution paragraph crediting @ikaric / `ikaric/jsonflux` + fork provenance.
- Add the runtime deps the tree imports (`duckdb>=1.4.3`, `pyarrow>=21.0.0`, plus `msgspec>=0.20.0` and `tabulate>=0.9.0`, both required by the vendored code for the import/render paths) and the per-file ruff ignores + a scoped mypy override so this repo's stricter gates accept the verbatim tree.
- **No behaviour wiring** — nothing dispatches into the package yet (that's T3).

## Source pin

MEHO.X `meho_app/jsonflux/` @ **`fc82cf932f74b7c0657d0b9b3e99d5e74bac5156`** — matches the merged ADR. MEHO.X HEAD was not mutated; the tree was extracted non-destructively via `git archive`.

## Notes on the strict-config gap (why pyproject grew more than the issue listed)

The vendored tree was lint/type-clean only under MEHO.X's **looser** config. To keep the source byte-identical (the whole point of Option B) instead of re-annotating ~3.3k LOC, this repo's stricter gates get carveouts scoped to the vendored module only:

- **ruff per-file-ignores** extended beyond the issue's base list to also cover `A002` / `N806` (rules this repo *selects* via `A`+`N`, MEHO.X does not) and `E501` / `RUF100` (this repo enforces both; MEHO.X ignores them globally — `RUF100` fires on the verbatim `# noqa: S608/S311` comments for the bandit ruleset this repo doesn't select).
- **mypy override** `module = ["meho_backplane.jsonflux.*"]` disables only `type-arg` (`disallow_any_generics`) and `attr-defined` (`no_implicit_reexport`) — the two `strict = true` sub-flags MEHO.X doesn't enable. The rest of strict mode stays in force on the tree, and the repo outside `jsonflux` is unaffected (full-repo mypy still passes on 243 files).
- **`msgspec` + `tabulate`** were not in the issue's stated dep list but are imported by the vendored code; the import acceptance gate cannot pass without `msgspec`, and `tabulate` is required by the `query_table`/`query_print` render paths. Both mirror MEHO.X's own declarations.

## Test plan

- [x] `uv sync` — succeeds in `backend/`
- [x] `uv run python -c "from meho_backplane.jsonflux import JsonFlux, JsonFluxConfig, QueryEngine; print('ok')"` — prints `ok`
- [x] `uv run mypy src/meho_backplane/jsonflux/` — Success, 10 files (and full `uv run mypy src/` — Success, 243 files)
- [x] `uv run ruff check src/meho_backplane/jsonflux/` — All checks passed (and full `uv run ruff check src/ tests/` — clean)
- [x] `uv run ruff format --check src/ tests/` — clean (verbatim tree needs no reformatting)
- [x] Zero `AGPL` strings: `grep -rn "AGPL" src/meho_backplane/jsonflux/` exits 1
- [x] Every vendored `.py` carries `# SPDX-License-Identifier: Apache-2.0` on line 1
- [x] `backend/pyproject.toml` lists `duckdb>=1.4.3` and `pyarrow>=21.0.0`
- [x] Smart `register()` landed verbatim with `unwrap: bool | str = "auto"` and `append: bool = False` — present in `query/engine.py:170`. (The signature spans multiple lines in the verbatim source, so the single-line `grep -E "def register\(.*unwrap.*append"` does not match; a cross-line check (`grep -Pzo` / `perl -0777`) matches. Reformatting to one line was rejected as it would break the verbatim-vendoring mandate and be reverted by `ruff format`.)
- [x] Functional smoke: smart `register()` unwrapped a `{"results":[...],"total":N}` wrapper and DuckDB executed an ORDER BY over it
- [x] `pytest --co` — 3624 tests collected, no collection errors

## Out of scope

- Wiring `JsonFluxReducer` into the dispatcher — T3.
- New tests against the vendored package — T3.
- Connector / seam-comment edits — T4.
- `docs/architecture/jsonflux.md` + `operations-substrate.md` — T5.

Adjacent finding (recorded, not actioned): the local `code-quality.py` advisory hook flags inherent complexity in the verbatim tree (file-size / function-size / cognitive complexity in `query/engine.py`, `core/analyzer.py`, etc.). This is vendored third-party code, not agent-authored, and the hook is **not** a CI/commit/push gate (CI runs only ruff + ruff-format + mypy + pytest; pre-commit runs hygiene + gitleaks + conventional-commit). The complexity is the same the per-file ruff carveouts already acknowledge; left verbatim per Option B.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #752


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JsonFlux, a JSON analysis and profiling tool with schema visualization, SQL querying, statistics collection, and performance metrics across multiple output formats (tree, tabular, bracket).
  * Supports analyzing JSON from dictionaries, file paths, strings, and lists.

* **Documentation**
  * Updated license notices for vendored dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/958?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->