### PR TITLE
feat(audit): G8.2-T1 audit_log.agent_session_id column + index + AuditLog ORM field

### DIFF
--- a/backend/alembic/versions/0014_add_audit_log_agent_session_id.py
+++ b/backend/alembic/versions/0014_add_audit_log_agent_session_id.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add ``audit_log.agent_session_id`` for MCP-session audit correlation.
+
+Revision ID: 0014
+Revises: 0013
+Create Date: 2026-05-24
+
+This migration is the schema foundation of Task #1009 (G8.2-T1 audit
+replay) under Initiative #377. It carries the column every other G8.2
+task reads or writes, but ships **no write path** -- the column lands
+NULL on every row until #1009's sibling T2 wires the MCP
+``Mcp-Session-Id`` header capture into ``write_mcp_audit_row``.
+
+What this migration adds
+------------------------
+
+* ``audit_log.agent_session_id uuid`` -- nullable. The MCP-session
+  correlation id. Populated only on **MCP** audit rows, sourced from
+  the inbound ``Mcp-Session-Id`` header (wired in T2). Chassis
+  HTTP-side audit rows are not agent sessions by design, so they leave
+  the column NULL; pre-G8.2 rows stay NULL too (no backfill -- that is
+  explicitly out of scope per #377). ``meho audit replay
+  <session-id>`` (T6) groups rows by this value to reconstruct an
+  agent's MCP session timeline.
+* ``audit_log_agent_session_id_idx`` -- b-tree index on the new
+  column. Drives the ``WHERE agent_session_id = ?`` probe that the
+  replay query (T3 un-gates the filter, T6 builds the CLI verb) runs.
+
+Why no foreign key clause in v0.2
+---------------------------------
+
+Identical rationale to the soft-FK columns ``audit_log.tenant_id``
+(0002), ``audit_log.target_id`` (0004), and the audit-tree linkage
+column added in 0006: keeping the column shape *soft* (no FK clause,
+no NOT NULL)
+makes the migration trivially reversible on a populated table and
+defers any tightening to a dedicated future migration. There is no
+``agent_session`` table to point a FK at -- the session id is an
+opaque correlation key sourced from the MCP transport header, not a
+row identifier in this schema. Any FK / NOT NULL tightening is
+v0.2.next territory (per #377 Out of scope).
+
+Dialect-portability decisions
+------------------------------
+
+Mirrors the same discipline 0002 / 0004 / 0006 established: pure DDL,
+no server defaults (Python-side ORM default of ``None`` works on both
+PG and SQLite), and a named index that is dropped explicitly in
+``downgrade()`` so the inverse works cleanly on both dialects.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` undoes everything ``upgrade()`` created in reverse
+order: drop the agent_session_id index -> drop the agent_session_id
+column. SQLite-portable because every step uses generic SQLAlchemy DDL
+the dialect understands without quoting tricks.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0014"
+down_revision: str | None = "0013"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``audit_log.agent_session_id`` column + named index."""
+    op.add_column(
+        "audit_log",
+        sa.Column("agent_session_id", sa.Uuid(), nullable=True),
+    )
+    op.create_index(
+        "audit_log_agent_session_id_idx",
+        "audit_log",
+        ["agent_session_id"],
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    """Reverse the upgrade -- drop the index and column."""
+    op.drop_index("audit_log_agent_session_id_idx", table_name="audit_log")
+    op.drop_column("audit_log", "agent_session_id")

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -94,6 +94,16 @@ Schema decisions for :class:`AuditLog`:
   Drives the recursive-CTE traversal at audit-replay time (G8.1 /
   G8.2). No FK to ``audit_log.id`` in v0.2 by the same soft-FK
   discipline established for ``tenant_id`` / ``target_id``.
+* ``agent_session_id`` — UUID, nullable. Added by migration ``0014``;
+  the MCP-session correlation id. Populated only on MCP audit rows,
+  sourced from the inbound ``Mcp-Session-Id`` header (wired by
+  G8.2-T2). Chassis HTTP-side audit rows are not agent sessions by
+  design and leave it NULL; pre-G8.2 rows stay NULL too (no backfill).
+  Drives the per-session audit-replay query (``meho audit replay
+  <session-id>``, G8.2-T6). No FK in v0.2 by the same soft-FK
+  discipline as ``tenant_id`` / ``target_id`` / ``parent_audit_id`` —
+  the session id is an opaque transport-header correlation key, not a
+  row identifier in this schema.
 
 Indexes on :class:`AuditLog`:
 
@@ -112,6 +122,10 @@ Indexes on :class:`AuditLog`:
 * ``audit_log_parent_audit_id_idx`` — b-tree on ``parent_audit_id``
   so the recursive-CTE traversal at audit-replay time hits the index.
   Added by migration ``0006``.
+* ``audit_log_agent_session_id_idx`` — b-tree on ``agent_session_id``
+  so the per-session ``WHERE agent_session_id = ?`` probe (the
+  ``meho audit replay <session-id>`` query shape) hits the index.
+  Added by migration ``0014``.
 
 Schema decisions for :class:`Target`:
 
@@ -397,6 +411,19 @@ class AuditLog(Base):
         nullable=True,
         default=None,
     )
+    # Nullable on purpose — the MCP-session correlation id. Populated
+    # only on MCP audit rows, sourced from the inbound ``Mcp-Session-Id``
+    # header (wired by G8.2-T2). Chassis HTTP-side audit rows are not
+    # agent sessions by design and leave this NULL; pre-G8.2 rows stay
+    # NULL too (no backfill). Drives the per-session audit-replay query
+    # (``meho audit replay <session-id>``, G8.2-T6). No FK in v0.2 --
+    # the session id is an opaque transport-header correlation key, not
+    # a row identifier in this schema. Added by migration ``0014``.
+    agent_session_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(),
+        nullable=True,
+        default=None,
+    )
 
     __table_args__ = (
         Index(
@@ -422,6 +449,11 @@ class AuditLog(Base):
         Index(
             "audit_log_parent_audit_id_idx",
             "parent_audit_id",
+            postgresql_using="btree",
+        ),
+        Index(
+            "audit_log_agent_session_id_idx",
+            "agent_session_id",
             postgresql_using="btree",
         ),
     )

--- a/backend/tests/test_migration_0014_agent_session_id.py
+++ b/backend/tests/test_migration_0014_agent_session_id.py
@@ -16,9 +16,12 @@ Test matrix
 * **Upgrade adds the column + index.** ``upgrade head`` from a clean
   DB leaves ``audit_log.agent_session_id`` present and nullable, and
   the named ``audit_log_agent_session_id_idx`` index defined.
-* **Reversibility round-trip.** ``downgrade -1`` drops both the column
-  and the index; a subsequent ``upgrade head`` re-creates them. This
-  is the 0006 reversibility contract this migration inherits.
+* **Reversibility round-trip.** ``downgrade "0013"`` (0014's
+  ``down_revision``) drops both the column and the index; a subsequent
+  ``upgrade head`` re-creates them. This is the 0006 reversibility
+  contract this migration inherits. The target is the explicit
+  revision rather than head-relative ``"-1"`` so the test keeps
+  reverting *0014* even once a later migration becomes head.
 * **parent_audit_id is untouched.** The migration must not re-add the
   pre-existing ``parent_audit_id`` column / index (it shipped in 0006);
   both survive the upgrade unchanged and `agent_session_id` is a
@@ -149,11 +152,18 @@ def test_upgrade_adds_agent_session_id_column_and_index(
 def test_downgrade_then_upgrade_round_trips(
     alembic_cfg: tuple[Config, str],
 ) -> None:
-    """``downgrade -1`` drops the column + index; ``upgrade head`` restores them.
+    """``downgrade "0013"`` drops the column + index; ``upgrade head`` restores them.
 
     This is the reversibility contract migration 0014 inherits from
     0006: the inverse must work cleanly on SQLite (and, by the same
     generic-DDL discipline, on PostgreSQL).
+
+    The downgrade target is the explicit revision ``"0013"`` (0014's
+    ``down_revision``) rather than head-relative ``"-1"``. ``"-1"``
+    reverts whatever sits at head, so the moment a later migration
+    (0015+) lands it would silently stop exercising 0014's reverse;
+    anchoring to ``"0013"`` keeps this test pinned to 0014 and matches
+    the repo convention (``test_targets_fingerprint.py``).
     """
     cfg, sync_url = alembic_cfg
     command.upgrade(cfg, "head")
@@ -162,7 +172,7 @@ def test_downgrade_then_upgrade_round_trips(
     assert "agent_session_id" in _audit_log_columns(sync_url)
     assert "audit_log_agent_session_id_idx" in _audit_log_indexes(sync_url)
 
-    command.downgrade(cfg, "-1")
+    command.downgrade(cfg, "0013")
     assert "agent_session_id" not in _audit_log_columns(sync_url), (
         "downgrade must drop audit_log.agent_session_id"
     )

--- a/backend/tests/test_migration_0014_agent_session_id.py
+++ b/backend/tests/test_migration_0014_agent_session_id.py
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0014_add_audit_log_agent_session_id``.
+
+Initiative #377 (G8.2 audit replay), Task #1009 (T1). The migration is
+the schema foundation of G8.2: it adds the nullable
+``audit_log.agent_session_id`` column + its b-tree index, mirroring the
+soft-FK discipline migrations 0002 / 0004 / 0006 established. No write
+path ships here -- the column lands NULL until T2 wires the MCP
+``Mcp-Session-Id`` header capture.
+
+Test matrix
+-----------
+
+* **Upgrade adds the column + index.** ``upgrade head`` from a clean
+  DB leaves ``audit_log.agent_session_id`` present and nullable, and
+  the named ``audit_log_agent_session_id_idx`` index defined.
+* **Reversibility round-trip.** ``downgrade -1`` drops both the column
+  and the index; a subsequent ``upgrade head`` re-creates them. This
+  is the 0006 reversibility contract this migration inherits.
+* **parent_audit_id is untouched.** The migration must not re-add the
+  pre-existing ``parent_audit_id`` column / index (it shipped in 0006);
+  both survive the upgrade unchanged and `agent_session_id` is a
+  *distinct* new column.
+* **ORM-field smoke.** :attr:`AuditLog.agent_session_id` resolves on
+  the mapped class and a freshly constructed ``AuditLog`` (without the
+  field) defaults it to ``None`` -- the Python-side default that
+  replaces the deliberately-absent server default.
+
+The tests follow the synchronous pattern established by
+:mod:`tests.test_migration_0011_backfill_when_to_use`:
+``alembic.command.upgrade`` calls ``asyncio.run`` internally via
+env.py's async cookbook, so the test function itself must be sync.
+SQLite is the test driver; PG-side shape parity is covered by the
+testcontainers replay suite in :mod:`tests.test_migration_rollback`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL.
+
+    The fixture is *sync* (returns rather than yields async) because
+    :func:`alembic.command.upgrade` calls :func:`asyncio.run`
+    internally via the env.py async cookbook -- the same constraint
+    that keeps every other migration test in
+    :mod:`tests.test_migration_0011_backfill_when_to_use` synchronous.
+
+    The DB file lives under pytest's ``tmp_path`` so each test gets an
+    isolated SQLite database; engine + settings caches are reset before
+    and after so the alembic env reads *this* DATABASE_URL.
+    """
+    db_path = tmp_path / "migration_0014.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _audit_log_columns(sync_url: str) -> set[str]:
+    """Return the set of ``audit_log`` column names via ``PRAGMA``."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA table_info(audit_log)")).all()
+    finally:
+        sync_eng.dispose()
+    # PRAGMA table_info columns: (cid, name, type, notnull, dflt_value, pk)
+    return {str(row[1]) for row in rows}
+
+
+def _audit_log_column_is_nullable(sync_url: str, column: str) -> bool:
+    """Return True when *column* on ``audit_log`` permits NULL."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA table_info(audit_log)")).all()
+    finally:
+        sync_eng.dispose()
+    for row in rows:
+        if str(row[1]) == column:
+            # notnull is index 3: 0 => nullable, 1 => NOT NULL.
+            return int(row[3]) == 0
+    raise AssertionError(f"column {column!r} not present on audit_log")
+
+
+def _audit_log_indexes(sync_url: str) -> set[str]:
+    """Return the set of index names declared on ``audit_log``."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA index_list(audit_log)")).all()
+    finally:
+        sync_eng.dispose()
+    # PRAGMA index_list columns: (seq, name, unique, origin, partial)
+    return {str(row[1]) for row in rows}
+
+
+def test_upgrade_adds_agent_session_id_column_and_index(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``upgrade head`` lands the nullable column + its named index."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    columns = _audit_log_columns(sync_url)
+    assert "agent_session_id" in columns, (
+        "migration 0014 must add audit_log.agent_session_id on upgrade head"
+    )
+    assert _audit_log_column_is_nullable(sync_url, "agent_session_id"), (
+        "agent_session_id must be nullable -- no NOT NULL in v0.2 (soft-FK discipline)"
+    )
+    assert "audit_log_agent_session_id_idx" in _audit_log_indexes(sync_url), (
+        "migration 0014 must create audit_log_agent_session_id_idx on upgrade head"
+    )
+
+
+def test_downgrade_then_upgrade_round_trips(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``downgrade -1`` drops the column + index; ``upgrade head`` restores them.
+
+    This is the reversibility contract migration 0014 inherits from
+    0006: the inverse must work cleanly on SQLite (and, by the same
+    generic-DDL discipline, on PostgreSQL).
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    # Sanity -- the upgrade landed the column + index before we reverse it.
+    assert "agent_session_id" in _audit_log_columns(sync_url)
+    assert "audit_log_agent_session_id_idx" in _audit_log_indexes(sync_url)
+
+    command.downgrade(cfg, "-1")
+    assert "agent_session_id" not in _audit_log_columns(sync_url), (
+        "downgrade must drop audit_log.agent_session_id"
+    )
+    assert "audit_log_agent_session_id_idx" not in _audit_log_indexes(sync_url), (
+        "downgrade must drop audit_log_agent_session_id_idx"
+    )
+
+    # Re-upgrade -- the column + index come back, proving the round-trip.
+    command.upgrade(cfg, "head")
+    assert "agent_session_id" in _audit_log_columns(sync_url)
+    assert "audit_log_agent_session_id_idx" in _audit_log_indexes(sync_url)
+
+
+def test_parent_audit_id_is_untouched(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """The pre-existing ``parent_audit_id`` column + index survive 0014.
+
+    Guards against the #377-original-body confusion that implied both
+    columns were new: ``parent_audit_id`` shipped in 0006 (G0.6-T7,
+    #398). 0014 adds *only* ``agent_session_id`` -- both columns must
+    coexist after upgrade, and neither index may be duplicated.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    columns = _audit_log_columns(sync_url)
+    assert "parent_audit_id" in columns, "0006's parent_audit_id must survive 0014"
+    assert "agent_session_id" in columns, "0014's agent_session_id must be present"
+    assert "parent_audit_id" != "agent_session_id"  # distinct columns, not a rename
+
+    indexes = _audit_log_indexes(sync_url)
+    assert "audit_log_parent_audit_id_idx" in indexes
+    assert "audit_log_agent_session_id_idx" in indexes
+
+
+def test_orm_field_resolves_and_defaults_none() -> None:
+    """:attr:`AuditLog.agent_session_id` resolves and defaults to ``None``.
+
+    The Python-side ORM default replaces the deliberately-absent
+    server default; an ``AuditLog`` constructed without the field must
+    read it back as ``None`` (the chassis/non-MCP-row default state).
+
+    Importing the model here (not at module top) keeps this smoke test
+    independent of the migration fixture -- it exercises the mapped
+    class, not the DDL.
+    """
+    from meho_backplane.db.models import AuditLog
+
+    # The mapped attribute exists on the class.
+    assert hasattr(AuditLog, "agent_session_id")
+
+    row = AuditLog(
+        operator_sub="op-smoke",
+        method="POST",
+        path="/mcp",
+        status_code=200,
+    )
+    assert row.agent_session_id is None, (
+        "an AuditLog built without agent_session_id must default it to None"
+    )

--- a/backend/tests/test_ui_session_store.py
+++ b/backend/tests/test_ui_session_store.py
@@ -11,8 +11,9 @@ The tests exercise the four entry points the
 
 Coverage matrix (Task #864 acceptance criteria):
 
-* ``alembic upgrade head`` / ``alembic downgrade -1`` round-trips
-  the ``web_session`` table cleanly (migration ``0012``).
+* ``alembic upgrade head`` then ``downgrade "0012"`` round-trips
+  the ``web_session`` table cleanly (created by migration ``0013``;
+  ``0012`` is its ``down_revision``).
 * :func:`create_session` -> :func:`load_session` -> :func:`revoke_session`
   round-trips work; the DB columns hold encrypted bytes, never the
   plaintext tokens.
@@ -100,11 +101,17 @@ def test_alembic_round_trip_web_session_table(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``alembic upgrade head`` then ``downgrade -1`` round-trips cleanly.
+    """``alembic upgrade head`` then ``downgrade "0012"`` round-trips cleanly.
 
     Exercises the reversibility contract documented on
     ``0013_create_web_session``: ``upgrade`` creates the table + two
     indexes; ``downgrade`` drops them in inverse order.
+
+    The downgrade target is the explicit revision ``"0012"`` (0013's
+    ``down_revision``) rather than head-relative ``"-1"`` so the test
+    keeps reverting the ``web_session`` migration regardless of how
+    many migrations stack on top of head -- matching the repo
+    convention (``test_targets_fingerprint.py``, ``test_db_models.py``).
 
     The test function is **sync** (not ``async def``) because
     :func:`alembic.command.upgrade` invokes :func:`asyncio.run`
@@ -155,8 +162,8 @@ def test_alembic_round_trip_web_session_table(
     assert "web_session_operator_sub_idx" in up_indexes
     assert "web_session_expires_at_idx" in up_indexes
 
-    # Step 3 -- downgrade -1 drops the table.
-    command.downgrade(cfg, "-1")
+    # Step 3 -- downgrade to 0012 (0013's down_revision) drops the table.
+    command.downgrade(cfg, "0012")
     down_tables, _down_indexes = _table_names_and_indexes()
     assert "web_session" not in down_tables
 

--- a/docs/codebase/audit_query.md
+++ b/docs/codebase/audit_query.md
@@ -27,7 +27,7 @@ this package never inserts, updates, or deletes.
 | `since` / `until` | `datetime \| None` | `audit_log.occurred_at` bracket. **Absolute datetimes only** — `"24h"` / `"7d"` shorthand is parsed in the T2 / T3 router. |
 | `audit_id` | `UUID \| None` | Exact-id lookup. |
 | `parent_audit_id` | `UUID \| None` | **Raises `UnsupportedFilterError`** in v0.2 — column lands with G0.6-T7 (#398). |
-| `agent_session_id` | `UUID \| None` | **Raises `UnsupportedFilterError`** in v0.2 — column not on any current roadmap. |
+| `agent_session_id` | `UUID \| None` | **Raises `UnsupportedFilterError`** in v0.2 — column lands with G8.2-T1 (#1009); the filter is un-gated by G8.2-T3. |
 | `limit` | `int` (1-1000) | Default 100. |
 | `cursor` | `str \| None` | Opaque forward-only cursor produced by a prior page. |
 
@@ -54,7 +54,7 @@ Field-to-source mapping:
 | `result_status` | Derived from `status_code` — 401/403 → `"denied"`, 4xx/5xx else → `"error"`, otherwise `"ok"`. |
 | `principal_name` | **None in v0.2** — JWT `name` claim is not captured by either write path. |
 | `parent_audit_id` | **None in v0.2** — column lands with G0.6-T7 (#398). |
-| `agent_session_id` | **None in v0.2** — no roadmap column. |
+| `agent_session_id` | **None in v0.2** — column lands with G8.2-T1 (#1009); populated by G8.2-T2, surfaced by G8.2-T3. |
 | `broadcast_event_id` | **None in v0.2** — FK direction is reversed: `BroadcastEvent.audit_id` points at the audit row. |
 
 The three computed fields use exactly the same rules
@@ -231,9 +231,12 @@ Reverse dependencies:
   `WHERE parent_audit_id = :parent_audit_id` clause. `AuditEntry` already
   exposes the field — only the column read needs to wire up.
 
-* **`agent_session_id` has no roadmap column.** Field is on `AuditEntry`
-  as None and the filter raises. If consumer demand crystallises, the
-  follow-up is a column + write-path binding + the same one-line filter add.
+* **`agent_session_id` waits on G8.2 (#377).** The column lands with
+  G8.2-T1 (#1009 — nullable + indexed, no write path); G8.2-T2 writes it
+  from the MCP `Mcp-Session-Id` header, and G8.2-T3 drops the
+  `UnsupportedFilterError` arm and adds the `WHERE agent_session_id =
+  :agent_session_id` clause. `AuditEntry` already exposes the field as
+  None — only the column read needs to wire up.
 
 * **`op_id` / `op_class` glob filtering is JSON-path-based.** On PostgreSQL
   the `payload->>'op_id'` lookup runs over the JSONB column without an index


### PR DESCRIPTION
## Summary
- Add the G8.2 audit-replay schema foundation: a nullable `audit_log.agent_session_id` UUID column + its b-tree index `audit_log_agent_session_id_idx`, mirroring migration `0006` (soft-FK discipline — no FK clause, no server default, named index dropped explicitly in `downgrade()` for dialect portability).
- Add the matching `AuditLog.agent_session_id: Mapped[uuid.UUID | None]` ORM field + index in `__table_args__` + docstring column/index inventory entries.
- **No write path** here — the column lands NULL until G8.2-T2 wires the MCP `Mcp-Session-Id` capture, and the audit-query filter stays gated (`UnsupportedFilterError`) until G8.2-T3. T1 adds **only** `agent_session_id`; `parent_audit_id` already shipped in `0006` (G0.6-T7 #398) and is untouched.

## Test plan
- [x] `ruff check` — clean (migration, model, test)
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/db/models.py` — clean
- [x] `pytest tests/test_migration_0014_agent_session_id.py` — 4 passed (upgrade adds column+index; `downgrade "0013"`→`upgrade head` round-trips; `parent_audit_id` untouched; ORM field resolves + defaults `None`)
- [x] `pytest tests/test_db_models.py tests/test_audit_query_schemas.py` — 22 passed (no regression from the AuditLog change)
- [x] `alembic upgrade head` → `downgrade 0013` → `downgrade 0012` → `upgrade head` CLI round-trip on SQLite — column + index created, dropped, restored
- [x] `scripts/ci/check_migration_compat.py` — exit 0 (purely additive `upgrade()`)
- [x] `grep -c parent_audit_id` in the new migration — `0` (no second column add, no duplicate index)
- [x] PostgreSQL-side shape parity uses identical generic DDL (the `0006` contract); exercised by the testcontainers replay suite in CI

## Out of scope
- MCP `Mcp-Session-Id` header capture + writing the column — **G8.2-T2**.
- Un-gating the `agent_session_id` filter / populating it on `AuditEntry` — **G8.2-T3**.
- Backfilling chassis-era rows; any FK / NOT NULL tightening — v0.2.next.

## Adjacent findings (not addressed)
- `backend/src/meho_backplane/db/models.py` is 2094 lines (code-quality file-size warning, pre-existing) — splitting it is out of scope for a schema-foundation task.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1009

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-24)

Addressed review findings from the iter-1 `REQUEST_CHANGES` review (commit `fd4cb6b`):

- **B1** (blocker, CI red) `fd4cb6b` — `test_ui_session_store.py`'s `web_session` round-trip anchored its downgrade to the explicit revision `"0012"` (0013's `down_revision`). Before this, head-relative `downgrade("-1")` reverted 0014 instead of dropping 0013's `web_session`, turning CI red.
- **M1** (major) `fd4cb6b` — the new `test_migration_0014_agent_session_id.py` reversibility test anchored its downgrade to the explicit revision `"0013"` (0014's `down_revision`), so it keeps exercising the `agent_session_id` revert once 0015+ becomes head. Docstrings + the test-matrix line updated to match.

Both anchors match the repo convention (`test_targets_fingerprint.py`, `test_db_models.py`). Verified: targeted `pytest` (17 passed) + full `alembic upgrade head → downgrade 0013 → downgrade 0012 → upgrade head` CLI round-trip clean.

Disputed: none.

Deferred: none (the suite's two remaining head-relative `downgrade("-1")` call sites were both anchored here; no `-1` sites remain in migration round-trip tests).

<!-- auto-implement-issue: continue, iteration 1 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended audit logs with a new `agent_session_id` field to enable session-specific audit tracking and filtering.

* **Tests**
  * Added comprehensive migration tests verifying schema changes, index creation, and model integrity.

* **Documentation**
  * Updated audit query documentation to clarify agent_session_id field availability and filtering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1017?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
