### PR TITLE
feat(audit): G8.2-T6 MCP replay — meho.audit.replay admin tool + meho.audit.* classifier + query_audit shape:tree

### DIFF
--- a/backend/src/meho_backplane/broadcast/events.py
+++ b/backend/src/meho_backplane/broadcast/events.py
@@ -220,8 +220,14 @@ def classify_op(op_id: str) -> str:
        freshly-minted secret in their response payload (e.g.
        ``harbor.robot.create``). Checked before the ``.create`` suffix
        so the allowlist wins over the mutation-suffix branch.
-    3. ``audit_query`` — every op-id with the ``audit.`` prefix
-       classifies as audit_query regardless of the verb suffix.
+    3. ``audit_query`` — every op-id with the ``audit.`` or
+       ``meho.audit.`` prefix classifies as audit_query regardless of
+       the verb suffix. The ``meho.audit.`` arm catches the admin
+       replay meta-tool (``meho.audit.replay``, G8.2-T6 #1014): the
+       MCP broadcast path classifies via ``classify_op(op_id)`` with
+       the tool name verbatim, so without this arm the replay tool
+       would fall through to ``other`` and broadcast its full
+       ``ReplayNode`` payload instead of the aggregate-only view.
     4. ``read`` / ``write`` — HTTP-method-prefixed ingested op IDs
        (e.g. ``GET:/api/v2.0/systeminfo``). ``GET:`` and ``HEAD:``
        map to ``read``; ``POST:``, ``PUT:``, ``PATCH:``, ``DELETE:``
@@ -243,6 +249,8 @@ def classify_op(op_id: str) -> str:
     'credential_mint'
     >>> classify_op("audit.query")
     'audit_query'
+    >>> classify_op("meho.audit.replay")
+    'audit_query'
     >>> classify_op("GET:/api/v2.0/systeminfo")
     'read'
     >>> classify_op("DELETE:/api/v2.0/projects/myproj/repositories/myrepo")
@@ -258,7 +266,7 @@ def classify_op(op_id: str) -> str:
         return "credential_read"
     if op_id in _CREDENTIAL_MINT_OPS:
         return "credential_mint"
-    if op_id.startswith("audit."):
+    if op_id.startswith(("audit.", "meho.audit.")):
         return "audit_query"
     # Ingested ops use HTTP-method prefixes (e.g. "GET:/api/v2.0/systeminfo").
     # GET/HEAD are safe reads by HTTP semantics; all mutation methods are writes.

--- a/backend/src/meho_backplane/mcp/tools/audit.py
+++ b/backend/src/meho_backplane/mcp/tools/audit.py
@@ -53,10 +53,14 @@ same per-field bounds.
 
 from __future__ import annotations
 
+import uuid
 from datetime import UTC, datetime
 from typing import Any, Final
 
+import sqlalchemy as sa
+import structlog
 from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.audit_query import (
     AuditQueryFilters,
@@ -65,16 +69,42 @@ from meho_backplane.audit_query import (
     UnsupportedFilterError,
     parse_duration,
     query_audit,
+    replay_session,
 )
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
 from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
 from meho_backplane.mcp.server import McpInvalidParamsError
 
 __all__: list[str] = []
 
+_log = structlog.get_logger(__name__)
 
 _TOOL_NAME: Final[str] = "query_audit"
+
+#: Hard cap on the number of audit rows a single replay may reconstruct.
+#: A pathological session (a long-running agent that fanned out thousands
+#: of operations) would otherwise build a multi-megabyte ``ReplayNode``
+#: tree and blow the agent's context window — exactly the failure the
+#: JSONFlux result-handle discipline exists to prevent. The MCP transport
+#: has no streaming body, so the guard is count-first: the closure size is
+#: counted before the (expensive) tree assembly runs, and an over-cap
+#: session is rejected with a JSON-RPC ``-32602`` carrying the
+#: ``session_too_large`` token (the MCP analogue of T4's REST 413). The
+#: cap matches T4's REST route so an operator sees the same boundary on
+#: both surfaces.
+_REPLAY_MAX_ROWS: Final[int] = 10_000
+
+_REPLAY_DEFAULT_MAX_DEPTH: Final[int] = 20
+
+#: Name of the structlog contextvar the MCP transport binds the inbound
+#: ``Mcp-Session-Id`` header into (G8.2-T2 #1010, via
+#: :func:`~meho_backplane.mcp.server._bind_mcp_session_id`). The
+#: ``shape="tree"`` self-session check reads this back to prove the
+#: caller is replaying their *own* session — the same value that lands on
+#: ``audit_log.agent_session_id`` for rows this request writes.
+_MCP_SESSION_CONTEXTVAR: Final[str] = "mcp_session_id"
 
 
 _INPUT_SCHEMA: Final[dict[str, Any]] = {
@@ -162,8 +192,26 @@ _INPUT_SCHEMA: Final[dict[str, Any]] = {
             "type": ["string", "null"],
             "format": "uuid",
             "description": (
-                "Filter to one agent session's audit trail. NOT supported "
-                "in v0.2 — returned as -32602 until a schema column lands."
+                "Filter to one agent session's audit trail "
+                "(`audit_log.agent_session_id`, the MCP-session "
+                "correlation id). Supported as a flat filter. Also "
+                'REQUIRED when `shape="tree"` — see `shape`.'
+            ),
+        },
+        "shape": {
+            "type": ["string", "null"],
+            "enum": ["flat", "tree", None],
+            "description": (
+                "Result shape. `flat` (default) returns the paginated "
+                "`{rows, next_cursor}` list. `tree` reconstructs the "
+                "agent session as a parent/child `ReplayNode` forest "
+                "(every operation plus the lineage graph between them) "
+                "and returns `{root, session_id, tenant_id, row_count}`. "
+                "`tree` is SELF-SESSION ONLY: `agent_session_id` must be "
+                "present and equal to the caller's own MCP session id; "
+                "any other value (or absence) is rejected with -32602. "
+                "To replay a DIFFERENT session, a tenant_admin uses the "
+                "`meho.audit.replay` tool."
             ),
         },
         "limit": {
@@ -209,8 +257,161 @@ _TOOL_DESCRIPTION: Final[str] = (
     "Returns `{rows: [AuditEntry, ...], next_cursor: <opaque|null>}` sorted "
     "by timestamp descending. Use `next_cursor` (when non-null) to page "
     "forward; `null` means the page is the end of the matching set under "
-    "the current filter."
+    "the current filter.\n\n"
+    'REPLAY YOUR OWN SESSION: pass `shape="tree"` together with '
+    "`agent_session_id=<your own session id>` to reconstruct the full "
+    "parent/child trace of your own agent session instead of a flat list. "
+    "The tree path is self-session-only; replaying another session needs "
+    "the tenant_admin `meho.audit.replay` tool."
 )
+
+
+def _coerce_max_depth(raw: Any) -> int:
+    """Validate the optional ``max_depth`` argument, defaulting to 20.
+
+    The inputSchema constrains ``max_depth`` to a bounded integer, so a
+    well-formed client never reaches the rejection branch; the explicit
+    check is defence-in-depth against a future schema drift. ``None`` /
+    absent → the substrate default.
+    """
+    if raw is None:
+        return _REPLAY_DEFAULT_MAX_DEPTH
+    if not isinstance(raw, int) or isinstance(raw, bool):
+        raise McpInvalidParamsError("max_depth must be a positive integer")
+    if raw < 1:
+        raise McpInvalidParamsError("max_depth must be a positive integer")
+    return raw
+
+
+async def _count_session_rows(
+    session_id: uuid.UUID,
+    *,
+    tenant_id: uuid.UUID,
+    session: AsyncSession,
+) -> int:
+    """Count the anchor rows for one tenant-scoped session.
+
+    Count-first guard for the replay path: the recursive-CTE closure can
+    only be *larger* than the anchor set (it adds lineage descendants),
+    so counting the cheap anchor predicate first is a sound lower bound —
+    if even the anchors exceed :data:`_REPLAY_MAX_ROWS` the full tree is
+    certainly over-cap, and we reject before paying for the recursive
+    walk + Python tree assembly. The tenant predicate mirrors
+    :func:`~meho_backplane.audit_query.replay.replay_session`'s anchor so
+    a cross-tenant session id counts zero.
+    """
+    stmt = sa.select(sa.func.count(AuditLog.id)).where(
+        AuditLog.agent_session_id == session_id,
+        AuditLog.tenant_id == tenant_id,
+    )
+    return int((await session.execute(stmt)).scalar_one())
+
+
+async def _build_replay_response(
+    session_id: uuid.UUID,
+    *,
+    tenant_id: uuid.UUID,
+    max_depth: int,
+) -> dict[str, Any]:
+    """Count-guard, reconstruct, and JSON-serialise one session's replay tree.
+
+    Shared by the ``meho.audit.replay`` admin tool and the
+    ``query_audit`` ``shape="tree"`` self-session branch. Opens a
+    transient session, applies the :data:`_REPLAY_MAX_ROWS` count-first
+    guard (surfaced as a JSON-RPC ``-32602`` with the
+    ``session_too_large`` token — the MCP analogue of T4's REST 413, the
+    transport has no streaming body for a 413-style partial), dispatches
+    through :func:`replay_session`, and returns the
+    ``{root, session_id, tenant_id, row_count}`` envelope. ``row_count``
+    is the assembled-node count (post depth-cap), so it reflects what the
+    caller actually receives.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        anchor_count = await _count_session_rows(
+            session_id,
+            tenant_id=tenant_id,
+            session=session,
+        )
+        if anchor_count > _REPLAY_MAX_ROWS:
+            _log.warning(
+                "audit_replay_session_too_large",
+                session_id=str(session_id),
+                anchor_count=anchor_count,
+                cap=_REPLAY_MAX_ROWS,
+            )
+            raise McpInvalidParamsError(
+                f"session_too_large: session has {anchor_count} audit rows, "
+                f"exceeding the {_REPLAY_MAX_ROWS}-row replay cap",
+            )
+        root = await replay_session(
+            session_id,
+            tenant_id=tenant_id,
+            session=session,
+            max_depth=max_depth,
+        )
+
+    serialized_root = [node.model_dump(mode="json") for node in root]
+    return {
+        "root": serialized_root,
+        "session_id": str(session_id),
+        "tenant_id": str(tenant_id),
+        "row_count": _count_tree_nodes(serialized_root),
+    }
+
+
+def _count_tree_nodes(nodes: list[dict[str, Any]]) -> int:
+    """Total node count across the serialised replay forest (recursive)."""
+    total = 0
+    for node in nodes:
+        total += 1
+        total += _count_tree_nodes(node.get("children", []))
+    return total
+
+
+def _resolve_self_session_id(arguments: dict[str, Any]) -> uuid.UUID:
+    """Resolve + authorise the ``shape="tree"`` self-session contract.
+
+    The ``tree`` shape replays ONLY the caller's own session. This is
+    intentionally STRICTER than ``query_audit``'s flat path, which
+    already returns other in-tenant principals' rows: cross-session
+    forensic replay is reserved for the ``tenant_admin``-gated
+    ``meho.audit.replay`` tool, so the operator-role tree path is locked
+    to "replay your own trace". Two conditions must hold:
+
+    1. ``agent_session_id`` is present in the arguments. Absence → -32602.
+    2. It equals the caller's bound MCP session id (the
+       :data:`_MCP_SESSION_CONTEXTVAR` the transport binds from the
+       inbound ``Mcp-Session-Id`` header). Any mismatch → -32602 —
+       including the case where the request carried no session header at
+       all, since the transport then binds a fresh per-call uuid4 that
+       the client cannot have predicted.
+    """
+    requested = arguments.get("agent_session_id")
+    if requested is None:
+        raise McpInvalidParamsError(
+            'shape="tree" requires agent_session_id (your own session id)',
+        )
+    try:
+        requested_id = uuid.UUID(str(requested))
+    except (TypeError, ValueError) as exc:
+        raise McpInvalidParamsError(
+            f"agent_session_id is not a valid UUID: {requested!r}",
+        ) from exc
+
+    bound_raw = structlog.contextvars.get_contextvars().get(_MCP_SESSION_CONTEXTVAR)
+    bound_id: uuid.UUID | None = None
+    if isinstance(bound_raw, str):
+        try:
+            bound_id = uuid.UUID(bound_raw)
+        except ValueError:
+            bound_id = None
+    if bound_id is None or bound_id != requested_id:
+        raise McpInvalidParamsError(
+            'shape="tree" replays only your own session: agent_session_id '
+            "must equal the caller's own MCP session id",
+        )
+    return requested_id
 
 
 async def _query_audit_handler(
@@ -239,9 +440,28 @@ async def _query_audit_handler(
        propagates and the dispatcher turns it into ``-32603``.
     4. Return the result as a JSON-safe dict via
        :meth:`AuditQueryResult.model_dump`.
+
+    ``shape="tree"`` short-circuits steps 1-4: it reconstructs the
+    caller's own session as a :class:`ReplayNode` forest via
+    :func:`_build_replay_response` after the self-session check in
+    :func:`_resolve_self_session_id`. ``shape`` is a tool-boundary
+    control, not a substrate filter, so it is stripped before
+    :class:`AuditQueryFilters` is constructed on the flat path. The tree
+    path uses the substrate's default depth cap — ``query_audit`` does
+    not expose a ``max_depth`` knob (that belongs to the dedicated
+    ``meho.audit.replay`` admin tool).
     """
-    now = datetime.now(UTC)
     materialized: dict[str, Any] = dict(arguments)
+    shape = materialized.pop("shape", None)
+    if shape == "tree":
+        session_id = _resolve_self_session_id(arguments)
+        return await _build_replay_response(
+            session_id,
+            tenant_id=operator.tenant_id,
+            max_depth=_REPLAY_DEFAULT_MAX_DEPTH,
+        )
+
+    now = datetime.now(UTC)
     try:
         if materialized.get("since") is not None:
             materialized["since"] = parse_duration(materialized["since"], now=now)
@@ -302,4 +522,147 @@ register_mcp_tool(
         op_class="audit_query",
     ),
     handler=_query_audit_handler,
+)
+
+
+# ---------------------------------------------------------------------------
+# meho.audit.replay — tenant_admin cross-session forensic replay
+# ---------------------------------------------------------------------------
+
+
+_REPLAY_TOOL_NAME: Final[str] = "meho.audit.replay"
+
+
+_REPLAY_INPUT_SCHEMA: Final[dict[str, Any]] = {
+    "type": "object",
+    "properties": {
+        "session_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": (
+                "The agent_session_id to reconstruct. Matched against "
+                "`audit_log.agent_session_id` scoped to the operator's "
+                "tenant; a session id from another tenant returns an "
+                "empty root, never another tenant's rows."
+            ),
+        },
+        "max_depth": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": _REPLAY_DEFAULT_MAX_DEPTH,
+            "description": (
+                "Defensive cap on tree depth (cycle / runaway defence). "
+                "A node at the cap keeps its own row but its children are "
+                "truncated. Default 20."
+            ),
+        },
+    },
+    "required": ["session_id"],
+    "additionalProperties": False,
+}
+
+
+_REPLAY_TOOL_DESCRIPTION: Final[str] = (
+    "Reconstruct the full trace of one agent session — every operation, "
+    "its result, and the parent/child graph between them — as a "
+    "chronological ReplayNode forest. tenant_admin forensic tool for "
+    "cross-session investigation (G8.2).\n\n"
+    "WHEN TO CALL: an admin investigates one agent's whole run after the "
+    "fact — 'show me everything session <id> did, in order, with the "
+    "lineage between composite operations'. The session id comes from a "
+    "prior `query_audit` row's `agent_session_id`, from the broadcast "
+    "feed, or from the agent's own logs.\n\n"
+    "WHEN NOT TO CALL: to replay YOUR OWN session, use `query_audit` with "
+    '`shape="tree"` (operator role, self-session-only) — this tool is '
+    "the admin escalation for replaying SOMEONE ELSE'S session. For a "
+    "flat filtered list rather than the tree, use `query_audit`.\n\n"
+    "Tenant scoping is automatic — the operator's JWT determines the "
+    "tenant boundary; a session id outside the tenant yields an empty "
+    "root. A session larger than the replay cap is rejected with -32602 "
+    "(`session_too_large`) rather than returning a context-blowing tree. "
+    "Filter/result contents are NEVER broadcast on the SSE feed — only "
+    "the `{op_class, result_status, row_count}` aggregate appears.\n\n"
+    "Returns `{root: [ReplayNode, ...], session_id, tenant_id, "
+    "row_count}`. `root` is the forest of session roots ascending by "
+    "timestamp; each node carries its full audit row plus `depth` and "
+    "`children`. `row_count` is the total node count in the returned "
+    "tree."
+)
+
+
+async def _replay_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Dispatch a ``meho.audit.replay`` admin call through the T3 substrate.
+
+    The dispatcher has jsonschema-validated *arguments* (``session_id``
+    present + UUID-shaped, ``max_depth`` an in-range integer when given)
+    and RBAC-gated the call to ``tenant_admin`` at both the list-time
+    filter and the call-time re-check. This handler resolves the session
+    id, validates ``max_depth`` defensively, and delegates to
+    :func:`_build_replay_response`, which applies the count-first cap and
+    serialises the tree. Tenant scope is taken from the validated JWT —
+    never from the arguments dict — so an admin cannot replay another
+    tenant's session.
+    """
+    raw_id = arguments.get("session_id")
+    if not isinstance(raw_id, str):
+        raise McpInvalidParamsError("session_id must be a string UUID")
+    try:
+        session_id = uuid.UUID(raw_id)
+    except (TypeError, ValueError) as exc:
+        raise McpInvalidParamsError(
+            f"session_id is not a valid UUID: {raw_id!r}",
+        ) from exc
+
+    max_depth = _coerce_max_depth(arguments.get("max_depth"))
+    return await _build_replay_response(
+        session_id,
+        tenant_id=operator.tenant_id,
+        max_depth=max_depth,
+    )
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name=_REPLAY_TOOL_NAME,
+        description=_REPLAY_TOOL_DESCRIPTION,
+        inputSchema=_REPLAY_INPUT_SCHEMA,
+        outputSchema={
+            "type": "object",
+            "properties": {
+                "root": {
+                    "type": "array",
+                    "items": {"type": "object"},
+                    "description": (
+                        "Session-root ReplayNode forest ascending by "
+                        "timestamp. See "
+                        "`meho_backplane.audit_query.schemas.ReplayNode` "
+                        "for the per-node field set (AuditEntry + depth + "
+                        "children)."
+                    ),
+                },
+                "session_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "The replayed agent_session_id.",
+                },
+                "tenant_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "The tenant boundary the replay ran under.",
+                },
+                "row_count": {
+                    "type": "integer",
+                    "description": "Total node count in the returned tree.",
+                },
+            },
+            "required": ["root", "session_id", "tenant_id", "row_count"],
+        },
+        required_role=TenantRole.TENANT_ADMIN,
+        op_class="audit_query",
+    ),
+    handler=_replay_handler,
 )

--- a/backend/tests/test_broadcast_events.py
+++ b/backend/tests/test_broadcast_events.py
@@ -197,6 +197,33 @@ class TestClassifyOp:
         assert classify_op(op_id) == "audit_query"
 
     @pytest.mark.parametrize(
+        "op_id",
+        [
+            "meho.audit.replay",
+            "meho.audit.query",
+        ],
+    )
+    def test_meho_audit_prefix_maps_to_audit_query(self, op_id: str) -> None:
+        """``meho.audit.*`` admin meta-tools classify as audit_query (G8.2-T6 #1014).
+
+        The MCP broadcast path derives op_class from ``classify_op(op_id)``
+        with the tool name verbatim — it does not honor the
+        ``ToolDefinition.op_class``. Without the ``meho.audit.`` prefix arm,
+        ``meho.audit.replay`` would fall through to ``other`` and broadcast
+        its full ``ReplayNode`` payload instead of the aggregate-only view.
+        """
+        assert classify_op(op_id) == "audit_query"
+
+    def test_meho_broadcast_prefix_is_not_audit_query(self) -> None:
+        """Only ``meho.audit.`` opts into audit_query — sibling meho.* tools don't.
+
+        Guards against the prefix arm being widened to a bare ``meho.``
+        match, which would mis-redact unrelated admin meta-tools like
+        ``meho.broadcast.overrides.set``.
+        """
+        assert classify_op("meho.broadcast.overrides.set") == "other"
+
+    @pytest.mark.parametrize(
         ("op_id", "expected"),
         [
             ("vsphere.vm.list", "read"),
@@ -345,6 +372,36 @@ class TestRedactPayload:
         """A malformed count never poisons the broadcast — fail-closed to None."""
         result = redact_payload("audit_query", {"row_count": "not-a-number"}, "error")
         assert result["row_count"] is None
+
+    def test_meho_audit_replay_broadcast_is_aggregate_only(self) -> None:
+        """``meho.audit.replay`` broadcasts aggregate-only — no ReplayNode tree (G8.2-T6 #1014).
+
+        The MCP broadcast path classifies via ``classify_op(op_id)`` and
+        redacts via ``redact_payload(op_class, raw_params, status)``. This
+        chains both with the replay tool's name + a representative
+        result-params dict to prove the SSE event carries only
+        ``{op_class, result_status, row_count}`` — never the ``root``
+        ReplayNode forest (full aggregate-only integration assertion is
+        T7).
+        """
+        op_class = classify_op("meho.audit.replay")
+        assert op_class == "audit_query"
+        result = redact_payload(
+            op_class,
+            {
+                "session_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                "root": [{"id": "secret-node", "payload": {"vm": "prod-db"}}],
+                "row_count": 12,
+            },
+            "ok",
+        )
+        assert result == {
+            "op_class": "audit_query",
+            "result_status": "ok",
+            "row_count": 12,
+        }
+        assert "root" not in result
+        assert "session_id" not in result
 
     def test_read_keeps_full_params(self) -> None:
         """AC #8 — generic read ops broadcast in full."""

--- a/backend/tests/test_mcp_tool_audit_replay.py
+++ b/backend/tests/test_mcp_tool_audit_replay.py
@@ -1,0 +1,595 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the audit-replay MCP surface (G8.2-T6 #1014).
+
+Two surfaces, one substrate (T3 :func:`replay_session`):
+
+* ``meho.audit.replay`` — a ``tenant_admin`` cross-session forensic
+  replay meta-tool. RBAC gate, tenant scoping, count-first 10k guard,
+  and tree shape.
+* ``query_audit`` with ``shape="tree"`` — an ``operator`` self-session
+  replay path. The self-session check rejects any ``agent_session_id``
+  that is not the caller's own bound MCP session id (-32602).
+
+The substrate (:func:`replay_session`) and the row-count helper are
+patched at the tool's import site so these tests don't depend on a
+PG/SQLite-seeded audit graph — that integration coverage is
+``tests/test_audit_replay.py`` (substrate) and T7 (E2E acceptance).
+The patch points are the names bound in
+:mod:`meho_backplane.mcp.tools.audit`.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.audit_query import ReplayNode
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.mcp.registry import get_tool
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    client_with_operator,  # noqa: F401 — pytest-discovered fixture
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+_REPLAY_PATCH = "meho_backplane.mcp.tools.audit.replay_session"
+_COUNT_PATCH = "meho_backplane.mcp.tools.audit._count_session_rows"
+
+_SESSION_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+_OTHER_SESSION_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+
+def _node(node_id: str, *, depth: int, children: list[ReplayNode] | None = None) -> ReplayNode:
+    """Build a minimal :class:`ReplayNode` for the patched substrate return."""
+    return ReplayNode(
+        id=uuid.UUID(node_id),
+        ts=datetime(2026, 5, 14, 12, 0, tzinfo=UTC),
+        tenant_id=OPERATOR_TENANT_ID,
+        principal_sub="op-test",
+        principal_name=None,
+        target_id=None,
+        target_name=None,
+        method="MCP",
+        path="/mcp/tools/call/call_operation",
+        status_code=200,
+        request_id=None,
+        duration_ms=None,
+        payload={"op_id": "vsphere.vm.list"},
+        op_id="vsphere.vm.list",
+        op_class="read",
+        result_status="ok",
+        parent_audit_id=None,
+        agent_session_id=uuid.UUID(_SESSION_ID),
+        broadcast_event_id=None,
+        depth=depth,
+        children=children or [],
+    )
+
+
+def _two_level_tree() -> list[ReplayNode]:
+    """A root with one child — a minimal multi-level replay forest."""
+    child = _node("22222222-2222-2222-2222-222222222222", depth=1)
+    root = _node("11111111-1111-1111-1111-111111111111", depth=0, children=[child])
+    return [root]
+
+
+# ---------------------------------------------------------------------------
+# meho.audit.replay — registration + RBAC
+# ---------------------------------------------------------------------------
+
+
+def test_replay_tool_registered_as_tenant_admin_audit_query() -> None:
+    """The admin tool is registered with the right role + op_class contract.
+
+    ``op_class="audit_query"`` is load-bearing twice over: the registry
+    contract, and (via the matching ``meho.audit.`` arm in
+    :func:`classify_op`) the MCP broadcast path's aggregate-only redaction.
+    """
+    entry = get_tool("meho.audit.replay")
+    assert entry is not None
+    defn, _handler = entry
+    assert defn.op_class == "audit_query"
+    assert defn.required_role == TenantRole.TENANT_ADMIN
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_replay_tool_in_tools_list_for_admin(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``tenant_admin`` sees ``meho.audit.replay`` in the catalogue."""
+    client, _op = client_with_operator
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    names = {t["name"] for t in response.json()["result"]["tools"]}
+    assert "meho.audit.replay" in names
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_replay_tool_hidden_from_operator_tools_list(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """The RBAC list-time filter hides the admin tool from sub-admin roles."""
+    client, _op = client_with_operator
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+    names = {t["name"] for t in response.json()["result"]["tools"]}
+    assert "meho.audit.replay" not in names
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR, TenantRole.READ_ONLY],
+    indirect=True,
+)
+def test_replay_tool_forbidden_for_non_admin(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``operator`` / ``read_only`` calling the admin tool get -32602 forbidden."""
+    client, _op = client_with_operator
+    mock_replay = AsyncMock(return_value=[])
+    with patch(_REPLAY_PATCH, new=mock_replay):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "meho.audit.replay",
+                    "arguments": {"session_id": _SESSION_ID},
+                },
+            },
+        )
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "forbidden" in body["error"]["message"].lower()
+    mock_replay.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# meho.audit.replay — happy path + tenant scoping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_replay_admin_returns_tree_envelope(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``tenant_admin`` gets the ``{root, session_id, tenant_id, row_count}`` tree."""
+    client, op = client_with_operator
+    mock_replay = AsyncMock(return_value=_two_level_tree())
+    mock_count = AsyncMock(return_value=2)
+    with patch(_REPLAY_PATCH, new=mock_replay), patch(_COUNT_PATCH, new=mock_count):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 10,
+                "method": "tools/call",
+                "params": {
+                    "name": "meho.audit.replay",
+                    "arguments": {"session_id": _SESSION_ID},
+                },
+            },
+        )
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["session_id"] == _SESSION_ID
+    assert payload["tenant_id"] == str(op.tenant_id)
+    # row_count counts every node in the returned tree (root + child).
+    assert payload["row_count"] == 2
+    assert len(payload["root"]) == 1
+    assert payload["root"][0]["id"] == "11111111-1111-1111-1111-111111111111"
+    assert payload["root"][0]["depth"] == 0
+    assert len(payload["root"][0]["children"]) == 1
+    assert payload["root"][0]["children"][0]["depth"] == 1
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_replay_admin_tenant_scope_from_jwt_not_args(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Tenant scope is the JWT's — never an argument; cross-tenant is impossible.
+
+    ``additionalProperties: false`` blocks smuggling a ``tenant_id``
+    argument, and the substrate is dispatched with the operator's JWT
+    tenant_id keyword. A tenant-B admin replaying a tenant-A session id
+    sees only their own tenant boundary (the substrate returns empty,
+    proven here by asserting the keyword passed to the substrate).
+    """
+    client, op = client_with_operator
+    mock_replay = AsyncMock(return_value=[])
+    mock_count = AsyncMock(return_value=0)
+    with patch(_REPLAY_PATCH, new=mock_replay), patch(_COUNT_PATCH, new=mock_count):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 11,
+                "method": "tools/call",
+                "params": {
+                    "name": "meho.audit.replay",
+                    "arguments": {"session_id": _OTHER_SESSION_ID},
+                },
+            },
+        )
+    assert response.json()["result"]["isError"] is False
+    assert mock_replay.await_args.kwargs["tenant_id"] == op.tenant_id
+    assert op.tenant_id == OPERATOR_TENANT_ID
+    # The count guard is also tenant-scoped to the JWT.
+    assert mock_count.await_args.kwargs["tenant_id"] == op.tenant_id
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_replay_admin_max_depth_passed_through(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """An explicit ``max_depth`` reaches the substrate; default is 20."""
+    client, _op = client_with_operator
+    mock_replay = AsyncMock(return_value=[])
+    mock_count = AsyncMock(return_value=0)
+    with patch(_REPLAY_PATCH, new=mock_replay), patch(_COUNT_PATCH, new=mock_count):
+        post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 12,
+                "method": "tools/call",
+                "params": {
+                    "name": "meho.audit.replay",
+                    "arguments": {"session_id": _SESSION_ID, "max_depth": 5},
+                },
+            },
+        )
+        assert mock_replay.await_args.kwargs["max_depth"] == 5
+
+        post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 13,
+                "method": "tools/call",
+                "params": {
+                    "name": "meho.audit.replay",
+                    "arguments": {"session_id": _SESSION_ID},
+                },
+            },
+        )
+        assert mock_replay.await_args.kwargs["max_depth"] == 20
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_replay_admin_session_too_large_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Count-first guard: an over-cap session is rejected with -32602 session_too_large.
+
+    The substrate is never dispatched — the count short-circuits before
+    the recursive walk runs.
+    """
+    client, _op = client_with_operator
+    mock_replay = AsyncMock(return_value=_two_level_tree())
+    mock_count = AsyncMock(return_value=10_001)
+    with patch(_REPLAY_PATCH, new=mock_replay), patch(_COUNT_PATCH, new=mock_count):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 14,
+                "method": "tools/call",
+                "params": {
+                    "name": "meho.audit.replay",
+                    "arguments": {"session_id": _SESSION_ID},
+                },
+            },
+        )
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "session_too_large" in body["error"]["message"]
+    mock_replay.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_replay_admin_requires_session_id(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``session_id`` is required by the schema — omission is -32602."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 15,
+            "method": "tools/call",
+            "params": {"name": "meho.audit.replay", "arguments": {}},
+        },
+    )
+    assert response.json()["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.TENANT_ADMIN],
+    indirect=True,
+)
+def test_replay_admin_rejects_additional_properties(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``additionalProperties: false`` blocks a smuggled ``tenant_id`` arg."""
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 16,
+            "method": "tools/call",
+            "params": {
+                "name": "meho.audit.replay",
+                "arguments": {
+                    "session_id": _SESSION_ID,
+                    "tenant_id": "11111111-1111-1111-1111-111111111111",
+                },
+            },
+        },
+    )
+    assert response.json()["error"]["code"] == INVALID_PARAMS
+
+
+# ---------------------------------------------------------------------------
+# query_audit shape="tree" — operator self-session path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_query_audit_tree_own_session_returns_tree(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """An operator replaying their OWN bound session gets the tree.
+
+    The ``Mcp-Session-Id`` header binds the caller's session id; passing
+    the same id as ``agent_session_id`` with ``shape="tree"`` satisfies
+    the self-session check and dispatches through the substrate.
+    """
+    client, op = client_with_operator
+    mock_replay = AsyncMock(return_value=_two_level_tree())
+    mock_count = AsyncMock(return_value=2)
+    with patch(_REPLAY_PATCH, new=mock_replay), patch(_COUNT_PATCH, new=mock_count):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 20,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_audit",
+                    "arguments": {"agent_session_id": _SESSION_ID, "shape": "tree"},
+                },
+            },
+            headers={"Mcp-Session-Id": _SESSION_ID},
+        )
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["session_id"] == _SESSION_ID
+    assert payload["tenant_id"] == str(op.tenant_id)
+    assert payload["row_count"] == 2
+    assert mock_replay.await_args.kwargs["tenant_id"] == op.tenant_id
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_query_audit_tree_foreign_session_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``shape="tree"`` with a DIFFERENT session id than the caller's own → -32602.
+
+    This is the self-session security contract: even though the flat path
+    would happily return other in-tenant principals' rows, the tree path
+    is locked to the caller's own session. The substrate is never reached.
+    """
+    client, _op = client_with_operator
+    mock_replay = AsyncMock(return_value=_two_level_tree())
+    mock_count = AsyncMock(return_value=2)
+    with patch(_REPLAY_PATCH, new=mock_replay), patch(_COUNT_PATCH, new=mock_count):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 21,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_audit",
+                    "arguments": {"agent_session_id": _OTHER_SESSION_ID, "shape": "tree"},
+                },
+            },
+            headers={"Mcp-Session-Id": _SESSION_ID},
+        )
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "own session" in body["error"]["message"].lower()
+    mock_replay.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_query_audit_tree_without_agent_session_id_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``shape="tree"`` with no ``agent_session_id`` → -32602 (must be self-targeted)."""
+    client, _op = client_with_operator
+    mock_replay = AsyncMock(return_value=_two_level_tree())
+    with patch(_REPLAY_PATCH, new=mock_replay):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 22,
+                "method": "tools/call",
+                "params": {"name": "query_audit", "arguments": {"shape": "tree"}},
+            },
+            headers={"Mcp-Session-Id": _SESSION_ID},
+        )
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "agent_session_id" in body["error"]["message"]
+    mock_replay.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_query_audit_tree_without_session_header_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """No ``Mcp-Session-Id`` header → the bound id is a random uuid4 the
+    client can't match → -32602.
+
+    With no header, the transport binds a fresh per-call uuid4 as the
+    session id, so any ``agent_session_id`` the client supplies cannot
+    equal it. The tree path stays self-session-only even when the caller
+    didn't establish an explicit session.
+    """
+    client, _op = client_with_operator
+    mock_replay = AsyncMock(return_value=_two_level_tree())
+    with patch(_REPLAY_PATCH, new=mock_replay):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 23,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_audit",
+                    "arguments": {"agent_session_id": _SESSION_ID, "shape": "tree"},
+                },
+            },
+        )
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    mock_replay.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_query_audit_tree_session_too_large_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """The self-session tree path shares the count-first 10k guard."""
+    client, _op = client_with_operator
+    mock_replay = AsyncMock(return_value=_two_level_tree())
+    mock_count = AsyncMock(return_value=10_001)
+    with patch(_REPLAY_PATCH, new=mock_replay), patch(_COUNT_PATCH, new=mock_count):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 24,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_audit",
+                    "arguments": {"agent_session_id": _SESSION_ID, "shape": "tree"},
+                },
+            },
+            headers={"Mcp-Session-Id": _SESSION_ID},
+        )
+    body = response.json()
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "session_too_large" in body["error"]["message"]
+    mock_replay.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_query_audit_flat_shape_still_dispatches_normally(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``shape="flat"`` (and absent shape) leave the flat query path untouched.
+
+    A regression guard: the tree branch must not swallow the default
+    list path. ``replay_session`` is never reached for a flat call.
+    """
+    from meho_backplane.audit_query import AuditQueryResult
+
+    client, _op = client_with_operator
+    mock_replay = AsyncMock(return_value=_two_level_tree())
+    mock_query = AsyncMock(return_value=AuditQueryResult(rows=[], next_cursor=None))
+    with (
+        patch(_REPLAY_PATCH, new=mock_replay),
+        patch("meho_backplane.mcp.tools.audit.query_audit", new=mock_query),
+    ):
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 25,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_audit",
+                    "arguments": {"shape": "flat", "agent_session_id": _SESSION_ID},
+                },
+            },
+            headers={"Mcp-Session-Id": _SESSION_ID},
+        )
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload == {"rows": [], "next_cursor": None}
+    mock_replay.assert_not_awaited()
+    mock_query.assert_awaited_once()
+    # The flat path still sees agent_session_id as a substrate filter.
+    assert mock_query.await_args.args[0].agent_session_id == uuid.UUID(_SESSION_ID)

--- a/docs/codebase/audit_query.md
+++ b/docs/codebase/audit_query.md
@@ -235,9 +235,10 @@ Error mapping at the tool boundary:
 * `pydantic.ValidationError` (post-jsonschema, e.g. malformed UUID
   slipping past `format: uuid`) — same mapping.
 * `InvalidCursorError` (substrate, tampered cursor) — same mapping.
-* `UnsupportedFilterError` (substrate, `parent_audit_id` /
-  `agent_session_id` in v0.2) — same mapping with the column-name
-  message.
+* `UnsupportedFilterError` (substrate, the flat `parent_audit_id`
+  filter, still gated in v0.2) — same mapping with the column-name
+  message. The `agent_session_id` filter is **un-gated** (G8.2-T3
+  #1011) and no longer raises.
 * Anything else propagates; the dispatcher's outer try/except turns
   it into JSON-RPC `-32603` Internal Error.
 
@@ -245,6 +246,71 @@ RBAC: `operator` role minimum. `read_only` callers find the tool
 absent from `tools/list` and get `-32602` on a direct `tools/call`
 attempt (the dispatcher's per-call RBAC re-check, not a transport
 401 — JSON-RPC has no 403 analogue).
+
+### `shape="tree"` self-session replay (G8.2-T6 #1014)
+
+`query_audit` grows a `shape` enum (`"flat"` default / `"tree"`). With
+`shape="tree"` the handler short-circuits the flat filter path and
+reconstructs the caller's session as a `ReplayNode` forest via
+`replay_session`, returning `{root, session_id, tenant_id, row_count}`
+(same envelope as the admin tool below).
+
+The tree path is **self-session only** and intentionally stricter than
+the flat path (which already returns other in-tenant principals' rows):
+`agent_session_id` must be present **and** equal to the caller's own
+bound MCP session id — the `mcp_session_id` structlog contextvar the
+transport binds from the inbound `Mcp-Session-Id` header (G8.2-T2
+#1010). Any mismatch — a different session id, an absent
+`agent_session_id`, or no session header at all (the transport then
+binds a fresh uuid4 the client can't predict) — is rejected with
+`-32602`. Cross-session forensic replay is the `tenant_admin`-gated
+`meho.audit.replay` tool, not this path.
+
+## `meho.audit.replay` admin tool (G8.2-T6 #1014)
+
+A dedicated `tenant_admin` meta-tool in the `meho.*` admin namespace
+(alongside `meho.broadcast.overrides.*`), registered in the same
+`mcp/tools/audit.py` module. It is the cross-session escalation: an
+admin replays *another* agent's session, where `query_audit`'s
+`shape="tree"` path replays only *your own*.
+
+* `inputSchema`: `{session_id: uuid (required), max_depth: int
+  (1–100, default 20)}`, `additionalProperties: false`.
+* Handler: count-first 10k guard (see below), then
+  `replay_session(session_id, tenant_id=operator.tenant_id,
+  session=…, max_depth=…)`. Tenant scope is the JWT's — never an
+  argument — so an admin cannot replay another tenant's session (a
+  foreign session id yields an empty `root`).
+* Returns `{root: [ReplayNode…], session_id, tenant_id, row_count}`
+  via `model_dump(mode="json")`; `row_count` is the total node count
+  in the returned tree.
+* `op_class="audit_query"`, so — via the matching `meho.audit.` arm
+  in `classify_op` — the MCP broadcast event is aggregate-only
+  (`{op_class, result_status, row_count}`), never the `ReplayNode`
+  payload.
+
+**Count-first 10k guard.** Both replay surfaces share
+`_build_replay_response`, which counts the tenant-scoped anchor rows
+(`agent_session_id = :id`) *before* the recursive walk + tree
+assembly. The anchor count is a sound lower bound on the closure size
+(the CTE only adds lineage descendants), so an over-cap session is
+rejected with `-32602` carrying the `session_too_large` token — the
+MCP analogue of T4's REST 413, since the JSON-RPC transport has no
+streaming body for a partial response. The cap (`_REPLAY_MAX_ROWS =
+10_000`) matches T4 so operators see the same boundary on both
+surfaces.
+
+### `meho.audit.` broadcast-classifier arm
+
+The MCP broadcast path derives `op_class` from `classify_op(op_id)`
+with the **tool name verbatim** — it does not honor
+`ToolDefinition.op_class`. `classify_op` therefore grew a
+`meho.audit.` prefix arm next to the existing `audit.` arm: without
+it, `meho.audit.replay` (prefix `meho.audit.`) would fall through to
+`other` and broadcast its full `ReplayNode` tree instead of the
+aggregate-only view. (The literal tool name `query_audit` has the same
+MCP-path classification gap today — a pre-existing G8.1 concern, out
+of scope for #377.)
 
 ## Dependencies
 
@@ -258,9 +324,10 @@ Reverse dependencies:
 
 * `meho_backplane.api.v1.audit` (T2 #466) — REST router for the four
   consumer-facing routes; dispatches every call through `query_audit`.
-* `meho_backplane.mcp.tools.audit` (T4 #468) — single MCP meta-tool
-  registered against the G0.5 registry; dispatches every call through
-  `query_audit`.
+* `meho_backplane.mcp.tools.audit` (T4 #468, extended G8.2-T6 #1014) —
+  the `query_audit` MCP meta-tool plus the `meho.audit.replay` admin
+  tool; dispatches flat queries through `query_audit` and replay
+  (admin tool + `shape="tree"`) through `replay_session`.
 * T3 #467 (CLI) follows.
 
 ## Known issues / v0.2 gaps


### PR DESCRIPTION
## Summary
- Adds the agent-facing (MCP) replay surface for G8.2 audit replay (Initiative #377).
- **`meho.audit.replay`** — a `tenant_admin` meta-tool in the `meho.*` admin namespace for cross-session forensic replay. Count-first 10k guard (JSON-RPC `-32602` `session_too_large`, the MCP analogue of T4's REST 413), tenant scope from the JWT, returns `{root, session_id, tenant_id, row_count}`.
- **`meho.audit.*` classifier arm** in `broadcast/events.py::classify_op` — the MCP broadcast path classifies via `classify_op(op_id)` with the tool name verbatim (it does not honor `ToolDefinition.op_class`), so without this arm `meho.audit.replay` would broadcast its full `ReplayNode` tree instead of the aggregate-only `{op_class, result_status, row_count}` view.
- **`query_audit` `shape:"tree"` facet** — an operator-role self-session replay path. `agent_session_id` must equal the caller's own bound `mcp_session_id` contextvar (T2); any mismatch/absence → `-32602`. Intentionally stricter than the flat path (which returns other in-tenant principals' rows) — cross-session replay is the `tenant_admin` `meho.audit.replay` tool.
- Refreshes the now-stale `agent_session_id` inputSchema description (T3 un-gated the filter); `parent_audit_id` stays gated per #377.

Both replay surfaces share `_build_replay_response` (count-first guard + `replay_session` dispatch + JSON serialise). `docs/codebase/audit_query.md` gains an MCP-replay subsection.

## Test plan
- [x] `ruff check` — clean (changed src + test files)
- [x] `ruff format --check` — clean
- [x] `mypy` — clean (changed src files)
- [x] `classify_op("meho.audit.replay") == "audit_query"` and `classify_op("audit.query") == "audit_query"` still holds — doctest + unit (`test_broadcast_events.py`)
- [x] `meho.audit.replay` RBAC — `operator`/`read_only` forbidden (`-32602`), `tenant_admin` returns the tree; tenant scope from JWT (`test_mcp_tool_audit_replay.py`)
- [x] `meho.audit.replay` returns the correct `ReplayNode` tree envelope; count-first `session_too_large` guard; `max_depth` pass-through; `additionalProperties:false`
- [x] `query_audit({agent_session_id:<own>, shape:"tree"})` returns the replay tree; foreign/absent session id or missing `Mcp-Session-Id` header → `-32602`; flat path unaffected
- [x] aggregate-only redaction for `meho.audit.replay` via `classify_op` → `redact_payload` unit (no `ReplayNode` payload in the broadcast event)
- [x] `make snapshot-openapi` dry-run — no REST OpenAPI diff (MCP tool schemas are not in the REST spec); CLI snapshot unchanged

## Out of scope
- REST replay route — **T4** (#1012); CLI — **T5** (#1013); recursive query substrate — **T3** (#1011, merged).
- Full aggregate-only broadcast integration assertion + PG E2E — **T7** (#1015).
- The pre-existing `query_audit` (literal tool name) MCP-path full-detail classification gap — separate G8.1 concern, noted not fixed.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1014
