### PR TITLE
feat(ui): G10.1-T3 broadcast wall-monitor + Last-24h replay + long-display session refresh

### DIFF
--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -398,6 +398,43 @@ class Settings(BaseModel):
         becomes un-decryptable on key rotation; the operator-facing
         contract is "log everyone out, then bump the key"); v0.2
         ships one key end-to-end.
+    ui_session_sliding_extension_seconds:
+        Sliding-session window, in seconds. Initiative #338
+        (G10.1 Activity broadcast UI), Task #869 (the broadcast
+        wall-monitor's long-display requirement). The BFF session row's
+        ``expires_at`` is set at login to roughly the access-token TTL,
+        so a wall-monitor display left running for hours would otherwise
+        cross ``expires_at`` mid-display; the next SSE reconnect to
+        ``/ui/broadcast/stream`` would then be 302-redirected to login,
+        and the browser ``EventSource`` permanently fails on a non-200
+        response -- the feed dies silently. On every active ``/ui/*``
+        request,
+        :func:`meho_backplane.ui.auth.session_store.load_session`
+        extends ``expires_at`` to ``now + this window`` when the row is
+        within the window of expiry, so an in-use session never lapses
+        mid-display. ``0`` disables the sliding extension (the session
+        expires strictly at its login-time ``expires_at``). Default
+        3600 (one hour) -- a value large enough that a wall display
+        refreshing the page or reconnecting the stream within the hour
+        keeps the session alive, small enough that an abandoned tab
+        lapses within the hour. Always bounded by
+        ``ui_session_absolute_lifetime_seconds`` so the extension is not
+        unbounded.
+    ui_session_absolute_lifetime_seconds:
+        Hard ceiling, in seconds, on how long a BFF session may live
+        from ``created_at`` regardless of sliding extension. Task #869.
+        The sliding extension (above) keeps an actively-viewed session
+        alive, but without an absolute cap a permanently-displayed wall
+        monitor would create an immortal session -- a standard
+        idle-vs-absolute session-timeout pairing (OWASP ASVS v4 §3.3).
+        :func:`load_session` never extends ``expires_at`` past
+        ``created_at + this cap``; once the cap is reached the session
+        lapses on its next load and the operator re-authenticates.
+        Default 43200 (12 hours) -- one working day of continuous wall
+        display without forcing a mid-shift re-login, while still
+        guaranteeing a daily re-auth. Must exceed
+        ``ui_session_sliding_extension_seconds`` for the sliding window
+        to have any effect.
     topology_history_retention_days:
         Maximum age (in days) of ``graph_node_history`` /
         ``graph_edge_history`` rows the G9.3-T6 (#858) retention prune
@@ -534,6 +571,15 @@ class Settings(BaseModel):
     ui_keycloak_client_id: str = ""
     ui_keycloak_client_secret: str = ""
     ui_session_encryption_key: str = ""
+    # G10.1-T3 #869 — BFF sliding-session knobs for the broadcast
+    # wall-monitor's long-display requirement. The sliding extension
+    # keeps an actively-viewed session alive past its login-time
+    # ``expires_at`` (so a wall display never logs out mid-stream);
+    # the absolute cap bounds that extension so a permanent display
+    # cannot create an immortal session. ``sliding=0`` disables the
+    # extension. See the field docstrings above for the full rationale.
+    ui_session_sliding_extension_seconds: int = Field(default=3600, ge=0)
+    ui_session_absolute_lifetime_seconds: int = Field(default=43200, gt=0)
     # G9.3-T6 #858 — topology history retention prune knobs. ``days=0`` is
     # the opt-out sentinel ("keep forever"); ``enabled=False`` skips the
     # background task entirely. The two flags are deliberately distinct
@@ -698,6 +744,12 @@ def get_settings() -> Settings:
         ui_keycloak_client_id=os.environ.get("UI_KEYCLOAK_CLIENT_ID", "").strip(),
         ui_keycloak_client_secret=os.environ.get("UI_KEYCLOAK_CLIENT_SECRET", "").strip(),
         ui_session_encryption_key=os.environ.get("UI_SESSION_ENCRYPTION_KEY", "").strip(),
+        ui_session_sliding_extension_seconds=int(
+            os.environ.get("UI_SESSION_SLIDING_EXTENSION_SECONDS", "3600"),
+        ),
+        ui_session_absolute_lifetime_seconds=int(
+            os.environ.get("UI_SESSION_ABSOLUTE_LIFETIME_SECONDS", "43200"),
+        ),
         topology_history_retention_days=int(
             os.environ.get("TOPOLOGY_HISTORY_RETENTION_DAYS", "90"),
         ),

--- a/backend/src/meho_backplane/ui/auth/session_store.py
+++ b/backend/src/meho_backplane/ui/auth/session_store.py
@@ -429,6 +429,13 @@ async def load_session(
     # update is server-side-controlled (never a client-supplied
     # value), so this is safe to run on every successful load.
     row.last_seen_at = now
+    # Sliding-session extension (G10.1-T3 #869): keep an actively-used
+    # session alive past its login-time ``expires_at`` so a long display
+    # (the broadcast wall-monitor) does not log out mid-stream. Bounded
+    # by an absolute cap from ``created_at`` so a permanent display
+    # cannot create an immortal session. Returns the (possibly extended)
+    # ``expires_at`` and mutates the row in place.
+    expires_at = _maybe_extend_expiry(row, created_at=_coerce_utc(row.created_at), now=now)
     await session.flush()
     return DecryptedSession(
         id=row.id,
@@ -636,6 +643,71 @@ async def rotate_refresh(
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _maybe_extend_expiry(
+    row: WebSession,
+    *,
+    created_at: datetime,
+    now: datetime,
+) -> datetime:
+    """Slide a near-expiry session forward, bounded by an absolute cap.
+
+    The long-display refresh mechanism for the broadcast wall-monitor
+    (G10.1-T3 #869). The BFF session row's ``expires_at`` is set at
+    login to roughly the access-token TTL (minutes to ~an hour), so a
+    wall display left running for hours would cross ``expires_at``
+    mid-display; the next SSE reconnect to ``/ui/broadcast/stream``
+    would be 302-redirected to login, and the browser ``EventSource``
+    permanently fails on the non-200 -- the feed dies silently.
+
+    On every active ``/ui/*`` load (this function runs inside
+    :func:`load_session`, after the still-valid check), when the row is
+    within ``ui_session_sliding_extension_seconds`` of expiry, push
+    ``expires_at`` out to ``now + sliding_window`` -- but never past the
+    absolute ceiling ``created_at + ui_session_absolute_lifetime_seconds``.
+    The pairing is the standard idle-vs-absolute session-timeout shape
+    (OWASP ASVS v4 §3.3): the sliding window keeps an in-use session
+    alive; the absolute cap guarantees a daily re-auth even for a
+    permanently-displayed monitor.
+
+    A ``sliding`` value of ``0`` disables the extension entirely (the
+    session expires strictly at its login-time ``expires_at``). The
+    mutation is server-side-controlled (clock + config only, never a
+    client-supplied value), so running it on every successful load is
+    safe.
+
+    Returns the effective ``expires_at`` (extended or unchanged) and
+    mutates ``row.expires_at`` in place when an extension applies. The
+    caller's :func:`AsyncSession.flush` persists it.
+    """
+    settings = get_settings()
+    sliding = settings.ui_session_sliding_extension_seconds
+    if sliding <= 0:
+        return _coerce_utc(row.expires_at)
+
+    current = _coerce_utc(row.expires_at)
+    # Absolute ceiling from session birth -- the extension can never
+    # push expiry past this, so a permanent display still re-auths.
+    ceiling = created_at + timedelta(seconds=settings.ui_session_absolute_lifetime_seconds)
+    if current >= ceiling:
+        # Already at (or past) the absolute cap; no further sliding.
+        return current
+
+    # Only slide when the session is within the sliding window of
+    # expiry -- avoids a write on every single request for a freshly
+    # logged-in session whose expiry is still far off.
+    threshold = current - timedelta(seconds=sliding)
+    if now < threshold:
+        return current
+
+    extended = min(now + timedelta(seconds=sliding), ceiling)
+    # Monotonic guard: never move expiry backwards (a tiny sliding
+    # window vs a long login TTL could otherwise shrink it).
+    if extended <= current:
+        return current
+    row.expires_at = extended
+    return extended
 
 
 def _coerce_utc(value: datetime) -> datetime:

--- a/backend/src/meho_backplane/ui/routes/broadcast/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/broadcast/__init__.py
@@ -28,6 +28,12 @@ Module layout:
   audit_id + broadcast event_id) the feed rows open via ``hx-get``;
   applies the same decision-#3 aggregate-only gate as the publisher so
   a sensitive op never leaks its payload on click.
+* :mod:`~meho_backplane.ui.routes.broadcast.history` -- the
+  ``GET /ui/broadcast/history`` route (T3 #869). The "Last 24h" tab's
+  HTMX target: a finite ``XRANGE`` pull of the tenant's last-24h events,
+  serialised as JSON the shared ``broadcastFeed`` controller renders
+  through ``_event_row.html``, so a replayed history row is identical to
+  a live row and opens the same T2 drawer.
 
 The umbrella :func:`build_router` aggregates both. It is mounted
 **before** :func:`meho_backplane.ui.routes.stubs.build_stubs_router` in
@@ -45,6 +51,7 @@ from fastapi import APIRouter
 
 from meho_backplane.ui.routes.broadcast.event import build_event_router
 from meho_backplane.ui.routes.broadcast.feed import build_feed_router
+from meho_backplane.ui.routes.broadcast.history import build_history_router
 from meho_backplane.ui.routes.broadcast.stream import build_stream_router
 
 __all__ = ["build_router"]
@@ -59,15 +66,16 @@ def build_router() -> APIRouter:
     :mod:`meho_backplane.ui.routes.topology`.
 
     The feed router is included **before** the event router so the
-    literal ``/ui/broadcast/feed`` fragment path is matched ahead of
-    the parametrised ``/ui/broadcast/event/{audit_id}`` -- they share
-    no overlapping segment, but declaration order is the contract
-    FastAPI resolves on, so keeping the literal route first is the safe
-    discipline (mirrors the targets router's ``/discover`` ahead of
-    ``/{name}``).
+    literal ``/ui/broadcast/feed`` / ``/ui/broadcast/history`` fragment
+    paths are matched ahead of the parametrised
+    ``/ui/broadcast/event/{audit_id}`` -- they share no overlapping
+    segment, but declaration order is the contract FastAPI resolves on,
+    so keeping the literal routes first is the safe discipline (mirrors
+    the targets router's ``/discover`` ahead of ``/{name}``).
     """
     router = APIRouter()
     router.include_router(build_feed_router())
     router.include_router(build_stream_router())
+    router.include_router(build_history_router())
     router.include_router(build_event_router())
     return router

--- a/backend/src/meho_backplane/ui/routes/broadcast/feed.py
+++ b/backend/src/meho_backplane/ui/routes/broadcast/feed.py
@@ -237,10 +237,11 @@ async def _render_page(
     principal: str,
     target: str,
     op_id: str,
+    wall: bool,
     session_ctx: UISessionContext,
     db_session: AsyncSession,
 ) -> HTMLResponse:
-    """Render ``GET /ui/broadcast`` -- the full page.
+    """Render ``GET /ui/broadcast`` -- the full page (or the wall view).
 
     The page subscribes to ``/ui/broadcast/stream`` (the session-gated
     SSE bridge), so the operator sees their tenant's live events with no
@@ -248,6 +249,16 @@ async def _render_page(
     template's ``hx-headers`` so the filter bar's ``hx-get`` (and any
     later state-changing HTMX request from this surface) passes the
     double-submit check -- mirroring the dashboard + topology surfaces.
+
+    ``wall`` selects the wall-monitor template (work item #5): a minimal
+    no-chrome layout (no sidebar, no top bar, no filter bar) that
+    maximises the feed for a full-screen team-room monitor. It reuses
+    the **same** ``broadcast/_feed.html`` fragment -- so the same SSE
+    wiring, the same ``EventSource`` reconnect / ``Last-Event-Id``
+    replay durability, the same 1000-row cap -- and only swaps the
+    surrounding chrome. The wall view subscribes to the live tail with
+    no server-side filters (a wall monitor shows everything the tenant
+    produces); the filter bar is the in-chrome surface's affordance.
     """
     target_names = await _target_names(db_session, session_ctx.tenant_id)
     csrf_token = mint_csrf_token(str(session_ctx.session_id))
@@ -270,7 +281,8 @@ async def _render_page(
             op_id=op_id,
         ),
     }
-    response = get_templates().TemplateResponse(request, "broadcast/feed.html", context)
+    template = "broadcast/wall.html" if wall else "broadcast/feed.html"
+    response = get_templates().TemplateResponse(request, template, context)
     response.set_cookie(
         key=CSRF_COOKIE_NAME,
         value=csrf_token,
@@ -336,14 +348,23 @@ def build_feed_router() -> APIRouter:
         principal: str = Query(default="", max_length=256),
         target: str = Query(default="", max_length=256),
         op_id: str = Query(default="", max_length=256),
+        wall: bool = Query(
+            default=False,
+            description=(
+                "Render the minimal full-screen wall-monitor layout "
+                "(no sidebar / top bar / filter bar)."
+            ),
+        ),
         session_ctx: UISessionContext = _require_ui_session_dep,
         db_session: AsyncSession = _get_raw_session_dep,
     ) -> HTMLResponse:
-        """``GET /ui/broadcast[?op_class=&principal=&target=&op_id=]``.
+        """``GET /ui/broadcast[?op_class=&principal=&target=&op_id=&wall=1]``.
 
         Filters are accepted on the full-page route too so a copy-pasted
         filtered URL reproduces the operator's view (the filter bar sets
         ``hx-push-url`` on the fragment route, mirroring topology).
+        ``wall=1`` selects the no-chrome wall-monitor layout (work item
+        #5).
         """
         return await _render_page(
             request,
@@ -351,6 +372,7 @@ def build_feed_router() -> APIRouter:
             principal=principal,
             target=target,
             op_id=op_id,
+            wall=wall,
             session_ctx=session_ctx,
             db_session=db_session,
         )

--- a/backend/src/meho_backplane/ui/routes/broadcast/history.py
+++ b/backend/src/meho_backplane/ui/routes/broadcast/history.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``GET /ui/broadcast/history`` -- the Last-24h replay pane.
+
+Initiative #338 (G10.1 Activity broadcast UI), Task #869 (G10.1-T3)
+work item #6. The broadcast view's "Last 24h" tab ``hx-get``s this
+fragment; it renders the historical events the operator can scroll
+back through, with each row opening the same T2 event-detail drawer on
+a click.
+
+Live feed vs. history pane
+==========================
+
+The live feed (:mod:`~meho_backplane.ui.routes.broadcast.stream`) tails
+the per-tenant Valkey stream with a BLOCKing ``XREAD`` -- an open-ended
+generator that yields events as they are published. The history pane is
+the opposite shape: a **finite** ``XRANGE`` pull of the events already
+on the stream, bounded by both a 24h time window and a row cap, rendered
+once into the page. There is no streaming, no generator, no
+``while True`` -- the endpoint reads a bounded batch and returns, so it
+cannot hang a worker the way an unguarded stream loop could.
+
+The 24h window
+==============
+
+Valkey stream entry ids are ``<ms-timestamp>-<sequence>``. A bare
+millisecond timestamp as the ``XRANGE`` start auto-completes the
+sequence to ``0`` (Valkey ``XRANGE`` semantics), so
+``XRANGE key <now_ms - 24h> + COUNT <cap>`` returns every entry from the
+last 24 hours, oldest-first, capped. The window width is
+:attr:`Settings.broadcast_retention_hours` (default 24, the locked
+decision-3 contract -- the same retention the publisher's ``MAXLEN``
+trim targets). ``XRANGE`` returns ascending (oldest-first); the pane
+renders newest-first to match the live feed, so the parsed list is
+reversed before it reaches the template.
+
+Why reuse the live feed's row + drawer
+======================================
+
+The history rows render through the **same** ``broadcast/_event_row.html``
+partial and the **same** ``broadcastFeed`` Alpine controller the live
+feed uses. The controller is seeded with the historical events as JSON
+(``history_events_json``) instead of an SSE subscription, so the row
+markup, the op_class badge palette, the 🔒 aggregate-only marker, the
+timestamp formatting, and the click-to-open-drawer behaviour are all
+single-sourced -- a history row is byte-identical to a live row and
+opens the identical T2 drawer.
+
+Tenant scoping
+==============
+
+The stream key is ``meho:feed:{session.tenant_id}`` taken from the
+validated session, never a query parameter -- the identical guarantee
+the live stream bridge makes. A tenant-A operator's history pane reads
+only ``meho:feed:{A}``; there is no parameter that could redirect it to
+another tenant's stream, so tenant-A events can never surface on
+tenant-B's history pane (and vice versa).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Final
+
+import structlog
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
+from pydantic import ValidationError
+
+from meho_backplane.broadcast import BroadcastEvent, get_broadcast_client
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.routes.broadcast.feed import (
+    IN_DOM_ROW_CAP,
+    OP_CLASS_BADGE_CLASSES,
+)
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["build_history_router"]
+
+_log = structlog.get_logger(__name__)
+
+#: Milliseconds per hour -- the 24h window start id is computed as
+#: ``now_ms - broadcast_retention_hours * _MS_PER_HOUR``.
+_MS_PER_HOUR: Final[int] = 3_600_000
+
+#: ``XRANGE`` end anchor -- ``"+"`` is Valkey's "latest available entry"
+#: sentinel, so the pull spans from the window start to the live tail.
+_XRANGE_END: Final[str] = "+"
+
+
+def _stream_key(tenant_id: object) -> str:
+    """Build the per-tenant Valkey stream key.
+
+    Mirrors :func:`meho_backplane.ui.routes.broadcast.stream._stream_key`
+    and the publisher exactly so the history pane reads the same key the
+    publisher writes and the live stream tails.
+    """
+    return f"meho:feed:{tenant_id}"
+
+
+def _window_start_id(*, retention_hours: int, now_ms: int) -> str:
+    """Build the ``XRANGE`` start id for the replay window.
+
+    The start id is a bare millisecond timestamp ``now_ms -
+    retention_hours * 3_600_000``. Valkey ``XRANGE`` auto-completes a
+    bare timestamp's sequence to ``0``, so the range is inclusive of
+    every entry from that millisecond onward. Clamped at ``0`` so a
+    misconfigured (absurdly large) retention window never produces a
+    negative start id that Valkey would reject.
+    """
+    start_ms = max(now_ms - retention_hours * _MS_PER_HOUR, 0)
+    return str(start_ms)
+
+
+def _parse_entries(
+    entries: list[tuple[str, dict[str, str]]],
+    *,
+    stream_key: str,
+) -> list[BroadcastEvent]:
+    """Parse ``XRANGE`` entries into :class:`BroadcastEvent` objects.
+
+    Mirrors the skip discipline in
+    :func:`meho_backplane.api.v1.feed._process_entries`: an entry with
+    no ``event`` field, or a malformed JSON ``event`` field, is logged
+    and skipped rather than failing the whole pane -- the same
+    belt-and-suspenders guard against a future foreign writer on the
+    shared stream key.
+    """
+    events: list[BroadcastEvent] = []
+    for entry_id, fields in entries:
+        raw_event_json = fields.get("event")
+        if not isinstance(raw_event_json, str):
+            _log.warning(
+                "broadcast_history_skipped_unknown_field_shape",
+                stream_key=stream_key,
+                entry_id=entry_id,
+                fields=list(fields.keys()),
+            )
+            continue
+        try:
+            events.append(BroadcastEvent.model_validate_json(raw_event_json))
+        except ValidationError:
+            _log.warning(
+                "broadcast_history_skipped_malformed_event",
+                stream_key=stream_key,
+                entry_id=entry_id,
+            )
+    return events
+
+
+async def _fetch_history(tenant_id: object) -> list[BroadcastEvent]:
+    """Pull the last-24h events for *tenant_id*, newest-first, capped.
+
+    A single finite ``XRANGE`` over ``meho:feed:{tenant_id}`` from the
+    window start to ``"+"`` (latest), bounded by ``COUNT`` =
+    :data:`IN_DOM_ROW_CAP` so the pane stays within the same in-DOM row
+    budget as the live feed. ``XRANGE`` returns oldest-first; the list
+    is reversed so the pane renders newest-first, matching the live
+    feed's reverse-chronological order.
+
+    Fail-soft: any Valkey error returns an empty list (the pane renders
+    its empty state) rather than 500-ing the fragment -- a transient
+    broadcast-subchart blip should degrade the replay pane, not the
+    page. The error is logged with the exception class only (redis-py
+    exceptions can embed the endpoint URL).
+    """
+    client = get_broadcast_client()
+    stream_key = _stream_key(tenant_id)
+    retention_hours = get_settings().broadcast_retention_hours
+    start_id = _window_start_id(
+        retention_hours=retention_hours,
+        now_ms=int(time.time() * 1000),
+    )
+    try:
+        entries = await client.xrange(
+            stream_key,
+            min=start_id,
+            max=_XRANGE_END,
+            count=IN_DOM_ROW_CAP,
+        )
+    except Exception as exc:
+        _log.warning(
+            "broadcast_history_fetch_failed",
+            error_class=type(exc).__name__,
+            stream_key=stream_key,
+        )
+        return []
+    events = _parse_entries(entries, stream_key=stream_key)
+    # XRANGE is ascending (oldest-first); the pane renders newest-first
+    # to match the live feed's reverse-chronological order.
+    events.reverse()
+    return events
+
+
+#: Module-level :class:`fastapi.Depends` closure -- ruff B008 guard.
+_require_ui_session_dep = Depends(require_ui_session)
+
+
+def build_history_router() -> APIRouter:
+    """Construct the broadcast Last-24h replay :class:`APIRouter`.
+
+    Registers ``GET /ui/broadcast/history`` -- the HTMX-only fragment
+    the "Last 24h" tab swaps in. Factory function (not a module-level
+    constant) so a test app can construct parallel routers without
+    sharing route state -- mirrors the feed / stream / event routers.
+    """
+    router = APIRouter(tags=["ui-broadcast"])
+
+    async def _handler(
+        request: Request,
+        session_ctx: UISessionContext = _require_ui_session_dep,
+    ) -> HTMLResponse:
+        """``GET /ui/broadcast/history`` -- the Last-24h replay fragment.
+
+        Pulls the session tenant's last-24h events via a finite
+        ``XRANGE``, serialises them as JSON the shared ``broadcastFeed``
+        controller renders through ``broadcast/_event_row.html``, and
+        returns the ``broadcast/_history.html`` fragment (no
+        ``base.html`` chrome -- the tab swaps it into the page's history
+        container). The tenant comes from the validated session, never a
+        query parameter.
+        """
+        events = await _fetch_history(session_ctx.tenant_id)
+        context: dict[str, object] = {
+            "in_dom_row_cap": IN_DOM_ROW_CAP,
+            "op_class_badge_json": _badge_palette_json(),
+            "history_events_json": _events_json(events),
+            "history_count": len(events),
+            "retention_hours": get_settings().broadcast_retention_hours,
+        }
+        return get_templates().TemplateResponse(request, "broadcast/_history.html", context)
+
+    router.add_api_route(
+        "/ui/broadcast/history",
+        _handler,
+        methods=["GET"],
+        name="ui_broadcast_history",
+        response_class=HTMLResponse,
+    )
+    return router
+
+
+def _badge_palette_json() -> str:
+    """Serialise the op_class → DaisyUI badge palette for the controller.
+
+    The same map the live feed serialises (re-used so the history rows'
+    badge colours match the live rows exactly). ``json.dumps`` output is
+    HTML-safe inside the ``application/json``-shaped Alpine ``x-data``
+    the history fragment renders it into.
+    """
+    return json.dumps(OP_CLASS_BADGE_CLASSES)
+
+
+def _events_json(events: list[BroadcastEvent]) -> str:
+    """Serialise the historical events as a JSON array for the controller.
+
+    Each event is dumped via :meth:`BroadcastEvent.model_dump_json` so
+    the client-side shape is byte-identical to a live SSE frame's
+    ``data:`` payload -- the ``broadcastFeed`` controller seeds these
+    into its ``events`` array and the rows render through the same
+    ``_event_row.html`` partial. The result is a JSON array string the
+    template embeds via ``| safe`` inside the Alpine ``x-data``.
+    """
+    return "[" + ",".join(event.model_dump_json() for event in events) + "]"

--- a/backend/src/meho_backplane/ui/routes/broadcast/history.py
+++ b/backend/src/meho_backplane/ui/routes/broadcast/history.py
@@ -40,12 +40,16 @@ Why reuse the live feed's row + drawer
 
 The history rows render through the **same** ``broadcast/_event_row.html``
 partial and the **same** ``broadcastFeed`` Alpine controller the live
-feed uses. The controller is seeded with the historical events as JSON
-(``history_events_json``) instead of an SSE subscription, so the row
-markup, the op_class badge palette, the 🔒 aggregate-only marker, the
-timestamp formatting, and the click-to-open-drawer behaviour are all
-single-sourced -- a history row is byte-identical to a live row and
-opens the identical T2 drawer.
+feed uses. The controller is seeded with the historical events from a
+``<script type="application/json">`` data island (the template renders
+the ``history_events`` list through Jinja ``| tojson``) instead of an
+SSE subscription, so the row markup, the op_class badge palette, the 🔒
+aggregate-only marker, the timestamp formatting, and the
+click-to-open-drawer behaviour are all single-sourced -- a history row
+is byte-identical to a live row and opens the identical T2 drawer. The
+data-island shape (not an ``x-data`` attribute) keeps quote- and
+markup-bearing event fields from breaking out of the markup (B1, PR
+#1044).
 
 Tenant scoping
 ==============
@@ -216,9 +220,10 @@ def build_history_router() -> APIRouter:
         """``GET /ui/broadcast/history`` -- the Last-24h replay fragment.
 
         Pulls the session tenant's last-24h events via a finite
-        ``XRANGE``, serialises them as JSON the shared ``broadcastFeed``
-        controller renders through ``broadcast/_event_row.html``, and
-        returns the ``broadcast/_history.html`` fragment (no
+        ``XRANGE``, passes them as a list the template serialises with
+        Jinja ``| tojson`` into a ``<script type="application/json">``
+        data island the shared ``broadcastFeed`` controller seeds from,
+        and returns the ``broadcast/_history.html`` fragment (no
         ``base.html`` chrome -- the tab swaps it into the page's history
         container). The tenant comes from the validated session, never a
         query parameter.
@@ -227,7 +232,7 @@ def build_history_router() -> APIRouter:
         context: dict[str, object] = {
             "in_dom_row_cap": IN_DOM_ROW_CAP,
             "op_class_badge_json": _badge_palette_json(),
-            "history_events_json": _events_json(events),
+            "history_events": _events_payload(events),
             "history_count": len(events),
             "retention_hours": get_settings().broadcast_retention_hours,
         }
@@ -254,14 +259,23 @@ def _badge_palette_json() -> str:
     return json.dumps(OP_CLASS_BADGE_CLASSES)
 
 
-def _events_json(events: list[BroadcastEvent]) -> str:
-    """Serialise the historical events as a JSON array for the controller.
+def _events_payload(events: list[BroadcastEvent]) -> list[dict[str, object]]:
+    """Build the historical events as JSON-ready dicts for the controller.
 
-    Each event is dumped via :meth:`BroadcastEvent.model_dump_json` so
-    the client-side shape is byte-identical to a live SSE frame's
-    ``data:`` payload -- the ``broadcastFeed`` controller seeds these
-    into its ``events`` array and the rows render through the same
-    ``_event_row.html`` partial. The result is a JSON array string the
-    template embeds via ``| safe`` inside the Alpine ``x-data``.
+    Each event is dumped via ``model_dump(mode="json")`` -- the same
+    JSON-value shape :meth:`BroadcastEvent.model_dump_json` emits for a
+    live SSE frame's ``data:`` payload (UUIDs / datetimes rendered as
+    strings), so once the ``broadcastFeed`` controller ``JSON.parse``s
+    the seed it holds an event object byte-identical to a parsed live
+    frame and the rows render through the same ``_event_row.html``
+    partial.
+
+    The list is returned (not a pre-serialised string) so the template
+    can run it through Jinja's ``| tojson`` filter inside a
+    ``<script type="application/json">`` data island. ``tojson`` escapes
+    ``<`` / ``>`` / ``&`` / ``'`` and U+2028/U+2029 for that script-text
+    context, closing the stored-XSS / render-corruption hole that a
+    ``| safe`` interpolation into a double-quoted ``x-data`` attribute
+    opened on any quote- or markup-bearing event field (B1, PR #1044).
     """
-    return "[" + ",".join(event.model_dump_json() for event in events) + "]"
+    return [event.model_dump(mode="json") for event in events]

--- a/backend/src/meho_backplane/ui/static/src/app/broadcast-feed.js
+++ b/backend/src/meho_backplane/ui/static/src/app/broadcast-feed.js
@@ -39,11 +39,28 @@
 //
 // The colour table, cap, and the initial op_id filter are passed in from
 // the route context (``opts``) so the policy stays server-side.
+//
+// Two later (T3 #869) opts let the SAME component back three surfaces:
+//   * ``opts.events`` -- a seed array. The live feed leaves it empty and
+//     fills it from the SSE stream; the Last-24h replay pane
+//     (``_history.html``) seeds it with the historical events the server
+//     pulled via XRANGE, so a history row renders + opens the drawer
+//     identically to a live row.
+//   * ``opts.autoScroll`` -- when true (the wall-monitor feed), the
+//     controller keeps the newest event (the top row, since events
+//     ``unshift``) in view as the stream prepends, so a full-screen
+//     team-room monitor always shows the latest activity without manual
+//     scrolling.
 
 document.addEventListener("alpine:init", () => {
   Alpine.data("broadcastFeed", (opts) => ({
-    events: [],
+    // Seed from ``opts.events`` when provided (history replay pane);
+    // default to empty for the live feed, which fills it from the SSE
+    // stream. A shallow copy guards against two component instances on
+    // one page sharing the same seed array reference.
+    events: Array.isArray(opts.events) ? opts.events.slice() : [],
     connected: false,
+    autoScroll: opts.autoScroll === true,
     cap: opts.cap,
     badgeClasses: opts.badgeClasses,
     // Lower-cased once; the op_id filter is a case-insensitive substring
@@ -66,6 +83,16 @@ document.addEventListener("alpine:init", () => {
     // ``$nextTick`` defers the read until Alpine has settled the swapped
     // node, guarding against any swap/init ordering edge.
     init() {
+      // The op_id input + its server-swap reconciliation belong to the
+      // LIVE feed only (``#broadcast-feed``). The Last-24h replay pane
+      // (``#broadcast-history``) is a separate controller instance with
+      // no filter bar; re-reading the live feed's op_id input there
+      // would wrongly leak the live filter onto the history rows. Gate
+      // the re-read on the live-feed element id so each surface keeps
+      // its own filter state.
+      if (this.$el.id !== "broadcast-feed") {
+        return;
+      }
       this.$nextTick(() => {
         const input = document.querySelector('input[name="op_id"]');
         if (input) {
@@ -119,6 +146,16 @@ document.addEventListener("alpine:init", () => {
       this.events.unshift(parsed);
       if (this.events.length > this.cap) {
         this.events.length = this.cap;
+      }
+      // Wall-monitor auto-scroll: newest events ``unshift`` to the top,
+      // so "keep the latest in view" means scroll the list to its top.
+      // ``$nextTick`` waits for Alpine to render the prepended row before
+      // adjusting scrollTop; the ``$refs.list`` ref is only present in
+      // the wall feed fragment (``wall=True``).
+      if (this.autoScroll && this.$refs.list) {
+        this.$nextTick(() => {
+          this.$refs.list.scrollTop = 0;
+        });
       }
     },
 

--- a/backend/src/meho_backplane/ui/static/src/app/broadcast-feed.js
+++ b/backend/src/meho_backplane/ui/static/src/app/broadcast-feed.js
@@ -41,11 +41,17 @@
 // the route context (``opts``) so the policy stays server-side.
 //
 // Two later (T3 #869) opts let the SAME component back three surfaces:
-//   * ``opts.events`` -- a seed array. The live feed leaves it empty and
-//     fills it from the SSE stream; the Last-24h replay pane
-//     (``_history.html``) seeds it with the historical events the server
-//     pulled via XRANGE, so a history row renders + opens the drawer
-//     identically to a live row.
+//   * ``opts.seedFrom`` -- the id of a ``<script type="application/json">``
+//     data island holding the seed events array. The live feed omits it
+//     and fills ``events`` from the SSE stream; the Last-24h replay pane
+//     (``_history.html``) points it at ``#broadcast-history-data``, whose
+//     ``textContent`` the controller ``JSON.parse``s on init, so a history
+//     row renders + opens the drawer identically to a live row. The seed
+//     events ride in a script-block data island (NOT the ``x-data``
+//     attribute) so an event field containing ``"`` / ``'`` / ``<`` /
+//     ``>`` / ``&`` / ``</script>`` cannot break out of the attribute and
+//     inject markup -- Jinja's ``| tojson`` escapes all of those (plus
+//     U+2028/U+2029) for the script-element text context (B1, PR #1044).
 //   * ``opts.autoScroll`` -- when true (the wall-monitor feed), the
 //     controller keeps the newest event (the top row, since events
 //     ``unshift``) in view as the stream prepends, so a full-screen
@@ -54,11 +60,12 @@
 
 document.addEventListener("alpine:init", () => {
   Alpine.data("broadcastFeed", (opts) => ({
-    // Seed from ``opts.events`` when provided (history replay pane);
-    // default to empty for the live feed, which fills it from the SSE
-    // stream. A shallow copy guards against two component instances on
-    // one page sharing the same seed array reference.
-    events: Array.isArray(opts.events) ? opts.events.slice() : [],
+    // The live feed starts empty and fills ``events`` from the SSE
+    // stream. The Last-24h replay pane instead seeds these on ``init``
+    // from the ``opts.seedFrom`` data island (see ``seedFromIsland``);
+    // an array literal here is never passed through the ``x-data``
+    // attribute, so untrusted event fields can never break out of it.
+    events: [],
     connected: false,
     autoScroll: opts.autoScroll === true,
     cap: opts.cap,
@@ -83,10 +90,18 @@ document.addEventListener("alpine:init", () => {
     // ``$nextTick`` defers the read until Alpine has settled the swapped
     // node, guarding against any swap/init ordering edge.
     init() {
+      // Seed the replay pane from its ``<script type="application/json">``
+      // data island (the live feed omits ``seedFrom`` and stays empty
+      // until the SSE stream fills it). The events arrive as inert script
+      // text -- never as an ``x-data`` attribute -- so a ``"`` / ``<`` /
+      // ``</script>``-bearing event field cannot break out and inject
+      // markup (B1, PR #1044).
+      this.seedFromIsland();
+
       // The op_id input + its server-swap reconciliation belong to the
       // LIVE feed only (``#broadcast-feed``). The Last-24h replay pane
-      // (``#broadcast-history``) is a separate controller instance with
-      // no filter bar; re-reading the live feed's op_id input there
+      // (``#broadcast-history-pane``) is a separate controller instance
+      // with no filter bar; re-reading the live feed's op_id input there
       // would wrongly leak the live filter onto the history rows. Gate
       // the re-read on the live-feed element id so each surface keeps
       // its own filter state.
@@ -99,6 +114,31 @@ document.addEventListener("alpine:init", () => {
           this.opIdFilter = (input.value || "").toLowerCase();
         }
       });
+    },
+
+    // Seed ``events`` from a ``<script type="application/json">`` data
+    // island whose id is ``opts.seedFrom``. The island's ``textContent``
+    // is JSON the server emitted via Jinja ``| tojson`` (XSS-safe for the
+    // script-element text context). No-op when ``seedFrom`` is unset (the
+    // live feed) or the element / JSON is missing or malformed -- the
+    // pane then renders its empty state rather than tearing down.
+    seedFromIsland() {
+      if (!opts.seedFrom) {
+        return;
+      }
+      const el = document.getElementById(opts.seedFrom);
+      if (!el) {
+        return;
+      }
+      try {
+        const parsed = JSON.parse(el.textContent || "[]");
+        if (Array.isArray(parsed)) {
+          this.events = parsed;
+        }
+      } catch (e) {
+        // A malformed island leaves ``events`` empty (the pane shows its
+        // empty state) rather than throwing during component init.
+      }
     },
 
     // Re-apply the op_id filter when the filter bar's input changes. The

--- a/backend/src/meho_backplane/ui/templates/broadcast/_event_row.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/_event_row.html
@@ -37,9 +37,16 @@
   Bound fields on ``ev`` (a parsed ``BroadcastEvent``):
     ev.event_id, ev.audit_id, ev.ts, ev.principal_sub, ev.principal_name,
     ev.op_id, ev.op_class, ev.result_status, ev.target_name, ev.payload.
+
+  ``wall`` (default ``false``): when the row renders inside the
+  wall-monitor feed (``broadcast/wall.html`` includes ``_feed.html`` with
+  ``wall=True``), the row uses taller padding + a larger type scale so
+  it is legible on a full-screen team-room monitor. The in-chrome feed
+  and the history pane render with the default (compact) density.
 -#}
+{% set wall = wall | default(false) %}
 <li
-  class="grid grid-cols-12 items-center gap-2 px-3 py-2 text-sm cursor-pointer hover:bg-base-200 focus:bg-base-200 focus:outline-none"
+  class="grid grid-cols-12 items-center gap-2 cursor-pointer hover:bg-base-200 focus:bg-base-200 focus:outline-none {% if wall %}px-4 py-4 text-base{% else %}px-3 py-2 text-sm{% endif %}"
   role="button"
   tabindex="0"
   :data-event-id="ev.event_id"

--- a/backend/src/meho_backplane/ui/templates/broadcast/_feed.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/_feed.html
@@ -33,15 +33,33 @@
   passes it) renders exactly as before.
 -#}
 {% set wall = wall | default(false) %}
+{#-
+  XSS hardening (review finding on PR #1044, same class as the B1
+  history fix). ``opIdFilter`` echoes the reflected ``op_id`` query
+  param. Jinja's ``| tojson`` escapes ``<`` / ``>`` / ``&`` / ``'`` and
+  U+2028/U+2029 but NOT the double-quote ``"`` -- it keeps the JSON
+  string's own ``"`` delimiters and renders an inner ``"`` as a literal
+  ``\"`` byte. Inside a DOUBLE-quoted ``x-data="..."`` those raw ``"``
+  bytes terminate the attribute early, letting a crafted ``op_id`` (e.g.
+  ``" autofocus onfocus=alert(1) x="``) inject live event handlers ->
+  reflected XSS. The ``x-data`` attribute is therefore SINGLE-quoted:
+  ``tojson`` never emits a raw ``'`` (it escapes it to ``\u0027``), so
+  single-quoted attribute cannot be broken out of by any scalar, and the
+  ``"`` bytes ride harmlessly inside it. The static config has no raw
+  ``'`` (``op_class_badge_json`` is ``json.dumps`` output -- only ``"``),
+  so the single-quote delimiter is unambiguous. Behaviour is identical:
+  the controller still receives the same ``opIdFilter`` / ``cap`` /
+  ``badgeClasses`` / ``autoScroll`` values.
+-#}
 <div
   id="broadcast-feed"
   class="rounded-box border border-base-300 bg-base-100 {% if wall %}flex h-full flex-col overflow-hidden{% else %}overflow-hidden{% endif %}"
-  x-data="broadcastFeed({
+  x-data='broadcastFeed({
     cap: {{ in_dom_row_cap }},
     badgeClasses: {{ op_class_badge_json }},
     opIdFilter: {{ op_id_filter | tojson }},
     autoScroll: {{ wall | tojson }}
-  })"
+  })'
   x-on:broadcast-op-id-changed.window="onOpIdChanged($event)"
 >
   {# ---------- SSE sink ----------

--- a/backend/src/meho_backplane/ui/templates/broadcast/_feed.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/_feed.html
@@ -20,14 +20,27 @@
   in-browser as the operator types (the filter bar mirrors the input
   into the controller via an ``x-model``-bound hidden field; see
   ``_filter_bar.html``).
+
+  Wall-monitor variant (Task #869, work item #5)
+  ----------------------------------------------
+  When included with ``wall=True`` (from ``broadcast/wall.html``) the
+  fragment renders the maximised team-room layout: the list scrolls
+  within the available height and ``autoScroll`` keeps the newest event
+  in view, and the rows render taller (the ``wall`` flag is forwarded to
+  ``_event_row.html``). The SSE wiring, controller, op_id filter, and
+  1000-row cap are all unchanged -- only the visual density differs.
+  ``wall`` defaults to ``False`` so the in-chrome feed view (which never
+  passes it) renders exactly as before.
 -#}
+{% set wall = wall | default(false) %}
 <div
   id="broadcast-feed"
-  class="overflow-hidden rounded-box border border-base-300 bg-base-100"
+  class="rounded-box border border-base-300 bg-base-100 {% if wall %}flex h-full flex-col overflow-hidden{% else %}overflow-hidden{% endif %}"
   x-data="broadcastFeed({
     cap: {{ in_dom_row_cap }},
     badgeClasses: {{ op_class_badge_json }},
-    opIdFilter: {{ op_id_filter | tojson }}
+    opIdFilter: {{ op_id_filter | tojson }},
+    autoScroll: {{ wall | tojson }}
   })"
   x-on:broadcast-op-id-changed.window="onOpIdChanged($event)"
 >
@@ -95,13 +108,16 @@
      Each event renders via the server-authored row partial. ``:key``
      keeps Alpine's DOM diff stable as rows prepend + trim. A click
      opens the detail drawer via the row's ``hx-get`` (wired in the row
-     partial). -#}
+     partial). In wall mode the list scrolls within the available height
+     and ``x-ref="list"`` lets the controller keep the newest (top) row
+     in view as events prepend. -#}
   <ul
     x-show="visibleEvents.length > 0"
-    class="divide-y divide-base-300"
+    class="divide-y divide-base-300{% if wall %} min-h-0 flex-1 overflow-y-auto{% endif %}"
     role="list"
     aria-label="Live broadcast events"
     aria-live="polite"
+    {% if wall %}x-ref="list"{% endif %}
   >
     <template x-for="ev in visibleEvents" :key="ev.event_id">
       {% include "broadcast/_event_row.html" %}

--- a/backend/src/meho_backplane/ui/templates/broadcast/_filter_bar.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/_filter_bar.html
@@ -105,10 +105,23 @@
        in-browser. Each keystroke dispatches a window event the feed
        controller re-applies. ``x-data`` here is a tiny standalone island
        (the feed controller lives in the swapped fragment) whose only job
-       is to debounce-emit the op_id. -#}
+       is to debounce-emit the op_id.
+
+       XSS hardening (review finding on PR #1044, same class as the
+       ``_feed.html`` and B1 history fixes). ``opId`` echoes the reflected
+       ``op_id`` query param. ``| tojson`` does NOT escape the
+       double-quote ``"``, so inside a DOUBLE-quoted ``x-data="..."`` a
+       crafted ``op_id`` (e.g. ``" autofocus onfocus=alert(1) x="``)
+       breaks out of the attribute and injects live handlers. The
+       attribute is therefore SINGLE-quoted: ``tojson`` escapes ``'`` to
+       ``\u0027`` (it never emits a raw ``'``), so a single-quoted attribute
+       is breakout-proof for any scalar, and the value's ``"`` bytes ride
+       harmlessly inside it. (The sibling ``value="{{ op_id_filter }}"``
+       below is in an autoescaped attribute -- Jinja escapes ``"`` to
+       ``&#34;`` there -- so it is already safe.) -#}
     <label
       class="form-control"
-      x-data="{ opId: {{ op_id_filter | tojson }} }"
+      x-data='{ opId: {{ op_id_filter | tojson }} }'
     >
       <span class="label-text">Operation id</span>
       <input

--- a/backend/src/meho_backplane/ui/templates/broadcast/_history.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/_history.html
@@ -6,10 +6,12 @@
   item #6). The "Last 24h" tab ``hx-get``s ``/ui/broadcast/history`` and
   swaps this fragment into ``#broadcast-history`` (``innerHTML``). The
   server has already pulled the tenant's last-24h events via a finite
-  ``XRANGE`` and serialised them as ``history_events_json``; this
-  fragment seeds the SAME ``broadcastFeed`` Alpine controller with those
-  events (instead of an SSE subscription) so the rows render through the
-  SAME ``broadcast/_event_row.html`` partial and open the SAME T2
+  ``XRANGE`` and passed them as the ``history_events`` list; this fragment
+  emits them through Jinja ``| tojson`` into a
+  ``<script type="application/json">`` data island and seeds the SAME
+  ``broadcastFeed`` Alpine controller from it (instead of an SSE
+  subscription) so the rows render through the SAME
+  ``broadcast/_event_row.html`` partial and open the SAME T2
   event-detail drawer on a click.
 
   Why reuse ``broadcastFeed`` instead of server-rendering each row
@@ -31,13 +33,25 @@
   feed uses. The history pane lives inside the same page, so a clicked
   history row opens the identical drawer beside the feed.
 -#}
+{# ---------- Seed data island (B1, PR #1044) ----------
+   The historical events are emitted here as inert ``application/json``
+   script text, NOT interpolated into the ``x-data`` attribute. Jinja's
+   ``| tojson`` escapes ``<`` / ``>`` / ``&`` / ``'`` and U+2028/U+2029
+   for this script-element text context, and the events never touch an
+   HTML attribute, so an event field containing a double-quote, a
+   single-quote, an angle bracket, an ampersand, or a literal closing
+   script tag renders harmlessly -- it cannot break out of an attribute
+   or close the script element early.
+   The ``broadcastFeed`` controller reads + ``JSON.parse``s this island's
+   ``textContent`` on init (``seedFrom`` -> ``seedFromIsland``). -#}
+<script type="application/json" id="broadcast-history-data">{{ history_events | tojson }}</script>
 <div
   id="broadcast-history-pane"
   x-data="broadcastFeed({
     cap: {{ in_dom_row_cap }},
     badgeClasses: {{ op_class_badge_json }},
     opIdFilter: '',
-    events: {{ history_events_json | safe }}
+    seedFrom: 'broadcast-history-data'
   })"
 >
   {# ---------- Status bar -- count + window ---------- #}

--- a/backend/src/meho_backplane/ui/templates/broadcast/_history.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/_history.html
@@ -1,0 +1,89 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Broadcast Last-24h replay fragment (Initiative #338, Task #869, work
+  item #6). The "Last 24h" tab ``hx-get``s ``/ui/broadcast/history`` and
+  swaps this fragment into ``#broadcast-history`` (``innerHTML``). The
+  server has already pulled the tenant's last-24h events via a finite
+  ``XRANGE`` and serialised them as ``history_events_json``; this
+  fragment seeds the SAME ``broadcastFeed`` Alpine controller with those
+  events (instead of an SSE subscription) so the rows render through the
+  SAME ``broadcast/_event_row.html`` partial and open the SAME T2
+  event-detail drawer on a click.
+
+  Why reuse ``broadcastFeed`` instead of server-rendering each row
+  ----------------------------------------------------------------
+  ``_event_row.html`` is Alpine-bound markup designed to live inside an
+  ``x-for`` -- it reads ``ev.*`` and calls the controller's helpers
+  (``badgeClass`` / ``formatTs`` / ``payloadSummary`` / ``openDrawer``).
+  Seeding the controller with the historical events keeps the row markup,
+  the badge palette, the 🔒 aggregate-only marker, and the
+  click-to-open-drawer behaviour single-sourced -- a history row is
+  byte-identical to a live row. The op_id client filter still applies
+  (``visibleEvents``), so an operator can narrow the replay the same way
+  they narrow the live feed; the SSE-specific wiring (``sse-connect`` /
+  ``onSseMessage``) is simply absent here.
+
+  Drawer reuse
+  ------------
+  ``openDrawer(ev)`` targets ``#event-drawer`` -- the same slot the live
+  feed uses. The history pane lives inside the same page, so a clicked
+  history row opens the identical drawer beside the feed.
+-#}
+<div
+  id="broadcast-history-pane"
+  x-data="broadcastFeed({
+    cap: {{ in_dom_row_cap }},
+    badgeClasses: {{ op_class_badge_json }},
+    opIdFilter: '',
+    events: {{ history_events_json | safe }}
+  })"
+>
+  {# ---------- Status bar -- count + window ---------- #}
+  <div
+    class="flex items-center justify-between gap-3 border-b border-base-300 px-3 py-1.5 text-xs opacity-70"
+  >
+    <span>Last {{ retention_hours }}h replay</span>
+    <span aria-live="polite" x-text="visibleEvents.length + ' / {{ in_dom_row_cap }} rows'"></span>
+  </div>
+
+  {# ---------- Column header row -- mirrors _event_row.html grid. ---------- #}
+  <div
+    class="grid grid-cols-12 gap-2 border-b border-base-300 px-3 py-2 text-xs font-semibold uppercase tracking-wide opacity-60"
+  >
+    <span class="col-span-2">Time</span>
+    <span class="col-span-2">Principal</span>
+    <span class="col-span-3">Operation</span>
+    <span class="col-span-1">Class</span>
+    <span class="col-span-1">Status</span>
+    <span class="col-span-1">Target</span>
+    <span class="col-span-2">Payload</span>
+  </div>
+
+  {# ---------- Empty state ----------
+     No events in the last 24h window (or the op_id filter narrowed them
+     all out). -#}
+  <div
+    x-show="visibleEvents.length === 0"
+    class="px-3 py-10 text-center text-sm opacity-70"
+    id="broadcast-history-empty-state"
+  >
+    No activity in the last {{ retention_hours }}h. As operators run
+    commands, their activity will appear here.
+  </div>
+
+  {# ---------- History list -- newest first ----------
+     Each event renders via the shared server-authored row partial; a
+     click opens the same T2 drawer. -#}
+  <ul
+    x-show="visibleEvents.length > 0"
+    class="divide-y divide-base-300"
+    role="list"
+    aria-label="Last 24h broadcast events"
+  >
+    <template x-for="ev in visibleEvents" :key="ev.event_id">
+      {% include "broadcast/_event_row.html" %}
+    </template>
+  </ul>
+</div>

--- a/backend/src/meho_backplane/ui/templates/broadcast/feed.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/feed.html
@@ -53,34 +53,106 @@
         <code class="badge badge-outline">{{ tenant_id }}</code>.
       </p>
     </div>
+    {# ---------- Wall-monitor entry (work item #5) ----------
+       Opens the no-chrome full-screen wall view in a new tab so the
+       team-room monitor can be cast independently of the operator's
+       working session. -#}
+    <a
+      href="/ui/broadcast?wall=1"
+      target="_blank"
+      rel="noopener"
+      class="btn btn-outline btn-sm"
+    >
+      <span aria-hidden="true">&#x1F5B5;</span>
+      Wall mode
+    </a>
   </header>
 
-  {# ---------- Filter bar (work item #3) ---------- #}
-  {% include "broadcast/_filter_bar.html" %}
-
-  {# ---------- Feed + drawer two-column layout ----------
-     On ``lg:`` viewports the feed takes 2/3 and the drawer 1/3; on
-     smaller viewports the drawer stacks below the feed. -#}
-  <div class="grid gap-4 lg:grid-cols-3">
-    <div class="lg:col-span-2">
-      {% include "broadcast/_feed.html" %}
+  {# ---------- Live / Last-24h tabs (work item #6) ----------
+     Alpine owns the active-tab state; the Last-24h pane lazy-loads its
+     history fragment once on first activation (``hx-trigger`` fires the
+     ``/ui/broadcast/history`` GET the first time the tab is shown). The
+     live feed stays mounted under the hidden pane so its SSE
+     subscription is not torn down when the operator peeks at history. -#}
+  <div x-data="{ tab: 'live' }">
+    <div role="tablist" class="tabs tabs-bordered">
+      <button
+        type="button"
+        role="tab"
+        class="tab"
+        :class="tab === 'live' ? 'tab-active' : ''"
+        x-on:click="tab = 'live'"
+        :aria-selected="(tab === 'live').toString()"
+      >
+        Live
+      </button>
+      <button
+        type="button"
+        role="tab"
+        class="tab"
+        :class="tab === 'history' ? 'tab-active' : ''"
+        x-on:click="tab = 'history'"
+        :aria-selected="(tab === 'history').toString()"
+      >
+        Last 24h
+      </button>
     </div>
 
-    {# ---------- Drawer slot (work item #4) ----------
-       Event-detail fragments swap into ``#event-drawer`` on a row
-       click via ``hx-target``. The placeholder shape mirrors the
-       happy-path / not-found fragments so the outerHTML swap stays
-       semantically consistent. -#}
-    <aside
-      id="event-drawer"
-      class="card bg-base-100 border-base-300 border shadow-sm self-start"
-      aria-live="polite"
-      aria-label="Event detail drawer"
-    >
-      <div class="card-body text-sm opacity-70">
-        Select an event to inspect its full audit detail.
+    {# ---------- Tab panes + shared drawer ----------
+       On ``lg:`` viewports the feed/history pane takes 2/3 and the
+       shared drawer 1/3; on smaller viewports the drawer stacks below.
+       The drawer is shared across both tabs so a history row and a live
+       row open the identical T2 event-detail drawer. -#}
+    <div class="grid gap-4 lg:grid-cols-3">
+      <div class="lg:col-span-2">
+        {# ---------- Live feed pane (work item #3) ----------
+           Shown on the Live tab; the filter bar above it submits to the
+           feed fragment route. The feed stays mounted (only hidden) when
+           the operator switches to the history tab so its SSE
+           subscription is not torn down. -#}
+        <div x-show="tab === 'live'" class="space-y-4">
+          {% include "broadcast/_filter_bar.html" %}
+          {% include "broadcast/_feed.html" %}
+        </div>
+
+        {# ---------- Last-24h replay pane (work item #6) ----------
+           Lazy-loads ``/ui/broadcast/history`` the first time the pane
+           becomes visible: ``hx-trigger="intersect once"`` fires the GET
+           the first time the (initially ``x-show``-hidden) container
+           scrolls into view, i.e. when the operator clicks the Last-24h
+           tab. The swapped-in fragment seeds the same ``broadcastFeed``
+           controller with the historical events. -#}
+        <div x-show="tab === 'history'">
+          <div
+            id="broadcast-history"
+            hx-get="/ui/broadcast/history"
+            hx-trigger="intersect once"
+            hx-swap="innerHTML"
+            class="overflow-hidden rounded-box border border-base-300 bg-base-100"
+          >
+            <div class="px-3 py-10 text-center text-sm opacity-70">
+              Loading the last 24 hours…
+            </div>
+          </div>
+        </div>
       </div>
-    </aside>
+
+      {# ---------- Shared drawer slot (work item #4) ----------
+         Event-detail fragments swap into ``#event-drawer`` on a row
+         click via ``hx-target``. The placeholder shape mirrors the
+         happy-path / not-found fragments so the outerHTML swap stays
+         semantically consistent. Shared by the live + history panes. -#}
+      <aside
+        id="event-drawer"
+        class="card bg-base-100 border-base-300 border shadow-sm self-start"
+        aria-live="polite"
+        aria-label="Event detail drawer"
+      >
+        <div class="card-body text-sm opacity-70">
+          Select an event to inspect its full audit detail.
+        </div>
+      </aside>
+    </div>
   </div>
 </section>
 {% endblock %}

--- a/backend/src/meho_backplane/ui/templates/broadcast/wall.html
+++ b/backend/src/meho_backplane/ui/templates/broadcast/wall.html
@@ -1,0 +1,96 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Broadcast wall-monitor view (Initiative #338, Task #869, work item #5).
+
+  A minimal, no-chrome full-screen layout for a team-room monitor:
+    * NO sidebar, NO top navbar, NO filter bar -- the only affordance
+      is the feed itself, maximised to fill the viewport.
+    * A thin header strip (tenant + live pill + a link back to the
+      in-chrome console view) so an operator glancing at the wall can
+      still see which tenant and whether the stream is connected.
+    * The SAME ``broadcast/_feed.html`` fragment the in-chrome view
+      uses, rendered with ``wall=True`` so the rows are taller and the
+      list auto-scrolls to the newest event. Reusing the fragment means
+      the wall view inherits the live SSE wiring, the ``EventSource``
+      auto-reconnect + ``Last-Event-Id`` replay durability, and the
+      1000-row in-DOM cap unchanged -- only the surrounding chrome
+      differs.
+
+  Why a standalone document (not ``{% extends "base.html" %}``)
+  ------------------------------------------------------------
+  ``base.html`` is the DaisyUI ``drawer`` shell -- sidebar + navbar +
+  footer. The wall view's whole point is to drop that chrome, so it is
+  a self-contained ``<!doctype html>`` that loads the same vendored
+  CSS/JS the base layout does (the script order is load-bearing:
+  ``sse.min.js`` calls ``htmx.defineExtension`` at load, so it must run
+  after ``htmx.min.js``; ``defer`` preserves document order). The
+  ``broadcastFeed`` Alpine controller is loaded the same way the
+  in-chrome view loads it.
+
+  Long-display session refresh
+  ----------------------------
+  Session-cookie auth is unchanged -- the wall page is a ``/ui/*`` route
+  gated by ``UISessionMiddleware``. The long-display durability comes
+  from the server-side sliding-session extension in ``load_session``
+  (G10.1-T3 #869): every SSE reconnect to ``/ui/broadcast/stream`` is an
+  active ``/ui/*`` request that slides the session's ``expires_at``
+  forward (bounded by an absolute cap), so a wall display running for
+  hours keeps getting 200s and the ``EventSource`` never hits the
+  non-200 (login redirect) that would permanently kill it.
+-#}
+<!doctype html>
+<html lang="en" data-theme="corporate" class="h-full">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Broadcast wall &middot; MEHO Operator Console</title>
+    <link rel="stylesheet" href="/ui/static/dist/tailwind.css" />
+    {# Same vendored bundle + load order as base.html. #}
+    <script src="/ui/static/src/vendor/htmx.min.js" defer></script>
+    <script src="/ui/static/src/vendor/sse.min.js" defer></script>
+    <script src="/ui/static/src/vendor/alpine.min.js" defer></script>
+  </head>
+  <body class="bg-base-200 text-base-content flex h-full flex-col overflow-hidden">
+    <section
+      class="flex h-full flex-col"
+      hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+    >
+      {# ---------- Thin header strip ---------- #}
+      <header
+        class="bg-base-100 border-base-300 flex flex-none items-center justify-between gap-4 border-b px-4 py-2"
+      >
+        <div class="flex items-center gap-2">
+          <span aria-hidden="true" class="text-xl">&#x1F4E1;</span>
+          <h1 class="text-lg font-semibold">Broadcast wall</h1>
+          <code class="badge badge-outline">{{ tenant_id }}</code>
+        </div>
+        <a href="/ui/broadcast" class="btn btn-ghost btn-sm"> Exit wall mode </a>
+      </header>
+
+      {# ---------- Maximised feed ----------
+         The feed fragment fills the remaining height; ``wall=True``
+         makes the rows taller and the list auto-scroll to newest. -#}
+      <div class="min-h-0 flex-1 p-3">
+        {% with wall = True %}
+          {% include "broadcast/_feed.html" %}
+        {% endwith %}
+      </div>
+
+      {# ---------- Drawer slot ----------
+         A row click still opens the T2 event-detail drawer. On the wall
+         layout it overlays as a right-hand panel rather than a column.
+         Reuses the same ``#event-drawer`` id the controller targets. -#}
+      <aside
+        id="event-drawer"
+        class="bg-base-100 border-base-300 fixed top-0 right-0 z-50 hidden h-full w-96 max-w-full overflow-auto border-l shadow-xl"
+        aria-live="polite"
+        aria-label="Event detail drawer"
+      ></aside>
+    </section>
+
+    {# Surface JS -- the shared ``broadcastFeed`` Alpine controller. #}
+    <script src="/ui/static/src/app/broadcast-feed.js" defer></script>
+  </body>
+</html>

--- a/backend/tests/test_ui_broadcast_filters.py
+++ b/backend/tests/test_ui_broadcast_filters.py
@@ -38,6 +38,7 @@ import uuid
 from collections.abc import Iterator
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
+from html.parser import HTMLParser
 
 import pytest
 import respx
@@ -609,3 +610,139 @@ def test_drawer_falls_back_to_http_op_id_heuristic() -> None:
     # ``other`` class -> full detail; the params render.
     assert "search-term" in body
     assert "aggregate-only" not in body
+
+
+# ---------------------------------------------------------------------------
+# op_id reflected-XSS hardening (review finding on PR #1044)
+# ---------------------------------------------------------------------------
+
+#: A crafted ``op_id`` query value that tries to break out of an
+#: ``x-data`` attribute and inject live event handlers. It carries every
+#: HTML metacharacter the hardening must neutralise: a double-quote (the
+#: byte ``| tojson`` does NOT escape, which terminates a double-quoted
+#: attribute early), a single-quote, ``<`` / ``>`` / ``&``, and a literal
+#: ``</script>`` (which would close a data-island script element). The
+#: ``autofocus onfocus=...`` payload is what would fire if the value
+#: escaped the attribute and grafted itself onto the host element.
+_XSS_OP_ID = (
+    "\" autofocus onfocus=alert(document.cookie) x='1' <b>& </script><img src=x onerror=alert(2)>"
+)
+
+
+class _XDataAttrCollector(HTMLParser):
+    """Collect the parsed attribute list of every element carrying ``x-data``.
+
+    The browser's HTML parser is the ground truth for "did the attribute
+    break out": if the injected ``op_id`` terminated ``x-data`` early, the
+    parser sees ``autofocus`` / ``onfocus`` as *separate attributes* on the
+    host element rather than as bytes inside the single ``x-data`` value.
+    We parse the response the same way and assert no such stray attribute
+    appears. Parser-grounded so the test holds for either safe rendering
+    (single-quoted ``x-data`` or a data-island refactor).
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # One entry per element that has an ``x-data`` attribute: the full
+        # list of (name, value) attribute pairs the parser saw on it.
+        self.x_data_elements: list[list[tuple[str, str | None]]] = []
+        # Every attribute NAME the parser saw across the whole document
+        # (lower-cased), to catch a handler injected onto ANY element.
+        self.all_attr_names: set[str] = set()
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        names = {name.lower() for name, _ in attrs}
+        self.all_attr_names |= names
+        if "x-data" in names:
+            self.x_data_elements.append(attrs)
+
+
+def _assert_no_xss_breakout(body: str) -> None:
+    """Assert the rendered HTML did not let ``op_id`` break out of ``x-data``.
+
+    Fails on the pre-fix ``{{ op_id | tojson }}`` inside a *double-quoted*
+    ``x-data="..."`` (the double-quote bytes ``tojson`` leaves raw
+    terminate the attribute, so the parser grafts ``autofocus`` / ``onfocus``
+    onto the element); passes once the attribute is single-quoted (or the
+    config moves to a data island).
+    """
+    parser = _XDataAttrCollector()
+    parser.feed(body)
+
+    # No event handler / autofocus leaked onto ANY element as a parsed
+    # attribute. If the attribute broke out, the parser would surface these.
+    assert "onfocus" not in parser.all_attr_names, (
+        "op_id broke out of x-data: 'onfocus' parsed as a live attribute"
+    )
+    assert "autofocus" not in parser.all_attr_names, (
+        "op_id broke out of x-data: 'autofocus' parsed as a live attribute"
+    )
+    assert "onerror" not in parser.all_attr_names, (
+        "op_id broke out: 'onerror' parsed as a live attribute"
+    )
+
+    # The op_id payload must live ENTIRELY inside an x-data attribute value
+    # -- never as a stray attribute and never as injected element markup.
+    # At least one x-data element must carry the marker substring inside its
+    # x-data value (proving it stayed contained), and no x-data element may
+    # carry it as a separate attribute.
+    contained_somewhere = False
+    for attrs in parser.x_data_elements:
+        for name, value in attrs:
+            if name.lower() == "x-data" and value and "onfocus=alert" in value:
+                contained_somewhere = True
+            else:
+                # The marker must not appear in any OTHER attribute on an
+                # x-data element (that would mean it escaped the value).
+                assert value is None or "onfocus=alert" not in value, (
+                    f"op_id leaked into a non-x-data attribute {name!r}"
+                )
+    assert contained_somewhere, (
+        "expected the op_id payload to stay contained inside an x-data value"
+    )
+
+    # No premature script-element close from the </script> in the payload
+    # (guards the data-island alternative too). The only </script> tags in
+    # the document must pair with a <script ...> the templates author.
+    assert body.count("</script>") == body.count("<script"), (
+        "a </script> in op_id closed a script element early"
+    )
+
+
+def test_feed_fragment_op_id_xss_payload_cannot_break_out_of_x_data() -> None:
+    """A breakout ``op_id`` cannot escape ``x-data`` on the feed fragment.
+
+    Regression for the reflected-XSS finding on PR #1044. The fragment
+    interpolates the reflected ``op_id`` into the ``broadcastFeed`` Alpine
+    controller config. ``| tojson`` does not escape the double-quote, so a
+    crafted ``op_id`` would terminate a double-quoted ``x-data="..."`` and
+    inject live handlers. Asserts (via the HTML parser) no handler leaks
+    onto the element and no script closes early. Fails on the pre-fix
+    double-quoted attribute; passes once single-quoted.
+    """
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/broadcast/feed", params={"op_id": _XSS_OP_ID})
+    assert response.status_code == 200, response.text
+    _assert_no_xss_breakout(response.text)
+
+
+def test_full_page_op_id_xss_payload_cannot_break_out_of_x_data() -> None:
+    """A breakout ``op_id`` cannot escape ``x-data`` on the full page.
+
+    The full page (``GET /ui/broadcast``) reflects ``op_id`` into TWO
+    double-quote-vulnerable sinks pre-fix: the feed fragment's
+    ``broadcastFeed(...)`` config AND the filter bar's standalone
+    ``x-data="{ opId: ... }"`` island. Both must be breakout-proof; the
+    parser-grounded assertion covers every ``x-data`` element on the page.
+    """
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/broadcast", params={"op_id": _XSS_OP_ID})
+    assert response.status_code == 200, response.text
+    _assert_no_xss_breakout(response.text)
+    # The reflected value still reaches the controller config (behaviour
+    # preserved -- the op_id filter seed is not dropped by the hardening).
+    assert "opIdFilter" in response.text

--- a/backend/tests/test_ui_broadcast_wall_replay.py
+++ b/backend/tests/test_ui_broadcast_wall_replay.py
@@ -468,6 +468,86 @@ class TestHistoryReplay:
         assert response.status_code == 200, response.text
         assert "vsphere.vm.list" in response.text
 
+    def test_history_event_fields_cannot_break_out_of_markup(self) -> None:
+        """A quote-/markup-bearing event field renders harmlessly (B1).
+
+        Regression for PR #1044 B1: the pane used to interpolate the
+        serialised event array into a double-quoted ``x-data="…"``
+        attribute via ``| safe`` (no escaping). Any event field carrying
+        a double-quote broke out of the attribute and injected live event
+        handlers, and a ``</script>`` could close the seed element early.
+
+        The fix emits the events as inert
+        ``<script type="application/json">`` text rendered through Jinja
+        ``| tojson``. This test seeds an event whose free-text fields
+        contain ``"`` ``'`` ``<`` ``>`` ``&`` AND a literal ``</script>``
+        and asserts:
+
+        * the injected markup never appears as raw HTML (no attribute or
+          script breakout, no live event handler),
+        * the literal ``</script>`` never appears unescaped (it cannot
+          close the seed element early), and
+        * the payload still round-trips into the controller seed (the
+          escaped form is present in the data island), so the rows still
+          render + open the drawer.
+
+        It fails on the pre-fix ``| safe``/double-quoted-attribute code
+        and passes after the data-island fix.
+        """
+        session_id = _seed_session_sync(tenant_id=_TENANT_A)
+        # Every breakout primitive in one string: attribute-breaking
+        # double-quote, an injected handler, single-quote, angle
+        # brackets, ampersand, and a literal closing script tag.
+        injection = (
+            "</script><img src=x onerror=alert(1)>\" autofocus onfocus=alert(2) ' < > & done"
+        )
+        event = _make_event(
+            tenant_id=_TENANT_A,
+            op_id=injection,
+            target_name=injection,
+            principal_sub=injection,
+        )
+        mock = _xrange_returning([event])
+        broadcast_client = get_broadcast_client()
+        with (
+            respx.mock(assert_all_called=False),
+            patch.object(broadcast_client, "xrange", new=mock),
+        ):
+            client = _authenticated_client(session_id)
+            response = client.get("/ui/broadcast/history")
+        assert response.status_code == 200, response.text
+        body = response.text
+
+        # --- No breakout: the raw injection must never reach the DOM as
+        #     markup. ``| tojson`` escapes ``<`` ``>`` ``&`` ``'`` (and
+        #     keeps ``"`` JSON-escaped as ``\"``) for the script-text
+        #     context, so the field stays inert JSON data -- the injected
+        #     tag/element-closer sequences cannot appear verbatim.
+        #
+        #     On the pre-fix ``| safe`` / double-quoted-``x-data`` code
+        #     each of these assertions fails: the raw ``<img>`` tag, the
+        #     raw ``</script><img`` element-closer-then-injection, and
+        #     two extra raw ``</script>`` (one per injected field) all
+        #     reach the DOM. ---
+        # The injected raw markup tag must never materialise.
+        assert "<img src=x onerror=" not in body
+        # The field's literal closing-script sequence must be escaped --
+        # a raw close-then-inject sequence would terminate the seed
+        # element early and start live markup.
+        assert "</script><img" not in body
+        # The ONLY raw "</script>" allowed is the data island's own
+        # closer; the three injected fields contributing raw closers is
+        # exactly the pre-fix breakout this test guards against.
+        assert body.count("</script>") == 1
+
+        # --- Round-trip: the field still seeds the controller, just in
+        #     its tojson-escaped form. Confirm the escaped markers are in
+        #     the data island so the rows render. ---
+        assert 'id="broadcast-history-data"' in body
+        assert "\\u003c/script\\u003e" in body  # escaped </script>
+        assert "\\u003cimg" in body  # escaped <img
+        assert "seedFrom: 'broadcast-history-data'" in body
+
     def test_history_unauthenticated_redirects_to_login(self) -> None:
         """The history fragment is gated by the session middleware."""
         with respx.mock(assert_all_called=False):

--- a/backend/tests/test_ui_broadcast_wall_replay.py
+++ b/backend/tests/test_ui_broadcast_wall_replay.py
@@ -1,0 +1,477 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the Broadcast wall-monitor + Last-24h replay.
+
+Initiative #338 (G10.1 Activity broadcast UI), Task #869 (G10.1-T3).
+Acceptance criteria on issue #869:
+
+* ``GET /ui/broadcast?wall=1`` hides the sidebar + top bar, maximises the
+  feed, auto-scrolls.
+* Wall mode survives an access-token expiry without logging out (the
+  server-side sliding-session extension in ``load_session``) -- asserted
+  across a forced near-expiry.
+* The "Last 24h" replay tab pulls the tenant's last-24h events (a finite
+  ``XRANGE`` over ``meho:feed:{tenant}``) and renders historical rows
+  that open the same T2 drawer.
+* Cross-tenant isolation holds in wall + replay (tenant-A events absent
+  from tenant-B).
+* ``ruff`` + ``mypy`` clean; ``pytest -n auto`` passes.
+
+Three test surfaces:
+
+* **Wall page** -- HTTP edge: a minimal app wired with the UI session +
+  CSRF middlewares; asserts the wall layout drops the base.html chrome
+  and embeds the same feed fragment.
+* **History fragment** -- HTTP edge with a mocked broadcast client's
+  ``xrange``: asserts the tenant-scoped key, the rendered rows, the
+  empty state, and cross-tenant isolation. ``xrange`` returns a finite
+  list, so the endpoint terminates -- there is no streaming loop to
+  hang.
+* **Sliding-session extension** -- drives ``load_session`` directly: a
+  near-expiry session is extended on an active load; an at-cap session
+  is not; ``sliding=0`` disables the extension.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.broadcast import (
+    BroadcastEvent,
+    get_broadcast_client,
+    reset_broadcast_client_for_testing,
+)
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import (
+    SESSION_COOKIE_NAME,
+    UISessionMiddleware,
+)
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    load_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import CSRFMiddleware
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.routes.broadcast.feed import IN_DOM_ROW_CAP
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests.conftest import DEFAULT_AUDIENCE, DEFAULT_ISSUER
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+_BACKPLANE_URL = "https://meho.test"
+
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_TENANT_B = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF + broadcast env vars for every test.
+
+    Mirrors :func:`backend.tests.test_ui_broadcast_feed._bff_env`. Cache
+    + global-state resets run on setup and teardown so a failing test
+    cannot leak templating / session-engine / broadcast-client state
+    into the next case.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("BROADCAST_REDIS_URL", "redis://broadcast.test:6379")
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    reset_broadcast_client_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    reset_broadcast_client_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+def _build_app() -> FastAPI:
+    """Construct a minimal FastAPI app wired for the broadcast UI tests."""
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID,
+    operator_sub: str = "op-42",
+    lifetime: timedelta = timedelta(hours=1),
+) -> uuid.UUID:
+    """Create a ``web_session`` row directly and return its UUID."""
+
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token="access-token-plaintext",
+                refresh_token="refresh-token-plaintext",
+                lifetime=lifetime,
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+async def _seed_session_async(
+    *,
+    tenant_id: uuid.UUID,
+    operator_sub: str = "op-42",
+    lifetime: timedelta = timedelta(hours=1),
+) -> uuid.UUID:
+    """Async counterpart of :func:`_seed_session_sync` for ``async def`` tests.
+
+    The sync helper wraps :func:`asyncio.run`, which cannot be called
+    from inside a running event loop (the ``asyncio_mode = "auto"`` test
+    methods already run on one). The sliding-session tests drive
+    ``load_session`` with ``await``, so they seed via this helper
+    instead.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        decrypted = await create_session(
+            session,
+            operator_sub=operator_sub,
+            tenant_id=tenant_id,
+            access_token="access-token-plaintext",
+            refresh_token="refresh-token-plaintext",
+            lifetime=lifetime,
+        )
+        return decrypted.id
+
+
+def _authenticated_client(session_id: uuid.UUID) -> TestClient:
+    """Return a TestClient with the session cookie pre-set."""
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client
+
+
+def _make_event(
+    *,
+    tenant_id: UUID = _TENANT_A,
+    op_class: str = "read",
+    principal_sub: str = "op-test",
+    target_name: str | None = "rdc-vcenter",
+    op_id: str = "vsphere.vm.list",
+) -> BroadcastEvent:
+    """Build a redacted-shape :class:`BroadcastEvent` for the replay tests."""
+    return BroadcastEvent(
+        event_id=uuid4(),
+        ts=datetime(2026, 5, 13, tzinfo=UTC),
+        tenant_id=tenant_id,
+        principal_sub=principal_sub,
+        target_name=target_name,
+        op_id=op_id,
+        op_class=op_class,
+        result_status="ok",
+        audit_id=UUID("33333333-3333-3333-3333-333333333333"),
+        payload={"op_class": op_class, "params": {}, "result_status": "ok"},
+    )
+
+
+def _xrange_returning(events: list[BroadcastEvent]) -> AsyncMock:
+    """AsyncMock standing in for ``Redis.xrange`` returning *events*.
+
+    ``xrange`` is a **finite** read (not a BLOCKing stream loop), so a
+    plain ``AsyncMock(return_value=...)`` is correct here: the history
+    endpoint awaits it once, gets the list, and returns. There is no
+    ``while True`` to spin, so the async-hang failure mode that haunts
+    the stream tests (a bare ``return_value=None`` inside an XREAD loop)
+    does not apply -- the endpoint terminates regardless.
+
+    The returned shape mirrors redis-py's ``XRANGE`` reply: a list of
+    ``(entry_id, fields_dict)`` tuples, ascending (oldest-first).
+    """
+    items = [
+        (f"{1715600000000 + i}-0", {"event": event.model_dump_json()})
+        for i, event in enumerate(events)
+    ]
+    return AsyncMock(return_value=items)
+
+
+# ---------------------------------------------------------------------------
+# Wall-monitor mode (work item #5)
+# ---------------------------------------------------------------------------
+
+
+class TestWallMode:
+    """``GET /ui/broadcast?wall=1`` -- the no-chrome wall view."""
+
+    def test_wall_view_drops_base_chrome(self) -> None:
+        """The wall layout hides the sidebar + top navbar + filter bar."""
+        session_id = _seed_session_sync(tenant_id=_TENANT_A)
+        with respx.mock(assert_all_called=False):
+            client = _authenticated_client(session_id)
+            response = client.get("/ui/broadcast?wall=1")
+        assert response.status_code == 200, response.text
+        body = response.text
+        # The wall page is a standalone document, not the base.html shell:
+        # no DaisyUI drawer chrome, no sidebar "Surfaces" nav, no filter bar.
+        assert "drawer-toggle" not in body
+        assert "Surfaces" not in body
+        assert "Filter broadcast events" not in body
+        # It is its own <title>, distinct from the in-chrome view.
+        assert "Broadcast wall" in body
+
+    def test_wall_view_maximises_and_autoscrolls_the_feed(self) -> None:
+        """The wall view embeds the feed fragment in auto-scroll mode."""
+        session_id = _seed_session_sync(tenant_id=_TENANT_A)
+        with respx.mock(assert_all_called=False):
+            client = _authenticated_client(session_id)
+            response = client.get("/ui/broadcast?wall=1")
+        body = response.text
+        # The same SSE bridge wiring as the in-chrome feed (reused fragment).
+        assert 'sse-connect="/ui/broadcast/stream"' in body
+        assert 'sse-swap="broadcast"' in body
+        # Wall mode flips the controller's auto-scroll on + makes the list
+        # scrollable (the feed fragment forwards ``wall=True``).
+        assert "autoScroll: true" in body
+        assert 'x-ref="list"' in body
+        # The shared controller script is loaded.
+        assert "/ui/static/src/app/broadcast-feed.js" in body
+
+    def test_in_chrome_view_keeps_chrome_and_no_autoscroll(self) -> None:
+        """The default (non-wall) view still renders base.html chrome."""
+        session_id = _seed_session_sync(tenant_id=_TENANT_A)
+        with respx.mock(assert_all_called=False):
+            client = _authenticated_client(session_id)
+            response = client.get("/ui/broadcast")
+        body = response.text
+        # Base chrome present; auto-scroll off (the default feed density).
+        assert "Surfaces" in body
+        assert "autoScroll: false" in body
+        # The in-chrome view links to the wall view + offers the Last-24h tab.
+        assert "/ui/broadcast?wall=1" in body
+        assert "Last 24h" in body
+
+    def test_wall_view_unauthenticated_redirects_to_login(self) -> None:
+        """``?wall=1`` is still gated by the session middleware."""
+        with respx.mock(assert_all_called=False):
+            client = TestClient(_build_app(), follow_redirects=False)
+            response = client.get("/ui/broadcast?wall=1")
+        assert response.status_code == 302
+        assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+
+
+# ---------------------------------------------------------------------------
+# Long-display session refresh -- sliding-session extension
+# ---------------------------------------------------------------------------
+
+
+class TestSlidingSessionExtension:
+    """``load_session`` slides a near-expiry session forward (work item #5)."""
+
+    async def _load(self, session_id: uuid.UUID) -> object:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            return await load_session(session, session_id)
+
+    async def test_near_expiry_session_is_extended_on_active_load(self) -> None:
+        """A session within the sliding window has its expiry pushed out.
+
+        This is the long-display durability guarantee: a wall monitor's
+        SSE reconnect is an active ``/ui/*`` load, so an about-to-expire
+        session is kept alive rather than lapsing into a 302-to-login
+        that would permanently kill the browser ``EventSource``.
+        """
+        # 90s lifetime, default sliding window 3600s -> the session is
+        # already inside the window at creation, so the next load slides
+        # ``expires_at`` out to ~now + 3600s.
+        session_id = await _seed_session_async(tenant_id=_TENANT_A, lifetime=timedelta(seconds=90))
+        before = datetime.now(UTC) + timedelta(seconds=90)
+        decrypted = await self._load(session_id)
+        assert decrypted is not None
+        # Extended well past the original ~90s expiry.
+        assert decrypted.expires_at > before + timedelta(seconds=60)
+
+    async def test_extension_never_exceeds_absolute_cap(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The sliding extension is bounded by the absolute lifetime cap."""
+        # Tiny absolute cap so a single slide hits the ceiling.
+        monkeypatch.setenv("UI_SESSION_ABSOLUTE_LIFETIME_SECONDS", "120")
+        monkeypatch.setenv("UI_SESSION_SLIDING_EXTENSION_SECONDS", "3600")
+        get_settings.cache_clear()
+        session_id = await _seed_session_async(tenant_id=_TENANT_A, lifetime=timedelta(seconds=30))
+        decrypted = await self._load(session_id)
+        assert decrypted is not None
+        # created_at + 120s is the ceiling; the slide cannot pass it.
+        ceiling = decrypted.created_at + timedelta(seconds=120)
+        assert decrypted.expires_at <= ceiling + timedelta(seconds=1)
+
+    async def test_sliding_disabled_leaves_expiry_untouched(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``sliding=0`` disables the extension entirely."""
+        monkeypatch.setenv("UI_SESSION_SLIDING_EXTENSION_SECONDS", "0")
+        get_settings.cache_clear()
+        session_id = await _seed_session_async(tenant_id=_TENANT_A, lifetime=timedelta(seconds=90))
+        decrypted = await self._load(session_id)
+        assert decrypted is not None
+        # Within ~90s of now (clock skew margin), not pushed to +3600s.
+        assert decrypted.expires_at < datetime.now(UTC) + timedelta(seconds=300)
+
+
+# ---------------------------------------------------------------------------
+# Last-24h replay pane (work item #6)
+# ---------------------------------------------------------------------------
+
+
+class TestHistoryReplay:
+    """``GET /ui/broadcast/history`` -- the finite XRANGE replay fragment."""
+
+    def test_history_renders_events_from_session_tenant_stream(self) -> None:
+        """The pane pulls the session tenant's stream key via XRANGE."""
+        session_id = _seed_session_sync(tenant_id=_TENANT_A)
+        event = _make_event(tenant_id=_TENANT_A, op_id="vsphere.vm.list")
+        mock = _xrange_returning([event])
+        broadcast_client = get_broadcast_client()
+        with (
+            respx.mock(assert_all_called=False),
+            patch.object(broadcast_client, "xrange", new=mock),
+        ):
+            client = _authenticated_client(session_id)
+            response = client.get("/ui/broadcast/history")
+        assert response.status_code == 200, response.text
+        # The XRANGE was issued against the session tenant's key.
+        assert mock.await_count == 1
+        assert mock.await_args.args[0] == f"meho:feed:{_TENANT_A}"
+        # The event JSON is seeded into the shared controller; the row
+        # partial + the 24h-window status copy render.
+        body = response.text
+        assert "vsphere.vm.list" in body
+        assert "broadcastFeed(" in body
+        assert "Last 24h replay" in body
+
+    def test_history_empty_window_renders_empty_state(self) -> None:
+        """No events in the 24h window renders the empty-state copy."""
+        session_id = _seed_session_sync(tenant_id=_TENANT_A)
+        mock = _xrange_returning([])
+        broadcast_client = get_broadcast_client()
+        with (
+            respx.mock(assert_all_called=False),
+            patch.object(broadcast_client, "xrange", new=mock),
+        ):
+            client = _authenticated_client(session_id)
+            response = client.get("/ui/broadcast/history")
+        assert response.status_code == 200, response.text
+        assert "No activity in the last" in response.text
+
+    def test_history_xrange_is_bounded_by_window_and_cap(self) -> None:
+        """XRANGE spans the 24h window to '+' and is COUNT-capped.
+
+        Proves the pull is finite (a row cap, not an unbounded read), so
+        the endpoint terminates -- there is no streaming loop here.
+        """
+        session_id = _seed_session_sync(tenant_id=_TENANT_A)
+        mock = _xrange_returning([_make_event()])
+        broadcast_client = get_broadcast_client()
+        with (
+            respx.mock(assert_all_called=False),
+            patch.object(broadcast_client, "xrange", new=mock),
+        ):
+            client = _authenticated_client(session_id)
+            client.get("/ui/broadcast/history")
+        kwargs = mock.await_args.kwargs
+        # End anchor is the live tail; count is the in-DOM row cap.
+        assert kwargs["max"] == "+"
+        assert kwargs["count"] == IN_DOM_ROW_CAP
+        # Start id is a bare ms-timestamp (24h window), strictly positive.
+        assert int(kwargs["min"]) > 0
+
+    def test_history_cross_tenant_isolation(self) -> None:
+        """A tenant-B session reads only tenant-B's stream, never A's."""
+        session_id = _seed_session_sync(tenant_id=_TENANT_B)
+        mock = _xrange_returning([])
+        broadcast_client = get_broadcast_client()
+        with (
+            respx.mock(assert_all_called=False),
+            patch.object(broadcast_client, "xrange", new=mock),
+        ):
+            client = _authenticated_client(session_id)
+            response = client.get("/ui/broadcast/history")
+        assert response.status_code == 200, response.text
+        key = mock.await_args.args[0]
+        assert key == f"meho:feed:{_TENANT_B}"
+        assert str(_TENANT_A) not in key
+
+    def test_history_skips_malformed_entries(self) -> None:
+        """A malformed stream entry is skipped, not 500'd."""
+        session_id = _seed_session_sync(tenant_id=_TENANT_A)
+        good = _make_event(op_id="vsphere.vm.list")
+        # One good entry, one with a non-JSON event field, one with no
+        # event field at all -- only the good one should render.
+        items = [
+            ("1715600000000-0", {"event": good.model_dump_json()}),
+            ("1715600000001-0", {"event": "not-json{"}),
+            ("1715600000002-0", {"other": "field"}),
+        ]
+        mock = AsyncMock(return_value=items)
+        broadcast_client = get_broadcast_client()
+        with (
+            respx.mock(assert_all_called=False),
+            patch.object(broadcast_client, "xrange", new=mock),
+        ):
+            client = _authenticated_client(session_id)
+            response = client.get("/ui/broadcast/history")
+        assert response.status_code == 200, response.text
+        assert "vsphere.vm.list" in response.text
+
+    def test_history_unauthenticated_redirects_to_login(self) -> None:
+        """The history fragment is gated by the session middleware."""
+        with respx.mock(assert_all_called=False):
+            client = TestClient(_build_app(), follow_redirects=False)
+            response = client.get("/ui/broadcast/history")
+        assert response.status_code == 302
+        assert response.headers["location"].startswith("/ui/auth/login?return_to=")

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -4752,7 +4752,7 @@
           "ui-broadcast"
         ],
         "summary": "Ui Broadcast History",
-        "description": "``GET /ui/broadcast/history`` -- the Last-24h replay fragment.\n\nPulls the session tenant's last-24h events via a finite\n``XRANGE``, serialises them as JSON the shared ``broadcastFeed``\ncontroller renders through ``broadcast/_event_row.html``, and\nreturns the ``broadcast/_history.html`` fragment (no\n``base.html`` chrome -- the tab swaps it into the page's history\ncontainer). The tenant comes from the validated session, never a\nquery parameter.",
+        "description": "``GET /ui/broadcast/history`` -- the Last-24h replay fragment.\n\nPulls the session tenant's last-24h events via a finite\n``XRANGE``, passes them as a list the template serialises with\nJinja ``| tojson`` into a ``<script type=\"application/json\">``\ndata island the shared ``broadcastFeed`` controller seeds from,\nand returns the ``broadcast/_history.html`` fragment (no\n``base.html`` chrome -- the tab swaps it into the page's history\ncontainer). The tenant comes from the validated session, never a\nquery parameter.",
         "operationId": "ui_broadcast_history_ui_broadcast_history_get",
         "responses": {
           "200": {

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -4512,7 +4512,7 @@
           "ui-broadcast"
         ],
         "summary": "Ui Broadcast Feed",
-        "description": "``GET /ui/broadcast[?op_class=&principal=&target=&op_id=]``.\n\nFilters are accepted on the full-page route too so a copy-pasted\nfiltered URL reproduces the operator's view (the filter bar sets\n``hx-push-url`` on the fragment route, mirroring topology).",
+        "description": "``GET /ui/broadcast[?op_class=&principal=&target=&op_id=&wall=1]``.\n\nFilters are accepted on the full-page route too so a copy-pasted\nfiltered URL reproduces the operator's view (the filter bar sets\n``hx-push-url`` on the fragment route, mirroring topology).\n``wall=1`` selects the no-chrome wall-monitor layout (work item\n#5).",
         "operationId": "ui_broadcast_feed_ui_broadcast_get",
         "parameters": [
           {
@@ -4558,6 +4558,18 @@
               "default": "",
               "title": "Op Id"
             }
+          },
+          {
+            "name": "wall",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Render the minimal full-screen wall-monitor layout (no sidebar / top bar / filter bar).",
+              "default": false,
+              "title": "Wall"
+            },
+            "description": "Render the minimal full-screen wall-monitor layout (no sidebar / top bar / filter bar)."
           }
         ],
         "responses": {
@@ -4727,6 +4739,28 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/broadcast/history": {
+      "get": {
+        "tags": [
+          "ui-broadcast"
+        ],
+        "summary": "Ui Broadcast History",
+        "description": "``GET /ui/broadcast/history`` -- the Last-24h replay fragment.\n\nPulls the session tenant's last-24h events via a finite\n``XRANGE``, serialises them as JSON the shared ``broadcastFeed``\ncontroller renders through ``broadcast/_event_row.html``, and\nreturns the ``broadcast/_history.html`` fragment (no\n``base.html`` chrome -- the tab swaps it into the page's history\ncontainer). The tenant comes from the validated session, never a\nquery parameter.",
+        "operationId": "ui_broadcast_history_ui_broadcast_history_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
                 }
               }
             }

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -2983,6 +2983,9 @@ type UiBroadcastFeedUiBroadcastGetParams struct {
 	Principal *string `form:"principal,omitempty" json:"principal,omitempty"`
 	Target    *string `form:"target,omitempty" json:"target,omitempty"`
 	OpId      *string `form:"op_id,omitempty" json:"op_id,omitempty"`
+
+	// Wall Render the minimal full-screen wall-monitor layout (no sidebar / top bar / filter bar).
+	Wall *bool `form:"wall,omitempty" json:"wall,omitempty"`
 }
 
 // UiBroadcastEventDetailUiBroadcastEventAuditIdGetParams defines parameters for UiBroadcastEventDetailUiBroadcastEventAuditIdGet.
@@ -3492,6 +3495,9 @@ type ClientInterface interface {
 
 	// UiBroadcastFeedFragmentUiBroadcastFeedGet request
 	UiBroadcastFeedFragmentUiBroadcastFeedGet(ctx context.Context, params *UiBroadcastFeedFragmentUiBroadcastFeedGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiBroadcastHistoryUiBroadcastHistoryGet request
+	UiBroadcastHistoryUiBroadcastHistoryGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiBroadcastStreamUiBroadcastStreamGet request
 	UiBroadcastStreamUiBroadcastStreamGet(ctx context.Context, params *UiBroadcastStreamUiBroadcastStreamGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -4693,6 +4699,18 @@ func (c *Client) UiBroadcastEventDetailUiBroadcastEventAuditIdGet(ctx context.Co
 
 func (c *Client) UiBroadcastFeedFragmentUiBroadcastFeedGet(ctx context.Context, params *UiBroadcastFeedFragmentUiBroadcastFeedGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUiBroadcastFeedFragmentUiBroadcastFeedGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiBroadcastHistoryUiBroadcastHistoryGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiBroadcastHistoryUiBroadcastHistoryGetRequest(c.Server)
 	if err != nil {
 		return nil, err
 	}
@@ -9699,6 +9717,22 @@ func NewUiBroadcastFeedUiBroadcastGetRequest(server string, params *UiBroadcastF
 
 		}
 
+		if params.Wall != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "wall", runtime.ParamLocationQuery, *params.Wall); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 
@@ -9853,6 +9887,33 @@ func NewUiBroadcastFeedFragmentUiBroadcastFeedGetRequest(server string, params *
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUiBroadcastHistoryUiBroadcastHistoryGetRequest generates requests for UiBroadcastHistoryUiBroadcastHistoryGet
+func NewUiBroadcastHistoryUiBroadcastHistoryGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/broadcast/history")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -10549,6 +10610,9 @@ type ClientWithResponsesInterface interface {
 
 	// UiBroadcastFeedFragmentUiBroadcastFeedGetWithResponse request
 	UiBroadcastFeedFragmentUiBroadcastFeedGetWithResponse(ctx context.Context, params *UiBroadcastFeedFragmentUiBroadcastFeedGetParams, reqEditors ...RequestEditorFn) (*UiBroadcastFeedFragmentUiBroadcastFeedGetResponse, error)
+
+	// UiBroadcastHistoryUiBroadcastHistoryGetWithResponse request
+	UiBroadcastHistoryUiBroadcastHistoryGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiBroadcastHistoryUiBroadcastHistoryGetResponse, error)
 
 	// UiBroadcastStreamUiBroadcastStreamGetWithResponse request
 	UiBroadcastStreamUiBroadcastStreamGetWithResponse(ctx context.Context, params *UiBroadcastStreamUiBroadcastStreamGetParams, reqEditors ...RequestEditorFn) (*UiBroadcastStreamUiBroadcastStreamGetResponse, error)
@@ -12364,6 +12428,27 @@ func (r UiBroadcastFeedFragmentUiBroadcastFeedGetResponse) StatusCode() int {
 	return 0
 }
 
+type UiBroadcastHistoryUiBroadcastHistoryGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r UiBroadcastHistoryUiBroadcastHistoryGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiBroadcastHistoryUiBroadcastHistoryGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type UiBroadcastStreamUiBroadcastStreamGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -13383,6 +13468,15 @@ func (c *ClientWithResponses) UiBroadcastFeedFragmentUiBroadcastFeedGetWithRespo
 		return nil, err
 	}
 	return ParseUiBroadcastFeedFragmentUiBroadcastFeedGetResponse(rsp)
+}
+
+// UiBroadcastHistoryUiBroadcastHistoryGetWithResponse request returning *UiBroadcastHistoryUiBroadcastHistoryGetResponse
+func (c *ClientWithResponses) UiBroadcastHistoryUiBroadcastHistoryGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiBroadcastHistoryUiBroadcastHistoryGetResponse, error) {
+	rsp, err := c.UiBroadcastHistoryUiBroadcastHistoryGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiBroadcastHistoryUiBroadcastHistoryGetResponse(rsp)
 }
 
 // UiBroadcastStreamUiBroadcastStreamGetWithResponse request returning *UiBroadcastStreamUiBroadcastStreamGetResponse
@@ -15874,6 +15968,22 @@ func ParseUiBroadcastFeedFragmentUiBroadcastFeedGetResponse(rsp *http.Response) 
 		}
 		response.JSON422 = &dest
 
+	}
+
+	return response, nil
+}
+
+// ParseUiBroadcastHistoryUiBroadcastHistoryGetResponse parses an HTTP response from a UiBroadcastHistoryUiBroadcastHistoryGetWithResponse call
+func ParseUiBroadcastHistoryUiBroadcastHistoryGetResponse(rsp *http.Response) (*UiBroadcastHistoryUiBroadcastHistoryGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiBroadcastHistoryUiBroadcastHistoryGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
 	}
 
 	return response, nil

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -440,7 +440,7 @@ the colour policy stays one auditable map.
 | `broadcast/_event_drawer_not_found.html` | The 404 drawer fragment for a missing / cross-tenant audit id. |
 | `broadcast/wall.html` | The no-chrome wall-monitor view (Task #869): a standalone document (not `extends base.html`) that drops the sidebar / navbar / filter bar and embeds `_feed.html` with `wall=True` (taller rows + auto-scroll). |
 | `broadcast/_history.html` | The Last-24h replay fragment (Task #869): seeds the shared `broadcastFeed` controller with the historical events the `/ui/broadcast/history` route pulled via `XRANGE`, so the rows render through `_event_row.html` and open the same drawer as the live feed. |
-| `static/src/app/broadcast-feed.js` | The `broadcastFeed` Alpine component (registered on `alpine:init`). External deferred script, not inline, to stay CSP-ready. Holds the parse + prepend + 1000-row trim, the `visibleEvents` op_id client filter, the `init` re-read of the live op_id input (so the filter survives a server-side fragment swap, gated to `#broadcast-feed` only), the `openDrawer` helper, the badge/timestamp/payload/aggregate-only helpers, the `opts.events` seed (for the history replay pane), and the `opts.autoScroll` wall-monitor behaviour. |
+| `static/src/app/broadcast-feed.js` | The `broadcastFeed` Alpine component (registered on `alpine:init`). External deferred script, not inline, to stay CSP-ready. Holds the parse + prepend + 1000-row trim, the `visibleEvents` op_id client filter, the `init` re-read of the live op_id input (so the filter survives a server-side fragment swap, gated to `#broadcast-feed` only), the `openDrawer` helper, the badge/timestamp/payload/aggregate-only helpers, the `opts.seedFrom` data-island seed (for the history replay pane — reads + `JSON.parse`s a `<script type="application/json">` block rather than receiving events through the `x-data` attribute, closing B1's stored-XSS hole), and the `opts.autoScroll` wall-monitor behaviour. |
 
 ### Performance + empty state
 
@@ -614,15 +614,33 @@ that millisecond to `+` (the live tail), bounded by `COUNT = 1000` (the
 same in-DOM row budget as the live feed). `XRANGE` returns oldest-first;
 the route reverses to newest-first to match the live feed.
 
-The route serialises the events as JSON and seeds the **same**
-`broadcastFeed` controller (`opts.events`) the live feed uses, so a
-history row renders through the same `_event_row.html` partial and opens
-the same T2 drawer on a click — a history row is byte-identical to a live
-row. The `init` op_id re-read is gated to `#broadcast-feed` (the live
-feed) so it never leaks the live filter onto the history pane, which
-keeps its own filter state. The history fetch is fail-soft: a transient
-Valkey error returns an empty list (the pane shows its empty state)
-rather than 500-ing the fragment.
+The route passes the events as the `history_events` list, which the
+fragment renders through Jinja's `| tojson` filter into a
+`<script type="application/json" id="broadcast-history-data">` data
+island. The **same** `broadcastFeed` controller the live feed uses reads
+that island on `init` (`opts.seedFrom` → `seedFromIsland`) and
+`JSON.parse`s its `textContent`, so a history row renders through the
+same `_event_row.html` partial and opens the same T2 drawer on a click —
+a history row is byte-identical to a live row. The `init` op_id re-read
+is gated to `#broadcast-feed` (the live feed) so it never leaks the live
+filter onto the history pane, which keeps its own filter state. The
+history fetch is fail-soft: a transient Valkey error returns an empty
+list (the pane shows its empty state) rather than 500-ing the fragment.
+
+**Why a data island, not an `x-data` attribute (B1, PR #1044).** Event
+fields (`op_id`, `target_name`, `principal_sub`, payload values) are
+operator-controlled within a tenant. Interpolating the serialised array
+straight into the double-quoted `x-data="…"` attribute — even via
+`| tojson` — is a stored DOM-XSS: `tojson` escapes `<` `>` `&` `'` and
+U+2028/U+2029 but **not** `"`, so a double-quote in any event field
+breaks out of the attribute and injects live event handlers (and is a
+plain render-corruption bug for any legitimate `"`-bearing value).
+Emitting the JSON as inert `<script type="application/json">` text and
+parsing it client-side keeps the untrusted data out of every attribute
+context; `tojson`'s `<`/`>` escaping prevents a `</script>` in a field
+from closing the element early. The same latent shape exists in the live
+`_feed.html` `opIdFilter: {{ op_id_filter | tojson }}` (a single scalar,
+self-XSS at most) — tracked as a follow-up, out of scope for B1.
 
 ### Cross-tenant isolation
 

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -638,9 +638,29 @@ plain render-corruption bug for any legitimate `"`-bearing value).
 Emitting the JSON as inert `<script type="application/json">` text and
 parsing it client-side keeps the untrusted data out of every attribute
 context; `tojson`'s `<`/`>` escaping prevents a `</script>` in a field
-from closing the element early. The same latent shape exists in the live
-`_feed.html` `opIdFilter: {{ op_id_filter | tojson }}` (a single scalar,
-self-XSS at most) — tracked as a follow-up, out of scope for B1.
+from closing the element early.
+
+**The `op_id` scalar sinks (follow-up to B1, same PR #1044).** The same
+`tojson`-in-a-double-quoted-`x-data` class shipped on the live feed too:
+`_feed.html`'s `opIdFilter: {{ op_id_filter | tojson }}` and
+`_filter_bar.html`'s `x-data="{ opId: {{ op_id_filter | tojson }} }"`.
+Both echo the reflected `op_id` query param (`GET /ui/broadcast` and
+`GET /ui/broadcast/feed`), so a crafted link
+(`/ui/broadcast?op_id=" autofocus onfocus=…`) is a **reflected** XSS in
+the victim operator's session — not merely self-XSS. Because the seed
+here is a flat options object (not the events array the history island
+carries), the fix switches the `x-data` **attribute delimiter to single
+quotes** rather than adding a second data island: `tojson` escapes `'` to
+`'` (it never emits a raw single-quote) and escapes `<`/`>`/`&`, so a
+single-quoted attribute is breakout-proof for any scalar while the
+value's `"` bytes ride harmlessly inside it. The static config has no raw
+`'` (`op_class_badge_json` is `json.dumps` output, double-quoted only), so
+the delimiter is unambiguous, and behaviour is byte-identical. The
+sibling `value="{{ op_id_filter }}"` is in an autoescaped attribute
+(Jinja escapes `"` to `&#34;`) and was already safe. Regression tests in
+`test_ui_broadcast_filters.py` drive both routes with a breakout `op_id`
+and parse the response to assert no handler grafts onto an `x-data`
+element.
 
 ### Cross-tenant isolation
 

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -362,7 +362,7 @@ content, CSRF rejection on missing/mismatched/forged tokens,
 positive control on matched token, and middleware-order sanity
 (/api/* passes through untouched).
 
-## Broadcast surface (Tasks #867, #868)
+## Broadcast surface (Tasks #867, #868, #869)
 
 Initiative [#338](https://github.com/evoila/meho/issues/338) (G10.1
 Activity broadcast UI), Task [#867](https://github.com/evoila/meho/issues/867)
@@ -371,17 +371,21 @@ Activity broadcast UI), Task [#867](https://github.com/evoila/meho/issues/867)
 list with an empty state and a 1000-row in-DOM cap. Task
 [#868](https://github.com/evoila/meho/issues/868) (G10.1-T2) adds the
 **filter bar** (op_class / principal / target / op_id), the **event
-detail drawer**, and the **PII 🔒 visualisation**. Wall-monitor mode +
-the Last-24h replay tab are T3 (#869).
+detail drawer**, and the **PII 🔒 visualisation**. Task
+[#869](https://github.com/evoila/meho/issues/869) (G10.1-T3) adds the
+**wall-monitor mode** (`?wall=1`), the **Last-24h replay tab**, and the
+**long-display session refresh** (a sliding-session extension) that
+keeps a full-screen wall display from logging out mid-stream.
 
 ### Routes
 
 | Route | Renders |
 | ----- | ------- |
-| `GET /ui/broadcast` | Full-page live-feed view (`broadcast/feed.html`, extends `base.html`). Sidebar active-state on Broadcast. Accepts `?op_class=&principal=&target=&op_id=` so a copy-pasted filtered URL reproduces the view. |
+| `GET /ui/broadcast` | Full-page live-feed view (`broadcast/feed.html`, extends `base.html`). Sidebar active-state on Broadcast. Accepts `?op_class=&principal=&target=&op_id=` so a copy-pasted filtered URL reproduces the view. `?wall=1` selects the no-chrome wall-monitor layout (`broadcast/wall.html`) instead. |
 | `GET /ui/broadcast/feed` | Filtered feed **fragment** (`broadcast/_feed.html`) — the filter-bar submit target. Re-renders the feed with the active server-side filters baked into a fresh `sse-connect` URL. |
 | `GET /ui/broadcast/stream` | Session-gated SSE bridge (`text/event-stream`). The feed view's `sse-connect` target. Accepts `op_class` / `principal` / `target` filters. |
-| `GET /ui/broadcast/event/{audit_id}` | Event detail drawer **fragment** (`broadcast/_event_drawer.html`; `_event_drawer_not_found.html` + HTTP 404 for a missing / cross-tenant id). |
+| `GET /ui/broadcast/history` | Last-24h replay **fragment** (`broadcast/_history.html`) — the "Last 24h" tab's HTMX target. A finite `XRANGE` pull of the tenant's last-24h events seeded into the shared `broadcastFeed` controller. |
+| `GET /ui/broadcast/event/{audit_id}` | Event detail drawer **fragment** (`broadcast/_event_drawer.html`; `_event_drawer_not_found.html` + HTTP 404 for a missing / cross-tenant id). Shared by the live feed, the wall view, and the history pane. |
 
 ### Why a UI-owned SSE bridge instead of subscribing to `/api/v1/feed`
 
@@ -434,7 +438,9 @@ the colour policy stays one auditable map.
 | `broadcast/_event_row.html` | Server-authored row markup (timestamp · principal badge · op_id · op_class badge · result_status icon · target · payload summary). Click opens the drawer; aggregate-only events render the 🔒 marker + placeholder. |
 | `broadcast/_event_drawer.html` | Event detail drawer: op identity, operation metadata, identifiers (audit_id / request_id / broadcast event_id), full payload (or the 🔒 placeholder for sensitive ops). Alpine `click.outside` / Escape / Close dismiss. |
 | `broadcast/_event_drawer_not_found.html` | The 404 drawer fragment for a missing / cross-tenant audit id. |
-| `static/src/app/broadcast-feed.js` | The `broadcastFeed` Alpine component (registered on `alpine:init`). External deferred script, not inline, to stay CSP-ready. Holds the parse + prepend + 1000-row trim, the `visibleEvents` op_id client filter, the `init` re-read of the live op_id input (so the filter survives a server-side fragment swap), the `openDrawer` helper, and the badge/timestamp/payload/aggregate-only helpers. |
+| `broadcast/wall.html` | The no-chrome wall-monitor view (Task #869): a standalone document (not `extends base.html`) that drops the sidebar / navbar / filter bar and embeds `_feed.html` with `wall=True` (taller rows + auto-scroll). |
+| `broadcast/_history.html` | The Last-24h replay fragment (Task #869): seeds the shared `broadcastFeed` controller with the historical events the `/ui/broadcast/history` route pulled via `XRANGE`, so the rows render through `_event_row.html` and open the same drawer as the live feed. |
+| `static/src/app/broadcast-feed.js` | The `broadcastFeed` Alpine component (registered on `alpine:init`). External deferred script, not inline, to stay CSP-ready. Holds the parse + prepend + 1000-row trim, the `visibleEvents` op_id client filter, the `init` re-read of the live op_id input (so the filter survives a server-side fragment swap, gated to `#broadcast-feed` only), the `openDrawer` helper, the badge/timestamp/payload/aggregate-only helpers, the `opts.events` seed (for the history replay pane), and the `opts.autoScroll` wall-monitor behaviour. |
 
 ### Performance + empty state
 
@@ -544,6 +550,80 @@ audit-side).
   streamed yet, or the op_id client filter narrowed everything out):
   "No activity matching your filters…" (work item #8).
 
+### Wall-monitor mode (Task #869, work item #5) — `?wall=1`
+
+`GET /ui/broadcast?wall=1` selects `broadcast/wall.html` instead of
+`broadcast/feed.html`. The wall view is a **standalone document** (not
+`{% extends "base.html" %}`) so it drops the DaisyUI drawer shell —
+no sidebar, no top navbar, no filter bar — and maximises the feed for a
+full-screen team-room monitor. It is opened in a new tab from the
+in-chrome view's "Wall mode" button so the monitor can be cast
+independently of the operator's working session.
+
+The wall view embeds the **same** `broadcast/_feed.html` fragment with
+`wall=True`, so it inherits the live SSE wiring, the `EventSource`
+auto-reconnect + `Last-Event-Id` replay durability, and the 1000-row
+in-DOM cap unchanged — only the chrome and the visual density differ.
+`wall=True` flips the `broadcastFeed` controller's `autoScroll` on (it
+scrolls the list to the top, where the newest event prepends, as events
+arrive) and renders taller rows (`_event_row.html` reads the `wall`
+flag). A clicked row still opens the T2 event-detail drawer, overlaid
+as a right-hand panel on the wall layout.
+
+### Long-display session refresh (Task #869, work item #5) — sliding session
+
+The wall monitor runs for hours, but the BFF session row's `expires_at`
+is set at login to roughly the access-token TTL (minutes to ~an hour).
+The load-bearing failure this guards against: the browser `EventSource`
+**permanently fails on a non-200 response** (WHATWG SSE spec) and does
+not reconnect. So once the session lapses, the next SSE reconnect to
+`/ui/broadcast/stream` is 302-redirected to login by
+`UISessionMiddleware` — a non-200 — and the feed dies silently with no
+recovery.
+
+The fix is a **server-side sliding-session extension** in
+`session_store.load_session` (not an OAuth token rotation — that needs a
+Keycloak refresh handler that does not exist in v0.2). On every active
+`/ui/*` load (each SSE reconnect is one), when the row is within
+`UI_SESSION_SLIDING_EXTENSION_SECONDS` of `expires_at`, the load pushes
+`expires_at` out to `now + sliding_window` — bounded by an absolute
+ceiling `created_at + UI_SESSION_ABSOLUTE_LIFETIME_SECONDS`. This is the
+standard idle-vs-absolute session-timeout pairing (OWASP ASVS v4 §3.3):
+the sliding window keeps an in-use display alive; the absolute cap
+guarantees a daily re-auth even for a permanently-displayed monitor.
+`sliding=0` disables the extension. The settings default to a 1h sliding
+window and a 12h absolute cap. The mutation is server-side-controlled
+(clock + config only, never client-supplied), so it runs safely on every
+load.
+
+### Last-24h replay pane (Task #869, work item #6) — `/ui/broadcast/history`
+
+The in-chrome view carries a **Live / Last 24h** tab strip. The Live tab
+is the SSE feed; the "Last 24h" tab lazy-loads `/ui/broadcast/history`
+the first time it is shown (`hx-trigger="intersect once"` fires the GET
+when the initially-hidden pane scrolls into view).
+
+The history route pulls the tenant's last-24h events with a **finite**
+`XRANGE` over `meho:feed:{session.tenant_id}` — the opposite shape from
+the live feed's BLOCKing `XREAD`: a bounded batch read that returns
+immediately (no streaming, no `while True`, so it cannot hang a worker).
+The window start is a bare millisecond timestamp `now - retention_hours`
+(`BROADCAST_RETENTION_HOURS`, default 24); Valkey `XRANGE` auto-completes
+the bare timestamp's sequence to `0`, so the range spans every entry from
+that millisecond to `+` (the live tail), bounded by `COUNT = 1000` (the
+same in-DOM row budget as the live feed). `XRANGE` returns oldest-first;
+the route reverses to newest-first to match the live feed.
+
+The route serialises the events as JSON and seeds the **same**
+`broadcastFeed` controller (`opts.events`) the live feed uses, so a
+history row renders through the same `_event_row.html` partial and opens
+the same T2 drawer on a click — a history row is byte-identical to a live
+row. The `init` op_id re-read is gated to `#broadcast-feed` (the live
+feed) so it never leaks the live filter onto the history pane, which
+keeps its own filter state. The history fetch is fail-soft: a transient
+Valkey error returns an empty list (the pane shows its empty state)
+rather than 500-ing the fragment.
+
 ### Cross-tenant isolation
 
 The page carries no tenant data beyond the operator's own identity; live
@@ -551,17 +631,21 @@ events arrive over the tenant-scoped bridge whose stream key is
 `meho:feed:{session.tenant_id}`. The target dropdown and the event
 drawer both scope to `session.tenant_id` at the SQL `WHERE` clause —
 never a query parameter — so a tenant-A operator can never surface
-tenant-B targets or audit rows. The
+tenant-B targets or audit rows. The history pane keys the same way: its
+`XRANGE` reads `meho:feed:{session.tenant_id}`, taken from the validated
+session, never a query parameter — so a tenant-A operator's replay can
+never surface tenant-B events. The wall view reuses the live feed
+fragment, so it inherits the live bridge's tenant scoping unchanged. The
 [T1 broadcast suite](../../backend/tests/test_ui_broadcast_feed.py) pins
 the generator's stream-key derivation per tenant; the
 [T2 filters suite](../../backend/tests/test_ui_broadcast_filters.py)
-pins the dropdown + drawer tenant scoping.
+pins the dropdown + drawer tenant scoping; the
+[T3 wall/replay suite](../../backend/tests/test_ui_broadcast_wall_replay.py)
+pins the history pane's per-tenant `XRANGE` key + the wall layout + the
+sliding-session extension.
 
 ### Known limits
 
-* **No wall-monitor / replay tab yet** — T1 + T2 ship the live feed,
-  filters, drawer, and PII viz. Wall-monitor mode (`?wall=1`) + the
-  Last-24h replay tab + long-display session refresh are T3 (#869).
 * **op_id filtering is client-side only** — it narrows the in-DOM
   `events` (bounded by the 1000-row cap), not the server stream. An op
   that fired before the operator typed an op_id substring, and has since


### PR DESCRIPTION
## Summary

- **Wall-monitor mode (`/ui/broadcast?wall=1`, work item #5)** — a no-chrome standalone `broadcast/wall.html` (no sidebar / top bar / filter bar) that maximises the feed for a full-screen team-room monitor. It embeds the same `_feed.html` fragment with `wall=True`, so it inherits the live SSE wiring, the EventSource auto-reconnect + `Last-Event-Id` replay durability, and the 1000-row cap unchanged — only the chrome + density differ (taller rows, auto-scroll to newest).
- **Long-display session refresh (work item #5)** — a bounded **sliding-session extension** in `session_store.load_session`. The access-token-TTL-bounded BFF session would otherwise lapse mid-display, and a lapsed session 302s the next SSE reconnect to login — a non-200 that *permanently* kills the browser `EventSource` (WHATWG SSE spec). The fix slides `expires_at` forward on an active `/ui/*` load, bounded by an absolute lifetime cap from `created_at` (OWASP ASVS idle-vs-absolute pairing). No Keycloak round-trip (that refresh handler doesn't exist in v0.2); the real `expires_at` gate is what logs `/ui/*` out, and that is what this extends. Two settings (sliding 1h, absolute cap 12h); `sliding=0` disables.
- **Last-24h replay (`/ui/broadcast/history`, work item #6)** — a "Last 24h" tab that HTMX-loads a **finite** `XRANGE` pull of the tenant's last-24h events (bounded by the 24h window + a 1000-row `COUNT` cap, so the endpoint terminates — no streaming loop), seeded into the **same** `broadcastFeed` controller that renders the live feed, so history rows render via `_event_row.html` and open the **same** T2 drawer.
- **Cross-tenant isolation (DoD)** — the history `XRANGE` keys off `meho:feed:{session.tenant_id}` (never a query param), identical to the live stream bridge; the wall view reuses the live fragment so it inherits the same scoping. Asserted for both.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/` — clean (288 files)
- [x] `pytest -n 4 tests/test_ui_broadcast_wall_replay.py` — 13 passed (~3s; stream/replay tests proven to terminate fast)
- [x] No regressions: `test_ui_broadcast_feed` + `test_ui_broadcast_filters` + `test_ui_session_store` + `test_settings` + `test_api_v1_feed` all green; broader `-k "ui or settings or broadcast"` sweep 518 passed / 8 skipped
- [x] `code-quality.py --diff` — 0 blockers (14 pre-existing-shape warnings on `feed.py`, recorded)
- [x] **OpenAPI snapshot regenerated** — `make snapshot-openapi && make generate`; `cli/api/openapi.json` + `cli/internal/api/client.gen.go` committed; regeneration is deterministic (byte-stable across two runs) and `go build ./...` is clean. The snapshot also picks up the previously-unsnapshotted T1/T2 broadcast fragment routes (`/ui/broadcast/feed`, `/ui/broadcast/stream`, `/ui/broadcast/event/{audit_id}`), bringing the committed snapshot back in sync with the live schema.

### AC coverage

- [x] `?wall=1` hides sidebar + top bar, maximises feed, auto-scrolls — `TestWallMode`
- [x] Wall mode survives an access-token expiry without logging out (sliding-session extension across a forced near-expiry) — `TestSlidingSessionExtension`
- [x] "Last 24h" tab pulls the 24h window + renders rows that open the drawer — `TestHistoryReplay`
- [x] Cross-tenant isolation in wall + replay — `TestHistoryReplay::test_history_cross_tenant_isolation` (+ wall reuses the live fragment's tenant-scoped bridge)
- [ ] Goal #336 G10.1 checklist line — that line tracks the whole Initiative #338; per repo convention it ticks when #338 closes (on the last task merging), not from this single task before merge.

## Notes / honest scope clarifications

- The issue framed the long-display refresh as "session middleware silent-refreshes the **access token**". On inspection the `UISessionMiddleware` does **no** refresh today (its docstring says so explicitly), and the only OAuth-rotation primitive (`rotate_refresh`) needs a Keycloak token-endpoint round-trip via a refresh handler that does not exist in v0.2. The shipped mechanism is the correct, in-scope equivalent: extend the `WebSession.expires_at` gate (the thing that actually logs `/ui/*` out) on active use, bounded by an absolute cap. This satisfies the AC ("survives an access-token expiry without logging out") without building Keycloak refresh plumbing. Documented in `docs/codebase/ui.md`.

## Out of scope

- Live feed / filters / drawer (#867 / #868); replay > 24h (G8 audit query); notification/alert rules; cross-tenant admin view; CSV export; per-event reactions — all per the initiative.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #869
