### PR TITLE
fix(connectors): close credential-cache fail-closed bypass for system operator in harbor + sddc-manager (#1008)

### DIFF
--- a/backend/src/meho_backplane/connectors/_shared/system_operator.py
+++ b/backend/src/meho_backplane/connectors/_shared/system_operator.py
@@ -44,6 +44,7 @@ from meho_backplane.auth.operator import Operator, TenantRole
 __all__ = [
     "SYSTEM_OPERATOR_PLACEHOLDER_JWT",
     "SYSTEM_OPERATOR_SUB",
+    "is_system_operator",
     "synthesise_system_operator",
 ]
 
@@ -91,3 +92,17 @@ def synthesise_system_operator() -> Operator:
         tenant_id=_SYSTEM_TENANT_ID,
         tenant_role=TenantRole.OPERATOR,
     )
+
+
+def is_system_operator(operator: Operator) -> bool:
+    """Return ``True`` iff *operator* is the synthesised system operator.
+
+    Identity is the :data:`SYSTEM_OPERATOR_SUB` sentinel ``sub`` (since
+    #980 the system operator carries a non-empty placeholder ``raw_jwt``,
+    so an empty-``raw_jwt`` check no longer identifies it). Connectors that
+    keep a per-target credential cache use this to keep the cache fast-path
+    closed to a system/operator-less caller: such a caller must run the
+    fail-closed loader rather than be served warm credentials it could not
+    itself resolve.
+    """
+    return operator.sub == SYSTEM_OPERATOR_SUB

--- a/backend/src/meho_backplane/connectors/harbor/connector.py
+++ b/backend/src/meho_backplane/connectors/harbor/connector.py
@@ -88,7 +88,10 @@ import httpx
 import structlog
 
 from meho_backplane.auth.operator import Operator
-from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
+from meho_backplane.connectors._shared.system_operator import (
+    is_system_operator,
+    synthesise_system_operator,
+)
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.harbor.session import (
     HarborCredentialsLoader,
@@ -245,10 +248,17 @@ class HarborConnector(HttpConnector):
         harbor-specific entry point to the shared operator-context
         Vault read; injected test loaders accept the same
         ``(target, operator)`` pair.
+
+        The cache fast-path is closed to the synthesised system operator
+        (``is_system_operator``): a system/operator-less caller always
+        runs the loader so its fail-closed guard applies, and can never be
+        served warm credentials a real operator primed but it could not
+        resolve itself (#1008). Real-operator behaviour is unchanged —
+        cold load → cache → reuse.
         """
         async with self._creds_lock:
             cached = self._creds_cache.get(target.name)
-            if cached is not None:
+            if cached is not None and not is_system_operator(operator):
                 return cached
             raw = await self._credentials_loader(target, operator)
             try:

--- a/backend/src/meho_backplane/connectors/sddc_manager/connector.py
+++ b/backend/src/meho_backplane/connectors/sddc_manager/connector.py
@@ -75,7 +75,10 @@ import httpx
 import structlog
 
 from meho_backplane.auth.operator import Operator
-from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
+from meho_backplane.connectors._shared.system_operator import (
+    is_system_operator,
+    synthesise_system_operator,
+)
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.schemas import (
     AuthModel,
@@ -200,10 +203,17 @@ class SddcManagerConnector(HttpConnector):
         sddc-manager-specific entry point to the shared
         operator-context Vault read; injected test loaders accept the
         same ``(target, operator)`` pair.
+
+        The cache fast-path is closed to the synthesised system operator
+        (``is_system_operator``): a system/operator-less caller always
+        runs the loader so its fail-closed guard applies, and can never be
+        served warm credentials a real operator primed but it could not
+        resolve itself (#1008). Real-operator behaviour is unchanged —
+        cold load → cache → reuse.
         """
         async with self._creds_lock:
             cached = self._creds_cache.get(target.name)
-            if cached is not None:
+            if cached is not None and not is_system_operator(operator):
                 return cached
             raw = await self._credentials_loader(target, operator)
             try:

--- a/backend/tests/test_connectors_harbor_auth.py
+++ b/backend/tests/test_connectors_harbor_auth.py
@@ -24,6 +24,11 @@ import pytest
 import respx
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.system_operator import (
+    SYSTEM_OPERATOR_SUB,
+    synthesise_system_operator,
+)
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.harbor import (
     HarborConnector,
@@ -221,6 +226,88 @@ async def test_auth_headers_reuses_cached_credentials_across_calls() -> None:
 
     assert h1 == h2
     assert call_count == 1
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# System-operator cache-bypass (fail-closed; #1008)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_warm_cache_not_served_to_system_operator_runs_loader() -> None:
+    """A warm cache primed by a real operator is NOT served to the system operator.
+
+    The system/operator-less caller (``synthesise_system_operator``) must
+    re-run the loader so its fail-closed behaviour applies — it can never
+    borrow warm credentials a real operator resolved (#1008). Keyed off
+    ``SYSTEM_OPERATOR_SUB``, not ``raw_jwt`` (the system operator carries a
+    non-empty placeholder JWT since #980).
+    """
+    call_log: list[str] = []
+
+    async def _counting_loader(_target: HarborTargetLike, operator: Operator) -> dict[str, str]:
+        call_log.append(operator.sub)
+        return {"username": "admin", "password": "stub-password"}
+
+    connector = HarborConnector(credentials_loader=_counting_loader)
+    # Real operator warms the cache (cold load).
+    await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    # System operator must re-run the loader rather than reuse the warm cache.
+    await connector.auth_headers(_TARGET_A, operator=synthesise_system_operator())
+
+    assert call_log == ["test-operator", SYSTEM_OPERATOR_SUB]
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_system_operator_fails_closed_against_warm_cache() -> None:
+    """With a warm cache, a system-operator load runs the loader and fails closed.
+
+    Proves the bypass is closed end to end: even though a real operator
+    primed the cache, the system caller hits the loader, which fails closed
+    per its contract (a system-initiated read cannot resolve per-target
+    credentials).
+    """
+
+    async def _failing_for_system_loader(
+        _target: HarborTargetLike, operator: Operator
+    ) -> dict[str, str]:
+        if operator.sub == SYSTEM_OPERATOR_SUB:
+            raise VaultCredentialsReadError(
+                "system-initiated calls cannot read per-target vendor credentials"
+            )
+        return {"username": "admin", "password": "stub-password"}
+
+    connector = HarborConnector(credentials_loader=_failing_for_system_loader)
+    await connector.auth_headers(_TARGET_A, operator=_make_operator())  # warm the cache
+    with pytest.raises(VaultCredentialsReadError, match=r"system-initiated"):
+        await connector.auth_headers(_TARGET_A, operator=synthesise_system_operator())
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_real_operator_reuse_unchanged_after_system_operator_call() -> None:
+    """Real-operator reuse is unaffected by the system-operator cache bypass.
+
+    A second real-operator call still reuses the warm cache (loader called
+    once for the real operator); only the interleaved system-operator call
+    re-runs the loader.
+    """
+    real_calls = 0
+
+    async def _counting_loader(_target: HarborTargetLike, operator: Operator) -> dict[str, str]:
+        nonlocal real_calls
+        if operator.sub != SYSTEM_OPERATOR_SUB:
+            real_calls += 1
+        return {"username": "admin", "password": "stub-password"}
+
+    connector = HarborConnector(credentials_loader=_counting_loader)
+    await connector.auth_headers(_TARGET_A, operator=_make_operator())  # cold real load
+    await connector.auth_headers(_TARGET_A, operator=synthesise_system_operator())  # bypass
+    await connector.auth_headers(_TARGET_A, operator=_make_operator())  # warm real reuse
+
+    assert real_calls == 1
     await connector.aclose()
 
 

--- a/backend/tests/test_connectors_sddc_manager_auth.py
+++ b/backend/tests/test_connectors_sddc_manager_auth.py
@@ -25,6 +25,11 @@ import pytest
 import respx
 
 from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors._shared.system_operator import (
+    SYSTEM_OPERATOR_SUB,
+    synthesise_system_operator,
+)
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
 from meho_backplane.connectors.adapters.http import HttpConnector
 from meho_backplane.connectors.registry import (
     clear_registry,
@@ -224,6 +229,88 @@ async def test_auth_headers_reuses_cached_credentials_across_calls() -> None:
 
     assert h1 == h2
     assert call_count == 1
+    await connector.aclose()
+
+
+# ---------------------------------------------------------------------------
+# System-operator cache-bypass (fail-closed; #1008)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_warm_cache_not_served_to_system_operator_runs_loader() -> None:
+    """A warm cache primed by a real operator is NOT served to the system operator.
+
+    The system/operator-less caller (``synthesise_system_operator``) must
+    re-run the loader so its fail-closed behaviour applies — it can never
+    borrow warm credentials a real operator resolved (#1008). Keyed off
+    ``SYSTEM_OPERATOR_SUB``, not ``raw_jwt`` (the system operator carries a
+    non-empty placeholder JWT since #980).
+    """
+    call_log: list[str] = []
+
+    async def _counting_loader(_target: SddcTargetLike, operator: Operator) -> dict[str, str]:
+        call_log.append(operator.sub)
+        return {"username": "svc-meho", "password": "stub-password"}
+
+    connector = SddcManagerConnector(credentials_loader=_counting_loader)
+    # Real operator warms the cache (cold load).
+    await connector.auth_headers(_TARGET_A, operator=_make_operator())
+    # System operator must re-run the loader rather than reuse the warm cache.
+    await connector.auth_headers(_TARGET_A, operator=synthesise_system_operator())
+
+    assert call_log == ["test-operator", SYSTEM_OPERATOR_SUB]
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_system_operator_fails_closed_against_warm_cache() -> None:
+    """With a warm cache, a system-operator load runs the loader and fails closed.
+
+    Proves the bypass is closed end to end: even though a real operator
+    primed the cache, the system caller hits the loader, which fails closed
+    per its contract (a system-initiated read cannot resolve per-target
+    credentials).
+    """
+
+    async def _failing_for_system_loader(
+        _target: SddcTargetLike, operator: Operator
+    ) -> dict[str, str]:
+        if operator.sub == SYSTEM_OPERATOR_SUB:
+            raise VaultCredentialsReadError(
+                "system-initiated calls cannot read per-target vendor credentials"
+            )
+        return {"username": "svc-meho", "password": "stub-password"}
+
+    connector = SddcManagerConnector(credentials_loader=_failing_for_system_loader)
+    await connector.auth_headers(_TARGET_A, operator=_make_operator())  # warm the cache
+    with pytest.raises(VaultCredentialsReadError, match=r"system-initiated"):
+        await connector.auth_headers(_TARGET_A, operator=synthesise_system_operator())
+    await connector.aclose()
+
+
+@pytest.mark.asyncio
+async def test_real_operator_reuse_unchanged_after_system_operator_call() -> None:
+    """Real-operator reuse is unaffected by the system-operator cache bypass.
+
+    A second real-operator call still reuses the warm cache (loader called
+    once for the real operator); only the interleaved system-operator call
+    re-runs the loader.
+    """
+    real_calls = 0
+
+    async def _counting_loader(_target: SddcTargetLike, operator: Operator) -> dict[str, str]:
+        nonlocal real_calls
+        if operator.sub != SYSTEM_OPERATOR_SUB:
+            real_calls += 1
+        return {"username": "svc-meho", "password": "stub-password"}
+
+    connector = SddcManagerConnector(credentials_loader=_counting_loader)
+    await connector.auth_headers(_TARGET_A, operator=_make_operator())  # cold real load
+    await connector.auth_headers(_TARGET_A, operator=synthesise_system_operator())  # bypass
+    await connector.auth_headers(_TARGET_A, operator=_make_operator())  # warm real reuse
+
+    assert real_calls == 1
     await connector.aclose()
 
 

--- a/docs/architecture/connector-auth.md
+++ b/docs/architecture/connector-auth.md
@@ -180,7 +180,7 @@ For a target tagged `shared_service_account`:
   `(target, connector-instance)` lifetime — every subsequent cache hit
   skips Vault entirely, which is the cache's whole point.
 
-### The four cache implementations
+### The cache implementations
 
 | Connector | File | Cache | Notes |
 | --- | --- | --- | --- |
@@ -189,19 +189,34 @@ For a target tagged `shared_service_account`:
 | vcf-automation (provider plane) | `backend/src/meho_backplane/connectors/vcf_automation/connector.py` | `_provider_tokens` (in `_provider_session_token`) | `X-VMWARE-VCLOUD-ACCESS-TOKEN` JWT cache. |
 | vcf-automation (tenant plane) | `backend/src/meho_backplane/connectors/vcf_automation/connector.py` | `_tenant_tokens` (in `_tenant_session_token`) | `{"token": ...}` body-value cache. |
 | vmware-rest | `backend/src/meho_backplane/connectors/vmware_rest/connector.py` | `_session_tokens` (in `_session_token`) | `vmware-api-session-id` cache; the G3.9 precedent every other cache here copied. |
+| harbor | `backend/src/meho_backplane/connectors/harbor/connector.py` | `_creds_cache` (in `_load_credentials`) | Credential dict cache; per-target `{username, password}` consumed via HTTP Basic. |
+| sddc-manager | `backend/src/meho_backplane/connectors/sddc_manager/connector.py` | `_creds_cache` (in `_load_credentials`) | Credential dict cache; per-target `{username, password}` consumed via HTTP Basic (username suffixed with `@sso_realm`). |
 
-All five cache sites apply the same fail-closed guard before the cache
-lookup: an empty `operator.raw_jwt` raises `VaultCredentialsReadError`
-without touching the cache. The **primary** fail-closed gate against empty
-`raw_jwt` lives one layer deeper, in the credential loader's
-`_resolve_secret_ref` helper at
+Every cache site applies a fail-closed guard before the cache lookup so a
+cache hit can never short-circuit past the loader and return
+previously-primed credentials to a caller that could not itself resolve
+them. The **primary** fail-closed gate lives one layer deeper, in the
+credential loader's `_resolve_secret_ref` helper at
 [`vault_creds.py:188`](../../backend/src/meho_backplane/connectors/_shared/vault_creds.py#L188);
-the cache guards exist as the **second** layer — defense-in-depth so a
-cache hit can never short-circuit past the loader and return a
-previously-primed token to a caller without an operator JWT. (Each
-consuming connector's `auth_headers` enforces a separate constraint —
-the `auth_model == "shared_service_account"` boundary — and does not
-itself reject empty `raw_jwt`; the loader and the cache guards do.)
+the cache guards are the **second** layer — defense-in-depth.
+
+The guards split on *how* they identify a system/operator-less caller:
+
+- The five session-token / VCF caches reject an **empty** `operator.raw_jwt`
+  at the cache method (`VaultCredentialsReadError` without touching the
+  cache).
+- The two HTTP-Basic credential caches (`harbor`, `sddc-manager`) instead
+  key off the `SYSTEM_OPERATOR_SUB` sentinel via
+  `is_system_operator(operator)` (#1008). Since #980 the synthesised
+  system operator carries a **non-empty placeholder** `raw_jwt`, so an
+  empty-`raw_jwt` check no longer identifies it. On a system-operator call
+  these connectors skip the cache fast-path and run the loader, which fails
+  closed (the placeholder JWT is not a valid Keycloak JWT). A real
+  operator's cold-load → cache → reuse path is unchanged.
+
+(Each consuming connector's `auth_headers` enforces a separate constraint —
+the `auth_model == "shared_service_account"` boundary — and does not itself
+reject the system caller; the loader and the cache guards do.)
 
 ### Why not key the cache on the operator too
 


### PR DESCRIPTION
## Summary
- Closes the credential-cache **fail-closed bypass** in the two HTTP-Basic connectors (`harbor`, `sddc-manager`): their per-target `_creds_cache` returned warm credentials *before* the operator-context loader ran, so a system/operator-less caller (`synthesise_system_operator()`) could be served credentials it could not itself resolve.
- `_load_credentials` now skips the cache fast-path for the synthesised system operator (`if cached is not None and not is_system_operator(operator)`), so a system caller always runs the loader and fails closed.
- New shared predicate `is_system_operator(operator)` in `connectors/_shared/system_operator.py` keys off `SYSTEM_OPERATOR_SUB`, **not** an empty `raw_jwt` (since #980 the system operator carries a non-empty placeholder JWT). One predicate, used by both connectors, so they don't drift.
- Real-operator behaviour is unchanged: cold load → cache → reuse.

## Test plan
- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy src/meho_backplane/ --ignore-missing-imports` — Success: no issues found in 269 source files
- [x] Full unit suite `pytest tests/ -n auto` — **4058 passed, 54 skipped**
- [x] AC: warm cache + system operator does **not** return cached creds, runs the loader — `test_warm_cache_not_served_to_system_operator_runs_loader` (harbor + sddc-manager)
- [x] AC: system operator fails closed against a warm cache — `test_system_operator_fails_closed_against_warm_cache` (harbor + sddc-manager)
- [x] AC: real-operator reuse unchanged (loader call count) — `test_real_operator_reuse_unchanged_after_system_operator_call` + existing `test_auth_headers_reuses_cached_credentials_across_calls` (both connectors)
- [x] AC: guard keys off `SYSTEM_OPERATOR_SUB`, not `raw_jwt` — verified by grep; cache guard references no `raw_jwt`
- [x] AC: no credential value in any log/error introduced — diff adds no `_log.` calls; existing credential-load events log only target/host
- [x] code-quality gate — 0 blockers (2 warnings are pre-existing legacy debt in `harbor/connector.py` file-size + `robot_create`, untouched)

## Out of scope (deferred per the issue)
- Full per-`(target, operator)` cache keying — coupled to the `per_user` auth model (#948); unnecessary under `shared_service_account`.
- The operator-less-probe auth model (how probe/fingerprint authenticate post-#980) — separate design question.
- Session-token connectors (vmware/nsx/vcf) — they cache derived tokens, not resolved creds by `target.name`.

## Docs
- Updated `docs/architecture/connector-auth.md` cache-implementations section: added harbor + sddc-manager rows and documented the two guard styles (empty-`raw_jwt` for the session-token caches vs `SYSTEM_OPERATOR_SUB` for the two HTTP-Basic credential caches).

## Adjacent findings
- `backend/src/meho_backplane/connectors/harbor/connector.py` is 552 lines (warn >400) and `robot_create` is 84 lines (warn >60) — pre-existing, not introduced here.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1008
