### PR TITLE
feat(ui): G10.0-T5 FastAPI /ui integration + dashboard + 5 stubs + CSRF + chassis smoke test

### DIFF
--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -47,6 +47,7 @@ from typing import Final
 
 import structlog
 from fastapi import FastAPI, Response
+from fastapi.staticfiles import StaticFiles
 
 from meho_backplane import __version__
 from meho_backplane.api.v1.audit import router as api_v1_audit_router
@@ -105,6 +106,11 @@ from meho_backplane.topology import (
     stop_topology_history_retention_sweeper,
     stop_topology_refresh_scheduler,
 )
+from meho_backplane.ui.auth import UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.csrf import CSRFMiddleware
+from meho_backplane.ui.paths import ensure_static_dist_dir, static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
 from meho_backplane.version import router as version_router
 
 _APP_NAME: Final[str] = "meho-backplane"
@@ -248,6 +254,14 @@ async def _run_lifespan_startup() -> None:
     # 401s with no signal. Crash loudly here with the remediation
     # instead of serving a dark, silent surface.
     _assert_mcp_resource_uri_configured()
+    # G10.0-T5 (#866) — ensure ``ui/static/dist/`` exists so the
+    # StaticFiles mount does not crash on a fresh clone where
+    # ``tailwindcss --watch`` has not yet materialised the compiled
+    # stylesheet. Idempotent; mkdir(exist_ok=True). The mount serves
+    # a 404 on ``/ui/static/dist/tailwind.css`` until the operator
+    # runs the Tailwind build -- the operator-facing remediation is
+    # documented in ``docs/codebase/ui.md``.
+    ensure_static_dist_dir()
     # Embedding model preload (G0.4-T2 #259); loud-but-non-fatal.
     await _preload_embedding_model()
 
@@ -353,10 +367,33 @@ app: FastAPI = FastAPI(
 # outermost layer (its ``__call__`` runs first on the request side and
 # last on the response side). The required runtime order for v0.2 is:
 #
-#   client → RequestContextMiddleware → BroadcastDetailMiddleware
+#   client → UISessionMiddleware → CSRFMiddleware
+#          → RequestContextMiddleware → BroadcastDetailMiddleware
 #          → AuditMiddleware → router → handler
 #
-# - ``RequestContextMiddleware`` outermost so ``request_id`` is bound
+# - ``UISessionMiddleware`` (G10.0-T4 #865, mounted by T5 #866)
+#   outermost so unauthenticated ``/ui/*`` requests 302 to
+#   ``/ui/auth/login`` BEFORE any inner middleware does
+#   request-context / audit work. Out-of-prefix paths
+#   (``/api/*`` / ``/mcp/*`` / ``/healthz`` / etc.) pass straight
+#   through to the inner chain -- the middleware is ``/ui/``-scoped
+#   by construction. Registering it *before* (i.e. outside) the
+#   JWT dependency chain is what the Initiative #337 acceptance
+#   criterion 4 means by "session middleware before JWT
+#   middleware": JWT verification is enforced as a route
+#   dependency on ``/api/*`` routes, and the session middleware
+#   short-circuits ``/ui/*`` requests so the JWT dependency never
+#   runs on them. The /api/* surface continues to flow through the
+#   inner chain unchanged.
+# - ``CSRFMiddleware`` (G10.0-T5 #866) runs second. It guards
+#   state-changing ``/ui/*`` requests (POST/PATCH/PUT/DELETE) with
+#   the OWASP double-submit cookie pattern. Out-of-prefix paths
+#   and read-only methods pass through. The middleware is
+#   intentionally registered *outside* the audit chain so a CSRF
+#   rejection produces a 403 without writing an unauthenticated
+#   audit row (the audit middleware skips when ``operator_sub`` is
+#   not bound, which is true on a CSRF rejection).
+# - ``RequestContextMiddleware`` next so ``request_id`` is bound
 #   before any inner middleware reads it; the
 #   :func:`~meho_backplane.middleware.verify_jwt_and_bind` dependency
 #   binds ``operator_sub`` deeper still, inside the handler invocation.
@@ -372,14 +409,17 @@ app: FastAPI = FastAPI(
 #
 # To achieve that with ``add_middleware``'s last-added-is-outermost
 # rule, ``AuditMiddleware`` is registered *first* (becomes innermost),
-# then ``BroadcastDetailMiddleware``, then ``RequestContextMiddleware``
-# (becomes outermost). Middleware is registered before routers so
-# every endpoint (including the Task #19 health/version/ready
-# surfaces and the Task #20 ``/metrics`` route) inherits the
-# request-id binding and the http_requests_total counter.
+# then ``BroadcastDetailMiddleware``, then ``RequestContextMiddleware``,
+# then ``CSRFMiddleware``, then ``UISessionMiddleware`` (becomes
+# outermost). Middleware is registered before routers so every
+# endpoint (including the Task #19 health/version/ready surfaces
+# and the Task #20 ``/metrics`` route) inherits the request-id
+# binding and the http_requests_total counter.
 app.add_middleware(AuditMiddleware)
 app.add_middleware(BroadcastDetailMiddleware)
 app.add_middleware(RequestContextMiddleware)
+app.add_middleware(CSRFMiddleware)
+app.add_middleware(UISessionMiddleware)
 
 app.include_router(health_router)
 app.include_router(version_router)
@@ -519,6 +559,33 @@ app.include_router(api_v1_broadcast_overrides_router)
 #   semantics on top.
 app.include_router(well_known_router)
 app.include_router(mcp_router)
+
+# G10.0-T5 (#866) -- Operator console surface. Three pieces ship
+# together: the static-asset mount for vendored JS + compiled
+# Tailwind, the BFF auth router (login/callback/logout), and the
+# umbrella UI router (dashboard + 5 surface stubs).
+#
+# Mount order:
+# * ``/ui/static`` -- StaticFiles wrapping the ``ui/static/``
+#   subtree. Covers both ``static/src/vendor/*.js`` (vendored HTMX /
+#   Alpine / Cytoscape) and ``static/dist/tailwind.css`` (compiled
+#   stylesheet, materialised by ``ensure_static_dist_dir`` at
+#   startup). The ``UISessionMiddleware`` short-circuits on the
+#   ``/ui/static/`` prefix so unauthenticated browsers can load
+#   the styled login page assets.
+# * UI auth router -- ``/ui/auth/{login,callback,logout}`` GET
+#   routes; reachable unauthenticated (the middleware exempts
+#   ``/ui/auth/``).
+# * UI router -- ``GET /ui/`` dashboard + the five
+#   ``GET /ui/{slug}`` surface stubs. All routes require a session;
+#   ``UISessionMiddleware`` redirects to login on miss.
+app.mount(
+    "/ui/static",
+    StaticFiles(directory=str(static_root_dir()), check_dir=False),
+    name="ui_static",
+)
+app.include_router(build_ui_auth_router())
+app.include_router(build_ui_router())
 
 # Opt-in stub routes for end-to-end verification of
 # :func:`~meho_backplane.auth.rbac.require_role`. Disabled by default

--- a/backend/src/meho_backplane/ui/csrf.py
+++ b/backend/src/meho_backplane/ui/csrf.py
@@ -1,0 +1,508 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Double-submit-cookie CSRF protection for ``/ui/*`` state-changing routes.
+
+Initiative #337 (G10.0 Frontend chassis), Task #866 (T5). The BFF
+session cookie already carries ``SameSite=Strict`` -- which by spec
+omits the cookie from every cross-site navigation, blocking the entire
+CSRF class on top-level requests. CSRF here is **belt-and-braces**
+against the residual same-site vector: a malicious sub-domain on
+``*.evba.lab`` (or a compromise of an unrelated path on the same host)
+could still issue an XHR carrying the session cookie. The
+double-submit token defeats that vector because a same-site attacker
+JS cannot read the session cookie (``HttpOnly``) and therefore cannot
+derive the matching CSRF token to echo back.
+
+Design: OWASP's "Signed Double-Submit Cookie" pattern
+=====================================================
+
+The naive double-submit pattern (random value cookie + same value in a
+custom header) is vulnerable to cookie injection from a sub-domain
+attacker who can set a cookie on the parent domain. OWASP's CSRF
+Prevention Cheat Sheet recommends binding the token to the user's
+session via HMAC:
+
+    token = hmac_sha256(secret, session_id || random) + "." + random
+
+The server validates by recomputing the HMAC from the presented random
+half + the session_id read from the validated ``meho_session`` cookie;
+mismatch → reject. An attacker forging the cookie cannot also forge a
+header echo matching the HMAC (the secret never leaves the server) and
+cannot read the session_id (``HttpOnly`` cookie + same-origin
+restriction on cross-origin JS).
+
+Why in-house instead of ``starlette-csrf``
+==========================================
+
+* The chassis policy (decisions #9 + #10) keeps the FE stack to
+  hand-rolled, zero-new-dep components. ``starlette-csrf`` adds a
+  transitive dependency for ~30 lines of crypto + middleware logic
+  that the chassis can carry directly.
+* ``starlette-csrf`` ties to its own cookie name / header name and
+  ignores the BFF's session_id; in-house lets us pin the HMAC to the
+  ``meho_session`` cookie value end-to-end.
+* The middleware shape mirrors :class:`UISessionMiddleware` (pure ASGI,
+  one ``__call__``, narrow path-prefix scope) so a single mental model
+  governs every ``/ui/*`` pre-routing hook.
+
+Scope
+=====
+
+The middleware short-circuits on three conditions before any token
+check happens:
+
+1. Non-HTTP scope (lifespan, websocket) -- passes through.
+2. Path outside ``/ui/*`` -- passes through (``/api/*`` and ``/mcp``
+   handle their own auth + idempotency).
+3. Method is read-only (``GET`` / ``HEAD`` / ``OPTIONS``) -- passes
+   through (CSRF protects state-changing requests only).
+
+The remaining ``POST`` / ``PATCH`` / ``PUT`` / ``DELETE`` requests
+under ``/ui/`` must carry the CSRF token in **either** the
+``X-CSRF-Token`` header (HTMX form-injected) **or** the ``csrf_token``
+form field (server-rendered form fallback). Missing or invalid →
+``403 Forbidden`` with a stable detail string.
+
+Token issuance
+==============
+
+The server mints a fresh token on every authenticated dashboard render
+(:func:`mint_csrf_token`). Surface templates embed the token in the
+HTMX-friendly shape::
+
+    <body hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'>
+
+so every HTMX ``hx-post`` / ``hx-delete`` request inherits the header
+automatically. Forms outside the HTMX surface include the token in a
+hidden field; the middleware accepts either source.
+
+References
+----------
+
+* OWASP CSRF Prevention Cheat Sheet (signed double-submit cookie):
+  https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html
+* RFC 6265bis -- ``SameSite`` cookie attribute:
+  https://datatracker.ietf.org/doc/draft-ietf-httpbis-rfc6265bis/
+* MDN: ``Set-Cookie`` Same-Site:
+  https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+from typing import Final
+from urllib.parse import parse_qs
+
+import structlog
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth.routes import SESSION_COOKIE_NAME
+
+__all__ = [
+    "CSRF_COOKIE_NAME",
+    "CSRF_FORM_FIELD",
+    "CSRF_HEADER_NAME",
+    "CSRFMiddleware",
+    "mint_csrf_token",
+    "verify_csrf_token",
+]
+
+
+#: Name of the cookie carrying the double-submit token. Separate from
+#: ``meho_session`` so the JS-readable half (the random tail of the
+#: token) can be set without ``HttpOnly`` -- HTMX needs to echo it
+#: back in the ``X-CSRF-Token`` header, which requires JavaScript
+#: access. The HMAC binding to the session_id is what defeats cookie
+#: injection from a sub-domain attacker.
+CSRF_COOKIE_NAME: Final[str] = "meho_csrf"
+
+#: Custom header HTMX populates on every state-changing request via
+#: ``hx-headers='{"X-CSRF-Token": "..."}'`` on the page ``<body>``.
+#: The header MUST be a custom name (not ``Cookie`` /
+#: ``Authorization``) so the same-origin restriction on cross-origin
+#: JS prevents an attacker on a different origin from sending it.
+CSRF_HEADER_NAME: Final[str] = "X-CSRF-Token"
+
+#: Hidden form-field name for surface templates rendering a classic
+#: ``<form method="post">`` that the HTMX header pattern can't reach
+#: (e.g. an HTML upload form without ``hx-encoding``). The middleware
+#: accepts either source.
+CSRF_FORM_FIELD: Final[str] = "csrf_token"
+
+#: HTTP methods that bypass CSRF. The remainder are state-changing and
+#: must carry a valid token.
+_SAFE_METHODS: Final[frozenset[str]] = frozenset({"GET", "HEAD", "OPTIONS"})
+
+#: Prefix every UI route lives under. Outside this prefix the
+#: middleware passes through; ``/api/*`` and ``/mcp/*`` enforce their
+#: own request validation via Bearer-token signatures.
+_UI_PREFIX: Final[str] = "/ui/"
+
+#: BFF auth surfaces -- ``/ui/auth/login`` / ``/ui/auth/callback`` /
+#: ``/ui/auth/logout`` are all ``GET`` per Task #865, so they fall
+#: through ``_SAFE_METHODS`` already. The constant is documented for
+#: greppability rather than as a runtime branch.
+_AUTH_PREFIX: Final[str] = "/ui/auth/"
+
+#: Random-half byte length. 32 bytes = 256 bits of entropy; comfortably
+#: above the OWASP "cryptographically strong random" floor.
+_RANDOM_BYTES: Final[int] = 32
+
+#: HMAC algorithm. SHA-256 keeps the token compact while exceeding
+#: the OWASP "strong cryptographic hash" floor.
+_HMAC_ALG = hashlib.sha256
+
+
+def _csrf_secret() -> bytes:
+    """Return the HMAC secret bytes.
+
+    Reuses :attr:`Settings.ui_session_encryption_key` as the keying
+    material instead of introducing a second env var. The session-store
+    Fernet key is a URL-safe base64 32-byte value -- already
+    cryptographically strong and rotation-managed by the same Vault
+    plumbing that lands the Fernet key itself. Mixing CSRF + session
+    encryption under one key is acceptable because the two consumers
+    apply different KDFs (Fernet's HMAC-SHA256 + AES; ours raw
+    HMAC-SHA256) over distinct input domains (session token bytes vs
+    ``session_id || random``).
+
+    Returns the key bytes verbatim -- :func:`hmac.new` accepts any
+    bytes-like key. Empty key (``UI_SESSION_ENCRYPTION_KEY`` unset) is
+    a deployment-time misconfiguration that the chassis already
+    surfaces from the session store
+    (:class:`~meho_backplane.ui.auth.session_store.EncryptionKeyMissingError`);
+    the CSRF middleware short-circuits with a deterministic 503-shape
+    only on a state-changing request, mirroring the chassis fail-fast
+    convention.
+    """
+    return get_settings().ui_session_encryption_key.encode("utf-8")
+
+
+def mint_csrf_token(session_id: str) -> str:
+    """Mint a fresh signed double-submit CSRF token for *session_id*.
+
+    Token shape: ``"<hmac_hex>.<random_hex>"`` where ``hmac_hex`` is
+    HMAC-SHA256(secret, ``session_id || random``) hex-encoded. The two
+    halves are joined with ``.`` so the random-half can be parsed out
+    by :func:`verify_csrf_token` without an explicit length parameter.
+
+    The token is the value the template embeds in
+    ``hx-headers='{"X-CSRF-Token": "<token>"}'`` AND the value the
+    middleware sets on the ``meho_csrf`` cookie. Both ride the same
+    response; the browser sends the cookie back automatically and the
+    HTMX wiring sends the header echo. Mismatch → 403.
+
+    The minting is stateless -- nothing persists server-side. Any
+    in-flight token presented with a matching ``session_id`` validates
+    until the operator logs out (or the session row expires); replay
+    is not a concern because the token's only valid recipient is the
+    backplane itself, and the SameSite=Strict session cookie blocks
+    cross-site replay outright.
+    """
+    random_bytes = secrets.token_bytes(_RANDOM_BYTES)
+    random_hex = random_bytes.hex()
+    payload = session_id.encode("ascii") + random_bytes
+    mac = hmac.new(_csrf_secret(), payload, _HMAC_ALG).hexdigest()
+    return f"{mac}.{random_hex}"
+
+
+def verify_csrf_token(session_id: str, token: str) -> bool:
+    """Return ``True`` iff *token* is a valid signed double-submit for *session_id*.
+
+    Stateless verification: split the token on ``.``, decode the
+    random half, recompute the HMAC, and compare via
+    :func:`hmac.compare_digest` (constant-time -- prevents the timing
+    side-channel a naive ``==`` would expose).
+
+    Returns ``False`` on any structural failure (no separator, wrong
+    field count, non-hex bytes, empty halves). The middleware logs the
+    failure class for forensic visibility but does not telegraph the
+    cause in the response body (the operator-facing remediation is
+    identical -- refresh the page).
+    """
+    if not token or "." not in token:
+        return False
+    parts = token.split(".")
+    if len(parts) != 2:
+        return False
+    mac_hex, random_hex = parts
+    if not mac_hex or not random_hex:
+        return False
+    try:
+        random_bytes = bytes.fromhex(random_hex)
+    except ValueError:
+        return False
+    payload = session_id.encode("ascii") + random_bytes
+    expected = hmac.new(_csrf_secret(), payload, _HMAC_ALG).hexdigest()
+    return hmac.compare_digest(expected, mac_hex)
+
+
+def _select_path(scope: Scope) -> str:
+    """Return the ASGI scope's path, defaulting to ``/``."""
+    raw = scope.get("path")
+    return raw if isinstance(raw, str) and raw else "/"
+
+
+def _select_method(scope: Scope) -> str:
+    """Return the ASGI scope's HTTP method, upper-cased."""
+    raw = scope.get("method")
+    return raw.upper() if isinstance(raw, str) else "GET"
+
+
+def _extract_cookie(scope: Scope, cookie_name: str) -> str | None:
+    """Pull a single cookie value out of the raw ASGI headers.
+
+    Mirrors :func:`~meho_backplane.ui.auth.middleware._extract_session_cookie`
+    so the two pre-routing hooks share the parse pattern.
+    """
+    headers = scope.get("headers")
+    if not isinstance(headers, list):
+        return None
+    name_bytes = cookie_name.encode("ascii")
+    for hdr_name, hdr_value in headers:
+        if not isinstance(hdr_name, (bytes, bytearray)) or hdr_name != b"cookie":
+            continue
+        if not isinstance(hdr_value, (bytes, bytearray)):
+            continue
+        value_bytes = bytes(hdr_value)
+        for chunk in value_bytes.split(b";"):
+            chunk = chunk.strip()
+            if not chunk or b"=" not in chunk:
+                continue
+            cookie_key, _, cookie_value = chunk.partition(b"=")
+            if cookie_key.strip() == name_bytes:
+                try:
+                    return cookie_value.decode("ascii")
+                except UnicodeDecodeError:
+                    return None
+    return None
+
+
+def _extract_header(scope: Scope, header_name: str) -> str | None:
+    """Pull a request-header value (latin-1 decoded) out of the ASGI scope."""
+    headers = scope.get("headers")
+    if not isinstance(headers, list):
+        return None
+    needle = header_name.lower().encode("ascii")
+    for hdr_name, hdr_value in headers:
+        if not isinstance(hdr_name, (bytes, bytearray)):
+            continue
+        if hdr_name.lower() != needle:
+            continue
+        if isinstance(hdr_value, (bytes, bytearray)):
+            return bytes(hdr_value).decode("latin-1")
+    return None
+
+
+def _forbidden_response(reason: str) -> tuple[int, list[tuple[bytes, bytes]], bytes]:
+    """Build the ASGI three-tuple (status, headers, body) for a 403.
+
+    Inlined rather than synthesised via :class:`fastapi.responses.JSONResponse`
+    so the middleware stays single-allocation on the rejection path.
+    """
+    body = b'{"detail":"csrf_token_invalid"}'
+    headers: list[tuple[bytes, bytes]] = [
+        (b"content-type", b"application/json"),
+        (b"content-length", str(len(body)).encode("ascii")),
+        (b"cache-control", b"no-store"),
+        (b"x-csrf-rejection-reason", reason.encode("ascii")),
+    ]
+    return 403, headers, body
+
+
+async def _send_forbidden(send: Send, reason: str) -> None:
+    """Emit the canonical 403 response shape for a CSRF rejection."""
+    status_code, headers, body = _forbidden_response(reason)
+    await send({"type": "http.response.start", "status": status_code, "headers": headers})
+    await send({"type": "http.response.body", "body": body, "more_body": False})
+
+
+async def _extract_form_token(receive: Receive) -> tuple[str | None, list[Message]]:
+    """Drain the request body, return ``(token, buffered_messages)``.
+
+    ASGI body messages can only be received once; if the middleware
+    consumes the body to read a form field, the downstream handler
+    gets an empty body unless we replay the captured messages via a
+    replacement ``receive`` closure. This function buffers up to a
+    bounded number of ``http.request`` messages, parses the
+    ``csrf_token`` form field, and returns both the parsed value and
+    the buffer for replay.
+
+    The bound is intentionally tight (256 KiB total / 32 messages) --
+    state-changing form submissions in v0.2 are small (logout button,
+    eventual scope-promotion form). A request exceeding the bound is
+    treated as "no form token" and falls through to the header check;
+    the original body still flows through to the handler verbatim
+    because we capture every message even past the parse-bail point.
+    """
+    buffered: list[Message] = []
+    body_parts: list[bytes] = []
+    body_total = 0
+    max_body = 256 * 1024
+    max_msgs = 32
+    while True:
+        message = await receive()
+        buffered.append(message)
+        if message["type"] != "http.request":
+            break
+        body_chunk = message.get("body", b"")
+        if isinstance(body_chunk, (bytes, bytearray)):
+            body_parts.append(bytes(body_chunk))
+            body_total += len(body_chunk)
+        if not message.get("more_body"):
+            break
+        if body_total > max_body or len(buffered) > max_msgs:
+            # Keep buffering until the client signals end -- otherwise
+            # downstream handler stalls. The token-parse step below
+            # bails on the oversize case by skipping the form parse.
+            continue
+    if body_total > max_body:
+        return None, buffered
+    body = b"".join(body_parts)
+    if not body:
+        return None, buffered
+    try:
+        parsed = parse_qs(body.decode("utf-8"), keep_blank_values=False)
+    except UnicodeDecodeError:
+        return None, buffered
+    values = parsed.get(CSRF_FORM_FIELD)
+    if not values:
+        return None, buffered
+    return values[0], buffered
+
+
+def _replay_receive(buffered: list[Message]) -> Receive:
+    """Return a fresh ``Receive`` that drains *buffered* before blocking.
+
+    Once the buffer is exhausted, subsequent ``receive`` calls (e.g. a
+    streaming handler waiting on disconnect) would hang forever -- so
+    the closure yields a synthetic ``http.disconnect`` after the last
+    buffered message so a chunked downstream loop terminates cleanly.
+    """
+    iterator = iter(buffered)
+
+    async def replay() -> Message:
+        try:
+            return next(iterator)
+        except StopIteration:
+            return {"type": "http.disconnect"}
+
+    return replay
+
+
+async def _resolve_presented_token(
+    scope: Scope,
+    receive: Receive,
+) -> tuple[str | None, Receive]:
+    """Return the presented CSRF token + a (possibly-replayed) ``receive``.
+
+    Tries the ``X-CSRF-Token`` request header first; falls back to the
+    ``csrf_token`` form field on a form-urlencoded request body. Form-
+    body parsing drains the ASGI receive stream, so the function
+    returns a replayed receive that yields the buffered messages back
+    to the downstream handler when the body fallback ran. When the
+    header is present the original ``receive`` is returned untouched.
+    """
+    header_token = _extract_header(scope, CSRF_HEADER_NAME)
+    if header_token is not None:
+        return header_token, receive
+    content_type = _extract_header(scope, "content-type") or ""
+    if "application/x-www-form-urlencoded" not in content_type.lower():
+        return None, receive
+    form_token, buffered = await _extract_form_token(receive)
+    return form_token, _replay_receive(buffered)
+
+
+def _validate_csrf(
+    *,
+    session_id: str | None,
+    cookie_token: str | None,
+    presented_token: str | None,
+) -> str | None:
+    """Return ``None`` on success, or the rejection reason string on failure.
+
+    Encapsulates the four-stage validation chain so the middleware
+    ``__call__`` stays a thin orchestrator:
+
+    1. Missing session cookie -- the UISessionMiddleware would have
+       already redirected an unauthenticated ``GET``; a state-changing
+       request without a session is rejected outright.
+    2. Missing token half (cookie or header) -- the double-submit
+       contract needs both presented.
+    3. Cookie value != presented value -- guards the naive
+       double-submit failure mode (cookie injection from a same-site
+       attacker echoing back an arbitrary value).
+    4. HMAC signature mismatch against the session_id -- the binding
+       that lifts the pattern to OWASP's "signed double-submit"
+       posture.
+    """
+    if not session_id:
+        return "no_session"
+    if not cookie_token or not presented_token:
+        return "missing_token"
+    if not hmac.compare_digest(cookie_token, presented_token):
+        return "value_mismatch"
+    if not verify_csrf_token(session_id, presented_token):
+        return "signature_invalid"
+    return None
+
+
+class CSRFMiddleware:
+    """Pure-ASGI middleware enforcing the double-submit CSRF token on ``/ui/*``.
+
+    Stateless beyond ``self.app`` -- one instance handles concurrent
+    requests. Verification logic lives in :func:`verify_csrf_token`
+    and the ``mint_csrf_token`` helper the dashboard handler calls;
+    this class only sequences the ASGI parsing.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = _select_path(scope)
+        if not path.startswith(_UI_PREFIX):
+            # Out-of-prefix -- /api/* and /mcp/* have their own auth
+            # and idempotency story. The CSRF middleware is /ui-only.
+            await self.app(scope, receive, send)
+            return
+
+        method = _select_method(scope)
+        if method in _SAFE_METHODS:
+            # Read-only methods cannot mutate state, so a CSRF token
+            # check is by definition not required. The double-submit
+            # cookie is set on the GET response by the dashboard
+            # handler (and refreshed on every authenticated render);
+            # subsequent state-changing requests carry the cookie back.
+            await self.app(scope, receive, send)
+            return
+
+        log = structlog.get_logger(__name__)
+        session_id = _extract_cookie(scope, SESSION_COOKIE_NAME)
+        cookie_token = _extract_cookie(scope, CSRF_COOKIE_NAME)
+        presented_token, replay = await _resolve_presented_token(scope, receive)
+
+        rejection = _validate_csrf(
+            session_id=session_id,
+            cookie_token=cookie_token,
+            presented_token=presented_token,
+        )
+        if rejection is not None:
+            log.info(
+                "ui_csrf_rejected",
+                path=path,
+                method=method,
+                reason=rejection,
+            )
+            await _send_forbidden(send, rejection)
+            return
+
+        await self.app(scope, replay, send)

--- a/backend/src/meho_backplane/ui/csrf.py
+++ b/backend/src/meho_backplane/ui/csrf.py
@@ -101,6 +101,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from meho_backplane.settings import get_settings
 from meho_backplane.ui.auth.routes import SESSION_COOKIE_NAME
+from meho_backplane.ui.auth.session_store import EncryptionKeyMissingError
 
 __all__ = [
     "CSRF_COOKIE_NAME",
@@ -170,16 +171,29 @@ def _csrf_secret() -> bytes:
     HMAC-SHA256) over distinct input domains (session token bytes vs
     ``session_id || random``).
 
+    Empty key (``UI_SESSION_ENCRYPTION_KEY`` unset) is a deployment-
+    time misconfiguration. Raising
+    :class:`~meho_backplane.ui.auth.session_store.EncryptionKeyMissingError`
+    surfaces the failure with the same exception type and remediation
+    pointer the session store uses (``_get_fernet`` line 252), so the
+    chassis fail-fast contract claimed in the docstring above is
+    actually enforced rather than papered over with a zero-byte HMAC
+    key (which would silently mint deterministic tokens an attacker
+    could forge off-line).
+
     Returns the key bytes verbatim -- :func:`hmac.new` accepts any
-    bytes-like key. Empty key (``UI_SESSION_ENCRYPTION_KEY`` unset) is
-    a deployment-time misconfiguration that the chassis already
-    surfaces from the session store
-    (:class:`~meho_backplane.ui.auth.session_store.EncryptionKeyMissingError`);
-    the CSRF middleware short-circuits with a deterministic 503-shape
-    only on a state-changing request, mirroring the chassis fail-fast
-    convention.
+    bytes-like key.
     """
-    return get_settings().ui_session_encryption_key.encode("utf-8")
+    key = get_settings().ui_session_encryption_key
+    if not key:
+        raise EncryptionKeyMissingError(
+            "UI_SESSION_ENCRYPTION_KEY is not set; the operator-console "
+            "CSRF middleware cannot derive its HMAC keying material. "
+            "Generate a key with `python -c 'from cryptography.fernet "
+            "import Fernet; print(Fernet.generate_key().decode())'` and "
+            "surface it as the UI_SESSION_ENCRYPTION_KEY env var."
+        )
+    return key.encode("utf-8")
 
 
 def mint_csrf_token(session_id: str) -> str:
@@ -488,6 +502,27 @@ class CSRFMiddleware:
         log = structlog.get_logger(__name__)
         session_id = _extract_cookie(scope, SESSION_COOKIE_NAME)
         cookie_token = _extract_cookie(scope, CSRF_COOKIE_NAME)
+
+        # Cheap pre-checks BEFORE draining the body. ``_resolve_presented_token``
+        # can buffer up to 256 KiB of form body to read the ``csrf_token``
+        # field; doing that work for a request that's about to be rejected
+        # on a missing session cookie or missing CSRF cookie is wasted
+        # allocation and a DoS-amplification vector (an unauthenticated
+        # attacker forces the chassis to buffer a 256 KiB body per request
+        # before the inevitable 403). The validation chain in
+        # ``_validate_csrf`` already short-circuits on these two reasons,
+        # so we run the same checks here -- ahead of the body parse -- and
+        # only call ``_resolve_presented_token`` when both halves of the
+        # double-submit cookie are actually present.
+        if not session_id:
+            log.info("ui_csrf_rejected", path=path, method=method, reason="no_session")
+            await _send_forbidden(send, "no_session")
+            return
+        if not cookie_token:
+            log.info("ui_csrf_rejected", path=path, method=method, reason="missing_token")
+            await _send_forbidden(send, "missing_token")
+            return
+
         presented_token, replay = await _resolve_presented_token(scope, receive)
 
         rejection = _validate_csrf(

--- a/backend/src/meho_backplane/ui/paths.py
+++ b/backend/src/meho_backplane/ui/paths.py
@@ -68,8 +68,42 @@ def static_dist_dir() -> Path:
       alongside ``uvicorn --reload``.
 
     The directory may not exist on first ``uvicorn`` start in a fresh
-    clone; T5 #866's startup hook surfaces the operator-facing remediation
-    (``run tailwindcss once``). For chassis-only use (this Task) the
-    directory is constructed but unused.
+    clone; T5 (#866) calls :func:`ensure_static_dist_dir` from the
+    FastAPI lifespan startup so the :class:`StaticFiles` mount does
+    not crash on construction.
     """
     return _UI_PACKAGE_ROOT / "static" / "dist"
+
+
+def static_root_dir() -> Path:
+    """Return the absolute path of the ``static/`` directory tree.
+
+    The single mount point T5 (#866) registers at ``/ui/static`` covers
+    *both* the vendored source tree (``static/src/vendor/*.js``) and
+    the compiled Tailwind output (``static/dist/tailwind.css``). One
+    mount keeps the URL shape ``/ui/static/{src,dist}/...`` consistent
+    with the references the chassis ``base.html`` already emits, while
+    avoiding a second :class:`StaticFiles` instance (each mount carries
+    its own ``check_dir`` constructor cost).
+    """
+    return _UI_PACKAGE_ROOT / "static"
+
+
+def ensure_static_dist_dir() -> Path:
+    """Create the ``static/dist/`` directory if missing, return its path.
+
+    Called from the FastAPI lifespan startup so the chassis
+    :class:`~starlette.staticfiles.StaticFiles` mount can subtree the
+    ``static/`` parent on a fresh clone where ``tailwindcss --watch``
+    has not yet materialised the directory. The mount succeeds; a
+    request for ``/ui/static/dist/tailwind.css`` returns 404 until the
+    Tailwind build writes the file, which is the documented behaviour
+    in ``docs/codebase/ui.md`` -- a missing compiled stylesheet is an
+    operator-facing remediation, not a chassis crash.
+
+    Idempotent: ``mkdir(parents=True, exist_ok=True)`` so repeat lifespan
+    starts (a uvicorn reload cycle) are no-ops.
+    """
+    dist = static_dist_dir()
+    dist.mkdir(parents=True, exist_ok=True)
+    return dist

--- a/backend/src/meho_backplane/ui/routes/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/__init__.py
@@ -1,17 +1,52 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""FastAPI route handlers for the operator console (stub).
+"""FastAPI route handlers for the operator console.
 
-Empty package for chassis Task #863. T5 (#866) lands the
-``APIRouter`` instance + dashboard view (``GET /ui/``) + the five
-surface stub routes (``GET /ui/broadcast``, ``/ui/knowledge``,
-``/ui/topology``, ``/ui/connectors``, ``/ui/memory``) that
-G10.1-G10.5 fill in. T4 (#865) lands the ``/ui/auth/*`` flow.
+Initiative #337 (G10.0 Frontend chassis), Task #866 (T5). The chassis
+ships the umbrella :func:`build_router` that aggregates:
 
-This package is imported by name from
-:mod:`meho_backplane.main` once T5 wires the router; until then the
-import surface stays intentionally empty so a stray
-``from meho_backplane.ui.routes import router`` fails loudly rather
-than silently importing nothing.
+* :mod:`~meho_backplane.ui.routes.dashboard` -- ``GET /ui/`` --
+  authenticated landing page with the 3x2 surface card grid, the
+  HTMX SSE last-5-events snippet, and the version + readiness card.
+* :mod:`~meho_backplane.ui.routes.stubs` -- ``GET /ui/{broadcast,
+  knowledge,topology,connectors,memory}`` -- placeholder routes the
+  surface Initiatives G10.1-G10.5 replace.
+
+Auth surfaces (``/ui/auth/login``, ``/ui/auth/callback``,
+``/ui/auth/logout``) live under
+:mod:`meho_backplane.ui.auth.routes` and are aggregated separately;
+T5's :func:`meho_backplane.main` ``include_router`` block mounts both
+routers.
+
+The router factory pattern (rather than module-level constants)
+mirrors :func:`meho_backplane.ui.auth.routes.build_router` so a
+test app can construct multiple parallel routers without sharing
+route state -- handy for the chassis smoke test's "minimal app"
+fixture that wires UI middleware + UI router without dragging the
+full backplane app in.
 """
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from meho_backplane.ui.routes.dashboard import build_dashboard_router
+from meho_backplane.ui.routes.stubs import build_stubs_router
+
+__all__ = ["build_dashboard_router", "build_router", "build_stubs_router"]
+
+
+def build_router() -> APIRouter:
+    """Aggregate the dashboard + stubs routers into a single ``/ui/*`` router.
+
+    Order matters for diagnostic clarity (FastAPI matches by
+    registration order on conflict; the dashboard ``/ui/`` does not
+    collide with the stub ``/ui/{slug}`` routes, but a future surface
+    Initiative replacing a stub will register *before* this aggregate
+    to win the match).
+    """
+    router = APIRouter()
+    router.include_router(build_dashboard_router())
+    router.include_router(build_stubs_router())
+    return router

--- a/backend/src/meho_backplane/ui/routes/dashboard.py
+++ b/backend/src/meho_backplane/ui/routes/dashboard.py
@@ -10,13 +10,15 @@ renders three components per the Initiative work-item #6:
   routes G10.1-G10.5 fill in. The sixth tile is a static
   "deploy details" card so the grid layout is balanced without a
   trailing empty slot.
-* A live "last 5 events" snippet wired to ``/api/v1/feed`` via the
+* A live recent-activity snippet wired to ``/api/v1/feed`` via the
   HTMX 2 SSE extension (``hx-ext="sse"`` + ``sse-connect="..."`` +
   ``sse-swap="broadcast"``). The feed endpoint validates the JWT via
   the Bearer header on ``/api/v1/feed``; the dashboard surface only
   renders the HTMX wiring -- the actual subscription happens
   browser-side once the page loads (and the operator's session cookie
-  is the auth boundary that gates ``/ui/``).
+  is the auth boundary that gates ``/ui/``). Trimming the rendered
+  tray to the last N events is G10.1 (#338) client-side surface work;
+  the underlying feed endpoint streams the live tail unbounded.
 * A version + readiness card sourced from
   :data:`meho_backplane.__version__` (always rendered) and the chassis
   readiness probe registry (``meho_backplane.health.run_probes_async``)
@@ -150,8 +152,14 @@ async def _render_dashboard(
         "csrf_token": csrf_token,
         # Endpoint the HTMX SSE snippet subscribes to. Lifted out so a
         # future deploy can swap to a CDN-hosted edge proxy without
-        # editing the template.
-        "feed_endpoint": "/api/v1/feed?limit=5",
+        # editing the template. ``/api/v1/feed`` is the canonical
+        # tenant-scoped SSE stream from G6.1-T4 (#310); the route does
+        # not accept a ``limit`` query parameter (FastAPI silently
+        # ignores unknown query params, so a hardcoded ``?limit=5``
+        # would be a no-op surface promise), so the dashboard subscribes
+        # to the full live stream. Trimming the tray to the last N
+        # events client-side is G10.1 (#338) surface work.
+        "feed_endpoint": "/api/v1/feed",
     }
     response = get_templates().TemplateResponse(request, "dashboard.html", context)
     # Mirror the SameSite + Secure posture of the session cookie. The

--- a/backend/src/meho_backplane/ui/routes/dashboard.py
+++ b/backend/src/meho_backplane/ui/routes/dashboard.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Dashboard view: ``GET /ui/`` -- the authenticated landing page.
+
+Initiative #337 (G10.0 Frontend chassis), Task #866 (T5). The dashboard
+renders three components per the Initiative work-item #6:
+
+* A 3x2 grid of DaisyUI ``card`` tiles linking to the five surface
+  routes G10.1-G10.5 fill in. The sixth tile is a static
+  "deploy details" card so the grid layout is balanced without a
+  trailing empty slot.
+* A live "last 5 events" snippet wired to ``/api/v1/feed`` via the
+  HTMX 2 SSE extension (``hx-ext="sse"`` + ``sse-connect="..."`` +
+  ``sse-swap="broadcast"``). The feed endpoint validates the JWT via
+  the Bearer header on ``/api/v1/feed``; the dashboard surface only
+  renders the HTMX wiring -- the actual subscription happens
+  browser-side once the page loads (and the operator's session cookie
+  is the auth boundary that gates ``/ui/``).
+* A version + readiness card sourced from
+  :data:`meho_backplane.__version__` (always rendered) and the chassis
+  readiness probe registry (``meho_backplane.health.run_probes_async``)
+  -- the same data ``/ready`` returns, surfaced as a single
+  ready/starting pill.
+
+The handler also sets the ``meho_csrf`` cookie on the response. Per
+the OWASP signed double-submit cookie pattern, the cookie is
+JS-readable (no ``HttpOnly``) so the HTMX ``hx-headers`` directive on
+the page can echo it back to the server on subsequent state-changing
+requests. The cookie's ``SameSite=Strict`` + ``Secure`` attributes
+mirror the session cookie's posture.
+
+Why one combined handler instead of split fragments
+---------------------------------------------------
+
+The Initiative explicitly scopes "dashboard view" to a single page; the
+HTMX SSE snippet swaps fragments into the same page rather than
+navigating to a sub-route. A future surface Initiative may add HTMX
+``hx-get`` partials (e.g. tenant selector dropdown), but those are
+G10.1+ scope. v0.2.0 ships the dashboard as one Jinja template.
+
+References
+----------
+
+* HTMX 2 SSE extension -- ``sse-connect`` / ``sse-swap``:
+  https://htmx.org/extensions/sse/
+* Chassis ``base.html`` reference (sidebar links, version footer):
+  ``backend/src/meho_backplane/ui/templates/base.html``
+* Per-tenant SSE feed endpoint (G6.1-T4, #310):
+  ``backend/src/meho_backplane/api/v1/feed.py``
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
+
+from meho_backplane import __version__
+from meho_backplane.health import run_probes_async
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["build_dashboard_router"]
+
+
+#: 3x2 surface-card grid descriptors. Each tile renders a DaisyUI
+#: ``card`` with an icon, a title, a one-line summary, and an
+#: ``href`` to the surface stub T5 also lands. The 6th tile is the
+#: "deploy info" cell so the grid stays balanced; the surface
+#: Initiatives (G10.1-G10.5) re-style this when their dashboards
+#: ship richer per-surface widgets.
+_SURFACE_TILES: Final[tuple[dict[str, str], ...]] = (
+    {
+        "title": "Broadcast",
+        "summary": "Live activity feed across the tenant.",
+        "href": "/ui/broadcast",
+        "icon": "\U0001f4e1",  # satellite antenna
+    },
+    {
+        "title": "Knowledge",
+        "summary": "Search + browse the team's distilled knowledge base.",
+        "href": "/ui/knowledge",
+        "icon": "\U0001f4da",  # books
+    },
+    {
+        "title": "Topology",
+        "summary": "Targets, clusters, and dependencies.",
+        "href": "/ui/topology",
+        "icon": "\U0001f578",  # spider web
+    },
+    {
+        "title": "Connectors",
+        "summary": "Manage tenant targets + per-target credentials.",
+        "href": "/ui/connectors",
+        "icon": "\U0001f50c",  # electric plug
+    },
+    {
+        "title": "Memory",
+        "summary": "Operator + tenant + target memories across 5 scopes.",
+        "href": "/ui/memory",
+        "icon": "\U0001f9e0",  # brain
+    },
+)
+
+
+async def _readiness_snapshot() -> dict[str, object]:
+    """Project the chassis readiness-probe results into the dashboard shape.
+
+    Returns ``{"ready": bool, "checks": [{"name": ..., "ok": ..., "detail": ...}, ...]}``.
+    The shape mirrors the ``/ready`` endpoint payload so a future
+    "expanded readiness card" surface Initiative reuses the same
+    contract.
+    """
+    results = await run_probes_async()
+    ready_ok = bool(results) and all(r.ok for r in results)
+    return {
+        "ready": ready_ok,
+        "checks": [{"name": r.name, "ok": r.ok, "detail": r.detail or ""} for r in results],
+    }
+
+
+async def _render_dashboard(
+    request: Request,
+    session: UISessionContext = Depends(require_ui_session),
+) -> HTMLResponse:
+    """Render ``GET /ui/`` for the authenticated operator.
+
+    Per acceptance criterion 1 on #866: returns 200 with
+    ``<title>MEHO Operator Console`` plus the 3x2 grid + sidebar
+    links to all five surfaces (the sidebar is inherited from
+    ``base.html``).
+
+    The handler also mints + sets the CSRF cookie so any subsequent
+    HTMX ``hx-post`` / ``hx-delete`` from this page passes the
+    double-submit check.
+    """
+    readiness = await _readiness_snapshot()
+    csrf_token = mint_csrf_token(str(session.session_id))
+    context = {
+        "page_title": "Dashboard",
+        "app_version": __version__,
+        "ready": readiness["ready"],
+        "readiness_checks": readiness["checks"],
+        "surface_tiles": _SURFACE_TILES,
+        "operator_sub": session.operator_sub,
+        "tenant_id": str(session.tenant_id),
+        "csrf_token": csrf_token,
+        # Endpoint the HTMX SSE snippet subscribes to. Lifted out so a
+        # future deploy can swap to a CDN-hosted edge proxy without
+        # editing the template.
+        "feed_endpoint": "/api/v1/feed?limit=5",
+    }
+    response = get_templates().TemplateResponse(request, "dashboard.html", context)
+    # Mirror the SameSite + Secure posture of the session cookie. The
+    # CSRF cookie is intentionally NOT HttpOnly -- HTMX needs to read
+    # it to populate ``X-CSRF-Token`` on outbound state-changing
+    # requests; the HMAC binding to the session_id defeats the
+    # cookie-injection attack JS-read would otherwise enable.
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=csrf_token,
+        httponly=False,
+        secure=True,
+        samesite="strict",
+        path="/ui",
+    )
+    return response
+
+
+def build_dashboard_router() -> APIRouter:
+    """Construct the dashboard :class:`APIRouter`.
+
+    Factory function (not module-level constant) so the umbrella
+    :func:`meho_backplane.ui.routes.build_router` can mount a fresh
+    instance per app under test without sharing route state.
+    """
+    router = APIRouter(tags=["ui"])
+    router.add_api_route(
+        "/ui/",
+        _render_dashboard,
+        methods=["GET"],
+        name="ui_dashboard",
+        # Returning HTML rather than JSON; reflect that in the
+        # OpenAPI surface (the dashboard route is not API-documented,
+        # but the response class hints aid tooling that walks the
+        # routing tree).
+        response_class=HTMLResponse,
+    )
+    return router

--- a/backend/src/meho_backplane/ui/routes/stubs.py
+++ b/backend/src/meho_backplane/ui/routes/stubs.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Surface-stub routes -- the five "coming soon" placeholders.
+
+Initiative #337 (G10.0 Frontend chassis), Task #866 (T5). The chassis
+ships routes at each of the five sidebar links so the navigation
+shell renders end-to-end before the per-surface Initiatives
+(G10.1-G10.5) replace them with the real views. Each stub returns
+200 with a minimal HTML page that:
+
+* Extends ``base.html`` so the chrome (navbar, sidebar, footer) is
+  identical to every other surface.
+* Displays a "Coming soon -- this surface ships with G10.x" panel
+  pointing at the relevant Initiative number.
+* Sets the same CSRF cookie the dashboard does, so a future
+  state-changing form rendered before the surface Initiative lands
+  has the double-submit chain in place from request one.
+
+The five paths are kept consistent with the chassis ``base.html``
+sidebar -- ``/ui/broadcast``, ``/ui/knowledge``, ``/ui/topology``,
+``/ui/connectors``, ``/ui/memory``. The Goal #336 done-when and
+Initiative #337 work-item #5 reference these exact URLs.
+
+Why one shared template
+-----------------------
+
+Each stub is a single template extension of ``base.html`` with the
+surface metadata varied per route. A shared ``_stub.html`` partial
+keeps the chassis from carrying five near-identical files; the
+surface Initiatives replace the route (and may template-extend or
+substitute entirely) without touching the others.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Final
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
+
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["build_stubs_router"]
+
+#: Type alias for the per-stub route handler closures. Each closure
+#: accepts the FastAPI :class:`Request` + the injected session and
+#: returns an :class:`HTMLResponse` -- ``Depends`` resolution happens
+#: at request time so the signature has ``session`` as a kwarg.
+_StubHandler = Callable[[Request, UISessionContext], Awaitable[HTMLResponse]]
+
+
+@dataclass(frozen=True)
+class _SurfaceStub:
+    """Descriptor for one surface stub route.
+
+    Frozen because the descriptors are module-level constants
+    enumerated below; mutability would imply per-request mutation
+    which the surface Initiatives explicitly do not need.
+    """
+
+    slug: str
+    title: str
+    initiative_number: int
+    summary: str
+
+
+_SURFACE_STUBS: Final[tuple[_SurfaceStub, ...]] = (
+    _SurfaceStub(
+        slug="broadcast",
+        title="Broadcast",
+        initiative_number=338,
+        summary="Live activity feed: SSE timeline + per-event drawer + wall-monitor mode.",
+    ),
+    _SurfaceStub(
+        slug="knowledge",
+        title="Knowledge",
+        initiative_number=339,
+        summary="Search + view + drag-and-drop upload + Markdown editor over the team kb.",
+    ),
+    _SurfaceStub(
+        slug="topology",
+        title="Topology",
+        initiative_number=342,
+        summary="Tabular target list + Cytoscape.js graph viz of the tenant infrastructure.",
+    ),
+    _SurfaceStub(
+        slug="connectors",
+        title="Connectors",
+        initiative_number=340,
+        summary="Per-tenant target CRUD + per-target detail (fingerprint, last probe, ops).",
+    ),
+    _SurfaceStub(
+        slug="memory",
+        title="Memory",
+        initiative_number=341,
+        summary="Browse + edit memories across the 5 scopes; scope-promotion UI.",
+    ),
+)
+
+
+def _make_stub_handler(stub: _SurfaceStub) -> _StubHandler:
+    """Build a closure rendering the placeholder page for *stub*.
+
+    Each closure binds the surface's title / initiative / summary at
+    construction time and pulls the operator's session at request
+    time. The closure's return type is the typed
+    :class:`HTMLResponse` so the route registration below can pin
+    the OpenAPI response class without an explicit cast.
+    """
+
+    async def _render(
+        request: Request,
+        session: UISessionContext = Depends(require_ui_session),
+    ) -> HTMLResponse:
+        csrf_token = mint_csrf_token(str(session.session_id))
+        context = {
+            "page_title": stub.title,
+            "surface_title": stub.title,
+            "initiative_number": stub.initiative_number,
+            "summary": stub.summary,
+            "operator_sub": session.operator_sub,
+            "csrf_token": csrf_token,
+            # ``base.html``'s footer reads ``ready`` to colour the
+            # readiness pill. Stubs do not poll readiness (the
+            # dashboard owns that surface) -- ship ``False`` so the
+            # ``StrictUndefined`` env does not raise on the read.
+            "ready": False,
+        }
+        response = get_templates().TemplateResponse(request, "_stub.html", context)
+        response.set_cookie(
+            key=CSRF_COOKIE_NAME,
+            value=csrf_token,
+            httponly=False,
+            secure=True,
+            samesite="strict",
+            path="/ui",
+        )
+        return response
+
+    _render.__name__ = f"ui_stub_{stub.slug}"
+    return _render
+
+
+def build_stubs_router() -> APIRouter:
+    """Construct the surface-stubs :class:`APIRouter`.
+
+    Registers one ``GET`` route per :data:`_SURFACE_STUBS` entry; the
+    surface Initiatives mount their own routers on top of this one
+    (FastAPI's ``include_router`` ordering means a later router with
+    the same path wins).
+    """
+    router = APIRouter(tags=["ui-stubs"])
+    for stub in _SURFACE_STUBS:
+        router.add_api_route(
+            f"/ui/{stub.slug}",
+            _make_stub_handler(stub),
+            methods=["GET"],
+            name=f"ui_stub_{stub.slug}",
+            response_class=HTMLResponse,
+        )
+    return router

--- a/backend/src/meho_backplane/ui/templates/_stub.html
+++ b/backend/src/meho_backplane/ui/templates/_stub.html
@@ -1,0 +1,42 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Surface-stub template (Initiative #337, Task #866). Rendered by the
+  five "coming soon" routes (broadcast / knowledge / topology /
+  connectors / memory) the chassis lands before the surface
+  Initiatives G10.1-G10.5 replace them.
+
+  Inherits base.html so the chrome (sidebar, navbar, footer) matches
+  every other surface. Carries the same hx-headers CSRF wiring as
+  the dashboard so any future placeholder form has the double-submit
+  chain set up.
+-#}
+{% extends "base.html" %}
+
+{% block page_title %}{{ surface_title }} &middot; MEHO Operator Console{% endblock %}
+
+{% block content %}
+<section
+  class="mx-auto max-w-2xl space-y-4"
+  hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+>
+  <header>
+    <h1 class="text-2xl font-semibold">{{ surface_title }}</h1>
+    <p class="text-sm opacity-70">Operator surface placeholder.</p>
+  </header>
+
+  <article class="card bg-base-100 border-base-300 border shadow-sm">
+    <div class="card-body">
+      <h2 class="card-title">Coming soon</h2>
+      <p>{{ summary }}</p>
+      <p class="text-sm opacity-70">
+        This surface ships with Initiative <code>#{{ initiative_number }}</code>.
+        The chassis (G10.0) routes this URL to a placeholder so the
+        sidebar navigation renders end-to-end; the surface Initiative
+        replaces the route handler with the real view.
+      </p>
+    </div>
+  </article>
+</section>
+{% endblock %}

--- a/backend/src/meho_backplane/ui/templates/dashboard.html
+++ b/backend/src/meho_backplane/ui/templates/dashboard.html
@@ -1,0 +1,151 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Dashboard view (Initiative #337, Task #866). Authenticated landing
+  page rendered for ``GET /ui/`` once the BFF session middleware loads
+  the operator's session.
+
+  Structure:
+    * <body> inherits the DaisyUI drawer chrome from base.html.
+    * <header>'s ``hx-headers`` directive wires every HTMX-issued
+      state-changing request from this page to echo the CSRF token
+      via the X-CSRF-Token header (double-submit cookie pattern).
+    * Three content blocks:
+      1. The 3x2 surface card grid (5 cards + 1 "deploy info" cell).
+      2. The live "last 5 events" snippet -- HTMX SSE extension
+         subscribes to /api/v1/feed?limit=5 and swaps events into the
+         ``#meho-feed-tray`` container as they arrive. Pre-render
+         placeholder text covers the SSE-not-yet-connected window.
+      3. Version + readiness card.
+-#}
+{% extends "base.html" %}
+
+{% block page_title %}MEHO Operator Console{% endblock %}
+
+{% block content %}
+{#-
+  HTMX 2 SSE extension wiring (https://htmx.org/extensions/sse/) --
+  ``hx-ext="sse"`` activates the extension on the wrapper element;
+  ``sse-connect`` points at the SSE endpoint;
+  ``sse-swap="broadcast"`` listens for ``event: broadcast`` frames the
+  feed emits per G6.1-T4 (#310) and swaps the data payload into
+  ``#meho-feed-tray``. The ``hx-headers`` on the wrapper forwards
+  the CSRF token on any state-changing HTMX request anywhere in this
+  page subtree.
+-#}
+<section
+  class="space-y-6"
+  hx-ext="sse"
+  hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+>
+
+  {# -------- Greeting -------- #}
+  <header class="flex items-center justify-between">
+    <div>
+      <h1 class="text-2xl font-semibold">Operator Console</h1>
+      <p class="text-sm opacity-70">
+        Signed in as <code class="badge badge-outline">{{ operator_sub }}</code>
+        in tenant <code class="badge badge-outline">{{ tenant_id }}</code>.
+      </p>
+    </div>
+  </header>
+
+  {# -------- 3x2 surface grid -------- #}
+  <div
+    class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3"
+    aria-label="Operator surfaces"
+  >
+    {% for tile in surface_tiles %}
+      <a
+        href="{{ tile.href }}"
+        class="card bg-base-100 border-base-300 hover:border-primary border shadow-sm transition"
+      >
+        <div class="card-body">
+          <div class="flex items-center gap-3">
+            <span class="text-2xl" aria-hidden="true">{{ tile.icon }}</span>
+            <h2 class="card-title">{{ tile.title }}</h2>
+          </div>
+          <p class="text-sm opacity-80">{{ tile.summary }}</p>
+        </div>
+      </a>
+    {% endfor %}
+
+    {# Sixth tile: deploy info. Keeps the grid 3x2 balanced. #}
+    <article class="card bg-base-100 border-base-300 border shadow-sm">
+      <div class="card-body">
+        <div class="flex items-center gap-3">
+          <span class="text-2xl" aria-hidden="true">&#x2699;</span>
+          <h2 class="card-title">Deploy</h2>
+        </div>
+        <dl class="text-sm opacity-80">
+          <div class="flex justify-between">
+            <dt>Backplane version</dt>
+            <dd><code>v{{ app_version }}</code></dd>
+          </div>
+          <div class="mt-1 flex items-center justify-between">
+            <dt>Readiness</dt>
+            <dd>
+              <span
+                class="badge {% if ready %}badge-success{% else %}badge-warning{% endif %}"
+              >
+                {% if ready %}ready{% else %}starting{% endif %}
+              </span>
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </article>
+  </div>
+
+  {# -------- Live feed snippet (HTMX SSE) -------- #}
+  <section
+    class="card bg-base-100 border-base-300 border shadow-sm"
+    aria-label="Last 5 broadcast events"
+  >
+    <div class="card-body">
+      <div class="flex items-baseline justify-between">
+        <h2 class="card-title">Recent activity</h2>
+        <a href="/ui/broadcast" class="link link-hover text-xs">
+          Open broadcast surface &rarr;
+        </a>
+      </div>
+      <ul
+        id="meho-feed-tray"
+        class="divide-base-300 divide-y text-sm"
+        sse-connect="{{ feed_endpoint }}"
+        sse-swap="broadcast"
+        hx-swap="afterbegin"
+      >
+        <li class="py-2 opacity-60">
+          Connecting to live feed&hellip;
+        </li>
+      </ul>
+    </div>
+  </section>
+
+  {# -------- Readiness card (expanded; the badge above is the summary) -------- #}
+  {% if readiness_checks %}
+    <section class="card bg-base-100 border-base-300 border shadow-sm">
+      <div class="card-body">
+        <h2 class="card-title">Readiness checks</h2>
+        <ul class="text-sm">
+          {% for check in readiness_checks %}
+            <li class="flex items-center gap-2 py-1">
+              <span
+                class="inline-block h-2 w-2 rounded-full {% if check.ok %}bg-success{% else %}bg-warning{% endif %}"
+                aria-hidden="true"
+              ></span>
+              <span class="font-mono text-xs">{{ check.name }}</span>
+              {% if check.detail %}
+                <span class="opacity-60">&mdash; {{ check.detail }}</span>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
+    </section>
+  {% endif %}
+
+</section>
+{% endblock %}

--- a/backend/src/meho_backplane/ui/templates/dashboard.html
+++ b/backend/src/meho_backplane/ui/templates/dashboard.html
@@ -13,10 +13,12 @@
       via the X-CSRF-Token header (double-submit cookie pattern).
     * Three content blocks:
       1. The 3x2 surface card grid (5 cards + 1 "deploy info" cell).
-      2. The live "last 5 events" snippet -- HTMX SSE extension
-         subscribes to /api/v1/feed?limit=5 and swaps events into the
+      2. The live recent-activity snippet -- HTMX SSE extension
+         subscribes to /api/v1/feed and swaps events into the
          ``#meho-feed-tray`` container as they arrive. Pre-render
          placeholder text covers the SSE-not-yet-connected window.
+         (Trim-to-last-N is G10.1 client-side surface work; the feed
+         endpoint streams the live tail.)
       3. Version + readiness card.
 -#}
 {% extends "base.html" %}

--- a/backend/src/meho_backplane/ui/templating.py
+++ b/backend/src/meho_backplane/ui/templating.py
@@ -46,6 +46,7 @@ from __future__ import annotations
 
 from typing import Final
 
+from fastapi.templating import Jinja2Templates
 from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
 
 from meho_backplane import __version__
@@ -56,6 +57,14 @@ from meho_backplane.ui.paths import templates_dir
 # type without ``cast``; lru_cache + Jinja2 + mypy has a known
 # False-positive on the cached return type at strict mode.
 _ENV: Environment | None = None
+
+#: Cached :class:`Jinja2Templates` wrapper bound to :data:`_ENV`. T5
+#: (#866) route handlers call ``TemplateResponse(request, name, context)``
+#: through this object so FastAPI's response wiring (URL reverse-lookup
+#: helper + ``request`` context injection) lights up. Constructed
+#: lazily alongside :func:`get_jinja_env` so the chassis-only Task #863
+#: stays free of FastAPI route plumbing.
+_TEMPLATES: Jinja2Templates | None = None
 
 _AUTOESCAPE_EXTS: Final[tuple[str, ...]] = ("html", "htm", "xml")
 
@@ -89,3 +98,42 @@ def get_jinja_env() -> Environment:
         )
         _ENV.globals["app_version"] = __version__
     return _ENV
+
+
+def get_templates() -> Jinja2Templates:
+    """Return the lazily-constructed :class:`Jinja2Templates` wrapper.
+
+    FastAPI 0.136's :class:`fastapi.templating.Jinja2Templates` accepts
+    a pre-built ``env=`` argument; we pass our chassis singleton so the
+    autoescape / ``StrictUndefined`` / ``app_version`` global plumbing
+    survives across the wrapper. The wrapper itself adds two things
+    on top of a bare :class:`~jinja2.Environment`:
+
+    * A :class:`fastapi.templating._TemplateResponse` factory invoked as
+      ``templates.TemplateResponse(request, "name.html", {...})`` -- the
+      ``request`` argument is the FastAPI-blessed shape (Starlette 1.0
+      deprecates the legacy ``(name, {request, ...})`` signature).
+    * A ``url_for`` Jinja global bound to the request's router so
+      surface templates can reverse route names instead of hard-coding
+      ``href=`` strings.
+
+    Module-level cache (rather than :func:`functools.lru_cache`) so the
+    type checker sees the concrete return type without ``cast``.
+    """
+    global _TEMPLATES
+    if _TEMPLATES is None:
+        _TEMPLATES = Jinja2Templates(env=get_jinja_env())
+    return _TEMPLATES
+
+
+def reset_templating_for_testing() -> None:
+    """Drop the cached env + templates wrapper. Test-only.
+
+    Production never mutates these caches under a running process. The
+    UI smoke test rebuilds the cache between cases (e.g. when verifying
+    the env loads against a tmp-path override) by calling this helper
+    inside its fixture teardown.
+    """
+    global _ENV, _TEMPLATES
+    _ENV = None
+    _TEMPLATES = None

--- a/backend/tests/test_ui_chassis_smoke.py
+++ b/backend/tests/test_ui_chassis_smoke.py
@@ -46,12 +46,14 @@ import httpx
 import pytest
 import respx
 from cryptography.fernet import Fernet
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.testclient import TestClient
 
 from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import Operator
 from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.middleware import verify_jwt_and_bind
 from meho_backplane.settings import get_settings
 from meho_backplane.ui.auth import (
     SESSION_COOKIE_NAME,
@@ -63,6 +65,7 @@ from meho_backplane.ui.auth.flow import (
     reset_verifier_store_for_testing,
 )
 from meho_backplane.ui.auth.session_store import (
+    EncryptionKeyMissingError,
     create_session,
     reset_fernet_cache_for_testing,
 )
@@ -70,6 +73,7 @@ from meho_backplane.ui.csrf import (
     CSRF_COOKIE_NAME,
     CSRF_HEADER_NAME,
     CSRFMiddleware,
+    _csrf_secret,
     mint_csrf_token,
 )
 from meho_backplane.ui.paths import static_root_dir
@@ -162,6 +166,13 @@ def _mock_oidc_metadata(
         )
 
 
+#: Dependency reference for the JWT-gated ``/api/sentinel`` route below.
+#: Lifted to module scope so the function signature stays compatible
+#: with ruff's B008 ("do not call function as default argument") which
+#: would trip on ``Depends(...)`` inlined into the parameter list.
+_REQUIRE_JWT = Depends(verify_jwt_and_bind)
+
+
 def _build_app() -> FastAPI:
     """Construct a minimal FastAPI app with the full UI chassis wired in.
 
@@ -169,12 +180,16 @@ def _build_app() -> FastAPI:
     StaticFiles at ``/ui/static`` + the BFF auth router + the
     surface router + ``UISessionMiddleware`` outermost +
     ``CSRFMiddleware`` next. The chassis smoke test does NOT
-    register the chassis JWT / Audit / RequestContext middlewares
-    because the test only exercises the ``/ui/*`` surface; the
-    inner-chain coverage lives in their own per-middleware suites.
-    A sentinel ``/api/sentinel`` route validates that the session
-    middleware passes ``/api/*`` paths through untouched (the
-    middleware-order acceptance criterion).
+    register the chassis Audit / RequestContext middlewares because
+    the test only exercises the ``/ui/*`` surface; the inner-chain
+    coverage lives in their own per-middleware suites. The
+    ``/api/sentinel`` route declares
+    :func:`~meho_backplane.middleware.verify_jwt_and_bind` so the
+    middleware-order acceptance criterion #4 ("/api/* still uses
+    JWT") is exercised end-to-end -- a missing Bearer header yields
+    401 from the JWT dependency, proving both that the UI session
+    middleware passed the request through AND that the production
+    JWT contract still gates the API surface.
     """
     app = FastAPI()
     # CSRF middleware registered first so the session middleware
@@ -191,13 +206,16 @@ def _build_app() -> FastAPI:
     app.include_router(build_ui_router())
 
     @app.get("/api/sentinel")
-    async def _api_sentinel() -> dict[str, str]:
-        # Stand-in for the ``/api/v1/*`` JWT-protected surface. If
-        # the session middleware ever stops gating on the ``/ui/``
-        # prefix and starts redirecting all paths, this sanity check
-        # catches it -- the dedicated middleware-order test below
-        # asserts the 200.
-        return {"ok": "true"}
+    async def _api_sentinel(operator: Operator = _REQUIRE_JWT) -> dict[str, str]:
+        # Stand-in for the ``/api/v1/*`` JWT-protected surface. Uses
+        # the same :func:`verify_jwt_and_bind` dependency the
+        # production ``/api/v1/*`` routes rely on -- so a missing
+        # Bearer header yields 401 from the JWT dependency (proving
+        # the UI session middleware passed the request through AND
+        # the JWT layer rejected it), while a valid Bearer with a
+        # mocked JWKS yields 200 (proving the JWT dependency
+        # resolves cleanly end-to-end).
+        return {"ok": "true", "operator_sub": operator.sub}
 
     return app
 
@@ -352,8 +370,13 @@ def test_dashboard_authenticated_renders_console_html() -> None:
     # 3x2 surface card grid present (DaisyUI ``card`` markup).
     # Five surface cards + one deploy card = 6 ``card`` blocks.
     assert body.count('class="card-body"') >= 6
-    # HTMX SSE wiring on the recent-activity tray.
-    assert 'sse-connect="/api/v1/feed?limit=5"' in body
+    # HTMX SSE wiring on the recent-activity tray. The dashboard
+    # subscribes to ``/api/v1/feed`` with no query parameters; the
+    # feed endpoint (G6.1-T4 #310) does not accept a ``limit`` knob
+    # and FastAPI silently drops unknown query params, so any
+    # ``?limit=N`` here would only be a no-op surface promise. Trim-
+    # to-last-N is G10.1 (#338) client-side surface work.
+    assert 'sse-connect="/api/v1/feed"' in body
     assert 'sse-swap="broadcast"' in body
     # Version footer renders the chassis version global.
     assert "MEHO backplane v" in body
@@ -480,27 +503,90 @@ def test_csrf_rejects_forged_signature() -> None:
     assert response.status_code == 403
 
 
+def test_csrf_secret_fails_fast_on_empty_encryption_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_csrf_secret`` raises ``EncryptionKeyMissingError`` when the key is empty.
+
+    The CSRF middleware reuses ``UI_SESSION_ENCRYPTION_KEY`` as its HMAC
+    keying material (see ``_csrf_secret`` docstring + the OWASP signed
+    double-submit cookie pattern). The previous implementation silently
+    returned ``b""`` on a missing key, which would mint deterministic
+    HMAC tokens an attacker could forge off-line. Mirrors the
+    ``_get_fernet`` fail-fast pattern in
+    :mod:`meho_backplane.ui.auth.session_store` so a single chassis
+    convention covers both the session-store and the CSRF keying
+    material.
+    """
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", "")
+    get_settings.cache_clear()
+    with pytest.raises(EncryptionKeyMissingError, match="UI_SESSION_ENCRYPTION_KEY"):
+        _csrf_secret()
+
+
 # ---------------------------------------------------------------------------
 # AC 7: middleware order -- /ui/* uses cookie auth; /api/* untouched
 # ---------------------------------------------------------------------------
 
 
-def test_middleware_passes_api_routes_through_untouched() -> None:
-    """``GET /api/sentinel`` is NOT 302'd by the UI session middleware.
+def test_middleware_passes_api_routes_through_to_jwt_layer() -> None:
+    """``GET /api/sentinel`` without a Bearer header -> 401 from the JWT dependency.
 
-    The session middleware is ``/ui/``-scoped; out-of-prefix paths
-    must reach the route handler unchanged. This is the "JWT
-    middleware still applies on /api/*" property the Initiative
-    #337 acceptance criterion #4 calls out -- the UI session check
-    must not steal requests from the chassis API surface.
+    The UI session middleware is ``/ui/``-scoped; out-of-prefix paths
+    must reach the route handler unchanged. ``/api/sentinel`` declares
+    :func:`verify_jwt_and_bind` (the production JWT contract on every
+    ``/api/v1/*`` route), so an unauthenticated request transits the
+    UI middlewares unchanged and is rejected by the JWT dependency
+    with a 401 ``missing_token``. The 401 proves BOTH halves of AC4
+    ("/ui/* uses session-cookie auth, /api/* uses JWT") --
+
+    * 401 (not 302) -> UI session middleware passed it through.
+    * 401 (not 200) -> the JWT dependency is in the call chain.
+
+    Replaces the prior 200 expectation (which only exercised the UI
+    middleware half and let the unprotected route silently violate
+    AC4's other half, the "/api/* JWT" claim).
     """
     with respx.mock(assert_all_called=False):
         client = TestClient(_build_app(), follow_redirects=False)
-        # No session cookie; the route is on /api/sentinel so the
-        # middleware should pass it through.
+        # No session cookie + no Bearer header; the UI middleware
+        # passes /api/sentinel through, the JWT dependency rejects.
         response = client.get("/api/sentinel")
-    assert response.status_code == 200
-    assert response.json() == {"ok": "true"}
+    assert response.status_code == 401, (
+        f"expected JWT layer to reject without Bearer; got {response.status_code}: {response.text}"
+    )
+    # Specific detail code surfaced by ``verify_jwt`` on a missing
+    # ``Authorization`` header (see ``auth.jwt._extract_bearer_token``).
+    assert response.json() == {"detail": "missing_token"}
+
+
+def test_middleware_lets_jwt_protected_api_route_through_with_valid_bearer() -> None:
+    """Positive control: a valid Bearer reaches ``/api/sentinel`` and returns 200.
+
+    Mirrors the production wiring: a JWT signed by the mocked Keycloak
+    JWKS validates cleanly through ``verify_jwt_and_bind`` and the
+    sentinel handler returns 200 with the operator's ``sub``. Confirms
+    the JWT chain (issuer + audience + signature + tenant claims) is
+    actually exercisable by the smoke harness -- without this assertion
+    the negative test above could pass simply because the route was
+    misconfigured into a permanent 401.
+    """
+    key = make_rsa_keypair("test-kid")
+    access_token = mint_token(key)
+    jwks = public_jwks(key)
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router, jwks=jwks)
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get(
+            "/api/sentinel",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+    assert response.status_code == 200, (
+        f"expected 200 with valid Bearer; got {response.status_code}: {response.text}"
+    )
+    payload = response.json()
+    assert payload["ok"] == "true"
+    assert payload["operator_sub"] == "op-42"
 
 
 def test_middleware_redirects_ui_routes_without_session() -> None:

--- a/backend/tests/test_ui_chassis_smoke.py
+++ b/backend/tests/test_ui_chassis_smoke.py
@@ -1,0 +1,576 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Chassis smoke test for the FastAPI ``/ui/*`` integration (Task #866, T5).
+
+Exercises every acceptance criterion on issue #866:
+
+* ``GET /ui/`` unauthenticated -> 302 ``/ui/auth/login`` with the
+  ``return_to`` query parameter pointing back to ``/ui/``.
+* ``GET /ui/auth/login`` -> 302 to Keycloak (mocked via ``respx``).
+* Simulated callback with valid ``code`` + ``state`` -> session row
+  created -> 302 to ``/ui/``.
+* ``GET /ui/`` with the ``meho_session`` cookie -> 200 carrying
+  ``<title>MEHO Operator Console`` + the 3x2 surface grid + sidebar
+  links to all five surfaces.
+* ``GET /ui/{broadcast,knowledge,topology,connectors,memory}`` ->
+  200 with placeholder content.
+* State-changing ``/ui/*`` request without a valid CSRF token -> 403.
+* Middleware order verified: ``/ui/*`` uses session-cookie auth;
+  ``/api/*`` still uses JWT (sanity check).
+
+Test app construction mirrors :mod:`backend.tests.test_ui_auth_flow`:
+a minimal :class:`FastAPI` instance with the BFF auth router + the
+UI routes + the session and CSRF middlewares. The session-cookie
+attribute set ``Secure=True`` would otherwise prevent the TestClient
+(non-TLS) from sending the cookie on subsequent requests; the test
+patches the cookie attributes via the TestClient cookie jar.
+
+The autouse fixtures in :mod:`backend.tests.conftest`
+(``_default_database_url`` + ``_schema_template_db``) provide a fresh
+file-backed SQLite DB migrated to head before every test, so the
+``web_session`` table is present without any per-test
+``alembic upgrade head`` replay.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Iterator
+from datetime import timedelta
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import (
+    SESSION_COOKIE_NAME,
+    UISessionMiddleware,
+)
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import (
+    CSRF_COOKIE_NAME,
+    CSRF_HEADER_NAME,
+    CSRFMiddleware,
+    mint_csrf_token,
+)
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests.conftest import (
+    DEFAULT_AUDIENCE,
+    DEFAULT_ISSUER,
+    DEFAULT_TENANT_ID,
+    make_rsa_keypair,
+    mint_token,
+    public_jwks,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_BACKPLANE_URL = "https://meho.test"
+_REDIRECT_URI = f"{_BACKPLANE_URL}/ui/auth/callback"
+_AUTHORIZATION_ENDPOINT = f"{DEFAULT_ISSUER}/protocol/openid-connect/auth"
+_TOKEN_ENDPOINT = f"{DEFAULT_ISSUER}/protocol/openid-connect/token"
+_END_SESSION_ENDPOINT = f"{DEFAULT_ISSUER}/protocol/openid-connect/logout"
+
+#: Five surface routes the chassis sidebar links to and the stubs
+#: register. The Initiative #337 work-item #5 enumerates these exact
+#: URLs; the chassis smoke test pins them so a future surface
+#: Initiative renaming the path triggers an explicit test break (not
+#: a silent sidebar-vs-route divergence).
+_SURFACE_ROUTES = ("/ui/broadcast", "/ui/knowledge", "/ui/topology", "/ui/connectors", "/ui/memory")
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars for every test.
+
+    Mirrors :mod:`backend.tests.test_ui_auth_flow._bff_env` so the
+    same baseline holds: chassis Keycloak / Vault / DB settings plus
+    the BFF encryption key + confidential client credentials.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+def _mock_oidc_metadata(
+    mock_router: respx.MockRouter,
+    *,
+    jwks: dict[str, Any] | None = None,
+) -> None:
+    """Stub Keycloak's discovery + (optional) JWKS endpoints.
+
+    Identical shape to the helper in :mod:`backend.tests.test_ui_auth_flow`;
+    duplicated here to keep the smoke test independent of that suite's
+    private helpers.
+    """
+    metadata: dict[str, Any] = {
+        "issuer": DEFAULT_ISSUER,
+        "authorization_endpoint": _AUTHORIZATION_ENDPOINT,
+        "token_endpoint": _TOKEN_ENDPOINT,
+        "end_session_endpoint": _END_SESSION_ENDPOINT,
+        "jwks_uri": f"{DEFAULT_ISSUER}/protocol/openid-connect/certs",
+    }
+    mock_router.get(f"{DEFAULT_ISSUER}/.well-known/openid-configuration").mock(
+        return_value=httpx.Response(200, json=metadata),
+    )
+    if jwks is not None:
+        mock_router.get(metadata["jwks_uri"]).mock(
+            return_value=httpx.Response(200, json=jwks),
+        )
+
+
+def _build_app() -> FastAPI:
+    """Construct a minimal FastAPI app with the full UI chassis wired in.
+
+    Mirrors the production wiring in :mod:`meho_backplane.main`:
+    StaticFiles at ``/ui/static`` + the BFF auth router + the
+    surface router + ``UISessionMiddleware`` outermost +
+    ``CSRFMiddleware`` next. The chassis smoke test does NOT
+    register the chassis JWT / Audit / RequestContext middlewares
+    because the test only exercises the ``/ui/*`` surface; the
+    inner-chain coverage lives in their own per-middleware suites.
+    A sentinel ``/api/sentinel`` route validates that the session
+    middleware passes ``/api/*`` paths through untouched (the
+    middleware-order acceptance criterion).
+    """
+    app = FastAPI()
+    # CSRF middleware registered first so the session middleware
+    # ends up outermost -- production wiring is the same shape
+    # (``main.py`` registers CSRF then UISession in that order).
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+
+    @app.get("/api/sentinel")
+    async def _api_sentinel() -> dict[str, str]:
+        # Stand-in for the ``/api/v1/*`` JWT-protected surface. If
+        # the session middleware ever stops gating on the ``/ui/``
+        # prefix and starts redirecting all paths, this sanity check
+        # catches it -- the dedicated middleware-order test below
+        # asserts the 200.
+        return {"ok": "true"}
+
+    return app
+
+
+def _trust_test_cookies(client: TestClient) -> None:
+    """Mark the TestClient as trusting the ``Secure`` cookies.
+
+    httpx's cookie jar refuses to send ``Secure`` cookies over HTTP.
+    TestClient (which httpx underpins) speaks HTTP only; the
+    backplane sets the ``Secure`` attribute unconditionally because
+    the production deploy terminates TLS at ingress. Patching the
+    jar in-place is the canonical workaround documented in the
+    Starlette TestClient discussion.
+    """
+    # No-op shim today; the TestClient transport accepts cookies it
+    # received on a 302 redirect chain without checking the Secure
+    # flag, and our tests rebuild a fresh TestClient between flow
+    # steps. Kept as a single point of override for a future
+    # transport-level change.
+    _ = client
+
+
+# ---------------------------------------------------------------------------
+# Helpers -- seed a session row + cookie shortcut for authenticated tests
+# ---------------------------------------------------------------------------
+
+
+def _seed_session_sync(
+    *,
+    operator_sub: str = "op-42",
+    tenant_id: uuid.UUID | None = None,
+    lifetime: timedelta = timedelta(hours=1),
+) -> uuid.UUID:
+    """Create a ``web_session`` row directly and return its UUID.
+
+    Bypasses the full callback round-trip for tests that only
+    exercise the dashboard render / stub routes. The Fernet key set
+    by the autouse fixture is the same one the session-store reads,
+    so the seeded row decrypts cleanly on the next ``load_session``.
+    """
+    tenant = tenant_id or uuid.UUID(DEFAULT_TENANT_ID)
+
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant,
+                access_token="access-token-plaintext",
+                refresh_token="refresh-token-plaintext",
+                lifetime=lifetime,
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+# ---------------------------------------------------------------------------
+# AC 1: unauthenticated /ui/ -> 302 /ui/auth/login?return_to=/ui/
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_unauthenticated_redirects_to_login() -> None:
+    """``GET /ui/`` without a session 302s to login with ``return_to=/ui/``."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/")
+    assert response.status_code == 302
+    location = response.headers["location"]
+    assert location.startswith("/ui/auth/login?return_to=")
+    return_to = parse_qs(urlparse(location).query)["return_to"][0]
+    assert return_to == "/ui/"
+
+
+# ---------------------------------------------------------------------------
+# AC 2: GET /ui/auth/login -> 302 to Keycloak
+# ---------------------------------------------------------------------------
+
+
+def test_login_redirects_to_keycloak() -> None:
+    """``GET /ui/auth/login`` 302s to Keycloak with PKCE + the resource indicator."""
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router)
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/auth/login")
+    assert response.status_code == 302
+    location = response.headers["location"]
+    assert location.startswith(_AUTHORIZATION_ENDPOINT)
+    params = parse_qs(urlparse(location).query)
+    assert params["code_challenge_method"] == ["S256"]
+    assert "state" in params
+
+
+# ---------------------------------------------------------------------------
+# AC 3: callback with valid code+verifier -> session row + 302 to /ui/
+# ---------------------------------------------------------------------------
+
+
+def test_callback_creates_session_and_redirects_to_dashboard() -> None:
+    """A valid callback creates a session row and 302s to ``/ui/``."""
+    key = make_rsa_keypair("test-kid")
+    access_token = mint_token(key)
+    jwks = public_jwks(key)
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router, jwks=jwks)
+        mock_router.post(_TOKEN_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "access_token": access_token,
+                    "refresh_token": "refresh-x",
+                    "expires_in": 3600,
+                    "token_type": "Bearer",
+                },
+            ),
+        )
+        client = TestClient(_build_app(), follow_redirects=False)
+        login_response = client.get("/ui/auth/login")  # default return_to=/ui/
+        state = parse_qs(urlparse(login_response.headers["location"]).query)["state"][0]
+        callback = client.get(
+            f"/ui/auth/callback?code=test-code&state={state}",
+        )
+    assert callback.status_code == 302
+    # Default return_to is /ui/ (the login route's safe default).
+    assert callback.headers["location"] == "/ui/"
+    cookie_value = callback.cookies[SESSION_COOKIE_NAME]
+    # Cookie parses as a UUID -- the session row's PK.
+    uuid.UUID(cookie_value)
+
+
+# ---------------------------------------------------------------------------
+# AC 4: authenticated /ui/ -> 200 + chassis HTML shape
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_authenticated_renders_console_html() -> None:
+    """``GET /ui/`` with a session 302s nothing -- renders the dashboard HTML."""
+    session_id = _seed_session_sync()
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+        response = client.get("/ui/")
+    assert response.status_code == 200
+    body = response.text
+    # Page title -- the chassis page_title block resolves to "MEHO
+    # Operator Console" via the dashboard.html override.
+    assert "<title>MEHO Operator Console" in body
+    # Sidebar links to every one of the 5 surface routes.
+    for route in _SURFACE_ROUTES:
+        assert f'href="{route}"' in body, f"sidebar link to {route} missing"
+    # 3x2 surface card grid present (DaisyUI ``card`` markup).
+    # Five surface cards + one deploy card = 6 ``card`` blocks.
+    assert body.count('class="card-body"') >= 6
+    # HTMX SSE wiring on the recent-activity tray.
+    assert 'sse-connect="/api/v1/feed?limit=5"' in body
+    assert 'sse-swap="broadcast"' in body
+    # Version footer renders the chassis version global.
+    assert "MEHO backplane v" in body
+    # CSRF cookie set on the response so subsequent state-changing
+    # requests can echo it back.
+    assert CSRF_COOKIE_NAME in response.cookies
+
+
+# ---------------------------------------------------------------------------
+# AC 5: 5 surface stub routes return 200 with placeholder content
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("route", _SURFACE_ROUTES)
+def test_surface_stub_returns_placeholder(route: str) -> None:
+    """Each of the five surface stubs renders the ``Coming soon`` placeholder."""
+    session_id = _seed_session_sync()
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+        response = client.get(route)
+    assert response.status_code == 200, f"{route} did not return 200"
+    body = response.text
+    assert "Coming soon" in body
+    # The surface title shows up in the page header AND the <title>
+    # suffix (verified by case-insensitive substring match).
+    surface_slug = route.rsplit("/", 1)[-1]
+    assert surface_slug.lower() in body.lower()
+
+
+# ---------------------------------------------------------------------------
+# AC 6: CSRF rejection on a state-changing request without a valid token
+# ---------------------------------------------------------------------------
+
+
+def test_csrf_rejects_state_change_without_token() -> None:
+    """``POST /ui/sentinel`` with a session but no CSRF token -> 403."""
+    session_id = _seed_session_sync()
+
+    app = _build_app()
+
+    # Register a single state-changing sentinel route that would
+    # otherwise return 200 if the CSRF middleware did not intercept.
+    @app.post("/ui/sentinel-write")
+    async def _sentinel_write() -> dict[str, str]:
+        return {"ok": "true"}
+
+    with respx.mock(assert_all_called=False):
+        client = TestClient(app, follow_redirects=False)
+        client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+        # No CSRF cookie + no header -> reject.
+        response = client.post("/ui/sentinel-write")
+    assert response.status_code == 403
+    assert response.json()["detail"] == "csrf_token_invalid"
+
+
+def test_csrf_rejects_state_change_with_mismatched_cookie_header() -> None:
+    """Cookie value != header value -> 403 (cookie-injection guard)."""
+    session_id = _seed_session_sync()
+
+    app = _build_app()
+
+    @app.post("/ui/sentinel-write")
+    async def _sentinel_write() -> dict[str, str]:  # pragma: no cover - never reached
+        return {"ok": "true"}
+
+    valid_token = mint_csrf_token(str(session_id))
+    with respx.mock(assert_all_called=False):
+        client = TestClient(app, follow_redirects=False)
+        client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+        client.cookies.set(CSRF_COOKIE_NAME, valid_token)
+        # Different value on the header than on the cookie -> reject.
+        response = client.post(
+            "/ui/sentinel-write",
+            headers={CSRF_HEADER_NAME: "tampered-mismatch-token"},
+        )
+    assert response.status_code == 403
+
+
+def test_csrf_accepts_matching_token() -> None:
+    """A matching cookie + header pair passes the double-submit check."""
+    session_id = _seed_session_sync()
+
+    app = _build_app()
+
+    @app.post("/ui/sentinel-write")
+    async def _sentinel_write() -> dict[str, str]:
+        return {"ok": "true"}
+
+    valid_token = mint_csrf_token(str(session_id))
+    with respx.mock(assert_all_called=False):
+        client = TestClient(app, follow_redirects=False)
+        client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+        client.cookies.set(CSRF_COOKIE_NAME, valid_token)
+        response = client.post(
+            "/ui/sentinel-write",
+            headers={CSRF_HEADER_NAME: valid_token},
+        )
+    assert response.status_code == 200
+
+
+def test_csrf_rejects_forged_signature() -> None:
+    """Cookie + header agree, but neither validates against the session_id."""
+    session_id = _seed_session_sync()
+
+    app = _build_app()
+
+    @app.post("/ui/sentinel-write")
+    async def _sentinel_write() -> dict[str, str]:  # pragma: no cover - never reached
+        return {"ok": "true"}
+
+    # An attacker who could only inject a cookie value (no access to
+    # the HMAC secret) would set both halves to the same arbitrary
+    # value. The HMAC binding to the session_id rejects.
+    forged = "deadbeef.cafebabe"
+    with respx.mock(assert_all_called=False):
+        client = TestClient(app, follow_redirects=False)
+        client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+        client.cookies.set(CSRF_COOKIE_NAME, forged)
+        response = client.post(
+            "/ui/sentinel-write",
+            headers={CSRF_HEADER_NAME: forged},
+        )
+    assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# AC 7: middleware order -- /ui/* uses cookie auth; /api/* untouched
+# ---------------------------------------------------------------------------
+
+
+def test_middleware_passes_api_routes_through_untouched() -> None:
+    """``GET /api/sentinel`` is NOT 302'd by the UI session middleware.
+
+    The session middleware is ``/ui/``-scoped; out-of-prefix paths
+    must reach the route handler unchanged. This is the "JWT
+    middleware still applies on /api/*" property the Initiative
+    #337 acceptance criterion #4 calls out -- the UI session check
+    must not steal requests from the chassis API surface.
+    """
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        # No session cookie; the route is on /api/sentinel so the
+        # middleware should pass it through.
+        response = client.get("/api/sentinel")
+    assert response.status_code == 200
+    assert response.json() == {"ok": "true"}
+
+
+def test_middleware_redirects_ui_routes_without_session() -> None:
+    """``GET /ui/broadcast`` without a session 302s to login (positive control)."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/broadcast")
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+
+
+def test_middleware_lets_authenticated_ui_request_through() -> None:
+    """Positive control: a valid session unblocks a surface stub route."""
+    session_id = _seed_session_sync()
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+        response = client.get("/ui/broadcast")
+    assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Sanity: full unauth -> login -> callback -> /ui/ end-to-end
+# ---------------------------------------------------------------------------
+
+
+def test_full_flow_unauth_login_callback_then_dashboard() -> None:
+    """End-to-end smoke: unauth -> login -> callback -> dashboard render."""
+    key = make_rsa_keypair("test-kid")
+    access_token = mint_token(key)
+    jwks = public_jwks(key)
+    with respx.mock(assert_all_called=False) as mock_router:
+        _mock_oidc_metadata(mock_router, jwks=jwks)
+        mock_router.post(_TOKEN_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "access_token": access_token,
+                    "refresh_token": "refresh-x",
+                    "expires_in": 3600,
+                    "token_type": "Bearer",
+                },
+            ),
+        )
+        client = TestClient(_build_app(), follow_redirects=False)
+        _trust_test_cookies(client)
+        # Step 1: hit /ui/ unauthenticated -> 302 to login.
+        first = client.get("/ui/")
+        assert first.status_code == 302
+        # Step 2: follow to /ui/auth/login -> 302 to Keycloak.
+        login_target = first.headers["location"]
+        assert login_target.startswith("/ui/auth/login")
+        login = client.get(login_target)
+        assert login.status_code == 302
+        # Step 3: simulate Keycloak's redirect back to /ui/auth/callback.
+        state = parse_qs(urlparse(login.headers["location"]).query)["state"][0]
+        callback = client.get(
+            f"/ui/auth/callback?code=test-code&state={state}",
+        )
+        assert callback.status_code == 302
+        assert callback.headers["location"] == "/ui/"
+        # The session cookie carries ``Secure=True`` (production
+        # terminates TLS at ingress); httpx's cookie jar refuses to
+        # send Secure cookies over the TestClient's HTTP transport, so
+        # we lift the cookie out of the callback response and re-set
+        # it on the jar to bypass the Secure filter. Production
+        # browsers see this transparently over HTTPS.
+        session_cookie = callback.cookies[SESSION_COOKIE_NAME]
+        client.cookies.set(SESSION_COOKIE_NAME, session_cookie)
+        # Step 4: hit /ui/ again -> 200 + dashboard HTML.
+        dash = client.get("/ui/")
+    assert dash.status_code == 200
+    assert "<title>MEHO Operator Console" in dash.text

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -3398,6 +3398,193 @@
         }
       }
     },
+    "/ui/auth/login": {
+      "get": {
+        "tags": [
+          "ui-auth"
+        ],
+        "summary": "Ui Auth Login",
+        "description": "Mint a PKCE authorization URL and 302 the browser to Keycloak.\n\n``?return_to=<path>`` is the originally-requested path the\noperator was bounced from (the middleware writes it). Validated\nvia :func:`_safe_return_to` to block open-redirect abuse.",
+        "operationId": "ui_auth_login_ui_auth_login_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/auth/callback": {
+      "get": {
+        "tags": [
+          "ui-auth"
+        ],
+        "summary": "Ui Auth Callback",
+        "description": "Finish the OAuth round-trip, create the session, set the cookie.",
+        "operationId": "ui_auth_callback_ui_auth_callback_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/auth/logout": {
+      "get": {
+        "tags": [
+          "ui-auth"
+        ],
+        "summary": "Ui Auth Logout",
+        "description": "Revoke the session row, clear the cookie, 302 to the end-session URL.",
+        "operationId": "ui_auth_logout_ui_auth_logout_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/": {
+      "get": {
+        "tags": [
+          "ui"
+        ],
+        "summary": "Ui Dashboard",
+        "description": "Render ``GET /ui/`` for the authenticated operator.\n\nPer acceptance criterion 1 on #866: returns 200 with\n``<title>MEHO Operator Console`` plus the 3x2 grid + sidebar\nlinks to all five surfaces (the sidebar is inherited from\n``base.html``).\n\nThe handler also mints + sets the CSRF cookie so any subsequent\nHTMX ``hx-post`` / ``hx-delete`` from this page passes the\ndouble-submit check.",
+        "operationId": "ui_dashboard_ui__get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/broadcast": {
+      "get": {
+        "tags": [
+          "ui-stubs"
+        ],
+        "summary": "Ui Stub Broadcast",
+        "operationId": "ui_stub_broadcast_ui_broadcast_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/knowledge": {
+      "get": {
+        "tags": [
+          "ui-stubs"
+        ],
+        "summary": "Ui Stub Knowledge",
+        "operationId": "ui_stub_knowledge_ui_knowledge_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/topology": {
+      "get": {
+        "tags": [
+          "ui-stubs"
+        ],
+        "summary": "Ui Stub Topology",
+        "operationId": "ui_stub_topology_ui_topology_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/connectors": {
+      "get": {
+        "tags": [
+          "ui-stubs"
+        ],
+        "summary": "Ui Stub Connectors",
+        "operationId": "ui_stub_connectors_ui_connectors_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/memory": {
+      "get": {
+        "tags": [
+          "ui-stubs"
+        ],
+        "summary": "Ui Stub Memory",
+        "operationId": "ui_stub_memory_ui_memory_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/": {
       "get": {
         "summary": "Root",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -2703,6 +2703,33 @@ type ClientInterface interface {
 	// ReadyReadyGet request
 	ReadyReadyGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// UiDashboardUiGet request
+	UiDashboardUiGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiAuthCallbackUiAuthCallbackGet request
+	UiAuthCallbackUiAuthCallbackGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiAuthLoginUiAuthLoginGet request
+	UiAuthLoginUiAuthLoginGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiAuthLogoutUiAuthLogoutGet request
+	UiAuthLogoutUiAuthLogoutGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiStubBroadcastUiBroadcastGet request
+	UiStubBroadcastUiBroadcastGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiStubConnectorsUiConnectorsGet request
+	UiStubConnectorsUiConnectorsGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiStubKnowledgeUiKnowledgeGet request
+	UiStubKnowledgeUiKnowledgeGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiStubMemoryUiMemoryGet request
+	UiStubMemoryUiMemoryGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiStubTopologyUiTopologyGet request
+	UiStubTopologyUiTopologyGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// VersionVersionGet request
 	VersionVersionGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
@@ -3585,6 +3612,114 @@ func (c *Client) MetricsMetricsGet(ctx context.Context, reqEditors ...RequestEdi
 
 func (c *Client) ReadyReadyGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewReadyReadyGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiDashboardUiGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiDashboardUiGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiAuthCallbackUiAuthCallbackGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiAuthCallbackUiAuthCallbackGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiAuthLoginUiAuthLoginGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiAuthLoginUiAuthLoginGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiAuthLogoutUiAuthLogoutGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiAuthLogoutUiAuthLogoutGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiStubBroadcastUiBroadcastGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiStubBroadcastUiBroadcastGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiStubConnectorsUiConnectorsGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiStubConnectorsUiConnectorsGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiStubKnowledgeUiKnowledgeGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiStubKnowledgeUiKnowledgeGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiStubMemoryUiMemoryGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiStubMemoryUiMemoryGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiStubTopologyUiTopologyGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiStubTopologyUiTopologyGetRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -7322,6 +7457,249 @@ func NewReadyReadyGetRequest(server string) (*http.Request, error) {
 	return req, nil
 }
 
+// NewUiDashboardUiGetRequest generates requests for UiDashboardUiGet
+func NewUiDashboardUiGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUiAuthCallbackUiAuthCallbackGetRequest generates requests for UiAuthCallbackUiAuthCallbackGet
+func NewUiAuthCallbackUiAuthCallbackGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/auth/callback")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUiAuthLoginUiAuthLoginGetRequest generates requests for UiAuthLoginUiAuthLoginGet
+func NewUiAuthLoginUiAuthLoginGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/auth/login")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUiAuthLogoutUiAuthLogoutGetRequest generates requests for UiAuthLogoutUiAuthLogoutGet
+func NewUiAuthLogoutUiAuthLogoutGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/auth/logout")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUiStubBroadcastUiBroadcastGetRequest generates requests for UiStubBroadcastUiBroadcastGet
+func NewUiStubBroadcastUiBroadcastGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/broadcast")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUiStubConnectorsUiConnectorsGetRequest generates requests for UiStubConnectorsUiConnectorsGet
+func NewUiStubConnectorsUiConnectorsGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/connectors")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUiStubKnowledgeUiKnowledgeGetRequest generates requests for UiStubKnowledgeUiKnowledgeGet
+func NewUiStubKnowledgeUiKnowledgeGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/knowledge")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUiStubMemoryUiMemoryGetRequest generates requests for UiStubMemoryUiMemoryGet
+func NewUiStubMemoryUiMemoryGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/memory")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUiStubTopologyUiTopologyGetRequest generates requests for UiStubTopologyUiTopologyGet
+func NewUiStubTopologyUiTopologyGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/topology")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewVersionVersionGetRequest generates requests for VersionVersionGet
 func NewVersionVersionGetRequest(server string) (*http.Request, error) {
 	var err error
@@ -7596,6 +7974,33 @@ type ClientWithResponsesInterface interface {
 
 	// ReadyReadyGetWithResponse request
 	ReadyReadyGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ReadyReadyGetResponse, error)
+
+	// UiDashboardUiGetWithResponse request
+	UiDashboardUiGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiDashboardUiGetResponse, error)
+
+	// UiAuthCallbackUiAuthCallbackGetWithResponse request
+	UiAuthCallbackUiAuthCallbackGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiAuthCallbackUiAuthCallbackGetResponse, error)
+
+	// UiAuthLoginUiAuthLoginGetWithResponse request
+	UiAuthLoginUiAuthLoginGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiAuthLoginUiAuthLoginGetResponse, error)
+
+	// UiAuthLogoutUiAuthLogoutGetWithResponse request
+	UiAuthLogoutUiAuthLogoutGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiAuthLogoutUiAuthLogoutGetResponse, error)
+
+	// UiStubBroadcastUiBroadcastGetWithResponse request
+	UiStubBroadcastUiBroadcastGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiStubBroadcastUiBroadcastGetResponse, error)
+
+	// UiStubConnectorsUiConnectorsGetWithResponse request
+	UiStubConnectorsUiConnectorsGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiStubConnectorsUiConnectorsGetResponse, error)
+
+	// UiStubKnowledgeUiKnowledgeGetWithResponse request
+	UiStubKnowledgeUiKnowledgeGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiStubKnowledgeUiKnowledgeGetResponse, error)
+
+	// UiStubMemoryUiMemoryGetWithResponse request
+	UiStubMemoryUiMemoryGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiStubMemoryUiMemoryGetResponse, error)
+
+	// UiStubTopologyUiTopologyGetWithResponse request
+	UiStubTopologyUiTopologyGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiStubTopologyUiTopologyGetResponse, error)
 
 	// VersionVersionGetWithResponse request
 	VersionVersionGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*VersionVersionGetResponse, error)
@@ -8898,6 +9303,198 @@ func (r ReadyReadyGetResponse) StatusCode() int {
 	return 0
 }
 
+type UiDashboardUiGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r UiDashboardUiGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiDashboardUiGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiAuthCallbackUiAuthCallbackGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *interface{}
+}
+
+// Status returns HTTPResponse.Status
+func (r UiAuthCallbackUiAuthCallbackGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiAuthCallbackUiAuthCallbackGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiAuthLoginUiAuthLoginGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *interface{}
+}
+
+// Status returns HTTPResponse.Status
+func (r UiAuthLoginUiAuthLoginGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiAuthLoginUiAuthLoginGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiAuthLogoutUiAuthLogoutGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *interface{}
+}
+
+// Status returns HTTPResponse.Status
+func (r UiAuthLogoutUiAuthLogoutGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiAuthLogoutUiAuthLogoutGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiStubBroadcastUiBroadcastGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r UiStubBroadcastUiBroadcastGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiStubBroadcastUiBroadcastGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiStubConnectorsUiConnectorsGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r UiStubConnectorsUiConnectorsGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiStubConnectorsUiConnectorsGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiStubKnowledgeUiKnowledgeGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r UiStubKnowledgeUiKnowledgeGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiStubKnowledgeUiKnowledgeGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiStubMemoryUiMemoryGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r UiStubMemoryUiMemoryGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiStubMemoryUiMemoryGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiStubTopologyUiTopologyGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r UiStubTopologyUiTopologyGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiStubTopologyUiTopologyGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type VersionVersionGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -9567,6 +10164,87 @@ func (c *ClientWithResponses) ReadyReadyGetWithResponse(ctx context.Context, req
 		return nil, err
 	}
 	return ParseReadyReadyGetResponse(rsp)
+}
+
+// UiDashboardUiGetWithResponse request returning *UiDashboardUiGetResponse
+func (c *ClientWithResponses) UiDashboardUiGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiDashboardUiGetResponse, error) {
+	rsp, err := c.UiDashboardUiGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiDashboardUiGetResponse(rsp)
+}
+
+// UiAuthCallbackUiAuthCallbackGetWithResponse request returning *UiAuthCallbackUiAuthCallbackGetResponse
+func (c *ClientWithResponses) UiAuthCallbackUiAuthCallbackGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiAuthCallbackUiAuthCallbackGetResponse, error) {
+	rsp, err := c.UiAuthCallbackUiAuthCallbackGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiAuthCallbackUiAuthCallbackGetResponse(rsp)
+}
+
+// UiAuthLoginUiAuthLoginGetWithResponse request returning *UiAuthLoginUiAuthLoginGetResponse
+func (c *ClientWithResponses) UiAuthLoginUiAuthLoginGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiAuthLoginUiAuthLoginGetResponse, error) {
+	rsp, err := c.UiAuthLoginUiAuthLoginGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiAuthLoginUiAuthLoginGetResponse(rsp)
+}
+
+// UiAuthLogoutUiAuthLogoutGetWithResponse request returning *UiAuthLogoutUiAuthLogoutGetResponse
+func (c *ClientWithResponses) UiAuthLogoutUiAuthLogoutGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiAuthLogoutUiAuthLogoutGetResponse, error) {
+	rsp, err := c.UiAuthLogoutUiAuthLogoutGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiAuthLogoutUiAuthLogoutGetResponse(rsp)
+}
+
+// UiStubBroadcastUiBroadcastGetWithResponse request returning *UiStubBroadcastUiBroadcastGetResponse
+func (c *ClientWithResponses) UiStubBroadcastUiBroadcastGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiStubBroadcastUiBroadcastGetResponse, error) {
+	rsp, err := c.UiStubBroadcastUiBroadcastGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiStubBroadcastUiBroadcastGetResponse(rsp)
+}
+
+// UiStubConnectorsUiConnectorsGetWithResponse request returning *UiStubConnectorsUiConnectorsGetResponse
+func (c *ClientWithResponses) UiStubConnectorsUiConnectorsGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiStubConnectorsUiConnectorsGetResponse, error) {
+	rsp, err := c.UiStubConnectorsUiConnectorsGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiStubConnectorsUiConnectorsGetResponse(rsp)
+}
+
+// UiStubKnowledgeUiKnowledgeGetWithResponse request returning *UiStubKnowledgeUiKnowledgeGetResponse
+func (c *ClientWithResponses) UiStubKnowledgeUiKnowledgeGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiStubKnowledgeUiKnowledgeGetResponse, error) {
+	rsp, err := c.UiStubKnowledgeUiKnowledgeGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiStubKnowledgeUiKnowledgeGetResponse(rsp)
+}
+
+// UiStubMemoryUiMemoryGetWithResponse request returning *UiStubMemoryUiMemoryGetResponse
+func (c *ClientWithResponses) UiStubMemoryUiMemoryGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiStubMemoryUiMemoryGetResponse, error) {
+	rsp, err := c.UiStubMemoryUiMemoryGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiStubMemoryUiMemoryGetResponse(rsp)
+}
+
+// UiStubTopologyUiTopologyGetWithResponse request returning *UiStubTopologyUiTopologyGetResponse
+func (c *ClientWithResponses) UiStubTopologyUiTopologyGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiStubTopologyUiTopologyGetResponse, error) {
+	rsp, err := c.UiStubTopologyUiTopologyGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiStubTopologyUiTopologyGetResponse(rsp)
 }
 
 // VersionVersionGetWithResponse request returning *VersionVersionGetResponse
@@ -11356,6 +12034,180 @@ func ParseReadyReadyGetResponse(rsp *http.Response) (*ReadyReadyGetResponse, err
 		}
 		response.JSON200 = &dest
 
+	}
+
+	return response, nil
+}
+
+// ParseUiDashboardUiGetResponse parses an HTTP response from a UiDashboardUiGetWithResponse call
+func ParseUiDashboardUiGetResponse(rsp *http.Response) (*UiDashboardUiGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiDashboardUiGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseUiAuthCallbackUiAuthCallbackGetResponse parses an HTTP response from a UiAuthCallbackUiAuthCallbackGetWithResponse call
+func ParseUiAuthCallbackUiAuthCallbackGetResponse(rsp *http.Response) (*UiAuthCallbackUiAuthCallbackGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiAuthCallbackUiAuthCallbackGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiAuthLoginUiAuthLoginGetResponse parses an HTTP response from a UiAuthLoginUiAuthLoginGetWithResponse call
+func ParseUiAuthLoginUiAuthLoginGetResponse(rsp *http.Response) (*UiAuthLoginUiAuthLoginGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiAuthLoginUiAuthLoginGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiAuthLogoutUiAuthLogoutGetResponse parses an HTTP response from a UiAuthLogoutUiAuthLogoutGetWithResponse call
+func ParseUiAuthLogoutUiAuthLogoutGetResponse(rsp *http.Response) (*UiAuthLogoutUiAuthLogoutGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiAuthLogoutUiAuthLogoutGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest interface{}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiStubBroadcastUiBroadcastGetResponse parses an HTTP response from a UiStubBroadcastUiBroadcastGetWithResponse call
+func ParseUiStubBroadcastUiBroadcastGetResponse(rsp *http.Response) (*UiStubBroadcastUiBroadcastGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiStubBroadcastUiBroadcastGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseUiStubConnectorsUiConnectorsGetResponse parses an HTTP response from a UiStubConnectorsUiConnectorsGetWithResponse call
+func ParseUiStubConnectorsUiConnectorsGetResponse(rsp *http.Response) (*UiStubConnectorsUiConnectorsGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiStubConnectorsUiConnectorsGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseUiStubKnowledgeUiKnowledgeGetResponse parses an HTTP response from a UiStubKnowledgeUiKnowledgeGetWithResponse call
+func ParseUiStubKnowledgeUiKnowledgeGetResponse(rsp *http.Response) (*UiStubKnowledgeUiKnowledgeGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiStubKnowledgeUiKnowledgeGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseUiStubMemoryUiMemoryGetResponse parses an HTTP response from a UiStubMemoryUiMemoryGetWithResponse call
+func ParseUiStubMemoryUiMemoryGetResponse(rsp *http.Response) (*UiStubMemoryUiMemoryGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiStubMemoryUiMemoryGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseUiStubTopologyUiTopologyGetResponse parses an HTTP response from a UiStubTopologyUiTopologyGetWithResponse call
+func ParseUiStubTopologyUiTopologyGetResponse(rsp *http.Response) (*UiStubTopologyUiTopologyGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiStubTopologyUiTopologyGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
 	}
 
 	return response, nil

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -325,12 +325,16 @@ Initiative #337 work-item #6:
 * A 3x2 grid of DaisyUI `card` tiles linking to the five surface
   routes. The sixth tile shows the backplane version + readiness
   badge sourced from `meho_backplane.health.run_probes_async`.
-* A live "recent activity" snippet wired to `/api/v1/feed?limit=5`
-  via the HTMX 2 SSE extension (`hx-ext="sse"` +
-  `sse-connect="..."` + `sse-swap="broadcast"`). The feed endpoint
-  itself runs the chassis JWT dependency, but the browser carries
-  the session cookie and the same operator's JWT will be issued by
-  Keycloak; G10.1 (`#338`) wires the live-token round-trip.
+* A live "recent activity" snippet wired to `/api/v1/feed` via the
+  HTMX 2 SSE extension (`hx-ext="sse"` + `sse-connect="..."` +
+  `sse-swap="broadcast"`). The feed endpoint itself runs the chassis
+  JWT dependency, but the browser carries the session cookie and the
+  same operator's JWT will be issued by Keycloak; G10.1 (`#338`)
+  wires the live-token round-trip and the client-side
+  trim-to-last-N rendering (the feed endpoint streams the live tail
+  unbounded -- it does not accept a `limit` query parameter, so a
+  hardcoded `?limit=N` would be a silent no-op given FastAPI's
+  unknown-query-param drop semantics).
 * A "readiness checks" panel listing every registered probe with a
   green/orange pill matching `/ready`'s shape.
 

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -7,9 +7,13 @@ that Task [#863](https://github.com/evoila/meho/issues/863) (G10.0-T2)
 landed — module layout, template-rendering shape, Tailwind 4 build
 pipeline, vendored JS assets — plus the **session storage** that Task
 [#864](https://github.com/evoila/meho/issues/864) (G10.0-T3) layered on
-top. Subsequent Tasks fill in the remaining pieces (`#865` auth
-flow, `#866` FastAPI mount + dashboard + smoke test); this doc grows
-with each Task.
+top, the **BFF auth flow** that Task
+[#865](https://github.com/evoila/meho/issues/865) (G10.0-T4) added,
+and the **FastAPI integration + dashboard + CSRF + surface stubs**
+that Task [#866](https://github.com/evoila/meho/issues/866) (G10.0-T5)
+wires into `main.py`. All four chassis Tasks have landed; the surface
+Initiatives G10.1–G10.5 fill in the per-surface views the stubs
+placeholder.
 
 ## Overview
 
@@ -40,7 +44,8 @@ Locked decisions:
 | ------ | ------- |
 | `meho_backplane.ui.paths` | Resolves `templates/`, `static/src/`, `static/dist/` directories at runtime. Source-tree dev and image deploy both work via `Path(__file__).resolve().parent`. |
 | `meho_backplane.ui.templating` | Jinja2 `Environment` factory with `FileSystemLoader`, `select_autoescape`, `StrictUndefined`, and the `app_version` global pre-bound from `meho_backplane.__version__`. |
-| `meho_backplane.ui.routes` | Stub package for chassis Task. T5 (#866) lands the `APIRouter` instance + dashboard view + the five surface stub routes. |
+| `meho_backplane.ui.routes` | Aggregate `APIRouter`. `build_router()` aggregates the dashboard (`GET /ui/`) plus five surface stubs (`GET /ui/{broadcast,knowledge,topology,connectors,memory}`). Each stub renders `_stub.html` with the placeholder shape; G10.1-G10.5 replace the route handler with the real view. T5 (#866) lands the dashboard + stubs. |
+| `meho_backplane.ui.csrf` | T5 (#866) double-submit-cookie CSRF middleware on state-changing `/ui/*` requests (POST/PATCH/PUT/DELETE). Signed-double-submit per OWASP -- the token is `hmac_sha256(session_secret, session_id || random) + "." + random`; the cookie is JS-readable (`meho_csrf`) so HTMX can echo it in `X-CSRF-Token`. Mismatch / missing token / forged signature -> 403. Read-only methods + out-of-prefix paths pass through. |
 | `meho_backplane.ui.auth` | BFF auth subpackage. T3 (#864) landed `session_store` (encrypted token custody + RFC 9700 refresh-token rotation); T4 (#865) lands `/ui/auth/{login,callback,logout}` + session middleware. |
 | `meho_backplane.ui.auth.session_store` | Fernet-encrypted server-side session storage. `create_session`, `load_session`, `revoke_session`, `rotate_refresh` against the `web_session` Postgres table. Replay of a used refresh token revokes the session and writes a `ui.session.refresh_replay` audit row on a dedicated transaction so the security signal survives caller rollback. |
 | `meho_backplane.ui.auth.flow` | OAuth 2.1 + PKCE client primitives layered on authlib's `AsyncOAuth2Client`. `build_authorization_request` mints the Keycloak redirect URL (S256 PKCE + RFC 8707 `resource` parameter) and registers the per-flow verifier in a server-side `PKCEVerifierStore`. `exchange_code_for_tokens` pops the verifier and exchanges code+verifier at the token endpoint. `resolve_oidc_endpoints` caches the discovery doc on the same TTL the JWKS cache uses. |
@@ -271,13 +276,88 @@ Initiatives fill the routes in.
 - **Tailwind standalone CLI** — runtime-of-image-build dependency
   only; never enters the running container or the wheel.
 
+## FastAPI integration (Task #866)
+
+T5 wires the chassis into the FastAPI app in
+[`backend/src/meho_backplane/main.py`](../../backend/src/meho_backplane/main.py).
+Five things land together:
+
+1. **`StaticFiles` mount** at `/ui/static` against the parent
+   `ui/static/` tree, so the URLs `/ui/static/src/vendor/htmx.min.js`
+   and `/ui/static/dist/tailwind.css` (referenced by `base.html`)
+   resolve to the same mount. `check_dir=False` keeps the mount
+   resilient on a fresh clone where `static/dist/` is empty; a
+   request for the compiled stylesheet 404s until the operator runs
+   the Tailwind build, which is the operator-facing remediation
+   surfaced by this doc and by the lifespan log line. The lifespan
+   startup also calls `ensure_static_dist_dir()` to create the
+   directory so the mount construction never raises on a fresh
+   clone.
+2. **UI auth router** -- `/ui/auth/{login,callback,logout}`. Mounted
+   via `build_router()` from `meho_backplane.ui.auth`. Reachable
+   unauthenticated.
+3. **UI surface router** -- aggregates the dashboard
+   (`GET /ui/`) + the five surface stubs. Mounted via
+   `build_router()` from `meho_backplane.ui.routes`. Every route
+   requires a session via the `require_ui_session` dependency.
+4. **`UISessionMiddleware`** registered as the OUTERMOST middleware
+   (added last in `add_middleware` LIFO order). Out-of-prefix paths
+   (`/api/*`, `/mcp/*`, `/healthz`, etc.) pass through untouched;
+   `/ui/*` paths are gated by the session-cookie check, with
+   `/ui/static/` and `/ui/auth/` exempted so the login flow + asset
+   loads work for unauthenticated browsers. The JWT dependency on
+   `/api/*` routes is untouched -- the session middleware short-
+   circuits `/ui/*` BEFORE the JWT chain runs, satisfying the
+   "session middleware before JWT" property the Initiative #337
+   acceptance criterion #4 requires.
+5. **`CSRFMiddleware`** registered just inside `UISessionMiddleware`.
+   Guards state-changing `/ui/*` requests via the OWASP signed
+   double-submit cookie pattern. The dashboard + stub handlers
+   mint a fresh token on every authenticated render and set the
+   `meho_csrf` cookie with `SameSite=Strict; Secure; Path=/ui`.
+   HTMX surfaces echo the token in the `X-CSRF-Token` header via
+   the `hx-headers` directive on the page `<body>`; classic HTML
+   forms include the value in a `csrf_token` hidden field.
+
+The dashboard view (`GET /ui/`) renders three components per
+Initiative #337 work-item #6:
+
+* A 3x2 grid of DaisyUI `card` tiles linking to the five surface
+  routes. The sixth tile shows the backplane version + readiness
+  badge sourced from `meho_backplane.health.run_probes_async`.
+* A live "recent activity" snippet wired to `/api/v1/feed?limit=5`
+  via the HTMX 2 SSE extension (`hx-ext="sse"` +
+  `sse-connect="..."` + `sse-swap="broadcast"`). The feed endpoint
+  itself runs the chassis JWT dependency, but the browser carries
+  the session cookie and the same operator's JWT will be issued by
+  Keycloak; G10.1 (`#338`) wires the live-token round-trip.
+* A "readiness checks" panel listing every registered probe with a
+  green/orange pill matching `/ready`'s shape.
+
+The five surface stubs render `_stub.html` with a "Coming soon"
+panel referencing the surface Initiative number (G10.1=#338,
+G10.2=#339, G10.3=#340, G10.4=#341, G10.5=#342). A surface
+Initiative landing its real view registers a router that overrides
+the stub route.
+
+The chassis smoke test
+[`backend/tests/test_ui_chassis_smoke.py`](../../backend/tests/test_ui_chassis_smoke.py)
+exercises every acceptance criterion: unauth dashboard -> 302
+login, login -> 302 Keycloak, callback -> session row + 302 /ui/,
+authenticated dashboard render (page title + 5 sidebar links + 6
+card cells + HTMX SSE wiring), 5 stub routes -> 200 with placeholder
+content, CSRF rejection on missing/mismatched/forged tokens,
+positive control on matched token, and middleware-order sanity
+(/api/* passes through untouched).
+
 ## Known issues / open items
 
 - **`static/dist/tailwind.css` is missing on first uvicorn start in
-  a fresh clone**. Local dev must run `tailwindcss --watch` once
-  before the FastAPI mount works. T5 (#866) adds a startup hook that
-  surfaces the operator-facing remediation rather than 404-ing the
-  CSS file silently.
+  a fresh clone**. T5 (#866) added `ensure_static_dist_dir()` in
+  the lifespan so the mount no longer crashes on construction, but
+  the request for the compiled stylesheet still 404s until the
+  operator runs `tailwindcss` once. Local dev must run
+  `tailwindcss --watch` once before the rendered UI is fully styled.
 - **CSP not configured yet**. The `<head>` deliberately avoids inline
   script so a future nonce-based CSP can land without template
   rewrites. T5 #866 / a follow-up Initiative wires the header.


### PR DESCRIPTION
## Summary
- Wires the G10.0 chassis into the backplane FastAPI app: mounts `/ui/static`, includes the BFF auth + UI surface routers, registers `UISessionMiddleware` as the outermost layer (so `/ui/*` short-circuits to `/ui/auth/login` before the JWT dependency runs on `/api/*`) and `CSRFMiddleware` just inside it.
- Dashboard (`GET /ui/`) renders the 3×2 surface card grid, HTMX 2 SSE wiring against `/api/v1/feed?limit=5`, and the version + readiness card from the chassis probe registry. Five surface stubs return 200 "Coming soon" placeholders that G10.1–G10.5 replace.
- CSRF uses OWASP's signed double-submit pattern (`hmac_sha256(secret, session_id || random) + "." + random`); cookie is JS-readable so HTMX can echo via `X-CSRF-Token`, HMAC binding defeats same-site cookie injection.

## Test plan
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy --ignore-missing-imports` — clean on `ui/` + `main.py`
- [x] `pytest backend/tests/test_ui_chassis_smoke.py` — 17 passed
- [x] `pytest backend/tests/test_ui_*.py` (existing UI suite) — 55 passed, no regression
- [x] `pytest backend/tests/test_middleware.py backend/tests/test_audit_middleware.py` — 13 passed (middleware-order regression guard)
- [x] App-boot smoke: `from meho_backplane.main import app` succeeds; 72 routes registered
- [x] Acceptance criterion 1 — unauthenticated `/ui/` → 302 `/ui/auth/login?return_to=/ui/`; authenticated → 200 with `<title>MEHO Operator Console` + sidebar links to all 5 surfaces + 6 card cells in the grid
- [x] Acceptance criterion 2 — five stub routes (`/ui/{broadcast,knowledge,topology,connectors,memory}`) return 200 with "Coming soon" placeholder content
- [x] Acceptance criterion 3 — state-changing `/ui/*` without a valid CSRF token → 403 (no token, mismatched token, forged signature all rejected; matched token accepted)
- [x] Acceptance criterion 4 — `/ui/*` uses cookie auth (302 to login on miss); `/api/sentinel` passes through the session middleware untouched
- [x] Acceptance criterion 5 — zero `.github/workflows/ci.yml` changes
- [x] Acceptance criterion 6 — Goal #336 G10.0 checklist line ticked (companion edit on the goal issue body)

## Middleware ordering (load-bearing)
Order on the request side (outer → inner):

```
client → UISessionMiddleware → CSRFMiddleware → RequestContextMiddleware → BroadcastDetailMiddleware → AuditMiddleware → router → handler
```

`UISessionMiddleware` is registered last with `app.add_middleware` so Starlette's LIFO ordering makes it the outermost layer. `/ui/*` requests without a session short-circuit to login before the inner chain runs; `/api/*` requests pass through untouched (the session middleware is `/ui/`-scoped by `path.startswith("/ui/")`). JWT verification continues to be enforced as a route dependency on `/api/*`, satisfying the "session middleware before JWT" acceptance criterion.

## CSRF design
- Cookie: `meho_csrf` (`Secure`, `SameSite=Strict`, `Path=/ui`, JS-readable)
- Header: `X-CSRF-Token` (HTMX-echoed via `hx-headers` on the page `<body>`)
- Form fallback: `csrf_token` hidden field on `application/x-www-form-urlencoded` bodies
- Signature: `HMAC-SHA256(UI_SESSION_ENCRYPTION_KEY, session_id || random) + "." + random_hex`
- Reuses the existing Vault-rendered `UI_SESSION_ENCRYPTION_KEY` rather than adding a second env var.

## Out of scope
- Surface views — G10.1 (#338) / G10.2 (#339) / G10.3 (#340) / G10.4 (#341) / G10.5 (#342) replace the stubs.
- Auth flow + session storage — landed by #863 / #864 / #865.

## Adjacent findings (recorded, not addressed in this PR)
- `backend/src/meho_backplane/main.py` is now 635 lines (was 567 pre-T5) — over the 600-line code-quality warn threshold. Pre-existing growth pattern; refactoring `app.include_router(...)` into a helper is a separate cleanup Initiative.
- `backend/src/meho_backplane/ui/csrf.py` lands at 509 lines including comprehensive docstrings on every helper — over the 400-line warn threshold, below the 600-line block threshold. The depth-of-comments was the deliberate posture for security-sensitive code; a split (e.g. extracting helpers into `_helpers.py`) would harm readability for the cross-reference reader.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #866


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the MEHO Operator Console dashboard with readiness, quick-surface navigation, SSE activity feed, and five “Coming soon” surface pages
  * Added OAuth-based UI login flow and session-backed authentication

* **Security**
  * Enabled double-submit CSRF protection for UI state-changing requests and ensured CSRF tokens are issued to the UI

* **Stability**
  * Prevent startup failures when compiled UI assets are missing by ensuring static/dist is created/mounted

* **Tests**
  * Added end-to-end UI integration smoke tests covering auth, dashboard rendering, stubs, CSRF, and middleware routing

* **Documentation**
  * Updated UI architecture and FastAPI integration docs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/960?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-23)

Addressed review findings from `/auto-review-pr` iteration 1
(`.claude/auto/review-results/pr-960-iter-1.json`):

- **B1** `55f9cc8` — Regenerated `cli/api/openapi.json` + `cli/internal/api/client.gen.go` via `make snapshot-openapi && make generate`. The 9 new `/ui/*` routes are now in the CLI snapshot; the `CLI API snapshot freshness` required check goes green.
- **M1** `c89f850` — `_csrf_secret()` now raises `EncryptionKeyMissingError` on empty `UI_SESSION_ENCRYPTION_KEY` (mirrors `_get_fernet` fail-fast); added unit test `test_csrf_secret_fails_fast_on_empty_encryption_key`.
- **M2** `c89f850` — CSRFMiddleware short-circuits on missing session/CSRF cookie BEFORE buffering the request body. Closes the DoS-amplification window on 256 KiB pre-rejection body parse.
- **M3** `c89f850` — `/api/sentinel` in the smoke test now declares `Depends(verify_jwt_and_bind)`. The middleware-order test asserts 401-without-Bearer (proving UI passthrough + JWT gating) plus a positive control with a valid Bearer.
- **m1** `c89f850` — Dropped `?limit=5` from the dashboard's `feed_endpoint`; `/api/v1/feed` does not accept `limit`, FastAPI silently dropped it. Updated test + docs/codebase/ui.md. Trim-to-last-N is G10.1 (#338) surface work.

Local gates after the fix:

- `ruff check` / `ruff format --check` / `mypy` — clean on touched files
- `pytest backend/tests/test_ui_chassis_smoke.py` — 19 passed (was 17; +2 new)
- `pytest backend/tests/test_ui_*.py` (UI suite) — 64 passed
- `cd cli && go build ./...` — clean after regen

<!-- auto-implement-issue: continue, iteration 2 -->
