### PR TITLE
feat(connectors): G3.8 follow-up - multi-word kubectl verbs (#1020)

### DIFF
--- a/backend/src/meho_backplane/connectors/holodeck/ops_read.py
+++ b/backend/src/meho_backplane/connectors/holodeck/ops_read.py
@@ -18,11 +18,13 @@ Adds the following typed ops onto :class:`HolodeckConnector`:
   -like 'Holo*' } | Select-Object Name,Status,DisplayName |
   ConvertTo-Json``; returns ``{rows, total}``.
 * ``holodeck.k8s.exec`` -- in-appliance ``kubectl <verb> ...``
-  passthrough. **Read-only**: the handler fails closed when the first
-  non-flag token after ``kubectl`` is not in
-  :data:`_K8S_READ_VERBS`. Schema also pins ``kubectl <verb> ...``
-  with a ``pattern`` so the dispatcher's validator catches the bad
-  shape before reaching the handler.
+  passthrough. **Read-only**: the handler fails closed when the verb
+  token after ``kubectl`` is neither in :data:`_K8S_READ_VERBS`
+  (single-word reads) nor a (parent, sub-verb) pair in
+  :data:`_K8S_MULTIWORD_READ_VERBS` (``config view`` / ``auth can-i``
+  / ...). Schema also pins ``kubectl <verb> ...`` with a ``pattern``
+  so the dispatcher's validator catches the bad shape before reaching
+  the handler.
 * ``holodeck.logs.tail`` -- ``tail -<lines> /holodeck-runtime/logs/
   <component>*.log`` over plain SSH (no ``pwsh`` indirection — the
   cmd is a stock POSIX shell pipeline). Returns the tail text plus
@@ -86,13 +88,15 @@ allowlist layers:
    re-parses the command via :func:`parse_kubectl_command`, which
    (a) scans the raw command for any character in
    :data:`_SHELL_METACHARS_RE` and refuses on hit, then (b) tokenises
-   via :func:`shlex.split` and (c) compares the verb to
-   :data:`_K8S_READ_VERBS`. Any rejected step raises
-   :exc:`KubectlSafetyError`, which the dispatcher's exception path
-   turns into a ``result_connector_error`` envelope. The metacharacter
-   reject is **load-bearing**: ``shlex.split`` in POSIX mode does not
-   treat shell separators as token boundaries, so a chained payload
-   like ``kubectl get pods; rm -rf /`` would otherwise tokenise to
+   via :func:`shlex.split`, (c) checks for a 2-token verb prefix
+   against :data:`_K8S_MULTIWORD_READ_VERBS` first, and (d) falls
+   through to the single-word :data:`_K8S_READ_VERBS` safelist. Any
+   rejected step raises :exc:`KubectlSafetyError`, which the
+   dispatcher's exception path turns into a
+   ``result_connector_error`` envelope. The metacharacter reject is
+   **load-bearing**: ``shlex.split`` in POSIX mode does not treat
+   shell separators as token boundaries, so a chained payload like
+   ``kubectl get pods; rm -rf /`` would otherwise tokenise to
    ``['kubectl', 'get', 'pods;', ...]`` -- the verb-safelist check
    on ``tokens[idx]`` would see ``'get'`` and approve, and the
    handler would then forward the **raw string** to
@@ -149,9 +153,9 @@ __all__ = [
 # Read-only kubectl guard
 # ---------------------------------------------------------------------------
 
-#: Whitelist of ``kubectl`` verbs the handler considers read-only.
-#: ``get`` / ``describe`` / ``logs`` are the three primary read verbs
-#: the Initiative #371 body calls out. ``top`` (metrics) and
+#: Whitelist of single-word ``kubectl`` verbs the handler considers
+#: read-only. ``get`` / ``describe`` / ``logs`` are the three primary
+#: read verbs the Initiative #371 body calls out. ``top`` (metrics) and
 #: ``explain`` (schema) are pure reads. ``api-resources`` /
 #: ``api-versions`` / ``cluster-info`` / ``version`` cover the
 #: inspection surface without mutating cluster state. Any verb absent
@@ -159,13 +163,14 @@ __all__ = [
 #: ``edit`` / ``replace`` / ``patch`` / ``scale`` / ``rollout``
 #: (``restart``) / ``label`` (``--overwrite``) / ``annotate`` /
 #: ``cp`` / ``exec`` / ``port-forward`` / ``proxy`` / ``drain`` /
-#: ``cordon`` -- fails closed. Multi-word inspection verbs
-#: (``config view``, ``auth can-i``) are intentionally **not**
-#: surfaced today: the safelist matches on the single verb token, so
-#: ``kubectl config get-contexts`` would be approved through the
-#: ``config`` parent verb. Surfacing them safely requires a verb +
-#: sub-verb safelist, which is deferred -- callers that need them
-#: should file a follow-up.
+#: ``cordon`` -- fails closed.
+#:
+#: Multi-word inspection verbs (``config view``, ``auth can-i``,
+#: ``config get-contexts``, ``auth whoami``) are handled separately
+#: through :data:`_K8S_MULTIWORD_READ_VERBS`: the parent token
+#: (``config`` / ``auth``) is a shared namespace where both reads and
+#: writes live, so the verb-safelist check must pin both the parent
+#: and the sub-verb together.
 _K8S_READ_VERBS: frozenset[str] = frozenset(
     {
         "get",
@@ -179,6 +184,46 @@ _K8S_READ_VERBS: frozenset[str] = frozenset(
         "version",
     }
 )
+
+#: Whitelist of multi-word ``kubectl <parent> <sub>`` read-only verb
+#: pairs. The single-word safelist (:data:`_K8S_READ_VERBS`) cannot
+#: cover these: the parent verb (``config`` / ``auth``) is a shared
+#: namespace where both read and write sub-verbs live -- e.g.
+#: ``kubectl config view`` is a read but ``kubectl config set-context``
+#: is a mutation. The check therefore matches on the verb + sub-verb
+#: pair, with both tokens looked up in this allowlist.
+#:
+#: Per the kubectl reference docs (Kubernetes 1.x current generated
+#: docs, see https://kubernetes.io/docs/reference/kubectl/generated/
+#: kubectl_config/ and https://kubernetes.io/docs/reference/access-
+#: authn-authz/authorization/#checking-api-access), the read-only
+#: ``config`` sub-verbs are ``view`` / ``get-contexts`` /
+#: ``get-clusters`` / ``get-users`` / ``current-context``; the
+#: read-only ``auth`` sub-verbs are ``can-i`` / ``whoami``. Adjacent
+#: mutating sub-verbs (``set-context``, ``set-cluster``,
+#: ``set-credentials``, ``unset``, ``use-context``, ``delete-context``,
+#: ``delete-cluster``, ``delete-user``, ``rename-context`` under
+#: ``config``; ``reconcile`` under ``auth``) are deliberately **not**
+#: present and fail closed -- a 2-token verb prefix walks this dict,
+#: hits the parent, then checks the sub-verb against the frozenset;
+#: absence is rejection.
+_K8S_MULTIWORD_READ_VERBS: dict[str, frozenset[str]] = {
+    "config": frozenset(
+        {
+            "view",
+            "get-contexts",
+            "get-clusters",
+            "get-users",
+            "current-context",
+        }
+    ),
+    "auth": frozenset(
+        {
+            "can-i",
+            "whoami",
+        }
+    ),
+}
 
 #: Shell metacharacters banned anywhere in a ``kubectl`` command line.
 #: ``shlex.split`` in POSIX mode does **not** treat these as token
@@ -218,43 +263,99 @@ class KubectlSafetyError(ValueError):
     """
 
 
+def _skip_global_flags(tokens: list[str]) -> int:
+    """Return the index of the first non-flag token after ``kubectl``.
+
+    Walks past leading flag tokens. Attached-value flags
+    (``--context=foo``) consume one token; separated-value flags
+    (``--context foo``) consume two. The returned index points at the
+    verb -- or off the end of ``tokens`` when there is no verb.
+    """
+    idx = 1
+    while idx < len(tokens) and tokens[idx].startswith("-"):
+        token = tokens[idx]
+        idx += 1
+        if "=" not in token and idx < len(tokens) and not tokens[idx].startswith("-"):
+            # Separated flag value (``--context foo``); consume.
+            idx += 1
+    return idx
+
+
+def _check_multiword_verb(tokens: list[str], idx: int, verb: str) -> tuple[str, list[str]]:
+    """Validate the 2-token ``(parent, sub-verb)`` prefix; return ``(canonical, args)``.
+
+    Pre-condition: ``verb == tokens[idx]`` AND ``verb in
+    _K8S_MULTIWORD_READ_VERBS``. Raises :exc:`KubectlSafetyError`
+    when the sub-verb is missing or not on the per-parent
+    frozenset. The canonical form returned is the space-joined
+    ``"<parent> <sub>"`` so callers can re-serialise; ``args`` is
+    every token after the sub-verb.
+    """
+    allowed_subs = _K8S_MULTIWORD_READ_VERBS[verb]
+    if idx + 1 >= len(tokens):
+        raise KubectlSafetyError(
+            f"kubectl multi-word verb {verb!r} requires a sub-verb; allowed: {sorted(allowed_subs)}"
+        )
+    sub_verb = tokens[idx + 1]
+    if sub_verb not in allowed_subs:
+        raise KubectlSafetyError(
+            f"kubectl sub-verb {sub_verb!r} under {verb!r} is not on "
+            f"the read-only safelist; allowed: {sorted(allowed_subs)}"
+        )
+    return f"{verb} {sub_verb}", tokens[idx + 2 :]
+
+
 def parse_kubectl_command(command: str) -> tuple[str, list[str]]:
     """Parse ``command`` into ``(verb, args)``; enforce the read-only safelist.
 
-    The first whitespace-separated token must be ``kubectl``. The
-    second non-flag token is the verb; the verb must appear in
-    :data:`_K8S_READ_VERBS`. Returns the verb and the remaining args
-    so callers can re-serialise the command for SSH.
+    The first whitespace-separated token must be ``kubectl``. After
+    walking past any global flags via :func:`_skip_global_flags`, the
+    verb is matched against two safelists in order:
+
+    1. **Multi-word prefix first** (:func:`_check_multiword_verb`).
+       If ``tokens[idx]`` is a key in :data:`_K8S_MULTIWORD_READ_VERBS`
+       (``config`` / ``auth``) AND ``tokens[idx + 1]`` is in the
+       corresponding sub-verb frozenset, the command is accepted; the
+       canonical verb returned is the space-joined ``"<parent> <sub>"``
+       form and ``args`` is everything after the sub-verb. A parent
+       with no sub-verb, or a sub-verb not on the per-parent
+       frozenset (``config set-context``, ``auth reconcile``), is
+       rejected -- the parent-only fallthrough is intentionally NOT
+       attempted, because the parent token is never a legal read verb
+       on its own.
+    2. **Single-word fallback.** Otherwise the verb is matched against
+       :data:`_K8S_READ_VERBS` (``get`` / ``describe`` / ``logs`` …).
+
+    Returns ``(verb, args)`` so callers can re-serialise the command
+    for SSH; for multi-word verbs ``verb`` is the space-joined form
+    (``"config view"``).
 
     Tokenisation runs via :func:`shlex.split` so quoted resource names
-    (``"my pod"``) survive the parse; the safety check operates on the
-    verb token, which is unquoted in every legal ``kubectl`` invocation.
+    (``"my pod"``) survive the parse. Before tokenisation the function
+    scans for POSIX-shell metacharacters (:data:`_SHELL_METACHARS_RE`)
+    and refuses the call if any are found. This is **load-bearing**:
+    ``shlex.split`` in POSIX mode does not treat ``;`` / ``&&`` /
+    ``|`` / ``$(...)`` / backticks / ``>`` / ``<`` / newlines as token
+    boundaries, so a chained payload like ``kubectl get pods; rm -rf /``
+    would tokenise to ``['kubectl', 'get', 'pods;', ...]``, the verb
+    check would approve ``get``, and the handler would forward the
+    **raw string** verbatim to ``asyncssh.SSHClientConnection.run`` --
+    which delegates to the remote login shell where the metacharacters
+    are interpreted. The metachar reject closes that hole before
+    tokenisation runs.
 
-    Before tokenisation the function scans for POSIX-shell
-    metacharacters (:data:`_SHELL_METACHARS_RE`) and refuses the call
-    if any are found. This is **load-bearing**: ``shlex.split`` in
-    POSIX mode does not treat ``;`` / ``&&`` / ``|`` / ``$(...)`` /
-    backticks / ``>`` / ``<`` as token boundaries, so a chained payload
-    like ``kubectl get pods; rm -rf /`` would tokenise to
-    ``['kubectl', 'get', 'pods;', 'rm', '-rf', '/']``, the verb check
-    on ``tokens[idx]`` would see ``'get'`` and approve, and the
-    handler would then forward the **raw string** verbatim to
-    ``asyncssh.SSHClientConnection.run`` -- which delegates to the
-    remote login shell where the metacharacters are interpreted. The
-    metachar reject closes that hole before tokenisation runs.
-
-    Empty command, or command containing shell metacharacters, or
-    command not starting with ``kubectl``, or verb not in
-    :data:`_K8S_READ_VERBS` -> :exc:`KubectlSafetyError`. The handler
-    raises before any SSH traffic happens.
+    Empty / metachar-bearing / non-``kubectl`` / safelist-misses raise
+    :exc:`KubectlSafetyError` before any SSH traffic happens.
 
     Examples
     --------
 
     >>> parse_kubectl_command("kubectl get pods -n holodeck")
     ('get', ['pods', '-n', 'holodeck'])
-    >>> parse_kubectl_command("kubectl describe pod my-pod")
-    ('describe', ['pod', 'my-pod'])
+    >>> parse_kubectl_command("kubectl config view")
+    ('config view', [])
+    >>> parse_kubectl_command("kubectl auth can-i list pods")
+    ('auth can-i', ['list', 'pods'])
     """
     if not command or not command.strip():
         raise KubectlSafetyError("kubectl command is empty")
@@ -278,22 +379,20 @@ def parse_kubectl_command(command: str) -> tuple[str, list[str]]:
         raise KubectlSafetyError("kubectl command tokenises to nothing")
     if tokens[0] != "kubectl":
         raise KubectlSafetyError(f"kubectl command must start with 'kubectl' (got {tokens[0]!r})")
-    # The verb is the first non-flag token after ``kubectl``. A handful
-    # of legal invocations open with a global flag (``kubectl
-    # --context=foo get pods``); we walk past leading flag tokens but
-    # only consume their *attached* values (``--context=foo``). When a
-    # flag is in the separated form (``--context foo``) the next token
-    # is the flag's value, not a verb -- we skip it too.
-    idx = 1
-    while idx < len(tokens) and tokens[idx].startswith("-"):
-        token = tokens[idx]
-        idx += 1
-        if "=" not in token and idx < len(tokens) and not tokens[idx].startswith("-"):
-            # Separated flag value (``--context foo``); consume.
-            idx += 1
+    idx = _skip_global_flags(tokens)
     if idx >= len(tokens):
         raise KubectlSafetyError("kubectl command has no verb after global flags")
     verb = tokens[idx]
+    # Multi-word prefix path checked first. The parent token
+    # (``config`` / ``auth``) is a shared namespace where both read
+    # and write sub-verbs live, so we MUST pin the (parent, sub)
+    # pair together -- a fallthrough to the single-word check on the
+    # parent alone would silently approve ``kubectl config set-context``
+    # by way of the ``config`` parent being legible. The single-word
+    # safelist does NOT include the multi-word parents, so a missing
+    # sub-verb fails closed via ``_check_multiword_verb``.
+    if verb in _K8S_MULTIWORD_READ_VERBS:
+        return _check_multiword_verb(tokens, idx, verb)
     if verb not in _K8S_READ_VERBS:
         raise KubectlSafetyError(
             f"kubectl verb {verb!r} is not on the read-only safelist; "
@@ -1035,13 +1134,17 @@ READ_OPS: tuple[HolodeckOp, ...] = (
             "Forwards a **read-only** ``kubectl`` command to the K8s "
             "cluster bundled on the HoloRouter appliance. The handler "
             "fails closed when the supplied command's verb is not on "
-            "the read-only safelist (allowed: ``get``, ``describe``, "
-            "``logs``, ``top``, ``explain``, ``api-resources``, "
-            "``api-versions``, ``cluster-info``, ``version``). Use to "
-            "inspect cluster state without mutating it. The schema "
-            "pattern enforces the ``kubectl <read-verb> ...`` shape at "
-            "the validator layer; the handler re-checks the verb as a "
-            "belt-and-braces safety gate."
+            "the read-only safelist. Allowed single-word verbs: "
+            "``get``, ``describe``, ``logs``, ``top``, ``explain``, "
+            "``api-resources``, ``api-versions``, ``cluster-info``, "
+            "``version``. Allowed multi-word verbs: ``config view``, "
+            "``config get-contexts``, ``config get-clusters``, "
+            "``config get-users``, ``config current-context``, "
+            "``auth can-i``, ``auth whoami``. Use to inspect cluster "
+            "state without mutating it. The schema pattern enforces "
+            "the ``kubectl <read-verb> ...`` shape at the validator "
+            "layer; the handler re-checks the verb as a belt-and-braces "
+            "safety gate."
         ),
         parameter_schema={
             "type": "object",
@@ -1069,9 +1172,29 @@ READ_OPS: tuple[HolodeckOp, ...] = (
                         # Verb alternation is followed by ``(?=[ \\t]
                         # |\\Z)`` so verb prefixes (``getfoo``) don't
                         # sneak through.
+                        #
+                        # Multi-word verb literals (``config view`` /
+                        # ``auth can-i`` / ...) appear FIRST in the
+                        # alternation. The regex engine tries
+                        # alternations left-to-right, so listing the
+                        # longer multi-word literal before the
+                        # single-word ``config`` / ``auth`` ensures
+                        # the engine commits to the multi-word match
+                        # when both could apply -- this matches the
+                        # handler-layer ordering in
+                        # :func:`parse_kubectl_command`. The
+                        # single-word safelist does NOT include
+                        # ``config`` or ``auth``, so a misshapen
+                        # ``kubectl config set-context`` falls through
+                        # both alternation branches and is rejected
+                        # at the schema layer too.
                         r"\Akubectl"
                         r"([ \t]+--?[A-Za-z0-9_-]+(=[A-Za-z0-9._/=:,@-]+)?)*"
-                        r"[ \t]+(get|describe|logs|top|explain|"
+                        r"[ \t]+("
+                        r"config[ \t]+(view|get-contexts|get-clusters|"
+                        r"get-users|current-context)|"
+                        r"auth[ \t]+(can-i|whoami)|"
+                        r"get|describe|logs|top|explain|"
                         r"api-resources|api-versions|cluster-info|"
                         r"version)(?=[ \t]|\Z)"
                         r"([ \t]+[A-Za-z0-9._/=:,@-]+)*"
@@ -1080,12 +1203,18 @@ READ_OPS: tuple[HolodeckOp, ...] = (
                     "description": (
                         "Full kubectl command line starting with "
                         "``kubectl`` and a read-only verb. Allowed "
-                        "verbs: get, describe, logs, top, explain, "
-                        "api-resources, api-versions, cluster-info, "
-                        "version. Mutating verbs (create, apply, "
+                        "single-word verbs: get, describe, logs, top, "
+                        "explain, api-resources, api-versions, "
+                        "cluster-info, version. Allowed multi-word "
+                        "verbs: config view, config get-contexts, "
+                        "config get-clusters, config get-users, "
+                        "config current-context, auth can-i, "
+                        "auth whoami. Mutating verbs (create, apply, "
                         "delete, edit, replace, patch, scale, "
                         "rollout, label, annotate, cp, exec, "
-                        "port-forward, proxy, drain, cordon) are "
+                        "port-forward, proxy, drain, cordon) and "
+                        "mutating sub-verbs (config set-context, "
+                        "config unset, auth reconcile, ...) are "
                         "rejected at the schema layer. Arguments are "
                         "restricted to ``[A-Za-z0-9._/=:,@-]`` -- shell "
                         "metacharacters (``;``, ``&``, ``|``, ``$``, "
@@ -1115,17 +1244,26 @@ READ_OPS: tuple[HolodeckOp, ...] = (
             "when_to_use": (
                 "Call when the operator wants to inspect the K8s "
                 "cluster bundled on the HoloRouter appliance via "
-                "``kubectl``. Only read-only verbs are allowed: ``get``, "
-                "``describe``, ``logs``, ``top``, ``explain``, "
-                "``api-resources``, ``api-versions``, ``cluster-info``, "
-                "``version``. Mutating verbs fail closed. " + _SSH_TRANSPORT_NOTE
+                "``kubectl``. Only read-only verbs are allowed. "
+                "Single-word: ``get``, ``describe``, ``logs``, "
+                "``top``, ``explain``, ``api-resources``, "
+                "``api-versions``, ``cluster-info``, ``version``. "
+                "Multi-word inspection: ``kubectl config view`` / "
+                "``config get-contexts`` / ``config get-clusters`` / "
+                "``config get-users`` / ``config current-context`` "
+                "for kubeconfig inspection; ``kubectl auth can-i "
+                "<verb> <resource>`` / ``kubectl auth whoami`` for "
+                "authorization inspection. Mutating verbs and "
+                "mutating sub-verbs (``config set-context``, "
+                "``auth reconcile``, etc.) fail closed. " + _SSH_TRANSPORT_NOTE
             ),
             "parameter_hints": {
                 "command": (
                     "Full kubectl invocation, e.g. ``kubectl get pods "
-                    "-n holodeck`` or ``kubectl describe service "
-                    "<name>``. Single-line; arguments tokenised via "
-                    "shlex."
+                    "-n holodeck``, ``kubectl describe service "
+                    "<name>``, ``kubectl config view``, or "
+                    "``kubectl auth can-i list pods``. Single-line; "
+                    "arguments tokenised via shlex."
                 ),
             },
             "output_shape": (

--- a/backend/tests/test_connectors_holodeck_ops.py
+++ b/backend/tests/test_connectors_holodeck_ops.py
@@ -9,7 +9,10 @@ Coverage matrix (per Task #854 acceptance criteria):
   into ``(verb, args)``; rejects mutating verbs with
   :exc:`KubectlSafetyError`; handles leading global flags (both
   ``--flag=value`` and ``--flag value`` forms); rejects non-kubectl
-  shells.
+  shells. Accepts multi-word inspection verbs (``config view``,
+  ``auth can-i``, ...) via the parent + sub-verb allowlist; rejects
+  adjacent mutating sub-verbs (``config set-context``,
+  ``auth reconcile``) under the same parents (G3.8 follow-up #1020).
 * :func:`parse_logs_tail_output` -- splits multi-file GNU ``tail``
   output by ``==> path <==`` header; single-file tail yields
   ``path=None``; empty / whitespace stdout returns ``files=[]``.
@@ -249,6 +252,116 @@ def test_parse_kubectl_command_safelist_includes_top_explain() -> None:
 
 def test_parse_kubectl_command_safelist_includes_cluster_info() -> None:
     assert parse_kubectl_command("kubectl cluster-info")[0] == "cluster-info"
+
+
+# ---------------------------------------------------------------------------
+# parse_kubectl_command -- multi-word verb safelist (G3.8 follow-up #1020)
+#
+# Multi-word inspection verbs (`kubectl config view`,
+# `kubectl auth can-i`, etc.) get their own (parent, sub-verb)
+# allowlist because the parent token is a shared namespace where
+# mutating sub-verbs (`config set-context`, `auth reconcile`) also
+# live. Adjacent-reject coverage: every accept-path has a paired
+# reject-test for an adjacent mutating sub-verb under the same parent.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_kubectl_command_multiword_config_view() -> None:
+    """``kubectl config view`` -- the canonical kubeconfig dump command."""
+    verb, args = parse_kubectl_command("kubectl config view")
+    assert verb == "config view"
+    assert args == []
+
+
+def test_parse_kubectl_command_multiword_config_get_contexts() -> None:
+    verb, args = parse_kubectl_command("kubectl config get-contexts")
+    assert verb == "config get-contexts"
+    assert args == []
+
+
+def test_parse_kubectl_command_multiword_config_current_context() -> None:
+    verb, _ = parse_kubectl_command("kubectl config current-context")
+    assert verb == "config current-context"
+
+
+def test_parse_kubectl_command_multiword_auth_can_i_with_args() -> None:
+    """``kubectl auth can-i list pods`` -- the canonical access-check shape."""
+    verb, args = parse_kubectl_command("kubectl auth can-i list pods")
+    assert verb == "auth can-i"
+    assert args == ["list", "pods"]
+
+
+def test_parse_kubectl_command_multiword_auth_whoami() -> None:
+    verb, args = parse_kubectl_command("kubectl auth whoami")
+    assert verb == "auth whoami"
+    assert args == []
+
+
+def test_parse_kubectl_command_multiword_with_global_flag() -> None:
+    """Global flags before a multi-word verb don't break the 2-token prefix walk."""
+    verb, _ = parse_kubectl_command("kubectl --context=foo config view")
+    assert verb == "config view"
+
+
+@pytest.mark.parametrize(
+    ("parent", "sub_verb"),
+    [
+        # Mutating ``config`` sub-verbs -- every adjacent reject path
+        # under the safelisted ``config`` parent verb.
+        ("config", "set-context"),
+        ("config", "set-cluster"),
+        ("config", "set-credentials"),
+        ("config", "unset"),
+        ("config", "use-context"),
+        ("config", "delete-context"),
+        ("config", "delete-cluster"),
+        ("config", "delete-user"),
+        ("config", "rename-context"),
+        # Mutating ``auth`` sub-verb -- the adjacent reject path under
+        # the safelisted ``auth`` parent verb.
+        ("auth", "reconcile"),
+    ],
+)
+def test_parse_kubectl_command_multiword_rejects_mutating_sub_verb(
+    parent: str, sub_verb: str
+) -> None:
+    """Adjacent-reject coverage: mutating sub-verbs fail closed.
+
+    The parent token (``config`` / ``auth``) is on the multi-word
+    safelist, but the sub-verb is not. The check pins both tokens
+    together; absence is rejection. This is the load-bearing
+    distinction that the single-word fallthrough would have lost --
+    a flat ``frozenset({"config", "auth", ...})`` would have approved
+    every sub-verb under either parent.
+    """
+    with pytest.raises(KubectlSafetyError) as excinfo:
+        parse_kubectl_command(f"kubectl {parent} {sub_verb}")
+    msg = str(excinfo.value)
+    assert sub_verb in msg
+    assert parent in msg
+
+
+def test_parse_kubectl_command_multiword_rejects_bare_parent() -> None:
+    """``kubectl config`` / ``kubectl auth`` with no sub-verb is rejected.
+
+    The parent token is never a legal stand-alone read verb -- it
+    requires a sub-verb to carry meaning. Reject the bare parent so
+    a future bug can't silently approve through the single-word
+    fallthrough.
+    """
+    for parent in ("config", "auth"):
+        with pytest.raises(KubectlSafetyError) as excinfo:
+            parse_kubectl_command(f"kubectl {parent}")
+        assert parent in str(excinfo.value)
+        assert "sub-verb" in str(excinfo.value)
+
+
+def test_parse_kubectl_command_multiword_rejects_unknown_sub_verb_under_safelisted_parent() -> None:
+    """Unknown / typo sub-verbs under a safelisted parent fail closed."""
+    with pytest.raises(KubectlSafetyError):
+        parse_kubectl_command("kubectl config get-something-new")
+    with pytest.raises(KubectlSafetyError):
+        parse_kubectl_command("kubectl auth garbage")
 
 
 # ---------------------------------------------------------------------------
@@ -587,6 +700,73 @@ async def test_k8s_exec_schema_pattern_accepts_read_verbs() -> None:
         "version",
     ):
         jsonschema.validate({"command": f"kubectl {verb} pods"}, schema)
+
+
+@pytest.mark.asyncio
+async def test_k8s_exec_schema_pattern_accepts_multiword_read_verbs() -> None:
+    """The schema must accept every multi-word read verb on the safelist.
+
+    Pairs with the handler-layer accept tests above
+    (``test_parse_kubectl_command_multiword_*``) -- both layers
+    independently approve the same multi-word verb set so a future
+    schema widening or narrowing cannot silently drift away from the
+    handler's authoritative gate.
+    """
+    k8s_op = next(op for op in READ_OPS if op.op_id == "holodeck.k8s.exec")
+    schema = k8s_op.parameter_schema
+    accepted = [
+        "kubectl config view",
+        "kubectl config get-contexts",
+        "kubectl config get-clusters",
+        "kubectl config get-users",
+        "kubectl config current-context",
+        "kubectl auth can-i list pods",
+        "kubectl auth can-i create deployments --namespace=holodeck",
+        "kubectl auth whoami",
+    ]
+    for command in accepted:
+        jsonschema.validate({"command": command}, schema)
+
+
+@pytest.mark.asyncio
+async def test_k8s_exec_schema_pattern_rejects_mutating_sub_verbs() -> None:
+    """Adjacent-reject: mutating sub-verbs fail the schema pattern too.
+
+    Same pairing as the accept test above: the schema layer rejects
+    the same mutating sub-verbs the handler-layer fails closed on, so
+    the dispatcher's ``validate_params`` catches the obvious bad shape
+    before reaching :func:`parse_kubectl_command`.
+    """
+    k8s_op = next(op for op in READ_OPS if op.op_id == "holodeck.k8s.exec")
+    schema = k8s_op.parameter_schema
+    rejected = [
+        "kubectl config set-context my-ctx",
+        "kubectl config set-cluster my-cluster",
+        "kubectl config set-credentials me",
+        "kubectl config unset users.me",
+        "kubectl config use-context my-ctx",
+        "kubectl config delete-context my-ctx",
+        "kubectl config delete-cluster my-cluster",
+        "kubectl config rename-context old new",
+        "kubectl auth reconcile",
+    ]
+    for command in rejected:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate({"command": command}, schema)
+
+
+@pytest.mark.asyncio
+async def test_k8s_exec_schema_pattern_rejects_bare_config_or_auth() -> None:
+    """The schema must reject ``kubectl config`` / ``kubectl auth`` with no sub-verb.
+
+    The parent token alone is never a legal read verb; the regex
+    alternation requires the multi-word sub-verb to be present.
+    """
+    k8s_op = next(op for op in READ_OPS if op.op_id == "holodeck.k8s.exec")
+    schema = k8s_op.parameter_schema
+    for command in ("kubectl config", "kubectl auth"):
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate({"command": command}, schema)
 
 
 @pytest.mark.asyncio

--- a/docs/codebase/connectors-holodeck.md
+++ b/docs/codebase/connectors-holodeck.md
@@ -173,21 +173,29 @@ disclosure (CLAUDE.md postulate 5 + Initiative #371).
   (`;`, `&&`, `||`, `|`, `$(...)`, backticks, `>`, `<`, newline):
 
   1. *Schema layer.* The `command` parameter has a `pattern` regex
-     anchored `\Akubectl ... \Z`. The verb alternation accepts the
-     nine read-only verbs (`get|describe|logs|top|explain|api-resources|
-     api-versions|cluster-info|version`); arguments are restricted to
-     `[A-Za-z0-9._/=:,@-]` so shell metacharacters can't survive
-     validator-layer rejection. Whitespace between tokens is constrained
-     to `[ \t]` (space or tab) so a newline can't smuggle a second
-     command line through the `\s` class. The dispatcher's
-     `validate_params` rejects bad shapes before reaching the handler.
+     anchored `\Akubectl ... \Z`. The verb alternation accepts both
+     the nine single-word read verbs (`get|describe|logs|top|explain|
+     api-resources|api-versions|cluster-info|version`) and a
+     fixed set of multi-word inspection verbs (`config view`,
+     `config get-contexts`, `config get-clusters`, `config get-users`,
+     `config current-context`, `auth can-i`, `auth whoami`).
+     Multi-word literals appear FIRST in the alternation so the regex
+     engine commits to the longer match when both could apply;
+     arguments are restricted to `[A-Za-z0-9._/=:,@-]` so shell
+     metacharacters can't survive validator-layer rejection. Whitespace
+     between tokens is constrained to `[ \t]` (space or tab) so a
+     newline can't smuggle a second command line through the `\s`
+     class. The dispatcher's `validate_params` rejects bad shapes
+     before reaching the handler.
   2. *Handler layer (authoritative).* `parse_kubectl_command`
      (a) scans the raw command against `_SHELL_METACHARS_RE`
      (`[;&|<>` + backtick + `$()\\` + newline + carriage return]`) and
      refuses on hit, (b) tokenises via `shlex.split`, (c) walks past
      leading global flags (`--flag=value` and `--flag value` forms),
-     and (d) confirms the verb is in `_K8S_READ_VERBS`. Any rejected
-     step raises `KubectlSafetyError`; the handler returns
+     (d) checks the 2-token (parent, sub-verb) prefix against
+     `_K8S_MULTIWORD_READ_VERBS` first, and (e) falls through to the
+     single-word `_K8S_READ_VERBS`. Any rejected step raises
+     `KubectlSafetyError`; the handler returns
      `{stdout, stderr, exit_status, error}` with `error` set to the
      safety-check message. The metacharacter reject is **load-bearing**:
      `shlex.split` in POSIX mode does not treat shell separators as
@@ -200,6 +208,16 @@ disclosure (CLAUDE.md postulate 5 + Initiative #371).
      back in the error message — only the rejected verb / metachar
      category — so operator-supplied resource names don't bleed into
      structured error envelopes.
+
+  The multi-word allowlist (added per G3.8 follow-up #1020) pins
+  parent + sub-verb pairs together because the parent token
+  (`config` / `auth`) is a shared namespace where both read and
+  write sub-verbs live — e.g. `kubectl config view` is a read but
+  `kubectl config set-context` is a mutation. The check refuses
+  ``kubectl config`` / ``kubectl auth`` with no sub-verb, and
+  refuses any sub-verb not in the per-parent frozenset, so
+  adjacent mutating sub-verbs (`config set-context`,
+  `config unset`, `auth reconcile`, ...) fail closed.
 
   Stderr from the appliance is truncated at 4096 chars, matching the
   `PwshRunError` convention.


### PR DESCRIPTION
## Summary

- Extend `holodeck.k8s.exec`'s read-verb safelist to support multi-word `kubectl` inspection commands (`kubectl config view`, `kubectl auth can-i ...`, etc.) — the deferred follow-up named in the iter-2 fix on PR #1005.
- New `_K8S_MULTIWORD_READ_VERBS: dict[str, frozenset[str]]` gates the sub-verb against a per-parent frozenset; `parse_kubectl_command` checks the 2-token prefix first and falls through to the single-word safelist. Schema regex extends the verb alternation with multi-word literals (longest-first).
- Adjacent mutating sub-verbs (`config set-context`, `auth reconcile`, ...) fail closed at both handler and schema layers; every accept-path has a paired reject-test for the matching mutating sub-verb under the same parent.

## Test plan

- [x] `ruff check src/meho_backplane/connectors/holodeck/ops_read.py tests/test_connectors_holodeck_ops.py` — clean
- [x] `ruff format --check ...` — clean
- [x] `mypy src/meho_backplane/connectors/holodeck/` — Success: no issues found in 5 source files
- [x] `pytest tests/test_connectors_holodeck_ops.py -q` — 162 passed (was 142 before; +20 new tests)
- [x] All 12 iter-2 shell-injection rejection tests still pass without modification
- [x] All 9 single-word allowlist tests still pass (regression)
- [x] `parse_kubectl_command("kubectl config view")` returns `("config view", [])`
- [x] `parse_kubectl_command("kubectl auth can-i list pods")` returns `("auth can-i", ["list", "pods"])`
- [x] `parse_kubectl_command("kubectl config set-context my-ctx")` raises `KubectlSafetyError`
- [x] `parse_kubectl_command("kubectl auth reconcile")` raises `KubectlSafetyError`
- [x] Schema pattern validates `kubectl config view`, `kubectl auth can-i list pods`; rejects `kubectl config set-context`, `kubectl auth reconcile`, bare `kubectl config` / `kubectl auth`
- [x] `holodeck.k8s.exec` `llm_instructions.when_to_use` updated to mention the new multi-word verbs
- [x] All 223 holodeck-specific tests pass (`test_connectors_holodeck_*`)
- [x] Code-quality gate clean (no blockers; warnings are pre-existing legacy)
- [x] `docs/codebase/connectors-holodeck.md` updated to describe the multi-word allowlist
- [x] Doctests pass (2 collected, 2 passed)

## Out of scope

- Write-capable verbs (`apply`, `delete`, `create`, etc.) — read-only by design per Initiative #371.
- `kubectl exec` meta-command — distinct from the `holodeck.k8s.exec` op name.
- Backporting the multi-word pattern to other connectors — each connector defines its own command safelist.
- Touching the metachar pre-scan or its 12 rejection tests — defenses preserved intact.
- Touching the CLI `meho holodeck k8s exec` verb — CLI just forwards verbatim; the backend remains the authoritative gate.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1020
