### PR TITLE
feat(connectors): G3.9-T3 wire vmware-rest live KV-v2 credential read + recorded-fixture E2E + opt-in lab smoke + onboarding (State 2)

### DIFF
--- a/backend/src/meho_backplane/connectors/vmware_rest/connector.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/connector.py
@@ -260,11 +260,12 @@ class VmwareRestConnector(HttpConnector):
 
         Lazily establishes the session on first call against *target*;
         subsequent calls reuse the cached token. The full ``operator`` is
-        threaded to the :class:`VsphereSessionLoader` so the (future,
-        G3.9-T3) live loader can read the service-account credentials
-        from Vault under the operator's identity
-        (``vault_client_for_operator(operator)``). The default stub
-        loader ignores it and raises until that lands.
+        threaded to the :class:`VsphereSessionLoader` so the default
+        loader (G3.9-T3's :func:`load_session_credentials_from_vault`)
+        can read the service-account credentials from Vault under the
+        operator's identity (``vault_client_for_operator(operator)``). An
+        injected test loader receives the same ``(target, operator)``
+        pair.
 
         Raises :exc:`NotImplementedError` (with ``target.name`` and the
         requested mode in the message) if ``target.auth_model`` is
@@ -334,11 +335,12 @@ class VmwareRestConnector(HttpConnector):
         on the legacy path — those are auth/server failures, not "this
         deployment doesn't have the modern endpoint".
 
-        ``operator`` is forwarded to the injected
+        ``operator`` is forwarded to the
         :class:`VsphereSessionLoader` so the credential read runs under
-        the operator's identity (G3.9-T3's live read). The default stub
-        loader ignores it; injected test loaders accept the (target,
-        operator) pair.
+        the operator's identity (G3.9-T3's live read). The default loader
+        (:func:`load_session_credentials_from_vault`) performs that live
+        operator-context Vault read; injected test loaders accept the
+        same ``(target, operator)`` pair.
         """
         async with self._session_lock:
             cached = self._session_tokens.get(target.name)

--- a/backend/src/meho_backplane/connectors/vmware_rest/session.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/session.py
@@ -15,13 +15,14 @@ narrow :class:`VsphereSessionLoader` callable so:
 * Integration tests against vcsim pass a loader that yields the
   simulator's hard-coded ``user``/``pass`` credentials.
 
-The default loader, :func:`load_session_credentials_from_vault`, is a
-deliberate stub: the operator-context per-target Vault credential read
-is not yet wired for the vmware-rest connector, so it raises
-:exc:`NotImplementedError`. It mirrors the
-shape :func:`~meho_backplane.connectors.kubernetes.kubeconfig.load_kubeconfig_from_vault`
-already established for :class:`KubernetesConnector`. The live read is
-tracked under the open
+The default loader, :func:`load_session_credentials_from_vault`, performs
+the **live** operator-context KV-v2 read: it forwards the operator's
+validated Keycloak JWT to Vault and reads ``target.secret_ref`` for the
+service-account ``{"username", "password"}`` pair. It delegates to the
+shared :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+helper (G3.9-T2) so the read, the no-secret-in-logs discipline, and the
+two-phase error contract live in one place every REST connector reuses.
+This is the rubric **State 2** wiring (`shared_service_account` only) per
 `Goal #214 (Connector parity) <https://github.com/evoila/meho/issues/214>`_.
 
 The :class:`VsphereTargetLike` Protocol captures the minimum target shape
@@ -40,6 +41,7 @@ from collections.abc import Awaitable, Callable
 from typing import Protocol, runtime_checkable
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.vault_creds import load_basic_credentials
 
 __all__ = [
     "SessionCredentials",
@@ -73,15 +75,20 @@ class VsphereTargetLike(Protocol):
     rather than silently authenticating as the shared service account.
 
     ``secret_ref`` is the Vault path the loader resolves to a
-    :class:`SessionCredentials`-shaped dict. ``port`` is optional —
-    vCenter defaults to 443 and :meth:`HttpConnector._base_url` already
-    handles the ``port is None or 443`` case correctly.
+    :class:`SessionCredentials`-shaped dict. It is ``str | None`` to
+    match the concrete ``Target.secret_ref`` column (nullable) and the
+    shared :class:`~meho_backplane.connectors._shared.vault_creds.BasicCredentialsTargetLike`
+    the loader forwards to; an unset ``secret_ref`` is rejected with a
+    clear error inside the loader (an unconfigured target), never a bare
+    ``KeyError``. ``port`` is optional — vCenter defaults to 443 and
+    :meth:`HttpConnector._base_url` already handles the
+    ``port is None or 443`` case correctly.
     """
 
     name: str
     host: str
     port: int | None
-    secret_ref: str
+    secret_ref: str | None
     auth_model: str | None
 
 
@@ -110,33 +117,32 @@ async def load_session_credentials_from_vault(
     target: VsphereTargetLike,
     operator: Operator,
 ) -> dict[str, str]:
-    """Default credential loader — Vault read by ``target.secret_ref``.
+    """Default credential loader — live operator-context Vault KV-v2 read.
 
-    Deliberate stub: the operator-context per-target Vault credential
-    read is not yet wired for the vmware-rest connector. Mirrors
-    :func:`~meho_backplane.connectors.kubernetes.kubeconfig.load_kubeconfig_from_vault`'s
-    NotImplementedError stub so the wiring shape is stable: a production
-    caller without an explicit loader override receives a clear error
-    rather than a silent fallback or a hallucinated credential pair.
+    Reads ``target.secret_ref`` as a KV-v2 secret **under the operator's
+    identity** (the operator's validated Keycloak JWT is forwarded to
+    Vault's JWT/OIDC auth method) and returns the service-account
+    ``{"username": ..., "password": ...}`` pair the connector POSTs to
+    ``/api/session``. Delegates to the shared
+    :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+    helper (G3.9-T2) so the read, the no-secret-in-logs discipline, and
+    the two-phase error contract are defined once for every REST
+    connector — this loader is the thin vmware-specific entry point.
 
-    ``operator`` is accepted (G3.9-T1 threads it down the auth surface)
-    but unused until G3.9-T3 implements the live read as
-    ``async with vault_client_for_operator(operator) as client: ...``.
+    The error contract is the helper's:
 
-    The supported workaround is to inject a custom
-    :class:`VsphereSessionLoader` (``session_loader``) on
-    ``VmwareRestConnector`` at construction time; tests and acceptance
-    harnesses do exactly that. The live read — which will read the
-    ``vsphere/<target.name>`` Vault path and return the parsed
-    ``{"username": ..., "password": ...}`` dict — is tracked under the
-    open Goal #214 (Connector parity).
+    * :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`
+      — read-phase failure (empty ``operator.raw_jwt`` for a
+      system-initiated call, unset ``target.secret_ref``, a malformed
+      KV-v2 payload, or a missing ``username``/``password`` field). Never
+      a bare ``KeyError``.
+    * :class:`~meho_backplane.auth.vault.VaultClientError` (and its
+      subclasses) — login-phase failure (Vault unreachable, role denied).
+      Propagated verbatim so callers can distinguish login from read.
+
+    A custom :class:`VsphereSessionLoader` can still be injected via
+    ``session_loader`` on ``VmwareRestConnector`` (tests do exactly that);
+    this default is what production targets at rubric State 2
+    (`shared_service_account`) use.
     """
-    del operator  # threaded for G3.9-T3's live read; the stub never uses it
-    raise NotImplementedError(
-        "load_session_credentials_from_vault is a deliberate stub: the "
-        "operator-context per-target Vault credential read is not yet wired "
-        f"for the vmware-rest connector; target={target.name!r} "
-        f"secret_ref={target.secret_ref!r}. Workaround: inject a custom "
-        "session_loader on VmwareRestConnector. Tracked under open "
-        "Goal #214 (Connector parity): https://github.com/evoila/meho/issues/214"
-    )
+    return await load_basic_credentials(target, operator)

--- a/backend/tests/integration/test_connectors_vmware_rest_lab_smoke.py
+++ b/backend/tests/integration/test_connectors_vmware_rest_lab_smoke.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G3.9-T3 — opt-in live lab-vCenter smoke for the vmware-rest credential read.
+
+The **live** counterpart to the recorded-fixture E2E
+(``tests/test_connectors_vmware_rest_credread.py``). Where that replays a
+canned Vault read + a respx-mocked vCenter in the secret-free unit lane,
+this test runs the *real* chain once against a real lab vCenter, reading
+the real service-account credential out of a real Vault under a real
+operator JWT — the rubric **State 2** proof against live infrastructure.
+
+It is **opt-in and skips cleanly by default** so secret-free CI stays
+green. The gate is the presence of every required env var; with any one
+unset, the module collects and the test reports ``skipped`` (verified by
+running the suite with the vars unset — the default everywhere except a
+deliberate operator-run lab smoke).
+
+Required env vars (all must be set for the test to run)
+======================================================
+
+* ``MEHO_LAB_VCENTER`` — the lab vCenter host (``vc.lab.example``); the
+  target ``host`` and the respx-free base URL.
+* ``MEHO_LAB_VCENTER_SECRET_REF`` — the Vault KV-v2 path holding the
+  service account's ``{username, password}`` (the target ``secret_ref``).
+* ``MEHO_LAB_OPERATOR_JWT`` — a real operator Keycloak JWT, forwarded to
+  Vault's JWT/OIDC method (``operator.raw_jwt``). Never logged or echoed.
+
+Why this drives ``auth_headers`` + ``_get_json`` (not ``fingerprint`` or full ``dispatch``)
+==========================================================================================
+
+The smoke proves the load-bearing leaf: *the default loader reads the
+real Vault credential, under the operator's identity, and establishes a
+real vCenter session.* The test passes a **real operator** (carrying the
+lab JWT) to :meth:`VmwareRestConnector.auth_headers`, which runs
+``_session_token`` → the default ``load_session_credentials_from_vault``
+(live operator-context Vault read) → ``POST /api/session`` (HTTP basic
+with the read creds) → a cached ``vmware-api-session-id`` token. It then
+issues one read (``GET /api/about`` via ``_get_json`` with the same
+operator) and asserts the response.
+
+It deliberately does **not** use ``fingerprint`` / ``probe``: those
+synthesise a *system* operator with an empty ``raw_jwt`` (the probe path
+is system-initiated), which the live loader fail-closes on by design — so
+they cannot exercise the operator-context read. A full ``dispatch`` would
+additionally need a seeded ``endpoint_descriptor`` row in the lab DB;
+``auth_headers`` + ``_get_json`` is the minimal real-infra path that
+proves State 2 under a real operator. The recorded-fixture E2E already
+proves the full ``dispatch`` path.
+
+The credential is read server-side and never returned; this test asserts
+session establishment + a reachable read response, never a credential
+value.
+"""
+
+from __future__ import annotations
+
+import os
+from uuid import UUID
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.vmware_rest import VmwareRestConnector
+
+# ---------------------------------------------------------------------------
+# Opt-in gate — every required var must be present, else skip the module.
+# ---------------------------------------------------------------------------
+
+_LAB_VCENTER = os.environ.get("MEHO_LAB_VCENTER")
+_LAB_SECRET_REF = os.environ.get("MEHO_LAB_VCENTER_SECRET_REF")
+_LAB_OPERATOR_JWT = os.environ.get("MEHO_LAB_OPERATOR_JWT")
+
+_LAB_READY = bool(_LAB_VCENTER and _LAB_SECRET_REF and _LAB_OPERATOR_JWT)
+_SKIP_REASON = (
+    "lab-vCenter smoke is opt-in: set MEHO_LAB_VCENTER, "
+    "MEHO_LAB_VCENTER_SECRET_REF, and MEHO_LAB_OPERATOR_JWT to run it "
+    "against real infra (skipped in secret-free CI)."
+)
+
+pytestmark = pytest.mark.skipif(not _LAB_READY, reason=_SKIP_REASON)
+
+
+class _LabTarget:
+    """A lab vCenter target satisfying ``VsphereTargetLike``."""
+
+    def __init__(self) -> None:
+        self.name = "vcenter-lab-smoke"
+        # Strip any scheme an operator may have included in the env var.
+        self.host = (_LAB_VCENTER or "").removeprefix("https://").removeprefix("http://")
+        self.port: int | None = 443
+        self.secret_ref = _LAB_SECRET_REF or ""
+        self.auth_model = "shared_service_account"
+
+
+def _lab_operator() -> Operator:
+    """Operator carrying the real lab JWT forwarded to Vault."""
+    return Operator(
+        sub="op-lab-smoke",
+        name=None,
+        email=None,
+        raw_jwt=_LAB_OPERATOR_JWT or "",
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def test_lab_vcenter_credread_session_and_read_under_operator() -> None:
+    """The default loader reads the real Vault creds (operator-context) and reads vCenter.
+
+    Runs the live chain once under a real operator JWT: default
+    ``load_session_credentials_from_vault`` → operator-context Vault read
+    → ``POST /api/session`` → cached session token → ``GET /api/about``.
+    Asserts the session header is minted + the read returns a vCenter
+    about payload; never asserts on a credential value.
+    """
+    connector = VmwareRestConnector()  # default (live) loader — no injection
+    target = _LabTarget()
+    operator = _lab_operator()
+    try:
+        # Establish the session under the operator's identity. This is the
+        # State-2 leaf: the live Vault read + the vCenter login.
+        headers = await connector.auth_headers(target, operator)
+        assert "vmware-api-session-id" in headers
+        assert headers["vmware-api-session-id"]
+
+        # One real read over the established session.
+        about = await connector._get_json(target, "/api/about", operator=operator)
+    finally:
+        await connector.aclose()
+
+    assert isinstance(about, dict)
+    # GET /api/about on a real vCenter carries a product_line_id (vpx for
+    # vCenter); presence is enough for the smoke — the recorded-fixture
+    # E2E covers the full field mapping.
+    assert about, f"GET /api/about returned an empty payload: {about!r}"

--- a/backend/tests/test_connectors_vmware_rest_auth.py
+++ b/backend/tests/test_connectors_vmware_rest_auth.py
@@ -51,6 +51,9 @@ from meho_backplane.connectors.vmware_rest import (
     VmwareRestConnector,
     VsphereTargetLike,
 )
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
 
 
 def _make_operator(raw_jwt: str = "") -> Operator:
@@ -63,6 +66,29 @@ def _make_operator(raw_jwt: str = "") -> Operator:
         tenant_id=UUID(int=0),
         tenant_role=TenantRole.OPERATOR,
     )
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the chassis env vars ``Settings`` reads at construction time.
+
+    The live default loader's ``load_basic_credentials`` →
+    ``vault_client_for_operator`` calls ``get_settings()`` which eagerly
+    reads ``KEYCLOAK_*`` / ``VAULT_*``. The respx-only tests in this
+    module never reach Vault (they inject a stub loader), but the
+    live-read test below does, so pin the env for the whole module — the
+    same shape ``test_connectors_vault_creds.py`` uses.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
 
 
 @pytest.fixture(autouse=True)
@@ -154,19 +180,60 @@ def test_importing_package_registers_against_v2_registry() -> None:
     assert registry[key] is VmwareRestConnector
 
 
-def test_default_session_loader_raises_deliberate_stub() -> None:
-    """The default Vault loader is a deliberate, clearly-labelled stub."""
-    import asyncio
+@pytest.mark.asyncio
+async def test_default_session_loader_does_live_vault_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default loader reads ``{username, password}`` from Vault, JWT-forwarded.
 
+    Replaces the former ``raises deliberate stub`` test: with G3.9-T2's
+    shared helper wired, the default loader performs the live KV-v2 read
+    under the operator's identity (rubric State 2). The in-process Vault
+    fake (``install_fake_client``) stands in for hvac so the unit lane
+    stays secret-free; the live Vault round-trip is the env-gated lab
+    smoke in ``tests/integration``.
+    """
     from meho_backplane.connectors.vmware_rest.session import (
         load_session_credentials_from_vault,
     )
 
-    async def _check() -> None:
-        with pytest.raises(NotImplementedError, match=r"deliberate stub.*#214"):
-            await load_session_credentials_from_vault(_TARGET_A, _make_operator())
+    fake = install_fake_client(
+        monkeypatch,
+        secret={"username": "svc-meho", "password": "vault-read-pw"},
+    )
 
-    asyncio.run(_check())
+    creds = await load_session_credentials_from_vault(_TARGET_A, _make_operator("op.jwt"))
+
+    assert creds == {"username": "svc-meho", "password": "vault-read-pw"}
+    # The operator's JWT was forwarded to Vault's JWT/OIDC login.
+    assert fake.auth.jwt.login_calls[-1]["jwt"] == "op.jwt"
+    # The read addressed the target's secret_ref under the default mount.
+    assert fake.secrets.kv.v2.read_calls[-1]["path"] == _TARGET_A.secret_ref
+
+
+@pytest.mark.asyncio
+async def test_default_session_loader_fails_closed_for_system_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A system-initiated call (empty raw_jwt) errors before touching Vault.
+
+    The shared helper's fail-closed carve-out: no operator JWT means no
+    operator-context read. Confirms the vmware default loader inherits
+    that contract rather than silently falling back.
+    """
+    from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+    from meho_backplane.connectors.vmware_rest.session import (
+        load_session_credentials_from_vault,
+    )
+
+    fake = install_fake_client(monkeypatch)
+
+    with pytest.raises(VaultCredentialsReadError):
+        await load_session_credentials_from_vault(_TARGET_A, _make_operator(raw_jwt=""))
+
+    # Vault was never reached — no login, no read.
+    assert fake.auth.jwt.login_calls == []
+    assert fake.secrets.kv.v2.read_calls == []
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_vmware_rest_credread.py
+++ b/backend/tests/test_connectors_vmware_rest_credread.py
@@ -1,0 +1,349 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Recorded-fixture E2E for the vmware-rest live credential-read chain (G3.9-T3 #942).
+
+Proves the **full** dispatch chain end to end with a real (default,
+non-injected) credential loader:
+
+    dispatch(...)
+      -> _resolve_connector_instance -> VmwareRestConnector()   # default loader
+      -> dispatch_ingested -> mount_op_path -> _session_token
+      -> load_session_credentials_from_vault            # the live loader
+      -> load_basic_credentials (G3.9-T2)               # operator-context Vault read
+      -> POST /api/session (HTTP basic with the read creds)
+      -> GET <op path>                                  # the actual read op
+      -> OperationResult(status="ok")
+
+The two "real" leaves are stubbed at their boundaries so the gate runs
+in the **secret-free unit lane** (``pytest -n auto`` /
+``--ignore=tests/integration``) with no Docker and no real secret:
+
+* **Vault** — the in-process fake (``install_fake_client``) patches
+  ``meho_backplane.auth.vault._build_client`` so the helper's real
+  JWT/OIDC login + KV-v2 read code path runs against canned creds. The
+  default loader is exercised verbatim — *not* an injected stub. This is
+  the load-bearing difference from ``test_connectors_vmware_rest_auth.py``
+  (which injects ``_stub_loader``): here the connector is constructed by
+  the resolver as ``VmwareRestConnector()`` with no ``session_loader``,
+  so the default ``load_session_credentials_from_vault`` runs.
+* **vCenter** — respx replays ``POST /api/session`` (returns the session
+  token) and the op ``GET`` (returns the read payload). No network.
+
+The live lab-vCenter run (real operator JWT against a real vCenter +
+Vault) is the env-gated opt-in smoke in
+``tests/integration/test_connectors_vmware_rest_lab_smoke.py``; it skips
+cleanly in CI.
+
+Why this lives in the unit lane (not ``tests/integration``)
+===========================================================
+
+The acceptance criterion requires this E2E to run in the default
+``pytest -n auto`` sweep — which deselects ``tests/integration`` (the
+container/PG lane). The recorded-fixture replay needs neither a real
+Vault nor a real vCenter (both stubbed at their boundaries) and only the
+autouse SQLite ``endpoint_descriptor`` schema the top-level conftest
+already migrates per worker. So it belongs here, mirroring the T2 split:
+unit ``test_connectors_vault_creds.py`` (fake) + integration
+``test_connectors_vault_creds_dev_e2e.py`` (live Vault). The live vendor
+round-trip is the integration-lane smoke.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+import respx
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog.testing import capture_logs
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.vmware_rest import VmwareRestConnector
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+# ---------------------------------------------------------------------------
+# Canary credential values — asserted to NEVER appear in the result or logs.
+# Generated nowhere near a real secret; these strings are the leak canaries.
+# ---------------------------------------------------------------------------
+
+_CANARY_USERNAME = "svc-vsphere-canary"
+_CANARY_PASSWORD = "p4ss-canary-must-not-leak-credread"
+
+#: The connector triple ``vmware-rest-9.0`` decodes to.
+_PRODUCT = "vmware"
+_VERSION = "9.0"
+_IMPL_ID = "vmware-rest"
+_CONNECTOR_ID = "vmware-rest-9.0"
+
+#: A spec-relative ingested GET op. ``mount_op_path`` prepends ``/api``
+#: (the modern mount the session establish selected) at dispatch time.
+_OP_ID = "GET:/vcenter/vm"
+_OP_PATH = "/vcenter/vm"
+
+#: respx base URL the target points at. Port 443 keeps ``_base_url`` from
+#: appending ``:port`` so the router matches the connector's client URL.
+#: ``.test.invalid`` (RFC 6761) guarantees no real egress.
+_VCENTER_HOST = "vcenter-credread.test.invalid"
+_VCENTER_BASE_URL = f"https://{_VCENTER_HOST}"
+_SESSION_TOKEN = "credread-session-token"
+
+#: The read op's response payload — set-shaped but small enough that the
+#: pass-through reducer returns it inline (no handle); shape doesn't matter
+#: for this test, only that ``status="ok"`` round-trips.
+_OP_RESPONSE: dict[str, Any] = {"vms": [{"vm": "vm-101", "name": "demo-vm"}]}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Vault client + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches + connector registry around every test.
+
+    The connector-instance cache must be clear so the resolver builds a
+    fresh ``VmwareRestConnector()`` (default loader) for this test rather
+    than reusing one a sibling test wired with an injected stub loader.
+    """
+    reset_dispatcher_caches()
+    clear_registry()
+    register_connector_v2(
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        cls=VmwareRestConnector,
+    )
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub for the seeded descriptor row."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    """Record broadcast events so the audit/broadcast leg is asserted."""
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _CredReadTarget:
+    """Target satisfying both ``VsphereTargetLike`` and the resolver shape.
+
+    Carries the resolver attributes (``product`` / ``fingerprint`` /
+    ``preferred_impl_id`` / ``id``) plus the vmware-loader attributes
+    (``name`` / ``host`` / ``port`` / ``secret_ref`` / ``auth_model``).
+    ``secret_ref`` is the Vault KV-v2 path the live default loader reads.
+    """
+
+    def __init__(self) -> None:
+        self.product = _PRODUCT
+        self.fingerprint = type("_FP", (), {"version": _VERSION})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.name = "vcenter-credread"
+        self.host = _VCENTER_HOST
+        self.port = 443
+        self.secret_ref = "secret/targets/op-credread/vcenter-credread"
+        self.auth_model = "shared_service_account"
+
+
+def _make_operator() -> Operator:
+    """Operator carrying a non-empty raw_jwt (the fail-closed gate passes)."""
+    return Operator(
+        sub="op-credread",
+        name="Cred Read Operator",
+        email=None,
+        raw_jwt="op.credread.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _seed_descriptor(session: AsyncSession, embedding: list[float]) -> None:
+    """Insert one enabled ingested GET descriptor for the read op."""
+    descriptor = EndpointDescriptor(
+        id=uuid.uuid4(),
+        tenant_id=None,
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        op_id=_OP_ID,
+        source_kind="ingested",
+        method="GET",
+        path=_OP_PATH,
+        handler_ref=None,
+        summary="List VMs",
+        description="List virtual machines in the vCenter inventory.",
+        tags=["inventory"],
+        parameter_schema={"type": "object", "properties": {}},
+        response_schema=None,
+        llm_instructions=None,
+        safety_level="safe",
+        requires_approval=False,
+        is_enabled=True,
+        embedding=embedding,
+        custom_description=None,
+        custom_notes=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    session.add(descriptor)
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_executes_full_credread_chain_returns_ok(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The full dispatch→loader→vCenter chain returns status="ok" with no injected loader."""
+    await _seed_descriptor(session, stub_embedding_service.encode_one.return_value)
+
+    # Vault leaf: the in-process fake returns the canary creds via the
+    # real ``load_basic_credentials`` -> ``vault_client_for_operator``
+    # path. No session_loader is injected anywhere — the resolver builds
+    # ``VmwareRestConnector()`` so the default loader runs.
+    fake = install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+
+    target = _CredReadTarget()
+    operator = _make_operator()
+
+    # ``assert_all_called=False``: the connector instance is owned by the
+    # resolver cache, so its ``aclose`` DELETE revoke fires on a *later*
+    # cache reset (after this block closes), not inside it. Registering
+    # the DELETE keeps any in-block teardown handled without forcing a
+    # call-count on a route this dispatch path doesn't reach. Same stance
+    # as ``tests/integration/test_connectors_vmware_rest_vcsim.py``.
+    async with respx.mock(base_url=_VCENTER_BASE_URL, assert_all_called=False) as mock:
+        session_route = mock.post("/api/session").respond(200, json=_SESSION_TOKEN)
+        op_route = mock.get("/api/vcenter/vm").respond(200, json=_OP_RESPONSE)
+        mock.delete("/api/session").respond(204)
+
+        result = await dispatch(
+            operator=operator,
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=target,
+            params={},
+        )
+
+    # The load-bearing assertion: the chain executed end to end.
+    assert result.status == "ok", result.error
+    assert isinstance(result.result, dict)
+    assert result.result == _OP_RESPONSE
+
+    # The default loader actually read Vault under the operator's identity.
+    assert fake.auth.jwt.login_calls[-1]["jwt"] == "op.credread.jwt"
+    assert fake.secrets.kv.v2.read_calls[-1]["path"] == target.secret_ref
+    # The session establish + the read op both hit the mocked vCenter.
+    assert session_route.called and session_route.call_count == 1
+    assert op_route.called and op_route.call_count == 1
+    # Basic auth carried the Vault-read creds (header present, opaque).
+    sent_auth = session_route.calls[0].request.headers.get("authorization")
+    assert sent_auth is not None and sent_auth.startswith("Basic ")
+    # One audit + one broadcast for the dispatched op.
+    assert len(captured_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_credread_chain_never_leaks_credential_in_result_or_logs(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No credential value appears in the OperationResult or any captured log event."""
+    await _seed_descriptor(session, stub_embedding_service.encode_one.return_value)
+
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+
+    target = _CredReadTarget()
+    operator = _make_operator()
+
+    with capture_logs() as captured:
+        async with respx.mock(base_url=_VCENTER_BASE_URL, assert_all_called=False) as mock:
+            mock.post("/api/session").respond(200, json=_SESSION_TOKEN)
+            mock.get("/api/vcenter/vm").respond(200, json=_OP_RESPONSE)
+            mock.delete("/api/session").respond(204)
+
+            result = await dispatch(
+                operator=operator,
+                connector_id=_CONNECTOR_ID,
+                op_id=_OP_ID,
+                target=target,
+                params={},
+            )
+
+    assert result.status == "ok", result.error
+
+    # The credential never rides the OperationResult (result, error, or
+    # any extras the envelope carries).
+    result_blob = repr(result)
+    assert _CANARY_PASSWORD not in result_blob
+    assert _CANARY_USERNAME not in result_blob
+
+    # The credential never rides any structlog event (loader, connector,
+    # dispatcher, audit, broadcast).
+    log_blob = repr(captured)
+    assert _CANARY_PASSWORD not in log_blob
+    assert _CANARY_USERNAME not in log_blob
+
+    # The credential never rides the broadcast event payload either.
+    events_blob = repr(captured_events)
+    assert _CANARY_PASSWORD not in events_blob
+    assert _CANARY_USERNAME not in events_blob

--- a/backend/tests/test_connectors_vmware_rest_credread.py
+++ b/backend/tests/test_connectors_vmware_rest_credread.py
@@ -179,7 +179,11 @@ class _CredReadTarget:
     Carries the resolver attributes (``product`` / ``fingerprint`` /
     ``preferred_impl_id`` / ``id``) plus the vmware-loader attributes
     (``name`` / ``host`` / ``port`` / ``secret_ref`` / ``auth_model``).
-    ``secret_ref`` is the Vault KV-v2 path the live default loader reads.
+    ``secret_ref`` is the **logical** KV-v2 path the live default loader
+    reads — relative to the mount root, no ``secret/`` prefix and no
+    ``/data/`` segment (hvac inserts ``/data/`` itself). This is the
+    exact shape an operator stores per
+    ``docs/cross-repo/vmware-rest-onboarding.md``.
     """
 
     def __init__(self) -> None:
@@ -190,7 +194,7 @@ class _CredReadTarget:
         self.name = "vcenter-credread"
         self.host = _VCENTER_HOST
         self.port = 443
-        self.secret_ref = "secret/targets/op-credread/vcenter-credread"
+        self.secret_ref = "targets/op-credread/vcenter-credread"
         self.auth_model = "shared_service_account"
 
 

--- a/docs/codebase/connector-release-readiness.md
+++ b/docs/codebase/connector-release-readiness.md
@@ -55,7 +55,9 @@ rg "op_id=.<connector-name>\." backend/src/meho_backplane/connectors/<connector-
 rg "raise NotImplementedError" backend/src/meho_backplane/connectors/<connector-name>/
 ```
 
-**v0.3.0 examples at this state:** `k8s-1.x`, `vmware-rest-9.0`.
+**v0.3.0 examples at this state:** `k8s-1.x`. (`vmware-rest-9.0` was at
+this state through v0.3.0; G3.9-T3 [#942](https://github.com/evoila/meho/issues/942)
+wired its live loader and moved it to State 2.)
 
 **Honest release-notes language:**
 
@@ -88,10 +90,17 @@ What's NOT shipped:
 - Other auth_models (`per_user`, `impersonation`) still raise a clear
   boundary error.
 
-**v0.3.0 examples at this state:** `bind9-ssh-9.x` (the SSH transport
+**Examples at this state:** `bind9-ssh-9.x` (the SSH transport
 loads credentials inline in the connector — no separate `session.py`
 stub; the credential read for `shared_service_account` is live). The
 consumer correctly noted this as the "closest to parity" connector.
+`vmware-rest-9.0` joined this state via G3.9-T3
+[#942](https://github.com/evoila/meho/issues/942): its default loader
+[`load_session_credentials_from_vault`](../../backend/src/meho_backplane/connectors/vmware_rest/session.py#L116)
+now performs the live operator-context KV-v2 read via the shared
+[`load_basic_credentials`](../../backend/src/meho_backplane/connectors/_shared/vault_creds.py)
+helper; `shared_service_account` executes against a real vCenter.
+Operator recipe: [`vmware-rest-onboarding.md`](../cross-repo/vmware-rest-onboarding.md).
 
 **Honest release-notes language:**
 
@@ -126,7 +135,7 @@ flow is the only auth_model; loader is live; consumer confirmed
 | `vault-1.x` | 3 | JWT-federated, live | ✅ |
 | `bind9-ssh-9.x` | 2-3 | `shared_service_account` inline | ✅ |
 | `k8s-1.x` | 1 | [`load_kubeconfig_from_vault`](../../backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py#L86) — `NotImplementedError` | ❌ (mock loader in test only) |
-| `vmware-rest-9.0` (composites) | 1 | [`load_session_credentials_from_vault`](../../backend/src/meho_backplane/connectors/vmware_rest/session.py#L107) — `NotImplementedError` | ❌ (mock loader in test only) |
+| `vmware-rest-9.0` | 2 | [`load_session_credentials_from_vault`](../../backend/src/meho_backplane/connectors/vmware_rest/session.py#L116) — live operator-context Vault read (G3.9-T3 [#942](https://github.com/evoila/meho/issues/942)) | ✅ (`shared_service_account`) |
 | `sddc-manager-9.0` | 0.5 | Class-side registered, no ops yet, loader stubbed | ❌ |
 | `harbor-2.x` | 0.5 | Class-side registered, no ops yet, loader stubbed | ❌ |
 | `kubernetes-asyncio-1.x` | 1 (shadow) | Same as `k8s-1.x` | ❌ |

--- a/docs/cross-repo/connector-vault-policy.md
+++ b/docs/cross-repo/connector-vault-policy.md
@@ -327,6 +327,9 @@ v0.x — see the carve-out in
   (role/mount from `vault_oidc_role` / `vault_oidc_mount_path`)
 - Connector secret-ref convention (k8s `kubeconfig` field):
   [`kubernetes-onboarding.md`](./kubernetes-onboarding.md)
+- First connector wired against this runbook (vSphere `{username,password}`
+  read, rubric State 2): [`vmware-rest-onboarding.md`](./vmware-rest-onboarding.md)
+  (G3.9-T3 #942)
 - Vault — [ACL policy templating](https://developer.hashicorp.com/vault/docs/concepts/policies)
 - Vault — [JWT/OIDC auth method](https://developer.hashicorp.com/vault/docs/auth/jwt)
 - Vault — [Audit devices](https://developer.hashicorp.com/vault/docs/audit)

--- a/docs/cross-repo/vmware-rest-onboarding.md
+++ b/docs/cross-repo/vmware-rest-onboarding.md
@@ -101,11 +101,28 @@ Use the per-target convention from the
 scoped to the operator identity segment the templated policy renders:
 
 ```text
-secret/data/targets/<operator-identity>/<target-name>
+targets/<operator-identity>/<target-name>
 ```
 
+This is the **logical KV-v2 path relative to the mount root** — no
+`secret/` mount prefix and no `/data/` segment. It is exactly the
+string you store as the target's `secret_ref` (see [Registering the
+target](#registering-the-target)) and the string the loader passes to
+hvac's `read_secret_version(path=…, mount_point="secret")`, which
+inserts the `/data/` itself
+([`connectors/_shared/vault_creds.py`](../../backend/src/meho_backplane/connectors/_shared/vault_creds.py)).
+
+> The KV-v2 **API/policy** form of the same secret is
+> `secret/data/targets/<operator-identity>/<target-name>` — that is the
+> shape the [Vault ACL policy](./connector-vault-policy.md) §2 grants
+> read on and the shape `vault kv get` shows in a `No value found at …`
+> error. **Do not** put that form in `secret_ref`; the loader would then
+> read `secret/data/secret/data/targets/…` and 404. The `secret_ref`
+> value is always the logical path above.
+
 Write it with the `meho vault kv put` op (the same dispatch path,
-audited):
+audited) — the mount (`secret`) and the logical path are separate
+arguments, so no `secret/`/`data/` prefix appears here either:
 
 ```console
 $ meho vault kv put --target rdc-vault secret \
@@ -134,7 +151,7 @@ $ meho targets create \
     --name vcenter-lab-01 \
     --product vmware \
     --host vc.lab.evba \
-    --secret-ref secret/targets/<operator-identity>/vcenter-lab-01 \
+    --secret-ref targets/<operator-identity>/vcenter-lab-01 \
     --auth-model shared_service_account
 ```
 

--- a/docs/cross-repo/vmware-rest-onboarding.md
+++ b/docs/cross-repo/vmware-rest-onboarding.md
@@ -1,0 +1,270 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# vmware-rest op surface onboarding — operator recipe
+
+> Operator-facing recipe for executing `vmware-rest-9.0` ops against a
+> **real** vCenter — the rubric **State 2** wiring G3.9 ships
+> ([Initiative #939](https://github.com/evoila/meho/issues/939)). With
+> the credential broker wired, `meho operation call <op> target=…`
+> reads the vSphere service account out of Vault under the operator's
+> identity and establishes a real vCenter session. The connector code
+> lives in
+> [`backend/src/meho_backplane/connectors/vmware_rest/`](../../backend/src/meho_backplane/connectors/vmware_rest/);
+> the deploy prerequisite is the Vault-policy runbook
+> [`connector-vault-policy.md`](./connector-vault-policy.md).
+
+## What this surface is
+
+The `vmware-rest-9.0` connector is a **hand-rolled `HttpConnector`
+subclass** over the vSphere Automation REST API. It dispatches under the
+`(product="vmware", version="9.0", impl_id="vmware-rest")` registry
+triple — connector id `vmware-rest-9.0` — and serves both the
+spec-ingested REST ops (`vcenter.yaml` → `endpoint_descriptor` rows) and
+the hand-coded composites listed in
+[`v0.3.0-feedback-reply-vmware-13-ops.md`](./v0.3.0-feedback-reply-vmware-13-ops.md).
+
+Every op dispatches through the same `POST /api/v1/operations/call`
+route the agent surface uses — auth, policy, audit, broadcast, and
+JSONFlux all run as documented in [CLAUDE.md](../../CLAUDE.md). There is
+**no `vmware` CLI verb tree and no per-op MCP tool**: operators reach
+vmware ops through the generic `meho operation call` verb or the
+[agent meta-tool path](#the-agent-meta-tool-path) (CLAUDE.md postulate 5
+— the narrow waist).
+
+### What "State 2" means here
+
+Per the
+[connector release-readiness rubric](../codebase/connector-release-readiness.md):
+
+- **State 1** (where this connector was before G3.9): dispatch + catalog
+  only — ops indexed and searchable, but the default credential loader
+  raised `NotImplementedError`, so a real `operation call` failed.
+- **State 2** (what G3.9-T3 ships): the default loader performs the live
+  operator-context Vault read for the **`shared_service_account`** auth
+  model. `operation call <op> target=…` executes end to end against a
+  real vCenter.
+- **State 3** (not yet): every advertised auth model wired; full catalog
+  in production rotation. `per_user` / `impersonation` still raise a
+  clear boundary error (see [Scope](#scope--state-2-shared_service_account-only)).
+
+## Prerequisites
+
+- **A reachable vCenter 8.5+.** The connector's
+  `supported_version_range` is `>=8.5,<10.0`. It POSTs to the modern
+  `POST /api/session` and falls back to the legacy
+  `POST /rest/com/vmware/cis/session` only on a 404 (real vCenter serves
+  both). Older vCenter (< 8.5) is out of range; the pyvmomi-typed
+  connector covers that surface separately.
+- **A vSphere service account.** A least-privilege vCenter local or SSO
+  account whose `{username, password}` the connector uses to mint the
+  per-target `vmware-api-session-id` session token. Scope it to the
+  read/write surface the operator workflows need — never a full
+  Administrator unless a write composite demands it.
+- **The service account stored in Vault** at the target's `secret_ref`
+  KV-v2 path (see [Storing the service account](#storing-the-service-account-in-vault)).
+- **The Vault policy + Keycloak→Vault identity** from the deploy runbook
+  [`connector-vault-policy.md`](./connector-vault-policy.md) — without
+  it the live read returns Vault 403 (`VaultRoleDeniedError`). This is
+  the load-bearing deploy prerequisite for State 2.
+- **A registered vmware target** carrying `product="vmware"`, `host`,
+  `port` (optional, defaults to 443), `secret_ref` (the Vault path), and
+  `auth_model="shared_service_account"`.
+- **An operator session.** `meho login <backplane-url>` writes the
+  session token the CLI reuses. The operator's JWT is what the
+  connector forwards to Vault — the read runs under *their* identity, so
+  the operator needs both the backplane `operator` role and a Vault
+  policy that grants read on the target's `secret_ref`.
+
+## Target + auth model
+
+The shipped connector's only auth model is `shared_service_account`: one
+vSphere service-account credential per target, stored in Vault, read
+under the acting operator's identity. The credential's field shape is the
+HTTP-basic pair vCenter's `POST /api/session` expects:
+
+| Secret field | Meaning |
+| --- | --- |
+| `username` | the vSphere service account (e.g. `svc-meho@vsphere.local`) |
+| `password` | its password |
+
+Both fields are required; a secret missing either raises
+`VaultCredentialsReadError` naming the target + field (never a bare
+`KeyError`), surfaced as a clean dispatch error.
+
+### Storing the service account in Vault
+
+Use the per-target convention from the
+[Vault-policy runbook](./connector-vault-policy.md) §1 — the path is
+scoped to the operator identity segment the templated policy renders:
+
+```text
+secret/data/targets/<operator-identity>/<target-name>
+```
+
+Write it with the `meho vault kv put` op (the same dispatch path,
+audited):
+
+```console
+$ meho vault kv put --target rdc-vault secret \
+    targets/<operator-identity>/vcenter-lab-01 \
+    --data @secret_ref.json
+```
+
+`secret_ref.json` shape:
+
+```json
+{
+  "username": "svc-meho@vsphere.local",
+  "password": "<vsphere-service-account-password>"
+}
+```
+
+The credential is read **server-side** and used to establish the session;
+it is never returned to the operator or the agent, never logged, and
+never rides an `OperationResult` (the chassis keeps it out of every log
+event — see [No credential ever leaves the backplane](#no-credential-ever-leaves-the-backplane)).
+
+### Registering the target
+
+```console
+$ meho targets create \
+    --name vcenter-lab-01 \
+    --product vmware \
+    --host vc.lab.evba \
+    --secret-ref secret/targets/<operator-identity>/vcenter-lab-01 \
+    --auth-model shared_service_account
+```
+
+Verify it round-trips — `probe` exercises the live credential read +
+session establish:
+
+```console
+$ meho targets probe vcenter-lab-01
+ok — vmware vcenter 9.0.0.0 reachable (GET /api/about)
+```
+
+`probe` runs the full chain: Vault read (operator-context) → `POST
+/api/session` (HTTP basic) → `GET /api/about` → reachable. A failure
+carries a distinct reason: a Vault 403 means the
+[policy/identity prerequisite](./connector-vault-policy.md) is missing; a
+session 401 means the stored service-account credential is wrong; a
+transport error means vCenter is unreachable.
+
+## Calling an op
+
+There is no vmware-specific verb; use the generic `operation call`:
+
+```console
+$ meho operation call vmware-rest-9.0 GET:/vcenter/vm \
+    --target vcenter-lab-01 --json | jq .result
+
+$ meho operation call vmware-rest-9.0 vmware.composite.datastore.usage \
+    --target vcenter-lab-01 --json | jq .result
+```
+
+The first call against a target establishes the session (one
+`POST /api/session`); subsequent calls reuse the cached
+`vmware-api-session-id` token until the connector is torn down (which
+revokes it via `DELETE /api/session`). The connector does **not**
+proactively refresh on the ~5-minute vSphere idle timeout — a 401 from a
+later call surfaces to the caller as a clean retry signal (deferred per
+the connector's *Session lifecycle* note).
+
+Set-shaped responses (the VM/datastore lists) come back as a JSONFlux
+result handle when they exceed the inline threshold; drill in with
+`result_query` / `result_aggregate` / `result_export` (CLAUDE.md §4).
+
+## The agent meta-tool path
+
+Agents never see a `vmware` tool. Per [CLAUDE.md](../../CLAUDE.md)
+postulate 5, an agent reaches every vmware op through the narrow-waist
+meta-tools:
+
+```text
+search_connectors(query="vsphere vcenter")        → finds vmware-rest-9.0
+list_operation_groups(connector_id="vmware-rest-9.0")
+                                                  → inventory / vm / storage / …
+search_operations(
+    connector_id="vmware-rest-9.0",
+    query="list virtual machines",
+    group="inventory",
+)                                                  → top hit: GET:/vcenter/vm
+call_operation(
+    connector_id="vmware-rest-9.0",
+    operation_id="GET:/vcenter/vm",
+    target={"name": "vcenter-lab-01"},
+    params={},
+)
+```
+
+`call_operation` and `meho operation call` dispatch the identical route,
+credential read, audit row, and broadcast event. The credential read
+happens under the **operator's** identity in both cases — the agent's
+session carries the operator JWT the connector forwards to Vault.
+
+## No credential ever leaves the backplane
+
+The State-2 wiring is built so the vSphere service-account credential is
+ephemeral in-memory state:
+
+- The shared loader
+  ([`connectors/_shared/vault_creds.py`](../../backend/src/meho_backplane/connectors/_shared/vault_creds.py))
+  logs only the target name, host, and the requested *field names* —
+  never a value.
+- The connector's session-establish + revoke log events carry the target
+  name, host, and session path — never the credential or the session
+  token.
+- The credential is consumed to build the HTTP-basic header for `POST
+  /api/session` and then dropped; it never enters the `OperationResult`,
+  the audit row payload, or the broadcast event.
+
+This is asserted by the recorded-fixture E2E
+([`tests/test_connectors_vmware_rest_credread.py`](../../backend/tests/test_connectors_vmware_rest_credread.py)):
+a canary password is seeded into the (faked) Vault read and asserted
+absent from the result, every captured log event, and the broadcast
+payload.
+
+## Scope — State 2 (`shared_service_account` only)
+
+G3.9-T3 ships the `shared_service_account` auth model only. The
+connector's `auth_headers` raises a clear `NotImplementedError` naming
+the target + requested mode for any other `auth_model`:
+
+- **`per_user`** (each operator has their own vSphere credential) is a
+  natural extension of the runbook's per-operator templated path —
+  deferred until a concrete need exists.
+- **`impersonation`** (the backplane authenticates as a privileged
+  account and acts *as* the operator) needs vendor-side support and is
+  deferred.
+
+System-initiated calls (background/scheduled work with no operator JWT)
+**cannot** perform an operator-context read — the loader fails closed
+with a clear error (the carve-out in
+[`connector-auth.md`](../architecture/connector-auth.md)).
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `status=error … VaultRoleDeniedError` | The `meho-mcp` role's policy doesn't grant the operator read on the target's `secret_ref`, or the operator's Vault entity-alias doesn't match their JWT `sub`. | Fix the policy/identity per [`connector-vault-policy.md`](./connector-vault-policy.md) §2/§3 — not the connector. Verify with that doc's §4 read check. |
+| `status=error … VaultCredentialsReadError … missing required field 'password'` | The Vault secret at `secret_ref` has `username` but not `password`. | Re-write the secret with both fields (see [Storing the service account](#storing-the-service-account-in-vault)). |
+| `status=error … operator-context credential read requires an authenticated operator` | A system-initiated call (no operator JWT) hit the loader. | Out of scope for v0.x — connector ops require an operator session. |
+| `RuntimeError … vsphere session establish failed … HTTP 401` | The stored service-account credential is wrong (Vault read succeeded, vCenter rejected the login). | Confirm the `{username, password}` in Vault are valid vSphere credentials; rotate if needed. |
+| `RuntimeError … POST /rest/com/vmware/cis/session returned HTTP 404` | Both the modern and legacy session endpoints 404'd — the host isn't a vCenter REST surface (or a reverse proxy strips `/api`). | Confirm the target host serves the vSphere Automation REST API. |
+| `status=error … unknown_op` | connector_id or op_id drift. | Use the full `vmware-rest-9.0` connector id; list ops via `meho connector list` / `search_operations`. |
+| `status=denied` on a write composite | `read_only` role, or a `requires_approval` op hit the (v0.2 deny-only) policy gate. | Use an `operator`-role token; write composites that require approval are gated until G10's approval queue lands. |
+
+## References
+
+- Initiative: [#939 G3.9 Connector credential broker](https://github.com/evoila/meho/issues/939); Goal [#214](https://github.com/evoila/meho/issues/214) (connector parity).
+- Tasks that shipped the credential broker: [#940](https://github.com/evoila/meho/issues/940) (operator threading), [#941](https://github.com/evoila/meho/issues/941) (shared Vault-creds helper), [#942](https://github.com/evoila/meho/issues/942) (this State-2 wiring + E2E + onboarding), [#943](https://github.com/evoila/meho/issues/943) (Vault-policy deploy runbook).
+- Decision: [`docs/architecture/connector-auth.md`](../architecture/connector-auth.md) (operator-context Vault read). Research: [`docs/research/214-connector-credential-broker.md`](../research/214-connector-credential-broker.md).
+- Deploy prerequisite (Vault policy + Keycloak→Vault identity): [`connector-vault-policy.md`](./connector-vault-policy.md).
+- Release-readiness rubric: [`docs/codebase/connector-release-readiness.md`](../codebase/connector-release-readiness.md).
+- Connector code: [`backend/src/meho_backplane/connectors/vmware_rest/`](../../backend/src/meho_backplane/connectors/vmware_rest/) (`connector.py` session lifecycle, `session.py` credential loader, `_mount.py` modern/legacy mount mapping). Shared loader: [`connectors/_shared/vault_creds.py`](../../backend/src/meho_backplane/connectors/_shared/vault_creds.py).
+- Tests: recorded-fixture E2E [`tests/test_connectors_vmware_rest_credread.py`](../../backend/tests/test_connectors_vmware_rest_credread.py); opt-in live lab smoke [`tests/integration/test_connectors_vmware_rest_lab_smoke.py`](../../backend/tests/integration/test_connectors_vmware_rest_lab_smoke.py); auth/session unit suite [`tests/test_connectors_vmware_rest_auth.py`](../../backend/tests/test_connectors_vmware_rest_auth.py).
+- vmware op model framing: [`v0.3.0-feedback-reply-vmware-13-ops.md`](./v0.3.0-feedback-reply-vmware-13-ops.md). vSphere Automation REST API: [VMware vSphere Automation REST API Programming Guide 8.0](https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere-sdks-tools/8-0/vmware-vsphere-automation-rest-programming-guide-8-0.html).
+- Onboarding-doc precedents: [`bind9-onboarding.md`](./bind9-onboarding.md), [`kubernetes-onboarding.md`](./kubernetes-onboarding.md), [`vault-onboarding.md`](./vault-onboarding.md), [`docs/cross-repo/README.md`](./README.md).


### PR DESCRIPTION
## Summary

- Wire the `vmware-rest-9.0` default credential loader to perform the **live operator-context Vault KV-v2 read**, delegating to the G3.9-T2 shared `load_basic_credentials` helper. This is the load-bearing vertical slice of Initiative #939: with T1 (operator threaded down the auth surface) and T2 (shared helper) merged, vmware-rest now executes against a real vCenter under operator-context auth at rubric **State 2** (`shared_service_account`).
- The default loader becomes a thin vmware entry point over the shared helper, inheriting its two-phase error contract and no-secret-in-logs discipline. `VsphereTargetLike.secret_ref` widened to `str | None` to match the concrete `Target` column + the shared protocol (mypy variance fix).
- Replace the default-loader-`NotImplementedError` test with a live-read test; add a secret-free recorded-fixture E2E and an opt-in live lab-vCenter smoke; add the operator onboarding doc + the rubric State-2 bump.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` (changed files) — clean
- [x] `mypy src/meho_backplane/` — clean (252 files)
- [x] `pytest` connector/operations/vault/dispatch slice (`--ignore=tests/integration`, `-n 6`) — 1793 passed, 16 skipped (pre-existing env/Docker gates), 0 failed
- [x] **AC1** default loader does the live KV-v2 read via the T2 helper; old "raises deliberate stub" test replaced by a passing live/recorded read test; injected-loader unit tests still pass
- [x] **AC2** recorded-fixture E2E (`tests/test_connectors_vmware_rest_credread.py`) proves the full `dispatch → auth_headers → _session_token → default loader → Vault → POST /api/session → GET op` chain returns `status="ok"`; asserts the credential never appears in the `OperationResult`, any captured log event, or the broadcast payload; runs in the default `pytest -n auto` unit lane with no real secret + no Docker
- [x] **AC3** opt-in lab smoke (`tests/integration/test_connectors_vmware_rest_lab_smoke.py`) collects and **skips cleanly** with its env vars unset (verified: `1 skipped`)
- [x] **AC4** `docs/cross-repo/vmware-rest-onboarding.md` exists and references the T4 Vault-policy runbook; reciprocal back-link added to `connector-vault-policy.md`
- [x] **AC5** `ruff` + `mypy` clean; `rg "deliberate stub" backend/src/.../vmware_rest/` returns nothing
- [x] **AC6** `docs/codebase/connector-release-readiness.md` state table updated: `vmware-rest-9.0` → State 2

## Design note

The recorded-fixture E2E lives in the **unit lane** (`backend/tests/`), not `tests/integration/`, because the acceptance criterion requires it to run in the default `pytest -n auto` sweep — which deselects `tests/integration/` (the container/PG lane). The replay needs neither a real Vault nor a real vCenter (both stubbed at their boundaries via the in-process Vault fake + respx) and only the autouse SQLite `endpoint_descriptor` schema the unit conftest already migrates. This mirrors the T2 split (unit `test_connectors_vault_creds.py` + integration `..._dev_e2e.py`). The live vendor round-trip is the env-gated integration-lane smoke.

## Out of scope

- nsx/sddc/harbor/vcf-* loaders — #G3.10 (this Initiative ships the helper + threading they reuse). The nsx loader docstring still cross-references the vmware loader as a "NotImplementedError stub" precedent (now stale); left untouched since nsx code is out of scope and #G3.10 will rewrite it.
- `per_user` / `impersonation` auth models; 401-driven proactive session refresh — deferred at the connector boundary.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #942

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-23)

Addressed review findings from [`pr-963-iter-1`](.claude/auto/review-results/pr-963-iter-1.json):

- **B1** `5dc9679` — corrected every `secret_ref` / `--secret-ref` example in `vmware-rest-onboarding.md` to the **logical** KV-v2 path (`targets/<operator-identity>/<target-name>` — no `secret/` prefix, no `/data/`), matching what the loader passes to hvac's `read_secret_version(path=…, mount_point="secret")`. Added a note distinguishing it from the KV-v2 API/policy form (`secret/data/…`) the Vault ACL policy in `connector-vault-policy.md` legitimately uses (left untouched). Aligned the recorded-fixture E2E's `_CredReadTarget.secret_ref` to the logical form (test stays green — pass-through assertion).
- **M1** `5dc9679` — refreshed the stale `auth_headers` / `_session_token` docstrings in `connector.py` that still called the default loader a stub that "ignores it and raises until that lands"; both now describe the live operator-context read `load_session_credentials_from_vault` performs.

Verification: `ruff check` + `ruff format --check` + `mypy src/meho_backplane/` clean; `pytest` credread + vmware-auth + vault-creds slice green (39 passed).

<!-- auto-implement-issue: continue, iteration 1 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VMware REST connector now supports live credential reads from Vault for shared service‑account vSphere authentication.

* **Documentation**
  * Added onboarding guide for VMware REST operations and updated connector release‑readiness and Vault policy references.

* **Tests**
  * Added opt‑in live lab smoke test, E2E-style credential‑read tests, and unit tests ensuring auth flows work and credentials never appear in results, logs, or broadcasts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/963?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
