### PR TITLE
docs(connectors): correct cache-guard docstrings — loader is primary gate (#993)

### DIFF
--- a/backend/src/meho_backplane/connectors/_shared/vcf_auth.py
+++ b/backend/src/meho_backplane/connectors/_shared/vcf_auth.py
@@ -301,12 +301,18 @@ class CredentialsCache:
         when ``operator.raw_jwt`` is empty -- defense-in-depth fail-closed
         check that mirrors the loader path's pre-Vault guard at
         :func:`~meho_backplane.connectors._shared.vault_creds._resolve_secret_ref`.
-        The primary gate is each consuming connector's :meth:`auth_headers`
-        rejecting system-initiated calls (no operator JWT) at the boundary;
-        the cache fast-path enforces the same invariant so a future
-        regression in the boundary check cannot open a silent cache-hit
-        path. Raised before the cache lookup so a primed entry from an
+        The primary fail-closed gate against empty ``raw_jwt`` is the
+        loader's ``vault_client_for_operator`` / ``load_basic_credentials``
+        call chain; this cache fast-path enforces the same invariant so a
+        future regression in the loader cannot return cached credentials
+        to an unauthenticated caller via a cache hit. Each consuming
+        connector's :meth:`auth_headers` enforces only the ``auth_model``
+        boundary (rejects ``per_user`` / ``impersonation`` under
+        ``shared_service_account`` scoping; see the ``auth_model`` block
+        above). Raised before the cache lookup so a primed entry from an
         authenticated caller cannot leak to a system-initiated caller.
+        See ``docs/architecture/connector-auth.md`` § "Cache scoping under
+        ``shared_service_account``" for the contract.
 
         Raises :exc:`RuntimeError` if the loader returns a dict missing
         ``"username"`` or ``"password"``. The error message names both the

--- a/backend/src/meho_backplane/connectors/vcf_automation/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_automation/connector.py
@@ -270,15 +270,19 @@ class VcfAutomationConnector(HttpConnector):
 
         Raises :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`
         when ``operator.raw_jwt`` is empty -- defense-in-depth fail-closed
-        check mirroring the loader path's pre-Vault guard. The primary
-        gate is :meth:`auth_headers` rejecting system-initiated calls
-        before either plane's session-token method is invoked; this cache
-        fast-path enforces the same invariant so a future regression in
-        the boundary check cannot return a cached provider JWT to an
-        unauthenticated caller. Raised before the cache lookup so a
-        primed token from an authenticated caller cannot leak to a
-        system-initiated caller. See ``docs/architecture/connector-auth.md``
-        § "Cache scoping under ``shared_service_account``" for the contract.
+        check mirroring the loader path's pre-Vault guard at
+        :func:`~meho_backplane.connectors._shared.vault_creds._resolve_secret_ref`.
+        The primary fail-closed gate against empty ``raw_jwt`` is the
+        loader's ``vault_client_for_operator`` / ``load_basic_credentials``
+        call chain; this cache fast-path enforces the same invariant so a
+        future regression in the loader cannot return a cached provider JWT
+        to an unauthenticated caller via a cache hit. :meth:`auth_headers`
+        enforces only the ``auth_model`` boundary (rejects ``per_user`` /
+        ``impersonation`` under ``shared_service_account`` scoping).
+        Raised before the cache lookup so a primed token from an
+        authenticated caller cannot leak to a system-initiated caller.
+        See ``docs/architecture/connector-auth.md`` § "Cache scoping under
+        ``shared_service_account``" for the contract.
         """
         if not operator.raw_jwt:
             raise VaultCredentialsReadError(
@@ -313,13 +317,17 @@ class VcfAutomationConnector(HttpConnector):
 
         Raises :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`
         when ``operator.raw_jwt`` is empty -- defense-in-depth fail-closed
-        check mirroring the loader path's pre-Vault guard and the
-        sibling check in :meth:`_provider_session_token`. The primary
-        gate is :meth:`auth_headers` rejecting system-initiated calls
-        before either plane's session-token method is invoked; this
-        cache fast-path enforces the same invariant so a future
-        regression in the boundary check cannot return a cached tenant
-        token to an unauthenticated caller. Raised before the cache
+        check mirroring the loader path's pre-Vault guard at
+        :func:`~meho_backplane.connectors._shared.vault_creds._resolve_secret_ref`
+        and the sibling check in :meth:`_provider_session_token`. The
+        primary fail-closed gate against empty ``raw_jwt`` is the loader's
+        ``vault_client_for_operator`` / ``load_basic_credentials`` call
+        chain; this cache fast-path enforces the same invariant so a
+        future regression in the loader cannot return a cached tenant
+        token to an unauthenticated caller via a cache hit.
+        :meth:`auth_headers` enforces only the ``auth_model`` boundary
+        (rejects ``per_user`` / ``impersonation`` under
+        ``shared_service_account`` scoping). Raised before the cache
         lookup so a primed token from an authenticated caller cannot
         leak to a system-initiated caller. See
         ``docs/architecture/connector-auth.md`` § "Cache scoping under

--- a/backend/src/meho_backplane/connectors/vcf_logs/connector.py
+++ b/backend/src/meho_backplane/connectors/vcf_logs/connector.py
@@ -296,16 +296,20 @@ class VcfLogsConnector(HttpConnector):
 
         Raises :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`
         when ``operator.raw_jwt`` is empty -- defense-in-depth fail-closed
-        check that mirrors the loader path's pre-Vault guard and the
-        sibling check in :class:`CredentialsCache.get`. The primary gate
-        is :meth:`auth_headers` rejecting system-initiated calls before
-        :meth:`_session_token` is invoked; this cache fast-path enforces
-        the same invariant so a future regression in the boundary check
-        cannot return a cached bearer to an unauthenticated caller.
+        check mirroring the loader path's pre-Vault guard at
+        :func:`~meho_backplane.connectors._shared.vault_creds._resolve_secret_ref`
+        and the sibling check in :class:`CredentialsCache.get`. The primary
+        fail-closed gate against empty ``raw_jwt`` is the loader's
+        ``vault_client_for_operator`` / ``load_basic_credentials`` call
+        chain; this cache fast-path enforces the same invariant so a
+        future regression in the loader cannot return a cached vRLI bearer
+        to an unauthenticated caller via a cache hit. :meth:`auth_headers`
+        enforces only the ``auth_model`` boundary (rejects ``per_user`` /
+        ``impersonation`` under ``shared_service_account`` scoping).
         Raised before the cache lookup so a primed token from an
         authenticated caller cannot leak to a system-initiated caller.
-        See ``docs/architecture/connector-auth.md`` § "Cache scoping
-        under ``shared_service_account``" for the contract.
+        See ``docs/architecture/connector-auth.md`` § "Cache scoping under
+        ``shared_service_account``" for the contract.
         """
         if not operator.raw_jwt:
             raise VaultCredentialsReadError(

--- a/backend/src/meho_backplane/connectors/vmware_rest/connector.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/connector.py
@@ -345,13 +345,17 @@ class VmwareRestConnector(HttpConnector):
 
         Raises :class:`~meho_backplane.connectors._shared.vault_creds.VaultCredentialsReadError`
         when ``operator.raw_jwt`` is empty -- defense-in-depth fail-closed
-        check that mirrors the loader path's pre-Vault guard. The primary
-        gate is :meth:`auth_headers` rejecting system-initiated calls
-        before :meth:`_session_token` is invoked; this cache fast-path
-        enforces the same invariant so a future regression in the
-        boundary check cannot return a cached vSphere session token to
-        an unauthenticated caller. Raised before the cache lookup so a
-        primed token from an authenticated caller cannot leak to a
+        check mirroring the loader path's pre-Vault guard at
+        :func:`~meho_backplane.connectors._shared.vault_creds._resolve_secret_ref`.
+        The primary fail-closed gate against empty ``raw_jwt`` is the
+        loader's ``vault_client_for_operator`` / ``load_basic_credentials``
+        call chain; this cache fast-path enforces the same invariant so a
+        future regression in the loader cannot return a cached vSphere
+        session token to an unauthenticated caller via a cache hit.
+        :meth:`auth_headers` enforces only the ``auth_model`` boundary
+        (rejects ``per_user`` / ``impersonation`` under
+        ``shared_service_account`` scoping). Raised before the cache lookup
+        so a primed token from an authenticated caller cannot leak to a
         system-initiated caller. See ``docs/architecture/connector-auth.md``
         § "Cache scoping under ``shared_service_account``" for the contract.
         """


### PR DESCRIPTION
## Summary

- Corrects five cache-guard docstrings that misstated the primary fail-closed gate against empty `operator.raw_jwt` as each connector's `auth_headers`. `auth_headers` only inspects `target.auth_model`; the actual primary gate is the loader path (`vault_client_for_operator` → `_resolve_secret_ref` at `_shared/vault_creds.py:188`).
- Aligns the inline docstrings with the corrected architecture doc shipped in #980 (`docs/architecture/connector-auth.md` § "Cache scoping under `shared_service_account`"), so future review cycles stop re-flagging these cache guards as "redundant with `auth_headers`".
- Docstring-only edit — no runtime change. The factually-correct `auth_model` boundary reference at `_shared/vcf_auth.py:296` is preserved untouched.

Sites updated:

- `backend/src/meho_backplane/connectors/vmware_rest/connector.py` (`_session_token`)
- `backend/src/meho_backplane/connectors/vcf_logs/connector.py` (`_session_token`)
- `backend/src/meho_backplane/connectors/vcf_automation/connector.py` (`_provider_session_token`, `_tenant_session_token`)
- `backend/src/meho_backplane/connectors/_shared/vcf_auth.py` (`CredentialsCache.get` — second `Raises` block)

## Test plan

- [x] `rg "primary gate is :meth:\`auth_headers\`" backend/src/meho_backplane/connectors/` — 0 matches.
- [x] `ruff check` — clean on all four touched files.
- [x] `ruff format --check` — all four already formatted.
- [x] `mypy --ignore-missing-imports` — clean on all four touched files.
- [x] `pytest backend/tests/test_connectors_{vmware_rest,vcf_logs,vcf_automation,vcf_operations,vcf_fleet}_credread.py` — 15 passed (text-only change; sanity check that the surrounding runtime paths still work).
- [x] `_shared/vcf_auth.py:296` `auth_model` boundary line unchanged — preserved as factually correct.

## Out of scope

- Any runtime change. Docstring-only.
- Sweeping for other stale arch claims elsewhere in the connector tree.
- Reformatting unrelated docstrings on the same files.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #993


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified internal authentication and caching documentation across multiple connectors to improve code clarity and ensure consistent security guarantees.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/994?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->