### PR TITLE
fix(connectors): G3.7 gcloud CLI output correctness — honest iam footer + decodeRowsResult absent-vs-empty

### DIFF
--- a/cli/internal/cmd/gcloud/gcloud.go
+++ b/cli/internal/cmd/gcloud/gcloud.go
@@ -450,20 +450,41 @@ func prettyJSON(raw json.RawMessage) (string, error) {
 	return string(out), nil
 }
 
+// errRowsKeyAbsent is returned by decodeRowsResult when the result
+// envelope is a well-formed JSON object that carries no `rows` key at
+// all. This is distinct from an empty list (`{"rows": []}`): an absent
+// key signals a malformed or unexpected envelope, so callers route it
+// to fallbackResultRender (dump the raw shape) rather than rendering a
+// misleading "(0 rows)" line. A sentinel so callers can branch on it
+// via errors.Is if they ever need to.
+var errRowsKeyAbsent = errors.New("rows key absent from result envelope")
+
 // decodeRowsResult decodes the canonical `{"rows": [...], "total": N}`
 // envelope that every set-shaped gcloud read op returns. Returns the
-// row list or an error when the shape doesn't match.
+// row list, or an error when the shape doesn't match.
+//
+// An absent `rows` key is treated as a malformed envelope and reported
+// as errRowsKeyAbsent — distinct from a legitimately-empty list
+// (`{"rows": []}`), which returns an empty slice and a nil error. A
+// JSON null result (or no result at all) is the operation's "nothing to
+// render" case and returns (nil, nil), unchanged from before.
 func decodeRowsResult(raw json.RawMessage) ([]map[string]any, error) {
 	if len(raw) == 0 || string(raw) == "null" {
 		return nil, nil
 	}
-	var envelope struct {
-		Rows []map[string]any `json:"rows"`
-	}
+	var envelope map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil, fmt.Errorf("decode rows envelope: %w", err)
+	}
+	rowsRaw, ok := envelope["rows"]
+	if !ok {
+		return nil, errRowsKeyAbsent
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal(rowsRaw, &rows); err != nil {
 		return nil, fmt.Errorf("decode rows: %w", err)
 	}
-	return envelope.Rows, nil
+	return rows, nil
 }
 
 // decodeFlatResult decodes a flat-dict result (gcloud.about,

--- a/cli/internal/cmd/gcloud/gcloud_test.go
+++ b/cli/internal/cmd/gcloud/gcloud_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -114,6 +115,58 @@ func TestDecodeRowsResultHappy(t *testing.T) {
 	}
 	if len(rows) != 1 || rows[0]["name"] != "compute.googleapis.com" {
 		t.Fatalf("decoded: %+v", rows)
+	}
+}
+
+// TestDecodeRowsResultEmptyVsAbsent pins the load-bearing distinction:
+// a legitimately-empty `rows` list is a clean empty result, while an
+// envelope with no `rows` key at all is malformed and reported via the
+// errRowsKeyAbsent sentinel so callers route it to the fallback raw
+// render instead of a misleading "(0 rows)" line.
+func TestDecodeRowsResultEmptyVsAbsent(t *testing.T) {
+	// Empty list: nil error, zero-length, non-nil slice (renders "0 rows").
+	rows, err := decodeRowsResult(json.RawMessage(`{"rows":[],"total":0}`))
+	if err != nil {
+		t.Fatalf("empty rows should not error; got %v", err)
+	}
+	if rows == nil {
+		t.Fatalf("empty rows should be a non-nil empty slice; got nil")
+	}
+	if len(rows) != 0 {
+		t.Fatalf("empty rows should have len 0; got %d", len(rows))
+	}
+
+	// Absent key: errRowsKeyAbsent sentinel, no rows.
+	rows, err = decodeRowsResult(json.RawMessage(`{"total":0}`))
+	if !errors.Is(err, errRowsKeyAbsent) {
+		t.Fatalf("absent rows key should report errRowsKeyAbsent; got %v", err)
+	}
+	if rows != nil {
+		t.Fatalf("absent rows key should return nil rows; got %+v", rows)
+	}
+}
+
+// TestDecodeRowsResultNullResult — a JSON null (or empty) result is the
+// "nothing to render" case: (nil, nil), not an error. Distinct from an
+// absent `rows` key inside a non-null object envelope.
+func TestDecodeRowsResultNullResult(t *testing.T) {
+	for _, raw := range []json.RawMessage{nil, json.RawMessage(`null`)} {
+		rows, err := decodeRowsResult(raw)
+		if err != nil {
+			t.Fatalf("null/empty result should not error; got %v", err)
+		}
+		if rows != nil {
+			t.Fatalf("null/empty result should return nil rows; got %+v", rows)
+		}
+	}
+}
+
+// TestDecodeRowsResultMalformedEnvelope — a non-object top-level (e.g. a
+// bare array) is malformed and returns a decode error, routing the
+// caller to the fallback render.
+func TestDecodeRowsResultMalformedEnvelope(t *testing.T) {
+	if _, err := decodeRowsResult(json.RawMessage(`[1,2,3]`)); err == nil {
+		t.Fatalf("non-object envelope should error")
 	}
 }
 
@@ -262,6 +315,82 @@ func TestPrintIamPolicyReadTable(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("printIamPolicyRead missing %q in output:\n%s", want, out)
 		}
+	}
+}
+
+// iamPolicyWithMembers builds a single-binding policy result with the
+// given member count (member:N for N in 1..count). Helper for the
+// footer-honesty tests.
+func iamPolicyWithMembers(count int) json.RawMessage {
+	members := make([]string, 0, count)
+	for i := 1; i <= count; i++ {
+		members = append(members, fmt.Sprintf("user:m%d@example.com", i))
+	}
+	b, err := json.Marshal(members)
+	if err != nil {
+		panic(err)
+	}
+	return json.RawMessage(fmt.Sprintf(
+		`{"version":1,"etag":"E","bindings":[{"role":"roles/viewer","members":%s}]}`, b))
+}
+
+// countMembersShown reports how many "user:mN@example.com" member lines
+// appear in the render. Used to assert the cap was actually applied.
+func countMembersShown(out string) int {
+	return strings.Count(out, "@example.com")
+}
+
+// TestPrintIamPolicyReadFooterHonestyUnderCap — a binding with no more
+// than the cap of members prints every member and emits NO "…" footer.
+// This is the bug the Task targets: the old code printed every member
+// and *then* appended a misleading "… (N total)" that implied a
+// truncation that never happened.
+func TestPrintIamPolicyReadFooterHonestyUnderCap(t *testing.T) {
+	// Exactly maxPolicyMembersShown members: every one printed, no footer.
+	r := &CallResult{
+		Status: "ok",
+		OpID:   "gcloud.iam.policy.read",
+		Result: iamPolicyWithMembers(maxPolicyMembersShown),
+	}
+	var buf bytes.Buffer
+	printIamPolicyRead(&buf, r)
+	out := buf.String()
+
+	if strings.Contains(out, "…") {
+		t.Errorf("no member should be elided at the cap; output must not contain an ellipsis:\n%s", out)
+	}
+	if strings.Contains(out, "total)") {
+		t.Errorf("no footer should print when nothing is hidden:\n%s", out)
+	}
+	if got := countMembersShown(out); got != maxPolicyMembersShown {
+		t.Errorf("all %d members should be printed; got %d:\n%s", maxPolicyMembersShown, got, out)
+	}
+}
+
+// TestPrintIamPolicyReadFooterHonestyOverCap — a binding with more than
+// the cap of members truncates to the cap and reports an honest footer
+// stating how many were hidden and the true total. The "…" now reflects
+// a real elision.
+func TestPrintIamPolicyReadFooterHonestyOverCap(t *testing.T) {
+	total := maxPolicyMembersShown + 3 // 3 hidden
+	r := &CallResult{
+		Status: "ok",
+		OpID:   "gcloud.iam.policy.read",
+		Result: iamPolicyWithMembers(total),
+	}
+	var buf bytes.Buffer
+	printIamPolicyRead(&buf, r)
+	out := buf.String()
+
+	// Exactly the cap of member lines is printed (truncation happened).
+	if got := countMembersShown(out); got != maxPolicyMembersShown {
+		t.Errorf("expected %d member lines (capped); got %d:\n%s", maxPolicyMembersShown, got, out)
+	}
+	// Footer reports the hidden count and the true total honestly.
+	hidden := total - maxPolicyMembersShown
+	wantFooter := fmt.Sprintf("… (%d more, %d total)", hidden, total)
+	if !strings.Contains(out, wantFooter) {
+		t.Errorf("expected honest footer %q in output:\n%s", wantFooter, out)
 	}
 }
 

--- a/cli/internal/cmd/gcloud/iam.go
+++ b/cli/internal/cmd/gcloud/iam.go
@@ -193,6 +193,15 @@ func runIamPolicyRead(
 	return renderCallResult(cmd, "gcloud.iam.policy.read", r, jsonOut, printIamPolicyRead)
 }
 
+// maxPolicyMembersShown caps how many members of a single role binding
+// the human-readable policy render prints before eliding the rest. Wide
+// bindings (a role with dozens of members) would otherwise flood the
+// terminal one line per member. The cap only affects the human path;
+// `--json` always emits every member. When members are elided, an
+// honest "… (M more, N total)" footer reports exactly how many were
+// hidden so the "…" never implies truncation that didn't happen.
+const maxPolicyMembersShown = 5
+
 // printIamPolicyRead renders the IAM policy. Surfaces version, etag,
 // and the role→members bindings table in the human path.
 func printIamPolicyRead(w io.Writer, r *CallResult) {
@@ -233,18 +242,25 @@ func printIamPolicyRead(w io.Writer, r *CallResult) {
 				}
 			}
 		}
-		// Print role with first member; subsequent members on indented lines.
+		// Print role with first member; subsequent members on indented
+		// lines, capped at maxPolicyMembersShown. When members are
+		// elided, the footer reports the exact count hidden so the "…"
+		// reflects a real truncation.
 		if len(members) == 0 {
 			fmt.Fprintf(w, "  %-50s (0 members)\n", truncate(role, 50))
 			continue
 		}
-		fmt.Fprintf(w, "  %-50s %s\n", truncate(role, 50), members[0])
-		for _, m := range members[1:] {
+		shown := members
+		if len(shown) > maxPolicyMembersShown {
+			shown = shown[:maxPolicyMembersShown]
+		}
+		fmt.Fprintf(w, "  %-50s %s\n", truncate(role, 50), shown[0])
+		for _, m := range shown[1:] {
 			fmt.Fprintf(w, "  %-50s %s\n", "", m)
 		}
-		if len(members) > 5 {
-			fmt.Fprintf(w, "  %-50s … (%d total)\n", "",
-				len(members))
+		if hidden := len(members) - len(shown); hidden > 0 {
+			fmt.Fprintf(w, "  %-50s … (%d more, %d total)\n", "",
+				hidden, len(members))
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- `meho gcloud iam policy read` no longer prints a misleading `… (N total)` footer after listing every member of a role binding. The render now actually truncates to a named cap (`maxPolicyMembersShown = 5`) and emits `… (M more, N total)` **only when members were genuinely elided**, so the ellipsis reflects a real truncation. The `--json` path is untouched and always carries every member.
- `decodeRowsResult` now distinguishes an **absent** `rows` key (malformed/partial envelope) from a legitimately-**empty** list. It decodes into a key map and reports an absent `rows` key via the `errRowsKeyAbsent` sentinel, which existing callers already route to `fallbackResultRender` (dump the raw shape). An empty list still returns a non-nil empty slice (renders "0 rows"); a JSON null result stays the `(nil, nil)` "nothing to render" case.

## Test plan

- [x] `gofmt -l internal/cmd/gcloud/` — clean (empty)
- [x] `go vet ./internal/cmd/gcloud/...` — clean
- [x] `go build ./...` — OK
- [x] `golangci-lint run ./internal/cmd/gcloud/...` (v2.12.2, CI config) — 0 issues
- [x] `CGO_ENABLED=1 go test -race ./internal/cmd/gcloud/...` — pass
- [x] **Acceptance:** >5-member policy renders an honest footer (no false `…` when nothing is hidden) — `TestPrintIamPolicyReadFooterHonestyOverCap` + `TestPrintIamPolicyReadFooterHonestyUnderCap`
- [x] **Acceptance:** result missing `rows` handled distinctly from empty `rows` — `TestDecodeRowsResultEmptyVsAbsent` (plus `TestDecodeRowsResultNullResult`, `TestDecodeRowsResultMalformedEnvelope`)

## Out of scope

- The cross-CLI behaviors the review also flagged (empty `--target` not failing fast at parse time; 401-after-refresh rendered as generic "Unexpected" instead of "auth_expired") are inherited verbatim from the shared bind9/k8s CLI helpers — a cross-CLI consistency decision spanning all connectors, to be filed separately against the shared helper if wanted.
- `docs/codebase/connectors-gcloud.md` documents the CLI verbs at the verb-table / envelope level; neither the old footer behavior nor the absent-vs-empty decode semantics were documented, so no doc change was needed (verified).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #988
