### PR TITLE
feat(connectors): G3.10-T3 vcf-automation dual-plane live credread + E2E (State 2)

### DIFF
--- a/backend/src/meho_backplane/connectors/vcf_automation/_auth.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/_auth.py
@@ -19,6 +19,7 @@ from typing import Any
 import httpx
 import structlog
 
+from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.vcf_automation._routing import (
     PROVIDER_CLOUDAPI_ACCEPT,
     PROVIDER_SESSION_PATH,
@@ -43,9 +44,10 @@ _log = structlog.get_logger(__name__)
 async def load_credentials_with_override(
     loader: VcfAutomationCredentialsLoader,
     target: VcfAutomationTargetLike,
+    operator: Operator,
     secret_ref: str | None,
 ) -> dict[str, str]:
-    """Invoke *loader* against *target* (optionally with override *secret_ref*).
+    """Invoke *loader* against ``(target, operator)`` (optionally with override *secret_ref*).
 
     When *secret_ref* matches ``target.secret_ref`` (or is ``None``)
     the target passes through unchanged. When it differs, the loader
@@ -53,10 +55,12 @@ async def load_credentials_with_override(
     attributes with ``secret_ref`` rewritten to the override -- this
     lets the provider plane resolve a distinct Vault path
     (``provider_secret_ref``) when the provider-plane password differs
-    from the SSO/tenant secret.
+    from the SSO/tenant secret. ``operator`` is forwarded verbatim so
+    the live default loader can perform the operator-context Vault
+    read under the operator's identity.
     """
     if secret_ref is None or secret_ref == target.secret_ref:
-        return await loader(target)
+        return await loader(target, operator)
     proxy = SimpleNamespace(
         name=target.name,
         host=target.host,
@@ -68,7 +72,7 @@ async def load_credentials_with_override(
         provider_username=getattr(target, "provider_username", None),
         provider_secret_ref=getattr(target, "provider_secret_ref", None),
     )
-    return await loader(proxy)
+    return await loader(proxy, operator)
 
 
 def _require_username_password(

--- a/backend/src/meho_backplane/connectors/vcf_automation/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/connector.py
@@ -210,13 +210,15 @@ class VcfAutomationConnector(HttpConnector):
         callers don't forward ``path`` -- this connector overrides
         both transports to thread ``path`` through. A stray path-less
         call raises :exc:`VcfAutomationConfigurationError` rather than
-        silently picking a plane. ``operator`` is accepted for the
-        shared HTTP auth surface (G3.9-T1) but unused; threading it into
-        vRA's credential loader is #G3.10. Raises
-        :exc:`NotImplementedError` for any ``target.auth_model`` other
-        than ``shared_service_account`` / ``None``.
+        silently picking a plane. ``operator`` is forwarded to the
+        :class:`VcfAutomationCredentialsLoader` on first session-establish
+        so the default loader (:func:`.session.load_credentials_from_vault`)
+        can perform the operator-context Vault read under the operator's
+        identity; cached tokens are reused on warm-path calls without
+        re-reading Vault. Raises :exc:`NotImplementedError` for any
+        ``target.auth_model`` other than ``shared_service_account`` /
+        ``None``.
         """
-        del operator  # SHARED_SERVICE_ACCOUNT does not forward operator identity
         auth_model = getattr(target, "auth_model", None)
         if not is_acceptable_auth_model(auth_model):
             raise NotImplementedError(
@@ -233,12 +235,12 @@ class VcfAutomationConnector(HttpConnector):
             )
         plane = plane_for_path(path)
         if plane == "provider":
-            token = await self._provider_session_token(target)
+            token = await self._provider_session_token(target, operator)
             return {
                 "Authorization": f"Bearer {token}",
                 "Accept": provider_accept_for_path(path),
             }
-        token = await self._tenant_session_token(target)
+        token = await self._tenant_session_token(target, operator)
         return {
             "Authorization": f"Bearer {token}",
             "Accept": TENANT_ACCEPT,
@@ -248,12 +250,18 @@ class VcfAutomationConnector(HttpConnector):
     # Per-plane session establishment
     # ------------------------------------------------------------------
 
-    async def _provider_session_token(self, target: VcfAutomationTargetLike) -> str:
+    async def _provider_session_token(
+        self, target: VcfAutomationTargetLike, operator: Operator
+    ) -> str:
         """Return the cached provider-plane JWT, establishing on first use.
 
-        When ``target.provider_secret_ref`` is set, the loader is
-        called with the override path so the provider account can
-        differ from the SSO/tenant account (the ``admin@System`` vs
+        ``operator`` is forwarded to the
+        :class:`VcfAutomationCredentialsLoader` so the credential read
+        runs under the operator's identity (the live default loader's
+        operator-context Vault KV-v2 read). When
+        ``target.provider_secret_ref`` is set, the loader is called
+        with the override path so the provider account can differ
+        from the SSO/tenant account (the ``admin@System`` vs
         ``svc-meho`` split documented in the consumer wrapper).
         Otherwise the default ``target.secret_ref`` pair is used for
         both planes. See :func:`._auth.vcfa_provider_login` for the
@@ -265,25 +273,32 @@ class VcfAutomationConnector(HttpConnector):
                 return cached
             override_ref = getattr(target, "provider_secret_ref", None)
             creds = await load_credentials_with_override(
-                self._credentials_loader, target, override_ref
+                self._credentials_loader, target, operator, override_ref
             )
             client = await self._http_client(target)
             jwt = await vcfa_provider_login(client, creds, target)
             self._provider_tokens[target.name] = jwt
             return jwt
 
-    async def _tenant_session_token(self, target: VcfAutomationTargetLike) -> str:
+    async def _tenant_session_token(
+        self, target: VcfAutomationTargetLike, operator: Operator
+    ) -> str:
         """Return the cached tenant-plane token, establishing on first use.
 
-        The tenant plane does NOT honour ``provider_secret_ref`` --
-        it's strictly an SSO-ish account flow against ``target.secret_ref``.
-        See :func:`._auth.tenant_login` for the wire-level POST.
+        ``operator`` is forwarded to the
+        :class:`VcfAutomationCredentialsLoader` so the credential read
+        runs under the operator's identity. The tenant plane does
+        NOT honour ``provider_secret_ref`` -- it's strictly an SSO-ish
+        account flow against ``target.secret_ref``. See
+        :func:`._auth.tenant_login` for the wire-level POST.
         """
         async with self._tenant_lock:
             cached = self._tenant_tokens.get(target.name)
             if cached is not None:
                 return cached
-            creds = await load_credentials_with_override(self._credentials_loader, target, None)
+            creds = await load_credentials_with_override(
+                self._credentials_loader, target, operator, None
+            )
             client = await self._http_client(target)
             token = await tenant_login(client, creds, target)
             self._tenant_tokens[target.name] = token

--- a/backend/src/meho_backplane/connectors/vcf_automation/session.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/session.py
@@ -21,17 +21,24 @@ The credential fetch (Vault path -> ``{"username": ..., "password": ...}``
 dict) is split out behind a narrow :class:`VcfAutomationCredentialsLoader`
 callable so:
 
-* Production deploys override the default loader at construction time
-  once the operator-context per-target Vault credential read is wired
-  for this connector (tracked under the open
-  `Goal #214 (Connector parity) <https://github.com/evoila/meho/issues/214>`_).
+* Production deploys use the default loader,
+  :func:`load_credentials_from_vault`, which performs the **live**
+  operator-context KV-v2 read via the shared
+  :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+  helper (G3.9-T2 #941). This is the rubric **State 2** wiring
+  (``shared_service_account`` only) per
+  `Goal #214 (Connector parity) <https://github.com/evoila/meho/issues/214>`_.
 * Unit tests inject their own (mock) loader returning a pre-built dict.
 * Integration tests against a recorded fixture or live VCFA appliance
   pass a loader that yields the appropriate service-account credentials.
 
-The default loader, :func:`load_credentials_from_vault`, raises
-:exc:`NotImplementedError` until the live read lands -- same posture as
-the NSX / SDDC Manager / vSphere precedents.
+The loader's signature carries the request-scoped
+:class:`~meho_backplane.auth.operator.Operator` so the default
+implementation can forward ``operator.raw_jwt`` to Vault's JWT/OIDC
+auth method (the locked Option A decision in
+:doc:`docs/architecture/connector-auth.md`). Injected test loaders
+receive the same ``(target, operator)`` pair and are free to ignore
+``operator`` when the test does not need per-operator attribution.
 
 The :class:`VcfAutomationTargetLike` Protocol captures the minimum
 target shape the connector reads: ``name`` (per-target token cache key),
@@ -54,6 +61,9 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from typing import Protocol, runtime_checkable
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.vault_creds import load_basic_credentials
 
 __all__ = [
     "SessionCredentials",
@@ -115,7 +125,7 @@ class VcfAutomationTargetLike(Protocol):
     name: str
     host: str
     port: int | None
-    secret_ref: str
+    secret_ref: str | None
     auth_model: str | None
     fqdn: str | None
     domain: str | None
@@ -123,47 +133,70 @@ class VcfAutomationTargetLike(Protocol):
     provider_secret_ref: str | None
 
 
-VcfAutomationCredentialsLoader = Callable[[VcfAutomationTargetLike], Awaitable[dict[str, str]]]
-"""Async callable resolving a target to ``{"username": ..., "password": ...}``.
+VcfAutomationCredentialsLoader = Callable[
+    [VcfAutomationTargetLike, Operator], Awaitable[dict[str, str]]
+]
+"""Async callable resolving a ``(target, operator)`` pair to credentials.
 
-The connector's
-:meth:`VcfAutomationConnector._load_credentials` invokes the loader on
-first session-establish per ``(target.name, secret_ref)`` and caches the
-result for the connector instance lifetime. The same loader is invoked
-a second time with ``target.provider_secret_ref`` when that override is
-set, so production deploys can resolve both via a single Vault read
-path. The return type is the looser ``dict[str, str]`` (not
-:class:`SessionCredentials`) because Python :class:`Protocol` instances
-aren't runtime-constructible without a matching class -- production
-code returns a plain dict and the connector reads ``creds["username"]``
-/ ``creds["password"]`` by key.
+Returns ``{"username": ..., "password": ...}``. The connector's
+:meth:`VcfAutomationConnector._provider_session_token` /
+:meth:`VcfAutomationConnector._tenant_session_token` invoke the loader
+on first session-establish per ``(target.name, secret_ref)``; the
+provider plane invokes it a second time with the override
+:attr:`VcfAutomationTargetLike.provider_secret_ref` when set, so a
+production deploy can resolve both via a single read path. The return
+type is the looser ``dict[str, str]`` (not :class:`SessionCredentials`)
+because Python :class:`Protocol` instances aren't runtime-constructible
+without a matching class -- production code returns a plain dict and
+the connector reads ``creds["username"]`` / ``creds["password"]`` by
+key.
+
+The ``operator`` parameter carries the full
+:class:`~meho_backplane.auth.operator.Operator` (frozen) so the live
+loader (:func:`load_credentials_from_vault`) can read the per-target
+secret under the operator's identity via
+``vault_client_for_operator(operator)`` -- the locked decision in
+:doc:`docs/architecture/connector-auth.md`.
 """
 
 
 async def load_credentials_from_vault(
     target: VcfAutomationTargetLike,
+    operator: Operator,
 ) -> dict[str, str]:
-    """Default credential loader -- Vault read by ``target.secret_ref``.
+    """Default credential loader -- live operator-context Vault KV-v2 read.
 
-    Deliberate stub: the operator-context per-target Vault credential
-    read is not yet wired for the VCF Automation connector. Raising
-    :exc:`NotImplementedError` here keeps the wiring shape stable -- a
-    production caller without an override receives a clear error rather
-    than a silent fallback or a hallucinated credential pair. The
-    supported workaround is to inject a custom ``credentials_loader``
-    on ``VcfAutomationConnector`` at construction time. The live read
-    is tracked under the open Goal #214 (Connector parity).
+    Reads ``target.secret_ref`` as a KV-v2 secret **under the operator's
+    identity** (``operator.raw_jwt`` is forwarded to Vault's JWT/OIDC
+    auth method) and returns the ``{"username": ..., "password": ...}``
+    pair the connector feeds into both planes' login flows. Delegates
+    to the shared
+    :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+    helper (G3.9-T2 #941) so the read, the no-secret-in-logs discipline,
+    and the two-phase error contract are defined once for every REST
+    connector -- this loader is the thin vcf-automation entry point.
 
-    Once the read lands, this function becomes the live implementation
-    that reads the ``vcf-automation/<target.name>`` Vault path (or
-    ``target.secret_ref`` directly when set) and returns the parsed
-    ``{"username": ..., "password": ...}`` dict.
+    The error contract is the helper's:
+
+    * :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`
+      -- read-phase failure (empty ``operator.raw_jwt`` for a
+      system-initiated call, unset ``target.secret_ref``, a malformed
+      KV-v2 payload, or a missing ``username``/``password`` field).
+      Never a bare ``KeyError``.
+    * :class:`~meho_backplane.auth.vault.VaultClientError` (and its
+      subclasses) -- login-phase failure (Vault unreachable, role
+      denied). Propagated verbatim so callers can distinguish login
+      from read.
+
+    The connector invokes this loader once per plane on first
+    session-establish; the provider plane re-invokes it with the
+    override ``target.provider_secret_ref`` when that field is set so
+    distinct provider-plane credentials (``admin@System`` vs the
+    SSO/tenant account) resolve from a different Vault path.
+
+    A custom :class:`VcfAutomationCredentialsLoader` can still be
+    injected via ``credentials_loader`` on ``VcfAutomationConnector``
+    (tests do exactly that); this default is what production targets
+    at rubric State 2 (``shared_service_account``) use.
     """
-    raise NotImplementedError(
-        "load_credentials_from_vault is a deliberate stub: the operator-context "
-        "per-target Vault credential read is not yet wired for the VCF Automation "
-        f"connector; target={target.name!r} secret_ref={target.secret_ref!r}. "
-        "Workaround: inject a custom credentials_loader on VcfAutomationConnector. "
-        "Tracked under open Goal #214 (Connector parity): "
-        "https://github.com/evoila/meho/issues/214"
-    )
+    return await load_basic_credentials(target, operator)

--- a/backend/tests/test_connectors_vcf_automation_auth.py
+++ b/backend/tests/test_connectors_vcf_automation_auth.py
@@ -118,8 +118,8 @@ _TARGET_B = _StubTarget(
 )
 
 
-async def _stub_loader(_target: VcfAutomationTargetLike) -> dict[str, str]:
-    """Return canned credentials regardless of the target."""
+async def _stub_loader(_target: VcfAutomationTargetLike, _operator: Operator) -> dict[str, str]:
+    """Return canned credentials regardless of the target / operator."""
     return {"username": "svc-meho", "password": "stub-password"}
 
 
@@ -161,17 +161,29 @@ def test_importing_package_registers_against_v2_registry() -> None:
     assert registry[key] is VcfAutomationConnector
 
 
-def test_default_credentials_loader_raises_until_goal_214() -> None:
-    """The default Vault loader stays unimplemented until Goal #214."""
+def test_default_loader_fails_closed_for_system_initiated_call() -> None:
+    """The default loader rejects an empty operator JWT (system-initiated call).
+
+    The vmware-rest precedent (#942) wired
+    :func:`load_credentials_from_vault` to delegate to the shared
+    :func:`load_basic_credentials` helper, which fails closed when
+    ``operator.raw_jwt`` is empty -- the locked decision's
+    system-initiated carve-out. The same contract holds here: a system
+    operator (synthesised with ``raw_jwt=""``) cannot resolve target
+    credentials through the operator-context read path. The error is a
+    :class:`VaultCredentialsReadError` naming the target, not a bare
+    ``KeyError`` or a fallback to a backplane identity.
+    """
     import asyncio
 
+    from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
     from meho_backplane.connectors.vcf_automation.session import (
         load_credentials_from_vault,
     )
 
     async def _check() -> None:
-        with pytest.raises(NotImplementedError, match=r"Goal #214"):
-            await load_credentials_from_vault(_TARGET_A)
+        with pytest.raises(VaultCredentialsReadError, match=r"vcfa-a"):
+            await load_credentials_from_vault(_TARGET_A, _make_operator(raw_jwt=""))
 
     asyncio.run(_check())
 
@@ -511,7 +523,9 @@ async def test_provider_secret_ref_override_invokes_loader_for_distinct_provider
 
     seen_secret_refs: list[str] = []
 
-    async def _ref_tracking_loader(t: VcfAutomationTargetLike) -> dict[str, str]:
+    async def _ref_tracking_loader(
+        t: VcfAutomationTargetLike, _operator: Operator
+    ) -> dict[str, str]:
         seen_secret_refs.append(t.secret_ref)
         if t.secret_ref == "kv/data/vcfa/provider":
             return {"username": "admin", "password": "provider-secret"}
@@ -604,7 +618,7 @@ async def test_tenant_login_empty_token_field_raises() -> None:
 async def test_loader_missing_password_raises_clear_error() -> None:
     """A loader returning a dict without ``password`` raises naming the target."""
 
-    async def _bad_loader(_t: VcfAutomationTargetLike) -> dict[str, str]:
+    async def _bad_loader(_t: VcfAutomationTargetLike, _operator: Operator) -> dict[str, str]:
         return {"username": "svc-meho"}  # type: ignore[return-value]
 
     connector = VcfAutomationConnector(credentials_loader=_bad_loader)

--- a/backend/tests/test_connectors_vcf_automation_credread.py
+++ b/backend/tests/test_connectors_vcf_automation_credread.py
@@ -1,0 +1,457 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Recorded-fixture E2E for the vcf-automation dual-plane credread chain (G3.10-T3 #947).
+
+Proves the **full** dual-plane dispatch chain end to end with the real
+(default, non-injected) credential loader:
+
+    dispatch(...)
+      -> _resolve_connector_instance -> VcfAutomationConnector()  # default loader
+      -> dispatch_ingested -> _request_json (path-aware)
+      -> _provider_session_token  /  _tenant_session_token
+      -> load_credentials_with_override (operator threaded)
+      -> load_credentials_from_vault                # the live loader
+      -> load_basic_credentials (G3.9-T2)           # operator-context Vault read
+      -> POST /cloudapi/1.0.0/sessions/provider     # HTTP Basic w/ read creds
+            -> X-VMWARE-VCLOUD-ACCESS-TOKEN JWT
+      -> POST /iaas/api/login                       # JSON body w/ read creds
+            -> {"token": ...}
+      -> GET <provider-op path>  +  GET <tenant-op path>   # the actual reads
+      -> OperationResult(status="ok")
+
+The two "real" leaves are stubbed at their boundaries so the gate runs
+in the **secret-free unit lane** (``pytest -n auto`` /
+``--ignore=tests/integration``) with no Docker and no real secret:
+
+* **Vault** — the in-process fake (``install_fake_client``) patches
+  ``meho_backplane.auth.vault._build_client`` so the helper's real
+  JWT/OIDC login + KV-v2 read code path runs against canned creds. The
+  default loader is exercised verbatim — *not* an injected stub. This is
+  the load-bearing difference from
+  ``test_connectors_vcf_automation_auth.py``
+  (which injects ``_stub_loader``) and
+  ``test_connectors_vcf_automation_e2e.py``
+  (which injects ``_vcfa_credentials_loader`` to keep its dispatch
+  acceptance tests focused on the dual-plane routing): here the
+  connector is constructed by the resolver as
+  ``VcfAutomationConnector()`` with no ``credentials_loader``, so the
+  default ``load_credentials_from_vault`` runs.
+* **VCFA appliance** — respx replays the per-plane login endpoints + a
+  provider-plane read op + a tenant-plane read op. No network.
+
+No credential value and no JWT bearer token may appear in any captured
+log event or any field of the returned ``OperationResult``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+import respx
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog.testing import capture_logs
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.vcf_automation import VcfAutomationConnector
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+# ---------------------------------------------------------------------------
+# Canary credential + JWT values — asserted to NEVER appear in the result
+# or any log event. Generated nowhere near a real secret; these strings
+# exist purely as leak canaries.
+# ---------------------------------------------------------------------------
+
+_CANARY_USERNAME = "svc-vcfa-canary"
+_CANARY_PASSWORD = "p4ss-canary-must-not-leak-credread-vcfa"
+_CANARY_PROVIDER_JWT = "vcfa-credread-provider-jwt-canary"
+_CANARY_TENANT_TOKEN = "vcfa-credread-tenant-token-canary"
+
+#: The connector triple ``vcfa-rest-9.0`` decodes to. ``parse_connector_id``
+#: pulls ``"vcfa"`` as the product slug; the connector class registers under
+#: the wider ``"vcf-automation"`` slug (same shape as sddc-manager / sddc).
+_DESCRIPTOR_PRODUCT = "vcfa"
+_CONNECTOR_PRODUCT = "vcf-automation"
+_VERSION = "9.0"
+_IMPL_ID = "vcfa-rest"
+_CONNECTOR_ID = "vcfa-rest-9.0"
+
+#: Two ingested ops -- one per plane -- so the read chain exercises both
+#: login flows and both Bearer-token shapes.
+_PROVIDER_OP_ID = "GET:/cloudapi/1.0.0/site"
+_PROVIDER_OP_PATH = "/cloudapi/1.0.0/site"
+_TENANT_OP_ID = "GET:/iaas/api/about"
+_TENANT_OP_PATH = "/iaas/api/about"
+
+#: respx base URL the target points at. ``.test.invalid`` (RFC 6761) so no
+#: real egress can fire even if respx-routing breaks.
+_VCFA_FQDN = "vcfa-credread.test.invalid"
+_VCFA_BASE_URL = f"https://{_VCFA_FQDN}"
+
+#: Recorded-fixture payloads — minimal but valid VCFA dual-plane responses.
+_PROVIDER_SITE_PAYLOAD: dict[str, Any] = {
+    "id": "site-credread",
+    "name": "VCFA-CREDREAD",
+    "productVersion": "9.0.0.0-credread",
+}
+_TENANT_ABOUT_PAYLOAD: dict[str, Any] = {
+    "latestApiVersion": "2024-01-01",
+    "supportedApis": [{"apiVersion": "2024-01-01"}],
+}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Vault client + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches + connector registry around every test.
+
+    The connector-instance cache must be clear so the resolver builds a
+    fresh ``VcfAutomationConnector()`` (default loader) for this test
+    rather than reusing one a sibling test wired with an injected stub
+    loader.
+    """
+    reset_dispatcher_caches()
+    clear_registry()
+    register_connector_v2(
+        product=_CONNECTOR_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        cls=VcfAutomationConnector,
+    )
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub for the seeded descriptor rows."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    """Record broadcast events so the audit/broadcast leg is asserted."""
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _CredReadTarget:
+    """Target satisfying both ``VcfAutomationTargetLike`` and the resolver shape.
+
+    Carries the resolver attributes (``product`` / ``fingerprint`` /
+    ``preferred_impl_id`` / ``id``) plus the loader attributes
+    (``name`` / ``host`` / ``port`` / ``secret_ref`` / ``auth_model`` /
+    ``fqdn`` / ``domain`` / ``provider_username`` /
+    ``provider_secret_ref``). ``secret_ref`` is the **logical** KV-v2
+    path the live default loader reads — relative to the mount root,
+    no ``secret/`` prefix and no ``/data/`` segment (hvac inserts
+    ``/data/`` itself). This is the exact shape an operator stores per
+    the future vcf-automation onboarding doc.
+    """
+
+    def __init__(self) -> None:
+        self.product = _CONNECTOR_PRODUCT
+        # ``resolve_connector`` reads ``fingerprint.version`` via attribute
+        # access; a tiny duck-typed stand-in keeps the test free of the
+        # full Pydantic FingerprintResult shape.
+        self.fingerprint = type("_FP", (), {"version": _VERSION})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.name = "vcfa-credread-target"
+        self.host = _VCFA_FQDN
+        self.port = 443
+        # FQDN already equals host, so vhost routing collapses to the
+        # plain URL; ``compose_base_url`` accepts a None ``fqdn`` when
+        # ``host`` is itself a hostname (not an IP).
+        self.fqdn: str | None = None
+        self.domain: str | None = None
+        self.provider_username: str | None = None
+        self.provider_secret_ref: str | None = None
+        self.secret_ref = "targets/op-credread/vcfa-credread"
+        self.auth_model = "shared_service_account"
+
+
+def _make_operator() -> Operator:
+    """Operator carrying a non-empty raw_jwt (the fail-closed gate passes)."""
+    return Operator(
+        sub="op-vcfa-credread",
+        name="VCFA Cred Read Operator",
+        email=None,
+        raw_jwt="op.vcfa.credread.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0fa"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _seed_descriptors(session: AsyncSession, embedding: list[float]) -> None:
+    """Insert two enabled ingested GET descriptors -- one per plane.
+
+    The descriptor rows use the ``"vcfa"`` product slug
+    :func:`parse_connector_id` derives from ``"vcfa-rest-9.0"``; the
+    connector class registers under the wider ``"vcf-automation"`` slug
+    (same dual-slug shape sddc-manager established).
+    """
+    now = datetime.now(UTC)
+    for op_id, method, path, summary in (
+        (_PROVIDER_OP_ID, "GET", _PROVIDER_OP_PATH, "Provider site root"),
+        (_TENANT_OP_ID, "GET", _TENANT_OP_PATH, "Tenant about (versions)"),
+    ):
+        session.add(
+            EndpointDescriptor(
+                id=uuid.uuid4(),
+                tenant_id=None,
+                product=_DESCRIPTOR_PRODUCT,
+                version=_VERSION,
+                impl_id=_IMPL_ID,
+                op_id=op_id,
+                source_kind="ingested",
+                method=method,
+                path=path,
+                handler_ref=None,
+                summary=summary,
+                description=summary,
+                tags=["spec:iaas" if path.startswith("/iaas/api/") else "spec:cloudapi"],
+                parameter_schema={"type": "object", "properties": {}},
+                response_schema=None,
+                llm_instructions=None,
+                safety_level="safe",
+                requires_approval=False,
+                is_enabled=True,
+                embedding=embedding,
+                custom_description=None,
+                custom_notes=None,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_executes_full_dual_plane_credread_chain_returns_ok(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The full provider+tenant cred-read chain returns status="ok" with no injected loader.
+
+    Exercises:
+
+    1. Default loader runs (no ``credentials_loader=`` injection on
+       ``VcfAutomationConnector``).
+    2. Operator-context Vault read fires under ``operator.raw_jwt``.
+    3. Provider plane: ``POST /cloudapi/1.0.0/sessions/provider`` with
+       HTTP Basic auth using the Vault-read creds -> ``X-VMWARE-VCLOUD-
+       ACCESS-TOKEN`` JWT cached as ``Authorization: Bearer ...`` on
+       the subsequent ``/cloudapi/*`` op.
+    4. Tenant plane: ``POST /iaas/api/login`` with JSON body using the
+       same Vault-read creds -> ``{"token": ...}`` cached as
+       ``Authorization: Bearer ...`` on the subsequent ``/iaas/api/*``
+       op.
+    5. Both reads return ``status="ok"`` envelopes carrying the
+       recorded-fixture payloads.
+    """
+    await _seed_descriptors(session, stub_embedding_service.encode_one.return_value)
+
+    # Vault leaf: the in-process fake returns the canary creds via the
+    # real ``load_basic_credentials`` -> ``vault_client_for_operator``
+    # path. No credentials_loader is injected anywhere — the resolver
+    # builds ``VcfAutomationConnector()`` so the default loader runs.
+    fake = install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+
+    target = _CredReadTarget()
+    operator = _make_operator()
+
+    # ``assert_all_called=False``: the connector instance is owned by
+    # the resolver cache, so any aclose teardown fires on a *later*
+    # cache reset (after this block closes), not inside it.
+    async with respx.mock(base_url=_VCFA_BASE_URL, assert_all_called=False) as mock:
+        provider_login = mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+            200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": _CANARY_PROVIDER_JWT}
+        )
+        tenant_login = mock.post("/iaas/api/login").respond(
+            200, json={"token": _CANARY_TENANT_TOKEN}
+        )
+        provider_route = mock.get(_PROVIDER_OP_PATH).respond(200, json=_PROVIDER_SITE_PAYLOAD)
+        tenant_route = mock.get(_TENANT_OP_PATH).respond(200, json=_TENANT_ABOUT_PAYLOAD)
+
+        provider_result = await dispatch(
+            operator=operator,
+            connector_id=_CONNECTOR_ID,
+            op_id=_PROVIDER_OP_ID,
+            target=target,
+            params={},
+        )
+        tenant_result = await dispatch(
+            operator=operator,
+            connector_id=_CONNECTOR_ID,
+            op_id=_TENANT_OP_ID,
+            target=target,
+            params={},
+        )
+
+    # ---- The load-bearing assertion: the chain executed end to end. ----
+    assert provider_result.status == "ok", provider_result.error
+    assert tenant_result.status == "ok", tenant_result.error
+    assert provider_result.result == _PROVIDER_SITE_PAYLOAD
+    assert tenant_result.result == _TENANT_ABOUT_PAYLOAD
+
+    # ---- The default loader actually read Vault under the operator. ----
+    # Exactly two reads -- one per plane's session-establish (provider
+    # uses target.secret_ref, tenant uses the same since
+    # provider_secret_ref is unset on the test target).
+    assert fake.auth.jwt.login_calls, "Vault JWT/OIDC login did not fire"
+    assert fake.auth.jwt.login_calls[-1]["jwt"] == operator.raw_jwt
+    assert len(fake.secrets.kv.v2.read_calls) == 2, (
+        "expected 2 KV-v2 reads (one per plane session-establish); got "
+        f"{fake.secrets.kv.v2.read_calls!r}"
+    )
+    for read in fake.secrets.kv.v2.read_calls:
+        assert read["path"] == target.secret_ref
+
+    # ---- Both plane logins + both read ops hit the mocked appliance. ----
+    assert provider_login.called and provider_login.call_count == 1
+    assert tenant_login.called and tenant_login.call_count == 1
+    assert provider_route.called and provider_route.call_count == 1
+    assert tenant_route.called and tenant_route.call_count == 1
+
+    # ---- Provider login carried HTTP Basic (header present, opaque). ----
+    sent_auth = provider_login.calls[0].request.headers.get("authorization")
+    assert sent_auth is not None and sent_auth.startswith("Basic ")
+
+    # ---- One audit/broadcast per dispatched op. ----
+    assert len(captured_events) == 2
+
+
+@pytest.mark.asyncio
+async def test_credread_chain_never_leaks_credential_or_jwt_in_result_or_logs(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No credential value and no Bearer JWT appears in OperationResult or any captured log.
+
+    Asserts the no-secret-in-logs invariant the locked decision in
+    ``docs/architecture/connector-auth.md`` requires. The grep target
+    set covers:
+
+    * the canary username + password (the KV-v2 secret values),
+    * the provider-plane JWT (the ``X-VMWARE-VCLOUD-ACCESS-TOKEN`` value),
+    * the tenant-plane bearer token (the ``token`` field value),
+    * the operator's raw JWT.
+
+    Each is asserted absent from:
+
+    * the ``OperationResult`` envelope ``repr`` (result / error / extras),
+    * every structlog event captured during the dispatch chain
+      (loader / connector / dispatcher / audit / broadcast),
+    * the broadcast event payload list.
+    """
+    await _seed_descriptors(session, stub_embedding_service.encode_one.return_value)
+
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+
+    target = _CredReadTarget()
+    operator = _make_operator()
+
+    with capture_logs() as captured:
+        async with respx.mock(base_url=_VCFA_BASE_URL, assert_all_called=False) as mock:
+            mock.post("/cloudapi/1.0.0/sessions/provider").respond(
+                200, headers={"X-VMWARE-VCLOUD-ACCESS-TOKEN": _CANARY_PROVIDER_JWT}
+            )
+            mock.post("/iaas/api/login").respond(200, json={"token": _CANARY_TENANT_TOKEN})
+            mock.get(_PROVIDER_OP_PATH).respond(200, json=_PROVIDER_SITE_PAYLOAD)
+            mock.get(_TENANT_OP_PATH).respond(200, json=_TENANT_ABOUT_PAYLOAD)
+
+            provider_result = await dispatch(
+                operator=operator,
+                connector_id=_CONNECTOR_ID,
+                op_id=_PROVIDER_OP_ID,
+                target=target,
+                params={},
+            )
+            tenant_result = await dispatch(
+                operator=operator,
+                connector_id=_CONNECTOR_ID,
+                op_id=_TENANT_OP_ID,
+                target=target,
+                params={},
+            )
+
+    assert provider_result.status == "ok", provider_result.error
+    assert tenant_result.status == "ok", tenant_result.error
+
+    secrets_to_check: tuple[str, ...] = (
+        _CANARY_PASSWORD,
+        _CANARY_USERNAME,
+        _CANARY_PROVIDER_JWT,
+        _CANARY_TENANT_TOKEN,
+        operator.raw_jwt,
+    )
+
+    for blob_name, blob in (
+        ("provider OperationResult", repr(provider_result)),
+        ("tenant OperationResult", repr(tenant_result)),
+        ("structlog capture", repr(captured)),
+        ("broadcast events", repr(captured_events)),
+    ):
+        for secret in secrets_to_check:
+            assert secret not in blob, (
+                f"{secret!r} leaked into {blob_name}; cred / JWT must not "
+                "appear in result envelopes or log events. Blob excerpt: "
+                f"{blob[:400]!r}"
+            )

--- a/backend/tests/test_connectors_vcf_automation_e2e.py
+++ b/backend/tests/test_connectors_vcf_automation_e2e.py
@@ -397,8 +397,15 @@ class _ForceHandleReducer:
 # ---------------------------------------------------------------------------
 
 
-async def _vcfa_credentials_loader(_target: object) -> dict[str, str]:
-    """Stub credentials loader -- bypasses the not-yet-wired Vault read."""
+async def _vcfa_credentials_loader(_target: object, _operator: Operator) -> dict[str, str]:
+    """Stub credentials loader -- bypasses the live Vault read for the E2E dispatch tests.
+
+    The dual-plane dispatch acceptance criteria in #840 don't exercise
+    the operator-context Vault read (that's the responsibility of the
+    cred-read recorded-fixture E2E in
+    ``test_connectors_vcf_automation_credread.py``). Keeping the stub
+    here avoids forcing every dispatch test to wire the Vault fake.
+    """
     return {"username": "svc-meho", "password": "vcfa-e2e-password"}
 
 

--- a/docs/codebase/connector-release-readiness.md
+++ b/docs/codebase/connector-release-readiness.md
@@ -136,6 +136,7 @@ flow is the only auth_model; loader is live; consumer confirmed
 | `bind9-ssh-9.x` | 2-3 | `shared_service_account` inline | ✅ |
 | `k8s-1.x` | 1 | [`load_kubeconfig_from_vault`](../../backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py#L86) — `NotImplementedError` | ❌ (mock loader in test only) |
 | `vmware-rest-9.0` | 2 | [`load_session_credentials_from_vault`](../../backend/src/meho_backplane/connectors/vmware_rest/session.py#L116) — live operator-context Vault read (G3.9-T3 [#942](https://github.com/evoila/meho/issues/942)) | ✅ (`shared_service_account`) |
+| `vcf-automation-9.0` | 2 | [`load_credentials_from_vault`](../../backend/src/meho_backplane/connectors/vcf_automation/session.py) — live operator-context Vault read via the shared [`load_basic_credentials`](../../backend/src/meho_backplane/connectors/_shared/vault_creds.py) helper; `operator` threaded through the bespoke dual-plane auth (G3.10-T3 [#947](https://github.com/evoila/meho/issues/947)) | ✅ (`shared_service_account`) |
 | `sddc-manager-9.0` | 0.5 | Class-side registered, no ops yet, loader stubbed | ❌ |
 | `harbor-2.x` | 0.5 | Class-side registered, no ops yet, loader stubbed | ❌ |
 | `kubernetes-asyncio-1.x` | 1 (shadow) | Same as `k8s-1.x` | ❌ |


### PR DESCRIPTION
## Summary

- Wires the vcf-automation connector's `NotImplementedError` loader stub to the live operator-context Vault KV-v2 read via the shared `_shared/vault_creds.load_basic_credentials` helper (#941), moving the connector from rubric State 1 → State 2 (`shared_service_account` live).
- Threads `operator` through the bespoke dual-plane auth — both `_provider_session_token` and `_tenant_session_token` now forward `(target, operator)` to the loader so each plane's first-use Vault read happens under the operator's Vault Identity entity (the locked Option A decision in `docs/architecture/connector-auth.md`).
- Adds a recorded-fixture E2E (`test_connectors_vcf_automation_credread.py`) proving the full chain in the secret-free unit lane and asserting no credential value, no provider/tenant Bearer token, and no operator JWT leaks into any log event or `OperationResult` field.

## Test plan

- [x] `ruff check` — clean across changed files
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane` — 253 source files, no issues
- [x] `pytest -x -q tests/test_connectors_vcf_automation_auth.py` — 43 passed (default-loader fail-closed test rewritten to assert `VaultCredentialsReadError` on empty operator JWT; `auth_model != shared_service_account` still raises)
- [x] `pytest -x -q tests/test_connectors_vcf_automation_e2e.py tests/test_connectors_vcf_automation_credread.py` — 20 passed (2 new credread tests + 18 existing E2E dispatch tests pass with the updated 2-arg stub loader)
- [x] Broader unit sweep `pytest -q -k "vcf or vault or vmware_rest"` — 597 passed, 13 env-gated skipped, no regressions
- [x] `python3 .claude/hooks/code-quality.py --diff` — pass (1 pre-existing file-size warning on `connector.py`, no agent-introduced blockers)

Acceptance criteria from #947:

- [x] vcf-automation default loader performs the live read via #941; `rg "deliberate stub" backend/src/meho_backplane/connectors/vcf_automation/` returns nothing.
- [x] `operator` is threaded through the dual-plane auth to the loader; `mypy` clean.
- [x] Recorded-fixture E2E covers provider-login → tenant-login → read, returns `status="ok"`, asserts no credential value (and no Bearer JWT) in result/captured logs, runs secret-free in default `pytest -n auto`.
- [x] Injected-loader unit tests updated to the 2-arg shape; `auth_model="per_user"` still raises (existing `test_auth_headers_rejects_non_shared_service_account_modes` covers this).
- [x] `ruff` + `mypy` clean; `docs/codebase/connector-release-readiness.md` updated: vcf-automation-9.0 row added at State 2.

## Out of scope

- nsx/harbor/sddc, vROps/vRLI/Fleet, k8s — sibling tasks #945, #946, #948.
- vcf-automation CLI verbs / onboarding doc (shipped under G3.6 #895); `--fqdn` vhost routing (already implemented).
- `per_user` / `impersonation`; rotation; dynamic-secret support.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #947


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end testing for vcf-automation connector operations and credential management
  * Implemented security invariant tests to ensure sensitive data is not leaked in results or logs

* **Chores**
  * Enhanced credential loading to support operator context for improved security and auditability
  * Updated connector production readiness documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/971?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->