### PR TITLE
feat(conventions): G7.1-T1 tenant_conventions + tenant_convention_history tables

### DIFF
--- a/backend/alembic/versions/0015_create_tenant_conventions.py
+++ b/backend/alembic/versions/0015_create_tenant_conventions.py
@@ -1,0 +1,304 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Create the tenant_conventions and tenant_convention_history tables.
+
+Revision ID: 0015
+Revises: 0014
+Create Date: 2026-05-24
+
+This is the schema foundation of Initiative #229 (G7.1 Tenant
+conventions + Layer 2 starter), Task #313 (T1). The migration adds
+two structural pieces that every subsequent G7.1 sibling task
+relies on:
+
+* ``tenant_conventions`` -- the current-state table for tenant-scoped
+  operational / workflow / reference rules. T2 (#314) wires the API
+  routes against this table; T3 (#315) the CLI verbs; T4 (#316) the
+  session-preamble assembler reads the ``kind='operational'`` subset
+  ordered by ``priority DESC, created_at ASC``; T5 (#317) seeds 8-12
+  rows for the ``rdc-internal`` tenant.
+* ``tenant_convention_history`` -- the diff trail for every convention
+  edit. The history row carries the before/after body, actor sub, and
+  a soft-FK to the audit row that triggered the change. T2's PATCH /
+  POST / DELETE routes insert a history row in the same DB
+  transaction as the conventions write; T2's ``GET /{slug}/history``
+  surfaces this table chronologically with the audit cross-reference.
+
+Why ``priority`` is non-nullable on ``tenant_conventions``
+---------------------------------------------------------
+
+T4's preamble assembler packs operational conventions
+**highest-priority-first** and drops lowest-priority entries whole
+when over the token budget (never mid-entry truncation of an
+operational rule). The column must exist with ``NOT NULL`` semantics
+before the T5 seed migration writes rows -- retrofitting a NOT NULL
+column after seeded data exists is a needless multi-step migration
+(add column nullable -> backfill -> tighten to NOT NULL). The PG
+server default of ``0`` and the ORM-side Python default of ``0``
+keep the T2 ``ConventionCreate`` contract backward-compatible
+(priority optional, defaults to 0) without forcing every API caller
+to set it explicitly.
+
+The Pydantic / API layer (T2) will validate the value range; the
+DB-layer ``SMALLINT`` already bounds the column to -32768..32767
+which is more than enough for the ranking key. Mirrors MCP
+2025-06-18's own resource ``priority`` annotation where 1.0 is
+"effectively required" -- the same semantic, on the SMALLINT
+column instead of the floating-point annotation, to avoid wasting
+a real-number comparison on what is fundamentally an ordering key.
+
+Why two tables instead of one
+-----------------------------
+
+``tenant_conventions`` carries current state for fast reads (the
+hot path: every session preamble assembly + every CLI list/show
+query). ``tenant_convention_history`` carries the diff trail
+without bloating the read path. Splitting the two means the
+preamble assembler can ``SELECT * FROM tenant_conventions WHERE
+tenant_id = ? AND kind = 'operational'`` without scanning historical
+rows, and ``meho conventions history <slug>`` queries the dedicated
+history table with a per-convention index. The ``audit_id`` soft-FK
+on history rows lets G8's audit query cross-reference the original
+audit row that authored the change.
+
+Why soft FKs (no ``REFERENCES tenant(id)`` clause)
+--------------------------------------------------
+
+The issue body specifies soft FKs throughout:
+
+  "Soft FKs everywhere matches the chassis convention -- column
+   types match the referenced tables but no REFERENCES ...
+   ON DELETE CASCADE clauses. Simplifies migration reversibility;
+   v0.2.next can tighten."
+
+This is a deliberate author choice, not an oversight: it keeps the
+two new tables aligned with the ``tenant_convention_history``
+soft-FK columns (``convention_id`` -> ``tenant_conventions.id``,
+``audit_id`` -> ``audit_log.id``) and defers cascade-policy
+decisions to a v0.2.next tightening migration once the surrounding
+delete semantics (does deleting a tenant cascade its conventions?
+its history?) are exercised in production. The application layer
+(T2's CRUD) enforces referential integrity at insert time until
+the tightening migration adds the FK clauses.
+
+Why ``kind`` is not a DB-level enum
+-----------------------------------
+
+The Out-of-Scope on the issue body explicitly defers DB-level enum
+enforcement for ``kind`` to the Pydantic / application layer:
+
+  "DB-level enum for kind -- Pydantic + application-level validation
+   is enough."
+
+Mirrors :class:`Target.auth_model` (free-form text + Pydantic
+validation) rather than :class:`OperationGroup.review_status`
+(DB-level CHECK constraint via portable enum-shape). Operators
+adding a new kind don't need a migration; the Pydantic layer is the
+single source of truth for the bounded set.
+
+Dialect-portability decisions
+-----------------------------
+
+Mirrors the discipline ``0001_create_audit_log.py`` and
+``0002_create_tenant_and_audit_tenant_id.py`` established. The
+migration runs cleanly against both PostgreSQL (production) and
+SQLite (dev/test via aiosqlite).
+
+* ``id`` server default -- PG 13+ ships ``gen_random_uuid()``
+  built-in (same assumption every prior migration makes); SQLite
+  leaves the column without a server default and lets the ORM
+  ``default=uuid.uuid4`` populate it Python-side.
+* ``created_at`` / ``updated_at`` / ``ts`` server defaults -- PG
+  gets ``now()``; SQLite leaves it to ORM-side
+  ``default=lambda: datetime.now(UTC)``. The ORM also declares
+  ``onupdate=lambda: datetime.now(UTC)`` on ``tenant_conventions.updated_at``
+  so ORM UPDATEs bump the timestamp; raw-SQL UPDATEs against PG do
+  not fire this hook (acceptable in v0.2 because T2's CRUD is the
+  sole writer path).
+* ``priority`` server default -- PG gets ``'0'`` (integer literal);
+  SQLite gets the same text literal. The portable
+  :class:`SmallInteger` type compiles to ``SMALLINT`` on both
+  dialects, so the server default text ``"0"`` parses identically.
+  The ORM also declares ``default=0`` so out-of-band inserts that
+  omit ``priority`` survive without depending on the dialect.
+* Indexes -- both the unique composite ``tenant_conventions_tenant_slug_idx``
+  on ``(tenant_id, slug)`` and the per-convention btree
+  ``tenant_convention_history_convention_idx`` on ``(convention_id, ts)``
+  declare ``postgresql_using="btree"`` explicitly so PG gets the
+  named btree (the dominant access shape) and SQLite gets a btree
+  no-op (the only index type SQLite supports). The unique index
+  enforces uniqueness exclusively; we deliberately omit ``unique=True``
+  on the ``slug`` column so PG does not auto-create a second unique
+  index next to the named one (same discipline as ``tenant_slug_idx``
+  in 0002).
+
+Reversibility contract
+----------------------
+
+``downgrade()`` removes everything ``upgrade()`` creates, in
+reverse order: drop the history index -> drop the history table ->
+drop the conventions unique index -> drop the conventions table.
+Both tables are brand-new in this migration so dropping them on
+downgrade is the only reversal needed; no chassis-era rows to
+preserve. The CI guard (``scripts/ci/check_migration_compat.py``)
+inspects only ``upgrade()`` -- the destructive operations in
+``downgrade()`` are allowed by design.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0015"
+down_revision: str | None = "0014"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create ``tenant_conventions`` + ``tenant_convention_history`` + indexes."""
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    op.create_table(
+        "tenant_conventions",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()") if is_postgres else None,
+        ),
+        # ``tenant_id`` -- soft FK to ``tenant.id`` per the issue body.
+        # NOT NULL because every convention belongs to exactly one
+        # tenant; uniqueness on ``(tenant_id, slug)`` enforced by the
+        # named index below.
+        sa.Column("tenant_id", sa.Uuid(), nullable=False),
+        sa.Column("slug", sa.Text(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False),
+        # ``kind`` -- free-form text, validated by Pydantic at the API
+        # layer (T2). DB-level enum deferred per the issue's Out of scope.
+        sa.Column("kind", sa.Text(), nullable=False),
+        # ``priority`` -- the ranking key T4's preamble assembler reads.
+        # Higher = packed first; over-budget drops drop lowest first.
+        # ``NOT NULL DEFAULT 0`` so T2's ``ConventionCreate`` contract
+        # stays backward-compatible (priority optional). SMALLINT
+        # bounds it to -32768..32767 -- more than enough for an
+        # ordering key.
+        sa.Column(
+            "priority",
+            sa.SmallInteger(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        # ``created_by_sub`` -- the JWT ``sub`` claim of the creator.
+        # Nullable for migration-seeded rows (T5's seed migration has
+        # no operator context); T2's POST route populates it from the
+        # request principal.
+        sa.Column("created_by_sub", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+    )
+    # Named **unique** composite btree on ``(tenant_id, slug)``. Single
+    # source of uniqueness enforcement -- we deliberately do not set
+    # ``unique=True`` on the ``slug`` column itself (PG would otherwise
+    # auto-create a second unique index alongside the named one, doubling
+    # per-write index maintenance for zero benefit). The named index is
+    # the stable identifier later migrations and the application's
+    # ``ON CONFLICT (tenant_id, slug)`` upsert target will reference.
+    op.create_index(
+        "tenant_conventions_tenant_slug_idx",
+        "tenant_conventions",
+        ["tenant_id", "slug"],
+        unique=True,
+        postgresql_using="btree",
+    )
+
+    op.create_table(
+        "tenant_convention_history",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()") if is_postgres else None,
+        ),
+        # ``convention_id`` -- soft FK to ``tenant_conventions.id``.
+        # NOT NULL because every history row attaches to exactly one
+        # convention; the index below makes the per-convention
+        # chronological query (``meho conventions history <slug>``) a
+        # btree probe instead of a table scan.
+        sa.Column("convention_id", sa.Uuid(), nullable=False),
+        # ``body_before`` -- nullable because the first history row
+        # (the CREATE event) has no prior state. T2's POST inserts a
+        # history row with ``body_before=NULL`` and
+        # ``body_after=<initial body>``; subsequent PATCHes shift the
+        # previous body into ``body_before``.
+        sa.Column("body_before", sa.Text(), nullable=True),
+        sa.Column("body_after", sa.Text(), nullable=False),
+        # ``actor_sub`` -- the JWT ``sub`` claim of the editor. NOT NULL
+        # because every history row must record who made the change;
+        # T5's seed migration uses a synthetic sub (``"system:seed"``)
+        # for the initial seed rows.
+        sa.Column("actor_sub", sa.Text(), nullable=False),
+        sa.Column(
+            "ts",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+        # ``audit_id`` -- soft FK to ``audit_log.id``. Nullable for
+        # migration-seeded rows (T5 has no audit_log row to point at);
+        # T2's CRUD routes populate it from the audit middleware's
+        # contextvar so G8's audit-query path can cross-reference the
+        # convention change back to the originating request.
+        sa.Column("audit_id", sa.Uuid(), nullable=True),
+    )
+    # ``(convention_id, ts)`` btree -- drives the ``meho conventions
+    # history <slug>`` query which fetches all history rows for a
+    # convention in chronological order. ``ts`` second means the index
+    # is also useful for "last N edits for this convention" probes
+    # without an extra ORDER BY scan.
+    op.create_index(
+        "tenant_convention_history_convention_idx",
+        "tenant_convention_history",
+        ["convention_id", "ts"],
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    """Reverse the upgrade -- drop both tables and their indexes.
+
+    Symmetric inverse of :func:`upgrade`. Indexes are dropped
+    explicitly even though ``op.drop_table`` cascades them on PG;
+    the explicit drops keep the reversal clean on SQLite (which does
+    not always cascade indexes on ``drop_table``) and survive dialect
+    drift. The CI guard (``scripts/ci/check_migration_compat.py``)
+    inspects only ``upgrade()`` -- the drops here are allowed by
+    design.
+    """
+    op.drop_index(
+        "tenant_convention_history_convention_idx",
+        table_name="tenant_convention_history",
+    )
+    op.drop_table("tenant_convention_history")
+    op.drop_index(
+        "tenant_conventions_tenant_slug_idx",
+        table_name="tenant_conventions",
+    )
+    op.drop_table("tenant_conventions")

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -221,6 +221,7 @@ from sqlalchemy import (
     Integer,
     LargeBinary,
     Numeric,
+    SmallInteger,
     Text,
     Uuid,
 )
@@ -245,6 +246,8 @@ __all__ = [
     "OperationGroup",
     "Target",
     "Tenant",
+    "TenantConvention",
+    "TenantConventionHistory",
     "WebSession",
 ]
 
@@ -2088,6 +2091,231 @@ class WebSession(Base):
         Index(
             "web_session_expires_at_idx",
             "expires_at",
+            postgresql_using="btree",
+        ),
+    )
+
+
+class TenantConvention(Base):
+    """A tenant-scoped operational / workflow / reference rule.
+
+    Initiative #229 (G7.1 Tenant conventions + Layer 2 starter), Task
+    #313 (T1). Schema foundation only -- T2 (#314) lands the API
+    routes, T3 (#315) the CLI verbs, T4 (#316) the session-preamble
+    assembler that reads the ``kind='operational'`` subset ordered by
+    ``priority DESC, created_at ASC``, T5 (#317) seeds rows for the
+    ``rdc-internal`` tenant.
+
+    Every row carries a per-tenant ``slug`` (operator-visible
+    identifier; ``rbac-canonical``, ``secret-handling``, etc.), a
+    ``title`` (display label), a free-form Markdown ``body``, a
+    ``kind`` discriminator (``operational`` | ``workflow`` |
+    ``reference``, enforced at the Pydantic layer in T2 -- not at the
+    DB layer per the issue's Out of scope), and a SMALLINT
+    ``priority`` (T4's preamble-packing ranking key, ``DEFAULT 0``).
+    The ``(tenant_id, slug)`` pair is unique within the table -- two
+    tenants can declare the same slug independently, but one tenant
+    cannot have two conventions with the same slug.
+
+    Soft-FK discipline
+    ------------------
+
+    ``tenant_id`` is NOT NULL with no ``REFERENCES tenant(id)``
+    clause per the issue body's explicit choice (#229 body: "Soft FKs
+    everywhere matches the chassis convention -- column types match
+    the referenced tables but no REFERENCES ... clauses. Simplifies
+    migration reversibility; v0.2.next can tighten."). The application
+    layer (T2's CRUD) enforces referential integrity at insert time
+    until a v0.2.next tightening migration adds the FK clauses.
+
+    Why ``priority`` is :class:`SmallInteger`
+    -----------------------------------------
+
+    T4's preamble assembler packs operational conventions
+    **highest-priority-first** and drops lowest-priority entries
+    whole when over the token budget (never mid-entry truncation of
+    an operational rule). The column is fundamentally a ranking key,
+    not a real-number similarity score, so SMALLINT (-32768..32767)
+    is more than enough range -- mirrors MCP 2025-06-18's own
+    resource ``priority`` annotation semantic, on the integer column
+    instead of the floating-point annotation, to avoid wasting a
+    real-number comparison on what is fundamentally an ordering
+    decision. ``NOT NULL DEFAULT 0`` so T2's ``ConventionCreate``
+    contract stays backward-compatible (priority optional).
+
+    Indexes
+    -------
+
+    * ``tenant_conventions_tenant_slug_idx`` -- unique composite btree
+      on ``(tenant_id, slug)``. Single source of uniqueness enforcement
+      and the natural-key probe for T2's ``GET /{slug}`` / ``PATCH /{slug}``
+      / ``DELETE /{slug}`` routes. Same single-named-index discipline
+      :class:`Tenant.slug` follows -- we deliberately omit ``unique=True``
+      on the ``slug`` column so PG does not auto-create a redundant
+      duplicate index alongside the named one.
+
+    The model deliberately ships with no helper methods; convention
+    rows are CRUD-shaped (read-mostly via the preamble assembler,
+    write-rarely via the API/CLI) and the query patterns are simple
+    enough to live at the call site in T2's CRUD module.
+    """
+
+    __tablename__ = "tenant_conventions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    # NOT NULL -- every convention belongs to exactly one tenant.
+    # No FK clause in v0.2 per the issue body (soft-FK discipline);
+    # the application layer enforces referential integrity at insert
+    # time until a v0.2.next tightening migration adds the FK.
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        nullable=False,
+    )
+    # Uniqueness enforced by the named composite
+    # ``tenant_conventions_tenant_slug_idx`` below (declared
+    # ``unique=True``). The column itself omits ``unique=True`` -- PG
+    # would otherwise auto-create a second unique index alongside the
+    # named one for zero benefit (same discipline as
+    # :class:`Tenant.slug`).
+    slug: Mapped[str] = mapped_column(Text, nullable=False)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    # Free-form text. Pydantic at the API layer (T2) bounds it to
+    # ``operational`` | ``workflow`` | ``reference``; DB-level enum
+    # deferred per the issue's Out of scope (Pydantic + application
+    # validation is enough).
+    kind: Mapped[str] = mapped_column(Text, nullable=False)
+    # ``priority`` -- T4's preamble-packing ranking key. SMALLINT
+    # because the value is fundamentally an ordering key, not a
+    # real-number score. NOT NULL DEFAULT 0 so T2's
+    # ``ConventionCreate`` contract stays backward-compatible
+    # (priority optional, defaults to 0).
+    priority: Mapped[int] = mapped_column(
+        SmallInteger,
+        nullable=False,
+        default=0,
+    )
+    # ``created_by_sub`` -- JWT ``sub`` of the convention's creator.
+    # Nullable for migration-seeded rows (T5's seed migration has no
+    # operator context); T2's POST route populates it from the
+    # authenticated principal.
+    created_by_sub: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    __table_args__ = (
+        Index(
+            "tenant_conventions_tenant_slug_idx",
+            "tenant_id",
+            "slug",
+            unique=True,
+            postgresql_using="btree",
+        ),
+    )
+
+
+class TenantConventionHistory(Base):
+    """One row per edit to a :class:`TenantConvention`.
+
+    Initiative #229, Task #313. Companion table to
+    :class:`TenantConvention`; T2's CRUD routes insert a history row
+    in the same DB transaction as every convention write (CREATE,
+    UPDATE, DELETE) so the diff trail stays causally consistent with
+    the current state. T3's ``meho conventions history <slug>`` verb
+    reads from this table chronologically and cross-references the
+    audit log via the ``audit_id`` soft-FK.
+
+    The ``body_before`` column is nullable -- the first history row
+    (the CREATE event) has no prior state. Subsequent PATCHes shift
+    the previous body into ``body_before`` and the new body into
+    ``body_after``. DELETE events get ``body_after=<final body>`` (a
+    legible last-known state for audit forensics) rather than a
+    sentinel marker; the lifecycle distinction lives in the audit
+    row, not in this table.
+
+    Soft-FK discipline
+    ------------------
+
+    Both ``convention_id`` and ``audit_id`` are soft FKs (column
+    types match the referenced tables, no ``REFERENCES`` clause) per
+    the issue body's explicit choice. ``convention_id`` is NOT NULL
+    because a history row without a parent convention has no semantic
+    meaning; ``audit_id`` is nullable to allow migration-seeded rows
+    (T5's seed migration has no audit_log row to point at). T2's
+    CRUD writes pull ``audit_id`` from the audit middleware's
+    contextvar so G8's audit-query path can join history back to the
+    originating request.
+
+    Indexes
+    -------
+
+    * ``tenant_convention_history_convention_idx`` -- composite btree
+      on ``(convention_id, ts)``. Drives ``meho conventions history
+      <slug>`` (per-convention chronological scan) and "last N edits
+      for this convention" probes without an extra ORDER BY sort.
+
+    The model deliberately ships with no helper methods; history rows
+    are write-once + read-mostly (T3's CLI is the only consumer in
+    v0.2) and the query patterns live at the call site.
+    """
+
+    __tablename__ = "tenant_convention_history"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    # NOT NULL -- every history row attaches to exactly one
+    # convention. Soft FK (no REFERENCES clause) per the issue body's
+    # explicit choice; T2's CRUD enforces referential integrity at
+    # insert time.
+    convention_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        nullable=False,
+    )
+    # Nullable -- the first history row (CREATE) has no prior state.
+    # T2's PATCH route copies the existing ``body`` into this column
+    # before writing the new ``body_after``.
+    body_before: Mapped[str | None] = mapped_column(Text, nullable=True)
+    body_after: Mapped[str] = mapped_column(Text, nullable=False)
+    # NOT NULL -- every history row must record who made the change.
+    # T5's seed migration uses a synthetic sub (``"system:seed"``) for
+    # the initial seed rows.
+    actor_sub: Mapped[str] = mapped_column(Text, nullable=False)
+    ts: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    # Nullable -- migration-seeded rows have no audit_log row to point
+    # at. T2's CRUD writes populate ``audit_id`` from the audit
+    # middleware's contextvar so G8's audit-query path can join
+    # history back to the originating request.
+    audit_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(),
+        nullable=True,
+        default=None,
+    )
+
+    __table_args__ = (
+        Index(
+            "tenant_convention_history_convention_idx",
+            "convention_id",
+            "ts",
             postgresql_using="btree",
         ),
     )

--- a/backend/tests/test_db_conventions.py
+++ b/backend/tests/test_db_conventions.py
@@ -1,0 +1,690 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :class:`TenantConvention` and :class:`TenantConventionHistory`.
+
+Coverage matrix (Task #313 acceptance criteria):
+
+* **Round-trip on :class:`TenantConvention`** -- insert a row, query
+  it back, every field survives the ORM round-trip. Drives the ORM
+  ``default=`` machinery (uuid, created_at, updated_at, priority)
+  against the SQLite dev/test driver where the migration's PG
+  server-side defaults are no-ops.
+* **Round-trip on :class:`TenantConventionHistory`** -- same shape,
+  plus the nullable ``body_before`` semantics for the CREATE event.
+* **``priority`` default and explicit value** -- omitted at insert
+  defaults to 0; an explicit value (positive or negative) persists.
+  Locks the T4 preamble-packing contract: priority is the ranking key.
+* **Unique ``(tenant_id, slug)``** -- two rows with the same
+  ``(tenant_id, slug)`` pair raise :class:`IntegrityError`. The named
+  ``tenant_conventions_tenant_slug_idx`` enforces uniqueness at the
+  DB layer, not just at a future UI validator.
+* **Cross-tenant: same ``slug`` in two tenants** -- the uniqueness
+  constraint is on ``(tenant_id, slug)``, not just ``slug``; two
+  tenants must be able to each have a ``rbac-canonical`` convention.
+* **Nullable ``body_before``** -- the CREATE event row's
+  ``body_before`` round-trips as ``None``.
+* **Schema-level smoke** -- ``alembic upgrade head`` against a fresh
+  SQLite DB creates the ``tenant_conventions`` + ``tenant_convention_history``
+  tables with the documented columns and indexes; the named indexes
+  are present and the unique constraint is materialised.
+* **Reversibility round-trip** -- ``alembic downgrade "0014"`` (the
+  ``down_revision``) drops both tables + indexes; a subsequent
+  ``upgrade head`` restores them.
+
+The tests run against ``sqlite+aiosqlite`` via the shared engine
+cache that the autouse ``_default_database_url`` fixture in
+:mod:`tests.conftest` already pre-migrates to ``alembic upgrade
+head``. Per-test isolation comes from the per-test ``tmp_path`` DB
+file, the same shape every other DB-touching test in the suite uses.
+
+SQLite datetime caveats -- identical to :mod:`tests.test_db_targets`:
+SQLite stores datetimes as ISO-8601 strings without timezone
+information; SQLAlchemy round-trips them as naive ``datetime`` even
+when the column is ``DateTime(timezone=True)``. All datetime
+assertions strip tzinfo before comparing the wall-clock parts.
+
+The schema-level migration tests follow the synchronous pattern from
+:mod:`tests.test_migration_0014_agent_session_id`:
+:func:`alembic.command.upgrade` calls :func:`asyncio.run` internally
+via env.py's async cookbook, so the test function itself must be
+sync.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy import select
+
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import TenantConvention, TenantConventionHistory
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module.
+
+    Mirrors the pattern in :mod:`tests.test_db_targets`: the autouse
+    ``_default_database_url`` fixture only pins ``DATABASE_URL``;
+    Keycloak/Vault knobs come from each test file. The
+    ``get_settings.cache_clear()`` brackets prevent a stale
+    ``Settings`` instance from a previous test from leaking.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# TenantConvention round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tenant_convention_round_trip_persists_every_field() -> None:
+    """Insert a :class:`TenantConvention`, query it back, every field matches.
+
+    Exercises the ORM ``default=`` machinery (uuid, created_at,
+    updated_at, priority) against the SQLite driver where the
+    migration's PG server-side defaults are no-ops. Asserting on every
+    field is what proves the column shape, type mapping, and default
+    machinery are wired correctly before T2's API CRUD layer starts
+    writing these rows in earnest.
+    """
+    sessionmaker = get_sessionmaker()
+    convention_id = uuid.uuid4()
+    tenant_id = uuid.uuid4()
+    now = datetime.now(UTC)
+
+    async with sessionmaker() as session:
+        session.add(
+            TenantConvention(
+                id=convention_id,
+                tenant_id=tenant_id,
+                slug="rbac-canonical",
+                title="RBAC is canonical",
+                body="Every operation runs through MEHO's RBAC layer.",
+                kind="operational",
+                priority=10,
+                created_by_sub="user:alice",
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(TenantConvention).where(TenantConvention.id == convention_id)
+        )
+        row = result.scalar_one()
+
+    assert row.id == convention_id
+    assert row.tenant_id == tenant_id
+    assert row.slug == "rbac-canonical"
+    assert row.title == "RBAC is canonical"
+    assert row.body == "Every operation runs through MEHO's RBAC layer."
+    assert row.kind == "operational"
+    assert row.priority == 10
+    assert row.created_by_sub == "user:alice"
+    # SQLite strips tzinfo -- compare wall-clock parts only.
+    assert row.created_at.replace(tzinfo=None) == now.replace(tzinfo=None)
+    assert row.updated_at.replace(tzinfo=None) == now.replace(tzinfo=None)
+
+
+@pytest.mark.asyncio
+async def test_tenant_convention_round_trip_with_optional_fields_omitted() -> None:
+    """Insert a minimal :class:`TenantConvention`, ORM defaults fire.
+
+    Proves that ``created_by_sub=None`` survives the round-trip as NULL
+    and the ORM column defaults (``priority=0``, ``created_at``,
+    ``updated_at``) fill in without explicit values. Locks the contract
+    that T2's ``ConventionCreate`` Pydantic model can omit ``priority``
+    (defaults to 0) and ``created_by_sub`` (resolved server-side from
+    the JWT) without violating any DB-level NOT NULL.
+    """
+    sessionmaker = get_sessionmaker()
+    convention_id = uuid.uuid4()
+    tenant_id = uuid.uuid4()
+
+    async with sessionmaker() as session:
+        session.add(
+            TenantConvention(
+                id=convention_id,
+                tenant_id=tenant_id,
+                slug="minimal-convention",
+                title="Minimal",
+                body="Body text.",
+                kind="reference",
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(TenantConvention).where(TenantConvention.id == convention_id)
+        )
+        row = result.scalar_one()
+
+    assert row.id == convention_id
+    assert row.created_by_sub is None
+    # The Python-side ORM default for priority is 0 (mirrors the PG
+    # server default that doesn't fire on SQLite).
+    assert row.priority == 0
+    # ORM defaults populated the timestamps even without explicit values.
+    assert row.created_at is not None
+    assert row.updated_at is not None
+
+
+# ---------------------------------------------------------------------------
+# priority semantics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tenant_convention_priority_default_is_zero_when_unspecified() -> None:
+    """Omitting ``priority`` defaults to 0 (the T4 preamble-packing baseline).
+
+    The PG server default of ``0`` and the ORM-side Python default of
+    ``0`` are intentionally redundant: PG production gets the server
+    default for out-of-band inserts, the ORM provides it for the SQLite
+    dev/test path and for ORM inserts that don't include the column.
+    The acceptance criterion explicitly calls out the round-trip:
+    "round-trip test asserts default = 0 when unspecified".
+    """
+    sessionmaker = get_sessionmaker()
+    convention_id = uuid.uuid4()
+
+    async with sessionmaker() as session:
+        session.add(
+            TenantConvention(
+                id=convention_id,
+                tenant_id=uuid.uuid4(),
+                slug="no-priority",
+                title="Default priority",
+                body="Body.",
+                kind="reference",
+                # priority deliberately omitted to exercise the default.
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(TenantConvention).where(TenantConvention.id == convention_id)
+        )
+        row = result.scalar_one()
+
+    assert row.priority == 0
+
+
+@pytest.mark.asyncio
+async def test_tenant_convention_priority_explicit_value_persists() -> None:
+    """An explicit non-default ``priority`` survives the round-trip.
+
+    Confirms the acceptance criterion bullet: "an explicit value
+    persists". Uses a deliberately non-trivial value (250) that no
+    silent ORM coercion (boolean to 0/1, string-to-int fail, etc.)
+    would happen to land on.
+    """
+    sessionmaker = get_sessionmaker()
+    convention_id = uuid.uuid4()
+
+    async with sessionmaker() as session:
+        session.add(
+            TenantConvention(
+                id=convention_id,
+                tenant_id=uuid.uuid4(),
+                slug="high-priority",
+                title="High priority rule",
+                body="Body.",
+                kind="operational",
+                priority=250,
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(TenantConvention).where(TenantConvention.id == convention_id)
+        )
+        row = result.scalar_one()
+
+    assert row.priority == 250
+
+
+# ---------------------------------------------------------------------------
+# (tenant_id, slug) unique constraint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tenant_convention_tenant_slug_uniqueness_enforced() -> None:
+    """Two rows with the same ``(tenant_id, slug)`` raise :class:`IntegrityError`.
+
+    The migration enforces uniqueness via the named
+    ``tenant_conventions_tenant_slug_idx`` (declared ``unique=True``);
+    this test proves the constraint fires at the DB layer, not just at
+    a future UI validator. Without it a regression that accidentally
+    dropped the unique flag would silently allow two conventions with
+    the same slug per tenant -- which would break T4's preamble
+    assembly (duplicate slugs in the preamble) and T2's ``GET /{slug}``
+    route (ambiguous row).
+    """
+    from sqlalchemy.exc import IntegrityError
+
+    sessionmaker = get_sessionmaker()
+    tenant_id = uuid.uuid4()
+
+    async with sessionmaker() as session:
+        session.add(
+            TenantConvention(
+                id=uuid.uuid4(),
+                tenant_id=tenant_id,
+                slug="dup-slug",
+                title="First",
+                body="Body.",
+                kind="operational",
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        session.add(
+            TenantConvention(
+                id=uuid.uuid4(),
+                tenant_id=tenant_id,
+                slug="dup-slug",
+                title="Second",
+                body="Body.",
+                kind="workflow",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_tenant_convention_same_slug_allowed_across_different_tenants() -> None:
+    """Same slug in two different tenants does not raise.
+
+    The uniqueness constraint is on ``(tenant_id, slug)``, not just
+    ``slug``. Two tenants must be able to each have a ``rbac-canonical``
+    convention; denying them would force awkward global namespacing and
+    break the per-tenant authorship model the issue body specifies
+    ("Cross-tenant: two tenants can have the same slug; no conflict").
+    """
+    sessionmaker = get_sessionmaker()
+    tenant_a = uuid.uuid4()
+    tenant_b = uuid.uuid4()
+
+    async with sessionmaker() as session:
+        session.add(
+            TenantConvention(
+                id=uuid.uuid4(),
+                tenant_id=tenant_a,
+                slug="rbac-canonical",
+                title="Tenant A rule",
+                body="Body A.",
+                kind="operational",
+            )
+        )
+        session.add(
+            TenantConvention(
+                id=uuid.uuid4(),
+                tenant_id=tenant_b,
+                slug="rbac-canonical",
+                title="Tenant B rule",
+                body="Body B.",
+                kind="operational",
+            )
+        )
+        # Must not raise -- different tenants, same slug is allowed.
+        await session.commit()
+
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(TenantConvention).where(TenantConvention.slug == "rbac-canonical")
+        )
+        rows = result.scalars().all()
+
+    assert len(rows) == 2
+    assert {r.tenant_id for r in rows} == {tenant_a, tenant_b}
+
+
+# ---------------------------------------------------------------------------
+# TenantConventionHistory round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tenant_convention_history_round_trip_persists_every_field() -> None:
+    """Insert a :class:`TenantConventionHistory` row, query it back, fields match.
+
+    Positive case for a PATCH-style history row: both ``body_before``
+    (the prior state) and ``body_after`` (the new state) are populated.
+    The ``audit_id`` soft-FK is set to a synthetic value to confirm the
+    round-trip without requiring a real audit_log row.
+    """
+    sessionmaker = get_sessionmaker()
+    history_id = uuid.uuid4()
+    convention_id = uuid.uuid4()
+    audit_id = uuid.uuid4()
+    now = datetime.now(UTC)
+
+    async with sessionmaker() as session:
+        session.add(
+            TenantConventionHistory(
+                id=history_id,
+                convention_id=convention_id,
+                body_before="Old body.",
+                body_after="New body.",
+                actor_sub="user:bob",
+                ts=now,
+                audit_id=audit_id,
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(TenantConventionHistory).where(TenantConventionHistory.id == history_id)
+        )
+        row = result.scalar_one()
+
+    assert row.id == history_id
+    assert row.convention_id == convention_id
+    assert row.body_before == "Old body."
+    assert row.body_after == "New body."
+    assert row.actor_sub == "user:bob"
+    assert row.audit_id == audit_id
+    assert row.ts.replace(tzinfo=None) == now.replace(tzinfo=None)
+
+
+@pytest.mark.asyncio
+async def test_tenant_convention_history_create_event_has_null_body_before() -> None:
+    """The CREATE event row's ``body_before`` round-trips as ``None``.
+
+    Locks the contract that the first history row (CREATE) has no
+    prior state. T2's POST route inserts a history row with
+    ``body_before=NULL``; subsequent PATCHes shift the previous body
+    into ``body_before``. A regression that made ``body_before`` NOT
+    NULL would force T2 to invent a sentinel ("") which is a silent
+    semantic shift.
+    """
+    sessionmaker = get_sessionmaker()
+    history_id = uuid.uuid4()
+
+    async with sessionmaker() as session:
+        session.add(
+            TenantConventionHistory(
+                id=history_id,
+                convention_id=uuid.uuid4(),
+                body_before=None,
+                body_after="Initial body.",
+                actor_sub="user:carol",
+                # audit_id deliberately omitted -- exercises the nullable default.
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(TenantConventionHistory).where(TenantConventionHistory.id == history_id)
+        )
+        row = result.scalar_one()
+
+    assert row.body_before is None
+    assert row.body_after == "Initial body."
+    assert row.audit_id is None
+
+
+# ---------------------------------------------------------------------------
+# Schema-level inspection -- migration installs the documented tables + indexes
+# ---------------------------------------------------------------------------
+
+
+def _alembic_upgrade_against_fresh_sqlite(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    db_filename: str,
+) -> tuple[str, object]:
+    """Pin env, reset caches, run ``alembic upgrade head`` on fresh SQLite.
+
+    Shared setup for the sync migration tests below. Returns
+    ``(sync_url, alembic_cfg)`` so callers can inspect the resulting
+    schema or run further migration ops.
+
+    Mirrors :func:`tests.test_db_targets._alembic_upgrade_against_fresh_sqlite`
+    exactly; kept local rather than hoisted to conftest because neither
+    module needs the other's helper.
+    """
+    from alembic import command
+
+    from meho_backplane.db.migrations import alembic_config
+
+    db_path = tmp_path / db_filename
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    command.upgrade(cfg, "head")
+    return sync_url, cfg
+
+
+def test_migration_installs_conventions_tables_and_indexes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``alembic upgrade head`` puts both tables + indexes in place.
+
+    Asserts via SQLite's schema inspector (the dialect-portable
+    equivalent of ``\\d+ tenant_conventions``):
+
+    * The ``tenant_conventions`` table exists with all documented columns.
+    * The ``tenant_convention_history`` table exists with all documented columns.
+    * The unique composite ``tenant_conventions_tenant_slug_idx`` is present
+      and marked unique.
+    * The composite ``tenant_convention_history_convention_idx`` is present.
+    * ``priority`` is NOT NULL on ``tenant_conventions``.
+
+    PG-side verification (``\\d+`` against a real container) lives in
+    the existing testcontainers suite that runs on CI.
+    """
+    sync_url, _ = _alembic_upgrade_against_fresh_sqlite(
+        monkeypatch, tmp_path, "conventions_schema.db"
+    )
+
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            inspector = sa_inspect(conn)
+            tables = set(inspector.get_table_names())
+            assert "tenant_conventions" in tables
+            assert "tenant_convention_history" in tables
+
+            # Column-set check for ``tenant_conventions``.
+            conventions_cols = {col["name"] for col in inspector.get_columns("tenant_conventions")}
+            expected_conventions_cols = {
+                "id",
+                "tenant_id",
+                "slug",
+                "title",
+                "body",
+                "kind",
+                "priority",
+                "created_by_sub",
+                "created_at",
+                "updated_at",
+            }
+            assert expected_conventions_cols <= conventions_cols, (
+                f"Missing columns in tenant_conventions: "
+                f"{expected_conventions_cols - conventions_cols}"
+            )
+
+            # ``priority`` must be NOT NULL (the v0.6 invariant T4 depends on).
+            priority_col = next(
+                col
+                for col in inspector.get_columns("tenant_conventions")
+                if col["name"] == "priority"
+            )
+            assert priority_col["nullable"] is False, (
+                "tenant_conventions.priority must be NOT NULL "
+                "so T4's preamble-packing has a well-defined ordering key"
+            )
+
+            # Column-set check for ``tenant_convention_history``.
+            history_cols = {
+                col["name"] for col in inspector.get_columns("tenant_convention_history")
+            }
+            expected_history_cols = {
+                "id",
+                "convention_id",
+                "body_before",
+                "body_after",
+                "actor_sub",
+                "ts",
+                "audit_id",
+            }
+            assert expected_history_cols <= history_cols, (
+                f"Missing columns in tenant_convention_history: "
+                f"{expected_history_cols - history_cols}"
+            )
+
+            # ``body_before`` must be nullable (CREATE event has no prior state).
+            body_before_col = next(
+                col
+                for col in inspector.get_columns("tenant_convention_history")
+                if col["name"] == "body_before"
+            )
+            assert body_before_col["nullable"] is True, (
+                "tenant_convention_history.body_before must be nullable "
+                "so the CREATE event can record NULL"
+            )
+
+            # Index presence on ``tenant_conventions``.
+            conventions_indexes = inspector.get_indexes("tenant_conventions")
+            conventions_index_names = {idx["name"] for idx in conventions_indexes}
+            assert "tenant_conventions_tenant_slug_idx" in conventions_index_names
+            slug_index = next(
+                idx
+                for idx in conventions_indexes
+                if idx["name"] == "tenant_conventions_tenant_slug_idx"
+            )
+            # SQLite returns ``1`` for unique flag; PG returns ``True``. Truthy
+            # comparison covers both dialects -- mirrors the pattern in
+            # :mod:`tests.test_db_models` / :mod:`tests.test_db_broadcast_override`.
+            assert slug_index["unique"], (
+                "tenant_conventions_tenant_slug_idx must enforce uniqueness on (tenant_id, slug)"
+            )
+            assert slug_index["column_names"] == ["tenant_id", "slug"]
+
+            # Index presence on ``tenant_convention_history``.
+            history_indexes = inspector.get_indexes("tenant_convention_history")
+            history_index_names = {idx["name"] for idx in history_indexes}
+            assert "tenant_convention_history_convention_idx" in history_index_names
+            history_index = next(
+                idx
+                for idx in history_indexes
+                if idx["name"] == "tenant_convention_history_convention_idx"
+            )
+            assert history_index["column_names"] == ["convention_id", "ts"]
+    finally:
+        sync_eng.dispose()
+
+
+def test_migration_upgrade_then_downgrade_is_reversible(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``alembic upgrade head`` -> ``alembic downgrade "0014"`` is a clean cycle.
+
+    Proves that migration ``0015`` is fully reversible: after
+    downgrading by exactly one revision (back to 0014, the
+    ``agent_session_id`` column add), both new tables and their indexes
+    must be gone while the rest of the schema (``tenant`` table,
+    ``audit_log.agent_session_id``) remains intact. Re-upgrading to
+    head must restore everything cleanly.
+
+    The downgrade target is the explicit revision ``"0014"`` (0015's
+    ``down_revision``) rather than head-relative ``"-1"``. ``"-1"``
+    reverts whatever sits at head, so the moment a later migration
+    (0016+) lands it would silently stop exercising 0015's reverse;
+    anchoring to ``"0014"`` keeps this test pinned to 0015 and matches
+    the repo convention (``test_migration_0014_agent_session_id``).
+    """
+    from alembic import command
+
+    sync_url, cfg = _alembic_upgrade_against_fresh_sqlite(
+        monkeypatch, tmp_path, "conventions_rev.db"
+    )
+
+    # Sanity -- upgrade landed both tables before we reverse.
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            tables_before = set(sa_inspect(conn).get_table_names())
+        assert "tenant_conventions" in tables_before
+        assert "tenant_convention_history" in tables_before
+    finally:
+        sync_eng.dispose()
+
+    # Downgrade by exactly one revision (back to 0014).
+    command.downgrade(cfg, "0014")
+
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            inspector = sa_inspect(conn)
+            tables_after_down = set(inspector.get_table_names())
+            # Both new tables must be gone.
+            assert "tenant_conventions" not in tables_after_down
+            assert "tenant_convention_history" not in tables_after_down
+            # The rest of the schema must survive.
+            assert "tenant" in tables_after_down
+            assert "audit_log" in tables_after_down
+            # 0014's column must still exist on audit_log.
+            audit_cols = {col["name"] for col in inspector.get_columns("audit_log")}
+            assert "agent_session_id" in audit_cols
+    finally:
+        sync_eng.dispose()
+
+    # Re-upgrade -- both tables come back, proving the round-trip.
+    command.upgrade(cfg, "head")
+
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            inspector = sa_inspect(conn)
+            tables_after_up = set(inspector.get_table_names())
+            assert "tenant_conventions" in tables_after_up
+            assert "tenant_convention_history" in tables_after_up
+            # Indexes restored too.
+            conventions_indexes = {
+                idx["name"] for idx in inspector.get_indexes("tenant_conventions")
+            }
+            assert "tenant_conventions_tenant_slug_idx" in conventions_indexes
+            history_indexes = {
+                idx["name"] for idx in inspector.get_indexes("tenant_convention_history")
+            }
+            assert "tenant_convention_history_convention_idx" in history_indexes
+    finally:
+        sync_eng.dispose()

--- a/docs/codebase/tenant_conventions.md
+++ b/docs/codebase/tenant_conventions.md
@@ -1,0 +1,231 @@
+# Tenant conventions (Layer 1 server-side rules)
+
+Initiative #229 (G7.1) ships a two-layer tenant-conventions surface.
+**Layer 1** is the database-backed table of operational / workflow /
+reference rules MEHO auto-loads into every authenticated agent's
+session preamble. **Layer 2** is the local `CLAUDE.md` template
+consumer repos copy in to teach their local Claude sessions to prefer
+MEHO features. This document covers Layer 1 -- the schema, ORM
+models, and access patterns. Layer 2 lives in
+[docs/examples/consumer-onboarding/](../examples/consumer-onboarding/)
+(landed by sibling task #318).
+
+This document is current as of T1 (#313). Sibling tasks T2-T5 will
+extend it with the API, CLI, preamble assembler, and seed details as
+they land.
+
+## Overview
+
+A **tenant convention** is a single named rule, scoped to one tenant,
+that the agent's session preamble incorporates at connect time. Each
+convention has:
+
+- a **slug** -- operator-visible identifier (`rbac-canonical`,
+  `secret-handling`) used in URLs, CLI commands, and audit log
+  references;
+- a **title** -- short display label;
+- a free-form Markdown **body** -- the rule text the agent sees;
+- a **kind** discriminator (`operational` / `workflow` /
+  `reference`) -- only `operational` conventions are packed into the
+  preamble; the others are reference material the operator surfaces
+  on demand;
+- a **priority** (`SMALLINT`) -- the ranking key the preamble
+  assembler uses to pack highest-priority-first and drop
+  lowest-priority entries whole when over the token budget.
+
+Conventions are **per-tenant**. Two tenants can declare the same
+slug independently; one tenant cannot have two conventions with the
+same slug (enforced by the unique composite index on
+`(tenant_id, slug)`).
+
+Every edit writes both a current-state row in `tenant_conventions`
+and an audit row in `tenant_convention_history`, in the same DB
+transaction.
+
+## Key types
+
+### `tenant_conventions` table
+
+```
+id              UUID    PK    -- gen_random_uuid() on PG, uuid4() on SQLite
+tenant_id       UUID    NOT NULL
+slug            TEXT    NOT NULL
+title           TEXT    NOT NULL
+body            TEXT    NOT NULL
+kind            TEXT    NOT NULL   -- 'operational' | 'workflow' | 'reference'
+priority        SMALLINT NOT NULL DEFAULT 0
+created_by_sub  TEXT    NULL
+created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+```
+
+Indexed by `tenant_conventions_tenant_slug_idx` -- unique composite
+btree on `(tenant_id, slug)`.
+
+### `tenant_convention_history` table
+
+```
+id              UUID    PK    -- gen_random_uuid() on PG, uuid4() on SQLite
+convention_id   UUID    NOT NULL    -- soft FK to tenant_conventions.id
+body_before     TEXT    NULL        -- NULL for CREATE events
+body_after      TEXT    NOT NULL
+actor_sub       TEXT    NOT NULL
+ts              TIMESTAMPTZ NOT NULL DEFAULT now()
+audit_id        UUID    NULL        -- soft FK to audit_log.id; nullable for seeds
+```
+
+Indexed by `tenant_convention_history_convention_idx` -- composite
+btree on `(convention_id, ts)`.
+
+### `TenantConvention` (SQLAlchemy 2.x ORM)
+
+Defined in
+[`backend/src/meho_backplane/db/models.py`](../../backend/src/meho_backplane/db/models.py).
+Standard `Mapped[...]` annotations; no helper methods. T2's CRUD
+module is the only writer.
+
+### `TenantConventionHistory` (SQLAlchemy 2.x ORM)
+
+Same module. Write-once, read-mostly. T3's `meho conventions history
+<slug>` verb is the only consumer in v0.2.
+
+## Control flow
+
+T1 (this task) ships **schema only** -- no read or write paths exist
+yet. The end-to-end flow lands across T2-T5:
+
+1. **POST /api/v1/conventions** (T2 #314) -- `tenant_admin` role
+   required. Inserts one row into `tenant_conventions` and one row
+   into `tenant_convention_history` (with `body_before=NULL`) inside
+   the same transaction. The audit middleware writes its own row
+   into `audit_log`; T2 captures the audit row id and stores it in
+   the history row's `audit_id` column so G8's audit-replay can
+   join.
+
+2. **PATCH /api/v1/conventions/{slug}** (T2) -- `tenant_admin` role
+   required. Looks up the existing row by `(tenant_id, slug)`,
+   updates `body` (and/or `title`), inserts a history row with the
+   previous body in `body_before` and the new body in `body_after`.
+   Same single-transaction discipline as POST.
+
+3. **DELETE /api/v1/conventions/{slug}** (T2) -- `tenant_admin` role
+   required. Deletes the row from `tenant_conventions`; the history
+   row gets `body_after=<final body>` (a legible last-known state)
+   rather than a sentinel marker. The lifecycle distinction lives in
+   the audit row, not in `tenant_convention_history`.
+
+4. **GET /api/v1/conventions** (T2) -- list all conventions for the
+   operator's tenant. Filters by `tenant_id` (resolved from the JWT
+   claim by G0.1's contextvar binding).
+
+5. **GET /api/v1/conventions/{slug}** (T2) -- single-row lookup by
+   `(tenant_id, slug)`; the unique index makes it a btree probe.
+
+6. **GET /api/v1/conventions/{slug}/history** (T2) -- chronological
+   list of history rows for the convention, with optional
+   cross-reference to `audit_log` via `audit_id`.
+
+7. **Session preamble** (T4 #316) -- on MCP `initialize`, MEHO loads
+   all `kind='operational'` conventions for the tenant, packs them
+   highest-priority-first into a budget-bounded Markdown block, and
+   emits the result as the spec-optional `instructions` field on the
+   `initialize` response. Over-budget entries are dropped whole
+   (never mid-entry truncation of an operational rule), and the
+   dropped-slug list flows back to callers so `meho conventions
+   list` can surface it.
+
+8. **MCP resource** `meho://tenant/<id>/conventions` (T4) -- the same
+   data is also exposed as an MCP resource collection. When (and
+   only when) `capabilities.resources.subscribe: true`, edits emit
+   `notifications/resources/updated` so subscribing clients refresh
+   mid-session.
+
+## Dependencies
+
+This task's dependencies (resolved by T1):
+
+- **G0.1-T1 (#231)** -- needs the `tenant` table for `tenant_id`
+  column types. Soft FK; no `REFERENCES` clause until v0.2.next.
+
+Downstream consumers (lands in sibling tasks):
+
+- **T2 (#314)** -- Pydantic schemas + 6 API routes.
+- **T3 (#315)** -- CLI verbs (`meho conventions list / show / edit /
+  history`).
+- **T4 (#316)** -- session-preamble assembler + MCP resource.
+- **T5 (#317)** -- seed migration for `rdc-internal` tenant.
+- **T6 (#318)** -- Layer 2 starter doc
+  (`docs/examples/consumer-onboarding/CLAUDE.md`).
+
+## Migration
+
+The schema is materialised by
+[`backend/alembic/versions/0015_create_tenant_conventions.py`](../../backend/alembic/versions/0015_create_tenant_conventions.py).
+Purely additive (no DROP / RENAME / SET NOT NULL on existing
+columns); the
+[CI guard](../../scripts/ci/check_migration_compat.py) verifies this.
+Reversibility is at the table level: `downgrade()` drops both new
+tables and their indexes.
+
+The migration follows the dialect-portability discipline established
+by 0001-0014:
+
+- `gen_random_uuid()` server defaults on PG; ORM `default=uuid.uuid4`
+  on SQLite.
+- `now()` server defaults on PG; ORM `default=lambda: datetime.now(UTC)`
+  on SQLite.
+- `priority` server default `0` on PG; ORM `default=0` for SQLite.
+- Soft FKs throughout (no `REFERENCES` clauses per the issue body's
+  explicit choice).
+
+## Known issues
+
+- **No FK enforcement.** Per the issue body's explicit choice, both
+  tables use soft FKs (column types match the referenced tables but
+  no `REFERENCES ...` clauses). T2's CRUD enforces referential
+  integrity at insert time. A v0.2.next tightening migration may
+  introduce real FKs once cascade-policy decisions are exercised in
+  production -- specifically, what should happen to conventions
+  and history rows when a tenant is deleted, and to history rows
+  when a convention is deleted.
+
+- **No DB-level enum on `kind`.** Per the issue body's Out of scope,
+  `kind` is free-form text; Pydantic at the API layer (T2) bounds it
+  to `operational` / `workflow` / `reference`. A regression that
+  bypassed the Pydantic layer could land an invalid `kind`; the API
+  layer's validation is the single line of defence in v0.2.
+
+- **No content validation.** T1 does not enforce length, format, or
+  budget limits on `body`. T2 will add over-budget write-time 422
+  validation (a single `operational` convention whose token estimate
+  exceeds the preamble budget is rejected at POST/PATCH time, not
+  silently dropped at every future preamble assembly).
+
+- **No backref from `Tenant`.** Querying "all conventions for tenant
+  X" goes through the application layer, not via a SQLAlchemy
+  relationship. Same discipline as the audit-log <-> tenant link;
+  see the `Tenant` docstring in
+  [`models.py`](../../backend/src/meho_backplane/db/models.py) for
+  the rationale.
+
+## References
+
+- Parent Initiative: [#229](https://github.com/evoila/meho/issues/229).
+- This task: [#313](https://github.com/evoila/meho/issues/313).
+- Existing migration to mirror:
+  [`backend/alembic/versions/0001_create_audit_log.py`](../../backend/alembic/versions/0001_create_audit_log.py)
+  (dialect portability),
+  [`backend/alembic/versions/0002_create_tenant_and_audit_tenant_id.py`](../../backend/alembic/versions/0002_create_tenant_and_audit_tenant_id.py)
+  (unique-index discipline).
+- Decision #4 (G7 partition):
+  [`docs/planning/v0.2-decisions.md`](../planning/v0.2-decisions.md).
+- MCP spec 2025-06-18 -- `initialize`:
+  https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle
+  (the spec-optional `instructions` field on the response carries
+  the assembled preamble in T4).
+- MCP spec 2025-06-18 -- resources:
+  https://modelcontextprotocol.io/specification/2025-06-18/server/resources
+  (`resources/subscribe` + `notifications/resources/updated` gated on
+  `capabilities.resources.subscribe`; the priority-ranked packing
+  mirrors the native resource `priority`/`audience` annotation
+  model).


### PR DESCRIPTION
## Summary

- Adds the schema foundation for Initiative #229 (G7.1 Tenant conventions + Layer 2 starter): two new tables (`tenant_conventions`, `tenant_convention_history`), two SQLAlchemy 2.x ORM models (`TenantConvention`, `TenantConventionHistory`), and a behavioural test matrix covering round-trip / uniqueness / priority semantics / nullable body_before / schema-level inspection / reversibility.
- `priority SMALLINT NOT NULL DEFAULT 0` lands in T1 so the T5 seed migration (#317) writes rows against the final column shape -- retrofitting NOT NULL after seeded data exists would be a needless multi-step migration. `DEFAULT 0` keeps T2's `ConventionCreate` contract backward-compatible.
- Soft FKs throughout per the issue body's explicit choice (matches the chassis convention for `audit_log.tenant_id` / `audit_log.target_id`); v0.2.next will tighten with FKs. `kind` stays free-form text at the DB layer; T2's Pydantic bounds it to `operational` / `workflow` / `reference` per the issue's Out of scope.
- Dialect-portability mirrors 0001-0014: `gen_random_uuid()` / `now()` server defaults on PG, ORM-side Python defaults on SQLite; `SmallInteger` compiles to `SMALLINT` on both dialects.

## Test plan

- [x] `ruff check src/ tests/ alembic/` — clean.
- [x] `ruff format --check` — clean (570 files already formatted).
- [x] `mypy src/ --ignore-missing-imports` — clean (270 source files).
- [x] `pytest tests/test_db_conventions.py -v` — 10 passed (covers every acceptance criterion: round-trip, unique `(tenant_id, slug)`, priority default + explicit, cross-tenant slug, nullable `body_before`, schema-level inspection, reversibility).
- [x] `pytest tests/test_db_*.py tests/test_migration_*.py` — 97 passed, 3 skipped (no regressions across all db / migration tests).
- [x] Full unit suite (`pytest tests/ --ignore=tests/integration --ignore=tests/acceptance`) — 3955 passed, 21 skipped.
- [x] `scripts/ci/check_migration_compat.py` — exit 0 (migration is purely additive, no DROP / RENAME / SET NOT NULL on existing columns).
- [x] `.claude/hooks/code-quality.py --diff` — exit 0 (one pre-existing file-size warning on `models.py`; not introduced by this change).

### Acceptance criteria

- [x] Migration upgrades cleanly; downgrade reverses cleanly — verified by `test_migration_upgrade_then_downgrade_is_reversible`.
- [x] Round-trip test: insert convention + history row; fields round-trip — verified by `test_tenant_convention_round_trip_persists_every_field` + `test_tenant_convention_history_round_trip_persists_every_field`.
- [x] Unique `(tenant_id, slug)` enforced — verified by `test_tenant_convention_tenant_slug_uniqueness_enforced` (raises `IntegrityError`).
- [x] `priority SMALLINT NOT NULL DEFAULT 0` present; round-trip test asserts default = 0 when unspecified and explicit value persists — verified by `test_tenant_convention_priority_default_is_zero_when_unspecified` + `test_tenant_convention_priority_explicit_value_persists`.
- [x] Cross-tenant: two tenants can have the same slug — verified by `test_tenant_convention_same_slug_allowed_across_different_tenants`.
- [x] `kind` accepts 'operational' / 'workflow' / 'reference' (enforced at Pydantic in T2, not DB) — documented in the migration docstring + the ORM `kind` column comment.
- [x] Index inspection: unique index on `(tenant_id, slug)` exists — verified by `test_migration_installs_conventions_tables_and_indexes` (asserts the unique flag + column ordering).

## Out of scope

- API routes (T2 #314).
- CLI verbs (T3 #315).
- Session preamble assembler (T4 #316).
- Seed content for `rdc-internal` (T5 #317).
- Layer 2 starter doc (T6 #318).
- DB-level enum for `kind` — Pydantic + application-level validation handles bounding per the issue body.
- FK tightening (`REFERENCES tenant(id)` etc.) — deferred to v0.2.next per the issue body's soft-FK discipline.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #313
