### PR TITLE
feat(connectors): G3.10-T4 wire k8s load_kubeconfig_from_vault + recorded + live k3d/Vault E2E (State 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,24 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Changed
+
+- **`k8s-1.x` typed connector — `shared_service_account` auth model live
+  (G3.10-T4 [#948](https://github.com/evoila/meho/issues/948)).** The
+  default
+  [`load_kubeconfig_from_vault`](./backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py)
+  now performs the live operator-context KV-v2 read (forwarding the
+  operator's Keycloak JWT to Vault's JWT/OIDC auth method, reading the
+  `kubeconfig` field at `target.secret_ref`, parsing the YAML into the
+  dict shape `kubernetes_asyncio.config.new_client_from_config_dict`
+  accepts). `operation call k8s.<op> target=…` executes end to end
+  against a real cluster — the rubric **State 2** wiring per
+  [`docs/codebase/connector-release-readiness.md`](./docs/codebase/connector-release-readiness.md).
+  Fail-closed on empty `operator.raw_jwt` (the system-call carve-out)
+  and unset `secret_ref`. Operator recipe:
+  [`kubernetes-onboarding.md`](./docs/cross-repo/kubernetes-onboarding.md).
+  `per_user` / `impersonation` remain out of scope.
+
 ## [0.5.1] - 2026-05-22
 
 **Connector raw-REST ingest on-ramp + topology change-history + UI

--- a/backend/src/meho_backplane/connectors/kubernetes/connector.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/connector.py
@@ -60,6 +60,8 @@ import httpx
 import structlog
 from kubernetes_asyncio import client, config
 
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
 from meho_backplane.connectors.base import Connector
 from meho_backplane.connectors.kubernetes.kubeconfig import (
     KubeconfigLoader,
@@ -266,8 +268,20 @@ class KubernetesConnector(Connector):
         self._lock = asyncio.Lock()
 
     async def fingerprint(self, target: KubernetesTargetLike) -> FingerprintResult:
-        """Canonical fingerprint built from ``VersionApi.get_code()``."""
-        api_client = await self._get_api_client(target)
+        """Canonical fingerprint built from ``VersionApi.get_code()``.
+
+        The fingerprint path has no acting operator (it runs from
+        :func:`~meho_backplane.connectors.resolver.resolve_connector` and
+        readiness probes); synthesise a system operator with an empty
+        ``raw_jwt`` so the kubeconfig loader's fail-closed guard surfaces
+        a clear error when there's no kubeconfig in the cache yet, rather
+        than silently authenticating as a backplane identity. The
+        :class:`~meho_backplane.connectors.kubernetes.kubeconfig.KubeconfigLoader`
+        contract receives the same ``(target, operator)`` pair the
+        operator-aware dispatch path uses.
+        """
+        operator = synthesise_system_operator()
+        api_client = await self._get_api_client(target, operator)
         version_api = client.VersionApi(api_client)
         version = await version_api.get_code()
         return FingerprintResult(
@@ -339,6 +353,7 @@ class KubernetesConnector(Connector):
 
     async def about(
         self,
+        operator: Operator,
         target: KubernetesTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
@@ -354,7 +369,12 @@ class KubernetesConnector(Connector):
         ``k8s.about`` dispatch regardless of how many other ops touch
         ``VersionApi``.
 
-        The returned dict is intentionally flat -- no nested
+        ``operator`` is the dispatch op's operator; it is forwarded to
+        :meth:`_get_api_client` so a cold-cache kubeconfig load happens
+        under the operator's identity (the locked Option A decision —
+        per-target Vault read under the operator's Identity entity).
+        ``dispatch_typed`` passes ``operator`` here because the signature
+        names it. The returned dict is intentionally flat -- no nested
         ``extras`` -- because the dispatcher's
         :class:`~meho_backplane.operations.reducer.PassThroughReducer`
         forwards the value verbatim. Future reducers (real JSONFlux
@@ -363,7 +383,7 @@ class KubernetesConnector(Connector):
         keys before and after the reducer swap.
         """
         del params  # declared in schema; the handler intentionally ignores them
-        api_client = await self._get_api_client(target)
+        api_client = await self._get_api_client(target, operator)
         version_api = client.VersionApi(api_client)
         version = await version_api.get_code()
         return {
@@ -380,6 +400,7 @@ class KubernetesConnector(Connector):
 
     async def k8s_namespace_list(
         self,
+        operator: Operator,
         target: KubernetesTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
@@ -392,13 +413,16 @@ class KubernetesConnector(Connector):
         ``namespace_row`` is unit-tested directly against synthetic
         :class:`V1Namespace` instances) and the live API path.
 
-        ``params`` is declared empty in the op's
+        ``operator`` is forwarded to :meth:`_get_api_client` so a
+        cold-cache kubeconfig load runs under the operator's identity;
+        see :meth:`about` for the threading rationale. ``params`` is
+        declared empty in the op's
         :attr:`~meho_backplane.connectors.kubernetes.ops_core.K8S_NAMESPACE_LIST_PARAMETER_SCHEMA`;
         the dispatcher's :class:`Draft202012Validator` rejects any extra
         keys before this handler runs.
         """
         del params
-        api_client = await self._get_api_client(target)
+        api_client = await self._get_api_client(target, operator)
         core_v1 = client.CoreV1Api(api_client)
         resp = await core_v1.list_namespace()
         rows = [namespace_row(ns) for ns in resp.items]
@@ -406,6 +430,7 @@ class KubernetesConnector(Connector):
 
     async def k8s_node_list(
         self,
+        operator: Operator,
         target: KubernetesTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
@@ -418,9 +443,12 @@ class KubernetesConnector(Connector):
         the role-label derivation are both helpers in :mod:`ops_core` so
         the unit tests pin those mappings against synthetic
         :class:`V1Node` instances without an event loop.
+
+        ``operator`` is forwarded to :meth:`_get_api_client`; see
+        :meth:`about` for the threading rationale.
         """
         del params
-        api_client = await self._get_api_client(target)
+        api_client = await self._get_api_client(target, operator)
         core_v1 = client.CoreV1Api(api_client)
         resp = await core_v1.list_node()
         rows = [node_row(n) for n in resp.items]
@@ -428,6 +456,7 @@ class KubernetesConnector(Connector):
 
     async def k8s_service_list(
         self,
+        operator: Operator,
         target: KubernetesTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
@@ -439,10 +468,13 @@ class KubernetesConnector(Connector):
         :func:`~meho_backplane.connectors.kubernetes.ops_network.service_row`.
         The helper is pure so the unit suite pins the wire shape against
         synthetic fixtures without booting an event loop.
+
+        ``operator`` is forwarded to :meth:`_get_api_client`; see
+        :meth:`about` for the threading rationale.
         """
         from meho_backplane.connectors.kubernetes.ops_network import service_row
 
-        api_client = await self._get_api_client(target)
+        api_client = await self._get_api_client(target, operator)
         core_v1 = client.CoreV1Api(api_client)
         resp = await core_v1.list_namespaced_service(namespace=params["namespace"])
         rows = [service_row(s) for s in resp.items]
@@ -450,6 +482,7 @@ class KubernetesConnector(Connector):
 
     async def k8s_ingress_list(
         self,
+        operator: Operator,
         target: KubernetesTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
@@ -459,10 +492,13 @@ class KubernetesConnector(Connector):
         ``NetworkingV1Api.list_namespaced_ingress(namespace)`` and
         projects each :class:`V1Ingress` through
         :func:`~meho_backplane.connectors.kubernetes.ops_network.ingress_row`.
+
+        ``operator`` is forwarded to :meth:`_get_api_client`; see
+        :meth:`about` for the threading rationale.
         """
         from meho_backplane.connectors.kubernetes.ops_network import ingress_row
 
-        api_client = await self._get_api_client(target)
+        api_client = await self._get_api_client(target, operator)
         networking_v1 = client.NetworkingV1Api(api_client)
         resp = await networking_v1.list_namespaced_ingress(namespace=params["namespace"])
         rows = [ingress_row(i) for i in resp.items]
@@ -470,6 +506,7 @@ class KubernetesConnector(Connector):
 
     async def k8s_configmap_list(
         self,
+        operator: Operator,
         target: KubernetesTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
@@ -482,10 +519,13 @@ class KubernetesConnector(Connector):
         which deliberately omits ``data`` / ``binary_data`` values.
         Operators wanting values call ``k8s.configmap.info`` per
         configmap so the audit row records the targeted read.
+
+        ``operator`` is forwarded to :meth:`_get_api_client`; see
+        :meth:`about` for the threading rationale.
         """
         from meho_backplane.connectors.kubernetes.ops_config import configmap_list_row
 
-        api_client = await self._get_api_client(target)
+        api_client = await self._get_api_client(target, operator)
         core_v1 = client.CoreV1Api(api_client)
         resp = await core_v1.list_namespaced_config_map(namespace=params["namespace"])
         rows = [configmap_list_row(cm) for cm in resp.items]
@@ -493,6 +533,7 @@ class KubernetesConnector(Connector):
 
     async def k8s_configmap_info(
         self,
+        operator: Operator,
         target: KubernetesTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
@@ -504,10 +545,13 @@ class KubernetesConnector(Connector):
         :func:`~meho_backplane.connectors.kubernetes.ops_config.configmap_info`.
         Counterpart to ``k8s.configmap.list``; the targeted read records
         a per-configmap audit row.
+
+        ``operator`` is forwarded to :meth:`_get_api_client`; see
+        :meth:`about` for the threading rationale.
         """
         from meho_backplane.connectors.kubernetes.ops_config import configmap_info
 
-        api_client = await self._get_api_client(target)
+        api_client = await self._get_api_client(target, operator)
         core_v1 = client.CoreV1Api(api_client)
         cm = await core_v1.read_namespaced_config_map(
             name=params["name"], namespace=params["namespace"]
@@ -516,6 +560,7 @@ class KubernetesConnector(Connector):
 
     async def k8s_event_list(
         self,
+        operator: Operator,
         target: KubernetesTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
@@ -566,7 +611,7 @@ class KubernetesConnector(Connector):
             limit = MAX_EVENT_LIMIT
         field_selector = params.get("field_selector")
 
-        api_client = await self._get_api_client(target)
+        api_client = await self._get_api_client(target, operator)
         core_v1 = client.CoreV1Api(api_client)
         # Always pull up to MAX_EVENT_LIMIT rows so the client-side
         # sort sees the full recency-relevant superset; the caller's
@@ -583,6 +628,7 @@ class KubernetesConnector(Connector):
 
     async def k8s_ls(
         self,
+        operator: Operator,
         target: KubernetesTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
@@ -614,6 +660,9 @@ class KubernetesConnector(Connector):
         future reducer-driven handle creation, audit row, broadcast --
         runs verbatim. The forwarding handler is structural plumbing, not
         a semantic shortcut.
+
+        ``operator`` is forwarded to :meth:`_get_api_client` (and to the
+        sub-op forwarder); see :meth:`about` for the threading rationale.
         """
         raw_path = params.get("path", "/")
         # Normalise the path: empty string and "/" both map to the root;
@@ -628,9 +677,9 @@ class KubernetesConnector(Connector):
         segments = [s for s in raw_path.split("/") if s]
 
         if not segments:
-            return await self._k8s_ls_root(target)
+            return await self._k8s_ls_root(target, operator)
         if len(segments) == 1:
-            return await self._k8s_ls_namespace(target, segments[0])
+            return await self._k8s_ls_namespace(target, operator, segments[0])
         if len(segments) == 2:
             return await self._k8s_ls_namespace_kind(target, segments[0], segments[1])
         # Deeper paths aren't a documented v0.2 shape; collapse to the
@@ -641,9 +690,10 @@ class KubernetesConnector(Connector):
     async def _k8s_ls_root(
         self,
         target: KubernetesTargetLike,
+        operator: Operator,
     ) -> dict[str, Any]:
         """Cluster-root view: list namespace names + the fixed cluster-kind list."""
-        api_client = await self._get_api_client(target)
+        api_client = await self._get_api_client(target, operator)
         core_v1 = client.CoreV1Api(api_client)
         resp = await core_v1.list_namespace()
         names = sorted(
@@ -660,6 +710,7 @@ class KubernetesConnector(Connector):
     async def _k8s_ls_namespace(
         self,
         target: KubernetesTargetLike,
+        operator: Operator,
         namespace: str,
     ) -> dict[str, Any]:
         """Per-namespace kind summary -- one round-trip per probed kind.
@@ -677,7 +728,7 @@ class KubernetesConnector(Connector):
         operator sees which kinds aren't enumerable rather than a single
         500-shaped failure for the whole ls.
         """
-        api_client = await self._get_api_client(target)
+        api_client = await self._get_api_client(target, operator)
         core_v1 = client.CoreV1Api(api_client)
         kinds: list[dict[str, Any]] = []
         for kind_label, method_name in K8S_NAMESPACED_KIND_LISTERS:
@@ -757,6 +808,7 @@ class KubernetesConnector(Connector):
 
     async def logs(
         self,
+        operator: Operator,
         target: KubernetesTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
@@ -771,16 +823,19 @@ class KubernetesConnector(Connector):
         per-op-handler-file split (one ``ops_<verb>.py`` per op,
         without a class) keeps the API stable.
 
-        Schema validation runs in the dispatcher before this method
-        is called; the function-level handler re-reads only
-        validated values.
+        ``operator`` is forwarded to the module-level handler so it can
+        reach the cached :class:`ApiClient` (cold-cache load happens
+        under the operator's identity). Schema validation runs in the
+        dispatcher before this method is called; the function-level
+        handler re-reads only validated values.
         """
         from meho_backplane.connectors.kubernetes.ops_logs import k8s_logs
 
-        return await k8s_logs(self, target, params)
+        return await k8s_logs(self, target, operator, params)
 
     async def k8s_pod_list(
         self,
+        operator: Operator,
         target: KubernetesTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
@@ -790,48 +845,66 @@ class KubernetesConnector(Connector):
         :func:`~meho_backplane.connectors.kubernetes.ops_workload.k8s_pod_list`.
         Same module-level-function shape :meth:`logs` uses so a future
         per-op-handler-file split keeps the registration API stable.
+
+        ``operator`` is forwarded to the module-level handler; see
+        :meth:`about` for the threading rationale.
         """
         from meho_backplane.connectors.kubernetes.ops_workload import (
             k8s_pod_list as _k8s_pod_list,
         )
 
-        return await _k8s_pod_list(self, target, params)
+        return await _k8s_pod_list(self, target, operator, params)
 
     async def k8s_pod_info(
         self,
+        operator: Operator,
         target: KubernetesTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
-        """Bound-method shim for the ``k8s.pod.info`` op (G3.2-T3 #323)."""
+        """Bound-method shim for the ``k8s.pod.info`` op (G3.2-T3 #323).
+
+        ``operator`` is forwarded to the module-level handler; see
+        :meth:`about` for the threading rationale.
+        """
         from meho_backplane.connectors.kubernetes.ops_workload import (
             k8s_pod_info as _k8s_pod_info,
         )
 
-        return await _k8s_pod_info(self, target, params)
+        return await _k8s_pod_info(self, target, operator, params)
 
     async def k8s_deployment_list(
         self,
+        operator: Operator,
         target: KubernetesTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
-        """Bound-method shim for the ``k8s.deployment.list`` op (G3.2-T3 #323)."""
+        """Bound-method shim for the ``k8s.deployment.list`` op (G3.2-T3 #323).
+
+        ``operator`` is forwarded to the module-level handler; see
+        :meth:`about` for the threading rationale.
+        """
         from meho_backplane.connectors.kubernetes.ops_workload import (
             k8s_deployment_list as _k8s_deployment_list,
         )
 
-        return await _k8s_deployment_list(self, target, params)
+        return await _k8s_deployment_list(self, target, operator, params)
 
     async def k8s_deployment_info(
         self,
+        operator: Operator,
         target: KubernetesTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
-        """Bound-method shim for the ``k8s.deployment.info`` op (G3.2-T3 #323)."""
+        """Bound-method shim for the ``k8s.deployment.info`` op (G3.2-T3 #323).
+
+        ``operator`` is forwarded to the module-level handler; see
+        :meth:`about` for the threading rationale.
+        """
         from meho_backplane.connectors.kubernetes.ops_workload import (
             k8s_deployment_info as _k8s_deployment_info,
         )
 
-        return await _k8s_deployment_info(self, target, params)
+        return await _k8s_deployment_info(self, target, operator, params)
 
     @classmethod
     async def register_operations(cls) -> None:
@@ -955,7 +1028,20 @@ class KubernetesConnector(Connector):
         (typed-connector internals, composite handlers) don't carry an
         :class:`~meho_backplane.auth.operator.Operator`, so the full
         dispatcher path (policy gate, audit, broadcast) doesn't run
-        from this entry point. The operator-aware surface is
+        from this entry point. To match the operator-aware handler
+        signatures the dispatcher now passes ``operator`` to, the shim
+        synthesises a system :class:`Operator` with an empty
+        ``raw_jwt`` (the same shape the fingerprint / probe paths use,
+        :func:`~meho_backplane.connectors._shared.system_operator.synthesise_system_operator`).
+        On a cold kubeconfig-cache miss this fails closed with a clear
+        error rather than silently authenticating as a backplane
+        identity — the system-call carve-out from
+        :doc:`docs/architecture/connector-auth.md`. The shim's
+        intra-connector callers (the ``k8s.ls /<ns>/<kind>`` forwarder)
+        run *after* the operator-aware op already warmed the
+        ``ApiClient`` cache, so the synthesised operator never reaches
+        the loader in practice; the fail-closed shape is the defensive
+        case. The operator-aware surface is
         ``POST /api/v1/operations/call`` via the G0.6 meta-tools; the
         pre-G0.6 chassis route was removed by G0.6-T11 (#412). Within
         the operator-less constraint the shim's contract is:
@@ -972,6 +1058,8 @@ class KubernetesConnector(Connector):
         # ``register_operations`` -- pure-python tests that exercise
         # ``fingerprint``/``probe`` shouldn't pay the operations
         # package's import cost.
+        import inspect
+
         from sqlalchemy import select
 
         from meho_backplane.db.engine import get_sessionmaker
@@ -1035,8 +1123,23 @@ class KubernetesConnector(Connector):
         if is_unbound_method(handler, type(self)):
             handler = handler.__get__(self, type(self))
 
+        # Signature introspection mirroring ``dispatch_typed``: the
+        # operator-aware handlers (every k8s op after #948) name
+        # ``operator`` in their signature so the dispatcher knows to
+        # forward it. The shim is operator-less, so it synthesises a
+        # system operator (empty ``raw_jwt``); the kubeconfig loader's
+        # fail-closed guard surfaces a clear error if the cache misses.
+        # The ``raw``/no-``operator``-named branch stays in place so
+        # the same shim works against an older handler that hasn't
+        # been re-shaped.
+        param_names = list(inspect.signature(handler).parameters.keys())
         try:
-            raw = await handler(target=target, params=params)
+            if "operator" in param_names:
+                raw = await handler(
+                    operator=synthesise_system_operator(), target=target, params=params
+                )
+            else:
+                raw = await handler(target=target, params=params)
         except Exception as exc:
             return result_connector_error(op_id, exc, _elapsed())
 
@@ -1072,20 +1175,43 @@ class KubernetesConnector(Connector):
         """
         return target.secret_ref
 
-    async def _get_api_client(self, target: KubernetesTargetLike) -> client.ApiClient:
+    async def _get_api_client(
+        self,
+        target: KubernetesTargetLike,
+        operator: Operator,
+    ) -> client.ApiClient:
         """Resolve (and cache) the :class:`ApiClient` for *target*.
 
         The single lock serialises concurrent first-use for any target;
         in practice the second caller hits the cache fast-path. The
         slow kubeconfig read happens under the lock so two concurrent
         callers for the same target don't both pay the cost.
+
+        ``operator`` is forwarded to the injected
+        :class:`~meho_backplane.connectors.kubernetes.kubeconfig.KubeconfigLoader`
+        so the default
+        :func:`~meho_backplane.connectors.kubernetes.kubeconfig.load_kubeconfig_from_vault`
+        can read the per-target kubeconfig under the operator's identity
+        (``vault_client_for_operator(operator)``). An injected test
+        loader receives the same ``(target, operator)`` pair so the
+        wiring is exercised by both the default and the injected path.
+
+        Cache-hit fast path: when the :class:`ApiClient` is already
+        cached for this target's :meth:`_cache_key`, the operator
+        argument is ignored (the kubeconfig has already been resolved
+        under a prior operator's identity). This is the v0.2 design
+        choice: kubeconfigs are tied to ``target.secret_ref`` (the
+        shared service account) rather than the acting operator, so the
+        client is shareable across operators. A future per-operator
+        auth model (impersonation) would re-key the cache on operator
+        identity; until then ``secret_ref`` is sufficient.
         """
         key = self._cache_key(target)
         async with self._lock:
             cached = self._api_clients.get(key)
             if cached is not None:
                 return cached
-            kubeconfig_dict = await self._kubeconfig_loader(target)
+            kubeconfig_dict = await self._kubeconfig_loader(target, operator)
             api_client = await config.new_client_from_config_dict(kubeconfig_dict)
             self._api_clients[key] = api_client
             _log.info(

--- a/backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py
@@ -9,27 +9,78 @@ injectable ``kubeconfig_loader`` callable. A concrete target model that
 exposes ``name``/``host``/``port``/``secret_ref`` satisfies the Protocol
 structurally with no edits here.
 
-The default loader, :func:`load_kubeconfig_from_vault`, is a deliberate
-stub: the operator-context per-target Vault credential read is not yet
-wired for the Kubernetes connector, so it raises
-:exc:`NotImplementedError`. The supported workaround is to inject a
-custom ``kubeconfig_loader`` on ``KubernetesConnector`` at construction
-time; unit and integration tests inject their own (mock) loader the
-same way. The live read is tracked under the open
-`Goal #214 (Connector parity) <https://github.com/evoila/meho/issues/214>`_.
+The default loader, :func:`load_kubeconfig_from_vault`, performs the
+**live** operator-context KV-v2 read: it forwards the operator's
+validated Keycloak JWT to Vault and reads ``target.secret_ref`` for the
+``kubeconfig`` field, parses the YAML into the dict shape
+``kubernetes_asyncio.config.new_client_from_config_dict`` accepts, and
+returns it. This is the rubric **State 2** wiring (`shared_service_account`
+only) per `Goal #214 (Connector parity)
+<https://github.com/evoila/meho/issues/214>`_. A custom
+``kubeconfig_loader`` can still be injected on ``KubernetesConnector``
+at construction time; unit and integration tests inject their own (mock)
+loader the same way.
+
+Why kubeconfig isn't shaped like the basic-credentials helper
+=============================================================
+
+The shared :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+helper returns a flat ``{field: str}`` dict — the right shape for the
+HTTP-basic ``{username, password}`` pairs every REST connector consumes.
+A kubeconfig is structurally different: it's a YAML document with nested
+``clusters`` / ``contexts`` / ``users`` arrays under a single Vault field
+``kubeconfig`` (decision #8 convention). So this loader reuses the lower-
+level Vault primitive (:func:`~meho_backplane.auth.vault.vault_client_for_operator`
++ ``read_secret_version``) directly and does its own YAML parse via
+:func:`parse_kubeconfig_yaml`, mirroring the shape of the shared helper
+but with a kubeconfig-shaped return type and a kubeconfig-specific error
+contract (a malformed YAML field is a value error, not a missing
+credential field).
+
+No kubeconfig content in logs
+=============================
+
+The loader's structlog event carries only ``target`` / ``host`` / the
+``secret_ref`` path / the field *name* — never the kubeconfig YAML, the
+server URL, the client certificate / token, or any other content from
+the parsed dict. The returned dict is treated as ephemeral in-memory
+state: it never enters a log event, an ``OperationResult``, or any
+durable artifact.
 """
 
+from __future__ import annotations
+
+import asyncio
 from collections.abc import Awaitable, Callable
 from typing import Any, Protocol, runtime_checkable
 
+import structlog
 import yaml
 
+from meho_backplane.auth.operator import Operator
+from meho_backplane.auth.vault import vault_client_for_operator
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+
 __all__ = [
+    "DEFAULT_KUBECONFIG_FIELD",
+    "DEFAULT_KUBECONFIG_KV_MOUNT",
     "KubeconfigLoader",
     "KubernetesTargetLike",
     "load_kubeconfig_from_vault",
     "parse_kubeconfig_yaml",
 ]
+
+
+#: KV-v2 mount the consumer convention addresses kubeconfig secrets
+#: under. Mirrors :data:`~meho_backplane.connectors._shared.vault_creds.DEFAULT_KV_MOUNT`;
+#: dev mode mounts ``secret/`` as v2 by default and the consumer
+#: ``targets.yaml`` ``secret_ref`` paths live under it.
+DEFAULT_KUBECONFIG_KV_MOUNT: str = "secret"
+
+#: KV-v2 field name the kubeconfig YAML lives under (decision #8). The
+#: operator stores the kubeconfig at ``<secret_ref>`` with this single
+#: field; the loader reads exactly this key.
+DEFAULT_KUBECONFIG_FIELD: str = "kubeconfig"
 
 
 @runtime_checkable
@@ -50,16 +101,23 @@ class KubernetesTargetLike(Protocol):
     secret_ref: str
 
 
-KubeconfigLoader = Callable[[KubernetesTargetLike], Awaitable[dict[str, Any]]]
-"""Async callable resolving a target to a parsed kubeconfig dict.
+KubeconfigLoader = Callable[[KubernetesTargetLike, Operator], Awaitable[dict[str, Any]]]
+"""Async callable resolving a (target, operator) pair to a kubeconfig dict.
 
 Injection point for the connector's auth flow. Tests pass a mock
 returning a pre-built dict; production passes
-:func:`load_kubeconfig_from_vault` (or a wrapper bound to an operator
-context). The dict shape matches what
+:func:`load_kubeconfig_from_vault`. The dict shape matches what
 ``kubernetes_asyncio.config.new_client_from_config_dict`` accepts —
 top-level keys ``apiVersion`` / ``clusters`` / ``contexts`` /
 ``current-context`` / ``users``.
+
+The ``operator`` parameter carries the full
+:class:`~meho_backplane.auth.operator.Operator` so the live loader
+reads the per-target secret under the operator's identity via
+``vault_client_for_operator(operator)`` — the locked decision in
+:doc:`docs/architecture/connector-auth.md`. An injected test loader
+receives the same ``(target, operator)`` pair so the wiring is
+exercised by both the default and the injected path.
 """
 
 
@@ -83,23 +141,182 @@ def parse_kubeconfig_yaml(kubeconfig_text: str) -> dict[str, Any]:
     return parsed
 
 
-async def load_kubeconfig_from_vault(target: KubernetesTargetLike) -> dict[str, Any]:
-    """Default kubeconfig loader — Vault read by ``target.secret_ref``.
+def _resolve_secret_ref(target: KubernetesTargetLike, operator: Operator) -> str:
+    """Validate the pre-read preconditions and return the KV-v2 path.
 
-    Deliberate stub: the operator-context per-target Vault credential
-    read is not yet wired for the Kubernetes connector. Raising
-    :exc:`NotImplementedError` here keeps the wiring shape stable — a
-    production caller without an override receives a clear error rather
-    than a silent fallback or a hallucinated kubeconfig. The supported
-    workaround is to inject a custom ``kubeconfig_loader`` on
-    ``KubernetesConnector`` at construction time. The live read is
-    tracked under the open Goal #214 (Connector parity).
+    Two fail-closed guards, both raising
+    :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`
+    *before* Vault is touched:
+
+    * empty ``operator.raw_jwt`` — an operator-context read requires an
+      authenticated operator. System-initiated calls (topology scheduler,
+      readiness probe) carry ``raw_jwt=""`` and must error here rather
+      than silently falling back to a backplane identity (the decision's
+      system-call carve-out, mirroring
+      :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`).
+    * unset ``target.secret_ref`` — the target is unconfigured.
+
+    Returns the stripped ``secret_ref`` path so trailing whitespace never
+    slips into the hvac call.
     """
-    raise NotImplementedError(
-        "load_kubeconfig_from_vault is a deliberate stub: the operator-context "
-        "per-target Vault credential read is not yet wired for the Kubernetes "
-        f"connector; target={target.name!r} secret_ref={target.secret_ref!r}. "
-        "Workaround: inject a custom kubeconfig_loader on KubernetesConnector. "
-        "Tracked under open Goal #214 (Connector parity): "
-        "https://github.com/evoila/meho/issues/214"
+    if not operator.raw_jwt:
+        raise VaultCredentialsReadError(
+            "operator-context credential read requires an authenticated operator; "
+            f"target={target.name!r} has no operator JWT (system-initiated calls "
+            "cannot read per-target kubeconfig credentials)"
+        )
+    if not target.secret_ref:
+        raise VaultCredentialsReadError(
+            f"target {target.name!r} has no secret_ref configured; cannot read "
+            "its kubeconfig from Vault"
+        )
+    return target.secret_ref.strip()
+
+
+def _structural_unwrap(payload: object, *, target_name: str) -> dict[str, object]:
+    """Unwrap hvac's ``read_secret_version`` payload to the secret data dict.
+
+    KV-v2's GET on ``/{mount}/data/{path}`` returns
+    ``{"data": {"data": {<secret kv>}, "metadata": {...}}}``. The secret
+    content is the *nested* ``data["data"]`` — the same double-unwrap the
+    shared :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+    helper performs. A malformed payload (missing either ``data`` level)
+    raises :class:`VaultCredentialsReadError` naming the target rather
+    than a bare ``KeyError`` deep inside hvac's response.
+    """
+    outer = payload.get("data") if isinstance(payload, dict) else None
+    secret_data = outer.get("data") if isinstance(outer, dict) else None
+    if not isinstance(secret_data, dict):
+        raise VaultCredentialsReadError(
+            f"vault KV-v2 read for target {target_name!r} returned a malformed "
+            "payload: expected a nested 'data.data' object holding the kubeconfig field"
+        )
+    return secret_data
+
+
+def _extract_kubeconfig_text(
+    secret_data: dict[str, object],
+    *,
+    target_name: str,
+    secret_ref: str,
+    field: str,
+) -> str:
+    """Pull the kubeconfig YAML string out of the secret data dict.
+
+    Missing field or wrong-type field both raise
+    :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`
+    naming the target + field + ``secret_ref`` — never a bare
+    ``KeyError`` or ``AttributeError``.
+    """
+    if field not in secret_data:
+        raise VaultCredentialsReadError(
+            f"vault secret for target {target_name!r} (secret_ref={secret_ref!r}) "
+            f"is missing required field {field!r} (expected kubeconfig YAML)"
+        )
+    kubeconfig_text = secret_data[field]
+    if not isinstance(kubeconfig_text, str):
+        raise VaultCredentialsReadError(
+            f"vault secret for target {target_name!r} (secret_ref={secret_ref!r}) "
+            f"has field {field!r} of type {type(kubeconfig_text).__name__}, "
+            "expected a YAML string"
+        )
+    return kubeconfig_text
+
+
+async def load_kubeconfig_from_vault(
+    target: KubernetesTargetLike,
+    operator: Operator,
+    *,
+    field: str = DEFAULT_KUBECONFIG_FIELD,
+    mount: str = DEFAULT_KUBECONFIG_KV_MOUNT,
+) -> dict[str, Any]:
+    """Default kubeconfig loader — live operator-context Vault KV-v2 read + YAML parse.
+
+    Opens :func:`~meho_backplane.auth.vault.vault_client_for_operator`
+    (JWT/OIDC login forwarding ``operator.raw_jwt``), reads
+    ``target.secret_ref`` as a KV-v2 secret off the event loop
+    (``asyncio.to_thread`` — hvac is synchronous), structurally unwraps
+    the nested ``data["data"]``, extracts the kubeconfig YAML from the
+    ``kubeconfig`` field, and returns the parsed dict.
+
+    This is the rubric **State 2** wiring (`shared_service_account` only)
+    per `Goal #214 (Connector parity) <https://github.com/evoila/meho/issues/214>`_.
+    A custom loader can still be injected via ``kubeconfig_loader`` on
+    :class:`KubernetesConnector`; this default is what production
+    targets use.
+
+    Parameters
+    ----------
+    target
+        The target whose ``secret_ref`` (a KV-v2 path string) holds the
+        kubeconfig YAML.
+    operator
+        The request-scoped operator. ``operator.raw_jwt`` is forwarded
+        to Vault's JWT/OIDC auth method — the read happens under the
+        operator's Vault Identity entity, giving per-operator RBAC and
+        audit (the locked Option A decision).
+    field
+        The KV-v2 secret field holding the kubeconfig YAML. Defaults to
+        ``"kubeconfig"`` (decision #8 convention); pass a different
+        value only for a non-default field name.
+    mount
+        The KV-v2 mount point. Defaults to ``"secret"`` (the consumer
+        convention); pass a different value only for a non-default mount.
+
+    Returns
+    -------
+    dict[str, Any]
+        The parsed kubeconfig in the shape
+        ``kubernetes_asyncio.config.new_client_from_config_dict`` accepts.
+
+    Raises
+    ------
+    VaultCredentialsReadError
+        Read-phase failure: ``operator.raw_jwt`` is empty (the
+        fail-closed system-call carve-out), ``target.secret_ref`` is
+        unset, the KV-v2 payload is malformed, or the requested
+        ``field`` is missing.
+    ValueError
+        Raised by :func:`parse_kubeconfig_yaml` when the kubeconfig
+        field is not parseable YAML or does not parse to a mapping.
+    meho_backplane.auth.vault.VaultClientError
+        Login-phase failure raised by
+        :func:`vault_client_for_operator` —
+        :class:`~meho_backplane.auth.vault.VaultUnreachableError`
+        (network/TLS) or
+        :class:`~meho_backplane.auth.vault.VaultRoleDeniedError` (Vault
+        rejected the JWT for the role). Propagated verbatim so callers
+        can distinguish login-phase from read-phase failure.
+    """
+    # Fail-closed precondition guards (empty JWT / unset secret_ref) run
+    # before Vault is touched; returns the stripped KV-v2 path.
+    path = _resolve_secret_ref(target, operator)
+
+    async with vault_client_for_operator(operator) as client:
+        payload = await asyncio.to_thread(
+            client.secrets.kv.v2.read_secret_version,
+            path=path,
+            mount_point=mount,
+            raise_on_deleted_version=False,
+        )
+
+    secret_data = _structural_unwrap(payload, target_name=target.name)
+    kubeconfig_text = _extract_kubeconfig_text(
+        secret_data, target_name=target.name, secret_ref=path, field=field
     )
+
+    # Log only non-secret attribution: target / host / secret_ref / field
+    # name — never any kubeconfig content. The parsed dict is ephemeral
+    # in-memory state and must not enter any log event, OperationResult,
+    # or durable artifact. Resolve the logger per-call so
+    # ``structlog.testing.capture_logs`` can reach it (same precedent +
+    # rationale as ``_shared.vault_creds.load_basic_credentials``).
+    structlog.get_logger(__name__).info(
+        "vault_kubeconfig_loaded",
+        target=target.name,
+        host=target.host,
+        secret_ref=path,
+        field=field,
+    )
+
+    return parse_kubeconfig_yaml(kubeconfig_text)

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_logs.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_logs.py
@@ -50,6 +50,7 @@ from typing import TYPE_CHECKING, Any
 from kubernetes_asyncio import client
 
 if TYPE_CHECKING:
+    from meho_backplane.auth.operator import Operator
     from meho_backplane.connectors.kubernetes.connector import KubernetesConnector
     from meho_backplane.connectors.kubernetes.kubeconfig import KubernetesTargetLike
 
@@ -397,6 +398,7 @@ def truncate_lines_to_byte_cap(lines: list[str], cap_bytes: int) -> tuple[list[s
 async def k8s_logs(
     connector: KubernetesConnector,
     target: KubernetesTargetLike,
+    operator: Operator,
     params: dict[str, Any],
 ) -> dict[str, Any]:
     """Handler for ``k8s.logs``.
@@ -407,6 +409,10 @@ async def k8s_logs(
     validation runs in the dispatcher, so ``params`` arrives
     pre-checked against :data:`K8S_LOGS_PARAMETER_SCHEMA` -- the
     handler only re-reads validated values.
+
+    ``operator`` is forwarded to
+    :meth:`KubernetesConnector._get_api_client` so a cold-cache
+    kubeconfig load runs under the operator's identity.
 
     Raises propagate to the dispatcher's ``connector_error`` branch:
 
@@ -432,7 +438,7 @@ async def k8s_logs(
     since_seconds = parse_duration(params.get("since"))
     previous = bool(params.get("previous", False))
 
-    api_client = await connector._get_api_client(target)
+    api_client = await connector._get_api_client(target, operator)
     v1 = client.CoreV1Api(api_client)
 
     exact_name, container_name = await resolve_pod_and_container(

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_workload.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_workload.py
@@ -101,6 +101,7 @@ if TYPE_CHECKING:
         V1Pod,
     )
 
+    from meho_backplane.auth.operator import Operator
     from meho_backplane.connectors.kubernetes.connector import KubernetesConnector
     from meho_backplane.connectors.kubernetes.kubeconfig import KubernetesTargetLike
 
@@ -658,6 +659,7 @@ def _next_continue_token(resp: Any) -> str | None:
 async def k8s_pod_list(
     connector: KubernetesConnector,
     target: KubernetesTargetLike,
+    operator: Operator,
     params: dict[str, Any],
 ) -> dict[str, Any]:
     """Handler for ``k8s.pod.list``.
@@ -667,10 +669,14 @@ async def k8s_pod_list(
     ``{rows, total, next_continue?}``; the ``next_continue`` key is
     only present when the server signalled more pages exist. Schema
     validation runs in the dispatcher before this handler is called.
+
+    ``operator`` is forwarded to
+    :meth:`KubernetesConnector._get_api_client` so a cold-cache
+    kubeconfig load runs under the operator's identity.
     """
     namespace: str | None = params.get("namespace")
     all_namespaces = bool(params.get("all_namespaces", False))
-    api_client = await connector._get_api_client(target)
+    api_client = await connector._get_api_client(target, operator)
     v1 = client.CoreV1Api(api_client)
     kwargs = _list_kwargs(params)
     if all_namespaces:
@@ -691,6 +697,7 @@ async def k8s_pod_list(
 async def k8s_pod_info(
     connector: KubernetesConnector,
     target: KubernetesTargetLike,
+    operator: Operator,
     params: dict[str, Any],
 ) -> dict[str, Any]:
     """Handler for ``k8s.pod.info``.
@@ -701,10 +708,14 @@ async def k8s_pod_info(
     differs from the input -- the prefix-resolution list response
     already contains the full :class:`V1Pod`, so the extra round-trip
     is skipped for the exact-name path.
+
+    ``operator`` is forwarded to
+    :meth:`KubernetesConnector._get_api_client` so a cold-cache
+    kubeconfig load runs under the operator's identity.
     """
     pod_name: str = params["pod_name"]
     namespace: str = params["namespace"]
-    api_client = await connector._get_api_client(target)
+    api_client = await connector._get_api_client(target, operator)
     v1 = client.CoreV1Api(api_client)
     pod = await resolve_pod_name(v1, namespace, pod_name)
     # The list-derived V1Pod carries the full spec + status by default,
@@ -717,6 +728,7 @@ async def k8s_pod_info(
 async def k8s_deployment_list(
     connector: KubernetesConnector,
     target: KubernetesTargetLike,
+    operator: Operator,
     params: dict[str, Any],
 ) -> dict[str, Any]:
     """Handler for ``k8s.deployment.list``.
@@ -725,10 +737,14 @@ async def k8s_deployment_list(
     ``field_selector`` knob is less commonly used against deployments
     (no ``status.phase`` filter equivalent), but the API accepts it so
     we forward it for parity with the pod path.
+
+    ``operator`` is forwarded to
+    :meth:`KubernetesConnector._get_api_client` so a cold-cache
+    kubeconfig load runs under the operator's identity.
     """
     namespace: str | None = params.get("namespace")
     all_namespaces = bool(params.get("all_namespaces", False))
-    api_client = await connector._get_api_client(target)
+    api_client = await connector._get_api_client(target, operator)
     apps_v1 = client.AppsV1Api(api_client)
     kwargs = _list_kwargs(params)
     if all_namespaces:
@@ -746,12 +762,18 @@ async def k8s_deployment_list(
 async def k8s_deployment_info(
     connector: KubernetesConnector,
     target: KubernetesTargetLike,
+    operator: Operator,
     params: dict[str, Any],
 ) -> dict[str, Any]:
-    """Handler for ``k8s.deployment.info``. Mirrors :func:`k8s_pod_info`."""
+    """Handler for ``k8s.deployment.info``. Mirrors :func:`k8s_pod_info`.
+
+    ``operator`` is forwarded to
+    :meth:`KubernetesConnector._get_api_client` so a cold-cache
+    kubeconfig load runs under the operator's identity.
+    """
     deployment_name: str = params["deployment_name"]
     namespace: str = params["namespace"]
-    api_client = await connector._get_api_client(target)
+    api_client = await connector._get_api_client(target, operator)
     apps_v1 = client.AppsV1Api(api_client)
     deployment = await resolve_deployment_name(apps_v1, namespace, deployment_name)
     return deployment_info(deployment)

--- a/backend/tests/integration/test_connectors_k8s_e2e.py
+++ b/backend/tests/integration/test_connectors_k8s_e2e.py
@@ -82,6 +82,7 @@ import pytest
 from sqlalchemy import delete, select
 
 import meho_backplane.operations._handler_resolve as _handler_resolve_module
+from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.kubernetes import (
     KUBERNETES_OPS,
     KubernetesConnector,
@@ -310,7 +311,7 @@ async def k8s_e2e(
         cls=KubernetesConnector,
     )
 
-    async def _loader(_t: KubernetesTargetLike) -> dict[str, Any]:
+    async def _loader(_t: KubernetesTargetLike, _operator: Operator) -> dict[str, Any]:
         return kubeconfig
 
     seeded_connector = KubernetesConnector(kubeconfig_loader=_loader)

--- a/backend/tests/integration/test_connectors_k8s_k3d.py
+++ b/backend/tests/integration/test_connectors_k8s_k3d.py
@@ -34,6 +34,7 @@ from urllib.parse import urlparse
 
 import pytest
 
+from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.kubernetes import (
     KubernetesConnector,
     KubernetesTargetLike,
@@ -127,6 +128,26 @@ def k3s_kubeconfig_and_target() -> Any:
         container.stop()
 
 
+def _make_k3d_operator() -> Operator:
+    """Build a non-system operator carrying a non-empty ``raw_jwt``.
+
+    G3.10-T4 (#948) added ``operator`` to every typed handler's
+    signature; the injected loader here ignores it (the test container's
+    kubeconfig is passed through verbatim), but the handler forwards it
+    to :meth:`KubernetesConnector._get_api_client`.
+    """
+    import uuid as _uuid
+
+    return Operator(
+        sub="op-k3d-test",
+        name="K3d Test Operator",
+        email=None,
+        raw_jwt="op.k3d.jwt",
+        tenant_id=_uuid.UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
 @pytest.fixture
 async def k3s_connector(
     k3s_kubeconfig_and_target: tuple[dict[str, Any], _K3sTarget],
@@ -134,7 +155,7 @@ async def k3s_connector(
     """Yield a connector whose loader returns the container's kubeconfig."""
     kubeconfig, target = k3s_kubeconfig_and_target
 
-    async def _loader(_target: KubernetesTargetLike) -> dict[str, Any]:
+    async def _loader(_target: KubernetesTargetLike, _operator: Operator) -> dict[str, Any]:
         return kubeconfig
 
     connector = KubernetesConnector(kubeconfig_loader=_loader)
@@ -190,7 +211,7 @@ async def test_probe_against_unreachable_host_returns_not_ok(
     """An invalid host yields an informative ``ok=False`` reason."""
     kubeconfig, _ = k3s_kubeconfig_and_target
 
-    async def _loader(_target: KubernetesTargetLike) -> dict[str, Any]:
+    async def _loader(_target: KubernetesTargetLike, _operator: Operator) -> dict[str, Any]:
         return kubeconfig
 
     bogus = _K3sTarget(
@@ -238,7 +259,7 @@ async def test_namespace_list_against_k3s_returns_default_set(
 ) -> None:
     """``k8s.namespace.list`` over k3s returns the bootstrap namespaces."""
     connector, target = k3s_connector
-    result = await connector.k8s_namespace_list(target, {})
+    result = await connector.k8s_namespace_list(_make_k3d_operator(), target, {})
     assert result["total"] >= 4  # default, kube-system, kube-public, kube-node-lease
     names = {row["name"] for row in result["rows"]}
     assert "default" in names
@@ -255,7 +276,7 @@ async def test_node_list_against_k3s_returns_at_least_one_node(
 ) -> None:
     """``k8s.node.list`` over k3s returns the single-node default cluster."""
     connector, target = k3s_connector
-    result = await connector.k8s_node_list(target, {})
+    result = await connector.k8s_node_list(_make_k3d_operator(), target, {})
     assert result["total"] >= 1
     node = result["rows"][0]
     # k3s nodes report Ready=True post-boot; the test waits implicitly via
@@ -276,7 +297,7 @@ async def test_ls_root_against_k3s_returns_namespaces_and_cluster_kinds(
 ) -> None:
     """``k8s.ls /`` over k3s returns the live namespace set + the fixed cluster kinds."""
     connector, target = k3s_connector
-    result = await connector.k8s_ls(target, {"path": "/"})
+    result = await connector.k8s_ls(_make_k3d_operator(), target, {"path": "/"})
     assert result["path"] == "/"
     assert "default" in result["namespaces"]
     assert "kube-system" in result["namespaces"]
@@ -290,7 +311,7 @@ async def test_ls_namespace_against_k3s_returns_kind_counts(
 ) -> None:
     """``k8s.ls /kube-system`` returns per-kind counts via remaining_item_count."""
     connector, target = k3s_connector
-    result = await connector.k8s_ls(target, {"path": "/kube-system"})
+    result = await connector.k8s_ls(_make_k3d_operator(), target, {"path": "/kube-system"})
     assert result["namespace"] == "kube-system"
     assert result["cluster_kinds_omitted"] is True
     kinds_by_label = {entry["kind"]: entry for entry in result["kinds"]}
@@ -320,7 +341,7 @@ async def test_ls_namespace_kind_against_k3s_forwards_to_unknown_op(
     by this module.
     """
     connector, target = k3s_connector
-    result = await connector.k8s_ls(target, {"path": "/default/pods"})
+    result = await connector.k8s_ls(_make_k3d_operator(), target, {"path": "/default/pods"})
     assert result["forwarded_to"] == "k8s.pod.list"
     inner = result["result"]
     assert inner["status"] == "error"
@@ -344,7 +365,9 @@ async def test_pod_list_against_k3s_returns_kube_system_pods(
     drift adds/removes shipped components.
     """
     connector, target = k3s_connector
-    result = await connector.k8s_pod_list(target, {"namespace": "kube-system"})
+    result = await connector.k8s_pod_list(
+        _make_k3d_operator(), target, {"namespace": "kube-system"}
+    )
     assert result["total"] >= 1
     sample = result["rows"][0]
     for key in ("name", "namespace", "status", "ready", "restarts", "age_seconds", "node", "ip"):
@@ -358,7 +381,7 @@ async def test_pod_list_all_namespaces_against_k3s(
 ) -> None:
     """``k8s.pod.list --all-namespaces`` returns pods spanning multiple namespaces."""
     connector, target = k3s_connector
-    result = await connector.k8s_pod_list(target, {"all_namespaces": True})
+    result = await connector.k8s_pod_list(_make_k3d_operator(), target, {"all_namespaces": True})
     assert result["total"] >= 1
     namespaces = {row["namespace"] for row in result["rows"]}
     # k3s' bootstrap pods live in kube-system.
@@ -371,7 +394,9 @@ async def test_pod_list_server_side_limit_caps_rows(
 ) -> None:
     """``limit=1`` enforces a one-row page; further pages reachable via continue_token."""
     connector, target = k3s_connector
-    result = await connector.k8s_pod_list(target, {"namespace": "kube-system", "limit": 1})
+    result = await connector.k8s_pod_list(
+        _make_k3d_operator(), target, {"namespace": "kube-system", "limit": 1}
+    )
     assert result["total"] == 1
     # next_continue presence depends on whether kube-system has >1 pod
     # (it normally does on k3s); single-pod namespaces omit the token.
@@ -379,6 +404,7 @@ async def test_pod_list_server_side_limit_caps_rows(
     # cleanly back through a second list call.
     if "next_continue" in result:
         page_2 = await connector.k8s_pod_list(
+            _make_k3d_operator(),
             target,
             {
                 "namespace": "kube-system",
@@ -395,7 +421,9 @@ async def test_pod_info_against_k3s_resolves_prefix(
 ) -> None:
     """``k8s.pod.info`` resolves a unique prefix and returns full container detail."""
     connector, target = k3s_connector
-    listing = await connector.k8s_pod_list(target, {"namespace": "kube-system"})
+    listing = await connector.k8s_pod_list(
+        _make_k3d_operator(), target, {"namespace": "kube-system"}
+    )
     assert listing["total"] >= 1
     pod_name = listing["rows"][0]["name"]
     # k3s pod names follow ``<deployment>-<hash>-<id>``; the first
@@ -405,7 +433,7 @@ async def test_pod_info_against_k3s_resolves_prefix(
     prefix_matches = [r for r in listing["rows"] if r["name"].startswith(prefix)]
     target_name = prefix if len(prefix_matches) == 1 else pod_name
     info = await connector.k8s_pod_info(
-        target, {"pod_name": target_name, "namespace": "kube-system"}
+        _make_k3d_operator(), target, {"pod_name": target_name, "namespace": "kube-system"}
     )
     assert info["name"] == pod_name
     assert info["namespace"] == "kube-system"
@@ -423,6 +451,7 @@ async def test_pod_info_not_found_raises_against_k3s(
     connector, target = k3s_connector
     with pytest.raises(WorkloadNotFoundError):
         await connector.k8s_pod_info(
+            _make_k3d_operator(),
             target,
             {"pod_name": "definitely-not-a-real-pod-zzz", "namespace": "kube-system"},
         )
@@ -439,7 +468,9 @@ async def test_deployment_list_against_k3s_kube_system(
     existential (at least one) for k3s-minor drift tolerance.
     """
     connector, target = k3s_connector
-    result = await connector.k8s_deployment_list(target, {"namespace": "kube-system"})
+    result = await connector.k8s_deployment_list(
+        _make_k3d_operator(), target, {"namespace": "kube-system"}
+    )
     assert result["total"] >= 1
     sample = result["rows"][0]
     for key in (
@@ -462,11 +493,13 @@ async def test_deployment_info_against_k3s_returns_full_detail(
 ) -> None:
     """``k8s.deployment.info`` returns the full template + status block."""
     connector, target = k3s_connector
-    listing = await connector.k8s_deployment_list(target, {"namespace": "kube-system"})
+    listing = await connector.k8s_deployment_list(
+        _make_k3d_operator(), target, {"namespace": "kube-system"}
+    )
     assert listing["total"] >= 1
     dep_name = listing["rows"][0]["name"]
     info = await connector.k8s_deployment_info(
-        target, {"deployment_name": dep_name, "namespace": "kube-system"}
+        _make_k3d_operator(), target, {"deployment_name": dep_name, "namespace": "kube-system"}
     )
     assert info["name"] == dep_name
     assert info["namespace"] == "kube-system"
@@ -486,7 +519,9 @@ async def test_service_list_against_k3s_returns_kubernetes_service(
 ) -> None:
     """``k8s.service.list --namespace default`` returns the bootstrap ``kubernetes`` service."""
     connector, target = k3s_connector
-    result = await connector.k8s_service_list(target, {"namespace": "default"})
+    result = await connector.k8s_service_list(
+        _make_k3d_operator(), target, {"namespace": "default"}
+    )
     # Every k3s cluster ships with the ``kubernetes`` ClusterIP service
     # in the ``default`` namespace -- it's the API server's in-cluster
     # endpoint. Use it as the existence assertion; specific cluster_ip
@@ -511,7 +546,9 @@ async def test_ingress_list_against_k3s_returns_empty_or_default(
     failed against a real cluster would surface as an exception here.
     """
     connector, target = k3s_connector
-    result = await connector.k8s_ingress_list(target, {"namespace": "default"})
+    result = await connector.k8s_ingress_list(
+        _make_k3d_operator(), target, {"namespace": "default"}
+    )
     assert isinstance(result["rows"], list)
     assert result["total"] == len(result["rows"])
 
@@ -529,7 +566,9 @@ async def test_configmap_list_against_k3s_keys_only_data_absent(
     or ``binary_data``.
     """
     connector, target = k3s_connector
-    result = await connector.k8s_configmap_list(target, {"namespace": "kube-system"})
+    result = await connector.k8s_configmap_list(
+        _make_k3d_operator(), target, {"namespace": "kube-system"}
+    )
     assert result["total"] >= 1, "k8s kube-system should ship at least one configmap"
     for row in result["rows"]:
         # Privacy contract: keys populated, values absent.
@@ -549,11 +588,13 @@ async def test_configmap_info_against_k3s_returns_full_data(
     happens to ship in this version.
     """
     connector, target = k3s_connector
-    list_result = await connector.k8s_configmap_list(target, {"namespace": "kube-system"})
+    list_result = await connector.k8s_configmap_list(
+        _make_k3d_operator(), target, {"namespace": "kube-system"}
+    )
     assert list_result["rows"], "need at least one configmap to exercise info"
     first = list_result["rows"][0]
     info_result = await connector.k8s_configmap_info(
-        target, {"name": first["name"], "namespace": "kube-system"}
+        _make_k3d_operator(), target, {"name": first["name"], "namespace": "kube-system"}
     )
     assert info_result["name"] == first["name"]
     assert info_result["namespace"] == "kube-system"
@@ -571,7 +612,9 @@ async def test_event_list_against_k3s_returns_namespaced_events(
 ) -> None:
     """``k8s.event.list --namespace kube-system`` returns recent events sorted recent-first."""
     connector, target = k3s_connector
-    result = await connector.k8s_event_list(target, {"namespace": "kube-system", "limit": 50})
+    result = await connector.k8s_event_list(
+        _make_k3d_operator(), target, {"namespace": "kube-system", "limit": 50}
+    )
     # k3s emits events during boot (pod scheduling, image pulls, leader
     # election); the kube-system namespace always has some.
     assert isinstance(result["rows"], list)
@@ -594,6 +637,7 @@ async def test_event_list_against_k3s_field_selector_filters(
     """
     connector, target = k3s_connector
     result = await connector.k8s_event_list(
+        _make_k3d_operator(),
         target,
         {"namespace": "kube-system", "field_selector": "type=Warning"},
     )

--- a/backend/tests/integration/test_connectors_k8s_live_vault.py
+++ b/backend/tests/integration/test_connectors_k8s_live_vault.py
@@ -1,0 +1,476 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G3.10-T4 — k3d + live Vault dev-mode E2E for the k8s kubeconfig-read chain.
+
+The **live** counterpart to the recorded-fixture E2E
+(``tests/test_connectors_k8s_credread.py``). Where that replays a canned
+Vault read + a mocked kubernetes_asyncio client in the secret-free unit
+lane, this test runs the *real* chain end to end against:
+
+* a real k3s container (booted via :class:`testcontainers.k3s.K3SContainer`),
+* a real Vault dev-mode container (booted via
+  :class:`testcontainers.vault.VaultContainer`),
+
+seeded with the k3s container's emitted kubeconfig. The operator-context
+JWT/OIDC login + KV-v2 read + YAML parse + ``ApiClient`` build +
+``CoreV1Api.list_namespace`` round-trip all run for real — the rubric
+**State 2** proof against live infrastructure.
+
+It is **opt-in and skips cleanly by default** so secret-free CI stays
+green. Two gates:
+
+* Docker socket missing — every integration test in this package skips
+  on the same heuristic (mirrors
+  ``tests/integration/conftest.py``).
+* ``MEHO_RUN_LIVE_K3D_VAULT`` is not set to ``"1"`` — the explicit opt-in
+  signal: even when Docker is available (e.g. on the integration-lane CI
+  runner), the test only runs when the operator flips this flag. This is
+  the same pattern other heavier opt-in tests in the suite use; the
+  default integration lane runs the recorded-fixture suite for k8s and
+  saves the live container boot for an operator-driven smoke.
+
+What this test proves
+======================
+
+The full dispatch->loader->Vault->kubeconfig->k3s chain executes once
+under a real operator JWT (synthesised against the dev-mode Vault's
+JWT/OIDC backend), reads a real kubeconfig out of a real Vault, parses
+it, builds a real ``ApiClient`` against a real k3s API server, and lists
+real namespaces. The kubeconfig YAML itself is asserted absent from the
+``OperationResult`` and from every captured structlog event — the
+no-leak contract pinned in the recorded-fixture E2E, re-asserted here
+against the live chain.
+
+What it does NOT prove
+======================
+
+* It does not exercise the real Keycloak->Vault federation chain. The
+  dev-mode Vault here is configured with a JWT/OIDC auth backend that
+  accepts a self-signed token built locally; the real
+  ``keycloak.<env>.example`` -> Vault Identity entity binding is a
+  deploy concern, validated by the cross-repo deploy runbook
+  (``docs/cross-repo/connector-vault-policy.md``) and by an operator-driven
+  smoke against the real lab Vault.
+* It does not run the dispatcher's full audit + broadcast machinery
+  end-to-end against a real Postgres; the recorded-fixture E2E
+  (``tests/test_connectors_k8s_credread.py``) covers that against the
+  per-worker SQLite engine.
+
+How to run it
+=============
+
+```bash
+# Run once against a Docker-having sandbox or CI runner:
+MEHO_RUN_LIVE_K3D_VAULT=1 \\
+  pytest backend/tests/integration/test_connectors_k8s_live_vault.py -v
+```
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock
+from urllib.parse import urlparse
+from uuid import UUID, uuid4
+
+import pytest
+from structlog.testing import capture_logs
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors.kubernetes import (
+    KubernetesConnector,
+    parse_kubeconfig_yaml,
+    register_kubernetes_typed_operations,
+)
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.reducer import PassThroughReducer
+from meho_backplane.settings import get_settings
+
+# ---------------------------------------------------------------------------
+# Opt-in gates: Docker AND the explicit MEHO_RUN_LIVE_K3D_VAULT=1 signal.
+# ---------------------------------------------------------------------------
+
+
+def _docker_socket_present() -> bool:
+    return Path("/var/run/docker.sock").exists() or os.environ.get("DOCKER_HOST") is not None
+
+
+_DOCKER_AVAILABLE: bool = _docker_socket_present()
+_RUN_LIVE: bool = os.environ.get("MEHO_RUN_LIVE_K3D_VAULT") == "1"
+
+_SKIP_REASON: str = (
+    "live k3d + Vault E2E is opt-in: set MEHO_RUN_LIVE_K3D_VAULT=1 to run it "
+    "against real container infra (skipped in default CI; the recorded-fixture "
+    "E2E covers the dispatch chain in the secret-free unit lane)."
+)
+
+
+pytestmark = pytest.mark.skipif(not (_DOCKER_AVAILABLE and _RUN_LIVE), reason=_SKIP_REASON)
+
+
+# ---------------------------------------------------------------------------
+# Container fixtures — module-scoped (one boot per session, multiple tests)
+# ---------------------------------------------------------------------------
+
+
+_VAULT_KUBECONFIG_PATH = "k8s/k3d-live-vault"
+
+
+@dataclass
+class _LiveK3dTarget:
+    """Target carrying the resolver + connector + loader attributes."""
+
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+    product: str = "k8s"
+    auth_model: str = "shared_service_account"
+
+    def __post_init__(self) -> None:
+        self.id: UUID = uuid4()
+        self.preferred_impl_id: str | None = None
+        self.fingerprint = type("_FP", (), {"version": "1.32.0"})()
+
+
+@pytest.fixture(scope="module")
+def k3s_kubeconfig_text() -> Iterator[str]:
+    """Boot a k3s container; yield the kubeconfig YAML it exposes."""
+    try:
+        from testcontainers.k3s import K3SContainer
+    except ImportError as exc:  # pragma: no cover — testcontainers ships k3s
+        pytest.skip(f"testcontainers.k3s unavailable: {exc}")
+
+    image = os.environ.get("MEHO_TEST_K3S_IMAGE", "rancher/k3s:v1.32.5-k3s1")
+    try:
+        container = K3SContainer(image=image)
+        container.start()
+    except Exception as exc:
+        pytest.skip(f"k3s container failed to start ({type(exc).__name__}): {exc}")
+
+    try:
+        yield container.config_yaml()
+    finally:
+        container.stop()
+
+
+@pytest.fixture(scope="module")
+def vault_container_and_token() -> Iterator[tuple[str, str]]:
+    """Boot a Vault dev-mode container; yield (address, root_token).
+
+    Dev mode mounts KV-v2 at ``secret/`` and seeds a known root token;
+    this test seeds the kubeconfig at ``secret/<path>`` directly via the
+    root token (the real JWT/OIDC backend wiring is the deploy concern
+    documented in ``docs/cross-repo/connector-vault-policy.md``).
+    """
+    try:
+        from testcontainers.vault import VaultContainer
+    except ImportError as exc:  # pragma: no cover — testcontainers ships vault
+        pytest.skip(f"testcontainers.vault unavailable: {exc}")
+
+    root_token = os.environ.get("MEHO_TEST_VAULT_ROOT_TOKEN", "meho-test-root-token")
+    image = os.environ.get("MEHO_TEST_VAULT_IMAGE", "hashicorp/vault:1.18.4")
+    try:
+        container = VaultContainer(image=image, root_token=root_token)
+        container.start()
+    except Exception as exc:
+        pytest.skip(f"Vault container failed to start ({type(exc).__name__}): {exc}")
+
+    try:
+        yield container.get_connection_url(), root_token
+    finally:
+        container.stop()
+
+
+@pytest.fixture(scope="module")
+def seeded_vault_target(
+    k3s_kubeconfig_text: str,
+    vault_container_and_token: tuple[str, str],
+) -> _LiveK3dTarget:
+    """Seed the kubeconfig into Vault; return the matching target stub.
+
+    Uses an hvac client with the dev-mode root token to write the
+    kubeconfig YAML at ``secret/<path>`` under the ``kubeconfig`` field
+    — the exact convention the live loader reads.
+    """
+    import hvac
+
+    vault_addr, root_token = vault_container_and_token
+    client = hvac.Client(url=vault_addr, token=root_token)
+    client.secrets.kv.v2.create_or_update_secret(
+        path=_VAULT_KUBECONFIG_PATH,
+        secret={"kubeconfig": k3s_kubeconfig_text},
+        mount_point="secret",
+    )
+
+    # Derive the target's host/port from the kubeconfig the container
+    # emitted — the live loader will parse the *same* YAML, build an
+    # ApiClient, and the dispatch's resolver-driven connector reach the
+    # same k3s API.
+    parsed_kc = parse_kubeconfig_yaml(k3s_kubeconfig_text)
+    server_url = parsed_kc["clusters"][0]["cluster"]["server"]
+    parsed = urlparse(server_url)
+    return _LiveK3dTarget(
+        name="k3d-live-vault",
+        host=parsed.hostname or "127.0.0.1",
+        port=parsed.port,
+        secret_ref=_VAULT_KUBECONFIG_PATH,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Settings + dispatcher wiring (mirrors the recorded-fixture suite, but
+# points Settings at the live Vault and configures the dev-mode JWT/OIDC
+# backend that mints tokens for the synthesised operator JWT below).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(
+    monkeypatch: pytest.MonkeyPatch,
+    vault_container_and_token: tuple[str, str],
+) -> Iterator[None]:
+    """Point Settings at the live Vault. The Keycloak vars are stubs;
+    the dev-mode Vault accepts the synthesised JWT via a configured
+    JWT/OIDC backend (configured by the ``configured_oidc`` fixture).
+    """
+    vault_addr, _ = vault_container_and_token
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", vault_addr)
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "10.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(scope="module")
+def configured_jwt_backend(
+    vault_container_and_token: tuple[str, str],
+) -> dict[str, Any]:
+    """Configure Vault's JWT/OIDC backend to accept a self-signed JWT.
+
+    Production reaches Vault via Keycloak's OIDC discovery + JWKS; the
+    dev-mode container here is configured with a static JWT validation
+    key matching the key the test signs the operator JWT with. This
+    short-circuits the Keycloak dependency without weakening what the
+    test proves: the loader's ``vault_client_for_operator`` code path
+    runs in full, the JWT is forwarded to Vault, Vault validates it
+    against its configured key, and the resulting token authorises the
+    KV-v2 read.
+
+    Returns ``{"private_key_pem", "kid", "role_name"}`` so the
+    operator-JWT minter can sign a token Vault will accept.
+    """
+    import hvac
+    from authlib.jose import JsonWebKey
+
+    vault_addr, root_token = vault_container_and_token
+    client = hvac.Client(url=vault_addr, token=root_token)
+
+    # Mount the JWT/OIDC auth method at "jwt/" (the default mount the
+    # ``VAULT_OIDC_MOUNT_PATH=jwt`` setting tracks).
+    import contextlib
+
+    with contextlib.suppress(Exception):
+        # pragma: no cover — already enabled across re-runs
+        client.sys.enable_auth_method(method_type="jwt", path="jwt")
+
+    # Generate an RSA keypair the test signs the operator JWT with;
+    # Vault validates against the public half.
+    key = JsonWebKey.generate_key("RSA", 2048, is_private=True)
+    public_pem = key.get_public_key().as_pem(is_private=False).decode("utf-8")
+    private_pem = key.as_pem(is_private=True).decode("utf-8")
+
+    # Configure the JWT/OIDC backend to validate against the public key.
+    client.auth.jwt.configure(
+        jwt_validation_pubkeys=[public_pem],
+        path="jwt",
+    )
+
+    # Create the role the connector uses (the ``VAULT_OIDC_ROLE`` setting).
+    # ``bound_audiences`` matches what ``vault_client_for_operator`` sends
+    # (Settings.keycloak_audience). The role grants the templated policy
+    # that lets the operator's identity read the kubeconfig path.
+    role_name = "meho-mcp"
+    policy_name = "meho-mcp-test"
+    client.sys.create_or_update_policy(
+        name=policy_name,
+        policy=f'path "secret/data/{_VAULT_KUBECONFIG_PATH}" {{ capabilities = ["read"] }}',
+    )
+    client.auth.jwt.create_role(
+        name=role_name,
+        token_policies=[policy_name],
+        role_type="jwt",
+        bound_audiences=["meho-backplane"],
+        user_claim="sub",
+        path="jwt",
+    )
+
+    return {
+        "private_key_pem": private_pem,
+        "role_name": role_name,
+    }
+
+
+def _mint_operator_jwt(private_key_pem: str) -> str:
+    """Mint a self-signed operator JWT Vault will accept."""
+    import time
+
+    from authlib.jose import jwt
+
+    header = {"alg": "RS256", "typ": "JWT"}
+    payload = {
+        "sub": "op-live-k3d",
+        "aud": "meho-backplane",
+        "iss": "https://keycloak.test/realms/meho",
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 3600,
+        "name": "Live K3d Operator",
+    }
+    return jwt.encode(header, payload, private_key_pem).decode("utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches + connector registry around every test."""
+    reset_dispatcher_caches()
+    set_default_reducer(PassThroughReducer())
+    clear_registry()
+    register_connector_v2(
+        product="k8s",
+        version="1.x",
+        impl_id="k8s",
+        cls=KubernetesConnector,
+    )
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def k8s_live_wired(
+    stub_embedding_service: AsyncMock,
+    pg_engine: None,
+) -> AsyncIterator[None]:
+    """Register the typed K8s ops into the live ``endpoint_descriptor`` table."""
+    await register_kubernetes_typed_operations(embedding_service=stub_embedding_service)
+    yield
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+async def test_live_dispatch_kubeconfig_from_vault_lists_namespaces(
+    seeded_vault_target: _LiveK3dTarget,
+    configured_jwt_backend: dict[str, Any],
+    captured_events: list[BroadcastEvent],
+    k8s_live_wired: None,
+    k3s_kubeconfig_text: str,
+) -> None:
+    """Live chain: dispatch -> live Vault read -> live k3s namespace list -> status=ok.
+
+    Exercises the full G3.10-T4 wiring against real containers. The
+    default loader is **not** overridden; the resolver builds
+    ``KubernetesConnector()`` and the
+    :func:`load_kubeconfig_from_vault` path runs verbatim under the
+    operator's JWT.
+
+    Asserts:
+
+    * ``status="ok"`` with a non-empty namespace list (k3s ships
+      ``default`` + ``kube-system`` + ``kube-public`` +
+      ``kube-node-lease`` at boot).
+    * The kubeconfig YAML never appears in the ``OperationResult`` or
+      in any captured structlog event — the no-leak contract.
+    """
+    operator_jwt = _mint_operator_jwt(configured_jwt_backend["private_key_pem"])
+    operator = Operator(
+        sub="op-live-k3d",
+        name="Live K3d Operator",
+        email=None,
+        raw_jwt=operator_jwt,
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+    with capture_logs() as captured:
+        result = await dispatch(
+            operator=operator,
+            connector_id="k8s-1.x",
+            op_id="k8s.namespace.list",
+            target=seeded_vault_target,
+            params={},
+        )
+
+    # The live chain returned status=ok with a real namespace list.
+    assert result.status == "ok", result.error
+    assert isinstance(result.result, dict)
+    assert result.result["total"] >= 4  # k3s default boot set
+    namespace_names = {row["name"] for row in result.result["rows"]}
+    assert "default" in namespace_names
+    assert "kube-system" in namespace_names
+
+    # No kubeconfig content appears in the result envelope. The server URL,
+    # client-cert PEM, and the token from the kubeconfig YAML are all
+    # canaries — independently asserted so a partial leak is named.
+    result_blob = repr(result)
+    parsed_kc = parse_kubeconfig_yaml(k3s_kubeconfig_text)
+    server_url = parsed_kc["clusters"][0]["cluster"]["server"]
+    cluster_block = parsed_kc["clusters"][0]["cluster"]
+    cert_data = cluster_block.get("certificate-authority-data")
+    user_block = parsed_kc["users"][0]["user"]
+    user_token = user_block.get("token")
+    user_cert = user_block.get("client-certificate-data")
+    user_key = user_block.get("client-key-data")
+
+    assert server_url not in result_blob, "server URL leaked into OperationResult"
+    if cert_data:
+        assert cert_data not in result_blob, "cluster CA cert leaked into OperationResult"
+    if user_token:
+        assert user_token not in result_blob, "bearer token leaked into OperationResult"
+    if user_cert:
+        assert user_cert not in result_blob, "client cert leaked into OperationResult"
+    if user_key:
+        assert user_key not in result_blob, "client key leaked into OperationResult"
+
+    # And no kubeconfig content in any captured structlog event.
+    log_blob = repr(captured)
+    assert server_url not in log_blob, "server URL leaked into structlog events"
+    if cert_data:
+        assert cert_data not in log_blob, "cluster CA cert leaked into structlog events"
+    if user_token:
+        assert user_token not in log_blob, "bearer token leaked into structlog events"
+    if user_cert:
+        assert user_cert not in log_blob, "client cert leaked into structlog events"
+    if user_key:
+        assert user_key not in log_blob, "client key leaked into structlog events"

--- a/backend/tests/test_connectors_k8s_auth.py
+++ b/backend/tests/test_connectors_k8s_auth.py
@@ -41,7 +41,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
+from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors import Connector
+from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors.kubernetes import (
     KubernetesConnector,
     KubernetesTargetLike,
@@ -53,6 +56,8 @@ from meho_backplane.connectors.kubernetes.kubeconfig import load_kubeconfig_from
 from meho_backplane.connectors.schemas import FingerprintResult, OperationResult, ProbeResult
 from meho_backplane.settings import get_settings
 
+from ._vault_fakes import install_fake_client
+
 
 @pytest.fixture(autouse=True)
 def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
@@ -62,11 +67,18 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     via the DB engine, so the lookup path needs ``Settings`` to
     construct -- which requires the three Keycloak/Vault env vars.
     Fingerprint / probe tests don't touch the DB but the fixture is
-    autouse so all tests in the module see a consistent env.
+    autouse so all tests in the module see a consistent env. The Vault
+    JWT/OIDC vars are needed too because G3.10-T4 (#948) wired the
+    default kubeconfig loader against ``vault_client_for_operator``,
+    which reads these on every call.
     """
     monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
     monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
     monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()
@@ -130,10 +142,35 @@ def _stub_version() -> MagicMock:
     return v
 
 
-def _make_connector_with_stub_kubeconfig() -> KubernetesConnector:
-    """Build a connector whose loader returns the stub kubeconfig dict."""
+def _make_operator(*, raw_jwt: str = "op.test.jwt") -> Operator:
+    """Build a non-system operator with a non-empty ``raw_jwt``.
 
-    async def _loader(target: KubernetesTargetLike) -> dict[str, Any]:
+    The empty-``raw_jwt`` case is the fail-closed system-call carve-out;
+    tests that exercise it pass ``raw_jwt=""`` (or call
+    :func:`synthesise_system_operator`).
+    """
+    return Operator(
+        sub="op-test",
+        name="Test Operator",
+        email=None,
+        raw_jwt=raw_jwt,
+        tenant_id=__import__("uuid").UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+def _make_connector_with_stub_kubeconfig() -> KubernetesConnector:
+    """Build a connector whose loader returns the stub kubeconfig dict.
+
+    The injected loader accepts the same ``(target, operator)`` pair the
+    production default
+    :func:`~meho_backplane.connectors.kubernetes.kubeconfig.load_kubeconfig_from_vault`
+    accepts (the G3.10-T4 #948 contract) so the wiring is exercised
+    end-to-end through the test seam as well.
+    """
+
+    async def _loader(target: KubernetesTargetLike, operator: Operator) -> dict[str, Any]:
+        del operator  # accepted by signature; stub doesn't need it
         return _stub_kubeconfig_dict()
 
     return KubernetesConnector(kubeconfig_loader=_loader)
@@ -157,12 +194,123 @@ def test_kubernetes_connector_subclasses_connector_abc() -> None:
     assert KubernetesConnector.impl_id == "k8s"
 
 
-def test_default_loader_raises_deliberate_stub() -> None:
-    """The default Vault-shaped loader is a deliberate, clearly-labelled stub."""
+def test_default_loader_fails_closed_on_empty_operator_jwt() -> None:
+    """The default loader fails closed on the system-call carve-out (no JWT).
+
+    Replaces the pre-G3.10-T4 (#948) ``deliberate stub`` test: the loader
+    is now live (reads Vault under the operator's identity) but still
+    fails closed when ``operator.raw_jwt`` is empty — the same fail-closed
+    boundary :func:`load_basic_credentials` enforces. The Vault leaf is
+    never reached on this path; the guard runs before
+    :func:`vault_client_for_operator` is touched.
+    """
 
     async def _check() -> None:
-        with pytest.raises(NotImplementedError, match=r"deliberate stub.*#214"):
-            await load_kubeconfig_from_vault(_TARGET_A)
+        with pytest.raises(VaultCredentialsReadError, match="no operator JWT"):
+            await load_kubeconfig_from_vault(_TARGET_A, synthesise_system_operator())
+
+    asyncio.run(_check())
+
+
+def test_default_loader_fails_closed_on_unset_secret_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset ``target.secret_ref`` raises before Vault is touched."""
+    unconfigured = _StubTarget(name="unconfigured", host="x.test.invalid", port=6443, secret_ref="")
+
+    async def _check() -> None:
+        with pytest.raises(VaultCredentialsReadError, match="no secret_ref configured"):
+            await load_kubeconfig_from_vault(unconfigured, _make_operator())
+
+    asyncio.run(_check())
+
+
+def test_default_loader_returns_parsed_kubeconfig_dict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Live loader reads the ``kubeconfig`` KV-v2 field + returns the parsed dict.
+
+    Uses the shared in-process Vault fake (``install_fake_client``)
+    seeded with a kubeconfig YAML; the loader's real
+    :func:`vault_client_for_operator` + ``read_secret_version`` code
+    path runs against the fake.
+    """
+    kubeconfig_yaml = (
+        "apiVersion: v1\n"
+        "kind: Config\n"
+        "current-context: default\n"
+        "contexts:\n"
+        "- name: default\n"
+        "  context: {cluster: c1, user: u1}\n"
+        "clusters:\n"
+        "- name: c1\n"
+        "  cluster: {server: 'https://k8s.test:6443'}\n"
+        "users:\n"
+        "- name: u1\n"
+        "  user: {token: stub-token}\n"
+    )
+    fake = install_fake_client(monkeypatch, secret={"kubeconfig": kubeconfig_yaml})
+
+    async def _check() -> None:
+        operator = _make_operator(raw_jwt="op.live.jwt")
+        result = await load_kubeconfig_from_vault(_TARGET_A, operator)
+        assert result["apiVersion"] == "v1"
+        assert result["clusters"][0]["cluster"]["server"] == "https://k8s.test:6443"
+        assert result["current-context"] == "default"
+        # The KV-v2 read happened under the operator's JWT (operator-context
+        # Vault read — the locked Option A decision).
+        assert fake.auth.jwt.login_calls[-1]["jwt"] == "op.live.jwt"
+        assert fake.secrets.kv.v2.read_calls[-1]["path"] == _TARGET_A.secret_ref
+
+    asyncio.run(_check())
+
+
+def test_default_loader_raises_on_missing_kubeconfig_field(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A KV-v2 secret missing the ``kubeconfig`` field surfaces a clear error."""
+    install_fake_client(monkeypatch, secret={"username": "wrong-shape"})
+
+    async def _check() -> None:
+        with pytest.raises(VaultCredentialsReadError, match="missing required field 'kubeconfig'"):
+            await load_kubeconfig_from_vault(_TARGET_A, _make_operator())
+
+    asyncio.run(_check())
+
+
+def test_default_loader_raises_on_non_string_kubeconfig_field(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``kubeconfig`` field that isn't a string surfaces a clear error.
+
+    Defence against a misconfigured secret that stored the kubeconfig as
+    a nested dict (e.g. someone wrote a parsed dict instead of the YAML
+    text) — the loader rejects it cleanly rather than passing a non-string
+    to :func:`parse_kubeconfig_yaml`.
+    """
+    install_fake_client(monkeypatch, secret={"kubeconfig": {"oops": "dict"}})
+
+    async def _check() -> None:
+        with pytest.raises(VaultCredentialsReadError, match="expected a YAML string"):
+            await load_kubeconfig_from_vault(_TARGET_A, _make_operator())
+
+    asyncio.run(_check())
+
+
+def test_default_loader_propagates_yaml_parse_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed kubeconfig YAML surfaces a :class:`ValueError` (not a bare YAMLError).
+
+    The loader's contract is one failure path for malformed YAML — the
+    :func:`parse_kubeconfig_yaml` normalisation. Callers don't need to
+    import ``yaml`` just to catch parse failures.
+    """
+    install_fake_client(monkeypatch, secret={"kubeconfig": "key: 'unterminated"})
+
+    async def _check() -> None:
+        with pytest.raises(ValueError, match="failed to parse"):
+            await load_kubeconfig_from_vault(_TARGET_A, _make_operator())
 
     asyncio.run(_check())
 
@@ -406,18 +554,20 @@ async def test_execute_returns_unknown_op_for_every_op_id() -> None:
 async def test_api_client_reused_for_same_target() -> None:
     loader_calls: list[str] = []
 
-    async def _loader(target: KubernetesTargetLike) -> dict[str, Any]:
+    async def _loader(target: KubernetesTargetLike, operator: Operator) -> dict[str, Any]:
+        del operator
         loader_calls.append(target.name)
         return _stub_kubeconfig_dict()
 
     connector = KubernetesConnector(kubeconfig_loader=_loader)
+    op = _make_operator()
     with patch(
         "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
         new_callable=AsyncMock,
         return_value=MagicMock(close=AsyncMock()),
     ) as factory:
-        c1 = await connector._get_api_client(_TARGET_A)
-        c2 = await connector._get_api_client(_TARGET_A)
+        c1 = await connector._get_api_client(_TARGET_A, op)
+        c2 = await connector._get_api_client(_TARGET_A, op)
 
     assert c1 is c2
     assert factory.call_count == 1
@@ -426,18 +576,20 @@ async def test_api_client_reused_for_same_target() -> None:
 
 @pytest.mark.asyncio
 async def test_api_clients_per_target_are_distinct() -> None:
-    async def _loader(target: KubernetesTargetLike) -> dict[str, Any]:
+    async def _loader(target: KubernetesTargetLike, operator: Operator) -> dict[str, Any]:
+        del operator
         return _stub_kubeconfig_dict()
 
     connector = KubernetesConnector(kubeconfig_loader=_loader)
+    op = _make_operator()
 
     with patch(
         "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
         new_callable=AsyncMock,
         side_effect=lambda _d: MagicMock(close=AsyncMock()),
     ):
-        c_a = await connector._get_api_client(_TARGET_A)
-        c_b = await connector._get_api_client(_TARGET_B)
+        c_a = await connector._get_api_client(_TARGET_A, op)
+        c_b = await connector._get_api_client(_TARGET_B, op)
 
     assert c_a is not c_b
 
@@ -458,17 +610,19 @@ async def test_api_client_cache_key_is_secret_ref_not_name() -> None:
         name="rke2-meho", host="t-b.test", port=6443, secret_ref="kv/data/tenant-b/k8s"
     )
 
-    async def _loader(target: KubernetesTargetLike) -> dict[str, Any]:
+    async def _loader(target: KubernetesTargetLike, operator: Operator) -> dict[str, Any]:
+        del operator
         return _stub_kubeconfig_dict()
 
     connector = KubernetesConnector(kubeconfig_loader=_loader)
+    op = _make_operator()
     with patch(
         "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
         new_callable=AsyncMock,
         side_effect=lambda _d: MagicMock(close=AsyncMock()),
     ) as factory:
-        c_a = await connector._get_api_client(tenant_a)
-        c_b = await connector._get_api_client(tenant_b)
+        c_a = await connector._get_api_client(tenant_a, op)
+        c_b = await connector._get_api_client(tenant_b, op)
 
     assert c_a is not c_b
     assert factory.call_count == 2
@@ -479,21 +633,49 @@ async def test_api_client_cache_key_is_secret_ref_not_name() -> None:
 
 
 @pytest.mark.asyncio
+async def test_loader_receives_operator_and_target() -> None:
+    """The injected loader receives the same ``(target, operator)`` pair the default does.
+
+    Locks in the G3.10-T4 (#948) contract: ``KubeconfigLoader`` carries
+    ``operator`` so the dispatch path threads the operator's identity to
+    the kubeconfig read. An injected test loader receives the same pair.
+    """
+    captured: list[tuple[str, str]] = []
+
+    async def _loader(target: KubernetesTargetLike, operator: Operator) -> dict[str, Any]:
+        captured.append((target.name, operator.sub))
+        return _stub_kubeconfig_dict()
+
+    connector = KubernetesConnector(kubeconfig_loader=_loader)
+    op = _make_operator()
+    with patch(
+        "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+        new_callable=AsyncMock,
+        return_value=MagicMock(close=AsyncMock()),
+    ):
+        await connector._get_api_client(_TARGET_A, op)
+
+    assert captured == [(_TARGET_A.name, "op-test")]
+
+
+@pytest.mark.asyncio
 async def test_aclose_closes_every_cached_client_and_clears_cache() -> None:
-    async def _loader(target: KubernetesTargetLike) -> dict[str, Any]:
+    async def _loader(target: KubernetesTargetLike, operator: Operator) -> dict[str, Any]:
+        del operator
         return _stub_kubeconfig_dict()
 
     connector = KubernetesConnector(kubeconfig_loader=_loader)
     client_a = MagicMock(close=AsyncMock())
     client_b = MagicMock(close=AsyncMock())
+    op = _make_operator()
 
     with patch(
         "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
         new_callable=AsyncMock,
         side_effect=[client_a, client_b],
     ):
-        await connector._get_api_client(_TARGET_A)
-        await connector._get_api_client(_TARGET_B)
+        await connector._get_api_client(_TARGET_A, op)
+        await connector._get_api_client(_TARGET_B, op)
 
     await connector.aclose()
 

--- a/backend/tests/test_connectors_k8s_core.py
+++ b/backend/tests/test_connectors_k8s_core.py
@@ -62,6 +62,7 @@ from kubernetes_asyncio.client.models import (
     V1Taint,
 )
 
+from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.kubernetes import (
     KUBERNETES_OPS,
     KubernetesConnector,
@@ -150,10 +151,26 @@ def _stub_kubeconfig() -> dict[str, Any]:
 
 
 def _make_connector() -> KubernetesConnector:
-    async def _loader(_target: KubernetesTargetLike) -> dict[str, Any]:
+    async def _loader(_target: KubernetesTargetLike, _operator: Operator) -> dict[str, Any]:
         return _stub_kubeconfig()
 
     return KubernetesConnector(kubeconfig_loader=_loader)
+
+
+def _make_operator() -> Operator:
+    """Build a non-system operator carrying a non-empty ``raw_jwt``.
+
+    G3.10-T4 (#948) added ``operator`` to every typed handler's
+    signature; the injected loader here ignores it.
+    """
+    return Operator(
+        sub="op-core-test",
+        name="Core Test Operator",
+        email=None,
+        raw_jwt="op.core.jwt",
+        tenant_id=__import__("uuid").UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -438,7 +455,7 @@ async def test_k8s_namespace_list_returns_rows_and_total() -> None:
         core_v1_cls.return_value.list_namespace = AsyncMock(
             return_value=V1NamespaceList(items=namespaces, metadata=V1ListMeta())
         )
-        result = await connector.k8s_namespace_list(_TARGET, {})
+        result = await connector.k8s_namespace_list(_make_operator(), _TARGET, {})
 
     assert result["total"] == 2
     assert len(result["rows"]) == 2
@@ -463,7 +480,7 @@ async def test_k8s_namespace_list_empty_cluster() -> None:
         core_v1_cls.return_value.list_namespace = AsyncMock(
             return_value=V1NamespaceList(items=[], metadata=V1ListMeta())
         )
-        result = await connector.k8s_namespace_list(_TARGET, {})
+        result = await connector.k8s_namespace_list(_make_operator(), _TARGET, {})
     assert result == {"rows": [], "total": 0}
 
 
@@ -491,7 +508,7 @@ async def test_k8s_node_list_returns_rows_and_total() -> None:
         core_v1_cls.return_value.list_node = AsyncMock(
             return_value=V1NodeList(items=nodes, metadata=V1ListMeta())
         )
-        result = await connector.k8s_node_list(_TARGET, {})
+        result = await connector.k8s_node_list(_make_operator(), _TARGET, {})
 
     assert result["total"] == 2
     names = [row["name"] for row in result["rows"]]
@@ -525,7 +542,7 @@ async def test_k8s_ls_root_returns_namespaces_and_cluster_kinds() -> None:
         core_v1_cls.return_value.list_namespace = AsyncMock(
             return_value=V1NamespaceList(items=namespaces, metadata=V1ListMeta())
         )
-        result = await connector.k8s_ls(_TARGET, {"path": "/"})
+        result = await connector.k8s_ls(_make_operator(), _TARGET, {"path": "/"})
 
     assert result["path"] == "/"
     assert result["namespaces"] == ["argocd", "kube-system", "zebra"]
@@ -548,7 +565,7 @@ async def test_k8s_ls_default_path_is_root() -> None:
         core_v1_cls.return_value.list_namespace = AsyncMock(
             return_value=V1NamespaceList(items=namespaces, metadata=V1ListMeta())
         )
-        result = await connector.k8s_ls(_TARGET, {})  # no path
+        result = await connector.k8s_ls(_make_operator(), _TARGET, {})  # no path
     assert result["path"] == "/"
     assert result["namespaces"] == ["default"]
 
@@ -603,7 +620,7 @@ async def test_k8s_ls_namespace_counts_via_remaining_item_count() -> None:
             return_value=core_v1_instance,
         ),
     ):
-        result = await connector.k8s_ls(_TARGET, {"path": "/argocd"})
+        result = await connector.k8s_ls(_make_operator(), _TARGET, {"path": "/argocd"})
 
     assert result["path"] == "/argocd"
     assert result["namespace"] == "argocd"
@@ -642,7 +659,7 @@ async def test_k8s_ls_namespace_kind_with_rbac_403_records_error() -> None:
             return_value=core_v1_instance,
         ),
     ):
-        result = await connector.k8s_ls(_TARGET, {"path": "/argocd"})
+        result = await connector.k8s_ls(_make_operator(), _TARGET, {"path": "/argocd"})
 
     kinds_by_label = {entry["kind"]: entry for entry in result["kinds"]}
     assert kinds_by_label["events"]["count"] is None
@@ -677,7 +694,7 @@ async def test_k8s_ls_namespace_kind_forwards_to_unknown_op_envelope() -> None:
     ):
         await KubernetesConnector.register_operations()
 
-    result = await connector.k8s_ls(_TARGET, {"path": "/argocd/statefulsets"})
+    result = await connector.k8s_ls(_make_operator(), _TARGET, {"path": "/argocd/statefulsets"})
 
     assert result["path"] == "/argocd/statefulsets"
     assert result["forwarded_to"] == "k8s.statefulset.list"
@@ -705,7 +722,9 @@ async def test_k8s_ls_path_with_extra_segments_collapses_to_two_arg_forward() ->
     ):
         await KubernetesConnector.register_operations()
 
-    result = await connector.k8s_ls(_TARGET, {"path": "/argocd/services/extra/segments"})
+    result = await connector.k8s_ls(
+        _make_operator(), _TARGET, {"path": "/argocd/services/extra/segments"}
+    )
     assert result["forwarded_to"] == "k8s.service.list"
     # The path retained is the canonical 2-segment shape.
     assert result["path"] == "/argocd/services"
@@ -785,7 +804,7 @@ async def test_k8s_ls_forwards_singular_ingress_path_without_mangling() -> None:
     ):
         await KubernetesConnector.register_operations()
 
-    result = await connector.k8s_ls(_TARGET, {"path": "/argocd/ingress"})
+    result = await connector.k8s_ls(_make_operator(), _TARGET, {"path": "/argocd/ingress"})
 
     assert result["path"] == "/argocd/ingress"
     assert result["forwarded_to"] == "k8s.ingress.list"

--- a/backend/tests/test_connectors_k8s_credread.py
+++ b/backend/tests/test_connectors_k8s_credread.py
@@ -1,0 +1,449 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Recorded-fixture E2E for the k8s live kubeconfig-read chain (G3.10-T4 #948).
+
+Proves the **full** dispatch chain end to end with a real (default,
+non-injected) kubeconfig loader:
+
+    dispatch(...)
+      -> _resolve_connector_instance -> KubernetesConnector()    # default loader
+      -> dispatch_typed -> handler                               # operator-aware
+      -> connector._get_api_client(target, operator)
+      -> load_kubeconfig_from_vault(target, operator)            # the live loader
+      -> vault_client_for_operator(operator)                     # operator-context login
+      -> read_secret_version("...", field="kubeconfig")          # KV-v2 read
+      -> parse_kubeconfig_yaml                                   # YAML -> dict
+      -> kubernetes_asyncio.config.new_client_from_config_dict
+      -> CoreV1Api.list_namespace                                # mocked out
+      -> OperationResult(status="ok")
+
+The two "real" leaves are stubbed at their boundaries so the gate runs
+in the **secret-free unit lane** (``pytest -n auto`` /
+``--ignore=tests/integration``) with no Docker and no real secret:
+
+* **Vault** — the in-process fake (``install_fake_client``) patches
+  ``meho_backplane.auth.vault._build_client`` so the helper's real
+  JWT/OIDC login + KV-v2 read code path runs against a canned kubeconfig
+  YAML. The default
+  :func:`~meho_backplane.connectors.kubernetes.kubeconfig.load_kubeconfig_from_vault`
+  is exercised verbatim — *not* an injected stub. This is the
+  load-bearing difference from
+  :mod:`tests.test_connectors_k8s_auth` (which injects a stub loader):
+  here the connector is constructed by the resolver as
+  ``KubernetesConnector()`` with no ``kubeconfig_loader``, so the
+  default loader runs.
+* **kubernetes_asyncio** —
+  ``config.new_client_from_config_dict`` and ``CoreV1Api.list_namespace``
+  are mocked so the parsed kubeconfig never reaches a real cluster.
+  No network. The kubeconfig YAML in the Vault fake is the canary the
+  no-leak assertions grep against.
+
+The live k3d + live-Vault E2E (a real Vault dev container seeded with a
+real k3s kubeconfig) is the env-gated opt-in in
+:mod:`tests.integration.test_connectors_k8s_live_vault`; it skips
+cleanly in the default sweep.
+
+Why this lives in the unit lane (not ``tests/integration``)
+===========================================================
+
+The acceptance criterion requires this E2E to run in the default
+``pytest -n auto`` sweep — which deselects ``tests/integration`` (the
+container/PG lane). The recorded-fixture replay needs neither a real
+Vault nor a real k3s (both stubbed at their boundaries) and only the
+autouse SQLite ``endpoint_descriptor`` schema the top-level conftest
+already migrates per worker. So it belongs here, mirroring the
+:mod:`tests.test_connectors_vmware_rest_credread` precedent verbatim
+(G3.9-T3 #942).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from structlog.testing import capture_logs
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors.kubernetes import KubernetesConnector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.operations import dispatch, reset_dispatcher_caches
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.reducer import PassThroughReducer
+from meho_backplane.settings import get_settings
+
+from ._vault_fakes import install_fake_client
+
+# ---------------------------------------------------------------------------
+# Canary kubeconfig values — asserted to NEVER appear in the result or logs.
+# Generated nowhere near a real cluster; these strings are the leak canaries.
+# The kubeconfig's server URL + client token are the load-bearing secret
+# fields: the server URL gives a remote attacker the API endpoint, and a
+# bearer token is a direct credential. Both MUST stay out of every log
+# event, OperationResult, and broadcast payload.
+# ---------------------------------------------------------------------------
+
+_CANARY_SERVER_URL = "https://k8s-credread-canary.test.invalid:6443"
+_CANARY_BEARER_TOKEN = "k8s-canary-bearer-must-not-leak-credread"
+_CANARY_CLIENT_CERT_PEM = (
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIBANARYCERTIFICATEBLOBfMUSTNOTLEAK\n"
+    "credread-k8s-cert-pem-canary==\n"
+    "-----END CERTIFICATE-----"
+)
+
+#: A kubeconfig YAML seeded into the Vault fake. The server URL +
+#: bearer token + client-cert are the canary fields the no-leak
+#: assertions grep against.
+_CANARY_KUBECONFIG_YAML = f"""apiVersion: v1
+kind: Config
+current-context: default
+contexts:
+- name: default
+  context: {{cluster: c1, user: u1}}
+clusters:
+- name: c1
+  cluster:
+    server: {_CANARY_SERVER_URL}
+    certificate-authority-data: {_CANARY_CLIENT_CERT_PEM!r}
+users:
+- name: u1
+  user:
+    token: {_CANARY_BEARER_TOKEN}
+"""
+
+#: The connector triple ``k8s-1.x`` decodes to.
+_PRODUCT = "k8s"
+_VERSION = "1.x"
+_IMPL_ID = "k8s"
+_CONNECTOR_ID = "k8s-1.x"
+
+#: A typed read op. ``k8s.namespace.list`` was wired in G3.2-T2 and
+#: takes empty params; the handler reaches CoreV1Api.list_namespace,
+#: which is mocked at the boundary so no real cluster is touched.
+_OP_ID = "k8s.namespace.list"
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis env vars Settings reads (Vault client + dispatcher)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches + connector registry around every test.
+
+    The connector-instance cache must be clear so the resolver builds a
+    fresh ``KubernetesConnector()`` (default loader) for this test
+    rather than reusing one a sibling test wired with an injected stub
+    loader. The pass-through reducer is the v0.2 default; set explicitly
+    so the dispatcher returns the handler's dict verbatim.
+    """
+    reset_dispatcher_caches()
+    set_default_reducer(PassThroughReducer())
+    clear_registry()
+    register_connector_v2(
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        cls=KubernetesConnector,
+    )
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub for the seeded descriptor row."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    """Record broadcast events so the audit/broadcast leg is asserted."""
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """AsyncSession against the autouse-migrated per-worker SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+class _CredReadTarget:
+    """Target satisfying both ``KubernetesTargetLike`` and the resolver shape.
+
+    Carries the resolver attributes (``product`` / ``fingerprint`` /
+    ``preferred_impl_id`` / ``id``) plus the k8s-loader attributes
+    (``name`` / ``host`` / ``port`` / ``secret_ref``). ``secret_ref`` is
+    the **logical** KV-v2 path the live default loader reads — relative
+    to the mount root, no ``secret/`` prefix and no ``/data/`` segment
+    (hvac inserts ``/data/`` itself). This is the exact shape an operator
+    stores per the kubeconfig-in-Vault convention documented in
+    ``docs/cross-repo/kubernetes-onboarding.md``.
+    """
+
+    def __init__(self) -> None:
+        self.product = _PRODUCT
+        self.fingerprint = type("_FP", (), {"version": "1.32.0"})()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = uuid.uuid4()
+        self.name = "k8s-credread"
+        self.host = "k8s-credread.test.invalid"
+        self.port = 6443
+        self.secret_ref = "targets/op-credread/k8s-credread"
+        self.auth_model = "shared_service_account"
+
+
+def _make_operator() -> Operator:
+    """Operator carrying a non-empty raw_jwt (the fail-closed gate passes)."""
+    return Operator(
+        sub="op-credread",
+        name="Cred Read Operator",
+        email=None,
+        raw_jwt="op.credread.jwt",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _seed_typed_descriptor(session: AsyncSession, embedding: list[float]) -> None:
+    """Insert one enabled typed descriptor for ``k8s.namespace.list``.
+
+    Points at the canonical bound-method handler shape — the
+    dispatcher's resolver finds the connector class via the v2 registry,
+    rebinds the unbound method against the resolver-built instance, and
+    invokes ``handler(operator=..., target=..., params=...)`` because
+    the bound method names ``operator`` in its signature.
+    """
+    descriptor = EndpointDescriptor(
+        id=uuid.uuid4(),
+        tenant_id=None,
+        product=_PRODUCT,
+        version=_VERSION,
+        impl_id=_IMPL_ID,
+        op_id=_OP_ID,
+        source_kind="typed",
+        method=None,
+        path=None,
+        handler_ref=(
+            "meho_backplane.connectors.kubernetes.connector.KubernetesConnector.k8s_namespace_list"
+        ),
+        summary="List namespaces",
+        description="List Kubernetes namespaces — one row per namespace.",
+        tags=["inventory"],
+        parameter_schema={"type": "object", "additionalProperties": False, "properties": {}},
+        response_schema=None,
+        llm_instructions=None,
+        safety_level="safe",
+        requires_approval=False,
+        is_enabled=True,
+        embedding=embedding,
+        custom_description=None,
+        custom_notes=None,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+    session.add(descriptor)
+    await session.commit()
+
+
+def _stub_namespace_list_response() -> Any:
+    """Build a CoreV1Api.list_namespace stub response with two namespaces.
+
+    The handler projects each :class:`V1Namespace` through
+    :func:`~meho_backplane.connectors.kubernetes.ops_core.namespace_row`,
+    which reads ``metadata.name`` / ``metadata.creation_timestamp`` /
+    ``metadata.labels`` / ``status.phase``. Use ``MagicMock`` for the
+    namespace items (sufficient for the test seam — the helper is
+    unit-tested directly against real V1Namespace instances elsewhere).
+    """
+    response = MagicMock()
+    ns1 = MagicMock()
+    ns1.metadata.name = "default"
+    ns1.metadata.creation_timestamp = datetime(2026, 1, 1, tzinfo=UTC)
+    ns1.metadata.labels = {}
+    ns1.status.phase = "Active"
+    ns2 = MagicMock()
+    ns2.metadata.name = "kube-system"
+    ns2.metadata.creation_timestamp = datetime(2026, 1, 1, tzinfo=UTC)
+    ns2.metadata.labels = {}
+    ns2.status.phase = "Active"
+    response.items = [ns1, ns2]
+    return response
+
+
+@pytest.mark.asyncio
+async def test_dispatch_executes_full_credread_chain_returns_ok(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The full dispatch->loader->kubeconfig->handler chain returns status="ok"."""
+    await _seed_typed_descriptor(session, stub_embedding_service.encode_one.return_value)
+
+    # Vault leaf: the in-process fake returns the canary kubeconfig via
+    # the real ``load_kubeconfig_from_vault`` ->
+    # ``vault_client_for_operator`` path. No kubeconfig_loader is
+    # injected anywhere — the resolver builds ``KubernetesConnector()``
+    # so the default loader runs verbatim.
+    fake = install_fake_client(monkeypatch, secret={"kubeconfig": _CANARY_KUBECONFIG_YAML})
+
+    target = _CredReadTarget()
+    operator = _make_operator()
+
+    # Mock ``config.new_client_from_config_dict`` so the parsed kubeconfig
+    # never reaches a real cluster — and ``CoreV1Api.list_namespace`` so
+    # the handler returns a deterministic response.
+    api_client_mock = MagicMock(close=AsyncMock())
+    core_v1_mock = MagicMock()
+    core_v1_mock.list_namespace = AsyncMock(return_value=_stub_namespace_list_response())
+
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=api_client_mock,
+        ) as config_factory,
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.client.CoreV1Api",
+            return_value=core_v1_mock,
+        ),
+    ):
+        result = await dispatch(
+            operator=operator,
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=target,
+            params={},
+        )
+
+    # The load-bearing assertion: the chain executed end to end.
+    assert result.status == "ok", result.error
+    assert isinstance(result.result, dict)
+    assert result.result["total"] == 2
+    assert {row["name"] for row in result.result["rows"]} == {"default", "kube-system"}
+
+    # The default loader actually read Vault under the operator's identity.
+    assert fake.auth.jwt.login_calls[-1]["jwt"] == "op.credread.jwt"
+    assert fake.secrets.kv.v2.read_calls[-1]["path"] == target.secret_ref
+
+    # The parsed kubeconfig dict was actually built and passed to k_a.
+    assert config_factory.call_count == 1
+    forwarded_kubeconfig = config_factory.call_args.args[0]
+    assert isinstance(forwarded_kubeconfig, dict)
+    assert forwarded_kubeconfig["apiVersion"] == "v1"
+
+    # The handler ran against the mocked CoreV1Api.
+    core_v1_mock.list_namespace.assert_awaited_once()
+
+    # One audit + one broadcast for the dispatched op.
+    assert len(captured_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_credread_chain_never_leaks_kubeconfig_in_result_or_logs(
+    stub_embedding_service: AsyncMock,
+    session: AsyncSession,
+    captured_events: list[BroadcastEvent],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No kubeconfig content rides the OperationResult or any captured log event.
+
+    The kubeconfig YAML in the Vault fake carries three canary fields
+    (server URL, bearer token, client cert PEM); each is asserted absent
+    from the dispatch result, every structlog event, and the broadcast
+    payload. The kubeconfig is treated as ephemeral in-memory state —
+    same discipline the shared
+    :func:`~meho_backplane.connectors._shared.vault_creds.load_basic_credentials`
+    helper enforces for the REST connectors.
+    """
+    await _seed_typed_descriptor(session, stub_embedding_service.encode_one.return_value)
+
+    install_fake_client(monkeypatch, secret={"kubeconfig": _CANARY_KUBECONFIG_YAML})
+
+    target = _CredReadTarget()
+    operator = _make_operator()
+
+    api_client_mock = MagicMock(close=AsyncMock())
+    core_v1_mock = MagicMock()
+    core_v1_mock.list_namespace = AsyncMock(return_value=_stub_namespace_list_response())
+
+    with (
+        capture_logs() as captured,
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=api_client_mock,
+        ),
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.client.CoreV1Api",
+            return_value=core_v1_mock,
+        ),
+    ):
+        result = await dispatch(
+            operator=operator,
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_ID,
+            target=target,
+            params={},
+        )
+
+    assert result.status == "ok", result.error
+
+    # The kubeconfig never rides the OperationResult (result, error, or
+    # any extras the envelope carries). All three canary fields checked
+    # independently so a partial leak surfaces with a clear name.
+    result_blob = repr(result)
+    assert _CANARY_SERVER_URL not in result_blob, "server URL leaked into OperationResult"
+    assert _CANARY_BEARER_TOKEN not in result_blob, "bearer token leaked into OperationResult"
+    assert _CANARY_CLIENT_CERT_PEM not in result_blob, "client cert PEM leaked into OperationResult"
+
+    # The kubeconfig never rides any structlog event (loader, connector,
+    # dispatcher, audit, broadcast).
+    log_blob = repr(captured)
+    assert _CANARY_SERVER_URL not in log_blob, "server URL leaked into structlog events"
+    assert _CANARY_BEARER_TOKEN not in log_blob, "bearer token leaked into structlog events"
+    assert _CANARY_CLIENT_CERT_PEM not in log_blob, "client cert PEM leaked into structlog events"
+
+    # The kubeconfig never rides the broadcast event payload either.
+    events_blob = repr(captured_events)
+    assert _CANARY_SERVER_URL not in events_blob, "server URL leaked into broadcast events"
+    assert _CANARY_BEARER_TOKEN not in events_blob, "bearer token leaked into broadcast events"
+    assert _CANARY_CLIENT_CERT_PEM not in events_blob, (
+        "client cert PEM leaked into broadcast events"
+    )

--- a/backend/tests/test_connectors_k8s_dispatcher_shim.py
+++ b/backend/tests/test_connectors_k8s_dispatcher_shim.py
@@ -46,6 +46,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors import (
     all_connectors,
     all_connectors_v2,
@@ -150,7 +151,7 @@ def _stub_kubeconfig_dict() -> dict[str, Any]:
 
 
 def _make_connector() -> KubernetesConnector:
-    async def _loader(_target: KubernetesTargetLike) -> dict[str, Any]:
+    async def _loader(_target: KubernetesTargetLike, _operator: Operator) -> dict[str, Any]:
         return _stub_kubeconfig_dict()
 
     return KubernetesConnector(kubeconfig_loader=_loader)

--- a/backend/tests/test_connectors_k8s_logs.py
+++ b/backend/tests/test_connectors_k8s_logs.py
@@ -41,6 +41,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.kubernetes import KubernetesConnector
 from meho_backplane.connectors.kubernetes.kubeconfig import KubernetesTargetLike
 from meho_backplane.connectors.kubernetes.ops_logs import (
@@ -86,10 +87,26 @@ def _stub_kubeconfig_dict() -> dict[str, Any]:
 
 
 def _make_connector() -> KubernetesConnector:
-    async def _loader(_target: KubernetesTargetLike) -> dict[str, Any]:
+    async def _loader(_target: KubernetesTargetLike, _operator: Operator) -> dict[str, Any]:
         return _stub_kubeconfig_dict()
 
     return KubernetesConnector(kubeconfig_loader=_loader)
+
+
+def _make_operator() -> Operator:
+    """Build a non-system operator carrying a non-empty ``raw_jwt``.
+
+    G3.10-T4 (#948) added ``operator`` to every typed handler's
+    signature; the injected loader here ignores it.
+    """
+    return Operator(
+        sub="op-logs-test",
+        name="Logs Test Operator",
+        email=None,
+        raw_jwt="op.logs.jwt",
+        tenant_id=__import__("uuid").UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
 
 
 def _pod_obj(name: str, containers: list[str]) -> MagicMock:
@@ -226,7 +243,10 @@ async def test_k8s_logs_default_tail_100_returns_lines() -> None:
     config_patch, core_v1_patch, core_v1 = _patch_api(log_body=body)
     with config_patch, core_v1_patch:
         result = await k8s_logs(
-            connector, _TARGET, {"pod_name": "argocd-server", "namespace": "argocd"}
+            connector,
+            _TARGET,
+            _make_operator(),
+            {"pod_name": "argocd-server", "namespace": "argocd"},
         )
 
     assert result["pod"] == "argocd-server-7c4b8d-x7r2k"
@@ -251,6 +271,7 @@ async def test_k8s_logs_explicit_tail_flows_to_api() -> None:
         await k8s_logs(
             connector,
             _TARGET,
+            _make_operator(),
             {"pod_name": "argocd-server", "namespace": "argocd", "tail": 500},
         )
     assert core_v1.read_namespaced_pod_log.call_args.kwargs["tail_lines"] == 500
@@ -265,6 +286,7 @@ async def test_k8s_logs_tail_clamps_at_max() -> None:
         await k8s_logs(
             connector,
             _TARGET,
+            _make_operator(),
             {"pod_name": "argocd-server", "namespace": "argocd", "tail": 99999},
         )
     assert core_v1.read_namespaced_pod_log.call_args.kwargs["tail_lines"] == MAX_TAIL_LINES
@@ -278,6 +300,7 @@ async def test_k8s_logs_since_resolves_to_seconds() -> None:
         await k8s_logs(
             connector,
             _TARGET,
+            _make_operator(),
             {"pod_name": "argocd-server", "namespace": "argocd", "since": "5m"},
         )
     assert core_v1.read_namespaced_pod_log.call_args.kwargs["since_seconds"] == 300
@@ -291,6 +314,7 @@ async def test_k8s_logs_previous_flows_to_api() -> None:
         await k8s_logs(
             connector,
             _TARGET,
+            _make_operator(),
             {"pod_name": "argocd-server", "namespace": "argocd", "previous": True},
         )
     assert core_v1.read_namespaced_pod_log.call_args.kwargs["previous"] is True
@@ -310,6 +334,7 @@ async def test_k8s_logs_explicit_container_in_multi_container_pod() -> None:
         result = await k8s_logs(
             connector,
             _TARGET,
+            _make_operator(),
             {
                 "pod_name": "istio-pilot-1",
                 "namespace": "istio",
@@ -329,6 +354,7 @@ async def test_k8s_logs_multi_container_without_container_param_errors() -> None
         await k8s_logs(
             connector,
             _TARGET,
+            _make_operator(),
             {"pod_name": "istio-pilot-1", "namespace": "istio"},
         )
     assert exc.value.containers == ["discovery", "istio-proxy"]
@@ -343,6 +369,7 @@ async def test_k8s_logs_unknown_container_in_multi_container_pod_errors() -> Non
         await k8s_logs(
             connector,
             _TARGET,
+            _make_operator(),
             {
                 "pod_name": "istio-pilot-1",
                 "namespace": "istio",
@@ -371,6 +398,7 @@ async def test_k8s_logs_pod_prefix_resolves_to_exact_name() -> None:
         result = await k8s_logs(
             connector,
             _TARGET,
+            _make_operator(),
             {"pod_name": "argocd-server", "namespace": "argocd"},
         )
     assert result["pod"] == "argocd-server-7c4b8d-x7r2k"
@@ -391,6 +419,7 @@ async def test_k8s_logs_pod_prefix_ambiguous_raises() -> None:
         await k8s_logs(
             connector,
             _TARGET,
+            _make_operator(),
             {"pod_name": "api", "namespace": "default"},
         )
     assert exc.value.candidates == ["api-1", "api-2"]
@@ -405,6 +434,7 @@ async def test_k8s_logs_pod_not_found_raises() -> None:
         await k8s_logs(
             connector,
             _TARGET,
+            _make_operator(),
             {"pod_name": "ghost", "namespace": "default"},
         )
     assert exc.value.candidates == []
@@ -425,6 +455,7 @@ async def test_k8s_logs_exact_match_wins_over_prefix_match() -> None:
         result = await k8s_logs(
             connector,
             _TARGET,
+            _make_operator(),
             {"pod_name": "api-1", "namespace": "default"},
         )
     assert result["pod"] == "api-1"
@@ -445,6 +476,7 @@ async def test_k8s_logs_body_under_cap_returns_untruncated() -> None:
         result = await k8s_logs(
             connector,
             _TARGET,
+            _make_operator(),
             {"pod_name": "argocd-server", "namespace": "argocd"},
         )
     assert result["truncated"] is False
@@ -464,6 +496,7 @@ async def test_k8s_logs_body_over_cap_truncates_from_front() -> None:
         result = await k8s_logs(
             connector,
             _TARGET,
+            _make_operator(),
             {"pod_name": "argocd-server", "namespace": "argocd"},
         )
 
@@ -499,6 +532,7 @@ async def test_k8s_logs_api_exception_propagates() -> None:
         await k8s_logs(
             connector,
             _TARGET,
+            _make_operator(),
             {"pod_name": "argocd-server", "namespace": "argocd"},
         )
 
@@ -514,5 +548,7 @@ async def test_kubernetes_connector_logs_method_delegates_to_handler() -> None:
     body = "delegated\n"
     config_patch, core_v1_patch, _core_v1 = _patch_api(log_body=body)
     with config_patch, core_v1_patch:
-        result = await connector.logs(_TARGET, {"pod_name": "argocd-server", "namespace": "argocd"})
+        result = await connector.logs(
+            _make_operator(), _TARGET, {"pod_name": "argocd-server", "namespace": "argocd"}
+        )
     assert result["lines"] == ["delegated"]

--- a/backend/tests/test_connectors_k8s_network_config.py
+++ b/backend/tests/test_connectors_k8s_network_config.py
@@ -65,6 +65,7 @@ from kubernetes_asyncio.client.models import (
     V1ServiceSpec,
 )
 
+from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.kubernetes import (
     KUBERNETES_OPS,
     KubernetesConnector,
@@ -165,10 +166,26 @@ def _stub_kubeconfig() -> dict[str, Any]:
 
 
 def _make_connector() -> KubernetesConnector:
-    async def _loader(_target: KubernetesTargetLike) -> dict[str, Any]:
+    async def _loader(_target: KubernetesTargetLike, _operator: Operator) -> dict[str, Any]:
         return _stub_kubeconfig()
 
     return KubernetesConnector(kubeconfig_loader=_loader)
+
+
+def _make_operator() -> Operator:
+    """Build a non-system operator carrying a non-empty ``raw_jwt``.
+
+    G3.10-T4 (#948) added ``operator`` to every typed handler's
+    signature; the injected loader here ignores it.
+    """
+    return Operator(
+        sub="op-net-config-test",
+        name="Net/Config Test Operator",
+        email=None,
+        raw_jwt="op.net.jwt",
+        tenant_id=__import__("uuid").UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -743,7 +760,9 @@ async def test_k8s_service_list_returns_rows_and_total() -> None:
         list_resp.items = services
         list_resp.metadata = V1ListMeta()
         core_v1_cls.return_value.list_namespaced_service = AsyncMock(return_value=list_resp)
-        result = await connector.k8s_service_list(_TARGET, {"namespace": "argocd"})
+        result = await connector.k8s_service_list(
+            _make_operator(), _TARGET, {"namespace": "argocd"}
+        )
 
         core_v1_cls.return_value.list_namespaced_service.assert_awaited_once_with(
             namespace="argocd"
@@ -771,7 +790,7 @@ async def test_k8s_service_list_empty_namespace() -> None:
         list_resp = MagicMock()
         list_resp.items = []
         core_v1_cls.return_value.list_namespaced_service = AsyncMock(return_value=list_resp)
-        result = await connector.k8s_service_list(_TARGET, {"namespace": "empty"})
+        result = await connector.k8s_service_list(_make_operator(), _TARGET, {"namespace": "empty"})
     assert result == {"rows": [], "total": 0}
 
 
@@ -807,7 +826,9 @@ async def test_k8s_ingress_list_returns_hosts_and_tls() -> None:
         list_resp = MagicMock()
         list_resp.items = [ingress]
         networking_cls.return_value.list_namespaced_ingress = AsyncMock(return_value=list_resp)
-        result = await connector.k8s_ingress_list(_TARGET, {"namespace": "argocd"})
+        result = await connector.k8s_ingress_list(
+            _make_operator(), _TARGET, {"namespace": "argocd"}
+        )
 
         networking_cls.return_value.list_namespaced_ingress.assert_awaited_once_with(
             namespace="argocd"
@@ -848,7 +869,9 @@ async def test_k8s_configmap_list_keys_only_data_absent() -> None:
         list_resp = MagicMock()
         list_resp.items = [cm]
         core_v1_cls.return_value.list_namespaced_config_map = AsyncMock(return_value=list_resp)
-        result = await connector.k8s_configmap_list(_TARGET, {"namespace": "argocd"})
+        result = await connector.k8s_configmap_list(
+            _make_operator(), _TARGET, {"namespace": "argocd"}
+        )
 
     assert result["total"] == 1
     row = result["rows"][0]
@@ -885,7 +908,7 @@ async def test_k8s_configmap_info_returns_full_data_and_binary_data() -> None:
     ):
         core_v1_cls.return_value.read_namespaced_config_map = AsyncMock(return_value=cm)
         result = await connector.k8s_configmap_info(
-            _TARGET, {"name": "argocd-cm", "namespace": "argocd"}
+            _make_operator(), _TARGET, {"name": "argocd-cm", "namespace": "argocd"}
         )
 
         core_v1_cls.return_value.read_namespaced_config_map.assert_awaited_once_with(
@@ -925,6 +948,7 @@ async def test_k8s_event_list_field_selector_forwarded() -> None:
         list_resp.items = [warn]
         core_v1_cls.return_value.list_namespaced_event = AsyncMock(return_value=list_resp)
         result = await connector.k8s_event_list(
+            _make_operator(),
             _TARGET,
             {"namespace": "argocd", "field_selector": "type=Warning"},
         )
@@ -977,7 +1001,7 @@ async def test_k8s_event_list_default_limit() -> None:
         list_resp = MagicMock()
         list_resp.items = api_events
         core_v1_cls.return_value.list_namespaced_event = AsyncMock(return_value=list_resp)
-        result = await connector.k8s_event_list(_TARGET, {"namespace": "argocd"})
+        result = await connector.k8s_event_list(_make_operator(), _TARGET, {"namespace": "argocd"})
         kwargs = core_v1_cls.return_value.list_namespaced_event.call_args.kwargs
         # Wire: always MAX_EVENT_LIMIT.
         assert kwargs["limit"] == MAX_EVENT_LIMIT
@@ -1035,7 +1059,9 @@ async def test_k8s_event_list_limit_respects_value_and_ordered_by_last_seen() ->
         list_resp = MagicMock()
         list_resp.items = api_events
         core_v1_cls.return_value.list_namespaced_event = AsyncMock(return_value=list_resp)
-        result = await connector.k8s_event_list(_TARGET, {"namespace": "argocd", "limit": 10})
+        result = await connector.k8s_event_list(
+            _make_operator(), _TARGET, {"namespace": "argocd", "limit": 10}
+        )
         kwargs = core_v1_cls.return_value.list_namespaced_event.call_args.kwargs
         # The handler always pulls up to MAX_EVENT_LIMIT, never the
         # caller's smaller ``limit`` -- the recency sort needs the
@@ -1101,7 +1127,9 @@ async def test_k8s_event_list_fetches_max_then_sorts_client_side() -> None:
         list_resp = MagicMock()
         list_resp.items = api_events
         core_v1_cls.return_value.list_namespaced_event = AsyncMock(return_value=list_resp)
-        result = await connector.k8s_event_list(_TARGET, {"namespace": "argocd", "limit": 5})
+        result = await connector.k8s_event_list(
+            _make_operator(), _TARGET, {"namespace": "argocd", "limit": 5}
+        )
         kwargs = core_v1_cls.return_value.list_namespaced_event.call_args.kwargs
         # Wire-side: ask for the superset, not the caller's limit.
         assert kwargs["limit"] == MAX_EVENT_LIMIT
@@ -1128,7 +1156,9 @@ async def test_k8s_event_list_limit_clamps_at_max() -> None:
         list_resp = MagicMock()
         list_resp.items = []
         core_v1_cls.return_value.list_namespaced_event = AsyncMock(return_value=list_resp)
-        await connector.k8s_event_list(_TARGET, {"namespace": "argocd", "limit": 99999})
+        await connector.k8s_event_list(
+            _make_operator(), _TARGET, {"namespace": "argocd", "limit": 99999}
+        )
         kwargs = core_v1_cls.return_value.list_namespaced_event.call_args.kwargs
         # The API request always asks for MAX_EVENT_LIMIT regardless
         # of how the caller's ``limit`` was clamped -- the clamp

--- a/backend/tests/test_connectors_k8s_workload.py
+++ b/backend/tests/test_connectors_k8s_workload.py
@@ -68,6 +68,7 @@ from kubernetes_asyncio.client.models import (
     V1VolumeMount,
 )
 
+from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.kubernetes import (
     KUBERNETES_OPS,
     KubernetesConnector,
@@ -159,10 +160,27 @@ def _stub_kubeconfig() -> dict[str, Any]:
 
 
 def _make_connector() -> KubernetesConnector:
-    async def _loader(_target: KubernetesTargetLike) -> dict[str, Any]:
+    async def _loader(_target: KubernetesTargetLike, _operator: Operator) -> dict[str, Any]:
         return _stub_kubeconfig()
 
     return KubernetesConnector(kubeconfig_loader=_loader)
+
+
+def _make_operator() -> Operator:
+    """Build a non-system operator carrying a non-empty ``raw_jwt``.
+
+    G3.10-T4 (#948) added ``operator`` to every typed handler's
+    signature; the injected loader here ignores it, but the handler
+    forwards it to :meth:`KubernetesConnector._get_api_client`.
+    """
+    return Operator(
+        sub="op-workload-test",
+        name="Workload Test Operator",
+        email=None,
+        raw_jwt="op.workload.jwt",
+        tenant_id=__import__("uuid").UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -632,7 +650,7 @@ async def test_k8s_pod_list_returns_rows_and_total() -> None:
         patch("meho_backplane.connectors.kubernetes.ops_workload.client.CoreV1Api") as core_v1_cls,
     ):
         core_v1_cls.return_value.list_namespaced_pod = AsyncMock(return_value=_pod_list(pods))
-        result = await connector.k8s_pod_list(_TARGET, {"namespace": "argocd"})
+        result = await connector.k8s_pod_list(_make_operator(), _TARGET, {"namespace": "argocd"})
 
     assert result["total"] == 2
     assert {row["name"] for row in result["rows"]} == {"argocd-server-x", "argocd-repo-y"}
@@ -660,7 +678,7 @@ async def test_k8s_pod_list_all_namespaces_uses_for_all_namespaces() -> None:
             return_value=_pod_list(pods)
         )
         core_v1_cls.return_value.list_namespaced_pod = AsyncMock()
-        result = await connector.k8s_pod_list(_TARGET, {"all_namespaces": True})
+        result = await connector.k8s_pod_list(_make_operator(), _TARGET, {"all_namespaces": True})
 
     assert result["total"] == 2
     core_v1_cls.return_value.list_pod_for_all_namespaces.assert_awaited_once()
@@ -677,7 +695,9 @@ async def test_k8s_pod_list_label_selector_flows_through() -> None:
     ):
         core_v1_cls.return_value.list_namespaced_pod = AsyncMock(return_value=_pod_list([]))
         await connector.k8s_pod_list(
-            _TARGET, {"namespace": "argocd", "label_selector": "app=argocd-server"}
+            _make_operator(),
+            _TARGET,
+            {"namespace": "argocd", "label_selector": "app=argocd-server"},
         )
     kwargs = core_v1_cls.return_value.list_namespaced_pod.call_args.kwargs
     assert kwargs["label_selector"] == "app=argocd-server"
@@ -693,7 +713,9 @@ async def test_k8s_pod_list_field_selector_flows_through() -> None:
     ):
         core_v1_cls.return_value.list_namespaced_pod = AsyncMock(return_value=_pod_list([]))
         await connector.k8s_pod_list(
-            _TARGET, {"namespace": "argocd", "field_selector": "status.phase=Running"}
+            _make_operator(),
+            _TARGET,
+            {"namespace": "argocd", "field_selector": "status.phase=Running"},
         )
     kwargs = core_v1_cls.return_value.list_namespaced_pod.call_args.kwargs
     assert kwargs["field_selector"] == "status.phase=Running"
@@ -711,7 +733,9 @@ async def test_k8s_pod_list_server_side_pagination_returns_next_continue() -> No
         core_v1_cls.return_value.list_namespaced_pod = AsyncMock(
             return_value=_pod_list(pods, continue_token="page-2")
         )
-        result = await connector.k8s_pod_list(_TARGET, {"namespace": "argocd", "limit": 5})
+        result = await connector.k8s_pod_list(
+            _make_operator(), _TARGET, {"namespace": "argocd", "limit": 5}
+        )
 
     assert result["total"] == 5
     assert result["next_continue"] == "page-2"
@@ -729,7 +753,9 @@ async def test_k8s_pod_list_continue_token_passed_to_api_as_underscore_continue(
         patch("meho_backplane.connectors.kubernetes.ops_workload.client.CoreV1Api") as core_v1_cls,
     ):
         core_v1_cls.return_value.list_namespaced_pod = AsyncMock(return_value=_pod_list([]))
-        await connector.k8s_pod_list(_TARGET, {"namespace": "argocd", "continue_token": "abc123"})
+        await connector.k8s_pod_list(
+            _make_operator(), _TARGET, {"namespace": "argocd", "continue_token": "abc123"}
+        )
     kwargs = core_v1_cls.return_value.list_namespaced_pod.call_args.kwargs
     assert kwargs["_continue"] == "abc123"
 
@@ -745,7 +771,7 @@ async def test_k8s_pod_list_omits_next_continue_when_no_more_pages() -> None:
         core_v1_cls.return_value.list_namespaced_pod = AsyncMock(
             return_value=_pod_list([_make_pod(name="solo", namespace="argocd")])
         )
-        result = await connector.k8s_pod_list(_TARGET, {"namespace": "argocd"})
+        result = await connector.k8s_pod_list(_make_operator(), _TARGET, {"namespace": "argocd"})
     assert "next_continue" not in result
 
 
@@ -765,7 +791,7 @@ async def test_k8s_pod_info_exact_match_returns_full_detail() -> None:
     ):
         core_v1_cls.return_value.list_namespaced_pod = AsyncMock(return_value=_pod_list([pod]))
         result = await connector.k8s_pod_info(
-            _TARGET, {"pod_name": "argocd-server", "namespace": "argocd"}
+            _make_operator(), _TARGET, {"pod_name": "argocd-server", "namespace": "argocd"}
         )
     assert result["name"] == "argocd-server"
     assert result["namespace"] == "argocd"
@@ -786,7 +812,7 @@ async def test_k8s_pod_info_unique_prefix_resolves_to_one_pod() -> None:
     ):
         core_v1_cls.return_value.list_namespaced_pod = AsyncMock(return_value=_pod_list(pods))
         result = await connector.k8s_pod_info(
-            _TARGET, {"pod_name": "argocd-server", "namespace": "argocd"}
+            _make_operator(), _TARGET, {"pod_name": "argocd-server", "namespace": "argocd"}
         )
     assert result["name"] == "argocd-server-7c4b8d-x7r2k"
 
@@ -805,7 +831,9 @@ async def test_k8s_pod_info_ambiguous_prefix_raises() -> None:
     ):
         core_v1_cls.return_value.list_namespaced_pod = AsyncMock(return_value=_pod_list(pods))
         with pytest.raises(AmbiguousPrefixError) as exc:
-            await connector.k8s_pod_info(_TARGET, {"pod_name": "api", "namespace": "argocd"})
+            await connector.k8s_pod_info(
+                _make_operator(), _TARGET, {"pod_name": "api", "namespace": "argocd"}
+            )
     assert exc.value.candidates == ["api-1", "api-2"]
 
 
@@ -819,7 +847,9 @@ async def test_k8s_pod_info_not_found_raises() -> None:
     ):
         core_v1_cls.return_value.list_namespaced_pod = AsyncMock(return_value=_pod_list([]))
         with pytest.raises(WorkloadNotFoundError):
-            await connector.k8s_pod_info(_TARGET, {"pod_name": "ghost", "namespace": "argocd"})
+            await connector.k8s_pod_info(
+                _make_operator(), _TARGET, {"pod_name": "ghost", "namespace": "argocd"}
+            )
 
 
 @pytest.mark.asyncio
@@ -835,7 +865,9 @@ async def test_k8s_pod_info_exact_match_wins_over_prefix() -> None:
         patch("meho_backplane.connectors.kubernetes.ops_workload.client.CoreV1Api") as core_v1_cls,
     ):
         core_v1_cls.return_value.list_namespaced_pod = AsyncMock(return_value=_pod_list(pods))
-        result = await connector.k8s_pod_info(_TARGET, {"pod_name": "api-1", "namespace": "argocd"})
+        result = await connector.k8s_pod_info(
+            _make_operator(), _TARGET, {"pod_name": "api-1", "namespace": "argocd"}
+        )
     assert result["name"] == "api-1"
 
 
@@ -858,7 +890,9 @@ async def test_k8s_deployment_list_returns_rows_and_total() -> None:
         apps_v1_cls.return_value.list_namespaced_deployment = AsyncMock(
             return_value=_deployment_list(deps)
         )
-        result = await connector.k8s_deployment_list(_TARGET, {"namespace": "argocd"})
+        result = await connector.k8s_deployment_list(
+            _make_operator(), _TARGET, {"namespace": "argocd"}
+        )
 
     assert result["total"] == 2
     names = {row["name"] for row in result["rows"]}
@@ -881,7 +915,9 @@ async def test_k8s_deployment_list_all_namespaces_routes_to_all_namespaces_api()
             return_value=_deployment_list(deps)
         )
         apps_v1_cls.return_value.list_namespaced_deployment = AsyncMock()
-        result = await connector.k8s_deployment_list(_TARGET, {"all_namespaces": True})
+        result = await connector.k8s_deployment_list(
+            _make_operator(), _TARGET, {"all_namespaces": True}
+        )
     assert result["total"] == 2
     apps_v1_cls.return_value.list_deployment_for_all_namespaces.assert_awaited_once()
     apps_v1_cls.return_value.list_namespaced_deployment.assert_not_awaited()
@@ -898,7 +934,9 @@ async def test_k8s_deployment_list_pagination_returns_next_continue() -> None:
         apps_v1_cls.return_value.list_namespaced_deployment = AsyncMock(
             return_value=_deployment_list(deps, continue_token="page-2")
         )
-        result = await connector.k8s_deployment_list(_TARGET, {"namespace": "argocd", "limit": 3})
+        result = await connector.k8s_deployment_list(
+            _make_operator(), _TARGET, {"namespace": "argocd", "limit": 3}
+        )
     assert result["next_continue"] == "page-2"
     kwargs = apps_v1_cls.return_value.list_namespaced_deployment.call_args.kwargs
     assert kwargs["limit"] == 3
@@ -921,7 +959,7 @@ async def test_k8s_deployment_info_exact_match_returns_full_detail() -> None:
             return_value=_deployment_list([dep])
         )
         result = await connector.k8s_deployment_info(
-            _TARGET, {"deployment_name": "argocd-server", "namespace": "argocd"}
+            _make_operator(), _TARGET, {"deployment_name": "argocd-server", "namespace": "argocd"}
         )
     assert result["name"] == "argocd-server"
     assert result["status"]["replicas"] == 3
@@ -943,7 +981,7 @@ async def test_k8s_deployment_info_prefix_resolves_to_one_deployment() -> None:
             return_value=_deployment_list(deps)
         )
         result = await connector.k8s_deployment_info(
-            _TARGET, {"deployment_name": "argocd-serv", "namespace": "argocd"}
+            _make_operator(), _TARGET, {"deployment_name": "argocd-serv", "namespace": "argocd"}
         )
     assert result["name"] == "argocd-server"
 
@@ -964,7 +1002,7 @@ async def test_k8s_deployment_info_ambiguous_prefix_raises() -> None:
         )
         with pytest.raises(AmbiguousPrefixError) as exc:
             await connector.k8s_deployment_info(
-                _TARGET, {"deployment_name": "api", "namespace": "argocd"}
+                _make_operator(), _TARGET, {"deployment_name": "api", "namespace": "argocd"}
             )
     assert exc.value.candidates == ["api-1", "api-2"]
 
@@ -981,5 +1019,5 @@ async def test_k8s_deployment_info_not_found_raises() -> None:
         )
         with pytest.raises(WorkloadNotFoundError):
             await connector.k8s_deployment_info(
-                _TARGET, {"deployment_name": "ghost", "namespace": "argocd"}
+                _make_operator(), _TARGET, {"deployment_name": "ghost", "namespace": "argocd"}
             )

--- a/docs/codebase/connector-release-readiness.md
+++ b/docs/codebase/connector-release-readiness.md
@@ -55,7 +55,9 @@ rg "op_id=.<connector-name>\." backend/src/meho_backplane/connectors/<connector-
 rg "raise NotImplementedError" backend/src/meho_backplane/connectors/<connector-name>/
 ```
 
-**v0.3.0 examples at this state:** `k8s-1.x`. (`vmware-rest-9.0` was at
+**v0.3.0 examples at this state:** none after G3.10. (`k8s-1.x` was at
+this state through v0.3.0; G3.10-T4 [#948](https://github.com/evoila/meho/issues/948)
+wired its live loader and moved it to State 2. `vmware-rest-9.0` was at
 this state through v0.3.0; G3.9-T3 [#942](https://github.com/evoila/meho/issues/942)
 wired its live loader and moved it to State 2.)
 
@@ -101,6 +103,20 @@ now performs the live operator-context KV-v2 read via the shared
 [`load_basic_credentials`](../../backend/src/meho_backplane/connectors/_shared/vault_creds.py)
 helper; `shared_service_account` executes against a real vCenter.
 Operator recipe: [`vmware-rest-onboarding.md`](../cross-repo/vmware-rest-onboarding.md).
+`k8s-1.x` joined this state via G3.10-T4
+[#948](https://github.com/evoila/meho/issues/948): its default loader
+[`load_kubeconfig_from_vault`](../../backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py)
+performs the live operator-context KV-v2 read (kubeconfig YAML under
+the `kubeconfig` field) and parses the result into the dict shape
+`kubernetes_asyncio.config.new_client_from_config_dict` accepts;
+`shared_service_account` executes against a real cluster. The
+kubeconfig is structurally different from the `{username, password}`
+the REST connectors consume — it's a single YAML document — so the
+loader reuses the lower-level `vault_client_for_operator` primitive
+directly rather than the `load_basic_credentials` helper, while still
+applying the same fail-closed contract (empty `operator.raw_jwt` →
+`VaultCredentialsReadError`) and the same no-secret-in-logs discipline.
+Operator recipe: [`kubernetes-onboarding.md`](../cross-repo/kubernetes-onboarding.md).
 
 **Honest release-notes language:**
 
@@ -134,13 +150,13 @@ flow is the only auth_model; loader is live; consumer confirmed
 |---|---|---|---|
 | `vault-1.x` | 3 | JWT-federated, live | ✅ |
 | `bind9-ssh-9.x` | 2-3 | `shared_service_account` inline | ✅ |
-| `k8s-1.x` | 1 | [`load_kubeconfig_from_vault`](../../backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py#L86) — `NotImplementedError` | ❌ (mock loader in test only) |
+| `k8s-1.x` | 2 | [`load_kubeconfig_from_vault`](../../backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py) — live operator-context Vault read (G3.10-T4 [#948](https://github.com/evoila/meho/issues/948)) | ✅ (`shared_service_account`) |
 | `vmware-rest-9.0` | 2 | [`load_session_credentials_from_vault`](../../backend/src/meho_backplane/connectors/vmware_rest/session.py#L116) — live operator-context Vault read (G3.9-T3 [#942](https://github.com/evoila/meho/issues/942)) | ✅ (`shared_service_account`) |
 | `vcf-automation-9.0` | 2 | [`load_credentials_from_vault`](../../backend/src/meho_backplane/connectors/vcf_automation/session.py) — live operator-context Vault read via the shared [`load_basic_credentials`](../../backend/src/meho_backplane/connectors/_shared/vault_creds.py) helper; `operator` threaded through the bespoke dual-plane auth (G3.10-T3 [#947](https://github.com/evoila/meho/issues/947)) | ✅ (`shared_service_account`) |
 | `nsx-4.2` | 2 | [`load_session_credentials_from_vault`](../../backend/src/meho_backplane/connectors/nsx/session.py) — live operator-context Vault read (G3.10-T1 [#945](https://github.com/evoila/meho/issues/945)) | ✅ (`shared_service_account`) |
 | `sddc-manager-9.0` | 2 | [`load_credentials_from_vault`](../../backend/src/meho_backplane/connectors/sddc_manager/session.py) — live operator-context Vault read (G3.10-T1 [#945](https://github.com/evoila/meho/issues/945)) | ✅ (`shared_service_account`) |
 | `harbor-2.x` | 2 | [`load_credentials_from_vault`](../../backend/src/meho_backplane/connectors/harbor/session.py) — live operator-context Vault read (G3.10-T1 [#945](https://github.com/evoila/meho/issues/945)) | ✅ (`shared_service_account`) |
-| `kubernetes-asyncio-1.x` | 1 (shadow) | Same as `k8s-1.x` | ❌ |
+| `kubernetes-asyncio-1.x` | 2 (shadow) | Same as `k8s-1.x` | ✅ (`shared_service_account`) |
 
 State 0.5 = `register_connector_v2` called but no ops registered yet.
 Since [T5 #733](https://github.com/evoila/meho/issues/733), these

--- a/docs/codebase/connectors-kubernetes.md
+++ b/docs/codebase/connectors-kubernetes.md
@@ -72,9 +72,21 @@ Source: `backend/src/meho_backplane/connectors/kubernetes/`.
   `Target` model once G0.3 (#224) lands; the structural shape there
   satisfies the Protocol unchanged.
 - **`load_kubeconfig_from_vault`** (`kubeconfig.py`) -- the default
-  kubeconfig loader stub. Raises `NotImplementedError` until G0.3
-  lands; tests and the integration suite inject a callable returning
-  a pre-built kubeconfig dict.
+  kubeconfig loader. After G3.10-T4 (#948) it performs the live
+  operator-context KV-v2 read: opens
+  `vault_client_for_operator(operator)` (forwards the operator's
+  validated Keycloak JWT to Vault's JWT/OIDC auth method), reads
+  `target.secret_ref`, extracts the `kubeconfig` field, and parses the
+  YAML into the dict shape
+  `kubernetes_asyncio.config.new_client_from_config_dict` accepts. The
+  read happens **under the operator's Vault Identity entity** —
+  per-operator RBAC + per-operator audit. Tests still inject a custom
+  loader for unit-scope determinism; the `(target, operator)` signature
+  is shared by the default and every injected loader. Fail-closed
+  guards: empty `operator.raw_jwt` (the system-call carve-out) and
+  unset `target.secret_ref` both raise `VaultCredentialsReadError`
+  before Vault is touched. This is the rubric **State 2** wiring
+  (`shared_service_account` only). Decision: [`docs/architecture/connector-auth.md`](../architecture/connector-auth.md).
 
 ## Shipped op surface
 

--- a/docs/cross-repo/kubernetes-onboarding.md
+++ b/docs/cross-repo/kubernetes-onboarding.md
@@ -7,12 +7,46 @@ Copyright (c) 2026 evoila Group
 
 > Operator-facing recipe for the G3.2 `k8s-1.x` op surface — the
 > `meho k8s …` verb tree, the agent meta-tool path, and the migration
-> off the consumer's `kubectl-vcf.sh` wrapper. The op handlers live in
+> off the consumer's `kubectl-vcf.sh` wrapper. With the G3.10-T4
+> [#948](https://github.com/evoila/meho/issues/948) credential-broker
+> wiring landed, `meho operation call k8s.<op> target=…` reads the
+> kubeconfig out of Vault under the operator's identity and executes a
+> real read against the cluster — the rubric **State 2** wiring per
+> [`docs/codebase/connector-release-readiness.md`](../codebase/connector-release-readiness.md).
+> The op handlers live in
 > [`backend/src/meho_backplane/connectors/kubernetes/`](../../backend/src/meho_backplane/connectors/kubernetes/);
 > the engineering-facing companion is
-> [`docs/codebase/connectors-kubernetes.md`](../codebase/connectors-kubernetes.md).
+> [`docs/codebase/connectors-kubernetes.md`](../codebase/connectors-kubernetes.md);
+> the deploy prerequisite is the Vault-policy runbook
+> [`connector-vault-policy.md`](./connector-vault-policy.md).
 > This doc is the cookbook every RDC operator reads when retiring
 > `kubectl-vcf.sh` in favour of `meho k8s …`.
+
+## What "State 2" means here
+
+Per the
+[connector release-readiness rubric](../codebase/connector-release-readiness.md):
+
+- **State 1** (where this connector was before G3.10): dispatch +
+  catalog only — ops indexed and searchable, but the default
+  kubeconfig loader raised `NotImplementedError`, so a real
+  `operation call` against a Vault-backed target failed and only the
+  injected-loader test path worked.
+- **State 2** (what G3.10-T4 ships): the default loader performs the
+  live operator-context Vault read for the **`shared_service_account`**
+  auth model. `operation call k8s.<op> target=…` executes end to end
+  against a real cluster. The kubeconfig YAML lives in Vault at the
+  target's `secret_ref` under the field name `kubeconfig`; the loader
+  forwards the operator's validated Keycloak JWT to Vault's JWT/OIDC
+  auth method, reads the YAML, parses it via
+  [`parse_kubeconfig_yaml`](../../backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py),
+  and feeds the resulting dict to
+  `kubernetes_asyncio.config.new_client_from_config_dict`.
+- **State 3** (not yet): every advertised auth model wired; full catalog
+  in production rotation. `per_user` (operator-by-operator user
+  impersonation via the K8s `User-Impersonation` headers) and
+  `impersonation` are not yet wired and a target tagged with either
+  raises a clear boundary error.
 
 ## What this surface is
 
@@ -96,14 +130,64 @@ What this means for the kubeconfig in Vault:
 
 - The kubeconfig YAML lives in Vault at the path the target's
   `secret_ref` points to (e.g. `secret/data/<tenant>/k8s/<cluster>-kubeconfig`)
-  under field name `kubeconfig`.
+  under field name `kubeconfig`. The path is the **logical KV-v2 path
+  relative to the mount root** — no `secret/` mount prefix and no
+  `/data/` segment. It is exactly the string you store as the target's
+  `secret_ref` and the string the loader passes to hvac's
+  `read_secret_version(path=…, mount_point="secret")`, which inserts
+  the `/data/` itself
+  ([`connectors/kubernetes/kubeconfig.py`](../../backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py)).
 - The backplane reads it lazily on first op invocation per target via
-  `load_kubeconfig_from_vault` (resolved through the operator's
-  federation chain); the resulting `kubernetes_asyncio.client.ApiClient`
-  is cached per `target.secret_ref` and reused across ops.
+  `load_kubeconfig_from_vault(target, operator)` (G3.10-T4 [#948](https://github.com/evoila/meho/issues/948));
+  the operator's validated Keycloak JWT is forwarded to Vault's
+  JWT/OIDC auth method via
+  [`vault_client_for_operator`](../../backend/src/meho_backplane/auth/vault.py)
+  so the read happens **under the operator's Vault Identity entity** —
+  per-operator RBAC + per-operator audit. The resulting
+  `kubernetes_asyncio.client.ApiClient` is cached per
+  `target.secret_ref` and reused across ops (an in-flight per-operator
+  cache key swap lands when `per_user` ships).
 - Rotation: re-write the kubeconfig in Vault, then restart the
   backplane (the cache lives in-process; future Initiative may add a
   cache-invalidation op). Until then, restart is the rotation path.
+
+### The deploy prerequisite (Vault policy + Keycloak → Vault identity)
+
+The `meho-mcp` Vault role's templated ACL policy must grant read on
+the target's `secret_ref`, and the operator's Keycloak JWT `sub` must
+match a Vault Identity entity alias on the corresponding identity
+provider so the operator's read is attributed to *their* entity rather
+than rejected. Without this in place the live read returns Vault 403
+(`VaultRoleDeniedError`). The cross-repo deploy runbook
+[`connector-vault-policy.md`](./connector-vault-policy.md) documents
+the exact policy + identity wiring; the same prerequisite gates the
+`vmware-rest-9.0` State 2 path.
+
+### No kubeconfig content leaves the backplane
+
+The State-2 wiring is built so the kubeconfig YAML is ephemeral
+in-memory state:
+
+- The loader
+  ([`connectors/kubernetes/kubeconfig.py`](../../backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py))
+  logs only the target name, host, `secret_ref` path, and the
+  requested *field name* (`kubeconfig`) — never any kubeconfig
+  content (no server URL, no client certificate, no bearer token).
+- The connector's `ApiClient`-build log event carries the target name
+  and host only — same discipline.
+- The parsed kubeconfig dict is consumed by
+  `kubernetes_asyncio.config.new_client_from_config_dict` to build the
+  `ApiClient` and then dropped; it never enters the
+  `OperationResult`, the audit row payload, or the broadcast event.
+
+This is asserted by the recorded-fixture E2E
+([`tests/test_connectors_k8s_credread.py`](../../backend/tests/test_connectors_k8s_credread.py)):
+canary server URL + bearer token + client-cert strings are seeded into
+the (faked) Vault read and asserted absent from the result, every
+captured log event, and the broadcast payload. The live k3d + Vault
+E2E ([`tests/integration/test_connectors_k8s_live_vault.py`](../../backend/tests/integration/test_connectors_k8s_live_vault.py))
+re-runs the same no-leak assertions against a real k3s + real Vault
+chain (env-gated via `MEHO_RUN_LIVE_K3D_VAULT=1`).
 
 ## Step-by-step onboarding
 


### PR DESCRIPTION
## Summary

- **Wires `load_kubeconfig_from_vault` live (G3.10-T4 [#948](https://github.com/evoila/meho/issues/948)).** The default kubeconfig loader now performs the operator-context KV-v2 read: forwards `operator.raw_jwt` to Vault's JWT/OIDC auth method, reads the `kubeconfig` field at `target.secret_ref`, and returns the parsed dict `kubernetes_asyncio.config.new_client_from_config_dict` accepts. `KubeconfigLoader` carries `operator`; every typed K8s handler (`about`, `k8s.namespace.list`, `k8s.node.list`, `k8s.pod.{list,info}`, `k8s.deployment.{list,info}`, `k8s.service.list`, `k8s.ingress.list`, `k8s.configmap.{list,info}`, `k8s.event.list`, `k8s.logs`, `k8s.ls`) names `operator` in its signature so `dispatch_typed` threads it through to `_get_api_client(target, operator)` and on to the loader. This is the rubric **State 2** wiring (`shared_service_account` only) for the k8s connector — `operation call k8s.<op> target=…` now executes end-to-end against a real cluster.
- **Fail-closed boundaries.** Empty `operator.raw_jwt` (the system-call carve-out) and unset `target.secret_ref` both raise `VaultCredentialsReadError` before Vault is touched, matching `load_basic_credentials`. `fingerprint` and the `execute` shim's intra-connector forwarders synthesise a system operator so the fail-closed guard catches misuse rather than silently authenticating as a backplane identity.
- **No kubeconfig in logs / `OperationResult`.** The loader logs only `target` / `host` / `secret_ref` / field name — never any kubeconfig content. Asserted by canary server URL + bearer token + client cert in the new recorded-fixture E2E.
- **Two new tests:**
  - [`backend/tests/test_connectors_k8s_credread.py`](backend/tests/test_connectors_k8s_credread.py) — recorded-fixture E2E in the secret-free unit lane. Drives the full `dispatch -> default loader -> Vault fake -> parse -> k_a` chain with mocked `new_client_from_config_dict` + `CoreV1Api.list_namespace`. The fake Vault returns a canary kubeconfig YAML; the no-leak assertions check server URL / bearer token / client-cert PEM are absent from result, logs, and broadcast.
  - [`backend/tests/integration/test_connectors_k8s_live_vault.py`](backend/tests/integration/test_connectors_k8s_live_vault.py) — env-gated (`MEHO_RUN_LIVE_K3D_VAULT=1`) live-Vault + live-k3d E2E. Boots `rancher/k3s` + `hashicorp/vault` dev-mode containers, seeds the k3s-emitted kubeconfig into Vault under the `kubeconfig` field, configures the JWT/OIDC backend against a generated keypair, signs an operator JWT, dispatches `k8s.namespace.list`, and asserts the no-leak contract on the live chain. Skips cleanly when the env var is absent.
- **Docs:**
  - [`docs/codebase/connector-release-readiness.md`](docs/codebase/connector-release-readiness.md) — k8s-1.x row moved from State 1 → 2; kubernetes-asyncio-1.x shadow row matched. The State 2 example section now describes the kubeconfig-specific wiring (why the loader reuses `vault_client_for_operator` directly rather than `load_basic_credentials`).
  - [`docs/cross-repo/kubernetes-onboarding.md`](docs/cross-repo/kubernetes-onboarding.md) — new "What State 2 means here" preamble + "Target + auth model" expanded with the deploy prerequisite cross-reference and the no-kubeconfig-in-logs discipline.
  - [`docs/codebase/connectors-kubernetes.md`](docs/codebase/connectors-kubernetes.md) — `load_kubeconfig_from_vault` entry rewritten to describe the live wiring + fail-closed contract.
  - `CHANGELOG.md` — `[Unreleased]` entry under Changed.

## Test plan

- [x] `ruff check` — clean across touched files
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/kubernetes/` — clean
- [x] `code-quality.py --diff` — 0 blockers (warnings are pre-existing legacy file sizes)
- [x] `pytest tests/test_connectors_k8s_*.py tests/test_app_starts.py` — 185 passed
- [x] `pytest tests/test_connectors_k8s_*.py tests/test_connectors_vmware_rest_*.py tests/test_connectors_vault*.py tests/test_app_starts.py tests/test_operations_dispatcher.py` — 418 passed
- [x] **Acceptance criterion** `load_kubeconfig_from_vault(target, operator)` performs the live read + parse; `rg "deliberate stub" backend/src/meho_backplane/connectors/kubernetes/kubeconfig.py` returns nothing — verified.
- [x] **Acceptance criterion** `KubeconfigLoader` carries `operator`; the connector threads it; empty `raw_jwt` fails closed with a clear error; `mypy` clean — verified.
- [x] **Acceptance criterion** k3d + live-Vault E2E lists a namespace via `dispatch` (the meta-tool dispatch path), returns `status="ok"`, asserts the kubeconfig YAML never appears in result/captured logs; env-gated so default `pytest -n auto` skips cleanly — verified (collects + skips without env var).
- [x] **Acceptance criterion** Injected-loader unit tests updated to the 2-arg shape; existing `test_connectors_k8s_*` pass — verified (185 tests).
- [x] **Acceptance criterion** `docs/cross-repo/kubernetes-onboarding.md` documents the kubeconfig-in-Vault convention + links the Vault-policy runbook — verified.
- [x] **Acceptance criterion** `ruff` + `mypy` clean; `docs/codebase/connector-release-readiness.md` k8s-1.x row updated to State 2 — verified.

## Out of scope

- HTTP/REST connector loaders — Wave 1A sibling tasks #945/#946/#947 (PRs #971/#972/#973).
- `per_user`/`impersonation` auth models, kubeconfig rotation, per-namespace RBAC beyond the kubeconfig's own — explicitly out of scope.
- ApiClient cache invalidation on kubeconfig rotation — restart is the documented rotation path (deferred per the in-flight per-operator cache-key swap when `per_user` lands).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #948


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kubernetes ops can run end-to-end against real clusters using operator-authenticated kubeconfigs loaded from Vault
  * Live kubeconfig loading from Vault KV-v2 with lazy per-target caching and fail-closed guards (requires operator JWT and configured secret reference)

* **Documentation**
  * Expanded Kubernetes onboarding and connector docs with State 2 wiring, deployment prerequisites, Vault policy/rotation guidance, and logging rules

* **Tests**
  * Added integration and unit tests (including opt-in live Vault+k3s E2E) that validate execution and assert no kubeconfig leaks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/975?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->