### PR TITLE
feat(audit): G8.2-T4 REST audit-replay route + 10k count-first 413 cap

### DIFF
--- a/backend/src/meho_backplane/api/v1/audit.py
+++ b/backend/src/meho_backplane/api/v1/audit.py
@@ -3,8 +3,10 @@
 
 """``/api/v1/audit/*`` — REST surface for the audit-query substrate (G8.1-T2).
 
-Mounts four routes, all of which dispatch through the T1
-:func:`~meho_backplane.audit_query.query_audit` handler:
+Mounts five routes. Four dispatch through the T1
+:func:`~meho_backplane.audit_query.query_audit` handler; the fifth
+(replay, G8.2-T4) dispatches through
+:func:`~meho_backplane.audit_query.replay_session`:
 
 * ``POST /api/v1/audit/query`` — full filter; body is
   :class:`~meho_backplane.api.v1.audit_models.AuditQueryRequest`.
@@ -15,12 +17,21 @@ Mounts four routes, all of which dispatch through the T1
 * ``GET /api/v1/audit/show/{audit_id}`` — single-row fetch. 404 (not
   403) when the audit row is not in the operator's tenant, so the
   route never leaks the existence of an audit row across tenants.
+* ``GET /api/v1/audit/sessions/{session_id}/replay`` — per-session
+  parent/child replay tree (G8.2-T4), dispatching through
+  :func:`~meho_backplane.audit_query.replay_session`. An unknown or
+  foreign session yields ``root=[]`` / ``row_count=0`` (never 404 —
+  same cross-tenant non-leakage posture as ``show``). A session
+  larger than :data:`_REPLAY_ROW_CAP` rows returns 413 from a
+  count-first guard evaluated *before* the recursive tree build runs,
+  so a runaway session cannot produce an unbounded response or pay
+  the cost of materializing the tree just to reject it.
 
 Tenant scoping
 ==============
 
 Every route passes ``operator.tenant_id`` (lifted from the JWT by
-:func:`~meho_backplane.auth.rbac.require_role`) to ``query_audit`` as
+:func:`~meho_backplane.auth.rbac.require_role`) to the substrate as
 the mandatory keyword-only ``tenant_id`` argument. Client-supplied
 ``tenant_id`` (or any other unknown field) in the POST body is
 rejected at 422 ``extra_forbidden`` per
@@ -31,32 +42,34 @@ queries are impossible by construction.
 Audit-on-audit-query (decision #3, ``docs/planning/v0.2-decisions.md``)
 ======================================================================
 
-Every route binds two audit-override contextvars before calling
-``query_audit`` so the row this request writes (via the chassis
+Every route binds two audit-override contextvars before calling the
+substrate so the row this request writes (via the chassis
 :class:`~meho_backplane.audit.AuditMiddleware`) carries the canonical
-audit-query identity:
+audit-surface identity:
 
-* ``audit_op_id = "meho.audit.query"`` — every audit-query call,
-  regardless of which of the four routes the operator hit, writes
-  under this canonical op_id. Operators querying ``audit_log`` for
-  "everyone who used the audit-query surface" filter on
-  ``payload->>'op_id' = 'meho.audit.query'``.
-* ``audit_op_class = "audit_query"`` — flips the broadcast event into
-  aggregate-only mode per
-  :func:`~meho_backplane.broadcast.events.classify_op` policy: SSE feed
-  + Slack subscribers see ``{op_id, result_status, row_count}`` only,
-  never the request filter contents. Audit-query filter shapes encode
-  the investigation target and the investigator's hunch — both are
-  privacy-sensitive.
+* ``audit_op_id`` — the four query routes write under
+  ``"meho.audit.query"`` (regardless of which one the operator hit);
+  the replay route writes under ``"meho.audit.replay"``. Operators
+  querying ``audit_log`` for "everyone who used the audit-query
+  surface" filter on ``payload->>'op_id' = 'meho.audit.query'``, and
+  on ``'meho.audit.replay'`` for replay usage.
+* ``audit_op_class = "audit_query"`` — bound by *every* route
+  (including replay). It flips the broadcast event into aggregate-only
+  mode per :func:`~meho_backplane.broadcast.events.classify_op`
+  policy: SSE feed + Slack subscribers see
+  ``{op_id, result_status, row_count}`` only, never the request filter
+  contents or the replayed ``ReplayNode`` payload. Audit-query filter
+  shapes and a replayed session tree both encode the investigation
+  target and the investigator's hunch — both are privacy-sensitive.
 
-``audit_row_count`` is bound after ``query_audit`` returns so the
+``audit_row_count`` is bound after the substrate call returns so the
 broadcast event's row-count field reflects the actual returned
 cardinality.
 
 RBAC
 ====
 
-All four routes require ``operator`` role minimum
+All five routes require ``operator`` role minimum
 (:class:`~meho_backplane.auth.operator.TenantRole.OPERATOR`).
 ``read_only`` gets 403; ``tenant_admin`` gets 200. The shape mirrors
 :mod:`~meho_backplane.api.v1.retrieve` and
@@ -82,10 +95,12 @@ import uuid
 from datetime import UTC, datetime
 from typing import Final
 
+import sqlalchemy as sa
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from meho_backplane.api.v1.audit_models import AuditQueryRequest
+from meho_backplane.api.v1.audit_models import AuditQueryRequest, AuditReplayResult
 from meho_backplane.audit_query import (
     AuditEntry,
     AuditQueryFilters,
@@ -95,10 +110,12 @@ from meho_backplane.audit_query import (
     UnsupportedFilterError,
     parse_duration,
     query_audit,
+    replay_session,
 )
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
 from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
 
 __all__ = ["router"]
 
@@ -116,23 +133,43 @@ _require_operator = Depends(require_role(TenantRole.OPERATOR))
 #: only mode.
 _AUDIT_QUERY_OP_ID: Final[str] = "meho.audit.query"
 
+#: op_id the replay route (G8.2-T4) emits. Distinct from
+#: :data:`_AUDIT_QUERY_OP_ID` so operators can tell replay usage apart
+#: from flat-query usage in ``audit_log``; it shares the same
+#: ``op_class="audit_query"`` so the broadcast event stays aggregate-
+#: only (no ``ReplayNode`` tree in the SSE / Slack payload).
+_AUDIT_REPLAY_OP_ID: Final[str] = "meho.audit.replay"
+
+#: Hard cap on the number of anchor rows a single replay may carry. A
+#: session above this returns 413 from the route's count-first guard
+#: (before the recursive tree build runs). The CLI (T5) turns the 413
+#: into a redirect to ``meho audit query --session-id``.
+_REPLAY_ROW_CAP: Final[int] = 10_000
+
 #: Default ``since`` for the two duration-shorthand GET routes. 24
 #: hours matches the issue body's default and the chassis's general
 #: "what happened today" framing.
 _DEFAULT_SINCE: Final[str] = "24h"
 
 
-def _bind_audit_overrides() -> None:
+def _bind_audit_overrides(op_id: str = _AUDIT_QUERY_OP_ID) -> None:
     """Bind the audit-override contextvars BEFORE the substrate call.
 
-    Binding early — i.e. before :func:`query_audit` runs — means a
-    handler exception still produces an audit row carrying the
-    correct ``op_id`` / ``op_class``; the row-count is bound after
-    success because a partial query never produced rows. Mirrors
+    Binding early — i.e. before the substrate runs — means a handler
+    exception still produces an audit row carrying the correct
+    ``op_id`` / ``op_class``; the row-count is bound after success
+    because a partial query never produced rows. Mirrors
     :func:`~meho_backplane.api.v1.retrieve_usage._bind_request_audit_context`.
+
+    :param op_id: the ``audit_op_id`` to bind. Defaults to the
+        canonical query op_id so the four query routes keep their
+        existing behaviour with no call-site change; the replay route
+        passes :data:`_AUDIT_REPLAY_OP_ID`. ``op_class`` is always
+        ``"audit_query"`` — every route on this surface is
+        aggregate-only by policy.
     """
     structlog.contextvars.bind_contextvars(
-        audit_op_id=_AUDIT_QUERY_OP_ID,
+        audit_op_id=op_id,
         audit_op_class="audit_query",
     )
 
@@ -272,3 +309,90 @@ async def show(
     if not result.rows:
         raise HTTPException(status_code=404, detail="audit row not found")
     return result.rows[0]
+
+
+async def _count_session_rows(
+    session_id: uuid.UUID,
+    *,
+    tenant_id: uuid.UUID,
+    session: AsyncSession,
+) -> int:
+    """Cheap tenant-scoped count of a session's *anchor* rows.
+
+    ``SELECT count(*) FROM audit_log WHERE agent_session_id = :id AND
+    tenant_id = :tid`` — hits the ``audit_log_agent_session_id_idx``
+    b-tree, materializes no rows, and never walks lineage. It is the
+    bound the count-first 413 guard evaluates and the ``row_count``
+    the 200 body echoes, so both report the same number.
+
+    The closure :func:`~meho_backplane.audit_query.replay_session`
+    walks can pull in NULL-session lineage children (a composite
+    ``dispatch_child`` whose own ``agent_session_id`` is NULL); those
+    are deliberately *not* counted — "session rows" are defined by the
+    ``agent_session_id`` anchor, matching the issue's WHERE clause.
+    """
+    stmt = (
+        sa.select(sa.func.count())
+        .select_from(AuditLog)
+        .where(
+            AuditLog.agent_session_id == session_id,
+            AuditLog.tenant_id == tenant_id,
+        )
+    )
+    return await session.scalar(stmt) or 0
+
+
+@router.get("/sessions/{session_id}/replay", response_model=AuditReplayResult)
+async def replay(
+    session_id: uuid.UUID,
+    operator: Operator = _require_operator,
+) -> AuditReplayResult:
+    """Replay one agent session as a tenant-scoped parent/child tree.
+
+    Dispatches through
+    :func:`~meho_backplane.audit_query.replay_session`. ``tenant_id``
+    is always ``operator.tenant_id`` from the JWT, never client input,
+    so a session belonging to another tenant — or one that does not
+    exist — yields ``root=[]`` / ``row_count=0`` (never 404; a foreign
+    session is indistinguishable from an empty one, the same
+    non-leakage posture :func:`show` takes).
+
+    A session larger than :data:`_REPLAY_ROW_CAP` anchor rows returns
+    413 from a count-first guard. The count runs *before*
+    :func:`replay_session`, so a runaway session never materializes its
+    tree just to be rejected — the recursive build is skipped entirely.
+    """
+    _bind_audit_overrides(_AUDIT_REPLAY_OP_ID)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row_count = await _count_session_rows(
+            session_id,
+            tenant_id=operator.tenant_id,
+            session=session,
+        )
+        if row_count > _REPLAY_ROW_CAP:
+            # Bind the count so the audit-on-replay broadcast still
+            # reports the (rejected) cardinality, then refuse before
+            # the recursive build runs.
+            structlog.contextvars.bind_contextvars(audit_row_count=row_count)
+            # FastAPI 0.136 renamed the 413 constant to
+            # ``HTTP_413_CONTENT_TOO_LARGE`` (same value, 413) and
+            # deprecated the old ``..._REQUEST_ENTITY_TOO_LARGE`` spelling.
+            raise HTTPException(
+                status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                detail={"detail": "session_too_large", "row_count": row_count},
+            )
+
+        root = await replay_session(
+            session_id,
+            tenant_id=operator.tenant_id,
+            session=session,
+        )
+
+    structlog.contextvars.bind_contextvars(audit_row_count=row_count)
+    return AuditReplayResult(
+        root=root,
+        session_id=session_id,
+        tenant_id=operator.tenant_id,
+        row_count=row_count,
+    )

--- a/backend/src/meho_backplane/api/v1/audit_models.py
+++ b/backend/src/meho_backplane/api/v1/audit_models.py
@@ -15,6 +15,13 @@ The response models (:class:`AuditEntry` / :class:`AuditQueryResult`)
 are re-exported from the substrate without modification so OpenAPI
 surfaces them under the audit-query tag without duplicating the schema.
 
+:class:`AuditReplayResult` is the 200 body for the per-session replay
+route (G8.2-T4) — a ``ReplayNode`` forest plus the echoed
+``session_id`` / ``tenant_id`` and the session's ``row_count``. It is
+defined here (not re-exported from the substrate) because it is a
+REST-surface envelope around the substrate's :class:`ReplayNode`, the
+same layering :class:`AuditQueryRequest` already follows.
+
 Tenant scoping by construction
 ==============================
 
@@ -34,12 +41,14 @@ import uuid
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from meho_backplane.audit_query import AuditEntry, AuditQueryResult
+from meho_backplane.audit_query import AuditEntry, AuditQueryResult, ReplayNode
 
 __all__ = [
     "AuditEntry",
     "AuditQueryRequest",
     "AuditQueryResult",
+    "AuditReplayResult",
+    "ReplayNode",
 ]
 
 
@@ -73,3 +82,41 @@ class AuditQueryRequest(BaseModel):
     agent_session_id: uuid.UUID | None = None
     limit: int = Field(default=100, ge=1, le=1000)
     cursor: str | None = Field(default=None, max_length=512)
+
+
+class AuditReplayResult(BaseModel):
+    """200 body for ``GET /api/v1/audit/sessions/{session_id}/replay``.
+
+    Wraps the substrate's :class:`ReplayNode` forest with the echoed
+    request identity. ``tenant_id`` is always the operator's tenant
+    (lifted from the JWT by the route), never client-supplied, so the
+    echo is a confirmation of the boundary the query ran under — not a
+    value the caller chose.
+
+    ``row_count`` is the count of *anchor* rows in the session — rows
+    whose ``agent_session_id`` equals ``session_id`` within the
+    operator's tenant. It is the same number the route's count-first
+    413 guard evaluates, so a session that returns 200 reports a
+    ``row_count`` identical to what its over-cap sibling would report
+    at 413. NULL-session lineage children pulled into ``root`` by the
+    replay closure (a composite ``dispatch_child`` whose own
+    ``agent_session_id`` is NULL but whose ``parent_audit_id`` links
+    into the session) are present in the tree but are not counted —
+    "session rows" are defined by the ``agent_session_id`` anchor, not
+    by tree membership.
+
+    An unknown session id, or one belonging to another tenant, yields
+    ``root=[]`` / ``row_count=0`` — never a 404 — so a foreign session
+    is indistinguishable from an empty one and existence never leaks
+    across tenants (the same non-leakage posture
+    ``GET /show/{audit_id}`` takes).
+
+    Frozen like the substrate models it carries.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    root: list[ReplayNode]
+    session_id: uuid.UUID
+    tenant_id: uuid.UUID
+    row_count: int

--- a/backend/tests/test_api_audit_routes.py
+++ b/backend/tests/test_api_audit_routes.py
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Behavioural tests for :mod:`meho_backplane.api.v1.audit` (G8.1-T2).
+"""Behavioural tests for :mod:`meho_backplane.api.v1.audit` (G8.1-T2, G8.2-T4).
 
 Coverage matrix (#466 acceptance criteria):
 
-* AC1 — All 4 routes mount + respond. Exercised implicitly by every
+* AC1 — All routes mount + respond. Exercised implicitly by every
   happy-path test below; the OpenAPI schema check
-  (:func:`test_openapi_schema_lists_all_four_routes`) is the explicit
+  (:func:`test_openapi_schema_lists_all_routes`) is the explicit
   AC9 surface.
 * AC2 — POST /query with empty body returns all tenant's rows up to
   ``limit=100``. Verified via the dispatched filter object on the
@@ -30,14 +30,23 @@ Coverage matrix (#466 acceptance criteria):
   ``audit_op_class="audit_query"`` contextvars before the substrate
   call, so the audit row written by :class:`AuditMiddleware` carries
   the canonical op_id and the broadcast event ships as aggregate-only.
-* AC9 — OpenAPI schema lists all four routes under the audit tag.
+* AC9 — OpenAPI schema lists all routes under the audit tag.
 * AC10 — ruff + mypy clean: Phase 7 of the implement-issue-slim
   skill, not a test here.
 
-The substrate (:func:`query_audit`) is patched at the route's import
-site so the route tests don't depend on PG/SQLite-seeded audit rows —
-the substrate has its own coverage in
-``tests/test_audit_query_handler.py``.
+G8.2-T4 replay (#1012) adds the
+``GET /api/v1/audit/sessions/{session_id}/replay`` route. Its tests
+seed real ``audit_log`` rows via ``get_sessionmaker()`` (the autouse
+SQLite-on-disk DB from ``conftest._default_database_url``) for the
+happy-path / tenant-isolation cases so the full route → ``replay_session``
+wiring is exercised end-to-end, and patch ``_count_session_rows`` /
+``replay_session`` for the 413-cap and RBAC cases so the count-first
+short-circuit is provable (the tree builder is asserted *not* awaited).
+
+The query substrate (:func:`query_audit`) is patched at the route's
+import site so the four query-route tests don't depend on seeded audit
+rows — the substrate has its own coverage in
+``tests/test_audit_query_handler.py`` / ``tests/test_audit_replay.py``.
 """
 
 from __future__ import annotations
@@ -45,8 +54,10 @@ from __future__ import annotations
 import io
 import json
 import logging
+import uuid
 from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from typing import Any
 from unittest.mock import AsyncMock, patch
 from uuid import UUID
@@ -56,6 +67,7 @@ import respx
 import structlog
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.api.v1.audit import router as audit_router
 from meho_backplane.audit import AuditMiddleware
@@ -67,6 +79,8 @@ from meho_backplane.audit_query import (
 )
 from meho_backplane.auth.jwt import clear_jwks_cache
 from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
 from meho_backplane.middleware import RequestContextMiddleware
 from meho_backplane.settings import get_settings
 
@@ -572,14 +586,15 @@ def test_tenant_admin_role_returns_200(client: TestClient) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_openapi_schema_lists_all_four_routes(client: TestClient) -> None:
-    """AC9: ``/openapi.json`` advertises all four audit routes under the audit tag."""
+def test_openapi_schema_lists_all_routes(client: TestClient) -> None:
+    """AC9: ``/openapi.json`` advertises every audit route under the audit tag."""
     schema = client.get("/openapi.json").json()
     paths = schema["paths"]
     assert "/api/v1/audit/query" in paths
     assert "/api/v1/audit/who-touched/{target}" in paths
     assert "/api/v1/audit/my-recent" in paths
     assert "/api/v1/audit/show/{audit_id}" in paths
+    assert "/api/v1/audit/sessions/{session_id}/replay" in paths
     # Every route is tagged "audit" so operators filtering /docs by tag
     # find them grouped under one section.
     assert "post" in paths["/api/v1/audit/query"]
@@ -587,3 +602,249 @@ def test_openapi_schema_lists_all_four_routes(client: TestClient) -> None:
     assert "audit" in paths["/api/v1/audit/who-touched/{target}"]["get"]["tags"]
     assert "audit" in paths["/api/v1/audit/my-recent"]["get"]["tags"]
     assert "audit" in paths["/api/v1/audit/show/{audit_id}"]["get"]["tags"]
+    assert "audit" in paths["/api/v1/audit/sessions/{session_id}/replay"]["get"]["tags"]
+    # The replay 200 body is the dedicated envelope, not the query result.
+    replay_get = paths["/api/v1/audit/sessions/{session_id}/replay"]["get"]
+    ok_schema = replay_get["responses"]["200"]["content"]["application/json"]["schema"]
+    assert ok_schema["$ref"].endswith("/AuditReplayResult")
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/audit/sessions/{session_id}/replay (G8.2-T4)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_audit_row(
+    s: AsyncSession,
+    *,
+    tenant_id: UUID,
+    second: int,
+    agent_session_id: UUID | None = None,
+    parent_audit_id: UUID | None = None,
+    row_id: UUID | None = None,
+) -> UUID:
+    """Insert one :class:`AuditLog` row at a fixed base + ``second`` offset."""
+    row_id = row_id or uuid.uuid4()
+    base = datetime(2026, 5, 14, 12, 0, 0, tzinfo=UTC)
+    s.add(
+        AuditLog(
+            id=row_id,
+            occurred_at=base + timedelta(seconds=second),
+            operator_sub="op-1",
+            tenant_id=tenant_id,
+            method="POST",
+            path="/mcp",
+            status_code=200,
+            duration_ms=Decimal("1.0"),
+            payload={"op_id": "vsphere.vm.list", "op_class": "read"},
+            agent_session_id=agent_session_id,
+            parent_audit_id=parent_audit_id,
+        ),
+    )
+    return row_id
+
+
+async def _seed_session_tree(tenant_id: UUID, session_id: UUID) -> tuple[UUID, UUID, UUID]:
+    """Seed a root → child → grandchild tree under ``session_id``; return ids."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        root = await _seed_audit_row(s, tenant_id=tenant_id, second=0, agent_session_id=session_id)
+        child = await _seed_audit_row(
+            s, tenant_id=tenant_id, second=1, agent_session_id=session_id, parent_audit_id=root
+        )
+        grandchild = await _seed_audit_row(
+            s, tenant_id=tenant_id, second=2, agent_session_id=session_id, parent_audit_id=child
+        )
+        await s.commit()
+    return root, child, grandchild
+
+
+@pytest.mark.asyncio
+async def test_replay_returns_seeded_multi_level_tree(client: TestClient) -> None:
+    """AC1: a seeded multi-level session replays to its tree; ids echo correctly."""
+    session_id = uuid.uuid4()
+    root, child, grandchild = await _seed_session_tree(_TENANT_A, session_id)
+
+    key = make_rsa_keypair("kid-A")
+    token = _token(key, tenant_id=_TENANT_A)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/audit/sessions/{session_id}/replay",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["session_id"] == str(session_id)
+    assert body["tenant_id"] == str(_TENANT_A)
+    assert body["row_count"] == 3  # three anchor rows in the session
+    assert len(body["root"]) == 1
+    node = body["root"][0]
+    assert node["id"] == str(root)
+    assert node["depth"] == 0
+    assert [c["id"] for c in node["children"]] == [str(child)]
+    assert node["children"][0]["depth"] == 1
+    assert [g["id"] for g in node["children"][0]["children"]] == [str(grandchild)]
+
+
+@pytest.mark.asyncio
+async def test_replay_tenant_isolation_foreign_session_is_empty(client: TestClient) -> None:
+    """AC2: tenant B requesting tenant A's session id gets empty — never A's rows."""
+    session_id = uuid.uuid4()
+    await _seed_session_tree(_TENANT_A, session_id)
+
+    key = make_rsa_keypair("kid-A")
+    # Caller is tenant B requesting the session id seeded under tenant A.
+    token = _token(key, tenant_id=_TENANT_B)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/audit/sessions/{session_id}/replay",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 200  # not 404 — foreign == empty, existence never leaks
+    body = resp.json()
+    assert body["root"] == []
+    assert body["row_count"] == 0
+    assert body["tenant_id"] == str(_TENANT_B)
+
+
+@pytest.mark.asyncio
+async def test_replay_unknown_session_returns_empty_not_404(client: TestClient) -> None:
+    """An unknown session id yields ``root=[]`` / ``row_count=0`` — not 404."""
+    session_id = uuid.uuid4()
+    key = make_rsa_keypair("kid-A")
+    token = _token(key, tenant_id=_TENANT_A)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/audit/sessions/{session_id}/replay",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "root": [],
+        "session_id": str(session_id),
+        "tenant_id": str(_TENANT_A),
+        "row_count": 0,
+    }
+
+
+def test_replay_over_cap_returns_413_without_building_tree(client: TestClient) -> None:
+    """AC3: > 10k rows → 413; the recursive tree build is never reached.
+
+    The count-first guard is proven by patching ``replay_session`` as a
+    spy and asserting it was never awaited — the route rejected on the
+    count alone, before materializing the tree.
+    """
+    session_id = uuid.uuid4()
+    key = make_rsa_keypair("kid-A")
+    token = _token(key, tenant_id=_TENANT_A)
+    spy_replay = AsyncMock(return_value=[])
+    over_cap_count = AsyncMock(return_value=10_001)
+    with (
+        respx.mock as r,
+        patch("meho_backplane.api.v1.audit.replay_session", new=spy_replay),
+        patch("meho_backplane.api.v1.audit._count_session_rows", new=over_cap_count),
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/audit/sessions/{session_id}/replay",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 413
+    assert resp.json()["detail"] == {"detail": "session_too_large", "row_count": 10_001}
+    spy_replay.assert_not_awaited()  # count-first: tree never built
+
+
+def test_replay_at_cap_boundary_returns_200(client: TestClient) -> None:
+    """A session of exactly 10k rows is allowed — the cap is strictly ``>``."""
+    session_id = uuid.uuid4()
+    key = make_rsa_keypair("kid-A")
+    token = _token(key, tenant_id=_TENANT_A)
+    spy_replay = AsyncMock(return_value=[])
+    at_cap_count = AsyncMock(return_value=10_000)
+    with (
+        respx.mock as r,
+        patch("meho_backplane.api.v1.audit.replay_session", new=spy_replay),
+        patch("meho_backplane.api.v1.audit._count_session_rows", new=at_cap_count),
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/audit/sessions/{session_id}/replay",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["row_count"] == 10_000
+    spy_replay.assert_awaited_once()
+
+
+def test_replay_read_only_role_returns_403(client: TestClient) -> None:
+    """AC4: ``read_only`` is below the operator gate — 403; substrate untouched."""
+    key = make_rsa_keypair("kid-A")
+    token = _token(key, role=TenantRole.READ_ONLY)
+    spy_replay = AsyncMock(return_value=[])
+    with (
+        respx.mock as r,
+        patch("meho_backplane.api.v1.audit.replay_session", new=spy_replay),
+    ):
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/audit/sessions/{uuid.uuid4()}/replay",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 403
+    spy_replay.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_replay_operator_and_tenant_admin_roles_return_200(client: TestClient) -> None:
+    """AC4: both ``operator`` and ``tenant_admin`` clear the gate."""
+    key = make_rsa_keypair("kid-A")
+    for role in (TenantRole.OPERATOR, TenantRole.TENANT_ADMIN):
+        token = _token(key, role=role, tenant_id=_TENANT_A)
+        with respx.mock as r:
+            mock_discovery_and_jwks(r, public_jwks(key))
+            resp = client.get(
+                f"/api/v1/audit/sessions/{uuid.uuid4()}/replay",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        assert resp.status_code == 200, role
+
+
+def test_replay_binds_replay_op_id_and_aggregate_only_class(
+    client: TestClient,
+    log_buffer: io.StringIO,
+) -> None:
+    """AC5: replay binds ``audit_op_id='meho.audit.replay'`` + aggregate-only class.
+
+    The route's own audit-on-replay broadcast must be aggregate-only
+    (``op_class='audit_query'``) and tagged with the distinct replay
+    op_id. We assert the contextvars are bound by checking the captured
+    structlog lines (full aggregate-only payload assertion is T7).
+    """
+    key = make_rsa_keypair("kid-A")
+    token = _token(key, tenant_id=_TENANT_A)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            f"/api/v1/audit/sessions/{uuid.uuid4()}/replay",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+
+    lines = _read_log_lines(log_buffer)
+    observed = [
+        line
+        for line in lines
+        if line.get("audit_op_id") == "meho.audit.replay"
+        and line.get("audit_op_class") == "audit_query"
+    ]
+    assert observed, (
+        "expected a structlog line carrying audit_op_id='meho.audit.replay' "
+        "+ audit_op_class='audit_query' bound by the replay route"
+    )

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -3478,6 +3478,60 @@
         }
       }
     },
+    "/api/v1/audit/sessions/{session_id}/replay": {
+      "get": {
+        "tags": [
+          "audit"
+        ],
+        "summary": "Replay",
+        "description": "Replay one agent session as a tenant-scoped parent/child tree.\n\nDispatches through\n:func:`~meho_backplane.audit_query.replay_session`. ``tenant_id``\nis always ``operator.tenant_id`` from the JWT, never client input,\nso a session belonging to another tenant \u2014 or one that does not\nexist \u2014 yields ``root=[]`` / ``row_count=0`` (never 404; a foreign\nsession is indistinguishable from an empty one, the same\nnon-leakage posture :func:`show` takes).\n\nA session larger than :data:`_REPLAY_ROW_CAP` anchor rows returns\n413 from a count-first guard. The count runs *before*\n:func:`replay_session`, so a runaway session never materializes its\ntree just to be rejected \u2014 the recursive build is skipped entirely.",
+        "operationId": "replay_api_v1_audit_sessions__session_id__replay_get",
+        "parameters": [
+          {
+            "name": "session_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Session Id"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditReplayResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/broadcast/overrides": {
       "get": {
         "tags": [
@@ -4345,6 +4399,40 @@
         ],
         "title": "AuditQueryResult",
         "description": "Page of audit rows plus the forward-only continuation cursor.\n\n``next_cursor`` is :data:`None` when fewer than ``limit`` rows were\navailable (the query reached the end of the matching set). Consumers\niterate by re-issuing the same filter with ``cursor = next_cursor``\nuntil ``next_cursor`` is None."
+      },
+      "AuditReplayResult": {
+        "properties": {
+          "root": {
+            "items": {
+              "$ref": "#/components/schemas/ReplayNode"
+            },
+            "type": "array",
+            "title": "Root"
+          },
+          "session_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Session Id"
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Tenant Id"
+          },
+          "row_count": {
+            "type": "integer",
+            "title": "Row Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "root",
+          "session_id",
+          "tenant_id",
+          "row_count"
+        ],
+        "title": "AuditReplayResult",
+        "description": "200 body for ``GET /api/v1/audit/sessions/{session_id}/replay``.\n\nWraps the substrate's :class:`ReplayNode` forest with the echoed\nrequest identity. ``tenant_id`` is always the operator's tenant\n(lifted from the JWT by the route), never client-supplied, so the\necho is a confirmation of the boundary the query ran under \u2014 not a\nvalue the caller chose.\n\n``row_count`` is the count of *anchor* rows in the session \u2014 rows\nwhose ``agent_session_id`` equals ``session_id`` within the\noperator's tenant. It is the same number the route's count-first\n413 guard evaluates, so a session that returns 200 reports a\n``row_count`` identical to what its over-cap sibling would report\nat 413. NULL-session lineage children pulled into ``root`` by the\nreplay closure (a composite ``dispatch_child`` whose own\n``agent_session_id`` is NULL but whose ``parent_audit_id`` links\ninto the session) are present in the tree but are not counted \u2014\n\"session rows\" are defined by the ``agent_session_id`` anchor, not\nby tree membership.\n\nAn unknown session id, or one belonging to another tenant, yields\n``root=[]`` / ``row_count=0`` \u2014 never a 404 \u2014 so a foreign session\nis indistinguishable from an empty one and existence never leaks\nacross tenants (the same non-leakage posture\n``GET /show/{audit_id}`` takes).\n\nFrozen like the substrate models it carries."
       },
       "AuthConfigResponse": {
         "properties": {
@@ -5948,6 +6036,141 @@
         ],
         "title": "RememberBody",
         "description": "POST body for ``/api/v1/memory`` -- create one memory.\n\n``slug`` is constrained to :data:`SLUG_PATTERN` at the model\nboundary; the service-layer\n:func:`~meho_backplane.memory.schemas.validate_slug` is the\nparallel gate for non-Pydantic callers. ``frozen=True`` matches\nthe rest of the memory + kb schemas (a handler accidentally\nmutating a parsed request body surfaces as a pydantic error\ninstead of a confused-deputy bug). ``extra=\"forbid\"`` rejects\nunknown fields at 422 so a typo (``\"bodytext\"``) doesn't\nsilently become a no-op.\n\n``target_name`` is required when ``scope`` is ``user-target`` or\n``target``; the service-level\n:meth:`MemoryService._require_target_name` raises ``ValueError``\nwhen missing, which this route maps to 422 (parity with\npydantic's own missing-field shape)."
+      },
+      "ReplayNode": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Id"
+          },
+          "ts": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Ts"
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "title": "Tenant Id"
+          },
+          "principal_sub": {
+            "type": "string",
+            "title": "Principal Sub"
+          },
+          "principal_name": {
+            "type": "string",
+            "nullable": true,
+            "title": "Principal Name"
+          },
+          "target_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "title": "Target Id"
+          },
+          "target_name": {
+            "type": "string",
+            "nullable": true,
+            "title": "Target Name"
+          },
+          "method": {
+            "type": "string",
+            "title": "Method"
+          },
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "status_code": {
+            "type": "integer",
+            "title": "Status Code"
+          },
+          "request_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "title": "Request Id"
+          },
+          "duration_ms": {
+            "type": "string",
+            "pattern": "^(?!^[-+.]*$)[+-]?0*\\d*\\.?\\d*$",
+            "nullable": true,
+            "title": "Duration Ms"
+          },
+          "payload": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Payload"
+          },
+          "op_id": {
+            "type": "string",
+            "title": "Op Id"
+          },
+          "op_class": {
+            "type": "string",
+            "title": "Op Class"
+          },
+          "result_status": {
+            "type": "string",
+            "title": "Result Status"
+          },
+          "parent_audit_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "title": "Parent Audit Id"
+          },
+          "agent_session_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "title": "Agent Session Id"
+          },
+          "broadcast_event_id": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true,
+            "title": "Broadcast Event Id"
+          },
+          "depth": {
+            "type": "integer",
+            "title": "Depth"
+          },
+          "children": {
+            "items": {
+              "$ref": "#/components/schemas/ReplayNode"
+            },
+            "type": "array",
+            "title": "Children"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "ts",
+          "tenant_id",
+          "principal_sub",
+          "principal_name",
+          "target_id",
+          "target_name",
+          "method",
+          "path",
+          "status_code",
+          "request_id",
+          "duration_ms",
+          "payload",
+          "op_id",
+          "op_class",
+          "result_status",
+          "parent_audit_id",
+          "agent_session_id",
+          "broadcast_event_id",
+          "depth"
+        ],
+        "title": "ReplayNode",
+        "description": "One node of a per-session audit-replay tree (G8.2-T3).\n\nSubclasses :class:`AuditEntry` so it carries every audit field verbatim \u2014\nforward-compatible with the v0.2.next compliance-export contract, which\ntreats a replay node as an audit row plus its position in the session\ngraph. Two structural fields are added:\n\n* ``depth`` \u2014 distance from the session root. ``0`` for roots; assigned\n  during tree assembly in :func:`~meho_backplane.audit_query.replay.replay_session`.\n* ``children`` \u2014 the node's direct children, ordered by ``(occurred_at,\n  id)``. Self-referential \u2014 the forward reference is resolved by the\n  module-level :func:`ReplayNode.model_rebuild` call below.\n\nFrozen like its parent: a node handed to a caller cannot mutate after the\ntree is built."
       },
       "RetireChecklistReport": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -284,6 +284,40 @@ type AuditQueryResult struct {
 	Rows       []AuditEntry `json:"rows"`
 }
 
+// AuditReplayResult 200 body for “GET /api/v1/audit/sessions/{session_id}/replay“.
+//
+// Wraps the substrate's :class:`ReplayNode` forest with the echoed
+// request identity. “tenant_id“ is always the operator's tenant
+// (lifted from the JWT by the route), never client-supplied, so the
+// echo is a confirmation of the boundary the query ran under — not a
+// value the caller chose.
+//
+// “row_count“ is the count of *anchor* rows in the session — rows
+// whose “agent_session_id“ equals “session_id“ within the
+// operator's tenant. It is the same number the route's count-first
+// 413 guard evaluates, so a session that returns 200 reports a
+// “row_count“ identical to what its over-cap sibling would report
+// at 413. NULL-session lineage children pulled into “root“ by the
+// replay closure (a composite “dispatch_child“ whose own
+// “agent_session_id“ is NULL but whose “parent_audit_id“ links
+// into the session) are present in the tree but are not counted —
+// "session rows" are defined by the “agent_session_id“ anchor, not
+// by tree membership.
+//
+// An unknown session id, or one belonging to another tenant, yields
+// “root=[]“ / “row_count=0“ — never a 404 — so a foreign session
+// is indistinguishable from an empty one and existence never leaks
+// across tenants (the same non-leakage posture
+// “GET /show/{audit_id}“ takes).
+//
+// Frozen like the substrate models it carries.
+type AuditReplayResult struct {
+	Root      []ReplayNode       `json:"root"`
+	RowCount  int                `json:"row_count"`
+	SessionId openapi_types.UUID `json:"session_id"`
+	TenantId  openapi_types.UUID `json:"tenant_id"`
+}
+
 // AuthConfigResponse OAuth discovery surface returned to “meho login“.
 //
 // Field names match the CLI's expected JSON keys (“keycloak_issuer“,
@@ -1216,6 +1250,45 @@ type RememberBody struct {
 	Scope      MemoryScope `json:"scope"`
 	Slug       *string     `json:"slug"`
 	TargetName *string     `json:"target_name"`
+}
+
+// ReplayNode One node of a per-session audit-replay tree (G8.2-T3).
+//
+// Subclasses :class:`AuditEntry` so it carries every audit field verbatim —
+// forward-compatible with the v0.2.next compliance-export contract, which
+// treats a replay node as an audit row plus its position in the session
+// graph. Two structural fields are added:
+//
+//   - “depth“ — distance from the session root. “0“ for roots; assigned
+//     during tree assembly in :func:`~meho_backplane.audit_query.replay.replay_session`.
+//   - “children“ — the node's direct children, ordered by “(occurred_at,
+//     id)“. Self-referential — the forward reference is resolved by the
+//     module-level :func:`ReplayNode.model_rebuild` call below.
+//
+// Frozen like its parent: a node handed to a caller cannot mutate after the
+// tree is built.
+type ReplayNode struct {
+	AgentSessionId   *openapi_types.UUID    `json:"agent_session_id"`
+	BroadcastEventId *openapi_types.UUID    `json:"broadcast_event_id"`
+	Children         *[]ReplayNode          `json:"children,omitempty"`
+	Depth            int                    `json:"depth"`
+	DurationMs       *string                `json:"duration_ms"`
+	Id               openapi_types.UUID     `json:"id"`
+	Method           string                 `json:"method"`
+	OpClass          string                 `json:"op_class"`
+	OpId             string                 `json:"op_id"`
+	ParentAuditId    *openapi_types.UUID    `json:"parent_audit_id"`
+	Path             string                 `json:"path"`
+	Payload          map[string]interface{} `json:"payload"`
+	PrincipalName    *string                `json:"principal_name"`
+	PrincipalSub     string                 `json:"principal_sub"`
+	RequestId        *openapi_types.UUID    `json:"request_id"`
+	ResultStatus     string                 `json:"result_status"`
+	StatusCode       int                    `json:"status_code"`
+	TargetId         *openapi_types.UUID    `json:"target_id"`
+	TargetName       *string                `json:"target_name"`
+	TenantId         *openapi_types.UUID    `json:"tenant_id"`
+	Ts               time.Time              `json:"ts"`
 }
 
 // RetireChecklistReport Top-level shape returned by :func:`compute_retire_checklist`.
@@ -2180,6 +2253,11 @@ type QueryApiV1AuditQueryPostParams struct {
 	Authorization *string `json:"authorization,omitempty"`
 }
 
+// ReplayApiV1AuditSessionsSessionIdReplayGetParams defines parameters for ReplayApiV1AuditSessionsSessionIdReplayGet.
+type ReplayApiV1AuditSessionsSessionIdReplayGetParams struct {
+	Authorization *string `json:"authorization,omitempty"`
+}
+
 // ShowApiV1AuditShowAuditIdGetParams defines parameters for ShowApiV1AuditShowAuditIdGet.
 type ShowApiV1AuditShowAuditIdGetParams struct {
 	Authorization *string `json:"authorization,omitempty"`
@@ -2741,6 +2819,9 @@ type ClientInterface interface {
 
 	QueryApiV1AuditQueryPost(ctx context.Context, params *QueryApiV1AuditQueryPostParams, body QueryApiV1AuditQueryPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// ReplayApiV1AuditSessionsSessionIdReplayGet request
+	ReplayApiV1AuditSessionsSessionIdReplayGet(ctx context.Context, sessionId openapi_types.UUID, params *ReplayApiV1AuditSessionsSessionIdReplayGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ShowApiV1AuditShowAuditIdGet request
 	ShowApiV1AuditShowAuditIdGet(ctx context.Context, auditId openapi_types.UUID, params *ShowApiV1AuditShowAuditIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -3022,6 +3103,18 @@ func (c *Client) QueryApiV1AuditQueryPostWithBody(ctx context.Context, params *Q
 
 func (c *Client) QueryApiV1AuditQueryPost(ctx context.Context, params *QueryApiV1AuditQueryPostParams, body QueryApiV1AuditQueryPostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewQueryApiV1AuditQueryPostRequest(c.Server, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ReplayApiV1AuditSessionsSessionIdReplayGet(ctx context.Context, sessionId openapi_types.UUID, params *ReplayApiV1AuditSessionsSessionIdReplayGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewReplayApiV1AuditSessionsSessionIdReplayGetRequest(c.Server, sessionId, params)
 	if err != nil {
 		return nil, err
 	}
@@ -4186,6 +4279,55 @@ func NewQueryApiV1AuditQueryPostRequestWithBody(server string, params *QueryApiV
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	if params != nil {
+
+		if params.Authorization != nil {
+			var headerParam0 string
+
+			headerParam0, err = runtime.StyleParamWithLocation("simple", false, "authorization", runtime.ParamLocationHeader, *params.Authorization)
+			if err != nil {
+				return nil, err
+			}
+
+			req.Header.Set("authorization", headerParam0)
+		}
+
+	}
+
+	return req, nil
+}
+
+// NewReplayApiV1AuditSessionsSessionIdReplayGetRequest generates requests for ReplayApiV1AuditSessionsSessionIdReplayGet
+func NewReplayApiV1AuditSessionsSessionIdReplayGetRequest(server string, sessionId openapi_types.UUID, params *ReplayApiV1AuditSessionsSessionIdReplayGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "session_id", runtime.ParamLocationPath, sessionId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/api/v1/audit/sessions/%s/replay", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	if params != nil {
 
@@ -8525,6 +8667,9 @@ type ClientWithResponsesInterface interface {
 
 	QueryApiV1AuditQueryPostWithResponse(ctx context.Context, params *QueryApiV1AuditQueryPostParams, body QueryApiV1AuditQueryPostJSONRequestBody, reqEditors ...RequestEditorFn) (*QueryApiV1AuditQueryPostResponse, error)
 
+	// ReplayApiV1AuditSessionsSessionIdReplayGetWithResponse request
+	ReplayApiV1AuditSessionsSessionIdReplayGetWithResponse(ctx context.Context, sessionId openapi_types.UUID, params *ReplayApiV1AuditSessionsSessionIdReplayGetParams, reqEditors ...RequestEditorFn) (*ReplayApiV1AuditSessionsSessionIdReplayGetResponse, error)
+
 	// ShowApiV1AuditShowAuditIdGetWithResponse request
 	ShowApiV1AuditShowAuditIdGetWithResponse(ctx context.Context, auditId openapi_types.UUID, params *ShowApiV1AuditShowAuditIdGetParams, reqEditors ...RequestEditorFn) (*ShowApiV1AuditShowAuditIdGetResponse, error)
 
@@ -8840,6 +8985,29 @@ func (r QueryApiV1AuditQueryPostResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r QueryApiV1AuditQueryPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ReplayApiV1AuditSessionsSessionIdReplayGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *AuditReplayResult
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r ReplayApiV1AuditSessionsSessionIdReplayGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ReplayApiV1AuditSessionsSessionIdReplayGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -10402,6 +10570,15 @@ func (c *ClientWithResponses) QueryApiV1AuditQueryPostWithResponse(ctx context.C
 	return ParseQueryApiV1AuditQueryPostResponse(rsp)
 }
 
+// ReplayApiV1AuditSessionsSessionIdReplayGetWithResponse request returning *ReplayApiV1AuditSessionsSessionIdReplayGetResponse
+func (c *ClientWithResponses) ReplayApiV1AuditSessionsSessionIdReplayGetWithResponse(ctx context.Context, sessionId openapi_types.UUID, params *ReplayApiV1AuditSessionsSessionIdReplayGetParams, reqEditors ...RequestEditorFn) (*ReplayApiV1AuditSessionsSessionIdReplayGetResponse, error) {
+	rsp, err := c.ReplayApiV1AuditSessionsSessionIdReplayGet(ctx, sessionId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseReplayApiV1AuditSessionsSessionIdReplayGetResponse(rsp)
+}
+
 // ShowApiV1AuditShowAuditIdGetWithResponse request returning *ShowApiV1AuditShowAuditIdGetResponse
 func (c *ClientWithResponses) ShowApiV1AuditShowAuditIdGetWithResponse(ctx context.Context, auditId openapi_types.UUID, params *ShowApiV1AuditShowAuditIdGetParams, reqEditors ...RequestEditorFn) (*ShowApiV1AuditShowAuditIdGetResponse, error) {
 	rsp, err := c.ShowApiV1AuditShowAuditIdGet(ctx, auditId, params, reqEditors...)
@@ -11225,6 +11402,39 @@ func ParseQueryApiV1AuditQueryPostResponse(rsp *http.Response) (*QueryApiV1Audit
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest AuditQueryResult
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseReplayApiV1AuditSessionsSessionIdReplayGetResponse parses an HTTP response from a ReplayApiV1AuditSessionsSessionIdReplayGetWithResponse call
+func ParseReplayApiV1AuditSessionsSessionIdReplayGetResponse(rsp *http.Response) (*ReplayApiV1AuditSessionsSessionIdReplayGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ReplayApiV1AuditSessionsSessionIdReplayGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest AuditReplayResult
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}

--- a/docs/codebase/audit_query.md
+++ b/docs/codebase/audit_query.md
@@ -157,12 +157,13 @@ Two-step shape:
 query, not a filtered list. It reuses `query._build_audit_entry` so a replay
 node and a `query_audit` row for the same audit id agree field-for-field.
 
-## REST surface (G8.1-T2 #466)
+## REST surface (G8.1-T2 #466, G8.2-T4 #1012)
 
-The four routes under `backend/src/meho_backplane/api/v1/audit.py` are the
-operator-facing entry into the substrate. All four dispatch through
-`query_audit` with `tenant_id=operator.tenant_id` (from the JWT) — the
-substrate's tenant-scoping invariant is enforced one layer up.
+The five routes under `backend/src/meho_backplane/api/v1/audit.py` are the
+operator-facing entry into the substrate. The first four dispatch through
+`query_audit`; the fifth (replay) dispatches through `replay_session`. All
+pass `tenant_id=operator.tenant_id` (from the JWT) — the substrate's
+tenant-scoping invariant is enforced one layer up.
 
 | Route | Filter shape | Notes |
 |---|---|---|
@@ -170,15 +171,29 @@ substrate's tenant-scoping invariant is enforced one layer up.
 | `GET /api/v1/audit/who-touched/{target}` | Path param becomes `filters.target`; `since` query defaults to `"24h"`. | Pre-canned shortcut. |
 | `GET /api/v1/audit/my-recent` | `filters.principal = operator.sub`; `since` query defaults to `"24h"`. | Pre-canned shortcut. |
 | `GET /api/v1/audit/show/{audit_id}` | `filters.audit_id = <path>`, `limit=1`. Substrate returns 0 rows for cross-tenant lookups → router raises **404** (not 403) so existence never leaks. | Single-row fetch. |
+| `GET /api/v1/audit/sessions/{session_id}/replay` | Dispatches `replay_session(session_id, tenant_id=operator.tenant_id, ...)`. 200 body is `AuditReplayResult` (`{root: [ReplayNode], session_id, tenant_id, row_count}`). Unknown / foreign session → `root=[]` / `row_count=0` (**not** 404 — same non-leakage as `show`). `row_count > 10_000` → **413** `{"detail": "session_too_large", "row_count": n}` from a count-first guard run *before* the recursive tree build. | Per-session replay (G8.2-T4). |
+
+The replay route's **413 cap** is a cheap tenant-scoped
+`SELECT count(*) WHERE agent_session_id = :id AND tenant_id = :tid` (the
+`_count_session_rows` helper, hitting `audit_log_agent_session_id_idx`),
+evaluated before `replay_session` runs — a runaway session is rejected on
+the count alone, never materializing a 10k-deep tree. The same count is
+the `row_count` echoed in the 200 body, so a 200 reports the same number
+its over-cap sibling would report at 413. NULL-session lineage children
+pulled into `root` by the closure CTE are present in the tree but are not
+counted — "session rows" are defined by the `agent_session_id` anchor.
 
 Every route binds two audit-override contextvars **before** the substrate
-call — `audit_op_id="meho.audit.query"` and `audit_op_class="audit_query"`
-— so the audit row written by `AuditMiddleware` carries the canonical
-op_id and the broadcast event ships as aggregate-only (`{op_id,
-result_status, row_count}` only, never the request filter). The
-`audit_row_count` contextvar is bound after the substrate returns so the
-broadcast event's `row_count` field reflects the actual returned
-cardinality. The shape mirrors `api/v1/retrieve_usage.py`.
+call — `audit_op_class="audit_query"` (always) plus an `audit_op_id`:
+`"meho.audit.query"` for the four query routes and `"meho.audit.replay"`
+for the replay route (so operators can tell replay usage apart from
+flat-query usage in `audit_log`). The shared `audit_query` op_class flips
+the broadcast event to aggregate-only (`{op_id, result_status,
+row_count}` only, never the request filter or the replayed `ReplayNode`
+tree). The `audit_row_count` contextvar is bound after the substrate
+returns — and on the 413 path before raising — so the broadcast event's
+`row_count` field reflects the actual cardinality. The shape mirrors
+`api/v1/retrieve_usage.py`.
 
 RBAC: `operator` role minimum. `read_only` → 403; `tenant_admin` → 200.
 


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/audit/sessions/{session_id}/replay` (G8.2-T4) to the G8.1-T2 audit router, dispatching through T3's `replay_session` to return a tenant-scoped `ReplayNode` parent/child tree. 200 body is a new frozen `AuditReplayResult` envelope (`{root, session_id, tenant_id, row_count}`).
- `tenant_id` is always `operator.tenant_id` from the JWT — an unknown or foreign session yields `root=[]` / `row_count=0` (never 404), the same cross-tenant non-leakage posture `show` takes.
- **10k count-first 413 cap:** a cheap tenant-scoped `SELECT count(*)` on the `agent_session_id` anchor runs *before* the recursive replay; `> 10_000` returns `413 {"detail":"session_too_large","row_count":n}` without ever materializing the tree. The same count is the `row_count` echoed at 200.
- Binds `audit_op_id="meho.audit.replay"` (distinct from query routes) + shared `audit_op_class="audit_query"` so the audit-on-replay broadcast stays aggregate-only. `_bind_audit_overrides()` is parametrized on `op_id`; the four query routes keep their default with no call-site change.
- Regenerates the CLI OpenAPI snapshot + Go client (`make snapshot-openapi && make generate`) — additive only (new replay path + `AuditReplayResult`/`ReplayNode` schemas + Go client method).

## Test plan
- [x] `ruff check` / `ruff format` — clean on changed files
- [x] `mypy src/.../audit.py audit_models.py` — clean
- [x] `pytest tests/test_api_audit_routes.py tests/test_audit_replay.py tests/test_audit_query_schemas.py` — 46 passed
- [x] Happy path — seeded multi-level session tree replays to correct shape; `row_count`/`session_id`/`tenant_id` echo correctly
- [x] Tenant isolation — tenant B requesting tenant A's session id gets `root=[]` / `row_count=0` (real SQLite-seeded 2-tenant case), plus unknown-session-is-empty-not-404
- [x] 413 — `> 10_000` returns 413; `replay_session` asserted **not** awaited (count-first short-circuit proven); boundary test confirms exactly 10k → 200
- [x] RBAC — `read_only` → 403 (substrate untouched); `operator` + `tenant_admin` → 200
- [x] Aggregate-only contextvars — `audit_op_id="meho.audit.replay"` + `audit_op_class="audit_query"` observed in captured structlog (full aggregate-only assertion is T7)
- [x] `code-quality.py --files` — pass (no violations)
- [x] `go build ./...` in `cli/` — regenerated client compiles
- Full PG integration acceptance (multi-tenant + >10k seed against real Postgres) is **T7**; this PR's seeded cases run on SQLite + CI testcontainers.

## Out of scope
- Recursive query itself — T3 (merged, #1011)
- CLI consumption / 413 redirect message — T5
- MCP replay tool — T6
- Cursor pagination over the tree — explicitly rejected (#377)

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1012
