### PR TITLE
fix(connectors): G3.7 gcloud SA-JSON-key gate fires on op/fingerprint/probe paths (#985)

### DIFF
--- a/backend/src/meho_backplane/connectors/gcloud/connector.py
+++ b/backend/src/meho_backplane/connectors/gcloud/connector.py
@@ -36,12 +36,16 @@ SA-JSON-key refusal
 -------------------
 
 Org policy ``constraints/iam.disableServiceAccountKeyCreation`` is in force
-on the consumer's GCP organization. :meth:`auth_headers` inspects the Vault
+on the consumer's GCP organization. :meth:`_ensure_token` — the single
+token-acquisition chokepoint every operation, :meth:`fingerprint`,
+:meth:`probe`, and :meth:`auth_headers` flow through — inspects the Vault
 ``secret_ref`` payload for SA-JSON-key field names (``private_key``,
 ``private_key_id``, ``client_email``, etc.) and raises a :exc:`ValueError`
 with a clear message before building any token. The error names the target
 and the offending fields so operators can identify and remove the misdirected
-key material.
+key material. Routing the gate through :meth:`_ensure_token` (rather than only
+:meth:`auth_headers`, which no live path calls) makes the refusal fire on the
+operation / fingerprint / probe paths too (#985).
 
 Target conventions
 ------------------
@@ -90,6 +94,7 @@ import httpx
 import structlog
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.gcloud.session import (
     GcloudCredentialsLoader,
@@ -300,20 +305,27 @@ class GcloudConnector(HttpConnector):
            ``IMPERSONATION`` or ``None`` (pre-G0.3 sentinel). Any other
            value raises :exc:`NotImplementedError`.
 
-        2. **SA-JSON-key refusal**: loads the Vault ``secret_ref`` payload
-           and checks for SA-JSON-key field names. If any are found, raises
+        2. **SA-JSON-key refusal**: :meth:`_ensure_token` loads the Vault
+           ``secret_ref`` payload and checks for SA-JSON-key field names
+           before building any token. If any are found, it raises
            :exc:`ValueError` naming the target and the offending fields.
            No token is built.
 
-        3. **Token fetch / cache**: calls :meth:`_ensure_token` which
-           builds impersonated credentials via ADC + impersonation if the
-           cache is empty, then returns the bearer token.
+        3. **Token fetch / cache**: :meth:`_ensure_token` builds
+           impersonated credentials via ADC + impersonation if the cache
+           is empty, then returns the bearer token.
 
-        The ``operator`` is forwarded to :meth:`_gate_sa_key_refusal` so the
-        credentials loader reads the per-target Vault secret under the
-        operator's identity. It is NOT forwarded to GCP — ``IMPERSONATION``
-        auth drives all GCP calls through the google-auth impersonation
-        chain, not the operator's OIDC JWT.
+        The ``operator`` is forwarded to :meth:`_ensure_token` (and from
+        there to :meth:`_gate_sa_key_refusal`) so the credentials loader
+        reads the per-target Vault secret under the operator's identity. It
+        is NOT forwarded to GCP — ``IMPERSONATION`` auth drives all GCP
+        calls through the google-auth impersonation chain, not the
+        operator's OIDC JWT.
+
+        ``auth_headers`` is no longer the only entry point that enforces the
+        SA-JSON-key refusal: the gate now lives inside :meth:`_ensure_token`,
+        the single token-acquisition chokepoint every operation,
+        :meth:`fingerprint`, and :meth:`probe` flow through. See #985.
         """
         auth_model = getattr(target, "auth_model", None)
         if not _is_acceptable_auth_model(auth_model):
@@ -322,8 +334,7 @@ class GcloudConnector(HttpConnector):
                 f"{AuthModel.IMPERSONATION.value!r}; target "
                 f"{target.name!r} requested auth_model={auth_model!r}"
             )
-        await self._gate_sa_key_refusal(target, operator)
-        token = await self._ensure_token(target)
+        token = await self._ensure_token(target, operator)
         return {"Authorization": f"Bearer {token}"}
 
     # ------------------------------------------------------------------
@@ -333,13 +344,16 @@ class GcloudConnector(HttpConnector):
     async def _gate_sa_key_refusal(self, target: GcloudTargetLike, operator: Operator) -> None:
         """Raise :exc:`ValueError` if the Vault secret carries SA-JSON-key fields.
 
-        The check runs on every :meth:`auth_headers` call (not just the
+        The check runs on every :meth:`_ensure_token` call (not just the
         first) so a Vault secret rotation that introduces key material is
-        caught on the next request rather than silently ignored due to
-        caching. The credentials_loader is responsible for cache behaviour;
-        this method only validates the shape. ``operator`` is forwarded to the
-        loader so the per-target Vault read happens under the operator's
-        identity.
+        caught on the next request rather than silently ignored due to token
+        caching. Because every operation, :meth:`fingerprint`, and
+        :meth:`probe` acquire their token through :meth:`_ensure_token`, the
+        refusal fires on all of those paths — not only on a direct
+        :meth:`auth_headers` call (#985). The credentials_loader is
+        responsible for cache behaviour; this method only validates the
+        shape. ``operator`` is forwarded to the loader so the per-target
+        Vault read happens under the operator's identity.
 
         Raises
         ------
@@ -366,7 +380,7 @@ class GcloudConnector(HttpConnector):
     # Token management
     # ------------------------------------------------------------------
 
-    async def _ensure_token(self, target: GcloudTargetLike) -> str:
+    async def _ensure_token(self, target: GcloudTargetLike, operator: Operator) -> str:
         """Return a valid bearer token for *target*, fetching if needed.
 
         Builds impersonated credentials on first use via
@@ -377,7 +391,19 @@ class GcloudConnector(HttpConnector):
         first-use callers for the same target without blocking callers for
         different targets (M1 fix). Subsequent calls take the fast path
         (cached token still valid) without acquiring any lock.
+
+        The SA-JSON-key refusal gate runs on **every** call — before the
+        cache fast path — so a Vault secret rotation that introduces key
+        material is refused on the next request regardless of a still-valid
+        cached token. This is the single token-acquisition chokepoint every
+        operation, :meth:`fingerprint`, :meth:`probe`, and
+        :meth:`auth_headers` flow through, so threading the gate here makes
+        the refusal fire on all of those paths (#985). ``operator`` is
+        forwarded to the gate so the per-target Vault read happens under the
+        operator's identity.
         """
+        await self._gate_sa_key_refusal(target, operator)
+
         # Fast path: cached and valid
         cached_token = self._token_cache.get(target.name)
         if cached_token is not None:
@@ -483,6 +509,7 @@ class GcloudConnector(HttpConnector):
         target: GcloudTargetLike,
         abs_url: str,
         *,
+        operator: Operator,
         params: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """GET an absolute GCP API URL, handle 401 with one token refresh.
@@ -492,10 +519,14 @@ class GcloudConnector(HttpConnector):
         The ``httpx.AsyncClient`` base_url is a placeholder; ``abs_url``
         overrides it fully.
 
+        ``operator`` is required and forwarded to :meth:`_ensure_token` so
+        the SA-JSON-key refusal gate runs (under the operator's identity)
+        before any token is built or GCP request issued (#985).
+
         On a 401 response, the token is refreshed once and the request
         retried. Any subsequent non-2xx raises ``httpx.HTTPStatusError``.
         """
-        token = await self._ensure_token(target)
+        token = await self._ensure_token(target, operator)
         client = await self._http_client(target)
         headers = {"Authorization": f"Bearer {token}"}
 
@@ -523,14 +554,24 @@ class GcloudConnector(HttpConnector):
         ``product="gcp-project"`` — this fingerprints the project resource
         itself, not the GCP API surface.
 
-        On any transport, auth, or status failure, returns a non-reachable
-        :class:`FingerprintResult` whose ``extras["error"]`` carries the
-        exception class + message.
+        The SA-JSON-key refusal gate runs at token acquisition (inside
+        :meth:`_get_json_abs` → :meth:`_ensure_token`). ``fingerprint`` and
+        :meth:`probe` are operator-less ABC entry points, so they synthesise
+        a frozen system operator (empty ``raw_jwt``) for the gate's Vault
+        read — the same stand-in the other operator-less probe paths use. A
+        target whose ``secret_ref`` carries SA-JSON-key fields therefore
+        raises :exc:`ValueError` from the gate, which is caught below and
+        surfaced as ``reachable=False`` rather than silently proceeding to a
+        GCP call (#985).
+
+        On any transport, auth, or status failure (including the SA-JSON-key
+        refusal), returns a non-reachable :class:`FingerprintResult` whose
+        ``extras["error"]`` carries the exception class + message.
         """
         probed_at = datetime.now(UTC)
         url = f"{_CRM_API_BASE}/v1/projects/{target.gcp_project}"
         try:
-            payload = await self._get_json_abs(target, url)
+            payload = await self._get_json_abs(target, url, operator=synthesise_system_operator())
         except (httpx.HTTPError, OSError, RuntimeError, ValueError) as exc:
             return FingerprintResult(
                 vendor="google",
@@ -573,14 +614,23 @@ class GcloudConnector(HttpConnector):
         4. The project exists and the impersonated SA has at minimum
            ``resourcemanager.projects.get`` permission.
 
+        The SA-JSON-key refusal gate runs at token acquisition (inside
+        :meth:`_get_json_abs` → :meth:`_ensure_token`). ``probe`` is an
+        operator-less ABC entry point, so it synthesises a frozen system
+        operator (empty ``raw_jwt``) for the gate's Vault read. A target
+        whose ``secret_ref`` carries SA-JSON-key fields raises
+        :exc:`ValueError` from the gate, which is caught below and surfaced
+        as ``ok=False`` + ``reason`` rather than silently proceeding (#985).
+
         Returns ``ok=True`` when the response is HTTP 200 with a
         ``projectId`` field matching ``target.gcp_project``.
-        Returns ``ok=False`` + ``reason`` on any failure.
+        Returns ``ok=False`` + ``reason`` on any failure (including the
+        SA-JSON-key refusal).
         """
         probed_at = datetime.now(UTC)
         url = f"{_CRM_API_BASE}/v1/projects/{target.gcp_project}"
         try:
-            payload = await self._get_json_abs(target, url)
+            payload = await self._get_json_abs(target, url, operator=synthesise_system_operator())
         except (httpx.HTTPError, OSError, RuntimeError, ValueError) as exc:
             return ProbeResult(
                 ok=False,
@@ -643,16 +693,22 @@ class GcloudConnector(HttpConnector):
         target: GcloudTargetLike,
         abs_url: str,
         *,
+        operator: Operator,
         json_body: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """POST to an absolute GCP API URL, handle 401 with one token refresh.
 
         Used by ops that call GCP APIs with POST semantics (e.g.
         ``cloudresourcemanager.googleapis.com/v1/projects/<id>:getIamPolicy``).
+
+        ``operator`` is required and forwarded to :meth:`_ensure_token` so
+        the SA-JSON-key refusal gate runs (under the operator's identity)
+        before any token is built or GCP request issued (#985).
+
         On a 401 response, the token is refreshed once and the request retried.
         Any subsequent non-2xx raises ``httpx.HTTPStatusError``.
         """
-        token = await self._ensure_token(target)
+        token = await self._ensure_token(target, operator)
         client = await self._http_client(target)
         headers = {"Authorization": f"Bearer {token}"}
 
@@ -758,25 +814,38 @@ class GcloudConnector(HttpConnector):
 
     async def gcloud_about(
         self,
+        operator: Operator,
         target: GcloudTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
         """Return GCP project identity summary.
 
-        Op-id: ``gcloud.about``. Wraps :meth:`fingerprint` to expose the same
-        project-identity data through the typed-op dispatcher as a flat dict.
+        Op-id: ``gcloud.about``. Exposes the same project-identity data as
+        :meth:`fingerprint` through the typed-op dispatcher as a flat dict,
+        but fetches the CRM project resource directly with the real
+        ``operator`` so the SA-JSON-key refusal gate runs under the
+        operator's identity (the dispatcher threads ``operator`` because the
+        handler signature names it — #985). Delegating to :meth:`fingerprint`
+        would instead run the gate under a synthesised system operator,
+        losing the operation's identity context.
         """
         del params
-        result = await self.fingerprint(target)
+        url = f"{_CRM_API_BASE}/v1/projects/{target.gcp_project}"
+        payload = await self._get_json_abs(target, url, operator=operator)
+        organization: str | None = None
+        parent = payload.get("parent") or {}
+        if parent.get("type") == "organization":
+            organization = parent.get("id")
         return {
-            "project_id": result.extras.get("project_id"),
-            "project_number": result.extras.get("project_number"),
-            "lifecycle_state": result.extras.get("lifecycle_state"),
-            "organization": result.extras.get("organization"),
+            "project_id": payload.get("projectId"),
+            "project_number": payload.get("projectNumber"),
+            "lifecycle_state": payload.get("lifecycleState"),
+            "organization": organization,
         }
 
     async def gcloud_project_describe(
         self,
+        operator: Operator,
         target: GcloudTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
@@ -787,10 +856,11 @@ class GcloudConnector(HttpConnector):
         """
         del params
         url = f"{_CRM_API_BASE}/v1/projects/{target.gcp_project}"
-        return await self._get_json_abs(target, url)
+        return await self._get_json_abs(target, url, operator=operator)
 
     async def gcloud_services_list(
         self,
+        operator: Operator,
         target: GcloudTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
@@ -812,7 +882,9 @@ class GcloudConnector(HttpConnector):
         while True:
             if page_token:
                 query_params["pageToken"] = page_token
-            payload = await self._get_json_abs(target, base_url, params=query_params)
+            payload = await self._get_json_abs(
+                target, base_url, operator=operator, params=query_params
+            )
             for svc in payload.get("services") or []:
                 config = svc.get("config") or {}
                 rows.append(
@@ -830,6 +902,7 @@ class GcloudConnector(HttpConnector):
 
     async def gcloud_iam_service_accounts_list(
         self,
+        operator: Operator,
         target: GcloudTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
@@ -847,7 +920,9 @@ class GcloudConnector(HttpConnector):
             query_params: dict[str, Any] = {}
             if page_token:
                 query_params["pageToken"] = page_token
-            payload = await self._get_json_abs(target, base_url, params=query_params or None)
+            payload = await self._get_json_abs(
+                target, base_url, operator=operator, params=query_params or None
+            )
             for sa in payload.get("accounts") or []:
                 rows.append(
                     {
@@ -864,8 +939,13 @@ class GcloudConnector(HttpConnector):
 
         return {"rows": rows, "total": len(rows)}
 
+    # C901 pre-existing (11>10): the zone/aggregated branch + paginated
+    # while-loops predate this Task. #985 only threads `operator` for the
+    # SA-key gate; complexity is unchanged from main. Refactoring the
+    # pagination shape is a separate concern.  # code-quality-allow: C901
     async def gcloud_compute_instances_list(
         self,
+        operator: Operator,
         target: GcloudTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
@@ -890,7 +970,9 @@ class GcloudConnector(HttpConnector):
                 query_params: dict[str, Any] = {}
                 if page_token:
                     query_params["pageToken"] = page_token
-                payload = await self._get_json_abs(target, base_url, params=query_params or None)
+                payload = await self._get_json_abs(
+                    target, base_url, operator=operator, params=query_params or None
+                )
                 for inst in payload.get("items") or []:
                     rows.append(_instance_row(inst, zone=zone))
                 page_token = payload.get("nextPageToken")
@@ -905,7 +987,9 @@ class GcloudConnector(HttpConnector):
                 query_params = {}
                 if page_token:
                     query_params["pageToken"] = page_token
-                payload = await self._get_json_abs(target, base_url, params=query_params or None)
+                payload = await self._get_json_abs(
+                    target, base_url, operator=operator, params=query_params or None
+                )
                 for zone_key, zone_data in (payload.get("items") or {}).items():
                     zone_name = zone_key.removeprefix("zones/")
                     for inst in zone_data.get("instances") or []:
@@ -918,6 +1002,7 @@ class GcloudConnector(HttpConnector):
 
     async def gcloud_compute_networks_list(
         self,
+        operator: Operator,
         target: GcloudTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
@@ -938,7 +1023,9 @@ class GcloudConnector(HttpConnector):
             query_params: dict[str, Any] = {}
             if page_token:
                 query_params["pageToken"] = page_token
-            payload = await self._get_json_abs(target, base_url, params=query_params or None)
+            payload = await self._get_json_abs(
+                target, base_url, operator=operator, params=query_params or None
+            )
             for net in payload.get("items") or []:
                 routing_config = net.get("routingConfig") or {}
                 rows.append(
@@ -956,8 +1043,13 @@ class GcloudConnector(HttpConnector):
 
         return {"rows": rows, "total": len(rows)}
 
+    # C901 pre-existing (11>10): the region/aggregated branch + paginated
+    # while-loops predate this Task. #985 only threads `operator` for the
+    # SA-key gate; complexity is unchanged from main. Refactoring the
+    # pagination shape is a separate concern.  # code-quality-allow: C901
     async def gcloud_compute_subnetworks_list(
         self,
+        operator: Operator,
         target: GcloudTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
@@ -980,7 +1072,9 @@ class GcloudConnector(HttpConnector):
                 query_params: dict[str, Any] = {}
                 if page_token:
                     query_params["pageToken"] = page_token
-                payload = await self._get_json_abs(target, base_url, params=query_params or None)
+                payload = await self._get_json_abs(
+                    target, base_url, operator=operator, params=query_params or None
+                )
                 for sn in payload.get("items") or []:
                     rows.append(_subnet_row(sn, region=region))
                 page_token = payload.get("nextPageToken")
@@ -995,7 +1089,9 @@ class GcloudConnector(HttpConnector):
                 query_params = {}
                 if page_token:
                     query_params["pageToken"] = page_token
-                payload = await self._get_json_abs(target, base_url, params=query_params or None)
+                payload = await self._get_json_abs(
+                    target, base_url, operator=operator, params=query_params or None
+                )
                 for region_key, region_data in (payload.get("items") or {}).items():
                     region_name = region_key.removeprefix("regions/")
                     for sn in region_data.get("subnetworks") or []:
@@ -1008,6 +1104,7 @@ class GcloudConnector(HttpConnector):
 
     async def gcloud_iam_policy_read(
         self,
+        operator: Operator,
         target: GcloudTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
@@ -1019,7 +1116,7 @@ class GcloudConnector(HttpConnector):
         """
         del params
         url = f"{_CRM_API_BASE}/v1/projects/{target.gcp_project}:getIamPolicy"
-        payload = await self._post_json_abs(target, url)
+        payload = await self._post_json_abs(target, url, operator=operator)
         return {
             "version": payload.get("version"),
             "etag": payload.get("etag"),

--- a/backend/tests/test_connectors_gcloud_auth.py
+++ b/backend/tests/test_connectors_gcloud_auth.py
@@ -488,7 +488,7 @@ async def test_401_triggers_token_refresh_and_retry() -> None:
 
         route.side_effect = _side_effect
 
-        result = await connector._get_json_abs(_TARGET_A, url)
+        result = await connector._get_json_abs(_TARGET_A, url, operator=_OPERATOR)
 
     assert result == {"projectId": "my-project-123"}
     assert call_count == 2  # initial + retry after refresh
@@ -707,3 +707,143 @@ async def test_aclose_with_empty_cache_is_noop() -> None:
     await connector.aclose()
     assert connector._token_cache == {}
     assert connector._clients == {}
+
+
+# ---------------------------------------------------------------------------
+# SA-JSON-key refusal fires on the operation / fingerprint / probe paths (#985)
+#
+# The gate used to be invoked only from auth_headers(); no live path calls
+# auth_headers(). These tests drive the real entry points — typed-op handlers
+# (which the dispatcher reaches), fingerprint(), and probe() — and assert the
+# refusal fires there, that no token is built, and that no GCP request is
+# issued.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_op_handler_get_path_refuses_sa_json_key() -> None:
+    """A GET-based typed op (gcloud.about) refuses an SA-JSON-key secret.
+
+    Drives the op-handler entry point the dispatcher invokes (signature
+    ``(operator, target, params)``) rather than ``auth_headers()`` directly.
+    Asserts the gate raises, no token is built, and — via respx with no routes
+    registered — that no GCP request was issued (respx raises on any unmocked
+    request, so reaching the wire would surface as a different error).
+    """
+    connector = GcloudConnector(credentials_loader=_sa_key_loader)
+    with respx.mock(assert_all_called=False), pytest.raises(ValueError) as exc_info:
+        await connector.gcloud_about(operator=_OPERATOR, target=_TARGET_A, params={})
+    msg = str(exc_info.value)
+    assert "gcloud-a" in msg
+    assert "private_key" in msg
+    assert "disableServiceAccountKeyCreation" in msg
+    assert _TARGET_A.name not in connector._token_cache
+    assert not connector._creds_cache
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_op_handler_post_path_refuses_sa_json_key() -> None:
+    """A POST-based typed op (gcloud.iam.policy.read) refuses an SA-JSON-key secret.
+
+    Exercises the ``_post_json_abs`` → ``_ensure_token`` path so the gate is
+    proven reachable from the POST entry point too, not only the GET one.
+    """
+    connector = GcloudConnector(credentials_loader=_sa_key_loader)
+    with respx.mock(assert_all_called=False), pytest.raises(ValueError) as exc_info:
+        await connector.gcloud_iam_policy_read(operator=_OPERATOR, target=_TARGET_A, params={})
+    msg = str(exc_info.value)
+    assert "gcloud-a" in msg
+    assert "private_key" in msg
+    assert _TARGET_A.name not in connector._token_cache
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_op_handler_compliant_secret_does_not_refuse() -> None:
+    """A compliant (empty) secret lets the op proceed to the GCP call.
+
+    Guards against the gate over-firing: the refusal must trigger only on
+    SA-JSON-key material, not on every call.
+    """
+    mock_creds = _make_mock_creds("tok")
+    adc_loader, _pf, _ = _make_adc_loader("tok")
+    connector = GcloudConnector(credentials_loader=_empty_loader, adc_loader=adc_loader)
+
+    url = "https://cloudresourcemanager.googleapis.com/v1/projects/my-project-123"
+    with (
+        patch("google.auth.impersonated_credentials.Credentials", return_value=mock_creds),
+        respx.mock() as mock,
+    ):
+        mock.get(url).respond(
+            200,
+            json={
+                "projectId": "my-project-123",
+                "projectNumber": "987654321",
+                "lifecycleState": "ACTIVE",
+                "parent": {"type": "organization", "id": "112233445566"},
+            },
+        )
+        result = await connector.gcloud_about(operator=_OPERATOR, target=_TARGET_A, params={})
+
+    assert result["project_id"] == "my-project-123"
+    assert result["project_number"] == "987654321"
+    assert result["organization"] == "112233445566"
+    assert connector._token_cache.get("gcloud-a") == "tok"
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_fingerprint_refuses_sa_json_key_returns_unreachable() -> None:
+    """fingerprint() surfaces the SA-JSON-key refusal as reachable=False.
+
+    fingerprint() has no operator in its ABC signature, so it synthesises a
+    system operator for the gate. The refusal ValueError is caught and turned
+    into a non-reachable result rather than silently proceeding to a GCP call.
+    """
+    connector = GcloudConnector(credentials_loader=_sa_key_loader)
+    with respx.mock(assert_all_called=False):
+        fp = await connector.fingerprint(_TARGET_A)
+    assert fp.reachable is False
+    assert "error" in fp.extras
+    assert "ValueError" in fp.extras["error"]
+    assert "private_key" in fp.extras["error"]
+    assert _TARGET_A.name not in connector._token_cache
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_probe_refuses_sa_json_key_returns_ok_false() -> None:
+    """probe() surfaces the SA-JSON-key refusal as ok=False + reason."""
+    connector = GcloudConnector(credentials_loader=_sa_key_loader)
+    with respx.mock(assert_all_called=False):
+        result = await connector.probe(_TARGET_A)
+    assert result.ok is False
+    assert result.reason is not None
+    assert "ValueError" in result.reason
+    assert "private_key" in result.reason
+    assert _TARGET_A.name not in connector._token_cache
+    await connector.aclose()
+
+
+def test_typed_op_handlers_name_operator_for_dispatcher_threading() -> None:
+    """Every gcloud typed-op handler names ``operator`` in its signature.
+
+    The dispatcher's ``dispatch_typed`` branch threads the operator to a
+    handler only when ``"operator"`` appears in the handler's parameter names
+    (see meho_backplane.operations._branches.dispatch_typed). This test pins
+    that contract for every registered gcloud op so the gate's Vault read runs
+    under the real operator's identity on the operation path (#985), and so a
+    future refactor that drops the parameter is caught.
+    """
+    import inspect
+
+    from meho_backplane.connectors.gcloud.ops import GCLOUD_OPS
+
+    for op in GCLOUD_OPS:
+        handler = getattr(GcloudConnector, op.handler_attr)
+        param_names = list(inspect.signature(handler).parameters.keys())
+        assert "operator" in param_names, (
+            f"gcloud op {op.op_id!r} handler {op.handler_attr!r} must name "
+            f"'operator' so the dispatcher threads it; got {param_names!r}"
+        )

--- a/backend/tests/test_connectors_gcloud_e2e.py
+++ b/backend/tests/test_connectors_gcloud_e2e.py
@@ -45,10 +45,17 @@ from unittest.mock import MagicMock, patch
 import pytest
 import respx
 
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
 from meho_backplane.connectors.gcloud import GcloudConnector
 from meho_backplane.connectors.gcloud.ops import GCLOUD_OPS
 from meho_backplane.connectors.gcloud.session import GcloudTargetLike
 from meho_backplane.connectors.schemas import AuthModel
+
+# Operator threaded to typed-op handlers (signature ``(operator, target,
+# params)``). The mock credentials loader ignores it; it satisfies the
+# operator-context signature the gate's Vault read requires.
+_OPERATOR: Operator = synthesise_system_operator()
 
 # ---------------------------------------------------------------------------
 # Module-level constants
@@ -141,7 +148,7 @@ def _make_connector(token: str = "e2e-bearer-token") -> GcloudConnector:
     """Return a GcloudConnector wired with a no-Vault credentials_loader."""
     adc_loader, _patch_fn, _mc = _make_adc_loader(token)
 
-    async def _empty_loader(_target: GcloudTargetLike) -> dict[str, Any]:
+    async def _empty_loader(_target: GcloudTargetLike, _operator: Operator) -> dict[str, Any]:
         return {}
 
     return GcloudConnector(
@@ -193,7 +200,7 @@ async def test_gcloud_e2e_about_returns_identity_fields() -> None:
                 "parent": {"type": "organization", "id": "112233445566"},
             },
         )
-        result = await connector.gcloud_about(_E2E_TARGET, params={})
+        result = await connector.gcloud_about(_OPERATOR, _E2E_TARGET, params={})
 
     assert result["project_id"] == _GCP_PROJECT
     assert result["project_number"] == "987654321"
@@ -224,7 +231,7 @@ async def test_gcloud_e2e_project_describe_returns_full_resource() -> None:
         mock.get(f"https://cloudresourcemanager.googleapis.com/v1/projects/{_GCP_PROJECT}").respond(
             200, json=raw_project
         )
-        result = await connector.gcloud_project_describe(_E2E_TARGET, params={})
+        result = await connector.gcloud_project_describe(_OPERATOR, _E2E_TARGET, params={})
 
     assert result == raw_project
     await connector.aclose()
@@ -259,7 +266,7 @@ async def test_gcloud_e2e_services_list_returns_enabled_services() -> None:
                 ]
             },
         )
-        result = await connector.gcloud_services_list(_E2E_TARGET, params={})
+        result = await connector.gcloud_services_list(_OPERATOR, _E2E_TARGET, params={})
 
     assert result["total"] == 2
     names = {r["name"] for r in result["rows"]}
@@ -299,7 +306,7 @@ async def test_gcloud_e2e_iam_service_accounts_list_returns_sa_rows() -> None:
                 ]
             },
         )
-        result = await connector.gcloud_iam_service_accounts_list(_E2E_TARGET, params={})
+        result = await connector.gcloud_iam_service_accounts_list(_OPERATOR, _E2E_TARGET, params={})
 
     assert result["total"] == 2
     emails = {r["email"] for r in result["rows"]}
@@ -361,7 +368,7 @@ async def test_gcloud_e2e_compute_instances_list_jsonflux_envelope() -> None:
                 }
             },
         )
-        result = await connector.gcloud_compute_instances_list(_E2E_TARGET, params={})
+        result = await connector.gcloud_compute_instances_list(_OPERATOR, _E2E_TARGET, params={})
 
     # JSONFlux-compatible envelope — must have 'rows' list and 'total' int
     assert "rows" in result, "result must have 'rows' key (JSONFlux envelope)"
@@ -416,7 +423,7 @@ async def test_gcloud_e2e_compute_networks_list_returns_network_rows() -> None:
                 ]
             },
         )
-        result = await connector.gcloud_compute_networks_list(_E2E_TARGET, params={})
+        result = await connector.gcloud_compute_networks_list(_OPERATOR, _E2E_TARGET, params={})
 
     assert result["total"] == 2
     names = {r["name"] for r in result["rows"]}
@@ -459,7 +466,7 @@ async def test_gcloud_e2e_compute_subnetworks_list_returns_subnet_rows() -> None
                 }
             },
         )
-        result = await connector.gcloud_compute_subnetworks_list(_E2E_TARGET, params={})
+        result = await connector.gcloud_compute_subnetworks_list(_OPERATOR, _E2E_TARGET, params={})
 
     assert result["total"] == 1
     assert result["rows"][0]["name"] == "default"
@@ -498,7 +505,7 @@ async def test_gcloud_e2e_iam_policy_read_returns_bindings() -> None:
                 ],
             },
         )
-        result = await connector.gcloud_iam_policy_read(_E2E_TARGET, params={})
+        result = await connector.gcloud_iam_policy_read(_OPERATOR, _E2E_TARGET, params={})
 
     assert result["version"] == 1
     assert result["etag"] == "BwXe2eABC"
@@ -581,7 +588,7 @@ async def test_gcloud_e2e_audit_params_hash_field_present_in_all_ops() -> None:
         }
         for op_id, (method_name, params) in handler_method_map.items():
             handler = getattr(connector, method_name)
-            result = await handler(_E2E_TARGET, params=params)
+            result = await handler(_OPERATOR, _E2E_TARGET, params=params)
             assert result is not None, (
                 f"{op_id}: handler returned None — dispatch audit would fail "
                 f"(dispatcher needs a non-None result to write the audit row)"
@@ -647,7 +654,7 @@ async def test_gcloud_e2e_instances_list_empty_project_returns_empty_envelope() 
         mock.get(
             f"https://compute.googleapis.com/compute/v1/projects/{_GCP_PROJECT}/aggregated/instances"
         ).respond(200, json={"items": {}})
-        result = await connector.gcloud_compute_instances_list(_E2E_TARGET, params={})
+        result = await connector.gcloud_compute_instances_list(_OPERATOR, _E2E_TARGET, params={})
 
     assert result == {"rows": [], "total": 0}, (
         f"Empty project must return empty JSONFlux envelope; got {result!r}"
@@ -687,7 +694,9 @@ async def test_gcloud_e2e_instances_list_zone_filter_uses_per_zone_api() -> None
                 ]
             },
         )
-        result = await connector.gcloud_compute_instances_list(_E2E_TARGET, params={"zone": zone})
+        result = await connector.gcloud_compute_instances_list(
+            _OPERATOR, _E2E_TARGET, params={"zone": zone}
+        )
 
     assert result["total"] == 1
     assert result["rows"][0]["name"] == "zone-specific-vm"
@@ -734,14 +743,14 @@ async def test_gcloud_live_integration_about() -> None:
         auth_model=AuthModel.IMPERSONATION.value,
     )
 
-    async def _no_key_loader(_target: GcloudTargetLike) -> dict[str, Any]:
+    async def _no_key_loader(_target: GcloudTargetLike, _operator: Operator) -> dict[str, Any]:
         # Real impersonation — no SA JSON key in secret_ref.
         return {}
 
     # Construct connector WITHOUT adc_loader override → uses google.auth.default()
     connector = GcloudConnector(credentials_loader=_no_key_loader)
     try:
-        result = await connector.gcloud_about(live_target, params={})
+        result = await connector.gcloud_about(_OPERATOR, live_target, params={})
         assert result["project_id"] == project, (
             f"Live gcloud.about project_id mismatch: got {result['project_id']!r} "
             f"expected {project!r}"
@@ -781,7 +790,7 @@ async def test_gcloud_live_integration_all_8_ops_return_ok_status() -> None:
         auth_model=AuthModel.IMPERSONATION.value,
     )
 
-    async def _no_key_loader(_target: GcloudTargetLike) -> dict[str, Any]:
+    async def _no_key_loader(_target: GcloudTargetLike, _operator: Operator) -> dict[str, Any]:
         return {}
 
     connector = GcloudConnector(credentials_loader=_no_key_loader)
@@ -798,7 +807,7 @@ async def test_gcloud_live_integration_all_8_ops_return_ok_status() -> None:
         ]
         for op_id, method_name, params in handler_method_map:
             handler = getattr(connector, method_name)
-            result = await handler(live_target, params=params)
+            result = await handler(_OPERATOR, live_target, params=params)
             assert result is not None, (
                 f"Live {op_id}: handler returned None — expected a non-None result dict"
             )

--- a/backend/tests/test_connectors_gcloud_ops.py
+++ b/backend/tests/test_connectors_gcloud_ops.py
@@ -32,10 +32,17 @@ import pytest
 import respx
 
 from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
 from meho_backplane.connectors.gcloud import GcloudConnector
 from meho_backplane.connectors.gcloud.ops import GCLOUD_OPS, GcloudOp
 from meho_backplane.connectors.gcloud.session import GcloudTargetLike
 from meho_backplane.connectors.schemas import AuthModel
+
+# Operator threaded to typed-op handlers. The mock credentials loaders ignore
+# it; it satisfies the dispatcher's ``(operator, target, params)`` handler
+# signature (the operator authenticates the gate's Vault read, not the GCP
+# request).
+_OPERATOR: Operator = synthesise_system_operator()
 
 # ---------------------------------------------------------------------------
 # Target stub
@@ -179,7 +186,7 @@ async def test_gcloud_about_returns_identity_fields() -> None:
                 "parent": {"type": "organization", "id": "112233445566"},
             },
         )
-        result = await connector.gcloud_about(_TARGET, params={})
+        result = await connector.gcloud_about(_OPERATOR, _TARGET, params={})
 
     assert result["project_id"] == "my-project-123"
     assert result["project_number"] == "987654321"
@@ -207,7 +214,7 @@ async def test_gcloud_about_no_org_when_parent_is_folder() -> None:
                 "parent": {"type": "folder", "id": "folder-42"},
             },
         )
-        result = await connector.gcloud_about(_TARGET, params={})
+        result = await connector.gcloud_about(_OPERATOR, _TARGET, params={})
 
     assert result["organization"] is None
     await connector.aclose()
@@ -240,7 +247,7 @@ async def test_gcloud_project_describe_returns_raw_crm_resource() -> None:
         mock.get("https://cloudresourcemanager.googleapis.com/v1/projects/my-project-123").respond(
             200, json=raw_project
         )
-        result = await connector.gcloud_project_describe(_TARGET, params={})
+        result = await connector.gcloud_project_describe(_OPERATOR, _TARGET, params={})
 
     assert result == raw_project
     await connector.aclose()
@@ -283,7 +290,7 @@ async def test_gcloud_services_list_enabled_only_default() -> None:
         mock.get("https://serviceusage.googleapis.com/v1/projects/my-project-123/services").mock(
             side_effect=_side_effect
         )
-        result = await connector.gcloud_services_list(_TARGET, params={})
+        result = await connector.gcloud_services_list(_OPERATOR, _TARGET, params={})
 
     assert result["total"] == 1
     assert result["rows"][0]["name"] == "compute.googleapis.com"
@@ -313,7 +320,9 @@ async def test_gcloud_services_list_disabled_skips_filter() -> None:
         mock.get("https://serviceusage.googleapis.com/v1/projects/my-project-123/services").mock(
             side_effect=_side_effect
         )
-        result = await connector.gcloud_services_list(_TARGET, params={"enabled_only": False})
+        result = await connector.gcloud_services_list(
+            _OPERATOR, _TARGET, params={"enabled_only": False}
+        )
 
     assert "filter" not in captured_params[0]
     assert result["total"] == 0
@@ -367,7 +376,7 @@ async def test_gcloud_services_list_follows_next_page_token() -> None:
         mock.get("https://serviceusage.googleapis.com/v1/projects/my-project-123/services").mock(
             side_effect=_side_effect
         )
-        result = await connector.gcloud_services_list(_TARGET, params={})
+        result = await connector.gcloud_services_list(_OPERATOR, _TARGET, params={})
 
     assert call_count == 2
     assert result["total"] == 2
@@ -412,7 +421,7 @@ async def test_gcloud_iam_service_accounts_list_returns_sa_rows() -> None:
                 ]
             },
         )
-        result = await connector.gcloud_iam_service_accounts_list(_TARGET, params={})
+        result = await connector.gcloud_iam_service_accounts_list(_OPERATOR, _TARGET, params={})
 
     assert result["total"] == 2
     assert result["rows"][0]["email"] == "svc@my-project-123.iam.gserviceaccount.com"
@@ -468,7 +477,7 @@ async def test_gcloud_iam_service_accounts_list_follows_pagination() -> None:
         mock.get("https://iam.googleapis.com/v1/projects/my-project-123/serviceAccounts").mock(
             side_effect=_side_effect
         )
-        result = await connector.gcloud_iam_service_accounts_list(_TARGET, params={})
+        result = await connector.gcloud_iam_service_accounts_list(_OPERATOR, _TARGET, params={})
 
     assert call_count == 2
     assert result["total"] == 2
@@ -516,7 +525,7 @@ async def test_gcloud_compute_instances_list_aggregated() -> None:
                 }
             },
         )
-        result = await connector.gcloud_compute_instances_list(_TARGET, params={})
+        result = await connector.gcloud_compute_instances_list(_OPERATOR, _TARGET, params={})
 
     assert result["total"] == 1
     row = result["rows"][0]
@@ -555,7 +564,7 @@ async def test_gcloud_compute_instances_list_per_zone() -> None:
             },
         )
         result = await connector.gcloud_compute_instances_list(
-            _TARGET, params={"zone": "europe-west3-a"}
+            _OPERATOR, _TARGET, params={"zone": "europe-west3-a"}
         )
 
     assert result["total"] == 1
@@ -624,7 +633,7 @@ async def test_gcloud_compute_instances_list_follows_pagination() -> None:
         mock.get(
             "https://compute.googleapis.com/compute/v1/projects/my-project-123/aggregated/instances"
         ).mock(side_effect=_side_effect)
-        result = await connector.gcloud_compute_instances_list(_TARGET, params={})
+        result = await connector.gcloud_compute_instances_list(_OPERATOR, _TARGET, params={})
 
     assert call_count == 2
     assert result["total"] == 2
@@ -647,7 +656,7 @@ async def test_gcloud_compute_instances_list_jsonflux_compatible_envelope() -> N
         mock.get(
             "https://compute.googleapis.com/compute/v1/projects/my-project-123/aggregated/instances"
         ).respond(200, json={"items": {}})
-        result = await connector.gcloud_compute_instances_list(_TARGET, params={})
+        result = await connector.gcloud_compute_instances_list(_OPERATOR, _TARGET, params={})
 
     # JSONFlux-compatible envelope: must have 'rows' list and 'total' int
     assert "rows" in result
@@ -694,7 +703,7 @@ async def test_gcloud_compute_networks_list_returns_network_rows() -> None:
                 ]
             },
         )
-        result = await connector.gcloud_compute_networks_list(_TARGET, params={})
+        result = await connector.gcloud_compute_networks_list(_OPERATOR, _TARGET, params={})
 
     assert result["total"] == 2
     assert result["rows"][0]["name"] == "default"
@@ -737,7 +746,7 @@ async def test_gcloud_compute_networks_list_follows_pagination() -> None:
         mock.get(
             "https://compute.googleapis.com/compute/v1/projects/my-project-123/global/networks"
         ).mock(side_effect=_side_effect)
-        result = await connector.gcloud_compute_networks_list(_TARGET, params={})
+        result = await connector.gcloud_compute_networks_list(_OPERATOR, _TARGET, params={})
 
     assert call_count == 2
     assert result["total"] == 2
@@ -780,7 +789,7 @@ async def test_gcloud_compute_subnetworks_list_aggregated() -> None:
                 }
             },
         )
-        result = await connector.gcloud_compute_subnetworks_list(_TARGET, params={})
+        result = await connector.gcloud_compute_subnetworks_list(_OPERATOR, _TARGET, params={})
 
     assert result["total"] == 1
     row = result["rows"][0]
@@ -818,7 +827,7 @@ async def test_gcloud_compute_subnetworks_list_per_region() -> None:
             },
         )
         result = await connector.gcloud_compute_subnetworks_list(
-            _TARGET, params={"region": "europe-west3"}
+            _OPERATOR, _TARGET, params={"region": "europe-west3"}
         )
 
     assert result["total"] == 1
@@ -882,7 +891,7 @@ async def test_gcloud_compute_subnetworks_list_follows_pagination() -> None:
         mock.get(
             "https://compute.googleapis.com/compute/v1/projects/my-project-123/aggregated/subnetworks"
         ).mock(side_effect=_side_effect)
-        result = await connector.gcloud_compute_subnetworks_list(_TARGET, params={})
+        result = await connector.gcloud_compute_subnetworks_list(_OPERATOR, _TARGET, params={})
 
     assert call_count == 2
     assert result["total"] == 2
@@ -934,7 +943,7 @@ async def test_gcloud_iam_policy_read_correct_url_and_method() -> None:
         mock.post(
             "https://cloudresourcemanager.googleapis.com/v1/projects/my-project-123:getIamPolicy"
         ).mock(side_effect=_side_effect)
-        result = await connector.gcloud_iam_policy_read(_TARGET, params={})
+        result = await connector.gcloud_iam_policy_read(_OPERATOR, _TARGET, params={})
 
     assert captured_method == ["POST"]
     assert result["version"] == 1
@@ -970,7 +979,7 @@ async def test_gcloud_iam_policy_read_bearer_auth_sent() -> None:
         mock.post(
             "https://cloudresourcemanager.googleapis.com/v1/projects/my-project-123:getIamPolicy"
         ).mock(side_effect=_side_effect)
-        await connector.gcloud_iam_policy_read(_TARGET, params={})
+        await connector.gcloud_iam_policy_read(_OPERATOR, _TARGET, params={})
 
     assert seen_headers[0] == "Bearer policy-token"
     await connector.aclose()

--- a/docs/codebase/connectors-gcloud.md
+++ b/docs/codebase/connectors-gcloud.md
@@ -33,7 +33,7 @@ under `connector_id="gcloud-rest-1.0"`.
 
 | Op ID | API surface | HTTP verb | Notes |
 |---|---|---|---|
-| `gcloud.about` | CRM v1 `projects.get` | GET | Identity summary; wraps `fingerprint()` |
+| `gcloud.about` | CRM v1 `projects.get` | GET | Identity summary; fetches CRM directly with the real operator so the SA-key gate runs under the operator's identity (#985) |
 | `gcloud.project.describe` | CRM v1 `projects.get` | GET | Full CRM resource dict |
 | `gcloud.services.list` | Service Usage v1 | GET | Follows `nextPageToken`; `enabled_only` param |
 | `gcloud.iam.service_accounts.list` | IAM v1 | GET | Follows `nextPageToken` |
@@ -85,7 +85,8 @@ and return a `ResultHandle` without any connector-side changes.
 - **`_SA_KEY_FIELDS`** (`session.py`) — `frozenset` of field names that
   identify a service-account JSON key file. The connector's
   `_gate_sa_key_refusal()` intersects the Vault record's keys against
-  this set on every `auth_headers()` call.
+  this set on every `_ensure_token()` call — i.e. on every operation,
+  `fingerprint()`, `probe()`, and `auth_headers()` call (#985).
 - **`_contains_sa_key_fields(record)`** (`session.py`) — pure function
   returning `True` if `record` contains any SA key field names.
 
@@ -103,12 +104,25 @@ and return a `ResultHandle` without any connector-side changes.
 
 ### Auth flow per request
 
+The single token-acquisition chokepoint is `_ensure_token(target, operator)`.
+Every operation (`_get_json_abs` / `_post_json_abs`), `fingerprint()`,
+`probe()`, and `auth_headers()` flow through it — so the SA-JSON-key refusal
+gate lives there, not only in `auth_headers()` (#985). Previously the gate
+was invoked only from `auth_headers()`, which no live path calls, so the
+control never fired for real usage.
+
 1. **auth_model gate** — `auth_headers()` checks `target.auth_model` is
    `IMPERSONATION` or `None`. Any other value → `NotImplementedError`.
-2. **SA-JSON-key refusal gate** — loads the Vault `secret_ref` payload
-   via the injectable `credentials_loader`; checks for SA key field names.
-   Any present → `ValueError` naming the target + fields.
-3. **Token resolution** — calls `_ensure_token(target)`:
+   (Operations skip this gate; the dispatcher resolved the connector by
+   product, and the impersonation model is the only one gcloud supports.)
+2. **SA-JSON-key refusal gate** — `_ensure_token(target, operator)` calls
+   `_gate_sa_key_refusal(target, operator)` **first, before the cache fast
+   path**, so a Vault rotation that introduces key material is refused on
+   the next request even with a still-valid cached token. The gate loads the
+   Vault `secret_ref` payload via the injectable `credentials_loader` (under
+   the operator's identity), checks for SA key field names; any present →
+   `ValueError` naming the target + fields. No token is built.
+3. **Token resolution** — `_ensure_token(target, operator)` continues:
    - Fast path: cached token + `creds.valid` → return cached.
    - Slow path (under per-target lock): calls `_fetch_token(target)` which:
      - Runs `_fetch_token_sync(target)` in a thread pool executor.
@@ -116,12 +130,25 @@ and return a `ResultHandle` without any connector-side changes.
        credentials, wraps with `impersonated_credentials.Credentials`,
        calls `creds.refresh(Request())`, returns `(token, creds)`.
      - Stores token + creds in `_token_cache` / `_creds_cache`.
-4. Returns `{"Authorization": "Bearer <token>"}`.
+4. `auth_headers()` returns `{"Authorization": "Bearer <token>"}`; operations
+   build the header inline from the same token.
+
+**Operator threading.** Typed-op handlers have signature
+`(self, operator, target, params)`; the dispatcher's `dispatch_typed`
+threads `operator` to a handler only when the parameter name appears in the
+signature (`meho_backplane.operations._branches.dispatch_typed`). Handlers
+forward `operator` to `_get_json_abs` / `_post_json_abs` → `_ensure_token`.
+`fingerprint()` and `probe()` are operator-less ABC entry points, so they
+synthesise a frozen system operator (empty `raw_jwt`,
+`synthesise_system_operator()`) for the gate's Vault read — the same stand-in
+the other operator-less probe paths use. A target whose `secret_ref` carries
+SA-JSON-key fields therefore surfaces `reachable=False` (fingerprint) /
+`ok=False` (probe) rather than silently proceeding.
 
 ### 401 auto-refresh
 
 GCP REST APIs return HTTP 401 when a bearer token has expired.
-`_get_json_abs(target, abs_url)`:
+`_get_json_abs(target, abs_url, *, operator)`:
 - Issues the GET with the current bearer token.
 - On 401: calls `refresh_token(target)` (acquires per-target lock, calls
   `creds.refresh()` in executor, updates cache) and retries once.
@@ -130,22 +157,26 @@ GCP REST APIs return HTTP 401 when a bearer token has expired.
 ### fingerprint()
 
 `GET https://cloudresourcemanager.googleapis.com/v1/projects/<gcp_project>`
-via `_get_json_abs`. Returns:
+via `_get_json_abs` (with a synthesised system operator for the gate).
+Returns:
 - `vendor="google"`, `product="gcp-project"`, `version=None`.
 - `extras["project_number"]`, `extras["lifecycle_state"]`,
   `extras["organization"]` (from `parent.id` when `parent.type="organization"`),
   `extras["project_id"]`.
-- On failure: `reachable=False`, `extras["error"]`.
+- On failure (including an SA-JSON-key refusal): `reachable=False`,
+  `extras["error"]`.
 
 ### probe()
 
-Same endpoint as `fingerprint()`. Verifies:
+Same endpoint as `fingerprint()` (also via the synthesised system operator).
+Verifies:
 - ADC source credentials are present and valid.
 - Impersonation chain succeeds (Token Creator role granted).
 - Cloud Resource Manager API reachable.
 - Response `projectId` matches `target.gcp_project`.
 
-Returns `ok=True` on success, `ok=False + reason` on failure.
+Returns `ok=True` on success, `ok=False + reason` on failure (an SA-JSON-key
+refusal surfaces as `ok=False`).
 
 ### execute()
 
@@ -162,10 +193,11 @@ pod restarts. Raises `AttributeError` if a `handler_attr` is missing (deploy
 bug, not a runtime degradation). Raises `ValueError` if a `group_key` has no
 entry in `_WHEN_TO_USE_BY_GROUP`.
 
-### _post_json_abs(target, abs_url, json_body)
+### _post_json_abs(target, abs_url, *, operator, json_body)
 
 POST variant of `_get_json_abs` for ops that call GCP APIs with POST
-semantics (e.g. `getIamPolicy`). Same 401-refresh-retry pattern.
+semantics (e.g. `getIamPolicy`). Same 401-refresh-retry pattern; `operator`
+is required and threaded to `_ensure_token` for the SA-JSON-key gate.
 
 ## Dependencies
 
@@ -234,6 +266,15 @@ real `GcloudConnector` against a live project.
 - `load_credentials_from_vault` is a stub until Goal #214 (Connector
   parity) wires the live Vault read. Inject `credentials_loader` on
   construction to test or run pre-production.
+- `fingerprint()` and `probe()` run the SA-JSON-key gate under a synthesised
+  system operator (empty `raw_jwt`), because their ABC signatures carry no
+  operator. Once the live `load_credentials_from_vault` lands (Goal #214),
+  the system operator's empty `raw_jwt` will fail closed on the Vault read —
+  which is the intended boundary for system-initiated credential reads, but
+  means probe/fingerprint on a target with a live Vault secret will need a
+  follow-up to thread a real operator (or an unauthenticated reachability
+  variant). Today, with the stub/injected loader, the gate runs and refuses
+  SA-key material correctly on these paths (#985).
 - `_fetch_token_sync` and `refresh_token` run synchronous
   `google.auth.transport.requests.Request()` calls in a thread pool
   executor. The executor is the event loop's default (unbounded); a


### PR DESCRIPTION
## Summary

- The gcloud SA-JSON-key refusal gate (org policy `constraints/iam.disableServiceAccountKeyCreation`) was invoked **only** from `GcloudConnector.auth_headers()`, which no live code path calls. Operations, `fingerprint()`, and `probe()` acquired tokens via `_get_json_abs`/`_post_json_abs` → `_ensure_token` and built the `Authorization: Bearer` header directly, bypassing the gate — the safety control never fired for real usage.
- Moved the gate into `_ensure_token` (the single token-acquisition chokepoint every path flows through), running it **before** the cache fast path so a Vault rotation that introduces key material is refused even with a still-valid cached token (preserves the per-call design).
- Threaded `operator` to the gate's Vault read: typed-op handlers gained the `(operator, target, params)` signature the dispatcher's `dispatch_typed` threads by parameter name. `gcloud_about` now fetches CRM directly with the real operator instead of delegating to `fingerprint()`. `fingerprint()`/`probe()` are operator-less ABC entry points, so they synthesise a frozen system operator for the gate — an SA-key refusal surfaces as `reachable=False` / `ok=False` rather than silently proceeding.
- Kept gcloud-local — no generic-dispatcher changes.

## Test plan

- [x] `ruff check` (gcloud src + 3 test files) — clean
- [x] `ruff format --check` — clean
- [x] `uv run mypy src/meho_backplane/connectors/gcloud` — clean
- [x] `code-quality.py --diff` — 0 blockers (pre-existing C901 on the two paginated compute handlers marked `code-quality-allow`; complexity unchanged from main)
- [x] New tests drive the refusal on a **real operation** via the op-handler path (`gcloud_about` GET + `gcloud_iam_policy_read` POST): assert `ValueError` naming the offending fields, no token built, no GCP request issued
- [x] New tests: `fingerprint()` → `reachable=False`, `probe()` → `ok=False` on SA-key secret
- [x] New test pins the dispatcher signature contract (every gcloud op handler names `operator`)
- [x] New positive test: a compliant (empty) secret does NOT trip the gate
- [x] Existing `auth_headers`-based gate tests still pass; updated existing op/e2e tests for the new handler signature + two-arg `credentials_loader`
- [x] `pytest tests/test_connectors_gcloud_auth.py tests/test_connectors_gcloud_ops.py tests/test_connectors_gcloud_e2e.py` — 68 passed, 2 skipped (live GCP, env-gated); dispatcher/typed-register suites green
- [x] `grep` proves `_gate_sa_key_refusal` is reachable from `_ensure_token` (line 405), not only `auth_headers`

## Out of scope

- IMPERSONATION auth model / ADC token source (the token never comes from the Vault secret; the gate is a policy/hygiene check only).
- Generic-dispatcher gating; pfSense / other connectors' analogous checks.
- The full `call_operation` DB-backed dispatch test (Target ORM lacks `gcp_project`/`gcp_impersonate_sa` columns — same constraint the existing e2e suite documents); covered via the op-handler path per the issue's accepted alternative.
- A follow-up (noted in `docs/codebase/connectors-gcloud.md` Known issues) for threading a real operator into `fingerprint()`/`probe()` once the live `load_credentials_from_vault` lands (Goal #214) — the empty-`raw_jwt` system operator will fail closed on a live Vault read.
- No collision with #988 (gcloud CLI output correctness — Go files only).

Closes #985
