### PR TITLE
feat(cli): G8.2-T5 meho audit replay + query --session-id

### DIFF
--- a/cli/internal/cmd/audit/audit.go
+++ b/cli/internal/cmd/audit/audit.go
@@ -57,7 +57,7 @@ import (
 func NewRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "audit",
-		Short: "Query the MEHO audit log (query / recent / show / who-touched / my-recent)",
+		Short: "Query the MEHO audit log (query / recent / show / who-touched / my-recent / replay)",
 		Long: "Query the WORM-grade audit log written by the backplane on " +
 			"every authenticated request. Wraps the G8.1-T2 REST surface " +
 			"(/api/v1/audit/*). All verbs are tenant-scoped via the operator's " +
@@ -69,6 +69,7 @@ func NewRootCmd() *cobra.Command {
 	cmd.AddCommand(newShowCmd())
 	cmd.AddCommand(newWhoTouchedCmd())
 	cmd.AddCommand(newMyRecentCmd())
+	cmd.AddCommand(newReplayCmd())
 	return cmd
 }
 
@@ -207,6 +208,21 @@ func renderHTTPError(
 			output.Unexpected("audit row not found"),
 			jsonOut,
 		)
+	case http.StatusRequestEntityTooLarge:
+		// Only the replay endpoint emits 413 (session_too_large): a
+		// session above the server's replayRowCap anchor rows. The
+		// replay verb intercepts this status before reaching here so it
+		// can append the `meho audit query --session-id <id>` redirect
+		// (it knows the session id; this shared renderer does not). This
+		// arm is the defensive fallback for any other caller — surface
+		// the cardinality and the same query-verb pointer.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"session too large to replay (%s rows, cap %d); "+
+					"use `meho audit query --session-id <id>` to page the flat rows",
+				decodeSessionTooLargeRowCount(he.Body), replayRowCap)),
+			jsonOut,
+		)
 	case http.StatusUnprocessableEntity:
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("invalid request: %s", he.Body)),
@@ -219,6 +235,42 @@ func renderHTTPError(
 			jsonOut,
 		)
 	}
+}
+
+// replayRowCap mirrors the backend `_REPLAY_ROW_CAP`
+// (`backend/src/meho_backplane/api/v1/audit.py`): the maximum number of
+// anchor rows a single session may carry before the replay route's
+// count-first guard refuses with 413 `session_too_large`. Surfaced in
+// the CLI's 413 redirect so the operator sees the threshold they
+// crossed. Kept in sync by hand — the value is part of the route's
+// public contract (the 413 body always quotes the actual `row_count`,
+// so a drift here only mis-renders the *cap* in the hint, never the
+// real count).
+const replayRowCap = 10000
+
+// sessionTooLargeDetail models the structured 413 body the replay route
+// emits: `{"detail": {"detail": "session_too_large", "row_count": N}}`.
+// FastAPI wraps the route's `HTTPException(detail=...)` dict under a
+// top-level `detail` key, so the row count lives two levels deep.
+type sessionTooLargeDetail struct {
+	Detail struct {
+		Detail   string      `json:"detail"`
+		RowCount json.Number `json:"row_count"`
+	} `json:"detail"`
+}
+
+// decodeSessionTooLargeRowCount pulls the `row_count` out of a 413
+// `session_too_large` body. Returns the count as a string (so a 64-bit
+// count renders exactly) or "?" when the body isn't the expected shape
+// — the redirect stays useful even if the backend changes the envelope.
+func decodeSessionTooLargeRowCount(body string) string {
+	var d sessionTooLargeDetail
+	if err := json.Unmarshal([]byte(body), &d); err == nil {
+		if rc := d.Detail.RowCount.String(); rc != "" {
+			return rc
+		}
+	}
+	return "?"
 }
 
 // detailEnvelope models FastAPI's HTTPException JSON shape.

--- a/cli/internal/cmd/audit/audit_test.go
+++ b/cli/internal/cmd/audit/audit_test.go
@@ -66,11 +66,11 @@ func newRunCmd(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
 	return cmd, &stdout, &stderr
 }
 
-// TestNewRootCmdRegistersAllFiveVerbs — AC1: every advertised verb
-// has a cobra subcommand. The CLI manifest is the contract operators
-// build muscle memory around; dropping a verb silently is the
-// regression class we want to catch at unit-time.
-func TestNewRootCmdRegistersAllFiveVerbs(t *testing.T) {
+// TestNewRootCmdRegistersAllVerbs — AC1: every advertised verb has a
+// cobra subcommand. The CLI manifest is the contract operators build
+// muscle memory around; dropping a verb silently is the regression
+// class we want to catch at unit-time. G8.2-T5 (#1013) added `replay`.
+func TestNewRootCmdRegistersAllVerbs(t *testing.T) {
 	root := NewRootCmd()
 	want := map[string]bool{
 		"query":       false,
@@ -78,6 +78,7 @@ func TestNewRootCmdRegistersAllFiveVerbs(t *testing.T) {
 		"show":        false,
 		"who-touched": false,
 		"my-recent":   false,
+		"replay":      false,
 	}
 	for _, sub := range root.Commands() {
 		// cobra splits `Use` on the first space to render <args>

--- a/cli/internal/cmd/audit/query.go
+++ b/cli/internal/cmd/audit/query.go
@@ -8,7 +8,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/backplane"
@@ -23,17 +25,18 @@ import (
 // special-cases the unset state because Go's zero-value int collides
 // with the backend's `ge=1` validation otherwise.
 type auditQueryRequest struct {
-	Target        *string `json:"target,omitempty"`
-	Principal     *string `json:"principal,omitempty"`
-	OpID          *string `json:"op_id,omitempty"`
-	OpClass       *string `json:"op_class,omitempty"`
-	ResultStatus  *string `json:"result_status,omitempty"`
-	Since         *string `json:"since,omitempty"`
-	Until         *string `json:"until,omitempty"`
-	AuditID       *string `json:"audit_id,omitempty"`
-	ParentAuditID *string `json:"parent_audit_id,omitempty"`
-	Limit         int     `json:"limit,omitempty"`
-	Cursor        *string `json:"cursor,omitempty"`
+	Target         *string `json:"target,omitempty"`
+	Principal      *string `json:"principal,omitempty"`
+	OpID           *string `json:"op_id,omitempty"`
+	OpClass        *string `json:"op_class,omitempty"`
+	ResultStatus   *string `json:"result_status,omitempty"`
+	Since          *string `json:"since,omitempty"`
+	Until          *string `json:"until,omitempty"`
+	AuditID        *string `json:"audit_id,omitempty"`
+	ParentAuditID  *string `json:"parent_audit_id,omitempty"`
+	AgentSessionID *string `json:"agent_session_id,omitempty"`
+	Limit          int     `json:"limit,omitempty"`
+	Cursor         *string `json:"cursor,omitempty"`
 }
 
 // newQueryCmd returns the `meho audit query` command.
@@ -52,6 +55,7 @@ type auditQueryRequest struct {
 //	  [--cursor C]                 # opaque forward-pagination cursor
 //	  [--audit-id ID]              # exact-id lookup
 //	  [--parent-audit-id ID]       # v0.2 substrate rejects (400)
+//	  [--session-id ID]            # narrow to one agent session (UUID)
 //	  [--json]                     # raw RetireChecklistReport JSON
 //	  [--backplane <url>]          # override the configured backplane
 //
@@ -75,6 +79,7 @@ func newQueryCmd() *cobra.Command {
 		cursor            string
 		auditID           string
 		parentAuditID     string
+		sessionID         string
 		jsonOut           bool
 		backplaneOverride string
 	)
@@ -105,6 +110,7 @@ func newQueryCmd() *cobra.Command {
 				Cursor:            cursor,
 				AuditID:           auditID,
 				ParentAuditID:     parentAuditID,
+				SessionID:         sessionID,
 				JSONOut:           jsonOut,
 				BackplaneOverride: backplaneOverride,
 			})
@@ -133,6 +139,8 @@ func newQueryCmd() *cobra.Command {
 	cmd.Flags().StringVar(&parentAuditID, "parent-audit-id", "",
 		"narrow to the composite-op subtree under this audit-id "+
 			"(v0.2 substrate rejects with 400; column lands with G0.6-T7 #398)")
+	cmd.Flags().StringVar(&sessionID, "session-id", "",
+		"narrow to one agent session (UUID); the flat companion to `meho audit replay`")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
 		"emit raw QueryResult JSON instead of the human table")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
@@ -152,6 +160,7 @@ type queryOptions struct {
 	Cursor            string
 	AuditID           string
 	ParentAuditID     string
+	SessionID         string
 	JSONOut           bool
 	BackplaneOverride string
 }
@@ -163,6 +172,20 @@ func runQuery(cmd *cobra.Command, opts queryOptions) error {
 			output.Unexpected(fmt.Sprintf("--limit must be between 1 and 1000; got %d", opts.Limit)),
 			opts.JSONOut,
 		)
+	}
+	if opts.SessionID != "" {
+		// The backend declares agent_session_id as a UUID and rejects a
+		// malformed value with 422. Catch it client-side so the operator
+		// sees a clear "not a UUID" message instead of a FastAPI
+		// validation envelope after a round-trip.
+		if _, err := uuid.Parse(strings.TrimSpace(opts.SessionID)); err != nil {
+			return output.RenderError(
+				cmd.ErrOrStderr(),
+				output.Unexpected(fmt.Sprintf(
+					"--session-id must be a valid UUID; %q is not a UUID", opts.SessionID)),
+				opts.JSONOut,
+			)
+		}
 	}
 	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
@@ -213,6 +236,9 @@ func buildQueryRequest(opts queryOptions) auditQueryRequest {
 	}
 	if opts.ParentAuditID != "" {
 		body.ParentAuditID = &opts.ParentAuditID
+	}
+	if opts.SessionID != "" {
+		body.AgentSessionID = &opts.SessionID
 	}
 	if opts.Cursor != "" {
 		body.Cursor = &opts.Cursor

--- a/cli/internal/cmd/audit/query_test.go
+++ b/cli/internal/cmd/audit/query_test.go
@@ -46,6 +46,7 @@ func TestBuildQueryRequestEveryFlagLandsOnWire(t *testing.T) {
 		Until:         "1h",
 		AuditID:       "00000000-0000-0000-0000-000000000001",
 		ParentAuditID: "00000000-0000-0000-0000-000000000002",
+		SessionID:     "00000000-0000-0000-0000-000000000003",
 		Limit:         50,
 		Cursor:        "opaque-cursor-bytes",
 	}
@@ -65,6 +66,7 @@ func TestBuildQueryRequestEveryFlagLandsOnWire(t *testing.T) {
 		`"until":"1h"`,
 		`"audit_id":"00000000-0000-0000-0000-000000000001"`,
 		`"parent_audit_id":"00000000-0000-0000-0000-000000000002"`,
+		`"agent_session_id":"00000000-0000-0000-0000-000000000003"`,
 		`"limit":50`,
 		`"cursor":"opaque-cursor-bytes"`,
 	} {
@@ -238,6 +240,47 @@ func TestRunQueryUnreachableSurfacesAsTransport(t *testing.T) {
 	// generic call-error wrapper. Both go through Unreachable.
 	if !strings.Contains(stderr.String(), "call ") {
 		t.Errorf("stderr does not look like Unreachable: %s", stderr.String())
+	}
+}
+
+// TestRunQuerySessionIDRejectsNonUUID — AC: a non-UUID --session-id
+// is rejected client-side with a clear message, before any network
+// round-trip (the backend would otherwise emit a 422 validation
+// envelope). The check runs in runQuery so the empty-flag case stays
+// unaffected.
+func TestRunQuerySessionIDRejectsNonUUID(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runQuery(cmd, queryOptions{SessionID: "not-a-uuid"})
+	if err == nil {
+		t.Fatalf("expected error for non-UUID --session-id")
+	}
+	if !strings.Contains(stderr.String(), "must be a valid UUID") {
+		t.Errorf("stderr missing UUID-rejection hint: %s", stderr.String())
+	}
+}
+
+// TestRunQuerySessionIDLandsInBody — a valid --session-id sets
+// agent_session_id on the wire so the backend narrows to that session.
+// This is the flat companion to `meho audit replay`.
+func TestRunQuerySessionIDLandsInBody(t *testing.T) {
+	sessionID := "11111111-1111-1111-1111-111111111111"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/query", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"agent_session_id":"`+sessionID+`"`) {
+			t.Errorf("body missing agent_session_id filter: %s", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"rows":[],"next_cursor":null}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runQuery(cmd, queryOptions{SessionID: sessionID, BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runQuery --session-id: %v; stderr=%s", err, stderr.String())
 	}
 }
 

--- a/cli/internal/cmd/audit/replay.go
+++ b/cli/internal/cmd/audit/replay.go
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package audit
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// defaultReplayMaxDepth is the depth past which the ASCII tree is
+// truncated client-side. The replay route itself does not accept a
+// depth parameter (its 413 count-first guard caps *rows*, not depth),
+// so --max-depth is purely a rendering knob: nodes deeper than the
+// limit are folded into a single "… N more level(s) (use --max-depth
+// to expand)" marker. 20 matches the issue's spec.
+const defaultReplayMaxDepth = 20
+
+// ReplayNode mirrors the backend `ReplayNode` Pydantic model
+// (`backend/src/meho_backplane/audit_query/schemas.py`), which
+// subclasses `AuditEntry` and adds `depth` + `children`. Like `Entry`
+// the fields are hand-written rather than aliased to the generated
+// `api.ReplayNode` so the audit package stays decoupled from
+// oapi-codegen churn — the same stance the rest of this package takes.
+//
+// Only the rendering-relevant fields are pulled out as named members;
+// every other audit column survives the --json round-trip because the
+// verb re-marshals the raw server bytes verbatim rather than this
+// struct (see runReplay's --json branch). `DurationMS` is a `*string`
+// because Pydantic v2 serialises `Decimal` as a quoted decimal string
+// (or null).
+type ReplayNode struct {
+	TS           string       `json:"ts"`
+	OpID         string       `json:"op_id"`
+	ResultStatus string       `json:"result_status"`
+	DurationMS   *string      `json:"duration_ms"`
+	Depth        int          `json:"depth"`
+	Children     []ReplayNode `json:"children"`
+}
+
+// ReplayResult mirrors the backend `AuditReplayResult` envelope — a
+// `ReplayNode` forest plus the echoed session/tenant identity and the
+// session's anchor-row count.
+type ReplayResult struct {
+	Root      []ReplayNode `json:"root"`
+	SessionID string       `json:"session_id"`
+	TenantID  string       `json:"tenant_id"`
+	RowCount  int          `json:"row_count"`
+}
+
+// newReplayCmd returns the `meho audit replay` command.
+//
+// CLI shape:
+//
+//	meho audit replay <session-id> [--json] [--max-depth N] [--backplane <url>]
+//
+// Calls GET /api/v1/audit/sessions/{session_id}/replay and renders the
+// session's parent/child audit tree. The default rendering is an ASCII
+// tree (one line per node); --json emits the raw `AuditReplayResult`
+// envelope verbatim (the v0.2.next compliance-export contract).
+//
+// A 413 from the backend means the session exceeds the server's
+// 10 000-anchor-row replay cap. The verb surfaces a friendly redirect
+// to `meho audit query --session-id <id>` (which paginates the flat
+// rows) and exits non-zero — see renderHTTPError's 413 arm in audit.go.
+//
+// Exit codes:
+//   - 0   tree rendered cleanly (incl. an empty / unknown session)
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (incl. 413 session_too_large, 422
+//     malformed-UUID, and the client-side non-UUID rejection)
+//   - 5   insufficient_role
+func newReplayCmd() *cobra.Command {
+	var (
+		jsonOut           bool
+		maxDepth          int
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "replay <session-id>",
+		Short: "Replay one agent session as a parent/child audit tree",
+		Long: "replay calls GET /api/v1/audit/sessions/{session_id}/replay " +
+			"and renders the session's audit rows as a parent/child tree. " +
+			"The argument must be a UUID (validated client-side). The " +
+			"default output is an ASCII tree — one line per node, children " +
+			"indented under their parent, roots in chronological order. " +
+			"--json emits the raw AuditReplayResult JSON for piping into " +
+			"jq or a compliance export. --max-depth folds nodes below the " +
+			"given depth (rendering only; the server caps on row count, " +
+			"not depth). A session larger than the server's 10 000-row cap " +
+			"returns 413 and the verb redirects to `meho audit query " +
+			"--session-id <id>`.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runReplay(cmd, replayOptions{
+				SessionID:         args[0],
+				JSONOut:           jsonOut,
+				MaxDepth:          maxDepth,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw AuditReplayResult JSON instead of the human ASCII tree")
+	cmd.Flags().IntVar(&maxDepth, "max-depth", defaultReplayMaxDepth,
+		"fold tree nodes deeper than this level (rendering only; default 20)")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type replayOptions struct {
+	SessionID         string
+	JSONOut           bool
+	MaxDepth          int
+	BackplaneOverride string
+}
+
+func runReplay(cmd *cobra.Command, opts replayOptions) error {
+	if _, err := uuid.Parse(strings.TrimSpace(opts.SessionID)); err != nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"replay requires a valid UUID <session-id>; %q is not a UUID", opts.SessionID)),
+			opts.JSONOut,
+		)
+	}
+	if opts.MaxDepth < 0 {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--max-depth must be >= 0; got %d", opts.MaxDepth)),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	raw, err := doAuthedRequest(
+		cmd.Context(), backplaneURL, "GET", buildReplayPath(opts.SessionID), nil)
+	if err != nil {
+		return renderReplayRequestError(cmd, backplaneURL, opts.SessionID, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		// Emit the server bytes verbatim so every audit column on each
+		// node survives the round-trip — the compliance-export contract
+		// must not be lossy through the CLI's render-only struct.
+		_, werr := cmd.OutOrStdout().Write(append(raw, '\n'))
+		return werr
+	}
+	var result ReplayResult
+	if derr := decodeAuditResponse(raw, &result); derr != nil {
+		return renderRequestError(cmd, backplaneURL, derr, opts.JSONOut)
+	}
+	printReplayTree(cmd.OutOrStdout(), &result, opts.MaxDepth)
+	return nil
+}
+
+// buildReplayPath assembles the GET path. Exposed for unit tests so the
+// URL encoding of the session id stays covered.
+func buildReplayPath(sessionID string) string {
+	return "/api/v1/audit/sessions/" + pathEscape(sessionID) + "/replay"
+}
+
+// renderReplayRequestError adds the 413 session-too-large redirect on
+// top of the shared error ladder. A 413 carries the session's row count
+// in its `{detail: {detail: "session_too_large", row_count: N}}` body;
+// the verb turns it into an actionable `meho audit query --session-id`
+// pointer (the query verb paginates the flat rows the over-cap tree
+// can't render). Every other status falls through to the shared
+// renderRequestError ladder used by the sibling verbs.
+func renderReplayRequestError(
+	cmd *cobra.Command,
+	backplaneURL, sessionID string,
+	err error,
+	jsonOut bool,
+) error {
+	var he *httpError
+	if errors.As(err, &he) && he.StatusCode == http.StatusRequestEntityTooLarge {
+		rows := decodeSessionTooLargeRowCount(he.Body)
+		msg := fmt.Sprintf(
+			"session %s has %s rows (cap %d); use: meho audit query --session-id %s",
+			sessionID, rows, replayRowCap, sessionID)
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(msg), jsonOut)
+	}
+	return renderRequestError(cmd, backplaneURL, err, jsonOut)
+}
+
+// printReplayTree renders the replay forest as an ASCII tree. Roots are
+// emitted in chronological order (the server already orders both roots
+// and children by (occurred_at, id)); each child is indented under its
+// parent with the standard `├──`/`└──` connectors and `│  `/`   `
+// continuation prefixes. Nodes deeper than maxDepth are folded into a
+// single marker so a pathological session can't flood the terminal.
+func printReplayTree(w io.Writer, r *ReplayResult, maxDepth int) {
+	if r == nil || len(r.Root) == 0 {
+		fmt.Fprintln(w, "no audit rows in this session")
+		return
+	}
+	for i := range r.Root {
+		printReplayNode(w, &r.Root[i], "", i == len(r.Root)-1, 0, maxDepth)
+	}
+}
+
+// printReplayNode renders one node and recurses into its children.
+// `prefix` is the accumulated indentation for this node's *children*'s
+// continuation lines; `isLast` selects the connector for this node.
+func printReplayNode(
+	w io.Writer,
+	node *ReplayNode,
+	prefix string,
+	isLast bool,
+	depth, maxDepth int,
+) {
+	connector := "├── "
+	childPrefix := prefix + "│   "
+	if isLast {
+		connector = "└── "
+		childPrefix = prefix + "    "
+	}
+	fmt.Fprintf(w, "%s%s%s\n", prefix, connector, formatReplayNode(node))
+
+	if depth >= maxDepth {
+		if hidden := countDescendants(node); hidden > 0 {
+			fmt.Fprintf(w, "%s└── … %d more node(s) below depth %d (raise --max-depth to expand)\n",
+				childPrefix, hidden, maxDepth)
+		}
+		return
+	}
+	for i := range node.Children {
+		printReplayNode(
+			w, &node.Children[i], childPrefix, i == len(node.Children)-1, depth+1, maxDepth)
+	}
+}
+
+// formatReplayNode renders one node's single line:
+//
+//	<occurred_at> <op_id> [<result_status>] (<duration_ms>ms)
+//
+// `occurred_at` is the node's `ts` field (the audit row's
+// `occurred_at`). A null duration renders as `(-ms)` so the column
+// stays present and grep-friendly across nodes.
+func formatReplayNode(node *ReplayNode) string {
+	dur := strDeref(node.DurationMS)
+	if dur == "" {
+		dur = "-"
+	}
+	return fmt.Sprintf("%s %s [%s] (%sms)", node.TS, node.OpID, node.ResultStatus, dur)
+}
+
+// countDescendants counts every node strictly below `node` (its whole
+// subtree minus itself). Used to summarise how many nodes the
+// --max-depth fold hid.
+func countDescendants(node *ReplayNode) int {
+	total := 0
+	for i := range node.Children {
+		total += 1 + countDescendants(&node.Children[i])
+	}
+	return total
+}

--- a/cli/internal/cmd/audit/replay_test.go
+++ b/cli/internal/cmd/audit/replay_test.go
@@ -1,0 +1,404 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package audit
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// twoLevelReplay returns a small `ReplayResult` with two chronological
+// roots; the first carries one child that itself carries a grandchild.
+// Used by the tree-render and max-depth tests so they share one fixture
+// and the expected line shapes stay in one place.
+func twoLevelReplay() ReplayResult {
+	dur := func(s string) *string { return &s }
+	return ReplayResult{
+		SessionID: "11111111-1111-1111-1111-111111111111",
+		TenantID:  "22222222-2222-2222-2222-222222222222",
+		RowCount:  4,
+		Root: []ReplayNode{
+			{
+				TS:           "2026-05-13T10:00:00Z",
+				OpID:         "vsphere.vm.migrate",
+				ResultStatus: "ok",
+				DurationMS:   dur("120.5"),
+				Depth:        0,
+				Children: []ReplayNode{
+					{
+						TS:           "2026-05-13T10:00:01Z",
+						OpID:         "vsphere.vm.power_off",
+						ResultStatus: "ok",
+						DurationMS:   dur("40"),
+						Depth:        1,
+						Children: []ReplayNode{
+							{
+								TS:           "2026-05-13T10:00:02Z",
+								OpID:         "vsphere.task.wait",
+								ResultStatus: "error",
+								DurationMS:   nil,
+								Depth:        2,
+							},
+						},
+					},
+				},
+			},
+			{
+				TS:           "2026-05-13T10:05:00Z",
+				OpID:         "vsphere.vm.list",
+				ResultStatus: "ok",
+				DurationMS:   dur("8"),
+				Depth:        0,
+			},
+		},
+	}
+}
+
+// TestBuildReplayPathEscapesSessionID — UUIDs are URL-safe, but the
+// segment is escaped defensively so a typo'd argument can't collapse
+// the path.
+func TestBuildReplayPathEscapesSessionID(t *testing.T) {
+	got := buildReplayPath("11111111-1111-1111-1111-111111111111")
+	want := "/api/v1/audit/sessions/11111111-1111-1111-1111-111111111111/replay"
+	if got != want {
+		t.Errorf("buildReplayPath: got %q; want %q", got, want)
+	}
+}
+
+// TestRunReplayRejectsNonUUID — AC: a non-UUID <session-id> is
+// rejected client-side with a clear message, before any network call.
+func TestRunReplayRejectsNonUUID(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runReplay(cmd, replayOptions{SessionID: "not-a-uuid"})
+	if err == nil {
+		t.Fatalf("expected error for non-UUID session-id")
+	}
+	if !strings.Contains(stderr.String(), "not a UUID") {
+		t.Errorf("stderr missing UUID-rejection hint: %s", stderr.String())
+	}
+}
+
+// TestRunReplayRejectsNegativeMaxDepth — a negative --max-depth is a
+// nonsensical render bound; surface it before the round-trip.
+func TestRunReplayRejectsNegativeMaxDepth(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runReplay(cmd, replayOptions{
+		SessionID: "11111111-1111-1111-1111-111111111111",
+		MaxDepth:  -1,
+	})
+	if err == nil {
+		t.Fatalf("expected error for negative --max-depth")
+	}
+	if !strings.Contains(stderr.String(), "max-depth must be") {
+		t.Errorf("stderr missing max-depth hint: %s", stderr.String())
+	}
+}
+
+// TestRunReplayHappyPathTree — AC1: a multi-level session renders an
+// ASCII tree with chronological roots, indented children, and the
+// documented per-line shape `<ts> <op_id> [<status>] (<ms>ms)`.
+func TestRunReplayHappyPathTree(t *testing.T) {
+	fixture := twoLevelReplay()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/sessions/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method: got %s; want GET", r.Method)
+		}
+		expected := "/api/v1/audit/sessions/11111111-1111-1111-1111-111111111111/replay"
+		if r.URL.Path != expected {
+			t.Errorf("path: got %q; want %q", r.URL.Path, expected)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(fixture)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runReplay(cmd, replayOptions{
+		SessionID:         "11111111-1111-1111-1111-111111111111",
+		MaxDepth:          defaultReplayMaxDepth,
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runReplay: %v; stderr=%s", err, stderr.String())
+	}
+	out := stdout.String()
+
+	// Per-line shape and the null-duration dash rendering.
+	for _, want := range []string{
+		"2026-05-13T10:00:00Z vsphere.vm.migrate [ok] (120.5ms)",
+		"2026-05-13T10:00:01Z vsphere.vm.power_off [ok] (40ms)",
+		"2026-05-13T10:00:02Z vsphere.task.wait [error] (-ms)",
+		"2026-05-13T10:05:00Z vsphere.vm.list [ok] (8ms)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("tree missing line %q in:\n%s", want, out)
+		}
+	}
+
+	// Roots emitted in chronological order: migrate's subtree before
+	// the later list root.
+	migrateIdx := strings.Index(out, "vsphere.vm.migrate")
+	listIdx := strings.Index(out, "vsphere.vm.list")
+	if migrateIdx < 0 || listIdx < 0 || migrateIdx > listIdx {
+		t.Errorf("roots not chronological (migrate before list):\n%s", out)
+	}
+
+	// Children are indented under parents: the grandchild line carries
+	// deeper indentation than the child, which is deeper than the root.
+	rootLine := lineContaining(t, out, "vsphere.vm.migrate")
+	childLine := lineContaining(t, out, "vsphere.vm.power_off")
+	grandLine := lineContaining(t, out, "vsphere.task.wait")
+	if indentOf(childLine) <= indentOf(rootLine) {
+		t.Errorf("child not indented under root:\nroot=%q\nchild=%q", rootLine, childLine)
+	}
+	if indentOf(grandLine) <= indentOf(childLine) {
+		t.Errorf("grandchild not indented under child:\nchild=%q\ngrand=%q", childLine, grandLine)
+	}
+}
+
+// TestRunReplayJSONVerbatim — AC2: --json emits the raw
+// AuditReplayResult JSON; nesting is parseable and matches the tree.
+func TestRunReplayJSONVerbatim(t *testing.T) {
+	fixture := twoLevelReplay()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/sessions/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(fixture)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runReplay(cmd, replayOptions{
+		SessionID:         "11111111-1111-1111-1111-111111111111",
+		JSONOut:           true,
+		MaxDepth:          defaultReplayMaxDepth,
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runReplay --json: %v; stderr=%s", err, stderr.String())
+	}
+	var decoded ReplayResult
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("--json output not parseable: %v\n%s", err, stdout.String())
+	}
+	if len(decoded.Root) != 2 {
+		t.Fatalf("--json root count: got %d; want 2", len(decoded.Root))
+	}
+	// Nesting survives: root[0] → child → grandchild.
+	if len(decoded.Root[0].Children) != 1 ||
+		len(decoded.Root[0].Children[0].Children) != 1 {
+		t.Errorf("--json nesting lost: %+v", decoded.Root[0])
+	}
+	if decoded.Root[0].Children[0].Children[0].OpID != "vsphere.task.wait" {
+		t.Errorf("--json grandchild op_id wrong: %+v", decoded.Root[0].Children[0].Children[0])
+	}
+	// row_count echoed verbatim.
+	if decoded.RowCount != 4 {
+		t.Errorf("--json row_count: got %d; want 4", decoded.RowCount)
+	}
+}
+
+// TestRunReplayMaxDepthTruncates — AC3: --max-depth 1 truncates
+// rendering below depth 1. The grandchild (depth 2) must be folded
+// into a "more node(s)" marker, not printed as its own line.
+func TestRunReplayMaxDepthTruncates(t *testing.T) {
+	fixture := twoLevelReplay()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/sessions/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(fixture)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runReplay(cmd, replayOptions{
+		SessionID:         "11111111-1111-1111-1111-111111111111",
+		MaxDepth:          1,
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runReplay --max-depth 1: %v; stderr=%s", err, stderr.String())
+	}
+	out := stdout.String()
+	// Depth 0 and 1 render; depth 2 is folded.
+	if !strings.Contains(out, "vsphere.vm.migrate") {
+		t.Errorf("depth-0 root missing: %s", out)
+	}
+	if !strings.Contains(out, "vsphere.vm.power_off") {
+		t.Errorf("depth-1 child missing: %s", out)
+	}
+	if strings.Contains(out, "vsphere.task.wait") {
+		t.Errorf("depth-2 grandchild should be folded at --max-depth 1: %s", out)
+	}
+	if !strings.Contains(out, "more node(s) below depth 1") {
+		t.Errorf("fold marker missing: %s", out)
+	}
+}
+
+// TestRunReplay413Redirects — AC4: a 413 session_too_large prints the
+// `meho audit query --session-id <id>` redirect (with the row count
+// and cap) and returns a non-nil error so the process exits non-zero.
+func TestRunReplay413Redirects(t *testing.T) {
+	sessionID := "11111111-1111-1111-1111-111111111111"
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/sessions/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		// FastAPI wraps the route's HTTPException dict under `detail`.
+		_, _ = w.Write([]byte(
+			`{"detail":{"detail":"session_too_large","row_count":12345}}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runReplay(cmd, replayOptions{
+		SessionID:         sessionID,
+		MaxDepth:          defaultReplayMaxDepth,
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected non-nil error on 413 (non-zero exit)")
+	}
+	got := stderr.String()
+	for _, want := range []string{
+		"has 12345 rows",
+		"cap 10000",
+		"meho audit query --session-id " + sessionID,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("413 redirect missing %q in: %s", want, got)
+		}
+	}
+}
+
+// TestRunReplayEmptySession — an unknown / foreign / empty session
+// returns root=[] / row_count=0 (never 404). The verb renders a clear
+// "no rows" line and exits zero — the same non-leakage posture `show`
+// takes.
+func TestRunReplayEmptySession(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/sessions/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(
+			`{"root":[],"session_id":"11111111-1111-1111-1111-111111111111",` +
+				`"tenant_id":"22222222-2222-2222-2222-222222222222","row_count":0}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runReplay(cmd, replayOptions{
+		SessionID:         "11111111-1111-1111-1111-111111111111",
+		MaxDepth:          defaultReplayMaxDepth,
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runReplay empty session: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "no audit rows in this session") {
+		t.Errorf("empty session missing helper line: %s", stdout.String())
+	}
+}
+
+// TestRunReplay403SurfacesInsufficientRole — a read_only operator is
+// below the audit gate; the backend returns 403 and the verb surfaces
+// the shared insufficient_role category.
+func TestRunReplay403SurfacesInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/sessions/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail":"requires operator role"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runReplay(cmd, replayOptions{
+		SessionID:         "11111111-1111-1111-1111-111111111111",
+		MaxDepth:          defaultReplayMaxDepth,
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error on 403")
+	}
+	if !strings.Contains(stderr.String(), "requires operator role") {
+		t.Errorf("stderr missing role detail: %s", stderr.String())
+	}
+}
+
+// TestPrintReplayTreeEmpty — the empty forest renders the helper line
+// (covered indirectly above, pinned here directly for the renderer).
+func TestPrintReplayTreeEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	printReplayTree(&buf, &ReplayResult{Root: []ReplayNode{}}, defaultReplayMaxDepth)
+	if !strings.Contains(buf.String(), "no audit rows in this session") {
+		t.Errorf("empty tree missing helper line: %s", buf.String())
+	}
+}
+
+// TestFormatReplayNodeNullDuration — a node with a null duration_ms
+// renders `(-ms)` so the column stays present and grep-friendly.
+func TestFormatReplayNodeNullDuration(t *testing.T) {
+	got := formatReplayNode(&ReplayNode{
+		TS:           "2026-05-13T10:00:00Z",
+		OpID:         "x.y",
+		ResultStatus: "ok",
+		DurationMS:   nil,
+	})
+	if !strings.Contains(got, "(-ms)") {
+		t.Errorf("null duration not rendered as dash: %q", got)
+	}
+}
+
+// TestDecodeSessionTooLargeRowCount — the 413 helper pulls the nested
+// row_count out of FastAPI's double-wrapped detail body, and falls
+// back to "?" on an unexpected shape so the redirect stays useful.
+func TestDecodeSessionTooLargeRowCount(t *testing.T) {
+	body := `{"detail":{"detail":"session_too_large","row_count":98765}}`
+	if got := decodeSessionTooLargeRowCount(body); got != "98765" {
+		t.Errorf("decodeSessionTooLargeRowCount: got %q; want 98765", got)
+	}
+	if got := decodeSessionTooLargeRowCount("Service Unavailable"); got != "?" {
+		t.Errorf("decodeSessionTooLargeRowCount fallback: got %q; want ?", got)
+	}
+}
+
+// lineContaining returns the first line of s that contains sub, failing
+// the test when none does. Used by the indentation assertions.
+func lineContaining(t *testing.T, s, sub string) string {
+	t.Helper()
+	for _, line := range strings.Split(s, "\n") {
+		if strings.Contains(line, sub) {
+			return line
+		}
+	}
+	t.Fatalf("no line containing %q in:\n%s", sub, s)
+	return ""
+}
+
+// indentOf returns the count of leading runes before the `├`/`└` tree
+// connector — a proxy for a node's render depth.
+func indentOf(line string) int {
+	idx := strings.IndexAny(line, "├└")
+	if idx < 0 {
+		return 0
+	}
+	return len([]rune(line[:idx]))
+}

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -38,7 +38,11 @@ names.
   `enable`, `disable`).
 - `meho audit ...` (G8.1-T3 #467) — audit-log query surface
   (`query`, `recent`, `show`, `who-touched`, `my-recent`) wrapping
-  the four `/api/v1/audit/*` routes shipped by G8.1-T2 (#466).
+  the four `/api/v1/audit/*` routes shipped by G8.1-T2 (#466). G8.2-T5
+  (#1013) adds `replay <session-id>` — an ASCII parent/child session
+  tree over `GET /api/v1/audit/sessions/{id}/replay` (`--json`,
+  `--max-depth`; a 413 `session_too_large` redirects to
+  `query --session-id`) — plus a `--session-id` filter on `query`.
 - `meho kb ...` (G4.1-T4 #418) — knowledge-base operator surface
   (`ingest`, `search`, `list`, `show`, `add`, `delete`) wrapping
   the five `/api/v1/kb*` routes shipped by G4.1-T2 (#416) plus the
@@ -109,9 +113,11 @@ cli/
     │   │   ├── show.go           # `meho audit show <audit-id>` (GET /api/v1/audit/show/{id}).
     │   │   ├── who_touched.go    # `meho audit who-touched <target>` (GET /api/v1/audit/who-touched/{target}).
     │   │   ├── my_recent.go      # `meho audit my-recent` (GET /api/v1/audit/my-recent).
+    │   │   ├── replay.go         # `meho audit replay <session-id>` (GET /api/v1/audit/sessions/{id}/replay) — ASCII tree + 413 redirect.
     │   │   ├── audit_test.go     # helper + URL-normalisation + register-all-verbs tests.
-    │   │   ├── query_test.go     # body-marshal + render + 400-passthrough tests.
+    │   │   ├── query_test.go     # body-marshal + render + 400-passthrough + --session-id tests.
     │   │   ├── show_test.go      # path-escape + 404 / 422 surface + summary render tests.
+    │   │   ├── replay_test.go    # tree render + --json + --max-depth fold + 413 redirect tests.
     │   │   ├── who_touched_test.go # query-param emit + table render tests.
     │   │   ├── my_recent_test.go # JWT-only-principal contract tests.
     │   │   └── recent_test.go    # since=24h binding + --json passthrough tests.


### PR DESCRIPTION
## Summary

- Adds `meho audit replay <session-id>` — the operator CLI front for the G8.2 audit-replay surface (substrate T3 #1011, REST route T4 #1012 already on `main`). Renders a session's parent/child audit tree as an ASCII tree by default (`<occurred_at> <op_id> [<status>] (<ms>ms)`, children indented, roots chronological), with `--json` (raw `AuditReplayResult` envelope, verbatim) and `--max-depth` (render-only fold).
- Adds a `--session-id` filter to `meho audit query` that sets `agent_session_id` on the request body (un-gated by T3) — the flat companion to `replay` for paging a session's rows.
- A 413 `session_too_large` from the count-first server cap is turned into an actionable redirect to `meho audit query --session-id <id>` and exits non-zero. The shared `audit.go` status→error switch gains a 413 arm plus the `replayRowCap` constant and a nested-`detail` row-count decoder.
- UUID is validated client-side on both verbs so a malformed value is rejected before the round-trip (clear message instead of a FastAPI 422 envelope).

## Design note

The replay route accepts no server-side depth parameter (its only param is `Authorization`; the 413 guard caps *rows*, not depth), so `--max-depth` is purely a client render knob — nodes below the limit fold into a "… N more node(s)" marker. This matches the acceptance criterion (`--max-depth 1` truncates rendering below depth 1), which is satisfiable client-side. Hand-written response structs (not the generated `api.ReplayNode`) follow the existing audit-package convention of staying decoupled from oapi-codegen churn.

## Test plan

- [x] `go test ./cli/internal/cmd/audit/...` — all pass (incl. tree render, `--json` verbatim/nesting, `--max-depth 1` fold, 413 redirect + non-zero exit, empty/foreign session, 403, `--session-id` UUID-reject + body-field).
- [x] `gofmt -l` — clean; `golangci-lint run ./internal/cmd/audit/...` — 0 issues (repo CLI v2 config).
- [x] `go vet ./internal/cmd/audit/...` — clean; `go build ./...` — clean.
- [x] `meho audit replay --help` works; `replay` registered under `meho audit`; `meho audit query --help` shows `--session-id`.
- [x] CLI-only change — no backend/OpenAPI files touched, so the OpenAPI freshness check stays green.

## Out of scope

- REST route / 413 cap logic (T4 #1012), substrate (T3 #1011), MCP replay tool (T6 #1014) — all merged.
- Color / TTY-aware rendering and pager paging — output stays plain, matching the sibling verbs.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1013
