### PR TITLE
test(ui): G10.0 hygiene — tighten BFF auth-flow tests + fix MD038

### DIFF
--- a/backend/tests/test_ui_auth_flow.py
+++ b/backend/tests/test_ui_auth_flow.py
@@ -368,6 +368,13 @@ def test_callback_creates_session_and_sets_cookie() -> None:
     assert "code_verifier=" in posted_body
     assert "grant_type=authorization_code" in posted_body
     assert "resource=https%3A%2F%2Fmeho.test%2Fapi" in posted_body
+    # Keycloak enforces exact-match on ``redirect_uri`` at the token
+    # endpoint (RFC 6749 §4.1.3); a regression that drops the field
+    # from the body breaks the exchange but the existing substring
+    # asserts above wouldn't notice. ``parse_qs`` returns
+    # percent-decoded values, so we compare against the bare URI.
+    posted_params = parse_qs(posted_body)
+    assert posted_params["redirect_uri"] == [_REDIRECT_URI]
     # ``Authorization: Basic <base64(client_id:client_secret)>`` --
     # the header is present (length > 'Basic '), but we deliberately
     # do not unpack the value because the secret-leak sweep in
@@ -568,6 +575,14 @@ def test_logout_without_cookie_still_redirects_and_clears() -> None:
     # the operator may have under a different tab also gets a
     # clean termination.
     assert response.headers["location"].startswith(_END_SESSION_ENDPOINT)
+    # The "and clears" part of the test name -- a stale browser
+    # cookie under the same name MUST be emitted with an expiry
+    # in the past so the next request lands without a cookie. A
+    # regression where ``_handle_logout`` skips the clear on the
+    # no-cookie path would leave a phantom cookie alive.
+    set_cookie = response.headers.get("set-cookie", "").lower()
+    assert f"{SESSION_COOKIE_NAME.lower()}=" in set_cookie
+    assert "max-age=0" in set_cookie or "expires=" in set_cookie
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -178,10 +178,10 @@ Round-trip shape:
 3. **Keycloak authenticates the operator.** Browser arrives at
    `/ui/auth/callback?code=...&state=...`.
 4. **`/ui/auth/callback`.** `exchange_code_for_tokens` pops the
-   verifier from the store (single-use), POSTs `code + code_verifier
-   + client_secret` to Keycloak's token endpoint, and returns the
-   access + refresh tokens. The callback then validates the access
-   token through the chassis JWT chain
+   verifier from the store (single-use), POSTs
+   `code+code_verifier+client_secret` to Keycloak's token endpoint,
+   and returns the access + refresh tokens. The callback then
+   validates the access token through the chassis JWT chain
    (`verify_jwt_for_audience`) so the BFF inherits issuer / audience
    / sub / tenant_id / tenant_role defences; on success it calls
    `create_session` to write the encrypted row and sets the


### PR DESCRIPTION
## Summary
- Tighten two `test_ui_auth_flow.py` tests whose docstring claims were not fully proven by their assertions (callback test now asserts `redirect_uri` in the posted token-exchange body; logout-without-cookie test now asserts the cookie-clear `Set-Cookie` header).
- Fix `docs/codebase/ui.md` markdownlint MD038 by tightening the inline `code + code_verifier + client_secret` span to `code+code_verifier+client_secret`.
- Pure test/doc polish — zero runtime behavior change.

## Test plan
- [x] `ruff check backend/tests/test_ui_auth_flow.py` — clean
- [x] `ruff format --check backend/tests/test_ui_auth_flow.py` — clean
- [x] `mypy` (project-scoped) — 253 source files, 0 issues
- [x] `pytest backend/tests/test_ui_auth_flow.py -x -q` — 32 passed
- [x] `test_callback_creates_session_and_sets_cookie` asserts `posted_params["redirect_uri"] == [_REDIRECT_URI]` (acceptance criterion 1)
- [x] `test_logout_without_cookie_still_redirects_and_clears` asserts session-cookie clearing header (cookie name + `max-age=0` or `expires=`) (acceptance criterion 2)
- [x] `docs/codebase/ui.md` inline code span tightened to remove embedded spaces (acceptance criterion 3)
- [x] Single PR, 23 LoC across two files (acceptance criterion 5)

## Out of scope
- Backfilling assertions on other tests in the same file (assert-once-per-claim precedent).
- Migrating to `httpx_mock` (file uses `respx`).
- Adjacent docs fixes in `ui.md` beyond the MD038 line.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #965


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced authentication flow tests to verify token exchange and session cookie handling, including validation of redirect URI parameters and cookie expiration directives.

* **Documentation**
  * Reformatted internal documentation for login flow authentication process for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/968?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->