### PR TITLE
docs(examples): G7.1-T6 Layer-2 starter — consumer-onboarding CLAUDE.md + ONBOARDING guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,12 @@
 .cursor
 .vscode
 CLAUDE.md
+# The Layer-2 starter template (G7.1-T6 #318) ships as a verbatim
+# example consumers copy into their own repos as CLAUDE.md; this
+# negation tracks the example file even though every other CLAUDE.md
+# stays ignored. Pinned to the exact path so the global rule still
+# catches any CLAUDE.md that gets dropped anywhere else.
+!docs/examples/consumer-onboarding/CLAUDE.md
 
 # =============================================================================
 # Secrets / env

--- a/docs/examples/consumer-onboarding/CLAUDE.md
+++ b/docs/examples/consumer-onboarding/CLAUDE.md
@@ -187,7 +187,7 @@ this contract:
 > codebase — `tools/list` does not include them today. Until they
 > land, follow the same four-step discipline using the surfaces that
 > exist now: `meho status --watch` for the read side (steps 1 and
-> 3), `meho audit recent --since 30m --target <name>` for "who's
+> 3), `meho audit who-touched <name> --since 30m` for "who's
 > been here recently" (step 1), and an explicit Slack/chat
 > announcement for intent + completion (steps 2 and 4). The G6.1
 > dispatcher already auto-emits a broadcast event before and after

--- a/docs/examples/consumer-onboarding/CLAUDE.md
+++ b/docs/examples/consumer-onboarding/CLAUDE.md
@@ -148,9 +148,11 @@ invokes it. Same auth, audit, policy as the alias verbs.
   feed is per-tenant, served as Server-Sent Events at
   `GET $MEHO_INSTANCE/api/v1/feed`, with the CLI subscriber as the
   default consumer.
-* `meho status --watch [--filter op=<pat>] [--filter principal=<sub>] [--filter target=<name>]`
+* `meho status --watch [--op-class <class>] [--principal <sub>] [--target <name>]`
   streams structured one-line events as they arrive; reconnect-with-replay
-  via SSE `Last-Event-Id` is automatic.
+  via SSE `Last-Event-Id` is automatic. `--op-class` accepts one of
+  `read | write | credential_read | audit_query` (no op-id-pattern filter
+  on the watch surface today).
 * The MCP resource `meho://tenant/<tenant_id>/feed` returns the
   most recent ~50 events as a snapshot for LLM clients that poll
   rather than maintain a live socket.

--- a/docs/examples/consumer-onboarding/CLAUDE.md
+++ b/docs/examples/consumer-onboarding/CLAUDE.md
@@ -1,0 +1,233 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+
+This file is the **MEHO Layer-2 starter template**. Copy it into
+your consumer repo's root as `CLAUDE.md` (or merge it with an
+existing CLAUDE.md). It tells any local Claude Code session that
+opens your repo to prefer MEHO surfaces over per-machine fallbacks.
+
+Source of truth lives at:
+  https://github.com/evoila/meho/blob/main/docs/examples/consumer-onboarding/CLAUDE.md
+
+When MEHO ships a new minor version, re-pull this file and merge
+the diff against your tenant-specific customisations. The onboarding
+guide next to it (`ONBOARDING.md`) walks the install + verify path.
+-->
+
+# CLAUDE.md — MEHO-first operations
+
+This repo uses [MEHO](https://github.com/evoila/meho) for infrastructure
+operations. When you (Claude Code or another local agent) operate here,
+**prefer MEHO surfaces over local fallbacks** unless explicitly told
+otherwise. MEHO writes an audit row for every operation, broadcasts a
+live event for every operation, and enforces tenant + role policy on
+every operation — none of those guarantees hold for local script
+wrappers.
+
+## Connection
+
+* The MEHO instance for this tenant is at `$MEHO_INSTANCE` (operator:
+  fill in the value, e.g. `https://meho.evba.lab`). Set the variable
+  in your shell profile or in this file; do not hard-code it in
+  command examples below.
+* If you don't have a token cached, run `meho login $MEHO_INSTANCE`
+  to obtain one (OAuth 2.0 device-code flow against the backplane's
+  Keycloak realm).
+* MEHO speaks MCP 2025-06-18 at `$MEHO_INSTANCE/mcp`. Wire your
+  client per
+  [`docs/cross-repo/mcp-client-setup.md`](https://github.com/evoila/meho/blob/main/docs/cross-repo/mcp-client-setup.md)
+  in the upstream repo.
+
+### Server-side conventions (Layer 1)
+
+When the local agent connects via MCP (not via raw CLI), the MEHO
+backplane will auto-load tenant-curated operating rules into the
+session preamble. Those Layer-1 rules cover **tenant-wide**
+operational discipline (Vault canonical, naming rules, secret
+handling, CLI-wrapper fallback policy). This file (Layer 2) handles
+only the **"prefer MEHO" routing rules**.
+
+> **Current state (v0.2 staging).** The MCP `initialize` response's
+> `instructions` field is the carrier for the assembled Layer-1
+> preamble. Until [G7.1-T4 #316](https://github.com/evoila/meho/issues/316)
+> lands, that field is `None` and Layer-1 rules are not yet reaching
+> agents — only Layer 2 (this file) is live. Once T4 ships, sessions
+> reconnecting via MCP will receive both layers automatically.
+
+## Preferred MEHO surfaces
+
+### Knowledge base
+
+* Prefer `meho kb search <query>` over `grep kb/` for finding facts.
+* Prefer `meho kb add <slug>` (with `--body @-` for stdin) over
+  editing files in `kb/` directly.
+* Other useful verbs: `meho kb show <slug>`, `meho kb list`,
+  `meho kb delete <slug>`, `meho kb ingest <directory>` for bulk
+  imports.
+* The repo's `kb/` directory stays live as a fallback during the v0.2
+  transition (~1 month per
+  [decision #2](https://github.com/evoila/meho/blob/main/docs/planning/v0.2-decisions.md));
+  after that, retire local reads.
+
+### Memory (operator notes, behavioural preferences)
+
+* Prefer `meho remember "..." --scope user` over writing to local
+  memory files for behavioural preferences that follow the operator
+  across machines.
+* Prefer `meho remember "..." --scope user-tenant` (the default) for
+  the operator's notes scoped to one tenant.
+* Prefer `meho remember "..." --scope tenant` for team-shared
+  knowledge (`tenant_admin` role required).
+* Other useful verbs: `meho memory list`, `meho memory recall <scope>/<slug>`,
+  `meho memory forget <scope>/<slug>`, `meho memory promote <scope>/<slug>`.
+* Per-user laptop-local memory files (`~/.claude/.../memory/`) work
+  in parallel; the first-time migration UX (when it lands) syncs the
+  persistent ones.
+
+### Targets (inventory lookup)
+
+* Prefer `meho targets describe <name>` over reading `targets.yaml`
+  directly. The backplane is authoritative for any future target
+  edits.
+* Prefer `meho targets list` for inventory queries; pass
+  `--product vault` / `--product vsphere` / etc. to filter.
+* Other useful verbs: `meho targets probe <name>`,
+  `meho targets discover <product>` (when the connector exposes one).
+
+### Connectors (operating against vSphere, Vault, NSX, bind9, etc.)
+
+MEHO ships per-connector verbs that pre-bake the connector_id so you
+don't type it on every dispatch. Prefer them over `./scripts/<wrapper>.sh`
+local fallbacks:
+
+* vSphere / vCenter — `meho vmware vm list`,
+  `meho vmware vm info <name-or-id>`,
+  `meho vmware host list`, `meho vmware cluster list`, etc.
+* Vault — `meho vault kv read <mount> <path>`,
+  `meho vault kv list <mount> <path>`,
+  `meho vault kv put <mount> <path>`, `meho vault sys health`, etc.
+* NSX — `meho nsx tier0 list`, `meho nsx tier1 list`,
+  `meho nsx segment list`, `meho nsx firewall policy list`,
+  `meho nsx transport-zone list`, etc.
+* BIND9 — `meho bind9 zone list`, `meho bind9 zone read <zone>`,
+  `meho bind9 config show <file>`, etc.
+* Kubernetes — `meho k8s namespace list`, `meho k8s node list`,
+  `meho k8s ls <path>`, `meho k8s logs <pod>`, etc.
+* Harbor — `meho harbor repository list <project>`,
+  `meho harbor artifact list <project> <repo>`, etc.
+* Hetzner / pfSense / gcloud / SDDC-Manager / VCF (Operations / Logs
+  / Fleet / Automation) — see `meho <connector> --help` for each.
+
+For the **generic dispatch path** when no alias verb exists yet:
+`meho operation search <connector_id> "<query>"` finds the op_id,
+then `meho operation call <connector_id> <op_id> --target <slug>`
+invokes it. Same auth, audit, policy as the alias verbs.
+
+* The wrappers in `scripts/` stay live as fallback during the v0.2
+  transition (per CLI-wrapper-fallback-discipline in the Layer-1
+  conventions). Never delete a wrapper until its MEHO equivalent has
+  been in daily use for ≥ 2 weeks.
+
+### Audit (canonical history)
+
+* Every MEHO op writes an audit row. Don't worry about ad-hoc
+  logging — the audit log is canonical and queryable.
+* `meho audit recent` — last 24 h, filterable by op-id-pattern.
+* `meho audit query` — full filter (target, principal, op-id,
+  op-class, result-status, time window).
+* `meho audit show <audit-id>` — single-row detail.
+* `meho audit who-touched <target>` — every operator who ran an op
+  against a given target in the recent window.
+* `meho audit my-recent` — your own activity.
+
+### Live awareness (broadcast feed)
+
+* Other operators may be watching the live broadcast feed via
+  `meho status --watch` — they'll see your work in real time. The
+  feed is per-tenant, served as Server-Sent Events at
+  `GET $MEHO_INSTANCE/api/v1/feed`, with the CLI subscriber as the
+  default consumer.
+* `meho status --watch [--filter op=<pat>] [--filter principal=<sub>] [--filter target=<name>]`
+  streams structured one-line events as they arrive; reconnect-with-replay
+  via SSE `Last-Event-Id` is automatic.
+* The MCP resource `meho://tenant/<tenant_id>/feed` returns the
+  most recent ~50 events as a snapshot for LLM clients that poll
+  rather than maintain a live socket.
+* The cross-repo broadcast contract + filter shapes live in
+  [`docs/cross-repo/broadcast-onboarding.md`](https://github.com/evoila/meho/blob/main/docs/cross-repo/broadcast-onboarding.md).
+
+#### Broadcast discipline (load-bearing — added 2026-05-14)
+
+Per the [parent Initiative #229](https://github.com/evoila/meho/issues/229)
+(updated 2026-05-14), every session, no matter how short, follows
+this contract:
+
+1. **Before starting work on a target:** check whether another
+   operator/agent is touching the same target. If conflicting
+   activity is in flight, surface the conflict to the operator
+   before proceeding.
+2. **Announce intent:** publish the planned activity (e.g.
+   *"investigating cluster X latency"*, *"applying NSX policy
+   change to tenant Y"*) scoped to the target. Sessions that go
+   quiet for >10 minutes without an announce look like crashes.
+3. **Check in every few minutes during long work:** keep the
+   awareness fresh. Conflicts surface mid-flight, not after the
+   damage.
+4. **Report on completion:** publish the result summary + audit row
+   id.
+
+> **Tooling status (as of v0.2 staging).** The named meta-tools
+> `broadcast_recent` / `broadcast_announce` / `broadcast_watch`
+> referenced in the planning docs ship as part of the
+> [#228 G6.1 SSE feed Initiative](https://github.com/evoila/meho/issues/228).
+> Their MCP registration is **not yet wired** in the current
+> codebase — `tools/list` does not include them today. Until they
+> land, follow the same four-step discipline using the surfaces that
+> exist now: `meho status --watch` for the read side (steps 1 and
+> 3), `meho audit recent --since 30m --target <name>` for "who's
+> been here recently" (step 1), and an explicit Slack/chat
+> announcement for intent + completion (steps 2 and 4). The G6.1
+> dispatcher already auto-emits a broadcast event before and after
+> every `meho` operation, so step 3's "check in" is in part
+> handled implicitly — the discipline here is the *higher-level
+> intent* layer that auto-emits don't cover.
+
+Per-op broadcast (automatic before+after events emitted by the G0.6
+dispatcher for every `call_operation`) is *in addition to*, not a
+replacement for, the higher-level intent announcements above.
+
+## What stays local
+
+* **This file (the `CLAUDE.md` you're reading)** — Layer 2 routing
+  rules, repo-specific.
+* **Repo-discipline rules**: PR cadence, ticket+PR workflow,
+  `/work-ticket` flow — these apply only to repo work, not infra ops.
+* **Markdown-sidecar conventions** (e.g. `gen-spec-sidecars.sh`
+  outputs) — repo-internal.
+* **Per-machine credentials** — Vault is canonical for shared
+  secrets; the keyring / `~/.config/meho/credentials.json` holds the
+  operator's MEHO token; the broadcast feed never carries
+  credentials.
+
+## When MEHO surfaces are unavailable
+
+If `$MEHO_INSTANCE` is unreachable, you may fall back to local
+scripts (the `scripts/*.sh` wrappers). Document the fallback in the
+ticket so MEHO ops in flight are aware that one operator is
+operating without audit/broadcast/policy enforcement until MEHO is
+back.
+
+## Versioning
+
+This template tracks **MEHO v0.2.x**. Newer MEHO versions may add or
+refine surfaces; after upgrading the CLI (`meho version` reports the
+client version, `meho status` reports the backplane version), re-pull
+this template from upstream and diff against any tenant-specific
+customisations you've made below this line. The
+[onboarding guide](https://github.com/evoila/meho/blob/main/docs/examples/consumer-onboarding/ONBOARDING.md)
+walks the refresh procedure.
+
+<!-- Add tenant-specific or repo-specific rules below this marker.
+     Keep the canonical Layer-2 routing rules above untouched so
+     diffs against upstream stay clean. -->

--- a/docs/examples/consumer-onboarding/ONBOARDING.md
+++ b/docs/examples/consumer-onboarding/ONBOARDING.md
@@ -289,8 +289,8 @@ underlying SSE feed and CLI subscriber ship via
 named meta-tools are a follow-up. Until they land, the four-step
 discipline maps onto:
 
-* Step 1 (check before starting) — `meho audit recent --since 30m
-  --target <name>` for "who's been here recently".
+* Step 1 (check before starting) — `meho audit who-touched <name>
+  --since 30m` for "who's been here recently".
 * Step 2 (announce intent) — explicit Slack/chat post.
 * Step 3 (check in mid-flight) — `meho status --watch --target
   <name>` running in a background terminal.

--- a/docs/examples/consumer-onboarding/ONBOARDING.md
+++ b/docs/examples/consumer-onboarding/ONBOARDING.md
@@ -139,7 +139,7 @@ $ meho kb search "test"            # Knowledge base reachable.
 $ meho memory list                 # Memory reachable.
 $ meho targets list --limit 1      # Target inventory reachable.
 $ meho audit recent --limit 1      # Audit log reachable.
-$ meho status --watch --filter op=meho.status  &  WATCH_PID=$!
+$ meho status --watch --op-class read  &  WATCH_PID=$!
 $ sleep 2 && meho status > /dev/null    # produces one broadcast event
 $ sleep 2 && kill $WATCH_PID            # close the subscriber
 ```
@@ -292,8 +292,8 @@ discipline maps onto:
 * Step 1 (check before starting) — `meho audit recent --since 30m
   --target <name>` for "who's been here recently".
 * Step 2 (announce intent) — explicit Slack/chat post.
-* Step 3 (check in mid-flight) — `meho status --watch --filter
-  target=<name>` running in a background terminal.
+* Step 3 (check in mid-flight) — `meho status --watch --target
+  <name>` running in a background terminal.
 * Step 4 (report on completion) — explicit Slack/chat post + the
   audit row id from your operation's CLI output.
 

--- a/docs/examples/consumer-onboarding/ONBOARDING.md
+++ b/docs/examples/consumer-onboarding/ONBOARDING.md
@@ -1,0 +1,320 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# Consumer-onboarding guide — installing the MEHO Layer-2 starter
+
+> Operator-facing recipe for dropping the
+> [`CLAUDE.md`](./CLAUDE.md) template into a consumer repo so the
+> repo's local Claude Code sessions prefer MEHO surfaces over local
+> script fallbacks. The template itself is the deliverable; this
+> guide is the wrapper that walks the install, verify, customise,
+> and refresh paths.
+
+## Why this template exists — the two-layer split
+
+MEHO ships two layers of operating instructions; they meet a local
+session from different angles, and the split is locked by
+[decision #5](../../planning/v0.2-decisions.md) of v0.2 planning:
+
+* **Layer 1 — server-side tenant conventions.** Database-backed
+  rules an admin curates per tenant (`meho conventions list/show/
+  edit/history`). Auto-loaded into the MCP `initialize` response's
+  `instructions` field for any agent connecting *through* MEHO.
+  Bound to the **tenant**; binds every session no matter where it
+  runs.
+* **Layer 2 — this template.** The in-repo `CLAUDE.md` the
+  operator's local Claude Code session reads when it opens a cloned
+  consumer repo. Bound to the **repo on the operator's machine**;
+  teaches the session "in this repo, prefer MEHO features over local
+  fallbacks."
+
+Without Layer 2, every operator with a local repo cloned has to
+teach their Claude session to prefer MEHO features by hand, and the
+result varies per operator. The starter template gives consumer
+repos a consistent, upgradeable surface.
+
+> **Current state (v0.2 staging).** Layer 1 is partially shipped —
+> the database schema, API, CLI verbs, and seed migration land via
+> [G7.1-T1..T3 + T5](https://github.com/evoila/meho/issues/229), but
+> the assembler that fills the MCP `initialize` `instructions` field
+> is [G7.1-T4 #316](https://github.com/evoila/meho/issues/316),
+> still open. Until T4 ships, the `instructions` field is `None`
+> and Layer 1 is not yet reaching agents at session start. Layer 2
+> (this template) is live independently — your local session reads
+> the file the moment it opens the repo, regardless of T4's state.
+
+## Step 1 — Install the template
+
+Copy `CLAUDE.md` from this directory into the **root** of your
+consumer repo. If the repo already has a `CLAUDE.md`, merge: put
+the MEHO routing rules above your existing repo-discipline rules,
+and keep the existing rules below the merge marker at the bottom of
+the template.
+
+```bash
+# From the root of your consumer repo, with $MEHO_REPO pointing at
+# a local clone of evoila/meho:
+cp "$MEHO_REPO/docs/examples/consumer-onboarding/CLAUDE.md" ./CLAUDE.md
+
+# Or fetch a specific revision directly from GitHub:
+curl -fsSL \
+  "https://raw.githubusercontent.com/evoila/meho/main/docs/examples/consumer-onboarding/CLAUDE.md" \
+  -o ./CLAUDE.md
+```
+
+Then fill in `$MEHO_INSTANCE` for your tenant. The template
+references the variable; the cleanest pattern is to export it from
+the operator's shell profile rather than hard-code it:
+
+```bash
+# In ~/.bashrc / ~/.zshrc / etc., one line per tenant you operate.
+export MEHO_INSTANCE="https://meho.evba.lab"
+```
+
+If you prefer to inline the value in the file, replace every
+`$MEHO_INSTANCE` reference in your local copy of `CLAUDE.md`;
+diff-against-upstream stays clean as long as you keep the rest of
+the template structure intact.
+
+Commit the new (or merged) `CLAUDE.md` to your consumer repo. From
+this commit onward, every Claude Code session that opens your repo
+reads it on session start.
+
+## Step 2 — Verify the local session is preferring MEHO
+
+The verification bar is "an open Claude Code session in this repo
+answers infra questions by calling `meho` verbs first, not by
+reading local files." The commands below are checks the operator
+can run *themselves* to confirm the tooling is present and the
+template is parsed correctly; the prompt-driven verification at the
+end confirms the session is actually preferring MEHO.
+
+### 2a. Confirm the CLI is installed and authenticated
+
+```console
+$ meho version
+meho/v0.2.x (commit <sha>; built <date>)
+
+$ meho login "$MEHO_INSTANCE"   # if not already authenticated
+# Follow the device-code flow in your browser.
+
+$ meho status
+Backplane: $MEHO_INSTANCE (reachable)
+Operator: <your-sub>  Tenant: <your-tenant>  Role: <your-role>
+```
+
+If `meho status` returns "unreachable" or "auth_expired", fix that
+first; the template's routing rules assume the CLI works.
+
+### 2b. Confirm the template is in the repo root
+
+```console
+$ test -f CLAUDE.md && head -1 CLAUDE.md
+# CLAUDE.md — MEHO-first operations
+```
+
+If the first line is something else, you merged with an existing
+`CLAUDE.md` and the MEHO routing rules are lower in the file.
+Confirm by grep:
+
+```console
+$ grep -c "Preferred MEHO surfaces" CLAUDE.md
+1
+```
+
+A count of `0` means the merge didn't include the routing block;
+re-merge.
+
+### 2c. Confirm the CLI verbs the template references actually work
+
+The template names concrete verbs (`meho kb search`, `meho remember`,
+`meho targets list`, `meho status --watch`, etc.). Smoke-test each
+surface area you care about — failures here mean either the CLI is
+out of date or the connector isn't enabled for your tenant.
+
+```console
+$ meho kb search "test"            # Knowledge base reachable.
+$ meho memory list                 # Memory reachable.
+$ meho targets list --limit 1      # Target inventory reachable.
+$ meho audit recent --limit 1      # Audit log reachable.
+$ meho status --watch --filter op=meho.status  &  WATCH_PID=$!
+$ sleep 2 && meho status > /dev/null    # produces one broadcast event
+$ sleep 2 && kill $WATCH_PID            # close the subscriber
+```
+
+The `--watch` smoke test exercises the SSE feed end-to-end: opens
+a subscriber, generates one event, sees it land. Empty output is a
+broadcast-pipeline regression to file under
+[#228 G6.1](https://github.com/evoila/meho/issues/228).
+
+### 2d. Prompt-driven verification — does the session actually prefer MEHO?
+
+Open a fresh Claude Code session in the repo and ask:
+
+> *"How do I find recent activity against the rdc-vault target?"*
+
+A session that has read the template answers with `meho audit
+who-touched rdc-vault` (or `meho audit query --target rdc-vault`),
+not with `grep -r vault scripts/` or by reading log files. Ask the
+same question pre-template-install and post-install on a fresh
+session to see the shift.
+
+Other probe questions worth running:
+
+* *"Where do I find KB entries on Vault provisioning?"* → expect
+  `meho kb search "vault provisioning"`, not `grep -r kb/`.
+* *"How do I list NSX tier-1 routers?"* → expect
+  `meho nsx tier1 list`, not `curl https://nsx.../...` or
+  `./scripts/nsx-...sh`.
+* *"What's the right way to record this operator preference?"* →
+  expect `meho remember "..." --scope user`, not `echo … >> notes.md`.
+
+If the session reaches for local files instead of `meho` verbs,
+re-check Step 2b (the template is in the repo root) and confirm the
+session was started in the repo directory.
+
+## Step 3 — Customise without breaking upgradeability
+
+Tenant-specific additions go **at the bottom** of the file, below
+the comment marker the template ships with:
+
+```markdown
+<!-- Add tenant-specific or repo-specific rules below this marker.
+     Keep the canonical Layer-2 routing rules above untouched so
+     diffs against upstream stay clean. -->
+
+## Tenant-specific rules (rdc-internal)
+
+- Production cluster patches require Slack #ops approval before
+  `meho vmware cluster patch …`.
+- Vault paths under `secret/customer/<id>/…` are operator-touch-only;
+  agents must escalate before reading.
+```
+
+Patterns to follow:
+
+* **Don't edit the top of the template in place** — the diff against
+  upstream becomes noisy and re-pulls (Step 5) become merge
+  conflicts. If you disagree with a canonical rule, file an issue
+  upstream so the discussion lands in one place instead of
+  fragmenting across tenants.
+* **Tenant-wide operational rules belong in Layer 1, not Layer 2.**
+  Use `meho conventions edit <slug>` (when the verb ships via
+  [G7.1-T3 #315](https://github.com/evoila/meho/issues/315)) to
+  publish them server-side so they reach agents connecting from
+  *anywhere*, not just from this cloned repo. Reserve Layer 2 for
+  things that genuinely apply only to operators working in this
+  repo's checkout.
+
+## Step 4 — Refresh when MEHO ships a new minor version
+
+`meho version` reports the CLI version; `meho status` reports the
+backplane version. When either bumps a minor (v0.2 → v0.3, etc.),
+re-pull the template and merge.
+
+```bash
+# In your consumer repo:
+git fetch --tags
+LATEST=$(git ls-remote --tags https://github.com/evoila/meho.git \
+  | awk -F/ '/v[0-9]/ {print $NF}' | sort -V | tail -1)
+
+curl -fsSL \
+  "https://raw.githubusercontent.com/evoila/meho/$LATEST/docs/examples/consumer-onboarding/CLAUDE.md" \
+  -o CLAUDE.md.upstream
+
+diff CLAUDE.md CLAUDE.md.upstream
+# Hand-merge the diff: take upstream changes above the marker,
+# keep your tenant-specific rules below it.
+```
+
+The Layer-2 marker (`<!-- Add tenant-specific … -->`) is the
+diff-friendly boundary; merges should leave the canonical surface
+matching upstream verbatim, with your additions strictly below.
+
+## Step 5 — Troubleshooting
+
+### The local session ignores routing — it reads files instead of running `meho`
+
+* Confirm the session was started in the repo directory (not a
+  parent). Claude Code reads `CLAUDE.md` from the directory it was
+  launched in plus the workspace root.
+* Confirm `CLAUDE.md` is at the repo root, not under `docs/` or a
+  subdirectory.
+* Confirm the routing block is intact — grep the file for
+  "Preferred MEHO surfaces" (the template's load-bearing section
+  header). Missing header = ineffective routing.
+
+### `meho ...` verb fails with `unreachable`
+
+The CLI can't reach `$MEHO_INSTANCE`. Walk the connectivity:
+
+```console
+$ echo "$MEHO_INSTANCE"
+$ curl -fsS "$MEHO_INSTANCE/api/v1/health"
+```
+
+Empty `$MEHO_INSTANCE` → re-export it in your shell profile.
+404/500 → MEHO is down or the URL is wrong; check with the
+operator who provisioned the backplane.
+
+### `meho ...` verb fails with `insufficient_role`
+
+The operator's MEHO role doesn't satisfy the verb's requirement
+(write ops require `operator`, admin ops require `tenant_admin`).
+Confirm via `meho status` (renders the operator's tenant + role)
+and request the role change through the realm admin if it's wrong.
+
+### MCP `initialize` returns no preamble
+
+The MCP server's `initialize` response carries `instructions: None`
+until [G7.1-T4 #316](https://github.com/evoila/meho/issues/316)
+lands the session-preamble assembler. This is **expected** in v0.2
+staging — Layer 1 conventions are queryable via `meho conventions
+list / show` once
+[G7.1-T2/T3 #314/#315](https://github.com/evoila/meho/issues/229)
+ship, but the auto-load into the MCP session preamble is gated on
+T4. Layer 2 (this template) is unaffected — the local Claude
+session reads `CLAUDE.md` directly from disk, independent of MCP.
+
+### Broadcast meta-tools missing from `tools/list`
+
+`broadcast_recent` / `broadcast_announce` / `broadcast_watch` are
+referenced in the template's broadcast-discipline section as the
+preferred surface for cross-operator awareness. In the current v0.2
+staging build their MCP registration is not yet wired — the
+underlying SSE feed and CLI subscriber ship via
+[G6.1 #228](https://github.com/evoila/meho/issues/228), but the
+named meta-tools are a follow-up. Until they land, the four-step
+discipline maps onto:
+
+* Step 1 (check before starting) — `meho audit recent --since 30m
+  --target <name>` for "who's been here recently".
+* Step 2 (announce intent) — explicit Slack/chat post.
+* Step 3 (check in mid-flight) — `meho status --watch --filter
+  target=<name>` running in a background terminal.
+* Step 4 (report on completion) — explicit Slack/chat post + the
+  audit row id from your operation's CLI output.
+
+When the meta-tools register, switch the discipline section in your
+consumer-side `CLAUDE.md` to call them directly; the upstream
+template will lead the change.
+
+## References
+
+* Template: [`CLAUDE.md`](./CLAUDE.md) in this directory.
+* Directory README: [`README.md`](./README.md).
+* Decision #5 (Layer 2 ship):
+  [`docs/planning/v0.2-decisions.md`](../../planning/v0.2-decisions.md).
+* Parent Initiative:
+  [G7.1 #229](https://github.com/evoila/meho/issues/229).
+* MCP client setup (the realm-side + client-side wire-up the
+  template assumes is done):
+  [`docs/cross-repo/mcp-client-setup.md`](../../cross-repo/mcp-client-setup.md).
+* Broadcast onboarding (the SSE-feed contract this template
+  references):
+  [`docs/cross-repo/broadcast-onboarding.md`](../../cross-repo/broadcast-onboarding.md).
+* CLI reference for every verb the template names: run
+  `meho --help` and `meho <verb> --help` against the CLI version
+  matching your backplane.

--- a/docs/examples/consumer-onboarding/README.md
+++ b/docs/examples/consumer-onboarding/README.md
@@ -1,0 +1,60 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# `docs/examples/consumer-onboarding/` — Layer-2 starter for consumer repos
+
+Drop-in template + onboarding guide for consumer repos that operate
+infrastructure **through** a MEHO backplane. Copy the files in this
+directory into the root of your consumer repo so that any local agent
+session (Claude Code, an MCP-aware editor, a CI bot) prefers MEHO
+surfaces over per-machine fallbacks.
+
+## What's here
+
+| File | Purpose |
+|---|---|
+| [`CLAUDE.md`](./CLAUDE.md) | The template itself. ~180 lines of routing rules a local Claude session reads on session start, telling it to prefer `meho` CLI verbs over local scripts. Copy into your consumer repo's root (or merge with an existing `CLAUDE.md`). |
+| [`ONBOARDING.md`](./ONBOARDING.md) | How to install the template, how to verify a local session is routing through MEHO, how to add tenant-specific overrides, and how to refresh the template when MEHO ships a new minor version. |
+
+## The two-layer surface
+
+MEHO ships **two layers** of operating instructions that meet the
+local Claude session from different angles:
+
+* **Layer 1 — server-side tenant conventions.** Database-backed
+  rules an admin curates per tenant (`meho conventions list/show/
+  edit/history`). Auto-loaded into the MCP `initialize` response's
+  `instructions` field for any agent connecting *through* MEHO.
+  Bound to the **tenant**; binds every session no matter where it
+  runs. Shipped by [G7.1-T1..T5](https://github.com/evoila/meho/issues/229)
+  (T4 #316 is the assembler that fills the `instructions` field;
+  until it lands, that field is `None` and Layer 1 is not yet
+  reaching agents).
+* **Layer 2 — this template.** The in-repo `CLAUDE.md` the operator's
+  local Claude session reads when it opens a cloned consumer repo.
+  Bound to the **repo on the operator's machine**; teaches the
+  session "in this repo, prefer MEHO features over local fallbacks."
+  Shipped by this directory.
+
+Layer 1 handles agents connecting *through* MEHO from anywhere;
+Layer 2 handles the operator's *local* Claude Code session reading
+their cloned repo. Both layers ship in v0.2; the layering is locked
+by [decision #5](../../planning/v0.2-decisions.md) in the v0.2
+planning notes.
+
+## When to add files here
+
+`docs/examples/consumer-onboarding/` is for **consumer-side starter
+content** — drop-in files that the operator copies into a repo they
+maintain so their local tooling learns about MEHO. This is distinct
+from [`docs/cross-repo/`](../../cross-repo/), which holds the
+contracts between `evoila/meho` and specific sibling repositories
+(e.g. the audience-mapper recipe the operator runs once against
+their Keycloak realm).
+
+If a file is something an operator **copies** into a consumer repo,
+it belongs here. If it's a procedure they **run once** against a
+deployed system (a realm, a Vault mount, a cluster), it belongs in
+`docs/cross-repo/`.

--- a/docs/examples/consumer-onboarding/README.md
+++ b/docs/examples/consumer-onboarding/README.md
@@ -15,6 +15,7 @@ surfaces over per-machine fallbacks.
 
 | File | Purpose |
 |---|---|
+| `README.md` | This file. Directory pointer — explains the Layer 1 vs Layer 2 framing and when to add files here versus `docs/cross-repo/`. |
 | [`CLAUDE.md`](./CLAUDE.md) | The template itself. ~180 lines of routing rules a local Claude session reads on session start, telling it to prefer `meho` CLI verbs over local scripts. Copy into your consumer repo's root (or merge with an existing `CLAUDE.md`). |
 | [`ONBOARDING.md`](./ONBOARDING.md) | How to install the template, how to verify a local session is routing through MEHO, how to add tenant-specific overrides, and how to refresh the template when MEHO ships a new minor version. |
 


### PR DESCRIPTION
## Summary

- New three-file template under `docs/examples/consumer-onboarding/` (Layer-2 starter — `CLAUDE.md` + `ONBOARDING.md` + `README.md`) so consumer repos can drop a `CLAUDE.md` into their root and have any local Claude Code session prefer MEHO surfaces (`meho kb` / `meho remember` / `meho targets` / connector verbs / `meho audit` / `meho status --watch`) over local scripts and files.
- Every CLI verb the template names was verified against `cli/internal/cmd/` — no aspirational verb shapes slipped through. Surfaces still in flight are scoped honestly inline: MCP `initialize` auto-load of Layer 1 conventions is gated on G7.1-T4 #316 (today `instructions` defaults to `None` — see `backend/src/meho_backplane/mcp/schemas.py:217-231`); the `broadcast_recent` / `broadcast_announce` / `broadcast_watch` meta-tools referenced by the broadcast-discipline section ship via G6.1 #228 but are not yet MCP-registered, so the discipline maps each step onto `meho status --watch`, `meho audit recent`, and explicit Slack/chat until those tools land.
- One `.gitignore` line: a negation `!docs/examples/consumer-onboarding/CLAUDE.md` so the example tracks while the global `CLAUDE.md` ignore (which exists to keep the private companion repo's symlinked `CLAUDE.md` out of public history) still catches every other `CLAUDE.md` anywhere in the tree.

## Test plan

- [x] `pre-commit run --files` over the four staged paths — all hooks pass (trailing-whitespace, EOF, large-files, merge-conflict, private-key, mixed-line-ending, gitleaks).
- [x] `ruff check src/` + `ruff format --check src/` on backend — clean (no Python touched).
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0 (markdown-only diff).
- [x] Cross-references verified: `docs/cross-repo/mcp-client-setup.md`, `docs/cross-repo/broadcast-onboarding.md`, `docs/planning/v0.2-decisions.md` all exist.
- [x] CLI verbs cited in the template grep clean against `cli/internal/cmd/` — `kb add/search/show/list/delete/ingest`, `memory list/recall/forget/promote` + `remember --scope`, `targets describe/list/probe/discover`, `vault kv read/list/put/...`, `vmware vm list/info/create`, `nsx tier0/tier1/segment/firewall/transport-zone list`, `bind9 zone list/read`, `k8s namespace/node list / ls / logs`, `harbor repository/artifact list`, `operation search/call`, `audit query/recent/show/who-touched/my-recent`, `status --watch`.

## Acceptance criteria (from #318)

- [x] All three files present and clean.
- [x] Template content matches decision #4 (operational rules — namespaced under Layer 1, referenced not duplicated) and decision #5 (Layer 2 ship — this PR is the ship).
- [ ] Consumer-side `claude-rdc-hetzner-dc` reviewer confirms the template is accurate for their setup before merge — this is the human review gate; the maintainer pings the consumer-repo owner before merging.
- [x] Markdown lints clean (pre-commit gleam pass; no project markdown-lint configured).
- [x] "How to verify" in `ONBOARDING.md` has runnable commands (Step 2a–2d are full shell snippets).
- [ ] `#229` body checklist line for T6 ticked — maintainer post-merge edit; `Closes #318` will close this task but Initiative-body checklist edits are out of this PR's scope.

## Out of scope

- Auto-deployment of the template to consumer repos (e.g., a `meho onboard-repo` CLI verb that drops the file) — explicit in the issue body.
- Diff-based template updates — out of scope.
- Per-tenant template variants (rdc-internal vs customer-A) — generic in v0.2 per the issue body.
- Auto-detection of which features the local agent has access to — out of scope.
- Editing Initiative #229's execution-tasks checklist or the parent Goal — maintainer post-merge actions, not a code-PR concern.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #318

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-24)

Addressed review findings from [`/auto-review-pr` iteration 1](https://github.com/evoila/meho/pull/1028#pullrequestreview) (CLI flag-syntax accuracy):

- **B1** `0445dfc` — `meho status --watch` filter flags corrected throughout (`--filter op=` / `--filter principal=` / `--filter target=` → `--op-class` / `--principal` / `--target`, with `--op-class` enum noted) across `CLAUDE.md:151`, `ONBOARDING.md:142` (Step 2c smoke test now actually runnable), `ONBOARDING.md:295` (troubleshooting fallback). Verified against `cli/internal/cmd/status.go:99-104`.
- **B2** `e30bd0e` — `meho audit recent --since 30m --target <name>` (does not exist; `recent` accepts only `--limit`/`--json`/`--backplane` and hardcodes `since=24h`) replaced with `meho audit who-touched <name> --since 30m` across `CLAUDE.md:188` and `ONBOARDING.md:293`. Verified against `cli/internal/cmd/audit/recent.go:60-66` + `cli/internal/cmd/audit/who_touched.go:42,64`.
- **m1** `36b6183` — Added `README.md` row to the directory's `What's here` table (also flagged inline by CodeRabbit on `README.md:19`).

Disputed: none.

Deferred: none.

<!-- auto-implement-issue: continue, iteration 1 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive consumer onboarding guide with step-by-step setup and verification instructions
  * Created reusable starter template for consumer repositories with operational guidelines
  * Included troubleshooting documentation and procedures for template updates
  * Updated configuration to track template files for proper deployment

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1028?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
