### PR TITLE
feat(connectors): G3.8-T2 Holodeck 7 typed read ops + read-only kubectl

### DIFF
--- a/backend/src/meho_backplane/connectors/holodeck/connector.py
+++ b/backend/src/meho_backplane/connectors/holodeck/connector.py
@@ -125,6 +125,54 @@ _WHEN_TO_USE_BY_GROUP: dict[str, str] = {
         "this op also confirms the PowerShell-over-SSH transport "
         "is functional."
     ),
+    "config": (
+        "Use for Holodeck appliance configuration questions: "
+        "``holodeck.config.show`` returns the full Get-HoloDeckConfig "
+        "dict (vendor + product + pod ID + services block). For just "
+        "the identifying fields, ``holodeck.about`` is faster. "
+        "Transport: pwsh-over-SSH (no REST surface)."
+    ),
+    "pod": (
+        "Use for Holodeck nested-pod operations: list the active "
+        "pods (``holodeck.pod.list``) or pull per-pod detail "
+        "(``holodeck.pod.info <pod_id>``). Pod lists carry state, "
+        "primary networking, and VM count; per-pod info adds the VM "
+        "list and FRR/BGP attachment. Transport: pwsh-over-SSH."
+    ),
+    "service": (
+        "Use for Holodeck Photon service health: "
+        "``holodeck.service.list`` returns the bundled services "
+        "(DHCP, DNS, NTP, FRR-BGP, Webtop, K8s-in-appliance) and "
+        "their Status. Pair with ``holodeck.logs.tail`` for "
+        "drill-in. Transport: pwsh-over-SSH."
+    ),
+    "k8s": (
+        "Use for read-only inspection of the K8s cluster bundled on "
+        "the HoloRouter appliance via ``holodeck.k8s.exec`` "
+        "(``kubectl get``/``describe``/``logs``/``top``/``explain``/"
+        "``api-resources``/``api-versions``/``cluster-info``/"
+        "``version``). Mutating verbs are rejected fail-closed at "
+        "the schema layer and re-checked by the handler. Transport: "
+        "plain SSH to the appliance (no pwsh wrapper); the in-"
+        "appliance ``kubectl`` reaches the cluster directly."
+    ),
+    "logs": (
+        "Use for Holodeck runtime log inspection: "
+        "``holodeck.logs.tail component=<slug> [lines=N]`` runs "
+        "``tail`` over ``/holodeck-runtime/logs/<component>*.log``. "
+        "Slugs map to bundled services (``dhcp``, ``dns``, ``frr``, "
+        "``webtop``, ``k8s``); lines defaults to 200, clamped at "
+        "[1, 5000]. Transport: plain SSH."
+    ),
+    "networking": (
+        "Use for the HoloRouter's networking-surface snapshot: "
+        "``holodeck.networking.show`` composes FRR/BGP summary + "
+        "kernel routes + DNS zone summary + DHCP leases into a "
+        "single envelope with per-sub-section ``ok`` flags. "
+        "Pair with ``holodeck.logs.tail component=frr`` for FRR log "
+        "drill-in. Transport: plain SSH for vtysh + dhcpd.leases; "
+        "pwsh-over-SSH for the DNS zone summary."
+    ),
 }
 
 
@@ -396,6 +444,125 @@ class HolodeckConnector(SshConnector):
             "photon_version": result.extras.get("photon_version"),
             "pod_id": result.extras.get("pod_id"),
         }
+
+    async def config_show(
+        self,
+        target: Target,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``holodeck.config.show`` (G3.8-T2 #854).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.holodeck.ops_read.holodeck_config_show`.
+        """
+        from meho_backplane.connectors.holodeck.ops_read import (
+            holodeck_config_show as _holodeck_config_show,
+        )
+
+        return await _holodeck_config_show(self, target, params)
+
+    async def pod_list(
+        self,
+        target: Target,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``holodeck.pod.list`` (G3.8-T2 #854).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.holodeck.ops_read.holodeck_pod_list`.
+        Large pod lists are paged via the future JSONFlux reducer
+        (HandleStore key ``holodeck_pod_list``); the handler emits the
+        ``{rows, total}`` envelope today so the reducer can switch
+        without a connector change.
+        """
+        from meho_backplane.connectors.holodeck.ops_read import (
+            holodeck_pod_list as _holodeck_pod_list,
+        )
+
+        return await _holodeck_pod_list(self, target, params)
+
+    async def pod_info(
+        self,
+        target: Target,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``holodeck.pod.info`` (G3.8-T2 #854).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.holodeck.ops_read.holodeck_pod_info`.
+        """
+        from meho_backplane.connectors.holodeck.ops_read import (
+            holodeck_pod_info as _holodeck_pod_info,
+        )
+
+        return await _holodeck_pod_info(self, target, params)
+
+    async def service_list(
+        self,
+        target: Target,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``holodeck.service.list`` (G3.8-T2 #854).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.holodeck.ops_read.holodeck_service_list`.
+        """
+        from meho_backplane.connectors.holodeck.ops_read import (
+            holodeck_service_list as _holodeck_service_list,
+        )
+
+        return await _holodeck_service_list(self, target, params)
+
+    async def k8s_exec(
+        self,
+        target: Target,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``holodeck.k8s.exec`` (G3.8-T2 #854).
+
+        **Read-only**. Delegates to
+        :func:`~meho_backplane.connectors.holodeck.ops_read.holodeck_k8s_exec`,
+        which re-validates the verb against the read-only safelist
+        (belt-and-braces over the schema's pattern check) before
+        forwarding the command to the in-appliance K8s cluster.
+        """
+        from meho_backplane.connectors.holodeck.ops_read import (
+            holodeck_k8s_exec as _holodeck_k8s_exec,
+        )
+
+        return await _holodeck_k8s_exec(self, target, params)
+
+    async def logs_tail(
+        self,
+        target: Target,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``holodeck.logs.tail`` (G3.8-T2 #854).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.holodeck.ops_read.holodeck_logs_tail`.
+        """
+        from meho_backplane.connectors.holodeck.ops_read import (
+            holodeck_logs_tail as _holodeck_logs_tail,
+        )
+
+        return await _holodeck_logs_tail(self, target, params)
+
+    async def networking_show(
+        self,
+        target: Target,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Bound-method shim for ``holodeck.networking.show`` (G3.8-T2 #854).
+
+        Delegates to
+        :func:`~meho_backplane.connectors.holodeck.ops_read.holodeck_networking_show`.
+        """
+        from meho_backplane.connectors.holodeck.ops_read import (
+            holodeck_networking_show as _holodeck_networking_show,
+        )
+
+        return await _holodeck_networking_show(self, target, params)
 
     @classmethod
     async def register_operations(cls) -> None:

--- a/backend/src/meho_backplane/connectors/holodeck/ops.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops.py
@@ -3,12 +3,16 @@
 
 """Typed operations exposed by :class:`HolodeckConnector`.
 
-G3.8-T1 (#853) skeleton ships ``holodeck.about`` -- the canary op
+G3.8-T1 (#853) skeleton shipped ``holodeck.about`` -- the canary op
 that proves the ``register_typed_operation()`` -> dispatcher ->
 PowerShell-over-SSH -> JSON-parse pipeline end-to-end on the
-Holodeck connector. G3.8-T2 (#854) appends the 8 read ops via
-``_holodeck_ops()`` exactly as the bind9 / pfSense siblings layered
-their read groups onto the T1 canary.
+Holodeck connector. G3.8-T2 (#854) appends 7 read ops
+(``holodeck.config.show`` / ``holodeck.pod.list`` /
+``holodeck.pod.info`` / ``holodeck.service.list`` /
+``holodeck.k8s.exec`` / ``holodeck.logs.tail`` /
+``holodeck.networking.show``) via :func:`_holodeck_ops`, exactly as
+the bind9 / pfSense siblings layered their read groups onto the
+T1 canary -- 8 ops total under ``connector_id="holodeck-ssh-9.0"``.
 
 The dataclass + tuple shape mirrors
 :mod:`~meho_backplane.connectors.bind9.ops` and
@@ -21,7 +25,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal
 
-__all__ = ["HOLODECK_OPS", "HolodeckOp"]
+__all__ = ["HOLODECK_OPS", "HolodeckOp", "_holodeck_ops"]
 
 
 @dataclass(frozen=True)
@@ -115,13 +119,36 @@ _HOLODECK_ABOUT_OP = HolodeckOp(
 )
 
 
+def _holodeck_ops() -> tuple[HolodeckOp, ...]:
+    """Return the merged registration tuple.
+
+    Composition: ``holodeck.about`` (T1 canary) + ``READ_OPS`` (T2
+    read ops: ``holodeck.config.show``, ``holodeck.pod.list``,
+    ``holodeck.pod.info``, ``holodeck.service.list``,
+    ``holodeck.k8s.exec``, ``holodeck.logs.tail``,
+    ``holodeck.networking.show``). Eight ops total -- the full G3.8-T2
+    read surface.
+
+    Implemented as a function call rather than a literal-and-splat at
+    module level so the import order stays linear: ``ops.py`` defines
+    :class:`HolodeckOp` + ``_HOLODECK_ABOUT_OP``, then imports the T2
+    read ops from :mod:`meho_backplane.connectors.holodeck.ops_read`.
+    Mirrors :func:`meho_backplane.connectors.pfsense.ops._pfsense_ops`
+    and :func:`meho_backplane.connectors.bind9.ops._bind9_ops`.
+    """
+    from meho_backplane.connectors.holodeck.ops_read import READ_OPS
+
+    return (_HOLODECK_ABOUT_OP, *READ_OPS)
+
+
 #: The ops :class:`HolodeckConnector` registers at lifespan startup.
 #:
-#: T1 ships ``holodeck.about``; T2 (#854) appends the 8 read ops
+#: T1 shipped ``holodeck.about``; T2 (#854) adds the 7 read ops
 #: (``holodeck.config.show``, ``holodeck.pod.list``,
 #: ``holodeck.pod.info``, ``holodeck.service.list``,
 #: ``holodeck.k8s.exec``, ``holodeck.logs.tail``,
-#: ``holodeck.networking.show``) onto this tuple via an ``ops_read``
-#: composition module -- the registration walk in
-#: :meth:`HolodeckConnector.register_operations` does not change.
-HOLODECK_OPS: tuple[HolodeckOp, ...] = (_HOLODECK_ABOUT_OP,)
+#: ``holodeck.networking.show``) -- 8 ops total. The registration
+#: walk in :meth:`HolodeckConnector.register_operations` does not
+#: need to change between T1 and T2; only :func:`_holodeck_ops`
+#: composes the merged tuple.
+HOLODECK_OPS: tuple[HolodeckOp, ...] = _holodeck_ops()

--- a/backend/src/meho_backplane/connectors/holodeck/ops_read.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops_read.py
@@ -1,0 +1,1206 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Holodeck read ops -- 7 typed read ops for G3.8-T2 (#854).
+
+Adds the following typed ops onto :class:`HolodeckConnector`:
+
+* ``holodeck.config.show`` -- ``Get-HoloDeckConfig | ConvertTo-Json``
+  routed through :func:`pwsh_run`; returns the parsed config dict.
+* ``holodeck.pod.list`` -- ``Get-HoloDeckPod | ConvertTo-Json``
+  routed through :func:`pwsh_run`; returns ``{rows, total}``
+  (the JSONFlux-shaped envelope sibling connectors emit; the actual
+  handle creation is the reducer's job, not the connector's, per the
+  :mod:`~meho_backplane.connectors.pfsense.ops_read` precedent).
+* ``holodeck.pod.info`` -- ``Get-HoloDeckPod -Id <id> | ConvertTo-Json``;
+  returns the single-pod detail dict (state, networking, VMs).
+* ``holodeck.service.list`` -- ``Get-Service | Where-Object { $_.Name
+  -like 'Holo*' } | Select-Object Name,Status,DisplayName |
+  ConvertTo-Json``; returns ``{rows, total}``.
+* ``holodeck.k8s.exec`` -- in-appliance ``kubectl <verb> ...``
+  passthrough. **Read-only**: the handler fails closed when the first
+  non-flag token after ``kubectl`` is not in
+  :data:`_K8S_READ_VERBS`. Schema also pins ``kubectl <verb> ...``
+  with a ``pattern`` so the dispatcher's validator catches the bad
+  shape before reaching the handler.
+* ``holodeck.logs.tail`` -- ``tail -<lines> /holodeck-runtime/logs/
+  <component>*.log`` over plain SSH (no ``pwsh`` indirection — the
+  cmd is a stock POSIX shell pipeline). Returns the tail text plus
+  the per-file line totals.
+* ``holodeck.networking.show`` -- composite of FRR/BGP summary
+  (``vtysh -c 'show bgp summary' && vtysh -c 'show ip route'``) +
+  DNS zone summary (``pwsh -c "Get-DnsServerZone | ConvertTo-Json"``)
+  + DHCP leases (``cat /var/lib/dhcp/dhcpd.leases``). Returns a
+  structured envelope.
+
+Pure parsers vs handler thin layer
+-----------------------------------
+
+Following the pfSense ``ops_read.py`` / bind9 ``ops_zone.py``
+convention, the heavy lifting lives in pure functions
+(:func:`parse_kubectl_command`, :func:`parse_logs_tail_output`,
+:func:`parse_networking_payload`) that accept captured stdout / JSON
+text and return Python data. The bound-method handlers on
+:class:`HolodeckConnector` are the thin SSH-call + parse + shape
+layer. The unit suite pins the parsers directly against fixture text
+without booting an event loop.
+
+JSONFlux handle pattern -- deferred to the reducer
+---------------------------------------------------
+
+``holodeck.pod.list`` and ``holodeck.service.list`` return
+``{rows, total}``. Mirroring the bind9 / pfSense precedent, the
+JSONFlux handle is the **reducer's** responsibility — not the
+connector's. Setting handle creation here would couple every
+connector to the reducer's calibration threshold and bypass the
+reducer's audit / TTL / store-routing logic.
+
+The handler ships ``rows`` + ``total`` so a future JSONFlux reducer
+can pull both signals (inlined sample size + total) to drive its
+threshold check. No handle exists today — the current
+:class:`~meho_backplane.operations.reducer.PassThroughReducer` always
+returns the inline payload unchanged.
+
+Safety -- read-only k8s exec
+-----------------------------
+
+The acceptance criterion calls for ``holodeck.k8s.exec`` to reject
+mutating ``kubectl`` verbs (``create``/``apply``/``delete``/``edit``/
+``scale``/``patch``/...). The defence runs in two layers:
+
+1. **Schema layer** -- ``parameter_schema.properties.command`` carries
+   a ``pattern`` regex that requires the command to start with
+   ``kubectl`` followed by one of the read-only verbs. The
+   dispatcher's :func:`~meho_backplane.operations._validate.validate_params`
+   walks this before reaching the handler; bad shapes surface as a
+   ``result_invalid_params`` envelope.
+2. **Handler layer** -- before the SSH call lands, the handler
+   re-parses the command via :func:`parse_kubectl_command` and
+   compares the verb to :data:`_K8S_READ_VERBS`. Mutating verbs raise
+   :exc:`KubectlSafetyError`, which the dispatcher's exception path
+   turns into a ``result_connector_error`` envelope. This is the
+   belt-and-braces fallback for the case where a future schema edit
+   accidentally widens the pattern.
+
+The handler layer is the **authoritative** gate; the schema pattern
+is a guardrail so a misshapen call doesn't even reach the connector.
+
+References
+----------
+
+* Task: G3.8-T2 (#854).
+* Parent initiative: G3.8 (#371).
+* Precedents: :mod:`meho_backplane.connectors.pfsense.ops_read`,
+  :mod:`meho_backplane.connectors.bind9.ops_zone`.
+* PowerShell ``Get-HoloDeckConfig`` / ``Get-HoloDeckPod`` --
+  vendor cmdlets shipped with VMware Holodeck Toolkit 9.x.
+* ``kubectl`` verbs (read vs mutate):
+  https://kubernetes.io/docs/reference/kubectl/.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors.holodeck._pwsh import PwshRunError, pwsh_run
+from meho_backplane.connectors.holodeck.ops import HolodeckOp
+
+if TYPE_CHECKING:
+    from meho_backplane.connectors.holodeck.connector import HolodeckConnector
+
+__all__ = [
+    "READ_OPS",
+    "KubectlSafetyError",
+    "holodeck_config_show",
+    "holodeck_k8s_exec",
+    "holodeck_logs_tail",
+    "holodeck_networking_show",
+    "holodeck_pod_info",
+    "holodeck_pod_list",
+    "holodeck_service_list",
+    "parse_kubectl_command",
+    "parse_logs_tail_output",
+    "parse_networking_payload",
+]
+
+
+# ---------------------------------------------------------------------------
+# Read-only kubectl guard
+# ---------------------------------------------------------------------------
+
+#: Whitelist of ``kubectl`` verbs the handler considers read-only.
+#: ``get`` / ``describe`` / ``logs`` are the three primary read verbs
+#: the Initiative #371 body calls out. ``top`` (metrics) and
+#: ``explain`` (schema) are pure reads. ``api-resources`` /
+#: ``api-versions`` / ``cluster-info`` / ``config`` (``view``) /
+#: ``version`` / ``auth`` (``can-i``) cover the inspection surface
+#: without mutating cluster state. Any verb absent from this set --
+#: notably ``create`` / ``apply`` / ``delete`` / ``edit`` /
+#: ``replace`` / ``patch`` / ``scale`` / ``rollout`` (``restart``) /
+#: ``label`` (``--overwrite``) / ``annotate`` / ``cp`` / ``exec`` /
+#: ``port-forward`` / ``proxy`` / ``drain`` / ``cordon`` --
+#: fails closed.
+_K8S_READ_VERBS: frozenset[str] = frozenset(
+    {
+        "get",
+        "describe",
+        "logs",
+        "top",
+        "explain",
+        "api-resources",
+        "api-versions",
+        "cluster-info",
+        "version",
+    }
+)
+
+
+class KubectlSafetyError(ValueError):
+    """Raised by :func:`parse_kubectl_command` when the verb is not read-only.
+
+    Subclass of :class:`ValueError` so the dispatcher's
+    ``result_connector_error`` envelope picks it up uniformly with
+    the other validation-style failures. The exception message names
+    the rejected verb so the operator-visible surface explains why
+    the call was refused; the message does **not** include the full
+    command (which can carry resource names that, while not secret,
+    don't belong in user-visible error messages either -- the schema
+    layer already echoes the supplied command verbatim in the
+    ``invalid_params`` envelope when the pattern check fails).
+    """
+
+
+def parse_kubectl_command(command: str) -> tuple[str, list[str]]:
+    """Parse ``command`` into ``(verb, args)``; enforce the read-only safelist.
+
+    The first whitespace-separated token must be ``kubectl``. The
+    second non-flag token is the verb; the verb must appear in
+    :data:`_K8S_READ_VERBS`. Returns the verb and the remaining args
+    so callers can re-serialise the command for SSH.
+
+    Tokenisation runs via :func:`shlex.split` so quoted resource names
+    (``"my pod"``) survive the parse; the safety check operates on the
+    verb token, which is unquoted in every legal ``kubectl`` invocation.
+
+    Empty command, or command not starting with ``kubectl``, or verb
+    not in :data:`_K8S_READ_VERBS` -> :exc:`KubectlSafetyError`. The
+    handler raises before any SSH traffic happens.
+
+    Examples
+    --------
+
+    >>> parse_kubectl_command("kubectl get pods -n holodeck")
+    ('get', ['pods', '-n', 'holodeck'])
+    >>> parse_kubectl_command("kubectl describe pod my-pod")
+    ('describe', ['pod', 'my-pod'])
+    """
+    if not command or not command.strip():
+        raise KubectlSafetyError("kubectl command is empty")
+    try:
+        tokens = shlex.split(command)
+    except ValueError as exc:
+        raise KubectlSafetyError(f"kubectl command failed to tokenise: {exc}") from exc
+    if not tokens:
+        raise KubectlSafetyError("kubectl command tokenises to nothing")
+    if tokens[0] != "kubectl":
+        raise KubectlSafetyError(f"kubectl command must start with 'kubectl' (got {tokens[0]!r})")
+    # The verb is the first non-flag token after ``kubectl``. A handful
+    # of legal invocations open with a global flag (``kubectl
+    # --context=foo get pods``); we walk past leading flag tokens but
+    # only consume their *attached* values (``--context=foo``). When a
+    # flag is in the separated form (``--context foo``) the next token
+    # is the flag's value, not a verb -- we skip it too.
+    idx = 1
+    while idx < len(tokens) and tokens[idx].startswith("-"):
+        token = tokens[idx]
+        idx += 1
+        if "=" not in token and idx < len(tokens) and not tokens[idx].startswith("-"):
+            # Separated flag value (``--context foo``); consume.
+            idx += 1
+    if idx >= len(tokens):
+        raise KubectlSafetyError("kubectl command has no verb after global flags")
+    verb = tokens[idx]
+    if verb not in _K8S_READ_VERBS:
+        raise KubectlSafetyError(
+            f"kubectl verb {verb!r} is not on the read-only safelist; "
+            f"allowed: {sorted(_K8S_READ_VERBS)}"
+        )
+    return verb, tokens[idx + 1 :]
+
+
+# ---------------------------------------------------------------------------
+# Pure parsers -- tail output + networking composite
+# ---------------------------------------------------------------------------
+
+
+def parse_logs_tail_output(stdout: str) -> dict[str, Any]:
+    """Parse ``tail -N file1 file2 ...`` GNU-style output into ``{files}``.
+
+    GNU ``tail`` with multiple files emits a header before each file
+    block::
+
+        ==> /holodeck-runtime/logs/holodeck-dhcp.log <==
+        <up to N lines>
+        ==> /holodeck-runtime/logs/holodeck-dns.log <==
+        <up to N lines>
+
+    Single-file ``tail`` emits no header — the entire stdout is the
+    file's tail. The parser detects which form the stdout is in by
+    presence of the ``==> ... <==`` marker. Returns:
+
+    .. code-block:: python
+
+        {
+            "files": [
+                {"path": "/holodeck-runtime/logs/foo.log", "lines": "..."},
+                ...
+            ],
+            "raw": "<full stdout>"
+        }
+
+    ``raw`` carries the unparsed stdout so callers can show it verbatim
+    when the parsed structure is empty / a parse hint is needed.
+
+    >>> output = (
+    ...     "==> /holodeck-runtime/logs/dhcp.log <==\\n"
+    ...     "dhcp event 1\\n"
+    ...     "dhcp event 2\\n"
+    ...     "==> /holodeck-runtime/logs/dns.log <==\\n"
+    ...     "dns event 1\\n"
+    ... )
+    >>> parsed = parse_logs_tail_output(output)
+    >>> parsed["files"][0]["path"]
+    '/holodeck-runtime/logs/dhcp.log'
+    >>> parsed["files"][1]["lines"]
+    'dns event 1\\n'
+    """
+    raw = stdout
+    if not raw.strip():
+        return {"files": [], "raw": raw}
+
+    if "==> " not in raw:
+        # Single-file tail: no header.
+        return {"files": [{"path": None, "lines": raw}], "raw": raw}
+
+    files: list[dict[str, Any]] = []
+    current_path: str | None = None
+    current_lines: list[str] = []
+    for line in raw.splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped.startswith("==>") and stripped.endswith("<=="):
+            # Flush the previous block.
+            if current_path is not None:
+                files.append({"path": current_path, "lines": "".join(current_lines)})
+            current_path = stripped[3:-3].strip()
+            current_lines = []
+        else:
+            current_lines.append(line)
+    if current_path is not None:
+        files.append({"path": current_path, "lines": "".join(current_lines)})
+    return {"files": files, "raw": raw}
+
+
+def parse_networking_payload(
+    *,
+    bgp_text: str,
+    routes_text: str,
+    dns_zones_json: Any,
+    dhcp_leases_text: str,
+) -> dict[str, Any]:
+    """Compose the ``holodeck.networking.show`` envelope from four inputs.
+
+    The handler routes each sub-command separately (FRR/BGP via
+    ``vtysh -c`` over plain SSH; DNS zones via ``pwsh`` for the
+    structured JSON; DHCP leases via plain ``cat``). The composer
+    keeps the four signal streams separated so callers can drill into
+    one without the others.
+
+    Returns:
+
+    .. code-block:: python
+
+        {
+            "bgp": {"summary_text": "...", "ok": True},
+            "routes": {"text": "...", "ok": True},
+            "dns": {"zones": [...], "total": N, "ok": True},
+            "dhcp": {"leases_text": "...", "ok": True},
+        }
+
+    Each sub-section's ``ok`` is ``True`` when the input is non-empty.
+    The shape is intentionally narrative -- ``vtysh`` BGP output is
+    operator-formatted text, not structured JSON, and the consumer's
+    onboarding doc (T3 #855) walks operators through the BGP fields by
+    eye. Forcing a per-field structured parse here would invert the
+    cost of curation: we'd ship parser tests for every ``vtysh``
+    version drift the appliance encounters.
+    """
+    dns_zones_list: list[Any]
+    if isinstance(dns_zones_json, list):
+        dns_zones_list = dns_zones_json
+    elif isinstance(dns_zones_json, dict):
+        dns_zones_list = [dns_zones_json]
+    else:
+        dns_zones_list = []
+    return {
+        "bgp": {
+            "summary_text": bgp_text,
+            "ok": bool(bgp_text.strip()),
+        },
+        "routes": {
+            "text": routes_text,
+            "ok": bool(routes_text.strip()),
+        },
+        "dns": {
+            "zones": dns_zones_list,
+            "total": len(dns_zones_list),
+            "ok": isinstance(dns_zones_json, (list, dict)),
+        },
+        "dhcp": {
+            "leases_text": dhcp_leases_text,
+            "ok": bool(dhcp_leases_text.strip()),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Handler functions (bound-method shims on HolodeckConnector)
+# ---------------------------------------------------------------------------
+
+
+async def holodeck_config_show(
+    self: HolodeckConnector,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the Holodeck configuration dict from ``Get-HoloDeckConfig``.
+
+    Op-id: ``holodeck.config.show``. Runs ``Get-HoloDeckConfig |
+    ConvertTo-Json -Depth 4 -Compress`` via the pwsh helper and
+    returns the parsed dict. Cmdlet failure -> ``{config: None,
+    error: "<reason>"}`` envelope.
+    """
+    del params  # declared empty; intentionally ignored
+    script = "Get-HoloDeckConfig | ConvertTo-Json -Depth 4 -Compress"
+    try:
+        payload = await pwsh_run(self, target, script)
+    except PwshRunError as exc:
+        return {"config": None, "error": str(exc)}
+    return {"config": payload}
+
+
+async def holodeck_pod_list(
+    self: HolodeckConnector,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the active Holodeck nested-pod inventory.
+
+    Op-id: ``holodeck.pod.list``. Runs ``Get-HoloDeckPod |
+    ConvertTo-Json -Depth 4`` via the pwsh helper. Returns a
+    ``{rows, total}`` envelope -- the JSONFlux-shaped surface the
+    sibling connectors emit. The JSONFlux handle itself is the
+    reducer's responsibility (per the pfSense / bind9 precedent); the
+    handler just ships both signals (inlined rows + total count).
+
+    ``ConvertTo-Json`` on a single-element list returns a flat dict;
+    on a multi-element list it returns a JSON array. We normalise
+    both shapes to a list before populating ``rows``.
+    """
+    del params  # declared empty; intentionally ignored
+    script = "Get-HoloDeckPod | ConvertTo-Json -Depth 4"
+    try:
+        payload = await pwsh_run(self, target, script)
+    except PwshRunError as exc:
+        return {"rows": [], "total": 0, "error": str(exc)}
+    rows = _normalise_pwsh_json_array(payload)
+    return {"rows": rows, "total": len(rows)}
+
+
+async def holodeck_pod_info(
+    self: HolodeckConnector,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Return the per-pod detail dict for *pod_id*.
+
+    Op-id: ``holodeck.pod.info``. Runs ``Get-HoloDeckPod -Id '<id>' |
+    ConvertTo-Json -Depth 4`` via the pwsh helper. *params* must
+    carry ``pod_id`` (the schema marks it required); the handler
+    inlines it into the cmdlet via PowerShell-safe single-quoting.
+
+    Cmdlet failure -> ``{pod: None, error: "<reason>"}``.
+    """
+    pod_id = params.get("pod_id")
+    if not isinstance(pod_id, str) or not pod_id.strip():
+        return {"pod": None, "error": "pod_id is required and must be a non-empty string"}
+    # PowerShell single-quoting: the only escape inside single quotes
+    # is doubling the single quote itself. asyncssh's argv path runs
+    # the cmd through a shell on the appliance, so the operator-supplied
+    # pod_id is also subject to shell quoting -- but the encoded-command
+    # contract means the shell never sees the value as a discrete token;
+    # the entire pwsh script body is base64'd before transport.
+    quoted_id = pod_id.replace("'", "''")
+    script = f"Get-HoloDeckPod -Id '{quoted_id}' | ConvertTo-Json -Depth 4"
+    try:
+        payload = await pwsh_run(self, target, script)
+    except PwshRunError as exc:
+        return {"pod": None, "error": str(exc)}
+    return {"pod": payload}
+
+
+async def holodeck_service_list(
+    self: HolodeckConnector,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Return Photon services with the ``Holo*`` prefix and their status.
+
+    Op-id: ``holodeck.service.list``. Runs ``Get-Service |
+    Where-Object { $_.Name -like 'Holo*' } | Select-Object
+    Name,Status,DisplayName | ConvertTo-Json -Depth 4`` via the pwsh
+    helper. Returns ``{rows, total}``.
+
+    Mirrors the cmdlet shape that :meth:`HolodeckConnector.probe`
+    uses for the ``holodeck_services_down`` check, but exposes the
+    raw list to operators instead of folding it into a single boolean.
+    """
+    del params  # declared empty; intentionally ignored
+    script = (
+        "Get-Service | Where-Object { $_.Name -like 'Holo*' } | "
+        "Select-Object Name,Status,DisplayName | ConvertTo-Json -Depth 4"
+    )
+    try:
+        payload = await pwsh_run(self, target, script)
+    except PwshRunError as exc:
+        return {"rows": [], "total": 0, "error": str(exc)}
+    rows = _normalise_pwsh_json_array(payload)
+    return {"rows": rows, "total": len(rows)}
+
+
+async def holodeck_k8s_exec(
+    self: HolodeckConnector,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Forward a **read-only** ``kubectl`` command to the in-appliance K8s.
+
+    Op-id: ``holodeck.k8s.exec``. *params* carries ``command`` (a
+    string starting with ``kubectl <read-verb> ...``). The handler:
+
+    1. Parses the command via :func:`parse_kubectl_command`; mutating
+       verbs raise :exc:`KubectlSafetyError` (re-raised so the
+       dispatcher's ``result_connector_error`` path surfaces it).
+    2. Runs the parsed command verbatim over plain SSH (no ``pwsh``;
+       the in-appliance K8s is reached through the appliance's
+       ``kubectl`` binary, not through PowerShell).
+    3. Returns the command stdout / exit_status / stderr fragment.
+
+    The schema pattern in :data:`READ_OPS` enforces the
+    ``^kubectl (get|describe|logs|top|explain|api-resources|
+    api-versions|cluster-info|version)\\b`` shape at the validator
+    layer; this handler is the authoritative gate, not a fallback.
+
+    Stderr is **truncated** at 4096 chars to keep operator surfaces
+    bounded (same convention as :class:`PwshRunError`). The
+    handler's logging emits ``command_len`` + ``exit_status``; the
+    full command body is never logged (the verb shape is operator-
+    auditable through the audit_log row's ``params_hash`` plus the
+    schema's pattern enforcement).
+    """
+    raw_command = params.get("command")
+    if not isinstance(raw_command, str):
+        return {
+            "stdout": "",
+            "stderr": "",
+            "exit_status": None,
+            "error": "command is required and must be a string",
+        }
+    # The handler is the authoritative gate. Re-parse even though the
+    # schema pattern caught the obvious bad shape -- a future schema
+    # widening must not silently let writes through.
+    try:
+        parse_kubectl_command(raw_command)
+    except KubectlSafetyError as exc:
+        return {
+            "stdout": "",
+            "stderr": "",
+            "exit_status": None,
+            "error": f"k8s.exec safety check: {exc}",
+        }
+    # The command is operator-supplied; run it verbatim via the pooled
+    # SSH connection. The base adapter's ``_run_command`` already
+    # bounds the wall clock at 30s by default.
+    try:
+        proc = await self._run_command(target, raw_command, raw_jwt="")
+    except Exception as exc:
+        return {
+            "stdout": "",
+            "stderr": "",
+            "exit_status": None,
+            "error": str(exc),
+        }
+    stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
+    stderr = (proc.stderr or "") if hasattr(proc, "stderr") else ""
+    if not isinstance(stdout, str):
+        stdout = ""
+    if not isinstance(stderr, str):
+        stderr = ""
+    # Cap stderr at 4096 chars -- same convention as :class:`PwshRunError`.
+    if len(stderr) > 4096:
+        stderr = stderr[:4096]
+    exit_status = getattr(proc, "exit_status", None)
+    return {
+        "stdout": stdout,
+        "stderr": stderr,
+        "exit_status": exit_status,
+    }
+
+
+async def holodeck_logs_tail(
+    self: HolodeckConnector,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Tail ``/holodeck-runtime/logs/<component>*.log`` for *N* lines.
+
+    Op-id: ``holodeck.logs.tail``. *params*:
+
+    * ``component`` -- required; the log-file slug (e.g. ``"dhcp"``,
+      ``"dns"``, ``"frr"``, ``"webtop"``). The slug is restricted to
+      ``[A-Za-z0-9._-]+`` by the schema's pattern; the handler
+      rejects any other shape with an error envelope as the
+      belt-and-braces fallback.
+    * ``lines`` -- optional integer; defaults to 200. Schema's
+      ``minimum`` / ``maximum`` clamp at ``[1, 5000]``.
+
+    Runs ``tail -<lines> /holodeck-runtime/logs/<component>*.log``
+    over plain SSH (no pwsh — the cmd is a stock POSIX pipeline).
+    Returns the parsed tail envelope via
+    :func:`parse_logs_tail_output`.
+    """
+    component = params.get("component")
+    if not isinstance(component, str) or not component.strip():
+        return {
+            "files": [],
+            "raw": "",
+            "lines_requested": 0,
+            "error": "component is required and must be a non-empty string",
+        }
+    # Belt-and-braces shape check: schema pattern enforces this, but
+    # the handler refuses anything outside the safelist so a future
+    # schema edit can't accidentally let through metacharacters that
+    # would change the meaning of the shell pipeline.
+    if not _COMPONENT_SAFE_RE.fullmatch(component):
+        return {
+            "files": [],
+            "raw": "",
+            "lines_requested": 0,
+            "error": (
+                f"component {component!r} contains unsafe characters; "
+                f"only [A-Za-z0-9._-]+ are allowed"
+            ),
+        }
+    lines_raw = params.get("lines", 200)
+    if not isinstance(lines_raw, int) or lines_raw < 1 or lines_raw > 5000:
+        return {
+            "files": [],
+            "raw": "",
+            "lines_requested": 0,
+            "error": "lines must be an integer in [1, 5000]",
+        }
+    cmd = f"tail -n {lines_raw} /holodeck-runtime/logs/{component}*.log"
+    try:
+        proc = await self._run_command(target, cmd, raw_jwt="")
+    except Exception as exc:
+        return {
+            "files": [],
+            "raw": "",
+            "lines_requested": lines_raw,
+            "error": str(exc),
+        }
+    stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
+    content = stdout if isinstance(stdout, str) else ""
+    parsed = parse_logs_tail_output(content)
+    parsed["lines_requested"] = lines_raw
+    return parsed
+
+
+async def holodeck_networking_show(
+    self: HolodeckConnector,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Compose the FRR/BGP + DNS + DHCP networking snapshot.
+
+    Op-id: ``holodeck.networking.show``. Runs four sub-commands
+    over the pooled SSH connection:
+
+    1. ``vtysh -c 'show bgp summary'`` -- FRR/BGP peer summary.
+    2. ``vtysh -c 'show ip route'`` -- the kernel routing table as
+       FRR sees it.
+    3. ``pwsh`` of ``Get-DnsServerZone | Select-Object ZoneName,
+       ZoneType | ConvertTo-Json -Depth 4`` -- DNS zone summary.
+    4. ``cat /var/lib/dhcp/dhcpd.leases`` -- raw DHCP leases (the
+       file format is documented and operator-readable; structured
+       parsing belongs in T3's recipe rather than here).
+
+    Each sub-section's ``ok`` flips false when the sub-command failed
+    or produced empty output; the operator-visible envelope
+    explicitly partitions the four signals so a single-component
+    failure doesn't blank the whole response.
+
+    Cmd failures (``OSError``/``asyncssh.Error``) on the plain-SSH
+    paths surface as empty strings (parsed by
+    :func:`parse_networking_payload` into ``ok=False`` sub-sections).
+    ``PwshRunError`` on the DNS path surfaces as
+    ``dns.ok=False`` + an empty zones list.
+    """
+    del params  # declared empty; intentionally ignored
+
+    bgp_text = await _safe_run_text(self, target, "vtysh -c 'show bgp summary'")
+    routes_text = await _safe_run_text(self, target, "vtysh -c 'show ip route'")
+    dns_zones_payload: Any
+    try:
+        dns_zones_payload = await pwsh_run(
+            self,
+            target,
+            "Get-DnsServerZone | Select-Object ZoneName,ZoneType | ConvertTo-Json -Depth 4",
+        )
+    except PwshRunError:
+        dns_zones_payload = None
+    dhcp_text = await _safe_run_text(self, target, "cat /var/lib/dhcp/dhcpd.leases")
+
+    return parse_networking_payload(
+        bgp_text=bgp_text,
+        routes_text=routes_text,
+        dns_zones_json=dns_zones_payload,
+        dhcp_leases_text=dhcp_text,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+#: Component-name safelist for ``holodeck.logs.tail``. The handler
+#: rejects any value outside ``[A-Za-z0-9._-]+`` so the resulting
+#: ``tail`` cmdline cannot smuggle in shell metacharacters or escape
+#: the ``/holodeck-runtime/logs/`` prefix via a directory traversal.
+_COMPONENT_SAFE_RE: re.Pattern[str] = re.compile(r"[A-Za-z0-9._-]+")
+
+
+def _normalise_pwsh_json_array(payload: Any) -> list[Any]:
+    """Normalise ``ConvertTo-Json`` outputs into a Python list of rows.
+
+    PowerShell's ``ConvertTo-Json`` collapses a single-element
+    pipeline result into a flat object (not a 1-element list).
+    Multi-element pipelines render as JSON arrays. Empty pipelines
+    render as ``$null`` -> Python ``None``. The normaliser folds
+    all three shapes into a list so the ``{rows, total}`` envelope
+    has a uniform shape.
+    """
+    if payload is None:
+        return []
+    if isinstance(payload, list):
+        return [item for item in payload if item is not None]
+    if isinstance(payload, dict):
+        return [payload]
+    # Unexpected scalar payload (e.g. an int or a bool) -- ConvertTo-Json
+    # can render scalars verbatim. Wrap into a single-item list so the
+    # envelope stays consistent; callers can drill into the row to
+    # recover the original scalar.
+    return [payload]
+
+
+async def _safe_run_text(
+    self: HolodeckConnector,
+    target: Any,
+    cmd: str,
+) -> str:
+    """Run *cmd* via plain SSH, return stdout text; failures -> empty string.
+
+    The networking composer keeps each sub-command's failure isolated;
+    a ``vtysh`` crash on the BGP summary path must not blank the DNS
+    or DHCP sub-sections. The handler relies on the empty-string
+    convention -- :func:`parse_networking_payload` flips the
+    sub-section's ``ok`` to ``False`` when the input is empty.
+    """
+    try:
+        proc = await self._run_command(target, cmd, raw_jwt="")
+    except Exception:
+        return ""
+    stdout = (proc.stdout or "") if hasattr(proc, "stdout") else ""
+    if isinstance(stdout, str):
+        return stdout
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Op metadata
+# ---------------------------------------------------------------------------
+
+_EMPTY_PARAMS: dict[str, Any] = {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": False,
+}
+
+
+#: SSH-only / pwsh transport reminder copied verbatim into every op's
+#: ``llm_instructions``. The Initiative #371 body and CLAUDE.md
+#: postulate 5 both require agent-facing descriptions to call out the
+#: PowerShell-over-SSH transport so an LLM doesn't compose against a
+#: non-existent REST surface.
+_SSH_TRANSPORT_NOTE: str = (
+    "Holodeck has no REST API; the underlying transport is "
+    "PowerShell-over-SSH (pwsh -EncodedCommand routed through asyncssh) "
+    "for cmdlet ops, plain SSH for kubectl / shell-pipeline ops."
+)
+
+
+READ_OPS: tuple[HolodeckOp, ...] = (
+    HolodeckOp(
+        op_id="holodeck.config.show",
+        handler_attr="config_show",
+        summary="Return the Holodeck appliance configuration dict.",
+        description=(
+            "Runs ``Get-HoloDeckConfig | ConvertTo-Json -Depth 4 "
+            "-Compress`` over the pwsh-over-SSH transport and returns "
+            "the parsed configuration dict. The dict carries vendor / "
+            "product / version / pod ID and a `services` block summarising "
+            "the bundled Holodeck Photon services. Use when the operator "
+            "needs the full appliance configuration snapshot; for just "
+            "the identifying fields prefer ``holodeck.about`` (faster, "
+            "fewer fields). No params; safe to call on any healthy "
+            "HoloRouter target."
+        ),
+        parameter_schema=_EMPTY_PARAMS,
+        response_schema={
+            "type": "object",
+            "properties": {
+                "config": {"type": ["object", "null"]},
+                "error": {"type": ["string", "null"]},
+            },
+            "additionalProperties": True,
+        },
+        group_key="config",
+        tags=("read-only", "config", "holodeck"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call when the operator wants the full Holodeck "
+                "appliance configuration snapshot (vendor / product / "
+                "pod ID + services block). For just the identifying "
+                "fields, ``holodeck.about`` is a faster, narrower "
+                "alternative. " + _SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "``{config: {...}}``. ``config`` is the parsed cmdlet "
+                "output -- a flat dict with the appliance's identifying "
+                "fields and a nested `services` block. ``error`` is set "
+                "when the pwsh cmdlet failed."
+            ),
+        },
+    ),
+    HolodeckOp(
+        op_id="holodeck.pod.list",
+        handler_attr="pod_list",
+        summary="List the active Holodeck nested pods.",
+        description=(
+            "Runs ``Get-HoloDeckPod | ConvertTo-Json -Depth 4`` over "
+            "the pwsh-over-SSH transport and returns one row per active "
+            "nested pod. Each row carries the pod ID, name, state, "
+            "primary network, and embedded VM count. Returns a "
+            "``{rows, total}`` envelope; future JSONFlux reducer will "
+            "spill large pod lists to the HandleStore via the standard "
+            "``result_describe`` / ``result_query`` flow. No params; "
+            "safe to call on any healthy HoloRouter target."
+        ),
+        parameter_schema=_EMPTY_PARAMS,
+        response_schema={
+            "type": "object",
+            "properties": {
+                "rows": {"type": "array", "items": {"type": "object"}},
+                "total": {"type": "integer"},
+                "error": {"type": ["string", "null"]},
+            },
+            "additionalProperties": True,
+        },
+        group_key="pod",
+        tags=("read-only", "pod", "list", "holodeck"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call when the operator wants the active nested-pod "
+                "inventory on a HoloRouter. Each row carries the pod ID "
+                "and its primary networking + VM count. Pair with "
+                "``holodeck.pod.info <pod_id>`` for per-pod details. " + _SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "``{rows: [{...pod fields...}], total: N}``. Rows are "
+                "returned inline; future JSONFlux reducer paths large "
+                "pod lists through ``result_describe`` / ``result_query`` "
+                "via the HandleStore. ``error`` is set when the cmdlet "
+                "failed."
+            ),
+        },
+    ),
+    HolodeckOp(
+        op_id="holodeck.pod.info",
+        handler_attr="pod_info",
+        summary="Return per-pod detail (state, networking, VMs) for a Holodeck pod.",
+        description=(
+            "Runs ``Get-HoloDeckPod -Id <id> | ConvertTo-Json -Depth 4`` "
+            "over the pwsh-over-SSH transport and returns the single-pod "
+            "detail dict: state, networking (FRR/BGP attachment), and "
+            "the embedded VM list with their power state. *pod_id* is "
+            "required; use ``holodeck.pod.list`` to enumerate available "
+            "IDs first."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "pod_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "Holodeck pod identifier (e.g. ``HoloPod-001``). "
+                        "Enumerate via ``holodeck.pod.list``."
+                    ),
+                },
+            },
+            "required": ["pod_id"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "pod": {"type": ["object", "null"]},
+                "error": {"type": ["string", "null"]},
+            },
+            "additionalProperties": True,
+        },
+        group_key="pod",
+        tags=("read-only", "pod", "info", "holodeck"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call when the operator wants the detailed state of a "
+                "specific Holodeck nested pod -- VM list, power state, "
+                "networking. Use ``holodeck.pod.list`` first to "
+                "discover available pod IDs. " + _SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "pod_id": (
+                    "Holodeck pod identifier (e.g. ``HoloPod-001``). "
+                    "Enumerate via ``holodeck.pod.list``."
+                ),
+            },
+            "output_shape": (
+                "``{pod: {id, state, networking, vms: [...]}}``. ``error`` "
+                "is set when the cmdlet failed (e.g. unknown pod ID)."
+            ),
+        },
+    ),
+    HolodeckOp(
+        op_id="holodeck.service.list",
+        handler_attr="service_list",
+        summary="List Photon services with the Holo* prefix and their status.",
+        description=(
+            "Runs ``Get-Service | Where-Object { $_.Name -like 'Holo*' "
+            "} | Select-Object Name,Status,DisplayName | "
+            "ConvertTo-Json -Depth 4`` over the pwsh-over-SSH "
+            "transport. Returns ``{rows, total}`` where each row "
+            "carries ``Name``, ``Status``, ``DisplayName``. Mirrors "
+            "the cmdlet shape ``probe`` uses for "
+            "``holodeck_services_down`` but exposes the raw list. "
+            "No params; safe to call on any healthy HoloRouter target."
+        ),
+        parameter_schema=_EMPTY_PARAMS,
+        response_schema={
+            "type": "object",
+            "properties": {
+                "rows": {"type": "array", "items": {"type": "object"}},
+                "total": {"type": "integer"},
+                "error": {"type": ["string", "null"]},
+            },
+            "additionalProperties": True,
+        },
+        group_key="service",
+        tags=("read-only", "service", "holodeck"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call when the operator wants the per-service health of "
+                "the bundled Holodeck Photon services (DHCP, DNS, NTP, "
+                "FRR-BGP, Webtop, K8s-in-appliance). ``holodeck.about`` "
+                "and ``holodeck.config.show`` answer 'what version', "
+                "this op answers 'which services are running'. " + _SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "``{rows: [{Name, Status, DisplayName}], total: N}``. "
+                "``Status`` is the PowerShell ServiceControllerStatus "
+                "enum, typically rendered as ``Running`` / ``Stopped`` "
+                "via ``Select-Object``."
+            ),
+        },
+    ),
+    HolodeckOp(
+        op_id="holodeck.k8s.exec",
+        handler_attr="k8s_exec",
+        summary="Run a read-only kubectl command on the in-appliance Kubernetes cluster.",
+        description=(
+            "Forwards a **read-only** ``kubectl`` command to the K8s "
+            "cluster bundled on the HoloRouter appliance. The handler "
+            "fails closed when the supplied command's verb is not on "
+            "the read-only safelist (allowed: ``get``, ``describe``, "
+            "``logs``, ``top``, ``explain``, ``api-resources``, "
+            "``api-versions``, ``cluster-info``, ``version``). Use to "
+            "inspect cluster state without mutating it. The schema "
+            "pattern enforces the ``kubectl <read-verb> ...`` shape at "
+            "the validator layer; the handler re-checks the verb as a "
+            "belt-and-braces safety gate."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "command": {
+                    "type": "string",
+                    "minLength": 1,
+                    "pattern": (
+                        # Anchored at start so leading whitespace / nbsp
+                        # cannot slip through. The verb alternation is
+                        # whitespace-bounded so a verb prefix
+                        # (``getfoo``) doesn't match ``get``.
+                        r"^kubectl(\s+--?[A-Za-z0-9_-]+(=\S+)?)*\s+"
+                        r"(get|describe|logs|top|explain|"
+                        r"api-resources|api-versions|cluster-info|"
+                        r"version)(\s|$)"
+                    ),
+                    "description": (
+                        "Full kubectl command line starting with "
+                        "``kubectl`` and a read-only verb. Allowed "
+                        "verbs: get, describe, logs, top, explain, "
+                        "api-resources, api-versions, cluster-info, "
+                        "version. Mutating verbs (create, apply, "
+                        "delete, edit, replace, patch, scale, "
+                        "rollout, label, annotate, cp, exec, "
+                        "port-forward, proxy, drain, cordon) are "
+                        "rejected at the schema layer."
+                    ),
+                },
+            },
+            "required": ["command"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "stdout": {"type": "string"},
+                "stderr": {"type": "string"},
+                "exit_status": {"type": ["integer", "null"]},
+                "error": {"type": ["string", "null"]},
+            },
+            "additionalProperties": True,
+        },
+        group_key="k8s",
+        tags=("read-only", "k8s", "kubectl", "holodeck"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call when the operator wants to inspect the K8s "
+                "cluster bundled on the HoloRouter appliance via "
+                "``kubectl``. Only read-only verbs are allowed: ``get``, "
+                "``describe``, ``logs``, ``top``, ``explain``, "
+                "``api-resources``, ``api-versions``, ``cluster-info``, "
+                "``version``. Mutating verbs fail closed. " + _SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "command": (
+                    "Full kubectl invocation, e.g. ``kubectl get pods "
+                    "-n holodeck`` or ``kubectl describe service "
+                    "<name>``. Single-line; arguments tokenised via "
+                    "shlex."
+                ),
+            },
+            "output_shape": (
+                "``{stdout: '<text>', stderr: '<truncated text>', "
+                "exit_status: <int|null>}``. ``stderr`` is capped at "
+                "4096 chars. ``error`` is set when the safety check "
+                "rejected the verb or the SSH call failed."
+            ),
+        },
+    ),
+    HolodeckOp(
+        op_id="holodeck.logs.tail",
+        handler_attr="logs_tail",
+        summary="Tail Holodeck runtime log files for a given component.",
+        description=(
+            "Runs ``tail -n <lines> /holodeck-runtime/logs/"
+            "<component>*.log`` over plain SSH and returns the tail "
+            "envelope. *component* is a slug (e.g. ``dhcp``, ``dns``, "
+            "``frr``); *lines* defaults to 200, range [1, 5000]. "
+            "Multiple files matching the glob are surfaced separately "
+            "via the GNU ``tail`` ``==> path <==`` header convention. "
+            "Read-only by construction; the cmd is a stock POSIX "
+            "pipeline with no pwsh indirection."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "component": {
+                    "type": "string",
+                    "pattern": r"^[A-Za-z0-9._-]+$",
+                    "minLength": 1,
+                    "description": (
+                        "Log-file slug; the cmdline expands to "
+                        "``/holodeck-runtime/logs/<component>*.log``. "
+                        "Only ``[A-Za-z0-9._-]+`` accepted to keep the "
+                        "shell pipeline injection-safe."
+                    ),
+                },
+                "lines": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 5000,
+                    "default": 200,
+                    "description": "Number of trailing lines to return per file.",
+                },
+            },
+            "required": ["component"],
+            "additionalProperties": False,
+        },
+        response_schema={
+            "type": "object",
+            "properties": {
+                "files": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": ["string", "null"]},
+                            "lines": {"type": "string"},
+                        },
+                    },
+                },
+                "raw": {"type": "string"},
+                "lines_requested": {"type": "integer"},
+                "error": {"type": ["string", "null"]},
+            },
+            "additionalProperties": True,
+        },
+        group_key="logs",
+        tags=("read-only", "logs", "tail", "holodeck"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call when the operator wants to inspect recent log "
+                "lines for a specific Holodeck Photon service (``dhcp``, "
+                "``dns``, ``frr``, ``webtop``, ``k8s``). Returns the "
+                "last <lines> lines per matching log file. " + _SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {
+                "component": (
+                    "Log-file slug; expands to "
+                    "``/holodeck-runtime/logs/<component>*.log``. "
+                    "Allowed chars: [A-Za-z0-9._-]+."
+                ),
+                "lines": "Trailing line count per file; default 200, max 5000.",
+            },
+            "output_shape": (
+                "``{files: [{path, lines}], raw: '<full stdout>', "
+                "lines_requested: N}``. When multiple log files match "
+                "the glob, each is surfaced under its own ``files`` "
+                "entry. Single-file matches have ``path=None`` (no "
+                "GNU tail header)."
+            ),
+        },
+    ),
+    HolodeckOp(
+        op_id="holodeck.networking.show",
+        handler_attr="networking_show",
+        summary="Composite FRR/BGP + DNS zone + DHCP lease snapshot for the appliance.",
+        description=(
+            "Runs four sub-commands over the pooled SSH connection: "
+            "``vtysh -c 'show bgp summary'``, ``vtysh -c 'show ip "
+            "route'``, ``pwsh`` of ``Get-DnsServerZone | "
+            "ConvertTo-Json -Depth 4``, and ``cat "
+            "/var/lib/dhcp/dhcpd.leases``. Returns an envelope with "
+            "four narrative sub-sections (``bgp``, ``routes``, ``dns``, "
+            "``dhcp``), each carrying its own ``ok`` flag so a "
+            "single-component failure doesn't blank the whole "
+            "response. Read-only; no mutating commands issued."
+        ),
+        parameter_schema=_EMPTY_PARAMS,
+        response_schema={
+            "type": "object",
+            "properties": {
+                "bgp": {
+                    "type": "object",
+                    "properties": {
+                        "summary_text": {"type": "string"},
+                        "ok": {"type": "boolean"},
+                    },
+                },
+                "routes": {
+                    "type": "object",
+                    "properties": {
+                        "text": {"type": "string"},
+                        "ok": {"type": "boolean"},
+                    },
+                },
+                "dns": {
+                    "type": "object",
+                    "properties": {
+                        "zones": {"type": "array"},
+                        "total": {"type": "integer"},
+                        "ok": {"type": "boolean"},
+                    },
+                },
+                "dhcp": {
+                    "type": "object",
+                    "properties": {
+                        "leases_text": {"type": "string"},
+                        "ok": {"type": "boolean"},
+                    },
+                },
+            },
+            "additionalProperties": True,
+        },
+        group_key="networking",
+        tags=("read-only", "networking", "bgp", "dns", "dhcp", "holodeck"),
+        safety_level="safe",
+        requires_approval=False,
+        llm_instructions={
+            "when_to_use": (
+                "Call when the operator wants a one-shot snapshot of "
+                "the HoloRouter's networking surface: FRR/BGP peer "
+                "summary + kernel routes + DNS zones + DHCP leases. "
+                "Use ``holodeck.logs.tail component=frr`` for FRR log "
+                "drill-in. " + _SSH_TRANSPORT_NOTE
+            ),
+            "parameter_hints": {},
+            "output_shape": (
+                "``{bgp: {summary_text, ok}, routes: {text, ok}, "
+                "dns: {zones, total, ok}, dhcp: {leases_text, ok}}``. "
+                "Each sub-section's ``ok`` flips false when its "
+                "sub-command failed or produced empty output. BGP and "
+                "routes are operator-formatted text (vtysh output); "
+                "DNS is structured (parsed JSON); DHCP is the raw "
+                "leases file."
+            ),
+        },
+    ),
+)

--- a/backend/src/meho_backplane/connectors/holodeck/ops_read.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops_read.py
@@ -66,24 +66,43 @@ Safety -- read-only k8s exec
 
 The acceptance criterion calls for ``holodeck.k8s.exec`` to reject
 mutating ``kubectl`` verbs (``create``/``apply``/``delete``/``edit``/
-``scale``/``patch``/...). The defence runs in two layers:
+``scale``/``patch``/...) **and** the canonical shell-injection
+exploit shapes (``;`` / ``&&`` / ``|`` / ``$(...)`` / backticks /
+``>`` / ``<`` / newline). The defence runs in two complementary
+allowlist layers:
 
 1. **Schema layer** -- ``parameter_schema.properties.command`` carries
-   a ``pattern`` regex that requires the command to start with
-   ``kubectl`` followed by one of the read-only verbs. The
-   dispatcher's :func:`~meho_backplane.operations._validate.validate_params`
-   walks this before reaching the handler; bad shapes surface as a
+   a ``pattern`` regex anchored ``\\A ... \\Z`` that requires the
+   command to start with ``kubectl``, hit one of the read-only verbs,
+   and carry only characters from the allowlist
+   ``[A-Za-z0-9._/=:,@-]`` in its arguments. Whitespace between tokens
+   is constrained to space-or-tab (``[ \\t]``) so a newline cannot
+   smuggle a second command line through the ``\\s`` class. The
+   dispatcher's
+   :func:`~meho_backplane.operations._validate.validate_params` walks
+   this before reaching the handler; bad shapes surface as a
    ``result_invalid_params`` envelope.
 2. **Handler layer** -- before the SSH call lands, the handler
-   re-parses the command via :func:`parse_kubectl_command` and
-   compares the verb to :data:`_K8S_READ_VERBS`. Mutating verbs raise
+   re-parses the command via :func:`parse_kubectl_command`, which
+   (a) scans the raw command for any character in
+   :data:`_SHELL_METACHARS_RE` and refuses on hit, then (b) tokenises
+   via :func:`shlex.split` and (c) compares the verb to
+   :data:`_K8S_READ_VERBS`. Any rejected step raises
    :exc:`KubectlSafetyError`, which the dispatcher's exception path
-   turns into a ``result_connector_error`` envelope. This is the
-   belt-and-braces fallback for the case where a future schema edit
-   accidentally widens the pattern.
+   turns into a ``result_connector_error`` envelope. The metacharacter
+   reject is **load-bearing**: ``shlex.split`` in POSIX mode does not
+   treat shell separators as token boundaries, so a chained payload
+   like ``kubectl get pods; rm -rf /`` would otherwise tokenise to
+   ``['kubectl', 'get', 'pods;', ...]`` -- the verb-safelist check
+   on ``tokens[idx]`` would see ``'get'`` and approve, and the
+   handler would then forward the **raw string** to
+   ``asyncssh.SSHClientConnection.run``, which delegates to the
+   remote login shell where the shell interprets the metacharacter.
 
 The handler layer is the **authoritative** gate; the schema pattern
 is a guardrail so a misshapen call doesn't even reach the connector.
+Both layers reject every chained-shell shape independently -- a
+future widening on either side does not silently re-open the hole.
 
 References
 ----------
@@ -134,14 +153,19 @@ __all__ = [
 #: ``get`` / ``describe`` / ``logs`` are the three primary read verbs
 #: the Initiative #371 body calls out. ``top`` (metrics) and
 #: ``explain`` (schema) are pure reads. ``api-resources`` /
-#: ``api-versions`` / ``cluster-info`` / ``config`` (``view``) /
-#: ``version`` / ``auth`` (``can-i``) cover the inspection surface
-#: without mutating cluster state. Any verb absent from this set --
-#: notably ``create`` / ``apply`` / ``delete`` / ``edit`` /
-#: ``replace`` / ``patch`` / ``scale`` / ``rollout`` (``restart``) /
-#: ``label`` (``--overwrite``) / ``annotate`` / ``cp`` / ``exec`` /
-#: ``port-forward`` / ``proxy`` / ``drain`` / ``cordon`` --
-#: fails closed.
+#: ``api-versions`` / ``cluster-info`` / ``version`` cover the
+#: inspection surface without mutating cluster state. Any verb absent
+#: from this set -- notably ``create`` / ``apply`` / ``delete`` /
+#: ``edit`` / ``replace`` / ``patch`` / ``scale`` / ``rollout``
+#: (``restart``) / ``label`` (``--overwrite``) / ``annotate`` /
+#: ``cp`` / ``exec`` / ``port-forward`` / ``proxy`` / ``drain`` /
+#: ``cordon`` -- fails closed. Multi-word inspection verbs
+#: (``config view``, ``auth can-i``) are intentionally **not**
+#: surfaced today: the safelist matches on the single verb token, so
+#: ``kubectl config get-contexts`` would be approved through the
+#: ``config`` parent verb. Surfacing them safely requires a verb +
+#: sub-verb safelist, which is deferred -- callers that need them
+#: should file a follow-up.
 _K8S_READ_VERBS: frozenset[str] = frozenset(
     {
         "get",
@@ -155,6 +179,28 @@ _K8S_READ_VERBS: frozenset[str] = frozenset(
         "version",
     }
 )
+
+#: Shell metacharacters banned anywhere in a ``kubectl`` command line.
+#: ``shlex.split`` in POSIX mode does **not** treat these as token
+#: boundaries (it only splits on whitespace + quotes), so a chained
+#: payload like ``kubectl get pods; rm -rf /`` parses to verb=``get``
+#: with the verb-safelist check happy -- and ``_run_command`` then
+#: hands the **raw string** to ``asyncssh.SSHClientConnection.run``,
+#: which delegates to the remote login shell where the
+#: metacharacter is interpreted. Allowlist for safe characters is
+#: applied as a positive check by the schema layer regex; this
+#: blocklist is the handler-layer equivalent and the authoritative
+#: gate (a future schema widening must not let writes through). The
+#: character set covers every POSIX-shell control operator that can
+#: chain a command, expand to a subshell, or redirect IO:
+#:
+#: * ``;`` / newline / CR -- statement separators
+#: * ``&`` / ``|`` -- background, AND/OR list, pipe
+#: * ``<`` / ``>`` -- input / output redirection
+#: * ``$`` / ``(`` / ``)`` -- arithmetic, command, process substitution
+#: * backtick -- legacy command substitution
+#: * ``\\`` -- line continuation / escape into the next char
+_SHELL_METACHARS_RE: re.Pattern[str] = re.compile(r"[;&|<>`$()\\\n\r]")
 
 
 class KubectlSafetyError(ValueError):
@@ -184,9 +230,23 @@ def parse_kubectl_command(command: str) -> tuple[str, list[str]]:
     (``"my pod"``) survive the parse; the safety check operates on the
     verb token, which is unquoted in every legal ``kubectl`` invocation.
 
-    Empty command, or command not starting with ``kubectl``, or verb
-    not in :data:`_K8S_READ_VERBS` -> :exc:`KubectlSafetyError`. The
-    handler raises before any SSH traffic happens.
+    Before tokenisation the function scans for POSIX-shell
+    metacharacters (:data:`_SHELL_METACHARS_RE`) and refuses the call
+    if any are found. This is **load-bearing**: ``shlex.split`` in
+    POSIX mode does not treat ``;`` / ``&&`` / ``|`` / ``$(...)`` /
+    backticks / ``>`` / ``<`` as token boundaries, so a chained payload
+    like ``kubectl get pods; rm -rf /`` would tokenise to
+    ``['kubectl', 'get', 'pods;', 'rm', '-rf', '/']``, the verb check
+    on ``tokens[idx]`` would see ``'get'`` and approve, and the
+    handler would then forward the **raw string** verbatim to
+    ``asyncssh.SSHClientConnection.run`` -- which delegates to the
+    remote login shell where the metacharacters are interpreted. The
+    metachar reject closes that hole before tokenisation runs.
+
+    Empty command, or command containing shell metacharacters, or
+    command not starting with ``kubectl``, or verb not in
+    :data:`_K8S_READ_VERBS` -> :exc:`KubectlSafetyError`. The handler
+    raises before any SSH traffic happens.
 
     Examples
     --------
@@ -198,6 +258,18 @@ def parse_kubectl_command(command: str) -> tuple[str, list[str]]:
     """
     if not command or not command.strip():
         raise KubectlSafetyError("kubectl command is empty")
+    # Metacharacter rejection -- load-bearing security gate (see
+    # docstring above and :data:`_SHELL_METACHARS_RE`). Don't echo the
+    # offending character back in the message: that's an
+    # operator-visible surface and the rejected verbatim character
+    # set is auditable through the audit_log row's ``params_hash``.
+    if _SHELL_METACHARS_RE.search(command):
+        raise KubectlSafetyError(
+            "kubectl command rejected: shell metacharacter detected; "
+            "only a single unchained kubectl invocation is allowed "
+            "(no ';', '&&', '||', '|', '$(...)', backticks, '>', '<', "
+            "newlines, or line continuations)"
+        )
     try:
         tokens = shlex.split(command)
     except ValueError as exc:
@@ -489,18 +561,22 @@ async def holodeck_k8s_exec(
     Op-id: ``holodeck.k8s.exec``. *params* carries ``command`` (a
     string starting with ``kubectl <read-verb> ...``). The handler:
 
-    1. Parses the command via :func:`parse_kubectl_command`; mutating
-       verbs raise :exc:`KubectlSafetyError` (re-raised so the
-       dispatcher's ``result_connector_error`` path surfaces it).
+    1. Parses the command via :func:`parse_kubectl_command`; shell
+       metacharacters and mutating verbs raise
+       :exc:`KubectlSafetyError` **before** any SSH transport is
+       touched. The exception is folded into a ``result_connector_
+       error`` envelope by the structured-error path below.
     2. Runs the parsed command verbatim over plain SSH (no ``pwsh``;
        the in-appliance K8s is reached through the appliance's
        ``kubectl`` binary, not through PowerShell).
     3. Returns the command stdout / exit_status / stderr fragment.
 
-    The schema pattern in :data:`READ_OPS` enforces the
-    ``^kubectl (get|describe|logs|top|explain|api-resources|
-    api-versions|cluster-info|version)\\b`` shape at the validator
-    layer; this handler is the authoritative gate, not a fallback.
+    The schema pattern in :data:`READ_OPS` enforces an allowlist
+    shape (``\\Akubectl ... (read-verb) ([ \\t]+[A-Za-z0-9._/=:,@-]+)*
+    \\Z``) at the validator layer; this handler is the authoritative
+    gate, not a fallback. Both layers reject the canonical
+    shell-injection shapes (``;`` / ``&&`` / ``|`` / ``$(...)`` /
+    backticks / ``>`` / ``<`` / newline) independently.
 
     Stderr is **truncated** at 4096 chars to keep operator surfaces
     bounded (same convention as :class:`PwshRunError`). The
@@ -978,14 +1054,32 @@ READ_OPS: tuple[HolodeckOp, ...] = (
                     "type": "string",
                     "minLength": 1,
                     "pattern": (
-                        # Anchored at start so leading whitespace / nbsp
-                        # cannot slip through. The verb alternation is
-                        # whitespace-bounded so a verb prefix
-                        # (``getfoo``) doesn't match ``get``.
-                        r"^kubectl(\s+--?[A-Za-z0-9_-]+(=\S+)?)*\s+"
-                        r"(get|describe|logs|top|explain|"
+                        # Allowlist-shaped regex: ``kubectl``, optional
+                        # global flags, a read-only verb, then a fully
+                        # constrained tail. The tail's character class
+                        # ``[A-Za-z0-9._/=:,@-]`` excludes every
+                        # POSIX-shell metacharacter that ``shlex.split``
+                        # would happily fold into a single token while
+                        # leaving the shell separator semantically
+                        # intact (``;`` / ``&`` / ``|`` / ``$`` /
+                        # backtick / ``>`` / ``<`` / parens / ``\\``).
+                        # Whitespace between tokens is constrained to
+                        # ``[ \\t]`` (space or tab) so a newline can't
+                        # be smuggled through ``\\s`` to introduce a
+                        # second command line. The end anchor ``\\Z``
+                        # is load-bearing -- without a tight end the
+                        # regex would accept ``kubectl get pods; rm
+                        # -rf /`` because the prefix is a valid match.
+                        # Verb alternation is followed by ``(?=[ \\t]
+                        # |\\Z)`` so verb prefixes (``getfoo``) don't
+                        # sneak through.
+                        r"\Akubectl"
+                        r"([ \t]+--?[A-Za-z0-9_-]+(=[A-Za-z0-9._/=:,@-]+)?)*"
+                        r"[ \t]+(get|describe|logs|top|explain|"
                         r"api-resources|api-versions|cluster-info|"
-                        r"version)(\s|$)"
+                        r"version)(?=[ \t]|\Z)"
+                        r"([ \t]+[A-Za-z0-9._/=:,@-]+)*"
+                        r"[ \t]*\Z"
                     ),
                     "description": (
                         "Full kubectl command line starting with "
@@ -996,7 +1090,11 @@ READ_OPS: tuple[HolodeckOp, ...] = (
                         "delete, edit, replace, patch, scale, "
                         "rollout, label, annotate, cp, exec, "
                         "port-forward, proxy, drain, cordon) are "
-                        "rejected at the schema layer."
+                        "rejected at the schema layer. Arguments are "
+                        "restricted to ``[A-Za-z0-9._/=:,@-]`` -- shell "
+                        "metacharacters (``;``, ``&``, ``|``, ``$``, "
+                        "backticks, ``>``, ``<``, parens, ``\\``) are "
+                        "rejected before the handler is reached."
                     ),
                 },
             },

--- a/backend/tests/test_connectors_holodeck_auth.py
+++ b/backend/tests/test_connectors_holodeck_auth.py
@@ -190,11 +190,14 @@ def test_package_import_registers_v2_entry_only() -> None:
     assert ("holodeck", "", "") not in v2
 
 
-def test_t1_ships_only_the_about_canary_op() -> None:
-    """T1 ships ``holodeck.about`` alone; T2 (#854) appends the 8 read ops."""
-    assert len(HOLODECK_OPS) == 1
+def test_about_canary_op_remains_at_index_zero() -> None:
+    """``holodeck.about`` is the T1 canary; T2 (#854) appends the 7 read ops
+    onto the same tuple while preserving the canary at index 0. The full T2
+    registration shape lives in ``test_connectors_holodeck_ops.py``.
+    """
     assert HOLODECK_OPS[0].op_id == "holodeck.about"
     assert HOLODECK_OPS[0].handler_attr == "about"
+    assert len(HOLODECK_OPS) == 8
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_holodeck_ops.py
+++ b/backend/tests/test_connectors_holodeck_ops.py
@@ -612,6 +612,157 @@ async def test_k8s_exec_returns_envelope_on_ssh_failure() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Shell-injection rejection (B1 -- review iter 1).
+#
+# These tests are the regression guard for the chained-shell exploit
+# the iter-1 review demonstrated: ``shlex.split`` in POSIX mode does
+# not treat ``;`` / ``&&`` / ``|`` / ``$(...)`` / backticks / ``>`` /
+# ``<`` / newline as token boundaries, so the verb-safelist check on
+# ``tokens[idx]`` would otherwise approve the leading ``kubectl get``
+# and the **raw** command would flow to
+# ``asyncssh.SSHClientConnection.run`` -- which delegates to the
+# remote login shell. The reject must fire **before** any SSH
+# transport is touched, so each test ALSO asserts that
+# ``_run_command`` is never awaited.
+# ---------------------------------------------------------------------------
+
+
+#: Injection payloads the iter-1 review demonstrated, plus their
+#: complement set: every POSIX shell control operator that can chain
+#: a command, expand to a subshell, or redirect IO. Test IDs name the
+#: metacharacter category for readable parametrise output.
+_K8S_INJECTION_PAYLOADS: tuple[tuple[str, str], ...] = (
+    ("semicolon", "kubectl get pods; rm -rf /"),
+    ("and-and", "kubectl get pods && rm -rf /"),
+    ("or-or", "kubectl get pods || rm -rf /"),
+    ("pipe", "kubectl get pods | xargs rm"),
+    ("dollar-paren", "kubectl get pods$(whoami)"),
+    ("backtick", "kubectl get `whoami`"),
+    ("gt-redirect", "kubectl get > /etc/passwd"),
+    ("lt-redirect", "kubectl get < /etc/passwd"),
+    ("newline", "kubectl get pods\nrm -rf /"),
+    ("carriage-return", "kubectl get pods\rrm -rf /"),
+    ("background-amp", "kubectl get pods & curl evil.com"),
+    ("escape-backslash", "kubectl get pods\\\nrm -rf /"),
+)
+
+
+@pytest.mark.parametrize(
+    ("label", "command"),
+    _K8S_INJECTION_PAYLOADS,
+    ids=[label for label, _ in _K8S_INJECTION_PAYLOADS],
+)
+def test_parse_kubectl_command_rejects_shell_injection(label: str, command: str) -> None:
+    """Handler-layer: ``parse_kubectl_command`` refuses metacharacters.
+
+    The exception message names the rejection category ('shell
+    metacharacter detected') without echoing the offending command
+    body back -- avoids leaking operator-supplied payload material
+    into operator-visible surfaces.
+    """
+    del label  # only used for parametrise IDs
+    with pytest.raises(KubectlSafetyError) as excinfo:
+        parse_kubectl_command(command)
+    msg = str(excinfo.value)
+    assert "shell metacharacter" in msg
+    # The full raw command must never appear in the error message --
+    # operator-supplied payload material doesn't belong in user-
+    # visible error envelopes.
+    assert "rm -rf" not in msg
+    assert "whoami" not in msg
+    assert "evil.com" not in msg
+
+
+@pytest.mark.parametrize(
+    ("label", "command"),
+    _K8S_INJECTION_PAYLOADS,
+    ids=[label for label, _ in _K8S_INJECTION_PAYLOADS],
+)
+@pytest.mark.asyncio
+async def test_k8s_exec_handler_rejects_shell_injection_before_ssh(
+    label: str, command: str
+) -> None:
+    """The k8s.exec handler refuses chained-shell payloads BEFORE any SSH call.
+
+    Mocks ``_run_command`` and asserts ``await_count == 0`` -- the
+    rejection must fire before the SSH transport is even touched, so
+    a future bug in the transport layer can't paper over a missing
+    safety check.
+    """
+    del label
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        result = await connector.k8s_exec(_TARGET, {"command": command})
+        mock_cmd.assert_not_awaited()
+        assert mock_cmd.await_count == 0
+    # Structured-error envelope, not a raised exception.
+    assert result["exit_status"] is None
+    assert result["stdout"] == ""
+    assert result["stderr"] == ""
+    assert "safety check" in result["error"]
+    assert "shell metacharacter" in result["error"]
+
+
+@pytest.mark.parametrize(
+    ("label", "command"),
+    _K8S_INJECTION_PAYLOADS,
+    ids=[label for label, _ in _K8S_INJECTION_PAYLOADS],
+)
+def test_k8s_exec_schema_pattern_rejects_shell_injection(label: str, command: str) -> None:
+    """Schema-layer guardrail: the dispatcher's validator catches the same shapes.
+
+    Belt-and-braces redundancy with the handler-layer reject -- a
+    future widening on either side must not silently re-open the
+    hole. This test pins the **schema pattern** (the dispatcher's
+    validator front-end) against the same injection corpus.
+    """
+    del label
+    k8s_op = next(op for op in READ_OPS if op.op_id == "holodeck.k8s.exec")
+    schema = k8s_op.parameter_schema
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate({"command": command}, schema)
+
+
+@pytest.mark.parametrize(
+    "verb",
+    [
+        "get",
+        "describe",
+        "logs",
+        "top",
+        "explain",
+        "api-resources",
+        "api-versions",
+        "cluster-info",
+        "version",
+    ],
+)
+@pytest.mark.asyncio
+async def test_k8s_exec_handler_accepts_every_safelist_verb(verb: str) -> None:
+    """Allowlist regression guard -- the tightened metachar/regex pair must
+    not break any verb on :data:`_K8S_READ_VERBS`.
+
+    Sibling to ``test_k8s_exec_schema_pattern_accepts_read_verbs``;
+    this one drives the **handler** path end-to-end with a mocked
+    SSH transport so the parser + metachar scan + verb-safelist
+    sequence is exercised together.
+    """
+    connector = HolodeckConnector()
+    # The ``cluster-info`` / ``version`` verbs take no positional arg
+    # so call them naked; everything else accepts ``pods`` as a
+    # placeholder resource name.
+    command = f"kubectl {verb}" if verb in {"cluster-info", "version"} else (f"kubectl {verb} pods")
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="(ok)\n")
+        result = await connector.k8s_exec(_TARGET, {"command": command})
+    mock_cmd.assert_awaited_once()
+    assert result["exit_status"] == 0
+    # No error envelope -- the safelist verb passed both safety
+    # checks and the SSH path was reached.
+    assert "error" not in result or result.get("error") is None
+
+
+# ---------------------------------------------------------------------------
 # Bound-method shims -- logs_tail
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_connectors_holodeck_ops.py
+++ b/backend/tests/test_connectors_holodeck_ops.py
@@ -1,0 +1,952 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the Holodeck read op group (G3.8-T2 #854).
+
+Coverage matrix (per Task #854 acceptance criteria):
+
+* :func:`parse_kubectl_command` -- parses ``kubectl`` invocations
+  into ``(verb, args)``; rejects mutating verbs with
+  :exc:`KubectlSafetyError`; handles leading global flags (both
+  ``--flag=value`` and ``--flag value`` forms); rejects non-kubectl
+  shells.
+* :func:`parse_logs_tail_output` -- splits multi-file GNU ``tail``
+  output by ``==> path <==`` header; single-file tail yields
+  ``path=None``; empty / whitespace stdout returns ``files=[]``.
+* :func:`parse_networking_payload` -- composes the four-section
+  envelope; per-sub-section ``ok`` flips false on empty / wrong-typed
+  input; ``ConvertTo-Json`` single-dict result normalised to a
+  ``[{...}]`` zone list.
+* Bound-method shims on :class:`HolodeckConnector` -- ``config_show``,
+  ``pod_list``, ``pod_info``, ``service_list``, ``k8s_exec``,
+  ``logs_tail``, ``networking_show`` -- each runs the correct
+  PowerShell / SSH commands, passes payloads through the parser,
+  and returns the expected envelope shape.
+* JSONFlux-shaped ``{rows, total}`` envelopes on ``pod_list`` and
+  ``service_list``; single-dict ``ConvertTo-Json`` result normalised
+  to a 1-row list (``Get-HoloDeckPod`` with one pod) and ``null``
+  result normalised to an empty list.
+* ``holodeck.k8s.exec`` rejects mutating verbs (``create``, ``apply``,
+  ``delete``, ``edit``, ``replace``, ``patch``, ``scale``,
+  ``rollout``) at the handler layer with a structured error envelope;
+  the parameter-schema pattern rejects them at the validator layer.
+* ``holodeck.logs.tail`` rejects components carrying shell
+  metacharacters; lines clamped to [1, 5000].
+* ``HOLODECK_OPS`` registration shape -- 8 ops total, all carry
+  ``safety_level='safe'``, ``additionalProperties=False`` on the
+  parameter schema, non-empty ``llm_instructions.when_to_use``, the
+  SSH-only transport note, and ``holodeck.`` namespace op_ids.
+* Secret/SSH-key leak canaries -- the connector's ``target.secret_ref``
+  password and the operator-supplied k8s command never appear in
+  returned result envelopes, captured stderr in error envelopes, or
+  log capture under failure-path runs.
+* k8s.exec stderr is truncated at 4096 chars.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import jsonschema
+import pytest
+
+import meho_backplane.connectors.holodeck  # noqa: F401 -- import for registry side-effects
+from meho_backplane.connectors.holodeck import HOLODECK_OPS, HolodeckConnector
+from meho_backplane.connectors.holodeck.ops_read import (
+    READ_OPS,
+    KubectlSafetyError,
+    parse_kubectl_command,
+    parse_logs_tail_output,
+    parse_networking_payload,
+)
+from meho_backplane.settings import get_settings
+
+# ---------------------------------------------------------------------------
+# Environment fixture (settings cache requires the env vars to resolve)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+_CANARY_PASSWORD = "holodeck-canary-pw-xyz-554"  # NOSONAR -- canary not a real cred
+# Synthetic canary that *resembles* a key footprint without tripping the
+# ``detect-private-key`` pre-commit hook -- the regex keys on the literal
+# ``BEGIN ... PRIVATE KEY`` opener. Substring-canary tests for the absence
+# of this exact 36-char marker in repr/log surfaces.
+_CANARY_SSH_KEY = "HOLODECK-CANARY-KEY-MARKER-ABCD1234XY"
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: dict[str, Any]
+
+
+_TARGET = _StubTarget(
+    name="holorouter-test",
+    host="holorouter.test.invalid",
+    port=22,
+    secret_ref={
+        "username": "root",
+        "password": _CANARY_PASSWORD,
+        "ssh_private_key": _CANARY_SSH_KEY,
+    },
+)
+
+
+def _proc(*, stdout: str = "", stderr: str = "", exit_status: int = 0) -> Any:
+    """Construct an ``SSHCompletedProcess``-shaped stub."""
+    proc = MagicMock()
+    proc.stdout = stdout
+    proc.stderr = stderr
+    proc.exit_status = exit_status
+    return proc
+
+
+def _serialise_for_leak_check(envelope: Any) -> str:
+    """Render an envelope to a single string for canary-substring scanning.
+
+    Uses ``repr`` so nested dicts / lists / tuples / exception messages
+    all surface. The leak invariant is that **no** secret material
+    bleeds into the envelope under any code path; ``repr`` is the
+    paranoid superset of every operator-visible serialisation.
+    """
+    return repr(envelope)
+
+
+# ---------------------------------------------------------------------------
+# parse_kubectl_command
+# ---------------------------------------------------------------------------
+
+
+def test_parse_kubectl_command_simple_get() -> None:
+    verb, args = parse_kubectl_command("kubectl get pods")
+    assert verb == "get"
+    assert args == ["pods"]
+
+
+def test_parse_kubectl_command_with_namespace_flag() -> None:
+    verb, args = parse_kubectl_command("kubectl get pods -n holodeck")
+    assert verb == "get"
+    assert args == ["pods", "-n", "holodeck"]
+
+
+def test_parse_kubectl_command_describe_pod() -> None:
+    verb, args = parse_kubectl_command('kubectl describe pod "my-pod-01"')
+    assert verb == "describe"
+    assert args == ["pod", "my-pod-01"]
+
+
+def test_parse_kubectl_command_logs() -> None:
+    verb, _ = parse_kubectl_command("kubectl logs my-pod -c my-container")
+    assert verb == "logs"
+
+
+def test_parse_kubectl_command_global_flag_separated() -> None:
+    """``kubectl --context foo get pods`` -- the verb is past the separated flag."""
+    verb, args = parse_kubectl_command("kubectl --context foo get pods")
+    assert verb == "get"
+    assert args == ["pods"]
+
+
+def test_parse_kubectl_command_global_flag_attached() -> None:
+    """``kubectl --context=foo get pods`` -- attached-value flag form."""
+    verb, args = parse_kubectl_command("kubectl --context=foo get pods")
+    assert verb == "get"
+    assert args == ["pods"]
+
+
+def test_parse_kubectl_command_multiple_global_flags() -> None:
+    verb, _ = parse_kubectl_command(
+        "kubectl --kubeconfig=/tmp/x.yaml --namespace=holodeck get pods"
+    )
+    assert verb == "get"
+
+
+def test_parse_kubectl_command_short_flag_attached() -> None:
+    verb, _ = parse_kubectl_command("kubectl -n holodeck get pods")
+    assert verb == "get"
+
+
+@pytest.mark.parametrize(
+    "verb",
+    [
+        "create",
+        "apply",
+        "delete",
+        "edit",
+        "replace",
+        "patch",
+        "scale",
+        "rollout",
+        "label",
+        "annotate",
+        "cp",
+        "exec",
+        "port-forward",
+        "proxy",
+        "drain",
+        "cordon",
+        "uncordon",
+        "taint",
+        "set",
+        "expose",
+        "run",
+    ],
+)
+def test_parse_kubectl_command_rejects_mutating_verb(verb: str) -> None:
+    """Every mutating kubectl verb must be rejected by the safelist."""
+    with pytest.raises(KubectlSafetyError) as excinfo:
+        parse_kubectl_command(f"kubectl {verb} pods")
+    assert verb in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "",
+        "   ",
+        "rm -rf /",
+        "echo kubectl get pods",  # not starting with kubectl
+        "kubectl",  # no verb
+        "kubectl --context=foo",  # no verb after global flags
+    ],
+)
+def test_parse_kubectl_command_rejects_malformed(command: str) -> None:
+    with pytest.raises(KubectlSafetyError):
+        parse_kubectl_command(command)
+
+
+def test_parse_kubectl_command_rejects_unbalanced_quoting() -> None:
+    """``shlex.split`` raises on an unbalanced quote; the parser refuses."""
+    with pytest.raises(KubectlSafetyError):
+        parse_kubectl_command("kubectl get 'pods")
+
+
+def test_parse_kubectl_command_safelist_includes_top_explain() -> None:
+    """Verify ``top`` and ``explain`` are accepted (read-only inspection verbs)."""
+    assert parse_kubectl_command("kubectl top pods")[0] == "top"
+    assert parse_kubectl_command("kubectl explain pods")[0] == "explain"
+
+
+def test_parse_kubectl_command_safelist_includes_cluster_info() -> None:
+    assert parse_kubectl_command("kubectl cluster-info")[0] == "cluster-info"
+
+
+# ---------------------------------------------------------------------------
+# parse_logs_tail_output
+# ---------------------------------------------------------------------------
+
+
+def test_parse_logs_tail_output_multi_file_with_headers() -> None:
+    output = (
+        "==> /holodeck-runtime/logs/dhcp.log <==\n"
+        "dhcp evt 1\n"
+        "dhcp evt 2\n"
+        "==> /holodeck-runtime/logs/dns.log <==\n"
+        "dns evt 1\n"
+    )
+    parsed = parse_logs_tail_output(output)
+    assert len(parsed["files"]) == 2
+    assert parsed["files"][0]["path"] == "/holodeck-runtime/logs/dhcp.log"
+    assert "dhcp evt 1" in parsed["files"][0]["lines"]
+    assert parsed["files"][1]["path"] == "/holodeck-runtime/logs/dns.log"
+    assert parsed["raw"] == output
+
+
+def test_parse_logs_tail_output_single_file_no_header() -> None:
+    """Single-file tail emits no ``==>`` header; ``path`` is None."""
+    output = "log line a\nlog line b\n"
+    parsed = parse_logs_tail_output(output)
+    assert len(parsed["files"]) == 1
+    assert parsed["files"][0]["path"] is None
+    assert parsed["files"][0]["lines"] == output
+
+
+def test_parse_logs_tail_output_empty_input_returns_empty_files() -> None:
+    assert parse_logs_tail_output("")["files"] == []
+    assert parse_logs_tail_output("   \n")["files"] == []
+
+
+def test_parse_logs_tail_output_carries_raw_stdout() -> None:
+    output = "==> /a.log <==\nfoo\n"
+    assert parse_logs_tail_output(output)["raw"] == output
+
+
+# ---------------------------------------------------------------------------
+# parse_networking_payload
+# ---------------------------------------------------------------------------
+
+
+def test_parse_networking_payload_all_ok() -> None:
+    payload = parse_networking_payload(
+        bgp_text="BGP summary\n",
+        routes_text="Routes\n",
+        dns_zones_json=[{"ZoneName": "lab.test"}],
+        dhcp_leases_text="lease 10.0.0.1\n",
+    )
+    assert payload["bgp"]["ok"] is True
+    assert payload["routes"]["ok"] is True
+    assert payload["dns"]["ok"] is True
+    assert payload["dns"]["total"] == 1
+    assert payload["dhcp"]["ok"] is True
+
+
+def test_parse_networking_payload_dns_single_dict_normalised_to_list() -> None:
+    """ConvertTo-Json on a single zone returns a dict, not a 1-element list."""
+    payload = parse_networking_payload(
+        bgp_text="",
+        routes_text="",
+        dns_zones_json={"ZoneName": "single.lab"},
+        dhcp_leases_text="",
+    )
+    assert isinstance(payload["dns"]["zones"], list)
+    assert len(payload["dns"]["zones"]) == 1
+    assert payload["dns"]["zones"][0]["ZoneName"] == "single.lab"
+
+
+def test_parse_networking_payload_per_section_ok_flips_false_on_empty() -> None:
+    payload = parse_networking_payload(
+        bgp_text="",
+        routes_text="   \n",
+        dns_zones_json=None,
+        dhcp_leases_text="",
+    )
+    assert payload["bgp"]["ok"] is False
+    assert payload["routes"]["ok"] is False
+    assert payload["dns"]["ok"] is False
+    assert payload["dns"]["zones"] == []
+    assert payload["dhcp"]["ok"] is False
+
+
+def test_parse_networking_payload_dns_ok_false_on_non_json_payload() -> None:
+    """A non-list, non-dict DNS payload (e.g. ``None`` from PwshRunError) -> ok=False."""
+    payload = parse_networking_payload(
+        bgp_text="x",
+        routes_text="y",
+        dns_zones_json="garbage",  # type: ignore[arg-type]
+        dhcp_leases_text="z",
+    )
+    assert payload["dns"]["ok"] is False
+
+
+# ---------------------------------------------------------------------------
+# Bound-method shims -- config_show
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_config_show_returns_parsed_dict() -> None:
+    connector = HolodeckConnector()
+    payload = {"Version": "9.0.3", "PodId": "HoloPod-001", "Services": []}
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        # pwsh_run hits ``_run_command`` -- the cmd ends ``pwsh -EncodedCommand ...``
+        import json as _stdlib_json
+
+        mock_cmd.return_value = _proc(stdout=_stdlib_json.dumps(payload))
+        result = await connector.config_show(_TARGET, {})
+    assert result["config"] == payload
+    # Verify the cmd was the expected encoded pwsh shape.
+    cmd = mock_cmd.await_args.args[1]
+    assert cmd.startswith("pwsh -NoProfile -NonInteractive -EncodedCommand ")
+
+
+@pytest.mark.asyncio
+async def test_config_show_returns_error_on_pwsh_failure() -> None:
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="", stderr="cmdlet broke", exit_status=1)
+        result = await connector.config_show(_TARGET, {})
+    assert result["config"] is None
+    assert "error" in result
+    assert isinstance(result["error"], str)
+
+
+# ---------------------------------------------------------------------------
+# Bound-method shims -- pod_list / pod_info / service_list (JSONFlux envelope)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pod_list_returns_rows_and_total_for_multi_pod_json_array() -> None:
+    connector = HolodeckConnector()
+    pods = [
+        {"PodId": "HoloPod-001", "Name": "lab-a", "State": "Running"},
+        {"PodId": "HoloPod-002", "Name": "lab-b", "State": "Stopped"},
+    ]
+    import json as _stdlib_json
+
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout=_stdlib_json.dumps(pods))
+        result = await connector.pod_list(_TARGET, {})
+    assert result["total"] == 2
+    assert len(result["rows"]) == 2
+    assert result["rows"][0]["PodId"] == "HoloPod-001"
+
+
+@pytest.mark.asyncio
+async def test_pod_list_normalises_single_pod_dict_to_1_row_list() -> None:
+    """``ConvertTo-Json`` on a single-pod result returns a dict, not a list."""
+    connector = HolodeckConnector()
+    single_pod = {"PodId": "HoloPod-001"}
+    import json as _stdlib_json
+
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout=_stdlib_json.dumps(single_pod))
+        result = await connector.pod_list(_TARGET, {})
+    assert result["total"] == 1
+    assert result["rows"] == [single_pod]
+
+
+@pytest.mark.asyncio
+async def test_pod_list_normalises_null_to_empty_rows() -> None:
+    """Empty pipeline -> ``null`` -> empty rows."""
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="null")
+        result = await connector.pod_list(_TARGET, {})
+    assert result["rows"] == []
+    assert result["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_pod_list_error_envelope_on_pwsh_failure() -> None:
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="", stderr="cmdlet failed", exit_status=2)
+        result = await connector.pod_list(_TARGET, {})
+    assert result["rows"] == []
+    assert result["total"] == 0
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_pod_info_requires_pod_id() -> None:
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        result = await connector.pod_info(_TARGET, {})
+        # No SSH call when pod_id is missing.
+        mock_cmd.assert_not_awaited()
+    assert result["pod"] is None
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_pod_info_returns_parsed_pod() -> None:
+    connector = HolodeckConnector()
+    detail = {"PodId": "HoloPod-001", "State": "Running", "VMs": []}
+    import json as _stdlib_json
+
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout=_stdlib_json.dumps(detail))
+        result = await connector.pod_info(_TARGET, {"pod_id": "HoloPod-001"})
+    assert result["pod"] == detail
+
+
+@pytest.mark.asyncio
+async def test_pod_info_quotes_pod_id_safely() -> None:
+    """A pod_id with a single quote must round-trip safely via PowerShell ''-escaping."""
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout='{"PodId": "x"}')
+        await connector.pod_info(_TARGET, {"pod_id": "Pod-O'Reilly"})
+    cmd = mock_cmd.await_args.args[1]
+    # The encoded base64 isn't trivial to decode here, but we can assert
+    # the request shape and trust the round-trip test for the encoding.
+    assert cmd.startswith("pwsh -NoProfile -NonInteractive -EncodedCommand ")
+
+
+@pytest.mark.asyncio
+async def test_service_list_returns_rows_for_multi_service_array() -> None:
+    connector = HolodeckConnector()
+    services = [
+        {"Name": "HoloDNS", "Status": "Running", "DisplayName": "Holodeck DNS"},
+        {"Name": "HoloDHCP", "Status": "Stopped", "DisplayName": "Holodeck DHCP"},
+    ]
+    import json as _stdlib_json
+
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout=_stdlib_json.dumps(services))
+        result = await connector.service_list(_TARGET, {})
+    assert result["total"] == 2
+    assert result["rows"][0]["Name"] == "HoloDNS"
+
+
+@pytest.mark.asyncio
+async def test_service_list_normalises_single_service_dict() -> None:
+    """``Where-Object`` filtering to a single match returns a flat dict."""
+    connector = HolodeckConnector()
+    single = {"Name": "HoloDNS", "Status": "Running", "DisplayName": "Holodeck DNS"}
+    import json as _stdlib_json
+
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout=_stdlib_json.dumps(single))
+        result = await connector.service_list(_TARGET, {})
+    assert result["total"] == 1
+    assert result["rows"] == [single]
+
+
+# ---------------------------------------------------------------------------
+# Bound-method shims -- k8s_exec (read-only enforcement)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_exec_runs_read_only_kubectl_get() -> None:
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="NAME READY STATUS\npod-1 1/1 Running\n")
+        result = await connector.k8s_exec(_TARGET, {"command": "kubectl get pods"})
+    mock_cmd.assert_awaited_once()
+    cmd = mock_cmd.await_args.args[1]
+    assert cmd == "kubectl get pods"
+    assert result["exit_status"] == 0
+    assert "pod-1" in result["stdout"]
+    assert "error" not in result or result.get("error") is None
+
+
+@pytest.mark.parametrize(
+    "verb",
+    ["create", "apply", "delete", "edit", "replace", "patch", "scale", "rollout"],
+)
+@pytest.mark.asyncio
+async def test_k8s_exec_handler_rejects_mutating_verb(verb: str) -> None:
+    """The handler is the authoritative gate; mutating verbs fail closed.
+
+    The schema's pattern catches it at the validator layer too, but the
+    handler re-checks so a future schema widening can't slip writes
+    through.
+    """
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        result = await connector.k8s_exec(_TARGET, {"command": f"kubectl {verb} pods"})
+        # The handler refuses **before** any SSH traffic.
+        mock_cmd.assert_not_awaited()
+    assert result["exit_status"] is None
+    assert "error" in result
+    assert "safety check" in result["error"]
+    assert verb in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_k8s_exec_handler_rejects_non_kubectl_shell() -> None:
+    """``rm -rf /`` or other shell escapes must be rejected by the handler."""
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        result = await connector.k8s_exec(_TARGET, {"command": "rm -rf /"})
+        mock_cmd.assert_not_awaited()
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_k8s_exec_schema_pattern_rejects_mutating_verb() -> None:
+    """The parameter_schema's pattern catches mutating verbs at validator layer."""
+    k8s_op = next(op for op in READ_OPS if op.op_id == "holodeck.k8s.exec")
+    schema = k8s_op.parameter_schema
+    # Apply / delete / patch must all fail the pattern.
+    for verb in ("apply", "delete", "patch", "scale", "create", "exec"):
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(
+                {"command": f"kubectl {verb} pods"},
+                schema,
+            )
+
+
+@pytest.mark.asyncio
+async def test_k8s_exec_schema_pattern_accepts_read_verbs() -> None:
+    """The schema must accept every read-only verb on the safelist."""
+    k8s_op = next(op for op in READ_OPS if op.op_id == "holodeck.k8s.exec")
+    schema = k8s_op.parameter_schema
+    for verb in (
+        "get",
+        "describe",
+        "logs",
+        "top",
+        "explain",
+        "api-resources",
+        "api-versions",
+        "cluster-info",
+        "version",
+    ):
+        jsonschema.validate({"command": f"kubectl {verb} pods"}, schema)
+
+
+@pytest.mark.asyncio
+async def test_k8s_exec_truncates_long_stderr_at_4096_chars() -> None:
+    """Cap stderr at the documented 4096-char limit for bounded operator surfaces."""
+    connector = HolodeckConnector()
+    huge_stderr = "x" * 10000
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stderr=huge_stderr, exit_status=1)
+        result = await connector.k8s_exec(_TARGET, {"command": "kubectl get pods"})
+    assert len(result["stderr"]) == 4096
+
+
+@pytest.mark.asyncio
+async def test_k8s_exec_returns_envelope_on_ssh_failure() -> None:
+    """SSH connect/run exceptions land in the ``error`` field, not propagated."""
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = OSError("connection refused")
+        result = await connector.k8s_exec(_TARGET, {"command": "kubectl get pods"})
+    assert result["exit_status"] is None
+    assert "connection refused" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Bound-method shims -- logs_tail
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_logs_tail_runs_tail_with_default_lines() -> None:
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="log line a\nlog line b\n")
+        result = await connector.logs_tail(_TARGET, {"component": "dhcp"})
+    cmd = mock_cmd.await_args.args[1]
+    assert cmd == "tail -n 200 /holodeck-runtime/logs/dhcp*.log"
+    assert result["lines_requested"] == 200
+    assert "log line a" in result["raw"]
+
+
+@pytest.mark.asyncio
+async def test_logs_tail_runs_tail_with_explicit_lines() -> None:
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="...")
+        await connector.logs_tail(_TARGET, {"component": "dns", "lines": 50})
+    cmd = mock_cmd.await_args.args[1]
+    assert cmd == "tail -n 50 /holodeck-runtime/logs/dns*.log"
+
+
+@pytest.mark.asyncio
+async def test_logs_tail_rejects_component_with_shell_metacharacters() -> None:
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        result = await connector.logs_tail(_TARGET, {"component": "../etc/passwd; cat"})
+        mock_cmd.assert_not_awaited()
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_logs_tail_rejects_empty_component() -> None:
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        result = await connector.logs_tail(_TARGET, {"component": ""})
+        mock_cmd.assert_not_awaited()
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_logs_tail_rejects_out_of_range_lines() -> None:
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        result = await connector.logs_tail(_TARGET, {"component": "dhcp", "lines": 0})
+        mock_cmd.assert_not_awaited()
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_logs_tail_parses_multi_file_output() -> None:
+    connector = HolodeckConnector()
+    output = (
+        "==> /holodeck-runtime/logs/frr.log <==\n"
+        "frr peer up\n"
+        "==> /holodeck-runtime/logs/frr-bgp.log <==\n"
+        "bgp peer up\n"
+    )
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout=output)
+        result = await connector.logs_tail(_TARGET, {"component": "frr"})
+    assert len(result["files"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Bound-method shims -- networking_show
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_networking_show_composes_four_sub_sections() -> None:
+    connector = HolodeckConnector()
+    # The handler runs four sub-commands; mock side_effect emits a
+    # different stdout per call. Order: vtysh bgp, vtysh routes,
+    # pwsh dns, cat dhcp.
+    import json as _stdlib_json
+
+    dns_json = _stdlib_json.dumps([{"ZoneName": "lab.test", "ZoneType": "Primary"}])
+    sequence = [
+        _proc(stdout="BGP summary text\n"),
+        _proc(stdout="Routes text\n"),
+        _proc(stdout=dns_json),
+        _proc(stdout="lease 10.0.0.1\n"),
+    ]
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = sequence
+        result = await connector.networking_show(_TARGET, {})
+    assert result["bgp"]["ok"] is True
+    assert result["routes"]["ok"] is True
+    assert result["dns"]["ok"] is True
+    assert result["dns"]["total"] == 1
+    assert result["dhcp"]["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_networking_show_isolates_sub_command_failures() -> None:
+    """One failing sub-command must not blank the others -- each has its own ok flag."""
+    connector = HolodeckConnector()
+    sequence = [
+        _proc(stdout="BGP fine\n"),
+        OSError("vtysh missing"),  # routes path fails
+        # DNS pwsh fails too (non-zero exit).
+        _proc(stdout="", stderr="dns pwsh broke", exit_status=1),
+        _proc(stdout="leases ok\n"),
+    ]
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.side_effect = sequence
+        result = await connector.networking_show(_TARGET, {})
+    assert result["bgp"]["ok"] is True
+    assert result["routes"]["ok"] is False
+    assert result["dns"]["ok"] is False
+    assert result["dhcp"]["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# HOLODECK_OPS registration shape
+# ---------------------------------------------------------------------------
+
+
+def test_holodeck_ops_has_eight_entries() -> None:
+    """T1 canary (about) + 7 T2 read ops = 8 total."""
+    assert len(HOLODECK_OPS) == 8
+
+
+def test_holodeck_ops_about_remains_at_index_zero() -> None:
+    assert HOLODECK_OPS[0].op_id == "holodeck.about"
+
+
+def test_holodeck_ops_covers_expected_op_ids() -> None:
+    op_ids = {op.op_id for op in HOLODECK_OPS}
+    expected = {
+        "holodeck.about",
+        "holodeck.config.show",
+        "holodeck.pod.list",
+        "holodeck.pod.info",
+        "holodeck.service.list",
+        "holodeck.k8s.exec",
+        "holodeck.logs.tail",
+        "holodeck.networking.show",
+    }
+    assert op_ids == expected
+
+
+def test_holodeck_ops_all_have_holodeck_namespace() -> None:
+    for op in HOLODECK_OPS:
+        assert op.op_id.startswith("holodeck."), f"{op.op_id!r} lacks holodeck. prefix"
+
+
+def test_holodeck_ops_all_safe() -> None:
+    """Every T2 read op is read-only -- safety_level='safe' is mandatory."""
+    for op in HOLODECK_OPS:
+        assert op.safety_level == "safe", (
+            f"{op.op_id!r} has safety_level={op.safety_level!r}; every T2 op must be safe"
+        )
+
+
+def test_holodeck_ops_all_no_approval_required() -> None:
+    for op in HOLODECK_OPS:
+        assert op.requires_approval is False, (
+            f"{op.op_id!r} should not require approval -- reads only"
+        )
+
+
+def test_holodeck_ops_all_parameter_schemas_have_additional_properties_false() -> None:
+    for op in HOLODECK_OPS:
+        assert op.parameter_schema.get("additionalProperties") is False, (
+            f"{op.op_id!r} parameter_schema missing additionalProperties=False"
+        )
+
+
+def test_holodeck_ops_all_have_llm_instructions() -> None:
+    for op in HOLODECK_OPS:
+        assert op.llm_instructions, f"{op.op_id!r} missing llm_instructions"
+        when_to_use = op.llm_instructions.get("when_to_use")
+        assert when_to_use, f"{op.op_id!r} missing llm_instructions.when_to_use"
+        assert isinstance(when_to_use, str) and when_to_use.strip()
+
+
+def test_holodeck_ops_llm_instructions_mention_ssh_transport() -> None:
+    """Every op's ``when_to_use`` must include the SSH-only transport note.
+
+    CLAUDE.md postulate 5 + Initiative #371 require agent-facing
+    descriptions to call out the PowerShell-over-SSH transport so an
+    LLM doesn't compose against a non-existent REST surface.
+    """
+    for op in HOLODECK_OPS:
+        when_to_use = op.llm_instructions.get("when_to_use", "")
+        assert "SSH" in when_to_use or "ssh" in when_to_use, (
+            f"{op.op_id!r} when_to_use lacks SSH transport mention"
+        )
+
+
+def test_holodeck_ops_group_keys_include_new_groups() -> None:
+    """T2 introduces the config / pod / service / k8s / logs / networking groups."""
+    group_keys = {op.group_key for op in HOLODECK_OPS if op.group_key}
+    assert {
+        "identity",
+        "config",
+        "pod",
+        "service",
+        "k8s",
+        "logs",
+        "networking",
+    } == group_keys
+
+
+def test_holodeck_ops_handler_attrs_exist_on_connector() -> None:
+    """Every ``handler_attr`` in HOLODECK_OPS resolves to a method on HolodeckConnector."""
+    for op in HOLODECK_OPS:
+        assert hasattr(HolodeckConnector, op.handler_attr), (
+            f"{op.op_id!r}: HolodeckConnector has no attr {op.handler_attr!r}"
+        )
+
+
+def test_holodeck_ops_jsonflux_list_ops_have_rows_and_total_in_response_schema() -> None:
+    """JSONFlux precedent: list ops emit ``{rows, total}`` envelopes."""
+    for op_id in ("holodeck.pod.list", "holodeck.service.list"):
+        op = next(o for o in HOLODECK_OPS if o.op_id == op_id)
+        assert op.response_schema is not None
+        properties = op.response_schema.get("properties", {})
+        assert "rows" in properties, f"{op_id!r} response missing 'rows'"
+        assert "total" in properties, f"{op_id!r} response missing 'total'"
+
+
+# ---------------------------------------------------------------------------
+# Secret-leak canary -- no credential bleed into envelopes / logs / repr
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pod_list_envelope_does_not_leak_target_secret(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``target.secret_ref`` password/key must not surface anywhere in the envelope or logs."""
+    connector = HolodeckConnector()
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout='[{"PodId":"x"}]')
+        with caplog.at_level("DEBUG"):
+            result = await connector.pod_list(_TARGET, {})
+    rendered = _serialise_for_leak_check(result)
+    assert _CANARY_PASSWORD not in rendered
+    assert _CANARY_SSH_KEY not in rendered
+    log_text = caplog.text
+    assert _CANARY_PASSWORD not in log_text
+    assert _CANARY_SSH_KEY not in log_text
+
+
+@pytest.mark.asyncio
+async def test_config_show_pwsh_error_envelope_does_not_leak_stderr_canary(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When pwsh fails, the stderr fragment must not carry secret-shaped substrings.
+
+    PwshRunError truncates stderr at 4096 chars but does **not** scrub
+    its content. The contract is: callers must not pass secret material
+    in the cmd; the connector's handlers never interpolate
+    ``target.secret_ref`` fields into pwsh scripts. We assert that
+    invariant here.
+    """
+    connector = HolodeckConnector()
+    # The stderr the connector emits cannot contain ``_CANARY_PASSWORD``
+    # because the connector never interpolates it into the script body.
+    # We assert this by exercising the PwshRunError envelope and
+    # confirming the canary is absent.
+    stderr_with_noise = "some pwsh failure stderr that does not include the secret"
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="", stderr=stderr_with_noise, exit_status=2)
+        with caplog.at_level("DEBUG"):
+            result = await connector.config_show(_TARGET, {})
+    rendered = _serialise_for_leak_check(result)
+    assert _CANARY_PASSWORD not in rendered
+    assert _CANARY_SSH_KEY not in rendered
+    assert _CANARY_PASSWORD not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_k8s_exec_envelope_does_not_leak_target_secret() -> None:
+    """The k8s.exec envelope must not surface ``target.secret_ref`` data.
+
+    The handler never inlines credential material into the command; we
+    assert the invariant under both happy-path and rejection paths.
+    """
+    connector = HolodeckConnector()
+    # Happy path: read-only kubectl.
+    with patch.object(connector, "_run_command", new_callable=AsyncMock) as mock_cmd:
+        mock_cmd.return_value = _proc(stdout="pod info\n")
+        ok_result = await connector.k8s_exec(_TARGET, {"command": "kubectl get pods"})
+    # Rejected path: mutating verb.
+    with patch.object(connector, "_run_command", new_callable=AsyncMock):
+        rejected_result = await connector.k8s_exec(_TARGET, {"command": "kubectl delete pod foo"})
+    for result in (ok_result, rejected_result):
+        rendered = _serialise_for_leak_check(result)
+        assert _CANARY_PASSWORD not in rendered
+        assert _CANARY_SSH_KEY not in rendered
+
+
+@pytest.mark.asyncio
+async def test_k8s_exec_envelope_does_not_leak_full_command_on_safety_rejection() -> None:
+    """The rejection envelope names the verb but **not** the full command line.
+
+    The full command may contain operator-supplied resource names; we
+    keep the operator-visible error surface narrow to the verb token
+    so a noisy command body doesn't bleed into structured error
+    payloads. The verb itself is part of the audit_log row's hashed
+    params anyway.
+    """
+    connector = HolodeckConnector()
+    full_command = "kubectl delete pod sensitive-internal-name-12345"
+    result = await connector.k8s_exec(_TARGET, {"command": full_command})
+    assert "error" in result
+    # The verb is allowed to appear; the resource name should not.
+    assert "delete" in result["error"]
+    assert "sensitive-internal-name-12345" not in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Connector method existence (handler_attr -> bound method roundtrip)
+# ---------------------------------------------------------------------------
+
+
+def test_connector_has_all_t2_handler_methods() -> None:
+    expected_attrs = (
+        "config_show",
+        "pod_list",
+        "pod_info",
+        "service_list",
+        "k8s_exec",
+        "logs_tail",
+        "networking_show",
+    )
+    for attr in expected_attrs:
+        assert callable(getattr(HolodeckConnector, attr, None)), (
+            f"HolodeckConnector lacks the T2 handler {attr!r}"
+        )

--- a/docs/codebase/connectors-holodeck.md
+++ b/docs/codebase/connectors-holodeck.md
@@ -168,22 +168,38 @@ disclosure (CLAUDE.md postulate 5 + Initiative #371).
   Name,Status,DisplayName | ConvertTo-Json -Depth 4`. Same `{rows, total}`
   envelope and the same single-dict / `null` normalisation as `pod.list`.
 - **`holodeck.k8s.exec`** (group `k8s`, **read-only**). Forwards a
-  ``kubectl`` command to the in-appliance K8s cluster. Two layers of
-  read-only enforcement:
+  ``kubectl`` command to the in-appliance K8s cluster. Two complementary
+  allowlist layers reject both mutating verbs and shell-injection shapes
+  (`;`, `&&`, `||`, `|`, `$(...)`, backticks, `>`, `<`, newline):
 
-  1. *Schema layer.* The `command` parameter has a `pattern` regex anchored
-     at `^kubectl(\s+--?...)*` followed by `(get|describe|logs|top|explain|
-     api-resources|api-versions|cluster-info|version)`. The dispatcher's
-     `validate_params` rejects mutating verbs before reaching the handler.
-  2. *Handler layer (authoritative).* `parse_kubectl_command` re-parses
-     the command via `shlex.split`, walks past leading global flags
-     (both `--flag=value` and `--flag value` forms), and confirms the
-     verb is in `_K8S_READ_VERBS`. Mutating verbs raise
-     `KubectlSafetyError`; the handler returns
+  1. *Schema layer.* The `command` parameter has a `pattern` regex
+     anchored `\Akubectl ... \Z`. The verb alternation accepts the
+     nine read-only verbs (`get|describe|logs|top|explain|api-resources|
+     api-versions|cluster-info|version`); arguments are restricted to
+     `[A-Za-z0-9._/=:,@-]` so shell metacharacters can't survive
+     validator-layer rejection. Whitespace between tokens is constrained
+     to `[ \t]` (space or tab) so a newline can't smuggle a second
+     command line through the `\s` class. The dispatcher's
+     `validate_params` rejects bad shapes before reaching the handler.
+  2. *Handler layer (authoritative).* `parse_kubectl_command`
+     (a) scans the raw command against `_SHELL_METACHARS_RE`
+     (`[;&|<>` + backtick + `$()\\` + newline + carriage return]`) and
+     refuses on hit, (b) tokenises via `shlex.split`, (c) walks past
+     leading global flags (`--flag=value` and `--flag value` forms),
+     and (d) confirms the verb is in `_K8S_READ_VERBS`. Any rejected
+     step raises `KubectlSafetyError`; the handler returns
      `{stdout, stderr, exit_status, error}` with `error` set to the
-     safety-check message. The full command body is **not** echoed back
-     in the error message — only the rejected verb — so operator-supplied
-     resource names don't bleed into structured error envelopes.
+     safety-check message. The metacharacter reject is **load-bearing**:
+     `shlex.split` in POSIX mode does not treat shell separators as
+     token boundaries, so without it `kubectl get pods; rm -rf /`
+     would tokenise to `['kubectl', 'get', 'pods;', ...]`, the verb
+     check would approve `get`, and the handler would forward the raw
+     string to `asyncssh.SSHClientConnection.run`, which delegates to
+     the remote login shell. The reject runs **before** any SSH
+     transport is touched. The full command body is **not** echoed
+     back in the error message — only the rejected verb / metachar
+     category — so operator-supplied resource names don't bleed into
+     structured error envelopes.
 
   Stderr from the appliance is truncated at 4096 chars, matching the
   `PwshRunError` convention.

--- a/docs/codebase/connectors-holodeck.md
+++ b/docs/codebase/connectors-holodeck.md
@@ -16,11 +16,13 @@ SSH-only typed connector in the inventory and the tier-4 closer for G3.
 
 The connector replaces the operator's `scripts/holodeck.sh` wrapper in the
 `claude-rdc-hetzner-dc` consumer repository. The G3.8-T1 (#853) skeleton
-ships only the `holodeck.about` canary op, the password-default + key-fallback
+ships the `holodeck.about` canary op, the password-default + key-fallback
 auth via the inherited `SshConnector._auth_config`, the fingerprint, the
 probe, and the `_pwsh.py` PowerShell-over-SSH helper. G3.8-T2 (#854) adds
-the 8 read ops; G3.8-T3 (#855) ships the CLI verbs + E2E acceptance suite +
-onboarding doc.
+the 7 read ops (`config.show`, `pod.list`, `pod.info`, `service.list`,
+`k8s.exec`, `logs.tail`, `networking.show`) for a final total of 8 ops
+registered under `connector_id="holodeck-ssh-9.0"`. G3.8-T3 (#855) ships
+the CLI verbs + E2E acceptance suite + onboarding doc.
 
 Source: `backend/src/meho_backplane/connectors/holodeck/`.
 
@@ -29,8 +31,19 @@ Source: `backend/src/meho_backplane/connectors/holodeck/`.
 - **`HolodeckConnector`** (`connector.py`) — `SshConnector` subclass. Class
   attributes: `product="holodeck"`, `version="9.0"`, `impl_id="holodeck-ssh"`.
   Inherits the per-target asyncssh connection pool, `_auth_config`,
-  `_run_command`, and `aclose()` from the adapter. T1 ships `fingerprint`,
-  `probe`, `execute`, `about`. T2 will add the 8 read-op bound-method shims.
+  `_run_command`, and `aclose()` from the adapter. T1 shipped `fingerprint`,
+  `probe`, `execute`, `about`. T2 (#854) adds the 7 read-op bound-method
+  shims: `config_show`, `pod_list`, `pod_info`, `service_list`, `k8s_exec`,
+  `logs_tail`, `networking_show`.
+
+- **Read-op handlers + parsers** (`ops_read.py`) — `holodeck_config_show`,
+  `holodeck_pod_list`, `holodeck_pod_info`, `holodeck_service_list`,
+  `holodeck_k8s_exec`, `holodeck_logs_tail`, `holodeck_networking_show`.
+  Pure parsers: `parse_kubectl_command` (verb-safelist enforcement),
+  `parse_logs_tail_output` (GNU `tail` `==> path <==` header split),
+  `parse_networking_payload` (four-section composer). `KubectlSafetyError`
+  is the `ValueError` subclass the dispatcher's error envelope picks up
+  when a mutating verb slips through.
 
 - **`_pwsh.py` — the novel primitive.** Houses `encode_pwsh_command(script)`
   (UTF-16LE-base64 per the `-EncodedCommand` convention), `pwsh_run(connector,
@@ -50,9 +63,10 @@ Source: `backend/src/meho_backplane/connectors/holodeck/`.
   original design.
 
 - **Op metadata** (`ops.py`) — the `HolodeckOp` dataclass and the
-  `HOLODECK_OPS` tuple. T1 ships the single `holodeck.about` canary; T2
-  will append the 8 read ops by extending the tuple from an `ops_read`-style
-  module, mirroring bind9's `_bind9_ops()` and pfSense's `_pfsense_ops()`.
+  `HOLODECK_OPS` tuple. T1 shipped the single `holodeck.about` canary; T2
+  (#854) extends the tuple via `_holodeck_ops()` which splats `READ_OPS`
+  (the 7 read ops defined in `ops_read.py`) onto the canary. The pattern
+  mirrors bind9's `_bind9_ops()` and pfSense's `_pfsense_ops()`.
 
 - **`parse_photon_version`** (`connector.py`) — pure parser for
   `/etc/photon-release` output; recovers the `<major>.<minor>(.<patch>)?`
@@ -123,6 +137,74 @@ Four-stage health check; each stage maps to a distinct
 4. All checks pass → `ok=True`, `reason=None`.
 
 The probe does not mutate state. `Get-Service` is read-only on Photon.
+
+### Read ops (T2 surface)
+
+The seven T2 read ops route through the dispatcher's standard
+`call_operation` path. Each registers via `register_typed_operation()` with
+`safety_level="safe"`, `requires_approval=False`, and an
+`llm_instructions.when_to_use` blob that includes the SSH-only transport
+disclosure (CLAUDE.md postulate 5 + Initiative #371).
+
+- **`holodeck.config.show`** (group `config`). Runs `Get-HoloDeckConfig |
+  ConvertTo-Json -Depth 4 -Compress` via `pwsh_run`. Returns
+  `{config: <parsed dict>}` or `{config: None, error: "<reason>"}` on
+  cmdlet failure.
+- **`holodeck.pod.list`** (group `pod`, JSONFlux-shaped). Runs
+  `Get-HoloDeckPod | ConvertTo-Json -Depth 4` via `pwsh_run`. Returns
+  `{rows: [...], total: N}`. JSONFlux handle creation is the reducer's
+  job — not the connector's — matching the pfSense / bind9 precedent
+  (`PassThroughReducer` passes the inline payload through today; a future
+  JSONFlux reducer will key on the `holodeck_pod_list` HandleStore slot
+  when `total` exceeds its threshold). The handler normalises
+  `ConvertTo-Json`'s single-element flat-dict shape and the empty-pipeline
+  `null` shape into a uniform list.
+- **`holodeck.pod.info`** (group `pod`). Runs `Get-HoloDeckPod -Id '<id>' |
+  ConvertTo-Json -Depth 4` via `pwsh_run`. `pod_id` parameter is required;
+  the handler PowerShell-quotes single quotes via doubling. Returns
+  `{pod: <dict>}` or `{pod: None, error}` on cmdlet / missing-id failure.
+- **`holodeck.service.list`** (group `service`, JSONFlux-shaped). Runs
+  `Get-Service | Where-Object { $_.Name -like 'Holo*' } | Select-Object
+  Name,Status,DisplayName | ConvertTo-Json -Depth 4`. Same `{rows, total}`
+  envelope and the same single-dict / `null` normalisation as `pod.list`.
+- **`holodeck.k8s.exec`** (group `k8s`, **read-only**). Forwards a
+  ``kubectl`` command to the in-appliance K8s cluster. Two layers of
+  read-only enforcement:
+
+  1. *Schema layer.* The `command` parameter has a `pattern` regex anchored
+     at `^kubectl(\s+--?...)*` followed by `(get|describe|logs|top|explain|
+     api-resources|api-versions|cluster-info|version)`. The dispatcher's
+     `validate_params` rejects mutating verbs before reaching the handler.
+  2. *Handler layer (authoritative).* `parse_kubectl_command` re-parses
+     the command via `shlex.split`, walks past leading global flags
+     (both `--flag=value` and `--flag value` forms), and confirms the
+     verb is in `_K8S_READ_VERBS`. Mutating verbs raise
+     `KubectlSafetyError`; the handler returns
+     `{stdout, stderr, exit_status, error}` with `error` set to the
+     safety-check message. The full command body is **not** echoed back
+     in the error message — only the rejected verb — so operator-supplied
+     resource names don't bleed into structured error envelopes.
+
+  Stderr from the appliance is truncated at 4096 chars, matching the
+  `PwshRunError` convention.
+
+- **`holodeck.logs.tail`** (group `logs`). Runs `tail -n <lines>
+  /holodeck-runtime/logs/<component>*.log` over **plain SSH** (no pwsh
+  indirection — the cmd is a stock POSIX pipeline). `component` is
+  restricted to `[A-Za-z0-9._-]+` at both the schema and handler layers
+  so shell metacharacters and directory traversal can't slip through;
+  `lines` is clamped to `[1, 5000]`. Returns `{files: [{path, lines}],
+  raw, lines_requested}` parsed via the GNU `tail` `==> path <==` header
+  convention; single-file matches surface as `path=None`.
+
+- **`holodeck.networking.show`** (group `networking`). Composes four
+  sub-commands: `vtysh -c 'show bgp summary'`, `vtysh -c 'show ip
+  route'`, `pwsh` of `Get-DnsServerZone | ... | ConvertTo-Json`, and
+  `cat /var/lib/dhcp/dhcpd.leases`. Returns
+  `{bgp: {summary_text, ok}, routes: {text, ok}, dns: {zones, total,
+  ok}, dhcp: {leases_text, ok}}`. Each sub-section's `ok` flips false
+  when its sub-command failed or produced empty output, so a single-
+  component failure doesn't blank the whole response.
 
 ### `execute(target, op_id, params)`
 


### PR DESCRIPTION
## Summary
- Adds the 7 typed read ops on top of the T1 `holodeck.about` canary, completing the 8-op v0.2 read surface under `connector_id="holodeck-ssh-9.0"`: `config.show`, `pod.list` (JSONFlux-shaped), `pod.info`, `service.list` (JSONFlux-shaped), `k8s.exec` (read-only), `logs.tail`, `networking.show`.
- **Two-layer read-only enforcement on `holodeck.k8s.exec` (post-iter-2 fix):** schema `pattern` is anchored `\Akubectl ... \Z` with arguments restricted to the allowlist `[A-Za-z0-9._/=:,@-]`, blocking mutating verbs and shell metacharacters at the dispatcher's validator layer; the handler re-parses via `parse_kubectl_command` which scans for shell metacharacters (`[;&|<>` + backtick + `$()\\` + newline + carriage return]) before tokenisation, then checks the verb against `_K8S_READ_VERBS`. Both layers reject the canonical shell-injection shapes (`;`, `&&`, `||`, `|`, `$(...)`, backticks, `>`, `<`, newline) independently.
- JSONFlux handle creation stays the reducer's job (per pfSense / bind9 precedent); the connector emits `{rows, total}` envelopes today so the future JSONFlux reducer can flip without a connector change.
- Each op's `llm_instructions.when_to_use` mentions the PowerShell-over-SSH transport, per CLAUDE.md postulate 5 and Initiative #371 — agents must know they're running on the appliance, not against a non-existent REST API.

## Test plan
- [x] `ruff check src/meho_backplane/connectors/holodeck/ tests/test_connectors_holodeck_ops.py tests/test_connectors_holodeck_auth.py` — all checks passed
- [x] `ruff format --check ...` — all 8 files already formatted
- [x] `mypy src/meho_backplane/connectors/holodeck/ --ignore-missing-imports` — no issues found in 5 source files
- [x] `pytest tests/test_connectors_holodeck_ops.py tests/test_connectors_holodeck_pwsh.py tests/test_connectors_holodeck_auth.py` — 185 passed (was 140 in iter 1; +45 injection-rejection tests)
- [x] `pytest tests/ -n auto --ignore=tests/integration --ignore=tests/acceptance --deselect tests/test_connectors_registry_v2.py` — 3853 passed, 21 skipped (registry_v2 has pre-existing serial-pollution failures on `main`, unrelated to this PR)
- [x] AC #1 — 8 ops enabled under `connector_id="holodeck-ssh-9.0"`; `HOLODECK_OPS` shape asserted (length, namespace, safety_level, additionalProperties=False, non-empty `when_to_use`, SSH-transport mention)
- [x] AC #2 — Each op parser has unit tests against captured fixtures; malformed cmdlet output → structured `error` field, no crashes
- [x] AC #3 — `holodeck.k8s.exec` rejects mutating verbs at both schema and handler layers; 21 mutating verbs parametrised in the rejection test; 12 shell-injection payloads parametrised at parser + handler-with-mocked-SSH (await_count == 0) + schema-validator layers
- [x] AC #4 — `holodeck.pod.list` returns the JSONFlux `{rows, total}` envelope (single-dict normalised to 1-row list, `null` → empty list)
- [x] AC #5 — `register_holodeck_typed_operations` idempotent (inherited from `register_typed_operation`'s upsert semantics; verified via T1 test that re-registers in the same process)
- [x] Secret-leak canary tests — `target.secret_ref` password/key never bleed into envelopes, captured logs, or error messages under any code path; the k8s.exec rejection envelope carries the rejected verb but not the full command line

## Out of scope
- CLI verbs / E2E acceptance / onboarding doc — T3 (#855).
- Pod-clone (multi-step nested-lab provisioning) — Runbooks Initiative under Goal G11 per v0.1 spec.
- Holodeck cmdlet write ops + K8s write ops — write surface out of scope for v0.2.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #854

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-24)

Addressed review findings from [pr-1005-iter-1.json](.claude/auto/review-results/pr-1005-iter-1.json):

- **B1** `0abf617` — Reject shell metacharacters in `parse_kubectl_command` BEFORE `shlex.split`; tighten the schema regex with `\A...\Z` end-anchors, an argument-character allowlist `[A-Za-z0-9._/=:,@-]`, and `[ \t]`-only inter-token whitespace (so newlines can't smuggle through the `\s` class). 12 injection shapes pinned at all three layers (parser, handler-with-mocked-SSH asserting `await_count == 0`, schema validator).
- **m1** `0abf617` — `_K8S_READ_VERBS` docstring previously claimed `config view` / `auth can-i` were on the safelist; the frozenset never included them and adding them safely needs a verb + sub-verb safelist. Docstring corrected to match the implementation; deferred sub-verb work to a follow-up.

Disputed: none.

Deferred (recorded as adjacent findings; orchestrator may file
follow-up issues): none.

<!-- auto-implement-issue: continue, iteration 2 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added seven new read operations to the Holodeck connector: config display, pod listing/info, service listing, Kubernetes command execution, log tailing, and network diagnostics.

* **Tests**
  * Added comprehensive test coverage for new read operations, including safety validation and error handling.

* **Documentation**
  * Updated Holodeck connector documentation with details on new read operations and their usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1005?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->