### PR TITLE
feat(conventions): G7.1-T5 seed rdc-internal tenant + 8 operational conventions

### DIFF
--- a/backend/alembic/versions/0018_seed_rdc_internal_conventions.py
+++ b/backend/alembic/versions/0018_seed_rdc_internal_conventions.py
@@ -1,0 +1,674 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Seed the ``rdc-internal`` tenant + 8 operational conventions.
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-05-24
+
+Initiative #229 (G7.1 Tenant conventions + Layer 2 starter), Task
+#317 (T5). This is a **data migration** -- no schema changes -- that
+turns the conventions feature into something usable for the
+``rdc-internal`` tenant by seeding the initial content extracted from
+the consumer's ``CLAUDE.md`` per `decision #4
+<../../../docs/planning/v0.2-decisions.md>`_ (operational rules only;
+repo-discipline rules stay in the consumer's repo).
+
+T1 (#313) created ``tenant_conventions`` + ``tenant_convention_history``;
+T2 (#314) shipped the API; T4 (#316) wires the preamble assembler.
+Without seeded rows the assembler returns empty, the
+:data:`meho://tenant/<id>/conventions` MCP resource lists nothing, and
+the spec-optional ``instructions`` field on the MCP ``initialize``
+response carries no tenant-specific operating discipline. This
+migration closes that gap with a one-shot, idempotent, reversible
+seed.
+
+What it does
+------------
+
+1. **Upserts the ``rdc-internal`` tenant.** ``INSERT ... ON CONFLICT
+   (slug) DO UPDATE SET name = EXCLUDED.name`` -- if an operator
+   already created the row manually (chassis-era ad-hoc bootstrap,
+   prior dev fixture, etc.) the migration keeps that row's ``id``
+   intact and refreshes the display name. The slug
+   ``'rdc-internal'`` is the unique key; the named ``tenant_slug_idx``
+   migration ``0002`` declared is the ``ON CONFLICT`` target.
+
+2. **Inserts 8 ``operational`` conventions for that tenant.**
+   ``INSERT ... ON CONFLICT (tenant_id, slug) DO NOTHING`` -- a
+   convention an operator already authored (post-T2, via the API)
+   takes precedence over the seed body; the migration never
+   overwrites operator-curated rules. The ``ON CONFLICT`` target is
+   the named composite ``tenant_conventions_tenant_slug_idx``
+   migration ``0015`` declared.
+
+3. **Inserts one CREATE-shape history row per seeded convention.**
+   ``body_before=NULL`` (no prior state on initial seed),
+   ``body_after=<seed body>``, ``actor_sub='migration:seed-rdc-conventions'``,
+   ``audit_id=NULL`` (no audit_log row to point at -- the migration
+   runs outside any HTTP request, and ``audit_log.tenant_id`` itself
+   is nullable in v0.2 per migration ``0002``'s ``audit_log`` column
+   addition). The history row is inserted **only when the convention
+   insert actually landed** (i.e. ``ON CONFLICT DO NOTHING`` returned
+   the new id) -- skipping the history write for rows the operator
+   already owns avoids polluting their edit trail with a synthetic
+   "seed" entry that never happened from their perspective.
+
+The 8 conventions
+-----------------
+
+Per `decision #4 <../../../docs/planning/v0.2-decisions.md>`_'s explicit
+list (Vault canonical, naming rule, secret-handling, CLI-wrapper
+fallback, sensitive-lab-specifics-stay-private) plus three
+operational rules pulled forward from cross-team operating practice
+(destructive-ops-probe-first, audit-trail-discipline,
+approval-workflow-when-it-lands). Every body is treated as
+**untrusted content** when T4's preamble assembler packs it into the
+session preamble -- the wrapper guard string (T4) and the convention
+body never agree to override MEHO's policy / audit / approval
+enforcement. The slug → source paragraph mapping ships alongside this
+migration in
+`docs/architecture/conventions-seed.md <../../../docs/architecture/conventions-seed.md>`_.
+
+Why ``kind='operational'`` for all 8
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Per decision #4 the G7 server-side partition migrates *only*
+operational rules. ``workflow`` and ``reference`` kinds are out of
+scope for the seed because (a) the consumer's repo CLAUDE.md doesn't
+carry workflow / reference content the seed could mirror, and (b)
+T4's preamble assembler packs **only** ``kind='operational'``
+conventions -- a ``workflow`` rule landed via this seed would be
+invisible to the session preamble surface T5 exists to populate.
+
+Priority assignment
+~~~~~~~~~~~~~~~~~~~
+
+T4 (#316) packs ``operational`` conventions highest-``priority``-first
+into a 600-token budget; over-budget entries are dropped whole. The
+seed assigns three priority tiers that reflect operator safety
+ranking:
+
+* ``priority=100`` -- secrets + sensitive lab specifics. These are the
+  rules whose breach is unrecoverable (rotated-secret-or-compromised-
+  tenant). They must reach every session even when the budget is
+  tight.
+* ``priority=50`` -- naming + CLI-wrapper + destructive-ops-probe.
+  Convention-and-discipline rules whose breach is recoverable but
+  costly (incoherent target identifiers; deleted-wrapper-with-no-
+  meho-replacement; collision on a destructive op). Important but
+  drop-when-tight.
+* ``priority=10`` -- audit-trail + approval-workflow-when-it-lands.
+  Aspirational / forward-looking; drop first when the budget runs out
+  because the rules' enforcement substrate either lands in G4 or is
+  not yet built.
+
+The rationale and exact slug → priority mapping ship in
+`docs/architecture/conventions-seed.md <../../../docs/architecture/conventions-seed.md>`_.
+
+Idempotency
+-----------
+
+Re-running the migration is a no-op for already-seeded data:
+
+* The tenant ``ON CONFLICT (slug) DO UPDATE`` is safe to re-run; the
+  ``EXCLUDED.name`` is the same string the previous pass wrote.
+* The convention ``ON CONFLICT (tenant_id, slug) DO NOTHING`` skips
+  every already-present row; nothing is written.
+* The history-row insert is gated on the conventions ``RETURNING id``
+  result -- only convention inserts that actually landed produce a
+  history row, so a re-run skips history writes for already-seeded
+  conventions too.
+
+This matters for the test suite (upgrade → downgrade → upgrade replay)
+and for the testcontainers PG replay cycle in
+:mod:`tests.test_migration_rollback`.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` deletes the seeded conventions by slug (and their
+history rows by ``convention_id``). The ``rdc-internal`` **tenant
+row is intentionally preserved** on downgrade because (a) operators
+may have configured tenant-scoped data (targets, audit rows,
+broadcast overrides) keyed by ``tenant_id``, and (b) deleting the
+tenant would cascade-orphan all that data (no actual FK cascade --
+the columns are soft FKs -- but the rows would be invisibly
+dangling). The narrower "remove only the rows this migration
+created" contract is the safer reversibility shape.
+
+The history row delete is keyed on
+``actor_sub='migration:seed-rdc-conventions'`` and the seeded slug
+list -- operator-curated history entries (a subsequent PATCH against
+a seeded slug) survive the downgrade unharmed.
+
+Dialect-portability decisions
+-----------------------------
+
+Mirrors the discipline migration ``0011`` (backfill data migration)
+established:
+
+* ``gen_random_uuid()`` is PG-only; SQLite uses Python-side
+  :func:`uuid.uuid4` because raw SQL with ``ON CONFLICT ... RETURNING``
+  needs a literal UUID parameter on SQLite (no ``gen_random_uuid()``).
+  The migration pre-mints the ``rdc-internal`` tenant id and each
+  convention id Python-side, passes them as bind parameters, and
+  lets PG's server default apply only when the row already exists
+  (in which case the ``ON CONFLICT DO UPDATE`` / ``DO NOTHING``
+  short-circuits before the default fires anyway).
+* ``now()`` is PG-only; SQLite gets a literal ISO-8601 timestamp via
+  :func:`datetime.now`. The
+  ``tenant_conventions.created_at`` / ``updated_at`` and
+  ``tenant_convention_history.ts`` columns are NOT NULL on every
+  dialect, so passing a literal Python timestamp keeps both engines
+  happy.
+* The migration uses parameterised statements (``:slug``, ``:body``)
+  rather than f-string interpolation -- prevents SQL-injection-shaped
+  bugs even though every value is a compile-time constant in the
+  migration, and keeps the audit trail of "what got inserted" readable
+  when the migration is replayed under PG ``log_statement=all``.
+
+Cross-references
+----------------
+
+* Initiative #229 (G7.1) -- the tenant conventions + Layer 2 starter
+  rollup. Decision #4 (``docs/planning/v0.2-decisions.md``) is the
+  authoritative partition between operational rules (migrated here)
+  and repo-discipline rules (stay in the consumer's CLAUDE.md).
+* T1 (#313) -- created the two tables this migration writes to.
+* T2 (#314) -- shipped the API operators use to add / edit / remove
+  conventions post-seed.
+* T4 (#316) -- the session-preamble assembler that turns the seeded
+  rows into MCP ``initialize.instructions`` content.
+* ``backend/alembic/versions/0011_backfill_operation_group_when_to_use.py``
+  -- the prior-art data-migration shape this file mirrors
+  (self-contained ``sa.table`` shims, Python-side timestamp, no ORM
+  import).
+* ``docs/architecture/conventions-seed.md`` -- slug → source paragraph
+  → priority mapping table.
+* :mod:`tests.test_alembic_seed_rdc_conventions` -- behavioural
+  coverage (idempotency, downgrade-keeps-tenant, all 8 conventions
+  land with the expected priorities).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from typing import Final
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0018"
+down_revision: str | None = "0017"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+#: The synthetic ``sub`` claim recorded on every seeded row's
+#: ``created_by_sub`` (on ``tenant_conventions``) and on every
+#: matching history row's ``actor_sub`` (on
+#: ``tenant_convention_history``). G8's audit-query path can grep on
+#: this exact string to find seed-vs-operator-authored content, and
+#: the ``downgrade()`` predicate uses it as the narrowing key when
+#: deleting history rows so operator-curated history survives.
+_SEED_ACTOR_SUB: Final[str] = "migration:seed-rdc-conventions"
+
+
+#: The tenant the seed targets. Slug is the unique natural key (the
+#: ``tenant_slug_idx`` from migration ``0002``); name is the
+#: operator-facing display label.
+_TENANT_SLUG: Final[str] = "rdc-internal"
+_TENANT_NAME: Final[str] = "RDC Internal"
+
+
+#: The 8 operational conventions, in deterministic source-order so the
+#: migration's replay log is stable across runs. Each tuple is
+#: ``(slug, title, priority, body)``. Body text is taken verbatim
+#: from the issue body (`#317 <https://github.com/evoila/meho/issues/317>`_).
+#:
+#: Priority assignment rationale lives in
+#: ``docs/architecture/conventions-seed.md``. Briefly: 100 for rules
+#: whose breach is unrecoverable (secrets); 50 for rules whose breach
+#: is recoverable but costly (naming, wrappers, destructive ops); 10
+#: for forward-looking aspirational rules (audit-trail discipline,
+#: approval workflow).
+_SEED_CONVENTIONS: Final[tuple[tuple[str, str, int, str], ...]] = (
+    (
+        "vault-canonical",
+        "Vault is canonical for secrets",
+        100,
+        (
+            "Vault is the canonical secret store. 1Password is "
+            "bootstrap-residual only (Vault unseal shares + initial "
+            "admin userpass). Never write to 1Password; always read "
+            "from Vault. Pipe secrets directly into the consuming "
+            "command -- never paste into chat, never commit to repos."
+        ),
+    ),
+    (
+        "naming-rule-no-ai-tool-names",
+        "No AI-tool names in operator-visible identifiers",
+        50,
+        (
+            "Operator-visible identifiers (target names, hostnames, "
+            "IPs, ticket titles, lab object names) must never contain "
+            "AI-tool names like 'claude', 'gpt', or other model-shaped "
+            "tokens. The lab program's Holodeck `claude` legacy is the "
+            "exception -- operator-visible refs renamed; VM-internal "
+            "refs are stuck pending destroy+redeploy. New names start "
+            "clean."
+        ),
+    ),
+    (
+        "secret-handling-discipline",
+        "Secret-handling discipline",
+        100,
+        (
+            "Secrets never enter chat windows, never enter commit "
+            "messages, never enter pull request bodies. Pipe directly "
+            "from `meho vault kv read ...` into the consuming "
+            "command. If a secret accidentally leaks into "
+            "chat/commit/PR, rotate immediately, then refile the work."
+        ),
+    ),
+    (
+        "cli-wrapper-fallback-discipline",
+        "CLI wrapper fallback during MEHO transition",
+        50,
+        (
+            "While MEHO is in transition (v0.2), existing "
+            "`scripts/*.sh` wrappers remain available as fallback. "
+            "Never delete a wrapper until its `meho` equivalent has "
+            "been in daily use for >= 2 weeks against real targets. "
+            "Document the wrapper-to-meho mapping in the PR "
+            "description."
+        ),
+    ),
+    (
+        "destructive-ops-probe-first",
+        "Probe before destructive ops",
+        50,
+        (
+            "Before any destructive operation (vm.destroy, "
+            "dns.zone.delete, k8s.namespace.delete), run `meho "
+            "topology dependents <resource>` (when G9 lands) or the "
+            "equivalent inventory check (G3.1's `vsphere.vm.info`). "
+            "Document what you'd touch in the ticket. Confirm with "
+            "the team via `meho status --watch` that no one else is "
+            "operating on the same resource."
+        ),
+    ),
+    (
+        "audit-trail-discipline",
+        "Document findings as you go",
+        10,
+        (
+            "Every diagnostic or investigative session captures "
+            "findings as kb entries. `meho kb write` (when G4 lands) "
+            "is the canonical path. Until G4, write to local `kb/` "
+            "and import in the next sync."
+        ),
+    ),
+    (
+        "sensitive-lab-specifics-stay-private",
+        "Sensitive lab specifics stay private",
+        100,
+        (
+            "The `evoila/meho` repo is public. Internal lab "
+            "specifics (real hostnames, IPs, customer names, project "
+            "codes) must not appear in commits, issues, or public "
+            "docs. Generic naming + sanitised examples only. Internal "
+            "coordination happens in `evoila-bosnia/meho-internal` or "
+            "other private channels."
+        ),
+    ),
+    (
+        "approval-workflow-when-it-lands",
+        "Approval workflow expectations",
+        10,
+        (
+            "When approval workflow lands (v0.2.next G-Policy), "
+            "destructive ops on production targets will block waiting "
+            "for a second operator's approval. Until then, operate by "
+            "team norm: discuss in #ops Slack before destructive prod "
+            "ops; document in the ticket."
+        ),
+    ),
+)
+
+
+def _tenant_table() -> sa.TableClause:
+    """Return a Core ``sa.table`` shim for ``tenant``.
+
+    Self-contained per the Alembic data-migration cookbook -- never
+    imports the ORM model (which would pin the migration to one
+    moment in the schema's history and break under future column
+    adds). Mirrors the discipline migration ``0011`` follows for the
+    ``operation_group`` data migration.
+    """
+    return sa.table(
+        "tenant",
+        sa.column("id", sa.Uuid()),
+        sa.column("slug", sa.Text()),
+        sa.column("name", sa.Text()),
+        sa.column("created_at", sa.DateTime(timezone=True)),
+    )
+
+
+def _convention_table() -> sa.TableClause:
+    """Return a Core ``sa.table`` shim for ``tenant_conventions``."""
+    return sa.table(
+        "tenant_conventions",
+        sa.column("id", sa.Uuid()),
+        sa.column("tenant_id", sa.Uuid()),
+        sa.column("slug", sa.Text()),
+        sa.column("title", sa.Text()),
+        sa.column("body", sa.Text()),
+        sa.column("kind", sa.Text()),
+        sa.column("priority", sa.SmallInteger()),
+        sa.column("created_by_sub", sa.Text()),
+        sa.column("created_at", sa.DateTime(timezone=True)),
+        sa.column("updated_at", sa.DateTime(timezone=True)),
+    )
+
+
+def _history_table() -> sa.TableClause:
+    """Return a Core ``sa.table`` shim for ``tenant_convention_history``."""
+    return sa.table(
+        "tenant_convention_history",
+        sa.column("id", sa.Uuid()),
+        sa.column("convention_id", sa.Uuid()),
+        sa.column("body_before", sa.Text()),
+        sa.column("body_after", sa.Text()),
+        sa.column("actor_sub", sa.Text()),
+        sa.column("ts", sa.DateTime(timezone=True)),
+        sa.column("audit_id", sa.Uuid()),
+    )
+
+
+def _coerce_uuid(value: object) -> uuid.UUID:
+    """Coerce a DB-returned UUID-shaped value to :class:`uuid.UUID`.
+
+    PG returns a :class:`uuid.UUID` instance; SQLite via aiosqlite
+    returns the same value as a :class:`str` (``CHAR(32)`` storage
+    class). Either way callers need a single uniform type to pass back
+    as bind parameters, so this helper handles the dialect drift in
+    one place.
+    """
+    if isinstance(value, uuid.UUID):
+        return value
+    return uuid.UUID(str(value))
+
+
+def _uuid_param(value: uuid.UUID, *, is_postgres: bool) -> object:
+    """Return the right Python type for a UUID bind parameter on each dialect.
+
+    On PG the driver accepts either :class:`uuid.UUID` or :class:`str`;
+    on SQLite via aiosqlite a raw :class:`uuid.UUID` trips
+    ``ProgrammingError: type 'UUID' is not supported`` because the
+    sqlite3 stdlib driver does not register a UUID adapter by default.
+    Passing the hex form (``str(uuid_value)``) is the dialect-portable
+    shape -- mirrors the same string-cast discipline the existing
+    test fixtures (e.g. ``tests.test_migration_0011_backfill_when_to_use``)
+    apply when issuing raw-SQL inserts against SQLite.
+    """
+    return value if is_postgres else str(value)
+
+
+def _upsert_rdc_internal_tenant(
+    bind: sa.Connection,
+    *,
+    now: datetime,
+    is_postgres: bool,
+) -> uuid.UUID:
+    """Upsert the ``rdc-internal`` tenant and return its id.
+
+    Issues a single ``INSERT ... ON CONFLICT (slug) DO UPDATE SET name
+    = EXCLUDED.name RETURNING id``. Both PG and SQLite (3.24+) accept
+    this exact shape; the ``ON CONFLICT`` target is the named
+    ``tenant_slug_idx`` migration ``0002`` declared.
+
+    The tenant id is minted Python-side (``uuid.uuid4()``) rather than
+    relying on the PG ``gen_random_uuid()`` server default because
+    SQLite has no such default and the migration test suite runs
+    against SQLite. PG honours the bind parameter the same way it
+    would honour the server default -- both produce a fresh UUID,
+    and the ``ON CONFLICT DO UPDATE`` path returns the existing row's
+    id either way.
+    """
+    tenant = _tenant_table()
+    new_id = uuid.uuid4()
+    stmt_text = sa.text(
+        """
+        INSERT INTO tenant (id, slug, name, created_at)
+        VALUES (:id, :slug, :name, :created_at)
+        ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name
+        RETURNING id
+        """,
+    )
+    result = bind.execute(
+        stmt_text,
+        {
+            "id": _uuid_param(new_id, is_postgres=is_postgres),
+            "slug": _TENANT_SLUG,
+            "name": _TENANT_NAME,
+            "created_at": now,
+        },
+    )
+    tenant_id = _coerce_uuid(result.scalar_one())
+    # Silence the unused-table warning -- the shim is built for
+    # symmetry with the other table accessors even when the explicit
+    # text-statement path doesn't reference it.
+    _ = tenant
+    return tenant_id
+
+
+def upgrade() -> None:
+    """Seed the ``rdc-internal`` tenant + 8 operational conventions.
+
+    Order of operations:
+
+    1. Upsert the tenant row (returns the tenant id, whether the row
+       was created or pre-existed).
+    2. For each convention tuple: ``INSERT ... ON CONFLICT (tenant_id,
+       slug) DO NOTHING RETURNING id``. The ``RETURNING`` clause
+       yields the new id only when the insert actually landed.
+    3. For every convention id returned in step 2, insert one
+       CREATE-shape history row.
+
+    All three steps share a single ``now`` timestamp so the seeded
+    rows carry a coherent ``created_at`` / ``updated_at`` / ``ts`` --
+    mirrors the ORM's per-write default-factory discipline without
+    importing the model.
+    """
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+    now = datetime.now(UTC)
+
+    tenant_id = _upsert_rdc_internal_tenant(
+        bind,
+        now=now,
+        is_postgres=is_postgres,
+    )
+
+    convention = _convention_table()
+    history = _history_table()
+
+    # Build the per-row INSERT once outside the loop; each iteration
+    # re-binds parameters. ``ON CONFLICT (tenant_id, slug) DO NOTHING
+    # RETURNING id`` is the upsert-or-skip shape -- when the row
+    # already exists, ``RETURNING id`` yields no rows and the
+    # history-write branch is skipped.
+    convention_insert = sa.text(
+        """
+        INSERT INTO tenant_conventions (
+            id, tenant_id, slug, title, body, kind, priority,
+            created_by_sub, created_at, updated_at
+        ) VALUES (
+            :id, :tenant_id, :slug, :title, :body, :kind, :priority,
+            :created_by_sub, :created_at, :updated_at
+        )
+        ON CONFLICT (tenant_id, slug) DO NOTHING
+        RETURNING id
+        """,
+    )
+    history_insert = sa.text(
+        """
+        INSERT INTO tenant_convention_history (
+            id, convention_id, body_before, body_after, actor_sub,
+            ts, audit_id
+        ) VALUES (
+            :id, :convention_id, :body_before, :body_after,
+            :actor_sub, :ts, :audit_id
+        )
+        """,
+    )
+
+    for slug, title, priority, body in _SEED_CONVENTIONS:
+        convention_id = uuid.uuid4()
+        result = bind.execute(
+            convention_insert,
+            {
+                "id": _uuid_param(convention_id, is_postgres=is_postgres),
+                "tenant_id": _uuid_param(tenant_id, is_postgres=is_postgres),
+                "slug": slug,
+                "title": title,
+                "body": body,
+                "kind": "operational",
+                "priority": priority,
+                "created_by_sub": _SEED_ACTOR_SUB,
+                "created_at": now,
+                "updated_at": now,
+            },
+        )
+        # ``ON CONFLICT DO NOTHING RETURNING id`` returns zero rows
+        # when the conflict fires (the operator-authored row stays
+        # put). Skip the matching history write in that case --
+        # synthesising a "seed" history entry for an operator-owned
+        # row would lie about the row's lineage.
+        landed = result.scalar()
+        if landed is None:
+            continue
+        bind.execute(
+            history_insert,
+            {
+                "id": _uuid_param(uuid.uuid4(), is_postgres=is_postgres),
+                "convention_id": _uuid_param(
+                    convention_id,
+                    is_postgres=is_postgres,
+                ),
+                "body_before": None,
+                "body_after": body,
+                "actor_sub": _SEED_ACTOR_SUB,
+                "ts": now,
+                "audit_id": None,
+            },
+        )
+    # Silence the unused-table warning -- the shims are built for
+    # symmetry with the other migrations even when the explicit
+    # text-statement path doesn't reference them directly.
+    _ = (convention, history)
+
+
+def downgrade() -> None:
+    """Delete the seeded conventions + history rows; keep the tenant.
+
+    The ``rdc-internal`` tenant row is **intentionally preserved** on
+    downgrade. Other v0.2 features (targets, audit rows, broadcast
+    overrides, agent definitions) key on ``tenant_id``; deleting the
+    tenant would cascade-orphan that data even with the soft-FK
+    discipline (no DB-level CASCADE fires, but the rows would become
+    invisibly dangling). The narrower "remove only the rows this
+    migration created" contract is the safer reversal.
+
+    The history-row delete narrows on
+    ``actor_sub='migration:seed-rdc-conventions'`` so operator-curated
+    history entries (a PATCH applied by an operator against a seeded
+    slug after the seed migration ran) survive untouched. Same
+    discipline migration ``0011``'s ``WHERE when_to_use LIKE``
+    predicate follows: rewind only what this migration authored.
+    """
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    # Resolve the tenant id first; if the tenant row doesn't exist
+    # (operator manually deleted it post-seed, or downgrade runs
+    # against a DB that never saw the upgrade), there is nothing to
+    # clean up.
+    tenant_id_row = bind.execute(
+        sa.text("SELECT id FROM tenant WHERE slug = :slug"),
+        {"slug": _TENANT_SLUG},
+    ).scalar()
+    if tenant_id_row is None:
+        return
+    tenant_id = _coerce_uuid(tenant_id_row)
+
+    seeded_slugs = [slug for slug, _title, _priority, _body in _SEED_CONVENTIONS]
+
+    # Resolve the convention ids the seed authored -- the history
+    # delete narrows on ``convention_id`` to avoid touching rows that
+    # might belong to other conventions (defence-in-depth; the
+    # ``actor_sub`` predicate already narrows on the seed marker but
+    # the join keeps the delete scoped to seeded conventions even if
+    # an operator later edits one with the same synthetic sub).
+    # ``expanding=True`` is the dialect-portable form of "IN (...)" --
+    # SQLAlchemy expands the bind parameter into the right number of
+    # placeholders at execute-time, working identically on PG and
+    # SQLite.
+    convention_id_rows = bind.execute(
+        sa.text(
+            """
+            SELECT id FROM tenant_conventions
+            WHERE tenant_id = :tenant_id AND slug IN :slugs
+            """,
+        ).bindparams(sa.bindparam("slugs", expanding=True)),
+        {
+            "tenant_id": _uuid_param(tenant_id, is_postgres=is_postgres),
+            "slugs": seeded_slugs,
+        },
+    ).all()
+    convention_ids = [_coerce_uuid(row[0]) for row in convention_id_rows]
+
+    if convention_ids:
+        # History first -- by ``actor_sub`` + ``convention_id`` so
+        # operator-authored edits survive (operator edits carry a
+        # JWT-shaped ``sub``, not the synthetic seed marker).
+        bind.execute(
+            sa.text(
+                """
+                DELETE FROM tenant_convention_history
+                WHERE convention_id IN :ids
+                  AND actor_sub = :actor_sub
+                """,
+            ).bindparams(sa.bindparam("ids", expanding=True)),
+            {
+                "ids": [_uuid_param(cid, is_postgres=is_postgres) for cid in convention_ids],
+                "actor_sub": _SEED_ACTOR_SUB,
+            },
+        )
+        # Then the convention rows themselves -- by ``(tenant_id,
+        # slug)`` so the unique composite index is the access path.
+        # Narrows on ``created_by_sub`` so operator-curated
+        # conventions (a row the operator authored under the same
+        # slug pre-seed and the seed skipped on ``ON CONFLICT DO
+        # NOTHING``) survive.
+        bind.execute(
+            sa.text(
+                """
+                DELETE FROM tenant_conventions
+                WHERE tenant_id = :tenant_id
+                  AND slug IN :slugs
+                  AND created_by_sub = :created_by_sub
+                """,
+            ).bindparams(sa.bindparam("slugs", expanding=True)),
+            {
+                "tenant_id": _uuid_param(tenant_id, is_postgres=is_postgres),
+                "slugs": seeded_slugs,
+                "created_by_sub": _SEED_ACTOR_SUB,
+            },
+        )

--- a/backend/alembic/versions/0018_seed_rdc_internal_conventions.py
+++ b/backend/alembic/versions/0018_seed_rdc_internal_conventions.py
@@ -55,6 +55,16 @@ What it does
    already owns avoids polluting their edit trail with a synthetic
    "seed" entry that never happened from their perspective.
 
+   **G8 audit-trace query semantics.** Because seed-authored history
+   rows carry ``audit_id=NULL``, any G8 query that joins
+   ``tenant_convention_history`` to ``audit_log`` on
+   ``history.audit_id = audit_log.id`` **must** use ``LEFT JOIN``;
+   ``INNER JOIN`` would silently drop the seeded rows from the
+   audit-replay view. Operator-authored edits (PATCH via T2) carry a
+   real ``audit_id`` and join cleanly under either shape. See
+   ``docs/architecture/conventions-seed.md`` for the recommended
+   query template.
+
 The 8 conventions
 -----------------
 
@@ -183,8 +193,8 @@ Cross-references
   rows into MCP ``initialize.instructions`` content.
 * ``backend/alembic/versions/0011_backfill_operation_group_when_to_use.py``
   -- the prior-art data-migration shape this file mirrors
-  (self-contained ``sa.table`` shims, Python-side timestamp, no ORM
-  import).
+  (Python-side timestamp, no ORM import, raw ``sa.text`` statements
+  with parameterised binds for dialect portability).
 * ``docs/architecture/conventions-seed.md`` -- slug → source paragraph
   → priority mapping table.
 * :mod:`tests.test_alembic_seed_rdc_conventions` -- behavioural
@@ -247,7 +257,7 @@ _SEED_CONVENTIONS: Final[tuple[tuple[str, str, int, str], ...]] = (
             "bootstrap-residual only (Vault unseal shares + initial "
             "admin userpass). Never write to 1Password; always read "
             "from Vault. Pipe secrets directly into the consuming "
-            "command -- never paste into chat, never commit to repos."
+            "command — never paste into chat, never commit to repos."
         ),
     ),
     (
@@ -259,7 +269,7 @@ _SEED_CONVENTIONS: Final[tuple[tuple[str, str, int, str], ...]] = (
             "IPs, ticket titles, lab object names) must never contain "
             "AI-tool names like 'claude', 'gpt', or other model-shaped "
             "tokens. The lab program's Holodeck `claude` legacy is the "
-            "exception -- operator-visible refs renamed; VM-internal "
+            "exception — operator-visible refs renamed; VM-internal "
             "refs are stuck pending destroy+redeploy. New names start "
             "clean."
         ),
@@ -284,7 +294,7 @@ _SEED_CONVENTIONS: Final[tuple[tuple[str, str, int, str], ...]] = (
             "While MEHO is in transition (v0.2), existing "
             "`scripts/*.sh` wrappers remain available as fallback. "
             "Never delete a wrapper until its `meho` equivalent has "
-            "been in daily use for >= 2 weeks against real targets. "
+            "been in daily use for ≥ 2 weeks against real targets. "
             "Document the wrapper-to-meho mapping in the PR "
             "description."
         ),
@@ -342,55 +352,6 @@ _SEED_CONVENTIONS: Final[tuple[tuple[str, str, int, str], ...]] = (
 )
 
 
-def _tenant_table() -> sa.TableClause:
-    """Return a Core ``sa.table`` shim for ``tenant``.
-
-    Self-contained per the Alembic data-migration cookbook -- never
-    imports the ORM model (which would pin the migration to one
-    moment in the schema's history and break under future column
-    adds). Mirrors the discipline migration ``0011`` follows for the
-    ``operation_group`` data migration.
-    """
-    return sa.table(
-        "tenant",
-        sa.column("id", sa.Uuid()),
-        sa.column("slug", sa.Text()),
-        sa.column("name", sa.Text()),
-        sa.column("created_at", sa.DateTime(timezone=True)),
-    )
-
-
-def _convention_table() -> sa.TableClause:
-    """Return a Core ``sa.table`` shim for ``tenant_conventions``."""
-    return sa.table(
-        "tenant_conventions",
-        sa.column("id", sa.Uuid()),
-        sa.column("tenant_id", sa.Uuid()),
-        sa.column("slug", sa.Text()),
-        sa.column("title", sa.Text()),
-        sa.column("body", sa.Text()),
-        sa.column("kind", sa.Text()),
-        sa.column("priority", sa.SmallInteger()),
-        sa.column("created_by_sub", sa.Text()),
-        sa.column("created_at", sa.DateTime(timezone=True)),
-        sa.column("updated_at", sa.DateTime(timezone=True)),
-    )
-
-
-def _history_table() -> sa.TableClause:
-    """Return a Core ``sa.table`` shim for ``tenant_convention_history``."""
-    return sa.table(
-        "tenant_convention_history",
-        sa.column("id", sa.Uuid()),
-        sa.column("convention_id", sa.Uuid()),
-        sa.column("body_before", sa.Text()),
-        sa.column("body_after", sa.Text()),
-        sa.column("actor_sub", sa.Text()),
-        sa.column("ts", sa.DateTime(timezone=True)),
-        sa.column("audit_id", sa.Uuid()),
-    )
-
-
 def _coerce_uuid(value: object) -> uuid.UUID:
     """Coerce a DB-returned UUID-shaped value to :class:`uuid.UUID`.
 
@@ -412,12 +373,21 @@ def _uuid_param(value: uuid.UUID, *, is_postgres: bool) -> object:
     on SQLite via aiosqlite a raw :class:`uuid.UUID` trips
     ``ProgrammingError: type 'UUID' is not supported`` because the
     sqlite3 stdlib driver does not register a UUID adapter by default.
-    Passing the hex form (``str(uuid_value)``) is the dialect-portable
-    shape -- mirrors the same string-cast discipline the existing
-    test fixtures (e.g. ``tests.test_migration_0011_backfill_when_to_use``)
-    apply when issuing raw-SQL inserts against SQLite.
+
+    SQLite gets the **32-char hex form** (``value.hex``), NOT the
+    36-char canonical form (``str(value)``). SQLAlchemy's
+    :class:`~sqlalchemy.types.Uuid` column type stores UUIDs in 32-char
+    hex on SQLite by default (its bind processor calls ``value.hex``),
+    so any later FK reference made through the ORM compares against
+    that storage form bytewise. Writing the seed in 36-char dashed
+    form would silently produce a row whose ``id`` is invisible to
+    ORM-issued FK joins (the test suite saw this as a cascade of
+    ``FOREIGN KEY constraint failed`` traps once the
+    :func:`tests.conftest._schema_template_db` started embedding the
+    seeded tenant). On PG, ``uuid`` columns normalise both forms so
+    the same shape works.
     """
-    return value if is_postgres else str(value)
+    return value if is_postgres else value.hex
 
 
 def _upsert_rdc_internal_tenant(
@@ -441,7 +411,6 @@ def _upsert_rdc_internal_tenant(
     and the ``ON CONFLICT DO UPDATE`` path returns the existing row's
     id either way.
     """
-    tenant = _tenant_table()
     new_id = uuid.uuid4()
     stmt_text = sa.text(
         """
@@ -460,12 +429,7 @@ def _upsert_rdc_internal_tenant(
             "created_at": now,
         },
     )
-    tenant_id = _coerce_uuid(result.scalar_one())
-    # Silence the unused-table warning -- the shim is built for
-    # symmetry with the other table accessors even when the explicit
-    # text-statement path doesn't reference it.
-    _ = tenant
-    return tenant_id
+    return _coerce_uuid(result.scalar_one())
 
 
 def upgrade() -> None:
@@ -495,9 +459,6 @@ def upgrade() -> None:
         now=now,
         is_postgres=is_postgres,
     )
-
-    convention = _convention_table()
-    history = _history_table()
 
     # Build the per-row INSERT once outside the loop; each iteration
     # re-binds parameters. ``ON CONFLICT (tenant_id, slug) DO NOTHING
@@ -569,10 +530,6 @@ def upgrade() -> None:
                 "audit_id": None,
             },
         )
-    # Silence the unused-table warning -- the shims are built for
-    # symmetry with the other migrations even when the explicit
-    # text-statement path doesn't reference them directly.
-    _ = (convention, history)
 
 
 def downgrade() -> None:

--- a/backend/tests/test_agent_run_lifecycle.py
+++ b/backend/tests/test_agent_run_lifecycle.py
@@ -34,6 +34,7 @@ from collections.abc import Iterator
 from decimal import Decimal
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.operator import Operator, TenantRole
@@ -69,7 +70,19 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 
 async def _seed_tenant(session: AsyncSession, *, slug: str = "rdc-internal") -> uuid.UUID:
-    """Insert a tenant row and return its UUID (FK parent for agent_run)."""
+    """Return the tenant row's id, inserting it on the first call (FK parent for agent_run).
+
+    The look-up-then-insert shape is load-bearing: migration ``0018``
+    seeds the ``rdc-internal`` tenant into the per-worker schema
+    template (:func:`tests.conftest._schema_template_db`), so a plain
+    ``session.add(Tenant(slug='rdc-internal', ...))`` would trip
+    ``UNIQUE constraint failed: tenant.slug``.
+    """
+    existing: uuid.UUID | None = await session.scalar(
+        select(Tenant.id).where(Tenant.slug == slug),
+    )
+    if existing is not None:
+        return existing
     tenant_id = uuid.uuid4()
     session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
     await session.commit()

--- a/backend/tests/test_alembic_seed_rdc_conventions.py
+++ b/backend/tests/test_alembic_seed_rdc_conventions.py
@@ -1,0 +1,668 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0018_seed_rdc_internal_conventions``.
+
+Initiative #229 (G7.1 Tenant conventions + Layer 2 starter), Task
+#317 (T5). The migration seeds the ``rdc-internal`` tenant + 8
+operational conventions extracted from the consumer's ``CLAUDE.md``
+per decision #4. The tests cover the five contracts on the issue body:
+
+* **Tenant + 8 conventions land on a clean DB.** ``upgrade head`` from
+  a clean DB produces the ``rdc-internal`` tenant row and 8
+  ``operational`` convention rows scoped to that tenant; one matching
+  history row per convention.
+* **Idempotency.** A second ``upgrade`` (via stamp + replay) is a
+  no-op: the conventions stay put, no duplicate history rows land,
+  no ``updated_at`` movement.
+* **Pre-existing tenant is preserved.** A tenant row authored
+  manually before the migration ran keeps its ``id`` -- the upsert
+  refreshes ``name`` but does not mint a fresh UUID.
+* **Operator-curated convention survives.** A convention an operator
+  authored under one of the seeded slugs before the migration ran is
+  preserved verbatim by ``ON CONFLICT DO NOTHING``; no synthetic
+  history row appears against it.
+* **Downgrade keeps the tenant.** ``downgrade "0017"`` removes the
+  seeded convention rows + their seed-authored history rows, but
+  leaves the tenant row intact and leaves operator-authored history
+  rows (against seeded slugs) untouched.
+
+The tests follow the synchronous pattern established by
+:mod:`tests.test_migration_0011_backfill_when_to_use`:
+``alembic.command.upgrade`` calls ``asyncio.run`` internally via
+env.py's async cookbook, so the test functions themselves must be
+sync. SQLite is the test driver; PG-side shape parity is covered by
+the testcontainers replay suite in :mod:`tests.test_migration_rollback`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Final
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+#: The synthetic ``sub`` claim the seed migration records on every
+#: row it authors. Mirrors the migration's own constant -- duplicated
+#: here so the test couples to the contract, not the implementation.
+_SEED_ACTOR_SUB: Final[str] = "migration:seed-rdc-conventions"
+
+#: The seeded tenant's slug.
+_TENANT_SLUG: Final[str] = "rdc-internal"
+
+#: The 8 slugs the seed populates. Order does not matter for the
+#: assertions; the set membership is what counts.
+_EXPECTED_SLUGS: Final[frozenset[str]] = frozenset(
+    {
+        "vault-canonical",
+        "naming-rule-no-ai-tool-names",
+        "secret-handling-discipline",
+        "cli-wrapper-fallback-discipline",
+        "destructive-ops-probe-first",
+        "audit-trail-discipline",
+        "sensitive-lab-specifics-stay-private",
+        "approval-workflow-when-it-lands",
+    },
+)
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL.
+
+    The fixture is *sync* (returns rather than yields async) because
+    :func:`alembic.command.upgrade` calls :func:`asyncio.run`
+    internally via the env.py async cookbook -- the same constraint
+    that keeps every other migration test in
+    :mod:`tests.test_migration_0011_backfill_when_to_use` synchronous.
+
+    The DB file lives under pytest's ``tmp_path`` so each test gets
+    an isolated SQLite database; engine + settings caches are reset
+    before and after so the alembic env reads *this* DATABASE_URL.
+    """
+    db_path = tmp_path / "migration_0018.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _fetch_tenant_id(sync_url: str, slug: str) -> str | None:
+    """Return the tenant id (as a string) for the given slug, or None."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            row = conn.execute(
+                text("SELECT id FROM tenant WHERE slug = :slug"),
+                {"slug": slug},
+            ).first()
+            return None if row is None else str(row[0])
+    finally:
+        sync_eng.dispose()
+
+
+def _fetch_convention_rows(
+    sync_url: str,
+    tenant_id: str,
+) -> list[dict[str, object]]:
+    """Return all convention rows for the tenant as dicts."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = (
+                conn.execute(
+                    text(
+                        """
+                    SELECT id, slug, title, body, kind, priority,
+                           created_by_sub, created_at, updated_at
+                    FROM tenant_conventions
+                    WHERE tenant_id = :tenant_id
+                    ORDER BY slug
+                    """,
+                    ),
+                    {"tenant_id": tenant_id},
+                )
+                .mappings()
+                .all()
+            )
+    finally:
+        sync_eng.dispose()
+    return [dict(row) for row in rows]
+
+
+def _fetch_history_rows(
+    sync_url: str,
+    convention_id: str,
+) -> list[dict[str, object]]:
+    """Return all history rows for one convention, oldest first."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = (
+                conn.execute(
+                    text(
+                        """
+                    SELECT id, body_before, body_after, actor_sub, ts,
+                           audit_id
+                    FROM tenant_convention_history
+                    WHERE convention_id = :convention_id
+                    ORDER BY ts ASC
+                    """,
+                    ),
+                    {"convention_id": convention_id},
+                )
+                .mappings()
+                .all()
+            )
+    finally:
+        sync_eng.dispose()
+    return [dict(row) for row in rows]
+
+
+def _insert_tenant_row(
+    sync_url: str,
+    *,
+    tenant_id: uuid.UUID,
+    slug: str,
+    name: str,
+) -> None:
+    """Insert one ``tenant`` row at a revision before the seed runs."""
+    sync_eng = sa_create_engine(sync_url)
+    now = datetime.now(UTC).isoformat()
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO tenant (id, slug, name, created_at)
+                    VALUES (:id, :slug, :name, :created_at)
+                    """,
+                ),
+                {
+                    "id": str(tenant_id),
+                    "slug": slug,
+                    "name": name,
+                    "created_at": now,
+                },
+            )
+    finally:
+        sync_eng.dispose()
+
+
+def _insert_convention_row(
+    sync_url: str,
+    *,
+    tenant_id: uuid.UUID,
+    slug: str,
+    title: str,
+    body: str,
+    created_by_sub: str,
+    priority: int = 0,
+    kind: str = "operational",
+) -> uuid.UUID:
+    """Insert one ``tenant_conventions`` row before the seed runs."""
+    sync_eng = sa_create_engine(sync_url)
+    convention_id = uuid.uuid4()
+    now = datetime.now(UTC).isoformat()
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO tenant_conventions (
+                        id, tenant_id, slug, title, body, kind, priority,
+                        created_by_sub, created_at, updated_at
+                    ) VALUES (
+                        :id, :tenant_id, :slug, :title, :body, :kind,
+                        :priority, :created_by_sub, :created_at,
+                        :updated_at
+                    )
+                    """,
+                ),
+                {
+                    "id": str(convention_id),
+                    "tenant_id": str(tenant_id),
+                    "slug": slug,
+                    "title": title,
+                    "body": body,
+                    "kind": kind,
+                    "priority": priority,
+                    "created_by_sub": created_by_sub,
+                    "created_at": now,
+                    "updated_at": now,
+                },
+            )
+    finally:
+        sync_eng.dispose()
+    return convention_id
+
+
+def _insert_history_row(
+    sync_url: str,
+    *,
+    convention_id: uuid.UUID,
+    body_before: str | None,
+    body_after: str,
+    actor_sub: str,
+) -> uuid.UUID:
+    """Insert one ``tenant_convention_history`` row before / after the seed."""
+    sync_eng = sa_create_engine(sync_url)
+    history_id = uuid.uuid4()
+    now = datetime.now(UTC).isoformat()
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO tenant_convention_history (
+                        id, convention_id, body_before, body_after,
+                        actor_sub, ts, audit_id
+                    ) VALUES (
+                        :id, :convention_id, :body_before, :body_after,
+                        :actor_sub, :ts, NULL
+                    )
+                    """,
+                ),
+                {
+                    "id": str(history_id),
+                    "convention_id": str(convention_id),
+                    "body_before": body_before,
+                    "body_after": body_after,
+                    "actor_sub": actor_sub,
+                    "ts": now,
+                },
+            )
+    finally:
+        sync_eng.dispose()
+    return history_id
+
+
+def test_seed_lands_tenant_and_eight_conventions(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``upgrade head`` from clean DB lands tenant + 8 conventions + 8 history rows.
+
+    Asserts the full acceptance contract from #317:
+
+    * Tenant ``rdc-internal`` exists.
+    * 8 conventions exist for that tenant, every one with
+      ``kind='operational'``.
+    * Slugs match the expected set verbatim.
+    * Every convention carries ``created_by_sub='migration:seed-rdc-conventions'``.
+    * Every convention has exactly one history row whose
+      ``body_before`` is NULL (CREATE event) and ``body_after`` matches
+      the convention's body.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    tenant_id = _fetch_tenant_id(sync_url, _TENANT_SLUG)
+    assert tenant_id is not None, "seed must create the rdc-internal tenant"
+
+    rows = _fetch_convention_rows(sync_url, tenant_id)
+    assert len(rows) == 8, f"expected 8 seeded conventions, got {len(rows)}"
+    assert {str(r["slug"]) for r in rows} == _EXPECTED_SLUGS
+    assert all(r["kind"] == "operational" for r in rows), (
+        "every seeded convention must carry kind='operational' per decision #4"
+    )
+    assert all(r["created_by_sub"] == _SEED_ACTOR_SUB for r in rows), (
+        "every seeded row must record the synthetic seed marker so G8 audit "
+        "queries can distinguish seed-vs-operator content"
+    )
+
+    # Every convention has exactly one CREATE-shape history row.
+    for row in rows:
+        history = _fetch_history_rows(sync_url, str(row["id"]))
+        assert len(history) == 1, (
+            f"expected exactly one CREATE history row for slug {row['slug']!r}, got {len(history)}"
+        )
+        h = history[0]
+        assert h["body_before"] is None, (
+            f"the CREATE history row for slug {row['slug']!r} must record body_before=NULL"
+        )
+        assert h["body_after"] == row["body"]
+        assert h["actor_sub"] == _SEED_ACTOR_SUB
+        assert h["audit_id"] is None, (
+            "the seed migration runs outside any HTTP request so the "
+            "history row's audit_id soft-FK has nothing to reference"
+        )
+
+
+def test_priority_tiers_match_documented_assignment(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """The three documented priority tiers are applied to the expected slugs.
+
+    ``docs/architecture/conventions-seed.md`` documents the priority
+    assignment:
+
+    * ``priority=100`` -- unrecoverable-breach rules (vault, secrets,
+      sensitive lab specifics).
+    * ``priority=50`` -- recoverable-but-costly rules (naming,
+      CLI-wrapper, destructive-ops-probe).
+    * ``priority=10`` -- aspirational rules (audit-trail,
+      approval-workflow).
+
+    This test couples to the contract (priorities documented in the
+    seed doc) so a regression in either the migration or the doc
+    surfaces here.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    tenant_id = _fetch_tenant_id(sync_url, _TENANT_SLUG)
+    assert tenant_id is not None
+    rows = _fetch_convention_rows(sync_url, tenant_id)
+    priority_by_slug = {str(r["slug"]): int(str(r["priority"])) for r in rows}
+
+    high_priority = {
+        "vault-canonical",
+        "secret-handling-discipline",
+        "sensitive-lab-specifics-stay-private",
+    }
+    medium_priority = {
+        "naming-rule-no-ai-tool-names",
+        "cli-wrapper-fallback-discipline",
+        "destructive-ops-probe-first",
+    }
+    low_priority = {
+        "audit-trail-discipline",
+        "approval-workflow-when-it-lands",
+    }
+
+    for slug in high_priority:
+        assert priority_by_slug[slug] == 100, (
+            f"slug {slug!r} should be priority=100 (unrecoverable breach tier)"
+        )
+    for slug in medium_priority:
+        assert priority_by_slug[slug] == 50, (
+            f"slug {slug!r} should be priority=50 (recoverable-but-costly tier)"
+        )
+    for slug in low_priority:
+        assert priority_by_slug[slug] == 10, (
+            f"slug {slug!r} should be priority=10 (aspirational tier)"
+        )
+
+
+def test_re_running_migration_is_idempotent(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """Re-running ``upgrade()`` against a seeded DB is a no-op.
+
+    The interesting assertion is the *narrower* "the migration's upsert
+    + ON CONFLICT DO NOTHING shape is filter-shaped, not stamp-shaped":
+    running ``upgrade()`` against an already-migrated DB is safe even
+    outside Alembic's revision gate. The test exercises that by
+    stamping back to 0017 and replaying upgrade -- the row count must
+    not change, and no duplicate history rows must land.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    tenant_id = _fetch_tenant_id(sync_url, _TENANT_SLUG)
+    assert tenant_id is not None
+
+    first_rows = _fetch_convention_rows(sync_url, tenant_id)
+    assert len(first_rows) == 8
+
+    # Replay -- stamp back to 0017 so the data path actually re-runs,
+    # then run the seed migration again.
+    command.stamp(cfg, "0017")
+    command.upgrade(cfg, "0018")
+
+    second_rows = _fetch_convention_rows(sync_url, tenant_id)
+    assert len(second_rows) == 8, (
+        "second invocation must not insert duplicate conventions -- "
+        "the ON CONFLICT (tenant_id, slug) DO NOTHING shape filters them out"
+    )
+    # The convention ids must be identical between the two passes --
+    # the existing rows survived and no fresh inserts landed.
+    assert {str(r["id"]) for r in first_rows} == {str(r["id"]) for r in second_rows}
+
+    # And no duplicate history rows landed -- the RETURNING-id gate in
+    # the migration's upgrade() skips the history write when the
+    # convention insert is skipped.
+    for row in second_rows:
+        history = _fetch_history_rows(sync_url, str(row["id"]))
+        assert len(history) == 1, (
+            f"second invocation must not duplicate history rows for slug "
+            f"{row['slug']!r}; got {len(history)} (expected 1)"
+        )
+
+
+def test_pre_existing_tenant_is_upserted_not_recreated(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """A tenant row authored manually pre-seed keeps its id; only name refreshes.
+
+    The migration uses ``ON CONFLICT (slug) DO UPDATE SET name =
+    EXCLUDED.name``, so an operator who manually created the
+    ``rdc-internal`` tenant (chassis-era bootstrap, prior dev
+    fixture) keeps their row's id. The conventions seed proceeds
+    against that pre-existing id.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0017")  # all tables created, no seed yet
+
+    pre_existing_id = uuid.uuid4()
+    _insert_tenant_row(
+        sync_url,
+        tenant_id=pre_existing_id,
+        slug=_TENANT_SLUG,
+        name="Operator's Custom Name",
+    )
+
+    command.upgrade(cfg, "head")
+
+    tenant_id = _fetch_tenant_id(sync_url, _TENANT_SLUG)
+    assert tenant_id == str(pre_existing_id), (
+        "the pre-existing tenant row's id must survive the upsert -- "
+        "ON CONFLICT (slug) DO UPDATE preserves the row, only refreshes name"
+    )
+
+    # The 8 conventions land against that pre-existing tenant id.
+    rows = _fetch_convention_rows(sync_url, str(pre_existing_id))
+    assert {str(r["slug"]) for r in rows} == _EXPECTED_SLUGS
+
+
+def test_operator_curated_convention_survives_seed(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """A convention an operator authored pre-seed under a seeded slug is preserved.
+
+    Contract: ``ON CONFLICT (tenant_id, slug) DO NOTHING`` -- the seed
+    never overwrites operator-authored content even when their slug
+    happens to collide with one the seed would write. The
+    operator-authored row's body, title, priority, and created_by_sub
+    survive verbatim. No synthetic seed history row is added because
+    the RETURNING-id gate yields nothing on the skipped insert.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0017")
+
+    operator_tenant_id = uuid.uuid4()
+    _insert_tenant_row(
+        sync_url,
+        tenant_id=operator_tenant_id,
+        slug=_TENANT_SLUG,
+        name="Operator Tenant",
+    )
+
+    operator_body = (
+        "Operator-curated override for the vault-canonical convention -- do not auto-rewrite."
+    )
+    operator_sub = "user:operator@example.com"
+    operator_convention_id = _insert_convention_row(
+        sync_url,
+        tenant_id=operator_tenant_id,
+        slug="vault-canonical",
+        title="Operator's title",
+        body=operator_body,
+        created_by_sub=operator_sub,
+        priority=42,
+    )
+
+    command.upgrade(cfg, "head")
+
+    # The operator's row survives unchanged.
+    rows = _fetch_convention_rows(sync_url, str(operator_tenant_id))
+    operator_row = next(r for r in rows if r["slug"] == "vault-canonical")
+    assert str(operator_row["id"]) == str(operator_convention_id), (
+        "operator-authored row id must survive -- ON CONFLICT DO NOTHING "
+        "skips the seed insert, the operator's row stays put"
+    )
+    assert operator_row["body"] == operator_body
+    assert operator_row["created_by_sub"] == operator_sub
+    assert int(str(operator_row["priority"])) == 42
+
+    # And no synthetic seed history row landed against the operator's
+    # convention -- the RETURNING-id gate yields zero rows when the
+    # insert was skipped, so the history-write branch never fires.
+    history = _fetch_history_rows(sync_url, str(operator_convention_id))
+    assert history == [], (
+        "no seed history row may land against an operator-authored "
+        "convention -- lying about the lineage of a row the operator owns"
+    )
+
+    # Sanity: the other 7 seeded conventions did land against the
+    # operator's tenant.
+    other_slugs = {str(r["slug"]) for r in rows} - {"vault-canonical"}
+    assert other_slugs == _EXPECTED_SLUGS - {"vault-canonical"}
+
+
+def test_downgrade_removes_seed_keeps_tenant_and_operator_history(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``downgrade "0017"`` removes seeded rows; tenant + operator edits survive.
+
+    Asserts the full reversibility contract:
+
+    * The 8 seeded conventions are removed.
+    * The seed-authored history rows are removed.
+    * The ``rdc-internal`` tenant row survives (other v0.2 features key
+      on tenant_id; cascading the delete would orphan that data).
+    * An operator-authored history row (against a seeded slug,
+      simulating a post-seed PATCH) survives the downgrade -- the
+      ``actor_sub`` narrowing in ``downgrade()`` keeps operator
+      history untouched.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    tenant_id_str = _fetch_tenant_id(sync_url, _TENANT_SLUG)
+    assert tenant_id_str is not None
+
+    rows_before_operator_edit = _fetch_convention_rows(sync_url, tenant_id_str)
+    target_row = next(r for r in rows_before_operator_edit if r["slug"] == "vault-canonical")
+
+    # Simulate an operator PATCH after the seed: write a second
+    # history row against the seeded convention. The downgrade must
+    # leave this row alone (it carries an operator JWT sub, not the
+    # seed marker).
+    operator_history_id = _insert_history_row(
+        sync_url,
+        convention_id=uuid.UUID(str(target_row["id"])),
+        body_before=str(target_row["body"]),
+        body_after="Operator's amended body",
+        actor_sub="user:operator@example.com",
+    )
+
+    command.downgrade(cfg, "0017")
+
+    # Tenant survives.
+    surviving_tenant_id = _fetch_tenant_id(sync_url, _TENANT_SLUG)
+    assert surviving_tenant_id == tenant_id_str, (
+        "rdc-internal tenant must survive downgrade -- other v0.2 "
+        "features key on tenant_id and dropping it would orphan data"
+    )
+
+    # Seeded convention rows are gone.
+    surviving_rows = _fetch_convention_rows(sync_url, tenant_id_str)
+    assert surviving_rows == [], "all 8 seed-authored conventions must be removed on downgrade"
+
+    # Operator-authored history row survived (under the deleted
+    # convention's id -- the soft-FK lets the row exist orphaned;
+    # the downgrade's narrowing predicate kept it because the
+    # actor_sub did not match the seed marker).
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            row = conn.execute(
+                text(
+                    """
+                    SELECT id FROM tenant_convention_history
+                    WHERE id = :id
+                    """,
+                ),
+                {"id": str(operator_history_id)},
+            ).first()
+    finally:
+        sync_eng.dispose()
+    assert row is not None, (
+        "operator-authored history row must survive downgrade -- the "
+        "actor_sub narrowing in downgrade() keeps operator content "
+        "untouched even when the parent convention was removed"
+    )
+
+
+def test_seed_conventions_fit_individual_token_budget(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """Each seeded body fits the individual 600-token write-time gate.
+
+    The T2 POST/PATCH route rejects a single ``operational`` body whose
+    estimated token cost exceeds
+    :data:`~meho_backplane.conventions.schemas.DEFAULT_MAX_PREAMBLE_TOKENS`.
+    The seed migration writes directly to the DB and bypasses the API
+    gate, but its bodies must still respect the budget so a future
+    PATCH against a seeded body (without changing the body itself)
+    doesn't trip 422 at validation time. This is a regression guard
+    on the seed prose.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    from meho_backplane.conventions.schemas import (
+        DEFAULT_MAX_PREAMBLE_TOKENS,
+        estimate_tokens,
+    )
+
+    tenant_id = _fetch_tenant_id(sync_url, _TENANT_SLUG)
+    assert tenant_id is not None
+    rows = _fetch_convention_rows(sync_url, tenant_id)
+
+    for row in rows:
+        body = str(row["body"])
+        estimated = estimate_tokens(body)
+        assert estimated <= DEFAULT_MAX_PREAMBLE_TOKENS, (
+            f"seeded body for slug {row['slug']!r} estimates "
+            f"{estimated} tokens, exceeding the per-entry budget of "
+            f"{DEFAULT_MAX_PREAMBLE_TOKENS}; a future PATCH against "
+            f"this slug would trip 422 at the API validation gate"
+        )

--- a/backend/tests/test_alembic_seed_rdc_conventions.py
+++ b/backend/tests/test_alembic_seed_rdc_conventions.py
@@ -205,7 +205,12 @@ def _insert_tenant_row(
                     """,
                 ),
                 {
-                    "id": str(tenant_id),
+                    # 32-char hex form mirrors SQLAlchemy's ``Uuid`` bind
+                    # processor for SQLite (``value.hex``); the seed
+                    # migration uses the same form via its ``_uuid_param``
+                    # helper so an ORM-issued FK lookup against the
+                    # seeded tenant matches bytewise.
+                    "id": tenant_id.hex,
                     "slug": slug,
                     "name": name,
                     "created_at": now,
@@ -246,8 +251,11 @@ def _insert_convention_row(
                     """,
                 ),
                 {
-                    "id": str(convention_id),
-                    "tenant_id": str(tenant_id),
+                    # 32-char hex form -- see ``_insert_tenant_row``
+                    # rationale above. Same store form as the ORM and
+                    # the seed migration's ``_uuid_param`` helper.
+                    "id": convention_id.hex,
+                    "tenant_id": tenant_id.hex,
                     "slug": slug,
                     "title": title,
                     "body": body,
@@ -290,8 +298,9 @@ def _insert_history_row(
                     """,
                 ),
                 {
-                    "id": str(history_id),
-                    "convention_id": str(convention_id),
+                    # 32-char hex -- same rationale as ``_insert_tenant_row``.
+                    "id": history_id.hex,
+                    "convention_id": convention_id.hex,
                     "body_before": body_before,
                     "body_after": body_after,
                     "actor_sub": actor_sub,
@@ -481,13 +490,13 @@ def test_pre_existing_tenant_is_upserted_not_recreated(
     command.upgrade(cfg, "head")
 
     tenant_id = _fetch_tenant_id(sync_url, _TENANT_SLUG)
-    assert tenant_id == str(pre_existing_id), (
+    assert tenant_id == pre_existing_id.hex, (
         "the pre-existing tenant row's id must survive the upsert -- "
         "ON CONFLICT (slug) DO UPDATE preserves the row, only refreshes name"
     )
 
     # The 8 conventions land against that pre-existing tenant id.
-    rows = _fetch_convention_rows(sync_url, str(pre_existing_id))
+    rows = _fetch_convention_rows(sync_url, pre_existing_id.hex)
     assert {str(r["slug"]) for r in rows} == _EXPECTED_SLUGS
 
 
@@ -531,9 +540,9 @@ def test_operator_curated_convention_survives_seed(
     command.upgrade(cfg, "head")
 
     # The operator's row survives unchanged.
-    rows = _fetch_convention_rows(sync_url, str(operator_tenant_id))
+    rows = _fetch_convention_rows(sync_url, operator_tenant_id.hex)
     operator_row = next(r for r in rows if r["slug"] == "vault-canonical")
-    assert str(operator_row["id"]) == str(operator_convention_id), (
+    assert str(operator_row["id"]) == operator_convention_id.hex, (
         "operator-authored row id must survive -- ON CONFLICT DO NOTHING "
         "skips the seed insert, the operator's row stays put"
     )
@@ -544,7 +553,7 @@ def test_operator_curated_convention_survives_seed(
     # And no synthetic seed history row landed against the operator's
     # convention -- the RETURNING-id gate yields zero rows when the
     # insert was skipped, so the history-write branch never fires.
-    history = _fetch_history_rows(sync_url, str(operator_convention_id))
+    history = _fetch_history_rows(sync_url, operator_convention_id.hex)
     assert history == [], (
         "no seed history row may land against an operator-authored "
         "convention -- lying about the lineage of a row the operator owns"
@@ -620,7 +629,7 @@ def test_downgrade_removes_seed_keeps_tenant_and_operator_history(
                     WHERE id = :id
                     """,
                 ),
-                {"id": str(operator_history_id)},
+                {"id": operator_history_id.hex},
             ).first()
     finally:
         sync_eng.dispose()

--- a/backend/tests/test_db_agent_run.py
+++ b/backend/tests/test_db_agent_run.py
@@ -90,12 +90,25 @@ async def _enable_sqlite_foreign_keys(session: AsyncSession) -> None:
 
 
 async def _seed_tenant(session: AsyncSession, *, slug: str = "rdc-internal") -> uuid.UUID:
-    """Insert a tenant row and return its UUID.
+    """Return the tenant row's id, inserting it on the first call.
 
     ``agent_run.tenant_id`` carries a real FK to :class:`Tenant`, so the
     per-test setup needs a parent tenant to avoid spurious
     ``IntegrityError`` under PRAGMA foreign_keys=ON.
+
+    The look-up-then-insert shape is load-bearing: migration ``0018``
+    seeds the ``rdc-internal`` tenant into the per-worker schema
+    template (:func:`tests.conftest._schema_template_db`), so a plain
+    ``session.add(Tenant(slug='rdc-internal', ...))`` would trip
+    ``UNIQUE constraint failed: tenant.slug``. Returning the seeded
+    row's id when the slug pre-exists keeps every existing caller
+    working without invasive per-test slug rewrites.
     """
+    existing: uuid.UUID | None = await session.scalar(
+        select(Tenant.id).where(Tenant.slug == slug),
+    )
+    if existing is not None:
+        return existing
     tenant_id = uuid.uuid4()
     session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
     await session.commit()

--- a/backend/tests/test_db_models.py
+++ b/backend/tests/test_db_models.py
@@ -111,6 +111,14 @@ async def test_tenant_round_trip_persists_every_field() -> None:
     slug, name, created_at — is what proves the ORM ``default=``
     machinery fires correctly under SQLite (the dev/test dialect
     where the migration's PG server defaults are no-ops).
+
+    The slug here is intentionally NOT ``rdc-internal``: migration
+    ``0018`` seeds that slug into the per-worker schema template
+    (:func:`tests.conftest._schema_template_db`), so this test would
+    trip ``UNIQUE constraint failed: tenant.slug`` if it tried to
+    insert a fresh tenant under that exact handle. A throwaway
+    fixture slug exercises the ORM contract this test owns without
+    coupling to a slug the seed migration claims.
     """
     sessionmaker = get_sessionmaker()
     tenant_id = uuid.uuid4()
@@ -119,8 +127,8 @@ async def test_tenant_round_trip_persists_every_field() -> None:
         session.add(
             Tenant(
                 id=tenant_id,
-                slug="rdc-internal",
-                name="RDC Internal Tenancy",
+                slug="round-trip-fixture",
+                name="Round Trip Tenant",
                 created_at=created_at,
             )
         )
@@ -131,8 +139,8 @@ async def test_tenant_round_trip_persists_every_field() -> None:
         row = result.scalar_one()
 
     assert row.id == tenant_id
-    assert row.slug == "rdc-internal"
-    assert row.name == "RDC Internal Tenancy"
+    assert row.slug == "round-trip-fixture"
+    assert row.name == "Round Trip Tenant"
     # SQLite stores datetimes as ISO-8601 strings without timezone
     # information; SQLAlchemy round-trips them as **naive**
     # ``datetime`` even when the column is declared

--- a/backend/tests/test_migration_rollback.py
+++ b/backend/tests/test_migration_rollback.py
@@ -470,6 +470,163 @@ class TestForwardCompatRollback:
 
 
 # ---------------------------------------------------------------------------
+# G7.1-T5 #317 — seed migration 0018 PG-side idempotency replay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason=_SKIP_REASON)
+class TestSeedRdcInternalConventionsPgIdempotency:
+    """Migration ``0018``'s upsert + ON CONFLICT shape is idempotent on real PG.
+
+    The always-on suite in :mod:`tests.test_alembic_seed_rdc_conventions`
+    proves the contract against SQLite (the dialect the per-test schema
+    template uses). PG has its own conflict-resolution semantics --
+    specifically the spec-conformant ``ON CONFLICT DO UPDATE`` /
+    ``DO NOTHING`` arbiter precedence -- so the same shape must replay
+    against an actual PG to lock in the cross-dialect guarantee.
+    Without this test the migration's "safe to re-run" promise rests
+    only on what SQLite tolerates.
+
+    Mirrors the testcontainers + ``alembic upgrade`` discipline
+    :class:`TestForwardCompatRollback` follows: spin up a PG container,
+    upgrade to ``head``, stamp back to ``0017``, upgrade to ``0018``
+    again, assert row counts are unchanged.
+    """
+
+    def test_seed_replay_against_pg_leaves_row_counts_unchanged(
+        self,
+        env_overrides: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Stamp 0017 + upgrade 0018 twice on real PG: tenant + 8 conventions, no dupes.
+
+        Test shape:
+
+        1. Spin up ``pgvector/pgvector:pg16`` and ``alembic upgrade
+           head`` -- this is the migration's first pass.
+        2. Read the post-first-pass counts:
+           ``tenant WHERE slug = 'rdc-internal'`` (must be 1), the
+           seeded ``tenant_conventions`` (must be 8), and the seeded
+           ``tenant_convention_history`` rows (must be 8 -- one
+           CREATE-shape row per convention).
+        3. Stamp back to ``0017`` (no data change), then ``upgrade
+           0018`` again -- this is the replay.
+        4. Re-read the same counts and assert they are unchanged.
+           A failing arbiter or a forgotten ``ON CONFLICT`` clause
+           would surface here as either an :class:`IntegrityError` on
+           the re-insert or as duplicated rows.
+
+        The test is synchronous for the same reason
+        :meth:`TestForwardCompatRollback.test_n_image_runs_cleanly_against_n_plus_1_schema`
+        is sync: ``alembic.command.upgrade`` invokes ``asyncio.run``
+        internally via the env.py async cookbook, so a
+        :func:`pytest.mark.asyncio` decoration would crash on re-entry.
+        Async work (the row-count read-backs) is wrapped in its own
+        ``asyncio.run`` boundary, the same idiom Alembic itself uses.
+        """
+        from testcontainers.postgres import PostgresContainer
+
+        image = os.environ.get("MEHO_TEST_PGVECTOR_IMAGE", "pgvector/pgvector:pg16")
+        with PostgresContainer(image) as pg:
+            sync_url = pg.get_connection_url()
+            async_url = _async_url_from(sync_url)
+
+            # Step 1 -- first ``upgrade head``. The seed migration
+            # runs as part of the chain.
+            monkeypatch.setenv("DATABASE_URL", async_url)
+            get_settings.cache_clear()
+            reset_engine_for_testing()
+
+            cfg = alembic_config()
+            cfg.set_main_option("sqlalchemy.url", async_url)
+            command.upgrade(cfg, "head")
+
+            first = asyncio.run(_fetch_seed_state(async_url))
+            assert first["tenant_count"] == 1, (
+                "first upgrade must land exactly one rdc-internal tenant row; "
+                f"got {first['tenant_count']}"
+            )
+            assert first["convention_count"] == 8, (
+                f"first upgrade must land 8 seeded conventions; got {first['convention_count']}"
+            )
+            assert first["history_count"] == 8, (
+                "first upgrade must land one CREATE-shape history row per "
+                f"seeded convention (8 total); got {first['history_count']}"
+            )
+
+            # Step 2 -- stamp back to 0017 so the seed migration's
+            # data path replays (a plain ``upgrade head`` against a
+            # DB already at head would be a no-op via Alembic's
+            # revision gate; stamping rewinds the revision pointer
+            # without touching data, then ``upgrade 0018`` re-runs
+            # the migration's actual ``upgrade()`` body).
+            command.stamp(cfg, "0017")
+            command.upgrade(cfg, "0018")
+
+            second = asyncio.run(_fetch_seed_state(async_url))
+            assert second["tenant_count"] == first["tenant_count"], (
+                "re-running 0018 must not duplicate the rdc-internal tenant -- "
+                "the ON CONFLICT (slug) DO UPDATE shape filters the second "
+                f"insert. Saw {first['tenant_count']} → {second['tenant_count']}."
+            )
+            assert second["convention_count"] == first["convention_count"], (
+                "re-running 0018 must not duplicate seeded conventions -- "
+                "the ON CONFLICT (tenant_id, slug) DO NOTHING shape filters "
+                f"the second pass. Saw {first['convention_count']} → "
+                f"{second['convention_count']}."
+            )
+            assert second["history_count"] == first["history_count"], (
+                "re-running 0018 must not duplicate history rows -- the "
+                "RETURNING-id gate in upgrade() skips the history write "
+                "when the convention insert was a no-op. Saw "
+                f"{first['history_count']} → {second['history_count']}."
+            )
+
+            asyncio.run(dispose_engine())
+            reset_engine_for_testing()
+
+
+async def _fetch_seed_state(async_url: str) -> dict[str, int]:
+    """Read the seeded row counts back through a short-lived engine.
+
+    Used by :class:`TestSeedRdcInternalConventionsPgIdempotency` -- a
+    fresh engine per call so the read is independent of any pool the
+    test may have already disposed.
+    """
+    engine = create_async_engine(async_url)
+    try:
+        async with engine.connect() as conn:
+            tenant_count = (
+                await conn.execute(
+                    text("SELECT COUNT(*) FROM tenant WHERE slug = 'rdc-internal'"),
+                )
+            ).scalar_one()
+            convention_count = (
+                await conn.execute(
+                    text(
+                        "SELECT COUNT(*) FROM tenant_conventions "
+                        "WHERE created_by_sub = 'migration:seed-rdc-conventions'",
+                    ),
+                )
+            ).scalar_one()
+            history_count = (
+                await conn.execute(
+                    text(
+                        "SELECT COUNT(*) FROM tenant_convention_history "
+                        "WHERE actor_sub = 'migration:seed-rdc-conventions'",
+                    ),
+                )
+            ).scalar_one()
+    finally:
+        await engine.dispose()
+    return {
+        "tenant_count": int(tenant_count),
+        "convention_count": int(convention_count),
+        "history_count": int(history_count),
+    }
+
+
+# ---------------------------------------------------------------------------
 # Always-on smoke — proves the synthetic-migration helper imports cleanly
 # even on no-Docker sandboxes, so a typo / syntax error surfaces fast in CI
 # without the full PG suite running.

--- a/backend/tests/test_tenancy_ensure.py
+++ b/backend/tests/test_tenancy_ensure.py
@@ -175,13 +175,19 @@ async def test_ensure_tenant_does_not_overwrite_existing_row() -> None:
     human-chosen slug / name. ``ensure_tenant`` must no-op on the
     conflict, never clobber the operator's values back to the derived
     placeholder.
+
+    A throwaway slug (not ``rdc-internal``) keeps this test independent
+    of migration ``0018``'s seeded row in the per-worker schema template
+    (:func:`tests.conftest._schema_template_db`); the contract under
+    test -- that an operator-named row survives -- is the same
+    regardless of which slug carries the human label.
     """
     tenant_id = uuid.uuid4()
     sessionmaker = get_sessionmaker()
 
     async with sessionmaker() as session, session.begin():
         session.add(
-            Tenant(id=tenant_id, slug="rdc-internal", name="RDC Internal"),
+            Tenant(id=tenant_id, slug="operator-named", name="Operator Named"),
         )
 
     async with sessionmaker() as session, session.begin():
@@ -189,5 +195,5 @@ async def test_ensure_tenant_does_not_overwrite_existing_row() -> None:
 
     async with sessionmaker() as session:
         row = (await session.execute(select(Tenant).where(Tenant.id == tenant_id))).scalars().one()
-    assert row.slug == "rdc-internal"
-    assert row.name == "RDC Internal"
+    assert row.slug == "operator-named"
+    assert row.name == "Operator Named"

--- a/backend/tests/test_topology_annotate.py
+++ b/backend/tests/test_topology_annotate.py
@@ -86,10 +86,21 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 
 async def _seed_tenant(slug: str = "rdc-internal") -> uuid.UUID:
-    """Insert one ``tenant`` row and return its id."""
+    """Return the tenant row's id, inserting it on the first call.
+
+    Look-up-then-insert -- migration ``0018`` seeds the ``rdc-internal``
+    tenant into the per-worker schema template
+    (:func:`tests.conftest._schema_template_db`); a plain INSERT would
+    trip ``UNIQUE constraint failed: tenant.slug``.
+    """
     sessionmaker = get_sessionmaker()
-    tenant_id = uuid.uuid4()
     async with sessionmaker() as session:
+        existing: uuid.UUID | None = await session.scalar(
+            select(Tenant.id).where(Tenant.slug == slug),
+        )
+        if existing is not None:
+            return existing
+        tenant_id = uuid.uuid4()
         session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
         await session.commit()
     return tenant_id

--- a/backend/tests/test_topology_bulk_import.py
+++ b/backend/tests/test_topology_bulk_import.py
@@ -68,9 +68,21 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 
 async def _seed_tenant(slug: str = "rdc-internal") -> uuid.UUID:
+    """Return the tenant row's id, inserting it on the first call.
+
+    Look-up-then-insert -- migration ``0018`` seeds the ``rdc-internal``
+    tenant into the per-worker schema template
+    (:func:`tests.conftest._schema_template_db`); a plain INSERT would
+    trip ``UNIQUE constraint failed: tenant.slug``.
+    """
     sessionmaker = get_sessionmaker()
-    tenant_id = uuid.uuid4()
     async with sessionmaker() as session:
+        existing: uuid.UUID | None = await session.scalar(
+            select(Tenant.id).where(Tenant.slug == slug),
+        )
+        if existing is not None:
+            return existing
+        tenant_id = uuid.uuid4()
         session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
         await session.commit()
     return tenant_id

--- a/backend/tests/test_topology_create_node.py
+++ b/backend/tests/test_topology_create_node.py
@@ -81,10 +81,22 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 
 async def _seed_tenant(slug: str = "rdc-internal") -> uuid.UUID:
-    """Insert one ``tenant`` row and return its id."""
+    """Return the tenant row's id, inserting it on the first call.
+
+    The look-up-then-insert shape is load-bearing: migration ``0018``
+    seeds the ``rdc-internal`` tenant into the per-worker schema
+    template (:func:`tests.conftest._schema_template_db`), so a plain
+    ``session.add(Tenant(slug='rdc-internal', ...))`` would trip
+    ``UNIQUE constraint failed: tenant.slug``.
+    """
     sessionmaker = get_sessionmaker()
-    tenant_id = uuid.uuid4()
     async with sessionmaker() as session:
+        existing: uuid.UUID | None = await session.scalar(
+            select(Tenant.id).where(Tenant.slug == slug),
+        )
+        if existing is not None:
+            return existing
+        tenant_id = uuid.uuid4()
         session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
         await session.commit()
     return tenant_id

--- a/backend/tests/test_topology_history_hook.py
+++ b/backend/tests/test_topology_history_hook.py
@@ -169,19 +169,31 @@ def _register_fake() -> None:
 
 
 async def _seed_tenant_and_target(slug: str = "rdc-internal") -> tuple[uuid.UUID, Target]:
-    """Insert one tenant + one target for it."""
+    """Insert one tenant + one target for it.
+
+    Look-up-then-insert on the tenant -- migration ``0018`` seeds the
+    ``rdc-internal`` tenant into the per-worker schema template
+    (:func:`tests.conftest._schema_template_db`); a plain INSERT would
+    trip ``UNIQUE constraint failed: tenant.slug``.
+    """
     sessionmaker = get_sessionmaker()
-    tenant_id = uuid.uuid4()
-    target = Target(
-        id=uuid.uuid4(),
-        tenant_id=tenant_id,
-        name=f"vcenter-{slug}",
-        aliases=[],
-        product="faketopo",
-        host="vc.example.test",
-    )
     async with sessionmaker() as session:
-        session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+        existing: uuid.UUID | None = await session.scalar(
+            select(Tenant.id).where(Tenant.slug == slug),
+        )
+        if existing is not None:
+            tenant_id = existing
+        else:
+            tenant_id = uuid.uuid4()
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+        target = Target(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            name=f"vcenter-{slug}",
+            aliases=[],
+            product="faketopo",
+            host="vc.example.test",
+        )
         session.add(target)
         await session.commit()
         await session.refresh(target)

--- a/backend/tests/test_topology_history_integration.py
+++ b/backend/tests/test_topology_history_integration.py
@@ -201,19 +201,31 @@ def _register_fake() -> None:
 
 
 async def _seed_tenant_and_target(slug: str) -> tuple[uuid.UUID, Target]:
-    """Insert one tenant + one target for it, returning both."""
+    """Insert one tenant + one target for it, returning both.
+
+    Look-up-then-insert on the tenant -- migration ``0018`` seeds the
+    ``rdc-internal`` tenant into the per-worker schema template
+    (:func:`tests.conftest._schema_template_db`); a plain INSERT would
+    trip ``UNIQUE constraint failed: tenant.slug``.
+    """
     sessionmaker = get_sessionmaker()
-    tenant_id = uuid.uuid4()
-    target = Target(
-        id=uuid.uuid4(),
-        tenant_id=tenant_id,
-        name=f"vcenter-{slug}",
-        aliases=[],
-        product="faketopo",
-        host="vc.example.test",
-    )
     async with sessionmaker() as session:
-        session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+        existing: uuid.UUID | None = await session.scalar(
+            select(Tenant.id).where(Tenant.slug == slug),
+        )
+        if existing is not None:
+            tenant_id = existing
+        else:
+            tenant_id = uuid.uuid4()
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+        target = Target(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            name=f"vcenter-{slug}",
+            aliases=[],
+            product="faketopo",
+            host="vc.example.test",
+        )
         session.add(target)
         await session.commit()
         await session.refresh(target)

--- a/backend/tests/test_topology_history_migration.py
+++ b/backend/tests/test_topology_history_migration.py
@@ -114,12 +114,23 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 
 async def _seed_tenant(session: AsyncSession, *, slug: str = "rdc-internal") -> uuid.UUID:
-    """Insert a tenant row and return its UUID.
+    """Return the tenant row's id, inserting it on the first call.
 
     Every :class:`GraphNodeHistory` / :class:`GraphEdgeHistory` carries
     a real FK to :class:`Tenant`, so the per-test setup needs a parent
     tenant. Mirrors :func:`tests.test_topology_schema._seed_tenant`.
+
+    The look-up-then-insert shape is load-bearing: migration ``0018``
+    seeds the ``rdc-internal`` tenant into the per-worker schema
+    template (:func:`tests.conftest._schema_template_db`), so a plain
+    ``session.add(Tenant(slug='rdc-internal', ...))`` would trip
+    ``UNIQUE constraint failed: tenant.slug``.
     """
+    existing: uuid.UUID | None = await session.scalar(
+        select(Tenant.id).where(Tenant.slug == slug),
+    )
+    if existing is not None:
+        return existing
     tenant_id = uuid.uuid4()
     session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
     await session.commit()

--- a/backend/tests/test_topology_refresh.py
+++ b/backend/tests/test_topology_refresh.py
@@ -120,19 +120,31 @@ def _register_fake() -> None:
 
 
 async def _seed_tenant_and_target(slug: str = "rdc-internal") -> tuple[uuid.UUID, Target]:
-    """Insert one tenant + one target for it; return ``(tenant_id, target)``."""
+    """Insert one tenant + one target for it; return ``(tenant_id, target)``.
+
+    Look-up-then-insert on the tenant -- migration ``0018`` seeds the
+    ``rdc-internal`` tenant into the per-worker schema template
+    (:func:`tests.conftest._schema_template_db`); a plain INSERT would
+    trip ``UNIQUE constraint failed: tenant.slug``.
+    """
     sessionmaker = get_sessionmaker()
-    tenant_id = uuid.uuid4()
-    target = Target(
-        id=uuid.uuid4(),
-        tenant_id=tenant_id,
-        name=f"vcenter-{slug}",
-        aliases=[],
-        product="faketopo",
-        host="vc.example.test",
-    )
     async with sessionmaker() as session:
-        session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+        existing: uuid.UUID | None = await session.scalar(
+            select(Tenant.id).where(Tenant.slug == slug),
+        )
+        if existing is not None:
+            tenant_id = existing
+        else:
+            tenant_id = uuid.uuid4()
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+        target = Target(
+            id=uuid.uuid4(),
+            tenant_id=tenant_id,
+            name=f"vcenter-{slug}",
+            aliases=[],
+            product="faketopo",
+            host="vc.example.test",
+        )
         session.add(target)
         await session.commit()
         await session.refresh(target)

--- a/backend/tests/test_topology_schema.py
+++ b/backend/tests/test_topology_schema.py
@@ -113,7 +113,7 @@ def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 
 async def _seed_tenant(session: AsyncSession, *, slug: str = "rdc-internal") -> uuid.UUID:
-    """Insert a tenant row and return its UUID.
+    """Return the tenant row's id, inserting it on the first call.
 
     Every :class:`GraphNode` / :class:`GraphEdge` carries a real FK to
     :class:`Tenant`, so the per-test setup needs a parent tenant to
@@ -121,7 +121,18 @@ async def _seed_tenant(session: AsyncSession, *, slug: str = "rdc-internal") -> 
     or NULL-violation traps from a stale FK target. The slug is
     parameterised so the cross-tenant tests can seed two distinct
     parents.
+
+    The look-up-then-insert shape is load-bearing: migration ``0018``
+    seeds the ``rdc-internal`` tenant into the per-worker schema
+    template (:func:`tests.conftest._schema_template_db`), so a plain
+    ``session.add(Tenant(slug='rdc-internal', ...))`` would trip
+    ``UNIQUE constraint failed: tenant.slug``.
     """
+    existing: uuid.UUID | None = await session.scalar(
+        select(Tenant.id).where(Tenant.slug == slug),
+    )
+    if existing is not None:
+        return existing
     tenant_id = uuid.uuid4()
     session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
     await session.commit()

--- a/docs/architecture/conventions-seed.md
+++ b/docs/architecture/conventions-seed.md
@@ -1,0 +1,112 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# Tenant conventions seed (`rdc-internal`)
+
+> Sister to [docs/codebase/tenant_conventions.md](../codebase/tenant_conventions.md) -- that doc owns the table shape, ORM models, and CRUD control flow; this doc owns the one-shot seed migration that populates the `rdc-internal` tenant with the 8 operational conventions extracted from the consumer's `CLAUDE.md` per [decision #4](../planning/v0.2-decisions.md).
+>
+> Covers the implementation that landed under [Initiative #229 G7.1](https://github.com/evoila/meho/issues/229), Task [#317 G7.1-T5](https://github.com/evoila/meho/issues/317).
+
+## What the seed does
+
+The seed migration [`backend/alembic/versions/0018_seed_rdc_internal_conventions.py`](../../backend/alembic/versions/0018_seed_rdc_internal_conventions.py) is a **data migration only** -- it adds no schema. The two tables it writes to (`tenant_conventions` and `tenant_convention_history`) were created by [T1 #313](../../backend/alembic/versions/0015_create_tenant_conventions.py).
+
+On `upgrade head` the migration:
+
+1. **Upserts** the `rdc-internal` tenant row (`INSERT ... ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name`). If an operator manually created the row before the migration ran, its `id` is preserved and only the display name refreshes.
+2. **Inserts 8 `operational` conventions** for that tenant (`INSERT ... ON CONFLICT (tenant_id, slug) DO NOTHING`). Operator-authored rows under the same slug take precedence over the seed body -- the migration never overwrites a curated convention.
+3. **Inserts one CREATE-shape history row per seeded convention** (`body_before=NULL`, `body_after=<seed body>`, `actor_sub='migration:seed-rdc-conventions'`, `audit_id=NULL`). The history row is only written when the convention insert actually landed, so already-curated rows don't get a spurious "seed" entry in their edit trail.
+
+On `downgrade` the migration removes the 8 seeded conventions and their matching history rows, but **leaves the `rdc-internal` tenant intact** -- other v0.2 features key on `tenant_id` and dropping the tenant would orphan that data.
+
+## Why decision #4
+
+[Decision #4](../planning/v0.2-decisions.md#4-g7-server-side-partition--operational-rules-only) draws the partition between the consumer's `CLAUDE.md` content that migrates to server-side conventions (Layer 1, this seed) and the content that stays in the consumer's repo. The principle: **operational rules** bind any session against the tenant regardless of where it runs (Slack agent, MCP client, CLI on a different machine); **repo-internal rules** apply only to repo work and have a filesystem of their own.
+
+Migrated to `rdc-internal` tenant conventions (this seed):
+
+- Vault canonical + 1Password residual
+- Naming rule -- no `claude` / AI-tool names in operator-visible identifiers
+- Secret-handling discipline (never paste into chat, never commit secrets)
+- CLI-wrapper fallback discipline during MEHO transition
+- Sensitive-lab-specifics-stay-private (no real hostnames/IPs in public repo)
+
+Not migrated (stay in repo `CLAUDE.md`):
+
+- `/work-ticket` flow + ticket+PR discipline
+- Markdown-sidecar convention for OpenAPI specs
+- PR cadence rules
+- Repo-internal naming for branches / commits
+
+The seed extends decision #4's five-rule list with three additional **operational** rules pulled from cross-team operating practice (destructive-ops probe, audit-trail discipline, approval workflow). These were called out as in-scope by [issue #317](https://github.com/evoila/meho/issues/317)'s context section -- they share the "binds any session, regardless of where it runs" property decision #4 keys on.
+
+## Slug -> source paragraph mapping
+
+The 8 seeded slugs and the source paragraphs they migrate from. Source refers to [`evoila-bosnia/claude-rdc-hetzner-dc/CLAUDE.md`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/CLAUDE.md) except where noted.
+
+| Slug | Title | Source |
+|---|---|---|
+| `vault-canonical` | Vault is canonical for secrets | `CLAUDE.md` "Secrets" section -- the canonical-vs-residual partition and the pipe-don't-paste discipline. |
+| `naming-rule-no-ai-tool-names` | No AI-tool names in operator-visible identifiers | `CLAUDE.md` "Naming rule" section -- the prohibition on AI-tool tokens in operator-visible identifiers + the Holodeck `claude`-legacy carve-out. |
+| `secret-handling-discipline` | Secret-handling discipline | `CLAUDE.md` "Secrets" + "How to work with secrets" sections -- the "never enter chat / commit / PR" envelope + the rotation-on-leak path. |
+| `cli-wrapper-fallback-discipline` | CLI wrapper fallback during MEHO transition | v0.2 transition rules (cross-team operating practice during the chassis -> MEHO transition window). |
+| `destructive-ops-probe-first` | Probe before destructive ops | Cross-team operating practice -- the dependents-check + ticket-document + team-confirm sequence operators apply before destructive ops on shared targets. |
+| `audit-trail-discipline` | Document findings as you go | Cross-team operating practice -- the kb-as-investigation-record discipline. Forward-looking on `meho kb write` (G4); falls back to local `kb/` until G4 lands. |
+| `sensitive-lab-specifics-stay-private` | Sensitive lab specifics stay private | `CLAUDE.md` "Sensitive lab specifics stay private" section -- the public/private repo partition + the sanitised-examples rule. |
+| `approval-workflow-when-it-lands` | Approval workflow expectations | Forward-looking placeholder for v0.2.next G-Policy. Captures the team-norm operate-by-discussion shape until approval-workflow lands. |
+
+## Priority assignment
+
+[T4 #316](https://github.com/evoila/meho/issues/316)'s preamble assembler packs `kind='operational'` conventions **highest-priority-first** into a 600-token budget; over-budget entries are dropped whole (never mid-entry truncation of an operational rule). The seed assigns three priority tiers that reflect operator safety ranking:
+
+| Priority | Tier | Conventions | Rationale |
+|---|---|---|---|
+| **100** | Unrecoverable breach | `vault-canonical`, `secret-handling-discipline`, `sensitive-lab-specifics-stay-private` | Breach is unrecoverable in the operator-time sense: rotated secret or compromised tenant or leaked specifics on a public repo. Must reach every session even when the budget is tight. |
+| **50** | Recoverable but costly | `naming-rule-no-ai-tool-names`, `cli-wrapper-fallback-discipline`, `destructive-ops-probe-first` | Breach is recoverable but costly: incoherent target identifiers; deleted-wrapper-with-no-`meho`-replacement; collision on a destructive op. Important but acceptable to drop when the budget is tight. |
+| **10** | Aspirational / forward-looking | `audit-trail-discipline`, `approval-workflow-when-it-lands` | Forward-looking; the enforcement substrate either lands in G4 (`meho kb write`) or is not yet built (G-Policy approval workflow). Drop first when the budget overflows because the rule cannot yet be enforced in v0.2 even if the agent reads it. |
+
+The total estimated token cost of all 8 conventions packed together is approximately **671 tokens** (sum of `ceil(len(body) / 3.3)` per `meho_backplane.conventions.schemas.estimate_tokens`), which slightly exceeds the 600-token default budget. T4's priority-ranked packer will drop one or both of the priority-10 conventions when packing the full seed against an untouched budget -- this is the intended behaviour and the reason the priority tiers exist. The acceptance contract on [#317](https://github.com/evoila/meho/issues/317) explicitly allows "all 8 titles + bodies (or truncated subset if over budget)" in the assembled preamble.
+
+Operators can re-rank individual conventions via the `PATCH /api/v1/conventions/{slug}` route (T2) once the seed has landed -- the seed sets initial priorities, not immutable ones.
+
+## Idempotency
+
+Re-running the migration is a no-op for already-seeded data:
+
+- The tenant `ON CONFLICT (slug) DO UPDATE` rewrites `name` to the same string the previous pass wrote.
+- The convention `ON CONFLICT (tenant_id, slug) DO NOTHING` skips every already-present row.
+- The history-row insert is gated on the conventions `RETURNING id` result -- only convention inserts that actually landed produce a history row.
+
+This matters for the test suite (the upgrade -> downgrade -> upgrade replay in [`backend/tests/test_alembic_seed_rdc_conventions.py`](../../backend/tests/test_alembic_seed_rdc_conventions.py)) and for the testcontainers PG replay cycle in [`backend/tests/test_migration_rollback.py`](../../backend/tests/test_migration_rollback.py).
+
+## Reversibility
+
+`downgrade()` removes the 8 seeded convention rows and their matching history rows, narrowed on `created_by_sub='migration:seed-rdc-conventions'` and `actor_sub='migration:seed-rdc-conventions'` respectively. The narrowing means:
+
+- A convention an operator authored under the same slug **before** the seed ran (and the seed skipped via `ON CONFLICT DO NOTHING`) survives the downgrade -- its `created_by_sub` carries the operator's JWT `sub`, not the seed marker.
+- A history entry the operator wrote against a seeded convention (via the T2 PATCH route) survives the downgrade -- its `actor_sub` carries the operator's JWT `sub`, not the seed marker.
+
+The `rdc-internal` tenant row is intentionally preserved on downgrade. Other v0.2 features (targets, audit rows, broadcast overrides, agent definitions) key on `tenant_id`; deleting the tenant would invisibly orphan that data even though the soft-FK discipline means no DB-level CASCADE would fire.
+
+## How to add new seeded conventions
+
+This migration is a **one-shot** seed -- new conventions land via the T2 API (or T3 CLI when it ships under [#315](https://github.com/evoila/meho/issues/315)), not by amending this file. A follow-up migration that needs to add a seeded convention should:
+
+1. Land its own new revision (e.g. `0019_seed_<convention>.py`) following the same upsert-or-skip discipline this migration established.
+2. Read the existing `rdc-internal` tenant id via `SELECT id FROM tenant WHERE slug = 'rdc-internal'` rather than inserting a duplicate tenant.
+3. Use the same `_SEED_ACTOR_SUB` synthetic marker (or a fresh one specific to that migration) so the downgrade predicate can be narrowed.
+4. Update the table in this doc to reflect the new slug + priority + source mapping.
+
+The reason for one-shot vs amend-and-replay: an operator who edited a seeded body post-seed should keep their edit. Re-running an amended seed migration cannot distinguish "operator hadn't gotten around to it" from "operator deliberately reverted to a different body" -- the `ON CONFLICT DO NOTHING` shape lets the operator's intent win every time.
+
+## References
+
+- Parent Initiative: [#229](https://github.com/evoila/meho/issues/229) (G7.1 tenant conventions + Layer 2 starter).
+- This task: [#317](https://github.com/evoila/meho/issues/317) (G7.1-T5 seed migration).
+- Companion docs:
+  - [`docs/codebase/tenant_conventions.md`](../codebase/tenant_conventions.md) -- schema + API + ORM detail.
+  - [`docs/planning/v0.2-decisions.md`](../planning/v0.2-decisions.md) -- decision #4 (the G7 server-side partition).
+- Source `CLAUDE.md`: [`evoila-bosnia/claude-rdc-hetzner-dc`](https://github.com/evoila-bosnia/claude-rdc-hetzner-dc/blob/main/CLAUDE.md) -- the operational paragraphs the seed migrates.
+- Prior-art data migration: [`backend/alembic/versions/0011_backfill_operation_group_when_to_use.py`](../../backend/alembic/versions/0011_backfill_operation_group_when_to_use.py) -- the self-contained `sa.table` shim discipline this migration mirrors.

--- a/docs/architecture/conventions-seed.md
+++ b/docs/architecture/conventions-seed.md
@@ -71,6 +71,30 @@ The total estimated token cost of all 8 conventions packed together is approxima
 
 Operators can re-rank individual conventions via the `PATCH /api/v1/conventions/{slug}` route (T2) once the seed has landed -- the seed sets initial priorities, not immutable ones.
 
+## Audit-trace join semantics (G8)
+
+Seed-authored history rows carry `audit_id = NULL` (the migration runs outside any HTTP request, so there is no `audit_log` row to point at). Any G8 audit-replay or audit-trace query that joins `tenant_convention_history` to `audit_log` **must use `LEFT JOIN`** -- an `INNER JOIN` silently drops every seeded history row from the result set.
+
+Operator-authored edits (PATCH via [T2 #314](https://github.com/evoila/meho/issues/314)'s API) carry a real `audit_id` and join cleanly under either shape, so the gap only shows up against seeded slugs whose history has never been touched by an operator.
+
+Recommended query template:
+
+```sql
+SELECT h.id,
+       h.convention_id,
+       h.actor_sub,
+       h.ts,
+       a.method,    -- NULL on seeded rows
+       a.path,      -- NULL on seeded rows
+       a.operator_sub  -- NULL on seeded rows; h.actor_sub carries the seed marker
+FROM tenant_convention_history h
+LEFT JOIN audit_log a ON a.id = h.audit_id
+WHERE h.convention_id = :convention_id
+ORDER BY h.ts ASC;
+```
+
+The `actor_sub = 'migration:seed-rdc-conventions'` row reliably identifies seeded history entries even when the `audit_log` columns come back `NULL`, so callers can distinguish "seeded, no audit trail" from "operator edit, audit row was somehow pruned".
+
 ## Idempotency
 
 Re-running the migration is a no-op for already-seeded data:


### PR DESCRIPTION
## Summary
- Adds Alembic migration 0018 -- a data migration (no schema changes) that seeds the `rdc-internal` tenant and 8 operational conventions extracted from the consumer's `CLAUDE.md` per decision #4 of v0.2 planning.
- Without this seed the T4 (#316) preamble assembler returns empty for `rdc-internal`; the MCP `initialize` response carries no tenant-specific operating discipline. This migration is the one-shot that turns G7.1's conventions feature into a usable thing for the first tenant.
- Idempotent (`ON CONFLICT (slug) DO UPDATE` for tenant; `ON CONFLICT (tenant_id, slug) DO NOTHING` for conventions), reversible (downgrade removes the 8 seeded rows but preserves the tenant + operator-authored history), and self-contained (raw `sa.text` statements with parameterised binds, no ORM imports -- same discipline migration `0011` follows).

## What lands
- `backend/alembic/versions/0018_seed_rdc_internal_conventions.py` -- the data migration.
- `docs/architecture/conventions-seed.md` -- slug -> source paragraph mapping table, priority tier rationale, idempotency + reversibility contract, G8 audit-trace LEFT-JOIN callout.
- `backend/tests/test_alembic_seed_rdc_conventions.py` -- 7 behavioural tests covering: clean-DB seed lands tenant + 8 conventions + 8 CREATE-shape history rows; the three documented priority tiers (100 / 50 / 10); idempotency under stamp + replay; pre-existing tenant is upserted, not recreated; operator-curated convention survives `ON CONFLICT DO NOTHING`; downgrade keeps the tenant + operator history; every seeded body fits the 600-token per-entry budget.

## Test plan
- [x] `ruff check backend/alembic/versions/0018_seed_rdc_internal_conventions.py backend/tests/test_alembic_seed_rdc_conventions.py` -- clean
- [x] `ruff format --check ...` -- clean
- [x] `mypy backend/src/meho_backplane/ backend/alembic/versions/0018_seed_rdc_internal_conventions.py` -- clean
- [x] `mypy backend/tests/test_alembic_seed_rdc_conventions.py` -- clean
- [x] `python3 .claude/hooks/code-quality.py --diff` -- exit 0
- [x] `pytest tests/test_alembic_seed_rdc_conventions.py` -- 7 passed
- [x] `pytest tests/test_migration_0011_backfill_when_to_use.py tests/test_alembic_probe.py tests/test_api_v1_conventions.py tests/test_alembic_seed_rdc_conventions.py` -- 60 passed (no regression in sibling migration tests or API tests)
- [x] Acceptance: migration creates `rdc-internal` tenant if missing -- covered by `test_seed_lands_tenant_and_eight_conventions` + `test_pre_existing_tenant_is_upserted_not_recreated`
- [x] Acceptance: migration inserts 8 conventions for `rdc-internal` -- covered by `test_seed_lands_tenant_and_eight_conventions`
- [x] Acceptance: idempotent (re-running doesn't error or duplicate) -- covered by `test_re_running_migration_is_idempotent`
- [x] Acceptance: `docs/architecture/conventions-seed.md` lists the slug -> source mapping -- shipped
- [x] Acceptance: every seeded body fits the per-entry preamble budget -- covered by `test_seed_conventions_fit_individual_token_budget`

## Stay-in-lane
- Touches only the 3 new files listed above, plus the test-helper sweep landed in iteration 2 below (see Follow-up section). Does not modify T1's `0015_create_tenant_conventions.py` migration or any file under `backend/src/meho_backplane/conventions/` (T4's lane, in parallel).
- Does not modify `AGENTS.md` or `CLAUDE.md`.

## Out of scope
- T4 (#316) preamble assembler integration test (sibling task; this PR just provides the data the assembler reads).
- Bulk-import-from-Markdown-files feature.
- Seeding any tenant other than `rdc-internal` (future tenants seed via the T2 API).
- Cross-repo review by the consumer (`claude-rdc-hetzner-dc`) -- acceptance criterion calls this out as a post-merge step.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #317

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-25)

Addressed review findings from `.claude/auto/review-results/pr-1045-iter-1.json`:

- **B1** `36744f5` -- swept `_seed_tenant` / `_seed_tenant_and_target` helpers across 14 test files to look-up-then-insert the tenant by slug (returns the seeded `rdc-internal` row when present), fixing `UNIQUE constraint failed: tenant.slug` across the whole backend suite. Two tests that genuinely needed a fresh `rdc-internal` insert (`test_db_models.py`, `test_tenancy_ensure.py`) switched to throwaway fixture slugs since the contract under test was the Tenant model itself, not the seeded slug. Also fixed a latent UUID-format bug in the migration's `_uuid_param`: SQLAlchemy's `Uuid` column stores UUIDs in 32-char hex on SQLite (`value.hex`), but the migration was writing the 36-char canonical form (`str(value)`), so ORM-issued FK lookups against the seeded tenant failed bytewise once the per-test schema template started embedding it. Migration now uses `value.hex` to match the ORM's storage shape; the in-PR seed test mirror helpers were updated to the same form so their operator-curated scenarios stay consistent.
- **M1** `059f247` -- added a testcontainers PG-backed idempotency test in `test_migration_rollback.py::TestSeedRdcInternalConventionsPgIdempotency`: spins up `pgvector/pgvector:pg16`, runs `alembic upgrade head`, stamps back to `0017`, upgrades to `0018` again, and asserts the seeded row counts (1 tenant + 8 conventions + 8 history rows) are unchanged. Skipped on sandboxes without Docker; runs in CI where containers are provisioned.
- **M2** `36744f5` -- added a G8 audit-trace LEFT-JOIN callout in both the migration docstring and `docs/architecture/conventions-seed.md`. Seeded history rows carry `audit_id=NULL` (the migration runs outside any HTTP request); queries joining `tenant_convention_history` to `audit_log` must use `LEFT JOIN` -- `INNER JOIN` would silently drop the seeded rows from the audit-replay view.
- **m1** `36744f5` -- restored Unicode em-dashes (`—`) and `≥` in the 8 seed convention bodies so the prose matches the verbatim form on issue #317. Postgres TEXT and SQLite both handle the Unicode characters fine.
- **m2** `36744f5` -- removed the build-and-discard `sa.table` factory helpers and the `_ = (...)` shim assignments; saves ~55 lines without changing the migration's behaviour. The cited prior-art migration `0011` doesn't carry the pattern either.

<!-- auto-implement-issue: continue, iteration 2 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Database initialization now automatically seeds an operational tenant with 8 pre-configured conventions, with idempotent migration and safe rollback support.

* **Documentation**
  * Added migration specification documenting seed behavior, conventions, and priority assignment.

* **Chores**
  * Added comprehensive database migration validation tests ensuring idempotency and correct rollback across platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1045?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->