### PR TITLE
test(cli): de-flake status --watch fakeFeed tests with request-wait

### DIFF
--- a/cli/internal/cmd/status_watch_test.go
+++ b/cli/internal/cmd/status_watch_test.go
@@ -75,13 +75,17 @@ type fakeFeedRecord struct {
 }
 
 type fakeFeed struct {
-	URL     string
-	mu      sync.Mutex
-	calls   []fakeFeedRecord
-	hits    atomic.Int64
-	cursor  atomic.Int64
-	frames  [][]byte
-	status  int
+	URL    string
+	mu     sync.Mutex
+	calls  []fakeFeedRecord
+	notify chan struct{}
+	hits   atomic.Int64
+	cursor atomic.Int64
+	frames [][]byte
+	status int
+	// dropMid: connection 0 writes the first half of frames then
+	// returns so the client EOFs and reconnects (exercises the
+	// reconnect path).
 	dropMid bool
 }
 
@@ -97,16 +101,51 @@ func (f *fakeFeed) Records() []fakeFeedRecord {
 	return out
 }
 
-// record appends one received-request snapshot under the mutex.
+// record appends one received-request snapshot under the mutex, then
+// pokes the notify channel so waiters wake and re-check the count.
+// The send is non-blocking (buffered cap-1 + default) so the http
+// handler never stalls when no test goroutine is waiting.
 func (f *fakeFeed) record(r fakeFeedRecord) {
 	f.mu.Lock()
 	f.calls = append(f.calls, r)
 	f.mu.Unlock()
+	select {
+	case f.notify <- struct{}{}:
+	default:
+	}
+}
+
+// waitForRequests blocks until the feed has recorded at least n
+// requests, then returns; it fails the test if that has not happened
+// within timeout. This replaces the fixed `time.Sleep` races that
+// gated assertions on wall-clock scheduling — the test waits on the
+// observable event (a request landing) instead of guessing how long
+// the client takes to dial. Must be called from the test goroutine,
+// since t.Fatalf may not run on a spawned goroutine.
+func (f *fakeFeed) waitForRequests(t *testing.T, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		f.mu.Lock()
+		got := len(f.calls)
+		f.mu.Unlock()
+		if got >= n {
+			return
+		}
+		select {
+		case <-f.notify:
+			// A request landed; loop to re-check the count. The
+			// notify channel is edge-triggered and coalesces, so the
+			// length check above is the source of truth.
+		case <-deadline:
+			t.Fatalf("timeout waiting for %d request(s); got %d", n, got)
+		}
+	}
 }
 
 func newFakeFeed(t *testing.T, status int, frames [][]byte, dropMid bool) *fakeFeed {
 	t.Helper()
-	feed := &fakeFeed{frames: frames, status: status, dropMid: dropMid}
+	feed := &fakeFeed{frames: frames, status: status, dropMid: dropMid, notify: make(chan struct{}, 1)}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/feed", func(w http.ResponseWriter, r *http.Request) {
 		idx := int(feed.hits.Add(1) - 1)
@@ -345,21 +384,25 @@ func TestRunWatch_FilterFlagsForwardToQuery(t *testing.T) {
 
 	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
 	go func() {
-		time.Sleep(30 * time.Millisecond)
-		cancel()
+		defer close(done)
+		_ = runWatch(ctx, watchOptions{
+			BackplaneURL: feed.URL,
+			OpClass:      "write",
+			Principal:    "alice",
+			Target:       "rdc-vcenter",
+			Stdout:       stdout,
+			Stderr:       stderr,
+			HTTPClient:   feed.client(),
+			Backoff:      fastBackoff,
+		})
 	}()
 
-	_ = runWatch(ctx, watchOptions{
-		BackplaneURL: feed.URL,
-		OpClass:      "write",
-		Principal:    "alice",
-		Target:       "rdc-vcenter",
-		Stdout:       stdout,
-		Stderr:       stderr,
-		HTTPClient:   feed.client(),
-		Backoff:      fastBackoff,
-	})
+	feed.waitForRequests(t, 1, 2*time.Second)
+	cancel()
+	<-done
 
 	records := feed.Records()
 	if len(records) == 0 {
@@ -380,20 +423,24 @@ func TestRunWatch_AuthHeaderSent(t *testing.T) {
 	feed := newFakeFeed(t, http.StatusOK, nil, false)
 	seedWatchCreds(t, xdg, feed.URL, jwtMarker)
 
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
 	go func() {
-		time.Sleep(30 * time.Millisecond)
-		cancel()
+		defer close(done)
+		_ = runWatch(ctx, watchOptions{
+			BackplaneURL: feed.URL,
+			Stdout:       stdout,
+			Stderr:       stderr,
+			HTTPClient:   feed.client(),
+			Backoff:      fastBackoff,
+		})
 	}()
 
-	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
-	_ = runWatch(ctx, watchOptions{
-		BackplaneURL: feed.URL,
-		Stdout:       stdout,
-		Stderr:       stderr,
-		HTTPClient:   feed.client(),
-		Backoff:      fastBackoff,
-	})
+	feed.waitForRequests(t, 1, 2*time.Second)
+	cancel()
+	<-done // runWatch returned: its stdout/stderr writes are complete
 
 	records := feed.Records()
 	if len(records) == 0 {
@@ -422,21 +469,27 @@ func TestRunWatch_ReconnectsWithLastEventID(t *testing.T) {
 
 	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
 	go func() {
-		// Allow first connection's first frame, the drop, the
-		// 1 ms backoff, the reconnect, the second frame, and a
-		// margin before cancelling.
-		time.Sleep(200 * time.Millisecond)
-		cancel()
+		defer close(done)
+		_ = runWatch(ctx, watchOptions{
+			BackplaneURL: feed.URL,
+			Stdout:       stdout,
+			Stderr:       stderr,
+			HTTPClient:   feed.client(),
+			Backoff:      fastBackoff,
+		})
 	}()
 
-	_ = runWatch(ctx, watchOptions{
-		BackplaneURL: feed.URL,
-		Stdout:       stdout,
-		Stderr:       stderr,
-		HTTPClient:   feed.client(),
-		Backoff:      fastBackoff,
-	})
+	// Wait for the initial connection plus the post-drop reconnect
+	// (2 requests) rather than guessing the dial + 1 ms backoff +
+	// redial timing with a fixed sleep. By the time the reconnect
+	// request lands, the client has parsed frame 0 and set its
+	// Last-Event-Id header, so the assertions below are stable.
+	feed.waitForRequests(t, 2, 2*time.Second)
+	cancel()
+	<-done
 
 	records := feed.Records()
 	if len(records) < 2 {

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -663,6 +663,14 @@ redaction stance applies, and the unit tests pin the marker.
   batch). The handler holds the connection open via
   `<-r.Context().Done()` after the scripted frames so the client's
   scanner sits in `Scan()` until the test cancels.
+- Tests that assert on recorded requests run `runWatch` in a
+  background goroutine and synchronise on `fakeFeed.waitForRequests`
+  (block until N requests have landed, bounded by a generous
+  timeout) before cancelling — never on a fixed `time.Sleep`. Gating
+  on the observable event instead of wall-clock scheduling is what
+  keeps the Go job green on slow CI runners; the joined `done`
+  channel also gives the happens-before that lets the assertions read
+  the captured `stdout`/`stderr` without racing the writer.
 - A `fastBackoff` schedule (five 1 ms slots) collapses the
   production 1/2/5/10/30 s schedule so the suite runs in
   milliseconds.


### PR DESCRIPTION
## Summary
- De-flake the `meho status --watch` test harness: `TestRunWatch_AuthHeaderSent` (CI Go job red on `main`) and its two siblings gated `feed.Records()` assertions on a fixed `time.Sleep` racing the first SSE request — on a slow runner `cancel()` fired before `runWatch` issued its first GET, so `Records()` was empty and the test `Fatal`'d.
- Add `fakeFeed.waitForRequests(t, n, timeout)`: an edge-notify channel (non-blocking send per recorded request) + a level check on the recorded-call count. Tests now wait on the **observable event** (N requests landing) with a generous bound, instead of wall-clock scheduling.
- The three affected tests run `runWatch` in a background goroutine, wait for the request(s), `cancel()`, then join via a `done` channel — the join also gives the happens-before that keeps the post-cancel `stdout`/`stderr` reads race-clean under `go test -race`.
- Test-only change; the SUT (`runWatch`/`watchOptions`) is untouched.

## Test plan
- [x] `gofmt -l` — clean
- [x] `go vet ./internal/cmd/` — clean
- [x] `go build ./...` — clean
- [x] `golangci-lint run` (v2.12.2, same as CI) — 0 issues
- [x] `go test -run TestRunWatch_AuthHeaderSent -count=200 ./internal/cmd/` — 200/200 green (AC #2)
- [x] `go test -race -run '<the three converted tests>' -count=100 ./internal/cmd/` — clean, no races, no flakes
- [ ] CI `Go (golangci-lint + go test)` green on the merge commit (AC #3 — verified by CI)

## Scope review (AC #4)
- `TestRunWatch_FilterFlagsForwardToQuery` (was line 364) — same sleep race → converted (`waitForRequests(1)`).
- `TestRunWatch_ReconnectsWithLastEventID` (was line 441) — same race, needs 2 requests → converted (`waitForRequests(2)`).
- `TestRunWatch_401_ExitsAuthExpired` (line 481) — reviewed, **not** in this race class: it gates on `runWatch` returning (401 → immediate error, no retry), not on a sleep. Left as-is.

## Out of scope
- Render-gated sleep tests (`RendersHumanLine` / `AggregateOnlyClass` / `JSONLines`) call `runWatch` synchronously and read `stdout` only after it returns; not part of the recorded-request race class and outside the task's explicit 364/441/481 review set. Noted as an adjacent finding.
- `testing/synctest` virtualised time — does not virtualise the real `httptest` TCP loopback `fakeFeed` uses, so channel-sync is the correct fix even though the module is now `go 1.25.8`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #579
