### PR TITLE
fix(ui): G10.0 hygiene — UI auth 302 OpenAPI typing + dashboard aria-label

### DIFF
--- a/backend/src/meho_backplane/ui/auth/routes.py
+++ b/backend/src/meho_backplane/ui/auth/routes.py
@@ -89,7 +89,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import timedelta
-from typing import Final
+from typing import Annotated, Final
 from urllib.parse import urlencode
 
 import httpx
@@ -98,7 +98,7 @@ from authlib.integrations.base_client.errors import (
     MismatchingStateError,
     OAuthError,
 )
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import APIRouter, HTTPException, Query, Request, status
 from fastapi.responses import RedirectResponse
 
 from meho_backplane.auth.jwt import verify_jwt_for_audience
@@ -270,16 +270,19 @@ def _build_end_session_url(
     return f"{end_session_endpoint}{separator}{query}"
 
 
-async def _handle_login(request: Request) -> RedirectResponse:
+async def _handle_login(
+    return_to: Annotated[str | None, Query()] = None,
+) -> RedirectResponse:
     """Mint a PKCE authorization URL and 302 the browser to Keycloak.
 
     ``?return_to=<path>`` is the originally-requested path the
-    operator was bounced from (the middleware writes it). Validated
+    operator was bounced from (the middleware writes it). Declared as
+    a typed FastAPI ``Query`` parameter so the OpenAPI document
+    reflects the real query-string contract; the value is validated
     via :func:`_safe_return_to` to block open-redirect abuse.
     """
     log = structlog.get_logger(__name__)
-    raw_return_to = request.query_params.get("return_to")
-    return_to = _safe_return_to(raw_return_to)
+    return_to = _safe_return_to(return_to)
     try:
         url, state = await build_authorization_request(
             redirect_uri=compute_redirect_uri(),
@@ -401,13 +404,33 @@ async def _persist_session_from_tokens(
     return decrypted.id, operator.sub, operator.tenant_id
 
 
-async def _handle_callback(request: Request) -> RedirectResponse:
-    """Finish the OAuth round-trip, create the session, set the cookie."""
+async def _handle_callback(
+    request: Request,
+    code: Annotated[str | None, Query()] = None,
+    state: Annotated[str | None, Query()] = None,
+    error: Annotated[str | None, Query()] = None,
+    error_description: Annotated[str | None, Query()] = None,
+) -> RedirectResponse:
+    """Finish the OAuth round-trip, create the session, set the cookie.
+
+    ``code``, ``state``, ``error``, and ``error_description`` are all
+    declared as typed FastAPI ``Query`` parameters so the OpenAPI
+    document reflects the real callback-URL contract. They are
+    optional because the IdP only ever populates one of the
+    ``code``/``state`` pair or the ``error``/``error_description``
+    pair; absent values in the wrong combination collapse to a 400
+    via :func:`_exchange_or_translate`. The full callback URL (which
+    authlib re-parses for token exchange) still comes from
+    ``request`` -- typed extraction is for OpenAPI fidelity, not a
+    behaviour change.
+    """
     log = structlog.get_logger(__name__)
-    idp_error = request.query_params.get("error")
-    if idp_error:
-        _raise_idp_error(idp_error, request.query_params.get("error_description"))
-    state = request.query_params.get("state")
+    # ``code`` is consumed by ``str(request.url)`` below (authlib
+    # re-parses the full URL); the typed extraction here exists purely
+    # so the OpenAPI document lists the parameter.
+    del code
+    if error:
+        _raise_idp_error(error, error_description)
     # ``str(request.url)`` carries the full callback URL with query
     # string -- authlib's :meth:`fetch_token` parses ``code`` and
     # ``state`` out of it.
@@ -501,17 +524,34 @@ def build_router() -> APIRouter:
     under test do not share mutable state.
     """
     router = APIRouter(prefix="/ui/auth", tags=["ui-auth"])
-    router.add_api_route("/login", _handle_login, methods=["GET"], name="ui_auth_login")
+    # ``response_class`` + ``status_code`` on each route declare the
+    # real 302-redirect contract in the OpenAPI document so the CLI's
+    # generated Go client at ``cli/internal/api/client.gen.go``
+    # reflects the runtime behaviour. Without these, FastAPI defaults
+    # the OpenAPI response to ``200 application/json`` -- correct for
+    # the typical handler, wrong for a pure-redirect surface.
+    router.add_api_route(
+        "/login",
+        _handle_login,
+        methods=["GET"],
+        name="ui_auth_login",
+        response_class=RedirectResponse,
+        status_code=status.HTTP_302_FOUND,
+    )
     router.add_api_route(
         "/callback",
         _handle_callback,
         methods=["GET"],
         name="ui_auth_callback",
+        response_class=RedirectResponse,
+        status_code=status.HTTP_302_FOUND,
     )
     router.add_api_route(
         "/logout",
         _handle_logout,
         methods=["GET"],
         name="ui_auth_logout",
+        response_class=RedirectResponse,
+        status_code=status.HTTP_302_FOUND,
     )
     return router

--- a/backend/src/meho_backplane/ui/templates/dashboard.html
+++ b/backend/src/meho_backplane/ui/templates/dashboard.html
@@ -103,7 +103,7 @@
   {# -------- Live feed snippet (HTMX SSE) -------- #}
   <section
     class="card bg-base-100 border-base-300 border shadow-sm"
-    aria-label="Last 5 broadcast events"
+    aria-label="Recent broadcast events (live)"
   >
     <div class="card-body">
       <div class="flex items-baseline justify-between">

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -3404,14 +3404,31 @@
           "ui-auth"
         ],
         "summary": "Ui Auth Login",
-        "description": "Mint a PKCE authorization URL and 302 the browser to Keycloak.\n\n``?return_to=<path>`` is the originally-requested path the\noperator was bounced from (the middleware writes it). Validated\nvia :func:`_safe_return_to` to block open-redirect abuse.",
+        "description": "Mint a PKCE authorization URL and 302 the browser to Keycloak.\n\n``?return_to=<path>`` is the originally-requested path the\noperator was bounced from (the middleware writes it). Declared as\na typed FastAPI ``Query`` parameter so the OpenAPI document\nreflects the real query-string contract; the value is validated\nvia :func:`_safe_return_to` to block open-redirect abuse.",
         "operationId": "ui_auth_login_ui_auth_login_get",
+        "parameters": [
+          {
+            "name": "return_to",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Return To"
+            }
+          }
+        ],
         "responses": {
-          "200": {
-            "description": "Successful Response",
+          "302": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3424,14 +3441,61 @@
           "ui-auth"
         ],
         "summary": "Ui Auth Callback",
-        "description": "Finish the OAuth round-trip, create the session, set the cookie.",
+        "description": "Finish the OAuth round-trip, create the session, set the cookie.\n\n``code``, ``state``, ``error``, and ``error_description`` are all\ndeclared as typed FastAPI ``Query`` parameters so the OpenAPI\ndocument reflects the real callback-URL contract. They are\noptional because the IdP only ever populates one of the\n``code``/``state`` pair or the ``error``/``error_description``\npair; absent values in the wrong combination collapse to a 400\nvia :func:`_exchange_or_translate`. The full callback URL (which\nauthlib re-parses for token exchange) still comes from\n``request`` -- typed extraction is for OpenAPI fidelity, not a\nbehaviour change.",
         "operationId": "ui_auth_callback_ui_auth_callback_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Code"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "State"
+            }
+          },
+          {
+            "name": "error",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Error"
+            }
+          },
+          {
+            "name": "error_description",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Error Description"
+            }
+          }
+        ],
         "responses": {
-          "200": {
-            "description": "Successful Response",
+          "302": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -3447,13 +3511,8 @@
         "description": "Revoke the session row, clear the cookie, 302 to the end-session URL.",
         "operationId": "ui_auth_logout_ui_auth_logout_get",
         "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            }
+          "302": {
+            "description": "Successful Response"
           }
         }
       }

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -2312,6 +2312,19 @@ type McpDispatchMcpPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// UiAuthCallbackUiAuthCallbackGetParams defines parameters for UiAuthCallbackUiAuthCallbackGet.
+type UiAuthCallbackUiAuthCallbackGetParams struct {
+	Code             *string `form:"code,omitempty" json:"code,omitempty"`
+	State            *string `form:"state,omitempty" json:"state,omitempty"`
+	Error            *string `form:"error,omitempty" json:"error,omitempty"`
+	ErrorDescription *string `form:"error_description,omitempty" json:"error_description,omitempty"`
+}
+
+// UiAuthLoginUiAuthLoginGetParams defines parameters for UiAuthLoginUiAuthLoginGet.
+type UiAuthLoginUiAuthLoginGetParams struct {
+	ReturnTo *string `form:"return_to,omitempty" json:"return_to,omitempty"`
+}
+
 // QueryApiV1AuditQueryPostJSONRequestBody defines body for QueryApiV1AuditQueryPost for application/json ContentType.
 type QueryApiV1AuditQueryPostJSONRequestBody = AuditQueryRequest
 
@@ -2707,10 +2720,10 @@ type ClientInterface interface {
 	UiDashboardUiGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiAuthCallbackUiAuthCallbackGet request
-	UiAuthCallbackUiAuthCallbackGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	UiAuthCallbackUiAuthCallbackGet(ctx context.Context, params *UiAuthCallbackUiAuthCallbackGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiAuthLoginUiAuthLoginGet request
-	UiAuthLoginUiAuthLoginGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	UiAuthLoginUiAuthLoginGet(ctx context.Context, params *UiAuthLoginUiAuthLoginGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiAuthLogoutUiAuthLogoutGet request
 	UiAuthLogoutUiAuthLogoutGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -3634,8 +3647,8 @@ func (c *Client) UiDashboardUiGet(ctx context.Context, reqEditors ...RequestEdit
 	return c.Client.Do(req)
 }
 
-func (c *Client) UiAuthCallbackUiAuthCallbackGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUiAuthCallbackUiAuthCallbackGetRequest(c.Server)
+func (c *Client) UiAuthCallbackUiAuthCallbackGet(ctx context.Context, params *UiAuthCallbackUiAuthCallbackGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiAuthCallbackUiAuthCallbackGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -3646,8 +3659,8 @@ func (c *Client) UiAuthCallbackUiAuthCallbackGet(ctx context.Context, reqEditors
 	return c.Client.Do(req)
 }
 
-func (c *Client) UiAuthLoginUiAuthLoginGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUiAuthLoginUiAuthLoginGetRequest(c.Server)
+func (c *Client) UiAuthLoginUiAuthLoginGet(ctx context.Context, params *UiAuthLoginUiAuthLoginGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiAuthLoginUiAuthLoginGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -7485,7 +7498,7 @@ func NewUiDashboardUiGetRequest(server string) (*http.Request, error) {
 }
 
 // NewUiAuthCallbackUiAuthCallbackGetRequest generates requests for UiAuthCallbackUiAuthCallbackGet
-func NewUiAuthCallbackUiAuthCallbackGetRequest(server string) (*http.Request, error) {
+func NewUiAuthCallbackUiAuthCallbackGetRequest(server string, params *UiAuthCallbackUiAuthCallbackGetParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -7503,6 +7516,76 @@ func NewUiAuthCallbackUiAuthCallbackGetRequest(server string) (*http.Request, er
 		return nil, err
 	}
 
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Code != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "code", runtime.ParamLocationQuery, *params.Code); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.State != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "state", runtime.ParamLocationQuery, *params.State); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Error != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "error", runtime.ParamLocationQuery, *params.Error); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ErrorDescription != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "error_description", runtime.ParamLocationQuery, *params.ErrorDescription); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
@@ -7512,7 +7595,7 @@ func NewUiAuthCallbackUiAuthCallbackGetRequest(server string) (*http.Request, er
 }
 
 // NewUiAuthLoginUiAuthLoginGetRequest generates requests for UiAuthLoginUiAuthLoginGet
-func NewUiAuthLoginUiAuthLoginGetRequest(server string) (*http.Request, error) {
+func NewUiAuthLoginUiAuthLoginGetRequest(server string, params *UiAuthLoginUiAuthLoginGetParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -7528,6 +7611,28 @@ func NewUiAuthLoginUiAuthLoginGetRequest(server string) (*http.Request, error) {
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.ReturnTo != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "return_to", runtime.ParamLocationQuery, *params.ReturnTo); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -7979,10 +8084,10 @@ type ClientWithResponsesInterface interface {
 	UiDashboardUiGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiDashboardUiGetResponse, error)
 
 	// UiAuthCallbackUiAuthCallbackGetWithResponse request
-	UiAuthCallbackUiAuthCallbackGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiAuthCallbackUiAuthCallbackGetResponse, error)
+	UiAuthCallbackUiAuthCallbackGetWithResponse(ctx context.Context, params *UiAuthCallbackUiAuthCallbackGetParams, reqEditors ...RequestEditorFn) (*UiAuthCallbackUiAuthCallbackGetResponse, error)
 
 	// UiAuthLoginUiAuthLoginGetWithResponse request
-	UiAuthLoginUiAuthLoginGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiAuthLoginUiAuthLoginGetResponse, error)
+	UiAuthLoginUiAuthLoginGetWithResponse(ctx context.Context, params *UiAuthLoginUiAuthLoginGetParams, reqEditors ...RequestEditorFn) (*UiAuthLoginUiAuthLoginGetResponse, error)
 
 	// UiAuthLogoutUiAuthLogoutGetWithResponse request
 	UiAuthLogoutUiAuthLogoutGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiAuthLogoutUiAuthLogoutGetResponse, error)
@@ -9327,7 +9432,7 @@ func (r UiDashboardUiGetResponse) StatusCode() int {
 type UiAuthCallbackUiAuthCallbackGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *interface{}
+	JSON422      *HTTPValidationError
 }
 
 // Status returns HTTPResponse.Status
@@ -9349,7 +9454,7 @@ func (r UiAuthCallbackUiAuthCallbackGetResponse) StatusCode() int {
 type UiAuthLoginUiAuthLoginGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *interface{}
+	JSON422      *HTTPValidationError
 }
 
 // Status returns HTTPResponse.Status
@@ -9371,7 +9476,6 @@ func (r UiAuthLoginUiAuthLoginGetResponse) StatusCode() int {
 type UiAuthLogoutUiAuthLogoutGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *interface{}
 }
 
 // Status returns HTTPResponse.Status
@@ -10176,8 +10280,8 @@ func (c *ClientWithResponses) UiDashboardUiGetWithResponse(ctx context.Context, 
 }
 
 // UiAuthCallbackUiAuthCallbackGetWithResponse request returning *UiAuthCallbackUiAuthCallbackGetResponse
-func (c *ClientWithResponses) UiAuthCallbackUiAuthCallbackGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiAuthCallbackUiAuthCallbackGetResponse, error) {
-	rsp, err := c.UiAuthCallbackUiAuthCallbackGet(ctx, reqEditors...)
+func (c *ClientWithResponses) UiAuthCallbackUiAuthCallbackGetWithResponse(ctx context.Context, params *UiAuthCallbackUiAuthCallbackGetParams, reqEditors ...RequestEditorFn) (*UiAuthCallbackUiAuthCallbackGetResponse, error) {
+	rsp, err := c.UiAuthCallbackUiAuthCallbackGet(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -10185,8 +10289,8 @@ func (c *ClientWithResponses) UiAuthCallbackUiAuthCallbackGetWithResponse(ctx co
 }
 
 // UiAuthLoginUiAuthLoginGetWithResponse request returning *UiAuthLoginUiAuthLoginGetResponse
-func (c *ClientWithResponses) UiAuthLoginUiAuthLoginGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiAuthLoginUiAuthLoginGetResponse, error) {
-	rsp, err := c.UiAuthLoginUiAuthLoginGet(ctx, reqEditors...)
+func (c *ClientWithResponses) UiAuthLoginUiAuthLoginGetWithResponse(ctx context.Context, params *UiAuthLoginUiAuthLoginGetParams, reqEditors ...RequestEditorFn) (*UiAuthLoginUiAuthLoginGetResponse, error) {
+	rsp, err := c.UiAuthLoginUiAuthLoginGet(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -12069,12 +12173,12 @@ func ParseUiAuthCallbackUiAuthCallbackGetResponse(rsp *http.Response) (*UiAuthCa
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest interface{}
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON200 = &dest
+		response.JSON422 = &dest
 
 	}
 
@@ -12095,12 +12199,12 @@ func ParseUiAuthLoginUiAuthLoginGetResponse(rsp *http.Response) (*UiAuthLoginUiA
 	}
 
 	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest interface{}
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
-		response.JSON200 = &dest
+		response.JSON422 = &dest
 
 	}
 
@@ -12118,16 +12222,6 @@ func ParseUiAuthLogoutUiAuthLogoutGetResponse(rsp *http.Response) (*UiAuthLogout
 	response := &UiAuthLogoutUiAuthLogoutGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest interface{}
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
 	}
 
 	return response, nil


### PR DESCRIPTION
## Summary

- Pass `response_class=RedirectResponse, status_code=302` on the three `add_api_route` calls in `backend/src/meho_backplane/ui/auth/routes.py:build_router()` and replace inline `request.query_params.get(...)` reads inside `_handle_login` / `_handle_callback` with typed `Annotated[str | None, Query()]` parameters. FastAPI's OpenAPI generator now emits the correct shape (302 response, declared query parameters); the CLI's generated Go client at `cli/internal/api/client.gen.go` inherits the real 302-redirect contract instead of the default `200 application/json` shape.
- Fix the dashboard "Recent activity" `aria-label` (`backend/src/meho_backplane/ui/templates/dashboard.html:106`) from "Last 5 broadcast events" to "Recent broadcast events (live)" — the `?limit=5` source parameter was dropped during PR #960's review/fix loop, but the screen-reader label was missed and would announce "Last 5" for what is now an unbounded live stream.
- Regenerated `cli/api/openapi.json` + `cli/internal/api/client.gen.go` via `cd cli && make snapshot-openapi && make generate`; the diff is scoped to the three affected operations (no unrelated drift). Typed-Query is runtime-equivalent to `request.query_params.get(...)`, so the 51 existing UI smoke + auth-flow tests pass unmodified.

## Test plan

- [x] `ruff check src/meho_backplane/ui/ tests/` — clean
- [x] `ruff format --check src/meho_backplane/ui/` — 13 files already formatted
- [x] `mypy src/meho_backplane/ui/auth/routes.py --ignore-missing-imports` — clean
- [x] `pytest tests/test_ui_auth_flow.py tests/test_ui_chassis_smoke.py -x -q` — 51 passed (existing smoke + auth-flow tests pass unchanged, proving the typed-Query refactor is runtime-equivalent)
- [x] `pytest tests/ -k ui_ -x -q` — 74 passed (broader UI sweep)
- [x] `cd cli && make snapshot-openapi && make generate` — runs idempotent; verified the `/ui/auth/login`, `/ui/auth/callback`, `/ui/auth/logout` entries in `cli/api/openapi.json` now show `302` responses + declared query params (`return_to`, `code`, `state`, `error`, `error_description`)
- [x] `cd cli && go build ./...` — clean (the regenerated `client.gen.go` compiles; no Go callers exist for `UiAuthLoginUiAuthLoginGet` / `UiAuthCallbackUiAuthCallbackGet` outside the generated file itself, so the signature change is a pure-types delta)
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers, 1 warning (`routes.py` at 558 lines, pre-existing; recorded as adjacent finding — see Out of scope)
- [x] Acceptance criteria from #966: `cli/api/openapi.json` shows `302` + declared query parameters; `cli/internal/api/client.gen.go` reflects the new types with no unrelated diff; `dashboard.html:106` updated to `aria-label="Recent broadcast events (live)"`; existing UI smoke tests pass unchanged.

## Out of scope

- Other route handlers that return `RedirectResponse` without `response_class=` (per #966's "Out of scope" — separate hygiene Task if needed).
- Broader a11y sweep of `dashboard.html` or other UI templates (per #966's "Out of scope" — single-line scoped fix).
- `routes.py` size (558 lines, under the 600 block threshold; pre-existing warning from `code-quality.py --diff`).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #966


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility announcements on the dashboard live feed card.

* **Refactor**
  * Enhanced authentication endpoint specifications to more accurately reflect redirect behavior and query parameter handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/969?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->