### PR TITLE
feat(ui): G10.1-T2 broadcast filters + event drawer + PII 🔒 viz

### DIFF
--- a/backend/src/meho_backplane/ui/routes/broadcast/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/broadcast/__init__.py
@@ -1,25 +1,33 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Broadcast UI routes: live feed page + session-gated SSE bridge.
+"""Broadcast UI routes: live feed page + SSE bridge + filters + drawer.
 
-Initiative #338 (G10.1 Activity broadcast UI), Task #867 (G10.1-T1).
-This subpackage ships the live activity feed surface the chassis stub
-(#866) placeholders for. Filters + the event-detail drawer + the PII
-visualisation land in T2 (#868); wall-monitor mode + the Last-24h
-replay tab land in T3 (#869).
+Initiative #338 (G10.1 Activity broadcast UI). Task #867 (G10.1-T1)
+shipped the live feed; Task #868 (G10.1-T2) adds the filter bar, the
+event-detail drawer, and the PII 🔒 visualisation. Wall-monitor mode +
+the Last-24h replay tab land in T3 (#869).
 
 Module layout:
 
 * :mod:`~meho_backplane.ui.routes.broadcast.feed` -- the
-  ``GET /ui/broadcast`` route. Renders the full-page live-feed view
-  (SSE wrapper + empty state + server-rendered event-row ``<template>``
-  + the Alpine 1000-row cap).
+  ``GET /ui/broadcast`` (full page) and ``GET /ui/broadcast/feed``
+  (filtered fragment) routes. The page renders the live-feed view (SSE
+  wrapper + filter bar + drawer slot + empty state + server-rendered
+  event-row ``<template>`` + the Alpine 1000-row cap); the fragment
+  route is the filter-submit target that re-renders the feed with the
+  active server-side filters baked into a fresh ``sse-connect`` URL.
 * :mod:`~meho_backplane.ui.routes.broadcast.stream` -- the
   ``GET /ui/broadcast/stream`` route. A UI-session-gated SSE source the
   feed view subscribes to; bridges the BFF session cookie to the
   tenant-scoped Valkey feed because the browser ``EventSource`` cannot
   send the Bearer header ``/api/v1/feed`` (G6.1-T4) requires.
+* :mod:`~meho_backplane.ui.routes.broadcast.event` -- the
+  ``GET /ui/broadcast/event/{audit_id}`` route. Renders the event
+  detail drawer fragment (full audit row payload + request_id +
+  audit_id + broadcast event_id) the feed rows open via ``hx-get``;
+  applies the same decision-#3 aggregate-only gate as the publisher so
+  a sensitive op never leaks its payload on click.
 
 The umbrella :func:`build_router` aggregates both. It is mounted
 **before** :func:`meho_backplane.ui.routes.stubs.build_stubs_router` in
@@ -35,6 +43,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from meho_backplane.ui.routes.broadcast.event import build_event_router
 from meho_backplane.ui.routes.broadcast.feed import build_feed_router
 from meho_backplane.ui.routes.broadcast.stream import build_stream_router
 
@@ -48,8 +57,17 @@ def build_router() -> APIRouter:
     construct multiple parallel routers without sharing route state --
     mirrors the chassis convention in
     :mod:`meho_backplane.ui.routes.topology`.
+
+    The feed router is included **before** the event router so the
+    literal ``/ui/broadcast/feed`` fragment path is matched ahead of
+    the parametrised ``/ui/broadcast/event/{audit_id}`` -- they share
+    no overlapping segment, but declaration order is the contract
+    FastAPI resolves on, so keeping the literal route first is the safe
+    discipline (mirrors the targets router's ``/discover`` ahead of
+    ``/{name}``).
     """
     router = APIRouter()
     router.include_router(build_feed_router())
     router.include_router(build_stream_router())
+    router.include_router(build_event_router())
     return router

--- a/backend/src/meho_backplane/ui/routes/broadcast/event.py
+++ b/backend/src/meho_backplane/ui/routes/broadcast/event.py
@@ -1,0 +1,266 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``GET /ui/broadcast/event/{audit_id}`` -- the event detail drawer.
+
+Initiative #338 (G10.1 Activity broadcast UI), Task #868 (G10.1-T2)
+work item #4. Renders the right-hand drawer the feed rows open via
+``hx-get`` / ``hx-target="#event-drawer"`` on a click. The drawer shows
+the **full audit row detail** behind a broadcast event:
+
+* the full request **payload** (``audit_log.payload``) -- but only when
+  the op is not a redacted/aggregate-only class (decision #3); a
+  ``credential_read`` / ``credential_mint`` / ``audit_query`` event
+  renders the 🔒 placeholder instead, never the raw payload,
+* the operation identity (``operator_sub``, ``method``, ``path``,
+  ``status_code``, ``occurred_at``, ``duration_ms``),
+* the ``request_id``, the ``audit_id`` (the row's own id), and the
+  broadcast ``event_id`` (passed through as a query param -- it is the
+  ephemeral Valkey-stream id, not a PG column).
+
+Why the path parameter is the audit id, not the broadcast event id
+==================================================================
+
+The broadcast ``event_id`` is generated per event and lives only on the
+ephemeral Valkey stream (``meho:feed:{tenant}``, MAXLEN-trimmed); it is
+**not** a column on any table. The canonical, queryable record of an
+operation is the ``audit_log`` row, keyed by ``audit_log.id`` -- which
+every :class:`~meho_backplane.broadcast.events.BroadcastEvent` carries
+as its ``audit_id`` field. The drawer's payload + ``request_id`` exist
+only on that row. So the drawer resolves by **audit id**: the feed row
+builder reads ``ev.audit_id`` for the path and passes ``ev.event_id``
+as the ``event_id`` query param purely for display. This is the only
+shape that can surface the full audit detail the work item requires; a
+route keyed on the ephemeral broadcast id would have nothing in PG to
+join against.
+
+Aggregate-only discipline (decision #3 / work item #7)
+======================================================
+
+The PII contract is enforced at *publish* time -- the broadcast event's
+payload is already redacted (:func:`redact_payload`). But the drawer
+reads the **audit_log** row, whose ``payload`` is the *unredacted*
+canonical record. Rendering that raw payload for a ``credential_read``
+op in the drawer would defeat decision #3 -- it would surface, on click,
+exactly the secret-bearing detail the feed row deliberately withholds.
+So the drawer reproduces the *same* aggregate-only decision the
+publisher made:
+
+* When the audit row carries ``payload["broadcast_detail_effective"]``
+  (the G6.3 resolver's recorded verdict -- ``"full"`` or
+  ``"aggregate"``), the drawer honours it verbatim. This is the
+  authoritative answer to "what detail did the feed actually show?",
+  including any per-tenant override that flipped a normally-sensitive op
+  to full detail.
+* Otherwise it falls back to classifying the op via :func:`classify_op`
+  and treating the sensitive classes
+  (:data:`AGGREGATE_ONLY_OP_CLASSES`) as aggregate-only.
+
+The op id is recovered from ``payload["op_id"]`` when present (the
+audit-middleware stamps it for connector-style routes), falling back to
+the publisher's own chassis-route heuristic ``http.{method}:{path}`` so
+the classification matches what the broadcast publisher computed
+byte-for-byte. An unknown op classifies ``other`` (full detail) only
+when it is genuinely a non-sensitive request.
+
+Tenant scoping
+==============
+
+The audit row is resolved with ``audit_log.tenant_id =
+session.tenant_id`` as the first ``WHERE`` predicate, so an id belonging
+to another tenant returns the same 404 fragment as a non-existent id --
+the boundary is opaque, never leaked. There is no tenant query
+parameter.
+
+The route is HTMX-only by design (no full-page render): the drawer is
+meaningful only beside the feed. A direct browser nav returns the bare
+fragment with no ``base.html`` chrome.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.broadcast import classify_op
+from meho_backplane.db.engine import get_raw_session
+from meho_backplane.db.models import AuditLog
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["AGGREGATE_ONLY_OP_CLASSES", "build_event_router"]
+
+#: Op classes whose detail is withheld from the broadcast surface per
+#: decision #3 -- the same classes :func:`redact_payload` strips at
+#: publish time. The drawer never renders the audit row's raw payload
+#: for these; it shows the 🔒 aggregate-only placeholder instead. Kept
+#: in sync with the redaction contract in
+#: :mod:`meho_backplane.broadcast.events`.
+AGGREGATE_ONLY_OP_CLASSES: frozenset[str] = frozenset(
+    {"credential_read", "credential_mint", "audit_query"}
+)
+
+#: Audit-only payload keys the drawer hides from the rendered request
+#: payload. ``op_id`` / ``op_class`` are the route-bound classification
+#: hints surfaced as first-class drawer fields, not request params;
+#: ``broadcast_detail_origin`` / ``broadcast_detail_effective`` are the
+#: G6.3 resolver's internal forensic metadata (``tenant_rule:<uuid>``
+#: origins are deliberately never shown to broadcast subscribers). The
+#: drawer renders the *request* payload, so these are stripped before
+#: the ``| tojson`` dump.
+_INTERNAL_PAYLOAD_KEYS: frozenset[str] = frozenset(
+    {"op_id", "op_class", "broadcast_detail_origin", "broadcast_detail_effective"}
+)
+
+
+async def _fetch_audit_row(
+    db_session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    audit_id: uuid.UUID,
+) -> AuditLog | None:
+    """Resolve ``(tenant_id, audit_id)`` to an ``audit_log`` row.
+
+    Returns ``None`` when no row matches. A cross-tenant id surfaces
+    identically -- the tenant boundary is opaque, mirroring the
+    topology drawer's ``_fetch_node`` contract.
+    """
+    stmt = select(AuditLog).where(
+        AuditLog.tenant_id == tenant_id,
+        AuditLog.id == audit_id,
+    )
+    result = await db_session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+def _resolve_op_id(row: AuditLog) -> str:
+    """Recover the op id for the row's sensitivity classification.
+
+    The audit middleware stamps the canonical op id into
+    ``payload["op_id"]`` for connector-style routes. When absent
+    (chassis HTTP routes, non-op requests) we fall back to the
+    publisher's own heuristic ``http.{method.lower()}:{path}`` -- the
+    exact string
+    :func:`meho_backplane.audit._resolve_op_id_and_class_override`
+    builds -- so :func:`classify_op` here yields the same class the
+    broadcast publisher computed. The ``:`` separator deliberately
+    avoids a route ending in ``.list`` being misread as a ``read`` verb
+    suffix (the publisher relies on the same guard).
+    """
+    op_id = row.payload.get("op_id")
+    if isinstance(op_id, str) and op_id:
+        return op_id
+    return f"http.{row.method.lower()}:{row.path}"
+
+
+def _is_aggregate_only(row: AuditLog, op_class: str) -> bool:
+    """Decide whether the drawer withholds the payload (decision #3).
+
+    Honours the G6.3 resolver's recorded verdict
+    (``payload["broadcast_detail_effective"]``) when present so the
+    drawer matches the detail the feed actually showed -- including a
+    per-tenant override that flipped a sensitive op to full detail.
+    Falls back to op-class membership in
+    :data:`AGGREGATE_ONLY_OP_CLASSES` for rows predating G6.3 (or rows
+    written when ``tenant_id`` was unresolved, which carry no effective
+    key).
+    """
+    effective = row.payload.get("broadcast_detail_effective")
+    if isinstance(effective, str) and effective:
+        return effective == "aggregate"
+    return op_class in AGGREGATE_ONLY_OP_CLASSES
+
+
+#: Module-level :class:`fastapi.Depends` closures -- ruff B008 guard.
+_require_ui_session_dep = Depends(require_ui_session)
+_get_raw_session_dep = Depends(get_raw_session)
+
+
+def build_event_router() -> APIRouter:
+    """Construct the broadcast event-detail :class:`APIRouter`.
+
+    Registers ``GET /ui/broadcast/event/{audit_id}``. Returns the drawer
+    fragment on success and a small 404 fragment for a missing /
+    cross-tenant id; both responses are designed for HTMX swap into
+    ``#event-drawer``.
+    """
+    router = APIRouter(tags=["ui-broadcast"])
+
+    async def _handler(
+        request: Request,
+        audit_id: uuid.UUID,
+        event_id: str = Query(
+            default="",
+            max_length=128,
+            description="Broadcast (Valkey-stream) event id, for display only.",
+        ),
+        session_ctx: UISessionContext = _require_ui_session_dep,
+        db_session: AsyncSession = _get_raw_session_dep,
+    ) -> HTMLResponse:
+        """``GET /ui/broadcast/event/{audit_id}[?event_id=...]``.
+
+        Resolves the audit row tenant-scoped, classifies its op for the
+        aggregate-only gate, and renders ``broadcast/_event_drawer.html``
+        with the full detail (or the 🔒 placeholder for sensitive
+        classes). A missing / cross-tenant id renders the not-found
+        fragment with HTTP 404.
+        """
+        row = await _fetch_audit_row(
+            db_session,
+            tenant_id=session_ctx.tenant_id,
+            audit_id=audit_id,
+        )
+        if row is None:
+            return get_templates().TemplateResponse(
+                request,
+                "broadcast/_event_drawer_not_found.html",
+                {"audit_id": str(audit_id)},
+                status_code=404,
+            )
+
+        op_id = _resolve_op_id(row)
+        op_class = classify_op(op_id)
+        aggregate_only = _is_aggregate_only(row, op_class)
+        # Strip the audit-only classification + G6.3 forensic keys so
+        # the drawer's "request payload" section shows only the request
+        # params. Only computed for the full-detail path -- the
+        # aggregate-only branch never renders the payload at all.
+        request_payload = (
+            {}
+            if aggregate_only
+            else {k: v for k, v in row.payload.items() if k not in _INTERNAL_PAYLOAD_KEYS}
+        )
+        context = {
+            "row": row,
+            "op_id": op_id,
+            "op_class": op_class,
+            "aggregate_only": aggregate_only,
+            "request_payload": request_payload,
+            # The ephemeral broadcast id, for display only -- not a PG
+            # column. Empty string when the row was opened from a path
+            # that did not carry it.
+            "event_id": event_id,
+        }
+        return get_templates().TemplateResponse(request, "broadcast/_event_drawer.html", context)
+
+    router.add_api_route(
+        "/ui/broadcast/event/{audit_id}",
+        _handler,
+        methods=["GET"],
+        name="ui_broadcast_event_detail",
+        response_class=HTMLResponse,
+        responses={
+            404: {
+                "description": (
+                    "Audit id does not exist in this tenant (or exists only "
+                    "for another tenant). Returns the not-found drawer fragment."
+                ),
+                "content": {"text/html": {}},
+            },
+        },
+    )
+    return router

--- a/backend/src/meho_backplane/ui/routes/broadcast/feed.py
+++ b/backend/src/meho_backplane/ui/routes/broadcast/feed.py
@@ -1,34 +1,44 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``GET /ui/broadcast`` -- the live activity feed view.
+"""``GET /ui/broadcast`` + ``GET /ui/broadcast/feed`` -- the live activity feed.
 
-Initiative #338 (G10.1 Activity broadcast UI), Task #867 (G10.1-T1)
-work items #1, #2, #8, #9. Renders the full broadcast surface page that
-streams the operator's tenant feed in reverse-chronological order.
+Initiative #338 (G10.1 Activity broadcast UI). Task #867 (G10.1-T1)
+shipped the full-page live feed (work items #1, #2, #8, #9); Task #868
+(G10.1-T2) adds the **filter bar** that re-renders the feed fragment
+with the active filter baked into a new SSE subscription URL (work item
+#3).
 
-What this route renders
-=======================
+Two routes, one feed
+====================
 
-A single full-page template (``broadcast/feed.html``, extends
-``base.html``) containing:
+* ``GET /ui/broadcast`` -- the full page (``broadcast/feed.html``,
+  extends ``base.html``). Renders the chrome, the filter bar, the
+  drawer slot, and the feed fragment (``broadcast/_feed.html``) inline.
+* ``GET /ui/broadcast/feed`` -- the filter-submit target. Returns the
+  **fragment only** (``broadcast/_feed.html``): the SSE sink wired to
+  ``/ui/broadcast/stream?<filters>`` plus the feed list. The filter bar
+  ``hx-get``s here with ``hx-target="#broadcast-feed"
+  hx-swap="outerHTML"``; the swapped-in fragment carries a fresh
+  ``sse-connect`` URL so the HTMX ``sse`` extension (which auto-processes
+  swapped content) tears down the old subscription and opens the
+  filtered one.
 
-* The HTMX ``sse``-extension wrapper subscribing to the session-gated
-  ``/ui/broadcast/stream`` bridge (see
-  :mod:`~meho_backplane.ui.routes.broadcast.stream` for why the UI does
-  not subscribe to ``/api/v1/feed`` directly -- the browser
-  ``EventSource`` cannot send the Bearer header that route requires).
-* The empty state shown before any event arrives / when none match.
-* A server-rendered ``<template>`` carrying the Jinja2 event-row markup
-  the client clones per incoming event (work item #2). The markup, the
-  DaisyUI badge palette, and the column structure are all authored
-  server-side in :mod:`broadcast/_event_row.html`; only the per-event
-  data binding happens client-side, because the shared ``/api/v1/feed``
-  substrate streams JSON (consumed identically by ``meho status
-  --watch`` and the MCP resource) and is out of scope to reshape into
-  HTML frames.
-* An Alpine.js controller that prepends each event and trims the in-DOM
-  list to :data:`IN_DOM_ROW_CAP` rows (work item #9).
+Server-side vs client-side filters
+==================================
+
+The stream bridge (:mod:`broadcast.stream`) and the canonical
+``/api/v1/feed`` accept exactly three filters -- ``op_class``,
+``principal`` (exact-match on ``principal_sub``), ``target`` (exact-match
+on ``target_name``). Those three ride into the ``sse-connect`` query
+string so the *server* drops non-matching events before they reach the
+browser. The fourth control, **op_id search**, is a free-text substring
+match the stream does not expose; layering it onto the shared stream
+filter would diverge the bridge from ``/api/v1/feed`` (out of scope).
+It is therefore applied **client-side** by the ``broadcastFeed`` Alpine
+controller against the already-streamed events -- the row count the
+operator sees narrows live as they type, and the server stream stays
+byte-compatible with the API feed.
 
 op_class colour-coding
 ======================
@@ -36,28 +46,35 @@ op_class colour-coding
 The event-row badge colour is keyed on the event's ``op_class`` via
 :data:`OP_CLASS_BADGE_CLASSES` -- a fixed map from the closed op-class
 vocabulary (:func:`meho_backplane.broadcast.classify_op`) to DaisyUI
-badge variants. The map is rendered into the page as a JSON object the
-Alpine row-builder reads, so the colour decision is authored server-side
-(one auditable table) even though the row is materialised client-side.
+badge variants, serialised into the page as JSON the Alpine row-builder
+reads. :data:`OP_CLASS_FILTER_OPTIONS` is the same vocabulary surfaced
+as the filter dropdown's options (``All`` plus the six classes).
 
 Tenant scoping
 ==============
 
-The page itself carries no tenant data beyond the operator's own
-identity; the live events arrive over the tenant-scoped stream bridge.
-There is no tenant query parameter on this route or on the stream it
-subscribes to, so a tenant-A operator's page can never surface tenant-B
-events -- the boundary is the session's ``tenant_id``.
+The target dropdown is populated from the ``targets`` table scoped to
+the session's ``tenant_id`` (never a query parameter), so a tenant-A
+operator can only filter by tenant-A targets. The live events arrive
+over the tenant-scoped stream bridge whose key is
+``meho:feed:{session.tenant_id}``; there is no tenant query parameter on
+either route, so a tenant-A operator's page can never surface tenant-B
+events.
 """
 
 from __future__ import annotations
 
 import json
 from typing import Final
+from urllib.parse import urlencode
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Query, Request
 from fastapi.responses import HTMLResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from meho_backplane.db.engine import get_raw_session
+from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
 from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
 from meho_backplane.ui.templating import get_templates
@@ -65,6 +82,7 @@ from meho_backplane.ui.templating import get_templates
 __all__ = [
     "IN_DOM_ROW_CAP",
     "OP_CLASS_BADGE_CLASSES",
+    "OP_CLASS_FILTER_OPTIONS",
     "build_feed_router",
 ]
 
@@ -92,43 +110,165 @@ OP_CLASS_BADGE_CLASSES: Final[dict[str, str]] = {
     "other": "badge-ghost",
 }
 
+#: The op_class filter dropdown options (work item #3). The empty string
+#: is the "All" sentinel -- it maps to *no* ``op_class`` query parameter
+#: on the stream so every class streams. The rest are the closed
+#: vocabulary keys of :data:`OP_CLASS_BADGE_CLASSES`, surfaced in the
+#: order the Initiative #338 work-item #3 lists them (read / write /
+#: credential_read / audit_query / other) plus ``credential_mint``,
+#: which shares the same sensitive (aggregate-only) treatment and would
+#: otherwise be unfilterable.
+OP_CLASS_FILTER_OPTIONS: Final[tuple[str, ...]] = (
+    "read",
+    "write",
+    "credential_read",
+    "credential_mint",
+    "audit_query",
+    "other",
+)
 
-async def _render_feed(
-    request: Request,
-    session: UISessionContext = Depends(require_ui_session),
-) -> HTMLResponse:
-    """Render ``GET /ui/broadcast`` for the authenticated operator.
+#: Max targets surfaced in the filter dropdown. The dropdown is an
+#: eyeball-scan filter, not a paginated browser (operators with denser
+#: target registries reach for the topology surface). Bounds the
+#: per-request SELECT so a tenant with thousands of targets does not
+#: balloon the page.
+_TARGET_OPTIONS_LIMIT: Final[int] = 500
 
-    The page subscribes to ``/ui/broadcast/stream`` (the session-gated
-    SSE bridge), so the operator sees their tenant's live events with
-    no further auth round-trip. The CSRF cookie is set + echoed via the
-    template's ``hx-headers`` so any future state-changing HTMX request
-    from this surface (T2's filters submit via ``hx-get``, which is
-    safe, but the chain is in place for any later mutation) passes the
-    double-submit check -- mirroring the dashboard + topology surfaces.
+#: The session-gated SSE bridge the live feed subscribes to. NOT
+#: ``/api/v1/feed`` -- see the stream module's docstring for the
+#: EventSource-cannot-set-Authorization rationale.
+_STREAM_ENDPOINT: Final[str] = "/ui/broadcast/stream"
+
+
+def _stream_url(*, op_class: str | None, principal: str | None, target: str | None) -> str:
+    """Build the ``sse-connect`` URL carrying the active server-side filters.
+
+    Only the three stream-supported filters (``op_class`` / ``principal``
+    / ``target``) ride into the query string; the op_id search is
+    client-side (see the module docstring). Empty / ``None`` filters are
+    omitted so the "All" selection streams everything. ``urlencode``
+    percent-encodes operator-supplied values (a principal sub or target
+    name can contain ``&`` / ``=`` / spaces) so the query string can
+    never be corrupted or injected.
     """
-    csrf_token = mint_csrf_token(str(session.session_id))
-    context = {
-        "page_title": "Broadcast",
-        "active_surface": "broadcast",
-        "operator_sub": session.operator_sub,
-        "tenant_id": str(session.tenant_id),
-        "csrf_token": csrf_token,
-        # The session-gated SSE bridge the live feed subscribes to.
-        # NOT ``/api/v1/feed`` -- see the stream module's docstring for
-        # the EventSource-cannot-set-Authorization rationale.
-        "stream_endpoint": "/ui/broadcast/stream",
+    params = {
+        key: value
+        for key, value in (
+            ("op_class", op_class),
+            ("principal", principal),
+            ("target", target),
+        )
+        if value
+    }
+    if not params:
+        return _STREAM_ENDPOINT
+    return f"{_STREAM_ENDPOINT}?{urlencode(params)}"
+
+
+async def _target_names(db_session: AsyncSession, tenant_id: object) -> list[str]:
+    """Return the tenant's target names for the filter dropdown.
+
+    Scoped to ``tenant_id`` at the SQL ``WHERE`` clause (never a query
+    parameter), ordered by name for stable rendering, capped at
+    :data:`_TARGET_OPTIONS_LIMIT`. The dropdown's values are matched
+    against :attr:`BroadcastEvent.target_name` by the stream filter, so
+    the option set is the target *names* -- the same string the
+    publisher stamps onto each event.
+    """
+    stmt = (
+        select(TargetORM.name)
+        .where(TargetORM.tenant_id == tenant_id)
+        .order_by(TargetORM.name)
+        .limit(_TARGET_OPTIONS_LIMIT)
+    )
+    result = await db_session.execute(stmt)
+    return list(result.scalars().all())
+
+
+def _feed_context(
+    *,
+    target_names: list[str],
+    op_class: str,
+    principal: str,
+    target: str,
+    op_id: str,
+) -> dict[str, object]:
+    """Build the context shared by the full page and the feed fragment.
+
+    The same shape feeds ``broadcast/feed.html`` and the standalone
+    ``broadcast/_feed.html`` fragment so the filter re-render and the
+    initial page load render an identical feed. The four filter values
+    are echoed back so the swapped fragment's filter bar keeps the
+    operator's selection and the embedded ``sse-connect`` URL carries
+    the three server-side filters.
+    """
+    # Normalise the "All" sentinel: an empty op_class means no server
+    # filter (stream everything). Same for blank principal / target.
+    server_op_class = op_class or None
+    server_principal = principal or None
+    server_target = target or None
+    return {
+        "stream_endpoint": _stream_url(
+            op_class=server_op_class,
+            principal=server_principal,
+            target=server_target,
+        ),
         "in_dom_row_cap": IN_DOM_ROW_CAP,
         # Serialised once server-side so the Alpine row-builder reads a
         # single authoritative colour table rather than duplicating the
         # mapping in JS. ``json.dumps`` output is HTML-safe inside the
         # ``application/json`` script block the template renders it into.
         "op_class_badge_json": json.dumps(OP_CLASS_BADGE_CLASSES),
+        "op_class_options": OP_CLASS_FILTER_OPTIONS,
+        "target_options": target_names,
+        # Echoed filter selections -- keep the <select>/<input> values
+        # after an HTMX swap.
+        "op_class_filter": op_class,
+        "principal_filter": principal,
+        "target_filter": target,
+        "op_id_filter": op_id,
+    }
+
+
+async def _render_page(
+    request: Request,
+    *,
+    op_class: str,
+    principal: str,
+    target: str,
+    op_id: str,
+    session_ctx: UISessionContext,
+    db_session: AsyncSession,
+) -> HTMLResponse:
+    """Render ``GET /ui/broadcast`` -- the full page.
+
+    The page subscribes to ``/ui/broadcast/stream`` (the session-gated
+    SSE bridge), so the operator sees their tenant's live events with no
+    further auth round-trip. The CSRF cookie is set + echoed via the
+    template's ``hx-headers`` so the filter bar's ``hx-get`` (and any
+    later state-changing HTMX request from this surface) passes the
+    double-submit check -- mirroring the dashboard + topology surfaces.
+    """
+    target_names = await _target_names(db_session, session_ctx.tenant_id)
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    context: dict[str, object] = {
+        "page_title": "Broadcast",
+        "active_surface": "broadcast",
+        "operator_sub": session_ctx.operator_sub,
+        "tenant_id": str(session_ctx.tenant_id),
+        "csrf_token": csrf_token,
         # ``base.html``'s footer reads ``ready`` to colour the readiness
         # pill; the broadcast surface does not poll readiness (the
         # dashboard owns that), so ship ``False`` so ``StrictUndefined``
         # does not raise on the read.
         "ready": False,
+        **_feed_context(
+            target_names=target_names,
+            op_class=op_class,
+            principal=principal,
+            target=target,
+            op_id=op_id,
+        ),
     }
     response = get_templates().TemplateResponse(request, "broadcast/feed.html", context)
     response.set_cookie(
@@ -142,20 +282,115 @@ async def _render_feed(
     return response
 
 
-def build_feed_router() -> APIRouter:
-    """Construct the broadcast feed-page :class:`APIRouter`.
+async def _render_fragment(
+    request: Request,
+    *,
+    op_class: str,
+    principal: str,
+    target: str,
+    op_id: str,
+    session_ctx: UISessionContext,
+    db_session: AsyncSession,
+) -> HTMLResponse:
+    """Render ``GET /ui/broadcast/feed`` -- the filtered feed fragment.
 
-    Registers ``GET /ui/broadcast``. Factory function (not a
-    module-level constant) so a test app can construct parallel routers
-    without sharing route state -- mirrors the chassis convention in
-    :mod:`meho_backplane.ui.routes.dashboard`.
+    Returns ``broadcast/_feed.html`` only (no chrome): the SSE sink
+    rewired to the filtered ``sse-connect`` URL plus the feed list. The
+    filter bar swaps this fragment into ``#broadcast-feed`` via
+    ``hx-swap="outerHTML"``; HTMX auto-processes the swapped content so
+    the ``sse`` extension closes the prior subscription (the replaced
+    node) and opens the new filtered one.
+    """
+    target_names = await _target_names(db_session, session_ctx.tenant_id)
+    context = _feed_context(
+        target_names=target_names,
+        op_class=op_class,
+        principal=principal,
+        target=target,
+        op_id=op_id,
+    )
+    return get_templates().TemplateResponse(request, "broadcast/_feed.html", context)
+
+
+#: Module-level :class:`fastapi.Depends` closures -- ruff B008 guard
+#: (a function call in a default argument position is disallowed except
+#: for the FastAPI-blessed call sites in ``extend-immutable-calls``).
+_require_ui_session_dep = Depends(require_ui_session)
+_get_raw_session_dep = Depends(get_raw_session)
+
+
+def build_feed_router() -> APIRouter:
+    """Construct the broadcast feed :class:`APIRouter`.
+
+    Registers ``GET /ui/broadcast`` (full page) and
+    ``GET /ui/broadcast/feed`` (filtered fragment). Factory function
+    (not a module-level constant) so a test app can construct parallel
+    routers without sharing route state -- mirrors the chassis
+    convention in :mod:`meho_backplane.ui.routes.topology`.
     """
     router = APIRouter(tags=["ui-broadcast"])
+
+    async def _page_handler(
+        request: Request,
+        op_class: str = Query(default="", max_length=64),
+        principal: str = Query(default="", max_length=256),
+        target: str = Query(default="", max_length=256),
+        op_id: str = Query(default="", max_length=256),
+        session_ctx: UISessionContext = _require_ui_session_dep,
+        db_session: AsyncSession = _get_raw_session_dep,
+    ) -> HTMLResponse:
+        """``GET /ui/broadcast[?op_class=&principal=&target=&op_id=]``.
+
+        Filters are accepted on the full-page route too so a copy-pasted
+        filtered URL reproduces the operator's view (the filter bar sets
+        ``hx-push-url`` on the fragment route, mirroring topology).
+        """
+        return await _render_page(
+            request,
+            op_class=op_class,
+            principal=principal,
+            target=target,
+            op_id=op_id,
+            session_ctx=session_ctx,
+            db_session=db_session,
+        )
+
+    async def _fragment_handler(
+        request: Request,
+        op_class: str = Query(default="", max_length=64),
+        principal: str = Query(default="", max_length=256),
+        target: str = Query(default="", max_length=256),
+        op_id: str = Query(default="", max_length=256),
+        session_ctx: UISessionContext = _require_ui_session_dep,
+        db_session: AsyncSession = _get_raw_session_dep,
+    ) -> HTMLResponse:
+        """``GET /ui/broadcast/feed[?op_class=&principal=&target=&op_id=]``.
+
+        The filter-bar submit target. Returns the feed fragment with the
+        filtered ``sse-connect`` URL embedded.
+        """
+        return await _render_fragment(
+            request,
+            op_class=op_class,
+            principal=principal,
+            target=target,
+            op_id=op_id,
+            session_ctx=session_ctx,
+            db_session=db_session,
+        )
+
     router.add_api_route(
         "/ui/broadcast",
-        _render_feed,
+        _page_handler,
         methods=["GET"],
         name="ui_broadcast_feed",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/broadcast/feed",
+        _fragment_handler,
+        methods=["GET"],
+        name="ui_broadcast_feed_fragment",
         response_class=HTMLResponse,
     )
     return router

--- a/backend/src/meho_backplane/ui/static/src/app/broadcast-feed.js
+++ b/backend/src/meho_backplane/ui/static/src/app/broadcast-feed.js
@@ -23,6 +23,13 @@
 //     no op_id parameter, so op_id narrows the streamed events in-browser
 //     via ``visibleEvents``. The filter bar's op_id input dispatches a
 //     ``broadcast-op-id-changed`` window event this controller listens for.
+//     On a server-side filter re-render (op_class/principal/target change)
+//     HTMX swaps ``#broadcast-feed`` and this controller re-initialises
+//     with a fresh, empty ``opIdFilter`` -- so ``init`` re-reads the live
+//     op_id input (which lives OUTSIDE the swapped fragment and keeps the
+//     operator's typed value) and re-seeds the filter. Without that read
+//     the op_id input would still show the typed text but active filtering
+//     would silently stop after every server re-render.
 //   * Open the event-detail drawer on a row click (work item #4):
 //     ``htmx.ajax`` GET ``/ui/broadcast/event/{audit_id}?event_id=...``
 //     into ``#event-drawer``.
@@ -42,7 +49,30 @@ document.addEventListener("alpine:init", () => {
     // Lower-cased once; the op_id filter is a case-insensitive substring
     // match against ``ev.op_id``. Seeded from the server context so a
     // copy-pasted filtered URL renders the narrowed view on first paint.
+    // ``init`` (below) then overrides this from the live op_id input so a
+    // server re-render -- which omits op_id and therefore seeds an empty
+    // ``opts.opIdFilter`` -- does not drop the operator's active filter.
     opIdFilter: (opts.opIdFilter || "").toLowerCase(),
+
+    // Alpine invokes ``init`` automatically when the component mounts --
+    // on the initial page load AND on every HTMX swap of the
+    // ``#broadcast-feed`` fragment (a server-side op_class/principal/target
+    // re-render). The op_id ``<input>`` lives outside the swapped fragment,
+    // so it survives the swap with the operator's typed value intact; the
+    // server fragment route, however, never receives op_id (it is excluded
+    // from the form's ``hx-include``) and so re-seeds ``opIdFilter`` empty.
+    // Reading the input here makes that input the single source of truth so
+    // the client-side narrowing keeps applying across server re-renders.
+    // ``$nextTick`` defers the read until Alpine has settled the swapped
+    // node, guarding against any swap/init ordering edge.
+    init() {
+      this.$nextTick(() => {
+        const input = document.querySelector('input[name="op_id"]');
+        if (input) {
+          this.opIdFilter = (input.value || "").toLowerCase();
+        }
+      });
+    },
 
     // Re-apply the op_id filter when the filter bar's input changes. The
     // ``.window`` listener is declared in the template; this handler

--- a/backend/src/meho_backplane/ui/static/src/app/broadcast-feed.js
+++ b/backend/src/meho_backplane/ui/static/src/app/broadcast-feed.js
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright (c) 2026 evoila Group
 //
-// Broadcast live-feed Alpine controller (Initiative #338 Task #867).
+// Broadcast live-feed Alpine controller (Initiative #338; Task #867
+// shipped the core, Task #868 added the op_id client filter + the
+// click-to-open drawer + the PII 🔒 marker helper).
 //
 // Registered on ``alpine:init`` so the ``x-data="broadcastFeed(...)"``
-// wrapper in ``broadcast/feed.html`` resolves to this component. Kept in
+// wrapper in ``broadcast/_feed.html`` resolves to this component. Kept in
 // a static file (loaded via ``<script src=... defer>`` from the page's
 // ``{% block scripts %}``) rather than an inline ``<script>`` block so a
 // future nonce-based CSP needs no inline-script exception -- matching the
@@ -14,15 +16,22 @@
 //   * Subscribe (indirectly) to the SSE feed: the HTMX ``sse`` extension
 //     owns the EventSource; this controller hooks
 //     ``htmx:sseBeforeMessage`` to parse each ``event: broadcast`` frame
-//     and route it into the Alpine ``events`` array instead of letting
-//     the extension swap the raw JSON text into the DOM.
+//     and route it into the ``events`` array instead of letting the
+//     extension swap the raw JSON text into the DOM.
 //   * Prepend newest-first and trim to the in-DOM row cap (work item #9).
+//   * Apply the op_id client-side filter (work item #3): the stream has
+//     no op_id parameter, so op_id narrows the streamed events in-browser
+//     via ``visibleEvents``. The filter bar's op_id input dispatches a
+//     ``broadcast-op-id-changed`` window event this controller listens for.
+//   * Open the event-detail drawer on a row click (work item #4):
+//     ``htmx.ajax`` GET ``/ui/broadcast/event/{audit_id}?event_id=...``
+//     into ``#event-drawer``.
 //   * Provide the row-render helpers the server-authored
 //     ``_event_row.html`` partial binds to (badge colour, timestamp,
-//     payload summary).
+//     payload summary, aggregate-only check).
 //
-// The colour table + cap are passed in from the route context
-// (``opts``) so the policy stays server-side.
+// The colour table, cap, and the initial op_id filter are passed in from
+// the route context (``opts``) so the policy stays server-side.
 
 document.addEventListener("alpine:init", () => {
   Alpine.data("broadcastFeed", (opts) => ({
@@ -30,6 +39,32 @@ document.addEventListener("alpine:init", () => {
     connected: false,
     cap: opts.cap,
     badgeClasses: opts.badgeClasses,
+    // Lower-cased once; the op_id filter is a case-insensitive substring
+    // match against ``ev.op_id``. Seeded from the server context so a
+    // copy-pasted filtered URL renders the narrowed view on first paint.
+    opIdFilter: (opts.opIdFilter || "").toLowerCase(),
+
+    // Re-apply the op_id filter when the filter bar's input changes. The
+    // ``.window`` listener is declared in the template; this handler
+    // normalises + stores the new value. ``$event.detail.opId`` is the
+    // payload the filter bar's ``$dispatch`` sends.
+    onOpIdChanged(evt) {
+      const next = (evt.detail && evt.detail.opId) || "";
+      this.opIdFilter = next.toLowerCase();
+    },
+
+    // The op_id-filtered view of ``events`` the template renders. An
+    // empty filter shows every streamed event; a non-empty filter keeps
+    // only events whose ``op_id`` contains the substring. Recomputed by
+    // Alpine reactivity whenever ``events`` or ``opIdFilter`` changes.
+    get visibleEvents() {
+      if (!this.opIdFilter) {
+        return this.events;
+      }
+      return this.events.filter(
+        (ev) => (ev.op_id || "").toLowerCase().includes(this.opIdFilter),
+      );
+    },
 
     // Parse one SSE ``event: broadcast`` frame and prepend it, trimming
     // to the in-DOM cap. ``$event.detail`` is the MessageEvent the sse
@@ -57,6 +92,32 @@ document.addEventListener("alpine:init", () => {
       }
     },
 
+    // Open the event-detail drawer for a clicked row (work item #4). The
+    // drawer is resolved by AUDIT id (the canonical PG row), not the
+    // broadcast event_id (ephemeral Valkey id) -- see the event route's
+    // docstring. The broadcast event_id rides along as a query param for
+    // display only. ``htmx.ajax`` issues the GET and swaps the response
+    // into ``#event-drawer`` (outerHTML) so the returned fragment's own
+    // ``id="event-drawer"`` replaces the slot.
+    openDrawer(ev) {
+      if (!ev || !ev.audit_id) {
+        return;
+      }
+      const params = new URLSearchParams();
+      if (ev.event_id) {
+        params.set("event_id", ev.event_id);
+      }
+      const qs = params.toString();
+      const url =
+        "/ui/broadcast/event/" +
+        encodeURIComponent(ev.audit_id) +
+        (qs ? "?" + qs : "");
+      window.htmx.ajax("GET", url, {
+        target: "#event-drawer",
+        swap: "outerHTML",
+      });
+    },
+
     // DaisyUI badge variant for an op_class; unknown classes fall back
     // to the neutral ghost badge.
     badgeClass(opClass) {
@@ -70,12 +131,22 @@ document.addEventListener("alpine:init", () => {
       return isNaN(d.getTime()) ? ts : d.toLocaleTimeString();
     },
 
-    // One-line payload summary. Aggregate-only events (credential reads,
-    // audit queries -- decision #3) carry no ``params`` key in their
-    // redacted payload, so they render the explicit ``(aggregate-only)``
-    // placeholder instead of an empty cell.
+    // True when the event is aggregate-only (credential reads, audit
+    // queries -- decision #3): its redacted payload carries no ``params``
+    // key. The row renders the 🔒 marker + placeholder for these instead
+    // of a param summary. Same signal ``payloadSummary`` keys off, lifted
+    // to a named predicate the template's PII branch reads.
+    isAggregateOnly(ev) {
+      const p = (ev && ev.payload) || {};
+      return !("params" in p);
+    },
+
+    // One-line payload summary for non-aggregate events. Aggregate-only
+    // events never reach here (the template branches on
+    // ``isAggregateOnly`` first), but the guard is kept so a direct call
+    // stays safe.
     payloadSummary(ev) {
-      const p = ev.payload || {};
+      const p = (ev && ev.payload) || {};
       if (!("params" in p)) {
         return "(aggregate-only)";
       }

--- a/backend/src/meho_backplane/ui/templates/broadcast/_event_drawer.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/_event_drawer.html
@@ -1,0 +1,112 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Event detail drawer fragment (Task #868 work item #4). Rendered by
+  ``GET /ui/broadcast/event/{audit_id}`` and swapped into
+  ``#event-drawer`` via HTMX ``hx-target`` (outerHTML) on a feed-row
+  click.
+
+  Dismiss model (Alpine click-outside)
+  ------------------------------------
+  The ``aside`` carries its own Alpine island: ``x-data="{ open: true }"``
+  + ``x-show="open"`` so it is visible on swap-in, and
+  ``x-on:click.outside="open = false"`` so a click anywhere outside the
+  drawer dismisses it. Alpine only evaluates ``.outside`` while the
+  element is visible, so the swap-in click that opened the drawer cannot
+  immediately re-close it (the documented race the ``.outside`` helper
+  guards against). A Close button mirrors the same ``open = false`` for
+  keyboard / explicit dismissal.
+
+  Sections:
+    1. Header -- op_id + op_class badge + close.
+    2. Operation -- operator, method/path, status, timing.
+    3. Identifiers -- request_id, audit_id, broadcast event_id.
+    4. Payload -- the full request payload JSON when the op is not
+       aggregate-only; the 🔒 placeholder otherwise (work item #7 carried
+       through to the drawer -- a sensitive op never leaks its payload
+       on click).
+-#}
+<aside
+  id="event-drawer"
+  class="card bg-base-100 border-base-300 border shadow-sm self-start"
+  aria-label="Event detail drawer"
+  x-data="{ open: true }"
+  x-show="open"
+  x-on:click.outside="open = false"
+  x-on:keydown.escape.window="open = false"
+>
+  <div class="card-body space-y-3">
+    <header class="flex items-start justify-between gap-2">
+      <div>
+        <h2 class="card-title text-base">
+          <span class="badge badge-sm">{{ op_class }}</span>
+          <span class="font-mono text-sm break-all">{{ op_id }}</span>
+        </h2>
+        <p class="text-xs opacity-70">Event detail</p>
+      </div>
+      <button
+        type="button"
+        class="btn btn-ghost btn-xs"
+        aria-label="Close event detail drawer"
+        x-on:click="open = false"
+      >
+        Close
+      </button>
+    </header>
+
+    {# ---------- Operation ---------- #}
+    <section aria-label="Operation">
+      <h3 class="text-sm font-semibold uppercase opacity-60">Operation</h3>
+      <dl class="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-sm">
+        <dt class="opacity-60">operator</dt>
+        <dd class="font-mono break-all">{{ row.operator_sub }}</dd>
+        <dt class="opacity-60">method</dt>
+        <dd>
+          <span class="badge badge-outline badge-xs">{{ row.method }}</span>
+          <span class="font-mono text-xs break-all">{{ row.path }}</span>
+        </dd>
+        <dt class="opacity-60">status</dt>
+        <dd>{{ row.status_code }}</dd>
+        <dt class="opacity-60">occurred_at</dt>
+        <dd>{{ row.occurred_at.isoformat() }}</dd>
+        {% if row.duration_ms is not none %}
+          <dt class="opacity-60">duration_ms</dt>
+          <dd>{{ row.duration_ms }}</dd>
+        {% endif %}
+      </dl>
+    </section>
+
+    {# ---------- Identifiers ---------- #}
+    <section aria-label="Identifiers">
+      <h3 class="text-sm font-semibold uppercase opacity-60">Identifiers</h3>
+      <dl class="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-sm">
+        <dt class="opacity-60">audit_id</dt>
+        <dd class="font-mono break-all">{{ row.id }}</dd>
+        <dt class="opacity-60">request_id</dt>
+        <dd class="font-mono break-all">
+          {% if row.request_id %}{{ row.request_id }}{% else %}<span class="opacity-50">—</span>{% endif %}
+        </dd>
+        <dt class="opacity-60">event_id</dt>
+        <dd class="font-mono break-all">
+          {% if event_id %}{{ event_id }}{% else %}<span class="opacity-50">—</span>{% endif %}
+        </dd>
+      </dl>
+    </section>
+
+    {# ---------- Payload (work item #7 gate) ---------- #}
+    <section aria-label="Payload">
+      <h3 class="text-sm font-semibold uppercase opacity-60">Payload</h3>
+      {% if aggregate_only %}
+        <p class="flex items-center gap-1 text-sm text-warning">
+          <span aria-hidden="true">&#x1F512;</span>
+          <span>(aggregate-only — credential read; details not broadcast)</span>
+        </p>
+      {% elif request_payload %}
+        <pre class="mt-1 max-h-72 overflow-auto rounded bg-base-200 p-2 text-xs">{{ request_payload | tojson(indent=2) }}</pre>
+      {% else %}
+        <p class="text-sm opacity-60">No request payload recorded.</p>
+      {% endif %}
+    </section>
+  </div>
+</aside>

--- a/backend/src/meho_backplane/ui/templates/broadcast/_event_drawer_not_found.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/_event_drawer_not_found.html
@@ -1,0 +1,47 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Drawer fragment rendered when the requested audit id does not resolve
+  in the operator's tenant. Returned with HTTP 404 by
+  ``GET /ui/broadcast/event/{audit_id}``.
+
+  The fragment swaps into ``#event-drawer`` exactly like the happy path
+  so the operator sees the not-found message without a full-page reload.
+  It carries the same ``x-data``/``click.outside`` dismiss island so a
+  click outside (or Escape / Close) clears it consistently. The audit
+  row may have aged out of the retention window, the id may belong to
+  another tenant (the boundary is opaque), or the feed may be stale.
+-#}
+<aside
+  id="event-drawer"
+  class="card bg-base-100 border-base-300 border shadow-sm self-start"
+  aria-label="Event detail drawer"
+  x-data="{ open: true }"
+  x-show="open"
+  x-on:click.outside="open = false"
+  x-on:keydown.escape.window="open = false"
+>
+  <div class="card-body space-y-2">
+    <header class="flex items-start justify-between gap-2">
+      <h2 class="card-title text-base">Event not found</h2>
+      <button
+        type="button"
+        class="btn btn-ghost btn-xs"
+        aria-label="Close event detail drawer"
+        x-on:click="open = false"
+      >
+        Close
+      </button>
+    </header>
+    <p class="text-sm opacity-70">
+      No audit record with id <code class="font-mono break-all">{{ audit_id }}</code>
+      exists in this tenant.
+    </p>
+    <p class="text-xs opacity-60">
+      The record may have aged out of the retention window, the id may belong to
+      another tenant (the boundary is opaque), or the feed may be stale — refresh
+      the page to re-subscribe.
+    </p>
+  </div>
+</aside>

--- a/backend/src/meho_backplane/ui/templates/broadcast/_event_row.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/_event_row.html
@@ -2,35 +2,51 @@
   SPDX-License-Identifier: Apache-2.0
   Copyright (c) 2026 evoila Group
 
-  Broadcast event-row partial (Initiative #338 Task #867, work item #2).
+  Broadcast event-row partial (Task #867 work item #2; extended by Task
+  #868 work items #4/#7).
 
   This is the server-authored Jinja2 markup for one feed row. It is
-  emitted inside an Alpine ``<template x-for="ev in events">`` in
-  ``feed.html`` so the column structure, the DaisyUI badge palette, and
-  the aggregate-only placeholder are all authored here (server-side, one
-  reviewable template) while the per-event data binding is Alpine
-  client-side.
+  emitted inside an Alpine ``<template x-for="ev in visibleEvents">`` in
+  ``_feed.html`` so the column structure, the DaisyUI badge palette, the
+  aggregate-only placeholder, and the 🔒 PII marker are all authored here
+  (server-side, one reviewable template) while the per-event data binding
+  is Alpine client-side.
 
   Why client-side data binding: the shared ``/api/v1/feed`` substrate
   (G6.1-T4) streams ``BroadcastEvent`` JSON -- consumed identically by
   ``meho status --watch`` and the MCP resource -- and is out of scope to
-  reshape into per-event HTML frames. The HTMX ``sse`` extension would
-  swap that JSON in as raw text; instead the feed controller parses each
-  frame and this template renders it.
+  reshape into per-event HTML frames.
 
   Columns (reverse-chronological list; newest prepended):
     timestamp · principal@tenant badge · op_id · op_class badge
-    (colour-coded) · result_status icon · target · payload summary
-    (``(aggregate-only)`` when the redacted payload carries no params).
+    (colour-coded) · result_status icon · target · payload summary.
+
+  T2 additions:
+    * Click-to-open drawer (work item #4): a click calls ``openDrawer(ev)``
+      which ``htmx.ajax``-GETs ``/ui/broadcast/event/{audit_id}?event_id=...``
+      into ``#event-drawer``. The row is keyboard-focusable + ``role=button``
+      so the drawer is reachable without a mouse.
+    * PII 🔒 marker (work item #7): aggregate-only events
+      (credential_read / credential_mint / audit_query -- decision #3)
+      render the 🔒 icon and the "(aggregate-only — credential read;
+      details not broadcast)" copy in the payload column instead of any
+      params. ``isAggregateOnly(ev)`` keys off the redacted payload's
+      missing ``params`` (the same signal T1 used) so the marker tracks
+      the publisher's redaction exactly.
 
   Bound fields on ``ev`` (a parsed ``BroadcastEvent``):
-    ev.ts, ev.principal_sub, ev.principal_name, ev.op_id, ev.op_class,
-    ev.result_status, ev.target_name, ev.payload.
+    ev.event_id, ev.audit_id, ev.ts, ev.principal_sub, ev.principal_name,
+    ev.op_id, ev.op_class, ev.result_status, ev.target_name, ev.payload.
 -#}
 <li
-  class="grid grid-cols-12 items-center gap-2 px-3 py-2 text-sm"
-  role="listitem"
+  class="grid grid-cols-12 items-center gap-2 px-3 py-2 text-sm cursor-pointer hover:bg-base-200 focus:bg-base-200 focus:outline-none"
+  role="button"
+  tabindex="0"
   :data-event-id="ev.event_id"
+  :aria-label="'Inspect event ' + ev.op_id"
+  x-on:click="openDrawer(ev)"
+  x-on:keydown.enter="openDrawer(ev)"
+  x-on:keydown.space.prevent="openDrawer(ev)"
 >
   {# ---------- timestamp ---------- #}
   <span class="col-span-2 font-mono text-xs opacity-70">
@@ -80,8 +96,21 @@
     <span x-text="ev.target_name || '—'"></span>
   </span>
 
-  {# ---------- payload summary ---------- #}
-  <span class="col-span-2 truncate text-xs opacity-60" :title="payloadSummary(ev)">
-    <span x-text="payloadSummary(ev)"></span>
+  {# ---------- payload summary / PII marker (work item #7) ----------
+     Aggregate-only events render the 🔒 lock + the placeholder copy; all
+     other events render the one-line param summary. -#}
+  <span class="col-span-2 truncate text-xs">
+    <template x-if="isAggregateOnly(ev)">
+      <span
+        class="flex items-center gap-1 text-warning"
+        title="Credential read — details are not broadcast (decision #3)"
+      >
+        <span aria-hidden="true">&#x1F512;</span>
+        <span class="truncate">(aggregate-only — credential read; details not broadcast)</span>
+      </span>
+    </template>
+    <template x-if="!isAggregateOnly(ev)">
+      <span class="opacity-60" :title="payloadSummary(ev)" x-text="payloadSummary(ev)"></span>
+    </template>
   </span>
 </li>

--- a/backend/src/meho_backplane/ui/templates/broadcast/_feed.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/_feed.html
@@ -1,0 +1,110 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Broadcast feed fragment (Task #868 work items #3/#4). This is BOTH the
+  feed body included by ``feed.html`` on initial page load AND the
+  standalone fragment ``GET /ui/broadcast/feed`` returns on a filter
+  submit. The filter bar ``hx-get``s the fragment route and swaps it
+  into ``#broadcast-feed`` with ``hx-swap="outerHTML"``; HTMX
+  auto-processes the swapped content, so the ``sse`` extension tears
+  down the prior subscription (the replaced node) and opens the new one
+  pointed at ``stream_endpoint`` -- the bridge URL carrying the active
+  server-side filters (op_class/principal/target).
+
+  The ``broadcastFeed`` Alpine controller wraps the WHOLE fragment so a
+  filter re-render replaces the SSE subscription AND resets the in-DOM
+  ``events`` array (the prior filter's rows must not linger). ``opIdFilter``
+  is the client-side op_id substring narrowing -- the stream has no op_id
+  param, so the controller filters the streamed events by ``op_id``
+  in-browser as the operator types (the filter bar mirrors the input
+  into the controller via an ``x-model``-bound hidden field; see
+  ``_filter_bar.html``).
+-#}
+<div
+  id="broadcast-feed"
+  class="overflow-hidden rounded-box border border-base-300 bg-base-100"
+  x-data="broadcastFeed({
+    cap: {{ in_dom_row_cap }},
+    badgeClasses: {{ op_class_badge_json }},
+    opIdFilter: {{ op_id_filter | tojson }}
+  })"
+  x-on:broadcast-op-id-changed.window="onOpIdChanged($event)"
+>
+  {# ---------- SSE sink ----------
+     Hidden element the sse extension binds the EventSource listener to.
+     ``sse-connect`` points at the bridge with the active server-side
+     filters embedded; ``sse-swap="broadcast"`` subscribes to the feed's
+     ``event: broadcast`` frames. We cancel the default swap in
+     ``htmx:sse-before-message`` and route the data through Alpine.
+  -#}
+  <div
+    hx-ext="sse"
+    sse-connect="{{ stream_endpoint }}"
+    sse-swap="broadcast"
+    class="hidden"
+    aria-hidden="true"
+    x-on:htmx:sse-before-message="onSseMessage($event)"
+    x-on:htmx:sse-open="connected = true"
+    x-on:htmx:sse-error="connected = false"
+  ></div>
+
+  {# ---------- Status bar -- connection + visible/cap row counts ---------- #}
+  <div
+    class="flex items-center justify-end gap-3 border-b border-base-300 px-3 py-1.5 text-xs opacity-70"
+  >
+    <span class="flex items-center gap-1" aria-live="polite">
+      <span
+        class="inline-block h-2 w-2 rounded-full"
+        :class="connected ? 'bg-success' : 'bg-warning'"
+        aria-hidden="true"
+      ></span>
+      <span x-text="connected ? 'live' : 'connecting…'"></span>
+    </span>
+    <span aria-live="polite" x-text="visibleEvents.length + ' / {{ in_dom_row_cap }} rows'"></span>
+  </div>
+
+  {# ---------- Column header row -- mirrors the grid in _event_row.html. ---------- #}
+  <div
+    class="grid grid-cols-12 gap-2 border-b border-base-300 px-3 py-2 text-xs font-semibold uppercase tracking-wide opacity-60"
+  >
+    <span class="col-span-2">Time</span>
+    <span class="col-span-2">Principal</span>
+    <span class="col-span-3">Operation</span>
+    <span class="col-span-1">Class</span>
+    <span class="col-span-1">Status</span>
+    <span class="col-span-1">Target</span>
+    <span class="col-span-2">Payload</span>
+  </div>
+
+  {# ---------- Empty state (work item #8) ----------
+     Shown until the first matching event lands or when the op_id filter
+     narrows everything out. ``visibleEvents`` is the op_id-filtered
+     view; an empty view (whether nothing streamed or the op_id filter
+     excluded all) renders this copy. -#}
+  <div
+    x-show="visibleEvents.length === 0"
+    class="px-3 py-10 text-center text-sm opacity-70"
+    id="broadcast-empty-state"
+  >
+    No activity matching your filters. Try adjusting the op_class or
+    target filter, or wait for new events.
+  </div>
+
+  {# ---------- Live list -- newest first ----------
+     Each event renders via the server-authored row partial. ``:key``
+     keeps Alpine's DOM diff stable as rows prepend + trim. A click
+     opens the detail drawer via the row's ``hx-get`` (wired in the row
+     partial). -#}
+  <ul
+    x-show="visibleEvents.length > 0"
+    class="divide-y divide-base-300"
+    role="list"
+    aria-label="Live broadcast events"
+    aria-live="polite"
+  >
+    <template x-for="ev in visibleEvents" :key="ev.event_id">
+      {% include "broadcast/_event_row.html" %}
+    </template>
+  </ul>
+</div>

--- a/backend/src/meho_backplane/ui/templates/broadcast/_filter_bar.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/_filter_bar.html
@@ -19,12 +19,20 @@
 
   op_id has no stream parameter (layering it on would diverge the bridge
   from ``/api/v1/feed``), so it narrows the already-streamed events
-  CLIENT-side. The op_id input lives OUTSIDE the swapped fragment so a
-  filter re-render does not reset it; on each keystroke it dispatches a
-  ``broadcast-op-id-changed`` event on ``window`` that the feed
-  fragment's ``broadcastFeed`` controller listens for
-  (``x-on:broadcast-op-id-changed.window``) and re-applies its
-  client-side filter -- without tearing down the live SSE subscription.
+  CLIENT-side. The op_id input lives OUTSIDE the swapped ``#broadcast-feed``
+  fragment, so the input ELEMENT (and the operator's typed value) survives
+  a server-side filter re-render. The ACTIVE filtering, though, lives in
+  the ``broadcastFeed`` controller INSIDE the swapped fragment: a server
+  re-render re-mounts that controller with a fresh, empty ``opIdFilter``
+  (op_id is excluded from ``hx-include`` below, so the server fragment
+  route never receives it and seeds the controller empty). The controller
+  closes that gap in its ``init`` -- on every mount, including each swap,
+  it re-reads this input's value as the single source of truth, so the
+  client-side narrowing keeps applying after a server re-render. On each
+  keystroke the input also dispatches a ``broadcast-op-id-changed`` event
+  on ``window`` that the controller listens for
+  (``x-on:broadcast-op-id-changed.window``) and re-applies live -- without
+  tearing down the SSE subscription.
 
   The form deliberately does NOT include the op_id field in its
   ``hx-include`` (``hx-include="[name=op_class],[name=principal],[name=target]"``)

--- a/backend/src/meho_backplane/ui/templates/broadcast/_filter_bar.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/_filter_bar.html
@@ -1,0 +1,120 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Broadcast filter bar (Task #868 work item #3). Four controls:
+
+    * op_class  -- <select>, the closed sensitivity vocabulary + "All".
+    * principal -- free-text, exact-match on the event ``principal_sub``.
+    * target    -- <select> of the tenant's target names (G0.3 registry).
+    * op_id     -- free-text substring search.
+
+  Server-side vs client-side
+  --------------------------
+  op_class / principal / target are the three filters the stream bridge
+  (and ``/api/v1/feed``) support. They ``hx-get`` to ``/ui/broadcast/feed``
+  and swap the ``#broadcast-feed`` fragment so the re-rendered fragment's
+  ``sse-connect`` URL carries them server-side -- the server drops
+  non-matching events before they reach the browser.
+
+  op_id has no stream parameter (layering it on would diverge the bridge
+  from ``/api/v1/feed``), so it narrows the already-streamed events
+  CLIENT-side. The op_id input lives OUTSIDE the swapped fragment so a
+  filter re-render does not reset it; on each keystroke it dispatches a
+  ``broadcast-op-id-changed`` event on ``window`` that the feed
+  fragment's ``broadcastFeed`` controller listens for
+  (``x-on:broadcast-op-id-changed.window``) and re-applies its
+  client-side filter -- without tearing down the live SSE subscription.
+
+  The form deliberately does NOT include the op_id field in its
+  ``hx-include`` (``hx-include="[name=op_class],[name=principal],[name=target]"``)
+  so an op_class/principal/target change never carries op_id to the
+  server (it is not a server filter); op_id rides the page URL only via
+  the controller, not the fragment route.
+-#}
+<form
+  class="card bg-base-100 border-base-300 border shadow-sm"
+  hx-get="/ui/broadcast/feed"
+  hx-target="#broadcast-feed"
+  hx-swap="outerHTML"
+  hx-trigger="change from:find select, input changed delay:300ms from:find input[name=principal]"
+  hx-include="[name=op_class], [name=principal], [name=target]"
+  hx-push-url="true"
+  role="search"
+  aria-label="Filter broadcast events"
+  onsubmit="return false;"
+>
+  <div class="card-body grid gap-3 md:grid-cols-4">
+    {# ---------- op_class ---------- #}
+    <label class="form-control">
+      <span class="label-text">Op class</span>
+      <select
+        name="op_class"
+        class="select select-bordered select-sm"
+        aria-label="Filter events by op class"
+      >
+        <option value="" {% if not op_class_filter %}selected{% endif %}>All</option>
+        {% for option in op_class_options %}
+          <option value="{{ option }}" {% if option == op_class_filter %}selected{% endif %}>
+            {{ option }}
+          </option>
+        {% endfor %}
+      </select>
+    </label>
+
+    {# ---------- principal ---------- #}
+    <label class="form-control">
+      <span class="label-text">Principal</span>
+      <input
+        type="search"
+        name="principal"
+        value="{{ principal_filter }}"
+        placeholder="Exact sub match"
+        class="input input-bordered input-sm"
+        aria-label="Filter events by principal sub"
+      />
+    </label>
+
+    {# ---------- target ---------- #}
+    <label class="form-control">
+      <span class="label-text">Target</span>
+      <select
+        name="target"
+        class="select select-bordered select-sm"
+        aria-label="Filter events by target"
+      >
+        <option value="" {% if not target_filter %}selected{% endif %}>All targets</option>
+        {% for option in target_options %}
+          <option value="{{ option }}" {% if option == target_filter %}selected{% endif %}>
+            {{ option }}
+          </option>
+        {% endfor %}
+      </select>
+    </label>
+
+    {# ---------- op_id (client-side) ----------
+       Not in the form's ``hx-include`` -- it narrows the streamed events
+       in-browser. Each keystroke dispatches a window event the feed
+       controller re-applies. ``x-data`` here is a tiny standalone island
+       (the feed controller lives in the swapped fragment) whose only job
+       is to debounce-emit the op_id. -#}
+    <label
+      class="form-control"
+      x-data="{ opId: {{ op_id_filter | tojson }} }"
+    >
+      <span class="label-text">Operation id</span>
+      <input
+        type="search"
+        name="op_id"
+        x-model="opId"
+        value="{{ op_id_filter }}"
+        placeholder="Substring match"
+        class="input input-bordered input-sm"
+        aria-label="Filter events by operation id substring"
+        x-on:input.debounce.250ms="
+          $dispatch('broadcast-op-id-changed', { opId });
+        "
+      />
+    </label>
+  </div>
+</form>

--- a/backend/src/meho_backplane/ui/templates/broadcast/feed.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/feed.html
@@ -2,35 +2,38 @@
   SPDX-License-Identifier: Apache-2.0
   Copyright (c) 2026 evoila Group
 
-  Broadcast live-feed view (Initiative #338 Task #867, work items
-  #1/#2/#8/#9). Extends ``base.html`` so the chrome (navbar, sidebar,
-  footer) matches every other surface; the sidebar's Broadcast link is
-  marked active via ``active_surface="broadcast"`` passed by the route.
+  Broadcast live-feed view. Task #867 (G10.1-T1) shipped the live feed
+  (work items #1/#2/#8/#9); Task #868 (G10.1-T2) adds the filter bar
+  (work item #3), the event-detail drawer (work item #4), and the PII 🔒
+  visualisation (work item #7).
 
-  Live-streaming model
-  --------------------
-  The HTMX ``sse`` extension (``hx-ext="sse"``, vendored in HTMX 2 as a
-  separate plugin) opens an ``EventSource`` to ``stream_endpoint`` --
-  the session-gated ``/ui/broadcast/stream`` bridge, NOT ``/api/v1/feed``
-  directly (the browser ``EventSource`` cannot send the Bearer header
-  that API route requires; see the stream route's docstring). The
-  extension owns connection lifecycle + exponential-backoff reconnect +
-  ``Last-Event-Id`` replay.
+  Layout (top-down):
+    * Header -- title + tenant badge + connection/row-count pills.
+    * Filter bar (``broadcast/_filter_bar.html``) -- op_class select,
+      principal text, target dropdown, op_id search. The three
+      stream-supported filters (op_class/principal/target) ``hx-get`` to
+      ``/ui/broadcast/feed`` and swap the feed fragment so a fresh
+      ``sse-connect`` URL carries them server-side; op_id narrows the
+      already-streamed events client-side (the stream has no op_id
+      param).
+    * Feed fragment (``broadcast/_feed.html``) -- the SSE sink +
+      reverse-chronological list. Wrapped in the ``broadcastFeed`` Alpine
+      controller; the whole fragment is the HTMX swap target so a filter
+      re-render replaces the SSE subscription AND resets the event list.
+    * Drawer slot (``#event-drawer``) -- event-detail fragments swap in
+      on a row click; Alpine click-outside dismisses.
 
-  A hidden sink element carries ``sse-swap="broadcast"`` so the extension
-  subscribes to the feed's ``event: broadcast`` frames. We hook
-  ``htmx:sseBeforeMessage`` (cancelable) to (a) parse the JSON payload
-  into the Alpine ``events`` array and (b) ``preventDefault()`` so the
-  extension does NOT swap the raw JSON text into the DOM. Each event then
-  renders through the server-authored ``broadcast/_event_row.html``
-  partial via an Alpine ``<template x-for>`` -- server-side markup,
-  client-side data binding (work item #2).
-
-  Performance discipline (work item #9): new events ``unshift`` to the
-  front (reverse-chronological) and the controller trims the array to
-  ``in_dom_row_cap`` (1000) so a sustained stream keeps the DOM bounded.
-
-  Empty state (work item #8): rendered while ``events`` is empty.
+  Live-streaming model (unchanged from T1)
+  ----------------------------------------
+  The HTMX ``sse`` extension opens an ``EventSource`` to the feed
+  fragment's ``sse-connect`` -- the session-gated ``/ui/broadcast/stream``
+  bridge, NOT ``/api/v1/feed`` directly (the browser ``EventSource``
+  cannot send the Bearer header that API route requires; see the stream
+  route's docstring). A hidden sink carries ``sse-swap="broadcast"``; the
+  ``broadcastFeed`` controller hooks ``htmx:sse-before-message``, parses
+  the JSON, ``preventDefault()``s the raw swap, and prepends the event
+  to its bounded ``events`` array. Each event renders through the
+  server-authored ``broadcast/_event_row.html`` partial.
 -#}
 {% extends "base.html" %}
 
@@ -40,10 +43,6 @@
 <section
   class="space-y-4"
   hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
-  x-data="broadcastFeed({
-    cap: {{ in_dom_row_cap }},
-    badgeClasses: {{ op_class_badge_json }}
-  })"
 >
   {# ---------- Header ---------- #}
   <header class="flex flex-wrap items-center justify-between gap-4">
@@ -54,79 +53,34 @@
         <code class="badge badge-outline">{{ tenant_id }}</code>.
       </p>
     </div>
-    <div class="flex items-center gap-3 text-sm opacity-70">
-      {# Connection status pill -- Alpine reflects the SSE open/error
-         state the extension surfaces via htmx:sseOpen / htmx:sseError. #}
-      <span class="flex items-center gap-1" aria-live="polite">
-        <span
-          class="inline-block h-2 w-2 rounded-full"
-          :class="connected ? 'bg-success' : 'bg-warning'"
-          aria-hidden="true"
-        ></span>
-        <span x-text="connected ? 'live' : 'connecting…'"></span>
-      </span>
-      <span aria-live="polite" x-text="events.length + ' / {{ in_dom_row_cap }} rows'"></span>
-    </div>
   </header>
 
-  {# ---------- SSE sink ----------
-     Hidden element the sse extension binds the EventSource listener to.
-     ``hx-ext="sse"`` activates the extension; ``sse-connect`` opens the
-     stream; ``sse-swap="broadcast"`` subscribes to the feed's
-     ``event: broadcast`` frames. We cancel the default swap in
-     ``htmx:sseBeforeMessage`` and route the data through Alpine instead.
-  -#}
-  <div
-    hx-ext="sse"
-    sse-connect="{{ stream_endpoint }}"
-    sse-swap="broadcast"
-    class="hidden"
-    aria-hidden="true"
-    x-on:htmx:sse-before-message="onSseMessage($event)"
-    x-on:htmx:sse-open="connected = true"
-    x-on:htmx:sse-error="connected = false"
-  ></div>
+  {# ---------- Filter bar (work item #3) ---------- #}
+  {% include "broadcast/_filter_bar.html" %}
 
-  {# ---------- Feed list ---------- #}
-  <div class="overflow-hidden rounded-box border border-base-300 bg-base-100">
-    {# Column header row -- mirrors the grid in _event_row.html. #}
-    <div
-      class="grid grid-cols-12 gap-2 border-b border-base-300 px-3 py-2 text-xs font-semibold uppercase tracking-wide opacity-60"
-    >
-      <span class="col-span-2">Time</span>
-      <span class="col-span-2">Principal</span>
-      <span class="col-span-3">Operation</span>
-      <span class="col-span-1">Class</span>
-      <span class="col-span-1">Status</span>
-      <span class="col-span-1">Target</span>
-      <span class="col-span-2">Payload</span>
+  {# ---------- Feed + drawer two-column layout ----------
+     On ``lg:`` viewports the feed takes 2/3 and the drawer 1/3; on
+     smaller viewports the drawer stacks below the feed. -#}
+  <div class="grid gap-4 lg:grid-cols-3">
+    <div class="lg:col-span-2">
+      {% include "broadcast/_feed.html" %}
     </div>
 
-    {# Empty state (work item #8) -- shown until the first event lands
-       or when filters (T2) match nothing. #}
-    <div
-      x-show="events.length === 0"
-      class="px-3 py-10 text-center text-sm opacity-70"
-      id="broadcast-empty-state"
-    >
-      No activity matching your filters. Try adjusting the op_class or
-      target filter, or wait for new events.
-    </div>
-
-    {# Live list -- newest first. Each event renders via the
-       server-authored row partial. ``:key`` keeps Alpine's DOM diff
-       stable as rows prepend + trim. #}
-    <ul
-      x-show="events.length > 0"
-      class="divide-y divide-base-300"
-      role="list"
-      aria-label="Live broadcast events"
+    {# ---------- Drawer slot (work item #4) ----------
+       Event-detail fragments swap into ``#event-drawer`` on a row
+       click via ``hx-target``. The placeholder shape mirrors the
+       happy-path / not-found fragments so the outerHTML swap stays
+       semantically consistent. -#}
+    <aside
+      id="event-drawer"
+      class="card bg-base-100 border-base-300 border shadow-sm self-start"
       aria-live="polite"
+      aria-label="Event detail drawer"
     >
-      <template x-for="ev in events" :key="ev.event_id">
-        {% include "broadcast/_event_row.html" %}
-      </template>
-    </ul>
+      <div class="card-body text-sm opacity-70">
+        Select an event to inspect its full audit detail.
+      </div>
+    </aside>
   </div>
 </section>
 {% endblock %}
@@ -134,7 +88,7 @@
 {# Surface JS -- the ``broadcastFeed`` Alpine controller. Loaded as an
    external deferred script (not inline) so a future nonce-based CSP
    needs no special-casing. Registers on ``alpine:init`` before Alpine
-   processes the ``x-data`` above. #}
+   processes the ``x-data`` in the feed fragment. #}
 {% block scripts %}
   <script src="/ui/static/src/app/broadcast-feed.js" defer></script>
 {% endblock %}

--- a/backend/tests/test_ui_broadcast_filters.py
+++ b/backend/tests/test_ui_broadcast_filters.py
@@ -394,6 +394,54 @@ def test_fragment_op_id_filter_seed_reaches_controller() -> None:
     assert "opIdFilter" in body
 
 
+def test_op_id_filter_survives_server_side_filter_re_render() -> None:
+    """op_id client filtering must survive an op_class/principal/target swap.
+
+    Regression guard for review finding B1 on PR #1041. A server-side
+    filter change (op_class/principal/target) ``hx-get``s the fragment
+    route -- WITHOUT op_id (it is excluded from the form's
+    ``hx-include``) -- and swaps ``#broadcast-feed``. The fresh fragment
+    therefore seeds ``opIdFilter`` empty, and the re-mounted Alpine
+    controller would drop the operator's active op_id filter even though
+    the op_id input (outside the swapped fragment) still shows the typed
+    value.
+
+    The fix: the controller's ``init`` re-reads the live op_id input on
+    every mount (initial load AND every swap), making the input the
+    single source of truth so the client-side narrowing keeps applying.
+    This test proves the two halves of that contract at the surface this
+    repo exposes (no headless browser harness):
+
+    1. The swap fragment for an op_class change (op_id absent) still
+       mounts the ``broadcastFeed`` controller -- so Alpine re-runs
+       ``init`` on the swapped-in node.
+    2. The served controller JS re-reads ``input[name="op_id"]`` in
+       ``init`` rather than relying solely on the server ``opIdFilter``
+       seed (which is empty on a server re-render).
+    """
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        # The exact swap that triggered B1: a server-side filter changes,
+        # op_id is NOT carried (excluded from hx-include).
+        fragment = client.get("/ui/broadcast/feed", params={"op_class": "write"})
+        controller_js = client.get("/ui/static/src/app/broadcast-feed.js")
+    assert fragment.status_code == 200, fragment.text
+    # 1. The swapped fragment re-mounts the controller (so Alpine re-runs
+    #    init on the swapped node).
+    assert "broadcastFeed(" in fragment.text
+    # op_id was not part of this server re-render, so the server seed is
+    # empty -- the survival cannot come from the server context.
+    assert "op_id=write" not in fragment.text
+
+    assert controller_js.status_code == 200, controller_js.text
+    js = controller_js.text
+    # 2. init re-reads the live op_id input -- the source of truth that
+    #    survives the swap -- rather than trusting only the server seed.
+    assert "init()" in js
+    assert "document.querySelector('input[name=\"op_id\"]')" in js
+
+
 def test_fragment_filter_values_echoed_for_selection_preservation() -> None:
     """The fragment echoes filter values so a re-render keeps the selection."""
     session_id = _seed_session_sync(tenant_id=_TENANT_A)

--- a/backend/tests/test_ui_broadcast_filters.py
+++ b/backend/tests/test_ui_broadcast_filters.py
@@ -1,0 +1,563 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the Broadcast filters + event-detail drawer.
+
+Initiative #338 (G10.1 Activity broadcast UI), Task #868 (G10.1-T2).
+Acceptance criteria on issue #868:
+
+* All 4 filters work; combined filters narrow correctly; the re-rendered
+  feed's SSE subscription carries the active filter (assert URL).
+* Event click → drawer with full payload (non-aggregate), request_id,
+  audit_id link, event_id; Alpine click-outside dismisses.
+* ``credential_read`` / aggregate-only events render 🔒 + the placeholder.
+* The target dropdown is tenant-scoped (from the tenant's targets).
+* ``ruff`` + ``mypy`` clean; ``pytest -n auto`` passes.
+
+The op_class/principal/target filters are the three the stream bridge
+supports; they ride into the feed fragment's ``sse-connect`` URL so the
+server drops non-matching events. op_id has no stream parameter, so it is
+the client-side substring filter the ``broadcastFeed`` Alpine controller
+applies -- exercised here by asserting the controller wiring + the
+op_id-filter seed reaches the page (the substring narrowing itself runs
+in-browser and is verified via the JS surface, not a server round-trip).
+
+Two test surfaces (mirroring :mod:`backend.tests.test_ui_broadcast_feed`):
+
+* **HTTP edge** -- a minimal app wired with the UI session + CSRF
+  middlewares, an authenticated client via a seeded ``web_session`` row.
+  Covers the filter fragment route, the target dropdown, the event
+  drawer (happy / aggregate-only / 404 / cross-tenant), and the unauth
+  redirect.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.broadcast import reset_broadcast_client_for_testing
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import (
+    SESSION_COOKIE_NAME,
+    UISessionMiddleware,
+)
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import CSRFMiddleware
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests.conftest import DEFAULT_AUDIENCE, DEFAULT_ISSUER
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+_BACKPLANE_URL = "https://meho.test"
+
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_TENANT_B = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF + broadcast env vars for every test.
+
+    Mirrors :func:`backend.tests.test_ui_broadcast_feed._bff_env`. Cache
+    + global-state resets run on setup and teardown so a failing test
+    cannot leak ``_TEMPLATES`` / session-engine / broadcast-client state
+    into the next case.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("BROADCAST_REDIS_URL", "redis://broadcast.test:6379")
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    reset_broadcast_client_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    reset_broadcast_client_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+def _build_app() -> FastAPI:
+    """Construct a minimal FastAPI app wired for the broadcast UI tests.
+
+    Mirrors the production wiring + the chassis/topology/feed suites:
+    StaticFiles at ``/ui/static``, BFF auth router + UI surface router
+    (which includes the broadcast routes ahead of the stubs),
+    ``UISessionMiddleware`` outermost + ``CSRFMiddleware`` next.
+    """
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID,
+    operator_sub: str = "op-42",
+    lifetime: timedelta = timedelta(hours=1),
+) -> uuid.UUID:
+    """Create a ``web_session`` row directly and return its UUID."""
+    from meho_backplane.db.engine import get_sessionmaker
+
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token="access-token-plaintext",
+                refresh_token="refresh-token-plaintext",
+                lifetime=lifetime,
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _seed_target(*, tenant_id: uuid.UUID, name: str, product: str = "vmware") -> None:
+    """Insert one ``targets`` row for the dropdown tenant-scoping test."""
+    from meho_backplane.db.engine import get_sessionmaker
+    from meho_backplane.db.models import Target as TargetORM
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                TargetORM(
+                    id=uuid.uuid4(),
+                    tenant_id=tenant_id,
+                    name=name,
+                    aliases=[],
+                    product=product,
+                    host=f"{name}.test",
+                ),
+            )
+
+    asyncio.run(_do())
+
+
+def _seed_audit_row(
+    *,
+    tenant_id: uuid.UUID,
+    payload: dict[str, object],
+    operator_sub: str = "op-42",
+    method: str = "POST",
+    path: str = "/api/v1/call",
+    status_code: int = 200,
+    request_id: uuid.UUID | None = None,
+) -> uuid.UUID:
+    """Insert one ``audit_log`` row and return its id (the drawer key)."""
+    from meho_backplane.db.engine import get_sessionmaker
+    from meho_backplane.db.models import AuditLog
+
+    audit_id = uuid.uuid4()
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                AuditLog(
+                    id=audit_id,
+                    occurred_at=datetime.now(UTC),
+                    operator_sub=operator_sub,
+                    method=method,
+                    path=path,
+                    status_code=status_code,
+                    request_id=request_id or uuid.uuid4(),
+                    duration_ms=Decimal("12.50"),
+                    payload=payload,
+                    tenant_id=tenant_id,
+                ),
+            )
+
+    asyncio.run(_do())
+    return audit_id
+
+
+def _authenticated_client(session_id: uuid.UUID) -> TestClient:
+    """Return a TestClient with the session cookie pre-set."""
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Authentication boundary
+# ---------------------------------------------------------------------------
+
+
+def test_feed_fragment_unauthenticated_redirects_to_login() -> None:
+    """``GET /ui/broadcast/feed`` without a session 302s to the BFF login."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/broadcast/feed")
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+
+
+def test_event_drawer_unauthenticated_redirects_to_login() -> None:
+    """``GET /ui/broadcast/event/<id>`` without a session 302s to login."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get(f"/ui/broadcast/event/{uuid.uuid4()}")
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+
+
+# ---------------------------------------------------------------------------
+# Filter bar -- full page render
+# ---------------------------------------------------------------------------
+
+
+def test_page_renders_filter_bar_with_all_four_controls() -> None:
+    """The full page renders the op_class / principal / target / op_id controls."""
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/broadcast")
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'name="op_class"' in body
+    assert 'name="principal"' in body
+    assert 'name="target"' in body
+    assert 'name="op_id"' in body
+    # The filter bar HTMX-submits the three server filters to the fragment route.
+    assert 'hx-get="/ui/broadcast/feed"' in body
+    assert 'hx-target="#broadcast-feed"' in body
+
+
+def test_page_op_class_options_cover_the_closed_vocabulary() -> None:
+    """The op_class dropdown offers All + the six sensitivity classes."""
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/broadcast")
+    body = response.text
+    assert ">All<" in body
+    for op_class in (
+        "read",
+        "write",
+        "credential_read",
+        "credential_mint",
+        "audit_query",
+        "other",
+    ):
+        assert f'value="{op_class}"' in body
+
+
+def test_target_dropdown_is_tenant_scoped() -> None:
+    """The target dropdown lists only the session tenant's target names."""
+    _seed_target(tenant_id=_TENANT_A, name="rdc-vcenter")
+    _seed_target(tenant_id=_TENANT_A, name="lab-k8s")
+    # A target in tenant B must NOT appear on tenant A's dropdown.
+    _seed_target(tenant_id=_TENANT_B, name="other-tenant-target")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/broadcast")
+    body = response.text
+    assert 'value="rdc-vcenter"' in body
+    assert 'value="lab-k8s"' in body
+    assert "other-tenant-target" not in body
+
+
+# ---------------------------------------------------------------------------
+# Filter fragment -- SSE URL carries the active filters
+# ---------------------------------------------------------------------------
+
+
+def test_fragment_no_filters_streams_unfiltered() -> None:
+    """No filters → the fragment's sse-connect is the bare bridge URL."""
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/broadcast/feed")
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Bare bridge URL -- no query string -> stream everything.
+    assert 'sse-connect="/ui/broadcast/stream"' in body
+    # The fragment is the swap target root.
+    assert 'id="broadcast-feed"' in body
+    # Fragment only -- no full-page chrome.
+    assert "<title>" not in body
+
+
+def test_fragment_single_filter_embedded_in_sse_url() -> None:
+    """A single op_class filter rides into the sse-connect query string."""
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/broadcast/feed", params={"op_class": "write"})
+    body = response.text
+    assert 'sse-connect="/ui/broadcast/stream?op_class=write"' in body
+
+
+def test_fragment_combined_filters_all_embedded_in_sse_url() -> None:
+    """Combined op_class + principal + target all ride the sse-connect URL."""
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(
+            "/ui/broadcast/feed",
+            params={"op_class": "read", "principal": "op-7", "target": "rdc-vcenter"},
+        )
+    body = response.text
+    # The three server filters are all present in the embedded URL.
+    assert "op_class=read" in body
+    assert "principal=op-7" in body
+    assert "target=rdc-vcenter" in body
+    assert 'sse-connect="/ui/broadcast/stream?' in body
+
+
+def test_fragment_principal_with_special_chars_is_url_encoded() -> None:
+    """A principal sub with reserved chars is percent-encoded in the URL.
+
+    A raw ``&`` / ``=`` / space in the value would corrupt the query
+    string; ``urlencode`` percent-encodes it so the bridge parses one
+    coherent ``principal`` parameter.
+    """
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(
+            "/ui/broadcast/feed",
+            params={"principal": "a&b=c d"},
+        )
+    body = response.text
+    # The raw value never appears unencoded inside the sse-connect URL.
+    assert "principal=a%26b%3Dc+d" in body
+
+
+def test_fragment_op_id_filter_seed_reaches_controller() -> None:
+    """op_id is a client-side filter; its seed is passed into the controller.
+
+    op_id has no stream parameter -- it never rides the sse-connect URL.
+    Instead the seed reaches the Alpine ``broadcastFeed`` controller so a
+    copy-pasted filtered URL renders the narrowed view client-side.
+    """
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/broadcast/feed", params={"op_id": "vm.list"})
+    body = response.text
+    # op_id is NOT a stream param -- it must not appear in the SSE URL.
+    assert "op_id=vm.list" not in body
+    # It IS seeded into the controller for client-side narrowing.
+    assert "vm.list" in body
+    assert "opIdFilter" in body
+
+
+def test_fragment_filter_values_echoed_for_selection_preservation() -> None:
+    """The fragment echoes filter values so a re-render keeps the selection."""
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(
+            "/ui/broadcast/feed",
+            params={"op_class": "credential_read"},
+        )
+    body = response.text
+    # The op_class selection is reflected in the embedded SSE URL.
+    assert "op_class=credential_read" in body
+
+
+# ---------------------------------------------------------------------------
+# Event detail drawer
+# ---------------------------------------------------------------------------
+
+
+def test_drawer_renders_full_detail_for_non_aggregate_op() -> None:
+    """A non-sensitive op renders the full payload + identifiers."""
+    request_id = uuid.uuid4()
+    audit_id = _seed_audit_row(
+        tenant_id=_TENANT_A,
+        payload={"op_id": "vsphere.vm.list", "params": {"datacenter": "dc-1"}},
+        request_id=request_id,
+    )
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(
+            f"/ui/broadcast/event/{audit_id}",
+            params={"event_id": "evt-9000"},
+        )
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Identifiers: audit_id, request_id, broadcast event_id.
+    assert str(audit_id) in body
+    assert str(request_id) in body
+    assert "evt-9000" in body
+    # Full payload params rendered (non-aggregate op).
+    assert "datacenter" in body
+    assert "dc-1" in body
+    # No PII placeholder for a non-sensitive op.
+    assert "aggregate-only" not in body
+    # Drawer carries the Alpine click-outside dismiss island.
+    assert 'id="event-drawer"' in body
+    assert "click.outside" in body
+
+
+def test_drawer_strips_internal_payload_keys() -> None:
+    """The drawer hides audit-only keys from the rendered request payload."""
+    audit_id = _seed_audit_row(
+        tenant_id=_TENANT_A,
+        payload={
+            "op_id": "vsphere.vm.create",
+            "params": {"name": "vm-new"},
+            "broadcast_detail_origin": "tenant_rule:abc-secret-uuid",
+            "broadcast_detail_effective": "full",
+        },
+    )
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(f"/ui/broadcast/event/{audit_id}")
+    body = response.text
+    assert "vm-new" in body
+    # Internal forensic keys never reach the drawer payload view.
+    assert "broadcast_detail_origin" not in body
+    assert "tenant_rule:abc-secret-uuid" not in body
+
+
+def test_drawer_credential_read_renders_lock_and_placeholder() -> None:
+    """A credential_read op renders 🔒 + the aggregate-only placeholder.
+
+    The drawer reads the canonical (unredacted) audit row; for a
+    sensitive op it must withhold the payload exactly as the feed row
+    does (decision #3 / work item #7) -- the secret params must never
+    surface even on click.
+    """
+    audit_id = _seed_audit_row(
+        tenant_id=_TENANT_A,
+        payload={"op_id": "vault.kv.read", "params": {"path": "secret/prod/db"}},
+    )
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(f"/ui/broadcast/event/{audit_id}")
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The 🔒 marker (rendered as the HTML entity) + the exact placeholder copy.
+    assert "&#x1F512;" in body
+    assert "aggregate-only — credential read; details not broadcast" in body
+    # The secret path must NEVER reach the drawer for a credential read.
+    assert "secret/prod/db" not in body
+
+
+def test_drawer_honours_effective_aggregate_verdict_for_audit_query() -> None:
+    """An audit_query op (aggregate effective) withholds the payload."""
+    audit_id = _seed_audit_row(
+        tenant_id=_TENANT_A,
+        payload={
+            "op_id": "audit.query",
+            "params": {"filter": "operator=alice"},
+            "broadcast_detail_effective": "aggregate",
+        },
+    )
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(f"/ui/broadcast/event/{audit_id}")
+    body = response.text
+    assert "aggregate-only" in body
+    assert "operator=alice" not in body
+
+
+def test_drawer_404_for_unknown_audit_id() -> None:
+    """A non-existent audit id renders the not-found fragment with 404."""
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(f"/ui/broadcast/event/{uuid.uuid4()}")
+    assert response.status_code == 404
+    assert "Event not found" in response.text
+
+
+def test_drawer_cross_tenant_audit_id_is_opaque_404() -> None:
+    """A tenant-B audit id returns 404 for a tenant-A operator.
+
+    Cross-tenant isolation: the tenant boundary is opaque, so a row that
+    exists only in another tenant is indistinguishable from a missing id.
+    """
+    audit_id = _seed_audit_row(
+        tenant_id=_TENANT_B,
+        payload={"op_id": "vsphere.vm.list", "params": {}},
+    )
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(f"/ui/broadcast/event/{audit_id}")
+    assert response.status_code == 404
+    assert "Event not found" in response.text
+
+
+def test_drawer_falls_back_to_http_op_id_heuristic() -> None:
+    """A row with no payload op_id classifies via the http.{method}:{path} form.
+
+    A chassis HTTP route audit row carries no ``op_id``; the drawer must
+    classify off the same ``http.{method.lower()}:{path}`` string the
+    publisher used so the verdict matches. A plain GET path classifies
+    ``other`` -> full detail.
+    """
+    audit_id = _seed_audit_row(
+        tenant_id=_TENANT_A,
+        payload={"params": {"q": "search-term"}},
+        method="GET",
+        path="/api/v1/connectors",
+    )
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(f"/ui/broadcast/event/{audit_id}")
+    assert response.status_code == 200, response.text
+    body = response.text
+    # ``other`` class -> full detail; the params render.
+    assert "search-term" in body
+    assert "aggregate-only" not in body

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -4185,8 +4185,54 @@
           "ui-broadcast"
         ],
         "summary": "Ui Broadcast Feed",
-        "description": "Render ``GET /ui/broadcast`` for the authenticated operator.\n\nThe page subscribes to ``/ui/broadcast/stream`` (the session-gated\nSSE bridge), so the operator sees their tenant's live events with\nno further auth round-trip. The CSRF cookie is set + echoed via the\ntemplate's ``hx-headers`` so any future state-changing HTMX request\nfrom this surface (T2's filters submit via ``hx-get``, which is\nsafe, but the chain is in place for any later mutation) passes the\ndouble-submit check -- mirroring the dashboard + topology surfaces.",
+        "description": "``GET /ui/broadcast[?op_class=&principal=&target=&op_id=]``.\n\nFilters are accepted on the full-page route too so a copy-pasted\nfiltered URL reproduces the operator's view (the filter bar sets\n``hx-push-url`` on the fragment route, mirroring topology).",
         "operationId": "ui_broadcast_feed_ui_broadcast_get",
+        "parameters": [
+          {
+            "name": "op_class",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 64,
+              "default": "",
+              "title": "Op Class"
+            }
+          },
+          {
+            "name": "principal",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 256,
+              "default": "",
+              "title": "Principal"
+            }
+          },
+          {
+            "name": "target",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 256,
+              "default": "",
+              "title": "Target"
+            }
+          },
+          {
+            "name": "op_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 256,
+              "default": "",
+              "title": "Op Id"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -4194,6 +4240,94 @@
               "text/html": {
                 "schema": {
                   "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/broadcast/feed": {
+      "get": {
+        "tags": [
+          "ui-broadcast"
+        ],
+        "summary": "Ui Broadcast Feed Fragment",
+        "description": "``GET /ui/broadcast/feed[?op_class=&principal=&target=&op_id=]``.\n\nThe filter-bar submit target. Returns the feed fragment with the\nfiltered ``sse-connect`` URL embedded.",
+        "operationId": "ui_broadcast_feed_fragment_ui_broadcast_feed_get",
+        "parameters": [
+          {
+            "name": "op_class",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 64,
+              "default": "",
+              "title": "Op Class"
+            }
+          },
+          {
+            "name": "principal",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 256,
+              "default": "",
+              "title": "Principal"
+            }
+          },
+          {
+            "name": "target",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 256,
+              "default": "",
+              "title": "Target"
+            }
+          },
+          {
+            "name": "op_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 256,
+              "default": "",
+              "title": "Op Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -4259,6 +4393,69 @@
         "responses": {
           "200": {
             "description": "Successful Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/broadcast/event/{audit_id}": {
+      "get": {
+        "tags": [
+          "ui-broadcast"
+        ],
+        "summary": "Ui Broadcast Event Detail",
+        "description": "``GET /ui/broadcast/event/{audit_id}[?event_id=...]``.\n\nResolves the audit row tenant-scoped, classifies its op for the\naggregate-only gate, and renders ``broadcast/_event_drawer.html``\nwith the full detail (or the \ud83d\udd12 placeholder for sensitive\nclasses). A missing / cross-tenant id renders the not-found\nfragment with HTTP 404.",
+        "operationId": "ui_broadcast_event_detail_ui_broadcast_event__audit_id__get",
+        "parameters": [
+          {
+            "name": "audit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "title": "Audit Id"
+            }
+          },
+          {
+            "name": "event_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "description": "Broadcast (Valkey-stream) event id, for display only.",
+              "default": "",
+              "title": "Event Id"
+            },
+            "description": "Broadcast (Valkey-stream) event id, for display only."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Audit id does not exist in this tenant (or exists only for another tenant). Returns the not-found drawer fragment.",
+            "content": {
+              "text/html": {}
+            }
           },
           "422": {
             "description": "Validation Error",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -2775,6 +2775,28 @@ type UiAuthLoginUiAuthLoginGetParams struct {
 	ReturnTo *string `form:"return_to,omitempty" json:"return_to,omitempty"`
 }
 
+// UiBroadcastFeedUiBroadcastGetParams defines parameters for UiBroadcastFeedUiBroadcastGet.
+type UiBroadcastFeedUiBroadcastGetParams struct {
+	OpClass   *string `form:"op_class,omitempty" json:"op_class,omitempty"`
+	Principal *string `form:"principal,omitempty" json:"principal,omitempty"`
+	Target    *string `form:"target,omitempty" json:"target,omitempty"`
+	OpId      *string `form:"op_id,omitempty" json:"op_id,omitempty"`
+}
+
+// UiBroadcastEventDetailUiBroadcastEventAuditIdGetParams defines parameters for UiBroadcastEventDetailUiBroadcastEventAuditIdGet.
+type UiBroadcastEventDetailUiBroadcastEventAuditIdGetParams struct {
+	// EventId Broadcast (Valkey-stream) event id, for display only.
+	EventId *string `form:"event_id,omitempty" json:"event_id,omitempty"`
+}
+
+// UiBroadcastFeedFragmentUiBroadcastFeedGetParams defines parameters for UiBroadcastFeedFragmentUiBroadcastFeedGet.
+type UiBroadcastFeedFragmentUiBroadcastFeedGetParams struct {
+	OpClass   *string `form:"op_class,omitempty" json:"op_class,omitempty"`
+	Principal *string `form:"principal,omitempty" json:"principal,omitempty"`
+	Target    *string `form:"target,omitempty" json:"target,omitempty"`
+	OpId      *string `form:"op_id,omitempty" json:"op_id,omitempty"`
+}
+
 // UiBroadcastStreamUiBroadcastStreamGetParams defines parameters for UiBroadcastStreamUiBroadcastStreamGet.
 type UiBroadcastStreamUiBroadcastStreamGetParams struct {
 	OpClass   *string `form:"op_class,omitempty" json:"op_class,omitempty"`
@@ -3233,7 +3255,13 @@ type ClientInterface interface {
 	UiAuthLogoutUiAuthLogoutGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiBroadcastFeedUiBroadcastGet request
-	UiBroadcastFeedUiBroadcastGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	UiBroadcastFeedUiBroadcastGet(ctx context.Context, params *UiBroadcastFeedUiBroadcastGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiBroadcastEventDetailUiBroadcastEventAuditIdGet request
+	UiBroadcastEventDetailUiBroadcastEventAuditIdGet(ctx context.Context, auditId openapi_types.UUID, params *UiBroadcastEventDetailUiBroadcastEventAuditIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiBroadcastFeedFragmentUiBroadcastFeedGet request
+	UiBroadcastFeedFragmentUiBroadcastFeedGet(ctx context.Context, params *UiBroadcastFeedFragmentUiBroadcastFeedGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiBroadcastStreamUiBroadcastStreamGet request
 	UiBroadcastStreamUiBroadcastStreamGet(ctx context.Context, params *UiBroadcastStreamUiBroadcastStreamGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -4313,8 +4341,32 @@ func (c *Client) UiAuthLogoutUiAuthLogoutGet(ctx context.Context, reqEditors ...
 	return c.Client.Do(req)
 }
 
-func (c *Client) UiBroadcastFeedUiBroadcastGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUiBroadcastFeedUiBroadcastGetRequest(c.Server)
+func (c *Client) UiBroadcastFeedUiBroadcastGet(ctx context.Context, params *UiBroadcastFeedUiBroadcastGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiBroadcastFeedUiBroadcastGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiBroadcastEventDetailUiBroadcastEventAuditIdGet(ctx context.Context, auditId openapi_types.UUID, params *UiBroadcastEventDetailUiBroadcastEventAuditIdGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiBroadcastEventDetailUiBroadcastEventAuditIdGetRequest(c.Server, auditId, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiBroadcastFeedFragmentUiBroadcastFeedGet(ctx context.Context, params *UiBroadcastFeedFragmentUiBroadcastFeedGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiBroadcastFeedFragmentUiBroadcastFeedGetRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -8908,7 +8960,7 @@ func NewUiAuthLogoutUiAuthLogoutGetRequest(server string) (*http.Request, error)
 }
 
 // NewUiBroadcastFeedUiBroadcastGetRequest generates requests for UiBroadcastFeedUiBroadcastGet
-func NewUiBroadcastFeedUiBroadcastGetRequest(server string) (*http.Request, error) {
+func NewUiBroadcastFeedUiBroadcastGetRequest(server string, params *UiBroadcastFeedUiBroadcastGetParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -8924,6 +8976,229 @@ func NewUiBroadcastFeedUiBroadcastGetRequest(server string) (*http.Request, erro
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.OpClass != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "op_class", runtime.ParamLocationQuery, *params.OpClass); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Principal != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "principal", runtime.ParamLocationQuery, *params.Principal); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Target != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "target", runtime.ParamLocationQuery, *params.Target); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.OpId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "op_id", runtime.ParamLocationQuery, *params.OpId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUiBroadcastEventDetailUiBroadcastEventAuditIdGetRequest generates requests for UiBroadcastEventDetailUiBroadcastEventAuditIdGet
+func NewUiBroadcastEventDetailUiBroadcastEventAuditIdGetRequest(server string, auditId openapi_types.UUID, params *UiBroadcastEventDetailUiBroadcastEventAuditIdGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "audit_id", runtime.ParamLocationPath, auditId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/broadcast/event/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.EventId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "event_id", runtime.ParamLocationQuery, *params.EventId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUiBroadcastFeedFragmentUiBroadcastFeedGetRequest generates requests for UiBroadcastFeedFragmentUiBroadcastFeedGet
+func NewUiBroadcastFeedFragmentUiBroadcastFeedGetRequest(server string, params *UiBroadcastFeedFragmentUiBroadcastFeedGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/broadcast/feed")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.OpClass != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "op_class", runtime.ParamLocationQuery, *params.OpClass); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Principal != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "principal", runtime.ParamLocationQuery, *params.Principal); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Target != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "target", runtime.ParamLocationQuery, *params.Target); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.OpId != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "op_id", runtime.ParamLocationQuery, *params.OpId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -9591,7 +9866,13 @@ type ClientWithResponsesInterface interface {
 	UiAuthLogoutUiAuthLogoutGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiAuthLogoutUiAuthLogoutGetResponse, error)
 
 	// UiBroadcastFeedUiBroadcastGetWithResponse request
-	UiBroadcastFeedUiBroadcastGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiBroadcastFeedUiBroadcastGetResponse, error)
+	UiBroadcastFeedUiBroadcastGetWithResponse(ctx context.Context, params *UiBroadcastFeedUiBroadcastGetParams, reqEditors ...RequestEditorFn) (*UiBroadcastFeedUiBroadcastGetResponse, error)
+
+	// UiBroadcastEventDetailUiBroadcastEventAuditIdGetWithResponse request
+	UiBroadcastEventDetailUiBroadcastEventAuditIdGetWithResponse(ctx context.Context, auditId openapi_types.UUID, params *UiBroadcastEventDetailUiBroadcastEventAuditIdGetParams, reqEditors ...RequestEditorFn) (*UiBroadcastEventDetailUiBroadcastEventAuditIdGetResponse, error)
+
+	// UiBroadcastFeedFragmentUiBroadcastFeedGetWithResponse request
+	UiBroadcastFeedFragmentUiBroadcastFeedGetWithResponse(ctx context.Context, params *UiBroadcastFeedFragmentUiBroadcastFeedGetParams, reqEditors ...RequestEditorFn) (*UiBroadcastFeedFragmentUiBroadcastFeedGetResponse, error)
 
 	// UiBroadcastStreamUiBroadcastStreamGetWithResponse request
 	UiBroadcastStreamUiBroadcastStreamGetWithResponse(ctx context.Context, params *UiBroadcastStreamUiBroadcastStreamGetParams, reqEditors ...RequestEditorFn) (*UiBroadcastStreamUiBroadcastStreamGetResponse, error)
@@ -11207,6 +11488,7 @@ func (r UiAuthLogoutUiAuthLogoutGetResponse) StatusCode() int {
 type UiBroadcastFeedUiBroadcastGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
 }
 
 // Status returns HTTPResponse.Status
@@ -11219,6 +11501,50 @@ func (r UiBroadcastFeedUiBroadcastGetResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r UiBroadcastFeedUiBroadcastGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiBroadcastEventDetailUiBroadcastEventAuditIdGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiBroadcastEventDetailUiBroadcastEventAuditIdGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiBroadcastEventDetailUiBroadcastEventAuditIdGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiBroadcastFeedFragmentUiBroadcastFeedGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiBroadcastFeedFragmentUiBroadcastFeedGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiBroadcastFeedFragmentUiBroadcastFeedGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -12150,12 +12476,30 @@ func (c *ClientWithResponses) UiAuthLogoutUiAuthLogoutGetWithResponse(ctx contex
 }
 
 // UiBroadcastFeedUiBroadcastGetWithResponse request returning *UiBroadcastFeedUiBroadcastGetResponse
-func (c *ClientWithResponses) UiBroadcastFeedUiBroadcastGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiBroadcastFeedUiBroadcastGetResponse, error) {
-	rsp, err := c.UiBroadcastFeedUiBroadcastGet(ctx, reqEditors...)
+func (c *ClientWithResponses) UiBroadcastFeedUiBroadcastGetWithResponse(ctx context.Context, params *UiBroadcastFeedUiBroadcastGetParams, reqEditors ...RequestEditorFn) (*UiBroadcastFeedUiBroadcastGetResponse, error) {
+	rsp, err := c.UiBroadcastFeedUiBroadcastGet(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseUiBroadcastFeedUiBroadcastGetResponse(rsp)
+}
+
+// UiBroadcastEventDetailUiBroadcastEventAuditIdGetWithResponse request returning *UiBroadcastEventDetailUiBroadcastEventAuditIdGetResponse
+func (c *ClientWithResponses) UiBroadcastEventDetailUiBroadcastEventAuditIdGetWithResponse(ctx context.Context, auditId openapi_types.UUID, params *UiBroadcastEventDetailUiBroadcastEventAuditIdGetParams, reqEditors ...RequestEditorFn) (*UiBroadcastEventDetailUiBroadcastEventAuditIdGetResponse, error) {
+	rsp, err := c.UiBroadcastEventDetailUiBroadcastEventAuditIdGet(ctx, auditId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiBroadcastEventDetailUiBroadcastEventAuditIdGetResponse(rsp)
+}
+
+// UiBroadcastFeedFragmentUiBroadcastFeedGetWithResponse request returning *UiBroadcastFeedFragmentUiBroadcastFeedGetResponse
+func (c *ClientWithResponses) UiBroadcastFeedFragmentUiBroadcastFeedGetWithResponse(ctx context.Context, params *UiBroadcastFeedFragmentUiBroadcastFeedGetParams, reqEditors ...RequestEditorFn) (*UiBroadcastFeedFragmentUiBroadcastFeedGetResponse, error) {
+	rsp, err := c.UiBroadcastFeedFragmentUiBroadcastFeedGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiBroadcastFeedFragmentUiBroadcastFeedGetResponse(rsp)
 }
 
 // UiBroadcastStreamUiBroadcastStreamGetWithResponse request returning *UiBroadcastStreamUiBroadcastStreamGetResponse
@@ -14394,6 +14738,68 @@ func ParseUiBroadcastFeedUiBroadcastGetResponse(rsp *http.Response) (*UiBroadcas
 	response := &UiBroadcastFeedUiBroadcastGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiBroadcastEventDetailUiBroadcastEventAuditIdGetResponse parses an HTTP response from a UiBroadcastEventDetailUiBroadcastEventAuditIdGetWithResponse call
+func ParseUiBroadcastEventDetailUiBroadcastEventAuditIdGetResponse(rsp *http.Response) (*UiBroadcastEventDetailUiBroadcastEventAuditIdGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiBroadcastEventDetailUiBroadcastEventAuditIdGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiBroadcastFeedFragmentUiBroadcastFeedGetResponse parses an HTTP response from a UiBroadcastFeedFragmentUiBroadcastFeedGetWithResponse call
+func ParseUiBroadcastFeedFragmentUiBroadcastFeedGetResponse(rsp *http.Response) (*UiBroadcastFeedFragmentUiBroadcastFeedGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiBroadcastFeedFragmentUiBroadcastFeedGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	}
 
 	return response, nil

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -434,7 +434,7 @@ the colour policy stays one auditable map.
 | `broadcast/_event_row.html` | Server-authored row markup (timestamp · principal badge · op_id · op_class badge · result_status icon · target · payload summary). Click opens the drawer; aggregate-only events render the 🔒 marker + placeholder. |
 | `broadcast/_event_drawer.html` | Event detail drawer: op identity, operation metadata, identifiers (audit_id / request_id / broadcast event_id), full payload (or the 🔒 placeholder for sensitive ops). Alpine `click.outside` / Escape / Close dismiss. |
 | `broadcast/_event_drawer_not_found.html` | The 404 drawer fragment for a missing / cross-tenant audit id. |
-| `static/src/app/broadcast-feed.js` | The `broadcastFeed` Alpine component (registered on `alpine:init`). External deferred script, not inline, to stay CSP-ready. Holds the parse + prepend + 1000-row trim, the `visibleEvents` op_id client filter, the `openDrawer` helper, and the badge/timestamp/payload/aggregate-only helpers. |
+| `static/src/app/broadcast-feed.js` | The `broadcastFeed` Alpine component (registered on `alpine:init`). External deferred script, not inline, to stay CSP-ready. Holds the parse + prepend + 1000-row trim, the `visibleEvents` op_id client filter, the `init` re-read of the live op_id input (so the filter survives a server-side fragment swap), the `openDrawer` helper, and the badge/timestamp/payload/aggregate-only helpers. |
 
 ### Performance + empty state
 
@@ -464,14 +464,25 @@ The filter bar exposes four controls but they split across two layers:
 * **op_id — client-side.** The stream exposes no op_id parameter, and
   adding one would diverge the bridge from `/api/v1/feed` (out of
   scope). Instead the op_id input lives **outside** the swapped
-  fragment (so a server-filter re-render does not reset it) and, on each
-  debounced keystroke, dispatches a `broadcast-op-id-changed` window
-  event. The `broadcastFeed` controller listens
+  fragment, so the input **element** (and the operator's typed value)
+  survives a server-filter re-render. The **active filtering**, though,
+  lives in the `broadcastFeed` controller **inside** the swapped
+  fragment: a server-side op_class/principal/target change `hx-get`s the
+  fragment route **without** op_id (it is excluded from `hx-include`),
+  re-mounts the controller, and seeds `opIdFilter` empty — so without
+  more, the op_id filter would silently stop applying after every server
+  re-render even though the input still shows the text. The controller
+  closes that gap in its `init`: on every mount (initial load **and**
+  each swap) it re-reads the live op_id input as the single source of
+  truth, so the client-side narrowing keeps applying. On each debounced
+  keystroke the input also dispatches a `broadcast-op-id-changed` window
+  event the controller listens for
   (`x-on:broadcast-op-id-changed.window`) and recomputes `visibleEvents`
   — a case-insensitive substring filter over the already-streamed
   `events` — without touching the live SSE subscription. The op_id seed
   is also passed into the controller on render so a copy-pasted
-  `?op_id=` URL narrows the view on first paint.
+  `?op_id=` URL narrows the view on first paint (the `init` read then
+  reconciles it with the live input value).
 
 The target dropdown is populated from the `targets` table scoped to the
 session tenant (`feed._target_names`, capped at 500) — a tenant-A

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -362,22 +362,26 @@ content, CSRF rejection on missing/mismatched/forged tokens,
 positive control on matched token, and middleware-order sanity
 (/api/* passes through untouched).
 
-## Broadcast surface (Task #867)
+## Broadcast surface (Tasks #867, #868)
 
 Initiative [#338](https://github.com/evoila/meho/issues/338) (G10.1
 Activity broadcast UI), Task [#867](https://github.com/evoila/meho/issues/867)
 (G10.1-T1) replaces the chassis stub at `/ui/broadcast` with the real
 **live activity feed**: an SSE-streamed, reverse-chronological event
-list with an empty state and a 1000-row in-DOM cap. Filters + the
-event-detail drawer + the PII visualisation are T2 (#868);
-wall-monitor mode + the Last-24h replay tab are T3 (#869).
+list with an empty state and a 1000-row in-DOM cap. Task
+[#868](https://github.com/evoila/meho/issues/868) (G10.1-T2) adds the
+**filter bar** (op_class / principal / target / op_id), the **event
+detail drawer**, and the **PII 🔒 visualisation**. Wall-monitor mode +
+the Last-24h replay tab are T3 (#869).
 
 ### Routes
 
 | Route | Renders |
 | ----- | ------- |
-| `GET /ui/broadcast` | Full-page live-feed view (`broadcast/feed.html`, extends `base.html`). Sidebar active-state on Broadcast. |
-| `GET /ui/broadcast/stream` | Session-gated SSE bridge (`text/event-stream`). The feed view's `sse-connect` target. |
+| `GET /ui/broadcast` | Full-page live-feed view (`broadcast/feed.html`, extends `base.html`). Sidebar active-state on Broadcast. Accepts `?op_class=&principal=&target=&op_id=` so a copy-pasted filtered URL reproduces the view. |
+| `GET /ui/broadcast/feed` | Filtered feed **fragment** (`broadcast/_feed.html`) — the filter-bar submit target. Re-renders the feed with the active server-side filters baked into a fresh `sse-connect` URL. |
+| `GET /ui/broadcast/stream` | Session-gated SSE bridge (`text/event-stream`). The feed view's `sse-connect` target. Accepts `op_class` / `principal` / `target` filters. |
+| `GET /ui/broadcast/event/{audit_id}` | Event detail drawer **fragment** (`broadcast/_event_drawer.html`; `_event_drawer_not_found.html` + HTTP 404 for a missing / cross-tenant id). |
 
 ### Why a UI-owned SSE bridge instead of subscribing to `/api/v1/feed`
 
@@ -424,9 +428,13 @@ the colour policy stays one auditable map.
 
 | File | Purpose |
 | ---- | ------- |
-| `broadcast/feed.html` | Full-page view: SSE sink wrapper, column header, empty state, the `<template x-for>` + `<script src>` for the controller. |
-| `broadcast/_event_row.html` | Server-authored row markup (timestamp · principal badge · op_id · op_class badge · result_status icon · target · payload summary). Aggregate-only events render `(aggregate-only)`. |
-| `static/src/app/broadcast-feed.js` | The `broadcastFeed` Alpine component (registered on `alpine:init`). External deferred script, not inline, to stay CSP-ready. Holds the parse + prepend + 1000-row trim + the badge/timestamp/payload helpers. |
+| `broadcast/feed.html` | Full-page view: header, filter bar include, feed-fragment include, drawer slot, `<script src>` for the controller. |
+| `broadcast/_filter_bar.html` | The op_class / principal / target / op_id controls. The three server filters `hx-get` to `/ui/broadcast/feed`; op_id dispatches a `broadcast-op-id-changed` window event for the client-side filter. |
+| `broadcast/_feed.html` | The swappable feed fragment: the SSE sink (with the filtered `sse-connect` URL), status bar, column header, empty state, `<template x-for>`. Wraps the `broadcastFeed` Alpine controller so a filter re-render resets the event list and re-subscribes. |
+| `broadcast/_event_row.html` | Server-authored row markup (timestamp · principal badge · op_id · op_class badge · result_status icon · target · payload summary). Click opens the drawer; aggregate-only events render the 🔒 marker + placeholder. |
+| `broadcast/_event_drawer.html` | Event detail drawer: op identity, operation metadata, identifiers (audit_id / request_id / broadcast event_id), full payload (or the 🔒 placeholder for sensitive ops). Alpine `click.outside` / Escape / Close dismiss. |
+| `broadcast/_event_drawer_not_found.html` | The 404 drawer fragment for a missing / cross-tenant audit id. |
+| `static/src/app/broadcast-feed.js` | The `broadcastFeed` Alpine component (registered on `alpine:init`). External deferred script, not inline, to stay CSP-ready. Holds the parse + prepend + 1000-row trim, the `visibleEvents` op_id client filter, the `openDrawer` helper, and the badge/timestamp/payload/aggregate-only helpers. |
 
 ### Performance + empty state
 
@@ -437,22 +445,118 @@ the colour policy stays one auditable map.
   filters match nothing): "No activity matching your filters…" (work
   item #8).
 
+### Filters (Task #868, work item #3) — server-side three vs client-side op_id
+
+The filter bar exposes four controls but they split across two layers:
+
+* **op_class / principal / target — server-side.** These are the three
+  filters the stream bridge (and `/api/v1/feed`) accept. The filter bar
+  `hx-get`s `/ui/broadcast/feed` (`hx-include` carries the three values,
+  `hx-target="#broadcast-feed"`, `hx-swap="outerHTML"`,
+  `hx-push-url="true"`). The fragment route embeds them in a fresh
+  `sse-connect="/ui/broadcast/stream?op_class=…&principal=…&target=…"`
+  URL (built by `_stream_url`, `urlencode`-escaped). HTMX
+  auto-processes the swapped fragment, so the `sse` extension tears down
+  the prior subscription (the replaced node) and opens the filtered one
+  — the **server** drops non-matching events before they reach the
+  browser. Empty filters are omitted from the URL so "All" streams
+  everything.
+* **op_id — client-side.** The stream exposes no op_id parameter, and
+  adding one would diverge the bridge from `/api/v1/feed` (out of
+  scope). Instead the op_id input lives **outside** the swapped
+  fragment (so a server-filter re-render does not reset it) and, on each
+  debounced keystroke, dispatches a `broadcast-op-id-changed` window
+  event. The `broadcastFeed` controller listens
+  (`x-on:broadcast-op-id-changed.window`) and recomputes `visibleEvents`
+  — a case-insensitive substring filter over the already-streamed
+  `events` — without touching the live SSE subscription. The op_id seed
+  is also passed into the controller on render so a copy-pasted
+  `?op_id=` URL narrows the view on first paint.
+
+The target dropdown is populated from the `targets` table scoped to the
+session tenant (`feed._target_names`, capped at 500) — a tenant-A
+operator can only filter by tenant-A targets.
+
+### Event detail drawer (Task #868, work item #4) — keyed on audit_id
+
+A feed-row click calls the controller's `openDrawer(ev)`, which
+`htmx.ajax`-GETs the drawer fragment into `#event-drawer`. The path
+parameter is the **audit id**, not the broadcast event id:
+
+* The broadcast `event_id` lives only on the ephemeral, MAXLEN-trimmed
+  Valkey stream — it is not a column on any table.
+* The canonical, queryable record is the `audit_log` row, keyed by
+  `audit_log.id`, which every `BroadcastEvent` carries as `audit_id`.
+  The drawer's full payload + `request_id` exist only there.
+
+So the row builder reads `ev.audit_id` for the path and passes
+`ev.event_id` as the `event_id` query param for display only. The route
+resolves the row tenant-scoped (`audit_log.tenant_id =
+session.tenant_id` as the first `WHERE` predicate; a cross-tenant id is
+an opaque 404) and renders identity + metadata + the three identifiers
+(audit_id / request_id / broadcast event_id). Alpine
+`x-on:click.outside` (+ Escape + Close) dismisses the drawer; Alpine
+only evaluates `.outside` while the element is visible, so the swap-in
+click cannot immediately re-close it.
+
+### PII discipline in the drawer (Task #868, work item #7)
+
+The feed row's 🔒 marker keys off the **redacted** broadcast payload
+(missing `params` ⇒ aggregate-only — the T1 signal). The drawer is the
+sharper case: it reads the **unredacted** `audit_log` payload, so
+rendering it raw for a `credential_read` op would defeat decision #3 on
+click. The drawer therefore reproduces the publisher's verdict:
+
+* When the audit row carries `payload["broadcast_detail_effective"]`
+  (the G6.3 resolver's recorded `"full"` / `"aggregate"` decision —
+  including any per-tenant override), the drawer honours it verbatim.
+* Otherwise it classifies the op via `classify_op` against the op id
+  (recovered from `payload["op_id"]`, falling back to the publisher's
+  own `http.{method}:{path}` heuristic so the class matches) and treats
+  the `credential_read` / `credential_mint` / `audit_query` classes as
+  aggregate-only.
+
+For an aggregate-only verdict the drawer never builds the payload view
+at all — it renders the 🔒 placeholder. For the full-detail path it
+strips the audit-only keys (`op_id`, `op_class`,
+`broadcast_detail_origin`, `broadcast_detail_effective`) before the
+`| tojson` dump so the drawer shows the request params only, never the
+internal forensic metadata (`tenant_rule:<uuid>` origins stay
+audit-side).
+
+### Performance + empty state
+
+* **1000-row cap** — `IN_DOM_ROW_CAP` is passed into the page; the
+  controller `unshift`s each event and trims `events.length` to the cap
+  so a sustained stream keeps the DOM bounded (work item #9).
+* **Empty state** — shown while `visibleEvents` is empty (no events
+  streamed yet, or the op_id client filter narrowed everything out):
+  "No activity matching your filters…" (work item #8).
+
 ### Cross-tenant isolation
 
 The page carries no tenant data beyond the operator's own identity; live
 events arrive over the tenant-scoped bridge whose stream key is
-`meho:feed:{session.tenant_id}`. There is no tenant query parameter on
-the page route or the stream, so a tenant-A operator can never surface
-tenant-B events. The
-[broadcast suite](../../backend/tests/test_ui_broadcast_feed.py) pins
-the generator's stream-key derivation per tenant.
+`meho:feed:{session.tenant_id}`. The target dropdown and the event
+drawer both scope to `session.tenant_id` at the SQL `WHERE` clause —
+never a query parameter — so a tenant-A operator can never surface
+tenant-B targets or audit rows. The
+[T1 broadcast suite](../../backend/tests/test_ui_broadcast_feed.py) pins
+the generator's stream-key derivation per tenant; the
+[T2 filters suite](../../backend/tests/test_ui_broadcast_filters.py)
+pins the dropdown + drawer tenant scoping.
 
 ### Known limits
 
-* **No filters / drawer / wall-monitor yet** — T1 ships the live feed
-  core only. op_class/principal/target/op_id filters + the event-detail
-  drawer + the PII 🔒 viz are T2 (#868); wall-monitor mode (`?wall=1`) +
-  the Last-24h replay tab are T3 (#869).
+* **No wall-monitor / replay tab yet** — T1 + T2 ship the live feed,
+  filters, drawer, and PII viz. Wall-monitor mode (`?wall=1`) + the
+  Last-24h replay tab + long-display session refresh are T3 (#869).
+* **op_id filtering is client-side only** — it narrows the in-DOM
+  `events` (bounded by the 1000-row cap), not the server stream. An op
+  that fired before the operator typed an op_id substring, and has since
+  scrolled past the cap, is not retroactively matched. This is the
+  intended scope (op_id is a live-narrowing convenience, not a history
+  query — that is G8 audit-query territory).
 * **Reconnect replay is exercised at the feed-endpoint layer** — the
   `Last-Event-Id` cursor resolver + validator are reused from
   `/api/v1/feed` (covered by `test_api_v1_feed`); the UI suite asserts


### PR DESCRIPTION
## Summary

- **Filter bar** (work item #3): op_class / principal / target / op_id. The three stream-supported filters `hx-get` the new `GET /ui/broadcast/feed` fragment route, which re-renders the feed with the active filters baked into a fresh `sse-connect` URL so the **server** drops non-matching events. op_id has no stream parameter, so it is a **client-side** substring filter the `broadcastFeed` controller applies over the streamed events (dispatched via a window event, so a server re-render never resets it or tears the live SSE subscription). The target dropdown is tenant-scoped from the `targets` table.
- **Event detail drawer** (work item #4): `GET /ui/broadcast/event/{audit_id}` renders a server-side drawer (full payload + `request_id` + `audit_id` + broadcast `event_id`) the feed rows open via `htmx.ajax` into `#event-drawer`; Alpine `click.outside` / Escape / Close dismisses. The route is keyed on the **audit id** (the canonical PG `audit_log` row) rather than the ephemeral broadcast `event_id`, which lives only on the MAXLEN-trimmed Valkey stream and has no PG column to join against; the broadcast `event_id` rides as a query param for display.
- **PII discipline** (work item #7): `credential_read` / `credential_mint` / `audit_query` events render 🔒 + "(aggregate-only — credential read; details not broadcast)". The drawer reads the **unredacted** `audit_log` payload, so it reproduces the publisher's decision-#3 verdict (honouring `payload["broadcast_detail_effective"]` when present, else `classify_op`) and never renders a sensitive op's payload on click; internal audit-only payload keys are stripped from the full-detail view.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/` — clean (283 files)
- [x] `pytest tests/test_ui_broadcast_filters.py` — 18 passed (new suite)
- [x] `pytest tests/test_ui_broadcast_feed.py` — 13 passed (T1 unchanged by the refactor)
- [x] `pytest -k "ui_ or broadcast or feed"` — 372 passed, 8 skipped (env-gated)
- [x] `code-quality.py --diff` — 0 blockers (6 soft warnings: FastAPI handler arg-count + factory-fn size, matching the topology/T1 precedent shape)
- [x] **OpenAPI snapshot regenerated** — `cd cli && make snapshot-openapi && make generate`; `git diff --exit-code -- cli/api/openapi.json cli/internal/api/client.gen.go` clean (idempotent); `go vet ./internal/api/` clean
- [x] `node --check broadcast-feed.js` — valid
- [x] All 4 filters: op_class/principal/target embed in the `sse-connect` URL (asserted, incl. URL-encoding); op_id seeds the client controller (asserted)
- [x] Event click → drawer with full payload, request_id, audit_id, event_id; aggregate-only renders 🔒 (asserted); credential_read never leaks its payload (asserted)
- [x] Target dropdown + drawer tenant-scoping (cross-tenant 404) asserted

## Out of scope

- **Wall-monitor mode (`?wall=1`) + Last-24h replay tab + long-display session refresh** — T3 (#869).
- op_id filtering is intentionally client-side (live-narrowing convenience, not a history query — that is G8 audit-query territory).
- FastAPI route-handler arg-count / factory-fn-size soft warnings left as-is — splitting them would break the FastAPI DI contract; matches the established topology/T1 router shape.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #868
