### PR TITLE
docs(operations): correct stale 'v0.2 ships only PassThroughReducer' wording post-#753

### DIFF
--- a/backend/src/meho_backplane/api/v1/health.py
+++ b/backend/src/meho_backplane/api/v1/health.py
@@ -193,8 +193,8 @@ async def _probe_vault_federation(
 
     if result.status == "ok":
         # The handler returns ``{"data": <secret>, "version": <int|None>}``;
-        # the dispatcher's :class:`PassThroughReducer` lands it as
-        # ``result.result`` unchanged.
+        # the dispatcher's default reducer passes this small scalar dict
+        # through as ``result.result`` unchanged.
         payload = result.result if isinstance(result.result, dict) else {}
         version = payload.get("version")
         detail = f"version={version}" if version is not None else "ok"

--- a/backend/src/meho_backplane/operations/__init__.py
+++ b/backend/src/meho_backplane/operations/__init__.py
@@ -32,11 +32,12 @@ Sub-modules:
   hands it to the composite handler in place of raw
   :func:`dispatch`; the callable owns the audit-tree linkage +
   bounded-depth guard so handlers read as plain business logic.
-* :mod:`.reducer` — the v0.2 :class:`PassThroughReducer` stub +
-  :class:`Reducer` Protocol + :class:`ResultHandle`. T6 (#397) will
-  ship the full reducer implementation; the dispatcher already
-  invokes the reducer slot so today's pass-through gets swapped in
-  cleanly later.
+* :mod:`.reducer` — the :class:`PassThroughReducer` shim (import-time
+  default) + :class:`Reducer` Protocol + :class:`ResultHandle`. The
+  production reducer
+  :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+  (G0.6.1-T3 #753) is installed at startup via :func:`set_default_reducer`,
+  swapping the pass-through default cleanly.
 * :mod:`.typed_register` — :func:`register_typed_operation` and its
   G3.1-T4 (#504) sibling :func:`register_composite_operation` for
   typed/composite connector init-time registration, plus

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -26,9 +26,10 @@ phases the parent Initiative names:
    structured ``no_connector`` error.
 6. Branch on ``descriptor.source_kind`` -- ``ingested`` / ``typed`` /
    ``composite``. See :mod:`meho_backplane.operations._branches`.
-7. JSONFlux-wrap the response via the :class:`Reducer` (v0.2 default
-   is :class:`~meho_backplane.operations.reducer.PassThroughReducer`;
-   T6 #397 ships the real reduction).
+7. JSONFlux-wrap the response via the :class:`Reducer` (production default
+   is :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`,
+   installed at startup; the import-time default is the
+   :class:`~meho_backplane.operations.reducer.PassThroughReducer` shim).
 8. Write the audit row synchronously + publish a broadcast event
    (:func:`~meho_backplane.operations._audit.audit_and_broadcast_safe`).
 9. Return the :class:`OperationResult`.
@@ -427,10 +428,12 @@ async def _reduce_or_error(
 ) -> tuple[Any, ResultHandle | None] | OperationResult:
     """Run the JSONFlux reducer; return ``(summary, handle)`` or a structured error.
 
-    The dispatcher's module docstring contracts "never raises". v0.2's
-    :class:`~meho_backplane.operations.reducer.PassThroughReducer` can't
-    raise, but :func:`set_default_reducer` invites swappable real reducers
-    (MinIO/S3 I/O, schema validation) that will. Any reducer exception is
+    The dispatcher's module docstring contracts "never raises". The
+    :class:`~meho_backplane.operations.reducer.PassThroughReducer` shim can't
+    raise, but the production
+    :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+    (and other swappable reducers — DuckDB materialization, future MinIO/S3
+    I/O, schema validation) can. Any reducer exception is
     converted to a structured ``connector_error``
     :class:`OperationResult` — same shape the handler-call exception path
     produces — and the audit row + broadcast event still fire so the

--- a/backend/src/meho_backplane/operations/reducer.py
+++ b/backend/src/meho_backplane/operations/reducer.py
@@ -1,23 +1,27 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""JSONFlux reducer protocol + v0.2 pass-through default.
+"""JSONFlux reducer protocol + pass-through shim (import-time default).
 
 G0.6-T6 (#397) of Initiative #388. The :class:`Reducer` :class:`typing.Protocol`
 is the contract every JSONFlux reducer satisfies; the dispatcher invokes
 :meth:`Reducer.reduce` after a handler returns and before the audit / broadcast
-phase fires (see :mod:`meho_backplane.operations.dispatcher`). v0.2 ships only
-:class:`PassThroughReducer` — the no-op default that returns the raw payload
-verbatim with a ``None`` :class:`ResultHandle`. Real reduction logic
-(set-shaped payload reduction, result-handle store, MinIO/S3 spill, the
-``result_query`` / ``result_aggregate`` meta-tools) ships in a follow-on
-Initiative once the first generic-ingested connectors produce real payloads
-to calibrate against.
+phase fires (see :mod:`meho_backplane.operations.dispatcher`). This module
+ships :class:`PassThroughReducer` — the no-op shim that returns the raw
+payload verbatim with a ``None`` :class:`ResultHandle`. It is the import-time
+``_DEFAULT_REDUCER`` and the reducer tests construct it explicitly; the
+**production** default is
+:class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+(G0.6.1-T3 #753), installed at app startup via :func:`set_default_reducer`,
+which reduces set-shaped payloads over the v0.1-spec §4 threshold
+(>50 rows / >4 KB) into a markdown summary + :class:`ResultHandle`. The
+result-handle spill backend (MinIO/S3) and the ``result_query`` /
+``result_aggregate`` read-back meta-tools remain a follow-on Initiative.
 
-The contract design is **future-proof hook with no-op default**: every
-connector ships JSONFlux-aware from day 1; swapping the real reducer in later
-touches one registration call, not every connector. See the parent Initiative
-#388 and v0.1-spec §"JSONFlux / result handles" L294-311.
+The contract design is **swappable hook with a no-op default**: every
+connector shipped JSONFlux-aware from day 1, so swapping the real reducer in
+(done in G0.6.1 #753) touched one registration call, not every connector. See
+the parent Initiative #388 and v0.1-spec §"JSONFlux / result handles" L294-311.
 
 :class:`ResultHandle` lives in :mod:`meho_backplane.connectors.schemas`
 alongside :class:`~meho_backplane.connectors.OperationResult` (which gained an
@@ -48,8 +52,10 @@ class Reducer(Protocol):
     The dispatcher always invokes :meth:`reduce` after the handler returns;
     the return value flows into the audit row's payload, the broadcast
     event, and the :class:`~meho_backplane.connectors.OperationResult` the
-    caller sees. v0.2 ships :class:`PassThroughReducer` as the only impl;
-    the real reducer (post-G0.6) returns a reduced payload + a
+    caller sees. Implementations: :class:`PassThroughReducer` (the no-op
+    shim / import-time default) and
+    :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+    (the production default since #753), which returns a reduced payload + a
     :class:`ResultHandle` for large set-shaped responses while leaving
     small / scalar payloads alone.
 


### PR DESCRIPTION
## Summary

- Companion to #978: sweep the same stale "v0.2 ships only `PassThroughReducer`" / "T6 #397 ships the real reduction" / "future reducer" wording out of the **operations-substrate** docstrings, now that #753 made `JsonFluxReducer` the live dispatcher default. Closes #1001.
- Files: `operations/reducer.py` (module + `Reducer` Protocol docstrings), `operations/dispatcher.py` (module docstring step 7 + `_reduce_or_error` docstring), `operations/__init__.py` (`.reducer` bullet), `api/v1/health.py`.

## Scope

- Docstring/comment-only — zero behavior change, zero code-logic change.
- Accurate `PassThroughReducer` mentions preserved: the import-time `_DEFAULT_REDUCER = PassThroughReducer()` default (`dispatcher.py:169`), the class definition, imports, `__all__`, and `main.py`'s swap comment.

## Test plan

- [x] `grep` operations/ + api/ stale default-reducer claims — zero
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/` — clean (265 files)
- [x] `code-quality.py --diff` — 0 blockers
- [x] targeted pytest (dispatcher / reducer / health) — 36 passed; full suite runs in CI

Closes #1001
