### PR TITLE
test(connectors): migrate G3.7 force-handle tests off ForceHandleReducer shim (#982)

### DIFF
--- a/backend/src/meho_backplane/connectors/hetzner_robot/core_ops.py
+++ b/backend/src/meho_backplane/connectors/hetzner_robot/core_ops.py
@@ -97,8 +97,10 @@ server.list JSONFlux note
 force-handle case dispatches. Hetzner Robot returns a top-level JSON
 array (or a ``{"server": [...]}`` envelope depending on the endpoint
 version normalised in :meth:`HetznerRobotConnector.fingerprint`). The
-:func:`~tests.acceptance._robot_canary_fixtures.ForceHandleReducer`
-handles the list shape; real JSONFlux reduction (MinIO/S3 spill,
+acceptance test drives the real
+:class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+in force mode (``row_threshold=0``); its collection detection handles
+the list shape. Production-grade JSONFlux reduction (MinIO/S3 spill,
 ``result_query`` meta-tool) is out of scope for v0.2 per Goal #214.
 
 auth_failed invariant

--- a/backend/tests/acceptance/test_g37_robot_dispatch_smoke.py
+++ b/backend/tests/acceptance/test_g37_robot_dispatch_smoke.py
@@ -8,7 +8,9 @@ Proves the acceptance criteria for issue #852:
 * AC1: every enabled op dispatches via the agent's ``call_operation``
   meta-tool and returns ``status='ok'`` against a respx-mocked Webservice.
 * AC2: ``hetzner-robot.server.list`` (``GET:/server``) also exercises the
-  JSONFlux handle path via a test-only :class:`ForceHandleReducer`.
+  JSONFlux handle path via the real
+  :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+  in force mode (``row_threshold=0``).
 * AC3: every dispatch writes an audit row (``op_id`` + ``target_id`` +
   ``params_hash``) — asserted by checking the backplane's audit log
   after each call.
@@ -51,11 +53,11 @@ import pytest
 from sqlalchemy import select
 
 from meho_backplane.connectors.hetzner_robot import ROBOT_CORE_OPS
-from meho_backplane.connectors.schemas import ResultHandle
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AuditLog
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
 from meho_backplane.operations.meta_tools import call_operation
 from meho_backplane.operations.reducer import PassThroughReducer
 from tests.acceptance._robot_canary_fixtures import (
@@ -176,54 +178,16 @@ async def test_dispatch_smoke_robot_core_op_returns_ok(
 # ---------------------------------------------------------------------------
 
 
-class ForceHandleReducer:
-    """Test-only reducer that always produces a :class:`ResultHandle`.
-
-    Used by AC2 to verify the JSONFlux seam is wired for server list without
-    depending on the production reducer (which ships as PassThrough in v0.2).
-    """
-
-    async def reduce(
-        self,
-        payload: Any,
-        schema: dict[str, Any] | None = None,
-        context: dict[str, Any] | None = None,
-    ) -> tuple[Any, ResultHandle | None]:
-        """Always return ``(summary_dict, ResultHandle)``."""
-        del schema, context
-        if isinstance(payload, list):
-            total = len(payload)
-            sample = tuple(payload[:5]) if payload else ()
-        elif isinstance(payload, dict):
-            for key in ("elements", "results", "value", "server"):
-                rows = payload.get(key)
-                if isinstance(rows, list):
-                    total = len(rows)
-                    sample = tuple(rows[:5]) if rows else ()
-                    break
-            else:
-                total = 1
-                sample = ()
-        else:
-            total = 1
-            sample = ()
-
-        handle = ResultHandle(
-            handle_id=uuid.uuid4(),
-            summary_md=f"force-mode handle ({total} rows)",
-            schema_={"type": "array", "items": {"type": "object"}},
-            total_rows=total,
-            sample_rows=sample if sample else None,
-            ttl_seconds=3600,
-        )
-        summary = {"row_count": total, "sample": list(sample)}
-        return summary, handle
-
-
 @pytest.fixture
 def force_handle_reducer() -> Any:
-    """Install :class:`ForceHandleReducer` as the dispatcher's default."""
-    set_default_reducer(ForceHandleReducer())
+    """Install :class:`JsonFluxReducer` in force mode as the dispatcher default.
+
+    ``row_threshold=0`` forces every non-empty set to materialize, so the
+    seeded server list (below the default 50-row threshold) produces a
+    handle. Teardown restores :class:`PassThroughReducer` so a follow-on
+    test in the same session sees the v0.2 default.
+    """
+    set_default_reducer(JsonFluxReducer(row_threshold=0))
     try:
         yield
     finally:
@@ -235,11 +199,14 @@ async def test_server_list_returns_jsonflux_handle(
     force_handle_reducer: None,
     ingested_robot_canary: IngestedRobotCanary,
 ) -> None:
-    """AC2: server list (GET:/server) populates OperationResult.handle via ForceHandleReducer.
+    """AC2: server list (GET:/server) populates OperationResult.handle via JsonFluxReducer.
 
-    Proves that the JSONFlux dispatcher seam is wired for Hetzner Robot's
-    server-list op — the most common inventory call and the one most
-    likely to produce large result sets in production.
+    Drives the real
+    :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+    in force mode (``row_threshold=0``) to prove the JSONFlux dispatcher
+    seam is wired for Hetzner Robot's server-list op — the most common
+    inventory call and the one most likely to produce large result sets
+    in production.
 
     Proves AC2 of #852: server.list E2E asserts the JSONFlux handle path.
     """
@@ -260,7 +227,7 @@ async def test_server_list_returns_jsonflux_handle(
     )
     handle = result_envelope.get("handle")
     assert handle is not None, (
-        "expected OperationResult.handle to be populated by ForceHandleReducer; "
+        "expected OperationResult.handle to be populated by JsonFluxReducer; "
         f"got handle=None on envelope={result_envelope!r}"
     )
     uuid.UUID(handle["handle_id"])
@@ -268,6 +235,13 @@ async def test_server_list_returns_jsonflux_handle(
         f"expected {expected_rows} servers; got handle.total_rows={handle['total_rows']}"
     )
     assert handle["summary_md"], "handle.summary_md must be non-empty"
+    assert str(expected_rows) in handle["summary_md"], (
+        f"expected summary_md to mention the row count; got {handle['summary_md']!r}"
+    )
+    sample_rows = handle.get("sample_rows")
+    assert sample_rows, (
+        f"expected ≥1 sample row from the seeded server list; got sample_rows={sample_rows!r}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/acceptance/test_g37_robot_jsonflux_force_handle.py
+++ b/backend/tests/acceptance/test_g37_robot_jsonflux_force_handle.py
@@ -3,19 +3,20 @@
 
 """G3.7-T8 JSONFlux force-mode acceptance for the Hetzner Robot connector.
 
-v0.2 ships only :class:`~meho_backplane.operations.reducer.PassThroughReducer`
-— the production reducer never produces a :class:`ResultHandle`. This test
-mirrors :mod:`tests.acceptance.test_g35_harbor_jsonflux_force_handle` verbatim,
-swapping in Hetzner Robot as the dispatched connector: it installs a test-only
-:class:`ForceHandleReducer` that wraps every payload in a synthetic handle,
-dispatches ``GET:/server`` against the seeded Robot core, and asserts
-the :class:`~meho_backplane.connectors.schemas.OperationResult`'s ``handle``
-field carries a populated :class:`ResultHandle`.
+Drives the **real**
+:class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+(G0.6.1-T3 #753) in force mode (``row_threshold=0``) as the dispatcher
+default. Mirrors :mod:`tests.acceptance.test_g36_vrops_jsonflux_force_handle`,
+swapping in Hetzner Robot as the dispatched connector: it dispatches
+``GET:/server`` against the seeded Robot core and asserts the
+:class:`~meho_backplane.connectors.schemas.OperationResult`'s ``handle``
+field carries a populated :class:`ResultHandle` with the real
+materialized shape.
 
-Hetzner Robot's ``GET:/server`` returns a JSON array of server wrapper
-objects (``[{"server": {...}}, ...]``). The
-:class:`ForceHandleReducer` handles this shape via its ``list`` branch so the
-dispatcher-seam test doesn't depend on the specific list-key name.
+Hetzner Robot's ``GET:/server`` returns a top-level JSON array of server
+wrapper objects (``[{"server": {...}}, ...]``). The reducer's collection
+detection hits its bare-top-level-list branch, so the dispatcher-seam
+test doesn't depend on a vendor-specific envelope key.
 
 Proves AC4 of G3.7-T8 #849: ``server.list`` returns a JSONFlux handle;
 ``result_describe`` / ``result_query`` resolve against it (the seam
@@ -30,9 +31,9 @@ from typing import Any
 
 import pytest
 
-from meho_backplane.connectors.schemas import ResultHandle
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
 from meho_backplane.operations.meta_tools import call_operation
 from meho_backplane.operations.reducer import PassThroughReducer
 from tests.acceptance._robot_canary_fixtures import (
@@ -43,59 +44,16 @@ from tests.acceptance._robot_canary_fixtures import (
 )
 
 
-class ForceHandleReducer:
-    """Test-only reducer that always produces a :class:`ResultHandle`.
-
-    Recognises four payload shapes Robot and sibling connectors use:
-
-    * ``list`` → total = ``len(payload)``.
-    * ``dict`` with ``"elements"`` key (SDDC Manager paginated envelope).
-    * ``dict`` with ``"results"`` key (NSX policy/manager API list shape).
-    * ``dict`` with ``"value"`` key (vCenter REST list shape).
-    * Anything else → total = 1, sample = ().
-    """
-
-    async def reduce(
-        self,
-        payload: Any,
-        schema: dict[str, Any] | None = None,
-        context: dict[str, Any] | None = None,
-    ) -> tuple[Any, ResultHandle | None]:
-        """Always return ``(summary_dict, ResultHandle)``."""
-        del schema, context
-        if isinstance(payload, list):
-            total = len(payload)
-            sample = tuple(payload[:5]) if payload else ()
-        elif isinstance(payload, dict):
-            for key in ("elements", "results", "value"):
-                rows = payload.get(key)
-                if isinstance(rows, list):
-                    total = len(rows)
-                    sample = tuple(rows[:5]) if rows else ()
-                    break
-            else:
-                total = 1
-                sample = ()
-        else:
-            total = 1
-            sample = ()
-
-        handle = ResultHandle(
-            handle_id=uuid.uuid4(),
-            summary_md=f"force-mode handle ({total} rows)",
-            schema_={"type": "array", "items": {"type": "object"}},
-            total_rows=total,
-            sample_rows=sample if sample else None,
-            ttl_seconds=3600,
-        )
-        summary = {"row_count": total, "sample": list(sample)}
-        return summary, handle
-
-
 @pytest.fixture
 def force_handle_reducer() -> Any:
-    """Install :class:`ForceHandleReducer` as the dispatcher's default."""
-    set_default_reducer(ForceHandleReducer())
+    """Install :class:`JsonFluxReducer` in force mode as the dispatcher default.
+
+    ``row_threshold=0`` forces every non-empty set to materialize, so
+    the seeded server list (below the default 50-row threshold) produces
+    a handle. Teardown restores :class:`PassThroughReducer` so a
+    follow-on test in the same session sees the v0.2 default.
+    """
+    set_default_reducer(JsonFluxReducer(row_threshold=0))
     try:
         yield
     finally:
@@ -124,10 +82,10 @@ async def test_force_handle_reducer_populates_operation_result_handle_for_robot(
     * ``result['row_count']`` matches the handle's total.
 
     The server list response is a JSON array of ``{"server": {...}}``
-    wrapper objects (not a pagination envelope), so the
-    :class:`ForceHandleReducer`'s ``list`` branch is exercised here —
-    different from the NSX and SDDC tests which hit the ``results[]``
-    and ``elements[]`` branches respectively.
+    wrapper objects (not a pagination envelope), so the reducer's
+    bare-top-level-list branch is exercised here — different from the
+    NSX and SDDC tests which hit the ``results[]`` and ``elements[]``
+    branches respectively.
 
     Proves AC4 of #849 (G3.7-T8): ``server.list`` returns a JSONFlux
     handle; the dispatcher seam is wired and ready for the production
@@ -151,8 +109,8 @@ async def test_force_handle_reducer_populates_operation_result_handle_for_robot(
 
     handle = result_envelope.get("handle")
     assert handle is not None, (
-        f"expected OperationResult.handle to be populated by ForceHandleReducer; "
-        f"got handle=None on envelope={result_envelope!r}"
+        f"expected OperationResult.handle to be populated by "
+        f"JsonFluxReducer; got handle=None on envelope={result_envelope!r}"
     )
     uuid.UUID(handle["handle_id"])
     assert handle["total_rows"] == expected_rows, (

--- a/backend/tests/test_connectors_pfsense_e2e.py
+++ b/backend/tests/test_connectors_pfsense_e2e.py
@@ -16,7 +16,8 @@ Acceptance criteria verified (Issue #850)
     dependency (asyncssh in-process server; SQLite via the autouse
     ``_default_database_url`` conftest fixture).
 (c) ``pfsense.firewall.state`` E2E asserts the JSONFlux handle path
-    (handle → ``result_query`` drills in) via a ``_ForceHandleReducer``.
+    (handle → ``result_query`` drills in) via the real
+    ``JsonFluxReducer`` in force mode (``row_threshold=0``).
 (d) All enabled ops write an audit row carrying ``op_id`` +
     ``target_id`` + ``params_hash``.
 (e) ``docs/cross-repo/pfsense-onboarding.md`` exists — not asserted
@@ -62,12 +63,12 @@ import meho_backplane.operations._audit as audit_module
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.connectors.pfsense import PFSENSE_OPS, PfSenseConnector
 from meho_backplane.connectors.registry import all_connectors_v2
-from meho_backplane.connectors.schemas import ResultHandle
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AuditLog
 from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.operations import reset_dispatcher_caches
 from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
 from meho_backplane.operations.meta_tools import call_operation
 from meho_backplane.operations.reducer import PassThroughReducer
 
@@ -265,47 +266,6 @@ EXPECTED_OP_IDS: tuple[str, ...] = (
     "pfsense.gateway.list",
     "pfsense.config.show",
 )
-
-# ---------------------------------------------------------------------------
-# _ForceHandleReducer for acceptance criterion (c)
-# ---------------------------------------------------------------------------
-
-
-class _ForceHandleReducer:
-    """Test-only reducer that wraps any ``{rows, total}`` payload in a ResultHandle.
-
-    Used exclusively to prove the acceptance criterion that
-    ``pfsense.firewall.state`` can produce a JSONFlux handle when a
-    handle-producing reducer is active.  Production uses the
-    PassThroughReducer (or the real JSONFlux reducer once it ships);
-    this test-only variant forces the handle path unconditionally so the
-    assertion doesn't depend on a row-count threshold.
-    """
-
-    async def reduce(
-        self,
-        payload: Any,
-        schema: dict[str, Any] | None = None,
-        context: dict[str, Any] | None = None,
-    ) -> tuple[Any, ResultHandle | None]:
-        del schema, context
-        # pfsense.firewall.state returns {"rows": [...], "total": N}
-        rows: list[Any] = []
-        total = 0
-        if isinstance(payload, dict):
-            rows = payload.get("rows") or []
-            total = int(payload.get("total", len(rows)))
-        sample = tuple(rows[:5]) if rows else ()
-        handle = ResultHandle(
-            handle_id=uuid.uuid4(),
-            summary_md=f"pfsense-e2e force-handle ({total} rows)",
-            schema_={"type": "object"},
-            total_rows=total,
-            sample_rows=sample or None,
-            ttl_seconds=3600,
-        )
-        return {"row_count": total, "sample": list(sample)}, handle
-
 
 # ---------------------------------------------------------------------------
 # Target + connector seeding helpers
@@ -670,12 +630,13 @@ async def test_pfsense_e2e_firewall_state_jsonflux_handle(
     pfsense_e2e: _PfsenseE2EBundle,
     captured_events: list[Any],
 ) -> None:
-    """pfsense.firewall.state with _ForceHandleReducer produces a ResultHandle.
+    """pfsense.firewall.state with the real JsonFluxReducer produces a ResultHandle.
 
     Exercises acceptance criterion (c): the firewall state table supports
-    the JSONFlux handle path.  The test injects a ``_ForceHandleReducer``
-    that unconditionally wraps the ``{rows, total}`` payload in a
-    ``ResultHandle``, then asserts:
+    the JSONFlux handle path.  The test installs the real
+    :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+    in force mode (``row_threshold=0``) so the seeded 3-row state table
+    materializes into a handle, then asserts:
 
     * The ``OperationResult.handle`` (top-level ``result["handle"]``) is
       present and non-None.
@@ -683,35 +644,41 @@ async def test_pfsense_e2e_firewall_state_jsonflux_handle(
     * The handle's ``sample_rows`` contains up to 5 rows.
     * ``result.result["row_count"]`` is the summary payload the reducer
       returns alongside the handle.
+
+    Teardown restores :class:`PassThroughReducer` so a follow-on test in
+    the same session sees the v0.2 default.
     """
-    set_default_reducer(_ForceHandleReducer())
+    set_default_reducer(JsonFluxReducer(row_threshold=0))
+    try:
+        result = await call_operation(
+            _OPERATOR,
+            {
+                "connector_id": "pfsense-ssh-2.7",
+                "op_id": "pfsense.firewall.state",
+                "target": {"name": _TARGET_NAME},
+                "params": {},
+            },
+        )
+        assert result["status"] == "ok", (
+            f"pfsense.firewall.state (force-handle) failed: {result.get('error')}"
+        )
 
-    result = await call_operation(
-        _OPERATOR,
-        {
-            "connector_id": "pfsense-ssh-2.7",
-            "op_id": "pfsense.firewall.state",
-            "target": {"name": _TARGET_NAME},
-            "params": {},
-        },
-    )
-    assert result["status"] == "ok", (
-        f"pfsense.firewall.state (force-handle) failed: {result.get('error')}"
-    )
+        # The result payload is the reducer's summary (not the raw rows).
+        assert result.get("result") is not None
+        assert "row_count" in result["result"]
+        assert result["result"]["row_count"] == 3
 
-    # The result payload is the reducer's summary (not the raw rows).
-    assert result.get("result") is not None
-    assert "row_count" in result["result"]
-    assert result["result"]["row_count"] == 3
-
-    # The top-level "handle" key must carry the ResultHandle
-    # (OperationResult serialises handle as a top-level field, not inside extras).
-    handle = result.get("handle")
-    assert handle is not None, (
-        f"Expected result['handle'] from _ForceHandleReducer; got result={result!r}"
-    )
-    assert handle["total_rows"] == 3
-    assert handle["sample_rows"] is not None
+        # The top-level "handle" key must carry the ResultHandle
+        # (OperationResult serialises handle as a top-level field, not inside extras).
+        handle = result.get("handle")
+        assert handle is not None, (
+            f"Expected result['handle'] from JsonFluxReducer; got result={result!r}"
+        )
+        assert handle["total_rows"] == 3
+        assert handle["sample_rows"] is not None
+    finally:
+        set_default_reducer(PassThroughReducer())
+        reset_dispatcher_caches()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Migrate the three G3.7 force-handle acceptance tests off the test-only `ForceHandleReducer` shim that #919 (Robot G3.7-T8), #934 (Robot G3.7-T9 smoke), and #933 (pfSense G3.7-T3) reintroduced/carried after #754 had removed it everywhere — restoring the zero-shim invariant.
- All three now drive the real `JsonFluxReducer(row_threshold=0)` as the dispatcher default via a `PassThroughReducer()`-restoring fixture/teardown, exactly like the #754 reference migration (`test_g36_vrops_jsonflux_force_handle.py`), and assert the real materialized `ResultHandle` shape (UUID `handle_id`, `total_rows`, non-empty `summary_md` mentioning the row count, populated `sample_rows`).
- The `hetzner_robot/core_ops.py` docstring cross-reference is repointed from the deleted shim to the live `JsonFluxReducer`.
- Test + docstring only — no production op-behavior change.

## Why this touches three test files, not the two named in #982
`grep -rn "ForceHandleReducer" backend/` (the binding acceptance gate) matched four locations, not two: the issue body named the jsonflux test + the core_ops docstring, but the same #919-wave landed an identical shim in the G3.7-T9 dispatch smoke test (#934), and #933 carried a sibling `_ForceHandleReducer` in the pfSense E2E. The gate cannot return zero unless all are migrated, so all three test files move to the real adapter. Verified the real reducer's collection detection handles each payload shape (Robot bare top-level list; pfSense `{"rows": [...], "total": N}` via the largest-list fallback).

## Test plan
- [x] `grep -rn "ForceHandleReducer" backend/` — exit 1, zero matches
- [x] `uv run pytest backend/tests/acceptance/test_g37_robot_jsonflux_force_handle.py -v` — passes asserting the real `ResultHandle` shape
- [x] `uv run pytest backend/tests/acceptance/test_g37_robot_dispatch_smoke.py backend/tests/test_connectors_pfsense_e2e.py -v` — 40 passed
- [x] `uv run pytest backend/tests/ -n auto` — 3965 passed, 54 skipped, 0 failed
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] `uv run mypy src/` (CI strict gate) — clean; no new errors introduced (the pre-existing `unused-ignore` noise under `mypy tests/` is identical before/after and not in the CI gate)
- [x] `code-quality.py --diff` — exit 0

## Out of scope
- Stale "v0.2 default PassThroughReducer" prose cleanup — tracked in #978.
- Reducer threshold tuning.
- The doc-prose `ForceHandleReducer` mentions under `docs/` (outside the `backend/` gate).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #982
