### PR TITLE
docs(connectors): correct stale 'PassThroughReducer default' wording post-#753

### DIFF
--- a/backend/src/meho_backplane/connectors/_shared/vault_creds.py
+++ b/backend/src/meho_backplane/connectors/_shared/vault_creds.py
@@ -18,9 +18,9 @@ The exact read already exists inside the Vault connector op
 ``vault/ops.py:294``): ``async with vault_client_for_operator(operator)
 as client: client.secrets.kv.v2.read_secret_version(...)`` then a
 structural unwrap of ``data["data"]``. That handler is coupled to the
-op-dispatch surface — it returns ``{"data", "version"}`` shaped for the
-``PassThroughReducer`` and is registered as a typed op with a JSON
-schema. A connector *loader* needs something narrower: a plain
+op-dispatch surface — it returns ``{"data", "version"}``, a scalar shape
+the dispatcher's default reducer passes through verbatim, and is
+registered as a typed op with a JSON schema. A connector *loader* needs something narrower: a plain
 ``dict[str, str]`` of named fields and an error contract distinct from
 the dispatcher's ``connector_error`` branch. So this helper reuses the
 lower-level primitive (:func:`vault_client_for_operator` +

--- a/backend/src/meho_backplane/connectors/pfsense/connector.py
+++ b/backend/src/meho_backplane/connectors/pfsense/connector.py
@@ -430,8 +430,9 @@ class PfSenseConnector(SshConnector):
         Delegates to
         :func:`~meho_backplane.connectors.pfsense.ops_read.pfsense_firewall_state`.
         The state table can contain thousands of rows on busy firewalls;
-        the future JSONFlux reducer spills to the HandleStore
-        (key ``pfsense_firewall_state``) when ``total`` exceeds its
+        the dispatcher's default
+        :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+        wraps the result in a ``ResultHandle`` when ``total`` exceeds its
         configured threshold.
         """
         from meho_backplane.connectors.pfsense.ops_read import (

--- a/backend/src/meho_backplane/connectors/pfsense/ops_read.py
+++ b/backend/src/meho_backplane/connectors/pfsense/ops_read.py
@@ -38,12 +38,12 @@ Setting handle creation here would couple every connector to the
 reducer's calibration threshold and bypass the reducer's
 audit / TTL / store-routing logic.
 
-The handler ships ``rows`` + ``total`` so a future JSONFlux reducer
-can pull both signals (inlined sample size + total) to drive its
-threshold check, exactly as the bind9 sibling does. No handle exists
-today — the current
-:class:`~meho_backplane.operations.reducer.PassThroughReducer` always
-returns the inline payload unchanged.
+The handler ships ``rows`` + ``total`` so the dispatcher's default
+reducer can pull both signals (inlined sample size + total) to drive its
+threshold check, exactly as the bind9 sibling does. The default
+:class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+wraps the payload in a ``ResultHandle`` once the set exceeds its
+threshold; smaller payloads pass through unchanged.
 
 References
 ----------
@@ -533,11 +533,12 @@ async def pfsense_firewall_state(
 
     Op-id: ``pfsense.firewall.state``. Active connection state tables
     on busy firewalls can contain thousands of rows; this handler ships
-    the full parsed list plus a ``total`` count so a future JSONFlux
-    reducer can spill out-of-band when the row count exceeds its
-    threshold (key ``pfsense_firewall_state``). Today's
-    :class:`~meho_backplane.operations.reducer.PassThroughReducer` always
-    returns the inline payload unchanged.
+    the full parsed list plus a ``total`` count so the dispatcher's
+    default reducer can spill out-of-band when the row count exceeds its
+    threshold (key ``pfsense_firewall_state``). The default
+    :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+    wraps large state tables in a ``ResultHandle``; smaller payloads pass
+    through unchanged.
     """
     del params  # declared empty; intentionally ignored
     proc = await self._run_command(target, "pfctl -ss", raw_jwt="")

--- a/backend/src/meho_backplane/connectors/schemas.py
+++ b/backend/src/meho_backplane/connectors/schemas.py
@@ -132,15 +132,16 @@ class ProbeResult(BaseModel):
 class ResultHandle(BaseModel):
     """Reference to a set-shaped payload stored out-of-band (MinIO / S3 / …).
 
-    JSONFlux contract per v0.1-spec L294-311. The v0.2 default reducer
-    (:class:`~meho_backplane.operations.reducer.PassThroughReducer`) **never**
-    produces a handle — the field on :class:`OperationResult` stays ``None``
-    on every successful dispatch in v0.2. Real reduction lands in a separate
-    Initiative once the first generic-ingested connectors produce real
-    response payloads to calibrate against; that work populates the handle
-    on >50-row / >4 KB set-shaped responses, stores the full payload in an
-    addressable backing store (MinIO/S3/Valkey), and ships the
-    ``result_query`` / ``result_aggregate`` meta-tools that read it back.
+    JSONFlux contract per v0.1-spec L294-311. The dispatcher's default
+    reducer
+    (:class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`,
+    installed via ``set_default_reducer``) populates this handle for
+    set-shaped responses above its threshold (>50 rows / >4 KB); smaller /
+    scalar payloads pass through and the field on :class:`OperationResult`
+    stays ``None``. The materialized payload is held in DuckDB (in-memory)
+    for v0.2; an addressable spill backing store (MinIO/S3/Valkey) and the
+    ``result_query`` / ``result_aggregate`` read-back meta-tools are a later
+    Initiative.
 
     ``schema_`` (trailing underscore) is the JSON Schema of the underlying
     payload — the trailing underscore avoids collision with Pydantic's own

--- a/backend/src/meho_backplane/connectors/vault/ops.py
+++ b/backend/src/meho_backplane/connectors/vault/ops.py
@@ -168,8 +168,8 @@ VAULT_KV_READ_PARAMETER_SCHEMA: dict[str, Any] = {
 
 
 #: JSON Schema for the ``vault.kv.read`` response payload. Informational
-#: in v0.2 (the dispatcher's :class:`PassThroughReducer` does not validate
-#: outbound payloads); declared so the meta-tools (T8 #399) can surface
+#: (the dispatcher's default reducer does not validate outbound payloads
+#: against them); declared so the meta-tools (T8 #399) can surface
 #: it on ``describe_operation`` calls without a schema-construction
 #: round-trip.
 _VAULT_KV_READ_RESPONSE_SCHEMA: dict[str, Any] = {
@@ -250,8 +250,9 @@ async def vault_kv_read(operator: Operator, target: Any, params: dict[str, Any])
     -------
     dict[str, Any]
         ``{"data": <secret data dict>, "version": <int|None>}``. The
-        dispatcher's reducer (v0.2 :class:`PassThroughReducer`) lands
-        this dict as :attr:`OperationResult.result` verbatim.
+        dispatcher's default reducer passes this dict through as
+        :attr:`OperationResult.result` verbatim (it is below the
+        reduction threshold).
 
     Raises
     ------

--- a/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/composites/schemas.py
@@ -253,9 +253,9 @@ NETWORK_PORTGROUP_AUDIT_PARAMETER_SCHEMA: dict[str, Any] = {
 # ---------------------------------------------------------------------------
 #
 # Each response schema captures the aggregated dict the corresponding
-# handler in :mod:`_read` returns. Informational in v0.2 (the
-# dispatcher's :class:`PassThroughReducer` does not validate outbound
-# payloads); declared so the meta-tools
+# handler in :mod:`_read` returns. Informational (the dispatcher's
+# default reducer does not validate outbound payloads against them);
+# declared so the meta-tools
 # (:mod:`meho_backplane.operations.meta_tools`) can surface the shape on
 # ``describe_operation`` calls and so the
 # :class:`~meho_backplane.db.models.EndpointDescriptor` row persists a


### PR DESCRIPTION
## Summary

- Sweep stale "v0.2 default is `PassThroughReducer`" / "future JSONFlux reducer" wording out of the **connector** docstrings/comments, now that #753 made `JsonFluxReducer` the live dispatcher default. Closes #978.
- Rewrote the `ResultHandle` docstring (`connectors/schemas.py`) — it claimed the default reducer "**never** produces a handle"; it now describes the live behavior (handles minted for >50-row / >4 KB set-shaped responses; DuckDB in-memory for v0.2; MinIO/S3 spill + `result_query`/`result_aggregate` meta-tools remain a later Initiative).
- Fixed reducer-name / "future reducer" wording in `vmware_rest/composites/schemas.py`, `pfsense/ops_read.py` (×2), `pfsense/connector.py`, `vault/ops.py` (×2), `_shared/vault_creds.py`.

## Scope

- **Connector docstrings/comments only** (#978's scope). Comment/docstring changes — zero behavior change, zero code-logic change.
- Restores two invariants under `connectors/`: no factually-wrong "default is `PassThroughReducer`" claim, and `grep -rn "future JSONFlux reducer\|future reducer" backend/src` == zero (a pfSense comment had reintroduced it).

## Out of scope (adjacent findings — recorded, not edited here)

The same stale claim also lives in the **operations-substrate core**, a different module area than #978's "connector docstrings":

- `operations/reducer.py` — module docstring ("v0.2 ships only `PassThroughReducer`") + `Reducer` Protocol docstring ("ships `PassThroughReducer` as the only impl")
- `operations/dispatcher.py` — module docstring step 7 ("v0.2 default is `PassThroughReducer`; T6 #397 ships the real reduction") + `_reduce_or_error` docstring
- `operations/__init__.py` — `.reducer` bullet ("the v0.2 `PassThroughReducer` stub … T6 #397 will ship the full reducer")
- `api/v1/health.py:196` — "the dispatcher's `PassThroughReducer` lands it as …"

Accurate `PassThroughReducer` mentions are left intact: the test shim, the import-time `_DEFAULT_REDUCER` module default the lifespan swaps, the class definition, imports, and `main.py:248-254`'s correct swap comment.

## Test plan

- [x] `grep` connectors/ stale wording — zero
- [x] `grep -rn "future JSONFlux reducer\|future reducer" backend/src` — zero (#754 invariant restored)
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/` — clean (265 files)
- [x] `code-quality.py --diff` — 0 blockers (12 pre-existing warnings)
- [x] targeted pytest (pfsense / vault / dispatcher / reducer / robot) — 71 passed; full suite runs in CI

Closes #978
