### PR TITLE
feat(ui): G10.0-T4 BFF OAuth2.1 + PKCE auth flow — /ui/auth/{login,callback,logout} + session middleware + meho-web Keycloak client

### DIFF
--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -344,6 +344,38 @@ class Settings(BaseModel):
         :func:`~meho_backplane.memory._internal.is_expired` until the
         external job reaps them. Read once at lifespan startup; toggling
         post-start requires a pod restart to take effect.
+    ui_keycloak_client_id:
+        OAuth ``client_id`` of the **confidential** Keycloak client the
+        operator-console BFF login flow authenticates against. Initiative
+        #337 (G10.0 Frontend chassis), Task #865. Distinct from
+        :attr:`keycloak_cli_client_id` (the public device-code client
+        ``meho login`` uses) and from :attr:`keycloak_audience` (the
+        resource-server identifier the backplane validates JWT ``aud``
+        claims against): the BFF needs a *confidential* client with a
+        secret because the authorization-code flow runs server-side at
+        ``/ui/auth/callback`` and the token-endpoint exchange carries
+        ``client_id`` + ``client_secret`` in the request body. Suggested
+        name ``meho-web``. Configured per the recipe in
+        ``docs/cross-repo/keycloak-web-client.md``. Default ``""``
+        (unset) keeps the chassis-only deploys booting; any ``/ui/auth/*``
+        request with the default surfaces an actionable error rather than
+        silently misusing one of the other client ids.
+    ui_keycloak_client_secret:
+        Client secret of the confidential ``meho-web`` Keycloak client.
+        Initiative #337, Task #865. Sourced from Vault in production
+        (same render-into-env chain that lands ``DATABASE_URL`` /
+        ``UI_SESSION_ENCRYPTION_KEY``): the deploy renders the value
+        into the pod's ``UI_KEYCLOAK_CLIENT_SECRET`` env var; this field
+        reads it once at startup via :func:`get_settings`. The value
+        leaves the pod environment only as the body of the POST to
+        Keycloak's token endpoint in :mod:`meho_backplane.ui.auth.flow`
+        — never logged, never surfaced in error bodies, never copied
+        into structlog context. Default ``""`` (unset) is fail-fast: the
+        BFF login flow rejects token-exchange attempts without an
+        explicit secret rather than silently falling back to an empty
+        body (which Keycloak would reject as ``invalid_client``, but the
+        explicit precheck names the missing knob so operator remediation
+        is unambiguous).
     ui_session_encryption_key:
         URL-safe base64-encoded 32-byte key used by
         :mod:`meho_backplane.ui.auth.session_store` to Fernet-encrypt
@@ -457,6 +489,8 @@ class Settings(BaseModel):
     memory_user_default_ttl_days: int = Field(default=7, ge=1, le=365)
     memory_expiry_tick_interval_seconds: int = Field(default=86400, ge=60, le=86400)
     memory_expiry_enabled: bool = True
+    ui_keycloak_client_id: str = ""
+    ui_keycloak_client_secret: str = ""
     ui_session_encryption_key: str = ""
     # G9.3-T6 #858 — topology history retention prune knobs. ``days=0`` is
     # the opt-out sentinel ("keep forever"); ``enabled=False`` skips the
@@ -600,6 +634,8 @@ def get_settings() -> Settings:
         memory_expiry_enabled=parse_bool_env(
             os.environ.get("MEMORY_EXPIRY_ENABLED", "true"),
         ),
+        ui_keycloak_client_id=os.environ.get("UI_KEYCLOAK_CLIENT_ID", ""),
+        ui_keycloak_client_secret=os.environ.get("UI_KEYCLOAK_CLIENT_SECRET", ""),
         ui_session_encryption_key=os.environ.get("UI_SESSION_ENCRYPTION_KEY", ""),
         topology_history_retention_days=int(
             os.environ.get("TOPOLOGY_HISTORY_RETENTION_DAYS", "90"),

--- a/backend/src/meho_backplane/ui/auth/__init__.py
+++ b/backend/src/meho_backplane/ui/auth/__init__.py
@@ -1,21 +1,54 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""BFF (Backend-for-Frontend) auth for the operator console (stub).
+"""BFF (Backend-for-Frontend) auth for the operator console.
 
-Empty package for chassis Task #863. The order subsequent Tasks fill
-this package in:
+Initiative #337 (G10.0 Frontend chassis) splits the BFF surface
+across four submodules so the layering is grep-explicit:
 
-* T3 (#864) -- ``session.py``: ``web_session`` ORM model +
-  ``SessionService`` with encrypted access-token / refresh-token
-  custody, refresh-rotation per RFC 9700, Alembic migration.
-* T4 (#865) -- ``flow.py`` + ``middleware.py``: OAuth 2.1
-  Authorization Code + PKCE flow against Keycloak, ``meho-web``
-  client registration, session-cookie middleware that loads operator
-  identity on every ``/ui/*`` request and 302-redirects to
-  ``/ui/auth/login`` when missing/expired.
+* :mod:`meho_backplane.ui.auth.session_store` (Task #864) -- the
+  encrypted token-custody substrate. ``create_session`` /
+  ``load_session`` / ``revoke_session`` /
+  ``rotate_refresh`` against the ``web_session`` Postgres table.
+* :mod:`meho_backplane.ui.auth.flow` (Task #865) -- OAuth 2.1
+  Authorization Code + PKCE client primitives.
+  ``build_authorization_request`` mints the IdP redirect URL +
+  registers the PKCE verifier server-side; ``exchange_code_for_tokens``
+  finishes the round-trip at the token endpoint.
+  ``resolve_oidc_endpoints`` exposes the cached discovery doc.
+* :mod:`meho_backplane.ui.auth.routes` (Task #865) -- the FastAPI
+  :class:`APIRouter` carrying ``GET /ui/auth/{login,callback,logout}``.
+  ``build_router`` returns the router; ``SESSION_COOKIE_NAME`` /
+  ``LOGIN_PATH`` are exported for the middleware to share.
+* :mod:`meho_backplane.ui.auth.middleware` (Task #865) -- the pure-ASGI
+  :class:`UISessionMiddleware` that loads operator identity from the
+  ``meho_session`` cookie on every ``/ui/*`` request and 302-redirects
+  to login on missing/expired session.
 
-This package is imported once T3 + T4 land; the stub keeps
-``from meho_backplane.ui.auth import ...`` failing loudly while the
-chassis is the only thing in place.
+T5 (#866) mounts the router and the middleware onto the FastAPI app;
+this subpackage exposes only the build-time surface.
 """
+
+from meho_backplane.ui.auth.middleware import (
+    AUTH_PREFIX,
+    STATIC_PREFIX,
+    UISessionContext,
+    UISessionMiddleware,
+    require_ui_session,
+)
+from meho_backplane.ui.auth.routes import (
+    LOGIN_PATH,
+    SESSION_COOKIE_NAME,
+    build_router,
+)
+
+__all__ = [
+    "AUTH_PREFIX",
+    "LOGIN_PATH",
+    "SESSION_COOKIE_NAME",
+    "STATIC_PREFIX",
+    "UISessionContext",
+    "UISessionMiddleware",
+    "build_router",
+    "require_ui_session",
+]

--- a/backend/src/meho_backplane/ui/auth/flow.py
+++ b/backend/src/meho_backplane/ui/auth/flow.py
@@ -1,0 +1,524 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""OAuth 2.1 Authorization Code + PKCE client primitives for the BFF.
+
+Initiative #337 (G10.0 Frontend chassis), Task #865 (T4). This module
+hosts the OAuth-client plumbing the ``/ui/auth/*`` route handlers in
+:mod:`meho_backplane.ui.auth.routes` call into:
+
+* :func:`build_authorization_request` -- mints a per-login
+  ``(state, code_verifier)`` pair, registers the verifier in the
+  module-level :class:`PKCEVerifierStore` (see
+  :mod:`meho_backplane.ui.auth.verifier_store`) keyed on ``state``,
+  and asks authlib's :class:`AsyncOAuth2Client` to build the Keycloak
+  authorization URL (carries ``code_challenge`` +
+  ``code_challenge_method=S256`` + ``resource=<backplane_url>/api`` per
+  RFC 8707).
+* :func:`exchange_code_for_tokens` -- callback-side hop. Pops the
+  ``code_verifier`` from the store (one-time use; absence on a second
+  callback request with the same ``state`` deliberately fails-closed),
+  then exchanges ``authorization_code`` + ``code_verifier`` against
+  Keycloak's token endpoint and returns the OAuth2-token dict.
+* :func:`resolve_oidc_endpoints` -- discovery-doc fetch that the
+  routes call at login + callback + logout time to obtain the
+  ``authorization_endpoint`` / ``token_endpoint`` /
+  ``end_session_endpoint`` URLs. Backed by a TTL'd in-process cache
+  identical in shape to :mod:`meho_backplane.auth.jwt`'s JWKS cache.
+
+Library choice (per Task #865 acceptance + ADR 0004): authlib's
+:class:`authlib.integrations.httpx_client.AsyncOAuth2Client`. authlib
+is already a backplane dependency (chassis JWT verification chain in
+:mod:`meho_backplane.auth.jwt`); its OAuth2 client primitive ships
+PKCE, state, and the RFC 8707 ``resource`` parameter as kwargs to the
+two methods above. We deliberately do **not** reach for
+:mod:`authlib.integrations.starlette_client` -- that integration owns
+its own session/cookie machinery, which the BFF cannot delegate
+(decision #11 keeps tokens server-side in
+:mod:`~meho_backplane.ui.auth.session_store`).
+
+Why PKCE on a confidential client
+---------------------------------
+
+OAuth 2.1 mandates PKCE for *every* authorization-code flow, not only
+public clients. The BCP rationale (RFC 9700 §2.1.1 /
+draft-ietf-oauth-browser-based-apps §6.1) is that PKCE is the only
+defence against authorization-code interception when an intermediate
+hop on the redirect path is not under the relying-party's control.
+``code_challenge_method=S256`` is the only method accepted; plain is
+not negotiable.
+
+Security discipline (#865 is auth)
+----------------------------------
+
+* The client secret resolved from
+  :attr:`Settings.ui_keycloak_client_secret` never enters a log
+  line, error body, or structlog context. The only seam that touches
+  it is :func:`_build_oauth_client` (writes it onto the
+  :class:`AsyncOAuth2Client` instance, which sends it as
+  ``client_secret_basic`` on the token endpoint Authorization header).
+
+* ``state`` is the CSRF guard on the callback. authlib's
+  :meth:`fetch_token` re-checks ``state`` when called with the
+  callback URL; this module's :func:`exchange_code_for_tokens`
+  delegates that check.
+
+* ``code_verifier`` is removed from the store as soon as the
+  callback consumes it (single-use semantics). A second callback
+  with the same ``state`` finds no verifier and is rejected.
+
+References
+----------
+
+* RFC 6749 §4.1 (Authorization Code grant):
+  https://www.rfc-editor.org/rfc/rfc6749
+* RFC 7636 (PKCE):
+  https://www.rfc-editor.org/rfc/rfc7636
+* RFC 8707 (Resource Indicators):
+  https://www.rfc-editor.org/rfc/rfc8707
+* RFC 9700 (OAuth Security BCP, Jan 2025):
+  https://datatracker.ietf.org/doc/rfc9700/
+* authlib AsyncOAuth2Client:
+  https://docs.authlib.org/en/latest/client/httpx.html
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Any, Final
+
+import httpx
+import structlog
+from authlib.common.security import generate_token
+from authlib.integrations.httpx_client import AsyncOAuth2Client
+
+from meho_backplane.settings import Settings, get_settings
+from meho_backplane.ui.auth.verifier_store import (
+    AUTHORIZATION_FLOW_TTL_SECONDS,
+    PendingFlow,
+    PKCEVerifierStore,
+    get_verifier_store,
+    reset_verifier_store_for_testing,
+)
+
+__all__ = [
+    "AUTHORIZATION_FLOW_TTL_SECONDS",
+    "MISSING_CLIENT_SECRET_DETAIL",
+    "OAuthFlowConfigurationError",
+    "OAuthFlowError",
+    "OIDCEndpoints",
+    "PKCEVerifierStore",
+    "TokenExchangeResult",
+    "build_authorization_request",
+    "clear_discovery_cache",
+    "exchange_code_for_tokens",
+    "get_verifier_store",
+    "reset_verifier_store_for_testing",
+    "resolve_oidc_endpoints",
+]
+
+
+#: HTTP timeout for the OIDC discovery hit. Mirrors
+#: :mod:`meho_backplane.auth.jwt`'s ``_HTTP_TIMEOUT_SECONDS`` -- a hung
+#: Keycloak should fail-closed quickly rather than starving request
+#: capacity. The same value applies on the token-endpoint POST that
+#: :class:`AsyncOAuth2Client` issues from :func:`exchange_code_for_tokens`.
+_HTTP_TIMEOUT_SECONDS: float = 5.0
+
+#: Detail token surfaced when :attr:`Settings.ui_keycloak_client_secret`
+#: is unset and the flow would otherwise silently send an empty
+#: ``client_secret`` on the token-endpoint POST (which Keycloak rejects
+#: as ``invalid_client`` -- a confusing error if the operator does not
+#: realise the secret was never rendered into the pod environment).
+MISSING_CLIENT_SECRET_DETAIL: Final[str] = (
+    "ui_oauth_not_configured: UI_KEYCLOAK_CLIENT_ID / "
+    "UI_KEYCLOAK_CLIENT_SECRET are unset. Render the confidential "
+    "client credentials from Vault per "
+    "docs/cross-repo/keycloak-web-client.md before serving /ui/auth/*."
+)
+
+
+class OAuthFlowError(Exception):
+    """Base class for BFF OAuth-flow failures.
+
+    Catch this when a single error-response shape is acceptable;
+    subclasses carry the specific intent.
+    """
+
+
+class OAuthFlowConfigurationError(OAuthFlowError):
+    """The BFF OAuth client is not configured.
+
+    Raised at the top of :func:`build_authorization_request` and
+    :func:`exchange_code_for_tokens` when
+    :attr:`Settings.ui_keycloak_client_id` or
+    :attr:`Settings.ui_keycloak_client_secret` is empty. The route
+    handler maps this into an operator-facing 503 with the
+    :data:`MISSING_CLIENT_SECRET_DETAIL` remediation.
+    """
+
+
+@dataclass(frozen=True)
+class OIDCEndpoints:
+    """Subset of the OIDC discovery document the BFF consumes.
+
+    Decoupled from :class:`Settings` because the discovery doc is the
+    realm's contract on which URLs the BFF posts to -- the operator
+    cannot override these without breaking the IdP round-trip. Resolved
+    at runtime by :func:`resolve_oidc_endpoints` and cached on a TTL.
+    """
+
+    issuer: str
+    authorization_endpoint: str
+    token_endpoint: str
+    end_session_endpoint: str | None
+
+
+@dataclass(frozen=True)
+class TokenExchangeResult:
+    """Outcome of a successful authorization-code exchange.
+
+    Frozen because callers stash the access + refresh tokens in the
+    encrypted session row and pass nothing else along; mutability is
+    a footgun (a downstream caller mutating the access token in-place
+    would silently desynchronise from the ciphertext in storage).
+    """
+
+    access_token: str
+    refresh_token: str
+    expires_in: int
+    return_to: str
+
+
+# ---------------------------------------------------------------------------
+# OIDC discovery
+# ---------------------------------------------------------------------------
+
+
+#: Module-level discovery cache. Mirrors the shape of
+#: :mod:`meho_backplane.auth.jwt`'s JWKS cache so the two surfaces
+#: stay grep-compatible. The TTL borrows
+#: :attr:`Settings.keycloak_jwks_cache_ttl_seconds` -- one operator
+#: knob governs "how often do we hit Keycloak's metadata".
+_discovery_cache: OIDCEndpoints | None = None
+_discovery_fetched_at: float = 0.0
+_discovery_lock: asyncio.Lock = asyncio.Lock()
+
+
+def clear_discovery_cache() -> None:
+    """Invalidate the discovery cache. Test-only -- never call from production."""
+    global _discovery_cache, _discovery_fetched_at
+    _discovery_cache = None
+    _discovery_fetched_at = 0.0
+
+
+async def _fetch_discovery_doc(settings: Settings) -> OIDCEndpoints:
+    """Fetch ``/.well-known/openid-configuration`` and project the BFF subset.
+
+    Network failures (DNS, TLS, read timeout, non-2xx) propagate as
+    :class:`httpx.HTTPError` -- the same error class
+    :mod:`meho_backplane.auth.jwt` raises on its own discovery hit, so
+    the operator-facing 502 mapping in the routes module is one shape.
+    """
+    issuer = str(settings.keycloak_issuer_url).rstrip("/")
+    discovery_url = f"{issuer}/.well-known/openid-configuration"
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as client:
+        response = await client.get(discovery_url)
+        response.raise_for_status()
+        doc: Any = response.json()
+    if not isinstance(doc, dict):
+        raise httpx.HTTPError(
+            f"expected JSON object from {discovery_url}, got {type(doc).__name__}"
+        )
+    authz = doc.get("authorization_endpoint")
+    token = doc.get("token_endpoint")
+    if not isinstance(authz, str) or not authz:
+        raise httpx.HTTPError(f"discovery doc at {discovery_url} missing 'authorization_endpoint'")
+    if not isinstance(token, str) or not token:
+        raise httpx.HTTPError(f"discovery doc at {discovery_url} missing 'token_endpoint'")
+    raw_end_session = doc.get("end_session_endpoint")
+    end_session = raw_end_session if isinstance(raw_end_session, str) and raw_end_session else None
+    return OIDCEndpoints(
+        issuer=issuer,
+        authorization_endpoint=authz,
+        token_endpoint=token,
+        end_session_endpoint=end_session,
+    )
+
+
+async def resolve_oidc_endpoints() -> OIDCEndpoints:
+    """Return the cached :class:`OIDCEndpoints`, fetching on cache miss.
+
+    The cache TTL is the same one
+    :attr:`Settings.keycloak_jwks_cache_ttl_seconds` governs -- the
+    discovery doc and the JWKS doc rotate on similar cadences, and
+    pinning both surfaces to one operator-tunable knob keeps the
+    operational story uniform.
+    """
+    global _discovery_cache, _discovery_fetched_at
+    settings = get_settings()
+    ttl = settings.keycloak_jwks_cache_ttl_seconds
+    if _discovery_cache is not None and (time.monotonic() - _discovery_fetched_at) < ttl:
+        return _discovery_cache
+    async with _discovery_lock:
+        if _discovery_cache is not None and (time.monotonic() - _discovery_fetched_at) < ttl:
+            return _discovery_cache
+        endpoints = await _fetch_discovery_doc(settings)
+        _discovery_cache = endpoints
+        _discovery_fetched_at = time.monotonic()
+        return endpoints
+
+
+# ---------------------------------------------------------------------------
+# Authorization request + token exchange
+# ---------------------------------------------------------------------------
+
+
+def _ensure_client_configured(settings: Settings) -> None:
+    """Raise :class:`OAuthFlowConfigurationError` when OAuth knobs are unset.
+
+    Defence-in-depth check: the route layer also surfaces an early
+    503 with the same detail, but this guard makes the failure
+    deterministic even when the route is reached by a path that
+    bypasses the early check (a future seam, a test that mounts the
+    APIRouter directly without lifespan startup, etc.).
+    """
+    if not settings.ui_keycloak_client_id or not settings.ui_keycloak_client_secret:
+        raise OAuthFlowConfigurationError(MISSING_CLIENT_SECRET_DETAIL)
+
+
+def _build_oauth_client(settings: Settings, *, redirect_uri: str) -> AsyncOAuth2Client:
+    """Construct a fresh :class:`AsyncOAuth2Client` bound to the BFF client.
+
+    A new instance per call: authlib's client carries per-flow state
+    on the instance, so reusing one across concurrent flows would
+    cross-contaminate. Construction is cheap.
+
+    ``scope='openid profile email'`` is the standard OIDC set that
+    yields ``sub`` / ``name`` / ``email`` / tenant claims on the
+    access token.
+
+    ``code_challenge_method='S256'`` is the only acceptable method;
+    OAuth 2.1 forbids plain.
+
+    The token-endpoint auth method defaults to
+    ``client_secret_basic`` (the authlib default when a secret is
+    supplied) -- carries the credentials in the ``Authorization``
+    header. Keycloak accepts both this and ``client_secret_post``.
+    """
+    return AsyncOAuth2Client(
+        client_id=settings.ui_keycloak_client_id,
+        client_secret=settings.ui_keycloak_client_secret,
+        redirect_uri=redirect_uri,
+        scope="openid profile email",
+        code_challenge_method="S256",
+        timeout=_HTTP_TIMEOUT_SECONDS,
+    )
+
+
+def _resource_indicator(settings: Settings) -> str:
+    """Derive the RFC 8707 ``resource`` parameter from ``Settings.backplane_url``.
+
+    Per work-item #2 on Initiative #337, the BFF requests a token
+    bound to ``<backplane_url>/api`` -- the chassis API surface,
+    distinct from the MCP-bound resource URI
+    (:attr:`Settings.mcp_resource_uri`). Treating the two as separate
+    audiences keeps an MCP-bound token from being accepted on a
+    ``/api/v1/*`` request and vice versa.
+
+    Falls back to an empty string when :attr:`Settings.backplane_url`
+    is unset; authlib forwards the parameter verbatim and Keycloak
+    silently ignores an empty value.
+    """
+    base = settings.backplane_url.rstrip("/")
+    return f"{base}/api" if base else ""
+
+
+async def build_authorization_request(
+    *,
+    redirect_uri: str,
+    return_to: str,
+) -> tuple[str, str]:
+    """Mint a PKCE-protected authorization URL and register the verifier.
+
+    Returns ``(authorization_url, state)``. The route handler 302s the
+    browser at *authorization_url* and stores nothing client-side --
+    the verifier (and the originally-requested *return_to* URL) live
+    in :class:`PKCEVerifierStore`, keyed on the returned *state*.
+
+    Parameters
+    ----------
+    redirect_uri
+        Absolute URL the IdP redirects back to on completion. Must
+        exactly match the redirect URI registered on the ``meho-web``
+        Keycloak client (Keycloak enforces exact-match on the
+        callback per OAuth 2.1).
+    return_to
+        The path the operator was trying to reach when the middleware
+        redirected them to login. Stored alongside the verifier so
+        the callback handler can finish the round-trip cleanly.
+
+    Raises
+    ------
+    OAuthFlowConfigurationError
+        :attr:`Settings.ui_keycloak_client_id` /
+        :attr:`Settings.ui_keycloak_client_secret` are unset.
+    """
+    settings = get_settings()
+    _ensure_client_configured(settings)
+    endpoints = await resolve_oidc_endpoints()
+    # PKCE verifier: authlib's :func:`generate_token` is an RFC-7636-
+    # compliant URL-safe random string. Length 48 yields ~64 chars of
+    # base64 -- comfortably above the spec's 43-128 char floor.
+    code_verifier = generate_token(48)
+    resource = _resource_indicator(settings)
+    async with _build_oauth_client(settings, redirect_uri=redirect_uri) as client:
+        url, state = client.create_authorization_url(
+            endpoints.authorization_endpoint,
+            code_verifier=code_verifier,
+            resource=resource,
+        )
+    await get_verifier_store().put(state, code_verifier=code_verifier, return_to=return_to)
+    return url, state
+
+
+async def _post_to_token_endpoint(
+    settings: Settings,
+    endpoints: OIDCEndpoints,
+    *,
+    redirect_uri: str,
+    authorization_response: str,
+    state: str,
+    pending: PendingFlow,
+) -> dict[str, Any]:
+    """Make the token-endpoint POST and return the raw token dict.
+
+    Extracted from :func:`exchange_code_for_tokens` to keep the public
+    entry-point under the 100-line code-quality cap. Encapsulates the
+    one authlib seam that actually issues the HTTP call.
+    """
+    async with _build_oauth_client(settings, redirect_uri=redirect_uri) as client:
+        # ``state`` is passed explicitly so authlib enforces the
+        # CSRF cross-check against the response, not just the stored
+        # client.state attribute. Mismatch raises authlib's own
+        # ``MismatchingStateError``.
+        token: Any = await client.fetch_token(
+            endpoints.token_endpoint,
+            authorization_response=authorization_response,
+            code_verifier=pending.code_verifier,
+            state=state,
+            resource=_resource_indicator(settings),
+        )
+    if not isinstance(token, dict):
+        raise OAuthFlowError("token_response_unexpected_shape")
+    return token
+
+
+def _project_token_response(token: dict[str, Any], return_to: str) -> TokenExchangeResult:
+    """Validate the token-endpoint response and project it into the dataclass.
+
+    Token endpoints are not infallible -- a Keycloak with
+    offline_access disabled may omit ``refresh_token``, an upstream
+    proxy may strip ``expires_in``. Each surface is mapped to a
+    structured error so the route handler can render a stable
+    operator-facing shape.
+
+    Raises
+    ------
+    OAuthFlowError
+        Token response missing ``access_token`` or ``refresh_token``.
+        Missing ``expires_in`` is non-fatal -- defaults to 3600.
+    """
+    access = token.get("access_token")
+    refresh = token.get("refresh_token")
+    expires_in = token.get("expires_in")
+    if not isinstance(access, str) or not access:
+        raise OAuthFlowError("token_response_missing_access_token")
+    if not isinstance(refresh, str) or not refresh:
+        # Keycloak with offline_access disabled may omit refresh_token.
+        # The BFF deliberately rejects that shape -- without a refresh
+        # token the session cannot survive access-token expiry.
+        raise OAuthFlowError("token_response_missing_refresh_token")
+    # ``expires_in`` is an RFC 6749 §4.2.2 OPTIONAL field; default to
+    # one hour when absent so the session lifetime calculation still
+    # produces a sensible value.
+    if not isinstance(expires_in, int) or expires_in <= 0:
+        expires_in = 3600
+    return TokenExchangeResult(
+        access_token=access,
+        refresh_token=refresh,
+        expires_in=expires_in,
+        return_to=return_to,
+    )
+
+
+async def exchange_code_for_tokens(
+    *,
+    redirect_uri: str,
+    authorization_response: str,
+    state: str | None,
+) -> TokenExchangeResult:
+    """Exchange the callback's ``code`` + stored ``code_verifier`` for tokens.
+
+    Parameters
+    ----------
+    redirect_uri
+        Same value passed to :func:`build_authorization_request`. The
+        token endpoint cross-checks this against the redirect URI
+        registered on the ``meho-web`` client.
+    authorization_response
+        Full callback URL including query string. authlib parses
+        ``code``, ``state``, and any ``error`` query parameter out of
+        this value.
+    state
+        Optional explicit ``state`` value. When passed, authlib
+        cross-checks the response's ``state`` against this value and
+        raises :class:`MismatchingStateError` on mismatch -- the
+        belt-and-braces CSRF guard.
+
+    Returns
+    -------
+    TokenExchangeResult
+        Access + refresh tokens, expiry (seconds), and the
+        ``return_to`` URL the original login flow stashed.
+
+    Raises
+    ------
+    OAuthFlowConfigurationError
+        Client knobs are unset.
+    OAuthFlowError
+        ``state`` is unknown / expired / the response is malformed.
+    httpx.HTTPError
+        Network failure on the token-endpoint POST.
+    """
+    settings = get_settings()
+    _ensure_client_configured(settings)
+    endpoints = await resolve_oidc_endpoints()
+    if state is None:
+        # No state means we cannot recover the verifier even if the
+        # IdP echoed code+state back. Fail-closed.
+        raise OAuthFlowError("missing_state")
+    pending = await get_verifier_store().pop(state)
+    if pending is None:
+        raise OAuthFlowError("unknown_or_expired_state")
+    token = await _post_to_token_endpoint(
+        settings,
+        endpoints,
+        redirect_uri=redirect_uri,
+        authorization_response=authorization_response,
+        state=state,
+        pending=pending,
+    )
+    result = _project_token_response(token, pending.return_to)
+    log = structlog.get_logger(__name__)
+    # Deliberately log NO token material -- only structural facts about
+    # the exchange. The state is the per-flow CSRF token, not a
+    # credential; safe to surface for correlation.
+    log.info(
+        "ui_auth_token_exchange_succeeded",
+        state=state,
+        expires_in=result.expires_in,
+    )
+    return result

--- a/backend/src/meho_backplane/ui/auth/middleware.py
+++ b/backend/src/meho_backplane/ui/auth/middleware.py
@@ -1,0 +1,340 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""BFF session middleware -- load operator identity from the cookie.
+
+Initiative #337 (G10.0 Frontend chassis), Task #865 (T4). This module
+ships :class:`UISessionMiddleware` -- the pure-ASGI middleware T5
+(#866) registers on the FastAPI app **before** the existing
+JWT/audit middlewares for ``/ui/*`` paths.
+
+Responsibilities
+----------------
+
+For every request whose path starts with ``/ui/`` (except the BFF
+auth surfaces themselves -- those routes set or clear the cookie and
+must be reachable unauthenticated):
+
+1. Read ``meho_session`` cookie.
+2. Parse it as a UUID -- malformed values are treated as "no
+   session" (no exception leaks; the operator just gets bounced to
+   login).
+3. Call :func:`meho_backplane.ui.auth.session_store.load_session` to
+   load + decrypt the row. ``None`` means missing / revoked /
+   expired -- all three collapse to "no session".
+4. On hit, bind ``operator_sub`` / ``tenant_id`` into the
+   :class:`UISessionContext` attached to ``request.state``. Route
+   handlers (T5 surfaces) read it via the :func:`require_ui_session`
+   dependency to render operator-scoped views.
+5. On miss, 302-redirect to ``/ui/auth/login?return_to=<original
+   path>`` so the operator lands back on the deep link after auth.
+
+Static assets bypass
+--------------------
+
+The chassis (#863) mounts ``/ui/static/*`` for vendored JS + the
+compiled Tailwind CSS. Those resources must NOT redirect to login
+because (a) the browser would follow the redirect and load the login
+page HTML in place of a CSS / JS file, breaking the rendered page,
+and (b) the asset paths are deliberately reachable unauthenticated
+so the operator sees a styled login surface rather than an unstyled
+default-browser-render. The middleware short-circuits on the
+``/ui/static/`` prefix.
+
+Pure ASGI, not :class:`BaseHTTPMiddleware`
+------------------------------------------
+
+Mirrors the pattern in :mod:`meho_backplane.middleware`'s
+:class:`RequestContextMiddleware`: Starlette 1.0+ docs recommend
+pure ASGI for any middleware that needs deterministic contextvar
+lifetimes or that touches the response start (the cookie set, or
+the 302 location). BaseHTTPMiddleware spawns an anyio task wrapper
+that has complicated streaming + contextvar interactions; the
+ASGI-level pattern below is the canonical "wrap send" recipe.
+
+Why no session refresh here
+---------------------------
+
+T5 (#866) will register a separate path that performs the
+RFC-9700-compliant refresh-token rotation when the access token is
+about to expire. Doing the refresh inside the middleware would
+require the middleware to know which surface needs the access
+token (most ``/ui/*`` page renders do not), and would inflate the
+hot path's DB cost. The session-store layer landed the rotation
+primitive in :func:`session_store.rotate_refresh`; the middleware
+only loads + validates the existing session row.
+
+References
+----------
+
+* OAuth 2.0 for Browser-Based Apps BCP § 6.1 (BFF pattern):
+  https://datatracker.ietf.org/doc/draft-ietf-oauth-browser-based-apps/
+* OWASP ASVS v4 §3.3.1 (session-cookie attributes):
+  https://owasp.org/www-project-application-security-verification-standard/
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Final, cast
+from urllib.parse import quote
+
+import structlog
+from fastapi import HTTPException, Request, status
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.ui.auth.routes import LOGIN_PATH, SESSION_COOKIE_NAME
+from meho_backplane.ui.auth.session_store import load_session
+
+__all__ = [
+    "AUTH_PREFIX",
+    "STATIC_PREFIX",
+    "UISessionContext",
+    "UISessionMiddleware",
+    "require_ui_session",
+]
+
+
+#: Prefix every UI route lives under. Requests outside the prefix
+#: pass through untouched; requests inside are subject to the
+#: session check unless they match :data:`AUTH_PREFIX` or
+#: :data:`STATIC_PREFIX`.
+_UI_PREFIX: Final[str] = "/ui/"
+#: Prefix the BFF auth surfaces live under (login, callback, logout).
+#: The middleware MUST let unauthenticated requests reach these so
+#: the operator can complete the round-trip. Exact-match on ``/ui/auth``
+#: is too narrow (``/ui/auth/login`` is the actual route).
+AUTH_PREFIX: Final[str] = "/ui/auth/"
+#: Prefix the chassis static-asset mount lives under (#863). The
+#: middleware short-circuits on this prefix so vendored JS / compiled
+#: CSS load without authentication -- otherwise the operator would
+#: see an unstyled login page when their session expires.
+STATIC_PREFIX: Final[str] = "/ui/static/"
+
+
+@dataclass(frozen=True)
+class UISessionContext:
+    """Per-request session identity exposed on ``request.state``.
+
+    Frozen so a route handler that stashes the context on a logger
+    or forwards it to a service layer cannot accidentally mutate
+    fields downstream. The shape mirrors :class:`Operator` for the
+    fields T5 (#866) needs to render an authenticated page header;
+    ``raw_jwt`` / ``tenant_role`` are intentionally absent because
+    the session-cookie path does not load them today (the encrypted
+    row carries only the access token, not the decoded claims).
+    """
+
+    session_id: uuid.UUID
+    operator_sub: str
+    tenant_id: uuid.UUID
+
+
+def _select_path(scope: Scope) -> str:
+    """Return the ASGI scope's path, defaulting to ``/`` on missing values."""
+    raw = scope.get("path")
+    return raw if isinstance(raw, str) and raw else "/"
+
+
+def _extract_session_cookie(scope: Scope) -> str | None:
+    """Pull the ``meho_session`` cookie value out of the raw headers.
+
+    Avoids the cost of constructing a :class:`Request` object for the
+    happy-path of "no cookie, redirect to login". The cookie header
+    is iterated once; allocation stays in raw bytes until the cookie
+    is found.
+    """
+    headers = scope.get("headers")
+    if not isinstance(headers, list):
+        return None
+    cookie_name_bytes = SESSION_COOKIE_NAME.encode("ascii")
+    for name, value in headers:
+        if not isinstance(name, (bytes, bytearray)) or name != b"cookie":
+            continue
+        if not isinstance(value, (bytes, bytearray)):
+            continue
+        # The cookie header is ``name1=value1; name2=value2; ...``.
+        # We decode lazily on the match -- non-meho cookies stay as
+        # bytes.
+        value_bytes = bytes(value)
+        for chunk in value_bytes.split(b";"):
+            chunk = chunk.strip()
+            if not chunk:
+                continue
+            if b"=" not in chunk:
+                continue
+            cookie_name, _, cookie_value = chunk.partition(b"=")
+            if cookie_name.strip() == cookie_name_bytes:
+                try:
+                    return cookie_value.decode("ascii")
+                except UnicodeDecodeError:
+                    return None
+    return None
+
+
+def _redirect_to_login(original_path_with_query: str) -> tuple[int, list[tuple[bytes, bytes]]]:
+    """Build the ASGI ``http.response.start`` shape for the login redirect.
+
+    Returns the status code + the encoded headers list. Constructing
+    the response by hand (rather than letting Starlette synthesise a
+    :class:`RedirectResponse`) keeps the middleware single-allocation
+    on the redirect path -- the body is empty.
+
+    The ``return_to`` query value is the original path with its query
+    string, URL-encoded so an operator-supplied target with reserved
+    characters round-trips cleanly. The login route's
+    :func:`_safe_return_to` validates the decoded value before it
+    lands in any subsequent redirect.
+    """
+    encoded = quote(original_path_with_query, safe="")
+    location = f"{LOGIN_PATH}?return_to={encoded}"
+    return status.HTTP_302_FOUND, [
+        (b"location", location.encode("ascii")),
+        (b"cache-control", b"no-store"),
+        (b"content-length", b"0"),
+    ]
+
+
+class UISessionMiddleware:
+    """Pure-ASGI middleware: load operator identity from the session cookie.
+
+    Constructed once at app startup and bound onto the FastAPI app
+    via :meth:`FastAPI.add_middleware` in T5 (#866). Per-request
+    state is held in the call's local scope; the class itself is
+    stateless.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        # Non-HTTP scopes (websocket, lifespan) pass through. The BFF
+        # has no websocket surface in v0.2 and the lifespan must not
+        # be intercepted.
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = _select_path(scope)
+        # Out-of-prefix paths pass through unchanged -- the middleware
+        # is /ui/-only by deliberate scoping. The chassis JWT
+        # middleware handles /api/* and /mcp.
+        if not path.startswith(_UI_PREFIX):
+            await self.app(scope, receive, send)
+            return
+
+        # Static asset paths bypass auth -- the operator sees a
+        # styled login page rather than an unstyled default render.
+        if path.startswith(STATIC_PREFIX):
+            await self.app(scope, receive, send)
+            return
+
+        # The BFF auth surfaces themselves -- login, callback,
+        # logout -- must be reachable without a session.
+        if path.startswith(AUTH_PREFIX):
+            await self.app(scope, receive, send)
+            return
+
+        # Look the session up. Any failure mode (no cookie, malformed
+        # UUID, missing row, revoked, expired) collapses to "redirect
+        # to login".
+        log = structlog.get_logger(__name__)
+        cookie_value = _extract_session_cookie(scope)
+        session_context: UISessionContext | None = None
+        if cookie_value is not None:
+            try:
+                cookie_id = uuid.UUID(cookie_value)
+            except ValueError:
+                log.info("ui_session_malformed_cookie", path=path)
+                cookie_id = None
+            if cookie_id is not None:
+                sessionmaker = get_sessionmaker()
+                async with sessionmaker() as session, session.begin():
+                    decrypted = await load_session(session, cookie_id)
+                if decrypted is not None:
+                    session_context = UISessionContext(
+                        session_id=decrypted.id,
+                        operator_sub=decrypted.operator_sub,
+                        tenant_id=decrypted.tenant_id,
+                    )
+
+        if session_context is None:
+            # Build the original-path-with-query for the post-login
+            # round-trip. ``raw_path`` is bytes; ``query_string`` is
+            # also bytes. Decode both as ASCII -- URLs are ASCII by
+            # protocol; non-ASCII bytes would have been percent-encoded
+            # already.
+            query_string_raw = scope.get("query_string")
+            query_string = (
+                query_string_raw.decode("ascii")
+                if isinstance(query_string_raw, (bytes, bytearray))
+                else ""
+            )
+            full_path = f"{path}?{query_string}" if query_string else path
+            status_code, headers = _redirect_to_login(full_path)
+            log.info(
+                "ui_session_missing_or_invalid",
+                path=path,
+                had_cookie=cookie_value is not None,
+            )
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": status_code,
+                    "headers": headers,
+                }
+            )
+            await send({"type": "http.response.body", "body": b"", "more_body": False})
+            return
+
+        # Happy path -- stash the session context on the scope so
+        # downstream consumers (FastAPI dependency wrappers) can
+        # reach it via ``request.state.ui_session``. ``scope["state"]``
+        # is a Starlette convention for per-request state passed
+        # between middlewares.
+        scope_state = scope.setdefault("state", {})
+        if isinstance(scope_state, dict):
+            scope_state["ui_session"] = session_context
+
+        await self.app(scope, receive, send)
+
+
+def require_ui_session(request: Request) -> UISessionContext:
+    """FastAPI dependency: surface the loaded :class:`UISessionContext`.
+
+    Route handlers under ``/ui/*`` (T5 #866) declare
+    ``Depends(require_ui_session)`` instead of reaching into
+    ``request.state`` directly. The middleware enforces the redirect
+    on missing sessions; this dependency is the guarded read.
+
+    Returns
+    -------
+    UISessionContext
+        The validated identity bound by the middleware.
+
+    Raises
+    ------
+    HTTPException(401)
+        The middleware short-circuited the request *before* this
+        dependency could run -- which means a route handler escaped
+        the redirect logic (a misconfiguration). The 401 is a hard
+        bug signal, not a normal flow.
+    """
+    context = getattr(request.state, "ui_session", None)
+    if context is None:
+        # The middleware guarantees a session is bound before any
+        # /ui/ route runs; reaching this branch means a route was
+        # registered without the middleware in front. Surface as a
+        # 401 so the operator's browser does not silently render a
+        # half-broken page.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="ui_session_required",
+        )
+    # The middleware only binds ``UISessionContext`` instances onto
+    # ``scope["state"]["ui_session"]``; the ``cast`` narrows the
+    # ``getattr`` return so the dependency's typed return survives
+    # the dynamic attribute access.
+    return cast(UISessionContext, context)

--- a/backend/src/meho_backplane/ui/auth/routes.py
+++ b/backend/src/meho_backplane/ui/auth/routes.py
@@ -1,0 +1,517 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""BFF auth routes -- ``/ui/auth/{login,callback,logout}``.
+
+Initiative #337 (G10.0 Frontend chassis), Task #865 (T4). This module
+ships the FastAPI :class:`APIRouter` that handles the three BFF
+auth surfaces:
+
+* ``GET /ui/auth/login`` -- builds the PKCE-protected authorization
+  URL and 302s the browser to Keycloak. The original
+  ``?return_to=<path>`` query parameter (default ``/ui/``) is
+  smuggled through the IdP round-trip via the PKCE verifier store
+  keyed on ``state`` -- it never appears on the URL the IdP sees, so
+  there is no open-redirect surface to harden.
+
+* ``GET /ui/auth/callback`` -- Keycloak's exact-match redirect target.
+  Verifies the ``state`` against the PKCE verifier store, exchanges
+  ``code`` + ``code_verifier`` for access + refresh tokens at the
+  token endpoint, validates the access token through the chassis
+  JWT chain (so the BFF inherits the same issuer / audience /
+  ``tenant_id`` / ``tenant_role`` defences as ``/api/*``), creates a
+  server-side session row, sets the ``meho_session`` cookie
+  (``HttpOnly; Secure; SameSite=Strict; Path=/``), and 302s to the
+  originally-requested page.
+
+* ``GET /ui/auth/logout`` -- revokes the session row, clears the
+  ``meho_session`` cookie, and 302s to Keycloak's end-session
+  endpoint. The IdP-side logout is best-effort: if the discovery doc
+  does not advertise an ``end_session_endpoint`` (a pre-OIDC-Session-
+  Management Keycloak release, hypothetically), the route still
+  drops the cookie and redirects to ``/ui/auth/login`` locally.
+
+This module imports but **does not** register itself onto
+:func:`meho_backplane.main.app` -- T5 (#866) wires the router onto
+the FastAPI app and decides the mount prefix. The route paths below
+are relative to ``/ui/auth`` so the mount in T5 lands the public
+surface at the documented URLs.
+
+Cookie attributes
+-----------------
+
+The session cookie is the only piece of user-controllable state the
+browser holds. Its attributes are non-negotiable per the BFF threat
+model (decision #11 in :file:`docs/planning/v0.2-decisions.md`):
+
+* ``HttpOnly`` -- JS cannot read the cookie. Defeats every
+  XSS-to-token exfiltration vector.
+* ``Secure`` -- TLS-only. The backplane terminates TLS at
+  ``meho.evba.lab``; a downgrade to HTTP would silently fail because
+  the cookie would not be sent.
+* ``SameSite=Strict`` -- the cookie is omitted from cross-site
+  navigations, blocking the entire CSRF class on state-changing
+  routes (T5's CSRF token is belt-and-braces against same-site
+  malicious sub-domains).
+* ``Path=/`` -- mounted at the root so the cookie covers ``/api``
+  fetches issued from the dashboard's HTMX surface as well as
+  ``/ui/*`` page navigations.
+* No ``Domain`` attribute -- defaults to the host-only cookie,
+  which is the safest shape. Setting ``Domain=`` would expand the
+  cookie to subdomains, which the deploy does not need.
+
+Security-sensitive log discipline
+---------------------------------
+
+Every log line in this module is reviewed for token / secret /
+verifier appearance. Permissible: ``state`` (per-flow CSRF token,
+not a credential), ``operator_sub`` (already in the JWT chain's log
+context), ``return_to`` (operator-supplied path, validated below).
+Forbidden: ``code``, ``code_verifier``, ``access_token``,
+``refresh_token``, the client secret. The :mod:`backend.tests.conftest`
+secret-leak sweep would catch any drift; the explicit care taken
+in this module is the first defence.
+
+References
+----------
+
+* RFC 6265bis (cookies):
+  https://datatracker.ietf.org/doc/draft-ietf-httpbis-rfc6265bis/
+* RFC 8707 (Resource Indicators):
+  https://www.rfc-editor.org/rfc/rfc8707
+* OIDC Session Management 1.0 (end_session_endpoint):
+  https://openid.net/specs/openid-connect-session-1_0.html
+* OAuth 2.0 for Browser-Based Apps BCP:
+  https://datatracker.ietf.org/doc/draft-ietf-oauth-browser-based-apps/
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from typing import Final
+from urllib.parse import urlencode
+
+import httpx
+import structlog
+from authlib.integrations.base_client.errors import (
+    MismatchingStateError,
+    OAuthError,
+)
+from fastapi import APIRouter, HTTPException, Request, status
+from fastapi.responses import RedirectResponse
+
+from meho_backplane.auth.jwt import verify_jwt_for_audience
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.settings import Settings, get_settings
+from meho_backplane.ui.auth.flow import (
+    MISSING_CLIENT_SECRET_DETAIL,
+    OAuthFlowConfigurationError,
+    OAuthFlowError,
+    TokenExchangeResult,
+    build_authorization_request,
+    exchange_code_for_tokens,
+    resolve_oidc_endpoints,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    revoke_session,
+)
+
+__all__ = [
+    "LOGIN_PATH",
+    "SESSION_COOKIE_NAME",
+    "build_router",
+    "compute_redirect_uri",
+    "set_session_cookie",
+]
+
+
+#: Path prefix mounted by T5 (#866) onto the FastAPI app. Kept as a
+#: module-level constant so the middleware (which builds the redirect
+#: URL when a session is missing) and the routes agree on the URL
+#: shape.
+LOGIN_PATH: Final[str] = "/ui/auth/login"
+_CALLBACK_PATH: Final[str] = "/ui/auth/callback"
+_LOGOUT_PATH: Final[str] = "/ui/auth/logout"
+
+#: Name of the BFF session cookie. The browser holds only this opaque
+#: value; the real tokens live encrypted in the ``web_session`` table.
+SESSION_COOKIE_NAME: Final[str] = "meho_session"
+
+#: Clock-skew margin trimmed off the access-token TTL when computing
+#: the session lifetime. Keeps the session from outliving the access
+#: token it represents -- if the token expires at T, the session
+#: expires no later than T - margin so a refresh round-trip can still
+#: succeed.
+_SESSION_TTL_MARGIN_SECONDS: Final[int] = 60
+
+#: Default landing path when no ``?return_to`` is supplied on
+#: ``/ui/auth/login``. T5 (#866) lands the dashboard at ``/ui/``.
+_DEFAULT_RETURN_TO: Final[str] = "/ui/"
+
+
+def compute_redirect_uri() -> str:
+    """Build the callback URL exact-match Keycloak enforces.
+
+    Derived at request time (not cached at import) so a test that
+    swaps :attr:`Settings.backplane_url` between cases sees the swap
+    take effect without a process restart. Production deploys pin the
+    URL via the env var; the redirect URI registered on the
+    ``meho-web`` Keycloak client must match this value exactly --
+    Keycloak rejects ``invalid_grant`` on the token endpoint
+    otherwise.
+    """
+    base = get_settings().backplane_url.rstrip("/")
+    return f"{base}{_CALLBACK_PATH}"
+
+
+def _safe_return_to(raw: str | None) -> str:
+    """Coerce *raw* into a safe local path or fall back to the default.
+
+    The login route accepts a ``?return_to=`` query parameter so an
+    unauthenticated request to a deep link can land there after
+    auth. The value is operator-supplied via the middleware redirect,
+    so it must be sanitised before it lands as a 302 ``Location``:
+
+    * Empty / absent → ``/ui/`` default.
+    * Absolute URLs (anything starting with a scheme or ``//``) →
+      ``/ui/`` default. Open-redirect guard -- a crafted phishing
+      link could otherwise bounce the operator to an attacker URL
+      after auth.
+    * Anything outside the ``/ui/`` subtree → ``/ui/`` default.
+      Keeps the post-login redirect inside the operator-console
+      surface; deep links into ``/api/*`` are not the BFF's job.
+
+    The trailing slash on the default matters: ``/ui`` would 308 to
+    ``/ui/``, doubling the round-trip.
+    """
+    if not raw:
+        return _DEFAULT_RETURN_TO
+    # Strip whitespace -- a stray newline from a misconstructed URL
+    # would otherwise smuggle past the prefix check.
+    candidate = raw.strip()
+    if not candidate:
+        return _DEFAULT_RETURN_TO
+    if candidate.startswith("//") or "://" in candidate:
+        return _DEFAULT_RETURN_TO
+    if not candidate.startswith("/ui/") and candidate != "/ui":
+        return _DEFAULT_RETURN_TO
+    return candidate
+
+
+def set_session_cookie(response: RedirectResponse, session_id: uuid.UUID) -> None:
+    """Attach the ``meho_session`` cookie to *response* with the BFF flags.
+
+    Centralised so every place the BFF sets the cookie (currently the
+    callback handler; logout uses :func:`clear_session_cookie`) emits
+    the exact same attributes. Drift between them is a security bug.
+    """
+    response.set_cookie(
+        key=SESSION_COOKIE_NAME,
+        value=str(session_id),
+        httponly=True,
+        secure=True,
+        samesite="strict",
+        path="/",
+        # ``max_age`` is deliberately omitted -- the cookie is a
+        # session cookie (no persistence across browser quits). The
+        # server-side row's ``expires_at`` is the actual TTL; a
+        # browser that hangs on to the cookie past expiry simply
+        # finds the session unloadable on next request and gets
+        # bounced to login.
+    )
+
+
+def _clear_session_cookie(response: RedirectResponse) -> None:
+    """Erase the ``meho_session`` cookie via the same attribute set.
+
+    Setting a cookie with the same name + ``Max-Age=0`` + ``Path=/``
+    expires it immediately on the browser. The other attributes must
+    match the original ``set_cookie`` call (``Secure``, ``HttpOnly``,
+    ``SameSite=Strict``) -- some user agents are picky about
+    attribute parity on overwrite, so matching them removes the
+    ambiguity.
+    """
+    response.delete_cookie(
+        key=SESSION_COOKIE_NAME,
+        path="/",
+        secure=True,
+        httponly=True,
+        samesite="strict",
+    )
+
+
+def _build_end_session_url(
+    end_session_endpoint: str,
+    *,
+    post_logout_redirect_uri: str,
+    client_id: str,
+) -> str:
+    """Construct the Keycloak end-session URL.
+
+    Keycloak's end-session endpoint accepts ``post_logout_redirect_uri``
+    + ``client_id`` to skip the confirmation page and land the
+    operator back on the BFF login URL. We deliberately do NOT send
+    ``id_token_hint`` -- it carries the operator's identity and would
+    require us to keep the ID token alongside the access/refresh
+    tokens (the chassis-locked decision #11 keeps only access +
+    refresh for refresh-rotation; the ID token has no further use
+    after the initial verify, and storing it just to drive a clean
+    logout is unwarranted).
+    """
+    query = urlencode(
+        {
+            "post_logout_redirect_uri": post_logout_redirect_uri,
+            "client_id": client_id,
+        }
+    )
+    separator = "&" if "?" in end_session_endpoint else "?"
+    return f"{end_session_endpoint}{separator}{query}"
+
+
+async def _handle_login(request: Request) -> RedirectResponse:
+    """Mint a PKCE authorization URL and 302 the browser to Keycloak.
+
+    ``?return_to=<path>`` is the originally-requested path the
+    operator was bounced from (the middleware writes it). Validated
+    via :func:`_safe_return_to` to block open-redirect abuse.
+    """
+    log = structlog.get_logger(__name__)
+    raw_return_to = request.query_params.get("return_to")
+    return_to = _safe_return_to(raw_return_to)
+    try:
+        url, state = await build_authorization_request(
+            redirect_uri=compute_redirect_uri(),
+            return_to=return_to,
+        )
+    except OAuthFlowConfigurationError:
+        log.warning("ui_auth_oauth_not_configured", route="login")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=MISSING_CLIENT_SECRET_DETAIL,
+        ) from None
+    except httpx.HTTPError as exc:
+        log.warning(
+            "ui_auth_discovery_failed",
+            route="login",
+            error_class=type(exc).__name__,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="upstream_auth_provider_unreachable",
+        ) from exc
+    log.info("ui_auth_login_redirect", state=state, return_to=return_to)
+    return RedirectResponse(url=url, status_code=status.HTTP_302_FOUND)
+
+
+def _raise_idp_error(idp_error: str, idp_error_description: str | None) -> None:
+    """Translate an IdP-emitted ``?error=...`` callback into a 400."""
+    log = structlog.get_logger(__name__)
+    log.warning(
+        "ui_auth_callback_idp_error",
+        idp_error=idp_error,
+        idp_error_description=idp_error_description,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="authorization_failed",
+    )
+
+
+async def _exchange_or_translate(
+    *,
+    state: str | None,
+    authorization_response: str,
+) -> TokenExchangeResult:
+    """Run the token exchange and map every error class to an HTTPException.
+
+    Encapsulates the chain of authlib / verifier-store / network
+    failures the callback can hit so the calling handler stays under
+    the 100-line code-quality cap. The token-side log discipline
+    (don't surface specific failure causes in the response body, only
+    in structlog) lives here.
+    """
+    log = structlog.get_logger(__name__)
+    try:
+        return await exchange_code_for_tokens(
+            redirect_uri=compute_redirect_uri(),
+            authorization_response=authorization_response,
+            state=state,
+        )
+    except OAuthFlowConfigurationError:
+        log.warning("ui_auth_oauth_not_configured", route="callback")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=MISSING_CLIENT_SECRET_DETAIL,
+        ) from None
+    except (OAuthFlowError, MismatchingStateError, OAuthError) as exc:
+        # State mismatch / verifier-store miss / IdP-side rejection
+        # all collapse to one 400. The specific cause goes to
+        # structlog only -- telegraphing it in the body helps an
+        # attacker probe.
+        log.warning(
+            "ui_auth_callback_rejected",
+            error_class=type(exc).__name__,
+            state=state,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="authorization_failed",
+        ) from exc
+    except httpx.HTTPError as exc:
+        log.warning(
+            "ui_auth_token_endpoint_unreachable",
+            error_class=type(exc).__name__,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="upstream_auth_provider_unreachable",
+        ) from exc
+
+
+async def _persist_session_from_tokens(
+    tokens: TokenExchangeResult,
+) -> tuple[uuid.UUID, str, uuid.UUID]:
+    """Validate the access token + write the encrypted session row.
+
+    Returns ``(session_id, operator_sub, tenant_id)`` -- the values
+    the calling handler needs to log + redirect, without holding the
+    plaintext tokens any longer than necessary.
+    """
+    settings = get_settings()
+    # Validate the access token through the chassis JWT chain so the
+    # BFF inherits the same issuer / audience / sub / tenant_id /
+    # tenant_role checks ``/api/*`` already enforces.
+    operator = await verify_jwt_for_audience(
+        f"Bearer {tokens.access_token}",
+        expected_audience=settings.keycloak_audience,
+    )
+    lifetime = timedelta(seconds=max(tokens.expires_in - _SESSION_TTL_MARGIN_SECONDS, 60))
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        decrypted = await create_session(
+            session,
+            operator_sub=operator.sub,
+            tenant_id=operator.tenant_id,
+            access_token=tokens.access_token,
+            refresh_token=tokens.refresh_token,
+            lifetime=lifetime,
+        )
+    return decrypted.id, operator.sub, operator.tenant_id
+
+
+async def _handle_callback(request: Request) -> RedirectResponse:
+    """Finish the OAuth round-trip, create the session, set the cookie."""
+    log = structlog.get_logger(__name__)
+    idp_error = request.query_params.get("error")
+    if idp_error:
+        _raise_idp_error(idp_error, request.query_params.get("error_description"))
+    state = request.query_params.get("state")
+    # ``str(request.url)`` carries the full callback URL with query
+    # string -- authlib's :meth:`fetch_token` parses ``code`` and
+    # ``state`` out of it.
+    tokens = await _exchange_or_translate(
+        state=state,
+        authorization_response=str(request.url),
+    )
+    session_id, operator_sub, tenant_id = await _persist_session_from_tokens(tokens)
+    log.info(
+        "ui_auth_session_created",
+        operator_sub=operator_sub,
+        tenant_id=str(tenant_id),
+        return_to=tokens.return_to,
+        session_id=str(session_id),
+    )
+    response = RedirectResponse(
+        url=tokens.return_to or _DEFAULT_RETURN_TO,
+        status_code=status.HTTP_302_FOUND,
+    )
+    set_session_cookie(response, session_id)
+    return response
+
+
+async def _revoke_session_if_present(cookie_value: str | None) -> None:
+    """Revoke the session row identified by *cookie_value*.
+
+    No-op when the cookie is absent or malformed; the calling handler
+    still 302s the operator at Keycloak so a half-stuck client can
+    recover.
+    """
+    if not cookie_value:
+        return
+    log = structlog.get_logger(__name__)
+    try:
+        cookie_id = uuid.UUID(cookie_value)
+    except ValueError:
+        log.info("ui_auth_logout_malformed_cookie")
+        return
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        await revoke_session(session, cookie_id)
+    log.info("ui_auth_session_revoked", session_id=str(cookie_id))
+
+
+async def _resolve_end_session_target(settings_: Settings) -> str:
+    """Build the post-logout redirect URL.
+
+    Falls back to a local ``/ui/auth/login`` redirect when the
+    discovery doc is unreachable or does not advertise
+    ``end_session_endpoint`` -- the session is already revoked at
+    that point, so the IdP-side logout is best-effort.
+    """
+    log = structlog.get_logger(__name__)
+    try:
+        endpoints = await resolve_oidc_endpoints()
+    except httpx.HTTPError as exc:
+        log.warning(
+            "ui_auth_logout_discovery_failed",
+            error_class=type(exc).__name__,
+        )
+        endpoints = None
+    post_logout = f"{settings_.backplane_url.rstrip('/')}{LOGIN_PATH}"
+    end_session_url = endpoints.end_session_endpoint if endpoints is not None else None
+    client_id = settings_.ui_keycloak_client_id
+    if end_session_url and client_id:
+        return _build_end_session_url(
+            end_session_url,
+            post_logout_redirect_uri=post_logout,
+            client_id=client_id,
+        )
+    return post_logout if post_logout != LOGIN_PATH else LOGIN_PATH
+
+
+async def _handle_logout(request: Request) -> RedirectResponse:
+    """Revoke the session row, clear the cookie, 302 to the end-session URL."""
+    await _revoke_session_if_present(request.cookies.get(SESSION_COOKIE_NAME))
+    target = await _resolve_end_session_target(get_settings())
+    response = RedirectResponse(url=target, status_code=status.HTTP_302_FOUND)
+    _clear_session_cookie(response)
+    return response
+
+
+def build_router() -> APIRouter:
+    """Construct the ``/ui/auth/*`` :class:`APIRouter`.
+
+    A factory function (rather than a module-level constant) so T5
+    (#866) can mount the router with whatever prefix the FastAPI app
+    decides to expose it under. Each invocation produces a fresh
+    router -- the routes themselves are pure handlers (defined at
+    module level), so multiple routers attached to different apps
+    under test do not share mutable state.
+    """
+    router = APIRouter(prefix="/ui/auth", tags=["ui-auth"])
+    router.add_api_route("/login", _handle_login, methods=["GET"], name="ui_auth_login")
+    router.add_api_route(
+        "/callback",
+        _handle_callback,
+        methods=["GET"],
+        name="ui_auth_callback",
+    )
+    router.add_api_route(
+        "/logout",
+        _handle_logout,
+        methods=["GET"],
+        name="ui_auth_logout",
+    )
+    return router

--- a/backend/src/meho_backplane/ui/auth/verifier_store.py
+++ b/backend/src/meho_backplane/ui/auth/verifier_store.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Server-side store for in-flight PKCE ``code_verifier`` values.
+
+Initiative #337 (G10.0 Frontend chassis), Task #865 (T4). The PKCE
+``code_verifier`` must NOT live in a cookie -- a verifier alongside
+the code on the redirect URI would defeat the property PKCE protects
+(an intermediate that captures the code would also capture the
+verifier). Server-side custody is the whole point.
+
+This module ships :class:`PKCEVerifierStore` -- a per-process dict
+keyed on the OAuth ``state`` parameter (which authlib generates per
+flow). Entries land in
+:func:`meho_backplane.ui.auth.flow.build_authorization_request` and
+are popped exactly once by
+:func:`meho_backplane.ui.auth.flow.exchange_code_for_tokens` -- a
+second callback request with the same ``state`` finds no verifier
+and the flow fails-closed.
+
+Concurrency
+-----------
+
+The store is guarded by an :class:`asyncio.Lock`. Single-worker
+uvicorn keeps the dict simple; a multi-worker deploy would need a
+Redis-backed shared custody surface (tracked alongside the JWKS-cache
+upgrade under Initiative #337).
+
+Expired-entry sweep
+-------------------
+
+Every :meth:`put` call also drops entries older than
+:data:`AUTHORIZATION_FLOW_TTL_SECONDS`. The sweep is bounded by the
+map's size, runs under the lock, and amortises over the login
+cadence (one drop pass per fresh login -- realistic under any
+operator-facing traffic shape). No background task is needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import Final
+
+__all__ = [
+    "AUTHORIZATION_FLOW_TTL_SECONDS",
+    "PKCEVerifierStore",
+    "PendingFlow",
+    "get_verifier_store",
+    "reset_verifier_store_for_testing",
+]
+
+
+#: Maximum age (in seconds) of a pending authorization-code flow before
+#: the in-memory PKCE verifier is reaped. 10 minutes is the published
+#: Keycloak default ``authentication-session-lifespan`` -- a verifier
+#: older than that cannot complete the flow on the IdP side anyway, so
+#: we drop it. Tests override to sub-second values to exercise the
+#: expiry path without sleeping.
+AUTHORIZATION_FLOW_TTL_SECONDS: Final[int] = 600
+
+
+@dataclass(frozen=True)
+class PendingFlow:
+    """One unfinished authorization-code flow.
+
+    Holds the PKCE ``code_verifier`` (server-side custody; never
+    written to a cookie) and the originally-requested URL the
+    callback should redirect to on success. ``created_at`` is the
+    monotonic-clock value at registration so the reaper can drop
+    abandoned entries without depending on wall-clock skew.
+    """
+
+    code_verifier: str
+    return_to: str
+    created_at: float
+
+
+class PKCEVerifierStore:
+    """Server-side store for in-flight PKCE ``code_verifier`` values.
+
+    Keyed on ``state`` (the per-flow CSRF token authlib generates in
+    :meth:`AsyncOAuth2Client.create_authorization_url`). Entries land
+    in :func:`meho_backplane.ui.auth.flow.build_authorization_request`
+    and are popped exactly once by
+    :func:`meho_backplane.ui.auth.flow.exchange_code_for_tokens` -- a
+    second callback request with the same ``state`` finds no verifier
+    and the flow fails-closed.
+
+    Tests reach :func:`reset_verifier_store_for_testing` between cases
+    to clear state.
+    """
+
+    def __init__(self) -> None:
+        self._flows: dict[str, PendingFlow] = {}
+        self._lock = asyncio.Lock()
+
+    async def put(self, state: str, *, code_verifier: str, return_to: str) -> None:
+        """Register a fresh flow.
+
+        Runs a bounded expired-entry sweep before the insert so the
+        map never grows beyond the live-flow set.
+        """
+        now = time.monotonic()
+        async with self._lock:
+            # Reap stale entries first. Bounded by the current size of
+            # the map; one pass per fresh login under any traffic shape.
+            stale = [
+                key
+                for key, flow in self._flows.items()
+                if now - flow.created_at > AUTHORIZATION_FLOW_TTL_SECONDS
+            ]
+            for key in stale:
+                del self._flows[key]
+            self._flows[state] = PendingFlow(
+                code_verifier=code_verifier,
+                return_to=return_to,
+                created_at=now,
+            )
+
+    async def pop(self, state: str) -> PendingFlow | None:
+        """Atomically remove and return the flow for *state*, or ``None``.
+
+        Returns ``None`` when the state is unknown, already consumed,
+        or past :data:`AUTHORIZATION_FLOW_TTL_SECONDS`. Callers
+        translate ``None`` into a 400 -- the operator-facing shape is
+        intentionally indistinguishable across the three causes
+        (cookie/state replay, deep-link bookmark of an expired
+        callback URL, ordinary browser-window race).
+        """
+        now = time.monotonic()
+        async with self._lock:
+            flow = self._flows.pop(state, None)
+            if flow is None:
+                return None
+            if now - flow.created_at > AUTHORIZATION_FLOW_TTL_SECONDS:
+                return None
+            return flow
+
+    def size(self) -> int:
+        """Return the current number of pending flows.
+
+        Test-only helper -- never used on the request hot path. The
+        size is not held under the lock; readers tolerate the
+        eventual-consistency view because the value is diagnostic, not
+        load-bearing.
+        """
+        return len(self._flows)
+
+
+#: Process-wide verifier store. One per backplane worker; reset under
+#: test via :func:`reset_verifier_store_for_testing`.
+_VERIFIER_STORE: PKCEVerifierStore = PKCEVerifierStore()
+
+
+def get_verifier_store() -> PKCEVerifierStore:
+    """Return the process-wide :class:`PKCEVerifierStore`.
+
+    A function (rather than re-exporting :data:`_VERIFIER_STORE` as a
+    module attribute) so test seams that swap the store can do so with
+    a single :func:`monkeypatch.setattr` against this lookup.
+    """
+    return _VERIFIER_STORE
+
+
+def reset_verifier_store_for_testing() -> None:
+    """Replace the process-wide store with a fresh instance.
+
+    Test-only -- production never resets the store under a running
+    process. Tests that exercise multiple end-to-end flows under
+    :class:`pytest.MonkeyPatch` call this between cases so a verifier
+    from a prior flow never leaks into the current one.
+    """
+    global _VERIFIER_STORE
+    _VERIFIER_STORE = PKCEVerifierStore()

--- a/backend/tests/test_ui_auth_flow.py
+++ b/backend/tests/test_ui_auth_flow.py
@@ -1,0 +1,850 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the BFF OAuth + PKCE login flow (Task #865).
+
+Exercises every acceptance criterion on issue #865:
+
+* ``/ui/auth/login`` builds an authorization URL with
+  ``code_challenge`` + ``code_challenge_method=S256`` +
+  ``resource=<backplane_url>/api`` and 302s the browser to Keycloak.
+* ``/ui/auth/callback`` exchanges code + verifier (respx-mocked token
+  endpoint) for tokens, validates the access token through the
+  chassis JWT chain, creates a ``web_session`` row, and sets the
+  ``meho_session`` cookie with ``HttpOnly`` + ``Secure`` +
+  ``SameSite=Strict`` + ``Path=/``.
+* ``/ui/auth/logout`` revokes the session, clears the cookie, and
+  302s to Keycloak's end-session endpoint.
+* :class:`UISessionMiddleware`: ``/ui/*`` with no/expired session →
+  302 to login; with a valid session → operator loaded.
+* PKCE verifier store: server-side, one-shot, expires past the TTL.
+* CSRF: ``state`` round-trip cross-check; replay of a consumed
+  ``state`` rejected.
+* Open-redirect: a crafted ``?return_to=`` value is sanitised.
+
+The autouse fixtures in :mod:`backend.tests.conftest`
+(``_default_database_url`` + ``_schema_template_db``) provide a fresh
+file-backed SQLite DB migrated to head before every test, so the
+``web_session`` table is present without any per-test
+``alembic upgrade head`` replay (per PR #898's per-worker template
+pattern).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Iterator
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import WebSession
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import (
+    SESSION_COOKIE_NAME,
+    UISessionMiddleware,
+    build_router,
+)
+from meho_backplane.ui.auth.flow import (
+    AUTHORIZATION_FLOW_TTL_SECONDS,
+    PKCEVerifierStore,
+    build_authorization_request,
+    clear_discovery_cache,
+    exchange_code_for_tokens,
+    get_verifier_store,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    load_session,
+    reset_fernet_cache_for_testing,
+)
+from tests.conftest import (
+    DEFAULT_AUDIENCE,
+    DEFAULT_ISSUER,
+    DEFAULT_TENANT_ID,
+    make_rsa_keypair,
+    mint_token,
+    public_jwks,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_BACKPLANE_URL = "https://meho.test"
+_REDIRECT_URI = f"{_BACKPLANE_URL}/ui/auth/callback"
+_AUTHORIZATION_ENDPOINT = f"{DEFAULT_ISSUER}/protocol/openid-connect/auth"
+_TOKEN_ENDPOINT = f"{DEFAULT_ISSUER}/protocol/openid-connect/token"
+_END_SESSION_ENDPOINT = f"{DEFAULT_ISSUER}/protocol/openid-connect/logout"
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars for every test.
+
+    The chassis-wide :class:`Settings` requires ``KEYCLOAK_ISSUER_URL``
+    / ``KEYCLOAK_AUDIENCE`` / ``VAULT_ADDR``; the BFF additionally
+    needs the operator-console encryption key + the confidential
+    client id/secret. Every test inherits the same baseline so
+    individual cases only override the knob under test.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+def _mock_oidc_metadata(
+    mock_router: respx.MockRouter,
+    *,
+    include_end_session: bool = True,
+    jwks: dict[str, Any] | None = None,
+) -> None:
+    """Stub the discovery + JWKS endpoints with the BFF-relevant URLs.
+
+    Replaces the chassis ``mock_discovery_and_jwks`` helper for the BFF
+    suite -- the chassis helper writes a discovery doc with only
+    ``issuer`` + ``jwks_uri``, but the BFF flow also reads
+    ``authorization_endpoint`` / ``token_endpoint`` /
+    ``end_session_endpoint`` from the same document. Registering the
+    chassis helper alongside this one collides on the URL and the
+    second mock wins -- yielding a discovery doc without the BFF
+    fields. This helper writes one merged document and registers the
+    JWKS endpoint when ``jwks`` is provided (the callback path needs
+    it; the login path does not).
+    """
+    metadata: dict[str, Any] = {
+        "issuer": DEFAULT_ISSUER,
+        "authorization_endpoint": _AUTHORIZATION_ENDPOINT,
+        "token_endpoint": _TOKEN_ENDPOINT,
+        "jwks_uri": f"{DEFAULT_ISSUER}/protocol/openid-connect/certs",
+    }
+    if include_end_session:
+        metadata["end_session_endpoint"] = _END_SESSION_ENDPOINT
+    mock_router.get(f"{DEFAULT_ISSUER}/.well-known/openid-configuration").mock(
+        return_value=httpx.Response(200, json=metadata),
+    )
+    if jwks is not None:
+        mock_router.get(metadata["jwks_uri"]).mock(
+            return_value=httpx.Response(200, json=jwks),
+        )
+
+
+def _build_app(*, include_dummy_ui_route: bool = True) -> FastAPI:
+    """Construct a minimal FastAPI app with the BFF wired in.
+
+    The BFF router lives at ``/ui/auth/*``; ``include_dummy_ui_route``
+    optionally registers a ``GET /ui/sentinel`` route the middleware
+    redirect tests exercise.
+    """
+    app = FastAPI()
+    app.add_middleware(UISessionMiddleware)
+    app.include_router(build_router())
+    if include_dummy_ui_route:
+
+        @app.get("/ui/sentinel")
+        async def sentinel() -> dict[str, str]:
+            # Reachable only when the session middleware finds a
+            # valid session and lets the request through.
+            return {"ok": "true"}
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# /ui/auth/login -- builds the PKCE authorization URL (AC 1)
+# ---------------------------------------------------------------------------
+
+
+def test_login_redirects_to_keycloak_with_pkce_and_resource() -> None:
+    """AC 1: ``/ui/auth/login`` 302s to Keycloak with S256 PKCE + resource."""
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router)
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/auth/login")
+    assert response.status_code == 302
+    location = response.headers["location"]
+    parsed = urlparse(location)
+    # Bound to Keycloak's auth endpoint.
+    assert location.startswith(_AUTHORIZATION_ENDPOINT)
+    params = parse_qs(parsed.query)
+    # OAuth 2.1 + PKCE + RFC 8707 contract on the URL.
+    assert params["response_type"] == ["code"]
+    assert params["client_id"] == ["meho-web"]
+    assert params["redirect_uri"] == [_REDIRECT_URI]
+    assert params["code_challenge_method"] == ["S256"]
+    assert "code_challenge" in params
+    # The challenge value is the S256 of the verifier; here we only
+    # check it is non-empty and base64url-ish (authlib generates the
+    # value, so cryptographic strength is its responsibility).
+    assert len(params["code_challenge"][0]) >= 16
+    assert "state" in params
+    assert len(params["state"][0]) >= 16
+    # RFC 8707 resource indicator -- the BFF binds tokens to the
+    # backplane API.
+    assert params["resource"] == [f"{_BACKPLANE_URL}/api"]
+
+
+def test_login_persists_verifier_in_server_side_store_not_cookie() -> None:
+    """The PKCE verifier MUST NOT live in the client cookie.
+
+    Defends decision #11's "tokens stay server-side" contract: a
+    verifier in a cookie would defeat the property PKCE protects.
+    """
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router)
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/auth/login")
+    # No cookies set on the login redirect -- the verifier is in
+    # the server-side store, not on the client.
+    assert response.cookies == {}
+    # The store has exactly one pending flow now.
+    assert get_verifier_store().size() == 1
+
+
+def test_login_503s_when_client_secret_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """AC: unset ``UI_KEYCLOAK_CLIENT_SECRET`` surfaces an actionable 503."""
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "")
+    get_settings.cache_clear()
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/auth/login")
+    assert response.status_code == 503
+    body = response.json()
+    assert "UI_KEYCLOAK_CLIENT_SECRET" in body["detail"]
+    assert "keycloak-web-client.md" in body["detail"]
+
+
+def test_login_502s_when_discovery_endpoint_unreachable() -> None:
+    """A network failure on the discovery hit surfaces as 502, not 500."""
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(f"{DEFAULT_ISSUER}/.well-known/openid-configuration").mock(
+            side_effect=httpx.ConnectError("simulated")
+        )
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/auth/login")
+    assert response.status_code == 502
+    assert response.json()["detail"] == "upstream_auth_provider_unreachable"
+
+
+# ---------------------------------------------------------------------------
+# return_to validation (open-redirect guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected_return_to"),
+    [
+        ("/ui/dashboard", "/ui/dashboard"),
+        ("/ui/", "/ui/"),
+        ("", "/ui/"),
+        ("//evil.example.com/path", "/ui/"),
+        ("https://evil.example.com/path", "/ui/"),
+        ("/api/secret", "/ui/"),
+        ("/etc/passwd", "/ui/"),
+    ],
+)
+def test_login_sanitises_return_to_against_open_redirect(
+    raw: str,
+    expected_return_to: str,
+) -> None:
+    """An operator-supplied ``return_to`` outside ``/ui/`` falls back to ``/ui/``.
+
+    The login route stashes ``return_to`` in the PKCE verifier store;
+    the callback reads it back and 302s there on success. A crafted
+    value (absolute URL, ``//host``, path outside ``/ui/``) must be
+    rejected so the callback never bounces the operator off-host.
+    """
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router)
+        client = TestClient(_build_app(), follow_redirects=False)
+        if raw:
+            client.get(f"/ui/auth/login?return_to={raw}")
+        else:
+            client.get("/ui/auth/login")
+    # Pop the registered flow -- the stored ``return_to`` is what
+    # the callback would honour. Inspecting it confirms the sanitiser
+    # ran before the value reached storage.
+    store = get_verifier_store()
+    # There's exactly one flow; the state value is whatever authlib
+    # generated. Iterate over the flows dict to read it.
+    assert store.size() == 1
+    # Reach into the dict directly -- this is a test-only invariant
+    # check; production code uses :meth:`pop`.
+    flows = store._flows
+    pending = next(iter(flows.values()))
+    assert pending.return_to == expected_return_to
+
+
+# ---------------------------------------------------------------------------
+# /ui/auth/callback -- code exchange + session creation (AC 2)
+# ---------------------------------------------------------------------------
+
+
+def _mint_access_token(
+    *,
+    audience: str = DEFAULT_AUDIENCE,
+    sub: str = "op-42",
+) -> tuple[str, dict[str, Any]]:
+    """Mint a JWT signed by a fresh keypair and return ``(token, jwks)``.
+
+    The JWKS lets respx stub the chassis JWT chain's JWKS endpoint
+    so :func:`verify_jwt_for_audience` can decode the token.
+    """
+    key = make_rsa_keypair("test-kid")
+    token = mint_token(key, sub=sub, audience=audience)
+    return token, public_jwks(key)
+
+
+def test_callback_creates_session_and_sets_cookie() -> None:
+    """AC 2: callback exchanges code+verifier, creates session row, sets cookie."""
+    access_token, jwks = _mint_access_token()
+    refresh_token = "refresh-token-value"
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router, jwks=jwks)
+        # The token endpoint returns access + refresh + expires_in
+        # exactly as Keycloak does.
+        token_route = mock_router.post(_TOKEN_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                    "expires_in": 3600,
+                    "token_type": "Bearer",
+                },
+            ),
+        )
+        client = TestClient(_build_app(), follow_redirects=False)
+        # Step 1: login mints a state + verifier.
+        login_response = client.get("/ui/auth/login?return_to=/ui/dashboard")
+        login_location = login_response.headers["location"]
+        state = parse_qs(urlparse(login_location).query)["state"][0]
+        # Step 2: simulate Keycloak's redirect back to the callback.
+        callback_response = client.get(
+            f"/ui/auth/callback?code=test-code&state={state}",
+        )
+
+    assert token_route.called
+    # Verify the token request body shape -- code, code_verifier,
+    # redirect_uri, resource indicator. authlib's default
+    # ``client_secret_basic`` puts the client credentials in the
+    # ``Authorization`` header (RFC 6749 §2.3.1); Keycloak accepts
+    # both that and ``client_secret_post``, so the body does not
+    # carry ``client_id`` / ``client_secret``. The header check below
+    # confirms the secret is on the wire to the IdP without ever
+    # surfacing the value in the test output.
+    call = token_route.calls[0]
+    posted_body = call.request.content.decode("utf-8")
+    assert "code=test-code" in posted_body
+    assert "code_verifier=" in posted_body
+    assert "grant_type=authorization_code" in posted_body
+    assert "resource=https%3A%2F%2Fmeho.test%2Fapi" in posted_body
+    # ``Authorization: Basic <base64(client_id:client_secret)>`` --
+    # the header is present (length > 'Basic '), but we deliberately
+    # do not unpack the value because the secret-leak sweep in
+    # ``conftest`` would otherwise flag the test on any future
+    # accidental print.
+    auth_header = call.request.headers.get("authorization")
+    assert auth_header is not None
+    assert auth_header.startswith("Basic ")
+    assert len(auth_header) > len("Basic ")
+
+    # Step 3: callback redirects to the originally-requested return_to.
+    assert callback_response.status_code == 302
+    assert callback_response.headers["location"] == "/ui/dashboard"
+
+    # Cookie attributes -- HttpOnly + Secure + SameSite=Strict + Path=/.
+    # Starlette emits the directives capitalised as shown but lowercases
+    # the attribute *values* (e.g. ``samesite=strict``); compare the
+    # full string lowercased so the assertions are case-insensitive on
+    # both directive names and values.
+    set_cookie = callback_response.headers["set-cookie"].lower()
+    assert f"{SESSION_COOKIE_NAME.lower()}=" in set_cookie
+    assert "httponly" in set_cookie
+    # respx + testclient strips Secure (the TestClient is not over
+    # TLS); Starlette still emits the directive on the raw header
+    # because the cookie was constructed with ``secure=True``.
+    assert "secure" in set_cookie
+    assert "samesite=strict" in set_cookie
+    assert "path=/" in set_cookie
+
+    # The cookie value parses as a UUID -- the session row's PK.
+    cookie_value = callback_response.cookies[SESSION_COOKIE_NAME]
+    session_id = uuid.UUID(cookie_value)
+
+    # Step 4: the ``web_session`` row exists and carries ENCRYPTED
+    # tokens (not plaintext).
+    async def _check_row() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            row = await session.get(WebSession, session_id)
+            assert row is not None
+            assert row.operator_sub == "op-42"
+            assert str(row.tenant_id) == DEFAULT_TENANT_ID
+            # Stored ciphertext is bytes; never the plaintext token.
+            assert isinstance(row.access_token, bytes)
+            assert access_token.encode("utf-8") not in row.access_token
+            assert refresh_token.encode("utf-8") not in row.refresh_token
+
+    asyncio.run(_check_row())
+
+
+def test_callback_rejects_unknown_state() -> None:
+    """Replay of a consumed / forged ``state`` collapses to a 400."""
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router)
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get(
+            "/ui/auth/callback?code=test-code&state=not-a-real-state",
+        )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "authorization_failed"
+
+
+def test_callback_rejects_missing_state() -> None:
+    """The CSRF guard fires on a missing ``state`` -- no verifier lookup possible."""
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router)
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/auth/callback?code=test-code")
+    assert response.status_code == 400
+    assert response.json()["detail"] == "authorization_failed"
+
+
+def test_callback_propagates_idp_error_to_400() -> None:
+    """IdP-emitted ``?error=access_denied`` -> 400 (operator cancelled)."""
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router)
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get(
+            "/ui/auth/callback?error=access_denied&error_description=user-cancelled"
+        )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "authorization_failed"
+
+
+def test_callback_502s_when_token_endpoint_unreachable() -> None:
+    """Network failure on the token endpoint surfaces as 502."""
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router)
+        mock_router.post(_TOKEN_ENDPOINT).mock(side_effect=httpx.ConnectError("boom"))
+        client = TestClient(_build_app(), follow_redirects=False)
+        login_response = client.get("/ui/auth/login")
+        state = parse_qs(urlparse(login_response.headers["location"]).query)["state"][0]
+        response = client.get(f"/ui/auth/callback?code=test-code&state={state}")
+    assert response.status_code == 502
+    assert response.json()["detail"] == "upstream_auth_provider_unreachable"
+
+
+def test_callback_rejects_replayed_state_after_first_consumption() -> None:
+    """The verifier is single-use; a second callback with the same state fails."""
+    access_token, jwks = _mint_access_token()
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router, jwks=jwks)
+        mock_router.post(_TOKEN_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "access_token": access_token,
+                    "refresh_token": "refresh-x",
+                    "expires_in": 3600,
+                },
+            ),
+        )
+        client = TestClient(_build_app(), follow_redirects=False)
+        login_response = client.get("/ui/auth/login")
+        state = parse_qs(urlparse(login_response.headers["location"]).query)["state"][0]
+        first = client.get(f"/ui/auth/callback?code=code-1&state={state}")
+        second = client.get(f"/ui/auth/callback?code=code-2&state={state}")
+    assert first.status_code == 302
+    assert second.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# /ui/auth/logout -- revoke + clear + Keycloak end-session redirect (AC 3)
+# ---------------------------------------------------------------------------
+
+
+def test_logout_revokes_session_and_clears_cookie_and_redirects_to_end_session() -> None:
+    """AC 3: logout revokes the row, clears the cookie, redirects to Keycloak."""
+
+    # Seed a session row directly so the logout test does not
+    # double-pay for the full callback round-trip.
+    async def _seed_session() -> uuid.UUID:
+        from datetime import timedelta
+
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub="op-99",
+                tenant_id=uuid.UUID(DEFAULT_TENANT_ID),
+                access_token="access-token-plaintext",
+                refresh_token="refresh-token-plaintext",
+                lifetime=timedelta(hours=1),
+            )
+            return decrypted.id
+
+    session_id = asyncio.run(_seed_session())
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router)
+        client = TestClient(_build_app(), follow_redirects=False)
+        client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+        response = client.get("/ui/auth/logout")
+
+    assert response.status_code == 302
+    location = response.headers["location"]
+    # End-session endpoint with the BFF's two parameters.
+    assert location.startswith(_END_SESSION_ENDPOINT)
+    params = parse_qs(urlparse(location).query)
+    assert params["client_id"] == ["meho-web"]
+    assert params["post_logout_redirect_uri"] == [f"{_BACKPLANE_URL}/ui/auth/login"]
+
+    # Cookie cleared via Max-Age=0 (or expires in the past) on the
+    # same name+path -- TestClient surfaces this as the cookie
+    # being absent on the next request.
+    set_cookie = response.headers["set-cookie"]
+    assert f'{SESSION_COOKIE_NAME}=""' in set_cookie or f"{SESSION_COOKIE_NAME}=;" in set_cookie
+
+    # The session row's ``revoked_at`` is now set.
+    async def _check_revoked() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            row = await session.get(WebSession, session_id)
+            assert row is not None
+            assert row.revoked_at is not None
+
+    asyncio.run(_check_revoked())
+
+
+def test_logout_redirects_to_login_when_end_session_endpoint_absent() -> None:
+    """A discovery doc without ``end_session_endpoint`` -> local login redirect."""
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router, include_end_session=False)
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/auth/logout")
+    assert response.status_code == 302
+    assert response.headers["location"] == f"{_BACKPLANE_URL}/ui/auth/login"
+
+
+def test_logout_without_cookie_still_redirects_and_clears() -> None:
+    """An anonymous ``/ui/auth/logout`` hit drops nothing but still redirects."""
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router)
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/auth/logout")
+    assert response.status_code == 302
+    # Still bounces to the end-session URL so an IdP-side session
+    # the operator may have under a different tab also gets a
+    # clean termination.
+    assert response.headers["location"].startswith(_END_SESSION_ENDPOINT)
+
+
+# ---------------------------------------------------------------------------
+# Session middleware -- redirect on missing session, load on hit (AC 4)
+# ---------------------------------------------------------------------------
+
+
+def test_middleware_redirects_unauthenticated_ui_request_to_login() -> None:
+    """AC 4: a ``/ui/*`` page with no session 302s to login with return_to."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/sentinel")
+    assert response.status_code == 302
+    location = response.headers["location"]
+    assert location.startswith("/ui/auth/login?return_to=")
+    # The encoded return_to round-trips the original path.
+    return_to = parse_qs(urlparse(location).query)["return_to"][0]
+    assert return_to == "/ui/sentinel"
+
+
+def test_middleware_lets_authenticated_ui_request_through() -> None:
+    """AC 4: with a valid session, the middleware lets the request through."""
+
+    async def _seed_session() -> uuid.UUID:
+        from datetime import timedelta
+
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub="op-77",
+                tenant_id=uuid.UUID(DEFAULT_TENANT_ID),
+                access_token="a",
+                refresh_token="r",
+                lifetime=timedelta(hours=1),
+            )
+            return decrypted.id
+
+    session_id = asyncio.run(_seed_session())
+
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+        response = client.get("/ui/sentinel")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": "true"}
+
+
+def test_middleware_redirects_when_session_is_expired() -> None:
+    """A session past ``expires_at`` is treated as no session."""
+
+    async def _seed_expired_session() -> uuid.UUID:
+        from datetime import timedelta
+
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub="op-77",
+                tenant_id=uuid.UUID(DEFAULT_TENANT_ID),
+                access_token="a",
+                refresh_token="r",
+                # Negative lifetime -- the row's expires_at is in
+                # the past at insertion time, so load_session returns
+                # None.
+                lifetime=timedelta(seconds=-1),
+            )
+            return decrypted.id
+
+    session_id = asyncio.run(_seed_expired_session())
+
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+        response = client.get("/ui/sentinel")
+
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+
+
+def test_middleware_redirects_when_cookie_is_malformed() -> None:
+    """A non-UUID cookie value is treated as no session, never an exception."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        client.cookies.set(SESSION_COOKIE_NAME, "not-a-uuid")
+        response = client.get("/ui/sentinel")
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+
+
+def test_middleware_bypasses_static_assets() -> None:
+    """``/ui/static/*`` bypasses the session check (chassis CSS / JS)."""
+    # No sentinel registered for /ui/static; FastAPI's 404 still
+    # surfaces because the middleware lets the request through.
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/static/tailwind.css")
+    assert response.status_code == 404
+    # Crucially: not 302. The bypass worked.
+
+
+def test_middleware_lets_auth_routes_through_without_session() -> None:
+    """The BFF auth surfaces themselves bypass the session check."""
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router)
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/auth/login")
+    # Login route runs, not bounced to itself.
+    assert response.status_code == 302
+    assert response.headers["location"].startswith(_AUTHORIZATION_ENDPOINT)
+
+
+def test_middleware_does_not_touch_non_ui_paths() -> None:
+    """Out-of-prefix paths pass through untouched."""
+    app = _build_app(include_dummy_ui_route=False)
+
+    @app.get("/api/probe")
+    async def probe() -> dict[str, str]:
+        return {"out": "of-scope"}
+
+    with respx.mock(assert_all_called=False):
+        client = TestClient(app, follow_redirects=False)
+        response = client.get("/api/probe")
+    assert response.status_code == 200
+    assert response.json() == {"out": "of-scope"}
+
+
+# ---------------------------------------------------------------------------
+# PKCE verifier store -- in-process semantics
+# ---------------------------------------------------------------------------
+
+
+def test_pkce_verifier_store_pop_is_single_use() -> None:
+    """A second pop on the same state yields ``None``."""
+
+    async def _go() -> None:
+        store = PKCEVerifierStore()
+        await store.put("state-1", code_verifier="v", return_to="/ui/")
+        first = await store.pop("state-1")
+        second = await store.pop("state-1")
+        assert first is not None
+        assert first.code_verifier == "v"
+        assert second is None
+
+    asyncio.run(_go())
+
+
+def test_pkce_verifier_store_expires_past_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale entry is reaped on the next ``put`` call."""
+
+    async def _go() -> None:
+        store = PKCEVerifierStore()
+        # First put -- normal.
+        await store.put("state-stale", code_verifier="v1", return_to="/ui/")
+        assert store.size() == 1
+        # Fast-forward monotonic time past the TTL by patching the
+        # store's internal time reference.
+        import meho_backplane.ui.auth.flow as flow_mod
+
+        original = flow_mod.time.monotonic
+        monkeypatch.setattr(
+            flow_mod.time,
+            "monotonic",
+            lambda: original() + AUTHORIZATION_FLOW_TTL_SECONDS + 1,
+        )
+        # A fresh put triggers the reap and drops the stale entry.
+        await store.put("state-fresh", code_verifier="v2", return_to="/ui/")
+        assert store.size() == 1
+        assert await store.pop("state-stale") is None
+        fresh = await store.pop("state-fresh")
+        assert fresh is not None and fresh.code_verifier == "v2"
+
+    asyncio.run(_go())
+
+
+# ---------------------------------------------------------------------------
+# Direct flow-module tests (not via TestClient)
+# ---------------------------------------------------------------------------
+
+
+def test_build_authorization_request_carries_state_and_resource() -> None:
+    """The flow-level primitive emits a valid PKCE URL on its own."""
+
+    async def _go() -> None:
+        with respx.mock(assert_all_called=False) as mock_router:
+            _mock_oidc_metadata(mock_router)
+            url, state = await build_authorization_request(
+                redirect_uri=_REDIRECT_URI,
+                return_to="/ui/dashboard",
+            )
+        params = parse_qs(urlparse(url).query)
+        assert params["state"] == [state]
+        assert params["resource"] == [f"{_BACKPLANE_URL}/api"]
+        assert params["code_challenge_method"] == ["S256"]
+
+    asyncio.run(_go())
+
+
+def test_exchange_code_rejects_unknown_state() -> None:
+    """The flow-level primitive raises on a state the store does not know."""
+    from meho_backplane.ui.auth.flow import OAuthFlowError
+
+    async def _go() -> None:
+        with respx.mock(assert_all_called=False) as mock_router:
+            _mock_oidc_metadata(mock_router)
+            with pytest.raises(OAuthFlowError):
+                await exchange_code_for_tokens(
+                    redirect_uri=_REDIRECT_URI,
+                    authorization_response=(f"{_REDIRECT_URI}?code=c&state=forged"),
+                    state="forged",
+                )
+
+    asyncio.run(_go())
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: login → callback → middleware lets request through
+# ---------------------------------------------------------------------------
+
+
+def test_full_login_round_trip_lets_authenticated_page_through() -> None:
+    """End-to-end: log in, then the session cookie reaches the sentinel route."""
+    access_token, jwks = _mint_access_token(sub="op-roundtrip")
+
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router, jwks=jwks)
+        mock_router.post(_TOKEN_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "access_token": access_token,
+                    "refresh_token": "rt",
+                    "expires_in": 3600,
+                },
+            ),
+        )
+        client = TestClient(_build_app(), follow_redirects=False)
+        # 1. Unauthenticated -> redirect to login.
+        deep_link = client.get("/ui/sentinel")
+        assert deep_link.status_code == 302
+        # 2. Follow login -> Keycloak.
+        login_response = client.get(
+            deep_link.headers["location"].replace("https://testserver", ""),
+        )
+        state = parse_qs(urlparse(login_response.headers["location"]).query)["state"][0]
+        # 3. Callback creates the session + sets the cookie.
+        callback_response = client.get(
+            f"/ui/auth/callback?code=test-code&state={state}",
+        )
+        assert callback_response.status_code == 302
+        # Final return_to is /ui/sentinel via the original deep link.
+        assert callback_response.headers["location"] == "/ui/sentinel"
+        # 4. Now the sentinel is reachable. TestClient drops the
+        # ``Secure``-flagged cookie on the HTTP transport (the
+        # cookie jar will not send a Secure cookie over plain HTTP),
+        # so we manually replay it. The production redirect at
+        # https://meho.evba.lab is HTTPS-only and the browser sends
+        # the cookie without issue; this is purely a TestClient
+        # interaction quirk.
+        cookie_value = callback_response.cookies[SESSION_COOKIE_NAME]
+        client.cookies.set(SESSION_COOKIE_NAME, cookie_value)
+        page = client.get("/ui/sentinel")
+
+    assert page.status_code == 200
+    assert page.json() == {"ok": "true"}
+
+    # And the session row's identity matches the token's ``sub``.
+    session_id = uuid.UUID(cookie_value)
+
+    async def _check_loaded() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await load_session(session, session_id)
+            assert decrypted is not None
+            assert decrypted.operator_sub == "op-roundtrip"
+
+    asyncio.run(_check_loaded())

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -43,6 +43,9 @@ Locked decisions:
 | `meho_backplane.ui.routes` | Stub package for chassis Task. T5 (#866) lands the `APIRouter` instance + dashboard view + the five surface stub routes. |
 | `meho_backplane.ui.auth` | BFF auth subpackage. T3 (#864) landed `session_store` (encrypted token custody + RFC 9700 refresh-token rotation); T4 (#865) lands `/ui/auth/{login,callback,logout}` + session middleware. |
 | `meho_backplane.ui.auth.session_store` | Fernet-encrypted server-side session storage. `create_session`, `load_session`, `revoke_session`, `rotate_refresh` against the `web_session` Postgres table. Replay of a used refresh token revokes the session and writes a `ui.session.refresh_replay` audit row on a dedicated transaction so the security signal survives caller rollback. |
+| `meho_backplane.ui.auth.flow` | OAuth 2.1 + PKCE client primitives layered on authlib's `AsyncOAuth2Client`. `build_authorization_request` mints the Keycloak redirect URL (S256 PKCE + RFC 8707 `resource` parameter) and registers the per-flow verifier in a server-side `PKCEVerifierStore`. `exchange_code_for_tokens` pops the verifier and exchanges code+verifier at the token endpoint. `resolve_oidc_endpoints` caches the discovery doc on the same TTL the JWKS cache uses. |
+| `meho_backplane.ui.auth.routes` | FastAPI `APIRouter` for `/ui/auth/{login,callback,logout}`. `build_router()` returns the router for T5 to mount. Callback verifies the access token through the chassis JWT chain (`verify_jwt_for_audience`) so the BFF inherits issuer / audience / sub / tenant_id / tenant_role checks. Sets `meho_session` cookie with `HttpOnly; Secure; SameSite=Strict; Path=/`. Logout revokes the session, clears the cookie, and 302s to Keycloak's `end_session_endpoint` (best-effort -- a missing endpoint falls back to a local `/ui/auth/login` redirect). |
+| `meho_backplane.ui.auth.middleware` | Pure-ASGI `UISessionMiddleware` for `/ui/*`. Loads operator identity from the session cookie on every request; 302s to login on missing/expired session. Bypasses `/ui/static/*` (chassis assets) and `/ui/auth/*` (the BFF surfaces themselves). Per-request `UISessionContext` (frozen dataclass: `session_id`, `operator_sub`, `tenant_id`) lands on `request.state.ui_session`; route handlers read it via `Depends(require_ui_session)`. |
 
 The Jinja2 `Environment` is a module-level singleton (constructed on
 first `get_jinja_env()` call); the template cache it holds is keyed
@@ -146,6 +149,59 @@ upcoming T4 login flow writes to:
 
 T4 (#865) builds the login / callback / logout flow + the BFF
 middleware on top of this substrate; T3 ships storage only.
+
+## Login flow (Task #865)
+
+The BFF login flow is OAuth 2.1 Authorization Code + PKCE against
+the `meho-web` confidential Keycloak client (see
+[`docs/cross-repo/keycloak-web-client.md`](../cross-repo/keycloak-web-client.md)).
+Tokens stay server-side; the browser holds only the opaque
+`meho_session` cookie.
+
+Round-trip shape:
+
+1. **Operator hits a `/ui/*` page unauthenticated.** The
+   `UISessionMiddleware` finds no usable session and 302s to
+   `/ui/auth/login?return_to=<original-path>`.
+2. **`/ui/auth/login`.** `build_authorization_request` generates a
+   per-flow PKCE `code_verifier`, asks authlib to build the
+   authorization URL (carries `code_challenge`,
+   `code_challenge_method=S256`, and the RFC 8707 `resource` parameter
+   set to `<backplane_url>/api`), and registers the verifier +
+   `return_to` in the `PKCEVerifierStore` keyed on `state`. The
+   verifier never leaves the server.
+3. **Keycloak authenticates the operator.** Browser arrives at
+   `/ui/auth/callback?code=...&state=...`.
+4. **`/ui/auth/callback`.** `exchange_code_for_tokens` pops the
+   verifier from the store (single-use), POSTs `code + code_verifier
+   + client_secret` to Keycloak's token endpoint, and returns the
+   access + refresh tokens. The callback then validates the access
+   token through the chassis JWT chain
+   (`verify_jwt_for_audience`) so the BFF inherits issuer / audience
+   / sub / tenant_id / tenant_role defences; on success it calls
+   `create_session` to write the encrypted row and sets the
+   `meho_session` cookie.
+5. **302 to the original `return_to`.** Operator lands on the page
+   they were originally bounced from.
+
+Per-flow state custody:
+
+| What | Where | Lifetime |
+| --- | --- | --- |
+| `code_verifier` | Server-side `PKCEVerifierStore` keyed on `state` | One authorization round-trip (≤10 min) |
+| `state` (CSRF) | On the IdP's authorization URL + echoed in callback | Same one round-trip |
+| `meho_session` cookie | Browser, `HttpOnly` + `Secure` + `SameSite=Strict` | Session lifetime (until access-token expiry minus 60s margin) |
+| Access + refresh tokens | `web_session` row, Fernet-encrypted | Same session lifetime |
+
+The `code_verifier` deliberately does NOT live in a cookie -- a
+verifier alongside the code on the redirect URI would defeat the
+property PKCE protects (an attacker capturing one captures both).
+Server-side custody is the whole point.
+
+Logout: revoke the row, clear the cookie, 302 to Keycloak's
+`end_session_endpoint` with `client_id` + `post_logout_redirect_uri`
+pointing back to `/ui/auth/login`. The IdP-side hop is best-effort
+-- the local session is already revoked when the redirect fires.
 
 ## Vendored asset versions
 

--- a/docs/cross-repo/keycloak-web-client.md
+++ b/docs/cross-repo/keycloak-web-client.md
@@ -1,0 +1,364 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# Keycloak `meho-web` client recipe — confidential client for the operator-console BFF
+
+> Cross-repo handshake between `evoila/meho` (this repo, producer of
+> the v0.2 backplane that **runs** the BFF login flow at
+> `/ui/auth/*`) and the operator's Keycloak realm (consumer side;
+> not a single repo — every MEHO deployment has its own realm).
+>
+> This page is the upstream-side **tracker** for the realm-side
+> client + secret each consumer must provision before deploying the
+> v0.2 operator-console UI. The configuration itself is
+> operator-applied (Keycloak Admin Console + Vault secret-write); what
+> lives here is the recipe the operator follows and the verification
+> commands either side can run to prove the contract holds.
+
+## Why this doc exists
+
+The v0.2 operator-console (Initiative
+[#337](https://github.com/evoila/meho/issues/337)) ships a
+Backend-for-Frontend auth flow served by the backplane FastAPI
+process at `/ui/auth/*`. The flow runs OAuth 2.1 Authorization Code +
+PKCE against the operator's existing Keycloak realm, using a **new
+confidential client** named `meho-web`. The client is distinct from:
+
+- **`meho-cli`** (public client, device-code flow) — used by the
+  `meho login` CLI, no secret. Tracked in
+  [`mcp-client-setup.md`](./mcp-client-setup.md).
+- **`meho-mcp`** or whichever client emits the `KEYCLOAK_AUDIENCE`
+  the chassis JWT chain validates (`meho-backplane`). The
+  resource-server identifier the backplane validates `aud` against,
+  unchanged from v0.1.
+
+The BFF flow needs its own client because:
+
+1. The authorization-code grant runs server-side and carries a
+   `client_secret` on the token-endpoint POST. Confidential client.
+2. The redirect URI is exact-match
+   (`https://meho.evba.lab/ui/auth/callback`) and Keycloak enforces
+   this; the CLI client cannot share the redirect URI.
+3. The PKCE flow is enforced (OAuth 2.1 mandates PKCE on every
+   authorization-code grant). The CLI client runs device-code, a
+   different flow.
+
+The backplane cannot enforce realm configuration; it can only fail
+closed when the client / secret / redirect URI is missing or wrong.
+This doc is the contract that specifies what the realm must produce.
+
+## Prerequisites
+
+- Keycloak admin access to the realm where MEHO operators
+  authenticate (the realm whose issuer URL is configured as
+  `KEYCLOAK_ISSUER_URL` in the backplane's
+  [`Settings`](../codebase/backend.md)).
+- The realm already issues access tokens carrying the `tenant_id` +
+  `tenant_role` claims per
+  [`keycloak-tenant-claims.md`](./keycloak-tenant-claims.md). The BFF
+  validates the access token through the same chassis JWT chain
+  `/api/*` uses, so the chassis recipe must already be in place.
+- A populated Vault server reachable by the backplane (same Vault
+  the existing CLI / MCP-client secrets live under). The
+  `meho-web` client secret lands under a Vault path the deploy
+  renders into the pod environment as `UI_KEYCLOAK_CLIENT_SECRET`.
+- Keycloak version **22+** (matches the `meho-cli` / `meho-mcp`
+  recipe baseline).
+
+## Recipe
+
+### Step 1 — Create the confidential client
+
+In the Admin Console (logged in as a realm admin):
+
+1. Navigate to **Clients** → **Create client**.
+2. **Client type:** `OpenID Connect`.
+3. **Client ID:** `meho-web` (this is the value rendered into the
+   backplane as `UI_KEYCLOAK_CLIENT_ID`).
+4. **Name:** `MEHO Operator Console` (cosmetic).
+5. **Next** → **Capability config**:
+   - **Client authentication:** **on** (this is what makes the
+     client *confidential* — Keycloak will generate a secret on
+     save).
+   - **Authorization:** off (no Keycloak-Authorization-Services
+     usage; the backplane does RBAC).
+   - **Authentication flow:** check **Standard flow**
+     (authorization-code grant). Leave the other grants off:
+     **Direct access grants**, **Service accounts roles**, and
+     **OAuth 2.0 Device Authorization Grant** all stay off — the
+     BFF uses authorization-code only, and enabling the other
+     grants on the same client widens the attack surface for no
+     gain.
+6. **Next** → **Login settings**:
+   - **Root URL:** `https://meho.evba.lab` (the deploy's public
+     URL).
+   - **Home URL:** `https://meho.evba.lab/ui/`.
+   - **Valid redirect URIs:**
+     `https://meho.evba.lab/ui/auth/callback` — **exact match
+     only**, no wildcards. Keycloak enforces exact match on the
+     token-endpoint exchange; a mismatch surfaces as
+     `invalid_grant` on the callback.
+   - **Valid post-logout redirect URIs:**
+     `https://meho.evba.lab/ui/auth/login` (the BFF logout flow
+     bounces the operator back to this URL after the IdP-side
+     end-session hop).
+   - **Web origins:** leave blank — CORS is not needed (the BFF
+     is same-origin with the operator-console UI).
+7. **Save.**
+
+### Step 2 — Pin PKCE and confirm the client-auth method
+
+PKCE is mandatory on every OAuth 2.1 authorization-code flow,
+including confidential clients (RFC 9700 §2.1.1; OAuth 2.0 for
+Browser-Based Apps BCP §6.1). The backplane's BFF always sends
+`code_challenge` + `code_challenge_method=S256` on the
+authorization URL, so the realm must accept this shape:
+
+1. On the `meho-web` client → **Advanced** tab.
+2. **Proof Key for Code Exchange Code Challenge Method:** set to
+   `S256`. (Leaving this unset lets the client send any method
+   including `plain`, which OAuth 2.1 forbids; pinning `S256`
+   here makes Keycloak reject a malformed BFF that drifted to
+   `plain` for any reason.)
+3. Confirm under the **Credentials** tab → **Client Authenticator**:
+   `Client Id and Secret` (the default).
+   - The token-endpoint authentication method `client_secret_post`
+     is the conventional default for confidential clients;
+     authlib picks this method on the BFF side. Keycloak accepts
+     both `client_secret_post` and `client_secret_basic` — either
+     works.
+4. **Save.**
+
+### Step 3 — Copy the client secret to Vault
+
+1. On the `meho-web` client → **Credentials** tab.
+2. Copy the **Client secret** value. Treat this value as
+   sensitive; do not paste it into chat logs or commit it to a
+   repo.
+3. Write the secret to Vault under the path the deploy renders
+   into the pod environment. Suggested layout (matches the
+   existing CLI / MCP-client conventions; adjust to the
+   deploy's path namespace):
+
+   ```bash
+   # Path layout: secret/meho/<environment>/ui/keycloak/web-client
+   # The deploy renders the secret value into the pod's
+   # UI_KEYCLOAK_CLIENT_SECRET env var via the same chain that
+   # lands DATABASE_URL / UI_SESSION_ENCRYPTION_KEY.
+   vault kv put secret/meho/prod/ui/keycloak/web-client \
+     client_secret='<paste-value-here>'
+   ```
+
+   For the dogfooding lab the path is
+   `secret/meho/evba-lab/ui/keycloak/web-client`; update the
+   Helm values `extraEnv` block (or the `ExternalSecret` /
+   `VaultSecret` CRD the deploy already uses for
+   `DATABASE_URL`) so the pod environment carries:
+
+   ```yaml
+   - name: UI_KEYCLOAK_CLIENT_ID
+     value: "meho-web"
+   - name: UI_KEYCLOAK_CLIENT_SECRET
+     valueFrom:
+       secretKeyRef:
+         name: meho-ui-keycloak-web
+         key: client_secret
+   ```
+
+   The exact secret-management chain depends on the deploy's
+   secret-rendering stack (External Secrets Operator, Vault
+   Agent Injector, Helm hook with `vault kv get`, etc.); the
+   contract is that `UI_KEYCLOAK_CLIENT_SECRET` is present in
+   the pod environment at startup. The backplane reads it once
+   via [`get_settings`](../codebase/backend.md) and never logs
+   or re-emits it.
+
+4. Verify by querying Vault for the key (the value MUST NOT be
+   pasted into logs or chat):
+
+   ```bash
+   vault kv get -field=client_secret secret/meho/prod/ui/keycloak/web-client \
+     | wc -c
+   # Expected: 30+ -- Keycloak issues 36-character UUID-style
+   # secrets by default. The check confirms the value lands
+   # without leaking it.
+   ```
+
+### Step 4 — Rotate by regenerating the secret on Keycloak
+
+The secret can be rotated at any time:
+
+1. **Credentials** tab → **Regenerate**. Copy the new value
+   immediately — the old value stops working on regenerate.
+2. `vault kv put secret/meho/<env>/ui/keycloak/web-client
+   client_secret='<new-value>'`.
+3. Restart the backplane pods (or trigger the deploy's
+   secret-refresh path) so the new value is read at startup.
+
+During the gap between "secret regenerated on Keycloak" and "pod
+restarted with the new secret", any in-flight BFF login attempts
+fail with `invalid_client` at the token endpoint — the operator
+sees a generic 400 and can retry after the deploy completes.
+Plan rotations during a low-traffic window or use the deploy's
+rolling-restart strategy to keep the failure surface small.
+
+## Verification
+
+Three checks. Run them after applying the recipe and before
+considering the realm "BFF-ready". Checks 1 and 2 prove the realm
+half (client + secret exist and PKCE is pinned); Check 3 proves
+the end-to-end contract.
+
+### Check 1 — `meho-web` client is configured correctly
+
+```bash
+# Replace REALM / ADMIN_TOKEN with values from your environment.
+ISSUER="https://keycloak.example.org/realms/<realm-name>"
+ADMIN_TOKEN="<a token from kcadm.sh config credentials>"
+
+curl -sS -H "Authorization: Bearer $ADMIN_TOKEN" \
+  "$ISSUER/clients?clientId=meho-web" \
+  | jq '.[0] | {
+      clientId,
+      publicClient,
+      standardFlowEnabled,
+      directAccessGrantsEnabled,
+      redirectUris,
+      pkceMethod: .attributes."pkce.code.challenge.method"
+    }'
+```
+
+Expected:
+
+```json
+{
+  "clientId": "meho-web",
+  "publicClient": false,
+  "standardFlowEnabled": true,
+  "directAccessGrantsEnabled": false,
+  "redirectUris": ["https://meho.evba.lab/ui/auth/callback"],
+  "pkceMethod": "S256"
+}
+```
+
+Mismatch on `publicClient: true` → client authentication is off;
+go back to Step 1. Mismatch on `pkceMethod` → re-apply Step 2.
+Mismatch on `redirectUris` → add the exact callback URL on the
+client's **Settings** tab.
+
+### Check 2 — discovery doc exposes `end_session_endpoint`
+
+The logout flow relies on Keycloak's OIDC Session Management
+end-session endpoint. The discovery doc lists it:
+
+```bash
+curl -sS "$ISSUER/.well-known/openid-configuration" \
+  | jq '{
+      authorization_endpoint,
+      token_endpoint,
+      end_session_endpoint
+    }'
+```
+
+All three URLs must be present. The BFF logout flow degrades
+gracefully when `end_session_endpoint` is absent (clears the local
+cookie + redirects to `/ui/auth/login`), but the IdP-side session
+stays alive until its own TTL — undesirable.
+
+### Check 3 — End-to-end login round-trip against the deployed BFF
+
+After the backplane is deployed with `UI_KEYCLOAK_CLIENT_ID=meho-web`
++ `UI_KEYCLOAK_CLIENT_SECRET=<value-from-Vault>` +
+`UI_SESSION_ENCRYPTION_KEY=<value-from-Vault>`:
+
+```bash
+# Visit the dashboard in a browser:
+open https://meho.evba.lab/ui/
+
+# Expected:
+# 1. 302 → /ui/auth/login?return_to=/ui/
+# 2. 302 → https://keycloak.example.org/realms/<realm>/protocol/openid-connect/auth
+#    Query string carries code_challenge + code_challenge_method=S256 +
+#    resource=https://meho.evba.lab/api + state=<random>.
+# 3. Operator authenticates at Keycloak.
+# 4. 302 → /ui/auth/callback?code=...&state=...
+# 5. Backplane sets the meho_session cookie (HttpOnly + Secure +
+#    SameSite=Strict + Path=/) and 302s to /ui/.
+# 6. Dashboard renders with the operator's identity in the header.
+```
+
+Failure modes:
+
+- **400 `authorization_failed` on callback** — usually a
+  `state` mismatch (the verifier store dropped the entry, which
+  can happen on a stale browser tab or after a backplane
+  restart) or a `client_secret` typo. Re-check Step 3 (the
+  rendered secret matches what Keycloak shows under
+  **Credentials**) and try the flow with a fresh browser tab.
+- **503 `ui_oauth_not_configured`** — `UI_KEYCLOAK_CLIENT_ID` or
+  `UI_KEYCLOAK_CLIENT_SECRET` is unset in the pod environment.
+  Re-check Step 3 (the Helm values rendered the env var) and
+  the deploy's secret-refresh path.
+- **502 `upstream_auth_provider_unreachable`** — the backplane
+  cannot reach Keycloak's discovery / token endpoint. DNS, TLS,
+  or network policy issue; outside the BFF's control.
+- **401 from the chassis JWT chain on callback** — the access
+  token Keycloak issued does not carry the `tenant_id` /
+  `tenant_role` claims, or the `aud` does not match
+  `KEYCLOAK_AUDIENCE`. The BFF inherits the same chassis JWT
+  checks the API surface enforces; re-run the checks in
+  [`keycloak-tenant-claims.md`](./keycloak-tenant-claims.md) §
+  Verification.
+
+## Why a separate `meho-web` client (and not reuse `meho-cli` or `meho-mcp`)
+
+- **`meho-cli` is public.** Public clients have no secret. The
+  authorization-code grant the BFF runs requires a secret on the
+  token-endpoint POST (confidential client). Reusing the CLI
+  client would force the realm to either weaken the CLI client to
+  accept public-grant flows it doesn't run, or shoehorn the BFF
+  into the device-code flow it isn't suited for.
+- **`meho-mcp` is the resource server.** The audience the
+  backplane validates against (`KEYCLOAK_AUDIENCE`). Tokens are
+  issued **for** that audience, not by that client. A confidential
+  client that issues a token with `aud=meho-mcp` is the right
+  shape; that confidential client is `meho-web`.
+- **Redirect URI exact match.** Each client has its own
+  redirect URIs list. The BFF callback URL
+  (`/ui/auth/callback`) is BFF-specific; mixing it with CLI
+  device-code URIs on one client confuses Keycloak's
+  redirect-validation logic.
+
+The cost of a separate client is one extra Admin Console object
++ one extra Vault secret. The benefit is each operator surface
+(CLI / MCP / Web) has its own client identity that the realm can
+audit / disable / rate-limit independently.
+
+## Status
+
+| Item | Side | State |
+| --- | --- | --- |
+| Recipe (this doc) | producer | landed in this PR ([`./keycloak-web-client.md`](./keycloak-web-client.md)) |
+| BFF reads `UI_KEYCLOAK_CLIENT_ID` / `UI_KEYCLOAK_CLIENT_SECRET` | producer | tracked at [#865](https://github.com/evoila/meho/issues/865) |
+| `meho-web` client provisioned on `evba.lab` realm | consumer | pending — applied by the dogfooding lab operator before deploying v0.2 operator-console |
+| Vault path `secret/meho/evba-lab/ui/keycloak/web-client` populated | consumer | pending — same operator step |
+| End-to-end browser login against the v0.2 BFF returns 200 on `/ui/` | consumer | pending — the closing-comment artefact on Initiative #337 |
+
+## References
+
+- Parent Initiative: [#337 — G10.0 Frontend chassis](https://github.com/evoila/meho/issues/337) — HTMX + Jinja2 + Tailwind + BFF auth + FastAPI `/ui` mount
+- Parent Goal: [#336 — G10 Operator web UI](https://github.com/evoila/meho/issues/336)
+- Sibling handshake: [`./keycloak-tenant-claims.md`](./keycloak-tenant-claims.md) — `tenant_id` + `tenant_role` protocol mappers (the BFF inherits these via the chassis JWT chain)
+- Sibling handshake: [`./mcp-client-setup.md`](./mcp-client-setup.md) — `meho-cli` / `meho-mcp` client recipes (this `meho-web` doc mirrors the same shape)
+- Backend codebase walkthrough: [`../codebase/ui.md`](../codebase/ui.md) — BFF auth flow + middleware + session storage
+- Settings: [`Settings.ui_keycloak_client_id`](../codebase/backend.md), [`Settings.ui_keycloak_client_secret`](../codebase/backend.md)
+- OAuth 2.0 Authorization Code grant — [RFC 6749 §4.1](https://www.rfc-editor.org/rfc/rfc6749)
+- PKCE — [RFC 7636](https://www.rfc-editor.org/rfc/rfc7636)
+- Resource indicators — [RFC 8707](https://www.rfc-editor.org/rfc/rfc8707)
+- OAuth Security BCP — [RFC 9700](https://datatracker.ietf.org/doc/rfc9700/)
+- OAuth 2.0 for Browser-Based Apps BCP — [draft-ietf-oauth-browser-based-apps](https://datatracker.ietf.org/doc/draft-ietf-oauth-browser-based-apps/)
+- Keycloak Server Admin Guide — [Client configuration](https://www.keycloak.org/docs/latest/server_admin/index.html#_client-configuration)
+- Keycloak OIDC layers — [OIDC endpoints](https://www.keycloak.org/securing-apps/oidc-layers)
+- Consumer's Keycloak realm: see `evoila-bosnia/claude-rdc-hetzner-dc/rdc-hetzner-dc/INVENTORY.md` Keycloak section


### PR DESCRIPTION
## Summary

- Lands the BFF (Backend-for-Frontend) OAuth 2.1 + PKCE auth flow for the operator-console UI on top of T3's encrypted session store (#864).
- Adds `/ui/auth/{login,callback,logout}` against a new `meho-web` confidential Keycloak client + a pure-ASGI session middleware that redirects unauthenticated `/ui/*` requests to login.
- All PKCE verifier custody is server-side (keyed on `state`, single-use, 10-min TTL); the access + refresh tokens never leave the encrypted `web_session` row; the browser holds only an opaque `HttpOnly; Secure; SameSite=Strict; Path=/` cookie.

## Module map (all under `backend/src/meho_backplane/ui/auth/`)

| File | Role |
| --- | --- |
| `verifier_store.py` | `PKCEVerifierStore` -- server-side dict keyed on `state`, single-use semantics, bounded reap on `put`. Process-local (single-worker uvicorn in v0.2). |
| `flow.py` | authlib `AsyncOAuth2Client` primitives. `build_authorization_request` (S256 PKCE + RFC 8707 `resource`), `exchange_code_for_tokens` (pops verifier + POSTs to token endpoint), `resolve_oidc_endpoints` (TTL-cached discovery doc). |
| `routes.py` | FastAPI `APIRouter` at `/ui/auth`. Callback verifies the access token through the chassis JWT chain so the BFF inherits issuer/audience/sub/tenant defences from `/api/*`. |
| `middleware.py` | Pure-ASGI `UISessionMiddleware`. Loads operator identity from the `meho_session` cookie on every `/ui/*` request; 302s to login on missing/expired/malformed. Bypasses `/ui/static/*` (chassis CSS/JS) and `/ui/auth/*` (the BFF surfaces themselves). |

## Test plan

- [x] `ruff check` -- clean (full repo).
- [x] `ruff format --check` -- clean.
- [x] `mypy src/` -- clean (strict).
- [x] `pytest tests/test_ui_auth_flow.py` -- **32 passed** (respx-mocked Keycloak).
- [x] Full unit suite -- 3339 passed, 19 skipped (no regressions from refactor).
- [x] `code-quality.py --diff` -- **0 blockers**.
- [x] AC1 `/ui/auth/login` builds authorization URL with `code_challenge_method=S256` + `resource=<backplane>/api`. Verified via `test_login_redirects_to_keycloak_with_pkce_and_resource` (asserts every query parameter).
- [x] AC2 `/ui/auth/callback` exchanges code+verifier, creates session row with encrypted tokens, sets cookie with all four attributes. Verified via `test_callback_creates_session_and_sets_cookie`.
- [x] AC3 `/ui/auth/logout` revokes session row + clears cookie + 302s to Keycloak `end_session_endpoint`. Verified via `test_logout_revokes_session_and_clears_cookie_and_redirects_to_end_session`.
- [x] AC4 middleware: redirect on missing/expired/malformed cookie, let through on valid session. Verified via four `test_middleware_*` cases.
- [x] AC5 `docs/cross-repo/keycloak-web-client.md` ships (mirrors `keycloak-tenant-claims.md` shape).
- [x] Security: PKCE verifier never in a cookie (`test_login_persists_verifier_in_server_side_store_not_cookie`), `state` is CSRF-checked (`test_callback_rejects_unknown_state`, `test_callback_rejects_replayed_state_after_first_consumption`), open-redirect guard (`test_login_sanitises_return_to_against_open_redirect` parametrised over 7 hostile inputs).
- [x] Defence-in-depth: callback re-validates the access token through `verify_jwt_for_audience` so the BFF inherits the chassis JWT chain's issuer/audience/sub/tenant checks.

## Settings

- New `UI_KEYCLOAK_CLIENT_ID` + `UI_KEYCLOAK_CLIENT_SECRET` env vars (precedent: `UI_SESSION_ENCRYPTION_KEY` from #864). Rendered from Vault in production by the same chain that lands `DATABASE_URL`. Missing secret surfaces 503 with the `keycloak-web-client.md` remediation pointer.
- Client secret never logged, never copied into structlog context, never surfaced in error bodies. The only seam that touches it is `_build_oauth_client`, which writes it onto the authlib client (the token-endpoint POST uses `client_secret_basic` per RFC 6749 §2.3.1).

## Out of scope (deferred to T5 #866 per the issue body)

- Mounting the router + middleware onto `backend/src/meho_backplane/main.py`.
- Dashboard view + CSRF token + smoke test + 5 surface stubs.
- Refresh-token rotation handler (the `rotate_refresh` primitive landed in T3 #864; the route consumer is T5 scope).

## Adjacent findings (not edited; recorded for orchestrator)

- `backend/src/meho_backplane/settings.py` now 650 lines (pre-existing 600-line warning). Splitting per-area when the file grows further is the standard playbook; not in #865 scope.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #865


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OAuth 2.1 with PKCE authorization added for secure user authentication in the operator console
  * Session-based access control protecting all operator UI routes
  * Login and logout functionality with server-side session management
  * Encrypted session storage with secure cookie-based persistence

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/959?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->