### PR TITLE
ci(license): allow asyncssh EPL-2.0 dual-license in dependency gate

### DIFF
--- a/.github/workflows/dependency-license-check.yml
+++ b/.github/workflows/dependency-license-check.yml
@@ -92,6 +92,14 @@ jobs:
         # Other/Proprietary. Remove either entry when upstream
         # license metadata is corrected. ``--ignore-packages`` accepts
         # ``nargs=*`` (space-separated), NOT a semicolon-joined string.
+        #
+        # ``EPL-2.0 OR GPL-2.0-or-later``: asyncssh (G0.2-T4, an existing
+        # accepted dependency) reports this PEP 639 dual-license expression
+        # under pip-licenses 5.5.5. The EPL-2.0 arm is weak (file-level)
+        # copyleft, which this workflow's policy explicitly permits inbound
+        # against the Apache-2.0 outbound (see header); we consume asyncssh
+        # unmodified as an SSH transport library. Allowing the exact emitted
+        # expression keeps the gate specific rather than broadening it.
         run: >
           pip-licenses --format=plain --ignore-packages py_rust_stemmers fastembed --allow-only="
           Apache Software License;
@@ -125,6 +133,7 @@ jobs:
           MIT AND PSF-2.0;
           MIT OR Apache-2.0;
           MPL-2.0 AND MIT;
+          EPL-2.0 OR GPL-2.0-or-later;
           "
 
   npm-licenses:


### PR DESCRIPTION
## What

Adds the exact PEP 639 dual-license expression `EPL-2.0 OR GPL-2.0-or-later` to the `--allow-only` list in the Python dependency license gate.

## Why

`asyncssh` (added in G0.2-T4, an existing **accepted** dependency) reports `EPL-2.0 OR GPL-2.0-or-later` under `pip-licenses==5.5.5`. This identifier is not in the allow-list, so the **required** `Python License Check` status check has been **red on `main`** since asyncssh resolved to `2.23.0` (~2026-05-20). Every open PR inherits this red required check.

The EPL-2.0 arm is weak (file-level) copyleft, which this workflow's documented policy explicitly permits inbound against the Apache-2.0 outbound. asyncssh is consumed unmodified as an SSH transport library. Per the workflow's own guidance ("expand the allow-list specifically rather than broadening it"), this adds the exact emitted expression rather than a wildcard.

## Verification

- `Python License Check` runs on this PR (touches the workflow file in its own path filter) and should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)