### PR TITLE
feat(connectors): G3.8-T1 HolodeckConnector skeleton + _pwsh.py (ConvertTo-Json) + registry v2

### DIFF
--- a/backend/src/meho_backplane/connectors/holodeck/__init__.py
+++ b/backend/src/meho_backplane/connectors/holodeck/__init__.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.holodeck -- HolodeckConnector package.
+
+Importing the package registers :class:`HolodeckConnector` against
+the v2 connector registry under the natural key
+``(product="holodeck", version="9.0", impl_id="holodeck-ssh")``, and
+queues the connector's typed-op upserts onto the lifespan-driven
+registrar list so ``endpoint_descriptor`` rows land before the first
+dispatch.
+
+Two-phase registration (same shape as
+:mod:`meho_backplane.connectors.bind9.__init__` and
+:mod:`meho_backplane.connectors.pfsense.__init__`):
+
+* **Synchronous (import time)** -- the v2 registry entry lands via
+  :func:`~meho_backplane.connectors.registry.register_connector_v2`
+  inside this module. The registry lookup tables are populated
+  before the lifespan begins so a probe firing during startup sees
+  a fully-populated registry.
+
+* **Asynchronous (lifespan startup)** --
+  :func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+  invokes :func:`register_holodeck_typed_operations`, which delegates
+  to :meth:`HolodeckConnector.register_operations`. Async because
+  the helper writes to the DB and the embedding-text encode step is
+  async. Idempotent on re-call with unchanged op text.
+
+The Holodeck connector intentionally does **not** call the v1
+``register_connector`` -- the v1 entry path is for chassis-route
+backwards compatibility (the deprecated ``POST /api/v1/connectors/
+{product}/{op_id}`` route removed by G0.6-T11 #412), and Holodeck
+has never shipped behind it. Skipping the v1 write keeps the
+resolver tie-break ladder unambiguous: only the v2 triple advertises
+this class.
+"""
+
+from meho_backplane.connectors.holodeck.connector import HolodeckConnector
+from meho_backplane.connectors.holodeck.ops import HOLODECK_OPS, HolodeckOp
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+
+async def register_holodeck_typed_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Module-level registrar wrapper for ``HolodeckConnector.register_operations``.
+
+    The canonical typed-op registration pattern (G0.6-T-Refactor-
+    Vault #390) is a module-level ``async def
+    register_xxx_typed_operations`` queued onto
+    :func:`run_typed_op_registrars` via
+    :func:`register_typed_op_registrar`. Holodeck implements the
+    underlying op walk as a classmethod on :class:`HolodeckConnector`
+    so the test suite can exercise it without lifespan plumbing;
+    this wrapper is the seam that lets the standard registrar
+    mechanism drive it.
+
+    The ``embedding_service`` keyword-only parameter mirrors the
+    bind9 / pfSense sibling contract (#463) -- ``run_typed_op_registrars``
+    passes the process-wide :class:`EmbeddingService` (or a chassis-
+    test stub) to every registrar via ``registrar(embedding_service=...)``,
+    so each registrar **must** accept the kwarg or the lifespan
+    crashes with :class:`TypeError`. The wrapper currently does not
+    forward the value because
+    :meth:`HolodeckConnector.register_operations` resolves the
+    embedding service via
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`'s
+    process-wide singleton fallback; the kwarg-accept-and-discard
+    shape matches the bind9 / pfSense siblings.
+    """
+    del embedding_service  # see docstring -- kwarg accepted for runner-compatibility
+    await HolodeckConnector.register_operations()
+
+
+__all__ = [
+    "HOLODECK_OPS",
+    "HolodeckConnector",
+    "HolodeckOp",
+    "register_holodeck_typed_operations",
+]
+
+
+# v2 entry -- the canonical resolver key. Holodeck has no v1 chassis
+# history, so the v1 ``register_connector`` write is intentionally
+# omitted (see module docstring).
+register_connector_v2(
+    product="holodeck",
+    version="9.0",
+    impl_id="holodeck-ssh",
+    cls=HolodeckConnector,
+)
+
+# Queue the typed-op upsert onto the lifespan-driven registrar list.
+# The registrar list is module-scope on
+# meho_backplane.operations.typed_register; the lifespan calls
+# ``run_typed_op_registrars`` after _eager_import_connectors so every
+# connector subpackage has self-registered by the time the runner
+# iterates.
+register_typed_op_registrar(register_holodeck_typed_operations)

--- a/backend/src/meho_backplane/connectors/holodeck/_pwsh.py
+++ b/backend/src/meho_backplane/connectors/holodeck/_pwsh.py
@@ -1,0 +1,245 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""PowerShell-over-SSH helper for the Holodeck connector.
+
+The HoloRouter appliance exposes no REST API; every cmdlet runs through
+``pwsh`` on the Photon OS appliance, reached via the pooled SSH
+connection :class:`~meho_backplane.connectors.adapters.ssh.SshConnector`
+maintains. This module is the **single** seam between the connector's
+Python handlers and that PowerShell surface; every fingerprint / probe
+/ op handler in the package routes its script through
+:func:`pwsh_run`.
+
+Wire shape
+----------
+
+1. The PowerShell text the caller hands in is UTF-16LE-encoded and
+   base64'd into the form ``pwsh`` expects for ``-EncodedCommand``.
+   Per Microsoft's about_pwsh reference (cited in #371): the encoded
+   payload is the base64 of the UTF-16LE bytes of the script, no BOM.
+   ``pwsh -EncodedCommand <encoded>`` is the supported portable form
+   for sending multi-line PowerShell through a single-argument
+   transport.
+2. The caller is responsible for piping the cmdlet's output through
+   ``| ConvertTo-Json`` (with ``-Compress`` and an explicit ``-Depth``
+   when the response tree is deeper than two levels). The Initiative
+   #371 body's design correction (2026-05-21) supersedes the original
+   CliXml note — every fingerprint/probe/op example uses
+   ``ConvertTo-Json``, and Json output parses with the stdlib :mod:`json`
+   without pulling in an undecided CliXml dependency (``pyclixml``).
+3. :func:`pwsh_run` runs ``pwsh -EncodedCommand <encoded>`` over the
+   pooled SSH connection and decodes ``stdout`` via
+   :func:`json.loads`, returning the parsed structure.
+4. Failures surface as a single structured :exc:`PwshRunError` that
+   carries the exit status and a truncated stderr fragment but never
+   embeds the original script body or any auth material.
+
+Safety contract
+---------------
+
+* The encoded base64 payload **does** appear on the remote process
+  argv (that's the contract of ``-EncodedCommand``). The PowerShell
+  script body the caller hands in is therefore visible to a privileged
+  observer on the remote host; this matches the wrapper's
+  ``./scripts/holodeck.sh`` behaviour and is acceptable because
+  Holodeck ops are deterministic (no per-call credentials embedded in
+  the script).
+* Logging emits ``script_len`` (an integer, the UTF-8 byte count of
+  the operator-supplied script) and ``exit_status`` only. Neither the
+  original script, the encoded payload, nor any field of
+  ``target.secret_ref`` is bound into any log event. The structured
+  error mirrors this: ``script`` and ``encoded`` are never written
+  into the error's user-visible attributes.
+* Callers must not pass credential material in ``script``. The helper
+  cannot enforce this because the script is opaque to it; the rule is
+  encoded in the connector's per-op handlers, none of which
+  interpolate secrets into the PowerShell text they assemble.
+
+Cited references
+----------------
+
+* PowerShell ``-EncodedCommand`` / ``about_pwsh``:
+  https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_pwsh
+* PowerShell ``ConvertTo-Json``:
+  https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/convertto-json
+* asyncssh ``SSHClientConnection.run``:
+  https://asyncssh.readthedocs.io/ (pinned via
+  ``asyncssh>=2.18,<3.0`` in ``backend/pyproject.toml``).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+import structlog
+
+__all__ = ["PWSH_DEFAULT_DEPTH", "PwshRunError", "encode_pwsh_command", "pwsh_run"]
+
+_log = structlog.get_logger(__name__)
+
+#: Default ``ConvertTo-Json -Depth`` value the helper recommends in its
+#: ``script`` argument. The PowerShell built-in defaults to 2, which
+#: silently truncates deeply nested cmdlet output (e.g. ``Get-Service``
+#: with nested ``RequiredServices``). The recipe in the #371 body uses
+#: an explicit ``-Depth 4``; we surface that as a constant so each
+#: caller doesn't reinvent the value.
+PWSH_DEFAULT_DEPTH: int = 4
+
+#: Maximum stderr fragment length retained on a :class:`PwshRunError`.
+#: Stderr from ``pwsh`` can be long (multi-line stack traces); a hard
+#: cap keeps log/audit payloads bounded and avoids any chance of
+#: secret-shaped substrings hidden deeper in the output bleeding into
+#: error surfaces.
+_STDERR_MAX_LEN: int = 4096
+
+
+class PwshRunError(RuntimeError):
+    """Structured failure from :func:`pwsh_run`.
+
+    Carried fields:
+
+    * ``exit_status`` — ``pwsh``'s exit code (``int``). Non-zero
+      indicates the cmdlet itself failed; ``None`` indicates
+      ``pwsh -EncodedCommand`` produced output that :mod:`json`
+      could not parse.
+    * ``stderr`` — the (truncated) ``pwsh`` stderr fragment. Capped at
+      :data:`_STDERR_MAX_LEN` characters so structured-log payloads
+      stay bounded.
+
+    The original script, the encoded base64 payload, and any
+    ``target.secret_ref`` field are intentionally **not** retained on
+    the exception — the dispatcher's ``connector_error`` envelope
+    surfaces ``str(exc)`` to the operator and any of those substrings
+    would be a leak.
+    """
+
+    def __init__(self, message: str, *, exit_status: int | None, stderr: str) -> None:
+        super().__init__(message)
+        self.exit_status = exit_status
+        self.stderr = stderr[:_STDERR_MAX_LEN]
+
+
+def encode_pwsh_command(script: str) -> str:
+    """Encode *script* per ``pwsh -EncodedCommand``'s contract.
+
+    The contract (Microsoft docs, ``about_pwsh``): the value following
+    ``-EncodedCommand`` is the base64 of the UTF-16LE bytes of the
+    PowerShell script. No BOM, no surrounding whitespace, no trailing
+    newline.
+
+    Example::
+
+        >>> encode_pwsh_command("Get-Service | ConvertTo-Json")
+        'RwBlAHQALQBTAGUAcgB2AGkAYwBlACAAfAAgAEMAbwBuAHYAZQByAHQAVABvAC0ASgBzAG8AbgA='
+
+    Public so the unit suite can assert the encoding round-trips
+    against the documented convention without re-deriving it inside
+    the test.
+    """
+    return base64.b64encode(script.encode("utf-16-le")).decode("ascii")
+
+
+async def pwsh_run(
+    connector: Any,
+    target: Any,
+    script: str,
+    *,
+    depth: int = PWSH_DEFAULT_DEPTH,
+    timeout: float = 30.0,
+) -> Any:
+    """Run *script* on *target* via ``pwsh -EncodedCommand``; parse JSON output.
+
+    Parameters
+    ----------
+    connector
+        An :class:`~meho_backplane.connectors.adapters.ssh.SshConnector`
+        instance (typically the :class:`HolodeckConnector` itself).
+        The helper reaches into its ``_run_command`` seam so the
+        adapter's pooling + auth machinery is preserved.
+    target
+        The :class:`Target` the SSH connection is keyed to. Passed
+        through to ``_run_command``.
+    script
+        The PowerShell script body the caller wants to run. Callers
+        are expected to pipe the cmdlet's output through
+        ``| ConvertTo-Json`` (or ``ConvertTo-Json -Compress -Depth N``
+        for deep cmdlet outputs); the helper does not append the
+        conversion itself because some ops construct multi-statement
+        scripts where only the final pipeline produces the JSON.
+    depth
+        Advisory — surfaced as the recommended ``-Depth`` value via
+        :data:`PWSH_DEFAULT_DEPTH`. The helper itself does not rewrite
+        the script; this argument exists so the constant has a public
+        named entry point on the function signature for callers that
+        want to assert "I used the default depth".
+    timeout
+        Wall-clock seconds for the remote command. Forwarded to
+        ``_run_command``; expiry raises :exc:`asyncio.TimeoutError`.
+
+    Returns
+    -------
+    The parsed JSON payload (typically a ``dict`` or ``list``).
+
+    Raises
+    ------
+    PwshRunError
+        ``pwsh`` exited non-zero, or stdout did not parse as JSON.
+        ``PwshRunError.exit_status`` carries the integer exit on
+        non-zero exit; ``None`` indicates the JSON parse failed.
+    """
+    del depth  # advisory — see docstring
+    encoded = encode_pwsh_command(script)
+    cmd = f"pwsh -NoProfile -NonInteractive -EncodedCommand {encoded}"
+
+    proc = await connector._run_command(target, cmd, raw_jwt="", timeout=timeout)
+
+    stdout: str = (proc.stdout or "") if hasattr(proc, "stdout") else ""
+    stderr: str = (proc.stderr or "") if hasattr(proc, "stderr") else ""
+    if not isinstance(stdout, str):
+        stdout = ""
+    if not isinstance(stderr, str):
+        stderr = ""
+    exit_status: int | None = getattr(proc, "exit_status", None)
+
+    # Structured logging discipline (mirrors the SSH adapter's
+    # ``ssh_command_executed`` event): only sizes + exit code; never
+    # the script body, never the encoded payload, never anything that
+    # could carry credential bytes.
+    _log.info(
+        "holodeck_pwsh_executed",
+        target=getattr(target, "name", None),
+        script_len=len(script.encode("utf-8")),
+        encoded_len=len(encoded),
+        exit_status=exit_status,
+    )
+
+    if exit_status is None or exit_status != 0:
+        raise PwshRunError(
+            f"pwsh -EncodedCommand exited with status {exit_status!r}",
+            exit_status=exit_status,
+            stderr=stderr,
+        )
+
+    if not stdout.strip():
+        raise PwshRunError(
+            "pwsh -EncodedCommand produced empty stdout; expected ConvertTo-Json output",
+            exit_status=exit_status,
+            stderr=stderr,
+        )
+
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        # ``json.loads`` raises with an ``int`` ``.pos`` field; the
+        # exception message itself is sanitised by :class:`PwshRunError`
+        # ('didn't parse' wording rather than the offending bytes) so
+        # the operator-visible surface never carries the raw payload.
+        del exc  # sanitised on purpose
+        raise PwshRunError(
+            "pwsh -EncodedCommand stdout was not valid JSON; expected ConvertTo-Json output",
+            exit_status=exit_status,
+            stderr=stderr,
+        ) from None

--- a/backend/src/meho_backplane/connectors/holodeck/connector.py
+++ b/backend/src/meho_backplane/connectors/holodeck/connector.py
@@ -1,0 +1,544 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""HolodeckConnector -- typed SSH-transport connector for VMware Holodeck 9.0.
+
+G3.8-T1 (#853) skeleton -- the tier-4 closer in the SSH-transport
+family (after bind9 G3.4 and pfSense G3.7). HoloRouter exposes no
+REST API; the connector's only transport is SSH-to-root driving
+``pwsh -EncodedCommand`` for Holodeck cmdlets, mediated by
+:mod:`meho_backplane.connectors.holodeck._pwsh`.
+
+This module ships:
+
+* :class:`HolodeckConnector`, subclass of
+  :class:`~meho_backplane.connectors.adapters.ssh.SshConnector`,
+  carrying the registry-v2 triple
+  ``("holodeck", "9.0", "holodeck-ssh")``.
+* :meth:`HolodeckConnector.fingerprint` -- SSH +
+  ``cat /etc/photon-release`` + a ``Get-HoloDeckConfig | ConvertTo-Json``
+  cmdlet routed through the pwsh helper. Returns the canonical
+  :class:`FingerprintResult` shape with ``vendor="vmware"`` /
+  ``product="holodeck"``; ``version`` is the parsed Holodeck release
+  string from the cmdlet output; ``extras`` carries
+  ``photon_version`` and ``pod_id``. Unreachable / SSH-failed /
+  cmdlet-failed targets surface as ``reachable=False`` +
+  ``extras["error"]`` with the exception message.
+* :meth:`HolodeckConnector.probe` -- TCP + SSH handshake + Photon
+  health check (``/etc/photon-release`` non-empty) + Holodeck
+  services check (``Get-Service ... | ConvertTo-Json``). Surfaces
+  four distinct ``ProbeResult.reason`` values per #371: ``tcp_unreachable``,
+  ``ssh_auth_failed``, ``photon_unhealthy``, ``holodeck_services_down``.
+* :meth:`HolodeckConnector.about` -- operator-facing wrapper around
+  :meth:`fingerprint`, registered as the ``holodeck.about`` typed op
+  (T1's canary).
+* :meth:`HolodeckConnector.execute` -- the G0.6 dispatcher shim
+  (same shape as :meth:`Bind9Connector.execute` and
+  :meth:`PfSenseConnector.execute`).
+
+Auth uses the base
+:class:`~meho_backplane.connectors.adapters.ssh.SshConnector._auth_config`
+unchanged: password-default (the HoloRouter OVA ships root password
+auth; ``secret_ref.password``) with key-fallback when
+``ssh_private_key`` is present. This inverts the pfSense connector
+(key-only, no password) and matches the Initiative #371 specification.
+
+The 8 read ops (config / pod / service / k8s / logs / networking)
+ship in G3.8-T2 (#854) by appending to
+:data:`~meho_backplane.connectors.holodeck.ops.HOLODECK_OPS` from a
+sibling module; the dispatcher shim does not change.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import asyncssh
+import structlog
+
+from meho_backplane.connectors.adapters.ssh import SshConnector
+from meho_backplane.connectors.holodeck._pwsh import PwshRunError, pwsh_run
+from meho_backplane.connectors.holodeck.ops import HOLODECK_OPS
+from meho_backplane.connectors.schemas import (
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+
+__all__ = ["HolodeckConnector"]
+
+_log = structlog.get_logger(__name__)
+
+# Forward declaration -- replaced with `from meho_backplane.targets import Target`
+# in G0.3's Target model rollout. Mirrors the placeholder in the SSH adapter
+# and the Bind9 / pfSense siblings.
+type Target = Any
+
+
+# ``/etc/photon-release`` ships in the form ``VMware Photon Linux <X>.<Y>``
+# on every Photon release this connector targets (4.x / 5.x). The version
+# token is the first ``<digit>.<digit>(.<digit>)?`` group on the line.
+_PHOTON_VERSION_RE: re.Pattern[str] = re.compile(r"(\d+\.\d+(?:\.\d+)?)")
+
+
+def parse_photon_version(content: str) -> str | None:
+    """Return the Photon version from ``/etc/photon-release``, or ``None``.
+
+    Examples
+    --------
+
+    >>> parse_photon_version("VMware Photon Linux 5.0\\nPHOTON_BUILD_NUMBER=...")
+    '5.0'
+    >>> parse_photon_version("VMware Photon OS 4.0")
+    '4.0'
+    >>> parse_photon_version("") is None
+    True
+    """
+    if not content.strip():
+        return None
+    match = _PHOTON_VERSION_RE.search(content)
+    return match.group(1) if match else None
+
+
+#: Curated ``when_to_use`` strings per group key, indexed by
+#: :meth:`HolodeckConnector.register_operations`. Each entry covers a
+#: ``group_key`` declared in :data:`HOLODECK_OPS`. T1 ships only the
+#: ``identity`` group (``holodeck.about``); T2 adds ``config`` /
+#: ``pod`` / ``service`` / ``k8s`` / ``logs`` / ``networking`` entries
+#: by appending to this mapping (the registration walk fails closed
+#: with a :class:`ValueError` if a ``group_key`` lacks a curated entry,
+#: per the bind9 / pfSense precedent).
+_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    "identity": (
+        "Use for Holodeck appliance identity questions before any "
+        "per-pod or per-service drill-in: 'which Holodeck version "
+        "is this HoloRouter running, on which Photon OS, and what "
+        "is the pod identifier?'. The single ``holodeck.about`` op "
+        "returns vendor / product / version (parsed Holodeck "
+        "release), the Photon OS version, and the pod ID. Call this "
+        "first when the agent needs to confirm the HoloRouter is "
+        "reachable via SSH + pwsh before issuing higher-level "
+        "pod / service / log ops -- Holodeck has no REST API, so "
+        "this op also confirms the PowerShell-over-SSH transport "
+        "is functional."
+    ),
+}
+
+
+class HolodeckConnector(SshConnector):
+    """VMware Holodeck 9.0 connector built on the :class:`SshConnector` adapter.
+
+    Registry v2 triple: ``("holodeck", "9.0", "holodeck-ssh")``. The
+    ``9.0`` version targets the current Holodeck Toolkit release as
+    of 2026. A future ``("holodeck", "10.x", ...)`` entry can ship
+    alongside without disturbing 9.0 targets.
+
+    **Auth: password-default + key-fallback.** Inherits the base
+    :class:`SshConnector` ``_auth_config`` unchanged: a Vault secret
+    with ``ssh_private_key`` prefers key auth, otherwise password
+    auth runs (the HoloRouter OVA ships root password auth out of
+    the box per #371). This inverts the pfSense connector's
+    key-only override; neither connector embeds the auth-selection
+    logic in its own module.
+
+    **Transport: PowerShell-over-SSH.** Holodeck cmdlets reach the
+    appliance through ``pwsh -EncodedCommand <base64-utf16le>``
+    routed by :func:`~meho_backplane.connectors.holodeck._pwsh.pwsh_run`.
+    Output is parsed via stdlib :mod:`json` from the cmdlet's
+    ``ConvertTo-Json`` pipe -- the #371 design correction (2026-05-21)
+    supersedes the original CliXml note.
+    """
+
+    product = "holodeck"
+    version = "9.0"
+    impl_id = "holodeck-ssh"
+
+    async def fingerprint(self, target: Target) -> FingerprintResult:
+        """Read Photon release + ``Get-HoloDeckConfig`` -- canonical fingerprint.
+
+        Runs (in order, sharing one pooled SSH connection):
+
+        1. ``cat /etc/photon-release`` -- read the Photon OS release
+           identifier. Parsed via :func:`parse_photon_version`.
+        2. ``pwsh -EncodedCommand`` of
+           ``Get-HoloDeckConfig | ConvertTo-Json -Compress``. The cmdlet
+           returns a flat object with the Holodeck version and pod
+           ID; the helper parses the JSON output via stdlib
+           :mod:`json` and returns a Python dict.
+
+        ``probe_method="ssh: pwsh Get-HoloDeckConfig"`` matches the
+        Initiative #371 specification.
+
+        Unreachable / SSH-failed / cmdlet-failed → ``reachable=False``
+        + ``extras["error"]`` with the exception message. The error
+        carries the exception class name + a sanitised stderr fragment
+        (truncated by :class:`PwshRunError`); credential material
+        cannot leak through because the connector handlers never
+        interpolate ``target.secret_ref`` fields into the PowerShell
+        text.
+        """
+        probed_at = datetime.now(UTC)
+
+        # Phase 1: read /etc/photon-release. Failure here is a hard
+        # fingerprint failure -- there's no Photon-less Holodeck shape
+        # to fall back to.
+        try:
+            photon_proc = await self._run_command(target, "cat /etc/photon-release", raw_jwt="")
+        except (OSError, asyncssh.Error) as exc:
+            _log.warning(
+                "holodeck_fingerprint_unreachable",
+                target=getattr(target, "name", None),
+                error=str(exc),
+            )
+            return FingerprintResult(
+                vendor="vmware",
+                product="holodeck",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method="ssh: pwsh Get-HoloDeckConfig",
+                extras={"error": str(exc)},
+            )
+
+        photon_raw = (photon_proc.stdout or "") if hasattr(photon_proc, "stdout") else ""
+        photon_content = photon_raw if isinstance(photon_raw, str) else ""
+        photon_version = parse_photon_version(photon_content)
+        photon_build = photon_content.strip().splitlines()[0] if photon_content.strip() else None
+
+        # Phase 2: pull the Holodeck config. The cmdlet is the only
+        # supported probe shape for the appliance's own version+pod
+        # data (Holodeck has no /etc/-style file equivalent).
+        try:
+            payload = await pwsh_run(
+                self,
+                target,
+                "Get-HoloDeckConfig | ConvertTo-Json -Compress",
+            )
+        except PwshRunError as exc:
+            _log.warning(
+                "holodeck_fingerprint_pwsh_failed",
+                target=getattr(target, "name", None),
+                exit_status=exc.exit_status,
+            )
+            return FingerprintResult(
+                vendor="vmware",
+                product="holodeck",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method="ssh: pwsh Get-HoloDeckConfig",
+                extras={
+                    "error": str(exc),
+                    "photon_version": photon_version,
+                    "photon_build": photon_build,
+                },
+            )
+
+        holodeck_version: str | None = None
+        pod_id: str | None = None
+        if isinstance(payload, dict):
+            raw_version = payload.get("Version") or payload.get("HolodeckVersion")
+            holodeck_version = raw_version if isinstance(raw_version, str) else None
+            raw_pod = payload.get("PodId") or payload.get("PodID")
+            pod_id = raw_pod if isinstance(raw_pod, str) else None
+
+        return FingerprintResult(
+            vendor="vmware",
+            product="holodeck",
+            version=holodeck_version,
+            build=photon_build,
+            reachable=True,
+            probed_at=probed_at,
+            probe_method="ssh: pwsh Get-HoloDeckConfig",
+            extras={
+                "photon_version": photon_version,
+                "pod_id": pod_id,
+            },
+        )
+
+    async def probe(self, target: Target) -> ProbeResult:
+        """Reachability + auth + Photon-health + Holodeck-services check.
+
+        Failure modes (each surfaces a distinct ``reason``):
+
+        * ``tcp_unreachable`` -- the SSH TCP socket cannot connect
+          (host down, firewall, wrong port). Catches :exc:`OSError`
+          raised inside asyncssh's connect() before the SSH handshake.
+        * ``ssh_auth_failed`` -- credentials were rejected
+          (:exc:`asyncssh.PermissionDenied`) or the handshake failed
+          for a non-auth reason (:exc:`asyncssh.DisconnectError`).
+          Both shapes fold into ``ssh_auth_failed`` per #371's
+          four-bucket failure-mode taxonomy (the Initiative does not
+          require the bind9-style split between ``auth_failed`` and
+          ``ssh_handshake_failed``; the Holodeck operator response is
+          the same -- check the Vault secret or the appliance's
+          ``/etc/ssh/sshd_config``).
+        * ``photon_unhealthy`` -- SSH succeeded but
+          ``/etc/photon-release`` is missing or empty. Photon OS
+          ships ``/etc/photon-release`` on every supported release;
+          an empty read signals a non-Photon target or a corrupt
+          appliance image.
+        * ``holodeck_services_down`` -- Photon is healthy but the
+          bundled Holodeck services check (``Get-Service`` filtered
+          to the Holodeck service set via pwsh) returns a non-empty
+          list of services not in the ``Running`` state. The cmdlet
+          shape mirrors the #371 body's example.
+
+        The probe does not mutate state. ``Get-Service`` is read-only
+        on Photon.
+        """
+        start = time.monotonic()
+        probed_at = datetime.now(UTC)
+
+        def _result(ok: bool, reason: str | None) -> ProbeResult:
+            latency_ms = (time.monotonic() - start) * 1000.0
+            return ProbeResult(
+                ok=ok,
+                reason=reason,
+                latency_ms=latency_ms,
+                probed_at=probed_at,
+            )
+
+        # Order matters: PermissionDenied (subclass of DisconnectError)
+        # must be caught before DisconnectError; OSError is the TCP-
+        # level failure. ValueError from _auth_config (missing
+        # credentials) folds into ssh_auth_failed -- the operator's
+        # remediation is the same as for a rejected password.
+        try:
+            await self._connect(target, raw_jwt="")
+        except asyncssh.PermissionDenied:
+            return _result(False, "ssh_auth_failed")
+        except asyncssh.DisconnectError:
+            return _result(False, "ssh_auth_failed")
+        except OSError:
+            return _result(False, "tcp_unreachable")
+        except ValueError:
+            return _result(False, "ssh_auth_failed")
+
+        # Photon health: ``/etc/photon-release`` must produce non-empty
+        # stdout. An empty read signals a non-Photon target (somebody
+        # repointed the Holodeck target's Vault secret at a stock
+        # Linux box) or a degraded appliance image.
+        try:
+            photon_proc = await self._run_command(target, "cat /etc/photon-release", raw_jwt="")
+        except (OSError, asyncssh.Error):
+            return _result(False, "ssh_auth_failed")
+        photon_raw = (photon_proc.stdout or "") if hasattr(photon_proc, "stdout") else ""
+        photon_content = photon_raw if isinstance(photon_raw, str) else ""
+        if not photon_content.strip() or photon_proc.exit_status != 0:
+            return _result(False, "photon_unhealthy")
+
+        # Holodeck services health: ``Get-Service`` filtered to the
+        # bundled Holodeck service set, piped through ConvertTo-Json
+        # so we get a structured list back. Any service not in the
+        # ``Running`` state flips the probe to ``holodeck_services_down``.
+        # The exact filter prefix tracks the #371 body's example; T2's
+        # ``holodeck.service.list`` op uses the same shape.
+        try:
+            services_payload = await pwsh_run(
+                self,
+                target,
+                "Get-Service | Where-Object { $_.Name -like 'Holo*' } | "
+                "Select-Object Name,Status | ConvertTo-Json",
+            )
+        except PwshRunError:
+            return _result(False, "holodeck_services_down")
+
+        # ``ConvertTo-Json`` on a single-element list returns a flat
+        # dict; on a multi-element list it returns a JSON array. We
+        # normalise both shapes to a list before walking it.
+        if isinstance(services_payload, dict):
+            services: list[Any] = [services_payload]
+        elif isinstance(services_payload, list):
+            services = services_payload
+        else:
+            services = []
+
+        for svc in services:
+            if not isinstance(svc, dict):
+                continue
+            status = svc.get("Status")
+            # PowerShell renders the ServiceControllerStatus enum as
+            # either the numeric int (``4`` for Running) or the string
+            # ``"Running"`` depending on the cmdlet's depth setting.
+            # Accept both shapes -- the canonical encoding is the
+            # string form via ``Select-Object``.
+            if status not in ("Running", 4):
+                return _result(False, "holodeck_services_down")
+
+        return _result(True, None)
+
+    async def about(
+        self,
+        target: Target,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Return the Holodeck appliance's product/version/Photon snapshot.
+
+        Op-id: ``holodeck.about``. The dispatcher routes here after
+        the JSON Schema validator has accepted *params* (declared
+        empty in :mod:`~meho_backplane.connectors.holodeck.ops`).
+        Reuses :meth:`fingerprint` so the operator-facing op and the
+        canonical fingerprint share one network round-trip per call
+        (two SSH commands plus the pwsh execution; one pooled
+        connection). The returned dict is flat (no nested ``extras``)
+        because the dispatcher's default reducer forwards the value
+        verbatim into ``OperationResult.result``.
+        """
+        del params  # declared empty in schema; intentionally ignored
+        result = await self.fingerprint(target)
+        return {
+            "vendor": result.vendor,
+            "product": result.product,
+            "version": result.version,
+            "build": result.build,
+            "photon_version": result.extras.get("photon_version"),
+            "pod_id": result.extras.get("pod_id"),
+        }
+
+    @classmethod
+    async def register_operations(cls) -> None:
+        """Upsert every op in :data:`HOLODECK_OPS` into ``endpoint_descriptor``.
+
+        Called from the application lifespan after the registry has
+        eager-imported every connector module. Walks
+        :data:`~meho_backplane.connectors.holodeck.ops.HOLODECK_OPS`
+        and routes each row through
+        :func:`~meho_backplane.operations.typed_register.register_typed_operation`.
+        Idempotent across pod restarts -- mirrors the
+        :meth:`Bind9Connector.register_operations` /
+        :meth:`PfSenseConnector.register_operations` shape.
+        """
+        from meho_backplane.operations.typed_register import register_typed_operation
+
+        bindings: list[tuple[Any, Any]] = []
+        for op in HOLODECK_OPS:
+            handler = getattr(cls, op.handler_attr, None)
+            if handler is None:
+                raise AttributeError(
+                    f"HolodeckConnector op {op.op_id!r} declares "
+                    f"handler_attr={op.handler_attr!r} but the class has no such attribute"
+                )
+            bindings.append((op, handler))
+
+        for op, handler in bindings:
+            when_to_use: str | None
+            if op.group_key is None:
+                when_to_use = None
+            else:
+                when_to_use = _WHEN_TO_USE_BY_GROUP.get(op.group_key)
+                if when_to_use is None:
+                    raise ValueError(
+                        f"HolodeckConnector op {op.op_id!r} declares "
+                        f"group_key={op.group_key!r} but no curated "
+                        f"when_to_use exists for that key. Add an entry "
+                        f"to _WHEN_TO_USE_BY_GROUP in "
+                        f"meho_backplane.connectors.holodeck.connector so "
+                        f"list_operation_groups surfaces a real "
+                        f"selection signal instead of the auto-derive "
+                        f"template."
+                    )
+            await register_typed_operation(
+                product=cls.product,
+                version=cls.version,
+                impl_id=cls.impl_id,
+                op_id=op.op_id,
+                handler=handler,
+                summary=op.summary,
+                description=op.description,
+                parameter_schema=op.parameter_schema,
+                response_schema=op.response_schema,
+                group_key=op.group_key,
+                when_to_use=when_to_use,
+                tags=list(op.tags),
+                safety_level=op.safety_level,
+                requires_approval=op.requires_approval,
+                llm_instructions=op.llm_instructions,
+            )
+        _log.info(
+            "holodeck_operations_registered",
+            count=len(bindings),
+            product=cls.product,
+            version=cls.version,
+            impl_id=cls.impl_id,
+        )
+
+    async def execute(
+        self,
+        target: Target,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Dispatcher shim -- delegate to the G0.6 lookup + invoke path.
+
+        Mirrors :meth:`Bind9Connector.execute` and
+        :meth:`PfSenseConnector.execute`. The dispatch shape is
+        operator-less (no policy gate, no audit row, no broadcast)
+        because direct callers do not carry an
+        :class:`~meho_backplane.auth.operator.Operator`; the
+        operator-aware surface is ``POST /api/v1/operations/call``
+        via the G0.6 meta-tools.
+        """
+        from sqlalchemy import select
+
+        from meho_backplane.db.engine import get_sessionmaker
+        from meho_backplane.db.models import EndpointDescriptor
+        from meho_backplane.operations._errors import (
+            result_connector_error,
+            result_invalid_params,
+            result_unknown_op,
+        )
+        from meho_backplane.operations._handler_resolve import (
+            import_handler,
+            is_unbound_method,
+        )
+        from meho_backplane.operations._lookup import count_known_ops
+        from meho_backplane.operations._validate import validate_params
+
+        start = time.monotonic()
+
+        def _elapsed() -> float:
+            return (time.monotonic() - start) * 1000.0
+
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.tenant_id.is_(None),
+                    EndpointDescriptor.product == self.product,
+                    EndpointDescriptor.version == self.version,
+                    EndpointDescriptor.impl_id == self.impl_id,
+                    EndpointDescriptor.op_id == op_id,
+                    EndpointDescriptor.is_enabled.is_(True),
+                )
+            )
+            descriptor = result.scalar_one_or_none()
+
+        if descriptor is None:
+            known_op_count = await count_known_ops(
+                product=self.product,
+                version=self.version,
+                impl_id=self.impl_id,
+            )
+            return result_unknown_op(op_id, known_op_count, _elapsed())
+
+        validation_errors = validate_params(descriptor.parameter_schema, params)
+        if validation_errors:
+            return result_invalid_params(op_id, validation_errors, _elapsed())
+
+        handler = import_handler(descriptor.handler_ref or "")
+        if is_unbound_method(handler, type(self)):
+            handler = handler.__get__(self, type(self))
+
+        try:
+            raw = await handler(target=target, params=params)
+        except Exception as exc:
+            return result_connector_error(op_id, exc, _elapsed())
+
+        return OperationResult(
+            status="ok",
+            op_id=op_id,
+            result=raw if isinstance(raw, (dict, list)) else {"value": raw},
+            duration_ms=_elapsed(),
+        )

--- a/backend/src/meho_backplane/connectors/holodeck/ops.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Typed operations exposed by :class:`HolodeckConnector`.
+
+G3.8-T1 (#853) skeleton ships ``holodeck.about`` -- the canary op
+that proves the ``register_typed_operation()`` -> dispatcher ->
+PowerShell-over-SSH -> JSON-parse pipeline end-to-end on the
+Holodeck connector. G3.8-T2 (#854) appends the 8 read ops via
+``_holodeck_ops()`` exactly as the bind9 / pfSense siblings layered
+their read groups onto the T1 canary.
+
+The dataclass + tuple shape mirrors
+:mod:`~meho_backplane.connectors.bind9.ops` and
+:mod:`~meho_backplane.connectors.pfsense.ops` so the registration
+walk reads identically across SSH-transport connectors.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+__all__ = ["HOLODECK_OPS", "HolodeckOp"]
+
+
+@dataclass(frozen=True)
+class HolodeckOp:
+    """Metadata for one Holodeck op the connector registers at startup.
+
+    Fields mirror the keyword arguments
+    :func:`~meho_backplane.operations.typed_register.register_typed_operation`
+    accepts so the connector's ``register_operations()`` classmethod
+    can splat the dataclass into the helper without per-op
+    boilerplate. ``handler_attr`` is the attribute name on
+    :class:`~meho_backplane.connectors.holodeck.connector.HolodeckConnector`
+    that exposes the async handler.
+    """
+
+    op_id: str
+    handler_attr: str
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any] | None
+    group_key: str | None
+    tags: tuple[str, ...]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
+    llm_instructions: dict[str, Any] | None
+
+
+#: The single T1 canary op. ``holodeck.about`` is the operator-facing
+#: wrapper around :meth:`HolodeckConnector.fingerprint`. T2 (#854)
+#: appends the 8 read ops onto :data:`HOLODECK_OPS` from
+#: ``ops_read``-style modules.
+_HOLODECK_ABOUT_OP = HolodeckOp(
+    op_id="holodeck.about",
+    handler_attr="about",
+    summary="Return the Holodeck appliance's product, version, and Photon OS snapshot.",
+    description=(
+        "Connects to the HoloRouter appliance over SSH and runs "
+        "``cat /etc/photon-release`` plus ``pwsh -EncodedCommand`` "
+        "of ``Get-HoloDeckConfig | ConvertTo-Json -Compress`` to "
+        "extract the Holodeck version, Photon OS version, and pod "
+        "ID. Returns a flat dict with the parsed Holodeck version, "
+        "the full Photon release line, the pod ID, and the vendor "
+        "(``vmware``). Holodeck exposes no REST API; this op (and "
+        "every other op in the connector) is the canonical surface "
+        "for identifying the appliance before issuing higher-level "
+        "pod/service/log ops. No params; safe to call on any healthy "
+        "HoloRouter target."
+    ),
+    parameter_schema={
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+    response_schema={
+        "type": "object",
+        "properties": {
+            "vendor": {"type": "string"},
+            "product": {"type": "string"},
+            "version": {"type": ["string", "null"]},
+            "build": {"type": ["string", "null"]},
+            "photon_version": {"type": ["string", "null"]},
+            "pod_id": {"type": ["string", "null"]},
+        },
+        "required": ["vendor", "product"],
+        "additionalProperties": True,
+    },
+    group_key="identity",
+    tags=("read-only", "identity", "holodeck"),
+    safety_level="safe",
+    requires_approval=False,
+    llm_instructions={
+        "when_to_use": (
+            "Call when the operator wants to identify the Holodeck "
+            "appliance behind a target before issuing higher-level "
+            "pod / service / log ops, or when the agent needs to "
+            "confirm the appliance is reachable via SSH + pwsh. "
+            "Holodeck has no REST surface; this op and the other "
+            "Holodeck ops are reached through PowerShell-over-SSH."
+        ),
+        "parameter_hints": {},
+        "output_shape": (
+            "Flat dict; ``version`` carries the parsed Holodeck "
+            "version string (e.g. ``9.0.0``) when the cmdlet output "
+            "was readable. ``photon_version`` carries the host "
+            "Photon OS release identifier (e.g. ``5.0``). ``pod_id`` "
+            "carries the Holodeck pod identifier when set on the "
+            "appliance, ``None`` otherwise."
+        ),
+    },
+)
+
+
+#: The ops :class:`HolodeckConnector` registers at lifespan startup.
+#:
+#: T1 ships ``holodeck.about``; T2 (#854) appends the 8 read ops
+#: (``holodeck.config.show``, ``holodeck.pod.list``,
+#: ``holodeck.pod.info``, ``holodeck.service.list``,
+#: ``holodeck.k8s.exec``, ``holodeck.logs.tail``,
+#: ``holodeck.networking.show``) onto this tuple via an ``ops_read``
+#: composition module -- the registration walk in
+#: :meth:`HolodeckConnector.register_operations` does not change.
+HOLODECK_OPS: tuple[HolodeckOp, ...] = (_HOLODECK_ABOUT_OP,)

--- a/backend/tests/test_connectors_holodeck_auth.py
+++ b/backend/tests/test_connectors_holodeck_auth.py
@@ -1,0 +1,609 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the HolodeckConnector skeleton (G3.8-T1 #853).
+
+Coverage matrix (per Task #853 acceptance criteria):
+
+* ``HolodeckConnector`` advertises the registry-v2 triple
+  ``("holodeck", "9.0", "holodeck-ssh")``.
+* Importing the package registers the connector against the v2
+  registry under that triple (and does **not** dual-write to v1).
+* :meth:`HolodeckConnector._auth_config` -- password-default works
+  (Vault secret with ``password`` and no ``ssh_private_key`` returns
+  ``{username, password}``); key-preferred works (Vault secret with
+  ``ssh_private_key`` returns ``{username, client_keys}``); missing
+  both fields raises :exc:`ValueError`.
+* Per-target connection isolation: two distinct targets do not share
+  a pooled connection object.
+* :func:`parse_photon_version` recovers the version token from the
+  Photon release strings the connector targets.
+* :meth:`HolodeckConnector.fingerprint` returns the canonical
+  :class:`FingerprintResult` shape against a mocked ``_run_command``
+  + ``pwsh_run`` seam with valid Photon + ``Get-HoloDeckConfig``
+  outputs.
+* :meth:`HolodeckConnector.fingerprint` with unreachable SSH ->
+  ``reachable=False`` + ``extras["error"]``.
+* :meth:`HolodeckConnector.fingerprint` with broken pwsh (cmdlet
+  fail) -> ``reachable=False`` and still surfaces the Photon snapshot
+  in ``extras``.
+* :meth:`HolodeckConnector.probe` returns the four distinct
+  ``ProbeResult.reason`` values from the matching failure modes:
+  ``tcp_unreachable``, ``ssh_auth_failed``, ``photon_unhealthy``,
+  ``holodeck_services_down``.
+* :meth:`HolodeckConnector.about` reuses :meth:`fingerprint` and
+  surfaces the flat dict the dispatcher's reducer forwards verbatim.
+* :meth:`HolodeckConnector.execute` after registration is the same
+  shape as the bind9 / pfSense siblings: unknown / invalid_params /
+  ok envelopes via the G0.6 dispatcher shim.
+* Secret-leak invariant: nothing in :meth:`fingerprint`,
+  :meth:`probe`, or :meth:`execute`'s observable surface (return
+  value, logs, exception messages) carries the canary password the
+  test target ships.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncssh
+import pytest
+
+import meho_backplane.connectors.holodeck  # noqa: F401 -- import for registry side-effects
+from meho_backplane.connectors import all_connectors_v2
+from meho_backplane.connectors.holodeck import HOLODECK_OPS, HolodeckConnector
+from meho_backplane.connectors.holodeck._pwsh import PwshRunError
+from meho_backplane.connectors.holodeck.connector import parse_photon_version
+from meho_backplane.connectors.registry import clear_registry
+from meho_backplane.settings import get_settings
+
+# ---------------------------------------------------------------------------
+# Environment fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Target + process stubs
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: dict[str, Any]
+
+
+# Canary credentials the secret-leak assertions key on. The fake
+# "private key" string is assembled at runtime from non-secret-shaped
+# fragments so gitleaks' ``private-key`` rule doesn't false-positive
+# on the test source: we want the assertion target to be the same
+# substring that real PEM headers would surface, without writing a
+# literal PEM-bracketed multi-line constant into the file.
+_CANARY_PASSWORD = "holodeck-canary-password-xyz"  # NOSONAR
+_FAKE_KEY_HEADER = "-----BEGIN " + "OPENSSH PRIVATE KEY" + "-----"
+_FAKE_KEY_FOOTER = "-----END " + "OPENSSH PRIVATE KEY" + "-----"
+_CANARY_PRIVATE_KEY = f"{_FAKE_KEY_HEADER}\nFAKE-CANARY-KEY-BODY\n{_FAKE_KEY_FOOTER}\n"
+
+
+def _password_target(name: str = "holorouter-pw") -> _StubTarget:
+    return _StubTarget(
+        name=name,
+        host=f"{name}.test.invalid",
+        port=22,
+        secret_ref={"username": "root", "password": _CANARY_PASSWORD},
+    )
+
+
+def _key_target(name: str = "holorouter-key") -> _StubTarget:
+    return _StubTarget(
+        name=name,
+        host=f"{name}.test.invalid",
+        port=22,
+        secret_ref={"username": "root", "ssh_private_key": _CANARY_PRIVATE_KEY},
+    )
+
+
+def _no_cred_target(name: str = "holorouter-empty") -> _StubTarget:
+    return _StubTarget(
+        name=name,
+        host=f"{name}.test.invalid",
+        port=22,
+        secret_ref={"username": "root"},
+    )
+
+
+def _completed_process(*, stdout: str = "", stderr: str = "", exit_status: int = 0) -> Any:
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = stderr
+    proc.exit_status = exit_status
+    return proc
+
+
+# Canonical Photon and Holodeck cmdlet outputs the fingerprint / probe
+# tests reuse.
+_PHOTON_5 = "VMware Photon Linux 5.0\nPHOTON_BUILD_NUMBER=12345\n"
+_HOLODECK_CONFIG_JSON = '{"Version":"9.0.0","PodId":"lab-pod-01"}'
+_HOLODECK_SERVICES_ALL_RUNNING_JSON = (
+    '[{"Name":"HoloDNS","Status":"Running"},{"Name":"HoloDHCP","Status":"Running"}]'
+)
+_HOLODECK_SERVICES_ONE_DOWN_JSON = (
+    '[{"Name":"HoloDNS","Status":"Running"},{"Name":"HoloDHCP","Status":"Stopped"}]'
+)
+
+
+# ---------------------------------------------------------------------------
+# Class-level registry v2 metadata + package import registration
+# ---------------------------------------------------------------------------
+
+
+def test_registry_v2_class_attrs() -> None:
+    """Class-level attrs match the v2 triple the package registers."""
+    assert HolodeckConnector.product == "holodeck"
+    assert HolodeckConnector.version == "9.0"
+    assert HolodeckConnector.impl_id == "holodeck-ssh"
+    assert HolodeckConnector.supported_version_range is None
+    assert HolodeckConnector.priority == 0
+
+
+def test_package_import_registers_v2_entry_only() -> None:
+    """Importing the package registers under the v2 triple, no v1 dual-write.
+
+    Drives the registry clear + reload itself so the assertion observes
+    the **side-effect of importing the package** rather than a fixture's
+    re-registration -- mirrors the bind9 / pfSense pattern.
+    """
+    import meho_backplane.connectors.holodeck as holodeck_pkg
+
+    clear_registry()
+    # Force the module-top-level ``register_connector_v2`` call in
+    # ``holodeck/__init__.py`` to fire under the cleared registry. The
+    # ``HolodeckConnector`` class object is owned by
+    # ``connectors.holodeck.connector`` which is *not* reloaded here,
+    # so the post-reload registry entry points at the same class object
+    # the rest of this module imports at the top.
+    importlib.reload(holodeck_pkg)
+
+    v2 = all_connectors_v2()
+    assert v2[("holodeck", "9.0", "holodeck-ssh")] is HolodeckConnector
+    # Holodeck has no v1 chassis history (see ``__init__.py`` docstring);
+    # the v1 ``register_connector`` write is intentionally absent.
+    # ``register_connector`` would also dual-write a ``(product, "",
+    # "")`` v2 entry; that key must not be present.
+    assert ("holodeck", "", "") not in v2
+
+
+def test_t1_ships_only_the_about_canary_op() -> None:
+    """T1 ships ``holodeck.about`` alone; T2 (#854) appends the 8 read ops."""
+    assert len(HOLODECK_OPS) == 1
+    assert HOLODECK_OPS[0].op_id == "holodeck.about"
+    assert HOLODECK_OPS[0].handler_attr == "about"
+
+
+# ---------------------------------------------------------------------------
+# parse_photon_version (AC #4 sub-bullet)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "content, expected",
+    [
+        ("VMware Photon Linux 5.0\nPHOTON_BUILD_NUMBER=...", "5.0"),
+        ("VMware Photon OS 4.0", "4.0"),
+        ("VMware Photon Linux 3.0\nID=photon\n", "3.0"),
+        ("Photon 5.0.2", "5.0.2"),
+    ],
+)
+def test_parse_photon_version_recovers_token(content: str, expected: str) -> None:
+    assert parse_photon_version(content) == expected
+
+
+def test_parse_photon_version_returns_none_on_garbage() -> None:
+    assert parse_photon_version("") is None
+    assert parse_photon_version("totally unrelated text") is None
+
+
+# ---------------------------------------------------------------------------
+# Auth: password-default + key-fallback + neither (AC #3)
+# ---------------------------------------------------------------------------
+
+
+async def test_auth_config_password_default() -> None:
+    """Password-only secret -> ``{username, password}``; no key path taken."""
+    connector = HolodeckConnector()
+    auth = await connector._auth_config(_password_target())
+    assert auth == {"username": "root", "password": _CANARY_PASSWORD}
+    assert "client_keys" not in auth
+
+
+async def test_auth_config_key_preferred_when_present() -> None:
+    """``ssh_private_key`` present in the secret wins over password.
+
+    The base ``_auth_config`` checks ``ssh_private_key`` first and
+    returns the key auth dict -- mirroring the wrapper's
+    ``PreferredAuthentications=publickey,password`` shape.
+    """
+    connector = HolodeckConnector()
+    # Stub ``asyncssh.import_private_key`` since the canary PEM is not
+    # a real key; we just need to confirm the key branch is taken and
+    # the result is shaped correctly.
+    stub_key = MagicMock(name="stub-private-key")
+    with patch("asyncssh.import_private_key", return_value=stub_key) as imp:
+        auth = await connector._auth_config(_key_target())
+    imp.assert_called_once_with(_CANARY_PRIVATE_KEY)
+    assert auth == {"username": "root", "client_keys": [stub_key]}
+    assert "password" not in auth
+
+
+async def test_auth_config_raises_when_neither_credential_is_set() -> None:
+    connector = HolodeckConnector()
+    with pytest.raises(ValueError, match="ssh_private_key or password"):
+        await connector._auth_config(_no_cred_target())
+
+
+# ---------------------------------------------------------------------------
+# Per-target connection isolation (AC #3 sub-bullet)
+# ---------------------------------------------------------------------------
+
+
+async def test_per_target_connection_isolation() -> None:
+    """Two distinct targets get distinct pooled connection objects."""
+    connector = HolodeckConnector()
+    conn_a = MagicMock(name="conn-A")
+    conn_a.is_closed.return_value = False
+    conn_b = MagicMock(name="conn-B")
+    conn_b.is_closed.return_value = False
+    with patch("asyncssh.connect", new=AsyncMock(side_effect=[conn_a, conn_b])):
+        a = await connector._connect(_password_target("holorouter-a"), raw_jwt="")
+        b = await connector._connect(_password_target("holorouter-b"), raw_jwt="")
+    assert a is conn_a
+    assert b is conn_b
+    assert a is not b
+    # Pool keyed by target.name; both entries present.
+    assert "holorouter-a" in connector._connections
+    assert "holorouter-b" in connector._connections
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint (AC #4)
+# ---------------------------------------------------------------------------
+
+
+async def test_fingerprint_returns_canonical_shape_against_mocked_seams() -> None:
+    connector = HolodeckConnector()
+    with (
+        patch.object(
+            connector,
+            "_run_command",
+            AsyncMock(return_value=_completed_process(stdout=_PHOTON_5, exit_status=0)),
+        ),
+        patch(
+            "meho_backplane.connectors.holodeck.connector.pwsh_run",
+            AsyncMock(return_value={"Version": "9.0.0", "PodId": "lab-pod-01"}),
+        ),
+    ):
+        result = await connector.fingerprint(_password_target())
+
+    assert result.vendor == "vmware"
+    assert result.product == "holodeck"
+    assert result.version == "9.0.0"
+    assert result.build == "VMware Photon Linux 5.0"
+    assert result.reachable is True
+    assert result.probe_method == "ssh: pwsh Get-HoloDeckConfig"
+    assert result.extras["photon_version"] == "5.0"
+    assert result.extras["pod_id"] == "lab-pod-01"
+
+
+async def test_fingerprint_unreachable_when_ssh_fails() -> None:
+    connector = HolodeckConnector()
+    with patch.object(
+        connector,
+        "_run_command",
+        AsyncMock(side_effect=OSError("connection refused")),
+    ):
+        result = await connector.fingerprint(_password_target())
+    assert result.reachable is False
+    assert "connection refused" in result.extras["error"]
+    # Auth canary must never appear in the fingerprint result.
+    assert _CANARY_PASSWORD not in str(result.extras)
+
+
+async def test_fingerprint_partial_when_pwsh_cmdlet_fails() -> None:
+    """Photon read OK but cmdlet failed -> reachable=False; Photon snapshot stays in extras."""
+    connector = HolodeckConnector()
+    with (
+        patch.object(
+            connector,
+            "_run_command",
+            AsyncMock(return_value=_completed_process(stdout=_PHOTON_5, exit_status=0)),
+        ),
+        patch(
+            "meho_backplane.connectors.holodeck.connector.pwsh_run",
+            AsyncMock(
+                side_effect=PwshRunError(
+                    "pwsh -EncodedCommand exited with status 1",
+                    exit_status=1,
+                    stderr="Get-HoloDeckConfig : cmdlet not found",
+                )
+            ),
+        ),
+    ):
+        result = await connector.fingerprint(_password_target())
+    assert result.reachable is False
+    assert "pwsh" in result.extras["error"]
+    # Photon snapshot is preserved so the operator sees how far the
+    # probe got before the cmdlet broke.
+    assert result.extras["photon_version"] == "5.0"
+
+
+# ---------------------------------------------------------------------------
+# Probe — four distinct reasons (AC #5)
+# ---------------------------------------------------------------------------
+
+
+async def test_probe_tcp_unreachable() -> None:
+    connector = HolodeckConnector()
+    with patch.object(connector, "_connect", AsyncMock(side_effect=OSError("no route"))):
+        result = await connector.probe(_password_target())
+    assert result.ok is False
+    assert result.reason == "tcp_unreachable"
+
+
+async def test_probe_ssh_auth_failed_on_permission_denied() -> None:
+    connector = HolodeckConnector()
+    with patch.object(
+        connector,
+        "_connect",
+        AsyncMock(side_effect=asyncssh.PermissionDenied(reason="bad password")),
+    ):
+        result = await connector.probe(_password_target())
+    assert result.ok is False
+    assert result.reason == "ssh_auth_failed"
+
+
+async def test_probe_ssh_auth_failed_on_disconnect_error() -> None:
+    """``DisconnectError`` (non-auth handshake failures) also folds into ``ssh_auth_failed``.
+
+    The Initiative #371 taxonomy uses four buckets; bind9 splits
+    auth-vs-handshake but Holodeck does not. The operator response is
+    the same.
+    """
+    connector = HolodeckConnector()
+    with patch.object(
+        connector,
+        "_connect",
+        AsyncMock(side_effect=asyncssh.DisconnectError(code=1, reason="protocol error")),
+    ):
+        result = await connector.probe(_password_target())
+    assert result.ok is False
+    assert result.reason == "ssh_auth_failed"
+
+
+async def test_probe_ssh_auth_failed_when_credentials_missing() -> None:
+    """``ValueError`` from ``_auth_config`` (no creds) folds into ``ssh_auth_failed``."""
+    connector = HolodeckConnector()
+    with patch.object(
+        connector,
+        "_connect",
+        AsyncMock(side_effect=ValueError("secret_ref must include ssh_private_key or password")),
+    ):
+        result = await connector.probe(_no_cred_target())
+    assert result.ok is False
+    assert result.reason == "ssh_auth_failed"
+
+
+async def test_probe_photon_unhealthy_on_empty_release_file() -> None:
+    connector = HolodeckConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock()),
+        patch.object(
+            connector,
+            "_run_command",
+            AsyncMock(return_value=_completed_process(stdout="", exit_status=0)),
+        ),
+    ):
+        result = await connector.probe(_password_target())
+    assert result.ok is False
+    assert result.reason == "photon_unhealthy"
+
+
+async def test_probe_photon_unhealthy_on_nonzero_exit() -> None:
+    connector = HolodeckConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock()),
+        patch.object(
+            connector,
+            "_run_command",
+            AsyncMock(return_value=_completed_process(stdout="", exit_status=1)),
+        ),
+    ):
+        result = await connector.probe(_password_target())
+    assert result.ok is False
+    assert result.reason == "photon_unhealthy"
+
+
+async def test_probe_holodeck_services_down_when_service_is_stopped() -> None:
+    connector = HolodeckConnector()
+    services_payload = [
+        {"Name": "HoloDNS", "Status": "Running"},
+        {"Name": "HoloDHCP", "Status": "Stopped"},
+    ]
+    with (
+        patch.object(connector, "_connect", AsyncMock()),
+        patch.object(
+            connector,
+            "_run_command",
+            AsyncMock(return_value=_completed_process(stdout=_PHOTON_5, exit_status=0)),
+        ),
+        patch(
+            "meho_backplane.connectors.holodeck.connector.pwsh_run",
+            AsyncMock(return_value=services_payload),
+        ),
+    ):
+        result = await connector.probe(_password_target())
+    assert result.ok is False
+    assert result.reason == "holodeck_services_down"
+
+
+async def test_probe_holodeck_services_down_when_pwsh_fails() -> None:
+    connector = HolodeckConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock()),
+        patch.object(
+            connector,
+            "_run_command",
+            AsyncMock(return_value=_completed_process(stdout=_PHOTON_5, exit_status=0)),
+        ),
+        patch(
+            "meho_backplane.connectors.holodeck.connector.pwsh_run",
+            AsyncMock(
+                side_effect=PwshRunError(
+                    "pwsh -EncodedCommand exited with status 1",
+                    exit_status=1,
+                    stderr="...",
+                )
+            ),
+        ),
+    ):
+        result = await connector.probe(_password_target())
+    assert result.ok is False
+    assert result.reason == "holodeck_services_down"
+
+
+async def test_probe_happy_path_returns_ok_true() -> None:
+    connector = HolodeckConnector()
+    services_payload = [
+        {"Name": "HoloDNS", "Status": "Running"},
+        {"Name": "HoloDHCP", "Status": "Running"},
+    ]
+    with (
+        patch.object(connector, "_connect", AsyncMock()),
+        patch.object(
+            connector,
+            "_run_command",
+            AsyncMock(return_value=_completed_process(stdout=_PHOTON_5, exit_status=0)),
+        ),
+        patch(
+            "meho_backplane.connectors.holodeck.connector.pwsh_run",
+            AsyncMock(return_value=services_payload),
+        ),
+    ):
+        result = await connector.probe(_password_target())
+    assert result.ok is True
+    assert result.reason is None
+    assert result.latency_ms is not None and result.latency_ms >= 0.0
+
+
+async def test_probe_accepts_single_service_dict_payload() -> None:
+    """``ConvertTo-Json`` on a single-element list emits a flat dict, not a list."""
+    connector = HolodeckConnector()
+    with (
+        patch.object(connector, "_connect", AsyncMock()),
+        patch.object(
+            connector,
+            "_run_command",
+            AsyncMock(return_value=_completed_process(stdout=_PHOTON_5, exit_status=0)),
+        ),
+        patch(
+            "meho_backplane.connectors.holodeck.connector.pwsh_run",
+            AsyncMock(return_value={"Name": "HoloDNS", "Status": "Running"}),
+        ),
+    ):
+        result = await connector.probe(_password_target())
+    assert result.ok is True
+
+
+# ---------------------------------------------------------------------------
+# about wrapper
+# ---------------------------------------------------------------------------
+
+
+async def test_about_reuses_fingerprint_and_returns_flat_dict() -> None:
+    connector = HolodeckConnector()
+    with (
+        patch.object(
+            connector,
+            "_run_command",
+            AsyncMock(return_value=_completed_process(stdout=_PHOTON_5, exit_status=0)),
+        ),
+        patch(
+            "meho_backplane.connectors.holodeck.connector.pwsh_run",
+            AsyncMock(return_value={"Version": "9.0.0", "PodId": "lab-pod-01"}),
+        ),
+    ):
+        payload = await connector.about(_password_target(), {})
+
+    assert payload == {
+        "vendor": "vmware",
+        "product": "holodeck",
+        "version": "9.0.0",
+        "build": "VMware Photon Linux 5.0",
+        "photon_version": "5.0",
+        "pod_id": "lab-pod-01",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Secret-leak invariants on fingerprint / probe / about result shapes
+# ---------------------------------------------------------------------------
+
+
+async def test_observable_paths_do_not_leak_canary_password() -> None:
+    """The canary password from secret_ref never appears in any observable surface."""
+    connector = HolodeckConnector()
+    with (
+        patch.object(
+            connector,
+            "_run_command",
+            AsyncMock(return_value=_completed_process(stdout=_PHOTON_5, exit_status=0)),
+        ),
+        patch(
+            "meho_backplane.connectors.holodeck.connector.pwsh_run",
+            AsyncMock(return_value={"Version": "9.0.0", "PodId": "lab-pod-01"}),
+        ),
+    ):
+        fp = await connector.fingerprint(_password_target())
+        about = await connector.about(_password_target(), {})
+
+    serialised = repr(fp) + repr(about)
+    assert _CANARY_PASSWORD not in serialised
+    # Private-key canary never enters; this is a password-only target.
+    assert "FAKE-CANARY-KEY-BODY" not in serialised
+
+
+async def test_observable_paths_do_not_leak_canary_private_key() -> None:
+    connector = HolodeckConnector()
+    with (
+        patch.object(
+            connector,
+            "_run_command",
+            AsyncMock(return_value=_completed_process(stdout=_PHOTON_5, exit_status=0)),
+        ),
+        patch(
+            "meho_backplane.connectors.holodeck.connector.pwsh_run",
+            AsyncMock(return_value={"Version": "9.0.0", "PodId": "lab-pod-01"}),
+        ),
+    ):
+        fp = await connector.fingerprint(_key_target())
+        about = await connector.about(_key_target(), {})
+
+    serialised = repr(fp) + repr(about)
+    assert "FAKE-CANARY-KEY-BODY" not in serialised
+    assert _CANARY_PASSWORD not in serialised

--- a/backend/tests/test_connectors_holodeck_pwsh.py
+++ b/backend/tests/test_connectors_holodeck_pwsh.py
@@ -1,0 +1,318 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the Holodeck connector's ``_pwsh`` helper (G3.8-T1 #853).
+
+Coverage matrix (per Task #853 AC #2):
+
+* :func:`encode_pwsh_command` round-trips the documented
+  ``pwsh -EncodedCommand`` convention (UTF-16LE-base64, no BOM).
+  Round-trip via :mod:`base64` + UTF-16-LE decode recovers the
+  original script byte-for-byte.
+* :func:`pwsh_run` constructs the remote command as
+  ``pwsh -NoProfile -NonInteractive -EncodedCommand <encoded>`` --
+  the script body is **not** in argv after encoding (it's in the
+  base64 payload, but no other interpolation).
+* :func:`pwsh_run` parses ``ConvertTo-Json`` stdout via stdlib
+  :mod:`json` and returns the parsed structure (dict, list, scalar).
+* :func:`pwsh_run` raises :class:`PwshRunError` on non-zero exit.
+* :func:`pwsh_run` raises :class:`PwshRunError` on non-JSON stdout
+  (e.g. a cmdlet failure message printed to stdout).
+* :func:`pwsh_run` raises :class:`PwshRunError` on empty stdout
+  (degenerate "cmdlet returned nothing" case).
+* :class:`PwshRunError` truncates the stderr fragment to the
+  documented cap so unbounded cmdlet errors never bleed into the
+  exception surface.
+* Secret-leak invariant: stdin / argv / log events emitted by the
+  helper never contain the original script text in plaintext, never
+  contain stderr's canary string verbatim past the truncation cap,
+  and never contain anything from ``target.secret_ref``.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from meho_backplane.connectors.holodeck._pwsh import (
+    PWSH_DEFAULT_DEPTH,
+    PwshRunError,
+    encode_pwsh_command,
+    pwsh_run,
+)
+from meho_backplane.settings import get_settings
+
+# ---------------------------------------------------------------------------
+# Settings fixture (settings/secret-leak sweep + conftest share the same env)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Target + SSHCompletedProcess stubs
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: dict[str, Any]
+
+
+_TARGET = _StubTarget(
+    name="holorouter-lab",
+    host="holorouter.test.invalid",
+    port=22,
+    secret_ref={
+        "username": "root",
+        # Canary password the secret-leak assertions key on.
+        "password": "holodeck-canary-password-xyz",  # NOSONAR
+    },
+)
+
+
+def _proc(*, stdout: str = "", stderr: str = "", exit_status: int = 0) -> Any:
+    """Construct an ``SSHCompletedProcess``-shaped stub.
+
+    Mirrors :func:`_completed_process` in the bind9 / pfSense suites:
+    the helper code only touches ``.stdout`` / ``.stderr`` /
+    ``.exit_status`` so a :class:`MagicMock` is enough.
+    """
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = stderr
+    proc.exit_status = exit_status
+    return proc
+
+
+def _connector_with_run(proc: Any) -> Any:
+    """Build a stub connector whose ``_run_command`` returns *proc*.
+
+    The helper reaches into ``connector._run_command(target, cmd, ...)``;
+    a :class:`MagicMock` with an :class:`AsyncMock` ``_run_command`` is
+    enough to assert what argv the helper passes (and what it does
+    with the returned proc).
+    """
+    connector = MagicMock()
+    connector._run_command = AsyncMock(return_value=proc)
+    return connector
+
+
+# ---------------------------------------------------------------------------
+# encode_pwsh_command — round-trip the documented convention
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "script",
+    [
+        "Get-Service | ConvertTo-Json",
+        "Get-HoloDeckConfig | ConvertTo-Json -Compress",
+        "Get-Service | Where-Object { $_.Name -like 'Holo*' } | "
+        "Select-Object Name,Status | ConvertTo-Json",
+        # Multi-line script (the ``-EncodedCommand`` form's primary
+        # reason for existing — sidesteps the shell's argument-parsing
+        # rules for embedded newlines and quotes).
+        "$x = Get-HoloDeckConfig\n$x.Version | ConvertTo-Json",
+    ],
+)
+def test_encode_pwsh_command_round_trips_utf16le_base64(script: str) -> None:
+    encoded = encode_pwsh_command(script)
+    # ``-EncodedCommand`` accepts only base64 ASCII; assert that.
+    assert encoded == base64.b64encode(script.encode("utf-16-le")).decode("ascii")
+    # And the round-trip via base64-decode + UTF-16-LE-decode recovers
+    # the script byte-for-byte.
+    recovered = base64.b64decode(encoded).decode("utf-16-le")
+    assert recovered == script
+
+
+def test_encode_pwsh_command_emits_no_bom() -> None:
+    """The convention is *no BOM* on the encoded payload (#371 cite)."""
+    encoded = encode_pwsh_command("Get-Service")
+    decoded_bytes = base64.b64decode(encoded)
+    # UTF-16-LE BOM is ``FF FE``; the convention's encoding skips it.
+    assert not decoded_bytes.startswith(b"\xff\xfe")
+
+
+def test_pwsh_default_depth_is_documented_4() -> None:
+    """The constant matches the #371 body's ``ConvertTo-Json -Depth 4`` recipe."""
+    assert PWSH_DEFAULT_DEPTH == 4
+
+
+# ---------------------------------------------------------------------------
+# pwsh_run — happy paths
+# ---------------------------------------------------------------------------
+
+
+async def test_pwsh_run_returns_parsed_json_dict_for_convertto_json_object() -> None:
+    payload = {"Version": "9.0.0", "PodId": "lab-pod-01"}
+    connector = _connector_with_run(_proc(stdout=json.dumps(payload), exit_status=0))
+
+    result = await pwsh_run(
+        connector,
+        _TARGET,
+        "Get-HoloDeckConfig | ConvertTo-Json -Compress",
+    )
+    assert result == payload
+
+
+async def test_pwsh_run_returns_parsed_json_list_for_convertto_json_array() -> None:
+    payload = [{"Name": "HoloDNS", "Status": "Running"}, {"Name": "HoloDHCP", "Status": "Running"}]
+    connector = _connector_with_run(_proc(stdout=json.dumps(payload), exit_status=0))
+
+    result = await pwsh_run(
+        connector,
+        _TARGET,
+        "Get-Service | ConvertTo-Json",
+    )
+    assert result == payload
+
+
+async def test_pwsh_run_calls_run_command_with_encoded_command_argv() -> None:
+    """argv is ``pwsh -NoProfile -NonInteractive -EncodedCommand <base64>``.
+
+    The script itself appears only inside the base64 payload — there is
+    no other shell-level interpolation of the script body. ``-NoProfile``
+    + ``-NonInteractive`` are non-negotiable: they prevent the appliance's
+    pwsh profile (if any) from injecting prompts or extra cmdlets that
+    would dirty stdout.
+    """
+    connector = _connector_with_run(_proc(stdout='{"ok": true}', exit_status=0))
+    script = "Get-HoloDeckConfig | ConvertTo-Json -Compress"
+
+    await pwsh_run(connector, _TARGET, script)
+
+    connector._run_command.assert_awaited_once()
+    args, kwargs = connector._run_command.call_args
+    target_arg, cmd_arg = args[0], args[1]
+    assert target_arg is _TARGET
+    expected_encoded = encode_pwsh_command(script)
+    assert cmd_arg == (f"pwsh -NoProfile -NonInteractive -EncodedCommand {expected_encoded}")
+    # raw_jwt / timeout are forwarded as kwargs.
+    assert kwargs.get("raw_jwt") == ""
+    assert "timeout" in kwargs
+
+
+async def test_pwsh_run_forwards_caller_timeout_to_run_command() -> None:
+    connector = _connector_with_run(_proc(stdout="null", exit_status=0))
+    await pwsh_run(connector, _TARGET, "Get-Service | ConvertTo-Json", timeout=5.0)
+
+    _, kwargs = connector._run_command.call_args
+    assert kwargs["timeout"] == 5.0
+
+
+# ---------------------------------------------------------------------------
+# pwsh_run — failure modes (AC #2 sub-bullet 3)
+# ---------------------------------------------------------------------------
+
+
+async def test_pwsh_run_raises_on_non_zero_exit_status() -> None:
+    connector = _connector_with_run(
+        _proc(stdout="", stderr="Get-HoloDeckConfig : cmdlet not found", exit_status=1)
+    )
+    with pytest.raises(PwshRunError) as exc_info:
+        await pwsh_run(connector, _TARGET, "Get-HoloDeckConfig | ConvertTo-Json")
+
+    assert exc_info.value.exit_status == 1
+    assert "cmdlet not found" in exc_info.value.stderr
+
+
+async def test_pwsh_run_raises_on_non_json_stdout() -> None:
+    """A cmdlet that prints text to stdout instead of JSON fails closed."""
+    connector = _connector_with_run(
+        _proc(stdout="Get-HoloDeckConfig: not a real cmdlet", exit_status=0)
+    )
+    with pytest.raises(PwshRunError) as exc_info:
+        await pwsh_run(connector, _TARGET, "Get-HoloDeckConfig | ConvertTo-Json")
+
+    # ``exit_status`` is the original non-zero-or-zero value at the time
+    # the parse error fires; the message names the JSON-parse failure
+    # without echoing the offending payload (the operator can re-run
+    # the cmdlet manually to see the raw output).
+    assert exc_info.value.exit_status == 0
+    assert "not valid JSON" in str(exc_info.value)
+
+
+async def test_pwsh_run_raises_on_empty_stdout() -> None:
+    """Empty stdout from a ``| ConvertTo-Json`` pipe is a probe failure."""
+    connector = _connector_with_run(_proc(stdout="", exit_status=0))
+    with pytest.raises(PwshRunError) as exc_info:
+        await pwsh_run(connector, _TARGET, "Get-HoloDeckConfig | ConvertTo-Json")
+    assert "empty stdout" in str(exc_info.value)
+
+
+async def test_pwsh_run_error_truncates_long_stderr() -> None:
+    """Stderr longer than the cap is truncated on :class:`PwshRunError`.
+
+    The cap protects the operator-visible surface from unbounded
+    cmdlet stack traces and any secret-shaped substring that might
+    happen to live deeper in the output.
+    """
+    long_stderr = "x" * 10_000
+    connector = _connector_with_run(_proc(stdout="", stderr=long_stderr, exit_status=1))
+    with pytest.raises(PwshRunError) as exc_info:
+        await pwsh_run(connector, _TARGET, "Get-HoloDeckConfig | ConvertTo-Json")
+
+    assert len(exc_info.value.stderr) <= 4096
+    # The truncated stderr still starts with the first bytes -- the
+    # cap doesn't drop content from the wrong end.
+    assert exc_info.value.stderr.startswith("x" * 100)
+
+
+# ---------------------------------------------------------------------------
+# Secret-leak invariants (Hard requirement: never log/expose creds or script)
+# ---------------------------------------------------------------------------
+
+
+async def test_pwsh_run_does_not_embed_script_in_log_events(
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """The helper logs ``script_len`` + ``exit_status`` only — not the script."""
+    from meho_backplane.logging import configure_logging
+
+    configure_logging()
+
+    canary_script = "Get-HoloDeckConfig | ConvertTo-Json -Compress # HOLODECK-CANARY-MARKER"
+    payload = {"ok": True}
+    connector = _connector_with_run(_proc(stdout=json.dumps(payload), exit_status=0))
+    await pwsh_run(connector, _TARGET, canary_script)
+
+    out, err = capfd.readouterr()
+    combined = out + err
+    # The structured-log event must record sizes only -- never the
+    # script body itself.
+    assert "HOLODECK-CANARY-MARKER" not in combined
+    # The canary password from the stub target must never appear in
+    # any log line the helper emits.
+    assert "holodeck-canary-password-xyz" not in combined
+
+
+async def test_pwsh_run_error_does_not_carry_script_text() -> None:
+    """Even on failure, the exception surface omits the original script."""
+    canary_script = "Get-HoloDeckConfig | ConvertTo-Json -Compress # HOLODECK-CANARY-IN-SCRIPT"
+    connector = _connector_with_run(_proc(stdout="", stderr="pwsh: command failed", exit_status=1))
+    with pytest.raises(PwshRunError) as exc_info:
+        await pwsh_run(connector, _TARGET, canary_script)
+
+    err = exc_info.value
+    # The script body must not appear in the exception message or
+    # any field of the structured error.
+    assert "HOLODECK-CANARY-IN-SCRIPT" not in str(err)
+    assert "HOLODECK-CANARY-IN-SCRIPT" not in err.stderr

--- a/backend/tests/test_connectors_registry_v2.py
+++ b/backend/tests/test_connectors_registry_v2.py
@@ -447,3 +447,25 @@ def test_hetzner_robot_connector_registered_under_v2_triple() -> None:
     key = ("hetzner-robot", "2026.04", "hetzner-rest")
     assert key in snapshot
     assert snapshot[key] is HetznerRobotConnector
+
+
+def test_holodeck_connector_registered_under_v2_triple() -> None:
+    """HolodeckConnector package registers under (holodeck, 9.0, holodeck-ssh).
+
+    G3.8-T1 (#853) skeleton. The autouse _clean_registry fixture clears the
+    registry before this test, so we manually re-register using the class
+    attributes to assert the triple resolves correctly. Same pattern as
+    the SDDC Manager / Harbor / pfSense tests above.
+    """
+    from meho_backplane.connectors.holodeck import HolodeckConnector
+
+    register_connector_v2(
+        product=HolodeckConnector.product,
+        version=HolodeckConnector.version,
+        impl_id=HolodeckConnector.impl_id,
+        cls=HolodeckConnector,
+    )
+    snapshot = all_connectors_v2()
+    key = ("holodeck", "9.0", "holodeck-ssh")
+    assert key in snapshot
+    assert snapshot[key] is HolodeckConnector

--- a/docs/codebase/connectors-holodeck.md
+++ b/docs/codebase/connectors-holodeck.md
@@ -1,0 +1,220 @@
+# Connector: holodeck (holodeck-9.0 / `holodeck-ssh`)
+
+## Overview
+
+The `holodeck` connector is the typed `Connector` subclass that dispatches
+operator-facing VMware Holodeck operations over SSH. It is registered under
+the `(product="holodeck", version="9.0", impl_id="holodeck-ssh")` registry
+triple and is the **third** typed-SSH tier child of the `SshConnector`
+adapter (G0.2-T4 #243), after `Bind9Connector` (G3.4) and `PfSenseConnector`
+(G3.7).
+
+HoloRouter exposes **no REST API** — the appliance's only operator surface
+is SSH-to-root driving `pwsh -EncodedCommand` for Holodeck PowerShell cmdlets
+(or `kubectl` for the in-appliance K8s). This makes Holodeck the canonical
+SSH-only typed connector in the inventory and the tier-4 closer for G3.
+
+The connector replaces the operator's `scripts/holodeck.sh` wrapper in the
+`claude-rdc-hetzner-dc` consumer repository. The G3.8-T1 (#853) skeleton
+ships only the `holodeck.about` canary op, the password-default + key-fallback
+auth via the inherited `SshConnector._auth_config`, the fingerprint, the
+probe, and the `_pwsh.py` PowerShell-over-SSH helper. G3.8-T2 (#854) adds
+the 8 read ops; G3.8-T3 (#855) ships the CLI verbs + E2E acceptance suite +
+onboarding doc.
+
+Source: `backend/src/meho_backplane/connectors/holodeck/`.
+
+## Key types
+
+- **`HolodeckConnector`** (`connector.py`) — `SshConnector` subclass. Class
+  attributes: `product="holodeck"`, `version="9.0"`, `impl_id="holodeck-ssh"`.
+  Inherits the per-target asyncssh connection pool, `_auth_config`,
+  `_run_command`, and `aclose()` from the adapter. T1 ships `fingerprint`,
+  `probe`, `execute`, `about`. T2 will add the 8 read-op bound-method shims.
+
+- **`_pwsh.py` — the novel primitive.** Houses `encode_pwsh_command(script)`
+  (UTF-16LE-base64 per the `-EncodedCommand` convention), `pwsh_run(connector,
+  target, script)` (runs `pwsh -NoProfile -NonInteractive -EncodedCommand
+  <encoded>` over the pooled SSH connection and parses `ConvertTo-Json`
+  stdout via stdlib `json`), `PwshRunError` (structured failure with the
+  truncated stderr fragment but no script body or auth material), and
+  `PWSH_DEFAULT_DEPTH = 4` (the recommended `ConvertTo-Json -Depth` per the
+  #371 body).
+
+  **Design correction (2026-05-21).** The Initiative body originally
+  specified CliXml output via `-OutputFormat Xml` + `pyclixml` parsing. T1
+  supersedes that with `ConvertTo-Json` + stdlib `json`: the #371 body's
+  fingerprint/probe/op examples all already use `ConvertTo-Json`, and Json
+  drops the undecided `pyclixml` dependency. The wire encoding (UTF-16LE-
+  base64) and the `-EncodedCommand` argv shape are unchanged from the
+  original design.
+
+- **Op metadata** (`ops.py`) — the `HolodeckOp` dataclass and the
+  `HOLODECK_OPS` tuple. T1 ships the single `holodeck.about` canary; T2
+  will append the 8 read ops by extending the tuple from an `ops_read`-style
+  module, mirroring bind9's `_bind9_ops()` and pfSense's `_pfsense_ops()`.
+
+- **`parse_photon_version`** (`connector.py`) — pure parser for
+  `/etc/photon-release` output; recovers the `<major>.<minor>(.<patch>)?`
+  Photon version token from the appliance's release file.
+
+## Control flow
+
+### Auth (inherited from `SshConnector._auth_config`)
+
+`_auth_config` is called by the base `SshConnector._connect` method before
+opening any TCP connection. It inspects `target.secret_ref`:
+
+1. `ssh_private_key` present → parse via `asyncssh.import_private_key`,
+   return `{username, client_keys=[key]}`. This is the key-preferred path
+   (mirrors the wrapper's `PreferredAuthentications=publickey,password`
+   header).
+2. No `ssh_private_key`, `password` present → return
+   `{username, password}`. This is the **default** path for the HoloRouter
+   OVA, which ships with root password auth enabled.
+3. Neither set → `ValueError` (the base adapter's standard message). The
+   probe folds this into `ssh_auth_failed`.
+
+The Holodeck connector intentionally does **not** override `_auth_config`.
+The inversion vs pfSense (key-only) is encoded in pfSense's override; the
+Holodeck connector's reliance on the base behaviour is the design choice.
+
+### `fingerprint(target)`
+
+Runs two SSH command paths in sequence over the pooled connection:
+
+1. `cat /etc/photon-release` → parsed via `parse_photon_version` to extract
+   the Photon OS version token. The first line of the file lands in `build`;
+   the parsed token lands in `extras["photon_version"]`.
+2. `pwsh -NoProfile -NonInteractive -EncodedCommand <base64-of-UTF16LE>` of
+   the script `Get-HoloDeckConfig | ConvertTo-Json -Compress`. Routed
+   through `pwsh_run`; the parsed JSON dict yields `version` (the
+   `Version`/`HolodeckVersion` field) and `extras["pod_id"]` (the
+   `PodId`/`PodID` field).
+
+Failure modes:
+
+- SSH connect / command fails (`OSError`, `asyncssh.Error`) → `reachable=False`
+  with `extras["error"]` set to `str(exc)`. The probe never opens a
+  follow-up pwsh call when the first SSH command fails.
+- `pwsh` cmdlet fails (`PwshRunError`) → `reachable=False` with both
+  `extras["error"]` and the Photon snapshot preserved in `extras`. The
+  operator sees how far the probe got before the cmdlet broke.
+
+`probe_method="ssh: pwsh Get-HoloDeckConfig"`.
+
+### `probe(target)`
+
+Four-stage health check; each stage maps to a distinct
+`ProbeResult.reason`:
+
+1. SSH connect — `OSError` → `tcp_unreachable`;
+   `asyncssh.PermissionDenied`, `asyncssh.DisconnectError`, or `ValueError`
+   from `_auth_config` → `ssh_auth_failed`.
+2. `cat /etc/photon-release` — empty stdout or non-zero exit →
+   `photon_unhealthy` (covers non-Photon targets and corrupt appliance
+   images).
+3. `pwsh` of
+   `Get-Service | Where-Object { $_.Name -like 'Holo*' } | Select-Object
+   Name,Status | ConvertTo-Json` — any service in the result with `Status`
+   ≠ `Running` (string or the numeric `4`) → `holodeck_services_down`. A
+   `PwshRunError` here also maps to `holodeck_services_down` (the cmdlet's
+   failure is itself a Holodeck-services signal).
+4. All checks pass → `ok=True`, `reason=None`.
+
+The probe does not mutate state. `Get-Service` is read-only on Photon.
+
+### `execute(target, op_id, params)`
+
+Same dispatcher shim shape as bind9 and pfSense:
+
+1. Look up the `EndpointDescriptor` row for `(tenant_id IS NULL, product,
+   version, impl_id, op_id, is_enabled=True)`.
+2. If absent → `result_unknown_op` envelope with the known-op-count for the
+   triple.
+3. Validate `params` against `descriptor.parameter_schema` → on failure,
+   `result_invalid_params` envelope.
+4. Resolve `descriptor.handler_ref` via `import_handler` (and bind to `self`
+   for unbound method paths).
+5. Invoke the handler; any exception → `result_connector_error` envelope.
+6. Happy path → `OperationResult(status="ok", op_id, result, duration_ms)`.
+
+### Two-phase registration
+
+`__init__.py` runs two phases:
+
+1. **Synchronous (import time).**
+   `register_connector_v2(product="holodeck", version="9.0",
+   impl_id="holodeck-ssh", cls=HolodeckConnector)` writes the v2 triple.
+   No v1 dual-write — Holodeck has no chassis history.
+2. **Asynchronous (lifespan startup).**
+   `register_typed_op_registrar(register_holodeck_typed_operations)` queues
+   the registrar; the lifespan calls it after `_eager_import_connectors`,
+   and the registrar walks `HOLODECK_OPS` upserting one
+   `endpoint_descriptor` row per op via `register_typed_operation`. The
+   `embedding_service` kwarg is accepted and discarded — matches the
+   bind9 / pfSense sibling shape; the helper uses the process-wide
+   singleton fallback.
+
+## Dependencies
+
+Direct:
+
+- `meho_backplane.connectors.adapters.ssh.SshConnector` — pooled-asyncssh
+  base + `_auth_config`.
+- `meho_backplane.connectors.holodeck._pwsh` — the PowerShell-over-SSH
+  helper; the **single** seam between the connector's Python handlers and
+  the appliance's pwsh surface.
+- `meho_backplane.connectors.registry.register_connector_v2` — v2 entry.
+- `meho_backplane.operations.typed_register.register_typed_operation` /
+  `register_typed_op_registrar` — async typed-op upsert + lifespan
+  scheduling.
+
+External (pinned in `backend/pyproject.toml`):
+
+- `asyncssh>=2.18,<3.0` — `import_private_key`, `connect`, `SSHClientConnection.run`.
+- Python stdlib `base64`, `json` — pwsh encoding + ConvertTo-Json output
+  parsing. No third-party CliXml parser; the design correction in T1
+  drops `pyclixml`.
+
+## Known issues
+
+- **Encoded payload visibility.** The base64 payload **does** appear on the
+  remote process argv — that's the contract of `-EncodedCommand`. A
+  privileged observer on the appliance can decode it and see the original
+  PowerShell text. This matches the consumer wrapper's behaviour and is
+  acceptable because Holodeck ops are deterministic; no per-call
+  credentials are interpolated into the script body. Callers must not pass
+  credential material in `script`.
+- **`ConvertTo-Json` depth.** PowerShell's `ConvertTo-Json` defaults to
+  `-Depth 2`, which silently truncates deeply nested cmdlet output. The
+  helper recommends `-Depth 4` via the `PWSH_DEFAULT_DEPTH` constant and
+  the #371 body's recipe; callers assemble their scripts to include the
+  explicit `-Depth N` argument.
+- **Holodeck simulator absence.** No published Holodeck simulator exists;
+  T1 ships unit tests against a mocked `pwsh_run` seam, and T3 will layer
+  recorded-fixture integration tests against captured cmdlet payloads (the
+  same shape as G3.6's VCF management-plane fixtures).
+- **Pod-clone deferred.** The consumer's sister wrapper
+  `clone-holodeck-instance.sh` covers nested-lab provisioning end-to-end
+  (multi-step orchestration). That op shape is **out of scope** for
+  v0.2 — it belongs in a Runbooks Initiative once the runbook engine ships
+  (Goal G11 per the v0.1 spec sequencing). The standalone wrapper stays in
+  place; G3.8 provides the inspection ops a runbook would compose against.
+
+## References
+
+- Initiative #371 (G3.8 typed-SSH connector).
+- Task #853 (T1 skeleton + `_pwsh.py`).
+- Adapter: `SshConnector` (G0.2-T4 #243).
+- Sibling SSH-canary precedents: bind9 (G3.4) `connectors-bind9.md`,
+  pfSense (G3.7) `connectors-pfsense.md`.
+- PowerShell `-EncodedCommand`:
+  https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_pwsh
+- `ConvertTo-Json`:
+  https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/convertto-json
+- VMware Holodeck Toolkit: https://core.vmware.com/holodeck-toolkit
+- Consumer wrapper replaced:
+  https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/holodeck.sh
+- Sister wrapper deferred to Runbooks Initiative:
+  https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/clone-holodeck-instance.sh


### PR DESCRIPTION
## Summary
- G3.8-T1 ships the `HolodeckConnector` skeleton — the third `SshConnector` child (after bind9 G3.4 and pfSense G3.7) and the canonical SSH-only typed connector. HoloRouter has no REST API; every cmdlet routes through `pwsh` on the Photon OS appliance via the pooled asyncssh connection.
- The novel primitive is `_pwsh.py`: `encode_pwsh_command` (UTF-16LE-base64 per `about_pwsh`), `pwsh_run` (runs `pwsh -NoProfile -NonInteractive -EncodedCommand <encoded>`, `json.loads` stdout), `PwshRunError` (structured failure with truncated stderr). **Output: `ConvertTo-Json` + stdlib `json`, NOT CliXml** — per the Initiative #371 body's design correction (2026-05-21), which supersedes work-item #2's CliXml note; the body's own fingerprint/probe/op examples all already use `ConvertTo-Json`, and Json drops the undecided `pyclixml` dependency.
- Auth: password-default + key-fallback via the inherited `SshConnector._auth_config` (unchanged) — the HoloRouter OVA ships root password auth out of the box; `ssh_private_key` is preferred when present in the Vault secret. This inverts pfSense (key-only); the inversion lives entirely in pfSense's override.
- Registry v2: `("holodeck", "9.0", "holodeck-ssh")`; v2-only (no v1 chassis history). T1 canary op `holodeck.about` registered at lifespan startup via `register_typed_operation`. The 8 read ops land in T2 (#854); CLI + E2E + onboarding doc in T3 (#855).

## Safety
- `_pwsh.py` never binds the original script, the encoded base64 payload, or any field of `target.secret_ref` into log events or `PwshRunError` attributes. Stderr capped at 4096 chars on the error surface.
- Tests assert canary password and canary script substrings never appear in `OperationResult` repr, capfd output, or `PwshRunError` fields under both happy-path and failure-path runs.

## Test plan
- [x] `ruff check src/meho_backplane/connectors/holodeck/ tests/test_connectors_holodeck_*.py tests/test_connectors_registry_v2.py` — clean.
- [x] `ruff format --check` on the same surface — clean.
- [x] `mypy src/meho_backplane/connectors/holodeck/ tests/test_connectors_holodeck_*.py` — clean (6 files, no issues).
- [x] `pytest tests/test_connectors_holodeck_pwsh.py tests/test_connectors_holodeck_auth.py` — 44 passed (encoding round-trip, ConvertTo-Json parse, non-zero exit error, non-JSON error, empty-stdout error, stderr truncation cap, password/key/no-creds auth paths, per-target isolation, parse_photon_version cases, fingerprint shape + unreachable + cmdlet-fail, probe 4 failure modes + happy path + single-service-dict shape, about wrapper, secret-leak invariants).
- [x] `pytest -n auto tests/ --ignore=tests/integration` — 3727 passed, 155 skipped (no regressions; pre-existing flake in `test_connectors_registry_v2.py` sibling tests when run in isolation is unrelated to this change).
- [x] AC #1 (registry v2 triple resolves): `test_holodeck_connector_registered_under_v2_triple` in `test_connectors_registry_v2.py`.
- [x] AC #2 (`_pwsh_run` round-trip + `ConvertTo-Json` parse + structured error): 11 tests in `test_connectors_holodeck_pwsh.py`.
- [x] AC #3 (auth password-default / key-preferred / neither + per-target isolation): 4 tests in `test_connectors_holodeck_auth.py`.
- [x] AC #4 (`fingerprint` parses Photon + Holodeck; unreachable → `reachable=False` + `extras["error"]`): 3 tests.
- [x] AC #5 (`probe` 4 distinct reasons): 7 tests covering `tcp_unreachable` / `ssh_auth_failed` / `photon_unhealthy` / `holodeck_services_down` plus happy-path + edge shapes.

## Out of scope
- The 8 read ops (`holodeck.config.show`, `holodeck.pod.list`, `holodeck.pod.info`, `holodeck.service.list`, `holodeck.k8s.exec`, `holodeck.logs.tail`, `holodeck.networking.show`) — T2 (#854).
- CLI verbs + MCP review + recorded-fixture E2E + onboarding doc — T3 (#855).
- CliXml / `pyclixml` parsing — superseded by `ConvertTo-Json` per the Initiative's design correction.
- Pod-clone (`clone-holodeck-instance.sh` surface) — out of scope for v0.2 per #371; future Runbooks Initiative under Goal G11.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #853
