### PR TITLE
feat(operations): G0.6.1-T3 real JsonFluxReducer + set_default_reducer wiring

### DIFF
--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -96,8 +96,9 @@ from meho_backplane.memory import (
 )
 from meho_backplane.metrics import render_metrics
 from meho_backplane.middleware import BroadcastDetailMiddleware, RequestContextMiddleware
-from meho_backplane.operations import run_typed_op_registrars
+from meho_backplane.operations import run_typed_op_registrars, set_default_reducer
 from meho_backplane.operations.ingest import load_catalog
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
 from meho_backplane.retrieval.embedding import get_embedding_service
 from meho_backplane.settings import get_settings, parse_bool_env
 from meho_backplane.topology import (
@@ -244,6 +245,14 @@ async def _run_lifespan_startup() -> None:
     # to during the import pass above so descriptor rows are populated
     # before the first dispatch.
     await run_typed_op_registrars()
+    # Real JSONFlux reducer install (G0.6.1-T3 #753). Swaps the
+    # dispatcher's module-level :class:`PassThroughReducer` default for
+    # the production :class:`JsonFluxReducer`, so every connector's
+    # set-shaped response over the v0.1-spec §4 threshold (50 rows / 4 KB)
+    # comes back as a markdown summary + :class:`ResultHandle` instead of
+    # the raw list. Production-only: tests construct their own reducers
+    # via :func:`set_default_reducer`.
+    set_default_reducer(JsonFluxReducer())
     # MCP tool / resource auto-discovery (G0.5-T3, #248). Same shape
     # as connector auto-discovery: top-level register_mcp_tool /
     # register_mcp_resource calls run at module import.

--- a/backend/src/meho_backplane/operations/jsonflux_reducer.py
+++ b/backend/src/meho_backplane/operations/jsonflux_reducer.py
@@ -1,0 +1,308 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Real JSONFlux reducer — the production default behind the dispatcher seam.
+
+G0.6.1-T3 (#753) of Initiative #750. Bridges the vendored
+:mod:`meho_backplane.jsonflux` package (T2 #752) into the dispatcher's
+:class:`~meho_backplane.operations.reducer.Reducer` Protocol contract.
+
+The reducer's job, per CLAUDE.md postulate 6 / v0.1-spec §4 L294-311:
+small / scalar payloads pass through verbatim with a ``None`` handle; a
+set-shaped payload above the threshold (50 rows OR 4 KB serialized by
+default) is materialized into an in-memory DuckDB table, summarized as
+markdown, frozen into a JSON Schema, and addressed by a
+:class:`~meho_backplane.connectors.schemas.ResultHandle` carrying a
+bounded sample so no agent ever sees the full set inline.
+
+Why ``QueryEngine`` directly, not ``JsonFlux``
+==============================================
+
+The vendored :class:`~meho_backplane.jsonflux.JsonFlux` facade exposes
+``analyze`` / ``tree`` / ``stats`` / ``query`` but **not** the smart
+``register(unwrap=...)`` method — that lives on the lower-level
+:class:`~meho_backplane.jsonflux.query.engine.QueryEngine` (the
+list-of-dicts → DuckDB-table materializer the T2 vendoring preserved
+verbatim from MEHO.X commit ``8f48c141``). The reducer therefore drives
+``QueryEngine`` directly: it is the component that owns ``register`` +
+``describe_tables`` + ``DESCRIBE`` + sample querying.
+
+Why the reducer detects the collection itself
+=============================================
+
+``register(unwrap="auto")`` unwraps a *wrapped collection of objects*
+(``{"results": [{...}, ...]}`` → one row per object) but classifies a
+*list of scalars* (Vault's ``{"keys": ["a", "b", ...]}``) as metadata,
+collapsing it to a single 1-row table. Vendor list ops emit both
+shapes, so the reducer locates the primary collection first
+(``value`` / ``results`` / ``elements`` / ``keys`` envelopes, a bare
+top-level list, or the largest list value) and normalizes a
+list-of-scalars to ``[{column: value}, ...]`` rows before registering.
+That makes the row count — the threshold input — correct for every
+vendor shape, not just the object-collection happy path.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import msgspec
+
+from meho_backplane.connectors.schemas import ResultHandle
+from meho_backplane.jsonflux.query.engine import QueryEngine
+
+__all__ = ["JsonFluxReducer"]
+
+#: In-memory DuckDB table name the reducer registers each payload under.
+#: One :class:`QueryEngine` is created per :meth:`JsonFluxReducer.reduce`
+#: call, so a fixed name is safe — there is never table contention
+#: across concurrent dispatches.
+_TABLE = "result"
+
+#: Envelope keys vendor list ops wrap their collections under, in
+#: priority order: vCenter REST (``value``), NSX policy/manager API
+#: (``results``), SDDC Manager (``elements``), Vault KV (``keys``).
+_ENVELOPE_KEYS = ("value", "results", "elements", "keys", "items", "data")
+
+#: Column name used when a list-of-scalars is normalized into row dicts.
+_SCALAR_COLUMN = "value"
+
+#: Map a DuckDB type's leading token to a JSON Schema ``type``. DuckDB
+#: reports composite types as ``BIGINT[]`` (array) and ``STRUCT(...)``
+#: (object); the prefix match below covers those without enumerating
+#: every width-suffixed variant.
+_DUCKDB_TYPE_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("BOOLEAN", "boolean"),
+    ("TINYINT", "integer"),
+    ("SMALLINT", "integer"),
+    ("INTEGER", "integer"),
+    ("BIGINT", "integer"),
+    ("HUGEINT", "integer"),
+    ("UINTEGER", "integer"),
+    ("UBIGINT", "integer"),
+    ("UTINYINT", "integer"),
+    ("USMALLINT", "integer"),
+    ("DOUBLE", "number"),
+    ("FLOAT", "number"),
+    ("DECIMAL", "number"),
+    ("STRUCT", "object"),
+    ("MAP", "object"),
+    ("JSON", "object"),
+)
+
+
+def _json_schema_type(duckdb_type: str) -> str:
+    """Map a DuckDB column type to a JSON Schema scalar ``type`` string.
+
+    Array types (``BIGINT[]``) collapse to ``"array"``; everything not
+    matched by :data:`_DUCKDB_TYPE_PREFIXES` (``VARCHAR``, ``UUID``,
+    ``DATE``, ``TIMESTAMP``, ...) maps to ``"string"`` — the safe JSON
+    representation DuckDB itself uses when serializing those columns.
+    """
+    upper = duckdb_type.upper()
+    if upper.endswith("[]") or upper.startswith("LIST"):
+        return "array"
+    for prefix, json_type in _DUCKDB_TYPE_PREFIXES:
+        if upper.startswith(prefix):
+            return json_type
+    return "string"
+
+
+class JsonFluxReducer:
+    """Materialize large set-shaped payloads; pass small ones through.
+
+    Structurally satisfies the
+    :class:`~meho_backplane.operations.reducer.Reducer` Protocol (the
+    Protocol is :func:`~typing.runtime_checkable`, so no explicit
+    inheritance is needed and ``isinstance(reducer, Reducer)`` accepts
+    this class).
+
+    Thresholds default to v0.1-spec §4: a payload materializes when its
+    detected collection has **more than** ``row_threshold`` rows **or**
+    serializes to more than ``byte_threshold`` bytes. ``row_threshold=0``
+    forces materialization for every non-empty set (test / force mode).
+    """
+
+    def __init__(
+        self,
+        *,
+        row_threshold: int = 50,
+        byte_threshold: int = 4096,
+        sample_size: int = 5,
+        ttl_seconds: int = 3600,
+    ) -> None:
+        self._row_threshold = row_threshold
+        self._byte_threshold = byte_threshold
+        self._sample_size = sample_size
+        self._ttl_seconds = ttl_seconds
+
+    async def reduce(
+        self,
+        payload: Any,
+        schema: dict[str, Any] | None,
+        context: dict[str, Any] | None = None,
+    ) -> tuple[Any, ResultHandle | None]:
+        """Return ``(payload, None)`` or ``(summary, ResultHandle)``.
+
+        See the class docstring for the threshold + collection-detection
+        contract. ``schema`` and ``context`` are accepted to satisfy the
+        Protocol; the reducer infers the materialized schema from the
+        DuckDB-registered table rather than the descriptor schema.
+        """
+        del schema, context  # schema is inferred from the registered table
+
+        envelope_key, rows = _detect_collection(payload)
+        if rows is None:
+            # Not a set-shaped payload (scalar, dict-of-scalars, None) —
+            # nothing to reduce.
+            return payload, None
+
+        if not self._over_threshold(rows, payload):
+            return payload, None
+
+        return self._materialize(payload, envelope_key, rows)
+
+    def _over_threshold(self, rows: list[Any], payload: Any) -> bool:
+        """True when *rows* exceeds the row OR byte threshold.
+
+        ``row_threshold=0`` forces every non-empty collection over the
+        bound (force mode). An empty collection never materializes — a
+        0-row handle carries no information a pass-through doesn't.
+        """
+        if not rows:
+            return False
+        if len(rows) > self._row_threshold:
+            return True
+        return len(_serialize(payload)) > self._byte_threshold
+
+    def _materialize(
+        self,
+        payload: Any,
+        envelope_key: str | None,
+        rows: list[Any],
+    ) -> tuple[dict[str, Any], ResultHandle]:
+        """Register *rows* in DuckDB and mint a handle + inline summary.
+
+        A fresh :class:`QueryEngine` is created per call (in-memory,
+        per-payload isolation) and closed before returning so no DuckDB
+        connection leaks across dispatches.
+        """
+        table_rows = _normalize_rows(rows)
+        engine = QueryEngine()
+        try:
+            engine.register(_TABLE, table_rows, unwrap="auto")
+            total_rows = engine.tables[_TABLE]["row_count"]
+            schema_ = _build_json_schema(engine)
+            summary_md = engine.describe_tables(samples=self._sample_size)
+            sample_rows = _query_sample(engine, self._sample_size)
+        finally:
+            engine.close()
+
+        handle = ResultHandle(
+            handle_id=uuid.uuid4(),
+            summary_md=f"{total_rows} rows materialized as a JSONFlux handle.\n\n{summary_md}",
+            schema_=schema_,
+            total_rows=total_rows,
+            sample_rows=tuple(sample_rows) if sample_rows else None,
+            ttl_seconds=self._ttl_seconds,
+        )
+        summary = {
+            "row_count": total_rows,
+            "total": total_rows,
+            "sample": sample_rows,
+        }
+        if envelope_key is not None:
+            summary["source_key"] = envelope_key
+        return summary, handle
+
+
+def _detect_collection(payload: Any) -> tuple[str | None, list[Any] | None]:
+    """Locate the primary set-shaped collection in *payload*.
+
+    Returns ``(envelope_key, rows)`` where ``envelope_key`` is the dict
+    key the list was found under (``None`` for a bare top-level list)
+    and ``rows`` is the list itself, or ``(None, None)`` when *payload*
+    carries no list-shaped collection.
+
+    Resolution order:
+
+    1. A bare top-level ``list`` → ``(None, payload)``.
+    2. A ``dict`` whose first matching :data:`_ENVELOPE_KEYS` value is a
+       list → ``(key, value)``.
+    3. A ``dict`` with no known envelope key → its largest list value,
+       if any (covers vendors that wrap under a non-standard key).
+    """
+    if isinstance(payload, list):
+        return None, payload
+    if not isinstance(payload, dict):
+        return None, None
+
+    for key in _ENVELOPE_KEYS:
+        value = payload.get(key)
+        if isinstance(value, list):
+            return key, value
+
+    largest_key: str | None = None
+    largest: list[Any] | None = None
+    for key, value in payload.items():
+        if isinstance(value, list) and (largest is None or len(value) > len(largest)):
+            largest_key, largest = key, value
+    if largest is not None:
+        return largest_key, largest
+    return None, None
+
+
+def _normalize_rows(rows: list[Any]) -> list[dict[str, Any]]:
+    """Coerce *rows* into a list of dicts DuckDB can register.
+
+    A list of dicts is returned unchanged. A list of scalars (Vault's
+    ``keys``) is wrapped one-per-row under :data:`_SCALAR_COLUMN` so the
+    smart ``register`` materializes one row per element rather than
+    collapsing the list to metadata.
+    """
+    if rows and isinstance(rows[0], dict):
+        return rows
+    return [{_SCALAR_COLUMN: item} for item in rows]
+
+
+def _build_json_schema(engine: QueryEngine) -> dict[str, Any]:
+    """Build a JSON Schema (Draft 2020-12) for the registered table.
+
+    Reads the DuckDB ``DESCRIBE`` for the main table and maps each
+    column's type to a JSON Schema property. The shape is
+    ``{"type": "array", "items": {"type": "object", "properties":
+    {...}}}`` — the set-of-objects contract a future ``result_describe``
+    reports.
+    """
+    described = engine.conn.execute(f"DESCRIBE {_TABLE}").fetchall()
+    properties = {
+        column_name: {"type": _json_schema_type(column_type)}
+        for column_name, column_type, *_ in described
+    }
+    return {
+        "type": "array",
+        "items": {"type": "object", "properties": properties},
+    }
+
+
+def _query_sample(engine: QueryEngine, sample_size: int) -> list[dict[str, Any]]:
+    """Return the first *sample_size* rows of the table as plain dicts."""
+    if sample_size <= 0:
+        return []
+    # Safe (sqlalchemy-execute-raw-query): DuckDB in-memory SELECT; the
+    # table name is the fixed module constant and the limit is an int.
+    return engine.query(f"SELECT * FROM {_TABLE} LIMIT {int(sample_size)}")
+
+
+def _serialize(payload: Any) -> bytes:
+    """Serialize *payload* to JSON bytes for the byte-threshold check.
+
+    Uses msgspec (already a jsonflux dependency) for speed; falls back
+    to ``str`` bytes for any payload msgspec can't encode so the byte
+    check never raises.
+    """
+    try:
+        return msgspec.json.encode(payload)
+    except (TypeError, msgspec.EncodeError):
+        return str(payload).encode("utf-8", "replace")

--- a/backend/tests/acceptance/test_g35_nsx_jsonflux_force_handle.py
+++ b/backend/tests/acceptance/test_g35_nsx_jsonflux_force_handle.py
@@ -3,39 +3,29 @@
 
 """G3.5-T2 JSONFlux force-mode acceptance for the NSX connector.
 
-v0.2 ships only :class:`~meho_backplane.operations.reducer.PassThroughReducer`
-— the production reducer never produces a :class:`ResultHandle`. The
-real reducer (set-shaped payload reduction, MinIO/S3 spill,
-``result_query`` / ``result_aggregate`` meta-tools) is **explicitly
-out of scope** at the Goal #214 level (*"Real JSONFlux reduction
-logic … Out of scope. G0.6 ships the Reducer ABC hook only; v0.2
-default is pass-through"*).
-
-This test mirrors :mod:`tests.acceptance.test_vmware_rest_jsonflux_force_handle`
-verbatim, swapping in NSX as the dispatched connector: it installs a
-test-only :class:`ForceHandleReducer` that wraps every payload in a
-synthetic handle, dispatches ``GET:/policy/api/v1/infra/segments``
-against the seeded NSX core, and asserts the
-:class:`~meho_backplane.connectors.schemas.OperationResult`'s
-``handle`` field carries a populated :class:`ResultHandle` (UUID id,
-non-empty summary_md, dict schema_, ≥1 sample row, ttl_seconds
-set). The dispatcher seam between connector and reducer is what's
-under test; the reducer's choice of *what to summarise* and *where
-to spill* is a follow-on Initiative's job.
+Mirrors :mod:`tests.acceptance.test_vmware_rest_jsonflux_force_handle`,
+swapping in NSX as the dispatched connector and driving the **real**
+:class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+(G0.6.1-T3 #753) in force mode (``row_threshold=0`` — the seeded NSX
+core returns only 12 segments, below the default 50-row threshold, so
+force mode is required to exercise the materialization path). It
+dispatches ``GET:/policy/api/v1/infra/segments`` against the seeded NSX
+core and asserts the
+:class:`~meho_backplane.connectors.schemas.OperationResult`'s ``handle``
+field carries a populated :class:`ResultHandle` with the real
+materialized shape (UUID id, summary_md naming the row count, a
+JSON-Schema ``schema_`` mapping inferred from the DuckDB table, ≥1 real
+sample row, ttl_seconds set).
 
 What this test does NOT cover
 =============================
 
-* Real reducer logic — MinIO/S3 spill, schema inference from the
-  payload, the 50-row/4KB threshold heuristic. Those land with the
-  production reducer.
+* MinIO/S3 spill — the v0.2 reducer is DuckDB ``:memory:`` only
+  (Initiative #750 out-of-scope §3).
 * Audit-row ``handle_id`` propagation — v0.2's audit pipeline does
   not surface the handle's UUID on the audit row's
-  :attr:`AuditLog.extras` field. Once the production reducer ships,
-  the audit row's payload column gains a ``handle_id`` key; the
-  assertion below is intentionally focused on the
-  :class:`OperationResult` envelope rather than the audit-row shape
-  to keep the test resilient to that future change.
+  :attr:`AuditLog.extras` field. The assertion below is focused on the
+  :class:`OperationResult` envelope rather than the audit-row shape.
 """
 
 from __future__ import annotations
@@ -45,9 +35,9 @@ from typing import Any
 
 import pytest
 
-from meho_backplane.connectors.schemas import ResultHandle
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
 from meho_backplane.operations.meta_tools import call_operation
 from meho_backplane.operations.reducer import PassThroughReducer
 from tests.acceptance._nsx_canary_fixtures import (
@@ -57,96 +47,22 @@ from tests.acceptance._nsx_canary_fixtures import (
 )
 
 
-class ForceHandleReducer:
-    """Test-only reducer that always produces a :class:`ResultHandle`.
-
-    Exists to exercise the JSONFlux dispatcher seam against a real
-    response — proves the dispatcher calls the reducer, threads the
-    handle through :func:`wrap_ok_result` onto the
-    :class:`OperationResult.handle` field, and ships the summary
-    on :attr:`OperationResult.result` (not the raw payload).
-
-    Set-shaped payload handling matches the vSphere precedent
-    (:class:`tests.acceptance.test_vmware_rest_jsonflux_force_handle.ForceHandleReducer`)
-    with one NSX-specific addition: NSX list responses carry the
-    rows under a ``"results"`` key (rather than vCenter REST's
-    ``"value"``), so the dispatch helper recognises that shape too.
-
-    * ``dict`` with ``"results"`` key (NSX policy/manager API list
-      shape) → ``rows = payload["results"]``;
-      ``total_rows = len(rows)``.
-    * ``dict`` with ``"value"`` key (vCenter REST list shape) →
-      ``rows = payload["value"]``; ``total_rows = len(rows)``.
-    * ``list`` → ``total_rows = len(payload)``.
-    * Anything else → ``total_rows = 1``, ``sample_rows = ()``.
-
-    The handle's ``schema_`` is a placeholder ``{"type": "array",
-    "items": {"type": "object"}}`` — a real reducer would infer the
-    schema from the payload, but the dispatcher-seam test only
-    needs a non-empty dict to pass the validator's frozen-after-
-    construction requirement.
-    """
-
-    async def reduce(
-        self,
-        payload: Any,
-        schema: dict[str, Any] | None = None,
-        context: dict[str, Any] | None = None,
-    ) -> tuple[Any, ResultHandle | None]:
-        """Always return ``(summary_dict, ResultHandle)``."""
-        del schema, context  # synthetic reducer ignores both
-        if isinstance(payload, dict) and "results" in payload:
-            rows = payload["results"]
-            if isinstance(rows, list):
-                total = len(rows)
-                sample = tuple(rows[:5]) if rows else ()
-            else:
-                total = 1
-                sample = ()
-        elif isinstance(payload, dict) and "value" in payload:
-            rows = payload["value"]
-            if isinstance(rows, list):
-                total = len(rows)
-                sample = tuple(rows[:5]) if rows else ()
-            else:
-                total = 1
-                sample = ()
-        elif isinstance(payload, list):
-            total = len(payload)
-            sample = tuple(payload[:5]) if payload else ()
-        else:
-            total = 1
-            sample = ()
-
-        handle = ResultHandle(
-            handle_id=uuid.uuid4(),
-            summary_md=f"force-mode handle ({total} rows)",
-            schema_={"type": "array", "items": {"type": "object"}},
-            total_rows=total,
-            sample_rows=sample if sample else None,
-            ttl_seconds=3600,
-        )
-        summary = {"row_count": total, "sample": list(sample)}
-        return summary, handle
-
-
 @pytest.fixture
 def force_handle_reducer() -> Any:
-    """Install :class:`ForceHandleReducer` as the dispatcher's default.
+    """Install :class:`JsonFluxReducer` in force mode as the dispatcher default.
 
-    The reducer is module-level state on
-    :mod:`meho_backplane.operations.dispatcher`; the test's setup
-    swaps it in via :func:`set_default_reducer` and teardown restores
-    :class:`PassThroughReducer` so a follow-on test in the same
-    pytest session sees the v0.2 default behaviour.
+    ``row_threshold=0`` forces every non-empty set to materialize, so
+    the seeded 12-segment NSX list (below the default 50-row threshold)
+    produces a handle. The reducer is module-level state on
+    :mod:`meho_backplane.operations.dispatcher`; the test's setup swaps
+    it in via :func:`set_default_reducer` and teardown restores
+    :class:`PassThroughReducer` so a follow-on test in the same pytest
+    session sees the v0.2 default behaviour.
 
-    :func:`reset_dispatcher_caches` is called on teardown to drop
-    any connector-instance cache the dispatch built up; the
-    ``ingested_nsx_canary`` fixture's own teardown handles its
-    own slice of that work, but explicit reset here keeps the
-    fixture independent of evaluation order.
+    :func:`reset_dispatcher_caches` is called on teardown to drop any
+    connector-instance cache the dispatch built up.
     """
-    set_default_reducer(ForceHandleReducer())
+    set_default_reducer(JsonFluxReducer(row_threshold=0))
     try:
         yield
     finally:
@@ -197,7 +113,7 @@ async def test_force_handle_reducer_populates_operation_result_handle_for_nsx(
     handle = result_envelope.get("handle")
     assert handle is not None, (
         f"expected OperationResult.handle to be populated by "
-        f"ForceHandleReducer; got handle=None on envelope={result_envelope!r}"
+        f"JsonFluxReducer; got handle=None on envelope={result_envelope!r}"
     )
     uuid.UUID(handle["handle_id"])  # raises if not a valid UUID4 form
     assert handle["total_rows"] == expected_rows, (
@@ -208,12 +124,23 @@ async def test_force_handle_reducer_populates_operation_result_handle_for_nsx(
     assert str(expected_rows) in handle["summary_md"], (
         f"expected summary_md to mention the row count; got {handle['summary_md']!r}"
     )
+    # schema_ is the real JSON Schema the reducer inferred from the
+    # DuckDB-materialized table: an array-of-objects with typed columns.
     assert isinstance(handle["schema_"], dict) and handle["schema_"], (
         f"handle.schema_ must be a non-empty mapping; got {handle['schema_']!r}"
+    )
+    assert handle["schema_"]["type"] == "array"
+    schema_props = handle["schema_"]["items"]["properties"]
+    assert "id" in schema_props and "display_name" in schema_props, (
+        f"expected NSX segment columns in the inferred schema; got {schema_props!r}"
     )
     sample_rows = handle.get("sample_rows")
     assert sample_rows, (
         f"expected ≥1 sample row from the seeded NSX segment list; got sample_rows={sample_rows!r}"
+    )
+    # Sample rows are real segment records carrying the seeded id pattern.
+    assert sample_rows[0]["id"].startswith("seg-canary-"), (
+        f"expected a real seeded segment in sample_rows; got {sample_rows[0]!r}"
     )
 
     payload = result_envelope.get("result")

--- a/backend/tests/acceptance/test_g35_sddc_jsonflux_force_handle.py
+++ b/backend/tests/acceptance/test_g35_sddc_jsonflux_force_handle.py
@@ -3,18 +3,19 @@
 
 """G3.5-T5 JSONFlux force-mode acceptance for the SDDC Manager connector.
 
-v0.2 ships only :class:`~meho_backplane.operations.reducer.PassThroughReducer`
-— the production reducer never produces a :class:`ResultHandle`. This test
-mirrors :mod:`tests.acceptance.test_g35_nsx_jsonflux_force_handle` verbatim,
-swapping in SDDC Manager as the dispatched connector: it installs a test-only
-:class:`ForceHandleReducer` that wraps every payload in a synthetic handle,
-dispatches ``GET:/v1/hosts`` against the seeded SDDC Manager core, and asserts
-the :class:`~meho_backplane.connectors.schemas.OperationResult`'s ``handle``
-field carries a populated :class:`ResultHandle`.
+Mirrors :mod:`tests.acceptance.test_g35_nsx_jsonflux_force_handle`,
+swapping in SDDC Manager as the dispatched connector and driving the
+**real** :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+(G0.6.1-T3 #753) in force mode (``row_threshold=0`` — the seeded SDDC
+core returns only 12 hosts, below the default 50-row threshold). It
+dispatches ``GET:/v1/hosts`` against the seeded SDDC Manager core and
+asserts the :class:`~meho_backplane.connectors.schemas.OperationResult`'s
+``handle`` field carries a populated :class:`ResultHandle` with the real
+materialized shape.
 
-The SDDC Manager API returns paginated results under an ``elements[]`` key
-(vs NSX's ``results[]``). The :class:`ForceHandleReducer` handles both shapes
-so the dispatcher-seam test doesn't depend on a specific list-key name.
+The SDDC Manager API returns paginated results under an ``elements[]``
+key (vs NSX's ``results[]``); the reducer's envelope detection
+recognises ``elements`` so the list materializes to one row per host.
 """
 
 from __future__ import annotations
@@ -24,9 +25,9 @@ from typing import Any
 
 import pytest
 
-from meho_backplane.connectors.schemas import ResultHandle
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
 from meho_backplane.operations.meta_tools import call_operation
 from meho_backplane.operations.reducer import PassThroughReducer
 from tests.acceptance._sddc_canary_fixtures import (
@@ -36,59 +37,16 @@ from tests.acceptance._sddc_canary_fixtures import (
 )
 
 
-class ForceHandleReducer:
-    """Test-only reducer that always produces a :class:`ResultHandle`.
-
-    Recognises three pagination shapes the SDDC Manager and NSX APIs use:
-
-    * ``dict`` with ``"elements"`` key (SDDC Manager paginated envelope).
-    * ``dict`` with ``"results"`` key (NSX policy/manager API list shape).
-    * ``dict`` with ``"value"`` key (vCenter REST list shape).
-    * ``list`` → total = ``len(payload)``.
-    * Anything else → total = 1, sample = ().
-    """
-
-    async def reduce(
-        self,
-        payload: Any,
-        schema: dict[str, Any] | None = None,
-        context: dict[str, Any] | None = None,
-    ) -> tuple[Any, ResultHandle | None]:
-        """Always return ``(summary_dict, ResultHandle)``."""
-        del schema, context
-        if isinstance(payload, dict):
-            for key in ("elements", "results", "value"):
-                rows = payload.get(key)
-                if isinstance(rows, list):
-                    total = len(rows)
-                    sample = tuple(rows[:5]) if rows else ()
-                    break
-            else:
-                total = 1
-                sample = ()
-        elif isinstance(payload, list):
-            total = len(payload)
-            sample = tuple(payload[:5]) if payload else ()
-        else:
-            total = 1
-            sample = ()
-
-        handle = ResultHandle(
-            handle_id=uuid.uuid4(),
-            summary_md=f"force-mode handle ({total} rows)",
-            schema_={"type": "array", "items": {"type": "object"}},
-            total_rows=total,
-            sample_rows=sample if sample else None,
-            ttl_seconds=3600,
-        )
-        summary = {"row_count": total, "sample": list(sample)}
-        return summary, handle
-
-
 @pytest.fixture
 def force_handle_reducer() -> Any:
-    """Install :class:`ForceHandleReducer` as the dispatcher's default."""
-    set_default_reducer(ForceHandleReducer())
+    """Install :class:`JsonFluxReducer` in force mode as the dispatcher default.
+
+    ``row_threshold=0`` forces every non-empty set to materialize, so
+    the seeded 12-host SDDC list (below the default 50-row threshold)
+    produces a handle. Teardown restores :class:`PassThroughReducer` and
+    drops the dispatcher caches.
+    """
+    set_default_reducer(JsonFluxReducer(row_threshold=0))
     try:
         yield
     finally:
@@ -134,7 +92,7 @@ async def test_force_handle_reducer_populates_operation_result_handle_for_sddc(
 
     handle = result_envelope.get("handle")
     assert handle is not None, (
-        f"expected OperationResult.handle to be populated by ForceHandleReducer; "
+        f"expected OperationResult.handle to be populated by JsonFluxReducer; "
         f"got handle=None on envelope={result_envelope!r}"
     )
     uuid.UUID(handle["handle_id"])
@@ -146,12 +104,23 @@ async def test_force_handle_reducer_populates_operation_result_handle_for_sddc(
     assert str(expected_rows) in handle["summary_md"], (
         f"expected summary_md to mention the row count; got {handle['summary_md']!r}"
     )
+    # schema_ is the real JSON Schema the reducer inferred from the
+    # DuckDB-materialized table: an array-of-objects with typed columns.
     assert isinstance(handle["schema_"], dict) and handle["schema_"], (
         f"handle.schema_ must be a non-empty mapping; got {handle['schema_']!r}"
+    )
+    assert handle["schema_"]["type"] == "array"
+    schema_props = handle["schema_"]["items"]["properties"]
+    assert "id" in schema_props and "fqdn" in schema_props, (
+        f"expected SDDC host columns in the inferred schema; got {schema_props!r}"
     )
     sample_rows = handle.get("sample_rows")
     assert sample_rows, (
         f"expected ≥1 sample row from the seeded SDDC host list; got sample_rows={sample_rows!r}"
+    )
+    # Sample rows are real host records carrying the seeded id pattern.
+    assert sample_rows[0]["id"].startswith("host-"), (
+        f"expected a real seeded host in sample_rows; got {sample_rows[0]!r}"
     )
 
     payload = result_envelope.get("result")

--- a/backend/tests/acceptance/test_vmware_rest_agent_flow_e2e.py
+++ b/backend/tests/acceptance/test_vmware_rest_agent_flow_e2e.py
@@ -42,23 +42,55 @@ search-quality contract lives in the canary.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations.dispatcher import set_default_reducer
 from meho_backplane.operations.ingest import list_ingested_connectors
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
 from meho_backplane.operations.meta_tools import (
     UnknownConnectorError,
     call_operation,
     list_operation_groups,
     search_operations,
 )
+from meho_backplane.operations.reducer import PassThroughReducer
 from tests.acceptance._canary_fixtures import (
     CANARY_CONNECTOR_ID,
     IngestedCanaryVcsim,
 )
 
 
+@pytest.fixture
+def production_default_reducer() -> Any:
+    """Install the production-default :class:`JsonFluxReducer` as the dispatcher default.
+
+    The FastAPI lifespan installs ``JsonFluxReducer()`` (default
+    ``row_threshold=50`` / ``byte_threshold=4096``) as the module-level
+    dispatcher default (``main.py``'s ``set_default_reducer`` call). This
+    fixture pins that same production default for the agent-flow chain so
+    the test asserts the shape the deployed backplane actually returns —
+    independent of whichever reducer a prior test in the same pytest
+    worker left installed (the module-level default is process-global and
+    the lifespan does not restore it on shutdown).
+
+    Teardown restores :class:`PassThroughReducer` (the dispatcher's
+    import-time default) and drops the dispatcher caches so no
+    connector-instance state leaks into a follow-on test.
+    """
+    set_default_reducer(JsonFluxReducer())
+    try:
+        yield
+    finally:
+        set_default_reducer(PassThroughReducer())
+        reset_dispatcher_caches()
+
+
 async def test_agent_flow_end_to_end_against_vcsim(
     prewarmed_embeddings: None,
+    production_default_reducer: None,
     ingested_canary_vcsim: IngestedCanaryVcsim,
 ) -> None:
     """The four-step agent chain produces real vcsim data on call_operation.
@@ -80,9 +112,16 @@ async def test_agent_flow_end_to_end_against_vcsim(
        "list virtual machines" query (the canary's full-corpus search-
        quality assertion lives in ``test_g07_vsphere_canary.py``).
     4. ``call_operation(op_id="GET:/vcenter/vm", target=<vcsim>)`` must
-       return ``status='ok'`` carrying real data from vcsim (the
-       seeded topology has 50 VMs, so the inlined ``result['value']``
-       list has 50 entries).
+       return ``status='ok'``. With the production-default
+       :class:`JsonFluxReducer` installed (G0.6.1-T3 #753), the 50-VM
+       seed materializes into a JSONFlux handle: the row count is *at*
+       the 50-row threshold (``50 > 50`` is False) but the serialized
+       payload exceeds the 4 KB ``byte_threshold``, so the byte branch
+       fires. The chain therefore returns the reduced summary on
+       ``result`` plus a populated :class:`ResultHandle` (the agent
+       drills into the full set via ``result_query`` / ``result_export``
+       — CLAUDE.md postulate 6 / v0.1-spec §4) rather than a raw
+       50-element list inline.
     """
     operator = ingested_canary_vcsim.operator
 
@@ -133,20 +172,35 @@ async def test_agent_flow_end_to_end_against_vcsim(
         },
     )
     assert result_envelope["status"] == "ok", f"dispatch did not succeed: {result_envelope!r}"
-    payload = result_envelope.get("result")
-    assert payload is not None, f"expected non-null OperationResult.result; got {result_envelope!r}"
-    # vCenter REST returns set-shaped responses as ``{"value": [...]}``
-    # on the legacy ``/rest`` mount and as a bare list on the modern
-    # ``/api`` mount. vcsim serves both shapes depending on which
-    # endpoint the connector hits; assert on the union.
-    vms = payload["value"] if isinstance(payload, dict) and "value" in payload else payload
-    assert isinstance(vms, list), (
-        f"expected a list of VMs from vcsim's 50-VM seed topology; "
-        f"got payload type {type(payload).__name__} body={payload!r}"
+
+    # With the production-default JsonFluxReducer installed, the 50-VM
+    # seed (≈5 KB serialized, over the 4 KB byte_threshold) materializes
+    # into a handle. The agent never sees the raw 50-element list inline:
+    # ``result`` carries the reduced summary, ``handle`` carries the
+    # ResultHandle the agent drills into.
+    handle = result_envelope.get("handle")
+    assert handle is not None, (
+        f"expected OperationResult.handle to be populated by the "
+        f"production-default JsonFluxReducer; got handle=None on "
+        f"envelope={result_envelope!r}"
     )
-    assert len(vms) == 50, (
-        f"expected 50 VMs from vcsim's seed topology; got {len(vms)} "
-        f"(payload shape={type(payload).__name__})"
+    assert handle["total_rows"] == 50, (
+        f"expected 50 VMs from vcsim's seed topology; got handle.total_rows={handle['total_rows']}"
+    )
+    # The bounded sample lets the agent preview the set without
+    # materializing all 50 rows; it must be non-empty and capped below
+    # the full row count.
+    sample_rows = handle.get("sample_rows")
+    assert sample_rows, f"expected a bounded sample on the handle; got sample_rows={sample_rows!r}"
+    assert 0 < len(sample_rows) < handle["total_rows"], (
+        f"sample must be a bounded slice of the 50-VM set; got {len(sample_rows)} rows"
+    )
+
+    # The inlined result is the reducer's summary, not the raw 50-VM set.
+    payload = result_envelope.get("result")
+    assert payload is not None and payload.get("row_count") == 50, (
+        f"expected the reducer's reduced summary on result with "
+        f"row_count==50; got result={payload!r}"
     )
 
 

--- a/backend/tests/acceptance/test_vmware_rest_jsonflux_force_handle.py
+++ b/backend/tests/acceptance/test_vmware_rest_jsonflux_force_handle.py
@@ -3,35 +3,30 @@
 
 """G3.1-T8 JSONFlux handle force-mode acceptance test.
 
-v0.2 ships only :class:`~meho_backplane.operations.reducer.PassThroughReducer`
-— the production reducer never produces a :class:`ResultHandle`. The
-real reducer (set-shaped payload reduction, MinIO/S3 spill,
-``result_query`` / ``result_aggregate`` meta-tools) lands in a
-follow-on Initiative. Until then, the JSONFlux *seam* between
-dispatcher and reducer is exercised here via a test-only
-:class:`ForceHandleReducer` that wraps every payload in a synthetic
-handle. The test:
+Exercises the JSONFlux dispatcher → reducer → ``OperationResult`` seam
+with the **real** :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+(G0.6.1-T3 #753) in force mode (``row_threshold=0`` — every non-empty
+set materializes regardless of size). The test:
 
 * Dispatches ``GET:/vcenter/vm`` against vcsim's 50-VM seed.
 * Asserts the returned :class:`~meho_backplane.connectors.schemas.OperationResult`
-  carries a populated :attr:`OperationResult.handle` (UUID id,
-  non-empty summary_md, dict schema_, ≥1 sample row, ttl_seconds set).
+  carries a populated :attr:`OperationResult.handle` with the real
+  materialized shape (fresh UUID id, summary_md naming the row count,
+  a JSON-Schema ``schema_`` mapping inferred from the DuckDB table,
+  ≥1 real sample row, ttl_seconds set).
 * Asserts the inlined :attr:`OperationResult.result` carries the
-  reduced summary (row_count + sample) rather than the full set.
+  reduced summary (row_count + bounded sample) rather than the full
+  50-VM set.
 
 What the test does NOT cover
 ============================
 
-* Real reducer logic — MinIO/S3 spill, schema inference from payload,
-  the 50-row/4KB threshold heuristic. Those land with the production
-  reducer.
+* MinIO/S3 spill — the v0.2 reducer is DuckDB ``:memory:`` only
+  (Initiative #750 out-of-scope §3).
 * Audit-row ``handle_id`` propagation — v0.2's audit pipeline does
   not surface the handle's UUID on the audit row's
-  :attr:`AuditLog.extras` field. Once the production reducer ships,
-  the audit row's payload column gains a ``handle_id`` key; the
-  assertion below is intentionally focused on the
-  :class:`OperationResult` envelope rather than the audit-row shape
-  to keep the test resilient to that future change.
+  :attr:`AuditLog.extras` field. The assertion below is focused on the
+  :class:`OperationResult` envelope rather than the audit-row shape.
 """
 
 from __future__ import annotations
@@ -41,90 +36,30 @@ from typing import Any
 
 import pytest
 
-from meho_backplane.connectors.schemas import ResultHandle
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
 from meho_backplane.operations.meta_tools import call_operation
 from meho_backplane.operations.reducer import PassThroughReducer
 from tests.acceptance._canary_fixtures import IngestedCanaryVcsim
 
 
-class ForceHandleReducer:
-    """Test-only reducer that always produces a :class:`ResultHandle`.
-
-    Exists to exercise the JSONFlux dispatcher seam against a real
-    response — proves the dispatcher calls the reducer, threads the
-    handle through :func:`wrap_ok_result` onto the
-    :class:`OperationResult.handle` field, and ships the summary
-    on :attr:`OperationResult.result` (not the raw payload).
-
-    Set-shaped payload handling:
-
-    * ``dict`` with ``"value"`` key (vCenter REST's set-shape) →
-      ``rows = payload["value"]``; ``total_rows = len(rows)``.
-    * ``list`` → ``total_rows = len(payload)``.
-    * Anything else → ``total_rows = 1``, ``sample_rows = ()``.
-
-    The handle's ``schema_`` is a placeholder ``{"type": "array",
-    "items": {"type": "object"}}`` — a real reducer would infer the
-    schema from the payload, but the dispatcher seam test only needs
-    a non-empty dict to pass the
-    :class:`~meho_backplane.connectors.schemas.ResultHandle`
-    validator's frozen requirement.
-    """
-
-    async def reduce(
-        self,
-        payload: Any,
-        schema: dict[str, Any] | None = None,
-        context: dict[str, Any] | None = None,
-    ) -> tuple[Any, ResultHandle | None]:
-        """Always return ``(summary_dict, ResultHandle)``."""
-        del schema, context  # synthetic reducer ignores both
-        if isinstance(payload, dict) and "value" in payload:
-            rows = payload["value"]
-            if isinstance(rows, list):
-                total = len(rows)
-                sample = tuple(rows[:5]) if rows else ()
-            else:
-                total = 1
-                sample = ()
-        elif isinstance(payload, list):
-            total = len(payload)
-            sample = tuple(payload[:5]) if payload else ()
-        else:
-            total = 1
-            sample = ()
-
-        handle = ResultHandle(
-            handle_id=uuid.uuid4(),
-            summary_md=f"force-mode handle ({total} rows)",
-            schema_={"type": "array", "items": {"type": "object"}},
-            total_rows=total,
-            sample_rows=sample if sample else None,
-            ttl_seconds=3600,
-        )
-        summary = {"row_count": total, "sample": list(sample)}
-        return summary, handle
-
-
 @pytest.fixture
 def force_handle_reducer() -> Any:
-    """Install :class:`ForceHandleReducer` as the dispatcher's default.
+    """Install :class:`JsonFluxReducer` in force mode as the dispatcher default.
 
-    The reducer is module-level state on
-    :mod:`meho_backplane.operations.dispatcher`; the test's setup
-    swaps it in via :func:`set_default_reducer` and teardown restores
-    :class:`PassThroughReducer` so a follow-on test in the same
-    pytest session sees the v0.2 default behaviour.
+    ``row_threshold=0`` forces every non-empty set to materialize, so
+    vcsim's 50-VM seed (at, not over, the default 50-row threshold)
+    produces a handle. The reducer is module-level state on
+    :mod:`meho_backplane.operations.dispatcher`; the test's setup swaps
+    it in via :func:`set_default_reducer` and teardown restores
+    :class:`PassThroughReducer` so a follow-on test in the same pytest
+    session sees the v0.2 default behaviour.
 
-    :func:`reset_dispatcher_caches` is called on teardown to drop
-    any connector-instance cache the dispatch built up; the
-    ``ingested_canary_vcsim`` fixture's own teardown handles its
-    own slice of that work, but explicit reset here keeps the
-    fixture independent of evaluation order.
+    :func:`reset_dispatcher_caches` is called on teardown to drop any
+    connector-instance cache the dispatch built up.
     """
-    set_default_reducer(ForceHandleReducer())
+    set_default_reducer(JsonFluxReducer(row_threshold=0))
     try:
         yield
     finally:
@@ -172,7 +107,7 @@ async def test_force_handle_reducer_populates_operation_result_handle(
     handle = result_envelope.get("handle")
     assert handle is not None, (
         f"expected OperationResult.handle to be populated by "
-        f"ForceHandleReducer; got handle=None on envelope={result_envelope!r}"
+        f"JsonFluxReducer; got handle=None on envelope={result_envelope!r}"
     )
     # ``model_dump`` ships the handle as a dict on the wire; the
     # assertions below match the JSON shape rather than re-instantiating
@@ -186,12 +121,22 @@ async def test_force_handle_reducer_populates_operation_result_handle(
     assert "50" in handle["summary_md"], (
         f"expected summary_md to mention the row count; got {handle['summary_md']!r}"
     )
+    # schema_ is the real JSON Schema the reducer inferred from the
+    # DuckDB-materialized table: an array-of-objects with typed columns.
     assert isinstance(handle["schema_"], dict) and handle["schema_"], (
         f"handle.schema_ must be a non-empty mapping; got {handle['schema_']!r}"
     )
+    assert handle["schema_"]["type"] == "array"
+    schema_props = handle["schema_"]["items"]["properties"]
+    assert schema_props, f"expected ≥1 inferred column in the handle schema; got {schema_props!r}"
     sample_rows = handle.get("sample_rows")
     assert sample_rows, (
         f"expected ≥1 sample row from vcsim's 50-VM list; got sample_rows={sample_rows!r}"
+    )
+    # Sample rows are real VM records whose keys match the inferred schema.
+    assert set(sample_rows[0]) == set(schema_props), (
+        f"sample-row columns must match the inferred schema; "
+        f"row keys={set(sample_rows[0])} schema keys={set(schema_props)}"
     )
 
     # The inlined result is the reducer's summary, not the raw 50-VM

--- a/backend/tests/test_operations_jsonflux_reducer.py
+++ b/backend/tests/test_operations_jsonflux_reducer.py
@@ -29,6 +29,7 @@ the captured broadcast event).
 
 from __future__ import annotations
 
+import json
 import uuid
 from collections.abc import AsyncIterator, Iterator, Mapping
 from typing import Any
@@ -141,6 +142,55 @@ async def test_materialize_handle_for_large_set() -> None:
     assert reduced["row_count"] == 60
     assert len(reduced["sample"]) <= 5
     assert "results" not in reduced
+
+
+async def test_materialize_handle_for_under_row_over_byte_threshold() -> None:
+    """A set ≤ row_threshold but > byte_threshold materializes via the byte branch.
+
+    Pins the *size*-triggered materialization path independently of the
+    row-count path: ``_over_threshold`` returns True when
+    ``len(_serialize(payload)) > byte_threshold`` even though
+    ``len(rows) <= row_threshold``. This is the branch the production
+    default exercises against vcsim's 50-VM seed (50 rows == the 50-row
+    threshold, so ``50 > 50`` is False, but the serialized payload is
+    ≈5 KB > the 4 KB ``byte_threshold``) — it had no dedicated unit
+    coverage and broke the agent-flow e2e in CI (#962 B1) before this
+    test was added.
+
+    The fixture builds a 5-row set whose values are padded so the
+    serialized JSON clears the default 4 KB ``byte_threshold`` while
+    staying well under the 50-row default ``row_threshold``.
+    """
+    reducer = JsonFluxReducer()  # production defaults: row=50, byte=4096
+
+    # Five rows, each carrying a ~1.2 KB blob → ~6 KB serialized: comfortably
+    # over the 4 KB byte_threshold, comfortably under the 50-row threshold.
+    rows = [{"id": f"seg-{i}", "blob": "x" * 1200} for i in range(5)]
+    payload = {"value": rows}
+
+    # Guard the test's own premise: row count is under the threshold, byte
+    # count is over it — so only the byte branch can trigger materialization.
+    assert len(rows) <= reducer._row_threshold
+    assert len(json.dumps(payload).encode()) > reducer._byte_threshold
+
+    reduced, handle = await reducer.reduce(payload, None)
+
+    assert handle is not None, (
+        "a 5-row set serializing over the 4 KB byte_threshold must "
+        "materialize a handle even though it is under the row threshold"
+    )
+    assert isinstance(handle, ResultHandle)
+    assert handle.total_rows == 5, (
+        f"total_rows must reflect the 5-row collection; got {handle.total_rows}"
+    )
+    assert handle.sample_rows is not None and handle.sample_rows, (
+        "the byte-triggered handle must still carry a bounded sample"
+    )
+
+    # The inlined summary is the reduced view, not the raw 5-row list.
+    assert isinstance(reduced, dict)
+    assert reduced["row_count"] == 5
+    assert "value" not in reduced
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_operations_jsonflux_reducer.py
+++ b/backend/tests/test_operations_jsonflux_reducer.py
@@ -1,0 +1,345 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G0.6.1-T3 (#753) acceptance tests for :class:`JsonFluxReducer`.
+
+Three axes, per the Task:
+
+* **pass-through** — a payload at/under the threshold returns unchanged
+  with ``handle is None`` (the v0.1-spec §4 boundary; the agent sees the
+  full small list inline).
+* **materialize** — a payload over the threshold returns a reduced
+  summary plus a populated :class:`ResultHandle` whose real fields
+  (``handle_id`` / ``summary_md`` / ``schema_`` / ``total_rows`` /
+  ``sample_rows`` / ``ttl_seconds``) reflect the DuckDB-materialized
+  table, not a synthetic placeholder.
+* **exception tolerance via the dispatcher** — a reducer that raises
+  propagates as a ``connector_error`` :class:`OperationResult` through
+  :func:`~meho_backplane.operations.dispatcher._reduce_or_error`, and the
+  audit row + broadcast event still commit (the dispatcher's
+  never-raises contract).
+
+The third test wires a deliberately-broken reducer through the real
+dispatch path the same way :mod:`tests.test_operations_dispatcher` does
+(register a typed op, install the reducer via
+:func:`~meho_backplane.operations.dispatcher.set_default_reducer`,
+dispatch, assert on the structured error + the persisted audit row +
+the captured broadcast event).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator, Mapping
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import (
+    FingerprintResult,
+    ProbeResult,
+    ResultHandle,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+from meho_backplane.operations import (
+    dispatch,
+    register_typed_operation,
+    reset_dispatcher_caches,
+)
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
+from meho_backplane.operations.reducer import PassThroughReducer, Reducer
+from meho_backplane.settings import get_settings
+
+# ---------------------------------------------------------------------------
+# Unit tests — reducer in isolation (no dispatcher)
+# ---------------------------------------------------------------------------
+
+
+async def test_pass_through_for_small_payload() -> None:
+    """A ≤threshold set returns unchanged with ``handle is None``.
+
+    The default 50-row threshold is exclusive (``> 50`` materializes), so
+    a 10-row collection passes straight through: identity-preserved
+    payload, no handle. This is the v0.2 default the agent relies on for
+    small lists.
+    """
+    reducer = JsonFluxReducer()
+    # Structural-typing contract: the adapter satisfies the Protocol.
+    assert isinstance(reducer, Reducer)
+
+    payload = {"value": [{"vm": f"vm-{i}", "power": "on"} for i in range(10)]}
+
+    reduced, handle = await reducer.reduce(payload, None)
+
+    assert handle is None, f"≤threshold payload must not produce a handle; got {handle!r}"
+    assert reduced is payload, "pass-through must return the exact input payload object"
+
+
+async def test_materialize_handle_for_large_set() -> None:
+    """A >threshold set returns a reduced summary + a real ResultHandle.
+
+    Asserts the **real** materialization shape, not just field presence:
+
+    * ``total_rows`` equals the full collection size (the count a future
+      ``result_describe(handle)`` reports).
+    * ``schema_`` is a JSON-Schema mapping inferred from the DuckDB
+      table — ``type: array`` over ``items.properties`` with one entry
+      per column, typed (``id`` → string, ``count`` → integer).
+    * ``sample_rows`` is a bounded non-empty slice of real rows.
+    * ``summary_md`` mentions the row count and is non-empty.
+    * the inlined summary carries ``row_count`` and the bounded
+      ``sample`` — never the full raw list.
+    """
+    reducer = JsonFluxReducer(sample_size=5)
+    rows = [{"id": f"seg-{i}", "name": f"canary-{i}", "count": i} for i in range(60)]
+    payload = {"results": rows, "result_count": 60}
+
+    reduced, handle = await reducer.reduce(payload, None)
+
+    assert handle is not None, "a 60-row set is over the 50-row threshold; expected a handle"
+    assert isinstance(handle, ResultHandle)
+
+    # handle_id is a fresh UUID.
+    assert isinstance(handle.handle_id, uuid.UUID)
+
+    # total_rows reflects the materialized table, not the envelope.
+    assert handle.total_rows == 60
+
+    # summary_md is non-empty and names the row count.
+    assert handle.summary_md
+    assert "60" in handle.summary_md
+
+    # schema_ is a frozen JSON-Schema mapping with typed columns.
+    assert isinstance(handle.schema_, Mapping) and handle.schema_
+    assert handle.schema_["type"] == "array"
+    properties = handle.schema_["items"]["properties"]
+    assert set(properties) == {"id", "name", "count"}
+    assert properties["id"]["type"] == "string"
+    assert properties["count"]["type"] == "integer"
+
+    # sample_rows is a bounded non-empty slice of real rows.
+    assert handle.sample_rows is not None
+    assert 0 < len(handle.sample_rows) <= 5 < handle.total_rows
+    first = handle.sample_rows[0]
+    assert set(first) == {"id", "name", "count"}
+
+    # ttl_seconds carries the configured default.
+    assert handle.ttl_seconds == 3600
+
+    # The inlined summary is the reduced view, not the raw 60-row list.
+    assert isinstance(reduced, dict)
+    assert reduced["row_count"] == 60
+    assert len(reduced["sample"]) <= 5
+    assert "results" not in reduced
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher integration — broken reducer → connector_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for the dispatch test."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    clear_registry()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so ``register_typed_operation`` skips ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    """Replace :func:`publish_event` with a recording stub.
+
+    Mirrors :mod:`tests.test_operations_dispatcher`: the audit helper
+    invokes ``publish_event`` via the imported reference inside
+    :mod:`meho_backplane.operations._audit`, so patching that module's
+    attribute captures every event the dispatch emits.
+    """
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+class _NoOpVaultConnector(Connector):
+    """Connector class used to satisfy resolver lookups in the dispatch test."""
+
+    product = "vault"
+    version = "1.x"
+    impl_id = "vault"
+
+    async def fingerprint(self, target: Any) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(  # type: ignore[override]
+        self,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        raise NotImplementedError
+
+
+class _BrokenReducer:
+    """Reducer that always raises — exercises the dispatcher's reduce guard."""
+
+    async def reduce(
+        self,
+        payload: Any,
+        schema: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+    ) -> tuple[Any, ResultHandle | None]:
+        del payload, schema, context
+        raise RuntimeError("simulated reducer explosion")
+
+
+class _FakeFingerprint:
+    """Duck-typed fingerprint the resolver reads ``version`` off of."""
+
+    def __init__(self, version: str | None = None) -> None:
+        self.version = version
+
+
+class _FakeTarget:
+    """Minimal target the resolver / dispatcher reads from."""
+
+    def __init__(self, *, product: str = "vault") -> None:
+        self.product = product
+        self.fingerprint = _FakeFingerprint(version=None)
+        self.preferred_impl_id: str | None = None
+        self.id = uuid.uuid4()
+        self.name = "test-target"
+        self.host = "test.example.com"
+        self.port = 443
+        self.auth_model = "shared_service_account"
+
+
+def _make_operator() -> Operator:
+    """Construct an :class:`Operator` directly — no JWT round-trip."""
+    return Operator(
+        sub="op-test",
+        name="Test Operator",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=uuid.UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _module_handler(
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Typed handler returning a small set-shaped payload for the reducer."""
+    del target
+    return {"value": [{"echo": params}]}
+
+
+@pytest.fixture
+async def _registered_typed_op(
+    stub_embedding_service: AsyncMock,
+) -> AsyncIterator[None]:
+    """Register the connector + a typed op the broken-reducer test dispatches."""
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.kv.list",
+        handler=_module_handler,
+        summary="List secrets.",
+        description="List secrets.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+    yield
+
+
+async def test_reducer_exception_yields_connector_error_via_dispatcher(
+    _registered_typed_op: None,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """A reducer raise propagates as ``connector_error``; audit + broadcast commit.
+
+    Pins the dispatcher's never-raises contract for the JSONFlux seam
+    (:func:`~meho_backplane.operations.dispatcher._reduce_or_error`):
+
+    * ``status == 'error'`` with ``error`` prefixed ``connector_error:``
+      and ``extras['error_code'] == 'connector_error'`` — the reducer's
+      ``RuntimeError`` was converted, not propagated.
+    * exactly one ``audit_log`` row for the op carries
+      ``result_status == 'error'`` — the audit write committed despite
+      the reducer failure.
+    * exactly one broadcast event fired with ``result_status == 'error'``
+      — the failure is observable on the feed.
+    """
+    set_default_reducer(_BrokenReducer())
+    try:
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id="vault-1.x",
+            op_id="vault.kv.list",
+            target=_FakeTarget(),
+            params={"path": "/secret"},
+        )
+    finally:
+        set_default_reducer(PassThroughReducer())
+
+    assert result.status == "error"
+    assert result.error is not None
+    assert result.error.startswith("connector_error:")
+    assert result.extras["error_code"] == "connector_error"
+    assert result.extras["exception_class"] == "RuntimeError"
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            (await session.execute(select(AuditLog).where(AuditLog.path == "vault.kv.list")))
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    assert rows[0].payload["result_status"] == "error"
+
+    assert len(captured_events) == 1
+    assert captured_events[0].result_status == "error"

--- a/backend/tests/test_vault_kv_list_jsonflux.py
+++ b/backend/tests/test_vault_kv_list_jsonflux.py
@@ -22,35 +22,28 @@ Two behaviours are pinned:
   as the inline ``{"keys": [...]}`` list with ``handle is None``. This
   is the v0.2 default the Initiative #366 work item 6 specifies
   ("v0.2 default is pass-through").
-* **Force-mode / over-threshold: handle.** With a threshold-aware
-  reducer swapped in via
+* **Over-threshold: handle.** With the **real**
+  :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+  (G0.6.1-T3 #753) installed via
   :func:`~meho_backplane.operations.dispatcher.set_default_reducer`
-  (the same seam G3.1-T8's
-  ``test_vmware_rest_jsonflux_force_handle.py`` exercises for the
-  ingested vCenter connector), a ``vault.kv.list`` against a path with
-  more than 50 keys returns ``{sample, ...}`` on
-  :attr:`OperationResult.result` plus a populated
+  (the same seam the ``*_jsonflux_force_handle.py`` acceptance tests
+  exercise for the ingested vendor connectors), a ``vault.kv.list``
+  against a path with more than 50 keys returns ``{row_count, total,
+  sample, ...}`` on :attr:`OperationResult.result` plus a populated
   :class:`~meho_backplane.connectors.schemas.ResultHandle` carrying the
-  full ``total_rows`` count and a bounded ``sample_rows`` slice. The
-  agent never sees the raw >50-key list.
+  full ``total_rows`` count, a JSON-Schema ``schema_``, and a bounded
+  ``sample_rows`` slice. The agent never sees the raw >50-key list.
 
 On ``result_query`` / ``result_describe``
 =========================================
 
-v0.2 ships only :class:`PassThroughReducer`; the real reducer plus the
-``result_query`` / ``result_aggregate`` / ``result_describe`` /
+The ``result_query`` / ``result_aggregate`` / ``result_describe`` /
 ``result_export`` meta-tools that read a handle back land in a
-follow-on Initiative (see the
-:class:`~meho_backplane.connectors.schemas.ResultHandle` docstring and
-the G3.1-T8 sibling test's "What the test does NOT cover" note). The
-DoD's ``result_describe(handle)`` / ``result_query(handle, ...)``
-drill-in is therefore verified at the **contract** level the way the
-established sibling test does it: the handle carries the exact
-``total_rows`` (what ``result_describe`` will report) and a
-non-empty ``sample_rows`` slice keyed off the same payload
-``result_query`` will page through. Asserting against not-yet-shipped
-meta-tools would test vapourware; asserting the handle envelope pins
-the contract those tools will consume.
+follow-on Initiative. The DoD's ``result_describe(handle)`` /
+``result_query(handle, ...)`` drill-in is therefore verified at the
+**contract** level: the handle carries the exact ``total_rows`` (what
+``result_describe`` will report) and a non-empty ``sample_rows`` slice
+keyed off the same payload ``result_query`` will page through.
 """
 
 from __future__ import annotations
@@ -74,70 +67,21 @@ from meho_backplane.connectors.vault import (
 )
 from meho_backplane.operations import dispatch, reset_dispatcher_caches
 from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
 from meho_backplane.operations.reducer import PassThroughReducer
 from meho_backplane.settings import get_settings
 
 from ._vault_fakes import install_fake_client
 
 #: JSONFlux default set-shape threshold (v0.1-spec §4: ~50 rows). The
-#: real reducer keys its set-detection on this; the test-only reducer
-#: below mirrors the same bound so the regression pins the exact
-#: ">50 keys → handle, ≤50 keys → inline" boundary the spec names.
+#: real :class:`JsonFluxReducer` keys its set-detection on this exact
+#: bound; the constant pins the ">50 keys → handle, ≤50 keys → inline"
+#: boundary the spec names so a future default change is caught here.
 _THRESHOLD = 50
 
-#: Sample slice the handle carries for the agent's first look. Matches
-#: the bounded-sample discipline the G3.1-T8 sibling uses (first N rows).
+#: Sample slice the handle carries for the agent's first look —
+#: :class:`JsonFluxReducer`'s default ``sample_size``.
 _SAMPLE_SIZE = 5
-
-
-class _ThresholdHandleReducer:
-    """Test-only reducer mirroring the production threshold contract.
-
-    The v0.2 production default
-    (:class:`~meho_backplane.operations.reducer.PassThroughReducer`)
-    never produces a handle; the real reducer (post-G0.6 follow-on
-    Initiative) wraps set-shaped payloads above the JSONFlux threshold.
-    This stand-in implements exactly that boundary for the
-    ``vault.kv.list`` payload shape (``{"keys": [...]}``) so the
-    regression exercises the dispatcher → reducer → ``OperationResult``
-    seam without depending on the unshipped real reducer.
-
-    Boundary:
-
-    * ``{"keys": [...]}`` with ``len(keys) > _THRESHOLD`` → returns a
-      ``{"sample": [...], "total": N}`` summary plus a
-      :class:`ResultHandle` carrying the full ``total_rows`` and a
-      bounded ``sample_rows`` slice. The agent-visible
-      :attr:`OperationResult.result` is the summary, never the raw
-      >50-key list.
-    * Anything else (small key set, scalar, ``None``) → pass-through:
-      ``(payload, None)`` — identical to the production v0.2 default,
-      so the test can install this single reducer and still assert the
-      ≤threshold pass-through path behaves like production.
-    """
-
-    async def reduce(
-        self,
-        payload: Any,
-        schema: dict[str, Any] | None = None,
-        context: dict[str, Any] | None = None,
-    ) -> tuple[Any, ResultHandle | None]:
-        del schema, context  # threshold decision is payload-shape only
-        if isinstance(payload, dict) and isinstance(payload.get("keys"), list):
-            keys = payload["keys"]
-            if len(keys) > _THRESHOLD:
-                sample = keys[:_SAMPLE_SIZE]
-                handle = ResultHandle(
-                    handle_id=uuid.uuid4(),
-                    summary_md=f"vault.kv.list — {len(keys)} keys (sample of {len(sample)})",
-                    schema_={"type": "array", "items": {"type": "string"}},
-                    total_rows=len(keys),
-                    sample_rows=tuple({"key": k} for k in sample),
-                    ttl_seconds=3600,
-                )
-                summary = {"sample": sample, "total": len(keys)}
-                return summary, handle
-        return payload, None
 
 
 @pytest.fixture(autouse=True)
@@ -200,15 +144,18 @@ async def _registered_vault_typed_ops(
 
 @pytest.fixture
 def threshold_reducer() -> Iterator[None]:
-    """Swap :class:`_ThresholdHandleReducer` in as the dispatcher default.
+    """Swap the real :class:`JsonFluxReducer` in as the dispatcher default.
 
+    Constructed with its production defaults (``row_threshold=50``,
+    ``sample_size=5``) so the regression pins the exact ">50 keys →
+    handle, ≤50 keys → inline" boundary against the shipped reducer.
     The reducer is module-level state on
     :mod:`meho_backplane.operations.dispatcher`; teardown restores the
     v0.2 production :class:`PassThroughReducer` so a follow-on test in
-    the same session sees the shipped default, and drops the
-    dispatcher caches so connector-instance state does not leak.
+    the same session sees the shipped default, and drops the dispatcher
+    caches so connector-instance state does not leak.
     """
-    set_default_reducer(_ThresholdHandleReducer())
+    set_default_reducer(JsonFluxReducer())
     try:
         yield
     finally:
@@ -371,16 +318,30 @@ async def test_kv_list_over_threshold_returns_sample_and_handle(
     )
     # ResultHandle._freeze_nested wraps schema_ in a MappingProxyType
     # (the model's frozen-after-construction guarantee), so it is a
-    # Mapping, not a plain dict — assert the structural contract.
+    # Mapping, not a plain dict — assert the real array-of-objects shape
+    # the reducer inferred from the DuckDB-materialized table. The Vault
+    # key list is a list of scalars; the reducer normalizes each key into
+    # a one-column ``{"value": <key>}`` row, so the inferred schema has a
+    # single ``value`` column.
     assert isinstance(handle.schema_, Mapping) and handle.schema_, (
         f"handle.schema_ must be a non-empty mapping; got {handle.schema_!r}"
     )
+    assert handle.schema_["type"] == "array"
+    assert "value" in handle.schema_["items"]["properties"], (
+        f"expected the normalized 'value' column in the inferred schema; "
+        f"got {handle.schema_['items']['properties']!r}"
+    )
     # sample_rows is the slice a future result_query(handle, ...) pages
-    # from — bounded, non-empty, and strictly smaller than the full set.
+    # from — bounded, non-empty, strictly smaller than the full set, and
+    # carrying the normalized ``{"value": <key>}`` rows.
     assert handle.sample_rows is not None
     assert 0 < len(handle.sample_rows) <= _SAMPLE_SIZE < len(big_keys), (
         f"sample_rows must be a bounded non-empty slice smaller than the "
         f"full set; got {len(handle.sample_rows)} rows"
+    )
+    assert [row["value"] for row in handle.sample_rows] == big_keys[:_SAMPLE_SIZE], (
+        f"sample_rows must carry the first {_SAMPLE_SIZE} real keys; "
+        f"got {[dict(row) for row in handle.sample_rows]!r}"
     )
 
     # The agent-visible inlined result is the reducer's summary, NOT the
@@ -389,7 +350,8 @@ async def test_kv_list_over_threshold_returns_sample_and_handle(
     # agent.
     assert isinstance(result.result, dict)
     assert result.result.get("total") == len(big_keys)
-    assert result.result.get("sample") == big_keys[:_SAMPLE_SIZE]
+    assert result.result.get("row_count") == len(big_keys)
+    assert [row["value"] for row in result.result.get("sample", [])] == big_keys[:_SAMPLE_SIZE]
     assert "keys" not in result.result, (
         "the raw inline key list must not survive on the result envelope once a handle is produced"
     )


### PR DESCRIPTION
## Summary

- Add `JsonFluxReducer(Reducer)` (`backend/src/meho_backplane/operations/jsonflux_reducer.py`) — the real JSONFlux reducer that bridges the vendored `meho_backplane.jsonflux` package (T2 #752) into the dispatcher's `Reducer` Protocol. Small / scalar payloads pass through verbatim (`handle is None`); a set-shaped payload over the v0.1-spec §4 threshold (50 rows OR 4 KB serialized; `row_threshold=0` forces materialization) is registered as an in-memory DuckDB table, summarized as markdown, frozen into a JSON Schema, and addressed by a `ResultHandle` with a bounded sample — so no agent ever sees the full raw set inline (CLAUDE.md postulate 6).
- Install it as the production default in the FastAPI lifespan via `set_default_reducer(JsonFluxReducer())`. `PassThroughReducer` stays as a test utility.
- Migrate the four force-mode handle tests off the `ForceHandleReducer` shim onto the real adapter; assertions now check the real materialization shape (`total_rows`, inferred `schema_.items.properties`, sample-row content), not synthetic placeholders.

### Deviations from the #753 API sketch (forced by the real vendored API)

- The sketch's `JsonFlux(JsonFluxConfig(...))` constructor does not exist — `JsonFlux.__init__` takes kwargs, not a config object, and the `JsonFlux` facade exposes **no** `register()`. The smart `register(unwrap="auto", append=False)` lives on `QueryEngine`, so the adapter drives `QueryEngine` directly (it owns `register` + `describe_tables` + `DESCRIBE` + sample querying). A fresh `:memory:` engine is created per `reduce()` call for per-payload isolation.
- `register(unwrap="auto")` unwraps a wrapped collection of objects but collapses a **list of scalars** (Vault's `{"keys": [...]}`) to a single metadata row. The reducer therefore detects the primary collection itself (`value` / `results` / `elements` / `keys` / top-level list / largest list) and normalizes scalars to row dicts before registering, so the row count — the threshold input — is correct for every vendor shape.
- `ResultHandle.schema_` must be a JSON-Schema **dict**, not the TypeScript string `describe_tables()` returns; the adapter builds the JSON Schema from the DuckDB `DESCRIBE`.

## Test plan

- [x] `uv run pytest backend/tests/test_operations_jsonflux_reducer.py -v` — 3 passed (`test_pass_through_for_small_payload`, `test_materialize_handle_for_large_set`, `test_reducer_exception_yields_connector_error_via_dispatcher`).
- [x] `uv run pytest backend/tests/acceptance/` — 76 passed, 36 skipped (Docker/secret-gated integration; migrated force-mode tests pass with real `ResultHandle` shape).
- [x] `uv run pytest backend/tests/ -n auto` — 3628 passed, 50 skipped (no dispatcher/connector regression).
- [x] `uv run mypy backend/src/` — clean (252 files).
- [x] `uv run ruff check backend/src/ backend/tests/` + `ruff format --check` — clean.
- [x] `grep -rn "set_default_reducer" backend/src/` finds `set_default_reducer(JsonFluxReducer())` in `main.py`.

## Out of scope

- MinIO/S3 spill — DuckDB `:memory:` only for v0.2 (Initiative #750 out-of-scope §3).
- Per-op reducer policy — global default only (#750 out-of-scope §4).
- Connector seam comments (T4), docs (T5).
- `main.py` file-size / `_run_lifespan_startup` length code-quality warnings are pre-existing (file was already over the 600-line budget before this change; the diff adds one startup call + comment, no new blocker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #753


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Large collection responses now auto-materialize into concise summaries with inferred JSON schemas, sample row previews, and handle IDs for paging.
  * Handles created when responses exceed configurable row or byte thresholds, enabling efficient retrieval of full payloads.

* **Tests**
  * Acceptance and unit tests updated to exercise the real reducer behavior and strengthened assertions around schemas, samples, and handle envelopes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/962?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-23)

Addressed review finding from `pr-962-iter-1.json` (REQUEST_CHANGES):

- **B1** `b25c4c0` — Migrated `test_vmware_rest_agent_flow_e2e.py::test_agent_flow_end_to_end_against_vcsim` to the JSONFlux-reduced contract. A dedicated `production_default_reducer` fixture installs `JsonFluxReducer()` (production defaults) so the chain asserts the deployed shape deterministically; the call leg now asserts `handle` present + `total_rows == 50` + bounded sample + reduced `row_count` summary instead of `isinstance(list)` / `len == 50`. Root cause: vcsim's 50-VM seed is at the row threshold but its ~5 KB serialized payload clears the 4 KB `byte_threshold`, so the byte branch materializes a handle. The test passed in isolation only because the module-global default reducer is swapped to `JsonFluxReducer` solely by the FastAPI lifespan (never triggered by a single-file local run) — caught only by CI's full xdist sweep.

Also strengthened (coverage gap the bug exposed):

- Added `test_materialize_handle_for_under_row_over_byte_threshold` to `test_operations_jsonflux_reducer.py` — a 5-row payload padded over 4 KB must materialize a handle even though it is under the 50-row threshold. The byte-threshold branch had no dedicated unit test before; it only fired live in the e2e.

Deferred (out of scope per Initiative #750):

- CodeRabbit's "handle_id not bound to durable storage" finding — MinIO/S3 spill + read-back meta-tools are v0.3+ / a separate Initiative.

<!-- auto-implement-issue: continue, iteration 1 -->
