### PR TITLE
fix(connectors): surface probe()/about() failures in typed-SSH connectors (#986)

### DIFF
--- a/backend/src/meho_backplane/connectors/adapters/ssh.py
+++ b/backend/src/meho_backplane/connectors/adapters/ssh.py
@@ -44,6 +44,7 @@ import asyncssh
 import structlog
 
 from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.schemas import FingerprintResult
 
 logger = structlog.get_logger()
 
@@ -52,6 +53,21 @@ logger = structlog.get_logger()
 type Target = Any
 
 _POOL_TTL_S: float = 300.0  # 5-minute idle eviction window
+
+
+class ConnectorUnreachableError(RuntimeError):
+    """An ``about``-style op ran against an unreachable target.
+
+    Raised by :meth:`SshConnector._assert_reachable` when a connector's
+    :meth:`fingerprint` returned ``reachable=False`` (connection drop,
+    auth failure, command failure mid-fingerprint). The G0.6 dispatcher
+    shim (``execute``) catches every handler exception and maps it to a
+    ``connector_error`` :class:`~meho_backplane.connectors.schemas.OperationResult`
+    (``status="error"``). Raising here is what stops an unreachable
+    target from being reported as a successful (``status="ok"``)
+    operation carrying a dict of empty/None identity fields — the
+    failure mode #986 fixes.
+    """
 
 
 class SshConnector(Connector):
@@ -163,6 +179,28 @@ class SshConnector(Connector):
             exit_code=result.exit_status,
         )
         return result
+
+    def _assert_reachable(self, result: FingerprintResult) -> None:
+        """Raise :exc:`ConnectorUnreachableError` when ``result`` is unreachable.
+
+        Shared guard for typed-SSH ``about``-style ops that delegate to
+        :meth:`fingerprint`. A subclass ``fingerprint`` that catches a
+        mid-call SSH failure returns ``FingerprintResult(reachable=False,
+        extras["error"]=...)`` rather than raising; without this check the
+        ``about`` op would map those empty/None identity fields into a
+        successful (``status="ok"``) :class:`~meho_backplane.connectors.schemas.OperationResult`,
+        masking the failure. Calling this immediately after ``fingerprint``
+        re-raises the failure as a connector error the dispatcher maps to
+        a non-ok result (#986). The original error message, when present,
+        is included so the operator sees the underlying cause.
+        """
+        if result.reachable:
+            return
+        cause = result.extras.get("error")
+        detail = f": {cause}" if cause else ""
+        raise ConnectorUnreachableError(
+            f"target unreachable for {result.product!r} via {result.probe_method!r}{detail}"
+        )
 
     async def aclose(self) -> None:
         """Close all pooled connections. Called by lifespan or cleanup."""

--- a/backend/src/meho_backplane/connectors/bind9/connector.py
+++ b/backend/src/meho_backplane/connectors/bind9/connector.py
@@ -427,24 +427,49 @@ class Bind9Connector(SshConnector):
 
         ``probe_method="ssh: named -v"`` matches the parent
         Initiative #367's WI2 specification.
-        """
-        named_proc = await self._run_command(target, "named -v", raw_jwt="")
-        banner_raw = (named_proc.stdout or "") if hasattr(named_proc, "stdout") else ""
-        banner = banner_raw.strip() if isinstance(banner_raw, str) else ""
-        version_triple = parse_named_version(banner)
 
-        os_proc = await self._run_command(target, "cat /etc/os-release", raw_jwt="")
-        os_raw = (os_proc.stdout or "") if hasattr(os_proc, "stdout") else ""
-        os_content = os_raw if isinstance(os_raw, str) else ""
-        os_identifier: str | None = None
-        if os_proc.exit_status == 0 and os_content.strip():
-            os_identifier = parse_os_release(os_content)
-        if os_identifier is None:
-            debian_proc = await self._run_command(target, "cat /etc/debian_version", raw_jwt="")
-            debian_raw = (debian_proc.stdout or "") if hasattr(debian_proc, "stdout") else ""
-            debian_content = debian_raw.strip() if isinstance(debian_raw, str) else ""
-            if debian_proc.exit_status == 0 and debian_content:
-                os_identifier = f"debian {debian_content}"
+        Unreachable or auth-failure mid-fingerprint (a connection drop,
+        an :exc:`asyncssh.Error`, or an :exc:`asyncio.TimeoutError` from a
+        command timeout) → ``reachable=False`` + ``extras["error"]`` with
+        the exception message, rather than propagating. This mirrors the
+        pfsense sibling and lets the shared
+        :meth:`~meho_backplane.connectors.adapters.ssh.SshConnector._assert_reachable`
+        guard surface the failure consistently from ``about`` (#986).
+        """
+        probed_at = datetime.now(UTC)
+
+        try:
+            named_proc = await self._run_command(target, "named -v", raw_jwt="")
+            banner_raw = (named_proc.stdout or "") if hasattr(named_proc, "stdout") else ""
+            banner = banner_raw.strip() if isinstance(banner_raw, str) else ""
+            version_triple = parse_named_version(banner)
+
+            os_proc = await self._run_command(target, "cat /etc/os-release", raw_jwt="")
+            os_raw = (os_proc.stdout or "") if hasattr(os_proc, "stdout") else ""
+            os_content = os_raw if isinstance(os_raw, str) else ""
+            os_identifier: str | None = None
+            if os_proc.exit_status == 0 and os_content.strip():
+                os_identifier = parse_os_release(os_content)
+            if os_identifier is None:
+                debian_proc = await self._run_command(target, "cat /etc/debian_version", raw_jwt="")
+                debian_raw = (debian_proc.stdout or "") if hasattr(debian_proc, "stdout") else ""
+                debian_content = debian_raw.strip() if isinstance(debian_raw, str) else ""
+                if debian_proc.exit_status == 0 and debian_content:
+                    os_identifier = f"debian {debian_content}"
+        except (OSError, asyncssh.Error) as exc:
+            _log.warning(
+                "bind9_fingerprint_unreachable",
+                target=getattr(target, "name", None),
+                error=str(exc),
+            )
+            return FingerprintResult(
+                vendor="isc",
+                product="bind9",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method="ssh: named -v",
+                extras={"error": str(exc)},
+            )
 
         # ``named.conf`` lives at ``/etc/bind/named.conf`` on every
         # Debian-family distro and at ``/etc/named.conf`` on
@@ -460,7 +485,7 @@ class Bind9Connector(SshConnector):
             version=version_triple,
             build=banner or None,
             reachable=True,
-            probed_at=datetime.now(UTC),
+            probed_at=probed_at,
             probe_method="ssh: named -v",
             extras={
                 "os": os_identifier,
@@ -491,6 +516,14 @@ class Bind9Connector(SshConnector):
         * ``named_config_invalid`` -- named is running but
           ``named-checkconf -p`` exited non-zero (the active
           config does not parse).
+        * ``command_failed`` -- the SSH handshake succeeded but a
+          post-connect command (``pgrep -x named`` /
+          ``named-checkconf -p``) raised (connection dropped mid-probe,
+          an :exc:`asyncssh.Error`, or an :exc:`asyncio.TimeoutError`
+          from the command timeout). Caught here so a mid-probe failure
+          maps to a non-ok
+          :class:`~meho_backplane.connectors.schemas.ProbeResult` rather
+          than escaping ``probe`` as an unhandled exception (#986).
 
         The probe does not mutate state and does not require a
         writable filesystem -- ``named-checkconf -p`` is read-only
@@ -522,23 +555,33 @@ class Bind9Connector(SshConnector):
         except OSError:
             return _result(False, "tcp_unreachable")
 
-        # ``pgrep -x named`` exits 0 iff a process named exactly
-        # ``named`` exists in the process table. ``-x`` requires an
-        # exact match so a different binary that happens to contain
-        # ``named`` in its argv (``named.conf`` editor, etc.) does
-        # not produce a false positive.
-        pgrep_proc = await self._run_command(target, "pgrep -x named", raw_jwt="")
-        if pgrep_proc.exit_status != 0:
-            return _result(False, "named_not_running")
+        # Post-connect commands are guarded: a connection drop, an
+        # ``asyncssh.Error``, or a timeout after a successful handshake
+        # must map to ``command_failed`` rather than propagating an
+        # unhandled exception out of ``probe`` (#986). ``(OSError,
+        # asyncssh.Error)`` mirrors ``fingerprint``'s catch tuple;
+        # ``TimeoutError`` is an ``OSError`` subclass so ``_run_command``'s
+        # ``asyncio.wait_for`` expiry is covered.
+        try:
+            # ``pgrep -x named`` exits 0 iff a process named exactly
+            # ``named`` exists in the process table. ``-x`` requires an
+            # exact match so a different binary that happens to contain
+            # ``named`` in its argv (``named.conf`` editor, etc.) does
+            # not produce a false positive.
+            pgrep_proc = await self._run_command(target, "pgrep -x named", raw_jwt="")
+            if pgrep_proc.exit_status != 0:
+                return _result(False, "named_not_running")
 
-        # ``named-checkconf -p`` parses the running config and emits
-        # the canonicalised form on stdout (which we discard). A
-        # non-zero exit means the config does not parse, which is the
-        # "named is running but the config it would load on reload is
-        # broken" failure mode operators most care about.
-        checkconf_proc = await self._run_command(
-            target, "named-checkconf -p > /dev/null", raw_jwt=""
-        )
+            # ``named-checkconf -p`` parses the running config and emits
+            # the canonicalised form on stdout (which we discard). A
+            # non-zero exit means the config does not parse, which is the
+            # "named is running but the config it would load on reload is
+            # broken" failure mode operators most care about.
+            checkconf_proc = await self._run_command(
+                target, "named-checkconf -p > /dev/null", raw_jwt=""
+            )
+        except (OSError, asyncssh.Error):
+            return _result(False, "command_failed")
         if checkconf_proc.exit_status != 0:
             return _result(False, "named_config_invalid")
 
@@ -566,9 +609,17 @@ class Bind9Connector(SshConnector):
         into ``OperationResult.result`` with a ``None`` handle; only
         set-shaped responses above the threshold are materialized into a
         :class:`~meho_backplane.connectors.schemas.ResultHandle`.
+
+        When the target is unreachable, :meth:`fingerprint` returns
+        ``reachable=False`` rather than raising. ``_assert_reachable``
+        re-raises that as a
+        :exc:`~meho_backplane.connectors.adapters.ssh.ConnectorUnreachableError`
+        so the dispatcher reports a non-ok op instead of a successful op
+        carrying empty/None identity fields (#986).
         """
         del params  # declared empty in schema; intentionally ignored
         result = await self.fingerprint(target)
+        self._assert_reachable(result)
         return {
             "vendor": result.vendor,
             "product": result.product,

--- a/backend/src/meho_backplane/connectors/pfsense/connector.py
+++ b/backend/src/meho_backplane/connectors/pfsense/connector.py
@@ -311,6 +311,13 @@ class PfSenseConnector(SshConnector):
           transient failure so operators get an actionable message
           ("enable SSH shell access on the pfSense WebGUI") rather
           than a generic timeout.
+        * ``command_failed`` -- the SSH handshake succeeded but the
+          post-connect ``cat /etc/version`` raised (connection dropped
+          mid-probe, an :exc:`asyncssh.Error`, or an
+          :exc:`asyncio.TimeoutError` from the command timeout). Caught
+          here so a mid-probe failure maps to a non-ok
+          :class:`~meho_backplane.connectors.schemas.ProbeResult` rather
+          than escaping ``probe`` as an unhandled exception (#986).
 
         The probe does not mutate state and does not write to any
         filesystem -- ``cat /etc/version`` is read-only.
@@ -352,7 +359,18 @@ class PfSenseConnector(SshConnector):
         # pfSense console menu and the command was swallowed. A non-zero
         # exit_status (file not found, permission denied) also signals a
         # broken shell environment and maps to no_shell_access.
-        version_proc = await self._run_command(target, "cat /etc/version", raw_jwt="")
+        #
+        # The post-connect command is guarded: a connection drop, an
+        # ``asyncssh.Error``, or a timeout after a successful handshake must
+        # map to ``command_failed`` rather than propagating an unhandled
+        # exception out of ``probe`` (#986). ``(OSError, asyncssh.Error)``
+        # is the same catch tuple ``fingerprint`` uses; ``TimeoutError`` is
+        # an ``OSError`` subclass so ``_run_command``'s ``asyncio.wait_for``
+        # expiry is covered.
+        try:
+            version_proc = await self._run_command(target, "cat /etc/version", raw_jwt="")
+        except (OSError, asyncssh.Error):
+            return _result(False, "command_failed")
         stdout = (version_proc.stdout or "") if hasattr(version_proc, "stdout") else ""
         content = stdout if isinstance(stdout, str) else ""
         if not content.strip() or version_proc.exit_status != 0:
@@ -374,9 +392,17 @@ class PfSenseConnector(SshConnector):
         fingerprint share one SSH command execution. The returned dict
         is flat (no nested ``extras``) because the dispatcher's default
         reducer forwards the value verbatim.
+
+        When the target is unreachable, :meth:`fingerprint` returns
+        ``reachable=False`` rather than raising. ``_assert_reachable``
+        re-raises that as a
+        :exc:`~meho_backplane.connectors.adapters.ssh.ConnectorUnreachableError`
+        so the dispatcher reports a non-ok op instead of a successful op
+        carrying empty/None identity fields (#986).
         """
         del params  # declared empty in schema; intentionally ignored
         result = await self.fingerprint(target)
+        self._assert_reachable(result)
         return {
             "vendor": result.vendor,
             "product": result.product,

--- a/backend/tests/test_connectors_bind9.py
+++ b/backend/tests/test_connectors_bind9.py
@@ -714,6 +714,126 @@ async def test_probe_ok_when_named_running_and_config_parses() -> None:
     assert result.latency_ms is not None and result.latency_ms >= 0.0
 
 
+@pytest.mark.parametrize(
+    "boom",
+    [
+        OSError("connection reset by peer"),
+        asyncssh.ConnectionLost("channel closed mid-command"),
+        TimeoutError("pgrep timed out"),
+    ],
+)
+async def test_probe_command_failed_when_run_command_raises_after_connect(
+    boom: Exception,
+) -> None:
+    """``_run_command`` raising after a successful ``_connect`` → ``command_failed``.
+
+    AC (#986): a mid-probe failure (connection drop, ``asyncssh.Error``,
+    or timeout after the handshake) must map to a non-ok
+    :class:`ProbeResult` with reason ``command_failed`` — no exception
+    escapes ``probe``. ``TimeoutError`` is an ``OSError`` subclass so the
+    ``(OSError, asyncssh.Error)`` catch tuple covers the timeout case.
+    """
+    connector = Bind9Connector()
+    with (
+        patch.object(connector, "_connect", AsyncMock(return_value=MagicMock())),
+        patch.object(connector, "_run_command", AsyncMock(side_effect=boom)),
+    ):
+        result = await connector.probe(_TARGET)
+    assert result.ok is False
+    assert result.reason == "command_failed"
+
+
+# ---------------------------------------------------------------------------
+# fingerprint -- unreachable guard mirrors pfsense (#986)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "boom",
+    [
+        OSError("Connection refused"),
+        asyncssh.PermissionDenied(reason="publickey auth failed"),
+        TimeoutError("named -v timed out"),
+    ],
+)
+async def test_fingerprint_unreachable_when_run_command_raises(boom: Exception) -> None:
+    """``_run_command`` raising → ``reachable=False`` + ``extras["error"]``.
+
+    AC (#986): bind9's ``fingerprint`` now guards the post-connect
+    commands the way the pfsense sibling does, so a mid-fingerprint
+    failure returns a non-reachable result rather than propagating. This
+    is what lets the shared ``_assert_reachable`` guard surface the
+    failure consistently from ``about``.
+    """
+    connector = Bind9Connector()
+    with patch.object(connector, "_run_command", AsyncMock(side_effect=boom)):
+        result = await connector.fingerprint(_TARGET)
+    assert result.reachable is False
+    assert result.vendor == "isc"
+    assert result.product == "bind9"
+    assert result.probe_method == "ssh: named -v"
+    assert "error" in result.extras
+
+
+# ---------------------------------------------------------------------------
+# about -- surfaces unreachability rather than masking it as status="ok" (#986)
+# ---------------------------------------------------------------------------
+
+
+async def test_about_raises_connector_unreachable_on_unreachable_target() -> None:
+    """``about`` against an unreachable target raises, never returns empty fields.
+
+    AC (#986): ``fingerprint`` returns ``reachable=False`` on a connection
+    failure; ``about`` must surface that as a
+    :exc:`ConnectorUnreachableError` rather than returning a dict of
+    empty/None identity fields the dispatcher would report as
+    ``status="ok"``.
+    """
+    from meho_backplane.connectors.adapters.ssh import ConnectorUnreachableError
+
+    connector = Bind9Connector()
+    with (
+        patch.object(
+            connector,
+            "_run_command",
+            AsyncMock(side_effect=OSError("Connection refused")),
+        ),
+        pytest.raises(ConnectorUnreachableError, match="Connection refused"),
+    ):
+        await connector.about(_TARGET, {})
+
+
+async def test_execute_about_unreachable_returns_connector_error_not_ok() -> None:
+    """End-to-end: ``execute("bind9.about")`` on an unreachable target → non-ok.
+
+    The dispatcher shim catches the ``ConnectorUnreachableError`` raised
+    by ``about`` and maps it to the ``connector_error`` envelope. The op
+    is reported as ``status="error"`` — not a successful op carrying empty
+    identity fields (#986).
+    """
+    from meho_backplane.operations import typed_register as tr_module
+    from meho_backplane.operations._handler_resolve import reset_handler_cache
+
+    reset_handler_cache()
+    with patch.object(tr_module, "encode_endpoint_text", AsyncMock(return_value=[0.1] * 384)):
+        await Bind9Connector.register_operations()
+
+    connector = Bind9Connector()
+    with patch.object(
+        connector,
+        "_run_command",
+        AsyncMock(side_effect=OSError("Connection refused")),
+    ):
+        result = await connector.execute(_TARGET, "bind9.about", {})
+
+    assert isinstance(result, OperationResult)
+    assert result.status == "error"
+    assert result.status != "ok"
+    assert result.error is not None and result.error.startswith("connector_error:")
+    assert result.extras.get("error_code") == "connector_error"
+    assert result.extras.get("exception_class") == "ConnectorUnreachableError"
+
+
 # ---------------------------------------------------------------------------
 # register_operations -- upsert + idempotency
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_pfsense_auth.py
+++ b/backend/tests/test_connectors_pfsense_auth.py
@@ -487,6 +487,96 @@ async def test_probe_ok_when_ssh_connects_and_version_returns_content() -> None:
     assert result.latency_ms >= 0.0
 
 
+@pytest.mark.parametrize(
+    "boom",
+    [
+        OSError("connection reset by peer"),
+        asyncssh.ConnectionLost("channel closed mid-command"),
+        TimeoutError("cat /etc/version timed out"),
+    ],
+)
+async def test_probe_command_failed_when_run_command_raises_after_connect(
+    boom: Exception,
+) -> None:
+    """``_run_command`` raising after a successful ``_connect`` → ``command_failed``.
+
+    AC (#986): a mid-probe failure (connection drop, ``asyncssh.Error``,
+    or timeout after the handshake) must map to a non-ok
+    :class:`ProbeResult` with reason ``command_failed`` — no exception
+    escapes ``probe``. ``TimeoutError`` is an ``OSError`` subclass so the
+    ``(OSError, asyncssh.Error)`` catch tuple covers the timeout case.
+    """
+    connector = PfSenseConnector()
+    conn_mock = MagicMock()
+    with (
+        patch.object(connector, "_connect", AsyncMock(return_value=conn_mock)),
+        patch.object(connector, "_run_command", AsyncMock(side_effect=boom)),
+    ):
+        result = await connector.probe(_NO_CREDS_TARGET)
+    assert result.ok is False
+    assert result.reason == "command_failed"
+
+
+# ---------------------------------------------------------------------------
+# about -- surfaces unreachability rather than masking it as status="ok" (#986)
+# ---------------------------------------------------------------------------
+
+
+async def test_about_raises_connector_unreachable_on_unreachable_target() -> None:
+    """``about`` against an unreachable target raises, never returns empty fields.
+
+    AC (#986): ``fingerprint`` returns ``reachable=False`` on a connection
+    failure; ``about`` must surface that as a
+    :exc:`ConnectorUnreachableError` rather than returning a dict of
+    empty/None identity fields the dispatcher would report as
+    ``status="ok"``.
+    """
+    from meho_backplane.connectors.adapters.ssh import ConnectorUnreachableError
+
+    connector = PfSenseConnector()
+    with (
+        patch.object(
+            connector,
+            "_run_command",
+            AsyncMock(side_effect=OSError("Connection refused")),
+        ),
+        pytest.raises(ConnectorUnreachableError, match="Connection refused"),
+    ):
+        await connector.about(_NO_CREDS_TARGET, {})
+
+
+async def test_execute_about_unreachable_returns_connector_error_not_ok() -> None:
+    """End-to-end: ``execute("pfsense.about")`` on an unreachable target → non-ok.
+
+    The dispatcher shim catches the ``ConnectorUnreachableError`` raised
+    by ``about`` and maps it to the ``connector_error`` envelope. The op
+    is reported as ``status="error"`` — not a successful op carrying empty
+    identity fields (#986).
+    """
+    from meho_backplane.connectors.schemas import OperationResult
+    from meho_backplane.operations import typed_register as tr_module
+    from meho_backplane.operations._handler_resolve import reset_handler_cache
+
+    reset_handler_cache()
+    with patch.object(tr_module, "encode_endpoint_text", AsyncMock(return_value=[0.1] * 384)):
+        await PfSenseConnector.register_operations()
+
+    connector = PfSenseConnector()
+    with patch.object(
+        connector,
+        "_run_command",
+        AsyncMock(side_effect=OSError("Connection refused")),
+    ):
+        result = await connector.execute(_NO_CREDS_TARGET, "pfsense.about", {})
+
+    assert isinstance(result, OperationResult)
+    assert result.status == "error"
+    assert result.status != "ok"
+    assert result.error is not None and result.error.startswith("connector_error:")
+    assert result.extras.get("error_code") == "connector_error"
+    assert result.extras.get("exception_class") == "ConnectorUnreachableError"
+
+
 # ---------------------------------------------------------------------------
 # Per-target isolation
 # ---------------------------------------------------------------------------

--- a/docs/codebase/connectors-bind9.md
+++ b/docs/codebase/connectors-bind9.md
@@ -146,6 +146,13 @@ both share one connection):
 (`/etc/bind/named.conf`); RHEL-family detection lands in a follow-up
 once T2 ships `bind9.config.show`.
 
+The `_run_command` calls are wrapped in a `(OSError, asyncssh.Error)`
+guard so a connection drop, an `asyncssh.Error`, or a timeout
+mid-fingerprint returns `reachable=False` + `extras["error"]` rather than
+propagating (mirrors the pfsense sibling). This is what lets the shared
+`SshConnector._assert_reachable` guard surface the failure consistently
+from `about` (#986).
+
 ## `probe(target)`
 
 Five distinct failure-reason values:
@@ -157,6 +164,19 @@ Five distinct failure-reason values:
 | `auth_failed` | `asyncssh.PermissionDenied` (credentials rejected) |
 | `named_not_running` | `pgrep -x named` exited non-zero |
 | `named_config_invalid` | `named-checkconf -p > /dev/null` exited non-zero |
+| `command_failed` | a post-connect command (`pgrep` / `named-checkconf`) raised after a successful connect (drop / `asyncssh.Error` / timeout) |
+
+The post-connect commands are wrapped in a `(OSError, asyncssh.Error)`
+guard so a mid-probe failure maps to `command_failed` rather than escaping
+`probe()` as an unhandled exception (#986). `TimeoutError` is an `OSError`
+subclass, so the command-timeout case is covered by the same tuple.
+
+`about` reuses `fingerprint` and calls the shared
+`SshConnector._assert_reachable(result)` guard, which raises
+`ConnectorUnreachableError` when the fingerprint is not reachable; the
+dispatcher maps it to a `connector_error` `OperationResult`
+(`status="error"`) rather than reporting empty identity fields as a
+successful op (#986).
 
 The probe is read-only and does not require a writable filesystem.
 `named-checkconf -p` parses the active config and emits its

--- a/docs/codebase/connectors-pfsense.md
+++ b/docs/codebase/connectors-pfsense.md
@@ -85,14 +85,32 @@ Unreachable targets (OSError or asyncssh.Error from `_run_command`) return
 | SSH handshake failed (protocol error) | `False` | `ssh_handshake_failed` |
 | SSH auth rejected | `False` | `auth_failed` |
 | `ValueError` from `_auth_config` (missing key) | `False` | `auth_failed` |
+| `cat /etc/version` raises after a successful connect (drop / `asyncssh.Error` / timeout) | `False` | `command_failed` |
 | `cat /etc/version` stdout empty or non-zero exit | `False` | `no_shell_access` |
 | SSH connects + `/etc/version` returns content | `True` | `None` |
+
+The post-connect `cat /etc/version` is wrapped in a `(OSError,
+asyncssh.Error)` guard so a connection drop, an `asyncssh.Error`, or a
+timeout after the handshake maps to `command_failed` rather than escaping
+`probe()` as an unhandled exception (#986). `TimeoutError` is an `OSError`
+subclass, so the command-timeout case is covered by the same tuple.
 
 The `no_shell_access` reason targets the console-menu trap: pfSense's
 default `admin` SSH session may land in the pfSense console menu (a PHP REPL)
 rather than a POSIX shell if the account is not configured with a forced
 command or if SSH key auth is not properly wired. In that scenario, `cat`
 returns no output; the probe correctly reports the shell is inaccessible.
+
+### About (`pfsense.about`) — unreachability surfacing
+
+`about()` reuses `fingerprint()`, which returns `reachable=False` (rather
+than raising) on a connection failure. `about()` calls the shared
+`SshConnector._assert_reachable(result)` guard immediately after, which
+raises `ConnectorUnreachableError` when the fingerprint is not reachable.
+Without this check `about()` would return a dict of empty/None identity
+fields that the dispatcher reports as a successful (`status="ok"`) op,
+masking the failure (#986). The raised error is caught by the dispatcher
+shim and mapped to a `connector_error` `OperationResult` (`status="error"`).
 
 ### Dispatcher shim (`execute`)
 


### PR DESCRIPTION
## Summary
- Guards the post-connect `_run_command` calls in `probe()` for both the pfsense and bind9 typed-SSH connectors — a connection drop, `asyncssh.Error`, or timeout after a successful handshake now maps to `ProbeResult(ok=False, reason="command_failed")` instead of escaping `probe()` as an unhandled exception.
- Makes `about()` surface unreachability instead of masking it: a new shared `SshConnector._assert_reachable` helper (plus a `ConnectorUnreachableError` on the SSH base) re-raises when `fingerprint()` returned `reachable=False`; the dispatcher shim maps that to a `connector_error` `OperationResult` (`status="error"`) rather than a successful op carrying empty/None identity fields.
- Aligns bind9's `fingerprint()` with the pfsense sibling (guards its `_run_command` calls, returns `reachable=False` on failure) so the shared `_assert_reachable` guard works uniformly across both — and future typed-SSH connectors inherit the correct shape from `SshConnector`.

## Test plan
- [x] `ruff check` — clean (5 files)
- [x] `ruff format --check` — clean
- [x] `mypy` (changed source) — `Success: no issues found in 3 source files`
- [x] `pytest tests/test_connectors_pfsense_auth.py tests/test_connectors_bind9.py` — 72 passed
- [x] AC: pfsense + bind9 `probe()` with a `_run_command` that raises after a successful `_connect` → `ProbeResult(ok=False, reason="command_failed")`, no exception escapes (`test_probe_command_failed_when_run_command_raises_after_connect`, parametrized over OSError / `asyncssh.ConnectionLost` / TimeoutError, in both test files)
- [x] AC: pfsense + bind9 `about()` against an unreachable target raises `ConnectorUnreachableError` and `execute("…​.about")` returns `status="error"` / `connector_error` — never `status="ok"` (`test_about_raises_connector_unreachable_on_unreachable_target` + `test_execute_about_unreachable_returns_connector_error_not_ok`)
- [x] code-quality gate (`--diff`) — 0 blockers (size/return-count warnings only, mostly pre-existing/docstring-dense)

## Out of scope
- Connectors not exhibiting the pattern; the HTTP connectors; redesigning the probe `reason` taxonomy (per issue).

## Adjacent findings (recorded, not fixed)
- `pfsense/connector.py` is 682 lines (pre-existing, > the 600-line soft cap); `probe()` / `execute()` / `register_operations()` in both connectors exceed the 60-line warn threshold (docstring-dense). pfsense `probe()` trips `PLR0911` (7 returns > 6) — a property of the distinct-per-reason design, which the issue puts out of scope.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #986
