### PR TITLE
test(conftest): snapshot/restore _DEFAULT_REDUCER in registry isolation (closes #981)

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -569,14 +569,28 @@ def _isolate_global_registries() -> Iterator[None]:
     local fixture; this generalises the snapshot/restore to all of
     them, process-wide.
 
-    Snapshot the *contents* (not the binding — other modules hold the
-    same dict/list objects, so rebinding would not propagate) at setup,
-    restore them verbatim at teardown. Restore-not-clear: registrations
-    a test legitimately makes survive *within* that test; only the
-    cross-test bleed is removed.
+    It also snapshots/restores the dispatcher's default reducer binding,
+    ``operations.dispatcher._DEFAULT_REDUCER``. The app lifespan swaps the
+    shipped ``PassThroughReducer`` for the production ``JsonFluxReducer``
+    via ``set_default_reducer(...)`` (``main.py``) and never restores it,
+    so the same lifespan-leak failure mode applied to the reducer too —
+    it bit the #753 vcsim e2e (green single-file, red in the full CI
+    sweep). This is the process-wide safety net beneath the per-test
+    reducer fixtures (e.g. those swapping in a row-thresholded
+    ``JsonFluxReducer``), which keep working unchanged.
+
+    Snapshot the registries' *contents* (not the binding — other modules
+    hold the same dict/list objects, so rebinding would not propagate)
+    and restore them verbatim. The reducer is the opposite shape: a
+    single module-level binding that ``dispatch()`` reads fresh on each
+    call, so its identity is captured and restored through the only
+    supported rebind path, ``set_default_reducer(saved)``. Restore-not-
+    clear: registrations (and reducer swaps) a test legitimately makes
+    survive *within* that test; only the cross-test bleed is removed.
     """
     from meho_backplane.connectors import registry as conn_reg
     from meho_backplane.mcp import registry as mcp_reg
+    from meho_backplane.operations import dispatcher, set_default_reducer
     from meho_backplane.operations import typed_register as typed_reg
 
     tools = dict(mcp_reg._TOOLS)
@@ -584,6 +598,7 @@ def _isolate_global_registries() -> Iterator[None]:
     connectors_v1 = dict(conn_reg._REGISTRY)
     connectors_v2 = dict(conn_reg._REGISTRY_V2)
     registrars = list(typed_reg._TYPED_OP_REGISTRARS)
+    default_reducer = dispatcher._DEFAULT_REDUCER
     try:
         yield
     finally:
@@ -596,6 +611,7 @@ def _isolate_global_registries() -> Iterator[None]:
         conn_reg._REGISTRY_V2.clear()
         conn_reg._REGISTRY_V2.update(connectors_v2)
         typed_reg._TYPED_OP_REGISTRARS[:] = registrars
+        set_default_reducer(default_reducer)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_operations_dispatcher.py
+++ b/backend/tests/test_operations_dispatcher.py
@@ -41,8 +41,8 @@ patched to a recording stub so tests can assert on the
 from __future__ import annotations
 
 import uuid
-from collections.abc import AsyncIterator, Iterator
-from typing import Any
+from collections.abc import AsyncIterator, Callable, Iterator
+from typing import Any, cast
 from unittest.mock import AsyncMock
 from uuid import UUID
 
@@ -936,6 +936,46 @@ async def test_dispatch_uses_swapped_reducer(
         assert seen == [{"echo": {"path": "/secret"}}]
     finally:
         set_default_reducer(PassThroughReducer())
+
+
+def test_isolate_global_registries_restores_default_reducer() -> None:
+    """The autouse isolation fixture restores the default reducer (#981).
+
+    A test that swaps the dispatcher's module-level default reducer (the
+    app lifespan does exactly this in production) must not leak that
+    binding into the next test on the same xdist worker. Drive the actual
+    conftest fixture as a generator: run its setup, install a sentinel
+    reducer mid-"test", then run its teardown and assert the pre-test
+    reducer identity is back. Driving the fixture by hand (rather than
+    relying on it autouse) makes the assertion observe the *post-teardown*
+    state, which a test body otherwise can't see.
+
+    ``@pytest.fixture`` wraps the generator function in a
+    ``FixtureFunctionDefinition`` whose original is reachable via
+    ``__wrapped__`` (set by the decorator); the type stub omits the
+    attribute, so it's read through a typed cast.
+    """
+    from meho_backplane.operations import dispatcher, set_default_reducer
+    from tests import conftest
+
+    isolate_gen_fn = cast(
+        "Callable[[], Iterator[None]]",
+        conftest._isolate_global_registries.__wrapped__,  # type: ignore[attr-defined]
+    )
+
+    pre_test_reducer = dispatcher._DEFAULT_REDUCER
+
+    gen = isolate_gen_fn()
+    next(gen)  # setup: snapshot the current bindings
+
+    sentinel = PassThroughReducer()
+    set_default_reducer(sentinel)
+    assert dispatcher._DEFAULT_REDUCER is sentinel
+
+    with pytest.raises(StopIteration):
+        next(gen)  # teardown: restore the snapshot
+
+    assert dispatcher._DEFAULT_REDUCER is pre_test_reducer
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Extend the autouse `_isolate_global_registries` fixture (`backend/tests/conftest.py`) to also snapshot and restore the dispatcher's default reducer (`dispatcher._DEFAULT_REDUCER`).
- Closes a test-isolation hole: since #753 the app lifespan swaps `PassThroughReducer` → production `JsonFluxReducer` via `set_default_reducer(...)` (`main.py:255`) and never restores it, so under xdist a `TestClient(app)` test leaked the production reducer into the next test on the same worker. It bit the #753 vcsim e2e (green single-file, red in the full CI sweep); #753 patched the symptom with a local fixture, leaving the contract's hole open for every other test.
- No production change — purely test isolation. The per-test reducer fixtures already in the suite are the layer above this process-wide net and keep working unchanged. The reducer is restored through the only supported rebind path, `set_default_reducer(saved)` (no getter exists — the module global is read directly at setup).

## Test plan
- [x] `ruff check backend/tests/conftest.py backend/tests/test_operations_dispatcher.py` — clean
- [x] `ruff format --check` (both files) — already formatted
- [x] `mypy src/` (the CI gate, `[tool.mypy] files = ["src"]`) — `Success: no issues found in 265 source files`; the new test block is mypy-clean too
- [x] New regression test `test_isolate_global_registries_restores_default_reducer` — passes (drives the fixture as a generator: setup → install sentinel reducer → teardown → assert pre-test reducer identity restored, observing the post-teardown state a normal test body can't see)
- [x] Full xdist sweep the way CI runs it (`pytest -n auto --dist loadscope --ignore=tests/integration tests/`) — **3779 passed, 49 skipped, 0 failed** (9m31s); includes the #753 vcsim e2e acceptance tests

## Out of scope
- Adding a public `get_default_reducer()` getter to the dispatcher (reading the module global in conftest is sufficient).
- Changing the production lifespan to restore the reducer on shutdown (irrelevant in prod — the process exits).
- The per-test reducer fixtures shipped by #753/#754 (they stay as-is).
- Docs unchanged — verified: `docs/architecture/{jsonflux,operations-substrate}.md` describe the production lifespan swap, which this test-only change does not alter; no `docs/codebase/` artifact covers the isolation fixture.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #981


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test isolation mechanism to prevent cross-test state leakage and improve test reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->