### PR TITLE
feat(connectors): G3.8-T3 Holodeck CLI verbs + MCP review + recorded-fixture E2E + onboarding doc

### DIFF
--- a/backend/src/meho_backplane/connectors/holodeck/ops.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops.py
@@ -25,7 +25,24 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal
 
-__all__ = ["HOLODECK_OPS", "HolodeckOp", "_holodeck_ops"]
+__all__ = ["HOLODECK_OPS", "SSH_TRANSPORT_NOTE", "HolodeckOp", "_holodeck_ops"]
+
+
+#: Canonical SSH-only/pwsh transport reminder copied verbatim into every
+#: op's ``llm_instructions``. The Initiative #371 body and CLAUDE.md
+#: postulate 5 both require agent-facing descriptions to call out the
+#: PowerShell-over-SSH transport so an LLM doesn't compose against a
+#: non-existent REST surface. G3.8-T3 (#855) hoisted this constant from
+#: ``ops_read.py`` into ``ops.py`` so the T1 canary op (``holodeck.about``,
+#: defined here) can share it verbatim with the 7 T2 read ops -- the MCP
+#: review acceptance criterion on #855 calls for the same wording across
+#: all 8 ops, and one shared constant is the cleanest way to keep that
+#: true forever (a future op author can't accidentally drift).
+SSH_TRANSPORT_NOTE: str = (
+    "Holodeck has no REST API; the underlying transport is "
+    "PowerShell-over-SSH (pwsh -EncodedCommand routed through asyncssh) "
+    "for cmdlet ops, plain SSH for kubectl / shell-pipeline ops."
+)
 
 
 @dataclass(frozen=True)
@@ -102,9 +119,7 @@ _HOLODECK_ABOUT_OP = HolodeckOp(
             "Call when the operator wants to identify the Holodeck "
             "appliance behind a target before issuing higher-level "
             "pod / service / log ops, or when the agent needs to "
-            "confirm the appliance is reachable via SSH + pwsh. "
-            "Holodeck has no REST surface; this op and the other "
-            "Holodeck ops are reached through PowerShell-over-SSH."
+            "confirm the appliance is reachable via SSH + pwsh. " + SSH_TRANSPORT_NOTE
         ),
         "parameter_hints": {},
         "output_shape": (

--- a/backend/src/meho_backplane/connectors/holodeck/ops_read.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops_read.py
@@ -124,7 +124,7 @@ import shlex
 from typing import TYPE_CHECKING, Any
 
 from meho_backplane.connectors.holodeck._pwsh import PwshRunError, pwsh_run
-from meho_backplane.connectors.holodeck.ops import HolodeckOp
+from meho_backplane.connectors.holodeck.ops import SSH_TRANSPORT_NOTE, HolodeckOp
 
 if TYPE_CHECKING:
     from meho_backplane.connectors.holodeck.connector import HolodeckConnector
@@ -825,16 +825,12 @@ _EMPTY_PARAMS: dict[str, Any] = {
 }
 
 
-#: SSH-only / pwsh transport reminder copied verbatim into every op's
-#: ``llm_instructions``. The Initiative #371 body and CLAUDE.md
-#: postulate 5 both require agent-facing descriptions to call out the
-#: PowerShell-over-SSH transport so an LLM doesn't compose against a
-#: non-existent REST surface.
-_SSH_TRANSPORT_NOTE: str = (
-    "Holodeck has no REST API; the underlying transport is "
-    "PowerShell-over-SSH (pwsh -EncodedCommand routed through asyncssh) "
-    "for cmdlet ops, plain SSH for kubectl / shell-pipeline ops."
-)
+#: Module-local alias for the canonical SSH-only/pwsh transport reminder
+#: hoisted onto :mod:`~meho_backplane.connectors.holodeck.ops` by
+#: G3.8-T3 (#855) so the T1 canary op (``holodeck.about``) shares the
+#: same string verbatim with the 7 T2 read ops below. The alias keeps
+#: every existing reference in this file readable without churn.
+_SSH_TRANSPORT_NOTE: str = SSH_TRANSPORT_NOTE
 
 
 READ_OPS: tuple[HolodeckOp, ...] = (

--- a/backend/tests/test_connectors_holodeck_e2e.py
+++ b/backend/tests/test_connectors_holodeck_e2e.py
@@ -1,0 +1,1005 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""G3.8-T3 Holodeck recorded-fixture / asyncssh fake-shell E2E test (#855).
+
+Drives every Holodeck read op through the full ``call_operation`` dispatch
+stack against an in-process asyncssh fake-shell server that replays
+pre-recorded ``pwsh -OutputFormat Json`` fixture responses + plain-SSH
+command stubs — no Docker dependency, no live HoloRouter appliance, no
+published Holodeck simulator (per Initiative #371, Task #855 reference
+to #536 — "no vendor CI simulator — recorded-fixture testing").
+
+The shape mirrors the G3.7 recorded-fixture E2E precedents
+(``test_connectors_pfsense_e2e.py``, ``test_connectors_gcloud_e2e.py``)
+that #855's body explicitly cites as the design source.
+
+Acceptance criteria verified (Issue #855)
+==========================================
+
+(a) ``meho holodeck --help`` lists the verb set; each verb POSTs to
+    ``/api/v1/operations/call`` with the right ``op_id`` — verified
+    Go-side in :file:`cli/internal/cmd/holodeck/holodeck_test.go`.
+(b) ``backend/tests/test_connectors_holodeck_e2e.py`` (this file) replays
+    captured pwsh / fake-shell fixtures for every enabled op and passes
+    in the ``meho-runners`` CI lane with no Docker dependency (asyncssh
+    in-process server; SQLite via the autouse ``_default_database_url``
+    conftest fixture).
+(c) ``holodeck.pod.list`` E2E asserts the JSONFlux handle path
+    (handle → ``result_query`` drills in) via the real
+    ``JsonFluxReducer`` in force mode (``row_threshold=0``).
+(d) All enabled ops write an audit row carrying ``op_id`` + ``target_id``
+    + ``params_hash``.
+(e) ``docs/cross-repo/holodeck-onboarding.md`` exists — not asserted
+    here, verified on the doc side.
+
+Fake-shell design
+=================
+
+The fake-shell is an in-process ``asyncssh.SSHServer`` whose
+``process_factory`` dispatches by command string to pre-recorded fixture
+outputs. The SSH user authenticates with an Ed25519 key pair generated
+once per test session.
+
+The Holodeck connector sends two transport shapes through the SSH layer:
+
+1. **Plain-SSH commands** — ``cat /etc/photon-release``,
+   ``tail -n N /holodeck-runtime/logs/<component>*.log``,
+   ``vtysh -c '...'``, ``cat /var/lib/dhcp/dhcpd.leases``, and the
+   operator-supplied ``kubectl ...`` invocation. The fake-shell looks
+   these up by full command string.
+
+2. **pwsh-over-SSH** — the connector wraps every PowerShell cmdlet in
+   ``pwsh -NoProfile -NonInteractive -EncodedCommand <b64-utf16le>``.
+   The base64 payload is a moving target (each test invocation produces
+   the same encoded bytes, but the per-test fixture has to be keyed by
+   the *script body*, not the encoded form). The fake-shell decodes the
+   ``-EncodedCommand`` argument back to the UTF-16LE script body and
+   then looks the script up in :data:`_PWSH_FIXTURES`.
+
+The :class:`HolodeckConnector` connects to ``127.0.0.1`` on the
+ephemeral server port, which means the connector's per-target connection
+pool is populated by a real asyncssh round-trip (``asyncssh.connect``)
+rather than a mock — the only stub is the *server side* returning
+fixture bytes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import types
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import asyncssh
+import pytest
+from sqlalchemy import select
+
+import meho_backplane.connectors.holodeck  # noqa: F401 -- import for registry side-effects
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.holodeck import HOLODECK_OPS, HolodeckConnector
+from meho_backplane.connectors.registry import all_connectors_v2
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations.dispatcher import set_default_reducer
+from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
+from meho_backplane.operations.meta_tools import call_operation
+from meho_backplane.operations.reducer import PassThroughReducer
+
+# ---------------------------------------------------------------------------
+# Module-level key material (generated once per session)
+# ---------------------------------------------------------------------------
+
+_SERVER_KEY = asyncssh.generate_private_key("ssh-ed25519")
+_CLIENT_KEY = asyncssh.generate_private_key("ssh-ed25519")
+_CLIENT_PUB = _CLIENT_KEY.convert_to_public()
+
+# ---------------------------------------------------------------------------
+# Fixture responses — minimal pre-recorded Holodeck 9.0 output
+# ---------------------------------------------------------------------------
+
+# /etc/photon-release fixture text. Used by fingerprint / about / probe.
+_FIXTURE_PHOTON_RELEASE = "VMware Photon Linux 5.0\nPHOTON_BUILD_NUMBER=12345\n"
+
+# pwsh fixtures, keyed by *decoded* script body. Each entry is the JSON
+# string the cmdlet would print to stdout (the Holodeck connector
+# expects ``ConvertTo-Json`` output).
+_PWSH_FIXTURES: dict[str, str] = {
+    # holodeck.about + probe + fingerprint all run Get-HoloDeckConfig.
+    # Two scripts are used: the compressed form (fingerprint/about) and
+    # the depth-4 form (config.show op).
+    "Get-HoloDeckConfig | ConvertTo-Json -Compress": (
+        '{"Vendor":"vmware","Product":"Holodeck","Version":"9.0.0",'
+        '"PodId":"HoloPod-Alpha","Build":"9.0.0-22345"}'
+    ),
+    "Get-HoloDeckConfig | ConvertTo-Json -Depth 4 -Compress": (
+        '{"Vendor":"vmware","Product":"Holodeck","Version":"9.0.0",'
+        '"PodId":"HoloPod-Alpha","Build":"9.0.0-22345",'
+        '"Services":{"DHCP":"Running","DNS":"Running"}}'
+    ),
+    # probe runs a narrower Get-Service shape (Name,Status only) to
+    # check the Holo* services are all Running.
+    "Get-Service | Where-Object { $_.Name -like 'Holo*' } | "
+    "Select-Object Name,Status | ConvertTo-Json": (
+        '[{"Name":"HoloDhcp","Status":"Running"},{"Name":"HoloDns","Status":"Running"}]'
+    ),
+    # holodeck.service.list uses the depth-4, with-DisplayName shape.
+    "Get-Service | Where-Object { $_.Name -like 'Holo*' } | "
+    "Select-Object Name,Status,DisplayName | ConvertTo-Json -Depth 4": (
+        '[{"Name":"HoloDhcp","Status":"Running","DisplayName":"Holodeck DHCP"},'
+        '{"Name":"HoloDns","Status":"Running","DisplayName":"Holodeck DNS"},'
+        '{"Name":"HoloFrr","Status":"Running","DisplayName":"Holodeck FRR-BGP"}]'
+    ),
+    # holodeck.pod.list — 3 active nested pods. Multi-element pipeline
+    # → JSON array, so the {rows, total} normaliser sees a list.
+    "Get-HoloDeckPod | ConvertTo-Json -Depth 4": (
+        '[{"Id":"HoloPod-001","Name":"lab-A","State":"Running","Network":"Tier-0-A","VMs":4},'
+        '{"Id":"HoloPod-002","Name":"lab-B","State":"Stopped","Network":"Tier-0-B","VMs":2},'
+        '{"Id":"HoloPod-003","Name":"lab-C","State":"Running","Network":"Tier-0-C","VMs":3}]'
+    ),
+    # holodeck.pod.info — single-pod detail dict.
+    "Get-HoloDeckPod -Id 'HoloPod-001' | ConvertTo-Json -Depth 4": (
+        '{"Id":"HoloPod-001","Name":"lab-A","State":"Running",'
+        '"Network":{"Tier0":"NSX-T0-Cluster","BGP_AS":65001},'
+        '"VMs":[{"Name":"esxi-1","Power":"On"},{"Name":"esxi-2","Power":"On"}]}'
+    ),
+    # holodeck.networking.show — DNS zones via pwsh; BGP + DHCP via
+    # plain SSH (see _PLAIN_SSH_FIXTURES below).
+    "Get-DnsServerZone | Select-Object ZoneName,ZoneType | ConvertTo-Json -Depth 4": (
+        '[{"ZoneName":"holodeck.lab","ZoneType":"Primary"},'
+        '{"ZoneName":"vmware.local","ZoneType":"Forwarder"}]'
+    ),
+}
+
+# Plain-SSH fixtures keyed by *full* command string (the Holodeck
+# connector sends these without pwsh wrapping).
+_PLAIN_SSH_FIXTURES: dict[str, str] = {
+    "cat /etc/photon-release": _FIXTURE_PHOTON_RELEASE,
+    # holodeck.logs.tail — single component, default 200 lines (the CLI
+    # default; the test calls dispatch directly so `lines` is whatever
+    # we pass).
+    "tail -n 200 /holodeck-runtime/logs/dhcp*.log": (
+        "==> /holodeck-runtime/logs/dhcp-server.log <==\n"
+        "2026-05-24 09:00:01 DHCPDISCOVER from aa:bb:cc:dd:ee:ff\n"
+        "2026-05-24 09:00:01 DHCPOFFER on 10.50.0.5\n"
+        "2026-05-24 09:00:02 DHCPREQUEST for 10.50.0.5\n"
+        "2026-05-24 09:00:02 DHCPACK on 10.50.0.5\n"
+    ),
+    # holodeck.networking.show — vtysh BGP summary + routes; the DNS
+    # sub-section is pwsh (above), DHCP is the leases file (below).
+    "vtysh -c 'show bgp summary'": (
+        "IPv4 Unicast Summary:\n"
+        "BGP router identifier 10.0.0.1, local AS number 65001\n"
+        "Neighbor        V         AS    MsgRcvd    MsgSent  Up/Down  State/PfxRcd\n"
+        "10.0.0.2        4      65002        100        100  00:30:00            5\n"
+    ),
+    "vtysh -c 'show ip route'": (
+        "Codes: K - kernel route, C - connected, S - static, R - RIP,\n"
+        "       O - OSPF, I - IS-IS, B - BGP\n"
+        "C>* 10.0.0.0/24 is directly connected, eth0\n"
+        "B>* 10.50.0.0/24 [20/0] via 10.0.0.2, eth0, 00:30:00\n"
+    ),
+    "cat /var/lib/dhcp/dhcpd.leases": (
+        "lease 10.50.0.5 {\n"
+        "  starts 4 2026/05/24 09:00:02;\n"
+        "  ends 4 2026/05/24 21:00:02;\n"
+        "  hardware ethernet aa:bb:cc:dd:ee:ff;\n"
+        '  client-hostname "esxi-1";\n'
+        "}\n"
+    ),
+    # holodeck.k8s.exec — verbatim kubectl forward. Two fixtures here:
+    # the safe `kubectl get pods` invocation that the read-only safelist
+    # accepts, and an alternate `kubectl get nodes` for the second test
+    # case. Mutating verbs / shell-metachar payloads are rejected
+    # **before** they reach the fake-shell, by the backend's
+    # parse_kubectl_command guard, so we don't need fixtures for them.
+    "kubectl get pods -n holodeck": (
+        "NAME                    READY   STATUS    RESTARTS   AGE\n"
+        "holo-dhcp-7d4f9c-abc12   1/1     Running   0          5d\n"
+        "holo-dns-5b6c7d-xyz45    1/1     Running   0          5d\n"
+    ),
+    "kubectl get nodes": (
+        "NAME             STATUS   ROLES                  AGE   VERSION\n"
+        "holorouter-1     Ready    control-plane,master   30d   v1.29.3\n"
+    ),
+}
+
+# ---------------------------------------------------------------------------
+# In-process fake-shell SSH server
+# ---------------------------------------------------------------------------
+
+
+def _decode_encoded_command(cmd: str) -> str | None:
+    """Decode the ``-EncodedCommand <b64>`` argument back to the script body.
+
+    The Holodeck pwsh helper sends commands in the form
+    ``pwsh -NoProfile -NonInteractive -EncodedCommand <b64-utf16le>``.
+    The fake-shell needs to recover the *script body* (a stable
+    fixture key) from the encoded form (per-call shape but deterministic
+    for the same input).
+
+    Returns ``None`` for non-pwsh commands or malformed encoding so
+    the caller falls through to the plain-SSH fixture lookup.
+    """
+    if "-EncodedCommand " not in cmd:
+        return None
+    encoded = cmd.rsplit("-EncodedCommand ", 1)[1].strip()
+    try:
+        return base64.b64decode(encoded).decode("utf-16-le")
+    except (ValueError, UnicodeDecodeError):
+        return None
+
+
+class _FakeShellSSHServer(asyncssh.SSHServer):
+    """In-process asyncssh server that accepts key auth for the test client key."""
+
+    def public_key_auth_supported(self) -> bool:
+        return True
+
+    def validate_public_key(self, username: str, key: Any) -> bool:  # type: ignore[override]
+        return bool(key == _CLIENT_PUB)
+
+
+async def _fake_shell_process_factory(process: Any) -> None:
+    """Dispatch by command string to pre-recorded fixture bytes.
+
+    Three lookup paths:
+
+    1. The command starts with ``pwsh ... -EncodedCommand``: decode the
+       b64 to recover the PowerShell script body and look up in
+       :data:`_PWSH_FIXTURES`.
+    2. The command matches a plain-SSH fixture key verbatim
+       (:data:`_PLAIN_SSH_FIXTURES`).
+    3. Neither path matches — return exit 127 + an explicit
+       "unknown command" stderr so the test failure is operator-readable.
+    """
+    cmd: str = process.command or ""
+
+    decoded_script = _decode_encoded_command(cmd)
+    if decoded_script is not None:
+        response = _PWSH_FIXTURES.get(decoded_script)
+        if response is not None:
+            process.stdout.write(response)
+            process.exit(0)
+            return
+        process.stderr.write(f"fake-shell: unknown pwsh script:\n{decoded_script!r}\n")
+        process.exit(127)
+        return
+
+    response = _PLAIN_SSH_FIXTURES.get(cmd)
+    if response is not None:
+        process.stdout.write(response)
+        process.exit(0)
+        return
+
+    process.stderr.write(f"fake-shell: unknown command: {cmd!r}\n")
+    process.exit(127)
+
+
+@pytest.fixture(scope="module")
+def event_loop_policy() -> asyncio.DefaultEventLoopPolicy:
+    """Use the default event loop policy for this module's async tests."""
+    return asyncio.DefaultEventLoopPolicy()
+
+
+@pytest.fixture
+async def fake_shell_server() -> AsyncIterator[types.SimpleNamespace]:
+    """Yield a running in-process fake-shell asyncssh server.
+
+    Shuts the server down after the test (RAII). The ephemeral port is
+    available as ``server.port``; ``server.host`` is always
+    ``"127.0.0.1"``.
+    """
+    srv = await asyncssh.create_server(
+        _FakeShellSSHServer,
+        "127.0.0.1",
+        0,
+        server_host_keys=[_SERVER_KEY],
+        process_factory=_fake_shell_process_factory,
+    )
+    port: int = srv.sockets[0].getsockname()[1]
+    yield types.SimpleNamespace(host="127.0.0.1", port=port)
+    srv.close()
+    await srv.wait_closed()
+
+
+# ---------------------------------------------------------------------------
+# Environment + DB + broadcast fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin env vars that :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    from meho_backplane.settings import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches around every test."""
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    """Stub out :func:`publish_event` so the broadcast bus doesn't fire."""
+    events: list[Any] = []
+
+    async def _capture(event: Any) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Operator and target constants
+# ---------------------------------------------------------------------------
+
+_OPERATOR_TENANT_ID: uuid.UUID = uuid.UUID("00000000-0000-0000-0000-00000000ddee")
+
+_OPERATOR = Operator(
+    sub="holodeck-e2e-test",
+    name="Holodeck E2E Test Operator",
+    email=None,
+    raw_jwt="<holodeck-e2e-raw-jwt>",
+    tenant_id=_OPERATOR_TENANT_ID,
+    tenant_role=TenantRole.TENANT_ADMIN,
+)
+
+_TARGET_NAME = "holodeck-e2e"
+
+# ---------------------------------------------------------------------------
+# Canary op IDs — pinned so a registration regression surfaces explicitly
+# ---------------------------------------------------------------------------
+
+EXPECTED_OP_IDS: tuple[str, ...] = (
+    "holodeck.about",
+    "holodeck.config.show",
+    "holodeck.pod.list",
+    "holodeck.pod.info",
+    "holodeck.service.list",
+    "holodeck.k8s.exec",
+    "holodeck.logs.tail",
+    "holodeck.networking.show",
+)
+
+# ---------------------------------------------------------------------------
+# Target + connector seeding helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_holodeck_target(host: str, port: int) -> TargetORM:
+    """Insert the E2E target row and return it (expunged from the session)."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        target = TargetORM(
+            tenant_id=_OPERATOR_TENANT_ID,
+            name=_TARGET_NAME,
+            aliases=[],
+            product="holodeck",
+            host=host,
+            port=port,
+            fqdn=None,
+            secret_ref="kv/dev/holodeck/e2e",
+            auth_model="shared_service_account",
+            vpn_required=False,
+            extras={},
+            fingerprint={"version": "9.0.0"},
+            notes="seeded by test_connectors_holodeck_e2e",
+        )
+        session.add(target)
+        await session.commit()
+        await session.refresh(target)
+        session.expunge(target)
+        return target
+
+
+@dataclass
+class _HolodeckE2EBundle:
+    """All wired-up state for an E2E Holodeck test."""
+
+    target: TargetORM
+    connector: HolodeckConnector
+
+
+def _wire_seeded_connector(host: str, port: int) -> HolodeckConnector:
+    """Return a :class:`HolodeckConnector` instance with SSH creds seeded.
+
+    The fake-shell server uses key auth. We inject a
+    ``_SeededHolodeckConnector`` subclass that short-circuits
+    :meth:`_auth_config` to return the test client key — the same
+    single-seam swap the pfsense / K8s E2E harnesses use.
+    """
+    del host, port  # connection params come from the seeded target row
+    registry = all_connectors_v2()
+    connector_cls = registry.get(("holodeck", "9.0", "holodeck-ssh"))
+    assert connector_cls is HolodeckConnector, (
+        f"HolodeckConnector not registered for (holodeck, 9.0, holodeck-ssh); got {connector_cls!r}"
+    )
+
+    class _SeededHolodeckConnector(HolodeckConnector):  # type: ignore[misc]
+        """Subclass that injects the test client key into _auth_config."""
+
+        async def _auth_config(self, target: Any) -> dict[str, Any]:
+            return {
+                "username": "root",
+                "client_keys": [_CLIENT_KEY],
+                "known_hosts": None,
+            }
+
+    instance = _SeededHolodeckConnector()
+    # Inject the seeded instance so the dispatcher uses it instead of a
+    # plain HolodeckConnector() which would try to load creds from Vault.
+    from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
+
+    _CONNECTOR_INSTANCE_CACHE[HolodeckConnector] = instance  # type: ignore[assignment]
+    return instance
+
+
+@pytest.fixture
+async def holodeck_e2e(
+    fake_shell_server: types.SimpleNamespace,
+    captured_events: list[Any],
+) -> AsyncIterator[_HolodeckE2EBundle]:
+    """Set up end-to-end Holodeck test state.
+
+    Seeds the fake-shell server on the ephemeral port, registers the
+    connector ops, and pre-wires the connector instance with injected
+    SSH credentials. Caller gets a :class:`_HolodeckE2EBundle` with
+    target + connector.
+
+    Teardown: closes the connector's SSH connection pool so asyncssh
+    background reader tasks do not leak into subsequent tests and block
+    the fake-shell server teardown (``srv.wait_closed``).
+    """
+    del captured_events  # autouse via parameter; reading drains the stub
+    set_default_reducer(PassThroughReducer())
+    await HolodeckConnector.register_operations()
+
+    target = await _seed_holodeck_target(
+        host=fake_shell_server.host,
+        port=fake_shell_server.port,
+    )
+    connector = _wire_seeded_connector(
+        host=fake_shell_server.host,
+        port=fake_shell_server.port,
+    )
+    yield _HolodeckE2EBundle(target=target, connector=connector)
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Tests — Op registration
+# ---------------------------------------------------------------------------
+
+
+def test_holodeck_ops_registration_count() -> None:
+    """All 8 Holodeck ops are registered in HOLODECK_OPS."""
+    op_ids = {op.op_id for op in HOLODECK_OPS}
+    missing = set(EXPECTED_OP_IDS) - op_ids
+    assert not missing, f"Missing ops: {missing}"
+    assert len(HOLODECK_OPS) == 8, f"Expected 8 ops, got {len(HOLODECK_OPS)}"
+
+
+def test_holodeck_ops_all_safe_and_no_approval_required() -> None:
+    """All read ops carry safety_level='safe' and requires_approval=False."""
+    for op in HOLODECK_OPS:
+        assert op.safety_level == "safe", f"{op.op_id} should be safe"
+        assert not op.requires_approval, f"{op.op_id} should not require approval"
+
+
+def test_holodeck_ops_all_have_llm_instructions() -> None:
+    """All 8 ops carry non-empty llm_instructions for agent discoverability."""
+    for op in HOLODECK_OPS:
+        assert op.llm_instructions, f"{op.op_id}: llm_instructions must not be empty"
+        instr = op.llm_instructions
+        assert "when_to_use" in instr, f"{op.op_id}: llm_instructions missing when_to_use"
+        assert "output_shape" in instr, f"{op.op_id}: llm_instructions missing output_shape"
+        assert instr["when_to_use"], f"{op.op_id}: when_to_use must not be empty"
+
+
+def test_holodeck_ops_all_carry_ssh_only_transport_note() -> None:
+    """MCP review acceptance criterion (#855): every op's `when_to_use`
+    surfaces the canonical "Holodeck has no REST API; transport is
+    PowerShell-over-SSH" note so agents don't compose against a
+    non-existent REST surface.
+
+    The exact phrase to look for is "Holodeck has no REST API"; the
+    shared :data:`SSH_TRANSPORT_NOTE` constant guarantees consistency
+    across all 8 ops.
+    """
+    canonical_phrase = "Holodeck has no REST API"
+    pwsh_phrase = "PowerShell-over-SSH"
+    for op in HOLODECK_OPS:
+        when_to_use = (op.llm_instructions or {}).get("when_to_use", "")
+        assert canonical_phrase in when_to_use, (
+            f"{op.op_id}: llm_instructions.when_to_use missing canonical SSH-only "
+            f"transport note; expected substring {canonical_phrase!r} so an LLM "
+            f"reading the op metadata understands Holodeck has no REST surface. "
+            f"Got: {when_to_use!r}"
+        )
+        assert pwsh_phrase in when_to_use, (
+            f"{op.op_id}: llm_instructions.when_to_use missing PowerShell-over-SSH "
+            f"phrase; the agent needs to know which transport carries cmdlet ops."
+        )
+
+
+def test_holodeck_ops_correct_group_keys() -> None:
+    """Op group_keys match the expected identity/config/pod/service/k8s/logs/networking grouping."""
+    expected_groups: dict[str, str] = {
+        "holodeck.about": "identity",
+        "holodeck.config.show": "config",
+        "holodeck.pod.list": "pod",
+        "holodeck.pod.info": "pod",
+        "holodeck.service.list": "service",
+        "holodeck.k8s.exec": "k8s",
+        "holodeck.logs.tail": "logs",
+        "holodeck.networking.show": "networking",
+    }
+    op_by_id = {op.op_id: op for op in HOLODECK_OPS}
+    for op_id, expected_group in expected_groups.items():
+        assert op_id in op_by_id, f"Op {op_id} not found in HOLODECK_OPS"
+        actual = op_by_id[op_id].group_key
+        assert actual == expected_group, (
+            f"{op_id}: expected group_key={expected_group!r}, got {actual!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests — Full dispatch path (acceptance criteria a, b, d)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_holodeck_e2e_about_dispatches_ok(
+    holodeck_e2e: _HolodeckE2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """holodeck.about returns vendor/product/version via fake-shell."""
+    del captured_events
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": "holodeck-ssh-9.0",
+            "op_id": "holodeck.about",
+            "target": {"name": _TARGET_NAME},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok", f"holodeck.about failed: {result.get('error')}"
+    assert result.get("result") is not None
+    assert result["result"].get("vendor") == "vmware"
+    assert result["result"].get("product") == "holodeck"
+    assert result["result"].get("version") == "9.0.0"
+    assert result["result"].get("photon_version") == "5.0"
+    assert result["result"].get("pod_id") == "HoloPod-Alpha"
+
+
+@pytest.mark.asyncio
+async def test_holodeck_e2e_config_show_dispatches_ok(
+    holodeck_e2e: _HolodeckE2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """holodeck.config.show returns the full config dict via fake-shell."""
+    del captured_events
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": "holodeck-ssh-9.0",
+            "op_id": "holodeck.config.show",
+            "target": {"name": _TARGET_NAME},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok", f"holodeck.config.show failed: {result.get('error')}"
+    cfg = result["result"].get("config")
+    assert isinstance(cfg, dict), f"Expected dict config; got {cfg!r}"
+    assert cfg.get("Version") == "9.0.0"
+    assert "Services" in cfg
+
+
+@pytest.mark.asyncio
+async def test_holodeck_e2e_pod_list_dispatches_ok(
+    holodeck_e2e: _HolodeckE2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """holodeck.pod.list returns the {rows, total} envelope via fake-shell."""
+    del captured_events
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": "holodeck-ssh-9.0",
+            "op_id": "holodeck.pod.list",
+            "target": {"name": _TARGET_NAME},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok", f"holodeck.pod.list failed: {result.get('error')}"
+    rows = result["result"].get("rows", [])
+    assert len(rows) == 3, f"Expected 3 pods in fixture; got {len(rows)}"
+    ids = {r.get("Id") for r in rows}
+    assert ids == {"HoloPod-001", "HoloPod-002", "HoloPod-003"}
+
+
+@pytest.mark.asyncio
+async def test_holodeck_e2e_pod_info_dispatches_ok(
+    holodeck_e2e: _HolodeckE2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """holodeck.pod.info returns single-pod detail via fake-shell."""
+    del captured_events
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": "holodeck-ssh-9.0",
+            "op_id": "holodeck.pod.info",
+            "target": {"name": _TARGET_NAME},
+            "params": {"pod_id": "HoloPod-001"},
+        },
+    )
+    assert result["status"] == "ok", f"holodeck.pod.info failed: {result.get('error')}"
+    pod = result["result"].get("pod")
+    assert isinstance(pod, dict)
+    assert pod.get("Id") == "HoloPod-001"
+    assert pod.get("State") == "Running"
+
+
+@pytest.mark.asyncio
+async def test_holodeck_e2e_service_list_dispatches_ok(
+    holodeck_e2e: _HolodeckE2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """holodeck.service.list returns {rows, total} of Holo* services."""
+    del captured_events
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": "holodeck-ssh-9.0",
+            "op_id": "holodeck.service.list",
+            "target": {"name": _TARGET_NAME},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok", f"holodeck.service.list failed: {result.get('error')}"
+    rows = result["result"].get("rows", [])
+    assert len(rows) == 3
+    names = {r.get("Name") for r in rows}
+    assert "HoloDhcp" in names
+    assert "HoloDns" in names
+
+
+@pytest.mark.asyncio
+async def test_holodeck_e2e_k8s_exec_safe_verb_dispatches_ok(
+    holodeck_e2e: _HolodeckE2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """holodeck.k8s.exec with a read-only verb (`kubectl get pods`)
+    succeeds and returns the fixture stdout. This exercises the full
+    safety path: the schema-layer pattern accepts the shape, the
+    handler-layer `parse_kubectl_command` accepts the verb, and the
+    fake-shell returns the fixture stdout.
+    """
+    del captured_events
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": "holodeck-ssh-9.0",
+            "op_id": "holodeck.k8s.exec",
+            "target": {"name": _TARGET_NAME},
+            "params": {"command": "kubectl get pods -n holodeck"},
+        },
+    )
+    assert result["status"] == "ok", f"holodeck.k8s.exec failed: {result.get('error')}"
+    out = result["result"].get("stdout", "")
+    assert "holo-dhcp" in out, f"Expected fixture stdout; got {out!r}"
+    assert result["result"].get("exit_status") == 0
+
+
+@pytest.mark.asyncio
+async def test_holodeck_e2e_k8s_exec_metachar_rejected(
+    holodeck_e2e: _HolodeckE2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """E2E regression for the iter-2 shell-injection fix on T2 (#1005).
+
+    A command containing a POSIX-shell metacharacter (``;``) must be
+    refused **before** any SSH traffic happens. The handler returns
+    status="ok" with an inline `error` string in the result envelope
+    (because the safety check raises KubectlSafetyError, which the
+    bound-method handler folds into the error envelope rather than
+    raising into result_connector_error).
+
+    This is the load-bearing regression test: if a future schema
+    widening or handler refactor accidentally re-opens the chained-shell
+    hole, the fixture lookup in the fake-shell would *succeed* against
+    a stub for the safe prefix (`kubectl get pods`) and the chained tail
+    (`rm -rf /`) would be forwarded to the appliance. The test guards
+    against that by asserting (a) the call returns status="ok" with an
+    inline error string, (b) the fixture stdout is NOT in the result
+    (no SSH round-trip happened), and (c) the error mentions
+    "metacharacter".
+    """
+    del captured_events
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": "holodeck-ssh-9.0",
+            "op_id": "holodeck.k8s.exec",
+            "target": {"name": _TARGET_NAME},
+            "params": {"command": "kubectl get pods; rm -rf /"},
+        },
+    )
+    # The schema-layer pattern rejects the shape first → result is
+    # status=error from result_invalid_params. (The handler-layer
+    # metachar reject is the load-bearing gate but the schema layer
+    # catches this shape earlier.) Either status is acceptable: what
+    # matters is that the fake-shell's safe-prefix fixture stdout
+    # NEVER lands in the response envelope.
+    fake_shell_stdout_marker = "holo-dhcp"
+    result_str = repr(result)
+    assert fake_shell_stdout_marker not in result_str, (
+        "Safe-prefix fixture stdout leaked into the response — the "
+        "metachar reject failed closed; the chained `rm -rf /` would "
+        "have been forwarded to the appliance shell."
+    )
+    # Either the schema layer (status=error) or the handler layer
+    # (status=ok with inline error) refused it; both are correct.
+    if result["status"] == "ok":
+        err_str = result["result"].get("error") or ""
+        assert err_str, "status=ok requires an inline error string from the safety check"
+        err_lower = err_str.lower()
+        assert "metacharacter" in err_lower or "safety" in err_lower, (
+            f"Expected safety-check error mention; got {err_str!r}"
+        )
+    else:
+        assert result["status"] in ("error", "denied"), (
+            f"Unexpected status for metachar-rejected call: {result['status']}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_holodeck_e2e_logs_tail_dispatches_ok(
+    holodeck_e2e: _HolodeckE2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """holodeck.logs.tail returns the parsed file tail via fake-shell."""
+    del captured_events
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": "holodeck-ssh-9.0",
+            "op_id": "holodeck.logs.tail",
+            "target": {"name": _TARGET_NAME},
+            "params": {"component": "dhcp", "lines": 200},
+        },
+    )
+    assert result["status"] == "ok", f"holodeck.logs.tail failed: {result.get('error')}"
+    files = result["result"].get("files", [])
+    assert len(files) == 1
+    assert "dhcp-server.log" in (files[0].get("path") or "")
+    assert "DHCPDISCOVER" in (files[0].get("lines") or "")
+    assert result["result"].get("lines_requested") == 200
+
+
+@pytest.mark.asyncio
+async def test_holodeck_e2e_networking_show_dispatches_ok(
+    holodeck_e2e: _HolodeckE2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """holodeck.networking.show composes the BGP + routes + DNS + DHCP envelope."""
+    del captured_events
+    result = await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": "holodeck-ssh-9.0",
+            "op_id": "holodeck.networking.show",
+            "target": {"name": _TARGET_NAME},
+            "params": {},
+        },
+    )
+    assert result["status"] == "ok", f"holodeck.networking.show failed: {result.get('error')}"
+    envelope = result["result"]
+    assert envelope["bgp"]["ok"] is True
+    assert "BGP router identifier" in envelope["bgp"]["summary_text"]
+    assert envelope["routes"]["ok"] is True
+    assert "B>" in envelope["routes"]["text"]
+    assert envelope["dns"]["ok"] is True
+    assert envelope["dns"]["total"] == 2
+    zone_names = {z.get("ZoneName") for z in envelope["dns"]["zones"]}
+    assert "holodeck.lab" in zone_names
+    assert envelope["dhcp"]["ok"] is True
+    assert "lease 10.50.0.5" in envelope["dhcp"]["leases_text"]
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion (c) — pod.list JSONFlux handle path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_holodeck_e2e_pod_list_jsonflux_handle(
+    holodeck_e2e: _HolodeckE2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """holodeck.pod.list with the real JsonFluxReducer produces a ResultHandle.
+
+    Exercises acceptance criterion (c): the pod list supports the
+    JSONFlux handle path. The test installs the real
+    :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`
+    in force mode (``row_threshold=0``) so the seeded 3-row pod list
+    materialises into a handle, then asserts:
+
+    * The ``OperationResult.handle`` (top-level ``result["handle"]``) is
+      present and non-None.
+    * The handle's ``total_rows`` equals the fixture row count (3).
+    * The handle's ``sample_rows`` is populated.
+    * ``result.result["row_count"]`` is the summary payload the reducer
+      returns alongside the handle.
+
+    Teardown restores :class:`PassThroughReducer` so a follow-on test
+    in the same session sees the v0.2 default.
+    """
+    del captured_events
+    set_default_reducer(JsonFluxReducer(row_threshold=0))
+    try:
+        result = await call_operation(
+            _OPERATOR,
+            {
+                "connector_id": "holodeck-ssh-9.0",
+                "op_id": "holodeck.pod.list",
+                "target": {"name": _TARGET_NAME},
+                "params": {},
+            },
+        )
+        assert result["status"] == "ok", (
+            f"holodeck.pod.list (force-handle) failed: {result.get('error')}"
+        )
+
+        # The result payload is the reducer's summary (not the raw rows).
+        assert result.get("result") is not None
+        assert "row_count" in result["result"]
+        assert result["result"]["row_count"] == 3
+
+        # The top-level "handle" key must carry the ResultHandle.
+        handle = result.get("handle")
+        assert handle is not None, (
+            f"Expected result['handle'] from JsonFluxReducer; got result={result!r}"
+        )
+        assert handle["total_rows"] == 3
+        assert handle["sample_rows"] is not None
+    finally:
+        set_default_reducer(PassThroughReducer())
+        reset_dispatcher_caches()
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion (d) — audit row written for every op
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_holodeck_e2e_dispatch_writes_audit_row(
+    holodeck_e2e: _HolodeckE2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """Each dispatch inserts an AuditLog row with op_id + target_id + params_hash.
+
+    Dispatches ``holodeck.about`` and asserts:
+    * Exactly one new ``AuditLog`` row with ``method='DISPATCH'``
+      and ``path == 'holodeck.about'``.
+    * ``row.target_id`` is not None (the Target row was resolved).
+    * ``row.payload["op_id"]`` equals ``holodeck.about``.
+    * ``row.payload["params_hash"]`` is a non-empty string.
+    """
+    del captured_events
+    op_id = "holodeck.about"
+    sessionmaker = get_sessionmaker()
+
+    async def _count_rows() -> int:
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(AuditLog).where(
+                    AuditLog.method == "DISPATCH",
+                    AuditLog.path == op_id,
+                )
+            )
+            return len(list(result.scalars().all()))
+
+    baseline = await _count_rows()
+
+    await call_operation(
+        _OPERATOR,
+        {
+            "connector_id": "holodeck-ssh-9.0",
+            "op_id": op_id,
+            "target": {"name": _TARGET_NAME},
+            "params": {},
+        },
+    )
+
+    after = await _count_rows()
+    assert after == baseline + 1, (
+        f"Expected exactly 1 new DISPATCH audit row for {op_id}; baseline={baseline} after={after}"
+    )
+
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(AuditLog)
+            .where(
+                AuditLog.method == "DISPATCH",
+                AuditLog.path == op_id,
+            )
+            .order_by(AuditLog.occurred_at.desc())
+            .limit(1)
+        )
+        row = result.scalar_one()
+
+    assert row.target_id is not None, "AuditLog.target_id must not be NULL for a dispatched op"
+    assert row.payload.get("op_id") == op_id, (
+        f"AuditLog.payload['op_id'] should be {op_id!r}; got {row.payload.get('op_id')!r}"
+    )
+    params_hash = row.payload.get("params_hash")
+    assert params_hash and isinstance(params_hash, str), (
+        "AuditLog.payload['params_hash'] must be a non-empty string"
+    )
+
+
+@pytest.mark.asyncio
+async def test_holodeck_e2e_all_ops_write_audit_rows(
+    holodeck_e2e: _HolodeckE2EBundle,
+    captured_events: list[Any],
+) -> None:
+    """All 8 Holodeck ops each produce an audit row after dispatch.
+
+    Dispatches every op in EXPECTED_OP_IDS and asserts that each one
+    inserted at least one ``DISPATCH`` AuditLog row.
+    """
+    del captured_events
+    sessionmaker = get_sessionmaker()
+
+    # Params each op needs (everything else is empty).
+    params_for_op: dict[str, dict[str, Any]] = {
+        "holodeck.pod.info": {"pod_id": "HoloPod-001"},
+        "holodeck.k8s.exec": {"command": "kubectl get nodes"},
+        "holodeck.logs.tail": {"component": "dhcp", "lines": 200},
+    }
+
+    for op_id in EXPECTED_OP_IDS:
+        params = params_for_op.get(op_id, {})
+        result = await call_operation(
+            _OPERATOR,
+            {
+                "connector_id": "holodeck-ssh-9.0",
+                "op_id": op_id,
+                "target": {"name": _TARGET_NAME},
+                "params": params,
+            },
+        )
+        assert result["status"] == "ok", f"Op {op_id} failed: {result.get('error')}"
+
+        async with sessionmaker() as session:
+            db_result = await session.execute(
+                select(AuditLog).where(
+                    AuditLog.method == "DISPATCH",
+                    AuditLog.path == op_id,
+                )
+            )
+            rows = list(db_result.scalars().all())
+        assert rows, f"No DISPATCH audit row found for op {op_id!r}"
+        assert rows[-1].payload.get("op_id") == op_id, f"Audit payload op_id mismatch for {op_id}"

--- a/cli/internal/cmd/holodeck/about.go
+++ b/cli/internal/cmd/holodeck/about.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package holodeck
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newAboutCmd returns the `meho holodeck about` command.
+//
+// CLI shape:
+//
+//	meho holodeck about \
+//	  [--target <slug>]     # HoloRouter target (required for dispatch)
+//	  [--json]              # machine-readable output
+//	  [--backplane <url>]   # override the backplane URL
+//
+// Maps to op_id `holodeck.about`. The renderer surfaces the vendor /
+// product / version / build / photon_version / pod_id fields the
+// handler returns; --json emits the raw OperationResult envelope.
+func newAboutCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "about",
+		Short: "Show Holodeck product / version / Photon OS for a target",
+		Long: "about dispatches holodeck.about against the connector_id=\n" +
+			"\"holodeck-ssh-9.0\" connector and renders the vendor / product /\n" +
+			"version / build / photon_version / pod_id fields the handler\n" +
+			"returns (parsed from /etc/photon-release + Get-HoloDeckConfig\n" +
+			"via pwsh-over-SSH). The human render is a short summary;\n" +
+			"--json emits the full OperationResult envelope for scripting.\n\n" +
+			"Exit codes mirror meho operation call:\n" +
+			"  - 0   status == ok\n" +
+			"  - 1   status == error / denied\n" +
+			"  - 2   auth_expired (run `meho login`)\n" +
+			"  - 3   unreachable (network / DNS / TLS)\n" +
+			"  - 4   unexpected response shape",
+		Example: "  meho holodeck about --target holorouter-hetzner-dc\n" +
+			"  meho holodeck about --target holorouter-hetzner-dc --json | jq .result",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runAbout(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to dispatch against (required)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON instead of the human render")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+func runAbout(cmd *cobra.Command, targetName string, jsonOut bool, backplaneOverride string) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "holodeck.about", targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "holodeck.about", r, jsonOut, printAbout)
+}
+
+// printAbout renders the holodeck.about result fields. The handler
+// returns a flat dict shaped `{"vendor", "product", "version", "build",
+// "photon_version", "pod_id"}` — the renderer pulls those fields and
+// falls back to the generic envelope renderer for unexpected shapes.
+func printAbout(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s holodeck.about — status=%s (%.0fms)\n", ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	about, err := decodeFlatResult(r.Result)
+	if err != nil || about == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	for _, key := range []string{"vendor", "product", "version", "build", "photon_version", "pod_id"} {
+		v, ok := about[key]
+		if !ok || v == nil {
+			continue
+		}
+		fmt.Fprintf(w, "  %-16s %v\n", key+":", v)
+	}
+}

--- a/cli/internal/cmd/holodeck/config.go
+++ b/cli/internal/cmd/holodeck/config.go
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package holodeck
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newConfigCmd returns the `meho holodeck config` parent with one
+// sub-verb: `show` (holodeck.config.show).
+func newConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "config",
+		Short:        "Holodeck appliance config sub-verbs (show)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newConfigShowCmd())
+	return cmd
+}
+
+// newConfigShowCmd returns the `meho holodeck config show` command.
+//
+// Maps to op_id `holodeck.config.show`. Runs `Get-HoloDeckConfig |
+// ConvertTo-Json -Depth 4 -Compress` over the pwsh-over-SSH transport
+// and returns the parsed configuration dict (vendor + product + pod ID
+// + services block).
+func newConfigShowCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Return the full Holodeck appliance configuration dict",
+		Long: "show dispatches holodeck.config.show and returns the full\n" +
+			"Get-HoloDeckConfig configuration dict (vendor + product +\n" +
+			"version + pod ID + services block). Use when the operator\n" +
+			"needs the full appliance configuration snapshot; for just\n" +
+			"the identifying fields, prefer `meho holodeck about`\n" +
+			"(faster, fewer fields).\n\n" +
+			"The human render pretty-prints the parsed dict; --json emits\n" +
+			"the full OperationResult envelope including the raw config\n" +
+			"sub-dict.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example: "  meho holodeck config show --target holorouter-hetzner-dc\n" +
+			"  meho holodeck config show --target holorouter-hetzner-dc --json | jq .result.config",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runConfigShow(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to dispatch against (required)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL from the most recent `meho login`)")
+	return cmd
+}
+
+func runConfigShow(
+	cmd *cobra.Command,
+	targetName string,
+	jsonOut bool,
+	backplaneOverride string,
+) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "holodeck.config.show", targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "holodeck.config.show", r, jsonOut, printConfigShow)
+}
+
+func printConfigShow(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s holodeck.config.show — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	flat, err := decodeFlatResult(r.Result)
+	if err != nil || flat == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if errStr, ok := flat["error"].(string); ok && errStr != "" {
+		fmt.Fprintf(w, "  error: %s\n", errStr)
+		return
+	}
+	cfg, ok := flat["config"].(map[string]any)
+	if !ok || cfg == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	// Pretty-print the parsed config. The dict shape varies by
+	// appliance release (Get-HoloDeckConfig is undocumented stable);
+	// json.MarshalIndent surfaces every field without forcing a per-
+	// version field map here.
+	rawCfg, _ := json.MarshalIndent(cfg, "", "  ")
+	for _, line := range splitLines(string(rawCfg)) {
+		fmt.Fprintln(w, "  "+line)
+	}
+}

--- a/cli/internal/cmd/holodeck/dispatch.go
+++ b/cli/internal/cmd/holodeck/dispatch.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package holodeck
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// CallResult mirrors the backend OperationResult Pydantic model.
+// Same shape as cmd/pfsense/CallResult; duplicated here because
+// cmd/holodeck can't import cmd/pfsense without an import cycle
+// (cmd/root.go grafts both onto the tree).
+type CallResult struct {
+	Status     string          `json:"status"`
+	OpID       string          `json:"op_id"`
+	Result     json.RawMessage `json:"result"`
+	Error      *string         `json:"error"`
+	Extras     json.RawMessage `json:"extras,omitempty"`
+	DurationMs float64         `json:"duration_ms"`
+}
+
+// callRequestBody mirrors the backend CallOperationBody Pydantic
+// model. Target uses a map[string]any so the empty case serialises
+// as `null` rather than an empty struct.
+type callRequestBody struct {
+	ConnectorID string         `json:"connector_id"`
+	OpID        string         `json:"op_id"`
+	Target      map[string]any `json:"target"`
+	Params      map[string]any `json:"params,omitempty"`
+}
+
+// errOpError is the sentinel returned when the dispatcher reported a
+// structured-failure result (status == "error" or status == "denied").
+var errOpError = errors.New("operation status not ok")
+
+// dispatchOp POSTs an OperationCall to the backplane and returns the
+// decoded CallResult. The pre-baked connector_id ("holodeck-ssh-9.0")
+// is baked in; callers pass op_id, an optional target slug (empty
+// string → no target field on the wire), and an optional params map.
+//
+// Centralised here so every verb in the package shares one
+// dispatcher implementation. A grep for `dispatchOp` finds every
+// alias-verb dispatch in the holodeck package.
+//
+// NOTE: holodeck.k8s.exec passes the operator's `kubectl` command
+// verbatim in `params["command"]`. The CLI does not pre-parse or
+// pre-validate that string — the read-only safelist + shell-
+// metacharacter guard live on the backend handler. Any operator
+// invocation containing `;` / `&&` / `|` / `$(...)` / backticks /
+// `>` / `<` / newline is refused with `result_connector_error` and
+// surfaces as a non-ok status on the CLI side.
+func dispatchOp(
+	ctx context.Context,
+	backplaneURL, opID, targetSlug string,
+	params map[string]any,
+) (*CallResult, error) {
+	body := callRequestBody{
+		ConnectorID: ConnectorID,
+		OpID:        opID,
+		Target:      nil,
+	}
+	if targetSlug != "" {
+		body.Target = map[string]any{"name": targetSlug}
+	}
+	if params != nil {
+		body.Params = params
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal call request: %w", err)
+	}
+	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
+	if err != nil {
+		return nil, err
+	}
+	var out CallResult
+	if err := json.Unmarshal(respBody, &out); err != nil {
+		return nil, fmt.Errorf("decode call response: %w", err)
+	}
+	return &out, nil
+}
+
+// renderCallResult handles the unified post-dispatch path every verb
+// uses: validate status enum, render the envelope (JSON or human),
+// then translate "error" / "denied" into the errOpError sentinel so
+// main propagates the right non-zero exit.
+func renderCallResult(
+	cmd *cobra.Command,
+	opID string,
+	r *CallResult,
+	jsonOut bool,
+	prettyPrinter func(w io.Writer, r *CallResult),
+) error {
+	switch r.Status {
+	case "ok", "error", "denied":
+		// fall through.
+	default:
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
+				r.Status,
+			)),
+			jsonOut,
+		)
+	}
+	if jsonOut {
+		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
+			return err
+		}
+	} else if prettyPrinter != nil {
+		prettyPrinter(cmd.OutOrStdout(), r)
+	} else {
+		printGenericResult(cmd.OutOrStdout(), opID, r)
+	}
+	if r.Status == "ok" {
+		return nil
+	}
+	return errOpError
+}
+
+// printGenericResult renders a CallResult in a generic envelope shape.
+func printGenericResult(w io.Writer, opID string, r *CallResult) {
+	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
+	if r.Status == "ok" {
+		if len(r.Result) > 0 && string(r.Result) != "null" {
+			pretty, err := prettyJSON(r.Result)
+			if err == nil {
+				fmt.Fprintln(w, pretty)
+				return
+			}
+			fmt.Fprintln(w, string(r.Result))
+		}
+		return
+	}
+	printErrorTrailer(w, r)
+}
+
+// printErrorTrailer surfaces the dispatcher error / extras envelope.
+func printErrorTrailer(w io.Writer, r *CallResult) {
+	if r.Error != nil && *r.Error != "" {
+		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
+	} else {
+		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
+	}
+	if len(r.Extras) > 0 && string(r.Extras) != "null" {
+		fmt.Fprintln(w, "extras:")
+		pretty, err := prettyJSON(r.Extras)
+		if err == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Extras))
+		}
+	}
+}
+
+// decodeRowsResult decodes the canonical `{"rows": [...], "total": N}`
+// envelope every set-shaped Holodeck read op returns
+// (holodeck.pod.list, holodeck.service.list).
+func decodeRowsResult(raw json.RawMessage) ([]map[string]any, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var envelope struct {
+		Rows []map[string]any `json:"rows"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil, fmt.Errorf("decode rows: %w", err)
+	}
+	return envelope.Rows, nil
+}
+
+// decodeFlatResult decodes a flat-dict result (holodeck.about,
+// holodeck.config.show, holodeck.pod.info, holodeck.networking.show,
+// holodeck.logs.tail, holodeck.k8s.exec).
+func decodeFlatResult(raw json.RawMessage) (map[string]any, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("decode flat: %w", err)
+	}
+	return m, nil
+}

--- a/cli/internal/cmd/holodeck/holodeck.go
+++ b/cli/internal/cmd/holodeck/holodeck.go
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package holodeck hosts the cobra commands under `meho holodeck ...`
+// for G3.8-T3 (#855) of Initiative #371 (G3.8 Holodeck typed-SSH
+// connector). The verb tree is a thin Cobra layer over
+// `POST /api/v1/operations/call`, identical pattern to
+// `meho pfsense ...` (#850), `meho bind9 ...` (#591), and
+// `meho k8s ...` (#326), pre-baking the
+// `connector_id="holodeck-ssh-9.0"` argument so operators don't type
+// the connector ID on every dispatch:
+//
+//   - `meho holodeck about [--target T]`                       — holodeck.about
+//   - `meho holodeck config show [--target T]`                 — holodeck.config.show
+//   - `meho holodeck pod list [--target T]`                    — holodeck.pod.list (JSONFlux)
+//   - `meho holodeck pod info <pod-id> [--target T]`           — holodeck.pod.info
+//   - `meho holodeck service list [--target T]`                — holodeck.service.list (JSONFlux)
+//   - `meho holodeck k8s exec <kubectl-cmd> [--target T]`      — holodeck.k8s.exec (read-only)
+//   - `meho holodeck logs tail <component> [--lines N] [--target T]` — holodeck.logs.tail
+//   - `meho holodeck networking show [--target T]`             — holodeck.networking.show
+//
+// Every verb is a thin Cobra command that POSTs to
+// `/api/v1/operations/call` with a pre-baked connector_id. No new
+// backend code; no new HTTP routes — the CLI alias verbs are pure
+// operator ergonomics over the existing dispatcher surface (per
+// CLAUDE.md postulate 5: agent surface stays narrow-waist meta-tools;
+// vendor-specific tooling lives only in the CLI).
+//
+// The verb tree replaces the consumer's `scripts/holodeck.sh` wrapper
+// (1:1 op mapping). The sister `scripts/clone-holodeck-instance.sh`
+// wrapper — multi-step nested-lab bring-up — stays in place for v0.2
+// and surfaces as a Runbook in a future Goal G11 once the runbook
+// engine ships; see `docs/cross-repo/holodeck-onboarding.md`.
+//
+// The `meho holodeck` surface is operator-only — the MCP / agent
+// surface continues to reach Holodeck ops via the narrow-waist
+// search_operations + call_operation meta-tools (CLAUDE.md
+// postulate 5). Each op's `llm_instructions.when_to_use` carries the
+// canonical "Holodeck has no REST API; the underlying transport is
+// PowerShell-over-SSH ..." note so agents know they're running on the
+// appliance, not against a hosted API surface.
+//
+// IMPORTANT: the `holodeck.k8s.exec` CLI verb passes the operator's
+// `kubectl` command verbatim into `params.command` of the typed op;
+// the read-only safelist + shell-metacharacter guard live on the
+// backend handler (see
+// `backend/src/meho_backplane/connectors/holodeck/ops_read.py::parse_kubectl_command`).
+// The CLI does NOT pre-parse, pre-validate, or sanitise — that would
+// duplicate (and risk drifting from) the authoritative gate. Forward
+// the raw string and let the backend refuse it if the verb is
+// mutating or the input contains `;` / `&&` / `|` / `$(...)` /
+// backticks / `>` / `<` / newline.
+package holodeck
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// ConnectorID is the pre-baked connector_id every verb under
+// `meho holodeck ...` dispatches against. Exported so the per-verb
+// files and tests reference the same constant; a future re-versioning
+// (holodeck-9.1 or holodeck-10.x) lands as a single line edit here.
+//
+// The id encodes the registry-v2 natural key triple
+// "(product="holodeck", version="9.0", impl_id="holodeck-ssh")" per
+// the connector_id parser convention in
+// `backend/src/meho_backplane/operations/_lookup.py::parse_connector_id`:
+// the trailing `-9.0` segment is the version; everything before is the
+// impl_id (`holodeck-ssh`); the product is the first hyphen segment of
+// the impl_id (`holodeck`). The impl_id discriminator (`-ssh`) leaves
+// room for a future non-SSH control surface without breaking the
+// resolver's tie-break ladder — relevant because Holodeck currently
+// has no REST API but a vendor could add one in a future Toolkit
+// release.
+const ConnectorID = "holodeck-ssh-9.0"
+
+// NewRootCmd returns the `meho holodeck` parent command. cmd/root.go
+// grafts this onto the top-level command tree alongside the other
+// built-in verb trees. The parent itself takes no args and prints its
+// own help; every piece of behaviour lives in the per-subcommand RunE
+// closures.
+//
+// Sub-tree layout follows the issue #855 verb table:
+//   - `holodeck about`                    — flat verb
+//   - `holodeck config <show>`            — sub-tree
+//   - `holodeck pod <list|info>`          — sub-tree
+//   - `holodeck service <list>`           — sub-tree
+//   - `holodeck k8s <exec>`               — sub-tree (read-only)
+//   - `holodeck logs <tail>`              — sub-tree
+//   - `holodeck networking <show>`        — sub-tree
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "holodeck",
+		Short: "Pre-scoped CLI verbs for the holodeck-ssh-9.0 connector",
+		Long: "holodeck is the operator-facing verb tree for the holodeck-ssh-9.0\n" +
+			"connector (registry triple (product=\"holodeck\", version=\"9.0\",\n" +
+			"impl_id=\"holodeck-ssh\")). Each verb dispatches through\n" +
+			"POST /api/v1/operations/call with connector_id=\"holodeck-ssh-9.0\"\n" +
+			"pre-baked so operators don't type the connector ID on every\n" +
+			"command. All shipped ops are read-only; write ops are out of\n" +
+			"scope for G3.8 (#371).\n\n" +
+			"Per CLAUDE.md postulate 5, these alias verbs are operator-only\n" +
+			"ergonomics — they are not mirrored on the MCP surface. Agents\n" +
+			"continue to use search_operations / call_operation against the\n" +
+			"narrow-waist meta-tool contract.\n\n" +
+			"Transport note: Holodeck exposes no REST API. The underlying\n" +
+			"transport is PowerShell-over-SSH (pwsh -EncodedCommand routed\n" +
+			"through asyncssh) for cmdlet ops, plain SSH for kubectl /\n" +
+			"shell-pipeline ops. The CLI does not see this directly — it\n" +
+			"POSTs JSON to the backplane — but the agent-facing\n" +
+			"llm_instructions on each op surface this transport so an LLM\n" +
+			"doesn't compose against a non-existent REST surface.\n\n" +
+			"Wrapper-retirement note: this verb tree replaces the\n" +
+			"consumer's scripts/holodeck.sh wrapper 1:1. The sister\n" +
+			"scripts/clone-holodeck-instance.sh wrapper (multi-step\n" +
+			"nested-lab bring-up) stays in place for v0.2 and surfaces as\n" +
+			"a Runbook in a future Goal G11 once the runbook engine ships;\n" +
+			"see docs/cross-repo/holodeck-onboarding.md.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newAboutCmd())
+	cmd.AddCommand(newConfigCmd())
+	cmd.AddCommand(newPodCmd())
+	cmd.AddCommand(newServiceCmd())
+	cmd.AddCommand(newK8sCmd())
+	cmd.AddCommand(newLogsCmd())
+	cmd.AddCommand(newNetworkingCmd())
+	return cmd
+}
+
+// errNoBackplaneConfigured wraps auth.ErrConfigNotFound so callers
+// can distinguish "operator never logged in" (→ auth_expired exit
+// code 2 — the right fix is `meho login`) from URL-parse failures
+// (→ unexpected exit code 4 — the right fix is correcting argv).
+type errNoBackplaneConfigured struct{ inner error }
+
+func (e *errNoBackplaneConfigured) Error() string {
+	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
+}
+func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
+
+// resolveBackplane mirrors the bind9 / pfsense / k8s sibling helpers:
+// --backplane override flag wins; otherwise read the URL the most
+// recent `meho login` wrote to config.json.
+func resolveBackplane(override string) (string, error) {
+	if override != "" {
+		return normaliseURL(override)
+	}
+	cfg, err := auth.LoadConfig()
+	if err != nil {
+		if errors.Is(err, auth.ErrConfigNotFound) {
+			return "", &errNoBackplaneConfigured{inner: err}
+		}
+		return "", err
+	}
+	return normaliseURL(cfg.BackplaneURL)
+}
+
+// classifyBackplaneError maps a resolveBackplane error to the right
+// output.StructuredError category. Identical routing to the bind9 /
+// pfsense / k8s siblings: missing-config → auth_expired; everything
+// else → unexpected.
+func classifyBackplaneError(err error) *output.StructuredError {
+	if errors.Is(err, auth.ErrConfigNotFound) {
+		return output.AuthExpired(err.Error())
+	}
+	return output.Unexpected(err.Error())
+}
+
+// normaliseURL strips trailing slashes + parses the URL to fail fast
+// on garbage input. Mirrors the bind9 / pfsense / k8s siblings.
+func normaliseURL(s string) (string, error) {
+	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
+	if trimmed == "" {
+		return "", errors.New("backplane URL is empty")
+	}
+	u, err := url.ParseRequestURI(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
+	}
+	if u.Host == "" {
+		return "", fmt.Errorf("backplane URL %q has no host", s)
+	}
+	u.Path = strings.TrimRight(u.Path, "/")
+	return u.String(), nil
+}
+
+// renderRequestError translates an error from doAuthedRequest into
+// the right output.RenderError category. Same classification ladder
+// as the pfsense sibling: token-not-found / no-refresh-token →
+// auth_expired; HTTP-error → unexpected; transport → unreachable.
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var he *httpError
+	if errors.As(err, &he) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, he.StatusCode, he.Body)),
+			jsonOut,
+		)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+// httpError carries a non-2xx response so renderRequestError can
+// pick the right StructuredError category.
+type httpError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// doAuthedRequest issues a single HTTP request against the backplane
+// with bearer injection + one-shot 401-refresh-retry. Mirrors the
+// pfsense / bind9 siblings verbatim (duplicated to avoid import
+// cycle — cmd/root.go grafts each onto the tree).
+func doAuthedRequest(
+	ctx context.Context,
+	backplaneURL, method, path string,
+	body []byte,
+) ([]byte, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	httpClient := authed.HTTPClient()
+	bearer := authed.AccessToken()
+	if bearer == "" {
+		return nil, errors.New("meho: stored token has no access_token")
+	}
+
+	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			resp.Body.Close()
+			return nil, rerr
+		}
+		resp.Body.Close()
+		bearer = authed.AccessToken()
+		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close()
+
+	// 2 MiB cap — holodeck.config.show can return a large appliance
+	// config and holodeck.logs.tail can return up to 5000 lines per
+	// log file (with multi-file glob). The cap leaves headroom while
+	// bounding pathological payloads.
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
+	}
+	return raw, nil
+}
+
+// sendRequest builds + fires the HTTP request. Mirrors the pfsense
+// sibling.
+func sendRequest(
+	ctx context.Context,
+	client *http.Client,
+	backplaneURL, method, path, bearer string,
+	body []byte,
+) (*http.Response, error) {
+	fullURL := backplaneURL + path
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return client.Do(req)
+}
+
+// truncate cuts s to maxLen runes, appending an ellipsis when
+// truncation happened. Operates on runes (not bytes) so multi-byte
+// UTF-8 in pod names or service descriptions survives without
+// producing an invalid UTF-8 cut. Same implementation as the pfsense
+// / bind9 / k8s siblings.
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}
+
+// prettyJSON pretty-prints a json.RawMessage with 2-space indent.
+func prettyJSON(raw json.RawMessage) (string, error) {
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return "", err
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// fallbackResultRender dumps the result envelope verbatim when the
+// typed per-verb decode fails.
+func fallbackResultRender(w io.Writer, r *CallResult) {
+	if len(r.Result) == 0 || string(r.Result) == "null" {
+		return
+	}
+	pretty, err := prettyJSON(r.Result)
+	if err == nil {
+		fmt.Fprintln(w, pretty)
+		return
+	}
+	fmt.Fprintln(w, string(r.Result))
+}
+
+// stringField pulls a string field from a row entry, returning empty
+// string when the field is missing or wrong type.
+func stringField(e map[string]any, key string) string {
+	v, ok := e[key]
+	if !ok {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// splitLines splits a string by newlines without the overhead of bufio.
+// Used by the multi-line renderers (config.show, logs.tail) to cap
+// human output at a sensible line count.
+func splitLines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	out := make([]string, 0, 32)
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			out = append(out, s[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		out = append(out, s[start:])
+	}
+	return out
+}

--- a/cli/internal/cmd/holodeck/holodeck_test.go
+++ b/cli/internal/cmd/holodeck/holodeck_test.go
@@ -1,0 +1,635 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package holodeck
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// ---------- helper tests (pure-function) ----------
+
+// TestConnectorIDIsFrozen pins the pre-baked connector_id constant.
+// Every verb file dispatches against this value; a regression here
+// would silently rebind every alias verb to a different connector.
+// The id encodes the registry-v2 natural key triple
+// `("holodeck", "9.0", "holodeck-ssh")` per parse_connector_id's grammar.
+func TestConnectorIDIsFrozen(t *testing.T) {
+	if ConnectorID != "holodeck-ssh-9.0" {
+		t.Fatalf("ConnectorID drifted: got %q want %q", ConnectorID, "holodeck-ssh-9.0")
+	}
+}
+
+// TestTruncatePassthroughAndCut covers the rune-aware truncate helper.
+func TestTruncatePassthroughAndCut(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     string
+		maxLen int
+		want   string
+	}{
+		{"within budget", "abc", 5, "abc"},
+		{"over budget ascii", "abcdef", 4, "abc…"},
+		{"multi-byte safe", "café world", 5, "café…"},
+		{"zero budget", "x", 0, ""},
+	}
+	for _, tt := range tests {
+		if got := truncate(tt.in, tt.maxLen); got != tt.want {
+			t.Errorf("%s: truncate(%q, %d) = %q; want %q", tt.name, tt.in, tt.maxLen, got, tt.want)
+		}
+	}
+}
+
+// TestNormaliseURLBasic mirrors the pfsense / bind9 siblings —
+// trailing-slash trimming + reject-empty are the load-bearing
+// properties.
+func TestNormaliseURLBasic(t *testing.T) {
+	got, err := normaliseURL("https://meho.test/")
+	if err != nil {
+		t.Fatalf("normaliseURL: %v", err)
+	}
+	if got != "https://meho.test" {
+		t.Fatalf("expected trailing slash stripped; got %q", got)
+	}
+	if _, err := normaliseURL("   "); err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Fatalf("empty should reject; got %v", err)
+	}
+}
+
+// TestClassifyBackplaneErrorRoutesByCause — ErrConfigNotFound (or
+// any wrapping error) maps to AuthExpired; everything else maps
+// to Unexpected.
+func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
+	wrapped := &errNoBackplaneConfigured{inner: auth.ErrConfigNotFound}
+	se := classifyBackplaneError(wrapped)
+	if se == nil || se.Code != "auth_expired" {
+		t.Fatalf("wrapped ErrConfigNotFound should classify as auth_expired; got %+v", se)
+	}
+	se = classifyBackplaneError(errors.New("parse failure"))
+	if se == nil || se.Code != "unexpected_response" {
+		t.Fatalf("parse failure should classify as unexpected_response; got %+v", se)
+	}
+}
+
+// ---------- decode helpers ----------
+
+func TestDecodeFlatResultHappy(t *testing.T) {
+	raw := json.RawMessage(`{"vendor":"vmware","version":"9.0.0"}`)
+	got, err := decodeFlatResult(raw)
+	if err != nil {
+		t.Fatalf("decodeFlatResult: %v", err)
+	}
+	if got["vendor"] != "vmware" || got["version"] != "9.0.0" {
+		t.Fatalf("decoded: %+v", got)
+	}
+}
+
+func TestDecodeFlatResultNullAndEmpty(t *testing.T) {
+	for _, raw := range []json.RawMessage{nil, json.RawMessage(`null`)} {
+		got, err := decodeFlatResult(raw)
+		if err != nil {
+			t.Fatalf("decodeFlatResult empty: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("empty should be nil map; got %+v", got)
+		}
+	}
+}
+
+func TestDecodeRowsResultHappy(t *testing.T) {
+	raw := json.RawMessage(`{"rows":[{"Id":"HoloPod-001","Name":"lab-A","State":"Running"}],"total":1}`)
+	rows, err := decodeRowsResult(raw)
+	if err != nil {
+		t.Fatalf("decodeRowsResult: %v", err)
+	}
+	if len(rows) != 1 || rows[0]["Id"] != "HoloPod-001" {
+		t.Fatalf("decoded: %+v", rows)
+	}
+}
+
+func TestDecodeRowsResultEmpty(t *testing.T) {
+	raw := json.RawMessage(`{"rows":[],"total":0}`)
+	rows, err := decodeRowsResult(raw)
+	if err != nil {
+		t.Fatalf("decodeRowsResult: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("expected empty rows; got %+v", rows)
+	}
+}
+
+// TestSplitLinesBasic — splitLines handles the basic cases including
+// empty string, single line, trailing newline.
+func TestSplitLinesBasic(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"abc", []string{"abc"}},
+		{"a\nb\nc", []string{"a", "b", "c"}},
+		{"a\nb\n", []string{"a", "b"}},
+	}
+	for _, tt := range tests {
+		got := splitLines(tt.in)
+		if len(got) != len(tt.want) {
+			t.Errorf("splitLines(%q): len=%d want %d; got %v", tt.in, len(got), len(tt.want), got)
+			continue
+		}
+		for i := range got {
+			if got[i] != tt.want[i] {
+				t.Errorf("splitLines(%q)[%d]=%q want %q", tt.in, i, got[i], tt.want[i])
+			}
+		}
+	}
+}
+
+// ---------- dispatcher wire-shape tests ----------
+
+type mockHandler = http.HandlerFunc
+
+func mockBackplane(t *testing.T, routes map[string]mockHandler) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		if h, ok := routes[key]; ok {
+			h(w, r)
+			return
+		}
+		if h, ok := routes[""]; ok {
+			h(w, r)
+			return
+		}
+		t.Errorf("mockBackplane: unhandled route %s", key)
+		w.WriteHeader(404)
+	}))
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, body any) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Errorf("writeJSON marshal: %v", err)
+		w.WriteHeader(500)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, err := w.Write(raw); err != nil {
+		t.Errorf("writeJSON write: %v", err)
+	}
+}
+
+func primeToken(t *testing.T, backplaneURL string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	cfg := filepath.Join(dir, "meho", "config.json")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	cfgBlob, _ := json.Marshal(map[string]string{"backplane_url": backplaneURL})
+	if err := os.WriteFile(cfg, cfgBlob, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	store, err := auth.NewTokenStore()
+	if err != nil {
+		t.Fatalf("NewTokenStore: %v", err)
+	}
+	if err := store.Save(service, user, auth.StoredToken{
+		AccessToken:  "test-bearer",
+		BackplaneURL: backplaneURL,
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+}
+
+// TestDispatchOpBakesConnectorID — every verb dispatches with
+// connector_id="holodeck-ssh-9.0" pre-baked. A regression here would
+// silently rebind every alias verb to a different connector.
+func TestDispatchOpBakesConnectorID(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if body.ConnectorID != "holodeck-ssh-9.0" {
+				t.Errorf("connector_id: got %q want holodeck-ssh-9.0", body.ConnectorID)
+			}
+			if body.OpID != "holodeck.about" {
+				t.Errorf("op_id: got %q want holodeck.about", body.OpID)
+			}
+			writeJSON(t, w, 200, CallResult{
+				Status: "ok",
+				OpID:   "holodeck.about",
+				Result: json.RawMessage(`{"vendor":"vmware","product":"holodeck"}`),
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	r, err := dispatchOp(context.Background(), srv.URL, "holodeck.about", "holorouter-hetzner-dc", nil)
+	if err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+	if r.Status != "ok" {
+		t.Fatalf("dispatch status: %s", r.Status)
+	}
+}
+
+// TestDispatchOpTargetSlugWrappedAsName — a non-empty target slug
+// must surface as `{"name": "<slug>"}` so the dispatcher's resolver
+// pulls it under the canonical TargetRef shape.
+func TestDispatchOpTargetSlugWrappedAsName(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var raw map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			tgt, _ := raw["target"].(map[string]any)
+			if tgt == nil || tgt["name"] != "holorouter-hetzner-dc" {
+				t.Errorf("target should wrap slug as {name: ...}; got %v", raw["target"])
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: "holodeck.about"})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	if _, err := dispatchOp(context.Background(), srv.URL, "holodeck.about", "holorouter-hetzner-dc", nil); err != nil {
+		t.Fatalf("dispatchOp: %v", err)
+	}
+}
+
+// TestDispatchOpEmptyTargetSendsNullTarget — an empty target slug must
+// result in `"target": null` on the wire (not `{"name": ""}`).
+func TestDispatchOpEmptyTargetSendsNullTarget(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var raw map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+				t.Errorf("decode: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			if raw["target"] != nil {
+				t.Errorf("empty target slug should serialise as null; got %v", raw["target"])
+			}
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: "holodeck.about"})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	if _, err := dispatchOp(context.Background(), srv.URL, "holodeck.about", "", nil); err != nil {
+		t.Fatalf("dispatchOp empty target: %v", err)
+	}
+}
+
+// TestAllOpsUseCanonicalOpIDs — pin the 8 canonical Holodeck op_ids
+// that the CLI dispatches. Any drift here surfaces as a test failure
+// rather than a silent 404 from the backplane op registry.
+func TestAllOpsUseCanonicalOpIDs(t *testing.T) {
+	expectedOps := []string{
+		"holodeck.about",
+		"holodeck.config.show",
+		"holodeck.pod.list",
+		"holodeck.pod.info",
+		"holodeck.service.list",
+		"holodeck.k8s.exec",
+		"holodeck.logs.tail",
+		"holodeck.networking.show",
+	}
+
+	dispatched := make(map[string]bool)
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+			var body callRequestBody
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Errorf("decode body: %v", err)
+				w.WriteHeader(400)
+				return
+			}
+			dispatched[body.OpID] = true
+			writeJSON(t, w, 200, CallResult{Status: "ok", OpID: body.OpID,
+				Result: json.RawMessage(`{}`)})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	for _, opID := range expectedOps {
+		if _, err := dispatchOp(context.Background(), srv.URL, opID, "holodeck-test", nil); err != nil {
+			t.Fatalf("dispatchOp %s: %v", opID, err)
+		}
+	}
+	for _, opID := range expectedOps {
+		if !dispatched[opID] {
+			t.Errorf("op_id %q was not dispatched", opID)
+		}
+	}
+}
+
+// TestNewRootCmdHasExpectedSubcommands — the root command must expose
+// the expected verb names so `meho holodeck --help` lists them.
+func TestNewRootCmdHasExpectedSubcommands(t *testing.T) {
+	root := NewRootCmd()
+	want := map[string]bool{
+		"about":      false,
+		"config":     false,
+		"pod":        false,
+		"service":    false,
+		"k8s":        false,
+		"logs":       false,
+		"networking": false,
+	}
+	for _, sub := range root.Commands() {
+		want[sub.Name()] = true
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("root command is missing subcommand %q", name)
+		}
+	}
+}
+
+// TestPodHasListAndInfo — the `pod` sub-command must have `list` and
+// `info` sub-verbs.
+func TestPodHasListAndInfo(t *testing.T) {
+	p := newPodCmd()
+	subs := make(map[string]bool)
+	for _, s := range p.Commands() {
+		subs[s.Name()] = true
+	}
+	for _, name := range []string{"list", "info"} {
+		if !subs[name] {
+			t.Errorf("pod is missing sub-verb %q", name)
+		}
+	}
+}
+
+// TestK8sHasExec — the `k8s` sub-command must have an `exec` sub-verb.
+func TestK8sHasExec(t *testing.T) {
+	k := newK8sCmd()
+	subs := make(map[string]bool)
+	for _, s := range k.Commands() {
+		subs[s.Name()] = true
+	}
+	if !subs["exec"] {
+		t.Errorf("k8s is missing sub-verb 'exec'")
+	}
+}
+
+// TestLogsHasTail — the `logs` sub-command must have a `tail` sub-verb.
+func TestLogsHasTail(t *testing.T) {
+	l := newLogsCmd()
+	subs := make(map[string]bool)
+	for _, s := range l.Commands() {
+		subs[s.Name()] = true
+	}
+	if !subs["tail"] {
+		t.Errorf("logs is missing sub-verb 'tail'")
+	}
+}
+
+// TestNetworkingHasShow — the `networking` sub-command must have a
+// `show` sub-verb.
+func TestNetworkingHasShow(t *testing.T) {
+	n := newNetworkingCmd()
+	subs := make(map[string]bool)
+	for _, s := range n.Commands() {
+		subs[s.Name()] = true
+	}
+	if !subs["show"] {
+		t.Errorf("networking is missing sub-verb 'show'")
+	}
+}
+
+// TestServiceHasList — the `service` sub-command must have a `list`
+// sub-verb.
+func TestServiceHasList(t *testing.T) {
+	s := newServiceCmd()
+	subs := make(map[string]bool)
+	for _, sc := range s.Commands() {
+		subs[sc.Name()] = true
+	}
+	if !subs["list"] {
+		t.Errorf("service is missing sub-verb 'list'")
+	}
+}
+
+// TestConfigHasShow — the `config` sub-command must have a `show`
+// sub-verb.
+func TestConfigHasShow(t *testing.T) {
+	c := newConfigCmd()
+	subs := make(map[string]bool)
+	for _, sc := range c.Commands() {
+		subs[sc.Name()] = true
+	}
+	if !subs["show"] {
+		t.Errorf("config is missing sub-verb 'show'")
+	}
+}
+
+// ---------- safety-critical: k8s.exec forwards command verbatim ----------
+
+// TestK8sExecForwardsCommandVerbatim — the most security-critical
+// invariant in the package. The CLI must pass the operator-supplied
+// kubectl command verbatim in params["command"], not pre-parse or
+// pre-validate. The backend handler
+// (`parse_kubectl_command` in ops_read.py) is the authoritative
+// safety gate; duplicating the check here would risk drift between
+// CLI and MCP code paths.
+//
+// This test pins three guarantees:
+//
+//  1. A safe kubectl command (`kubectl get pods`) lands on the wire
+//     in params["command"] verbatim.
+//  2. A shell-metacharacter payload (`kubectl get pods; rm -rf /`)
+//     ALSO lands on the wire verbatim — the CLI doesn't filter or
+//     refuse it client-side, the backend's metachar reject in
+//     `_SHELL_METACHARS_RE` is what fails the call (with
+//     `result_connector_error`). This is intentional: a client-side
+//     reject would mask whether the backend gate is firing.
+//  3. The connector_id is "holodeck-ssh-9.0" so the dispatch hits
+//     the correct typed-op surface (where the safety gate lives).
+func TestK8sExecForwardsCommandVerbatim(t *testing.T) {
+	cases := []struct {
+		name string
+		cmd  string
+	}{
+		{"safe verb", "kubectl get pods -n holodeck"},
+		{"metachar payload", "kubectl get pods; rm -rf /"},
+		{"complex flags", "kubectl --context=foo get pods -o yaml"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured map[string]any
+			srv := mockBackplane(t, map[string]mockHandler{
+				"POST /api/v1/operations/call": func(w http.ResponseWriter, r *http.Request) {
+					if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+						t.Errorf("decode body: %v", err)
+						w.WriteHeader(400)
+						return
+					}
+					writeJSON(t, w, 200, CallResult{Status: "ok", OpID: "holodeck.k8s.exec",
+						Result: json.RawMessage(`{"stdout":"","stderr":"","exit_status":0}`)})
+				},
+			})
+			defer srv.Close()
+			primeToken(t, srv.URL)
+
+			params := map[string]any{"command": tc.cmd}
+			if _, err := dispatchOp(context.Background(), srv.URL, "holodeck.k8s.exec", "holorouter-test", params); err != nil {
+				t.Fatalf("dispatchOp: %v", err)
+			}
+
+			if captured["connector_id"] != "holodeck-ssh-9.0" {
+				t.Errorf("connector_id drift: %v", captured["connector_id"])
+			}
+			gotParams, _ := captured["params"].(map[string]any)
+			if gotParams == nil {
+				t.Fatalf("missing params on wire: %v", captured)
+			}
+			if gotParams["command"] != tc.cmd {
+				t.Errorf("command not forwarded verbatim: got %q want %q",
+					gotParams["command"], tc.cmd)
+			}
+		})
+	}
+}
+
+// ---------- per-verb pretty printers ----------
+
+// TestPrintAboutRendersFields — printAbout writes the canonical field
+// set; regression against a future field-name drift.
+func TestPrintAboutRendersFields(t *testing.T) {
+	r := &CallResult{
+		Status:     "ok",
+		OpID:       "holodeck.about",
+		Result:     json.RawMessage(`{"vendor":"vmware","product":"holodeck","version":"9.0.0","build":"VMware Photon Linux 5.0","photon_version":"5.0","pod_id":"HoloPod-Alpha"}`),
+		DurationMs: 42,
+	}
+	var buf bytes.Buffer
+	printAbout(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"vmware", "holodeck", "9.0.0", "Photon", "HoloPod-Alpha"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printAbout output missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// TestPrintPodListRendersTable — printPodList writes the header row
+// and one data row for a single-pod result.
+func TestPrintPodListRendersTable(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		OpID:   "holodeck.pod.list",
+		Result: json.RawMessage(`{"rows":[{"Id":"HoloPod-001","Name":"lab-A","State":"Running","Network":"NSX-T-Tier-0"}],"total":1}`),
+	}
+	var buf bytes.Buffer
+	printPodList(&buf, r)
+	out := buf.String()
+	if !strings.Contains(out, "POD-ID") || !strings.Contains(out, "HoloPod-001") {
+		t.Errorf("printPodList output unexpected; got:\n%s", out)
+	}
+}
+
+// TestPrintPodListTruncatesAt20 — printPodList caps the human render
+// at 20 rows and appends a truncation note.
+func TestPrintPodListTruncatesAt20(t *testing.T) {
+	rows := make([]map[string]any, 25)
+	for i := range rows {
+		rows[i] = map[string]any{
+			"Id":      "HoloPod-" + string(rune('A'+i)),
+			"Name":    "pod",
+			"State":   "Running",
+			"Network": "net0",
+		}
+	}
+	rowsJSON, _ := json.Marshal(map[string]any{"rows": rows, "total": 25})
+	r := &CallResult{
+		Status: "ok",
+		OpID:   "holodeck.pod.list",
+		Result: json.RawMessage(rowsJSON),
+	}
+	var buf bytes.Buffer
+	printPodList(&buf, r)
+	out := buf.String()
+	if !strings.Contains(out, "more rows") {
+		t.Errorf("expected truncation note for 25 rows; got:\n%s", out)
+	}
+}
+
+// TestPrintK8sExecSafetyRejectSurfacesError — when the backend's
+// safety gate refuses the call, it returns status="ok" with an
+// inline `error` string in the result envelope. The human render
+// must surface that error string so the operator sees the rejection
+// without needing --json.
+func TestPrintK8sExecSafetyRejectSurfacesError(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		OpID:   "holodeck.k8s.exec",
+		Result: json.RawMessage(`{"stdout":"","stderr":"","exit_status":null,"error":"k8s.exec safety check: kubectl command rejected: shell metacharacter detected"}`),
+	}
+	var buf bytes.Buffer
+	printK8sExec(&buf, r)
+	out := buf.String()
+	if !strings.Contains(out, "metacharacter") {
+		t.Errorf("expected safety-reject error in human render; got:\n%s", out)
+	}
+}
+
+// TestPrintLogsTailRendersFiles — printLogsTail surfaces each matching
+// file under its own GNU-style header.
+func TestPrintLogsTailRendersFiles(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		OpID:   "holodeck.logs.tail",
+		Result: json.RawMessage(`{"files":[{"path":"/holodeck-runtime/logs/dhcp-server.log","lines":"event1\nevent2\n"}],"raw":"...","lines_requested":100}`),
+	}
+	var buf bytes.Buffer
+	printLogsTail(&buf, r)
+	out := buf.String()
+	if !strings.Contains(out, "==>") || !strings.Contains(out, "dhcp-server.log") {
+		t.Errorf("expected file header in human render; got:\n%s", out)
+	}
+}
+
+// TestPrintNetworkingShowRendersSections — printNetworkingShow surfaces
+// each of the four sub-sections (bgp, routes, dns, dhcp) with ok flags.
+func TestPrintNetworkingShowRendersSections(t *testing.T) {
+	r := &CallResult{
+		Status: "ok",
+		OpID:   "holodeck.networking.show",
+		Result: json.RawMessage(`{"bgp":{"summary_text":"BGP peer 10.0.0.1 Established\n","ok":true},"routes":{"text":"","ok":false},"dns":{"zones":[{"ZoneName":"holodeck.local","ZoneType":"Primary"}],"total":1,"ok":true},"dhcp":{"leases_text":"","ok":false}}`),
+	}
+	var buf bytes.Buffer
+	printNetworkingShow(&buf, r)
+	out := buf.String()
+	for _, want := range []string{"bgp:", "routes:", "dns:", "dhcp:", "holodeck.local"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printNetworkingShow output missing %q; got:\n%s", want, out)
+		}
+	}
+}

--- a/cli/internal/cmd/holodeck/k8s.go
+++ b/cli/internal/cmd/holodeck/k8s.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package holodeck
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newK8sCmd returns the `meho holodeck k8s` parent with one sub-verb:
+// `exec <kubectl-command>` (holodeck.k8s.exec).
+func newK8sCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "k8s",
+		Short:        "In-appliance K8s sub-verbs (exec — read-only)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newK8sExecCmd())
+	return cmd
+}
+
+// newK8sExecCmd returns the `meho holodeck k8s exec <kubectl-cmd>`
+// command.
+//
+// Maps to op_id `holodeck.k8s.exec`. Forwards a **read-only**
+// `kubectl` command to the K8s cluster bundled on the HoloRouter
+// appliance.
+//
+// SAFETY-CRITICAL: the CLI passes the operator-supplied command
+// argument **verbatim** into `params["command"]` of the typed op.
+// The CLI does NOT pre-parse, pre-validate, or sanitise that string
+// — the authoritative read-only safelist + shell-metacharacter
+// guard live on the backend handler
+// (`backend/src/meho_backplane/connectors/holodeck/ops_read.py::parse_kubectl_command`,
+// shipped by G3.8-T2 iter-2 #1005). Forwarding the raw string is the
+// correct behaviour: duplicating the gate on the client side risks
+// drift between CLI and MCP code paths the moment one tightens
+// without the other. The backend handler refuses with
+// `result_connector_error` if:
+//
+//   - the verb isn't on the read-only safelist (allowed: get,
+//     describe, logs, top, explain, api-resources, api-versions,
+//     cluster-info, version);
+//   - the command contains POSIX-shell metacharacters
+//     (`;` / `&&` / `||` / `|` / `$(...)` / backticks / `>` /
+//     `<` / newline / line continuation);
+//   - the schema-layer pattern rejects the shape (a guardrail in
+//     front of the handler-layer authoritative gate).
+//
+// Operators see the structured error in the CLI's exit-code-1
+// envelope; --json surfaces the full `error` string.
+func newK8sExecCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "exec <kubectl-command>",
+		Short: "Run a read-only kubectl command on the in-appliance K8s cluster",
+		Long: "exec dispatches holodeck.k8s.exec, forwarding the supplied\n" +
+			"kubectl command verbatim to the in-appliance K8s cluster on\n" +
+			"the HoloRouter appliance via plain SSH (no pwsh indirection).\n\n" +
+			"Read-only: only `get`, `describe`, `logs`, `top`, `explain`,\n" +
+			"`api-resources`, `api-versions`, `cluster-info`, and `version`\n" +
+			"verbs are accepted by the backend. Mutating verbs (create,\n" +
+			"apply, delete, edit, replace, patch, scale, rollout, label,\n" +
+			"annotate, cp, exec, port-forward, proxy, drain, cordon) and\n" +
+			"shell metacharacters (`;` / `&&` / `||` / `|` / `$(...)` /\n" +
+			"backticks / `>` / `<` / newline / line continuation) are\n" +
+			"refused at the backend with result_connector_error.\n\n" +
+			"The CLI does not pre-parse the command — the backend handler\n" +
+			"is the authoritative gate. The whole string is passed as\n" +
+			"params.command on the wire.\n\n" +
+			"The human render surfaces stdout + exit_status; stderr is\n" +
+			"shown when non-empty (capped at 4096 chars by the backend).\n" +
+			"--json emits the full OperationResult envelope.\n\n" +
+			"Quote the kubectl command so the shell hands it to meho as a\n" +
+			"single argv element. Examples below show the recommended\n" +
+			"quoting form.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied (safety reject or kubectl\n" +
+			"failure), 2=auth_expired, 3=unreachable, 4=unexpected.",
+		Example: "  meho holodeck k8s exec 'kubectl get pods -A' --target holorouter-hetzner-dc\n" +
+			"  meho holodeck k8s exec 'kubectl describe node holorouter-node-1' --target holorouter-hetzner-dc\n" +
+			"  meho holodeck k8s exec 'kubectl logs -n kube-system <pod>' --target holorouter-hetzner-dc --json",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runK8sExec(cmd, args[0], targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to dispatch against (required)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL from the most recent `meho login`)")
+	return cmd
+}
+
+func runK8sExec(
+	cmd *cobra.Command,
+	kubectlCommand, targetName string,
+	jsonOut bool,
+	backplaneOverride string,
+) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	// Pass the operator-supplied command verbatim. The backend handler
+	// owns the safety check; the CLI must not pre-parse or pre-validate
+	// to avoid drift with the authoritative gate.
+	params := map[string]any{"command": kubectlCommand}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "holodeck.k8s.exec", targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "holodeck.k8s.exec", r, jsonOut, printK8sExec)
+}
+
+func printK8sExec(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s holodeck.k8s.exec — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	flat, err := decodeFlatResult(r.Result)
+	if err != nil || flat == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	// Safety-reject path: the handler returns status="ok" with an
+	// inline error string when the safety check refused the verb.
+	// Surface the error string so the operator sees the rejection
+	// without needing --json.
+	if errStr, ok := flat["error"].(string); ok && errStr != "" {
+		fmt.Fprintf(w, "  error: %s\n", errStr)
+		return
+	}
+	exit, _ := flat["exit_status"].(float64)
+	fmt.Fprintf(w, "  exit_status: %d\n", int(exit))
+	if stdout, ok := flat["stdout"].(string); ok && stdout != "" {
+		fmt.Fprintln(w, "  stdout:")
+		for _, line := range splitLines(stdout) {
+			fmt.Fprintln(w, "    "+line)
+		}
+	}
+	if stderr, ok := flat["stderr"].(string); ok && stderr != "" {
+		fmt.Fprintln(w, "  stderr:")
+		for _, line := range splitLines(stderr) {
+			fmt.Fprintln(w, "    "+line)
+		}
+	}
+}

--- a/cli/internal/cmd/holodeck/logs.go
+++ b/cli/internal/cmd/holodeck/logs.go
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package holodeck
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newLogsCmd returns the `meho holodeck logs` parent with one
+// sub-verb: `tail <component>` (holodeck.logs.tail).
+func newLogsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "logs",
+		Short:        "Holodeck runtime log sub-verbs (tail)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newLogsTailCmd())
+	return cmd
+}
+
+// newLogsTailCmd returns the `meho holodeck logs tail <component>`
+// command.
+//
+// Maps to op_id `holodeck.logs.tail`. Runs `tail -n <lines>
+// /holodeck-runtime/logs/<component>*.log` over plain SSH (no pwsh
+// indirection) and returns the parsed tail envelope.
+//
+// The component slug is restricted on the backend to
+// `[A-Za-z0-9._-]+` so the resulting `tail` cmdline cannot smuggle
+// shell metacharacters or escape the `/holodeck-runtime/logs/` prefix
+// via a directory traversal. The CLI forwards the value verbatim and
+// the backend refuses misshapen slugs.
+//
+// The `--lines` flag is clamped on the backend to [1, 5000]; defaults
+// to 200.
+func newLogsTailCmd() *cobra.Command {
+	var (
+		targetName        string
+		lines             int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "tail <component>",
+		Short: "Tail Holodeck runtime log files for a given component",
+		Long: "tail dispatches holodeck.logs.tail and returns the last\n" +
+			"<lines> lines per matching log file under\n" +
+			"/holodeck-runtime/logs/<component>*.log on the appliance.\n\n" +
+			"Component slugs map to bundled services: `dhcp`, `dns`,\n" +
+			"`frr`, `webtop`, `k8s`. Allowed chars: [A-Za-z0-9._-]+.\n\n" +
+			"--lines defaults to 200; backend clamps to [1, 5000].\n\n" +
+			"The human render surfaces each matching file separately\n" +
+			"(GNU `tail` `==> path <==` headers). --json emits the full\n" +
+			"OperationResult envelope including the raw stdout.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example: "  meho holodeck logs tail dhcp --target holorouter-hetzner-dc\n" +
+			"  meho holodeck logs tail frr --lines 500 --target holorouter-hetzner-dc\n" +
+			"  meho holodeck logs tail dns --target holorouter-hetzner-dc --json | jq .result",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runLogsTail(cmd, args[0], lines, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to dispatch against (required)")
+	cmd.Flags().IntVar(&lines, "lines", 200,
+		"number of trailing lines to return per file (backend clamps to [1, 5000])")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL from the most recent `meho login`)")
+	return cmd
+}
+
+func runLogsTail(
+	cmd *cobra.Command,
+	component string,
+	lines int,
+	targetName string,
+	jsonOut bool,
+	backplaneOverride string,
+) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params := map[string]any{
+		"component": component,
+		"lines":     lines,
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "holodeck.logs.tail", targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "holodeck.logs.tail", r, jsonOut, printLogsTail)
+}
+
+func printLogsTail(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s holodeck.logs.tail — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	flat, err := decodeFlatResult(r.Result)
+	if err != nil || flat == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if errStr, ok := flat["error"].(string); ok && errStr != "" {
+		fmt.Fprintf(w, "  error: %s\n", errStr)
+		return
+	}
+	reqLines, _ := flat["lines_requested"].(float64)
+	fmt.Fprintf(w, "  lines_requested: %d\n", int(reqLines))
+	files, _ := flat["files"].([]any)
+	if len(files) == 0 {
+		fmt.Fprintln(w, "  (no matching log files)")
+		return
+	}
+	for _, fileEntry := range files {
+		entry, ok := fileEntry.(map[string]any)
+		if !ok {
+			continue
+		}
+		path := ""
+		if p, ok := entry["path"].(string); ok {
+			path = p
+		}
+		linesText, _ := entry["lines"].(string)
+		if path != "" {
+			fmt.Fprintf(w, "  ==> %s <==\n", path)
+		} else {
+			fmt.Fprintln(w, "  ==> (single-file tail) <==")
+		}
+		for _, line := range splitLines(linesText) {
+			fmt.Fprintln(w, "    "+line)
+		}
+	}
+}

--- a/cli/internal/cmd/holodeck/networking.go
+++ b/cli/internal/cmd/holodeck/networking.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package holodeck
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newNetworkingCmd returns the `meho holodeck networking` parent with
+// one sub-verb: `show` (holodeck.networking.show).
+func newNetworkingCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "networking",
+		Short:        "Holodeck networking sub-verbs (show)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newNetworkingShowCmd())
+	return cmd
+}
+
+// newNetworkingShowCmd returns the `meho holodeck networking show`
+// command.
+//
+// Maps to op_id `holodeck.networking.show`. Runs four sub-commands
+// over the pooled SSH connection on the appliance:
+//
+//  1. `vtysh -c 'show bgp summary'` (FRR/BGP peer summary).
+//  2. `vtysh -c 'show ip route'` (kernel routes as FRR sees them).
+//  3. `pwsh` of `Get-DnsServerZone | Select-Object ZoneName,ZoneType
+//     | ConvertTo-Json -Depth 4` (DNS zone summary).
+//  4. `cat /var/lib/dhcp/dhcpd.leases` (raw DHCP leases file).
+//
+// Returns the composed envelope with four narrative sub-sections.
+func newNetworkingShowCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "show",
+		Short: "Composite FRR/BGP + DNS + DHCP snapshot for the appliance",
+		Long: "show dispatches holodeck.networking.show and returns a\n" +
+			"composite envelope with four sub-sections:\n" +
+			"  - bgp     — FRR/BGP peer summary text (vtysh)\n" +
+			"  - routes  — kernel routing table text (vtysh)\n" +
+			"  - dns     — DNS zone summary (parsed JSON via pwsh)\n" +
+			"  - dhcp    — raw DHCP leases file content\n\n" +
+			"Each sub-section carries an `ok` boolean so a single-component\n" +
+			"failure does not blank the whole response. Pair with\n" +
+			"`meho holodeck logs tail frr` for FRR log drill-in.\n\n" +
+			"The human render lists each sub-section's ok flag and the\n" +
+			"first few lines of any text payload; --json emits the full\n" +
+			"OperationResult envelope.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example: "  meho holodeck networking show --target holorouter-hetzner-dc\n" +
+			"  meho holodeck networking show --target holorouter-hetzner-dc --json | jq .result.bgp",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runNetworkingShow(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to dispatch against (required)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL from the most recent `meho login`)")
+	return cmd
+}
+
+func runNetworkingShow(
+	cmd *cobra.Command,
+	targetName string,
+	jsonOut bool,
+	backplaneOverride string,
+) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "holodeck.networking.show", targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "holodeck.networking.show", r, jsonOut, printNetworkingShow)
+}
+
+func printNetworkingShow(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s holodeck.networking.show — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	flat, err := decodeFlatResult(r.Result)
+	if err != nil || flat == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	// BGP / routes / DHCP carry textual `summary_text` / `text` /
+	// `leases_text`; DNS carries a structured `zones` list + `total`.
+	renderTextSection(w, "bgp", flat["bgp"], "summary_text", 8)
+	renderTextSection(w, "routes", flat["routes"], "text", 8)
+	renderDNSSection(w, flat["dns"])
+	renderTextSection(w, "dhcp", flat["dhcp"], "leases_text", 6)
+}
+
+// renderTextSection prints a `{summary_text, ok}`-shaped sub-section
+// with a capped line preview. The first non-empty line count is
+// surfaced; --json gives operators full content.
+func renderTextSection(w io.Writer, label string, raw any, textKey string, previewLines int) {
+	section, ok := raw.(map[string]any)
+	if !ok || section == nil {
+		fmt.Fprintf(w, "  %s: (missing)\n", label)
+		return
+	}
+	okFlag, _ := section["ok"].(bool)
+	text, _ := section[textKey].(string)
+	if !okFlag {
+		fmt.Fprintf(w, "  %s: ok=false (empty / cmd failed)\n", label)
+		return
+	}
+	lines := splitLines(text)
+	limit := len(lines)
+	truncated := false
+	if limit > previewLines {
+		limit = previewLines
+		truncated = true
+	}
+	fmt.Fprintf(w, "  %s: ok=true (%d lines)\n", label, len(lines))
+	for _, line := range lines[:limit] {
+		fmt.Fprintln(w, "    "+line)
+	}
+	if truncated {
+		fmt.Fprintf(w, "    … (%d more lines — use --json to inspect all)\n", len(lines)-previewLines)
+	}
+}
+
+// renderDNSSection prints the `{zones, total, ok}` DNS sub-section.
+func renderDNSSection(w io.Writer, raw any) {
+	section, ok := raw.(map[string]any)
+	if !ok || section == nil {
+		fmt.Fprintln(w, "  dns: (missing)")
+		return
+	}
+	okFlag, _ := section["ok"].(bool)
+	total, _ := section["total"].(float64)
+	if !okFlag {
+		fmt.Fprintf(w, "  dns: ok=false (zones=%d)\n", int(total))
+		return
+	}
+	fmt.Fprintf(w, "  dns: ok=true (zones=%d)\n", int(total))
+	zones, _ := section["zones"].([]any)
+	for i, zone := range zones {
+		if i >= 10 {
+			fmt.Fprintf(w, "    … (%d more zones — use --json to inspect all)\n", len(zones)-10)
+			break
+		}
+		entry, ok := zone.(map[string]any)
+		if !ok {
+			continue
+		}
+		name := stringField(entry, "ZoneName")
+		ztype := stringField(entry, "ZoneType")
+		fmt.Fprintf(w, "    %-30s %s\n", name, ztype)
+	}
+}

--- a/cli/internal/cmd/holodeck/pod.go
+++ b/cli/internal/cmd/holodeck/pod.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package holodeck
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newPodCmd returns the `meho holodeck pod` parent with two sub-verbs:
+// `list` (holodeck.pod.list) and `info <pod-id>` (holodeck.pod.info).
+func newPodCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "pod",
+		Short:        "Holodeck nested-pod sub-verbs (list, info)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newPodListCmd())
+	cmd.AddCommand(newPodInfoCmd())
+	return cmd
+}
+
+// newPodListCmd returns the `meho holodeck pod list` command.
+//
+// Maps to op_id `holodeck.pod.list`. Runs `Get-HoloDeckPod |
+// ConvertTo-Json -Depth 4` over the pwsh-over-SSH transport and
+// returns a JSONFlux-shaped `{rows, total}` envelope. The JSONFlux
+// handle itself is the reducer's responsibility; the CLI surfaces
+// rows inline today.
+//
+// This is the 1:1 replacement for the consumer's
+// `./scripts/holodeck.sh --target holorouter 'pwsh -c
+// "Get-HoloDeckPod | Format-Table"'` invocation.
+func newPodListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List active Holodeck nested pods (Get-HoloDeckPod)",
+		Long: "list dispatches holodeck.pod.list and renders one row per\n" +
+			"active nested pod (pod ID / name / state / primary network /\n" +
+			"VM count). Returns the JSONFlux-shaped `{rows, total}`\n" +
+			"envelope; future JSONFlux reducer will spill large pod lists\n" +
+			"to the HandleStore via the standard result_describe /\n" +
+			"result_query flow.\n\n" +
+			"The human render caps at 20 rows; --json emits the full\n" +
+			"OperationResult envelope.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example: "  meho holodeck pod list --target holorouter-hetzner-dc\n" +
+			"  meho holodeck pod list --target holorouter-hetzner-dc --json | jq '.result.rows[]'",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runPodList(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to dispatch against (required)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL from the most recent `meho login`)")
+	return cmd
+}
+
+func runPodList(
+	cmd *cobra.Command,
+	targetName string,
+	jsonOut bool,
+	backplaneOverride string,
+) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "holodeck.pod.list", targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "holodeck.pod.list", r, jsonOut, printPodList)
+}
+
+func printPodList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s holodeck.pod.list — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	rows, err := decodeRowsResult(r.Result)
+	if err != nil || rows == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	limit := len(rows)
+	truncated := false
+	if limit > 20 {
+		limit = 20
+		truncated = true
+	}
+	fmt.Fprintf(w, "  %-20s %-20s %-10s %s\n", "POD-ID", "NAME", "STATE", "NETWORK")
+	for _, row := range rows[:limit] {
+		podID := stringField(row, "Id")
+		if podID == "" {
+			podID = stringField(row, "PodId")
+		}
+		name := stringField(row, "Name")
+		state := stringField(row, "State")
+		network := truncate(stringField(row, "Network"), 30)
+		fmt.Fprintf(w, "  %-20s %-20s %-10s %s\n",
+			truncate(podID, 20), truncate(name, 20), state, network)
+	}
+	if truncated {
+		fmt.Fprintf(w, "  … (%d more rows — use --json to inspect all)\n", len(rows)-20)
+	}
+	fmt.Fprintf(w, "  (%d pods total)\n", len(rows))
+}
+
+// newPodInfoCmd returns the `meho holodeck pod info <pod-id>` command.
+//
+// Maps to op_id `holodeck.pod.info`. Runs `Get-HoloDeckPod -Id '<id>'
+// | ConvertTo-Json -Depth 4` over the pwsh-over-SSH transport and
+// returns the single-pod detail dict (state, networking, VMs).
+//
+// pod-id is a positional argument so the command line reads
+// `meho holodeck pod info HoloPod-001 --target ...` like a normal
+// shell verb. The CLI does not interpolate the value into a shell
+// pipeline; the backend handler PowerShell-quotes it before
+// constructing the cmdlet (`Get-HoloDeckPod -Id '<id>'`).
+func newPodInfoCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "info <pod-id>",
+		Short: "Return per-pod detail (state, networking, VMs) for a Holodeck pod",
+		Long: "info dispatches holodeck.pod.info and returns the single-pod\n" +
+			"detail dict: state, networking (FRR/BGP attachment), and the\n" +
+			"embedded VM list with their power state. Use\n" +
+			"`meho holodeck pod list` first to enumerate available pod IDs.\n\n" +
+			"The human render pretty-prints the parsed dict; --json emits\n" +
+			"the full OperationResult envelope.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example: "  meho holodeck pod info HoloPod-001 --target holorouter-hetzner-dc\n" +
+			"  meho holodeck pod info HoloPod-001 --target holorouter-hetzner-dc --json | jq .result.pod",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPodInfo(cmd, args[0], targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to dispatch against (required)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL from the most recent `meho login`)")
+	return cmd
+}
+
+func runPodInfo(
+	cmd *cobra.Command,
+	podID, targetName string,
+	jsonOut bool,
+	backplaneOverride string,
+) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	params := map[string]any{"pod_id": podID}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "holodeck.pod.info", targetName, params)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "holodeck.pod.info", r, jsonOut, printPodInfo)
+}
+
+func printPodInfo(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s holodeck.pod.info — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	flat, err := decodeFlatResult(r.Result)
+	if err != nil || flat == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	if errStr, ok := flat["error"].(string); ok && errStr != "" {
+		fmt.Fprintf(w, "  error: %s\n", errStr)
+		return
+	}
+	pod, ok := flat["pod"].(map[string]any)
+	if !ok || pod == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	rawPod, _ := json.MarshalIndent(pod, "", "  ")
+	for _, line := range splitLines(string(rawPod)) {
+		fmt.Fprintln(w, "  "+line)
+	}
+}

--- a/cli/internal/cmd/holodeck/service.go
+++ b/cli/internal/cmd/holodeck/service.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package holodeck
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newServiceCmd returns the `meho holodeck service` parent with one
+// sub-verb: `list` (holodeck.service.list).
+func newServiceCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "service",
+		Short:        "Holodeck Photon service sub-verbs (list)",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newServiceListCmd())
+	return cmd
+}
+
+// newServiceListCmd returns the `meho holodeck service list` command.
+//
+// Maps to op_id `holodeck.service.list`. Runs `Get-Service |
+// Where-Object { $_.Name -like 'Holo*' } | Select-Object
+// Name,Status,DisplayName | ConvertTo-Json -Depth 4` over the
+// pwsh-over-SSH transport and returns a JSONFlux-shaped
+// `{rows, total}` envelope.
+func newServiceListCmd() *cobra.Command {
+	var (
+		targetName        string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List Holodeck Photon services and their status",
+		Long: "list dispatches holodeck.service.list and renders the bundled\n" +
+			"Holodeck Photon services (DHCP, DNS, NTP, FRR-BGP, Webtop,\n" +
+			"K8s-in-appliance) with their Status. Pair with\n" +
+			"`meho holodeck logs tail <component>` for drill-in.\n\n" +
+			"--json emits the full OperationResult envelope.\n\n" +
+			"Exit codes: 0=ok, 1=error/denied, 2=auth_expired,\n" +
+			"3=unreachable, 4=unexpected.",
+		Example: "  meho holodeck service list --target holorouter-hetzner-dc\n" +
+			"  meho holodeck service list --target holorouter-hetzner-dc --json | jq '.result.rows[]'",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runServiceList(cmd, targetName, jsonOut, backplaneOverride)
+		},
+	}
+	cmd.Flags().StringVar(&targetName, "target", "",
+		"target slug to dispatch against (required)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit the full OperationResult envelope as JSON")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL (defaults to the URL from the most recent `meho login`)")
+	return cmd
+}
+
+func runServiceList(
+	cmd *cobra.Command,
+	targetName string,
+	jsonOut bool,
+	backplaneOverride string,
+) error {
+	backplaneURL, err := resolveBackplane(backplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
+	}
+	r, err := dispatchOp(cmd.Context(), backplaneURL, "holodeck.service.list", targetName, nil)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	return renderCallResult(cmd, "holodeck.service.list", r, jsonOut, printServiceList)
+}
+
+func printServiceList(w io.Writer, r *CallResult) {
+	fmt.Fprintf(w, "%s holodeck.service.list — status=%s (%.0fms)\n",
+		ConnectorID, r.Status, r.DurationMs)
+	if r.Status != "ok" {
+		printErrorTrailer(w, r)
+		return
+	}
+	rows, err := decodeRowsResult(r.Result)
+	if err != nil || rows == nil {
+		fallbackResultRender(w, r)
+		return
+	}
+	fmt.Fprintf(w, "  %-20s %-12s %s\n", "NAME", "STATUS", "DISPLAY-NAME")
+	for _, row := range rows {
+		name := stringField(row, "Name")
+		status := stringField(row, "Status")
+		display := truncate(stringField(row, "DisplayName"), 48)
+		fmt.Fprintf(w, "  %-20s %-12s %s\n",
+			truncate(name, 20), status, display)
+	}
+	fmt.Fprintf(w, "  (%d services)\n", len(rows))
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/evoila/meho/cli/internal/cmd/gcloud"
 	"github.com/evoila/meho/cli/internal/cmd/harbor"
 	hetznerrobot "github.com/evoila/meho/cli/internal/cmd/hetzner-robot"
+	"github.com/evoila/meho/cli/internal/cmd/holodeck"
 	"github.com/evoila/meho/cli/internal/cmd/k8s"
 	"github.com/evoila/meho/cli/internal/cmd/kb"
 	"github.com/evoila/meho/cli/internal/cmd/memory"
@@ -345,6 +346,29 @@ func newRootCmd() *cobra.Command {
 	// Registered before registerDynamicSubcommands so the backplane manifest
 	// cannot shadow the built-in `hetzner-robot` parent.
 	root.AddCommand(hetznerrobot.NewRootCmd())
+
+	// G3.8-T3 (#855) -- holodeck-ssh-9.0 operator alias verbs for
+	// Initiative #371 (G3.8 Holodeck typed-SSH connector — closes the G3
+	// wrapper-retirement story per Goal #214). The verb tree pre-bakes
+	// connector_id="holodeck-ssh-9.0" on top of the existing
+	// /api/v1/operations/call dispatcher route so operators don't type
+	// the connector ID on every invocation. Ships the 8 read-only ops
+	// (about, config show, pod list/info, service list, k8s exec
+	// (read-only), logs tail, networking show) registered by G3.8-T1/T2
+	// (#853/#854). `meho holodeck pod list --target holorouter` replaces
+	// the consumer's `holodeck.sh --target holorouter 'pwsh -c
+	// "Get-HoloDeckPod | Format-Table"'` invocation 1:1. The sister
+	// `clone-holodeck-instance.sh` wrapper (multi-step nested-lab
+	// bring-up) stays in the wrapper for v0.2 and surfaces as a Runbook
+	// in a future Goal G11 per docs/cross-repo/holodeck-onboarding.md.
+	// IMPORTANT: the holodeck.k8s.exec CLI verb forwards the
+	// operator-supplied kubectl command verbatim; the read-only safelist
+	// + shell-metacharacter guard live on the backend handler
+	// (parse_kubectl_command). Duplicating the gate client-side would
+	// risk drift with the authoritative backend gate.
+	// Registered before registerDynamicSubcommands so the backplane
+	// manifest cannot shadow the built-in `holodeck` parent.
+	root.AddCommand(holodeck.NewRootCmd())
 
 	// G3.6-T12 (#840) -- vcfa-rest-9.0 operator alias verbs for
 	// Initiative #369. The verb tree pre-bakes connector_id=

--- a/docs/cross-repo/holodeck-onboarding.md
+++ b/docs/cross-repo/holodeck-onboarding.md
@@ -1,0 +1,452 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# Holodeck op surface onboarding — operator recipe
+
+> Operator-facing recipe for the G3.8 `holodeck-ssh-9.0` op surface —
+> the `meho holodeck …` verb tree, the agent meta-tool path, and the
+> migration off the consumer's `scripts/holodeck.sh` wrapper. The op
+> handlers live in
+> [`backend/src/meho_backplane/connectors/holodeck/`](../../backend/src/meho_backplane/connectors/holodeck/);
+> the engineering-facing companion is
+> [`docs/codebase/connectors-holodeck.md`](../codebase/connectors-holodeck.md)
+> (if present). This doc is the cookbook every RDC operator reads when
+> retiring the bash wrapper in favour of `meho holodeck …`.
+
+## What this surface is
+
+The `holodeck-ssh-9.0` connector is a **typed** connector: hand-coded
+handlers over `asyncssh`, registered into the G0.6
+`endpoint_descriptor` table at backplane startup. It dispatches under
+the `(product="holodeck", version="9.0", impl_id="holodeck-ssh")`
+registry triple — the connector id `holodeck-ssh-9.0`.
+
+The `-ssh` discriminator in the impl_id leaves room for a future
+`holodeck-rest-9.x` sibling without breaking the resolver's tie-break
+ladder; **Holodeck has no REST API today**. Every Holodeck cmdlet runs
+through `pwsh -EncodedCommand <b64-utf16le>` over the pooled SSH
+connection; every shell command (`kubectl`, `vtysh`, `tail`,
+`cat /var/lib/dhcp/dhcpd.leases`) runs over plain SSH on the same
+appliance. This is the canonical SSH-only target in the inventory.
+
+The v0.1 op surface (Initiative
+[#371](https://github.com/evoila/meho/issues/371)) is the read-only
+working set operators use for nested-lab inspection:
+
+| Group | Ops | Class |
+| --- | --- | --- |
+| `identity` | `holodeck.about` | read-only fingerprint |
+| `config` | `holodeck.config.show` | read-only config dict |
+| `pod` | `holodeck.pod.list`, `holodeck.pod.info` | read-only |
+| `service` | `holodeck.service.list` | read-only |
+| `k8s` | `holodeck.k8s.exec` | read-only (verb safelisted) |
+| `logs` | `holodeck.logs.tail` | read-only |
+| `networking` | `holodeck.networking.show` | read-only composite |
+
+Eight ops total. Every op dispatches through the same
+`POST /api/v1/operations/call` route the agent surface uses — auth,
+policy, audit, broadcast, and JSONFlux all run as documented in
+[CLAUDE.md](../../CLAUDE.md) §6. The CLI verb tree is operator
+ergonomics over that one route; it is **not** a separate data path
+and is **not** mirrored on the MCP surface (CLAUDE.md postulate 5 —
+the agent reaches every Holodeck op via the narrow-waist meta-tools,
+see the [agent meta-tool path](#the-agent-meta-tool-path) section).
+
+## Pod-clone stays on the wrapper (deferred to G11)
+
+This onboarding doc covers the **inspection** surface only —
+`scripts/holodeck.sh` is fully replaced by `meho holodeck …`. The
+**sister wrapper**
+[`scripts/clone-holodeck-instance.sh`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/scripts/clone-holodeck-instance.sh)
+covers multi-step nested-lab provisioning end-to-end (validate templates
+→ reserve resources → boot sequence → post-provision validation).
+
+**Pod-clone explicitly stays in the wrapper for v0.2.** Per Initiative
+#371 §6 ("Pod-clone op as a separate v0.2.next consideration"), the
+multi-step orchestration belongs in a future **Runbooks** Initiative
+under Goal G11 (per the v0.1 spec sequencing) once the runbook engine
+ships. The decomposition runs roughly:
+
+| Step in `clone-holodeck-instance.sh` | Future runbook composition |
+| --- | --- |
+| Validate source pod state | `holodeck.pod.info` (already shipped) |
+| Reserve resources on appliance | New `holodeck.pod.reserve` op (G11) |
+| Boot nested-lab sequence | Multi-step runbook + `holodeck.pod.clone` (G11) |
+| Post-provision validation | `holodeck.networking.show` + `holodeck.service.list` (already shipped) |
+
+The inspection ops shipped today (G3.8) are the **read primitives a
+future runbook composes against**. The standalone wrapper stays in
+place; the runbook lands when the engine ships. No further action is
+required of operators today.
+
+## Prerequisites
+
+- **An SSH-reachable HoloRouter 9.0 appliance.** The connector talks
+  Holodeck over SSH using `asyncssh`. The target must run Holodeck
+  Toolkit 9.x on Photon OS 4.x / 5.x and expose port 22 with root SSH
+  enabled.
+- **Auth: password-default + key-fallback.** The HoloRouter OVA ships
+  with `root` password auth enabled by default; the connector reads
+  the password from Vault at `secret_ref.password`. If you've added an
+  SSH key on the appliance and stored its private half in Vault at
+  `secret_ref.ssh_private_key`, the connector prefers key auth
+  (mirroring the wrapper's `PreferredAuthentications=publickey,password`
+  behaviour). Either is supported; password is the v0.2 default.
+- **`pwsh` installed on the appliance.** Holodeck cmdlets reach the
+  appliance through `pwsh -EncodedCommand` so PowerShell 7+ must be on
+  the appliance's `$PATH`. HoloRouter 9.0 OVAs ship `pwsh`
+  pre-installed.
+- **The bundled Holodeck services running.** The probe asserts
+  `Get-Service | Where-Object { $_.Name -like 'Holo*' }` returns each
+  service in `Running` state. A `holodeck_services_down` probe means
+  one of DHCP / DNS / NTP / FRR-BGP / Webtop / K8s-in-appliance is
+  Stopped.
+- **A registered Holodeck target.** The CLI verbs take `--target <slug>`.
+  The slug resolves server-side to a row in the `targets` table. The
+  target carries `product="holodeck"`, `host`, `port` (optional,
+  defaults to 22), `secret_ref` (Vault path), and `auth_model`.
+- **`auth_model = shared_service_account`** — the only auth model v0.2
+  ships. The connector reads the SSH credential out of `secret_ref`
+  (resolved from Vault); both password auth (default) and key auth
+  (fallback) are supported.
+- **An operator session.** `meho login <backplane-url>` writes the
+  session token the CLI reuses across every verb.
+
+## Target + auth model — Vault credential setup
+
+The shipped connector's auth model is `shared_service_account` over
+either SSH password auth (the HoloRouter OVA default) or SSH key auth.
+The credential is stored in Vault at a per-host path under the operator
+tenant's KV-v2 mount, then materialized onto the target row's
+`secret_ref` column.
+
+### Password auth (the v0.2 default)
+
+The HoloRouter OVA ships root password auth enabled; operators
+typically have not installed SSH keys on the appliance.
+
+```console
+$ meho vault kv put --target rdc-vault secret \
+    rdc-hetzner-dc/holodeck/holorouter-01 \
+    --data @holodeck_secret_ref.json
+```
+
+`holodeck_secret_ref.json` shape:
+
+```json
+{
+  "username": "root",
+  "password": "<HoloRouter OVA root password>"
+}
+```
+
+### Key auth (fallback when SSH keys are installed)
+
+If you've added the operator's public key to `/root/.ssh/authorized_keys`
+on the appliance and want to retire password auth, swap in:
+
+```json
+{
+  "username": "root",
+  "ssh_private_key": "<PEM-encoded OpenSSH private key>"
+}
+```
+
+The `ssh_private_key` value is the contents of the private-key file as
+a single JSON string with literal `\n` newlines, `BEGIN` / `END`
+headers, and the trailing newline. `asyncssh`'s `import_private_key`
+parses Ed25519, ECDSA, RSA, and OpenSSH-format PEM keys. When both
+fields are present in the Vault secret, the connector prefers the key
+(matching the wrapper's `PreferredAuthentications=publickey,password`
+order).
+
+### Registering the target
+
+```console
+$ meho targets create \
+    --name holorouter-hetzner-dc \
+    --product holodeck \
+    --host 10.5.20.1 \
+    --port 22 \
+    --secret-ref secret/rdc-hetzner-dc/holodeck/holorouter-01 \
+    --auth-model shared_service_account
+```
+
+Verify the target is reachable:
+
+```console
+$ meho targets probe holorouter-hetzner-dc
+ok — holodeck 9.0.0 reachable; Photon 5.0 healthy; Holo* services Running
+
+$ meho holodeck about --target holorouter-hetzner-dc
+holodeck-ssh-9.0 holodeck.about — status=ok (124ms)
+  vendor:          vmware
+  product:         holodeck
+  version:         9.0.0
+  build:           VMware Photon Linux 5.0
+  photon_version:  5.0
+  pod_id:          HoloPod-Alpha
+```
+
+`probe` exercises the four-bucket failure ladder per Initiative #371:
+
+| `reason` | Meaning | Operator remediation |
+| --- | --- | --- |
+| `tcp_unreachable` | SSH socket can't connect | check host, firewall, port 22 |
+| `ssh_auth_failed` | credentials rejected or handshake failed | check `secret_ref` password / key in Vault |
+| `photon_unhealthy` | SSH ok but `/etc/photon-release` empty / non-zero exit | non-Photon target or corrupt appliance image |
+| `holodeck_services_down` | Photon ok but `Get-Service Holo*` shows a non-Running service | log onto the appliance, `Restart-Service` the affected unit |
+
+## Known gotchas
+
+### Holodeck has no REST API — every op goes over SSH
+
+Unlike the rest of the v0.3 connector inventory (vSphere REST, NSX,
+SDDC Manager, vCF, …) the Holodeck appliance exposes no HTTP control
+surface. Every op in this connector dispatches through SSH:
+
+- **Cmdlet ops** (`about`, `config show`, `pod list/info`, `service list`)
+  go through `pwsh -NoProfile -NonInteractive -EncodedCommand <b64>`
+  where the base64 payload is the UTF-16LE bytes of the PowerShell
+  script. Output is piped through `ConvertTo-Json` and parsed by the
+  backend with stdlib `json`. There is no CliXml dependency — the
+  Initiative #371 design correction (2026-05-21) supersedes the
+  original CliXml note in favour of `ConvertTo-Json`.
+- **Shell ops** (`k8s exec`, `logs tail`, `networking show`'s
+  `vtysh` / `cat` sub-commands) go over plain SSH with no `pwsh`
+  indirection.
+
+The agent-facing `llm_instructions` on every op spells this out so an
+LLM doesn't compose against a non-existent REST surface.
+
+### `holodeck.k8s.exec` is read-only — verbs are safelisted
+
+The `kubectl` command operators pass to `meho holodeck k8s exec` is
+forwarded **verbatim** to the backend. The backend handler
+(`parse_kubectl_command` in `ops_read.py`) is the authoritative gate
+and enforces two complementary defences:
+
+1. **Verb safelist.** Only `get`, `describe`, `logs`, `top`, `explain`,
+   `api-resources`, `api-versions`, `cluster-info`, and `version` are
+   accepted. Mutating verbs (`create`, `apply`, `delete`, `edit`,
+   `replace`, `patch`, `scale`, `rollout`, `label`, `annotate`,
+   `cp`, `exec`, `port-forward`, `proxy`, `drain`, `cordon`) are
+   refused with `result_connector_error`.
+2. **Shell-metacharacter reject.** Any command containing `;`, `&&`,
+   `||`, `|`, `$(...)`, backticks, `>`, `<`, newline, or line
+   continuation is refused **before** any SSH traffic happens. The
+   reject is load-bearing because `shlex.split` in POSIX mode does
+   not treat these as token boundaries, so `kubectl get pods; rm -rf /`
+   would otherwise tokenise to `['kubectl', 'get', 'pods;', ...]` —
+   the verb-safelist check would see `'get'` and approve, and the raw
+   string would land at the appliance shell. The metachar reject
+   closes that hole.
+
+If you need a verb that's not on the safelist, file a follow-up — do
+not work around the safety check at the CLI layer. The CLI is
+deliberately a pure forwarder so the safety gate has one location.
+
+### Holodeck cmdlets need `Get-HoloDeckModule` to be loaded
+
+The appliance's `pwsh` profile imports the Holodeck cmdlet module on
+session start. If the bundled module is uninstalled or its path is
+wrong, every cmdlet op will return `pwsh -EncodedCommand exited with
+status 1` and the operator-facing surface will fail with a connector
+error.
+
+Log onto the appliance and confirm `Get-Module -ListAvailable Holodeck`
+shows the module; reinstall via the Holodeck Toolkit OVA refresh if
+missing.
+
+### `holodeck.networking.show` per-section `ok` flag
+
+The networking composite runs four sub-commands and folds each into a
+`{ok, …}` sub-section. A `bgp.ok=false` means the `vtysh` sub-command
+returned empty or failed — not that BGP is broken. Use
+`meho holodeck logs tail frr` to drill into the FRR log if BGP shows
+`ok=false`.
+
+### Pod-clone is NOT covered by `meho holodeck`
+
+If you need to spin up a fresh nested lab, **continue to use
+`scripts/clone-holodeck-instance.sh`** for now. This is the explicit
+deferral in Initiative #371 §6 — multi-step orchestration belongs in a
+Runbooks Initiative (future Goal G11) once the runbook engine ships.
+The standalone wrapper stays in place. Inspect with `meho holodeck`;
+provision with the wrapper.
+
+## The CLI verb surface
+
+Every verb pre-bakes `connector_id="holodeck-ssh-9.0"` so operators
+never type the connector id. All verbs accept `--target <slug>`
+(required), `--json` (emit the full `OperationResult` envelope for
+`jq`), and `--backplane <url>` (override the URL from the last
+`meho login`). Exit codes mirror `meho operation call` (0=ok,
+1=error/denied, 2=auth_expired, 3=unreachable, 4=unexpected).
+
+### Identity — `meho holodeck about`
+
+```console
+$ meho holodeck about --target holorouter-hetzner-dc
+$ meho holodeck about --target holorouter-hetzner-dc --json | jq .result
+```
+
+Returns vendor / product / version / build / photon_version / pod_id
+from `/etc/photon-release` + `Get-HoloDeckConfig`. Use before issuing
+higher-level ops to confirm reachability + version.
+
+### Config — `meho holodeck config show`
+
+```console
+$ meho holodeck config show --target holorouter-hetzner-dc
+$ meho holodeck config show --target holorouter-hetzner-dc --json | jq .result.config
+```
+
+Returns the full `Get-HoloDeckConfig` dict (vendor + product + pod ID
++ services block). For just the identifying fields, prefer
+`meho holodeck about` (fewer fields, slightly faster).
+
+### Pod — `meho holodeck pod list` / `info <id>`
+
+```console
+# 1:1 replacement for ./scripts/holodeck.sh --target holorouter
+#   'pwsh -c "Get-HoloDeckPod | Format-Table"'
+$ meho holodeck pod list --target holorouter-hetzner-dc
+
+# Drill into a single pod
+$ meho holodeck pod info HoloPod-001 --target holorouter-hetzner-dc
+$ meho holodeck pod info HoloPod-001 --target holorouter-hetzner-dc --json | jq .result.pod
+```
+
+`list` runs `Get-HoloDeckPod | ConvertTo-Json -Depth 4` and surfaces
+the JSONFlux-shaped `{rows, total}` envelope (rows inline today; a
+future JSONFlux reducer will spill large pod lists via the standard
+`result_describe` / `result_query` flow).
+
+`info` runs `Get-HoloDeckPod -Id '<id>' | ConvertTo-Json -Depth 4` and
+returns the single-pod detail dict (state, networking, VMs).
+
+### Service — `meho holodeck service list`
+
+```console
+$ meho holodeck service list --target holorouter-hetzner-dc
+$ meho holodeck service list --target holorouter-hetzner-dc --json \
+    | jq '.result.rows[] | select(.Status != "Running")'
+```
+
+Runs `Get-Service | Where-Object { $_.Name -like 'Holo*' } |
+Select-Object Name,Status,DisplayName | ConvertTo-Json -Depth 4`.
+Pair with `meho holodeck logs tail <component>` for drill-in.
+
+### K8s — `meho holodeck k8s exec '<cmd>'`
+
+```console
+$ meho holodeck k8s exec 'kubectl get pods -A' --target holorouter-hetzner-dc
+$ meho holodeck k8s exec 'kubectl describe node holorouter-node-1' --target holorouter-hetzner-dc
+$ meho holodeck k8s exec 'kubectl logs -n kube-system <pod>' --target holorouter-hetzner-dc --json
+```
+
+Forwards the supplied `kubectl` invocation verbatim to the in-appliance
+K8s cluster via plain SSH. **Read-only** — verbs and shell metacharacters
+are policed on the backend; see [Known gotchas](#holodeckk8sexec-is-read-only--verbs-are-safelisted).
+Always single-quote the kubectl command so it lands in `meho`'s argv as
+one element.
+
+### Logs — `meho holodeck logs tail <component>`
+
+```console
+$ meho holodeck logs tail dhcp --target holorouter-hetzner-dc
+$ meho holodeck logs tail frr --lines 500 --target holorouter-hetzner-dc
+$ meho holodeck logs tail dns --target holorouter-hetzner-dc --json | jq -r '.result.files[].lines'
+```
+
+Runs `tail -n <lines> /holodeck-runtime/logs/<component>*.log` over
+plain SSH. Component slugs map to the bundled services: `dhcp`, `dns`,
+`frr`, `webtop`, `k8s`. Allowed chars: `[A-Za-z0-9._-]+` (backend
+rejects anything else). `--lines` defaults to 200; backend clamps to
+[1, 5000].
+
+### Networking — `meho holodeck networking show`
+
+```console
+$ meho holodeck networking show --target holorouter-hetzner-dc
+$ meho holodeck networking show --target holorouter-hetzner-dc --json | jq .result.bgp
+```
+
+Composes FRR/BGP peer summary (`vtysh -c 'show bgp summary'`) + kernel
+routes (`vtysh -c 'show ip route'`) + DNS zone summary
+(`Get-DnsServerZone | ConvertTo-Json`) + DHCP leases
+(`cat /var/lib/dhcp/dhcpd.leases`) into one envelope with per-section
+`ok` flags. Each sub-command's failure is isolated — a `vtysh` crash on
+the BGP summary path doesn't blank the DNS or DHCP sub-sections.
+
+## The agent meta-tool path
+
+Per CLAUDE.md postulate 5, these CLI verbs are **operator-only
+ergonomics** — they are not mirrored on the MCP surface. Agents reach
+Holodeck ops via the same narrow-waist `search_operations` +
+`call_operation` meta-tools used for every other connector:
+
+```
+search_operations(connector_id="holodeck-ssh-9.0", query="pod list")
+→ [{"op_id": "holodeck.pod.list", "summary": "List the active Holodeck nested pods.", ...}]
+
+call_operation(op_id="holodeck.pod.list", target={"name": "holorouter-hetzner-dc"}, params={})
+→ OperationResult{status="ok", result={"rows": [...], "total": 3}}
+```
+
+The `llm_instructions` on each op provide agent-readable guidance.
+Every op's `when_to_use` carries the canonical SSH-only transport note
+so agents don't compose against a non-existent REST surface:
+
+> Holodeck has no REST API; the underlying transport is
+> PowerShell-over-SSH (pwsh -EncodedCommand routed through asyncssh)
+> for cmdlet ops, plain SSH for kubectl / shell-pipeline ops.
+
+| Op | `when_to_use` summary |
+| --- | --- |
+| `holodeck.about` | Identify Holodeck version + confirm SSH/pwsh reachability |
+| `holodeck.config.show` | Full Get-HoloDeckConfig snapshot (vendor + pod ID + services block) |
+| `holodeck.pod.list` | Inventory the active nested pods on the appliance |
+| `holodeck.pod.info` | Per-pod detail (state, networking, VMs) |
+| `holodeck.service.list` | Bundled Holodeck Photon services + their Status |
+| `holodeck.k8s.exec` | Read-only kubectl inspection of the in-appliance K8s cluster |
+| `holodeck.logs.tail` | Tail `/holodeck-runtime/logs/<component>*.log` per service |
+| `holodeck.networking.show` | Composite FRR/BGP + DNS + DHCP snapshot |
+
+## Wrapper-flip recipe — retiring `scripts/holodeck.sh`
+
+The consumer's `scripts/holodeck.sh` wrapper calls `pwsh` cmdlets and
+plain shell commands over SSH with hard-coded credentials. Replace each
+invocation with the `meho holodeck` verb:
+
+| Old `holodeck.sh` invocation | New `meho holodeck` equivalent |
+| --- | --- |
+| `./scripts/holodeck.sh --target T 'pwsh -c "Get-HoloDeckConfig"'` | `meho holodeck config show --target T` |
+| `./scripts/holodeck.sh --target T 'pwsh -c "Get-HoloDeckPod \| Format-Table"'` | `meho holodeck pod list --target T` |
+| `./scripts/holodeck.sh --target T "pwsh -c 'Get-HoloDeckPod -Id <id>'"` | `meho holodeck pod info <id> --target T` |
+| `./scripts/holodeck.sh --target T 'pwsh -c "Get-Service Holo*"'` | `meho holodeck service list --target T` |
+| `./scripts/holodeck.sh --target T 'kubectl get pods -A'` | `meho holodeck k8s exec 'kubectl get pods -A' --target T` |
+| `./scripts/holodeck.sh --target T 'tail -n 200 /holodeck-runtime/logs/dhcp*.log'` | `meho holodeck logs tail dhcp --target T` |
+| `./scripts/holodeck.sh --target T 'vtysh -c "show bgp summary"'` | `meho holodeck networking show --target T` (composite) |
+
+Once every calling site in `evoila-bosnia/claude-rdc-hetzner-dc` is
+migrated:
+
+1. Add the Holodeck target with `meho targets create` (see above).
+2. Store the SSH credential in Vault with `meho vault kv put`.
+3. Run `meho targets probe holorouter-hetzner-dc` to confirm
+   end-to-end connectivity.
+4. Remove `scripts/holodeck.sh` from the consumer repo and update any
+   CI or runbook references.
+5. **Leave `scripts/clone-holodeck-instance.sh` in place** — pod-clone
+   is the deferred multi-step Runbook (Goal G11; see
+   [Pod-clone stays on the wrapper](#pod-clone-stays-on-the-wrapper-deferred-to-g11)).
+
+## Goal #214 G3.8 Holodeck checklist
+
+- [x] G3.8-T1 (#853) — Holodeck connector skeleton + `_pwsh.py` (ConvertTo-Json) + registry v2
+- [x] G3.8-T2 (#854) — Holodeck 7 typed read ops + read-only kubectl with two-layer shell-injection defence
+- [x] G3.8-T3 (#855) — Holodeck CLI verbs + MCP review (SSH-only transport copy) + recorded-fixture/asyncssh E2E + this onboarding doc


### PR DESCRIPTION
## Summary

- Operator-facing closer for Goal #214 G3.8 Initiative #371 — the
  typed-SSH Holodeck connector. Final Task in the linear T1 → T2 → T3
  chain. Closes the G3 wrapper-retirement story.
- Adds `cli/internal/cmd/holodeck/` — 8 Cobra verbs (`about`,
  `config show`, `pod list/info`, `service list`, `k8s exec`,
  `logs tail`, `networking show`) mirroring the `cli/internal/cmd/pfsense/`
  precedent. `meho holodeck pod list --target holorouter` replaces the
  consumer's `./scripts/holodeck.sh --target holorouter 'pwsh -c
  "Get-HoloDeckPod | Format-Table"'` 1:1.
- MCP review: hoisted `SSH_TRANSPORT_NOTE` from `ops_read.py` into
  `ops.py` so the T1 canary op (`holodeck.about`) shares the same
  "Holodeck has no REST API; transport is PowerShell-over-SSH" string
  with the 7 T2 read ops. Regression-tested.
- Adds `backend/tests/test_connectors_holodeck_e2e.py` — recorded-
  fixture / asyncssh fake-shell E2E mirroring G3.7's precedents
  (#1004's `test_connectors_pfsense_e2e.py` and
  `test_connectors_gcloud_e2e.py`). 17 tests cover registration shape,
  per-op dispatch, the `holodeck.pod.list` JSONFlux handle path,
  audit-row emission, and a load-bearing regression for the iter-2
  shell-injection reject (`k8s.exec` metachar payload refused before
  SSH traffic).
- Adds `docs/cross-repo/holodeck-onboarding.md` — operator recipe with
  Vault setup, the wrapper-flip table, the agent meta-tool path, and
  the **explicit deferral note** that pod-clone (multi-step nested-lab
  bring-up via `clone-holodeck-instance.sh`) stays in the wrapper for
  v0.2 and surfaces as a Runbook in a future Goal G11.
- Goal #214 G3.8 checklist line ticked via separate `gh api` PATCH
  (PR body amendments are body-only mutations on the parent Goal).

## Safety-critical: `holodeck.k8s.exec` defenses preserved

The CLI passes the operator-supplied `kubectl` command **verbatim**
into `params["command"]`. The CLI does NOT pre-parse, pre-validate, or
sanitise — the authoritative read-only safelist +
shell-metacharacter guard live on the backend handler
(`parse_kubectl_command` in `ops_read.py`, shipped by T2 iter-2 #1005).
Duplicating the gate client-side would risk drift between CLI and MCP
paths. The Go test suite pins this with
`TestK8sExecForwardsCommandVerbatim` (three cases: safe verb,
metachar payload, complex global flags); the Python E2E suite pins
the backend-side metachar reject with
`test_holodeck_e2e_k8s_exec_metachar_rejected`.

## CLI snapshot freshness

`cd cli && make snapshot-openapi && make generate` produces no diff —
the new CLI verbs POST to the existing `/api/v1/operations/call`
route. `cli/api/openapi.json` and `cli/internal/api/client.gen.go`
are unchanged.

## Test plan

- [x] `ruff check src/meho_backplane/connectors/holodeck/ tests/test_connectors_holodeck_e2e.py` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/holodeck/` — Success, 5 files
- [x] `pytest tests/test_connectors_holodeck_*` — 202 passed (185 unit + 17 E2E)
- [x] `go test ./cli/...` — all packages pass (cmd/holodeck race-clean)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers, 5 pre-existing warnings on T2 surface
- [x] Acceptance criterion (a): `meho holodeck --help` lists 7 verbs; each verb POSTs to `/api/v1/operations/call` with the right `op_id` (Go test `TestAllOpsUseCanonicalOpIDs` asserts)
- [x] Acceptance criterion (b): E2E file passes with no Docker dependency (asyncssh in-process + SQLite via the autouse conftest fixture)
- [x] Acceptance criterion (c): `holodeck.pod.list` JSONFlux handle path asserted via `JsonFluxReducer(row_threshold=0)` in `test_holodeck_e2e_pod_list_jsonflux_handle`
- [x] Acceptance criterion (d): every op writes a `DISPATCH` audit row with `op_id` + `target_id` + `params_hash`, asserted in `test_holodeck_e2e_all_ops_write_audit_rows`
- [x] Acceptance criterion (e): `docs/cross-repo/holodeck-onboarding.md` shipped with the pod-clone-stays-wrapper / Runbook-in-G11 note
- [x] Goal #214 G3.8 checklist line ticked (separate body PATCH; not part of this code PR's diff)

## Out of scope

- Pod-clone (multi-step nested-lab provisioning via
  `clone-holodeck-instance.sh`) — deferred to a future Runbooks
  Initiative under Goal G11 per Initiative #371 §6 and the new
  onboarding doc.
- Write ops on the Holodeck cmdlet surface (`Set-*` / `New-*` /
  `Remove-*`) — v0.2 ships the inspection surface only.
- `holodeck.k8s.exec` write verbs — read-only safelist deliberately
  pinned at T2's iter-2 (`get`/`describe`/`logs`/`top`/`explain`/
  `api-resources`/`api-versions`/`cluster-info`/`version`). Mutating
  verbs file as follow-ups if needed.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #855
