### PR TITLE
feat(connectors): G3.10-T1 wire nsx + harbor + sddc-manager loaders to operator-context Vault read + recorded-fixture E2E (State 2)

### DIFF
--- a/backend/src/meho_backplane/connectors/harbor/connector.py
+++ b/backend/src/meho_backplane/connectors/harbor/connector.py
@@ -201,11 +201,13 @@ class HarborConnector(HttpConnector):
         """Return ``{"Authorization": "Basic ..."}`` for the request.
 
         Loads credentials from Vault on first call against *target*, caches
-        them, and reuses the cached values on subsequent calls. ``operator``
-        is accepted for the shared HTTP auth surface (G3.9-T1) but unused —
-        :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` authenticates with a
-        Vault-sourced service account, not the operator's OIDC token.
-        Threading the operator into Harbor's credential loader is #G3.10.
+        them, and reuses the cached values on subsequent calls. The full
+        ``operator`` is forwarded to :meth:`_load_credentials` so the live
+        default loader (G3.10-T1 #945) reads the per-target Vault secret
+        under the operator's identity (``vault_client_for_operator(operator)``).
+        :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` selects the Vault-sourced
+        service account once the loader has resolved it; the operator's
+        JWT only authenticates the read, not the Harbor request itself.
 
         The Basic auth username is sent verbatim from the Vault-loaded
         credentials — no ``sso_realm`` suffix is appended. Both admin
@@ -215,7 +217,6 @@ class HarborConnector(HttpConnector):
         Raises :exc:`NotImplementedError` if ``target.auth_model`` is
         anything other than ``shared_service_account`` or ``None``.
         """
-        del operator  # SHARED_SERVICE_ACCOUNT mode does not forward operator identity
         auth_model = getattr(target, "auth_model", None)
         if not _is_acceptable_auth_model(auth_model):
             raise NotImplementedError(
@@ -223,10 +224,12 @@ class HarborConnector(HttpConnector):
                 f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
                 f"{target.name!r} requested auth_model={auth_model!r}"
             )
-        creds = await self._load_credentials(target)
+        creds = await self._load_credentials(target, operator)
         return {"Authorization": _basic_auth_header(creds["username"], creds["password"])}
 
-    async def _load_credentials(self, target: HarborTargetLike) -> dict[str, str]:
+    async def _load_credentials(
+        self, target: HarborTargetLike, operator: Operator
+    ) -> dict[str, str]:
         """Return the cached credentials for *target*, loading from Vault on first use.
 
         The lock serialises concurrent first-use callers for the same target;
@@ -234,12 +237,20 @@ class HarborConnector(HttpConnector):
         dict must contain ``"username"`` and ``"password"`` keys; missing
         keys raise a :exc:`RuntimeError` naming the target and the missing
         key so operators can identify a misconfigured Vault path.
+
+        ``operator`` is forwarded to the
+        :class:`HarborCredentialsLoader` so the default loader can read
+        the per-target Vault secret under the operator's identity
+        (G3.10-T1's live read). The default loader is the thin
+        harbor-specific entry point to the shared operator-context
+        Vault read; injected test loaders accept the same
+        ``(target, operator)`` pair.
         """
         async with self._creds_lock:
             cached = self._creds_cache.get(target.name)
             if cached is not None:
                 return cached
-            raw = await self._credentials_loader(target)
+            raw = await self._credentials_loader(target, operator)
             try:
                 _ = raw["username"]
                 _ = raw["password"]

--- a/backend/src/meho_backplane/connectors/harbor/session.py
+++ b/backend/src/meho_backplane/connectors/harbor/session.py
@@ -13,19 +13,19 @@ The credential fetch (Vault path → ``{"username": ..., "password": ...}``
 dict) is split out behind a narrow :class:`HarborCredentialsLoader` callable
 so:
 
-* Production deploys override the default loader at construction time once
-  the operator-context per-target Vault credential read is wired for this
-  connector (tracked under the open
-  `Goal #214 (Connector parity) <https://github.com/evoila/meho/issues/214>`_).
+* Production deploys reuse the default loader, which now performs the
+  **live** operator-context KV-v2 read via the shared
+  :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+  helper (G3.10-T1 #945).
 * Unit tests inject their own (mock) loader returning a pre-built dict.
 * Integration tests pass a loader that yields the appropriate service-account
   credentials.
 
-The default loader, :func:`load_credentials_from_vault`, raises
-:exc:`NotImplementedError` until the live read lands. Mirrors the shape
-:func:`~meho_backplane.connectors.sddc_manager.session.load_credentials_from_vault`
-established for :class:`SddcManagerConnector` — both stubs are tracked
-under the open Goal #214 and switch over together.
+The default loader, :func:`load_credentials_from_vault`, performs the live
+operator-context KV-v2 read by delegating to
+:func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`.
+This is the rubric **State 2** wiring (`shared_service_account` only) per
+`Goal #214 (Connector parity) <https://github.com/evoila/meho/issues/214>`_.
 
 Harbor supports two account forms:
 
@@ -50,6 +50,9 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from typing import Protocol, runtime_checkable
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.vault_creds import load_basic_credentials
 
 __all__ = [
     "HarborCredentialsLoader",
@@ -82,9 +85,14 @@ class HarborTargetLike(Protocol):
     rather than silently authenticating as the shared service account.
 
     ``secret_ref`` is the Vault path the loader resolves to a
-    :class:`SessionCredentials`-shaped dict. ``port`` is optional —
-    Harbor defaults to 443 and :meth:`HttpConnector._base_url` already
-    handles the ``port is None or 443`` case correctly.
+    :class:`SessionCredentials`-shaped dict. It is ``str | None`` to
+    match the concrete ``Target.secret_ref`` column (nullable) and the
+    shared :class:`~meho_backplane.connectors._shared.vault_creds.BasicCredentialsTargetLike`
+    the loader forwards to; an unset ``secret_ref`` is rejected with a
+    clear error inside the loader (an unconfigured target), never a
+    bare ``KeyError``. ``port`` is optional — Harbor defaults to 443
+    and :meth:`HttpConnector._base_url` already handles the
+    ``port is None or 443`` case correctly.
 
     No ``sso_realm`` field — Harbor sends ``username:password`` as-is;
     no realm suffix is appended.
@@ -93,46 +101,66 @@ class HarborTargetLike(Protocol):
     name: str
     host: str
     port: int | None
-    secret_ref: str
+    secret_ref: str | None
     auth_model: str | None
 
 
-HarborCredentialsLoader = Callable[[HarborTargetLike], Awaitable[dict[str, str]]]
-"""Async callable resolving a target to ``{"username": ..., "password": ...}``.
+HarborCredentialsLoader = Callable[[HarborTargetLike, Operator], Awaitable[dict[str, str]]]
+"""Async callable resolving a (target, operator) pair to credentials.
 
-The connector's :meth:`HarborConnector._load_credentials` invokes the
-loader exactly once per target (first-use), caching the resulting dict under
+Returns ``{"username": ..., "password": ...}``. The connector's
+:meth:`HarborConnector._load_credentials` invokes the loader exactly
+once per target (first-use), caching the resulting dict under
 ``target.name``. The return type is the looser ``dict[str, str]`` (not
 :class:`SessionCredentials`) because Python :class:`Protocol` instances
 aren't runtime-constructible without a matching class — production code
 returns a plain dict and the connector reads ``creds["username"]`` /
 ``creds["password"]`` by key.
+
+The ``operator`` parameter carries the full
+:class:`~meho_backplane.auth.operator.Operator` (frozen) so the live
+loader reads the per-target secret under the operator's identity via
+``vault_client_for_operator(operator)`` — the locked decision in
+[docs/architecture/connector-auth.md](docs/architecture/connector-auth.md).
 """
 
 
 async def load_credentials_from_vault(
     target: HarborTargetLike,
+    operator: Operator,
 ) -> dict[str, str]:
-    """Default credential loader — Vault read by ``target.secret_ref``.
+    """Default credential loader — live operator-context Vault KV-v2 read.
 
-    Deliberate stub: the operator-context per-target Vault credential read
-    is not yet wired for the Harbor connector. Raising
-    :exc:`NotImplementedError` here keeps the wiring shape stable — a
-    production caller without an override receives a clear error rather
-    than a silent fallback or a hallucinated credential pair. The supported
-    workaround is to inject a custom ``credentials_loader`` on
-    ``HarborConnector`` at construction time. The live read is tracked
-    under the open Goal #214 (Connector parity).
+    Reads ``target.secret_ref`` as a KV-v2 secret **under the operator's
+    identity** (the operator's validated Keycloak JWT is forwarded to
+    Vault's JWT/OIDC auth method) and returns the service-account
+    ``{"username": ..., "password": ...}`` pair the connector sends as
+    HTTP Basic auth on every Harbor API call. Delegates to the shared
+    :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+    helper (G3.9-T2 #941) so the read, the no-secret-in-logs discipline,
+    and the two-phase error contract are defined once for every REST
+    connector — this loader is the thin harbor-specific entry point.
 
-    Once the read lands, this function becomes the live implementation that
-    reads the ``harbor/<target.name>`` Vault path and returns the parsed
-    ``{"username": ..., "password": ...}`` dict.
+    Both admin usernames (``"admin"``) and robot account usernames
+    (``"robot$project+name"``) are stored verbatim in Vault; the helper
+    returns the stored string as-is so the connector sends it unchanged
+    on the Basic auth header.
+
+    The error contract is the helper's:
+
+    * :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`
+      — read-phase failure (empty ``operator.raw_jwt`` for a
+      system-initiated call, unset ``target.secret_ref``, a malformed
+      KV-v2 payload, or a missing ``username``/``password`` field).
+      Never a bare ``KeyError``.
+    * :class:`~meho_backplane.auth.vault.VaultClientError` (and its
+      subclasses) — login-phase failure (Vault unreachable, role
+      denied). Propagated verbatim so callers can distinguish login
+      from read.
+
+    A custom :class:`HarborCredentialsLoader` can still be injected via
+    ``credentials_loader`` on :class:`HarborConnector` (tests do exactly
+    that); this default is what production targets at rubric State 2
+    (`shared_service_account`) use.
     """
-    raise NotImplementedError(
-        "load_credentials_from_vault is a deliberate stub: the operator-context "
-        "per-target Vault credential read is not yet wired for the Harbor "
-        f"connector; target={target.name!r} secret_ref={target.secret_ref!r}. "
-        "Workaround: inject a custom credentials_loader on HarborConnector. "
-        "Tracked under open Goal #214 (Connector parity): "
-        "https://github.com/evoila/meho/issues/214"
-    )
+    return await load_basic_credentials(target, operator)

--- a/backend/src/meho_backplane/connectors/nsx/connector.py
+++ b/backend/src/meho_backplane/connectors/nsx/connector.py
@@ -56,6 +56,14 @@ clear :exc:`NotImplementedError` naming the target + the requested
 mode. Per-user and impersonation modes are deferred to v0.2.next,
 same posture the vSphere precedent established.
 
+The operator's validated Keycloak JWT is forwarded through
+:meth:`auth_headers` -> :meth:`_session_token` -> the
+:class:`NsxSessionLoader` so the live default loader reads the
+per-target Vault secret under the operator's identity (G3.10-T1 #945,
+following the G3.9 vmware-rest precedent). The NSX session establish
+itself stays HTTP-form against the resolved service account -- the
+operator's JWT authenticates the Vault read, not the NSX login.
+
 Session lifecycle
 -----------------
 
@@ -187,11 +195,14 @@ class NsxConnector(HttpConnector):
         """Return ``{"X-XSRF-TOKEN": <token>}`` for the request.
 
         Lazily establishes the session on first call against *target*;
-        subsequent calls reuse the cached token. ``operator`` is accepted
-        for the shared HTTP auth surface (G3.9-T1) but unused --
-        :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` authenticates with a
-        Vault-sourced service account, not the operator's OIDC token.
-        Threading the operator into NSX's credential loader is #G3.10.
+        subsequent calls reuse the cached token. The full ``operator`` is
+        forwarded to :meth:`_session_token` so the live default loader
+        (G3.10-T1 #945) can read the per-target secret under the
+        operator's identity (``vault_client_for_operator(operator)``).
+        :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` selects the
+        Vault-sourced service account once the loader has resolved it;
+        the operator's JWT only authenticates the read, not the NSX
+        session itself.
 
         The JSESSIONID cookie that pairs with this XSRF token lives in
         the per-target client's cookie jar
@@ -202,7 +213,6 @@ class NsxConnector(HttpConnector):
         requested mode in the message) if ``target.auth_model`` is
         anything other than ``shared_service_account`` or ``None``.
         """
-        del operator  # SHARED_SERVICE_ACCOUNT does not forward operator identity
         auth_model = getattr(target, "auth_model", None)
         if not _is_acceptable_auth_model(auth_model):
             raise NotImplementedError(
@@ -210,10 +220,10 @@ class NsxConnector(HttpConnector):
                 f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
                 f"{target.name!r} requested auth_model={auth_model!r}"
             )
-        token = await self._session_token(target)
+        token = await self._session_token(target, operator)
         return {_XSRF_HEADER: token}
 
-    async def _session_token(self, target: NsxTargetLike) -> str:
+    async def _session_token(self, target: NsxTargetLike, operator: Operator) -> str:
         """Return the cached XSRF token for *target*, establishing one on first use.
 
         The lock serialises concurrent first-use for one target; the
@@ -227,12 +237,20 @@ class NsxConnector(HttpConnector):
         and ``Set-Cookie: JSESSIONID=...`` which the per-target httpx
         client jar captures automatically. The response body is not
         used.
+
+        ``operator`` is forwarded to the
+        :class:`NsxSessionLoader` so the default loader can read the
+        per-target Vault secret under the operator's identity
+        (G3.10-T1's live read). The default loader is the thin
+        nsx-specific entry point to the shared operator-context Vault
+        read; injected test loaders accept the same
+        ``(target, operator)`` pair.
         """
         async with self._session_lock:
             cached = self._session_tokens.get(target.name)
             if cached is not None:
                 return cached
-            creds = await self._session_loader(target)
+            creds = await self._session_loader(target, operator)
             try:
                 username = creds["username"]
                 password = creds["password"]

--- a/backend/src/meho_backplane/connectors/nsx/session.py
+++ b/backend/src/meho_backplane/connectors/nsx/session.py
@@ -10,33 +10,38 @@ NSX's ``POST /api/session/create`` endpoint (form-encoded
 service-account ``{"username": ..., "password": ...}`` dict) is split out
 behind a narrow :class:`NsxSessionLoader` callable so:
 
-* Production deploys override the default loader at construction time
-  once G0.3 (#224) lands the operator-context Vault read path.
+* Production deploys reuse the default loader, which now performs the
+  **live** operator-context KV-v2 read via the shared
+  :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+  helper (G3.10-T1 #945). The vertical-slice precedent is G3.9-T3 #942 on
+  :mod:`meho_backplane.connectors.vmware_rest`.
 * Unit tests inject their own (mock) loader returning a pre-built dict.
 * Integration tests against a recorded-fixture or live NSX target pass a
   loader that yields the appropriate service-account credentials.
 
-The default loader, :func:`load_session_credentials_from_vault`, raises
-:exc:`NotImplementedError` until G0.3 (#224) merges. Mirrors the shape
-:func:`~meho_backplane.connectors.vmware_rest.session.load_session_credentials_from_vault`
-established for :class:`VmwareRestConnector` -- once the Target model +
-operator-context Vault reads land, both loaders pick up the concrete
-implementation in a single follow-up commit.
+The default loader, :func:`load_session_credentials_from_vault`, performs
+the live operator-context KV-v2 read by delegating to
+:func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`.
+This is the rubric **State 2** wiring (`shared_service_account` only) per
+`Goal #214 (Connector parity) <https://github.com/evoila/meho/issues/214>`_.
 
 The :class:`NsxTargetLike` Protocol captures the minimum target shape
 the connector reads: ``name`` (for the per-target session-token cache
 key), ``host``, ``port`` (forwarded to :meth:`HttpConnector._base_url`),
 ``secret_ref`` (the Vault path the loader resolves), and ``auth_model``
 (checked by :meth:`NsxConnector.auth_headers` to reject ``per_user`` /
-``impersonation`` targets at the boundary). Once G0.3 ships its
-concrete ``Target`` model in :mod:`meho_backplane.targets`, the model
-satisfies this Protocol structurally -- no edits here.
+``impersonation`` targets at the boundary). The concrete ``Target``
+model in :mod:`meho_backplane.targets` satisfies this Protocol
+structurally; no edits here.
 """
 
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from typing import Protocol, runtime_checkable
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.vault_creds import load_basic_credentials
 
 __all__ = [
     "NsxSessionLoader",
@@ -63,62 +68,81 @@ class SessionCredentials(Protocol):
 class NsxTargetLike(Protocol):
     """Minimum target shape :class:`NsxConnector` reads.
 
-    Structural Protocol -- once G0.3 (#224) lands the concrete
-    ``Target`` model in :mod:`meho_backplane.targets`, that model
-    satisfies this Protocol unchanged. ``auth_model`` is checked at the
-    boundary so a target tagged ``per_user`` or ``impersonation`` raises
-    a clear error rather than silently authenticating as the shared
-    service account.
+    Structural Protocol -- the concrete ``Target`` model in
+    :mod:`meho_backplane.targets` satisfies this Protocol unchanged.
+    ``auth_model`` is checked at the boundary so a target tagged
+    ``per_user`` or ``impersonation`` raises a clear error rather than
+    silently authenticating as the shared service account.
 
     ``secret_ref`` is the Vault path the loader resolves to a
-    :class:`SessionCredentials`-shaped dict. ``port`` is optional --
-    NSX manager defaults to 443 and
-    :meth:`HttpConnector._base_url` already handles the
+    :class:`SessionCredentials`-shaped dict. It is ``str | None`` to
+    match the concrete ``Target.secret_ref`` column (nullable) and the
+    shared :class:`~meho_backplane.connectors._shared.vault_creds.BasicCredentialsTargetLike`
+    the loader forwards to; an unset ``secret_ref`` is rejected with a
+    clear error inside the loader (an unconfigured target), never a
+    bare ``KeyError``. ``port`` is optional -- NSX manager defaults to
+    443 and :meth:`HttpConnector._base_url` already handles the
     ``port is None or 443`` case correctly.
     """
 
     name: str
     host: str
     port: int | None
-    secret_ref: str
+    secret_ref: str | None
     auth_model: str | None
 
 
-NsxSessionLoader = Callable[[NsxTargetLike], Awaitable[dict[str, str]]]
-"""Async callable resolving a target to ``{"username": ..., "password": ...}``.
+NsxSessionLoader = Callable[[NsxTargetLike, Operator], Awaitable[dict[str, str]]]
+"""Async callable resolving a (target, operator) pair to credentials.
 
-The connector's :meth:`NsxConnector._session_token` invokes the loader
-on every session-establish (first use against a target, and again after
-a 401-driven invalidation). The return type is the looser
+Returns ``{"username": ..., "password": ...}``. The connector's
+:meth:`NsxConnector._session_token` invokes the loader on every
+session-establish (first use against a target, and again after a
+401-driven invalidation). The return type is the looser
 ``dict[str, str]`` (not :class:`SessionCredentials`) because Python
 :class:`Protocol` instances aren't runtime-constructible without a
 matching class -- production code returns a plain dict and the
 connector reads ``creds["username"]`` / ``creds["password"]`` by key.
+
+The ``operator`` parameter carries the full
+:class:`~meho_backplane.auth.operator.Operator` (frozen) so the live
+loader reads the per-target secret under the operator's identity via
+``vault_client_for_operator(operator)`` -- the locked decision in
+[docs/architecture/connector-auth.md](docs/architecture/connector-auth.md).
 """
 
 
 async def load_session_credentials_from_vault(
     target: NsxTargetLike,
+    operator: Operator,
 ) -> dict[str, str]:
-    """Default credential loader -- Vault read by ``target.secret_ref``.
+    """Default credential loader -- live operator-context Vault KV-v2 read.
 
-    Stubbed until G0.3 (#224) lands the ``Target`` model and the
-    operator-context Vault read path. Mirrors
-    :func:`~meho_backplane.connectors.vmware_rest.session.load_session_credentials_from_vault`'s
-    ``NotImplementedError`` stub so the wiring shape is stable: a
-    production caller without an explicit loader override receives a
-    clear error rather than a silent fallback or a hallucinated
-    credential pair.
+    Reads ``target.secret_ref`` as a KV-v2 secret **under the operator's
+    identity** (the operator's validated Keycloak JWT is forwarded to
+    Vault's JWT/OIDC auth method) and returns the service-account
+    ``{"username": ..., "password": ...}`` pair the connector POSTs to
+    ``/api/session/create`` (form-encoded). Delegates to the shared
+    :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+    helper (G3.9-T2 #941) so the read, the no-secret-in-logs discipline,
+    and the two-phase error contract are defined once for every REST
+    connector -- this loader is the thin nsx-specific entry point.
 
-    Once G0.3 lands, this function becomes the live implementation that
-    reads the ``nsx/<target.name>`` Vault path and returns the parsed
-    ``{"username": ..., "password": ...}`` dict. Until then, tests and
-    any acceptance harness inject a custom :class:`NsxSessionLoader` on
-    connector construction.
+    The error contract is the helper's:
+
+    * :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`
+      -- read-phase failure (empty ``operator.raw_jwt`` for a
+      system-initiated call, unset ``target.secret_ref``, a malformed
+      KV-v2 payload, or a missing ``username``/``password`` field).
+      Never a bare ``KeyError``.
+    * :class:`~meho_backplane.auth.vault.VaultClientError` (and its
+      subclasses) -- login-phase failure (Vault unreachable, role
+      denied). Propagated verbatim so callers can distinguish login
+      from read.
+
+    A custom :class:`NsxSessionLoader` can still be injected via
+    ``session_loader`` on :class:`NsxConnector` (tests do exactly that);
+    this default is what production targets at rubric State 2
+    (`shared_service_account`) use.
     """
-    raise NotImplementedError(
-        "load_session_credentials_from_vault requires G0.3 Target model + "
-        f"operator-context Vault read; target={target.name!r} "
-        f"secret_ref={target.secret_ref!r}. Inject a custom session_loader "
-        "on NsxConnector until G0.3 lands."
-    )
+    return await load_basic_credentials(target, operator)

--- a/backend/src/meho_backplane/connectors/sddc_manager/connector.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/connector.py
@@ -156,12 +156,14 @@ class SddcManagerConnector(HttpConnector):
         """Return ``{"Authorization": "Basic ..."}`` for the request.
 
         Loads credentials from Vault on first call against *target*, caches
-        them, and reuses the cached values on subsequent calls. ``operator``
-        is accepted for the shared HTTP auth surface (G3.9-T1) but unused —
-        :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` authenticates with a
-        Vault-sourced service account, not the operator's OIDC token.
-        Threading the operator into SDDC Manager's credential loader is
-        #G3.10.
+        them, and reuses the cached values on subsequent calls. The full
+        ``operator`` is forwarded to :meth:`_load_credentials` so the live
+        default loader (G3.10-T1 #945) reads the per-target Vault secret
+        under the operator's identity (``vault_client_for_operator(operator)``).
+        :attr:`AuthModel.SHARED_SERVICE_ACCOUNT` selects the Vault-sourced
+        service account once the loader has resolved it; the operator's
+        JWT only authenticates the read, not the SDDC Manager request
+        itself.
 
         The Basic auth username is ``{creds['username']}@{target.sso_realm}``
         where ``sso_realm`` defaults to ``"vsphere.local"`` when unset or
@@ -170,7 +172,6 @@ class SddcManagerConnector(HttpConnector):
         Raises :exc:`NotImplementedError` if ``target.auth_model`` is
         anything other than ``shared_service_account`` or ``None``.
         """
-        del operator  # SHARED_SERVICE_ACCOUNT mode does not forward operator identity
         auth_model = getattr(target, "auth_model", None)
         if not _is_acceptable_auth_model(auth_model):
             raise NotImplementedError(
@@ -178,12 +179,12 @@ class SddcManagerConnector(HttpConnector):
                 f"{AuthModel.SHARED_SERVICE_ACCOUNT.value!r}; target "
                 f"{target.name!r} requested auth_model={auth_model!r}"
             )
-        creds = await self._load_credentials(target)
+        creds = await self._load_credentials(target, operator)
         sso_realm = getattr(target, "sso_realm", None) or _DEFAULT_SSO_REALM
         auth_username = f"{creds['username']}@{sso_realm}"
         return {"Authorization": _basic_auth_header(auth_username, creds["password"])}
 
-    async def _load_credentials(self, target: SddcTargetLike) -> dict[str, str]:
+    async def _load_credentials(self, target: SddcTargetLike, operator: Operator) -> dict[str, str]:
         """Return the cached credentials for *target*, loading from Vault on first use.
 
         The lock serialises concurrent first-use callers for the same target;
@@ -191,12 +192,20 @@ class SddcManagerConnector(HttpConnector):
         dict must contain ``"username"`` and ``"password"`` keys; missing
         keys raise a :exc:`RuntimeError` naming the target and the missing
         key so operators can identify a misconfigured Vault path.
+
+        ``operator`` is forwarded to the
+        :class:`SddcCredentialsLoader` so the default loader can read
+        the per-target Vault secret under the operator's identity
+        (G3.10-T1's live read). The default loader is the thin
+        sddc-manager-specific entry point to the shared
+        operator-context Vault read; injected test loaders accept the
+        same ``(target, operator)`` pair.
         """
         async with self._creds_lock:
             cached = self._creds_cache.get(target.name)
             if cached is not None:
                 return cached
-            raw = await self._credentials_loader(target)
+            raw = await self._credentials_loader(target, operator)
             try:
                 _ = raw["username"]
                 _ = raw["password"]

--- a/backend/src/meho_backplane/connectors/sddc_manager/session.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/session.py
@@ -13,19 +13,19 @@ The credential fetch (Vault path → ``{"username": ..., "password": ...}``
 dict) is split out behind a narrow :class:`SddcCredentialsLoader` callable
 so:
 
-* Production deploys override the default loader at construction time once
-  the operator-context per-target Vault credential read is wired for this
-  connector (tracked under the open
-  `Goal #214 (Connector parity) <https://github.com/evoila/meho/issues/214>`_).
+* Production deploys reuse the default loader, which now performs the
+  **live** operator-context KV-v2 read via the shared
+  :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+  helper (G3.10-T1 #945).
 * Unit tests inject their own (mock) loader returning a pre-built dict.
 * Integration tests pass a loader that yields the appropriate service-account
   credentials.
 
-The default loader, :func:`load_credentials_from_vault`, raises
-:exc:`NotImplementedError` until the live read lands. Mirrors the shape
-:func:`~meho_backplane.connectors.vmware_rest.session.load_session_credentials_from_vault`
-established for :class:`VmwareRestConnector` — both stubs are tracked
-under the open Goal #214 and switch over together.
+The default loader, :func:`load_credentials_from_vault`, performs the live
+operator-context KV-v2 read by delegating to
+:func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`.
+This is the rubric **State 2** wiring (`shared_service_account` only) per
+`Goal #214 (Connector parity) <https://github.com/evoila/meho/issues/214>`_.
 
 The :class:`SddcTargetLike` Protocol captures the minimum target shape the
 connector reads: ``name`` (for the per-target credential cache key), ``host``,
@@ -41,6 +41,9 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from typing import Protocol, runtime_checkable
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.vault_creds import load_basic_credentials
 
 __all__ = [
     "SddcCredentialsLoader",
@@ -74,9 +77,14 @@ class SddcTargetLike(Protocol):
     rather than silently authenticating as the shared service account.
 
     ``secret_ref`` is the Vault path the loader resolves to a
-    :class:`SessionCredentials`-shaped dict. ``port`` is optional —
-    SDDC Manager defaults to 443 and :meth:`HttpConnector._base_url`
-    already handles the ``port is None or 443`` case correctly.
+    :class:`SessionCredentials`-shaped dict. It is ``str | None`` to
+    match the concrete ``Target.secret_ref`` column (nullable) and the
+    shared :class:`~meho_backplane.connectors._shared.vault_creds.BasicCredentialsTargetLike`
+    the loader forwards to; an unset ``secret_ref`` is rejected with a
+    clear error inside the loader (an unconfigured target), never a
+    bare ``KeyError``. ``port`` is optional — SDDC Manager defaults to
+    443 and :meth:`HttpConnector._base_url` already handles the
+    ``port is None or 443`` case correctly.
 
     ``sso_realm`` is the vSphere SSO domain appended to ``username`` when
     constructing the Basic auth header (``username@sso_realm``). Defaults
@@ -87,47 +95,64 @@ class SddcTargetLike(Protocol):
     name: str
     host: str
     port: int | None
-    secret_ref: str
+    secret_ref: str | None
     auth_model: str | None
     sso_realm: str
 
 
-SddcCredentialsLoader = Callable[[SddcTargetLike], Awaitable[dict[str, str]]]
-"""Async callable resolving a target to ``{"username": ..., "password": ...}``.
+SddcCredentialsLoader = Callable[[SddcTargetLike, Operator], Awaitable[dict[str, str]]]
+"""Async callable resolving a (target, operator) pair to credentials.
 
-The connector's :meth:`SddcManagerConnector._load_credentials` invokes the
-loader exactly once per target (first-use), caching the resulting dict under
+Returns ``{"username": ..., "password": ...}``. The connector's
+:meth:`SddcManagerConnector._load_credentials` invokes the loader
+exactly once per target (first-use), caching the resulting dict under
 ``target.name``. The return type is the looser ``dict[str, str]`` (not
 :class:`SessionCredentials`) because Python :class:`Protocol` instances
 aren't runtime-constructible without a matching class — production code
 returns a plain dict and the connector reads ``creds["username"]`` /
 ``creds["password"]`` by key.
+
+The ``operator`` parameter carries the full
+:class:`~meho_backplane.auth.operator.Operator` (frozen) so the live
+loader reads the per-target secret under the operator's identity via
+``vault_client_for_operator(operator)`` — the locked decision in
+[docs/architecture/connector-auth.md](docs/architecture/connector-auth.md).
 """
 
 
 async def load_credentials_from_vault(
     target: SddcTargetLike,
+    operator: Operator,
 ) -> dict[str, str]:
-    """Default credential loader — Vault read by ``target.secret_ref``.
+    """Default credential loader — live operator-context Vault KV-v2 read.
 
-    Deliberate stub: the operator-context per-target Vault credential read
-    is not yet wired for the SDDC Manager connector. Raising
-    :exc:`NotImplementedError` here keeps the wiring shape stable — a
-    production caller without an override receives a clear error rather
-    than a silent fallback or a hallucinated credential pair. The supported
-    workaround is to inject a custom ``credentials_loader`` on
-    ``SddcManagerConnector`` at construction time. The live read is
-    tracked under the open Goal #214 (Connector parity).
+    Reads ``target.secret_ref`` as a KV-v2 secret **under the operator's
+    identity** (the operator's validated Keycloak JWT is forwarded to
+    Vault's JWT/OIDC auth method) and returns the service-account
+    ``{"username": ..., "password": ...}`` pair the connector sends as
+    HTTP Basic auth on every SDDC Manager API call. Delegates to the
+    shared
+    :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+    helper (G3.9-T2 #941) so the read, the no-secret-in-logs discipline,
+    and the two-phase error contract are defined once for every REST
+    connector — this loader is the thin sddc-manager-specific entry
+    point.
 
-    Once the read lands, this function becomes the live implementation that
-    reads the ``sddc-manager/<target.name>`` Vault path and returns the
-    parsed ``{"username": ..., "password": ...}`` dict.
+    The error contract is the helper's:
+
+    * :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`
+      — read-phase failure (empty ``operator.raw_jwt`` for a
+      system-initiated call, unset ``target.secret_ref``, a malformed
+      KV-v2 payload, or a missing ``username``/``password`` field).
+      Never a bare ``KeyError``.
+    * :class:`~meho_backplane.auth.vault.VaultClientError` (and its
+      subclasses) — login-phase failure (Vault unreachable, role
+      denied). Propagated verbatim so callers can distinguish login
+      from read.
+
+    A custom :class:`SddcCredentialsLoader` can still be injected via
+    ``credentials_loader`` on :class:`SddcManagerConnector` (tests do
+    exactly that); this default is what production targets at rubric
+    State 2 (`shared_service_account`) use.
     """
-    raise NotImplementedError(
-        "load_credentials_from_vault is a deliberate stub: the operator-context "
-        "per-target Vault credential read is not yet wired for the SDDC Manager "
-        f"connector; target={target.name!r} secret_ref={target.secret_ref!r}. "
-        "Workaround: inject a custom credentials_loader on SddcManagerConnector. "
-        "Tracked under open Goal #214 (Connector parity): "
-        "https://github.com/evoila/meho/issues/214"
-    )
+    return await load_basic_credentials(target, operator)

--- a/backend/tests/acceptance/_harbor_canary_fixtures.py
+++ b/backend/tests/acceptance/_harbor_canary_fixtures.py
@@ -440,8 +440,15 @@ def _param_schema_for(path: str) -> dict[str, object]:
     }
 
 
-async def _harbor_credentials_loader(_target: HarborTargetLike) -> dict[str, str]:
-    """Stub credentials loader — bypasses the not-yet-wired Vault read."""
+async def _harbor_credentials_loader(
+    _target: HarborTargetLike, _operator: Operator
+) -> dict[str, str]:
+    """Stub credentials loader — bypasses the live operator-context Vault read.
+
+    The 2-arg signature matches the
+    :class:`~meho_backplane.connectors.harbor.session.HarborCredentialsLoader`
+    G3.10-T1 (#945) introduced.
+    """
     return {"username": "harbor-canary-svc", "password": "harbor-canary-pw"}
 
 

--- a/backend/tests/acceptance/_nsx_canary_fixtures.py
+++ b/backend/tests/acceptance/_nsx_canary_fixtures.py
@@ -331,13 +331,15 @@ def _param_schema_for(path: str) -> dict[str, object]:
     }
 
 
-async def _nsx_session_loader(_target: object) -> dict[str, str]:
-    """Stub session loader — bypasses the not-yet-wired Vault read.
+async def _nsx_session_loader(_target: object, _operator: Operator) -> dict[str, str]:
+    """Stub session loader — bypasses the live operator-context Vault read.
 
     The respx ``POST /api/session/create`` route accepts any pair, so
     the values are illustrative. Mirrors the same pattern
     :func:`tests.acceptance._canary_fixtures._vcenter_rest_session_loader`
-    uses for vSphere.
+    uses for vSphere; the ``_operator`` argument matches the 2-arg
+    :class:`~meho_backplane.connectors.nsx.session.NsxSessionLoader`
+    signature G3.10-T1 (#945) introduced.
     """
     return {"username": "nsx-canary-svc", "password": "nsx-canary-pw"}
 

--- a/backend/tests/acceptance/_sddc_canary_fixtures.py
+++ b/backend/tests/acceptance/_sddc_canary_fixtures.py
@@ -363,8 +363,13 @@ def _param_schema_for(path: str) -> dict[str, object]:
     }
 
 
-async def _sddc_credentials_loader(_target: object) -> dict[str, str]:
-    """Stub credentials loader — bypasses the not-yet-wired Vault read."""
+async def _sddc_credentials_loader(_target: object, _operator: Operator) -> dict[str, str]:
+    """Stub credentials loader — bypasses the live operator-context Vault read.
+
+    The 2-arg signature matches the
+    :class:`~meho_backplane.connectors.sddc_manager.session.SddcCredentialsLoader`
+    G3.10-T1 (#945) introduced.
+    """
     return {"username": "sddc-canary-svc", "password": "sddc-canary-pw"}
 
 

--- a/backend/tests/integration/test_connectors_harbor_container.py
+++ b/backend/tests/integration/test_connectors_harbor_container.py
@@ -389,7 +389,11 @@ async def harbor_e2e(
 
 
 def _make_credentials_loader(username: str, password: str):  # type: ignore[no-untyped-def]
-    async def _loader(_target: HarborTargetLike) -> dict[str, str]:
+    # Inner loader uses 2-arg signature (target, operator) per
+    # G3.10-T1 #945's HarborCredentialsLoader contract; the operator
+    # is unused here because the container test injects credentials
+    # directly without touching Vault.
+    async def _loader(_target: HarborTargetLike, _operator: object) -> dict[str, str]:
         return {"username": username, "password": password}
 
     return _loader

--- a/backend/tests/test_broadcast_credential_mint_dispatch.py
+++ b/backend/tests/test_broadcast_credential_mint_dispatch.py
@@ -94,8 +94,15 @@ _FORBIDDEN_SUBSTRINGS: tuple[str, ...] = (_SENTINEL_SECRET,)
 # ---------------------------------------------------------------------------
 
 
-async def _stub_credentials_loader(_target: HarborTargetLike) -> dict[str, str]:
-    """Return hard-coded admin credentials — no Vault call."""
+async def _stub_credentials_loader(
+    _target: HarborTargetLike, _operator: Operator
+) -> dict[str, str]:
+    """Return hard-coded admin credentials — no Vault call.
+
+    The 2-arg signature matches the
+    :class:`~meho_backplane.connectors.harbor.session.HarborCredentialsLoader`
+    G3.10-T1 (#945) introduced.
+    """
     return {"username": "admin", "password": "test-password"}
 
 

--- a/backend/tests/test_connectors_harbor_auth.py
+++ b/backend/tests/test_connectors_harbor_auth.py
@@ -97,12 +97,12 @@ _TARGET_B = _StubTarget(
 )
 
 
-async def _stub_loader(_target: HarborTargetLike) -> dict[str, str]:
-    """Return canned admin credentials regardless of the target."""
+async def _stub_loader(_target: HarborTargetLike, _operator: Operator) -> dict[str, str]:
+    """Return canned admin credentials regardless of the target or operator."""
     return {"username": "admin", "password": "stub-password"}
 
 
-async def _stub_robot_loader(_target: HarborTargetLike) -> dict[str, str]:
+async def _stub_robot_loader(_target: HarborTargetLike, _operator: Operator) -> dict[str, str]:
     """Return canned robot-account credentials."""
     return {"username": "robot$myproject+myrobot", "password": "robot-secret"}
 
@@ -142,14 +142,24 @@ def test_importing_package_registers_against_v2_registry() -> None:
     assert registry[key] is HarborConnector
 
 
-def test_default_credentials_loader_raises_until_g03_lands() -> None:
+def test_default_credentials_loader_delegates_to_shared_basic_loader() -> None:
+    """The default loader is the thin wrapper around ``load_basic_credentials``.
+
+    G3.10-T1 (#945) wired the live read; the loader now delegates to
+    :func:`load_basic_credentials` rather than raising
+    :exc:`NotImplementedError`. The fail-closed precondition (empty
+    ``operator.raw_jwt``) is asserted via a :class:`VaultCredentialsReadError`
+    on a system-initiated synthetic operator (no Vault is touched).
+    """
     import asyncio
 
+    from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
     from meho_backplane.connectors.harbor.session import load_credentials_from_vault
 
     async def _check() -> None:
-        with pytest.raises(NotImplementedError, match=r"Goal #214"):
-            await load_credentials_from_vault(_TARGET_A)
+        system_operator = _make_operator(raw_jwt="")
+        with pytest.raises(VaultCredentialsReadError, match=r"system-initiated"):
+            await load_credentials_from_vault(_TARGET_A, system_operator)
 
     asyncio.run(_check())
 
@@ -200,7 +210,7 @@ async def test_auth_headers_reuses_cached_credentials_across_calls() -> None:
     """Second auth_headers call against the same target does NOT re-invoke the loader."""
     call_count = 0
 
-    async def _counting_loader(_target: HarborTargetLike) -> dict[str, str]:
+    async def _counting_loader(_target: HarborTargetLike, _operator: Operator) -> dict[str, str]:
         nonlocal call_count
         call_count += 1
         return {"username": "admin", "password": "stub-password"}
@@ -224,7 +234,7 @@ async def test_per_target_isolation_keeps_credentials_separate() -> None:
     """Two targets get two distinct credential cache entries; no cross-target leakage."""
     call_log: list[str] = []
 
-    async def _tracking_loader(target: HarborTargetLike) -> dict[str, str]:
+    async def _tracking_loader(target: HarborTargetLike, _operator: Operator) -> dict[str, str]:
         call_log.append(target.name)
         return {"username": f"svc-{target.name}", "password": "pass"}
 
@@ -247,7 +257,7 @@ async def test_per_target_isolation_keeps_credentials_separate() -> None:
 
 @pytest.mark.asyncio
 async def test_loader_missing_password_key_raises_runtime_error_naming_target() -> None:
-    async def _bad_loader(_target: HarborTargetLike) -> dict[str, str]:
+    async def _bad_loader(_target: HarborTargetLike, _operator: Operator) -> dict[str, str]:
         return {"username": "admin"}  # type: ignore[return-value]
 
     connector = HarborConnector(credentials_loader=_bad_loader)
@@ -260,7 +270,7 @@ async def test_loader_missing_password_key_raises_runtime_error_naming_target() 
 
 @pytest.mark.asyncio
 async def test_loader_missing_username_key_raises_runtime_error_naming_target() -> None:
-    async def _bad_loader(_target: HarborTargetLike) -> dict[str, str]:
+    async def _bad_loader(_target: HarborTargetLike, _operator: Operator) -> dict[str, str]:
         return {"password": "stub-password"}  # type: ignore[return-value]
 
     connector = HarborConnector(credentials_loader=_bad_loader)

--- a/backend/tests/test_connectors_harbor_credread.py
+++ b/backend/tests/test_connectors_harbor_credread.py
@@ -1,0 +1,320 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Recorded-fixture E2E for the harbor live credential-read chain (G3.10-T1 #945).
+
+Proves the **full** dispatch chain end to end with a real (default,
+non-injected) credential loader:
+
+    dispatch(...)
+      -> _resolve_connector_instance -> HarborConnector()        # default loader
+      -> dispatch_ingested -> _request_json -> auth_headers
+      -> _load_credentials -> load_credentials_from_vault        # the live loader
+      -> load_basic_credentials (#941)                           # operator-context Vault read
+      -> GET <op path> (HTTP Basic auth w/ Vault-read creds)
+      -> OperationResult(status="ok")
+
+Harbor differs from nsx/vmware in that there is no session establish
+call — HTTP Basic auth rides every request. The credential read still
+goes through the shared operator-context Vault helper; the cred is
+then base64-encoded into the ``Authorization`` header on every API call.
+
+The two "real" leaves are stubbed at their boundaries so the gate runs
+in the **secret-free unit lane** (``pytest -n auto`` /
+``--ignore=tests/integration``) with no Docker and no real secret:
+
+* **Vault** — the in-process fake (``install_fake_client``) patches
+  ``meho_backplane.auth.vault._build_client`` so the helper's real
+  JWT/OIDC login + KV-v2 read code path runs against canned creds. The
+  default loader is exercised verbatim — *not* an injected stub.
+* **Harbor** — respx replays the op ``GET`` (returns the read payload).
+  No network.
+
+Mirrors :mod:`tests.test_connectors_vmware_rest_credread` (G3.9-T3 #942
+precedent) — same lifecycle, same canary-credential leak assertions.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+import respx
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog.testing import capture_logs
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors.harbor import HarborConnector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+# ---------------------------------------------------------------------------
+# Canary credential values — asserted to NEVER appear in the result or logs.
+# Generated nowhere near a real secret; these strings are the leak canaries.
+# ---------------------------------------------------------------------------
+
+_CANARY_USERNAME = "svc-harbor-canary"
+_CANARY_PASSWORD = "p4ss-canary-must-not-leak-credread-harbor"
+
+#: The connector triple ``harbor-rest-2.x`` decodes to.
+_PRODUCT = "harbor"
+_VERSION = "2.x"
+_IMPL_ID = "harbor-rest"
+_CONNECTOR_ID = "harbor-rest-2.x"
+
+#: A spec-relative ingested GET op against Harbor's systeminfo endpoint.
+_OP_ID = "GET:/api/v2.0/systeminfo"
+_OP_PATH = "/api/v2.0/systeminfo"
+
+#: respx base URL the target points at. Port 443 keeps ``_base_url`` from
+#: appending ``:port`` so the router matches the connector's client URL.
+_HARBOR_HOST = "harbor-credread.test.invalid"
+_HARBOR_BASE_URL = f"https://{_HARBOR_HOST}"
+
+#: The read op's response payload — shaped to look like Harbor systeminfo.
+_OP_RESPONSE: dict[str, Any] = {
+    "harbor_version": "v2.11.0-credread",
+    "auth_mode": "db_auth",
+    "registry_url": "harbor-credread.test.invalid",
+    "external_url": "https://harbor-credread.test.invalid",
+}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Vault client + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches + connector registry around every test.
+
+    The connector-instance cache must be clear so the resolver builds a
+    fresh ``HarborConnector()`` (default loader) for this test rather
+    than reusing one a sibling test wired with an injected stub loader.
+    """
+    reset_dispatcher_caches()
+    clear_registry()
+    register_connector_v2(
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        cls=HarborConnector,
+    )
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub for the seeded descriptor row."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    """Record broadcast events so the audit/broadcast leg is asserted."""
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _CredReadTarget:
+    """Target satisfying both ``HarborTargetLike`` and the resolver shape."""
+
+    def __init__(self) -> None:
+        self.product = _PRODUCT
+        # ``Connector.supported_version_range`` is ``">=2.0,<3.0"``; the
+        # resolver parses target.fingerprint.version as PEP 440, so use a
+        # concrete dotted version (not the wildcard ``"2.x"`` triple
+        # version that names the connector key but isn't PEP-440 parseable).
+        self.fingerprint = type("_FP", (), {"version": "2.11.0"})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.name = "harbor-credread"
+        self.host = _HARBOR_HOST
+        self.port = 443
+        self.secret_ref = "targets/op-credread/harbor-credread"
+        self.auth_model = "shared_service_account"
+
+
+def _make_operator() -> Operator:
+    """Operator carrying a non-empty raw_jwt (the fail-closed gate passes)."""
+    return Operator(
+        sub="op-credread-harbor",
+        name="Harbor Cred Read Operator",
+        email=None,
+        raw_jwt="op.credread.harbor.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0a2"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _seed_descriptor(session: AsyncSession, embedding: list[float]) -> None:
+    """Insert one enabled ingested GET descriptor for the read op."""
+    descriptor = EndpointDescriptor(
+        id=uuid.uuid4(),
+        tenant_id=None,
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        op_id=_OP_ID,
+        source_kind="ingested",
+        method="GET",
+        path=_OP_PATH,
+        handler_ref=None,
+        summary="Read Harbor system info",
+        description="Return the Harbor general system information.",
+        tags=["readiness"],
+        parameter_schema={"type": "object", "properties": {}},
+        response_schema=None,
+        llm_instructions=None,
+        safety_level="safe",
+        requires_approval=False,
+        is_enabled=True,
+        embedding=embedding,
+        custom_description=None,
+        custom_notes=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    session.add(descriptor)
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_executes_full_credread_chain_returns_ok(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The full dispatch->loader->Harbor chain returns status="ok" with no injected loader."""
+    await _seed_descriptor(session, stub_embedding_service.encode_one.return_value)
+
+    # Vault leaf: the in-process fake returns the canary creds via the
+    # real ``load_basic_credentials`` -> ``vault_client_for_operator``
+    # path. No credentials_loader is injected anywhere — the resolver
+    # builds ``HarborConnector()`` so the default loader runs.
+    fake = install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+
+    target = _CredReadTarget()
+    operator = _make_operator()
+
+    async with respx.mock(base_url=_HARBOR_BASE_URL, assert_all_called=False) as mock:
+        op_route = mock.get("/api/v2.0/systeminfo").respond(200, json=_OP_RESPONSE)
+
+        result = await dispatch(
+            operator=operator,
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=target,
+            params={},
+        )
+
+    # The load-bearing assertion: the chain executed end to end.
+    assert result.status == "ok", result.error
+    assert isinstance(result.result, dict)
+    assert result.result == _OP_RESPONSE
+
+    # The default loader actually read Vault under the operator's identity.
+    assert fake.auth.jwt.login_calls[-1]["jwt"] == "op.credread.harbor.jwt"
+    assert fake.secrets.kv.v2.read_calls[-1]["path"] == target.secret_ref
+    # The read op hit the mocked Harbor instance with HTTP Basic auth.
+    assert op_route.called and op_route.call_count == 1
+    sent_auth = op_route.calls[0].request.headers.get("authorization")
+    assert sent_auth is not None and sent_auth.startswith("Basic ")
+    # One audit + one broadcast for the dispatched op.
+    assert len(captured_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_credread_chain_never_leaks_credential_in_result_or_logs(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No credential value appears in the OperationResult or any captured log event."""
+    await _seed_descriptor(session, stub_embedding_service.encode_one.return_value)
+
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+
+    target = _CredReadTarget()
+    operator = _make_operator()
+
+    with capture_logs() as captured:
+        async with respx.mock(base_url=_HARBOR_BASE_URL, assert_all_called=False) as mock:
+            mock.get("/api/v2.0/systeminfo").respond(200, json=_OP_RESPONSE)
+
+            result = await dispatch(
+                operator=operator,
+                connector_id=_CONNECTOR_ID,
+                op_id=_OP_ID,
+                target=target,
+                params={},
+            )
+
+    assert result.status == "ok", result.error
+
+    # The credential never rides the OperationResult (result, error, or
+    # any extras the envelope carries).
+    result_blob = repr(result)
+    assert _CANARY_PASSWORD not in result_blob
+    assert _CANARY_USERNAME not in result_blob
+
+    # The credential never rides any structlog event (loader, connector,
+    # dispatcher, audit, broadcast).
+    log_blob = repr(captured)
+    assert _CANARY_PASSWORD not in log_blob
+    assert _CANARY_USERNAME not in log_blob
+
+    # The credential never rides the broadcast event payload either.
+    events_blob = repr(captured_events)
+    assert _CANARY_PASSWORD not in events_blob
+    assert _CANARY_USERNAME not in events_blob

--- a/backend/tests/test_connectors_harbor_robot.py
+++ b/backend/tests/test_connectors_harbor_robot.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 import pytest
 import respx
 
+from meho_backplane.auth.operator import Operator
 from meho_backplane.broadcast.events import classify_op, redact_payload
 from meho_backplane.connectors.harbor import HarborConnector, HarborTargetLike
 from meho_backplane.connectors.registry import clear_registry, register_connector_v2
@@ -73,7 +74,8 @@ _TARGET = _StubTarget(
 )
 
 
-async def _stub_loader(_target: HarborTargetLike) -> dict[str, str]:
+async def _stub_loader(_target: HarborTargetLike, _operator: Operator) -> dict[str, str]:
+    """Stub loader matching the 2-arg signature G3.10-T1 #945 introduced."""
     return {"username": "admin", "password": "test-password"}
 
 

--- a/backend/tests/test_connectors_nsx_auth.py
+++ b/backend/tests/test_connectors_nsx_auth.py
@@ -99,8 +99,8 @@ _TARGET_B = _StubTarget(
 )
 
 
-async def _stub_loader(_target: NsxTargetLike) -> dict[str, str]:
-    """Return canned credentials regardless of the target."""
+async def _stub_loader(_target: NsxTargetLike, _operator: Operator) -> dict[str, str]:
+    """Return canned credentials regardless of the target or operator."""
     return {"username": "svc-meho", "password": "stub-password"}
 
 
@@ -135,17 +135,24 @@ def test_importing_package_registers_against_v2_registry() -> None:
     assert registry[key] is NsxConnector
 
 
-def test_default_session_loader_raises_until_g03_lands() -> None:
-    """The default Vault loader stays unimplemented until G0.3."""
+def test_default_session_loader_delegates_to_shared_basic_loader() -> None:
+    """The default loader is the thin wrapper around ``load_basic_credentials``.
+
+    G3.10-T1 (#945) wired the live read; the loader now delegates to
+    :func:`load_basic_credentials` rather than raising
+    :exc:`NotImplementedError`. The fail-closed precondition (empty
+    ``operator.raw_jwt``) is asserted via a :class:`VaultCredentialsReadError`
+    on a system-initiated synthetic operator (no Vault is touched).
+    """
     import asyncio
 
-    from meho_backplane.connectors.nsx.session import (
-        load_session_credentials_from_vault,
-    )
+    from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+    from meho_backplane.connectors.nsx.session import load_session_credentials_from_vault
 
     async def _check() -> None:
-        with pytest.raises(NotImplementedError, match=r"G0\.3"):
-            await load_session_credentials_from_vault(_TARGET_A)
+        system_operator = _make_operator(raw_jwt="")
+        with pytest.raises(VaultCredentialsReadError, match=r"system-initiated"):
+            await load_session_credentials_from_vault(_TARGET_A, system_operator)
 
     asyncio.run(_check())
 
@@ -292,7 +299,7 @@ async def test_session_create_missing_xsrf_header_raises() -> None:
 async def test_loader_missing_password_key_raises_clear_error() -> None:
     """A loader returning a dict without 'password' surfaces a clear message."""
 
-    async def _bad_loader(_target: NsxTargetLike) -> dict[str, str]:
+    async def _bad_loader(_target: NsxTargetLike, _operator: Operator) -> dict[str, str]:
         return {"username": "svc-meho"}  # type: ignore[return-value]
 
     connector = NsxConnector(session_loader=_bad_loader)

--- a/backend/tests/test_connectors_nsx_credread.py
+++ b/backend/tests/test_connectors_nsx_credread.py
@@ -1,0 +1,348 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Recorded-fixture E2E for the nsx live credential-read chain (G3.10-T1 #945).
+
+Proves the **full** dispatch chain end to end with a real (default,
+non-injected) credential loader:
+
+    dispatch(...)
+      -> _resolve_connector_instance -> NsxConnector()           # default loader
+      -> dispatch_ingested -> _request_json -> auth_headers
+      -> _session_token -> load_session_credentials_from_vault   # the live loader
+      -> load_basic_credentials (#941)                           # operator-context Vault read
+      -> POST /api/session/create (form body w/ Vault-read creds)
+      -> GET <op path>                                           # the actual read op
+      -> OperationResult(status="ok")
+
+The two "real" leaves are stubbed at their boundaries so the gate runs
+in the **secret-free unit lane** (``pytest -n auto`` /
+``--ignore=tests/integration``) with no Docker and no real secret:
+
+* **Vault** — the in-process fake (``install_fake_client``) patches
+  ``meho_backplane.auth.vault._build_client`` so the helper's real
+  JWT/OIDC login + KV-v2 read code path runs against canned creds. The
+  default loader is exercised verbatim — *not* an injected stub. This is
+  the load-bearing difference from ``test_connectors_nsx_auth.py``
+  (which injects ``_stub_loader``): here the connector is constructed by
+  the resolver as ``NsxConnector()`` with no ``session_loader``, so the
+  default ``load_session_credentials_from_vault`` runs.
+* **NSX manager** — respx replays ``POST /api/session/create`` (returns
+  ``X-XSRF-TOKEN`` + ``JSESSIONID`` cookie) and the op ``GET`` (returns
+  the read payload). No network.
+
+Mirrors :mod:`tests.test_connectors_vmware_rest_credread` for the
+vmware-rest connector verbatim (G3.9-T3 #942 precedent) — same lifecycle,
+same canary-credential leak assertions.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+import respx
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog.testing import capture_logs
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors.nsx import NsxConnector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+# ---------------------------------------------------------------------------
+# Canary credential values — asserted to NEVER appear in the result or logs.
+# Generated nowhere near a real secret; these strings are the leak canaries.
+# ---------------------------------------------------------------------------
+
+_CANARY_USERNAME = "svc-nsx-canary"
+_CANARY_PASSWORD = "p4ss-canary-must-not-leak-credread-nsx"
+
+#: The connector triple ``nsx-rest-4.2`` decodes to.
+_PRODUCT = "nsx"
+_VERSION = "4.2"
+_IMPL_ID = "nsx-rest"
+_CONNECTOR_ID = "nsx-rest-4.2"
+
+#: A spec-relative ingested GET op. NSX's hand-rolled connector does not
+#: override ``mount_op_path``, so the path is unchanged at dispatch.
+_OP_ID = "GET:/api/v1/node"
+_OP_PATH = "/api/v1/node"
+
+#: respx base URL the target points at. Port 443 keeps ``_base_url`` from
+#: appending ``:port`` so the router matches the connector's client URL.
+#: ``.test.invalid`` (RFC 6761) guarantees no real egress.
+_NSX_HOST = "nsx-credread.test.invalid"
+_NSX_BASE_URL = f"https://{_NSX_HOST}"
+_XSRF_TOKEN = "credread-nsx-xsrf-token"
+
+#: The read op's response payload — set-shaped but small enough that the
+#: pass-through reducer returns it inline (no handle).
+_OP_RESPONSE: dict[str, Any] = {
+    "node_version": "4.2.0.0.0.21761695",
+    "kernel_version": "5.10.0-nsx",
+    "node_uuid": "credread-nsx-node-uuid",
+    "hostname": _NSX_HOST,
+}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Vault client + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches + connector registry around every test.
+
+    The connector-instance cache must be clear so the resolver builds a
+    fresh ``NsxConnector()`` (default loader) for this test rather than
+    reusing one a sibling test wired with an injected stub loader.
+    """
+    reset_dispatcher_caches()
+    clear_registry()
+    register_connector_v2(
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        cls=NsxConnector,
+    )
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub for the seeded descriptor row."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    """Record broadcast events so the audit/broadcast leg is asserted."""
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _CredReadTarget:
+    """Target satisfying both ``NsxTargetLike`` and the resolver shape.
+
+    Carries the resolver attributes (``product`` / ``fingerprint`` /
+    ``preferred_impl_id`` / ``id``) plus the nsx-loader attributes
+    (``name`` / ``host`` / ``port`` / ``secret_ref`` / ``auth_model``).
+    """
+
+    def __init__(self) -> None:
+        self.product = _PRODUCT
+        self.fingerprint = type("_FP", (), {"version": _VERSION})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.name = "nsx-credread"
+        self.host = _NSX_HOST
+        self.port = 443
+        self.secret_ref = "targets/op-credread/nsx-credread"
+        self.auth_model = "shared_service_account"
+
+
+def _make_operator() -> Operator:
+    """Operator carrying a non-empty raw_jwt (the fail-closed gate passes)."""
+    return Operator(
+        sub="op-credread-nsx",
+        name="NSX Cred Read Operator",
+        email=None,
+        raw_jwt="op.credread.nsx.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0a1"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _seed_descriptor(session: AsyncSession, embedding: list[float]) -> None:
+    """Insert one enabled ingested GET descriptor for the read op."""
+    descriptor = EndpointDescriptor(
+        id=uuid.uuid4(),
+        tenant_id=None,
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        op_id=_OP_ID,
+        source_kind="ingested",
+        method="GET",
+        path=_OP_PATH,
+        handler_ref=None,
+        summary="Read NSX node info",
+        description="Return the NSX manager node version + uuid.",
+        tags=["readiness"],
+        parameter_schema={"type": "object", "properties": {}},
+        response_schema=None,
+        llm_instructions=None,
+        safety_level="safe",
+        requires_approval=False,
+        is_enabled=True,
+        embedding=embedding,
+        custom_description=None,
+        custom_notes=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    session.add(descriptor)
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_executes_full_credread_chain_returns_ok(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The full dispatch->loader->NSX chain returns status="ok" with no injected loader."""
+    await _seed_descriptor(session, stub_embedding_service.encode_one.return_value)
+
+    # Vault leaf: the in-process fake returns the canary creds via the
+    # real ``load_basic_credentials`` -> ``vault_client_for_operator``
+    # path. No session_loader is injected anywhere — the resolver builds
+    # ``NsxConnector()`` so the default loader runs.
+    fake = install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+
+    target = _CredReadTarget()
+    operator = _make_operator()
+
+    async with respx.mock(base_url=_NSX_BASE_URL, assert_all_called=False) as mock:
+        session_route = mock.post("/api/session/create").respond(
+            200,
+            headers={
+                "X-XSRF-TOKEN": _XSRF_TOKEN,
+                "Set-Cookie": "JSESSIONID=credread-nsx-jsess; Path=/; HttpOnly",
+            },
+        )
+        op_route = mock.get("/api/v1/node").respond(200, json=_OP_RESPONSE)
+
+        result = await dispatch(
+            operator=operator,
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=target,
+            params={},
+        )
+
+    # The load-bearing assertion: the chain executed end to end.
+    assert result.status == "ok", result.error
+    assert isinstance(result.result, dict)
+    assert result.result == _OP_RESPONSE
+
+    # The default loader actually read Vault under the operator's identity.
+    assert fake.auth.jwt.login_calls[-1]["jwt"] == "op.credread.nsx.jwt"
+    assert fake.secrets.kv.v2.read_calls[-1]["path"] == target.secret_ref
+    # The session establish + the read op both hit the mocked NSX manager.
+    assert session_route.called and session_route.call_count == 1
+    assert op_route.called and op_route.call_count == 1
+    # Form-encoded body carried the Vault-read creds (j_username, j_password).
+    sent_body = session_route.calls[0].request.content.decode()
+    # The body is form-encoded; specific creds must be present.
+    assert "j_username=" in sent_body
+    assert "j_password=" in sent_body
+    # XSRF token on the read-op GET (cookie travels via the client jar).
+    op_xsrf = op_route.calls[0].request.headers.get("x-xsrf-token")
+    assert op_xsrf == _XSRF_TOKEN
+    # One audit + one broadcast for the dispatched op.
+    assert len(captured_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_credread_chain_never_leaks_credential_in_result_or_logs(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No credential value appears in the OperationResult or any captured log event."""
+    await _seed_descriptor(session, stub_embedding_service.encode_one.return_value)
+
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+
+    target = _CredReadTarget()
+    operator = _make_operator()
+
+    with capture_logs() as captured:
+        async with respx.mock(base_url=_NSX_BASE_URL, assert_all_called=False) as mock:
+            mock.post("/api/session/create").respond(
+                200,
+                headers={
+                    "X-XSRF-TOKEN": _XSRF_TOKEN,
+                    "Set-Cookie": "JSESSIONID=credread-nsx-jsess; Path=/",
+                },
+            )
+            mock.get("/api/v1/node").respond(200, json=_OP_RESPONSE)
+
+            result = await dispatch(
+                operator=operator,
+                connector_id=_CONNECTOR_ID,
+                op_id=_OP_ID,
+                target=target,
+                params={},
+            )
+
+    assert result.status == "ok", result.error
+
+    # The credential never rides the OperationResult (result, error, or
+    # any extras the envelope carries).
+    result_blob = repr(result)
+    assert _CANARY_PASSWORD not in result_blob
+    assert _CANARY_USERNAME not in result_blob
+
+    # The credential never rides any structlog event (loader, connector,
+    # dispatcher, audit, broadcast).
+    log_blob = repr(captured)
+    assert _CANARY_PASSWORD not in log_blob
+    assert _CANARY_USERNAME not in log_blob
+
+    # The credential never rides the broadcast event payload either.
+    events_blob = repr(captured_events)
+    assert _CANARY_PASSWORD not in events_blob
+    assert _CANARY_USERNAME not in events_blob

--- a/backend/tests/test_connectors_sddc_manager_auth.py
+++ b/backend/tests/test_connectors_sddc_manager_auth.py
@@ -99,8 +99,8 @@ _TARGET_B = _StubTarget(
 )
 
 
-async def _stub_loader(_target: SddcTargetLike) -> dict[str, str]:
-    """Return canned credentials regardless of the target."""
+async def _stub_loader(_target: SddcTargetLike, _operator: Operator) -> dict[str, str]:
+    """Return canned credentials regardless of the target or operator."""
     return {"username": "svc-meho", "password": "stub-password"}
 
 
@@ -142,15 +142,24 @@ def test_importing_package_registers_against_v2_registry() -> None:
     assert registry[key] is SddcManagerConnector
 
 
-def test_default_credentials_loader_raises_until_g03_lands() -> None:
-    """The default Vault loader stays unimplemented until G0.3."""
+def test_default_credentials_loader_delegates_to_shared_basic_loader() -> None:
+    """The default loader is the thin wrapper around ``load_basic_credentials``.
+
+    G3.10-T1 (#945) wired the live read; the loader now delegates to
+    :func:`load_basic_credentials` rather than raising
+    :exc:`NotImplementedError`. The fail-closed precondition (empty
+    ``operator.raw_jwt``) is asserted via a :class:`VaultCredentialsReadError`
+    on a system-initiated synthetic operator (no Vault is touched).
+    """
     import asyncio
 
+    from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
     from meho_backplane.connectors.sddc_manager.session import load_credentials_from_vault
 
     async def _check() -> None:
-        with pytest.raises(NotImplementedError, match=r"Goal #214"):
-            await load_credentials_from_vault(_TARGET_A)
+        system_operator = _make_operator(raw_jwt="")
+        with pytest.raises(VaultCredentialsReadError, match=r"system-initiated"):
+            await load_credentials_from_vault(_TARGET_A, system_operator)
 
     asyncio.run(_check())
 
@@ -204,7 +213,7 @@ async def test_auth_headers_reuses_cached_credentials_across_calls() -> None:
     """Second auth_headers call against the same target does NOT re-invoke the loader."""
     call_count = 0
 
-    async def _counting_loader(_target: SddcTargetLike) -> dict[str, str]:
+    async def _counting_loader(_target: SddcTargetLike, _operator: Operator) -> dict[str, str]:
         nonlocal call_count
         call_count += 1
         return {"username": "svc-meho", "password": "stub-password"}
@@ -223,7 +232,7 @@ async def test_per_target_isolation_keeps_credentials_separate() -> None:
     """Two targets get two distinct credential cache entries; no cross-target leakage."""
     call_log: list[str] = []
 
-    async def _tracking_loader(target: SddcTargetLike) -> dict[str, str]:
+    async def _tracking_loader(target: SddcTargetLike, _operator: Operator) -> dict[str, str]:
         call_log.append(target.name)
         return {"username": f"svc-{target.name}", "password": "pass"}
 
@@ -249,7 +258,7 @@ async def test_per_target_isolation_keeps_credentials_separate() -> None:
 async def test_loader_missing_password_key_raises_runtime_error_naming_target() -> None:
     """A loader returning a dict without 'password' surfaces a clear RuntimeError."""
 
-    async def _bad_loader(_target: SddcTargetLike) -> dict[str, str]:
+    async def _bad_loader(_target: SddcTargetLike, _operator: Operator) -> dict[str, str]:
         return {"username": "svc-meho"}  # type: ignore[return-value]
 
     connector = SddcManagerConnector(credentials_loader=_bad_loader)
@@ -264,7 +273,7 @@ async def test_loader_missing_password_key_raises_runtime_error_naming_target() 
 async def test_loader_missing_username_key_raises_runtime_error_naming_target() -> None:
     """A loader returning a dict without 'username' surfaces a clear RuntimeError."""
 
-    async def _bad_loader(_target: SddcTargetLike) -> dict[str, str]:
+    async def _bad_loader(_target: SddcTargetLike, _operator: Operator) -> dict[str, str]:
         return {"password": "stub-password"}  # type: ignore[return-value]
 
     connector = SddcManagerConnector(credentials_loader=_bad_loader)

--- a/backend/tests/test_connectors_sddc_manager_credread.py
+++ b/backend/tests/test_connectors_sddc_manager_credread.py
@@ -1,0 +1,336 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Recorded-fixture E2E for the sddc-manager live credential-read chain (G3.10-T1 #945).
+
+Proves the **full** dispatch chain end to end with a real (default,
+non-injected) credential loader:
+
+    dispatch(...)
+      -> _resolve_connector_instance -> SddcManagerConnector()   # default loader
+      -> dispatch_ingested -> _request_json -> auth_headers
+      -> _load_credentials -> load_credentials_from_vault        # the live loader
+      -> load_basic_credentials (#941)                           # operator-context Vault read
+      -> GET <op path> (HTTP Basic auth w/ username@sso_realm)
+      -> OperationResult(status="ok")
+
+SDDC Manager differs from nsx/vmware in that there is no session
+establish call — HTTP Basic auth rides every request. The username is
+formatted as ``username@sso_realm`` (default ``vsphere.local``) before
+the base64 encode; the password is the Vault-read value verbatim. The
+credential read still goes through the shared operator-context Vault
+helper.
+
+The two "real" leaves are stubbed at their boundaries so the gate runs
+in the **secret-free unit lane** (``pytest -n auto`` /
+``--ignore=tests/integration``) with no Docker and no real secret:
+
+* **Vault** — the in-process fake (``install_fake_client``) patches
+  ``meho_backplane.auth.vault._build_client`` so the helper's real
+  JWT/OIDC login + KV-v2 read code path runs against canned creds. The
+  default loader is exercised verbatim — *not* an injected stub.
+* **SDDC Manager** — respx replays the op ``GET`` (returns the read
+  payload). No network.
+
+Mirrors :mod:`tests.test_connectors_vmware_rest_credread` (G3.9-T3 #942
+precedent) — same lifecycle, same canary-credential leak assertions.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+import respx
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog.testing import capture_logs
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.sddc_manager import SddcManagerConnector
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+# ---------------------------------------------------------------------------
+# Canary credential values — asserted to NEVER appear in the result or logs.
+# Generated nowhere near a real secret; these strings are the leak canaries.
+# ---------------------------------------------------------------------------
+
+_CANARY_USERNAME = "svc-sddc-canary"
+_CANARY_PASSWORD = "p4ss-canary-must-not-leak-credread-sddc"
+
+#: The connector triple ``sddc-rest-9.0`` decodes to. Note the asymmetry:
+#: the v2 registry uses ``product="sddc-manager"`` (and so does the
+#: target row + the resolver), but ``parse_connector_id("sddc-rest-9.0")``
+#: returns ``product="sddc"`` — the descriptor + dispatcher leg uses that
+#: form. See sddc_manager/core_ops.py docstring §SDDC_PRODUCT for the
+#: locked rationale.
+_REGISTRY_PRODUCT = "sddc-manager"
+_DESCRIPTOR_PRODUCT = "sddc"
+_VERSION = "9.0"
+_IMPL_ID = "sddc-rest"
+_CONNECTOR_ID = "sddc-rest-9.0"
+
+#: A spec-relative ingested GET op against SDDC Manager's primary endpoint.
+_OP_ID = "GET:/v1/sddc-managers"
+_OP_PATH = "/v1/sddc-managers"
+
+#: respx base URL the target points at. Port 443 keeps ``_base_url`` from
+#: appending ``:port`` so the router matches the connector's client URL.
+_SDDC_HOST = "sddc-credread.test.invalid"
+_SDDC_BASE_URL = f"https://{_SDDC_HOST}"
+
+#: The read op's response payload — shaped to look like a real SDDC Manager response.
+_OP_RESPONSE: dict[str, Any] = {
+    "elements": [
+        {
+            "id": "sddc-credread-id",
+            "fqdn": _SDDC_HOST,
+            "version": "9.0.0.0",
+            "build": "credread-build",
+            "domain": {"id": "mgmt-dom", "name": "mgmt"},
+        }
+    ],
+}
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Vault client + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches + connector registry around every test.
+
+    The connector-instance cache must be clear so the resolver builds a
+    fresh ``SddcManagerConnector()`` (default loader) for this test
+    rather than reusing one a sibling test wired with an injected stub
+    loader.
+    """
+    reset_dispatcher_caches()
+    clear_registry()
+    register_connector_v2(
+        product=_REGISTRY_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        cls=SddcManagerConnector,
+    )
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub for the seeded descriptor row."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    """Record broadcast events so the audit/broadcast leg is asserted."""
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _CredReadTarget:
+    """Target satisfying both ``SddcTargetLike`` and the resolver shape."""
+
+    def __init__(self) -> None:
+        # Target rows use the v2 registry product ``"sddc-manager"`` — the
+        # resolver matches ``Connector.product`` against this. The descriptor
+        # row (seeded below) uses ``"sddc"`` (from ``parse_connector_id``).
+        self.product = _REGISTRY_PRODUCT
+        self.fingerprint = type("_FP", (), {"version": _VERSION})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.name = "sddc-credread"
+        self.host = _SDDC_HOST
+        self.port = 443
+        self.secret_ref = "targets/op-credread/sddc-credread"
+        self.auth_model = "shared_service_account"
+        self.sso_realm = "vsphere.local"
+
+
+def _make_operator() -> Operator:
+    """Operator carrying a non-empty raw_jwt (the fail-closed gate passes)."""
+    return Operator(
+        sub="op-credread-sddc",
+        name="SDDC Cred Read Operator",
+        email=None,
+        raw_jwt="op.credread.sddc.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0a3"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _seed_descriptor(session: AsyncSession, embedding: list[float]) -> None:
+    """Insert one enabled ingested GET descriptor for the read op."""
+    descriptor = EndpointDescriptor(
+        id=uuid.uuid4(),
+        tenant_id=None,
+        # Descriptor uses ``"sddc"`` (parse_connector_id of "sddc-rest-9.0");
+        # the connector class + target row both use ``"sddc-manager"``.
+        product=_DESCRIPTOR_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        op_id=_OP_ID,
+        source_kind="ingested",
+        method="GET",
+        path=_OP_PATH,
+        handler_ref=None,
+        summary="Read SDDC Manager inventory",
+        description="Return the SDDC Manager appliance(s) under management.",
+        tags=["readiness"],
+        parameter_schema={"type": "object", "properties": {}},
+        response_schema=None,
+        llm_instructions=None,
+        safety_level="safe",
+        requires_approval=False,
+        is_enabled=True,
+        embedding=embedding,
+        custom_description=None,
+        custom_notes=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    session.add(descriptor)
+    await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_executes_full_credread_chain_returns_ok(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The full dispatch->loader->SDDC chain returns status="ok" with no injected loader."""
+    await _seed_descriptor(session, stub_embedding_service.encode_one.return_value)
+
+    # Vault leaf: the in-process fake returns the canary creds via the
+    # real ``load_basic_credentials`` -> ``vault_client_for_operator``
+    # path. No credentials_loader is injected anywhere — the resolver
+    # builds ``SddcManagerConnector()`` so the default loader runs.
+    fake = install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+
+    target = _CredReadTarget()
+    operator = _make_operator()
+
+    async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+        op_route = mock.get("/v1/sddc-managers").respond(200, json=_OP_RESPONSE)
+
+        result = await dispatch(
+            operator=operator,
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=target,
+            params={},
+        )
+
+    # The load-bearing assertion: the chain executed end to end.
+    assert result.status == "ok", result.error
+    assert isinstance(result.result, dict)
+    assert result.result == _OP_RESPONSE
+
+    # The default loader actually read Vault under the operator's identity.
+    assert fake.auth.jwt.login_calls[-1]["jwt"] == "op.credread.sddc.jwt"
+    assert fake.secrets.kv.v2.read_calls[-1]["path"] == target.secret_ref
+    # The read op hit the mocked SDDC Manager with HTTP Basic auth.
+    assert op_route.called and op_route.call_count == 1
+    sent_auth = op_route.calls[0].request.headers.get("authorization")
+    assert sent_auth is not None and sent_auth.startswith("Basic ")
+    # One audit + one broadcast for the dispatched op.
+    assert len(captured_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_credread_chain_never_leaks_credential_in_result_or_logs(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No credential value appears in the OperationResult or any captured log event."""
+    await _seed_descriptor(session, stub_embedding_service.encode_one.return_value)
+
+    install_fake_client(
+        monkeypatch,
+        secret={"username": _CANARY_USERNAME, "password": _CANARY_PASSWORD},
+    )
+
+    target = _CredReadTarget()
+    operator = _make_operator()
+
+    with capture_logs() as captured:
+        async with respx.mock(base_url=_SDDC_BASE_URL, assert_all_called=False) as mock:
+            mock.get("/v1/sddc-managers").respond(200, json=_OP_RESPONSE)
+
+            result = await dispatch(
+                operator=operator,
+                connector_id=_CONNECTOR_ID,
+                op_id=_OP_ID,
+                target=target,
+                params={},
+            )
+
+    assert result.status == "ok", result.error
+
+    # The credential never rides the OperationResult (result, error, or
+    # any extras the envelope carries).
+    result_blob = repr(result)
+    assert _CANARY_PASSWORD not in result_blob
+    assert _CANARY_USERNAME not in result_blob
+
+    # The credential never rides any structlog event (loader, connector,
+    # dispatcher, audit, broadcast).
+    log_blob = repr(captured)
+    assert _CANARY_PASSWORD not in log_blob
+    assert _CANARY_USERNAME not in log_blob
+
+    # The credential never rides the broadcast event payload either.
+    events_blob = repr(captured_events)
+    assert _CANARY_PASSWORD not in events_blob
+    assert _CANARY_USERNAME not in events_blob

--- a/docs/codebase/connector-release-readiness.md
+++ b/docs/codebase/connector-release-readiness.md
@@ -137,8 +137,9 @@ flow is the only auth_model; loader is live; consumer confirmed
 | `k8s-1.x` | 1 | [`load_kubeconfig_from_vault`](../../backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py#L86) — `NotImplementedError` | ❌ (mock loader in test only) |
 | `vmware-rest-9.0` | 2 | [`load_session_credentials_from_vault`](../../backend/src/meho_backplane/connectors/vmware_rest/session.py#L116) — live operator-context Vault read (G3.9-T3 [#942](https://github.com/evoila/meho/issues/942)) | ✅ (`shared_service_account`) |
 | `vcf-automation-9.0` | 2 | [`load_credentials_from_vault`](../../backend/src/meho_backplane/connectors/vcf_automation/session.py) — live operator-context Vault read via the shared [`load_basic_credentials`](../../backend/src/meho_backplane/connectors/_shared/vault_creds.py) helper; `operator` threaded through the bespoke dual-plane auth (G3.10-T3 [#947](https://github.com/evoila/meho/issues/947)) | ✅ (`shared_service_account`) |
-| `sddc-manager-9.0` | 0.5 | Class-side registered, no ops yet, loader stubbed | ❌ |
-| `harbor-2.x` | 0.5 | Class-side registered, no ops yet, loader stubbed | ❌ |
+| `nsx-4.2` | 2 | [`load_session_credentials_from_vault`](../../backend/src/meho_backplane/connectors/nsx/session.py) — live operator-context Vault read (G3.10-T1 [#945](https://github.com/evoila/meho/issues/945)) | ✅ (`shared_service_account`) |
+| `sddc-manager-9.0` | 2 | [`load_credentials_from_vault`](../../backend/src/meho_backplane/connectors/sddc_manager/session.py) — live operator-context Vault read (G3.10-T1 [#945](https://github.com/evoila/meho/issues/945)) | ✅ (`shared_service_account`) |
+| `harbor-2.x` | 2 | [`load_credentials_from_vault`](../../backend/src/meho_backplane/connectors/harbor/session.py) — live operator-context Vault read (G3.10-T1 [#945](https://github.com/evoila/meho/issues/945)) | ✅ (`shared_service_account`) |
 | `kubernetes-asyncio-1.x` | 1 (shadow) | Same as `k8s-1.x` | ❌ |
 
 State 0.5 = `register_connector_v2` called but no ops registered yet.


### PR DESCRIPTION
## Summary

- Wire `nsx-4.2`, `harbor-2.x`, and `sddc-manager-9.0` to the live
  operator-context Vault read via the shared `_shared/vault_creds.load_basic_credentials`
  helper (#941). All three connectors move from rubric **State 1 → State 2**
  (`shared_service_account` live).
- Thread the full `Operator` through each connector's `auth_headers` →
  `_session_token` / `_load_credentials` → loader path. The loader contract
  switches from 1-arg `(target)` to 2-arg `(target, operator)`, matching the
  vmware-rest precedent #942 set.
- Add 3 recorded-fixture E2E tests (one per connector) proving the full
  `dispatch → loader → Vault read → vendor → result` chain with no injected
  loader and assertions that the credential value never lands in the
  `OperationResult`, structlog events, or broadcast payload.

## Test plan

- [x] `ruff check` — clean across all touched files
- [x] `ruff format --check` — clean (4 files reformatted to match)
- [x] `mypy src/meho_backplane/` — Success: no issues found in 253 source files
- [x] `pytest tests/test_connectors_{nsx,harbor,sddc_manager}_{auth,core_ops,e2e,credread}.py tests/test_connectors_vmware_rest_{auth,credread}.py tests/test_broadcast_credential_mint_dispatch.py` — 200 passed, 3 skipped
- [x] `pytest tests/ -k connector --ignore=tests/integration --ignore=tests/acceptance` — 1351 passed (1 pre-existing flake in `test_targets_fingerprint.py::test_probe_connector_raise_does_not_mutate_db` from parallel sibling worktree's pytest, passes in isolation)
- [x] **Acceptance: each default loader performs live KV-v2 read via #941** — proven by `tests/test_connectors_{nsx,harbor,sddc_manager}_credread.py::test_dispatch_executes_full_credread_chain_returns_ok` (no injected loader; resolver builds `NsxConnector()` / `HarborConnector()` / `SddcManagerConnector()`, default loader runs through `vault_client_for_operator` → `read_secret_version`)
- [x] **Acceptance: no credential value in result/logs** — proven by `tests/test_connectors_{nsx,harbor,sddc_manager}_credread.py::test_credread_chain_never_leaks_credential_in_result_or_logs` (canary username + password asserted absent from `OperationResult` repr, captured structlog events, and broadcast payload)
- [x] **Acceptance: injected-loader unit tests updated to 2-arg `(target, operator)` shape and passing; `per_user` still raises** — 66 auth tests pass; per_user/impersonation rejection paths unchanged
- [x] **Acceptance: `rg "raise NotImplementedError" backend/src/meho_backplane/connectors/{nsx,harbor,sddc_manager}/session.py` returns nothing** — verified clean
- [x] **Acceptance: `docs/codebase/connector-release-readiness.md` updated** — nsx/harbor/sddc-manager rows promoted from State 1/0.5 to State 2 with G3.10-T1 #945 citation

## Scope discipline

This PR touches only the nsx/harbor/sddc-manager files plus the canary
fixtures + integration tests that import their loader signatures. It
does NOT touch `_shared/vcf_auth.py` (sibling #946's territory for
vROps/vRLI/Fleet), `vcf_automation/` (#947), or `kubernetes/` (#948).
The shared state-table `docs/codebase/connector-release-readiness.md`
update touches only the 3 rows this task owns; the other rows are
preserved verbatim so siblings can update theirs without conflict.

## Out of scope

- vROps/vRLI/Fleet (`_shared/vcf_auth.py`) — sibling #946
- vcf-automation dual-plane — sibling #947
- k8s/kubeconfig — sibling #948
- Per-user / impersonation auth models — still raise the boundary
  `NotImplementedError` per the rubric

## Adjacent findings (deferred)

- `HarborConnector.robot_create` / `robot_delete` (typed ops) call
  `auth_headers(target, synthesise_system_operator())` internally — the
  synthetic operator has `raw_jwt=""` which now triggers
  `VaultCredentialsReadError` on the live Vault path. This is a
  pre-existing harbor design issue (the typed-op handler signature
  doesn't accept `operator`; the dispatcher's parameter-name routing
  in `operations/_branches.py` therefore can't thread it). The existing
  `tests/test_connectors_harbor_robot.py` masks this with a stubbed
  loader. Out of scope for #945 (operations/composites are
  G3.5/G3.6 territory); should be filed as a follow-up to make harbor
  robot ops production-callable.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #945


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Harbor, NSX, and SDDC Manager connectors now perform operator-aware live credential resolution from Vault for shared-service-account auth.

* **Tests**
  * Added end-to-end integration tests for full credential-read dispatch paths and new tests ensuring credentials never appear in results, logs, or broadcasts.

* **Documentation**
  * Updated connector readiness/state documentation to reflect live loader wiring and readiness level.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/972?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->