### PR TITLE
feat(agent-runtime): G11.1-T3 toolset resolution + handler→agent-tool adapter

### DIFF
--- a/backend/src/meho_backplane/agent/__init__.py
+++ b/backend/src/meho_backplane/agent/__init__.py
@@ -33,15 +33,23 @@ from meho_backplane.agent.run import (
     PydanticAgentRun,
     default_model_factory,
 )
+from meho_backplane.agent.toolset import (
+    META_TOOL_NAMES,
+    MetaToolSpec,
+    resolve_agent_tools,
+)
 
 __all__ = [
+    "META_TOOL_NAMES",
     "AgentDefinition",
     "AgentRun",
     "AgentRunError",
     "AgentRunHandle",
     "AgentRunResult",
     "AgentRunStatus",
+    "MetaToolSpec",
     "ModelFactory",
     "PydanticAgentRun",
     "default_model_factory",
+    "resolve_agent_tools",
 ]

--- a/backend/src/meho_backplane/agent/run.py
+++ b/backend/src/meho_backplane/agent/run.py
@@ -32,15 +32,20 @@ an in-process :class:`asyncio.Task`:
 Tools
 =====
 
-For T1 the loop is wired with two existing MEHO meta-tools —
-:func:`~meho_backplane.operations.meta_tools.list_operation_groups`
-(discovery) and
-:func:`~meho_backplane.operations.meta_tools.call_operation` (execution) —
-adapted from their ``(operator, arguments) -> dict`` handler shape onto the
-framework's tool interface via :func:`_register_meta_tools`. The handler
-*is* the dispatch path REST + MCP use; the agent gets no special surface.
-Full toolset resolution (the toolset ∩ identity-permissions intersection)
-is T3 (#810); this Task proves the one path end to end.
+The loop's tools are MEHO's own meta-tools, adapted from their
+``(operator, arguments) -> dict`` handler shape onto the framework's tool
+interface. The handler *is* the dispatch path REST + MCP use; the agent gets
+no special surface (CLAUDE.md postulate 5).
+
+Which meta-tools register is decided by T3's toolset resolver
+(:func:`~meho_backplane.agent.toolset.resolve_agent_tools`): given the
+definition's :attr:`AgentDefinition.toolset` spec and the run's operator, it
+returns exactly the meta-tools that are in the **intersection** of (the
+spec's allow-list) ∩ (the meta-tools the operator's role admits). A tool the
+identity may not call is not registered. When :attr:`AgentDefinition.toolset`
+is ``None`` the seam falls back to the original two hand-wired meta-tools
+(:func:`_register_default_meta_tools`) — the T1 path, kept so a definition
+constructed without a toolset (and the T1 test corpus) still runs.
 
 Why a model factory, not the ``LlmClient`` seam
 ===============================================
@@ -73,6 +78,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from pydantic_ai import Agent, RunContext, UsageLimits
 from pydantic_ai.exceptions import UsageLimitExceeded
 
+from meho_backplane.agent.toolset import resolve_agent_tools
 from meho_backplane.auth.operator import Operator
 from meho_backplane.operations.meta_tools import call_operation, list_operation_groups
 
@@ -156,6 +162,15 @@ class AgentDefinition(BaseModel):
     model: str | None = None
     #: Optional structured-output schema (a Pydantic ``BaseModel`` subclass).
     output_type: type[BaseModel] | None = Field(default=None, exclude=True)
+    #: Optional toolset spec — the allowed meta-tools / connectors, resolved
+    #: against the run's identity by
+    #: :func:`~meho_backplane.agent.toolset.resolve_agent_tools` (T3 #810).
+    #: ``None`` selects the T1 default surface (the two hand-wired meta-tools
+    #: in :func:`_register_default_meta_tools`); a dict (even ``{}``) routes
+    #: through the resolver. See :mod:`meho_backplane.agent.toolset` for the
+    #: shape. Persisted definitions (T2 #809) materialise their stored
+    #: ``toolset`` JSON into this field.
+    toolset: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -264,8 +279,8 @@ def default_model_factory() -> Model:
     return AnthropicModel(settings.agent_default_model, provider=provider)
 
 
-def _register_meta_tools(agent: Agent[Operator, Any]) -> None:
-    """Wire the MEHO meta-tools onto *agent* as framework tools.
+def _register_default_meta_tools(agent: Agent[Operator, Any]) -> None:
+    """Wire the T1 default two-meta-tool surface onto *agent*.
 
     Adapts the existing ``(operator, arguments) -> dict`` handler shape
     onto the framework's ``RunContext``-first tool signature: the operator
@@ -275,9 +290,12 @@ def _register_meta_tools(agent: Agent[Operator, Any]) -> None:
     descriptions, so the agent picks tools from the same prose operators
     read.
 
-    Only two tools are wired for T1 — enough to prove discovery + execution
-    end to end. T3 (#810) replaces this hand-wiring with toolset resolution
-    that registers the agent identity's full permitted surface.
+    This is the fallback path used when an :class:`AgentDefinition` carries
+    no ``toolset`` spec (``toolset is None``): exactly the two meta-tools T1
+    hand-wired (discovery + execution), enough to run a definition that never
+    asked for a specific surface. A definition *with* a toolset routes
+    through :func:`~meho_backplane.agent.toolset.resolve_agent_tools`
+    instead, which enforces the spec ∩ identity-permissions intersection.
     """
 
     @agent.tool
@@ -333,16 +351,38 @@ class PydanticAgentRun:
 
     model_factory: ModelFactory = field(default=default_model_factory)
 
-    def _build_agent(self, definition: AgentDefinition) -> Agent[Operator, Any]:
-        """Construct the framework agent for *definition*."""
+    def _build_agent(
+        self,
+        definition: AgentDefinition,
+        operator: Operator,
+    ) -> Agent[Operator, Any]:
+        """Construct the framework agent for *definition* under *operator*.
+
+        When *definition* carries a ``toolset`` spec, the tools registered
+        are the intersection of (spec) ∩ (operator's permissions), resolved
+        by :func:`~meho_backplane.agent.toolset.resolve_agent_tools` and
+        passed to the framework via the ``tools=`` constructor argument. A
+        definition with no toolset (``toolset is None``) falls back to the T1
+        default two-meta-tool surface.
+        """
         model = self.model_factory()
-        agent: Agent[Operator, Any] = Agent(
+        if definition.toolset is not None:
+            tools = resolve_agent_tools(definition.toolset, operator)
+            agent: Agent[Operator, Any] = Agent(
+                model,
+                deps_type=Operator,
+                system_prompt=definition.system_prompt,
+                output_type=definition.output_type if definition.output_type is not None else str,
+                tools=tools,
+            )
+            return agent
+        agent = Agent(
             model,
             deps_type=Operator,
             system_prompt=definition.system_prompt,
             output_type=definition.output_type if definition.output_type is not None else str,
         )
-        _register_meta_tools(agent)
+        _register_default_meta_tools(agent)
         return agent
 
     async def _run_loop(
@@ -412,7 +452,7 @@ class PydanticAgentRun:
                 "AgentRun.start requires a running event loop; "
                 "the sync invocation surface (T4) bridges at the edge",
             ) from exc
-        agent = self._build_agent(definition)
+        agent = self._build_agent(definition, operator)
         run_id = uuid4()
         task = asyncio.create_task(
             self._run_loop(agent, definition, operator, inputs, run_id),

--- a/backend/src/meho_backplane/agent/toolset.py
+++ b/backend/src/meho_backplane/agent/toolset.py
@@ -1,0 +1,405 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Toolset resolution + handler-to-agent-tool adapter (G11.1-T3 / #810).
+
+This module turns an agent definition's *toolset spec* plus the run's
+*identity* into the concrete list of :class:`pydantic_ai.Tool` objects the
+:class:`~meho_backplane.agent.run.PydanticAgentRun` loop registers. The
+registered set is the **intersection** of two sets:
+
+* **toolset spec** — what the definition author asked for (a free-shaped
+  JSON object persisted on
+  :class:`~meho_backplane.db.models.AgentDefinition.toolset`; T2 #809 only
+  stores it, this Task resolves it).
+* **identity permissions** — what the agent's identity is allowed to call.
+  The permission *model* (a per-op grant table) is G11.2; until it lands,
+  the permission an identity carries today is its tenant role, gated the
+  same way every other MEHO surface gates it: each meta-tool declares a
+  :class:`~meho_backplane.auth.operator.TenantRole` floor and
+  :func:`~meho_backplane.mcp.registry.role_at_least` decides admission.
+  This Task *consumes* that gate; it does not invent a new one.
+
+A meta-tool the identity may not call is **not registered** — it is absent
+from the agent's tool surface, so the model cannot even attempt it. This is
+the least-privilege posture: the safest tool is one that does not exist on
+the surface (ai_engineering best practices, tool-surface minimisation).
+
+Why the agent surface is meta-tools, not per-op tools
+=====================================================
+
+CLAUDE.md postulate 5 is load-bearing: the agent never sees vendor-specific
+tools (no ``vsphere.vm.list`` in the tool list). All execution flows through
+``call_operation(connector_id, op_id, ...)``. So "connector-ops ∩ identity
+permissions" is **not** "register one Pydantic AI tool per connector op" —
+that would put vendor identifiers in tool names, which the architecture
+forbids. Connector-op scoping instead rides on the ``call_operation`` tool:
+the toolset spec may carry a ``connectors`` allow-list, and the wrapped
+``call_operation`` rejects a dispatch to a connector outside that list with
+a structured, agent-reasonable error (a :class:`pydantic_ai.ModelRetry`,
+not a crash). Per-op RBAC + tenant scoping + audit + sanitization still fire
+unchanged inside :func:`~meho_backplane.operations.dispatch` — the agent
+layer adds connector-level scoping on top, it does not replace the
+dispatch-time gate.
+
+Toolset spec shape
+==================
+
+The spec is intentionally small and forward-compatible (JSON-shaped so it
+can grow without a migration — the T2 design constraint):
+
+.. code-block:: json
+
+    {
+      "meta_tools": ["list_operation_groups", "search_operations", "call_operation"],
+      "connectors": ["vmware-rest-9.0", "vault-1.x"]
+    }
+
+* ``meta_tools`` — the allow-list of meta-tool names to register. Omitted /
+  ``null`` means "all meta-tools the identity's role admits" (the safe
+  default for a definition that just wants the standard discovery +
+  execution surface). An empty list registers no tools.
+* ``connectors`` — an optional allow-list of ``connector_id`` values the
+  agent may reach through ``call_operation``. Omitted / ``null`` means "no
+  connector-level restriction beyond what dispatch already enforces"
+  (the tenant boundary + per-op RBAC still apply). An empty list forbids
+  every connector — ``call_operation`` is registered but every dispatch
+  is rejected before it reaches the dispatcher.
+
+Unknown keys in the spec are ignored (forward-compat): a future spec field
+must not break an older runtime.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+import structlog
+from pydantic_ai import ModelRetry, RunContext, Tool
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.mcp.registry import role_at_least
+from meho_backplane.operations.meta_tools import (
+    call_operation,
+    list_operation_groups,
+    search_operations,
+)
+
+__all__ = [
+    "META_TOOL_NAMES",
+    "MetaToolSpec",
+    "resolve_agent_tools",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: The shape of a handler the agent meta-tools adapt: the existing
+#: ``(operator, arguments) -> dict`` MEHO meta-tool signature shared by the
+#: REST, MCP, and CLI surfaces. The adapter repacks the framework's
+#: ``RunContext``-first, keyword-only tool call onto this shape.
+_MetaToolHandler = Callable[[Operator, dict[str, Any]], Awaitable[dict[str, Any]]]
+
+
+class MetaToolSpec:
+    """One meta-tool's agent-facing wiring: handler + schema + role floor.
+
+    The agent front-end's source of truth for *its* tool surface, parallel
+    to the MCP front-end's :func:`~meho_backplane.mcp.registry.register_mcp_tool`
+    registrations in :mod:`meho_backplane.mcp.tools.operations`. Both adapt
+    the same handlers in :mod:`meho_backplane.operations.meta_tools`; neither
+    is a wrapper around the other (the CLAUDE.md dual-front-end contract).
+
+    Fields:
+
+    * ``name`` — the tool name the model sees (matches the MCP tool name so
+      a definition author's allow-list reads identically across surfaces).
+    * ``handler`` — the ``(operator, arguments) -> dict`` meta-tool handler.
+    * ``description`` — the model-facing prompt for *when* to call the tool.
+    * ``parameter_schema`` — JSON Schema 2020-12 for the tool's arguments;
+      the framework advertises it to the model. The dispatcher re-validates
+      ``call_operation`` params against the descriptor's own
+      ``parameter_schema`` (defence in depth — the agent-tool schema only
+      shapes the meta-tool *arguments*, not the per-op params).
+    * ``required_role`` — the :class:`TenantRole` floor; the identity must
+      meet it (via :func:`role_at_least`) for the tool to register.
+    """
+
+    __slots__ = ("description", "handler", "name", "parameter_schema", "required_role")
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        handler: _MetaToolHandler,
+        description: str,
+        parameter_schema: dict[str, Any],
+        required_role: TenantRole,
+    ) -> None:
+        self.name = name
+        self.handler = handler
+        self.description = description
+        self.parameter_schema = parameter_schema
+        self.required_role = required_role
+
+
+#: Argument key on the ``call_operation`` meta-tool that names the connector
+#: the dispatch targets. Lifted to a constant so the connector allow-list
+#: check and the schema stay in lock-step.
+_CONNECTOR_ID_ARG = "connector_id"
+
+
+#: The agent meta-tool catalog. Three meta-tools form the agent's working
+#: surface over the G0.6 substrate (CLAUDE.md "the load-bearing pattern":
+#: pick connector → list operation groups → search operations → call). The
+#: parameter schemas mirror the canonical MCP ``inputSchema`` fragments in
+#: :mod:`meho_backplane.mcp.tools.operations`; the descriptions are the
+#: model's prompt for when to reach for each tool.
+_META_TOOL_CATALOG: tuple[MetaToolSpec, ...] = (
+    MetaToolSpec(
+        name="list_operation_groups",
+        handler=list_operation_groups,
+        description=(
+            "List a connector's enabled operation groups so you can scope a "
+            "later operation search. Call this FIRST when you don't yet know "
+            "which operation to invoke: it narrows hundreds of operations to "
+            "a handful of relevant groups, each with a `when_to_use` blurb. "
+            "Argument: `connector_id` in `<impl_id>-<version>` form (e.g. "
+            '"vmware-rest-9.0", "vault-1.x") — not the bare product name.'
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "connector_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "Connector identifier in `<impl_id>-<version>` form "
+                        '(e.g. "vmware-rest-9.0", "vault-1.x").'
+                    ),
+                },
+            },
+            "required": ["connector_id"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.OPERATOR,
+    ),
+    MetaToolSpec(
+        name="search_operations",
+        handler=search_operations,
+        description=(
+            "Hybrid lexical + semantic search over a connector's enabled "
+            "operations. Use this AFTER `list_operation_groups` has narrowed "
+            "the surface to one group, or directly when the query is specific "
+            "enough. Returns ranked operations; inspect each hit's "
+            "`safety_level` and `requires_approval` before calling it. "
+            "Arguments: `connector_id` (required), `query` (required, "
+            "free-form), `group` (optional group_key), `limit` (default 10, "
+            "max 50)."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "connector_id": {"type": "string", "minLength": 1},
+                "query": {"type": "string", "minLength": 1},
+                "group": {"type": ["string", "null"]},
+                "limit": {"type": "integer", "minimum": 1, "maximum": 50, "default": 10},
+            },
+            "required": ["connector_id", "query"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.OPERATOR,
+    ),
+    MetaToolSpec(
+        name="call_operation",
+        handler=call_operation,
+        description=(
+            "Invoke an operation through MEHO's governed dispatch path. Use "
+            "ONLY after `search_operations` returned an `op_id` you've "
+            "confirmed is appropriate (check `safety_level` and "
+            "`requires_approval`). The dispatcher validates `params` against "
+            "the operation's parameter schema and returns either the result "
+            '(`status="ok"`) or a structured error in the same envelope. '
+            "Arguments: `connector_id` (required), `op_id` (required), "
+            '`target` (optional `{"name": "<slug>"}` for ops acting on a '
+            "managed target), `params` (operation-specific)."
+        ),
+        parameter_schema={
+            "type": "object",
+            "properties": {
+                "connector_id": {"type": "string", "minLength": 1},
+                "op_id": {"type": "string", "minLength": 1},
+                "target": {
+                    "type": ["object", "null"],
+                    "properties": {
+                        "name": {"type": "string", "minLength": 1},
+                        "fqdn": {"type": "string", "minLength": 1},
+                    },
+                },
+                "params": {"type": "object"},
+            },
+            "required": ["connector_id", "op_id"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.OPERATOR,
+    ),
+)
+
+#: The set of meta-tool names the agent surface knows about. Public so a
+#: toolset spec validator (or a test) can check an allow-list against the
+#: real catalog without importing the catalog tuple itself.
+META_TOOL_NAMES: frozenset[str] = frozenset(spec.name for spec in _META_TOOL_CATALOG)
+
+
+def _extract_str_list(spec: dict[str, Any], key: str) -> list[str] | None:
+    """Return *spec[key]* as a list of strings, or ``None`` if absent.
+
+    A missing key (or an explicit ``null``) returns ``None`` — the "no
+    restriction" sentinel both ``meta_tools`` and ``connectors`` use. A
+    present-but-non-list value, or a list with a non-string element, raises
+    :class:`ValueError`: a mis-shaped spec is a definition-authoring bug that
+    should fail loud at resolution time, not silently widen or narrow the
+    agent's surface.
+    """
+    if key not in spec or spec[key] is None:
+        return None
+    value = spec[key]
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(
+            f"toolset spec field {key!r} must be a list of strings when present; "
+            f"got {type(value).__name__}"
+        )
+    return value
+
+
+def _make_meta_tool(
+    meta: MetaToolSpec,
+    *,
+    allowed_connectors: frozenset[str] | None,
+) -> Tool[Operator]:
+    """Build one :class:`pydantic_ai.Tool` wrapping *meta*'s handler.
+
+    The wrapper adapts the framework's ``RunContext``-first, keyword-only
+    tool call onto the ``(operator, arguments) -> dict`` handler shape: the
+    operator comes from ``ctx.deps`` (so dispatch-time RBAC + audit + the
+    sanitizing reducer all see the run's real principal), and the validated
+    keyword arguments are repacked into the ``arguments`` dict the handler
+    reads.
+
+    For ``call_operation`` with a connector allow-list, the wrapper performs
+    a pre-dispatch connector check and raises :class:`ModelRetry` — an
+    agent-reasonable structured error, not a crash — when the requested
+    connector is outside the spec's ``connectors`` list. Every other path
+    (and every other meta-tool) flows straight through to the handler.
+    """
+
+    handler = meta.handler
+    is_call_operation = meta.name == "call_operation"
+
+    async def _tool(ctx: RunContext[Operator], **arguments: Any) -> dict[str, Any]:
+        if is_call_operation and allowed_connectors is not None:
+            connector_id = arguments.get(_CONNECTOR_ID_ARG)
+            if connector_id not in allowed_connectors:
+                # Mirror the dispatcher's `denied` envelope shape but raise
+                # it as a ModelRetry so the model receives a tool-level
+                # retry prompt it can reason about (pick an allowed
+                # connector) rather than a tool-execution crash.
+                _log.info(
+                    "agent_tool_connector_denied",
+                    connector_id=connector_id,
+                    operator_sub=ctx.deps.sub,
+                    tenant_id=str(ctx.deps.tenant_id),
+                )
+                raise ModelRetry(
+                    f"connector_id {connector_id!r} is not in this agent's "
+                    f"allowed connectors {sorted(allowed_connectors)!r}. Pick "
+                    f"an allowed connector or stop."
+                )
+        return await handler(ctx.deps, dict(arguments))
+
+    return Tool.from_schema(
+        _tool,
+        name=meta.name,
+        description=meta.description,
+        json_schema=meta.parameter_schema,
+        takes_ctx=True,
+    )
+
+
+def resolve_agent_tools(
+    toolset: dict[str, Any] | None,
+    operator: Operator,
+) -> list[Tool[Operator]]:
+    """Resolve the toolset spec ∩ identity permissions into Pydantic AI tools.
+
+    Returns the list of :class:`pydantic_ai.Tool` objects to register on the
+    loop's :class:`~pydantic_ai.Agent`. The set is the intersection of:
+
+    * the spec's ``meta_tools`` allow-list (or all meta-tools when omitted),
+      and
+    * the meta-tools the *operator*'s role admits (via
+      :func:`~meho_backplane.mcp.registry.role_at_least`).
+
+    A meta-tool failing either side is absent from the result — the
+    least-privilege default. A meta-tool name in the spec that the catalog
+    does not know is ignored with a warning (forward-compat: an allow-list
+    may name a tool a newer runtime ships; an older runtime simply can't
+    register it).
+
+    The spec's ``connectors`` allow-list (when present) is threaded into the
+    ``call_operation`` tool so a dispatch to a connector outside the list is
+    rejected with a structured, agent-reasonable error before it reaches the
+    dispatcher.
+
+    Args:
+        toolset: the definition's toolset spec (``AgentDefinition.toolset``),
+            or ``None`` for the default surface. See the module docstring for
+            the shape.
+        operator: the run's principal; its ``tenant_role`` is the identity
+            permission the meta-tool floors are intersected against.
+
+    Returns:
+        The meta-tools to register, in catalog order.
+
+    Raises:
+        ValueError: when ``meta_tools`` or ``connectors`` is present but not
+            a list of strings.
+    """
+    spec = toolset or {}
+    requested_names = _extract_str_list(spec, "meta_tools")
+    connectors = _extract_str_list(spec, "connectors")
+    allowed_connectors = frozenset(connectors) if connectors is not None else None
+
+    # An unknown name in the spec is forward-compat noise, not an error;
+    # log it once so a definition author sees the typo / version gap.
+    if requested_names is not None:
+        for name in requested_names:
+            if name not in META_TOOL_NAMES:
+                _log.warning(
+                    "agent_toolset_unknown_meta_tool",
+                    meta_tool=name,
+                    known=sorted(META_TOOL_NAMES),
+                )
+
+    tools: list[Tool[Operator]] = []
+    for meta in _META_TOOL_CATALOG:
+        # Side 1 — toolset spec: omitted allow-list means "all"; a present
+        # list must contain the name.
+        if requested_names is not None and meta.name not in requested_names:
+            continue
+        # Side 2 — identity permissions: the role must meet the tool's floor.
+        # A tool the identity can't call is simply not registered.
+        if not role_at_least(operator.tenant_role, meta.required_role):
+            continue
+        tools.append(_make_meta_tool(meta, allowed_connectors=allowed_connectors))
+
+    connector_allow_list = sorted(allowed_connectors) if allowed_connectors is not None else None
+    _log.info(
+        "agent_toolset_resolved",
+        operator_sub=operator.sub,
+        tenant_id=str(operator.tenant_id),
+        tenant_role=operator.tenant_role.value,
+        registered=[t.name for t in tools],
+        connector_allow_list=connector_allow_list,
+    )
+    return tools

--- a/backend/tests/test_agent_run.py
+++ b/backend/tests/test_agent_run.py
@@ -385,3 +385,127 @@ async def test_default_model_factory_fail_closed_without_key(
             default_model_factory()
     finally:
         get_settings.cache_clear()
+
+
+async def test_toolset_definition_drives_resolved_call_operation(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A definition with a toolset spec runs the resolved ``call_operation`` end to end.
+
+    Proves T3 (#810) integrates into the live seam: the loop registers the
+    toolset-resolved tools (here just ``call_operation``) and dispatches a
+    seeded op under the run's operator — the same dispatch path REST + MCP
+    use (#810 ACs 1 + 2).
+    """
+    await _seed_echo_op(stub_embedding_service)
+    _seen_operator_subs.clear()
+
+    # The resolved meta-tool is named ``call_operation`` (matching the MCP
+    # surface), not the T1 hand-wired ``call_operation_tool``; call it once
+    # then finish.
+    def call_op_then_done(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        has_tool_return = any(
+            part.part_kind == "tool-return"
+            for message in messages
+            if isinstance(message, ModelRequest)
+            for part in message.parts
+        )
+        if not has_tool_return:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        "call_operation",
+                        {
+                            "connector_id": "vault-1.x",
+                            "op_id": "vault.kv.read",
+                            "params": {"path": "secret/foo"},
+                        },
+                    )
+                ]
+            )
+        return ModelResponse(parts=[TextPart("done via toolset")])
+
+    model = FunctionModel(call_op_then_done)
+    runtime = PydanticAgentRun(model_factory=lambda: model)
+    definition = AgentDefinition(
+        name="scoped-reader",
+        system_prompt="read via the scoped toolset",
+        request_limit=5,
+        toolset={"meta_tools": ["call_operation"], "connectors": ["vault-1.x"]},
+    )
+
+    operator = _make_operator(sub="op-toolset-principal")
+    handle = runtime.start(definition, operator, "read secret/foo")
+    result = await runtime.result(handle)
+
+    assert runtime.poll(handle) is AgentRunStatus.SUCCEEDED
+    assert result.output == "done via toolset"
+    assert result.tool_call_count == 1
+    # The operator threaded through the resolved tool to the dispatch handler.
+    assert _seen_operator_subs == ["op-toolset-principal"]
+
+
+async def test_toolset_omitting_call_operation_makes_it_absent_from_surface(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A meta-tool omitted from the toolset spec is not on the model's surface.
+
+    The intersection means the model literally cannot see / call a tool the
+    spec excluded. The ``FunctionModel`` callback inspects ``info.function_tools``
+    to assert ``call_operation`` is absent when the spec lists only
+    ``list_operation_groups`` (#810 AC 1: disallowed ops are absent).
+    """
+    await _seed_echo_op(stub_embedding_service)
+    captured: dict[str, list[str]] = {}
+
+    def inspect_surface(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        captured["tool_names"] = sorted(td.name for td in info.function_tools)
+        return ModelResponse(parts=[TextPart("inspected")])
+
+    model = FunctionModel(inspect_surface)
+    runtime = PydanticAgentRun(model_factory=lambda: model)
+    definition = AgentDefinition(
+        name="discovery-only",
+        system_prompt="discover only",
+        request_limit=3,
+        toolset={"meta_tools": ["list_operation_groups"]},
+    )
+
+    handle = runtime.start(definition, _make_operator(), "what groups exist?")
+    await runtime.result(handle)
+
+    assert captured["tool_names"] == ["list_operation_groups"]
+    assert "call_operation" not in captured["tool_names"]
+
+
+async def test_read_only_identity_gets_no_tools_in_loop(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A read_only identity ranks below every meta-tool floor -> empty surface.
+
+    The seam-level mirror of the unit intersection test: even with all
+    meta-tools listed in the spec, a ``read_only`` operator's loop registers
+    no tools, so the agent cannot dispatch anything (#810 AC: an op outside
+    the identity's perms is not callable).
+    """
+    await _seed_echo_op(stub_embedding_service)
+    captured: dict[str, list[str]] = {}
+
+    def inspect_surface(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        captured["tool_names"] = sorted(td.name for td in info.function_tools)
+        return ModelResponse(parts=[TextPart("no tools for me")])
+
+    model = FunctionModel(inspect_surface)
+    runtime = PydanticAgentRun(model_factory=lambda: model)
+    definition = AgentDefinition(
+        name="read-only-agent",
+        system_prompt="read only",
+        request_limit=3,
+        toolset={"meta_tools": ["list_operation_groups", "search_operations", "call_operation"]},
+    )
+
+    read_only = _make_operator(role=TenantRole.READ_ONLY, sub="op-ro")
+    handle = runtime.start(definition, read_only, "do something")
+    await runtime.result(handle)
+
+    assert captured["tool_names"] == []

--- a/backend/tests/test_agent_toolset.py
+++ b/backend/tests/test_agent_toolset.py
@@ -1,0 +1,353 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for toolset resolution + the handler-to-agent-tool adapter (G11.1-T3 / #810).
+
+The adapter turns an agent definition's toolset spec plus the run's identity
+into the concrete Pydantic AI tools the loop registers. The #810 acceptance
+criteria map onto the tests here as:
+
+* ``test_default_registers_all_meta_tools`` / ``test_meta_tools_allow_list_*``
+  — the registered set is exactly toolset ∩ identity perms; disallowed tools
+  are absent.
+* ``test_read_only_role_excludes_operator_floor_tools`` — **the intersection
+  test**: an identity whose role is below a tool's floor cannot call that
+  tool (it is not registered), even when the spec lists it.
+* ``test_wrapped_tool_threads_operator_to_handler`` — each tool call routes
+  the run's operator through the handler (so dispatch RBAC + audit + the
+  sanitizing reducer fire identically to REST / MCP).
+* ``test_tool_input_schema_reflects_meta_tool_schema`` — tool input schemas
+  reflect the meta-tool parameter schemas the model is advertised.
+* ``test_connector_not_in_allow_list_raises_model_retry`` — a denied
+  connector returns a structured, agent-reasonable error (ModelRetry), not a
+  crash.
+
+The wrapped handlers are stubbed so these tests stay offline (no DB, no
+network): the adapter's contract is *which* tools register and *how* they
+thread the operator, not what the handlers do once called.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+import pytest
+from pydantic_ai import ModelRetry, RunContext
+
+import meho_backplane.agent.toolset as toolset_mod
+from meho_backplane.agent.toolset import (
+    META_TOOL_NAMES,
+    resolve_agent_tools,
+)
+from meho_backplane.auth.operator import Operator, TenantRole
+
+_TENANT_A = UUID("11111111-1111-1111-1111-111111111111")
+
+
+def _make_operator(
+    *,
+    role: TenantRole = TenantRole.OPERATOR,
+    sub: str = "op-agent",
+) -> Operator:
+    return Operator(
+        sub=sub,
+        name="Agent Operator",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT_A,
+        tenant_role=role,
+    )
+
+
+def _tool_names(tools: list[Any]) -> set[str]:
+    return {t.name for t in tools}
+
+
+# ---------------------------------------------------------------------------
+# Side 1 of the intersection — the toolset spec allow-list
+# ---------------------------------------------------------------------------
+
+
+def test_default_registers_all_meta_tools() -> None:
+    """A ``None`` toolset spec registers every meta-tool the role admits."""
+    tools = resolve_agent_tools(None, _make_operator())
+    assert _tool_names(tools) == set(META_TOOL_NAMES)
+
+
+def test_empty_spec_dict_registers_all_meta_tools() -> None:
+    """An empty spec dict (no ``meta_tools`` key) means 'all role admits'.
+
+    Distinct from a spec with ``meta_tools: []`` — an *omitted* allow-list is
+    the 'no restriction' sentinel, an empty list is 'restrict to nothing'.
+    """
+    tools = resolve_agent_tools({}, _make_operator())
+    assert _tool_names(tools) == set(META_TOOL_NAMES)
+
+
+def test_meta_tools_allow_list_registers_only_listed() -> None:
+    """A ``meta_tools`` allow-list registers exactly the listed tools."""
+    spec = {"meta_tools": ["list_operation_groups", "call_operation"]}
+    tools = resolve_agent_tools(spec, _make_operator())
+    assert _tool_names(tools) == {"list_operation_groups", "call_operation"}
+    assert "search_operations" not in _tool_names(tools)
+
+
+def test_empty_meta_tools_list_registers_nothing() -> None:
+    """``meta_tools: []`` registers no tools (restrict-to-nothing)."""
+    tools = resolve_agent_tools({"meta_tools": []}, _make_operator())
+    assert tools == []
+
+
+def test_unknown_meta_tool_name_is_ignored() -> None:
+    """An unknown name in the allow-list is forward-compat noise, not a crash."""
+    spec = {"meta_tools": ["call_operation", "some_future_tool"]}
+    tools = resolve_agent_tools(spec, _make_operator())
+    assert _tool_names(tools) == {"call_operation"}
+
+
+# ---------------------------------------------------------------------------
+# Side 2 of the intersection — identity permissions (THE intersection test)
+# ---------------------------------------------------------------------------
+
+
+def test_read_only_role_excludes_operator_floor_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An op outside the identity's perms is NOT callable (#810 AC).
+
+    The three meta-tools carry an ``OPERATOR`` floor; a ``read_only``
+    identity ranks below it, so even with every tool explicitly listed in the
+    spec, none register — the intersection (spec ∩ identity perms) is empty.
+    To prove the gate is *role-driven* (not a blanket 'read_only gets
+    nothing'), one catalog entry is patched down to a ``READ_ONLY`` floor and
+    must then register for the same identity.
+    """
+    spec = {"meta_tools": list(META_TOOL_NAMES)}
+    read_only = _make_operator(role=TenantRole.READ_ONLY, sub="op-read-only")
+
+    # Every catalog tool floors at OPERATOR -> read_only sees nothing.
+    assert resolve_agent_tools(spec, read_only) == []
+
+    # An OPERATOR identity, same spec -> full surface (the tools ARE callable
+    # for a role that meets the floor).
+    operator_tools = resolve_agent_tools(spec, _make_operator())
+    assert _tool_names(operator_tools) == set(META_TOOL_NAMES)
+
+    # Drop one tool's floor to READ_ONLY and confirm it now registers for the
+    # read_only identity — proving the gate keys off the role, not the tool.
+    patched = tuple(
+        toolset_mod.MetaToolSpec(
+            name=m.name,
+            handler=m.handler,
+            description=m.description,
+            parameter_schema=m.parameter_schema,
+            required_role=(
+                TenantRole.READ_ONLY if m.name == "list_operation_groups" else m.required_role
+            ),
+        )
+        for m in toolset_mod._META_TOOL_CATALOG
+    )
+    monkeypatch.setattr(toolset_mod, "_META_TOOL_CATALOG", patched)
+    relaxed_tools = resolve_agent_tools(spec, read_only)
+    assert _tool_names(relaxed_tools) == {"list_operation_groups"}
+
+
+def test_tenant_admin_sees_all_operator_floor_tools() -> None:
+    """A higher role (tenant_admin) admits every operator-floored tool."""
+    admin = _make_operator(role=TenantRole.TENANT_ADMIN, sub="op-admin")
+    tools = resolve_agent_tools(None, admin)
+    assert _tool_names(tools) == set(META_TOOL_NAMES)
+
+
+# ---------------------------------------------------------------------------
+# Adapter behaviour — operator threading, schema, structured denial
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wrapped_tool_threads_operator_to_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The wrapped tool passes the run's operator + repacked args to the handler."""
+    seen: dict[str, Any] = {}
+
+    async def fake_list_groups(operator: Operator, arguments: dict[str, Any]) -> dict[str, Any]:
+        seen["operator_sub"] = operator.sub
+        seen["arguments"] = arguments
+        return {"groups": []}
+
+    # Patch the catalog entry's handler so no DB is touched.
+    patched = tuple(
+        toolset_mod.MetaToolSpec(
+            name=m.name,
+            handler=(fake_list_groups if m.name == "list_operation_groups" else m.handler),
+            description=m.description,
+            parameter_schema=m.parameter_schema,
+            required_role=m.required_role,
+        )
+        for m in toolset_mod._META_TOOL_CATALOG
+    )
+    monkeypatch.setattr(toolset_mod, "_META_TOOL_CATALOG", patched)
+
+    operator = _make_operator(sub="op-distinct-principal")
+    tools = resolve_agent_tools({"meta_tools": ["list_operation_groups"]}, operator)
+    (tool,) = tools
+
+    ctx = _make_run_context(operator)
+    result = await tool.function(ctx, connector_id="vault-1.x")
+
+    assert result == {"groups": []}
+    assert seen["operator_sub"] == "op-distinct-principal"
+    assert seen["arguments"] == {"connector_id": "vault-1.x"}
+
+
+def test_tool_input_schema_reflects_meta_tool_schema() -> None:
+    """The registered tool's JSON schema reflects the meta-tool parameter schema."""
+    tools = resolve_agent_tools({"meta_tools": ["call_operation"]}, _make_operator())
+    (tool,) = tools
+    schema = tool.function_schema.json_schema
+    props = schema["properties"]
+    # call_operation's canonical arguments are present in the advertised schema.
+    assert set(schema["required"]) == {"connector_id", "op_id"}
+    assert "params" in props
+    assert "target" in props
+
+
+@pytest.mark.asyncio
+async def test_connector_not_in_allow_list_raises_model_retry() -> None:
+    """A connector outside the spec's allow-list yields a ModelRetry, not a crash."""
+    spec = {"meta_tools": ["call_operation"], "connectors": ["vault-1.x"]}
+    operator = _make_operator()
+    tools = resolve_agent_tools(spec, operator)
+    (tool,) = tools
+
+    ctx = _make_run_context(operator)
+    with pytest.raises(ModelRetry, match="not in this agent's allowed connectors"):
+        await tool.function(
+            ctx,
+            connector_id="vmware-rest-9.0",
+            op_id="GET:/api/vcenter/cluster",
+        )
+
+
+@pytest.mark.asyncio
+async def test_connector_in_allow_list_reaches_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A connector inside the allow-list flows through to the handler."""
+    seen: dict[str, Any] = {}
+
+    async def fake_call_operation(operator: Operator, arguments: dict[str, Any]) -> dict[str, Any]:
+        seen["connector_id"] = arguments["connector_id"]
+        return {"status": "ok", "op_id": arguments["op_id"]}
+
+    patched = tuple(
+        toolset_mod.MetaToolSpec(
+            name=m.name,
+            handler=(fake_call_operation if m.name == "call_operation" else m.handler),
+            description=m.description,
+            parameter_schema=m.parameter_schema,
+            required_role=m.required_role,
+        )
+        for m in toolset_mod._META_TOOL_CATALOG
+    )
+    monkeypatch.setattr(toolset_mod, "_META_TOOL_CATALOG", patched)
+
+    spec = {"meta_tools": ["call_operation"], "connectors": ["vault-1.x"]}
+    operator = _make_operator()
+    tools = resolve_agent_tools(spec, operator)
+    (tool,) = tools
+
+    ctx = _make_run_context(operator)
+    result = await tool.function(ctx, connector_id="vault-1.x", op_id="vault.kv.read")
+    assert result == {"status": "ok", "op_id": "vault.kv.read"}
+    assert seen["connector_id"] == "vault-1.x"
+
+
+def test_empty_connectors_list_forbids_all_connectors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``connectors: []`` registers call_operation but forbids every dispatch."""
+
+    async def _never(operator: Operator, arguments: dict[str, Any]) -> dict[str, Any]:
+        raise AssertionError("handler must not be reached when connector is denied")
+
+    patched = tuple(
+        toolset_mod.MetaToolSpec(
+            name=m.name,
+            handler=(_never if m.name == "call_operation" else m.handler),
+            description=m.description,
+            parameter_schema=m.parameter_schema,
+            required_role=m.required_role,
+        )
+        for m in toolset_mod._META_TOOL_CATALOG
+    )
+    monkeypatch.setattr(toolset_mod, "_META_TOOL_CATALOG", patched)
+
+    spec: dict[str, Any] = {"meta_tools": ["call_operation"], "connectors": []}
+    operator = _make_operator()
+    tools = resolve_agent_tools(spec, operator)
+    assert _tool_names(tools) == {"call_operation"}
+
+    import asyncio
+
+    ctx = _make_run_context(operator)
+    (tool,) = tools
+    with pytest.raises(ModelRetry):
+        asyncio.run(tool.function(ctx, connector_id="vault-1.x", op_id="vault.kv.read"))
+
+
+# ---------------------------------------------------------------------------
+# Spec validation
+# ---------------------------------------------------------------------------
+
+
+def test_mis_shaped_meta_tools_raises() -> None:
+    """A non-list ``meta_tools`` is a definition-authoring bug -> ValueError."""
+    with pytest.raises(ValueError, match="meta_tools"):
+        resolve_agent_tools({"meta_tools": "call_operation"}, _make_operator())
+
+
+def test_mis_shaped_connectors_raises() -> None:
+    """A non-list ``connectors`` is a definition-authoring bug -> ValueError."""
+    with pytest.raises(ValueError, match="connectors"):
+        resolve_agent_tools({"connectors": {"vault-1.x": True}}, _make_operator())
+
+
+def test_unknown_spec_keys_are_ignored() -> None:
+    """An unrecognised spec key is forward-compat tolerated, not rejected."""
+    spec = {"meta_tools": ["call_operation"], "future_field": {"x": 1}}
+    tools = resolve_agent_tools(spec, _make_operator())
+    assert _tool_names(tools) == {"call_operation"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_run_context(operator: Operator) -> RunContext[Operator]:
+    """Build a minimal RunContext carrying *operator* as deps.
+
+    The wrapped tool only reads ``ctx.deps``; the rest of the RunContext is
+    framework plumbing the adapter never touches, so a constructed context
+    with the deps set is sufficient to exercise the wrapper directly without
+    a full model run.
+    """
+    from pydantic_ai.usage import RunUsage
+
+    return RunContext(deps=operator, model=_StubModel(), usage=RunUsage())
+
+
+class _StubModel:
+    """A stand-in model object for constructing a RunContext in unit tests.
+
+    ``RunContext`` requires a ``model`` argument but the adapter never reads
+    it; only ``system`` / ``model_name`` attributes are accessed by the
+    framework's repr, so a tiny stub avoids constructing a real provider
+    client.
+    """
+
+    system = "test"
+    model_name = "stub"

--- a/docs/codebase/agent-runtime.md
+++ b/docs/codebase/agent-runtime.md
@@ -14,9 +14,9 @@ run-handle store, and audit wiring remain MEHO's. Nothing outside
 `meho_backplane.agent` imports `pydantic_ai`.
 
 This document describes the G11.1-T1 foundation (the seam + one bounded
-loop). Later G11.1 tasks build on it: agent-definition persistence (T2),
-toolset resolution (T3), the public sync/async invocation surface (T4),
-agent-invokes-agent composition (T5), and durable run records (T6).
+loop) and the G11.1-T3 toolset resolution layered on it. Other G11.1 tasks:
+agent-definition persistence (T2), the public sync/async invocation surface
+(T4), agent-invokes-agent composition (T5), and durable run records (T6).
 
 ## Key types
 
@@ -25,9 +25,16 @@ All public types are re-exported from `meho_backplane.agent`
 
 - **`AgentDefinition`** — frozen Pydantic model holding the static shape of
   one run: `name`, `system_prompt`, `request_limit` (the turn budget),
-  optional `model` id override, and optional `output_type` (a Pydantic
-  model class for structured output). T2 will materialise persisted rows
-  into this shape.
+  optional `model` id override, optional `output_type` (a Pydantic model
+  class for structured output), and optional `toolset` (the spec
+  `resolve_agent_tools` intersects with the run's identity; `None` selects
+  the default two-meta-tool surface). T2 materialises persisted rows into
+  this shape.
+- **`resolve_agent_tools` / `MetaToolSpec` / `META_TOOL_NAMES`** (in
+  `agent/toolset.py`) — the toolset resolver + handler-to-agent-tool adapter.
+  `resolve_agent_tools(toolset, operator)` returns the `pydantic_ai.Tool`
+  list to register: (spec allow-list) ∩ (meta-tools the operator's role
+  admits). See "Tools" below.
 - **`AgentRun`** — the runtime-checkable Protocol every consumer depends
   on: `start(definition, operator, inputs) -> AgentRunHandle`,
   `poll(handle) -> AgentRunStatus`, `result(handle) -> AgentRunResult`,
@@ -57,8 +64,10 @@ All public types are re-exported from `meho_backplane.agent`
 1. A caller constructs an `AgentDefinition` and a `PydanticAgentRun`
    (injecting a `ModelFactory`; the default builds a real Anthropic model).
 2. `start(definition, operator, inputs)` builds a framework `Agent` from the
-   definition, wires the meta-tools, and launches the bounded loop as an
-   `asyncio.Task`. It returns immediately with an `AgentRunHandle`.
+   definition, resolves its tools (`resolve_agent_tools` when the definition
+   carries a `toolset`, else the default two meta-tools), and launches the
+   bounded loop as an `asyncio.Task`. It returns immediately with an
+   `AgentRunHandle`.
 3. The loop runs: the model emits tool calls, each tool dispatches through
    `call_operation` / `list_operation_groups` under the injected operator,
    tool results return to the model, and the loop repeats until the model
@@ -77,19 +86,68 @@ audit see the real principal.
 
 ## Tools
 
-For T1 the loop is wired with exactly two existing MEHO meta-tools, adapted
-from their `(operator, arguments) -> dict` handler shape onto the
-framework's `RunContext`-first tool signature in `_register_meta_tools`:
+The loop's tools are MEHO's own meta-tools, adapted from their
+`(operator, arguments) -> dict` handler shape onto the framework's
+`RunContext`-first tool signature. The handler *is* the dispatch path REST +
+MCP use; the agent gets no vendor-specific surface (CLAUDE.md postulate 5 —
+the agent never sees `vsphere.vm.list`; it reaches every connector op
+*through* `call_operation`).
 
-- `call_operation_tool` → `meta_tools.call_operation` (execution)
-- `list_operation_groups_tool` → `meta_tools.list_operation_groups`
-  (discovery)
+### Toolset resolution (T3 #810)
 
-The handler *is* the dispatch path REST + MCP use; the agent gets no
-special surface. The handler docstrings double as the model-facing tool
-descriptions. T3 (#810) replaces this hand-wiring with toolset resolution
-that registers the agent identity's full permitted surface (toolset ∩
-identity permissions).
+Which meta-tools register is decided by `resolve_agent_tools` in
+`meho_backplane/agent/toolset.py`, given the definition's `toolset` spec and
+the run's operator. The registered set is the **intersection** of:
+
+- **toolset spec** — the definition author's allow-list (`AgentDefinition.toolset`).
+- **identity permissions** — what the run's identity may call. The G11.2
+  per-op permission *model* is not built yet; the permission an identity
+  carries today is its `TenantRole`, gated by `role_at_least` exactly as the
+  MCP and REST surfaces gate it. Each meta-tool declares a role floor; an
+  identity below the floor does not get the tool. This Task *consumes* that
+  gate, it does not invent a new one.
+
+A meta-tool failing either side is **not registered** — it is absent from the
+agent's tool surface, so the model cannot attempt it (least-privilege:
+the safest tool is one that does not exist on the surface).
+
+The `PydanticAgentRun` seam routes through the resolver when the definition
+carries a `toolset` (passing the resolved `Tool` objects via the framework's
+`tools=` constructor argument). A definition with `toolset is None` falls
+back to `_register_default_meta_tools` — the original two hand-wired
+meta-tools (`call_operation` + `list_operation_groups`) — so a definition
+constructed without a toolset still runs.
+
+### Toolset spec shape
+
+JSON-shaped (so it can grow without a migration):
+
+```json
+{
+  "meta_tools": ["list_operation_groups", "search_operations", "call_operation"],
+  "connectors": ["vmware-rest-9.0", "vault-1.x"]
+}
+```
+
+- `meta_tools` — allow-list of meta-tool names. Omitted / `null` means "all
+  meta-tools the role admits"; `[]` registers nothing. The catalog of known
+  meta-tools is `META_TOOL_NAMES`; an unknown name in the list is ignored
+  with a warning (forward-compat).
+- `connectors` — optional allow-list of `connector_id` values the agent may
+  reach through `call_operation`. Omitted / `null` means "no connector-level
+  restriction beyond what dispatch already enforces" (the tenant boundary +
+  per-op RBAC still apply); `[]` forbids every connector. A `call_operation`
+  to a connector outside the list is rejected with a `ModelRetry` — a
+  structured, agent-reasonable error the model can recover from, not a crash.
+  This keeps the "connector-ops ∩ identity permissions" intersection honest
+  without putting vendor identifiers in tool names (postulate 5). Per-op RBAC
+  + tenant scoping + audit + sanitization still fire unchanged inside
+  `dispatch`; the agent layer adds connector-level scoping on top.
+
+The adapter (`MetaToolSpec` catalog) is the agent front-end's source of truth
+for *its* tool surface, parallel to the MCP front-end's `register_mcp_tool`
+registrations — both adapt the same `meta_tools` handlers; neither wraps the
+other.
 
 ## Dependencies
 
@@ -100,10 +158,14 @@ identity permissions).
   inside `default_model_factory` (lazy-imported, so processes that never run
   an agent against Anthropic do not load it).
 - **`meho_backplane.operations.meta_tools`** — `call_operation`,
-  `list_operation_groups`: the existing dispatch entry points the loop's
-  tools call.
-- **`meho_backplane.auth.operator.Operator`** — the principal injected as
-  the framework dependency.
+  `list_operation_groups`, `search_operations`: the existing dispatch entry
+  points the loop's tools call.
+- **`meho_backplane.mcp.registry.role_at_least`** — the role-rank comparison
+  the toolset resolver reuses for the identity-permission side of the
+  intersection (single-source with the MCP surface's RBAC filter).
+- **`meho_backplane.auth.operator.Operator` / `TenantRole`** — the principal
+  injected as the framework dependency, and the role gated against the
+  meta-tool floors.
 - **`meho_backplane.settings`** — `anthropic_api_key` (fail-closed: empty
   means the model factory raises) and `agent_default_model` (the pinned
   model id, never a `-latest` tag).
@@ -126,8 +188,15 @@ Foundation) is G11.5.
 - `backend/tests/test_agent_run.py` — unit tests against a deterministic
   `FunctionModel` (no network): the loop calls `call_operation` against a
   seeded typed op, the turn budget caps a runaway loop, `output_type` is
-  validated, the operator is threaded into tool calls, and the default
-  model factory fails closed without a key.
+  validated, the operator is threaded into tool calls, the default model
+  factory fails closed without a key, and (T3) a toolset-driven definition
+  registers the resolved tools, a meta-tool omitted from the spec is absent
+  from the model's surface, and a `read_only` identity gets an empty surface.
+- `backend/tests/test_agent_toolset.py` — unit tests for the resolver /
+  adapter directly (no model run): the spec ∩ identity-perms intersection
+  (including the read_only-floor exclusion), operator threading, tool input
+  schemas reflecting the meta-tool schemas, the connector allow-list yielding
+  a `ModelRetry`, and spec validation.
 - `backend/tests/integration/test_agent_run_anthropic.py` — opt-in
   real-Anthropic loop (skipped unless `ANTHROPIC_API_KEY` is set; marked
   `slow`). Proves the seam drives a live model that calls a real operation
@@ -141,13 +210,19 @@ Foundation) is G11.5.
   transport lives.
 - Run handles are in-memory `asyncio.Task`s. Durable `agent_run` records +
   a session-id lineage key + cancellation are T6 (#813).
-- The toolset is hand-wired to two meta-tools. Full toolset resolution is
-  T3 (#810).
+- The identity-permission side of the intersection is the tenant role today.
+  When the G11.2 per-op permission model lands, the resolver's role gate is
+  the seam to extend (or replace) with the real per-op grant check — the
+  intersection shape (spec ∩ identity perms) and the "absent, not denied"
+  posture stay the same.
 
 ## References
 
-- Goal #800 (G11 agentic ops runtime); Initiative #802 (G11.1); Task #808.
+- Goal #800 (G11 agentic ops runtime); Initiative #802 (G11.1); Tasks #808
+  (T1 seam), #810 (T3 toolset resolution).
 - Pydantic AI: agent concepts (`UsageLimits`, `run`, `deps`/`RunContext`,
-  `output_type`), Anthropic model + provider.
+  `output_type`), tool registration (`Tool.from_schema`, the `tools=`
+  constructor arg, `ModelRetry`), Anthropic model + provider.
 - Grounding: `operations/dispatcher.py` (`dispatch`), `operations/meta_tools.py`
-  (`call_operation`, `list_operation_groups`), `auth/operator.py`.
+  (`call_operation`, `list_operation_groups`, `search_operations`),
+  `mcp/registry.py` (`role_at_least`), `auth/operator.py`.


### PR DESCRIPTION
## Summary

- Adds the **toolset resolution + handler→agent-tool adapter** (G11.1-T3): given an agent definition's toolset spec + the run's identity, registers Pydantic AI tools for exactly the **intersection** of (toolset spec) ∩ (identity permissions). A tool the identity can't call is not registered (least-privilege: absent from the surface, not denied at runtime).
- Each registered tool wraps the existing `(operator, arguments) -> dict` meta-tool handler via `Tool.from_schema(takes_ctx=True)`, threading the run's `operator` from `RunContext.deps` so dispatch-time **RBAC + audit + sanitization fire unchanged** (the same path REST + MCP use). Tool input schemas derive from the meta-tool parameter schemas.
- The `PydanticAgentRun` seam routes through `resolve_agent_tools` when a definition carries a `toolset`; `toolset is None` keeps T1's default two-meta-tool fallback so the existing corpus still runs.

### A note on "connector-ops ∩ identity permissions"

The task names "meta-tools/connector-ops". CLAUDE.md postulate 5 is load-bearing: the agent never sees vendor-specific tools (no `vsphere.vm.list` in the tool list) — every connector op is reached *through* `call_operation`. So "connector-ops" is **not** "one Pydantic AI tool per connector op" (that would put vendor identifiers in tool names). Connector-op scoping instead rides on `call_operation`: the spec's optional `connectors` allow-list is checked before dispatch, and a connector outside it yields a structured `ModelRetry` the model can reason about, not a crash. Per-op RBAC + tenant scoping + audit + sanitization still fire unchanged inside `dispatch`; the agent layer adds connector-level scoping on top.

The G11.2 per-op permission *model* is out of scope (this consumes it). The identity permission an agent carries today is its `TenantRole`, gated by `mcp.registry.role_at_least` — the same gate the MCP + REST surfaces use. When G11.2 lands, the resolver's role gate is the seam to extend; the intersection shape and the "absent, not denied" posture stay.

## Test plan

- [x] `ruff check` (src + tests) — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/` — clean (280 source files)
- [x] `pytest tests/test_agent_run.py tests/test_agent_toolset.py` — 24 passed
- [x] Full unit suite (excl. integration/acceptance) — 4175 passed, 13 skipped
- [x] **Intersection asserted**: `test_read_only_role_excludes_operator_floor_tools` (unit) + `test_read_only_identity_gets_no_tools_in_loop` (seam) — an op outside the identity's perms is not callable; `test_toolset_omitting_call_operation_makes_it_absent_from_surface` — a disallowed meta-tool is absent from the model's surface
- [x] Operator threading: `test_wrapped_tool_threads_operator_to_handler` + `test_toolset_definition_drives_resolved_call_operation` (real loop dispatch)
- [x] Input schema reflects meta-tool schema: `test_tool_input_schema_reflects_meta_tool_schema`
- [x] Permission-denied is structured, not a crash: `test_connector_not_in_allow_list_raises_model_retry`

## Out of scope

- The G11.2 per-op permission model (this consumes the existing role gate).
- The invocation surface (T4 #811), composition (T5 #812), run records (T6 #813).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #810
