### PR TITLE
refactor(connectors): G0.6.1-T4 replace JSONFlux seam comments + remove ForceHandleReducer shim

### DIFF
--- a/backend/src/meho_backplane/connectors/bind9/connector.py
+++ b/backend/src/meho_backplane/connectors/bind9/connector.py
@@ -560,11 +560,12 @@ class Bind9Connector(SshConnector):
         (two SSH command executions, one pooled connection).
 
         The returned dict is intentionally flat -- no nested
-        ``extras`` -- because the dispatcher's default reducer
-        forwards the value verbatim. Future reducers (real JSONFlux
-        reduction in a follow-on Initiative) flatten nested shapes
-        anyway; staying flat now means the v0.2 callers see the same
-        keys before and after the reducer swap.
+        ``extras`` -- so the dispatcher's default
+        :class:`meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+        passes this scalar (non-set-shaped) payload through verbatim
+        into ``OperationResult.result`` with a ``None`` handle; only
+        set-shaped responses above the threshold are materialized into a
+        :class:`~meho_backplane.connectors.schemas.ResultHandle`.
         """
         del params  # declared empty in schema; intentionally ignored
         result = await self.fingerprint(target)

--- a/backend/src/meho_backplane/connectors/bind9/ops_config.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops_config.py
@@ -1396,9 +1396,9 @@ CONFIG_OPS: tuple[Bind9Op, ...] = (
             "``/var/backups/meho-bind9/`` and returns the backup ID + "
             "a listing of existing backups (newest-first). Additive "
             "(non-destructive); does NOT route through atomic-apply "
-            "because nothing in ``/etc/bind/`` mutates. The future "
-            "JSONFlux reducer swaps the ``rows`` list for a result "
-            "handle when ``total > 20``."
+            "because nothing in ``/etc/bind/`` mutates. The dispatcher's "
+            "default JsonFluxReducer wraps the ``rows`` list in a result "
+            "handle once the set exceeds its threshold."
         ),
         parameter_schema=BIND9_CONFIG_BACKUP_PARAMETER_SCHEMA,
         response_schema=_BIND9_CONFIG_BACKUP_RESPONSE_SCHEMA,

--- a/backend/src/meho_backplane/connectors/bind9/ops_config.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops_config.py
@@ -892,9 +892,13 @@ async def bind9_config_backup(
     Returns ``{backup_id, path, rows, total, op_class, state_after}``;
     ``rows`` is the listing (one row per existing ``.tar.gz`` file
     with ``{id, path, size, modified}``); ``total`` is the un-truncated
-    count. A future JSONFlux reducer reads ``rows`` + ``total`` and
-    swaps the row list for a result handle when ``total > 20`` -- the
-    K8s precedent (``ops_core.py``) is what this op extends.
+    count. The dispatcher's default reducer
+    (:class:`meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`,
+    installed in ``main.py`` via ``set_default_reducer``) reads the
+    ``rows`` collection and swaps it for a result handle once it crosses
+    the materialization threshold -- the K8s precedent
+    (``ops_core.py``) is what this op extends. See
+    ``docs/architecture/jsonflux.md``.
 
     ``op_class="write"`` because the op creates an artifact, but the
     artifact lives outside ``/etc/bind/`` so the audit row carries
@@ -1100,8 +1104,8 @@ BIND9_CONFIG_BACKUP_LLM_INSTRUCTIONS: dict[str, Any] = {
         "{'backup_id': <timestamp[-tag]>, 'path': <abs tar.gz path>, "
         "'rows': [{id, path, size, modified}, ...] newest-first, "
         "'total': <int>, 'op_class': 'write', 'state_after': "
-        "<backup_id>}. The future JSONFlux reducer swaps ``rows`` for "
-        "a result handle when ``total > 20``."
+        "<backup_id>}. The dispatcher's default JsonFluxReducer swaps "
+        "``rows`` for a result handle once it crosses the threshold."
     ),
 }
 

--- a/backend/src/meho_backplane/connectors/bind9/ops_zone.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops_zone.py
@@ -39,7 +39,7 @@ handlers are the thin SSH-call + parse + shape layer. The unit suite
 pins the parsers directly against fixture text without booting an event
 loop.
 
-JSONFlux handle pattern -- deferred to the reducer
+JSONFlux handle pattern -- owned by the reducer
 --------------------------------------------------
 
 The Issue #588 body's acceptance language ("JSONFlux handle when the
@@ -47,9 +47,9 @@ parsed record list exceeds ~20 rows / 4 KB") was patterned on Issue
 #322's identical clause for the K8s connector. The K8s landing
 (``ops_core.py``) **deliberately did not implement** per-handler
 threshold logic; that module's docstring spells out the rationale and
-points at :mod:`~meho_backplane.operations.reducer` (the v0.2 default is
-:class:`PassThroughReducer` -- handle creation is the future real
-reducer's job, not the connector's). The bind9 read group adopts the
+points at :mod:`~meho_backplane.operations.reducer` (handle creation is
+the dispatcher's default ``JsonFluxReducer``'s job, not the connector's,
+per ``docs/architecture/jsonflux.md``). The bind9 read group adopts the
 same posture for the same reasons:
 
 * Coupling every connector to the reducer's threshold calibration

--- a/backend/src/meho_backplane/connectors/bind9/ops_zone.py
+++ b/backend/src/meho_backplane/connectors/bind9/ops_zone.py
@@ -75,9 +75,11 @@ References
 * Sibling precedent: G3.2-T2 K8s core ops (#322 / ``ops_core.py``)
   documents the reducer-side-handle decision verbatim.
 * Substrate: :mod:`meho_backplane.operations.reducer` (the
-  ``PassThroughReducer`` default + the
-  :class:`~meho_backplane.operations.reducer.Reducer` Protocol the
-  future JSONFlux reducer satisfies).
+  :class:`~meho_backplane.operations.reducer.Reducer` Protocol) +
+  :class:`meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`,
+  the live dispatcher default (installed in ``main.py`` via
+  ``set_default_reducer``) that satisfies it. See
+  ``docs/architecture/jsonflux.md``.
 * ISC bind9 9.18 docs:
   https://bind9.readthedocs.io/en/v9.18/manpages.html#named-checkconf
   (named-checkconf), https://bind9.readthedocs.io/en/v9.18/chapter3.html
@@ -363,10 +365,11 @@ async def bind9_zone_read(
     own configuration.
 
     Returns ``{zone, file, rows, total}``. The full row list lands
-    inline -- a future JSONFlux reducer is responsible for spilling
-    large zonefiles to handles per the module-docstring rationale; this
-    handler emits the raw shape so the reducer has the inlined sample
-    size + total count to drive its threshold check.
+    inline -- the dispatcher's default
+    :class:`meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+    spills large zonefiles to handles per the module-docstring
+    rationale; this handler emits the raw shape so the reducer has the
+    inlined sample size + total count to drive its threshold check.
     """
     zone_name: str = params["zone"]
     # Step 1 -- locate the zonefile path. Reuses the same
@@ -454,8 +457,9 @@ _BIND9_ZONE_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
             "type": "integer",
             "description": (
                 "Row count emitted in ``rows``. Useful as the "
-                "pre-reduction count -- a future JSONFlux reducer "
-                "tracks both the inlined sample size and this total."
+                "pre-reduction count -- the dispatcher's default "
+                "JsonFluxReducer tracks both the inlined sample size "
+                "and this total."
             ),
         },
     },
@@ -538,9 +542,9 @@ BIND9_ZONE_READ_LLM_INSTRUCTIONS: dict[str, Any] = {
         "passes the zone *name*, not the file path. Each rrset member "
         "lands as its own row (an MX rrset with two priorities yields "
         "two rows, not one row with a list rdata). For large zones the "
-        "full row list lands inline today; once the JSONFlux reducer "
-        "ships, a zone with thousands of records will be wrapped in a "
-        "``ResultHandle`` and the agent will drill in via "
+        "full row list lands inline; the dispatcher's default "
+        "JsonFluxReducer wraps a zone with thousands of records in a "
+        "``ResultHandle`` and the agent drills in via "
         "``result_query`` / ``result_aggregate`` rather than receiving "
         "the full row list in the inline result."
     ),
@@ -608,8 +612,8 @@ ZONE_OPS: tuple[Bind9Op, ...] = (
             "priorities yields two rows. Useful for the operator "
             "questions 'what's the current value of <fqdn>?' and "
             "'list everything in zone X'. The handler emits the full "
-            "row list inline today; once the JSONFlux reducer ships, "
-            "large zones will be wrapped in a result handle that the "
+            "row list inline; the dispatcher's default JsonFluxReducer "
+            "wraps large zones in a result handle that the "
             "agent drills into via ``result_query`` / "
             "``result_aggregate`` rather than receiving the full row "
             "list. Read-only; safe against any zone bind9 has loaded."

--- a/backend/src/meho_backplane/connectors/kubernetes/connector.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/connector.py
@@ -375,12 +375,12 @@ class KubernetesConnector(Connector):
         per-target Vault read under the operator's Identity entity).
         ``dispatch_typed`` passes ``operator`` here because the signature
         names it. The returned dict is intentionally flat -- no nested
-        ``extras`` -- because the dispatcher's
-        :class:`~meho_backplane.operations.reducer.PassThroughReducer`
-        forwards the value verbatim. Future reducers (real JSONFlux
-        reduction in a follow-on Initiative) flatten nested shapes
-        anyway; staying flat now means the v0.2 callers see the same
-        keys before and after the reducer swap.
+        ``extras`` -- so the dispatcher's default
+        :class:`meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+        passes this scalar (non-set-shaped) payload through verbatim
+        into ``OperationResult.result`` with a ``None`` handle; only
+        set-shaped responses above the threshold are materialized into a
+        :class:`~meho_backplane.connectors.schemas.ResultHandle`.
         """
         del params  # declared in schema; the handler intentionally ignores them
         api_client = await self._get_api_client(target, operator)
@@ -657,9 +657,11 @@ class KubernetesConnector(Connector):
         Forwarding-through-execute (rather than calling
         ``CoreV1Api.list_namespaced_<kind>`` directly here) means the
         kind-specific ops' own dispatcher path -- parameter validation,
-        future reducer-driven handle creation, audit row, broadcast --
-        runs verbatim. The forwarding handler is structural plumbing, not
-        a semantic shortcut.
+        the default
+        :class:`meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+        handle creation, audit row, broadcast -- runs verbatim. The
+        forwarding handler is structural plumbing, not a semantic
+        shortcut.
 
         ``operator`` is forwarded to :meth:`_get_api_client` (and to the
         sub-op forwarder); see :meth:`about` for the threading rationale.

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_core.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_core.py
@@ -40,21 +40,22 @@ The Issue body's "Handle threshold tested: against k3d populated with
 50+ namespaces, sample of 20 + handle returned" criterion assumed the
 shared :class:`HandleStore` from G3.1-T4 (#304) would be in place. #304
 was **superseded** (closed without a HandleStore landing -- the
-Initiative-redraft note on the issue spells this out), and the
-substrate currently in the tree ships
-:class:`~meho_backplane.operations.reducer.PassThroughReducer` as the
-only reducer -- it never populates :attr:`OperationResult.handle`.
+Initiative-redraft note on the issue spells this out). The substrate
+now in the tree ships
+:class:`meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+(G0.6.1 #750), installed as the dispatcher default in ``main.py`` via
+``set_default_reducer`` -- it materializes set-shaped responses into a
+:class:`~meho_backplane.connectors.schemas.ResultHandle`.
 
 The handlers in this module emit **raw row lists** in the response
-dict, exactly the shape the future JSONFlux reducer will see when it
-ships. That reducer -- not the connector -- owns the threshold check,
-the row truncation, the spill to MinIO/S3/Valkey, and the
-``ResultHandle`` construction. Putting threshold logic per-handler
-would couple every connector to the eventual reducer's calibration
-choice and double-implement the spill path; per the substrate split
-documented on
+dict, exactly the shape the default JsonFluxReducer reduces. That
+reducer -- not the connector -- owns the threshold check, the row
+truncation, the spill to MinIO/S3/Valkey, and the ``ResultHandle``
+construction. Putting threshold logic per-handler would couple every
+connector to the reducer's calibration choice and double-implement
+the spill path; per the substrate split documented on
 :mod:`meho_backplane.operations.reducer`, set-shaped reduction is the
-reducer's job, not the connector's.
+reducer's job, not the connector's. See ``docs/architecture/jsonflux.md``.
 
 A small forward-compat marker stays in the response envelope so future
 agent prompts (which inline ``llm_instructions.output_shape``) know
@@ -411,8 +412,9 @@ _K8S_NAMESPACE_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
             "type": "integer",
             "description": (
                 "Row count emitted in ``rows``. Useful as the "
-                "pre-reduction count -- a future JSONFlux reducer "
-                "tracks both the inlined sample size and this total."
+                "pre-reduction count -- the dispatcher's default "
+                "JsonFluxReducer tracks both the inlined sample size "
+                "and this total."
             ),
         },
     },

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_logs.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_logs.py
@@ -75,11 +75,13 @@ __all__ = [
 #: log line length.
 MAX_TAIL_LINES = 5000
 
-#: 1 MiB serialised body cap. The dispatcher's ``PassThroughReducer``
-#: lands the returned dict verbatim into
-#: :attr:`OperationResult.result`; large log payloads inflate the
-#: JSONFlux reducer's reduction overhead linearly and blow past the
-#: audit row's display size. 1 MiB matches the operator's typical
+#: 1 MiB serialised body cap. The dispatcher's default
+#: :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+#: materializes the returned ``lines`` collection into a
+#: :class:`~meho_backplane.connectors.schemas.ResultHandle` once it
+#: crosses the threshold; capping the body keeps reduction overhead
+#: bounded and the payload below the audit row's display size. 1 MiB
+#: matches the operator's typical
 #: terminal scrollback and the MCP envelope's practical payload
 #: ceiling (no hard limit, but >1 MB choices stall clients).
 MAX_BODY_BYTES = 1024 * 1024
@@ -154,7 +156,8 @@ K8S_LOGS_PARAMETER_SCHEMA: dict[str, Any] = {
 
 
 #: Informational response schema for the meta-tools. The dispatcher's
-#: pass-through reducer does not validate outbound payloads in v0.2.
+#: default reducer does not validate outbound payloads against this
+#: schema; it is descriptive metadata for ``describe_operation``.
 K8S_LOGS_RESPONSE_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_workload.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_workload.py
@@ -1026,8 +1026,8 @@ K8S_DEPLOYMENT_INFO_LLM_INSTRUCTIONS: dict[str, Any] = {
 
 
 # ---------------------------------------------------------------------------
-# Response schemas -- informational; the dispatcher's pass-through reducer
-# does not validate outbound payloads in v0.2.
+# Response schemas -- informational; the dispatcher's default reducer
+# (JsonFluxReducer) does not validate outbound payloads against them.
 # ---------------------------------------------------------------------------
 
 

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_workload.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_workload.py
@@ -36,12 +36,14 @@ Wire shape conventions
 The list handlers emit ``{"rows": [...], "total": N}`` plus an optional
 ``next_continue`` key when the server signals more pages via
 ``V1ListMeta._continue``. T2's module docstring spells out the
-rationale: connector handlers stay reducer-agnostic (raw rows + total),
-and the v0.2 substrate's :class:`PassThroughReducer` lands the dict
-verbatim into :attr:`OperationResult.result`. A future JSONFlux reducer
-owns set-shaped truncation + handle creation; the ``next_continue``
-token is the same server-side cursor the operator can pass back as
-``continue_token`` for the next page.
+rationale: connector handlers stay reducer-agnostic (raw rows + total).
+The dispatcher's default
+:class:`meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+(installed in ``main.py`` via ``set_default_reducer``) owns set-shaped
+truncation + handle creation; small payloads pass through verbatim into
+:attr:`OperationResult.result`. The ``next_continue`` token is the same
+server-side cursor the operator can pass back as ``continue_token`` for
+the next page. See ``docs/architecture/jsonflux.md``.
 
 The ``info`` handlers emit a flat dict structured around the API
 object's spec + status. Pod info includes container statuses (with

--- a/backend/tests/acceptance/test_g35_harbor_jsonflux_force_handle.py
+++ b/backend/tests/acceptance/test_g35_harbor_jsonflux_force_handle.py
@@ -3,19 +3,21 @@
 
 """G3.5-T8 JSONFlux force-mode acceptance for the Harbor connector.
 
-v0.2 ships only :class:`~meho_backplane.operations.reducer.PassThroughReducer`
-— the production reducer never produces a :class:`ResultHandle`. This test
-mirrors :mod:`tests.acceptance.test_g35_sddc_jsonflux_force_handle` verbatim,
-swapping in Harbor as the dispatched connector: it installs a test-only
-:class:`ForceHandleReducer` that wraps every payload in a synthetic handle,
-dispatches ``harbor.artifact.list`` against the seeded Harbor core, and asserts
-the :class:`~meho_backplane.connectors.schemas.OperationResult`'s ``handle``
-field carries a populated :class:`ResultHandle`.
+Drives the **real**
+:class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+(G0.6.1-T3 #753) in force mode (``row_threshold=0``) as the dispatcher
+default. Mirrors :mod:`tests.acceptance.test_g35_sddc_jsonflux_force_handle`,
+swapping in Harbor as the dispatched connector: it dispatches
+``harbor.artifact.list`` against the seeded Harbor core and asserts the
+:class:`~meho_backplane.connectors.schemas.OperationResult`'s ``handle``
+field carries a populated :class:`ResultHandle` with the real
+materialized shape (UUID id, summary_md naming the row count, an
+inferred JSON-Schema ``schema_``, ≥1 real sample row).
 
-Harbor's artifact list returns a plain JSON array (not a pagination envelope
-like NSX's ``results[]`` or SDDC's ``elements[]``). The
-:class:`ForceHandleReducer` handles this shape via its ``list`` branch so the
-dispatcher-seam test doesn't depend on the specific list-key name.
+Harbor's artifact list returns a plain JSON array (not a pagination
+envelope like NSX's ``results[]`` or SDDC's ``elements[]``). The
+reducer's collection detection handles a bare top-level list directly,
+so the dispatcher-seam test doesn't depend on a specific list-key name.
 """
 
 from __future__ import annotations
@@ -25,9 +27,9 @@ from typing import Any
 
 import pytest
 
-from meho_backplane.connectors.schemas import ResultHandle
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
 from meho_backplane.operations.meta_tools import call_operation
 from meho_backplane.operations.reducer import PassThroughReducer
 from tests.acceptance._harbor_canary_fixtures import (
@@ -38,59 +40,16 @@ from tests.acceptance._harbor_canary_fixtures import (
 )
 
 
-class ForceHandleReducer:
-    """Test-only reducer that always produces a :class:`ResultHandle`.
-
-    Recognises four payload shapes Harbor and sibling connectors use:
-
-    * ``list`` → total = ``len(payload)``.
-    * ``dict`` with ``"elements"`` key (SDDC Manager paginated envelope).
-    * ``dict`` with ``"results"`` key (NSX policy/manager API list shape).
-    * ``dict`` with ``"value"`` key (vCenter REST list shape).
-    * Anything else → total = 1, sample = ().
-    """
-
-    async def reduce(
-        self,
-        payload: Any,
-        schema: dict[str, Any] | None = None,
-        context: dict[str, Any] | None = None,
-    ) -> tuple[Any, ResultHandle | None]:
-        """Always return ``(summary_dict, ResultHandle)``."""
-        del schema, context
-        if isinstance(payload, list):
-            total = len(payload)
-            sample = tuple(payload[:5]) if payload else ()
-        elif isinstance(payload, dict):
-            for key in ("elements", "results", "value"):
-                rows = payload.get(key)
-                if isinstance(rows, list):
-                    total = len(rows)
-                    sample = tuple(rows[:5]) if rows else ()
-                    break
-            else:
-                total = 1
-                sample = ()
-        else:
-            total = 1
-            sample = ()
-
-        handle = ResultHandle(
-            handle_id=uuid.uuid4(),
-            summary_md=f"force-mode handle ({total} rows)",
-            schema_={"type": "array", "items": {"type": "object"}},
-            total_rows=total,
-            sample_rows=sample if sample else None,
-            ttl_seconds=3600,
-        )
-        summary = {"row_count": total, "sample": list(sample)}
-        return summary, handle
-
-
 @pytest.fixture
 def force_handle_reducer() -> Any:
-    """Install :class:`ForceHandleReducer` as the dispatcher's default."""
-    set_default_reducer(ForceHandleReducer())
+    """Install :class:`JsonFluxReducer` in force mode as the dispatcher default.
+
+    ``row_threshold=0`` forces every non-empty set to materialize, so
+    the seeded artifact list (below the default 50-row threshold)
+    produces a handle. Teardown restores :class:`PassThroughReducer` so
+    a follow-on test in the same session sees the v0.2 default.
+    """
+    set_default_reducer(JsonFluxReducer(row_threshold=0))
     try:
         yield
     finally:
@@ -119,9 +78,9 @@ async def test_force_handle_reducer_populates_operation_result_handle_for_harbor
     * ``result['row_count']`` matches the handle's total.
 
     The artifact list response is a plain JSON array (not a pagination
-    envelope), so the :class:`ForceHandleReducer`'s ``list`` branch is
+    envelope), so the reducer's bare-top-level-list detection branch is
     exercised here — different from the NSX and SDDC tests which hit the
-    ``results[]`` and ``elements[]`` branches respectively.
+    ``results[]`` and ``elements[]`` envelope branches respectively.
     """
     expected_rows = len(HARBOR_CANARY_ARTIFACTS)
 
@@ -141,7 +100,7 @@ async def test_force_handle_reducer_populates_operation_result_handle_for_harbor
 
     handle = result_envelope.get("handle")
     assert handle is not None, (
-        f"expected OperationResult.handle to be populated by ForceHandleReducer; "
+        f"expected OperationResult.handle to be populated by JsonFluxReducer; "
         f"got handle=None on envelope={result_envelope!r}"
     )
     uuid.UUID(handle["handle_id"])

--- a/backend/tests/acceptance/test_g36_vrops_jsonflux_force_handle.py
+++ b/backend/tests/acceptance/test_g36_vrops_jsonflux_force_handle.py
@@ -3,27 +3,23 @@
 
 """G3.6-T2 JSONFlux force-mode acceptance for the vROps connector.
 
-v0.2 ships only :class:`~meho_backplane.operations.reducer.PassThroughReducer`
-— the production reducer never produces a :class:`ResultHandle`. The
-real reducer (set-shaped payload reduction, MinIO/S3 spill,
-``result_query`` / ``result_aggregate`` meta-tools) is **explicitly
-out of scope** at the Goal #214 level.
-
-This test mirrors :mod:`tests.acceptance.test_g35_nsx_jsonflux_force_handle`
-verbatim, swapping in vROps as the dispatched connector: it installs
-a test-only :class:`ForceHandleReducer` that wraps every payload in a
-synthetic handle, dispatches ``GET:/suite-api/api/resources`` against
-the seeded vROps core, and asserts the
+Drives the **real**
+:class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+(G0.6.1-T3 #753) in force mode (``row_threshold=0``) as the dispatcher
+default. Mirrors :mod:`tests.acceptance.test_g35_nsx_jsonflux_force_handle`,
+swapping in vROps as the dispatched connector: it dispatches
+``GET:/suite-api/api/resources`` against the seeded vROps core and
+asserts the
 :class:`~meho_backplane.connectors.schemas.OperationResult`'s
-``handle`` field carries a populated :class:`ResultHandle`.
+``handle`` field carries a populated :class:`ResultHandle` with the
+real materialized shape.
 
 vROps' suite-api wraps list payloads under noun-specific keys
 (``resourceList``, ``alerts``, ``symptoms``, etc.) rather than the
-generic ``results`` / ``value`` keys NSX and vSphere use. The
-:class:`ForceHandleReducer` below adds the noun-specific keys to its
-discovery loop so the dispatcher-seam test still observes the
-expected row count without leaking vendor-specific shape into the
-production reducer ABC.
+generic ``results`` / ``value`` keys NSX and vSphere use. The reducer's
+collection detection falls back to the largest top-level list value
+when no known envelope key matches, so it locates ``resourceList``
+without the test leaking vendor-specific shape into the reducer.
 """
 
 from __future__ import annotations
@@ -33,9 +29,9 @@ from typing import Any
 
 import pytest
 
-from meho_backplane.connectors.schemas import ResultHandle
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
 from meho_backplane.operations.meta_tools import call_operation
 from meho_backplane.operations.reducer import PassThroughReducer
 from tests.acceptance._vrops_canary_fixtures import (
@@ -45,73 +41,16 @@ from tests.acceptance._vrops_canary_fixtures import (
 )
 
 
-class ForceHandleReducer:
-    """Test-only reducer that always produces a :class:`ResultHandle`.
-
-    Recognises both the cross-connector list shapes (``elements``,
-    ``results``, ``value``) and the vROps-specific wrapper keys
-    (``resourceList``, ``alerts``, ``alertDefinitions``, ``symptoms``,
-    ``recommendations``, ``superMetrics``).
-
-    * ``list`` → total = ``len(payload)``.
-    * ``dict`` with one of the recognised list-wrapper keys → rows = the
-      wrapped list.
-    * Anything else → total = 1, sample = ().
-    """
-
-    _LIST_KEYS: tuple[str, ...] = (
-        "elements",
-        "results",
-        "value",
-        "resourceList",
-        "alerts",
-        "alertDefinitions",
-        "symptoms",
-        "recommendations",
-        "superMetrics",
-    )
-
-    async def reduce(
-        self,
-        payload: Any,
-        schema: dict[str, Any] | None = None,
-        context: dict[str, Any] | None = None,
-    ) -> tuple[Any, ResultHandle | None]:
-        """Always return ``(summary_dict, ResultHandle)``."""
-        del schema, context
-        if isinstance(payload, list):
-            total = len(payload)
-            sample = tuple(payload[:5]) if payload else ()
-        elif isinstance(payload, dict):
-            for key in self._LIST_KEYS:
-                rows = payload.get(key)
-                if isinstance(rows, list):
-                    total = len(rows)
-                    sample = tuple(rows[:5]) if rows else ()
-                    break
-            else:
-                total = 1
-                sample = ()
-        else:
-            total = 1
-            sample = ()
-
-        handle = ResultHandle(
-            handle_id=uuid.uuid4(),
-            summary_md=f"force-mode handle ({total} rows)",
-            schema_={"type": "array", "items": {"type": "object"}},
-            total_rows=total,
-            sample_rows=sample if sample else None,
-            ttl_seconds=3600,
-        )
-        summary = {"row_count": total, "sample": list(sample)}
-        return summary, handle
-
-
 @pytest.fixture
 def force_handle_reducer() -> Any:
-    """Install :class:`ForceHandleReducer` as the dispatcher's default."""
-    set_default_reducer(ForceHandleReducer())
+    """Install :class:`JsonFluxReducer` in force mode as the dispatcher default.
+
+    ``row_threshold=0`` forces every non-empty set to materialize, so
+    the seeded resource list (below the default 50-row threshold)
+    produces a handle. Teardown restores :class:`PassThroughReducer` so
+    a follow-on test in the same session sees the v0.2 default.
+    """
+    set_default_reducer(JsonFluxReducer(row_threshold=0))
     try:
         yield
     finally:
@@ -163,7 +102,7 @@ async def test_force_handle_reducer_populates_operation_result_handle_for_vrops(
     handle = result_envelope.get("handle")
     assert handle is not None, (
         f"expected OperationResult.handle to be populated by "
-        f"ForceHandleReducer; got handle=None on envelope={result_envelope!r}"
+        f"JsonFluxReducer; got handle=None on envelope={result_envelope!r}"
     )
     uuid.UUID(handle["handle_id"])
     assert handle["total_rows"] == expected_rows, (

--- a/backend/tests/test_connectors_nsx_e2e.py
+++ b/backend/tests/test_connectors_nsx_e2e.py
@@ -16,7 +16,9 @@ Covers all four acceptance criteria from Issue #615:
     ``method='DISPATCH'``, a non-null ``target_id``, and a
     ``payload["params_hash"]`` key.
 (d) JSONFlux handle path: ``GET:/policy/api/v1/infra/segments``
-    dispatched with a ``ForceHandleReducer`` returns a populated
+    dispatched with the real
+    :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+    in force mode (``row_threshold=0``) returns a populated
     ``OperationResult.handle`` with at least one ``sample_rows``
     entry.
 
@@ -49,12 +51,12 @@ from meho_backplane.connectors.nsx import (
     NsxConnector,
 )
 from meho_backplane.connectors.registry import all_connectors_v2
-from meho_backplane.connectors.schemas import ResultHandle
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AuditLog, Target
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
 from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
 from meho_backplane.operations.meta_tools import call_operation
 from meho_backplane.operations.reducer import PassThroughReducer
 from tests.acceptance._nsx_canary_fixtures import (
@@ -138,46 +140,6 @@ def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
 
     monkeypatch.setattr(audit_module, "publish_event", _capture)
     return events
-
-
-# ---------------------------------------------------------------------------
-# ForceHandleReducer (acceptance criterion d)
-# ---------------------------------------------------------------------------
-
-
-class _ForceHandleReducer:
-    """Test-only reducer that always wraps an NSX list payload in a ResultHandle.
-
-    Installed for the JSONFlux handle-path test only; all other tests
-    use the v0.2 default :class:`PassThroughReducer`.
-    """
-
-    async def reduce(
-        self,
-        payload: Any,
-        schema: dict[str, Any] | None = None,
-        context: dict[str, Any] | None = None,
-    ) -> tuple[Any, ResultHandle | None]:
-        del schema, context
-        if isinstance(payload, dict) and "results" in payload:
-            rows = payload["results"]
-            total = len(rows) if isinstance(rows, list) else 1
-            sample: tuple[Any, ...] = tuple(rows[:5]) if isinstance(rows, list) and rows else ()
-        elif isinstance(payload, list):
-            total = len(payload)
-            sample = tuple(payload[:5]) if payload else ()
-        else:
-            total = 1
-            sample = ()
-        handle = ResultHandle(
-            handle_id=uuid.uuid4(),
-            summary_md=f"force-mode handle ({total} rows)",
-            schema_={"type": "array", "items": {"type": "object"}},
-            total_rows=total,
-            sample_rows=sample or None,
-            ttl_seconds=3600,
-        )
-        return {"row_count": total, "sample": list(sample)}, handle
 
 
 # ---------------------------------------------------------------------------
@@ -542,7 +504,7 @@ async def test_nsx_e2e_dispatch_writes_audit_row(
 async def test_nsx_e2e_jsonflux_handle_populated_for_segment_list(
     nsx_e2e_canary: _NsxE2EBundle,
 ) -> None:
-    """Segment list dispatched with ForceHandleReducer returns a populated handle.
+    """Segment list dispatched with the real JsonFluxReducer returns a populated handle.
 
     Exercises acceptance criterion (d): the JSONFlux dispatcher seam
     threads the reducer's :class:`ResultHandle` onto
@@ -559,7 +521,7 @@ async def test_nsx_e2e_jsonflux_handle_populated_for_segment_list(
     """
     expected_rows = len(NSX_CANARY_SEGMENTS["results"])  # type: ignore[arg-type]
 
-    set_default_reducer(_ForceHandleReducer())
+    set_default_reducer(JsonFluxReducer(row_threshold=0))
     try:
         result_envelope = await call_operation(
             _OPERATOR,
@@ -579,7 +541,7 @@ async def test_nsx_e2e_jsonflux_handle_populated_for_segment_list(
 
     handle = result_envelope.get("handle")
     assert handle is not None, (
-        "Expected OperationResult.handle to be populated by _ForceHandleReducer; "
+        "Expected OperationResult.handle to be populated by JsonFluxReducer; "
         f"got handle=None on envelope={result_envelope!r}"
     )
 

--- a/backend/tests/test_connectors_sddc_manager_e2e.py
+++ b/backend/tests/test_connectors_sddc_manager_e2e.py
@@ -14,9 +14,10 @@ Covers all four acceptance criteria from Issue #618:
 (c) Audit rows: each dispatch inserts an ``AuditLog`` row carrying
     ``method='DISPATCH'``, a non-null ``target_id``, and a
     ``payload["params_hash"]`` key.
-(d) JSONFlux handle path: ``GET:/v1/hosts`` dispatched with a
-    ``ForceHandleReducer`` returns a populated ``OperationResult.handle``
-    with at least one ``sample_rows`` entry.
+(d) JSONFlux handle path: ``GET:/v1/hosts`` dispatched with the real
+    :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+    in force mode (``row_threshold=0``) returns a populated
+    ``OperationResult.handle`` with at least one ``sample_rows`` entry.
 
 Database: SQLite via the autouse ``_default_database_url`` conftest
 fixture (no ``pg_engine`` required). Runs in the ``meho-runners``
@@ -38,7 +39,6 @@ from sqlalchemy import select
 import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.registry import all_connectors_v2
-from meho_backplane.connectors.schemas import ResultHandle
 from meho_backplane.connectors.sddc_manager import (
     SDDC_CONNECTOR_ID,
     SDDC_CORE_OPS,
@@ -51,6 +51,7 @@ from meho_backplane.db.models import AuditLog, Target
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
 from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
 from meho_backplane.operations.meta_tools import call_operation
 from meho_backplane.operations.reducer import PassThroughReducer
 from tests.acceptance._sddc_canary_fixtures import (
@@ -120,43 +121,6 @@ def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
 
     monkeypatch.setattr(audit_module, "publish_event", _capture)
     return events
-
-
-# ---------------------------------------------------------------------------
-# ForceHandleReducer (acceptance criterion d)
-# ---------------------------------------------------------------------------
-
-
-class _ForceHandleReducer:
-    """Test-only reducer that always wraps an SDDC Manager list payload in a ResultHandle."""
-
-    async def reduce(
-        self,
-        payload: Any,
-        schema: dict[str, Any] | None = None,
-        context: dict[str, Any] | None = None,
-    ) -> tuple[Any, ResultHandle | None]:
-        del schema, context
-        # SDDC Manager wraps lists in {"elements": [...]}
-        if isinstance(payload, dict) and "elements" in payload:
-            rows = payload["elements"]
-            total = len(rows) if isinstance(rows, list) else 1
-            sample: tuple[Any, ...] = tuple(rows[:5]) if isinstance(rows, list) and rows else ()
-        elif isinstance(payload, list):
-            total = len(payload)
-            sample = tuple(payload[:5]) if payload else ()
-        else:
-            total = 1
-            sample = ()
-        handle = ResultHandle(
-            handle_id=uuid.uuid4(),
-            summary_md=f"force-mode handle ({total} rows)",
-            schema_={"type": "array", "items": {"type": "object"}},
-            total_rows=total,
-            sample_rows=sample or None,
-            ttl_seconds=3600,
-        )
-        return {"row_count": total, "sample": list(sample)}, handle
 
 
 # ---------------------------------------------------------------------------
@@ -407,7 +371,7 @@ async def test_sddc_e2e_dispatch_writes_audit_row(
 async def test_sddc_e2e_jsonflux_handle_populated_for_host_list(
     sddc_e2e_canary: _SddcE2EBundle,
 ) -> None:
-    """Host list dispatched with ForceHandleReducer returns a populated handle.
+    """Host list dispatched with the real JsonFluxReducer returns a populated handle.
 
     Exercises acceptance criterion (d): the JSONFlux dispatcher seam
     threads the reducer's :class:`ResultHandle` onto
@@ -425,7 +389,7 @@ async def test_sddc_e2e_jsonflux_handle_populated_for_host_list(
     """
     expected_rows = len(SDDC_CANARY_HOSTS["elements"])  # type: ignore[arg-type]
 
-    set_default_reducer(_ForceHandleReducer())
+    set_default_reducer(JsonFluxReducer(row_threshold=0))
     try:
         result_envelope = await call_operation(
             _OPERATOR,
@@ -445,7 +409,7 @@ async def test_sddc_e2e_jsonflux_handle_populated_for_host_list(
 
     handle = result_envelope.get("handle")
     assert handle is not None, (
-        "Expected OperationResult.handle to be populated by _ForceHandleReducer; "
+        "Expected OperationResult.handle to be populated by JsonFluxReducer; "
         f"got handle=None on envelope={result_envelope!r}"
     )
 

--- a/backend/tests/test_connectors_vcf_automation_e2e.py
+++ b/backend/tests/test_connectors_vcf_automation_e2e.py
@@ -69,7 +69,7 @@ from sqlalchemy import select
 import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.registry import all_connectors_v2
-from meho_backplane.connectors.schemas import FingerprintResult, ResultHandle
+from meho_backplane.connectors.schemas import FingerprintResult
 from meho_backplane.connectors.vcf_automation import (
     VCFA_CONNECTOR_ID,
     VCFA_CORE_GROUPS,
@@ -84,6 +84,7 @@ from meho_backplane.db.models import AuditLog, EndpointDescriptor, OperationGrou
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
 from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
 from meho_backplane.operations.meta_tools import call_operation
 from meho_backplane.operations.reducer import PassThroughReducer
 
@@ -354,42 +355,6 @@ def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
 
     monkeypatch.setattr(audit_module, "publish_event", _capture)
     return events
-
-
-# ---------------------------------------------------------------------------
-# ForceHandleReducer (acceptance criterion d)
-# ---------------------------------------------------------------------------
-
-
-class _ForceHandleReducer:
-    """Test-only reducer that always wraps a VCFA tenant list payload in a ResultHandle."""
-
-    async def reduce(
-        self,
-        payload: Any,
-        schema: dict[str, Any] | None = None,
-        context: dict[str, Any] | None = None,
-    ) -> tuple[Any, ResultHandle | None]:
-        del schema, context
-        if isinstance(payload, dict) and "content" in payload:
-            rows = payload["content"]
-            total = len(rows) if isinstance(rows, list) else 1
-            sample: tuple[Any, ...] = tuple(rows[:5]) if isinstance(rows, list) and rows else ()
-        elif isinstance(payload, list):
-            total = len(payload)
-            sample = tuple(payload[:5]) if payload else ()
-        else:
-            total = 1
-            sample = ()
-        handle = ResultHandle(
-            handle_id=uuid.uuid4(),
-            summary_md=f"force-mode handle ({total} rows)",
-            schema_={"type": "array", "items": {"type": "object"}},
-            total_rows=total,
-            sample_rows=sample or None,
-            ttl_seconds=3600,
-        )
-        return {"row_count": total, "sample": list(sample)}, handle
 
 
 # ---------------------------------------------------------------------------
@@ -785,14 +750,14 @@ async def test_vcfa_e2e_dispatch_writes_audit_row(
 async def test_vcfa_e2e_jsonflux_handle_populated_for_deployment_list(
     vcfa_e2e_canary: _VcfaE2EBundle,
 ) -> None:
-    """Tenant deployment list dispatched with ForceHandleReducer returns a populated handle.
+    """Tenant deployment list dispatched with the real JsonFluxReducer returns a populated handle.
 
     Exercises acceptance criterion (d) -- the JSONFlux seam threads
     the reducer's :class:`ResultHandle` onto :class:`OperationResult`.
     """
     expected_rows = len(_TENANT_DEPLOYMENTS["content"])  # type: ignore[arg-type]
 
-    set_default_reducer(_ForceHandleReducer())
+    set_default_reducer(JsonFluxReducer(row_threshold=0))
     try:
         result_envelope = await call_operation(
             _OPERATOR,
@@ -811,7 +776,7 @@ async def test_vcfa_e2e_jsonflux_handle_populated_for_deployment_list(
     )
     handle = result_envelope.get("handle")
     assert handle is not None, (
-        "Expected OperationResult.handle to be populated by _ForceHandleReducer; "
+        "Expected OperationResult.handle to be populated by JsonFluxReducer; "
         f"got handle=None on envelope={result_envelope!r}"
     )
     uuid.UUID(handle["handle_id"])

--- a/backend/tests/test_connectors_vcf_fleet_e2e.py
+++ b/backend/tests/test_connectors_vcf_fleet_e2e.py
@@ -51,7 +51,6 @@ from sqlalchemy import select
 import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.registry import all_connectors_v2
-from meho_backplane.connectors.schemas import ResultHandle
 from meho_backplane.connectors.vcf_fleet import (
     FLEET_CONNECTOR_ID,
     FLEET_CORE_OPS,
@@ -62,6 +61,7 @@ from meho_backplane.db.models import AuditLog, Target
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
 from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
 from meho_backplane.operations.meta_tools import call_operation
 from meho_backplane.operations.reducer import PassThroughReducer
 from tests.acceptance._vcf_fleet_canary_fixtures import (
@@ -149,47 +149,6 @@ def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
 
     monkeypatch.setattr(audit_module, "publish_event", _capture)
     return events
-
-
-# ---------------------------------------------------------------------------
-# ForceHandleReducer (acceptance criterion c)
-# ---------------------------------------------------------------------------
-
-
-class _ForceHandleReducer:
-    """Test-only reducer that always wraps a Fleet list payload in a ResultHandle.
-
-    Fleet returns bare JSON arrays for the curated read ops (no
-    ``elements`` / ``results`` envelope), so the reducer's payload
-    branch checks for the bare-list case first.
-    """
-
-    async def reduce(
-        self,
-        payload: Any,
-        schema: dict[str, Any] | None = None,
-        context: dict[str, Any] | None = None,
-    ) -> tuple[Any, ResultHandle | None]:
-        del schema, context
-        if isinstance(payload, list):
-            total = len(payload)
-            sample: tuple[Any, ...] = tuple(payload[:5]) if payload else ()
-        elif isinstance(payload, dict) and "data" in payload:
-            rows = payload["data"]
-            total = len(rows) if isinstance(rows, list) else 1
-            sample = tuple(rows[:5]) if isinstance(rows, list) and rows else ()
-        else:
-            total = 1
-            sample = ()
-        handle = ResultHandle(
-            handle_id=uuid.uuid4(),
-            summary_md=f"force-mode handle ({total} rows)",
-            schema_={"type": "array", "items": {"type": "object"}},
-            total_rows=total,
-            sample_rows=sample or None,
-            ttl_seconds=3600,
-        )
-        return {"row_count": total, "sample": list(sample)}, handle
 
 
 # ---------------------------------------------------------------------------
@@ -455,7 +414,7 @@ async def test_fleet_e2e_dispatch_writes_audit_row(
 async def test_fleet_e2e_jsonflux_handle_populated_for_environment_list(
     fleet_e2e_canary: _FleetE2EBundle,
 ) -> None:
-    """Environment list dispatched with ForceHandleReducer returns a populated handle.
+    """Environment list dispatched with the real JsonFluxReducer returns a populated handle.
 
     Exercises acceptance criterion (c): the JSONFlux dispatcher seam
     threads the reducer's :class:`ResultHandle` onto
@@ -474,7 +433,7 @@ async def test_fleet_e2e_jsonflux_handle_populated_for_environment_list(
     """
     expected_rows = len(FLEET_CANARY_ENVIRONMENTS)
 
-    set_default_reducer(_ForceHandleReducer())
+    set_default_reducer(JsonFluxReducer(row_threshold=0))
     try:
         result_envelope = await call_operation(
             _OPERATOR,
@@ -494,7 +453,7 @@ async def test_fleet_e2e_jsonflux_handle_populated_for_environment_list(
 
     handle = result_envelope.get("handle")
     assert handle is not None, (
-        "Expected OperationResult.handle to be populated by _ForceHandleReducer; "
+        "Expected OperationResult.handle to be populated by JsonFluxReducer; "
         f"got handle=None on envelope={result_envelope!r}"
     )
 

--- a/backend/tests/test_connectors_vcf_logs_e2e.py
+++ b/backend/tests/test_connectors_vcf_logs_e2e.py
@@ -40,7 +40,9 @@ Covers the four acceptance criteria from Issue #838:
     ``payload["params_hash"]`` key.
 
 (d) JSONFlux handle path — ``GET:/api/v2/events/{constraints}``
-    dispatched with a ``ForceHandleReducer`` returns a populated
+    dispatched with the real
+    :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+    in force mode (``row_threshold=0``) returns a populated
     ``OperationResult.handle`` with at least one ``sample_rows``
     entry. Asserts the reducer-summarised envelope carries
     ``row_count`` matching the seeded event count.
@@ -67,7 +69,6 @@ from sqlalchemy import select
 import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.registry import all_connectors_v2
-from meho_backplane.connectors.schemas import ResultHandle
 from meho_backplane.connectors.vcf_logs import (
     VRLI_CONNECTOR_ID,
     VRLI_CORE_OPS,
@@ -80,6 +81,7 @@ from meho_backplane.db.models import AuditLog, Target
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
 from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
 from meho_backplane.operations.meta_tools import call_operation
 from meho_backplane.operations.reducer import PassThroughReducer
 from tests.acceptance._vrli_canary_fixtures import (
@@ -148,49 +150,6 @@ def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
 
     monkeypatch.setattr(audit_module, "publish_event", _capture)
     return events
-
-
-# ---------------------------------------------------------------------------
-# ForceHandleReducer (acceptance criterion d)
-# ---------------------------------------------------------------------------
-
-
-class _ForceHandleReducer:
-    """Test-only reducer that always wraps a vRLI list payload in a ResultHandle.
-
-    Installed for the JSONFlux handle-path test only; all other tests
-    use the v0.5 default :class:`PassThroughReducer`.
-
-    Recognises the vRLI shape ``{"events": [...]}`` (the headline list
-    op response envelope) and counts ``events`` as rows.
-    """
-
-    async def reduce(
-        self,
-        payload: Any,
-        schema: dict[str, Any] | None = None,
-        context: dict[str, Any] | None = None,
-    ) -> tuple[Any, ResultHandle | None]:
-        del schema, context
-        if isinstance(payload, dict) and "events" in payload:
-            rows = payload["events"]
-            total = len(rows) if isinstance(rows, list) else 1
-            sample: tuple[Any, ...] = tuple(rows[:5]) if isinstance(rows, list) and rows else ()
-        elif isinstance(payload, list):
-            total = len(payload)
-            sample = tuple(payload[:5]) if payload else ()
-        else:
-            total = 1
-            sample = ()
-        handle = ResultHandle(
-            handle_id=uuid.uuid4(),
-            summary_md=f"force-mode handle ({total} rows)",
-            schema_={"type": "array", "items": {"type": "object"}},
-            total_rows=total,
-            sample_rows=sample or None,
-            ttl_seconds=3600,
-        )
-        return {"row_count": total, "sample": list(sample)}, handle
 
 
 # ---------------------------------------------------------------------------
@@ -656,7 +615,7 @@ async def test_vrli_e2e_dispatch_writes_audit_row(
 async def test_vrli_e2e_jsonflux_handle_populated_for_event_query(
     vrli_e2e_canary: _VrliE2EBundle,
 ) -> None:
-    """Event query dispatched with ForceHandleReducer returns a populated handle.
+    """Event query dispatched with the real JsonFluxReducer returns a populated handle.
 
     Exercises acceptance criterion (d) — the issue body's "vcf-logs
     query E2E asserts the JSONFlux handle path (handle →
@@ -668,7 +627,7 @@ async def test_vrli_e2e_jsonflux_handle_populated_for_event_query(
     assert isinstance(events_payload, list)
     expected_rows = len(events_payload)
 
-    set_default_reducer(_ForceHandleReducer())
+    set_default_reducer(JsonFluxReducer(row_threshold=0))
     try:
         result_envelope = await call_operation(
             _OPERATOR,
@@ -688,7 +647,7 @@ async def test_vrli_e2e_jsonflux_handle_populated_for_event_query(
 
     handle = result_envelope.get("handle")
     assert handle is not None, (
-        "Expected OperationResult.handle to be populated by _ForceHandleReducer; "
+        "Expected OperationResult.handle to be populated by JsonFluxReducer; "
         f"got handle=None on envelope={result_envelope!r}"
     )
 

--- a/backend/tests/test_connectors_vcf_operations_e2e.py
+++ b/backend/tests/test_connectors_vcf_operations_e2e.py
@@ -17,7 +17,9 @@ Covers all four acceptance criteria from Issue #837:
     ``method='DISPATCH'``, a non-null ``target_id``, and a
     ``payload["params_hash"]`` key.
 (d) JSONFlux handle path: ``GET:/suite-api/api/resources`` dispatched
-    with a ``ForceHandleReducer`` returns a populated
+    with the real
+    :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+    in force mode (``row_threshold=0``) returns a populated
     ``OperationResult.handle`` with at least one ``sample_rows`` entry.
 
 Database: SQLite via the autouse ``_default_database_url`` conftest
@@ -56,7 +58,6 @@ from sqlalchemy import select
 import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.registry import all_connectors_v2
-from meho_backplane.connectors.schemas import ResultHandle
 from meho_backplane.connectors.vcf_operations import (
     VROPS_CONNECTOR_ID,
     VROPS_CORE_OPS,
@@ -69,6 +70,7 @@ from meho_backplane.db.models import AuditLog, Target
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.operations._handler_resolve import get_or_create_connector_instance
 from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
 from meho_backplane.operations.meta_tools import call_operation
 from meho_backplane.operations.reducer import PassThroughReducer
 from tests.acceptance._vrops_canary_fixtures import (
@@ -153,69 +155,6 @@ def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
 
     monkeypatch.setattr(audit_module, "publish_event", _capture)
     return events
-
-
-# ---------------------------------------------------------------------------
-# ForceHandleReducer (acceptance criterion d)
-# ---------------------------------------------------------------------------
-
-
-class _ForceHandleReducer:
-    """Test-only reducer that wraps a vROps list payload in a ResultHandle.
-
-    vROps' suite-api wraps list payloads under noun-specific keys
-    (``resourceList``, ``alerts``, ``alertDefinitions``, ``symptoms``,
-    ``recommendations``, ``superMetrics``) rather than the generic
-    ``results`` / ``elements`` / ``value`` shapes NSX, SDDC Manager,
-    and vSphere use. Recognise both families so the same reducer
-    works against any list op the JSONFlux force-handle case might
-    target in the future.
-    """
-
-    _LIST_KEYS: tuple[str, ...] = (
-        "elements",
-        "results",
-        "value",
-        "resourceList",
-        "alerts",
-        "alertDefinitions",
-        "symptoms",
-        "recommendations",
-        "superMetrics",
-    )
-
-    async def reduce(
-        self,
-        payload: Any,
-        schema: dict[str, Any] | None = None,
-        context: dict[str, Any] | None = None,
-    ) -> tuple[Any, ResultHandle | None]:
-        del schema, context
-        if isinstance(payload, list):
-            total = len(payload)
-            sample: tuple[Any, ...] = tuple(payload[:5]) if payload else ()
-        elif isinstance(payload, dict):
-            for key in self._LIST_KEYS:
-                rows = payload.get(key)
-                if isinstance(rows, list):
-                    total = len(rows)
-                    sample = tuple(rows[:5]) if rows else ()
-                    break
-            else:
-                total = 1
-                sample = ()
-        else:
-            total = 1
-            sample = ()
-        handle = ResultHandle(
-            handle_id=uuid.uuid4(),
-            summary_md=f"force-mode handle ({total} rows)",
-            schema_={"type": "array", "items": {"type": "object"}},
-            total_rows=total,
-            sample_rows=sample or None,
-            ttl_seconds=3600,
-        )
-        return {"row_count": total, "sample": list(sample)}, handle
 
 
 # ---------------------------------------------------------------------------
@@ -480,7 +419,7 @@ async def test_vcf_operations_e2e_dispatch_writes_audit_row(
 async def test_vcf_operations_e2e_jsonflux_handle_populated_for_resource_list(
     vcf_operations_e2e_canary: _VropsE2EBundle,
 ) -> None:
-    """Resource list dispatched with ForceHandleReducer returns a populated handle.
+    """Resource list dispatched with the real JsonFluxReducer returns a populated handle.
 
     Acceptance criterion (d). Resource list is the largest list
     surface in a real vROps deployment (hundreds to thousands of
@@ -499,7 +438,7 @@ async def test_vcf_operations_e2e_jsonflux_handle_populated_for_resource_list(
     assert isinstance(resource_list, list)
     expected_rows = len(resource_list)
 
-    set_default_reducer(_ForceHandleReducer())
+    set_default_reducer(JsonFluxReducer(row_threshold=0))
     try:
         result_envelope = await call_operation(
             _OPERATOR,
@@ -519,7 +458,7 @@ async def test_vcf_operations_e2e_jsonflux_handle_populated_for_resource_list(
 
     handle = result_envelope.get("handle")
     assert handle is not None, (
-        "Expected OperationResult.handle to be populated by _ForceHandleReducer; "
+        "Expected OperationResult.handle to be populated by JsonFluxReducer; "
         f"got handle=None on envelope={result_envelope!r}"
     )
 


### PR DESCRIPTION
## Summary

Closes #754 (G0.6.1-T4). Mechanical sweep + verification — no new behavior, no op-code changes.

Now that the real `JsonFluxReducer` is the dispatcher default (#753), this:

1. **Replaces the `future JSONFlux reducer` / `future reducer` seam comments** across the connector modules with concrete references to the now-live adapter `meho_backplane.operations.jsonflux_reducer.JsonFluxReducer` (installed via `set_default_reducer` in `main.py`), pointing at `docs/architecture/jsonflux.md`. Files: `bind9/{connector,ops_config,ops_zone}.py`, `kubernetes/{connector,ops_core,ops_logs,ops_workload}.py`.
2. **Removes the test-only `ForceHandleReducer` shim everywhere** and migrates the affected force-mode / e2e tests to the real adapter in force mode (`JsonFluxReducer(row_threshold=0)`), asserting the **real** materialized `ResultHandle` shape (`handle_id` UUID, `total_rows`, sample) instead of the synthetic shim shape. Migrated tests: `test_g35_harbor_jsonflux_force_handle.py`, `test_g36_vrops_jsonflux_force_handle.py`, and the `nsx` / `sddc_manager` / `vcf_automation` / `vcf_fleet` / `vcf_logs` / `vcf_operations` e2e suites.

## Verification

- `grep -rn "future JSONFlux reducer\|future reducer" backend/src --include="*.py"` → zero.
- `grep -rn "ForceHandleReducer" backend/` → zero.
- `uv run ruff check src/ tests/` → clean; `ruff format --check` → 511 files formatted; `uv run mypy src/` → no issues (253 files).
- Targeted connector + force-handle + e2e suites: 173 passed.
- Full non-integration suite under xdist: green.

## Notes

- Pure comment + test migration; no production reducer/dispatcher/op-code changes.
- The migrated tests reuse the proven `set_default_reducer(...)`-in-fixture-with-teardown pattern (restores `PassThroughReducer`) — no global-reducer leak across tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified dispatcher/reducer behavior, payload materialization thresholds, and how large results are represented.

* **Tests**
  * Updated acceptance and E2E tests to exercise the real reducer in force mode; adjusted assertions and test narratives accordingly.

* **Refactor**
  * Removed synthetic/test-only reducer implementations and simplified test wiring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->