### PR TITLE
feat(agent-runtime): G11.1-T5 agent-invokes-agent composition (depth-capped, budget-aware, audited)

### DIFF
--- a/backend/src/meho_backplane/agent/__init__.py
+++ b/backend/src/meho_backplane/agent/__init__.py
@@ -22,6 +22,16 @@ The wider G11.1 initiative (#802) builds on this seam: definition persistence
 types this package exports.
 """
 
+from meho_backplane.agent.invoke import (
+    AGENT_INVOKE_DEPTH_TOP_LEVEL,
+    AgentInvocationDepthExceeded,
+    ChildAgentResolver,
+    ChildRunner,
+    ChildRunRecorder,
+    agent_invoke_depth_var,
+    current_agent_run_id_var,
+    make_invoke_agent_tool,
+)
 from meho_backplane.agent.run import (
     AgentDefinition,
     AgentRun,
@@ -40,16 +50,24 @@ from meho_backplane.agent.toolset import (
 )
 
 __all__ = [
+    "AGENT_INVOKE_DEPTH_TOP_LEVEL",
     "META_TOOL_NAMES",
     "AgentDefinition",
+    "AgentInvocationDepthExceeded",
     "AgentRun",
     "AgentRunError",
     "AgentRunHandle",
     "AgentRunResult",
     "AgentRunStatus",
+    "ChildAgentResolver",
+    "ChildRunRecorder",
+    "ChildRunner",
     "MetaToolSpec",
     "ModelFactory",
     "PydanticAgentRun",
+    "agent_invoke_depth_var",
+    "current_agent_run_id_var",
     "default_model_factory",
+    "make_invoke_agent_tool",
     "resolve_agent_tools",
 ]

--- a/backend/src/meho_backplane/agent/invoke.py
+++ b/backend/src/meho_backplane/agent/invoke.py
@@ -1,0 +1,434 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Agent-invokes-agent composition (G11.1-T5 / #812).
+
+This module gives a running agent's loop one extra meta-tool, ``invoke_agent``,
+that runs **another** agent definition in the same tenant as a child run. From
+MEHO's view a child agent run is just another governed call: the child resolves
+through the same identity, the same RBAC-filtered toolset
+(:func:`~meho_backplane.agent.toolset.resolve_agent_tools`), the same dispatch +
+audit machinery. There is no "tier" concept here -- the *consumer's* harness may
+escalate a cheap-tier agent to a deep-tier agent, but MEHO only sees one agent
+run invoking another.
+
+Two independent bounds keep a cascade from escaping
+====================================================
+
+A naive agent-invokes-agent surface is the textbook runaway-cost foot-gun
+(ai_engineering best practices, "no LLM calls from inside a tool ... if a tool
+needs reasoning, it's a sub-agent -- *name it as such*"): a definition that
+invokes itself, directly or transitively, spawns an unbounded chain of LLM runs.
+This module bounds it on two axes, and a cascade terminates on whichever it
+hits first:
+
+* **Depth** -- the *height* of the invocation tree. A per-task contextvar
+  (:data:`agent_invoke_depth_var`) tracks how many ``invoke_agent`` frames the
+  current :mod:`asyncio` task is nested inside. :func:`make_invoke_agent_tool`'s
+  tool pre-increments + checks it against :attr:`Settings.agent_invoke_max_depth`
+  *before* the child run starts, so an over-depth invocation never spends. This
+  mirrors the composite-recursion cap exactly
+  (:data:`~meho_backplane.operations.composite.composite_depth_var` +
+  :attr:`Settings.composite_max_depth`).
+* **Budget** -- the *total turn count* across the whole cascade. The child run
+  is driven with ``usage=ctx.usage`` (Pydantic AI's budget-propagation knob),
+  so the parent's :class:`~pydantic_ai.usage.RunUsage` accumulator is shared
+  with the child. The shared ``UsageLimits(request_limit=...)`` is enforced
+  against the running total, so a deep-but-narrow cascade and a shallow-but-wide
+  one both trip the same budget. The framework raises
+  :class:`~pydantic_ai.exceptions.UsageLimitExceeded`, which the seam surfaces
+  as a failed run (:class:`~meho_backplane.agent.run.AgentRunError`).
+
+Why a structured retry, not a crash
+===================================
+
+An over-depth invocation raises :class:`~pydantic_ai.ModelRetry`, the same
+agent-reasonable error shape the connector-allow-list check in
+:mod:`meho_backplane.agent.toolset` uses. The model receives a tool-level retry
+prompt ("you've reached the maximum invocation depth; answer directly or stop")
+it can reason about -- it is not a tool-execution crash that fails the whole run.
+The depth ceiling is a deterministic termination condition the *model never
+controls* (ai_engineering best practices, "termination is deterministic ...
+never rely on the model to stop").
+
+Lineage -- the cascade tree is reconstructable
+==============================================
+
+The child run is recorded as a child of the parent in two parallel lineages,
+both threaded by this module so the cascade tree is walkable after the fact:
+
+* **Run lineage** -- the child ``agent_run`` row's
+  :attr:`~meho_backplane.db.models.AgentRun.parent_run_id` points at the parent
+  run's id, and its
+  :attr:`~meho_backplane.db.models.AgentRun.trigger` is
+  :attr:`~meho_backplane.db.models.AgentRunTrigger.AGENT_INVOKED`. Recording the
+  child row is delegated to an injected :class:`ChildRunRecorder` callback (the
+  T4 #811 invocation surface / T6 #813 lifecycle service own the DB session);
+  when no recorder is wired (the pure in-process T1 path) the depth + budget
+  bounds still apply, the lineage row is simply not persisted.
+* **Session lineage** -- :data:`current_agent_run_id_var` carries the *current*
+  run's id for the duration of a child invocation, so a nested ``invoke_agent``
+  reads it as the next child's ``parent_run_id`` and every per-tool-call audit
+  row the child writes can be correlated to its run. Bound + reset with a token
+  so siblings see clean state even if the child raises.
+
+Why this is a tool factory, not a standalone service function
+=============================================================
+
+The acceptance criterion is that a *running agent* can invoke another -- so the
+mechanism has to be reachable from inside the loop, i.e. a registered tool. The
+factory shape (rather than a module-level tool) lets the caller inject the
+``child_runner`` (which owns the framework ``Agent`` construction + the
+``usage=ctx.usage`` call, keeping ``pydantic_ai`` loop-driving confined to
+:mod:`meho_backplane.agent.run`) and the optional ``recorder`` without this
+module reaching into either.
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextvars import ContextVar
+from typing import TYPE_CHECKING, Any, Protocol
+
+import structlog
+from pydantic_ai import ModelRetry, RunContext, Tool
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.settings import get_settings
+
+if TYPE_CHECKING:  # pragma: no cover - typing-only imports
+    from pydantic_ai.usage import RunUsage
+
+    # Imported under TYPE_CHECKING to break the import cycle with
+    # ``meho_backplane.agent.run`` (which imports this module at module scope
+    # to wire the ``invoke_agent`` tool into its agent builder). The runtime
+    # ``except AgentRunError`` in the tool body does a local import instead.
+    from meho_backplane.agent.run import AgentDefinition
+
+__all__ = [
+    "AGENT_INVOKE_DEPTH_TOP_LEVEL",
+    "AgentInvocationDepthExceeded",
+    "ChildAgentResolver",
+    "ChildRunRecorder",
+    "ChildRunner",
+    "agent_invoke_depth_var",
+    "current_agent_run_id_var",
+    "make_invoke_agent_tool",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+#: Sentinel depth for a top-level run -- nothing has entered an
+#: ``invoke_agent`` frame yet. The first ``invoke_agent`` call advances
+#: depth to ``1``; an agent invoked *by* that child (invoke-inside-invoke)
+#: advances to ``2``; and so on, until :attr:`Settings.agent_invoke_max_depth`.
+AGENT_INVOKE_DEPTH_TOP_LEVEL: int = 0
+
+
+#: ContextVar tracking how deep the current :mod:`asyncio` task is into an
+#: agent-invokes-agent cascade. Top-level runs see the default (``0``). The
+#: ``invoke_agent`` tool pre-increments this before each child run and compares
+#: the result against :attr:`Settings.agent_invoke_max_depth`, raising
+#: :class:`AgentInvocationDepthExceeded` *before* the child loop starts when the
+#: next level would breach the cap. Per the asyncio contextvar contract the
+#: value is per-task, not per-process -- two concurrent cascades see independent
+#: counters. Mirrors
+#: :data:`~meho_backplane.operations.composite.composite_depth_var`.
+agent_invoke_depth_var: ContextVar[int] = ContextVar(
+    "agent_invoke_depth",
+    default=AGENT_INVOKE_DEPTH_TOP_LEVEL,
+)
+
+
+#: ContextVar carrying the *current* agent run's id for the duration of a child
+#: invocation. The ``invoke_agent`` tool reads it as the parent_run_id when it
+#: records a child run, then binds it to the child's id around the child loop so
+#: a nested ``invoke_agent`` sees the right parent. ``None`` at the top level (a
+#: run not yet associated with a durable ``agent_run`` row -- the pure
+#: in-process T1 path). The T4/T6 surface sets it to the run's id at start.
+current_agent_run_id_var: ContextVar[uuid.UUID | None] = ContextVar(
+    "current_agent_run_id",
+    default=None,
+)
+
+
+class AgentInvocationDepthExceeded(RuntimeError):  # noqa: N818 -- parallels CompositeRecursionLimitExceeded
+    """Raised when an ``invoke_agent`` call would breach the depth cap.
+
+    Carries the attempted depth, the configured cap, and the chain of agent
+    names that led to the violation, so the failure is actionable when it
+    surfaces (the ``invoke_agent`` tool catches it and re-raises as a
+    :class:`~pydantic_ai.ModelRetry` the model can reason about). The attempted
+    child run never starts -- no LLM spend, no child ``agent_run`` row.
+    """
+
+    def __init__(
+        self,
+        *,
+        attempted_depth: int,
+        max_depth: int,
+        agent_name_chain: tuple[str, ...],
+    ) -> None:
+        self.attempted_depth = attempted_depth
+        self.max_depth = max_depth
+        self.agent_name_chain = agent_name_chain
+        chain_repr = " -> ".join(agent_name_chain) if agent_name_chain else "(empty)"
+        super().__init__(
+            f"agent invocation depth limit exceeded: attempted depth "
+            f"{attempted_depth} > max_depth {max_depth}; "
+            f"agent chain: {chain_repr}"
+        )
+
+
+#: ContextVar accumulating the chain of agent names the current cascade has
+#: descended through, so :class:`AgentInvocationDepthExceeded` can name *which*
+#: chain blew the cap. Bound + reset around each child invocation, same token
+#: discipline as :data:`agent_invoke_depth_var`.
+_agent_name_chain_var: ContextVar[tuple[str, ...]] = ContextVar(
+    "agent_invoke_name_chain",
+    default=(),
+)
+
+
+class ChildAgentResolver(Protocol):
+    """Resolve a child agent name to a runnable definition in the same tenant.
+
+    The ``invoke_agent`` tool calls this with the *parent* operator and the
+    requested agent name; the implementation looks the definition up scoped to
+    ``operator.tenant_id`` (so cross-tenant invocation is structurally
+    impossible -- a name in another tenant simply does not resolve) and returns
+    a :class:`~meho_backplane.agent.run.AgentDefinition` ready to run, or
+    ``None`` when no such definition exists / is enabled for the tenant.
+    """
+
+    async def __call__(
+        self,
+        operator: Operator,
+        agent_name: str,
+    ) -> AgentDefinition | None: ...
+
+
+class ChildRunner(Protocol):
+    """Drive one child agent loop, threading the parent's usage budget.
+
+    Implemented in :mod:`meho_backplane.agent.run` (which owns the framework
+    ``Agent`` construction + the ``usage=ctx.usage`` call), so ``pydantic_ai``
+    loop-driving stays confined there. Returns the child's free-text / structured
+    output. Raises :class:`~meho_backplane.agent.run.AgentRunError` when the
+    child loop fails -- including when the shared budget (``usage``) trips the
+    :class:`~pydantic_ai.exceptions.UsageLimitExceeded` the framework raises.
+    """
+
+    async def __call__(
+        self,
+        *,
+        definition: AgentDefinition,
+        operator: Operator,
+        inputs: str,
+        usage: RunUsage,
+    ) -> Any: ...
+
+
+class ChildRunRecorder(Protocol):
+    """Persist a child ``agent_run`` row linked to its parent, return its id.
+
+    Optional -- injected by the T4 #811 invocation surface / T6 #813 lifecycle
+    service, which own the DB session. Called *after* the depth check passes and
+    *before* the child loop starts, so the child run is inspectable while it
+    runs. The returned id becomes the child's ``current_agent_run_id_var`` for
+    the duration of its loop (so a grand-child invocation links to it). When no
+    recorder is wired, the in-process bounds still hold; the lineage row is just
+    not written.
+    """
+
+    async def __call__(
+        self,
+        *,
+        operator: Operator,
+        definition: AgentDefinition,
+        parent_run_id: uuid.UUID | None,
+    ) -> uuid.UUID: ...
+
+
+def _check_invoke_depth(child_agent_name: str) -> int:
+    """Read + check the per-task invocation depth; return the next depth.
+
+    Pre-increments the would-be depth from :data:`agent_invoke_depth_var` and
+    compares against :attr:`Settings.agent_invoke_max_depth`. Raises
+    :class:`AgentInvocationDepthExceeded` when the next call would breach the
+    cap, with the agent-name chain that led there. Returns the validated next
+    depth so the caller can pass it to :func:`agent_invoke_depth_var.set`.
+    """
+    current_depth = agent_invoke_depth_var.get()
+    attempted_depth = current_depth + 1
+    max_depth = get_settings().agent_invoke_max_depth
+    if attempted_depth > max_depth:
+        current_chain = _agent_name_chain_var.get()
+        raise AgentInvocationDepthExceeded(
+            attempted_depth=attempted_depth,
+            max_depth=max_depth,
+            agent_name_chain=(*current_chain, child_agent_name),
+        )
+    return attempted_depth
+
+
+def make_invoke_agent_tool(
+    *,
+    resolver: ChildAgentResolver,
+    child_runner: ChildRunner,
+    recorder: ChildRunRecorder | None = None,
+) -> Tool[Operator]:
+    """Build the ``invoke_agent`` meta-tool for a running agent's loop.
+
+    The returned :class:`pydantic_ai.Tool` lets the loop invoke another agent
+    definition in the same tenant as a depth-capped, budget-aware, audited child
+    run. Register it alongside the discovery + execution meta-tools (it is the
+    composition surface on top of them).
+
+    Args:
+        resolver: Resolves the requested child agent name to a runnable
+            :class:`~meho_backplane.agent.run.AgentDefinition`, scoped to the
+            parent operator's tenant.
+        child_runner: Drives the child loop with the parent's shared usage
+            budget (owns the ``pydantic_ai`` ``Agent`` + ``usage=`` call).
+        recorder: Optional persistence of the child ``agent_run`` lineage row.
+            ``None`` for the pure in-process path (bounds still apply).
+
+    Returns:
+        The ``invoke_agent`` :class:`pydantic_ai.Tool`.
+    """
+
+    # Local import (function scope) breaks the module-level cycle with
+    # ``meho_backplane.agent.run`` -- resolved once at factory-build time, not
+    # per child invocation.
+    from meho_backplane.agent.run import AgentRunError
+
+    async def _invoke_agent(
+        ctx: RunContext[Operator],
+        agent_name: str,
+        inputs: str,
+    ) -> dict[str, Any]:
+        operator = ctx.deps
+
+        # Bound 1 -- depth. Checked BEFORE any resolution / spend, so an
+        # over-depth invocation never starts a child loop. Surfaced to the
+        # model as a ModelRetry it can recover from (answer directly / stop),
+        # never the model's call to make.
+        try:
+            attempted_depth = _check_invoke_depth(agent_name)
+        except AgentInvocationDepthExceeded as exc:
+            _log.warning(
+                "agent_invoke_depth_exceeded",
+                agent_name=agent_name,
+                attempted_depth=exc.attempted_depth,
+                max_depth=exc.max_depth,
+                operator_sub=operator.sub,
+                tenant_id=str(operator.tenant_id),
+            )
+            raise ModelRetry(
+                f"cannot invoke agent {agent_name!r}: maximum invocation depth "
+                f"{exc.max_depth} reached (chain: "
+                f"{' -> '.join(exc.agent_name_chain)}). Answer directly or stop."
+            ) from exc
+
+        # Resolve the child in the parent's tenant. A name that does not
+        # resolve (typo, disabled, or another tenant's definition) is a
+        # ModelRetry -- the model picks a real agent or stops, it does not
+        # crash the run.
+        definition = await resolver(operator, agent_name)
+        if definition is None:
+            raise ModelRetry(
+                f"no agent definition named {agent_name!r} is available in this "
+                f"tenant. Pick an existing agent or answer directly."
+            )
+
+        parent_run_id = current_agent_run_id_var.get()
+        child_run_id: uuid.UUID | None = None
+        if recorder is not None:
+            child_run_id = await recorder(
+                operator=operator,
+                definition=definition,
+                parent_run_id=parent_run_id,
+            )
+
+        # Bind depth + name-chain + the child run id for the duration of the
+        # child loop, so a nested invoke_agent sees the right depth and parent.
+        # Tokens make the resets exception-safe.
+        depth_token = agent_invoke_depth_var.set(attempted_depth)
+        chain_token = _agent_name_chain_var.set(
+            (*_agent_name_chain_var.get(), definition.name),
+        )
+        run_id_token = current_agent_run_id_var.set(
+            child_run_id if child_run_id is not None else parent_run_id,
+        )
+        _log.info(
+            "agent_invoke_child_started",
+            child_agent=definition.name,
+            depth=attempted_depth,
+            parent_run_id=str(parent_run_id) if parent_run_id is not None else None,
+            child_run_id=str(child_run_id) if child_run_id is not None else None,
+            operator_sub=operator.sub,
+            tenant_id=str(operator.tenant_id),
+        )
+        try:
+            # Bound 2 -- budget. Sharing ctx.usage threads the child's turns
+            # into the parent's running total; the shared UsageLimits the loop
+            # carries is enforced against that total, so the whole cascade
+            # terminates when the budget trips (UsageLimitExceeded surfaces as
+            # AgentRunError from the child_runner).
+            output = await child_runner(
+                definition=definition,
+                operator=operator,
+                inputs=inputs,
+                usage=ctx.usage,
+            )
+        except AgentRunError as exc:
+            _log.warning(
+                "agent_invoke_child_failed",
+                child_agent=definition.name,
+                depth=attempted_depth,
+                error=str(exc),
+                operator_sub=operator.sub,
+            )
+            # A failed child (budget exhausted, tool raised, model errored) is
+            # a tool-level outcome the parent model can reason about, not a
+            # crash that aborts the parent run.
+            raise ModelRetry(
+                f"child agent {definition.name!r} failed: {exc}. "
+                f"Try a different approach or answer directly."
+            ) from exc
+        finally:
+            current_agent_run_id_var.reset(run_id_token)
+            _agent_name_chain_var.reset(chain_token)
+            agent_invoke_depth_var.reset(depth_token)
+
+        return {"agent": definition.name, "output": output}
+
+    return Tool.from_schema(
+        _invoke_agent,
+        name="invoke_agent",
+        description=(
+            "Invoke another agent definition in your tenant as a child run when "
+            "the task needs a different agent's system prompt or toolset (e.g. "
+            "escalating a hard sub-problem to a more capable agent). The child "
+            "runs under your identity with its own RBAC-filtered tools; its "
+            "turns count against your shared budget and the call is "
+            "depth-capped, so a runaway chain terminates with a structured "
+            "error rather than unbounded spend. Arguments: `agent_name` (the "
+            "name of the agent definition to invoke) and `inputs` (the task / "
+            "prompt to hand the child). Returns the child's `output`. Prefer "
+            "answering directly when you can -- invoke another agent only when "
+            "it is genuinely better suited."
+        ),
+        json_schema={
+            "type": "object",
+            "properties": {
+                "agent_name": {"type": "string", "minLength": 1},
+                "inputs": {"type": "string", "minLength": 1},
+            },
+            "required": ["agent_name", "inputs"],
+            "additionalProperties": False,
+        },
+        takes_ctx=True,
+    )

--- a/backend/src/meho_backplane/agent/run.py
+++ b/backend/src/meho_backplane/agent/run.py
@@ -75,9 +75,15 @@ from uuid import UUID, uuid4
 
 import structlog
 from pydantic import BaseModel, ConfigDict, Field
-from pydantic_ai import Agent, RunContext, UsageLimits
+from pydantic_ai import Agent, RunContext, Tool, UsageLimits
 from pydantic_ai.exceptions import UsageLimitExceeded
+from pydantic_ai.usage import RunUsage
 
+from meho_backplane.agent.invoke import (
+    ChildAgentResolver,
+    ChildRunRecorder,
+    make_invoke_agent_tool,
+)
 from meho_backplane.agent.toolset import resolve_agent_tools
 from meho_backplane.auth.operator import Operator
 from meho_backplane.operations.meta_tools import call_operation, list_operation_groups
@@ -350,6 +356,20 @@ class PydanticAgentRun:
     """
 
     model_factory: ModelFactory = field(default=default_model_factory)
+    #: Optional child-agent resolver (G11.1-T5 #812). When set, every built
+    #: agent additionally carries the ``invoke_agent`` meta-tool, so a running
+    #: agent can invoke another definition in its tenant as a depth-capped,
+    #: budget-aware, audited child run. ``None`` (the default) means
+    #: composition is off -- the T1/T3 surface is unchanged. Injected at the
+    #: edge by the T4 invocation surface, which owns the
+    #: :class:`~meho_backplane.agent.invoke.ChildAgentResolver` (the
+    #: tenant-scoped definition lookup).
+    child_agent_resolver: ChildAgentResolver | None = None
+    #: Optional persistence of the child ``agent_run`` lineage row (G11.1-T5 /
+    #: T6 #813). Passed straight to
+    #: :func:`~meho_backplane.agent.invoke.make_invoke_agent_tool`. ``None``
+    #: keeps the in-process bounds without writing the lineage row.
+    child_run_recorder: ChildRunRecorder | None = None
 
     def _build_agent(
         self,
@@ -364,10 +384,20 @@ class PydanticAgentRun:
         passed to the framework via the ``tools=`` constructor argument. A
         definition with no toolset (``toolset is None``) falls back to the T1
         default two-meta-tool surface.
+
+        When this runtime carries a :attr:`child_agent_resolver` (G11.1-T5),
+        the ``invoke_agent`` composition tool is appended to whichever surface
+        the definition selected, so a running agent can invoke another
+        definition. The tool is bound to :meth:`run_child` as its
+        :class:`~meho_backplane.agent.invoke.ChildRunner`, so the child loop
+        runs with the parent's shared usage budget.
         """
         model = self.model_factory()
+        invoke_tool = self._maybe_build_invoke_tool()
         if definition.toolset is not None:
             tools = resolve_agent_tools(definition.toolset, operator)
+            if invoke_tool is not None:
+                tools = [*tools, invoke_tool]
             agent: Agent[Operator, Any] = Agent(
                 model,
                 deps_type=Operator,
@@ -381,9 +411,26 @@ class PydanticAgentRun:
             deps_type=Operator,
             system_prompt=definition.system_prompt,
             output_type=definition.output_type if definition.output_type is not None else str,
+            tools=[invoke_tool] if invoke_tool is not None else [],
         )
         _register_default_meta_tools(agent)
         return agent
+
+    def _maybe_build_invoke_tool(self) -> Tool[Operator] | None:
+        """Build the ``invoke_agent`` tool when composition is wired, else ``None``.
+
+        Composition is on exactly when a :attr:`child_agent_resolver` is
+        injected. The tool's :class:`~meho_backplane.agent.invoke.ChildRunner`
+        is :meth:`run_child` (bound to this instance), so the child loop shares
+        the parent's usage budget and the framework stays confined here.
+        """
+        if self.child_agent_resolver is None:
+            return None
+        return make_invoke_agent_tool(
+            resolver=self.child_agent_resolver,
+            child_runner=self.run_child,
+            recorder=self.child_run_recorder,
+        )
 
     async def _run_loop(
         self,
@@ -428,6 +475,55 @@ class PydanticAgentRun:
             operator_sub=operator.sub,
         )
         return result
+
+    async def run_child(
+        self,
+        *,
+        definition: AgentDefinition,
+        operator: Operator,
+        inputs: str,
+        usage: RunUsage,
+    ) -> Any:
+        """Drive one child loop budget-aware, sharing the parent's usage.
+
+        The :class:`~meho_backplane.agent.invoke.ChildRunner` the
+        ``invoke_agent`` tool (G11.1-T5 #812) calls. Builds the child agent
+        from *definition* under the parent's *operator* (so the child's tools
+        are resolved + RBAC-filtered exactly like a top-level run), then drives
+        the loop with ``usage=usage`` -- the parent's
+        :class:`~pydantic_ai.usage.RunUsage` accumulator -- so the child's turns
+        count against the parent's running total. The shared
+        ``UsageLimits(request_limit=...)`` (the child's own
+        :attr:`AgentDefinition.request_limit`) is enforced against that shared
+        total, so a cascade that would exceed the budget trips
+        :class:`~pydantic_ai.exceptions.UsageLimitExceeded` -- surfaced here as
+        :class:`AgentRunError`, the seam's uniform failure type.
+
+        Unlike :meth:`start`, this awaits the child loop inline (it runs inside
+        the parent loop's ``invoke_agent`` tool call, on the parent's event
+        loop) and returns the child's output directly rather than a handle: the
+        parent tool needs the child's answer to continue, and the child's
+        lifecycle is bounded by the parent tool call.
+        """
+        child = self._build_agent(definition, operator)
+        limits = UsageLimits(request_limit=definition.request_limit)
+        try:
+            run_result = await child.run(
+                inputs,
+                deps=operator,
+                usage=usage,
+                usage_limits=limits,
+            )
+        except UsageLimitExceeded as exc:
+            _log.warning(
+                "agent_child_run_budget_exhausted",
+                agent=definition.name,
+                request_limit=definition.request_limit,
+                shared_requests=usage.requests,
+                operator_sub=operator.sub,
+            )
+            raise AgentRunError(f"turn budget exhausted: {exc}") from exc
+        return run_result.output
 
     def start(
         self,

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -297,6 +297,31 @@ class Settings(BaseModel):
         ``COMPOSITE_MAX_DEPTH`` env var. Read once per
         ``dispatch_child`` call -- no caching beyond
         :func:`get_settings`'s :func:`lru_cache`.
+    agent_invoke_max_depth:
+        Hard cap on how deep an agent-invokes-agent cascade
+        (G11.1-T5 #812) may nest. The ``invoke_agent`` tool a running
+        agent's loop carries lets one agent run another agent
+        definition in the same tenant; without a cap, a definition that
+        (directly or transitively) invokes itself would spawn an
+        unbounded chain of LLM runs, burning the provider budget before
+        anything stops it. The cap mirrors :attr:`composite_max_depth`:
+        a per-task contextvar tracks the current invocation depth, the
+        ``invoke_agent`` tool pre-increments + checks it against this
+        ceiling before starting the child run, and an over-depth
+        invocation raises a structured error the model receives as a
+        :class:`pydantic_ai.ModelRetry` (it can pick a different action
+        or stop) rather than spending. Default 4 -- a cheap-tier agent
+        escalating to a deep-tier agent is depth-1; a two-hop
+        escalation chain is depth-2; 4 gives headroom for legitimate
+        composition while catching a runaway self-invocation in
+        seconds. Distinct from the *budget* cap (the shared turn count
+        threaded via ``usage=ctx.usage``, enforced by the loop's
+        ``UsageLimits``): depth bounds the *tree height*, budget bounds
+        the *total turns* across the whole cascade -- a cascade
+        terminates on whichever it hits first. Operators whose agents
+        compose more deeply override via ``AGENT_INVOKE_MAX_DEPTH``.
+        Read once per ``invoke_agent`` call through
+        :func:`get_settings`'s cache.
     topology_refresh_interval_seconds:
         Cadence of the G9.1-T3 background topology-refresh loop, in
         seconds. The scheduler (registered in the FastAPI lifespan)
@@ -527,6 +552,7 @@ class Settings(BaseModel):
     )
     broadcast_retention_hours: int = Field(default=24, gt=0)
     composite_max_depth: int = Field(default=8, gt=0)
+    agent_invoke_max_depth: int = Field(default=4, gt=0)
     topology_refresh_interval_seconds: int = Field(default=3600, gt=0)
     memory_user_default_ttl_days: int = Field(default=7, ge=1, le=365)
     memory_expiry_tick_interval_seconds: int = Field(default=86400, ge=60, le=86400)
@@ -682,6 +708,9 @@ def get_settings() -> Settings:
         ),
         composite_max_depth=int(
             os.environ.get("COMPOSITE_MAX_DEPTH", "8"),
+        ),
+        agent_invoke_max_depth=int(
+            os.environ.get("AGENT_INVOKE_MAX_DEPTH", "4"),
         ),
         topology_refresh_interval_seconds=int(
             os.environ.get("TOPOLOGY_REFRESH_INTERVAL_SECONDS", "3600"),

--- a/backend/tests/test_agent_invoke.py
+++ b/backend/tests/test_agent_invoke.py
@@ -1,0 +1,420 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for agent-invokes-agent composition (G11.1-T5 / #812).
+
+These exercise the ``invoke_agent`` meta-tool against a deterministic
+:class:`~pydantic_ai.models.function.FunctionModel` (no real LLM hit;
+python_best_practices §14 -- no network in unit tests). The #812 acceptance
+criteria map onto the tests as:
+
+* ``test_running_agent_invokes_child_under_same_identity`` -- a running agent
+  invokes another definition; the child runs under the same operator and its
+  output flows back. Proves the composition path end to end.
+* ``test_cascade_terminates_on_depth_cap`` -- a self-invoking cascade is stopped
+  by ``agent_invoke_max_depth``; the over-depth call never starts a child and
+  the model receives a structured retry, not unbounded spend.
+* ``test_cascade_terminates_on_budget`` -- the child's turns count against the
+  shared ``usage`` budget, so a cascade exceeding the turn budget trips
+  ``UsageLimitExceeded`` (surfaced as ``AgentRunError``), terminating the chain.
+* ``test_child_run_linked_to_parent_in_lineage`` -- the recorder is called with
+  the parent run id, so the cascade tree (``parent_run_id`` lineage) is
+  reconstructable.
+* ``test_unknown_child_agent_is_a_model_retry`` -- an unresolvable agent name is
+  a recoverable ``ModelRetry``, not a crash.
+
+The ``FunctionModel`` callback decides each turn from the message history: a
+parent that has not yet seen a tool return emits an ``invoke_agent`` call; once
+the child's result is in history it emits a final answer.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic_ai import ModelRetry
+from pydantic_ai.messages import (
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+)
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.usage import RunUsage
+
+from meho_backplane.agent import (
+    AGENT_INVOKE_DEPTH_TOP_LEVEL,
+    AgentDefinition,
+    AgentInvocationDepthExceeded,
+    AgentRunError,
+    agent_invoke_depth_var,
+    current_agent_run_id_var,
+    make_invoke_agent_tool,
+)
+from meho_backplane.agent.run import PydanticAgentRun
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.settings import get_settings
+
+pytestmark = pytest.mark.asyncio
+
+_TENANT_A = UUID("11111111-1111-1111-1111-111111111111")
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the env vars :class:`Settings` requires + reset the cache per test."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_invoke_contextvars() -> Iterator[None]:
+    """Guard against contextvar leakage between tests (per-task by contract, but
+    the test runner shares a task)."""
+    yield
+    assert agent_invoke_depth_var.get() == AGENT_INVOKE_DEPTH_TOP_LEVEL
+    assert current_agent_run_id_var.get() is None
+
+
+def _make_operator(
+    *,
+    tenant_id: UUID = _TENANT_A,
+    role: TenantRole = TenantRole.OPERATOR,
+    sub: str = "op-agent",
+) -> Operator:
+    return Operator(
+        sub=sub,
+        name="Agent Operator",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=tenant_id,
+        tenant_role=role,
+    )
+
+
+def _always_invoke(child_name: str):
+    """FunctionModel callback that invokes a child every turn (never stops).
+
+    Used to build a self-recursive cascade: each level invokes the same child,
+    so only the depth cap (or budget) can terminate it.
+    """
+
+    def fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[
+                ToolCallPart(
+                    "invoke_agent",
+                    {"agent_name": child_name, "inputs": "recurse"},
+                )
+            ]
+        )
+
+    return fn
+
+
+async def test_running_agent_invokes_child_under_same_identity() -> None:
+    """A running agent invokes another definition; the child runs + returns.
+
+    Exercises the real wiring: a ``PydanticAgentRun`` with a
+    ``child_agent_resolver`` injected carries the ``invoke_agent`` tool, so a
+    started run can invoke a child. The child runs under the same operator.
+    """
+    seen_child_operators: list[Operator] = []
+
+    child_def = AgentDefinition(
+        name="deep-agent",
+        system_prompt="You answer hard sub-questions.",
+        request_limit=5,
+        # The child uses the FunctionModel below; an empty toolset keeps its
+        # surface to just whatever the runtime appends (none here).
+        toolset={"meta_tools": []},
+    )
+
+    async def resolver(operator: Operator, agent_name: str) -> AgentDefinition | None:
+        if agent_name == "deep-agent":
+            seen_child_operators.append(operator)
+            return child_def
+        return None
+
+    # One FunctionModel serves both the parent (invoke once, then finish) and
+    # the child (no tool return possible -> emit final text immediately, since
+    # the child's first turn has no prior tool return either). Disambiguate by
+    # system prompt content in the message history.
+    def model_fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        is_child = any(
+            part.part_kind == "system-prompt" and "hard sub-questions" in part.content
+            for message in messages
+            if isinstance(message, ModelRequest)
+            for part in message.parts
+        )
+        if is_child:
+            return ModelResponse(parts=[TextPart("child answer")])
+        # parent: invoke once, then finish
+        has_tool_return = any(
+            part.part_kind == "tool-return"
+            for message in messages
+            if isinstance(message, ModelRequest)
+            for part in message.parts
+        )
+        if not has_tool_return:
+            return ModelResponse(
+                parts=[
+                    ToolCallPart(
+                        "invoke_agent",
+                        {"agent_name": "deep-agent", "inputs": "sub-task"},
+                    )
+                ]
+            )
+        return ModelResponse(parts=[TextPart("parent done")])
+
+    runtime = PydanticAgentRun(
+        model_factory=lambda: FunctionModel(model_fn),
+        child_agent_resolver=resolver,
+    )
+    parent_def = AgentDefinition(
+        name="cheap-agent",
+        system_prompt="You delegate hard sub-tasks.",
+        request_limit=5,
+        toolset={"meta_tools": []},
+    )
+
+    operator = _make_operator()
+    handle = runtime.start(parent_def, operator, "delegate this")
+    result = await runtime.result(handle)
+
+    assert result.output == "parent done"
+    assert len(seen_child_operators) == 1
+    assert seen_child_operators[0].tenant_id == operator.tenant_id
+    assert seen_child_operators[0].sub == operator.sub
+
+
+async def test_cascade_terminates_on_depth_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A self-invoking cascade is stopped by ``agent_invoke_max_depth``.
+
+    Cap is set to 2: depth-1 and depth-2 invocations start children; the
+    depth-3 invocation never starts -- it raises
+    :class:`AgentInvocationDepthExceeded`, surfaced to the model as a
+    ``ModelRetry``. The recursive model only ever calls ``invoke_agent`` (it
+    never produces a final answer), so once the cap denies the deepest call the
+    framework exhausts the tool's retries and the run fails -- the seam
+    surfaces that as :class:`AgentRunError`. That is the deterministic
+    termination we want: the chain stopped at the cap (a structured error), it
+    did not spend unbounded. The ``child_starts == 2`` assertion proves the
+    over-depth child never resolved or ran.
+    """
+    monkeypatch.setenv("AGENT_INVOKE_MAX_DEPTH", "2")
+    get_settings.cache_clear()
+
+    child_starts = 0
+
+    recursive_def = AgentDefinition(
+        name="recursive-agent",
+        system_prompt="loop",
+        request_limit=20,
+        toolset={"meta_tools": []},
+    )
+
+    async def resolver(operator: Operator, agent_name: str) -> AgentDefinition | None:
+        nonlocal child_starts
+        if agent_name == "recursive-agent":
+            child_starts += 1
+            return recursive_def
+        return None
+
+    runtime = PydanticAgentRun(
+        model_factory=lambda: FunctionModel(_always_invoke("recursive-agent")),
+        child_agent_resolver=resolver,
+    )
+
+    # The top-level agent recurses too; the cascade is depth-bounded.
+    handle = runtime.start(recursive_def, _make_operator(), "start")
+    with pytest.raises(AgentRunError):
+        await runtime.result(handle)
+
+    # depth-1 + depth-2 children resolved + started; depth-3 was rejected at
+    # the depth check, before the resolver was reached.
+    assert child_starts == 2
+
+
+async def test_depth_check_rejects_before_spend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unit-level: an over-depth invoke raises before resolving / running.
+
+    Isolates the depth guard from the framework: pre-set the depth contextvar to
+    the cap, then assert the tool's resolver + child_runner are never reached and
+    the model sees a ``ModelRetry``.
+    """
+    monkeypatch.setenv("AGENT_INVOKE_MAX_DEPTH", "1")
+    get_settings.cache_clear()
+
+    resolver_calls = 0
+    runner_calls = 0
+
+    async def resolver(operator: Operator, agent_name: str) -> AgentDefinition | None:
+        nonlocal resolver_calls
+        resolver_calls += 1
+        return AgentDefinition(name=agent_name, system_prompt="x", request_limit=3)
+
+    async def child_runner(
+        *, definition: AgentDefinition, operator: Operator, inputs: str, usage: RunUsage
+    ) -> Any:
+        nonlocal runner_calls
+        runner_calls += 1
+        return "should-not-run"
+
+    invoke_tool = make_invoke_agent_tool(resolver=resolver, child_runner=child_runner)
+    fn = invoke_tool.function
+
+    # Pre-set depth to the cap so the next invoke breaches it.
+    token = agent_invoke_depth_var.set(1)
+    try:
+        ctx = _FakeCtx(deps=_make_operator(), usage=RunUsage())
+        with pytest.raises(ModelRetry, match="maximum invocation depth"):
+            await fn(ctx, agent_name="anything", inputs="go")
+    finally:
+        agent_invoke_depth_var.reset(token)
+
+    assert resolver_calls == 0  # rejected before resolution
+    assert runner_calls == 0  # never spent
+
+
+async def test_cascade_terminates_on_budget() -> None:
+    """The child's turns share the parent budget, so the cascade trips it.
+
+    The child model loops forever (only tool-less text would stop it; here it
+    keeps emitting an op-less response that the FunctionModel turns into model
+    requests). Driven with a shared usage at ``request_limit=1`` via
+    ``run_child``, the child trips ``UsageLimitExceeded`` -> ``AgentRunError``.
+    """
+
+    def loop_forever(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        # Emit a tool call so the loop never self-terminates on a final answer.
+        return ModelResponse(parts=[ToolCallPart("noop_tool", {})])
+
+    child_def = AgentDefinition(
+        name="runaway-child",
+        system_prompt="loop",
+        request_limit=1,  # shared budget exhausts immediately
+    )
+
+    runtime = PydanticAgentRun(model_factory=lambda: FunctionModel(loop_forever))
+
+    # Pre-load the shared usage near/at the limit so the child run trips it.
+    shared = RunUsage(requests=1)
+    with pytest.raises(AgentRunError, match="turn budget exhausted"):
+        await runtime.run_child(
+            definition=child_def,
+            operator=_make_operator(),
+            inputs="go",
+            usage=shared,
+        )
+
+
+async def test_child_run_linked_to_parent_in_lineage() -> None:
+    """The recorder is called with the parent run id -> cascade tree walkable."""
+    parent_run_id = uuid4()
+    child_run_id = uuid4()
+    recorded: list[dict[str, Any]] = []
+
+    child_def = AgentDefinition(name="deep-agent", system_prompt="answer", request_limit=5)
+
+    async def resolver(operator: Operator, agent_name: str) -> AgentDefinition | None:
+        return child_def
+
+    seen_run_id_in_child: list[UUID | None] = []
+
+    async def child_runner(
+        *, definition: AgentDefinition, operator: Operator, inputs: str, usage: RunUsage
+    ) -> Any:
+        # During the child loop, the current-run contextvar is the child's id.
+        seen_run_id_in_child.append(current_agent_run_id_var.get())
+        return "child answer"
+
+    async def recorder(
+        *,
+        operator: Operator,
+        definition: AgentDefinition,
+        parent_run_id: UUID | None,
+    ) -> UUID:
+        recorded.append(
+            {
+                "tenant_id": operator.tenant_id,
+                "definition_name": definition.name,
+                "parent_run_id": parent_run_id,
+            }
+        )
+        return child_run_id
+
+    invoke_tool = make_invoke_agent_tool(
+        resolver=resolver, child_runner=child_runner, recorder=recorder
+    )
+    fn = invoke_tool.function
+
+    # Simulate a parent run already associated with a durable agent_run row.
+    run_token = current_agent_run_id_var.set(parent_run_id)
+    try:
+        ctx = _FakeCtx(deps=_make_operator(), usage=RunUsage())
+        out = await fn(ctx, agent_name="deep-agent", inputs="sub-task")
+    finally:
+        current_agent_run_id_var.reset(run_token)
+
+    assert out == {"agent": "deep-agent", "output": "child answer"}
+    assert len(recorded) == 1
+    assert recorded[0]["parent_run_id"] == parent_run_id
+    assert recorded[0]["definition_name"] == "deep-agent"
+    assert recorded[0]["tenant_id"] == _TENANT_A
+    # Inside the child loop the lineage contextvar was the recorded child id.
+    assert seen_run_id_in_child == [child_run_id]
+
+
+async def test_unknown_child_agent_is_a_model_retry() -> None:
+    """An unresolvable agent name yields a recoverable ``ModelRetry``."""
+
+    async def resolver(operator: Operator, agent_name: str) -> AgentDefinition | None:
+        return None  # nothing resolves (typo / disabled / cross-tenant)
+
+    async def child_runner(
+        *, definition: AgentDefinition, operator: Operator, inputs: str, usage: RunUsage
+    ) -> Any:
+        raise AssertionError("child_runner must not run when resolution fails")
+
+    invoke_tool = make_invoke_agent_tool(resolver=resolver, child_runner=child_runner)
+    fn = invoke_tool.function
+
+    ctx = _FakeCtx(deps=_make_operator(), usage=RunUsage())
+    with pytest.raises(ModelRetry, match="no agent definition named"):
+        await fn(ctx, agent_name="ghost", inputs="go")
+
+
+async def test_depth_exceeded_carries_chain() -> None:
+    """The exception names the agent chain that blew the cap (actionable)."""
+    exc = AgentInvocationDepthExceeded(
+        attempted_depth=3,
+        max_depth=2,
+        agent_name_chain=("a", "b", "c"),
+    )
+    assert exc.attempted_depth == 3
+    assert exc.max_depth == 2
+    assert exc.agent_name_chain == ("a", "b", "c")
+    assert "a -> b -> c" in str(exc)
+
+
+class _FakeCtx:
+    """Minimal stand-in for ``RunContext`` carrying just ``deps`` + ``usage``.
+
+    The ``invoke_agent`` tool reads only ``ctx.deps`` (the operator) and
+    ``ctx.usage`` (the shared budget), so a tiny duck-typed context lets the
+    unit-level tests drive the tool's function directly without a full
+    framework run.
+    """
+
+    def __init__(self, *, deps: Operator, usage: RunUsage) -> None:
+        self.deps = deps
+        self.usage = usage

--- a/docs/codebase/agent-runtime.md
+++ b/docs/codebase/agent-runtime.md
@@ -14,9 +14,10 @@ run-handle store, and audit wiring remain MEHO's. Nothing outside
 `meho_backplane.agent` imports `pydantic_ai`.
 
 This document describes the G11.1-T1 foundation (the seam + one bounded
-loop) and the G11.1-T3 toolset resolution layered on it. Other G11.1 tasks:
-agent-definition persistence (T2), the public sync/async invocation surface
-(T4), agent-invokes-agent composition (T5), and durable run records (T6).
+loop), the G11.1-T3 toolset resolution layered on it, and the G11.1-T5
+agent-invokes-agent composition. Other G11.1 tasks: agent-definition
+persistence (T2), the public sync/async invocation surface (T4), and durable
+run records (T6).
 
 ## Key types
 
@@ -149,6 +150,72 @@ for *its* tool surface, parallel to the MCP front-end's `register_mcp_tool`
 registrations — both adapt the same `meta_tools` handlers; neither wraps the
 other.
 
+## Composition — agent invokes agent (T5 #812)
+
+A running agent can invoke **another** agent definition in its tenant as a
+child run, via the `invoke_agent` meta-tool (in `meho_backplane/agent/invoke.py`).
+From MEHO's view a child run is just another governed call: it resolves through
+the same identity, the same RBAC-filtered toolset, the same dispatch + audit
+machinery. There is no "tier" concept in MEHO — a consumer's harness may
+escalate a cheap-tier agent to a deep-tier agent, but MEHO sees one agent run
+invoking another.
+
+`invoke_agent` is **off by default**. It is appended to a built agent only when
+the `PydanticAgentRun` carries a `child_agent_resolver` (injected at the edge by
+the T4 invocation surface, which owns the tenant-scoped definition lookup). With
+no resolver, the T1/T3 surface is unchanged.
+
+### Two independent bounds keep a cascade from escaping
+
+A naive agent-invokes-agent surface is the textbook runaway-cost foot-gun (a
+definition that invokes itself, directly or transitively, spawns an unbounded
+chain of LLM runs). The mechanism bounds it on two axes; a cascade terminates on
+whichever it hits first:
+
+- **Depth** — the *height* of the invocation tree. A per-task contextvar
+  (`agent_invoke_depth_var`) tracks how many `invoke_agent` frames the current
+  asyncio task is nested inside. The tool pre-increments + checks it against
+  `Settings.agent_invoke_max_depth` (default 4, env `AGENT_INVOKE_MAX_DEPTH`)
+  *before* the child run starts, so an over-depth invocation never spends. This
+  mirrors the composite-recursion cap exactly (`composite_depth_var` +
+  `Settings.composite_max_depth`).
+- **Budget** — the *total turn count* across the whole cascade. The child loop
+  is driven with `usage=ctx.usage` (Pydantic AI's budget-propagation knob), so
+  the parent's `RunUsage` accumulator is shared with the child. The shared
+  `UsageLimits(request_limit=...)` is enforced against the running total, so a
+  deep-but-narrow cascade and a shallow-but-wide one both trip the same budget.
+  The framework raises `UsageLimitExceeded`, surfaced as `AgentRunError`.
+
+An over-depth invocation (and an unresolvable agent name, and a failed child
+run) surfaces to the model as a `ModelRetry` — a structured, agent-reasonable
+error it can recover from ("answer directly or stop"), not a tool-execution
+crash. The depth ceiling is a deterministic termination condition the model
+never controls.
+
+### Lineage — the cascade tree is reconstructable
+
+The child run is recorded as a child of the parent in two parallel lineages:
+
+- **Run lineage** — the child `agent_run` row's `parent_run_id` points at the
+  parent run's id, and its `trigger` is `agent-invoked` (`AgentRunTrigger`).
+  Recording the row is delegated to an injected `ChildRunRecorder` callback (the
+  T4/T6 surface owns the DB session); when no recorder is wired (the pure
+  in-process path) the depth + budget bounds still apply, the row is just not
+  persisted.
+- **Session lineage** — `current_agent_run_id_var` carries the current run's id
+  for the duration of a child invocation, so a nested `invoke_agent` reads it as
+  the next child's `parent_run_id` and per-tool-call audit rows correlate to
+  their run.
+
+### Why a tool factory, not a standalone service
+
+The acceptance criterion is that a *running agent* can invoke another — so the
+mechanism is a registered tool, reachable from inside the loop. The factory
+shape (`make_invoke_agent_tool(resolver, child_runner, recorder)`) injects the
+`child_runner` (`PydanticAgentRun.run_child`, which owns the framework `Agent`
+construction + the `usage=ctx.usage` call, keeping `pydantic_ai` confined to
+`agent/run.py`) without `invoke.py` importing the framework's loop driver.
+
 ## Dependencies
 
 - **`pydantic-ai-slim[anthropic]`** (pinned in `backend/pyproject.toml`) —
@@ -210,6 +277,12 @@ Foundation) is G11.5.
   transport lives.
 - Run handles are in-memory `asyncio.Task`s. Durable `agent_run` records +
   a session-id lineage key + cancellation are T6 (#813).
+- The `invoke_agent` composition tool (T5) takes an injected
+  `child_agent_resolver` / `child_run_recorder`; the T4 invocation surface
+  (#811) wires the concrete resolver (tenant-scoped `AgentDefinitionService`
+  lookup) and recorder (`agent_run` lifecycle service) at the edge. Until then
+  the bounds (depth + shared budget) hold and a recorder-less run simply does
+  not persist the lineage row.
 - The identity-permission side of the intersection is the tenant role today.
   When the G11.2 per-op permission model lands, the resolver's role gate is
   the seam to extend (or replace) with the real per-op grant check — the
@@ -219,10 +292,15 @@ Foundation) is G11.5.
 ## References
 
 - Goal #800 (G11 agentic ops runtime); Initiative #802 (G11.1); Tasks #808
-  (T1 seam), #810 (T3 toolset resolution).
+  (T1 seam), #810 (T3 toolset resolution), #812 (T5 composition), #813 (T6 run
+  records).
 - Pydantic AI: agent concepts (`UsageLimits`, `run`, `deps`/`RunContext`,
-  `output_type`), tool registration (`Tool.from_schema`, the `tools=`
-  constructor arg, `ModelRetry`), Anthropic model + provider.
+  `output_type`, budget-aware sub-runs via `usage=ctx.usage`), tool
+  registration (`Tool.from_schema`, the `tools=` constructor arg, `ModelRetry`),
+  Anthropic model + provider.
 - Grounding: `operations/dispatcher.py` (`dispatch`), `operations/meta_tools.py`
   (`call_operation`, `list_operation_groups`, `search_operations`),
-  `mcp/registry.py` (`role_at_least`), `auth/operator.py`.
+  `mcp/registry.py` (`role_at_least`), `auth/operator.py`; composition cap
+  precedent `operations/composite.py` (`composite_depth_var` +
+  `Settings.composite_max_depth`) and `operations/agent_run.py`
+  (`create_run(parent_run_id=...)`).


### PR DESCRIPTION
## Summary

- G11.1-T5: a running agent can invoke **another** agent definition in its tenant as a child run, via the new `invoke_agent` meta-tool (`backend/src/meho_backplane/agent/invoke.py`). From MEHO's view a child run is just another governed call — same identity, same RBAC-filtered toolset, same dispatch + audit. No "tier" concept in MEHO.
- **Depth-capped + budget-aware** — a cascade terminates on whichever bound it hits first. Depth: a per-task contextvar checked against the new `agent_invoke_max_depth` setting (default 4) *before* the child run starts, so an over-depth invocation never spends; surfaced as a `ModelRetry` (deterministic termination the model never controls). Budget: the child loop runs with `usage=ctx.usage` so its turns count against the parent's shared `RunUsage` and the shared `UsageLimits` terminates the whole cascade.
- **Lineage** — the child `agent_run` row links to the parent via `parent_run_id` (`trigger=agent-invoked`) through an injected `ChildRunRecorder`; `current_agent_run_id_var` carries the session lineage so nested invocations link correctly. The cascade tree is reconstructable.
- **Off by default + framework-confined** — `invoke_agent` is appended only when the `PydanticAgentRun` carries a `child_agent_resolver` (injected at the edge by the T4 surface). `pydantic_ai` loop-driving stays in `agent/run.py` (the tool's `ChildRunner` is `run_child`, which owns the `Agent` + `usage=` call).

## Test plan

- [x] `ruff check` — clean (agent/, settings.py, test)
- [x] `ruff format --check` — clean
- [x] `mypy` — clean (5 source files, no issues)
- [x] `code-quality.py` — pass (exit 0, no agent-introduced violations)
- [x] **Depth termination** — `test_cascade_terminates_on_depth_cap`: a self-invoking cascade with `AGENT_INVOKE_MAX_DEPTH=2` stops at the cap (depth-3 child never resolves or runs → `child_starts == 2`), failing with a structured `AgentRunError` rather than unbounded spend; `test_depth_check_rejects_before_spend` isolates the guard (resolver + runner never reached).
- [x] **Budget termination** — `test_cascade_terminates_on_budget`: a child driven with a shared `usage` at the limit trips `UsageLimitExceeded` → `AgentRunError`.
- [x] **Same/derived identity + RBAC + audit** — `test_running_agent_invokes_child_under_same_identity`: the child runs under the parent operator (tenant + sub), tools resolved through the same path.
- [x] **Parent lineage** — `test_child_run_linked_to_parent_in_lineage`: recorder called with the parent run id; child loop sees the child run id on `current_agent_run_id_var`.
- [x] Full agent + settings + db + mcp + api suite green: 137 passed.
- [x] Docs: `docs/codebase/agent-runtime.md` extended with a Composition (T5) section; composition moved out of "future work".

## Out of scope

- The consumer's tiering workflow (R1 sample) — that's harness code, not MEHO.
- Cross-tenant invocation — structurally disallowed (the resolver is only ever called with the parent operator's tenant; a name in another tenant does not resolve).
- Wiring the concrete `child_agent_resolver` (tenant-scoped `AgentDefinitionService` lookup) + `child_run_recorder` (`agent_run` lifecycle) at the invocation edge lands with the T4 surface (#811, in parallel). Until then the bounds hold and a recorder-less run simply does not persist the lineage row.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #812
