### PR TITLE
feat(audit): G8.2-T2 capture Mcp-Session-Id + MCP_REQUIRE_SESSION_ID + write agent_session_id

### DIFF
--- a/backend/src/meho_backplane/mcp/audit.py
+++ b/backend/src/meho_backplane/mcp/audit.py
@@ -85,6 +85,47 @@ def compute_params_hash(params: dict[str, Any]) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+def _resolve_uuid_contextvar(name: str) -> uuid.UUID | None:
+    """Read structlog contextvar *name* and parse it as :class:`uuid.UUID`.
+
+    Mirrors :func:`~meho_backplane.audit._resolve_target_id`: the binder
+    stores the value as ``str(some_uuid)`` and this reader parses it
+    back. Used for the two graph columns on the MCP audit row:
+
+    * ``mcp_session_id`` — bound by
+      :func:`~meho_backplane.mcp.server._bind_mcp_session_id` from the
+      inbound ``Mcp-Session-Id`` header (G8.2-T2 #1010); lands on
+      ``AuditLog.agent_session_id``.
+    * ``parent_audit_id`` — forward-compat hook (G8.2-T2 #1010): in v0.2
+      no MCP caller binds it, but reading it now means a future
+      tool-calls-tool flow only has to ``bind_contextvars`` the parent
+      op's audit id for the closure walk (G8.2 recursive-CTE replay) to
+      see the edge.
+
+    Unbound → ``None`` (the chassis-era default for HTTP rows, and the
+    v0.2 default for ``parent_audit_id``). A bound value that fails the
+    type / UUID-parse check is a programming error (the binders only
+    bind canonical UUID strings); the row is still committed with the
+    column ``None`` and the malformed value is logged so the invariant
+    violation is visible rather than silently fatal.
+    """
+    raw = structlog.contextvars.get_contextvars().get(name)
+    if raw is None:
+        return None
+    log = structlog.get_logger(__name__)
+    if not isinstance(raw, str):
+        log.error("mcp_audit_malformed_uuid_contextvar", name=name, value=raw)
+        return None
+    try:
+        return uuid.UUID(raw)
+    except ValueError:
+        log.error("mcp_audit_malformed_uuid_contextvar", name=name, value=raw)
+        return None
+
+
+# code-quality-allow: linear fail-closed audit write; the length is a
+# compliance-critical docstring documenting the merge + fail-closed contract,
+# not branching logic — extracting helpers would fragment one DB transaction.
 async def write_mcp_audit_row(
     *,
     operator: Operator,
@@ -121,6 +162,10 @@ async def write_mcp_audit_row(
     parity) is the v0.2 caller; future MCP meta-tools that bind
     ``audit_*`` contextvars inherit the same surfacing automatically.
 
+    The ``agent_session_id`` / ``parent_audit_id`` graph columns are
+    read from contextvars via :func:`_resolve_uuid_contextvar`
+    (G8.2-T2 #1010), not the ``audit_*`` payload merge.
+
     Raises any DB-side exception verbatim — the caller's ``finally``
     block converts it into a JSON-RPC ``-32603`` so the client sees
     the operation as failed and the audit-write failure is the
@@ -147,6 +192,11 @@ async def write_mcp_audit_row(
     if contextvar_payload:
         payload = {**contextvar_payload, **payload}
 
+    # Graph columns off contextvars (G8.2-T2 #1010) — real columns, not
+    # payload keys; see :func:`_resolve_uuid_contextvar` for bind sources.
+    agent_session_id = _resolve_uuid_contextvar("mcp_session_id")
+    parent_audit_id = _resolve_uuid_contextvar("parent_audit_id")
+
     log = structlog.get_logger(__name__)
     if audit_id is None:
         audit_id = uuid.uuid4()
@@ -157,6 +207,8 @@ async def write_mcp_audit_row(
             occurred_at=datetime.now(UTC),
             operator_sub=operator.sub,
             tenant_id=operator.tenant_id,
+            agent_session_id=agent_session_id,
+            parent_audit_id=parent_audit_id,
             method=method,
             path=path,
             status_code=status_code,

--- a/backend/src/meho_backplane/mcp/server.py
+++ b/backend/src/meho_backplane/mcp/server.py
@@ -491,7 +491,7 @@ def _bind_mcp_session_id(
     any audit row is written.
     """
     session_header = request.headers.get("mcp-session-id")
-    has_header = bool(session_header)
+    has_header = session_header is not None and session_header != ""
 
     if not has_header and get_settings().mcp_require_session_id:
         _log.warning("mcp_session_id_required_but_missing")

--- a/backend/src/meho_backplane/mcp/server.py
+++ b/backend/src/meho_backplane/mcp/server.py
@@ -76,6 +76,7 @@ References
 from __future__ import annotations
 
 import json
+import uuid
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -102,6 +103,7 @@ from meho_backplane.mcp.schemas import (
     JsonRpcResponse,
     ServerCapabilities,
 )
+from meho_backplane.settings import get_settings
 
 __all__ = ["McpInvalidParamsError", "register_method", "router"]
 
@@ -441,6 +443,77 @@ def _validate_protocol_version_header(
     )
 
 
+def _bind_mcp_session_id(
+    request: Request,
+    payload: dict[str, Any],
+) -> JSONResponse | None:
+    """Capture the ``Mcp-Session-Id`` header into a structlog contextvar.
+
+    Per the MCP 2025-06-18 Streamable HTTP transport §"Session
+    Management", a server MAY assign a session id at ``initialize`` time
+    that the client echoes in the ``Mcp-Session-Id`` header on every
+    later request. MEHO runs no stateful session store in v0.2 — it
+    only needs the id for **audit correlation** so per-session replay
+    (``meho audit replay <session-id>``, G8.2) can reconstruct one
+    agent's full operation trace. The header is bound as a structlog
+    contextvar (stored as the canonical UUID string, mirroring how
+    :func:`~meho_backplane.targets.resolver.resolve_target` binds
+    ``target_id``); :func:`~meho_backplane.mcp.audit.write_mcp_audit_row`
+    reads it back and writes ``audit_log.agent_session_id``. The
+    contextvar propagates down the request's async call chain, so the
+    write picks it up without threading the value through every handler
+    signature.
+
+    Resolution rules (issue #1010):
+
+    * Present and a parseable UUID → bind that id.
+    * Present but not a UUID → treated as absent. A non-UUID id can't
+      go in a ``uuid`` column, and a malformed *client* header must not
+      500 the call (the client is in the wrong, not the server).
+    * Absent / empty → generate a fresh :func:`uuid.uuid4` for the
+      single-call duration so the row still carries a stable, non-NULL
+      session id (the spec explicitly permits servers to not require
+      sessions; single-call sessions are valid).
+
+    When :attr:`~meho_backplane.settings.Settings.mcp_require_session_id`
+    is ``True`` (``MCP_REQUIRE_SESSION_ID`` env), a missing/empty header
+    short-circuits to a JSON-RPC ``-32600`` Invalid Request **before**
+    dispatch, mirroring the early-return shape of
+    :func:`_validate_protocol_version_header`. A present-but-malformed
+    header is *not* a rejection in require-mode: the client did send a
+    session id, so the require-a-session contract is satisfied; the
+    malformed value just falls back to a fresh uuid4 the same way it
+    does in the default mode.
+
+    Returns ``None`` on the OK path (contextvar bound); a
+    :class:`JSONResponse` (HTTP 200 + JSON-RPC ``-32600`` envelope) on
+    the require-mode rejection so the caller can early-return it before
+    any audit row is written.
+    """
+    session_header = request.headers.get("mcp-session-id")
+    has_header = bool(session_header)
+
+    if not has_header and get_settings().mcp_require_session_id:
+        _log.warning("mcp_session_id_required_but_missing")
+        return _error_response(
+            _coerce_request_id(payload),
+            INVALID_REQUEST,
+            "invalid request: Mcp-Session-Id header is required",
+        )
+
+    session_id: uuid.UUID | None = None
+    if has_header:
+        try:
+            session_id = uuid.UUID(session_header)
+        except ValueError:
+            _log.warning("mcp_malformed_session_id", header=session_header)
+    if session_id is None:
+        session_id = uuid.uuid4()
+
+    structlog.contextvars.bind_contextvars(mcp_session_id=str(session_id))
+    return None
+
+
 def _build_success_response(
     request_id: JsonRpcId,
     result: _McpHandlerResult,
@@ -600,6 +673,15 @@ async def mcp_dispatch(
     protocol_error = _validate_protocol_version_header(request, jrpc.method, payload)
     if protocol_error is not None:
         return protocol_error
+
+    # Capture the Mcp-Session-Id header (G8.2-T2 #1010) so the audit
+    # writer can correlate every row of this call to one agent session.
+    # Bound for both requests and notifications — notifications still
+    # write audit rows downstream. In MCP_REQUIRE_SESSION_ID mode a
+    # missing header short-circuits to -32600 before any dispatch.
+    session_error = _bind_mcp_session_id(request, payload)
+    if session_error is not None:
+        return session_error
 
     # Notification detection: JSON-RPC §4.1.2 says a notification is a
     # request without an ``id`` member. Pydantic-side, ``jrpc.id``

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -439,6 +439,18 @@ class Settings(BaseModel):
         retention is policy-driven); ``enabled=False`` skips starting
         the loop entirely (no audit-row noise, no log line). Read once
         at lifespan startup; toggling post-start requires a pod restart.
+    mcp_require_session_id:
+        Whether ``POST /mcp`` rejects requests that omit the
+        ``Mcp-Session-Id`` header (G8.2-T2 #1010). Default ``False``:
+        the MCP 2025-06-18 Streamable HTTP transport explicitly permits
+        servers to not require sessions, and MEHO only needs the id for
+        audit correlation, so a missing header falls back to a fresh
+        single-call ``uuid4()``. Flip ``MCP_REQUIRE_SESSION_ID=true``
+        in deployments that mandate every agent call carry a stable
+        session id (compliance environments that forbid synthetic
+        single-call ids); a missing/empty header then returns a
+        JSON-RPC ``-32600`` Invalid Request before dispatch, so no
+        audit row is written for the rejected call.
     """
 
     keycloak_issuer_url: HttpUrl
@@ -516,6 +528,7 @@ class Settings(BaseModel):
     topology_history_retention_days: int = Field(default=90, ge=0, le=3650)
     topology_history_prune_interval_seconds: int = Field(default=604800, ge=60, le=604800)
     topology_history_prune_enabled: bool = True
+    mcp_require_session_id: bool = False
 
     @field_validator("broadcast_redis_url")
     @classmethod
@@ -669,5 +682,8 @@ def get_settings() -> Settings:
         ),
         topology_history_prune_enabled=parse_bool_env(
             os.environ.get("TOPOLOGY_HISTORY_PRUNE_ENABLED", "true"),
+        ),
+        mcp_require_session_id=parse_bool_env(
+            os.environ.get("MCP_REQUIRE_SESSION_ID"),
         ),
     )

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -229,6 +229,16 @@ async def seeded_operator_tenant() -> None:
         )
 
 
-def post_mcp(client: TestClient, body: Any) -> Any:
-    """POST a JSON-RPC envelope to ``/mcp`` and return the ``Response``."""
-    return client.post("/mcp", json=body)
+def post_mcp(
+    client: TestClient,
+    body: Any,
+    *,
+    headers: dict[str, str] | None = None,
+) -> Any:
+    """POST a JSON-RPC envelope to ``/mcp`` and return the ``Response``.
+
+    ``headers`` lets a test exercise transport-level header handling
+    (e.g. ``Mcp-Session-Id`` capture, G8.2-T2 #1010) without bypassing
+    the shared helper.
+    """
+    return client.post("/mcp", json=body, headers=headers)

--- a/backend/tests/test_audit_middleware.py
+++ b/backend/tests/test_audit_middleware.py
@@ -248,6 +248,10 @@ async def test_authenticated_request_writes_one_audit_row(
     # ``verify_jwt_and_bind`` binds into contextvars and the audit
     # middleware reads back, parses, and writes here.
     assert row.tenant_id is not None
+    # G8.2-T2 (#1010): chassis HTTP-side rows are not part of an agent
+    # session — ``agent_session_id`` stays NULL. Only the MCP transport's
+    # ``Mcp-Session-Id`` capture populates it (see tests.test_mcp_audit).
+    assert row.agent_session_id is None
     assert str(row.tenant_id) == _DEFAULT_TENANT_ID
 
 

--- a/backend/tests/test_mcp_audit.py
+++ b/backend/tests/test_mcp_audit.py
@@ -37,7 +37,8 @@ from meho_backplane.auth.operator import Operator
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AuditLog
 from meho_backplane.mcp.audit import compute_params_hash, write_mcp_audit_row
-from meho_backplane.mcp.schemas import INTERNAL_ERROR, INVALID_PARAMS
+from meho_backplane.mcp.schemas import INTERNAL_ERROR, INVALID_PARAMS, INVALID_REQUEST
+from meho_backplane.settings import get_settings
 from tests.mcp_test_fixtures import (
     build_operator,
     client_with_operator,  # noqa: F401 — pytest-discovered fixture
@@ -328,3 +329,183 @@ async def test_write_mcp_audit_row_persists_every_field() -> None:
     # SQLite stores Numeric via _PORTABLE_JSON if applicable; check value
     assert float(row.duration_ms or 0) == pytest.approx(12.34)
     assert json.loads(json.dumps(row.payload)) == payload
+
+
+# ---------------------------------------------------------------------------
+# G8.2-T2 (#1010): Mcp-Session-Id capture → agent_session_id column
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_session_header_propagates_to_agent_session_id(
+    client_with_operator: tuple[TestClient, Operator],
+) -> None:
+    """AC: a ``Mcp-Session-Id`` header lands on ``audit_log.agent_session_id``."""
+    client, _op = client_with_operator
+    session_id = uuid4()
+
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "meho.status", "arguments": {}},
+        },
+        headers={"Mcp-Session-Id": str(session_id)},
+    )
+    assert response.status_code == 200
+
+    rows = await _audit_rows()
+    mcp_rows = [r for r in rows if r.method == "MCP"]
+    assert len(mcp_rows) == 1
+    assert mcp_rows[0].agent_session_id == session_id
+
+
+@pytest.mark.asyncio
+async def test_absent_session_header_gets_fresh_uuid_per_call(
+    client_with_operator: tuple[TestClient, Operator],
+) -> None:
+    """AC: no header → non-NULL ``agent_session_id``; two calls differ.
+
+    Single-call sessions are valid per the MCP spec; the fresh uuid4
+    keeps the column non-NULL so the row is still session-addressable.
+    Two header-less calls must get two distinct ids — otherwise the
+    fallback would collide every unattributed call into one bucket.
+    """
+    client, _op = client_with_operator
+    envelope = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "meho.status", "arguments": {}},
+    }
+
+    assert post_mcp(client, envelope).status_code == 200
+    assert post_mcp(client, {**envelope, "id": 2}).status_code == 200
+
+    rows = await _audit_rows()
+    mcp_rows = [r for r in rows if r.method == "MCP"]
+    assert len(mcp_rows) == 2
+    ids = [r.agent_session_id for r in mcp_rows]
+    assert all(i is not None for i in ids)
+    assert ids[0] != ids[1]
+
+
+@pytest.mark.asyncio
+async def test_malformed_session_header_falls_back_to_fresh_uuid(
+    client_with_operator: tuple[TestClient, Operator],
+) -> None:
+    """AC: a non-UUID ``Mcp-Session-Id`` does not 500 — it falls back.
+
+    A malformed *client* header can't go in the ``uuid`` column, so it
+    is treated as absent: the call succeeds (no transport error) and the
+    row carries a fresh, non-NULL uuid4 rather than the bad header value.
+    """
+    client, _op = client_with_operator
+
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "meho.status", "arguments": {}},
+        },
+        headers={"Mcp-Session-Id": "not-a-uuid"},
+    )
+    assert response.status_code == 200
+    assert response.json()["result"]["isError"] is False
+
+    rows = await _audit_rows()
+    mcp_rows = [r for r in rows if r.method == "MCP"]
+    assert len(mcp_rows) == 1
+    assert mcp_rows[0].agent_session_id is not None
+
+
+@pytest.mark.asyncio
+async def test_require_session_id_rejects_missing_header_without_audit_row(
+    client_with_operator: tuple[TestClient, Operator],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC: ``MCP_REQUIRE_SESSION_ID=true`` + no header → -32600, no row.
+
+    The reject must fire *before* dispatch, so no audit row is written
+    for the rejected call (the operation never ran).
+    """
+    client, _op = client_with_operator
+    monkeypatch.setenv("MCP_REQUIRE_SESSION_ID", "true")
+    get_settings.cache_clear()
+
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "meho.status", "arguments": {}},
+        },
+    )
+    assert response.json()["error"]["code"] == INVALID_REQUEST
+
+    rows = await _audit_rows()
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_require_session_id_accepts_when_header_present(
+    client_with_operator: tuple[TestClient, Operator],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """AC: require-mode still succeeds when the header is supplied."""
+    client, _op = client_with_operator
+    monkeypatch.setenv("MCP_REQUIRE_SESSION_ID", "true")
+    get_settings.cache_clear()
+    session_id = uuid4()
+
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "meho.status", "arguments": {}},
+        },
+        headers={"Mcp-Session-Id": str(session_id)},
+    )
+    assert response.status_code == 200
+
+    rows = await _audit_rows()
+    mcp_rows = [r for r in rows if r.method == "MCP"]
+    assert len(mcp_rows) == 1
+    assert mcp_rows[0].agent_session_id == session_id
+
+
+@pytest.mark.asyncio
+async def test_write_helper_leaves_agent_session_id_null_without_contextvar() -> None:
+    """HTTP-shaped rows stay NULL: the writer reads no session contextvar.
+
+    The chassis ``AuditMiddleware`` never binds ``mcp_session_id``, so a
+    direct ``write_mcp_audit_row`` call with no contextvar bound (the
+    helper-level path) leaves ``agent_session_id`` / ``parent_audit_id``
+    NULL — proving the column is opt-in via the MCP transport's bind,
+    not a default on every row.
+    """
+    import structlog
+
+    structlog.contextvars.clear_contextvars()
+    op = build_operator()
+
+    await write_mcp_audit_row(
+        operator=op,
+        method="MCP",
+        path="/mcp/tools/call/test.tool",
+        status_code=200,
+        duration_ms=1.0,
+        payload={"op_id": "test.tool", "op_class": "read"},
+    )
+
+    rows = await _audit_rows()
+    assert len(rows) == 1
+    assert rows[0].agent_session_id is None
+    assert rows[0].parent_audit_id is None

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -53,6 +53,7 @@ from meho_backplane.mcp.schemas import (
     PARSE_ERROR,
     PROTOCOL_VERSION,
 )
+from meho_backplane.settings import get_settings
 
 _DISPATCH_TEST_OPERATOR: Operator = Operator(
     sub="dispatcher-test-operator",
@@ -79,7 +80,7 @@ async def _fixture_verify_mcp_jwt_and_bind() -> Operator:
 
 
 @pytest.fixture
-def client() -> Iterator[TestClient]:
+def client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     """:class:`TestClient` with ``verify_mcp_jwt_and_bind`` overridden.
 
     The shared :mod:`conftest` autouse fixture supplies a per-test
@@ -89,12 +90,29 @@ def client() -> Iterator[TestClient]:
     plumbing here. The dependency override skips the full Bearer-token
     chain (covered in :mod:`tests.test_mcp_auth`) so each test in this
     file can focus on JSON-RPC dispatch semantics.
+
+    The chassis env vars (``KEYCLOAK_ISSUER_URL`` / ``KEYCLOAK_AUDIENCE``
+    / ``VAULT_ADDR`` / ``BACKPLANE_URL``) are pinned here because the
+    dispatch path now calls :func:`~meho_backplane.settings.get_settings`
+    (to read ``mcp_require_session_id`` in
+    :func:`~meho_backplane.mcp.server._bind_mcp_session_id`), and
+    ``Settings`` raises on an unset Keycloak knob. This mirrors the
+    convention documented in :mod:`tests.conftest` (every test file pins
+    these) and the ``required_settings_env`` fixture in
+    :mod:`tests.mcp_test_fixtures`. The ``cache_clear`` brackets evict any
+    ``Settings`` constructed under a different env before/after this test.
     """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", "https://meho.test")
+    get_settings.cache_clear()
     app.dependency_overrides[verify_mcp_jwt_and_bind] = _fixture_verify_mcp_jwt_and_bind
     try:
         yield TestClient(app)
     finally:
         app.dependency_overrides.pop(verify_mcp_jwt_and_bind, None)
+        get_settings.cache_clear()
 
 
 def _post_mcp(client: TestClient, body: Any) -> Any:

--- a/backend/tests/test_settings.py
+++ b/backend/tests/test_settings.py
@@ -163,3 +163,59 @@ def test_get_settings_preserves_empty_string_default_for_unset_ui_env_vars(
         assert settings.ui_session_encryption_key == ""
     finally:
         get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# G8.2-T2 (#1010) — MCP_REQUIRE_SESSION_ID env knob
+# ---------------------------------------------------------------------------
+
+
+def _base_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin the chassis-required env vars so ``get_settings()`` constructs."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+
+def test_mcp_require_session_id_defaults_false_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset ``MCP_REQUIRE_SESSION_ID`` → ``False`` (sessions optional)."""
+    _base_env(monkeypatch)
+    monkeypatch.delenv("MCP_REQUIRE_SESSION_ID", raising=False)
+    get_settings.cache_clear()
+    try:
+        assert get_settings().mcp_require_session_id is False
+    finally:
+        get_settings.cache_clear()
+
+
+@pytest.mark.parametrize("raw", ["1", "true", "yes", "on", "TRUE", "On"])
+def test_mcp_require_session_id_truthy_spellings(
+    monkeypatch: pytest.MonkeyPatch,
+    raw: str,
+) -> None:
+    """Canonical truthy spellings flip the knob to ``True`` via ``parse_bool_env``."""
+    _base_env(monkeypatch)
+    monkeypatch.setenv("MCP_REQUIRE_SESSION_ID", raw)
+    get_settings.cache_clear()
+    try:
+        assert get_settings().mcp_require_session_id is True
+    finally:
+        get_settings.cache_clear()
+
+
+@pytest.mark.parametrize("raw", ["0", "false", "no", "off", "disabled", ""])
+def test_mcp_require_session_id_non_truthy_stays_false(
+    monkeypatch: pytest.MonkeyPatch,
+    raw: str,
+) -> None:
+    """Anything outside the accept-list (incl. typos / empty) stays ``False``."""
+    _base_env(monkeypatch)
+    monkeypatch.setenv("MCP_REQUIRE_SESSION_ID", raw)
+    get_settings.cache_clear()
+    try:
+        assert get_settings().mcp_require_session_id is False
+    finally:
+        get_settings.cache_clear()

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -30,6 +30,16 @@ The locked decision (#7 in [v0.2-decisions.md](../planning/v0.2-decisions.md)) w
 
 **Streamable HTTP**, not stdio. MEHO is a hosted server, not a local subprocess. The `/mcp` route accepts JSON-RPC 2.0 POST requests with a single envelope per body (batch arrays are unsupported — MCP Streamable HTTP transport mandates single envelopes).
 
+### Session id capture (audit correlation)
+
+Per the spec's *Session Management* section, a server MAY assign a session id at `initialize` that the client echoes in the `Mcp-Session-Id` header on later requests. MEHO runs **no** stateful session store in v0.2 — it captures the header purely for **audit correlation** so per-session replay (`meho audit replay <session-id>`, G8.2) can reconstruct one agent's full operation trace. On every `POST /mcp`, [`_bind_mcp_session_id`](../../backend/src/meho_backplane/mcp/server.py) binds an `mcp_session_id` structlog contextvar (G8.2-T2 #1010):
+
+- Header present and a parseable UUID → bind it.
+- Header present but malformed (non-UUID) → treated as absent (a malformed *client* header never 500s the call; a non-UUID can't go in a `uuid` column).
+- Header absent/empty → fresh `uuid4()` for the single-call duration, so the audit row still carries a stable, non-NULL session id (the spec permits servers to not require sessions).
+
+`MCP_REQUIRE_SESSION_ID=true` ([`Settings.mcp_require_session_id`](../../backend/src/meho_backplane/settings.py), default `false`) turns a missing/empty header into a JSON-RPC `-32600` Invalid Request **before** dispatch — no audit row is written for the rejected call. A present-but-malformed header is not a rejection in require-mode (the client did send an id); it falls back to a fresh `uuid4()` as in the default mode.
+
 Response shapes per the spec's *Sending Messages to the Server* section:
 
 | Input | Response |
@@ -39,6 +49,7 @@ Response shapes per the spec's *Sending Messages to the Server* section:
 | Parse error | HTTP 200 + `error: { code: -32700, ... }` |
 | Invalid request | HTTP 200 + `error: { code: -32600, ... }` |
 | Unsupported `MCP-Protocol-Version` | **HTTP 400** + JSON-RPC error envelope (spec MUST) |
+| Missing `Mcp-Session-Id` **and** `MCP_REQUIRE_SESSION_ID=true` | HTTP 200 + `error: { code: -32600, ... }` (no audit row written) |
 | Missing/invalid Bearer token | HTTP 401 + `WWW-Authenticate: Bearer resource_metadata="..."` |
 | Insufficient scope/role | HTTP 403 |
 | GET on `/mcp` | HTTP 405 (FastAPI default; SSE-on-GET unimplemented in v0.2) |
@@ -129,15 +140,19 @@ Per [G0.5-T5 (#250, PR #300)](https://github.com/evoila/meho/pull/300): MCP hand
 The per-operation writer is [`mcp/audit.py::write_mcp_audit_row`](../../backend/src/meho_backplane/mcp/audit.py), called from inside [`mcp/handlers.py`](../../backend/src/meho_backplane/mcp/handlers.py) for both `tools/call` and `resources/read`. MCP audit row shape:
 
 ```text
-operator_sub  ← from JWT (validated by /mcp auth chain)
-tenant_id     ← operator.tenant_id
-request_id    ← from RequestContextMiddleware (still runs)
-method        ← "MCP"
-path          ← "/mcp/tools/call/{tool_name}" or "/mcp/resources/read/{uri}"
-status_code   ← 200 / 400 / 403 / 404 / 500 (derived from JSON-RPC outcome)
-duration_ms   ← time.monotonic() bracket
-payload       ← {op_id, params_hash, op_class}
+operator_sub     ← from JWT (validated by /mcp auth chain)
+tenant_id        ← operator.tenant_id
+agent_session_id ← Mcp-Session-Id header (or fresh uuid4); NULL on chassis HTTP rows (G8.2-T2)
+parent_audit_id  ← parent_audit_id contextvar (forward-compat; unbound in v0.2)
+request_id       ← from RequestContextMiddleware (still runs)
+method           ← "MCP"
+path             ← "/mcp/tools/call/{tool_name}" or "/mcp/resources/read/{uri}"
+status_code      ← 200 / 400 / 403 / 404 / 500 (derived from JSON-RPC outcome)
+duration_ms      ← time.monotonic() bracket
+payload          ← {op_id, params_hash, op_class}
 ```
+
+`agent_session_id` and `parent_audit_id` are real `audit_log` columns (not payload keys), read from contextvars by [`_resolve_uuid_contextvar`](../../backend/src/meho_backplane/mcp/audit.py) — the same pattern the chassis uses for `target_id`. Chassis HTTP-side rows (written by `AuditMiddleware`) leave `agent_session_id` NULL by design: they are not part of an agent session.
 
 Fail-closed: audit write failure → MCP call fails with JSON-RPC `INTERNAL_ERROR` (-32603). Compliance-critical.
 


### PR DESCRIPTION
## Summary

- Capture the inbound `Mcp-Session-Id` header on every `POST /mcp` into an `mcp_session_id` structlog contextvar (`_bind_mcp_session_id` in `mcp/server.py`), and read it back in `write_mcp_audit_row` to populate `audit_log.agent_session_id` — making per-session audit replay (G8.2) addressable. Mirrors the existing `target_id` contextvar pattern.
- Resolution rules per MCP 2025-06-18 Streamable HTTP §Session Management: parseable UUID → bind it; malformed (non-UUID) client header → treated as absent (no 500); absent/empty → fresh `uuid4()` so MCP rows are never NULL (single-call sessions are valid).
- New `MCP_REQUIRE_SESSION_ID` setting (default `false`): when `true`, a missing/empty header returns JSON-RPC `-32600` Invalid Request **before** dispatch, so no audit row is written for the rejected call.
- Forward-compat: also reads an optional `parent_audit_id` contextvar (unbound in v0.2) so future tool-calls-tool flows just bind it for the recursive-CTE replay closure. Chassis HTTP-side `AuditMiddleware` is untouched — HTTP rows keep `agent_session_id` NULL by design.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (all changed files)
- [x] `mypy src/.../mcp/server.py mcp/audit.py settings.py --ignore-missing-imports` — Success, no issues
- [x] `code-quality.py --diff` — 0 blockers
- [x] `pytest tests/test_settings.py` — 23 passed (incl. 3 new `mcp_require_session_id` env tests)
- [x] 6 new `tests/test_mcp_audit.py` tests — 6 passed:
  - header → `agent_session_id` column propagation
  - absent header → fresh non-NULL uuid4, two calls get distinct ids
  - malformed header → no 500, falls back to fresh uuid4
  - `MCP_REQUIRE_SESSION_ID=true` + no header → `-32600`, **no** audit row
  - require-mode accepts when header present
  - helper-level: no contextvar bound → `agent_session_id` / `parent_audit_id` stay NULL
- [x] `tests/test_audit_middleware.py` — extended the happy-path row assertion to prove HTTP rows keep `agent_session_id = NULL` (full file deferred to CI: local per-test app-lifespan boot is pathologically slow per #771; CI xdist runs it)

## Out of scope

- Stateful MCP session store / resumption / `DELETE /mcp` teardown — not needed for audit correlation in v0.2.
- Replay query module, REST route, CLI verb, MCP replay tool — sibling Tasks T3–T6.
- Writing `agent_session_id` on HTTP rows — NULL by design.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1010
