### PR TITLE
feat(conventions): G7.1-T3 CLI verbs — meho conventions list/show/create/edit/delete/history

### DIFF
--- a/cli/internal/cmd/conventions/conventions.go
+++ b/cli/internal/cmd/conventions/conventions.go
@@ -1,0 +1,538 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package conventions hosts the cobra commands under `meho conventions ...`
+// for G7.1-T3 (#315) of Initiative #229 (tenant conventions). v0.2 ships
+// six operator-facing verbs that wrap the T2 REST surface
+// (`backend/src/meho_backplane/api/v1/conventions.py`) shipped by
+// G7.1-T2 (#314):
+//
+//   - `meho conventions list [--kind K] [--json]` — paginated listing via
+//     GET /api/v1/conventions. Role: operator.
+//   - `meho conventions show <slug> [--json]` — single-convention fetch
+//     via GET /api/v1/conventions/{slug}. Role: operator. Renders the
+//     body as plain Markdown unless --json is set.
+//   - `meho conventions create --slug S --kind K --title T --body @file
+//     [--priority N] [--json]` — create via POST /api/v1/conventions.
+//     Role: tenant_admin.
+//   - `meho conventions edit <slug> [--title T] [--body @file]
+//     [--priority N] [--json]` — partial PATCH via PATCH
+//     /api/v1/conventions/{slug}. Role: tenant_admin. With no --title /
+//     --body / --priority flags, opens $EDITOR on the current body and
+//     submits the saved content as a PATCH (the operator surface for
+//     conversational rule edits).
+//   - `meho conventions delete <slug> [--confirm] [--json]` — delete via
+//     DELETE /api/v1/conventions/{slug}. Role: tenant_admin.
+//   - `meho conventions history <slug> [--limit N] [--json]` — history
+//     trail via GET /api/v1/conventions/{slug}/history. Role: operator.
+//     Renders unified diffs between consecutive entries by default.
+//
+// Each verb wraps one backplane route. Authentication piggybacks on the
+// token meho login wrote — same pattern as `meho kb`, `meho agent`,
+// `meho audit`. The backend writes the audit_log row keyed by op_id
+// (`conventions.<verb>`); the CLI just calls the route.
+//
+// The implementation deliberately follows the in-package HTTP helper
+// pattern the sibling verb trees use (a local doAuthedRequest /
+// renderRequestError pair) rather than a shared client package, for the
+// import-cycle reason every sibling cites: each verb tree is grafted
+// onto the root command, so a shared helper imported from cmd/* and
+// from a per-tree package would close the cycle.
+package conventions
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// NewRootCmd returns the `meho conventions` parent command. Grafted onto
+// the top-level meho tree by cmd/root.go alongside `meho kb`,
+// `meho agent`, etc. The parent itself takes no args and prints its own
+// help; every behaviour lives in the per-subcommand RunE closures.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "conventions",
+		Short: "Manage tenant conventions (list / show / create / edit / delete / history)",
+		Long: "Manage tenant-scoped operational / workflow / reference " +
+			"conventions wired by G7.1. A convention is a Markdown rule " +
+			"the MEHO agent runtime auto-loads into the session preamble " +
+			"(operational kind) or surfaces on demand (workflow / " +
+			"reference). Write verbs (create / edit / delete) require " +
+			"tenant_admin; read verbs (list / show / history) are " +
+			"operator-level. Tenant scoping is enforced server-side via " +
+			"the JWT — no surface accepts a tenant id, and cross-tenant " +
+			"probes return 404 so existence is not leaked across tenant " +
+			"boundaries.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newListCmd())
+	cmd.AddCommand(newShowCmd())
+	cmd.AddCommand(newCreateCmd())
+	cmd.AddCommand(newEditCmd())
+	cmd.AddCommand(newDeleteCmd())
+	cmd.AddCommand(newHistoryCmd())
+	return cmd
+}
+
+// Convention mirrors the backend Convention pydantic model
+// (`backend/src/meho_backplane/api/v1/conventions.py`). Hand-written
+// rather than aliased to the generated oapi-codegen client type so the
+// conventions package stays decoupled from generator churn — the kb /
+// agent / audit packages take the same stance. `CreatedBySub` is a
+// pointer because the seed migration (T5) inserts rows with no
+// authenticated principal (the seed pre-dates any HTTP request).
+type Convention struct {
+	ID           string  `json:"id"`
+	TenantID     string  `json:"tenant_id"`
+	Slug         string  `json:"slug"`
+	Title        string  `json:"title"`
+	Body         string  `json:"body"`
+	Kind         string  `json:"kind"`
+	Priority     int     `json:"priority"`
+	CreatedBySub *string `json:"created_by_sub"`
+	CreatedAt    string  `json:"created_at"`
+	UpdatedAt    string  `json:"updated_at"`
+}
+
+// Summary mirrors the backend ConventionSummary pydantic model — the
+// lighter list-row shape returned by GET /api/v1/conventions. Omits the
+// full `body` so a list of 20 conventions doesn't materialise 20 KB of
+// rule text on every list call.
+type Summary struct {
+	ID           string  `json:"id"`
+	TenantID     string  `json:"tenant_id"`
+	Slug         string  `json:"slug"`
+	Title        string  `json:"title"`
+	Kind         string  `json:"kind"`
+	Priority     int     `json:"priority"`
+	CreatedBySub *string `json:"created_by_sub"`
+	CreatedAt    string  `json:"created_at"`
+	UpdatedAt    string  `json:"updated_at"`
+}
+
+// ListResponse mirrors the backend ConventionListResponse envelope —
+// wrapped in `{"entries": [...]}` for forward-compat with future paging
+// fields. Same shape kb / agent adopted.
+type ListResponse struct {
+	Entries []Summary `json:"entries"`
+}
+
+// HistoryEntry mirrors the backend ConventionHistoryEntry pydantic
+// model. `BodyBefore` is a pointer because the first history row (the
+// CREATE event) has no prior state; `AuditID` is a pointer because the
+// T5 seed migration inserts history rows with no audit_log row.
+type HistoryEntry struct {
+	ID           string  `json:"id"`
+	ConventionID string  `json:"convention_id"`
+	BodyBefore   *string `json:"body_before"`
+	BodyAfter    string  `json:"body_after"`
+	ActorSub     string  `json:"actor_sub"`
+	AuditID      *string `json:"audit_id"`
+	Ts           string  `json:"ts"`
+}
+
+// validKinds mirrors the backend ConventionKind enum. CLI-side
+// validation gives the operator an immediate rejection rather than a
+// remote 422.
+var validKinds = map[string]bool{"operational": true, "workflow": true, "reference": true}
+
+// errMissingAccessToken is the sentinel doAuthedRequest returns when
+// the stored token row exists but its access_token is empty — a
+// credential-state failure that renderRequestError maps to
+// auth_expired with a `meho login` hint. Mirrors the kb / agent shape.
+var errMissingAccessToken = errors.New("meho: stored token has no access_token")
+
+// renderRequestError translates a request error into the right
+// output.StructuredError category. Maps the conventions REST surface's
+// status codes:
+//
+//   - empty stored bearer → auth_expired.
+//   - 401 (refresh failed) → auth_expired with a `meho login` hint.
+//   - 403 → insufficient_role (the backend's detail names the required
+//     role, typically "tenant_admin required" on write verbs).
+//   - 404 → unexpected with the backend's detail (`convention_not_found`;
+//     cross-tenant probes land here per the no-existence-leak posture).
+//   - 409 → unexpected with the duplicate detail
+//     (`convention_already_exists` on create with a slug that already
+//     exists in the same tenant).
+//   - 422 → unexpected with the validation envelope. The conventions
+//     route has a domain-specific 422 the others don't: the over-budget
+//     gate, raised when an `operational` body exceeds the preamble
+//     token budget. The detail string is human-friendly verbatim
+//     ("convention body exceeds preamble budget (estimated=X,
+//     budget=Y)"); surface it as-is so the operator sees exactly how
+//     many tokens over they are.
+//   - Other 4xx/5xx → unexpected with the raw body.
+//   - Pure transport errors → unreachable.
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if errors.Is(err, errMissingAccessToken) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored credentials for %s are incomplete; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var he *httpError
+	if errors.As(err, &he) {
+		return renderHTTPError(cmd, backplaneURL, he, jsonOut)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+// renderHTTPError classifies a non-2xx response into the right
+// StructuredError category.
+func renderHTTPError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	he *httpError,
+	jsonOut bool,
+) error {
+	switch he.StatusCode {
+	case http.StatusUnauthorized:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"backplane rejected the stored token; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	case http.StatusForbidden:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.InsufficientRole(decodeDetailString(he.Body)),
+			jsonOut,
+		)
+	case http.StatusNotFound:
+		// `show / edit / delete / history` on an absent slug surface
+		// here; the backend's `convention_not_found` covers both genuine
+		// absence and cross-tenant probes (the conflation prevents
+		// enumerating other tenants via status-code differential). For
+		// `list` / `create` (no slug in the path) a 404 means the route
+		// doesn't exist on this backplane — typically an older deploy
+		// without T2.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(decodeDetailString(he.Body)),
+			jsonOut,
+		)
+	case http.StatusConflict:
+		// `create` with a slug that already exists in the same tenant
+		// surfaces here (`convention_already_exists`).
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(decodeDetailString(he.Body)),
+			jsonOut,
+		)
+	case http.StatusUnprocessableEntity:
+		// The conventions surface emits two distinct 422s:
+		//   1. Pydantic validation envelope (`{"detail":[{...}]}`) on
+		//      malformed input (invalid slug shape, missing field, bad
+		//      kind value).
+		//   2. The over-budget gate detail string when an `operational`
+		//      body exceeds DEFAULT_MAX_PREAMBLE_TOKENS. Backend emits a
+		//      string detail with the estimated and budget token counts
+		//      so the operator can re-size the body precisely.
+		//
+		// decodeDetailString returns the string detail verbatim when the
+		// JSON shape matches `{"detail": "..."}`; on the pydantic
+		// envelope shape (`{"detail": [...]}`) it falls through to the
+		// raw body. Both surface as unexpected so callers can branch
+		// on exit code 4.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("invalid request: %s", decodeDetailString(he.Body))),
+			jsonOut,
+		)
+	default:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, he.StatusCode, he.Body)),
+			jsonOut,
+		)
+	}
+}
+
+// detailEnvelope models FastAPI's HTTPException JSON shape.
+type detailEnvelope struct {
+	Detail json.RawMessage `json:"detail"`
+}
+
+// decodeDetailString pulls the `detail` field out of a FastAPI error
+// body when it's a plain string. Falls back to the raw body when the
+// JSON shape doesn't match (the pydantic validation envelope's `detail`
+// is a list, not a string).
+func decodeDetailString(body string) string {
+	var env detailEnvelope
+	if err := json.Unmarshal([]byte(body), &env); err == nil {
+		var s string
+		if jerr := json.Unmarshal(env.Detail, &s); jerr == nil && s != "" {
+			return s
+		}
+	}
+	return strings.TrimSpace(body)
+}
+
+// doAuthedRequest issues a single HTTP request against the backplane
+// with bearer injection and one-shot 401-refresh-retry. Returns the
+// response body bytes (already drained) on 2xx, or an *httpError on
+// non-2xx, or an error categorised by api.IsTokenNotFound /
+// api.IsNoRefreshToken / generic transport. A 204 yields a nil body
+// without error (the DELETE verb hits this path).
+func doAuthedRequest(
+	ctx context.Context,
+	backplaneURL, method, path string,
+	body []byte,
+) ([]byte, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	httpClient := authed.HTTPClient()
+	bearer := authed.AccessToken()
+	if bearer == "" {
+		return nil, errMissingAccessToken
+	}
+
+	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			resp.Body.Close()
+			return nil, rerr
+		}
+		resp.Body.Close()
+		bearer = authed.AccessToken()
+		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close()
+
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, responseBodyCap+1))
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if int64(len(raw)) > responseBodyCap {
+		return nil, fmt.Errorf(
+			"response body exceeds %d-byte cap; refusing to decode possibly-truncated JSON",
+			responseBodyCap,
+		)
+	}
+	if resp.StatusCode == http.StatusNoContent {
+		return nil, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
+	}
+	return raw, nil
+}
+
+// responseBodyCap bounds the response body the CLI will read. A
+// convention body is a Markdown rule (the operational kind is hard-
+// capped at the preamble token budget, ~3 KB; workflow / reference can
+// be larger but ~50 KB is realistic). 1 MiB is comfortable headroom
+// and protects against an adversarial / misconfigured backplane sending
+// an unbounded response.
+const responseBodyCap int64 = 1 << 20
+
+// httpError carries a non-2xx response so per-verb runners render the
+// right category.
+type httpError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+func sendRequest(
+	ctx context.Context,
+	client *http.Client,
+	backplaneURL, method, path, bearer string,
+	body []byte,
+) (*http.Response, error) {
+	fullURL := backplaneURL + path
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return client.Do(req)
+}
+
+// pathEscape escapes a single path segment.
+func pathEscape(segment string) string {
+	// url.PathEscape is the right call but we shouldn't import net/url
+	// just for this; mirror the kb package's helper signature so the
+	// per-verb buildShowPath / buildHistoryPath stays unit-testable.
+	return urlPathEscape(segment)
+}
+
+// loadBodyFlag reads the --body flag value supporting inline text,
+// `@<path>` for file references, and `@-` for stdin. Returns the
+// loaded body or an error. The backend's `body` field has a min_length=1
+// constraint, so an empty result is rejected at the CLI rather than
+// after a 422 round-trip.
+//
+// `@-` reads from cmd.InOrStdin() so tests can wire a bytes.Buffer; the
+// read is bounded by `loadBodyStdinCap` to protect against an
+// adversarial pipe.
+//
+// Trailing newlines (LF or CRLF) are stripped from file / stdin reads
+// so a 1-line file passed via `@` doesn't carry a gratuitous trailing
+// newline through the JSON body. Embedded newlines inside the text are
+// preserved; only the final CRLF / LF is stripped. Inline text values
+// pass through verbatim.
+//
+// Mirrors `loadBodyFlag` in cli/internal/cmd/kb/kb.go so the surface
+// shape (`--body @file` / `--body @-` / `--body "inline"`) is the same
+// across the operator-facing verb trees.
+func loadBodyFlag(cmd *cobra.Command, raw string) (string, error) {
+	if raw == "" {
+		return "", errors.New("--body is required (inline text, @<path>, or @-)")
+	}
+	if !strings.HasPrefix(raw, "@") {
+		return raw, nil
+	}
+	path := strings.TrimPrefix(raw, "@")
+	if path == "-" {
+		blob, err := io.ReadAll(io.LimitReader(cmd.InOrStdin(), loadBodyStdinCap+1))
+		if err != nil {
+			return "", fmt.Errorf("read --body from stdin: %w", err)
+		}
+		if int64(len(blob)) > loadBodyStdinCap {
+			return "", fmt.Errorf(
+				"--body from stdin exceeds %d-byte cap; pass a file with @<path> instead",
+				loadBodyStdinCap,
+			)
+		}
+		out := strings.TrimRight(string(blob), "\r\n")
+		if out == "" {
+			return "", errors.New("--body @- read empty input; cannot create convention with empty body")
+		}
+		return out, nil
+	}
+	blob, err := readBodyFile(path)
+	if err != nil {
+		return "", err
+	}
+	out := strings.TrimRight(string(blob), "\r\n")
+	if out == "" {
+		return "", fmt.Errorf("--body file %q is empty; cannot create convention with empty body", path)
+	}
+	return out, nil
+}
+
+// loadBodyStdinCap bounds the @- read so an adversarial / malformed
+// pipe can't pin a create / edit verb in unbounded ReadAll. 256 KiB is
+// generous for any realistic convention body (operational rules are
+// bounded by the preamble token budget; reference material is the
+// loose-bound case).
+const loadBodyStdinCap int64 = 256 << 10
+
+// readBodyFile is the file-read seam — split out so conventions_test.go
+// can stub it deterministically without touching the filesystem.
+var readBodyFile = func(path string) ([]byte, error) {
+	blob, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read --body file %q: %w", path, err)
+	}
+	return blob, nil
+}
+
+// confirmPrompt prompts on stdin/stdout with the given message and
+// returns true only when the operator types y/yes/Y. EOF (closed
+// stdin) is treated as a no — scripted use must pass --confirm.
+// Mirrors the kb / agent package's confirm helper.
+func confirmPrompt(cmd *cobra.Command, prompt string) bool {
+	fmt.Fprintf(cmd.OutOrStdout(), "%s [y/N]: ", prompt)
+	var answer string
+	if _, err := fmt.Fscanln(cmd.InOrStdin(), &answer); err != nil {
+		// Most common error: io.EOF from a piped empty stdin. Treat as
+		// "no" so scripts that pipe /dev/null don't accidentally delete
+		// a convention.
+		return false
+	}
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	return answer == "y" || answer == "yes"
+}
+
+// urlPathEscape escapes a path segment. Pulled out for a per-package
+// seam — agents have a richer pathEscape with multi-segment handling;
+// conventions doesn't need that level today.
+func urlPathEscape(s string) string {
+	// Per RFC 3986, a path segment may contain unreserved (ALPHA / DIGIT /
+	// `-._~`), `pct-encoded`, sub-delims (`!$&'()*+,;=`), and `:@`.
+	// Conventions slugs are constrained server-side to lowercase ASCII +
+	// digits + hyphen (the V_SLUG pattern), so the escape is a no-op in
+	// the realistic case — but we still escape defensively so an
+	// adversarial slug (e.g., from a buggy script) can't smuggle a path
+	// separator. Using net/url here directly to keep the implementation
+	// stdlib-only and the code path obvious.
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case 'a' <= c && c <= 'z',
+			'A' <= c && c <= 'Z',
+			'0' <= c && c <= '9',
+			c == '-', c == '.', c == '_', c == '~':
+			b.WriteByte(c)
+		default:
+			fmt.Fprintf(&b, "%%%02X", c)
+		}
+	}
+	return b.String()
+}
+
+// runEditor lives in editor.go alongside the other editor-related
+// helpers — keep this file focused on the HTTP / auth helpers shared
+// across the verb tree.

--- a/cli/internal/cmd/conventions/conventions_test.go
+++ b/cli/internal/cmd/conventions/conventions_test.go
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package conventions
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/auth"
+)
+
+// seedXDGAndToken seeds a per-test config dir + token store that
+// backplane.Resolve / doAuthedRequest read. Mirrors the same helper in
+// cli/internal/cmd/agent/agent_test.go.
+func seedXDGAndToken(t *testing.T, backplaneURL string) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("MEHO_KEYRING_DISABLE", "1")
+	store, err := auth.NewFileStore()
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	if err := store.Save(service, user, auth.StoredToken{
+		BackplaneURL: backplaneURL,
+		AccessToken:  "eyJ.test.token",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(1 * time.Hour),
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+	if err := auth.SaveConfigAt(
+		filepath.Join(dir, "meho", "config.json"),
+		auth.Config{BackplaneURL: backplaneURL},
+	); err != nil {
+		t.Fatalf("SaveConfigAt: %v", err)
+	}
+	return dir
+}
+
+// newRunCmd builds a fresh cobra.Command with stdout/stderr buffers
+// wired so per-verb runners can be exercised directly without going
+// through the full cobra arg-parsing path.
+func newRunCmd(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	cmd.SetContext(ctx)
+	return cmd, &stdout, &stderr
+}
+
+// TestNewRootCmdRegistersAllSixVerbs — every advertised verb has a
+// cobra subcommand. The CLI manifest is the contract operators build
+// muscle memory around; dropping a verb silently is the regression
+// class this catches at unit time.
+func TestNewRootCmdRegistersAllSixVerbs(t *testing.T) {
+	root := NewRootCmd()
+	want := map[string]bool{
+		"list":    false,
+		"show":    false,
+		"create":  false,
+		"edit":    false,
+		"delete":  false,
+		"history": false,
+	}
+	for _, sub := range root.Commands() {
+		name := strings.SplitN(sub.Use, " ", 2)[0]
+		if _, ok := want[name]; ok {
+			want[name] = true
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("verb %q not registered on `meho conventions`", name)
+		}
+	}
+}
+
+// TestRootCmdHelpMentionsAllVerbs — the parent's help text should
+// mention every verb so operators new to the surface find them.
+func TestRootCmdHelpMentionsAllVerbs(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("`meho conventions --help` failed: %v", err)
+	}
+	help := buf.String()
+	for _, want := range []string{"list", "show", "create", "edit", "delete", "history", "tenant"} {
+		if !strings.Contains(help, want) {
+			t.Errorf("expected help to mention %q; got:\n%s", want, help)
+		}
+	}
+}
+
+// TestLoadBodyFlagInline — inline text passes through verbatim.
+func TestLoadBodyFlagInline(t *testing.T) {
+	cmd, _, _ := newRunCmd(t)
+	got, err := loadBodyFlag(cmd, "rule body text")
+	if err != nil {
+		t.Fatalf("loadBodyFlag inline: %v", err)
+	}
+	if got != "rule body text" {
+		t.Errorf("inline got %q", got)
+	}
+}
+
+// TestLoadBodyFlagEmptyRejected — backend has min_length=1 on body;
+// fail fast at the CLI.
+func TestLoadBodyFlagEmptyRejected(t *testing.T) {
+	cmd, _, _ := newRunCmd(t)
+	if _, err := loadBodyFlag(cmd, ""); err == nil {
+		t.Errorf("empty --body should be rejected")
+	}
+}
+
+// TestLoadBodyFlagStdin — @- reads from stdin with trailing newline
+// stripping.
+func TestLoadBodyFlagStdin(t *testing.T) {
+	cmd, _, _ := newRunCmd(t)
+	cmd.SetIn(strings.NewReader("one\ntwo\n"))
+	got, err := loadBodyFlag(cmd, "@-")
+	if err != nil {
+		t.Fatalf("loadBodyFlag @-: %v", err)
+	}
+	if got != "one\ntwo" {
+		t.Errorf("@- got %q; want %q", got, "one\ntwo")
+	}
+}
+
+// TestLoadBodyFlagStdinEmptyRejected — empty stdin can't seed a body.
+func TestLoadBodyFlagStdinEmptyRejected(t *testing.T) {
+	cmd, _, _ := newRunCmd(t)
+	cmd.SetIn(strings.NewReader(""))
+	if _, err := loadBodyFlag(cmd, "@-"); err == nil {
+		t.Errorf("empty stdin should be rejected")
+	}
+}
+
+// TestLoadBodyFlagFile — @<path> reads a file; stub readBodyFile so we
+// don't touch the filesystem.
+func TestLoadBodyFlagFile(t *testing.T) {
+	orig := readBodyFile
+	defer func() { readBodyFile = orig }()
+	readBodyFile = func(path string) ([]byte, error) {
+		if path != "rule.md" {
+			t.Errorf("readBodyFile path: %q", path)
+		}
+		return []byte("file body\n"), nil
+	}
+	cmd, _, _ := newRunCmd(t)
+	got, err := loadBodyFlag(cmd, "@rule.md")
+	if err != nil {
+		t.Fatalf("loadBodyFlag @file: %v", err)
+	}
+	if got != "file body" {
+		t.Errorf("@file got %q; want %q", got, "file body")
+	}
+}
+
+// TestDecodeDetailStringPydanticEnvelope — the FastAPI HTTPException
+// shape `{"detail": "..."}` extracts cleanly.
+func TestDecodeDetailStringPydanticEnvelope(t *testing.T) {
+	got := decodeDetailString(`{"detail":"convention_not_found"}`)
+	if got != "convention_not_found" {
+		t.Errorf("decodeDetailString string: %q", got)
+	}
+}
+
+// TestDecodeDetailStringFallsThroughOnListDetail — the pydantic
+// validation envelope's `detail` is a list, not a string; fall back to
+// the raw body in that case.
+func TestDecodeDetailStringFallsThroughOnListDetail(t *testing.T) {
+	raw := `{"detail":[{"loc":["body","slug"],"msg":"string too short"}]}`
+	got := decodeDetailString(raw)
+	if !strings.Contains(got, "string too short") {
+		t.Errorf("list-detail fall-through lost content: %q", got)
+	}
+}
+
+// TestURLPathEscapePreservesUnreserved — slug-shaped strings (the
+// V_SLUG pattern) round-trip without escaping.
+func TestURLPathEscapePreservesUnreserved(t *testing.T) {
+	for _, slug := range []string{"vault-canonical", "rbac.canonical", "secret-handling_v2"} {
+		if urlPathEscape(slug) != slug {
+			t.Errorf("urlPathEscape mutated unreserved slug %q -> %q", slug, urlPathEscape(slug))
+		}
+	}
+}
+
+// TestURLPathEscapeEscapesPathSeparator — defensive escape of an
+// adversarial slug containing `/` so it can't smuggle a path
+// boundary.
+func TestURLPathEscapeEscapesPathSeparator(t *testing.T) {
+	got := urlPathEscape("not/a/slug")
+	if strings.Contains(got, "/") {
+		t.Errorf("urlPathEscape failed to escape `/`: %q", got)
+	}
+}
+
+// TestValidKindsCoversAllThree — the closed vocabulary is the
+// API-layer single line of defence; the CLI mirrors it so a typo
+// surfaces locally.
+func TestValidKindsCoversAllThree(t *testing.T) {
+	for _, k := range []string{"operational", "workflow", "reference"} {
+		if !validKinds[k] {
+			t.Errorf("validKinds missing %q", k)
+		}
+	}
+	if validKinds["garbage"] {
+		t.Errorf("validKinds should reject garbage")
+	}
+}

--- a/cli/internal/cmd/conventions/create.go
+++ b/cli/internal/cmd/conventions/create.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package conventions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// createRequest mirrors the backend ConventionCreate pydantic model.
+// `Priority` is a pointer so the field is omitted from the JSON body
+// when the operator doesn't pass --priority (backend defaults to 0,
+// matching the SmallInteger column's server_default; round-trips
+// identically through create + show).
+type createRequest struct {
+	Slug     string `json:"slug"`
+	Title    string `json:"title"`
+	Body     string `json:"body"`
+	Kind     string `json:"kind"`
+	Priority *int   `json:"priority,omitempty"`
+}
+
+// newCreateCmd returns the `meho conventions create` command.
+//
+//	meho conventions create \
+//	  --slug S --kind K --title T --body @file|@-|<inline-text> \
+//	  [--priority N] [--json] [--backplane <url>]
+//
+// Role: tenant_admin. Operator-role JWT lands as 403 insufficient_role.
+//
+// A duplicate (tenant, slug) returns 409 with detail
+// `convention_already_exists`. An over-budget `operational` body
+// returns 422 with the estimated-and-budget detail surfaced verbatim.
+//
+// Exit codes:
+//   - 0   convention created (201)
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (incl. 409 duplicate, 422 invalid /
+//     over-budget)
+//   - 5   insufficient_role
+func newCreateCmd() *cobra.Command {
+	var (
+		slug              string
+		kind              string
+		title             string
+		body              string
+		priority          int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create one convention (tenant_admin)",
+		Long: "create calls POST /api/v1/conventions to create one " +
+			"convention under the operator's tenant. Tenant_admin only — " +
+			"operator-role JWT lands as 403 insufficient_role.\n\n" +
+			"--slug is the operator-visible identifier (lowercase ASCII, " +
+			"digits, hyphen; max 128 chars; enforced server-side). " +
+			"--kind is one of operational | workflow | reference; only " +
+			"operational conventions are packed into the preamble. " +
+			"--title is a short display label. --body accepts inline " +
+			"text, @<path> to read a file, or @- to read from stdin; the " +
+			"realistic shape is @<path> with a Markdown rule file. " +
+			"--priority (default 0) is the ranking key the T4 preamble " +
+			"assembler uses to pack highest-priority-first — operational " +
+			"conventions with higher priority survive over-budget drops.\n\n" +
+			"A duplicate (same tenant + slug) returns 409 with detail " +
+			"convention_already_exists. An over-budget operational body " +
+			"returns 422 with an `estimated=X, budget=Y` detail so the " +
+			"operator can re-size the body precisely.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runCreate(cmd, createOptions{
+				Slug:              slug,
+				Kind:              kind,
+				Title:             title,
+				BodyArg:           body,
+				Priority:          priority,
+				prioritySet:       cmd.Flags().Changed("priority"),
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&slug, "slug", "",
+		"operator-visible identifier (lowercase ASCII, digits, hyphen; max 128 chars)")
+	cmd.Flags().StringVar(&kind, "kind", "",
+		"convention kind: operational | workflow | reference")
+	cmd.Flags().StringVar(&title, "title", "",
+		"short display label")
+	cmd.Flags().StringVar(&body, "body", "",
+		"convention body: inline text, @<path> to read a file, or @- to read from stdin")
+	cmd.Flags().IntVar(&priority, "priority", 0,
+		"ranking key (default 0; range -32768..32767; higher wins on over-budget drops)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw Convention JSON instead of the human summary")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	_ = cmd.MarkFlagRequired("slug")
+	_ = cmd.MarkFlagRequired("kind")
+	_ = cmd.MarkFlagRequired("title")
+	_ = cmd.MarkFlagRequired("body")
+	return cmd
+}
+
+type createOptions struct {
+	Slug              string
+	Kind              string
+	Title             string
+	BodyArg           string
+	Priority          int
+	prioritySet       bool
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runCreate(cmd *cobra.Command, opts createOptions) error {
+	if opts.Slug == "" {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("create requires a non-empty --slug"), opts.JSONOut)
+	}
+	if opts.Title == "" {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("create requires a non-empty --title"), opts.JSONOut)
+	}
+	if !validKinds[opts.Kind] {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"--kind must be one of: operational, workflow, reference; got %q",
+				opts.Kind,
+			)),
+			opts.JSONOut)
+	}
+	// SMALLINT column range (PG); the server would otherwise return a
+	// confusing low-level OverflowError-style 500 / 422 mix on a value
+	// outside [-32768, 32767]. Fail fast at the CLI.
+	if opts.prioritySet && (opts.Priority < -32768 || opts.Priority > 32767) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"--priority must be between -32768 and 32767; got %d",
+				opts.Priority,
+			)),
+			opts.JSONOut)
+	}
+	body, err := loadBodyFlag(cmd, opts.BodyArg)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+
+	req := createRequest{
+		Slug:  opts.Slug,
+		Kind:  opts.Kind,
+		Title: opts.Title,
+		Body:  body,
+	}
+	if opts.prioritySet {
+		p := opts.Priority
+		req.Priority = &p
+	}
+	conv, err := postCreate(cmd.Context(), backplaneURL, req)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), conv)
+	}
+	printCreateSummary(cmd.OutOrStdout(), conv)
+	return nil
+}
+
+func postCreate(ctx context.Context, backplaneURL string, req createRequest) (*Convention, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("marshal conventions create request: %w", err)
+	}
+	raw, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/conventions", body)
+	if err != nil {
+		return nil, err
+	}
+	var out Convention
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode conventions create response: %w", err)
+	}
+	return &out, nil
+}
+
+// printCreateSummary renders the created convention as a compact
+// one-line confirmation plus the round-tripped slug / timestamps /
+// body length. Operators who want the full body should chase with
+// `meho conventions show <slug>`.
+func printCreateSummary(w io.Writer, c *Convention) {
+	if c == nil {
+		return
+	}
+	fmt.Fprintf(w, "created convention %q\n", c.Slug)
+	fmt.Fprintf(w, "%-14s %s\n", "id:", c.ID)
+	fmt.Fprintf(w, "%-14s %s\n", "tenant_id:", c.TenantID)
+	fmt.Fprintf(w, "%-14s %s\n", "kind:", c.Kind)
+	fmt.Fprintf(w, "%-14s %d\n", "priority:", c.Priority)
+	fmt.Fprintf(w, "%-14s %s\n", "title:", c.Title)
+	fmt.Fprintf(w, "%-14s %s\n", "created_at:", c.CreatedAt)
+	fmt.Fprintf(w, "%-14s %s\n", "updated_at:", c.UpdatedAt)
+	fmt.Fprintf(w, "%-14s %d bytes\n", "body:", len(c.Body))
+}

--- a/cli/internal/cmd/conventions/crud_test.go
+++ b/cli/internal/cmd/conventions/crud_test.go
@@ -1,0 +1,871 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package conventions
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func sampleConvention() Convention {
+	return Convention{
+		ID:        "11111111-1111-1111-1111-111111111111",
+		TenantID:  "22222222-2222-2222-2222-222222222222",
+		Slug:      "vault-canonical",
+		Title:     "Vault is canonical",
+		Body:      "Vault is the canonical secret store.\nNever paste secrets into chat.",
+		Kind:      "operational",
+		Priority:  10,
+		CreatedAt: "2026-05-24T00:00:00Z",
+		UpdatedAt: "2026-05-24T00:00:00Z",
+	}
+}
+
+func sampleSummary() Summary {
+	return Summary{
+		ID:        "11111111-1111-1111-1111-111111111111",
+		TenantID:  "22222222-2222-2222-2222-222222222222",
+		Slug:      "vault-canonical",
+		Title:     "Vault is canonical",
+		Kind:      "operational",
+		Priority:  10,
+		CreatedAt: "2026-05-24T00:00:00Z",
+		UpdatedAt: "2026-05-24T00:00:00Z",
+	}
+}
+
+// --- list ---
+
+func TestBuildListPath(t *testing.T) {
+	if got := buildListPath(listOptions{}); got != "/api/v1/conventions" {
+		t.Fatalf("empty opts: got %q", got)
+	}
+	got := buildListPath(listOptions{Kind: "operational"})
+	if !strings.Contains(got, "kind=operational") {
+		t.Errorf("buildListPath kind: got %q", got)
+	}
+}
+
+func TestRunListRejectsBadKind(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runList(cmd, listOptions{Kind: "garbage"})
+	if err == nil {
+		t.Fatalf("expected error for bad kind")
+	}
+	if !strings.Contains(stderr.String(), "operational, workflow, reference") {
+		t.Errorf("stderr missing kind hint; got %q", stderr.String())
+	}
+}
+
+func TestRunListHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			t.Errorf("missing Authorization header")
+		}
+		_ = json.NewEncoder(w).Encode(ListResponse{Entries: []Summary{sampleSummary()}})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	if err := runList(cmd, listOptions{BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runList: %v; stderr=%s", err, stderr.String())
+	}
+	for _, want := range []string{"SLUG", "vault-canonical", "operational", "Vault is canonical"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("stdout missing %q in %q", want, stdout.String())
+		}
+	}
+}
+
+func TestRunListJSONPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(ListResponse{Entries: []Summary{sampleSummary()}})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	if err := runList(cmd, listOptions{BackplaneOverride: srv.URL, JSONOut: true}); err != nil {
+		t.Fatalf("runList --json: %v", err)
+	}
+	var got ListResponse
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode stdout JSON: %v; raw=%s", err, stdout.String())
+	}
+	if len(got.Entries) != 1 || got.Entries[0].Slug != "vault-canonical" {
+		t.Errorf("decoded JSON unexpected: %+v", got)
+	}
+}
+
+func TestPrintListTableEmpty(t *testing.T) {
+	var sb strings.Builder
+	printListTable(&sb, &ListResponse{})
+	if !strings.Contains(sb.String(), "no conventions registered") {
+		t.Errorf("empty render missing hint; got %q", sb.String())
+	}
+}
+
+// --- show ---
+
+func TestBuildShowPath(t *testing.T) {
+	if got := buildShowPath("vault-canonical"); got != "/api/v1/conventions/vault-canonical" {
+		t.Fatalf("buildShowPath: got %q", got)
+	}
+}
+
+func TestRunShowHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions/vault-canonical", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(sampleConvention())
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runShow(cmd, showOptions{Slug: "vault-canonical", BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runShow: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Vault is the canonical secret store") {
+		t.Errorf("stdout missing body; got %q", stdout.String())
+	}
+}
+
+func TestRunShow404SurfacesNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions/nope", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"detail":"convention_not_found"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runShow(cmd, showOptions{Slug: "nope", BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected error on 404")
+	}
+	if !strings.Contains(stderr.String(), "convention_not_found") {
+		t.Errorf("stderr missing convention_not_found; got %q", stderr.String())
+	}
+}
+
+func TestRunShowEmptySlugRejected(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runShow(cmd, showOptions{Slug: ""})
+	if err == nil {
+		t.Fatalf("empty slug should be rejected")
+	}
+	if !strings.Contains(stderr.String(), "non-empty <slug>") {
+		t.Errorf("stderr missing hint; got %q", stderr.String())
+	}
+}
+
+// --- create ---
+
+func TestRunCreateHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method: got %s; want POST", r.Method)
+		}
+		var body createRequest
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if body.Slug != "vault-canonical" || body.Kind != "operational" || body.Title != "Vault is canonical" {
+			t.Errorf("unexpected request body: %+v", body)
+		}
+		if body.Body == "" {
+			t.Errorf("body missing")
+		}
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(sampleConvention())
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runCreate(cmd, createOptions{
+		Slug:              "vault-canonical",
+		Kind:              "operational",
+		Title:             "Vault is canonical",
+		BodyArg:           "Vault is the canonical secret store.",
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runCreate: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "created convention") {
+		t.Errorf("stdout missing confirmation; got %q", stdout.String())
+	}
+}
+
+func TestRunCreateRejectsBadKind(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runCreate(cmd, createOptions{
+		Slug: "x", Kind: "garbage", Title: "t", BodyArg: "b",
+	})
+	if err == nil {
+		t.Fatalf("expected error for bad kind")
+	}
+	if !strings.Contains(stderr.String(), "operational, workflow, reference") {
+		t.Errorf("stderr missing kind hint; got %q", stderr.String())
+	}
+}
+
+func TestRunCreateRejectsOutOfRangePriority(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runCreate(cmd, createOptions{
+		Slug: "x", Kind: "operational", Title: "t", BodyArg: "b",
+		Priority: 99999, prioritySet: true,
+	})
+	if err == nil {
+		t.Fatalf("expected error for out-of-range priority")
+	}
+	if !strings.Contains(stderr.String(), "-32768 and 32767") {
+		t.Errorf("stderr missing range hint; got %q", stderr.String())
+	}
+}
+
+func TestRunCreateRejectsEmptyTitle(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runCreate(cmd, createOptions{
+		Slug: "x", Kind: "operational", Title: "", BodyArg: "b",
+	})
+	if err == nil {
+		t.Fatalf("expected error for empty title")
+	}
+	if !strings.Contains(stderr.String(), "non-empty --title") {
+		t.Errorf("stderr missing title hint; got %q", stderr.String())
+	}
+}
+
+func TestRunCreate409SurfacesDuplicate(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		fmt.Fprint(w, `{"detail":"convention_already_exists"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runCreate(cmd, createOptions{
+		Slug: "dup", Kind: "operational", Title: "t", BodyArg: "b",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error on 409")
+	}
+	if !strings.Contains(stderr.String(), "convention_already_exists") {
+		t.Errorf("stderr missing duplicate detail; got %q", stderr.String())
+	}
+}
+
+func TestRunCreate403SurfacesInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"detail":"Insufficient role: tenant_admin required"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runCreate(cmd, createOptions{
+		Slug: "x", Kind: "operational", Title: "t", BodyArg: "b",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error on 403")
+	}
+	if !strings.Contains(stderr.String(), "insufficient_role") {
+		t.Errorf("stderr missing insufficient_role; got %q", stderr.String())
+	}
+}
+
+func TestRunCreate422SurfacesOverBudget(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		fmt.Fprint(w, `{"detail":"convention body exceeds preamble budget (estimated=1200, budget=800)"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runCreate(cmd, createOptions{
+		Slug: "x", Kind: "operational", Title: "t", BodyArg: "b",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error on 422")
+	}
+	if !strings.Contains(stderr.String(), "exceeds preamble budget") {
+		t.Errorf("stderr missing over-budget detail; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "estimated=1200") {
+		t.Errorf("stderr missing estimated count; got %q", stderr.String())
+	}
+}
+
+func TestRunCreatePriorityOmittedWhenNotSet(t *testing.T) {
+	var got createRequest
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		// Confirm "priority" key is not in the JSON when not set.
+		if strings.Contains(string(raw), `"priority"`) {
+			t.Errorf("priority key present when --priority not set: %s", raw)
+		}
+		_ = json.Unmarshal(raw, &got)
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(sampleConvention())
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runCreate(cmd, createOptions{
+		Slug: "x", Kind: "operational", Title: "t", BodyArg: "b",
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runCreate: %v; stderr=%s", err, stderr.String())
+	}
+}
+
+// --- edit ---
+
+func TestBuildEditRequestFlagDriven(t *testing.T) {
+	cmd, _, _ := newRunCmd(t)
+	req, err := buildEditRequest(cmd, "", editOptions{
+		Slug: "x", Title: "new title", titleSet: true,
+		Priority: 5, prioritySet: true,
+	})
+	if err != nil {
+		t.Fatalf("buildEditRequest flag-driven: %v", err)
+	}
+	if req.Title == nil || *req.Title != "new title" {
+		t.Errorf("title not set: %+v", req.Title)
+	}
+	if req.Priority == nil || *req.Priority != 5 {
+		t.Errorf("priority not set: %+v", req.Priority)
+	}
+	if req.Body != nil {
+		t.Errorf("body should be nil; got %+v", req.Body)
+	}
+}
+
+func TestBuildEditRequestRejectsBadPriority(t *testing.T) {
+	cmd, _, _ := newRunCmd(t)
+	_, err := buildEditRequest(cmd, "", editOptions{
+		Slug: "x", Priority: 99999, prioritySet: true,
+	})
+	if err == nil {
+		t.Fatalf("expected error for out-of-range priority")
+	}
+}
+
+func TestRunEditFlagDrivenHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions/vault-canonical", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("method: got %s; want PATCH", r.Method)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(raw), "priority") {
+			t.Errorf("PATCH body missing priority: %s", raw)
+		}
+		conv := sampleConvention()
+		conv.Priority = 20
+		_ = json.NewEncoder(w).Encode(conv)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runEdit(cmd, editOptions{
+		Slug: "vault-canonical", Priority: 20, prioritySet: true,
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runEdit: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "updated convention") {
+		t.Errorf("stdout missing confirmation; got %q", stdout.String())
+	}
+}
+
+func TestRunEditEditorModeHappyPath(t *testing.T) {
+	// Stub the runEditor seam so the test doesn't spawn a real editor.
+	orig := runEditor
+	defer func() { runEditor = orig }()
+	runEditor = func(_ *cobra.Command, initial string) (string, error) {
+		if !strings.Contains(initial, "Vault is the canonical") {
+			return "", fmt.Errorf("editor seed missing original body: %q", initial)
+		}
+		return initial + "\nAdditional rule line.\n", nil
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions/vault-canonical", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(sampleConvention())
+		case http.MethodPatch:
+			raw, _ := io.ReadAll(r.Body)
+			var body updateRequest
+			_ = json.Unmarshal(raw, &body)
+			if body.Body == nil {
+				t.Errorf("PATCH body missing body field: %s", raw)
+			} else if !strings.Contains(*body.Body, "Additional rule line") {
+				t.Errorf("PATCH body lost editor edit: %s", *body.Body)
+			}
+			if body.Title != nil || body.Priority != nil {
+				t.Errorf("PATCH body should only have body field: %+v", body)
+			}
+			conv := sampleConvention()
+			conv.Body = *body.Body
+			_ = json.NewEncoder(w).Encode(conv)
+		default:
+			t.Errorf("unexpected method %s", r.Method)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runEdit(cmd, editOptions{
+		Slug:              "vault-canonical",
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runEdit editor mode: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "updated convention") {
+		t.Errorf("stdout missing confirmation; got %q", stdout.String())
+	}
+}
+
+func TestRunEditEditorModeAbortsOnEmptyBody(t *testing.T) {
+	orig := runEditor
+	defer func() { runEditor = orig }()
+	runEditor = func(_ *cobra.Command, _ string) (string, error) {
+		// Operator opened editor and saved an empty buffer (cleared
+		// the content). Treat as abort.
+		return "\n\n", nil
+	}
+
+	patchCount := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions/vault-canonical", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(sampleConvention())
+			return
+		}
+		if r.Method == http.MethodPatch {
+			patchCount++
+			t.Errorf("PATCH should not be called on empty editor save")
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runEdit(cmd, editOptions{
+		Slug:              "vault-canonical",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error on empty editor body")
+	}
+	if !strings.Contains(stderr.String(), "empty") {
+		t.Errorf("stderr missing empty-body hint; got %q", stderr.String())
+	}
+	if patchCount != 0 {
+		t.Errorf("PATCH called %d times; want 0", patchCount)
+	}
+}
+
+func TestRunEditEditorModeAbortsOnUnchangedBody(t *testing.T) {
+	orig := runEditor
+	defer func() { runEditor = orig }()
+	runEditor = func(_ *cobra.Command, initial string) (string, error) {
+		// Operator opened, saved without changes. Skip the round-trip.
+		return initial, nil
+	}
+
+	patchCount := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions/vault-canonical", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(sampleConvention())
+			return
+		}
+		if r.Method == http.MethodPatch {
+			patchCount++
+			t.Errorf("PATCH should not be called when body unchanged")
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runEdit(cmd, editOptions{
+		Slug:              "vault-canonical",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error on unchanged editor body")
+	}
+	if !strings.Contains(stderr.String(), "unchanged") {
+		t.Errorf("stderr missing unchanged hint; got %q", stderr.String())
+	}
+	if patchCount != 0 {
+		t.Errorf("PATCH called %d times; want 0", patchCount)
+	}
+}
+
+func TestRunEditEditorModeAbortsOnEditorFailure(t *testing.T) {
+	orig := runEditor
+	defer func() { runEditor = orig }()
+	runEditor = func(_ *cobra.Command, _ string) (string, error) {
+		return "", fmt.Errorf("editor exited 1")
+	}
+
+	patchCount := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions/vault-canonical", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(sampleConvention())
+			return
+		}
+		if r.Method == http.MethodPatch {
+			patchCount++
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runEdit(cmd, editOptions{
+		Slug:              "vault-canonical",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error on editor failure")
+	}
+	if !strings.Contains(stderr.String(), "editor session aborted") {
+		t.Errorf("stderr missing editor abort hint; got %q", stderr.String())
+	}
+	if patchCount != 0 {
+		t.Errorf("PATCH called %d times; want 0", patchCount)
+	}
+}
+
+func TestRunEditEditorMode404SurfacesNotFoundFromShowFetch(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions/nope", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"detail":"convention_not_found"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runEdit(cmd, editOptions{
+		Slug:              "nope",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error on 404")
+	}
+	if !strings.Contains(stderr.String(), "convention_not_found") {
+		t.Errorf("stderr missing not-found detail; got %q", stderr.String())
+	}
+}
+
+func TestRunEdit422OverBudgetSurfacedInline(t *testing.T) {
+	orig := runEditor
+	defer func() { runEditor = orig }()
+	runEditor = func(_ *cobra.Command, initial string) (string, error) {
+		return initial + "\nOversized line.", nil
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions/vault-canonical", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(sampleConvention())
+		case http.MethodPatch:
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			fmt.Fprint(w, `{"detail":"convention body exceeds preamble budget (estimated=900, budget=800)"}`)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runEdit(cmd, editOptions{
+		Slug:              "vault-canonical",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error on 422")
+	}
+	if !strings.Contains(stderr.String(), "exceeds preamble budget") {
+		t.Errorf("stderr missing over-budget detail; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "estimated=900") {
+		t.Errorf("stderr missing estimated token count; got %q", stderr.String())
+	}
+}
+
+// --- delete ---
+
+func TestRunDeleteConfirmHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions/vault-canonical", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("method: got %s; want DELETE", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runDelete(cmd, deleteOptions{
+		Slug: "vault-canonical", Confirm: true, BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runDelete: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "deleted convention") {
+		t.Errorf("stdout missing confirmation; got %q", stdout.String())
+	}
+}
+
+func TestRunDeleteDeclinedExitsZero(t *testing.T) {
+	cmd, stdout, _ := newRunCmd(t)
+	cmd.SetIn(strings.NewReader("n\n"))
+	err := runDelete(cmd, deleteOptions{Slug: "vault-canonical"})
+	if err != nil {
+		t.Fatalf("declined delete should exit 0; got %v", err)
+	}
+	if !strings.Contains(stdout.String(), "declined") {
+		t.Errorf("stdout missing declined line; got %q", stdout.String())
+	}
+}
+
+func TestRunDelete404SurfacesNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions/nope", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"detail":"convention_not_found"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runDelete(cmd, deleteOptions{Slug: "nope", Confirm: true, BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected error on 404")
+	}
+	if !strings.Contains(stderr.String(), "convention_not_found") {
+		t.Errorf("stderr missing convention_not_found; got %q", stderr.String())
+	}
+}
+
+// --- history ---
+
+func TestBuildHistoryPath(t *testing.T) {
+	if got := buildHistoryPath("vault-canonical"); got != "/api/v1/conventions/vault-canonical/history" {
+		t.Fatalf("buildHistoryPath: got %q", got)
+	}
+}
+
+func TestRunHistoryHappyPathRendersDiffs(t *testing.T) {
+	bodyBefore := "Vault is canonical."
+	entries := []HistoryEntry{
+		{
+			ID:           "h2",
+			ConventionID: "11111111-1111-1111-1111-111111111111",
+			BodyBefore:   &bodyBefore,
+			BodyAfter:    "Vault is canonical.\nAdded rule.",
+			ActorSub:     "ops-admin",
+			Ts:           "2026-05-25T00:00:00Z",
+		},
+		{
+			ID:           "h1",
+			ConventionID: "11111111-1111-1111-1111-111111111111",
+			BodyBefore:   nil,
+			BodyAfter:    "Vault is canonical.",
+			ActorSub:     "ops-admin",
+			Ts:           "2026-05-24T00:00:00Z",
+		},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions/vault-canonical/history", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(entries)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runHistory(cmd, historyOptions{Slug: "vault-canonical", BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runHistory: %v; stderr=%s", err, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"=== 2026-05-25T00:00:00Z",
+		"+ Added rule.",
+		"--- /dev/null", // CREATE row
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("history output missing %q in %q", want, out)
+		}
+	}
+}
+
+func TestRunHistoryLimit(t *testing.T) {
+	bodyBefore := "x"
+	mkEntry := func(id string, ts string) HistoryEntry {
+		return HistoryEntry{
+			ID: id, BodyBefore: &bodyBefore, BodyAfter: "y", Ts: ts, ActorSub: "ops",
+		}
+	}
+	entries := []HistoryEntry{
+		mkEntry("h3", "2026-05-26T00:00:00Z"),
+		mkEntry("h2", "2026-05-25T00:00:00Z"),
+		mkEntry("h1", "2026-05-24T00:00:00Z"),
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions/x/history", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(entries)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runHistory(cmd, historyOptions{Slug: "x", Limit: 2, BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runHistory --limit: %v; stderr=%s", err, stderr.String())
+	}
+	if strings.Contains(stdout.String(), "h1") {
+		t.Errorf("--limit 2 included beyond-limit row: %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "h2") {
+		t.Errorf("--limit 2 dropped on-limit row: %q", stdout.String())
+	}
+}
+
+func TestRunHistoryEmpty(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions/x/history", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode([]HistoryEntry{})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	err := runHistory(cmd, historyOptions{Slug: "x", BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runHistory empty: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "no history") {
+		t.Errorf("empty render missing hint; got %q", stdout.String())
+	}
+}
+
+func TestRunHistoryRejectsNegativeLimit(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runHistory(cmd, historyOptions{Slug: "x", Limit: -1})
+	if err == nil {
+		t.Fatalf("expected error for negative --limit")
+	}
+	if !strings.Contains(stderr.String(), "non-negative") {
+		t.Errorf("stderr missing range hint; got %q", stderr.String())
+	}
+}
+
+func TestRunHistoryJSON(t *testing.T) {
+	bodyBefore := "x"
+	entries := []HistoryEntry{
+		{ID: "h1", BodyBefore: &bodyBefore, BodyAfter: "y", Ts: "2026-05-24T00:00:00Z", ActorSub: "ops"},
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions/x/history", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(entries)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	err := runHistory(cmd, historyOptions{Slug: "x", JSONOut: true, BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runHistory --json: %v", err)
+	}
+	var got []HistoryEntry
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode stdout JSON: %v; raw=%s", err, stdout.String())
+	}
+	if len(got) != 1 || got[0].ID != "h1" {
+		t.Errorf("decoded JSON unexpected: %+v", got)
+	}
+}
+
+// --- writeUnifiedDiff ---
+
+func TestWriteUnifiedDiffEmitsAddRemove(t *testing.T) {
+	var sb strings.Builder
+	writeUnifiedDiff(&sb, "a\nb\nc", "a\nc\nd")
+	out := sb.String()
+	if !strings.Contains(out, "- b") {
+		t.Errorf("missing removed line: %q", out)
+	}
+	if !strings.Contains(out, "+ d") {
+		t.Errorf("missing added line: %q", out)
+	}
+	if !strings.Contains(out, "  a") {
+		t.Errorf("missing context line: %q", out)
+	}
+}
+
+// Confirm the cobra import isn't unused if no test happens to reference
+// it directly — keep the symbol live.
+var _ = cobra.Command{}

--- a/cli/internal/cmd/conventions/delete.go
+++ b/cli/internal/cmd/conventions/delete.go
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package conventions
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newDeleteCmd returns the `meho conventions delete` command.
+//
+//	meho conventions delete <slug> [--confirm] [--json] [--backplane <url>]
+//
+// Role: tenant_admin. Without --confirm the verb prompts for a y/N
+// confirmation on stdin; --confirm skips the prompt for scripted use.
+// A 404 (`convention_not_found`) covers absence / cross-tenant.
+//
+// The substrate writes a DELETE event into the convention's history
+// trail (a `body_after` containing the final body), so a deleted-then-
+// recreated slug retains an audit trail.
+//
+// Exit codes:
+//   - 0   delete succeeded (204) or operator declined the prompt
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response
+//   - 5   insufficient_role
+func newDeleteCmd() *cobra.Command {
+	var (
+		confirm           bool
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "delete <slug>",
+		Short: "Delete one convention by slug (tenant_admin)",
+		Long: "delete calls DELETE /api/v1/conventions/{slug}. " +
+			"Tenant_admin only. Without --confirm the verb prompts on " +
+			"stdin for a y/N confirmation; --confirm skips the prompt for " +
+			"scripted use (CI pipelines, etc.). Declining the prompt " +
+			"exits 0 without calling the backend.\n\n" +
+			"The substrate writes a DELETE event into the convention's " +
+			"history trail so audit forensics retain the final body — a " +
+			"deleted-then-recreated slug keeps a complete edit history.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDelete(cmd, deleteOptions{
+				Slug:              args[0],
+				Confirm:           confirm,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&confirm, "confirm", false,
+		"skip the stdin confirmation prompt")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit a machine-readable success envelope instead of the human line")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type deleteOptions struct {
+	Slug              string
+	Confirm           bool
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+// deleteResult is the structure printed in --json mode.
+type deleteResult struct {
+	Slug   string `json:"slug"`
+	Status string `json:"status"`
+}
+
+func runDelete(cmd *cobra.Command, opts deleteOptions) error {
+	if opts.Slug == "" {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("delete requires a non-empty <slug> argument"), opts.JSONOut)
+	}
+	// Confirm BEFORE resolving the backplane so an operator who
+	// declines (or hits EOF on a piped /dev/null) exits 0 with the
+	// declined envelope regardless of whether `meho login` has been
+	// run. Mirrors the kb / agent delete shape.
+	if !opts.Confirm {
+		prompt := fmt.Sprintf("Delete convention %q. Continue?", opts.Slug)
+		if !confirmPrompt(cmd, prompt) {
+			result := deleteResult{Slug: opts.Slug, Status: "declined"}
+			if opts.JSONOut {
+				return output.PrintJSON(cmd.OutOrStdout(), result)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "declined: convention %q not deleted\n", opts.Slug)
+			return nil
+		}
+	}
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	if err := callDelete(cmd.Context(), backplaneURL, opts.Slug); err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	result := deleteResult{Slug: opts.Slug, Status: "deleted"}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), result)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "deleted convention %q\n", opts.Slug)
+	return nil
+}
+
+func callDelete(ctx context.Context, backplaneURL, slug string) error {
+	// doAuthedRequest returns (nil, nil) on a 204; the success signal
+	// is the absence of an error.
+	_, err := doAuthedRequest(ctx, backplaneURL, "DELETE", buildShowPath(slug), nil)
+	return err
+}

--- a/cli/internal/cmd/conventions/edit.go
+++ b/cli/internal/cmd/conventions/edit.go
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package conventions
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// updateRequest mirrors the backend ConventionUpdate pydantic model
+// (PATCH /api/v1/conventions/{slug}). Pydantic v2's
+// `model_fields_set` distinguishes "field absent from JSON" from "field
+// present with null", and the route handler applies only the
+// explicitly-set keys to the ORM row. Each field is a pointer so an
+// omitted CLI flag is left out of the JSON body via omitempty.
+//
+// `slug` and `kind` are absent from this struct by design — they're
+// not in the PATCH surface. Renaming a convention is delete + recreate
+// (the audit log and history rows reference the old slug); changing a
+// convention's kind in-place would silently change its preamble-
+// inclusion behaviour (operational → reference would disappear from
+// every future preamble without an audit signal), so the substrate
+// rejects it.
+type updateRequest struct {
+	Title    *string `json:"title,omitempty"`
+	Body     *string `json:"body,omitempty"`
+	Priority *int    `json:"priority,omitempty"`
+}
+
+// newEditCmd returns the `meho conventions edit` command.
+//
+//	meho conventions edit <slug> \
+//	  [--title T] [--body @file|@-|<inline-text>] [--priority N] \
+//	  [--json] [--backplane <url>]
+//
+// Role: tenant_admin. Two interaction modes:
+//
+//  1. **Flag-driven PATCH.** When any of --title / --body / --priority
+//     is set, the verb runs a partial PATCH with only those fields.
+//     Mirrors the agent / kb edit shape. This is the scripting path
+//     (CI pipelines, batch updates).
+//
+//  2. **$EDITOR interactive.** When no field flag is set, the verb
+//     fetches the current body, opens $EDITOR (or $VISUAL, fallback
+//     `vi`) on the seeded body, and submits the saved content as a
+//     PATCH on `body` only. This is the operator path for conversational
+//     rule edits — read the current body, edit in vim/nano/emacs/code,
+//     save, ship.
+//
+//     Editor failure or empty saved body aborts with no API call. A
+//     422 over-budget response is surfaced inline (estimated and budget
+//     token counts) so the operator sees the rejection before the
+//     buffer is discarded.
+//
+// A 404 (`convention_not_found`) covers both genuine absence and
+// cross-tenant probes. A 422 over-budget happens only when the saved
+// body is an `operational` convention exceeding the preamble token
+// budget; surface verbatim.
+//
+// Exit codes:
+//   - 0   convention updated cleanly
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (incl. 404, 422 invalid / over-budget)
+//   - 5   insufficient_role
+func newEditCmd() *cobra.Command {
+	var (
+		title             string
+		body              string
+		priority          int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "edit <slug>",
+		Short: "Edit one convention via flags or $EDITOR (tenant_admin)",
+		Long: "edit calls PATCH /api/v1/conventions/{slug}. Tenant_admin " +
+			"only.\n\n" +
+			"Two modes:\n\n" +
+			"1. Flag-driven PATCH: when any of --title / --body / " +
+			"--priority is set, only those fields are sent. Mirrors the " +
+			"agent / kb edit shape — the scripting path.\n\n" +
+			"2. $EDITOR interactive: when no field flag is set, the verb " +
+			"fetches the current body, opens $EDITOR (or $VISUAL, " +
+			"fallback vi) on the seeded body, and submits the saved " +
+			"content as a PATCH on body only. Editor failure or empty " +
+			"saved body aborts with no API call. A 422 over-budget " +
+			"response is surfaced inline (with estimated and budget " +
+			"token counts) before the buffer is discarded.\n\n" +
+			"--body accepts inline text, @<path>, or @-. The slug and " +
+			"kind are not editable: renaming is delete + recreate, " +
+			"changing kind would silently change preamble inclusion.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runEdit(cmd, editOptions{
+				Slug:              args[0],
+				Title:             title,
+				BodyArg:           body,
+				Priority:          priority,
+				titleSet:          cmd.Flags().Changed("title"),
+				bodySet:           cmd.Flags().Changed("body"),
+				prioritySet:       cmd.Flags().Changed("priority"),
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&title, "title", "", "new short display label")
+	cmd.Flags().StringVar(&body, "body", "",
+		"new body: inline text, @<path>, or @- (omit for $EDITOR mode)")
+	cmd.Flags().IntVar(&priority, "priority", 0,
+		"new ranking key (range -32768..32767)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw Convention JSON instead of the human summary")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type editOptions struct {
+	Slug              string
+	Title             string
+	BodyArg           string
+	Priority          int
+	titleSet          bool
+	bodySet           bool
+	prioritySet       bool
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runEdit(cmd *cobra.Command, opts editOptions) error {
+	if opts.Slug == "" {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("edit requires a non-empty <slug> argument"), opts.JSONOut)
+	}
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+
+	req, err := buildEditRequest(cmd, backplaneURL, opts)
+	if err != nil {
+		// buildEditRequest may surface either a CLI-level validation
+		// error (unexpected category) or an upstream HTTP error
+		// (rendered via renderRequestError already in $EDITOR mode).
+		// Distinguish by checking for our editorAbortError sentinel.
+		var abort *editorAbortError
+		if errors.As(err, &abort) {
+			// Editor mode aborted (editor failure or empty buffer).
+			// Render as unexpected; the message includes the specific
+			// reason. No API call was made.
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.Unexpected(abort.Error()), opts.JSONOut)
+		}
+		var preflight *editFetchError
+		if errors.As(err, &preflight) {
+			// Show-side fetch failed (404 / 401 / transport); render
+			// using the standard ladder so 404 carries the backend's
+			// convention_not_found detail.
+			return renderRequestError(cmd, backplaneURL, preflight.cause, opts.JSONOut)
+		}
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()), opts.JSONOut)
+	}
+	if req == nil {
+		// Defence in depth — buildEditRequest only returns nil when no
+		// fields end up populated, which buildEditRequest itself
+		// rejects upstream. Belt-and-braces in case of a future
+		// refactor.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("edit produced an empty PATCH body"), opts.JSONOut)
+	}
+
+	conv, err := patchEdit(cmd.Context(), backplaneURL, opts.Slug, *req)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), conv)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "updated convention %q\n", conv.Slug)
+	fmt.Fprintf(cmd.OutOrStdout(), "%-14s %s\n", "kind:", conv.Kind)
+	fmt.Fprintf(cmd.OutOrStdout(), "%-14s %d\n", "priority:", conv.Priority)
+	fmt.Fprintf(cmd.OutOrStdout(), "%-14s %s\n", "title:", conv.Title)
+	fmt.Fprintf(cmd.OutOrStdout(), "%-14s %s\n", "updated_at:", conv.UpdatedAt)
+	fmt.Fprintf(cmd.OutOrStdout(), "%-14s %d bytes\n", "body:", len(conv.Body))
+	return nil
+}
+
+// editorAbortError signals that $EDITOR mode aborted (editor exited
+// non-zero, returned an empty buffer, etc.) — no API call was made.
+// The runEdit caller renders this as `unexpected` exit-code 4 so the
+// failure is distinguishable from a remote rejection.
+type editorAbortError struct {
+	reason string
+}
+
+func (e *editorAbortError) Error() string { return e.reason }
+
+// editFetchError wraps the pre-edit Show fetch failure so runEdit can
+// route it through the standard error-classification ladder (a 404 on
+// the show call must surface as convention_not_found, not as a generic
+// "couldn't fetch" message).
+type editFetchError struct {
+	cause error
+}
+
+func (e *editFetchError) Error() string { return e.cause.Error() }
+func (e *editFetchError) Unwrap() error { return e.cause }
+
+// buildEditRequest assembles the PATCH body from the flag set or from
+// $EDITOR depending on which mode the operator invoked. Returns the
+// populated updateRequest or an error.
+//
+// Split from runEdit so the field-selection logic stays unit-testable
+// without standing up an httptest.Server in every test.
+func buildEditRequest(cmd *cobra.Command, backplaneURL string, opts editOptions) (*updateRequest, error) {
+	anyFlagSet := opts.titleSet || opts.bodySet || opts.prioritySet
+
+	if anyFlagSet {
+		req := &updateRequest{}
+		if opts.titleSet {
+			t := opts.Title
+			req.Title = &t
+		}
+		if opts.bodySet {
+			body, err := loadBodyFlag(cmd, opts.BodyArg)
+			if err != nil {
+				return nil, err
+			}
+			req.Body = &body
+		}
+		if opts.prioritySet {
+			if opts.Priority < -32768 || opts.Priority > 32767 {
+				return nil, fmt.Errorf("--priority must be between -32768 and 32767; got %d", opts.Priority)
+			}
+			p := opts.Priority
+			req.Priority = &p
+		}
+		return req, nil
+	}
+
+	// $EDITOR mode: fetch current body, open editor on it, PATCH the
+	// saved content as `body` only.
+	current, err := getConvention(cmd.Context(), backplaneURL, opts.Slug)
+	if err != nil {
+		return nil, &editFetchError{cause: err}
+	}
+	saved, err := runEditor(cmd, current.Body)
+	if err != nil {
+		return nil, &editorAbortError{reason: fmt.Sprintf("editor session aborted: %v", err)}
+	}
+	trimmed := strings.TrimRight(saved, "\r\n")
+	if trimmed == "" {
+		return nil, &editorAbortError{reason: "edited body is empty; aborting without API call"}
+	}
+	if trimmed == strings.TrimRight(current.Body, "\r\n") {
+		return nil, &editorAbortError{reason: "edited body is unchanged; aborting without API call"}
+	}
+	req := &updateRequest{Body: &trimmed}
+	return req, nil
+}
+
+func patchEdit(
+	ctx context.Context,
+	backplaneURL, slug string,
+	body updateRequest,
+) (*Convention, error) {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal conventions edit request: %w", err)
+	}
+	resp, err := doAuthedRequest(ctx, backplaneURL, "PATCH", buildShowPath(slug), raw)
+	if err != nil {
+		return nil, err
+	}
+	var out Convention
+	if err := json.Unmarshal(resp, &out); err != nil {
+		return nil, fmt.Errorf("decode conventions edit response: %w", err)
+	}
+	return &out, nil
+}

--- a/cli/internal/cmd/conventions/editor.go
+++ b/cli/internal/cmd/conventions/editor.go
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package conventions
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// runEditor opens the operator's preferred editor on a tempfile seeded
+// with `initialContent` and returns the post-save contents. The
+// editor's exit code is propagated as an error (non-zero exit aborts
+// the edit verb with no API call). The tempfile is removed on return.
+//
+// Editor precedence follows the issue body's contract: $EDITOR first,
+// then $VISUAL, then `vi`. (Standard POSIX is VISUAL first then
+// EDITOR; many CLIs — git, crontab — invert this. The issue body
+// pinned the order explicitly; we honour it.) The editor value is
+// word-split on whitespace so values like `vim -u NORC` or
+// `code --wait` work; we deliberately do NOT route through a shell
+// (no `sh -c`) so an editor value containing shell metacharacters
+// can't smuggle injection.
+//
+// The tempfile carries a `.md` suffix so editors that auto-pick syntax
+// highlighting (vim, emacs, code) render Markdown by default.
+//
+// `runEditor` is a package-level var so unit tests can stub the editor
+// integration without spawning a real editor — see crud_test.go.
+var runEditor = func(cmd *cobra.Command, initialContent string) (string, error) {
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = os.Getenv("VISUAL")
+	}
+	if editor == "" {
+		editor = "vi"
+	}
+
+	tmp, err := os.CreateTemp("", "meho-conv-*.md")
+	if err != nil {
+		return "", fmt.Errorf("create tempfile for editor: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmp.WriteString(initialContent); err != nil {
+		tmp.Close()
+		return "", fmt.Errorf("seed tempfile: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return "", fmt.Errorf("close tempfile: %w", err)
+	}
+
+	// Split the editor value on whitespace so `EDITOR="vim -u NORC"`
+	// invokes vim with the flag, not a binary literally named
+	// "vim -u NORC". No shell expansion (no sh -c) — the goal is to
+	// support the realistic editor-with-flags case, not to evaluate
+	// arbitrary shell.
+	parts := strings.Fields(editor)
+	if len(parts) == 0 {
+		return "", fmt.Errorf("editor command is empty after parsing %q", editor)
+	}
+	args := append(parts[1:], tmpPath)
+
+	editorCmd := exec.CommandContext(cmd.Context(), parts[0], args...) //nolint:gosec // operator-supplied editor; documented contract
+	editorCmd.Stdin = os.Stdin
+	editorCmd.Stdout = os.Stdout
+	editorCmd.Stderr = os.Stderr
+	if err := editorCmd.Run(); err != nil {
+		return "", fmt.Errorf("editor %q exited with error: %w", editor, err)
+	}
+
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		return "", fmt.Errorf("read edited tempfile: %w", err)
+	}
+	return string(data), nil
+}

--- a/cli/internal/cmd/conventions/history.go
+++ b/cli/internal/cmd/conventions/history.go
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package conventions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newHistoryCmd returns the `meho conventions history` command.
+//
+//	meho conventions history <slug> [--limit N] [--json] [--backplane <url>]
+//
+// Role: operator. Fetches the convention's edit trail via
+// GET /api/v1/conventions/{slug}/history, newest first (the route's
+// ORDER BY `ts DESC` enforces this).
+//
+// Default output renders unified diffs between consecutive entries:
+// for each pair of rows newest→oldest, the diff is between
+// `body_before` and `body_after` of that row, showing what changed in
+// that single edit. The first history row (CREATE) has no body_before
+// and shows only `body_after`; the DELETE row keeps the final body in
+// `body_after` for forensic completeness.
+//
+// `--limit N` bounds the number of history rows fetched + rendered
+// (client-side cap; the route returns the full trail). `--json` emits
+// the raw history rows for jq pipelines.
+//
+// Exit codes:
+//   - 0   history rendered cleanly
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (includes 404 slug-not-found)
+//   - 5   insufficient_role
+func newHistoryCmd() *cobra.Command {
+	var (
+		limit             int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "history <slug>",
+		Short: "Show the edit history of one convention",
+		Long: "history calls GET /api/v1/conventions/{slug}/history and " +
+			"renders the convention's edit trail newest first. Default " +
+			"output renders unified diffs between consecutive entries — " +
+			"each row shows what changed in that single edit. The CREATE " +
+			"row has no body_before and renders only the initial body; " +
+			"the DELETE row keeps the final body in body_after for " +
+			"forensic completeness. --limit N caps the number of rows " +
+			"rendered (default: all). --json emits the raw history rows.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runHistory(cmd, historyOptions{
+				Slug:              args[0],
+				Limit:             limit,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().IntVar(&limit, "limit", 0,
+		"cap the number of history rows rendered (default: all)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw history rows as JSON instead of the unified-diff view")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type historyOptions struct {
+	Slug              string
+	Limit             int
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runHistory(cmd *cobra.Command, opts historyOptions) error {
+	if opts.Slug == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("history requires a non-empty <slug> argument"),
+			opts.JSONOut,
+		)
+	}
+	if opts.Limit < 0 {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--limit must be non-negative; got %d", opts.Limit)),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	entries, err := getHistory(cmd.Context(), backplaneURL, opts.Slug)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.Limit > 0 && len(entries) > opts.Limit {
+		entries = entries[:opts.Limit]
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), entries)
+	}
+	printHistoryDiffs(cmd.OutOrStdout(), opts.Slug, entries)
+	return nil
+}
+
+// buildHistoryPath assembles the GET path. Exposed for unit tests.
+func buildHistoryPath(slug string) string {
+	return "/api/v1/conventions/" + pathEscape(slug) + "/history"
+}
+
+func getHistory(ctx context.Context, backplaneURL, slug string) ([]HistoryEntry, error) {
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildHistoryPath(slug), nil)
+	if err != nil {
+		return nil, err
+	}
+	var out []HistoryEntry
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode conventions history response: %w", err)
+	}
+	return out, nil
+}
+
+// printHistoryDiffs renders each history row as a header + a unified
+// diff of body_before → body_after for that single edit. The CREATE
+// row (no body_before) renders the initial body without a diff prefix;
+// the DELETE row would surface as a final-body block too. Subsequent
+// edits show the per-edit diff so an operator scanning the trail sees
+// what each session changed.
+//
+// Why per-row diffs (not cross-row): each history row already carries
+// both before + after for the edit that produced it. Computing diffs
+// across consecutive rows (row[i].body_after vs row[i+1].body_after)
+// would double-emit the same change and lose the natural
+// transaction boundary. The substrate writes one history row per
+// transaction, so the row-local before/after pair is already the right
+// granularity.
+func printHistoryDiffs(w io.Writer, slug string, entries []HistoryEntry) {
+	if len(entries) == 0 {
+		fmt.Fprintf(w, "no history for convention %q\n", slug)
+		return
+	}
+	for i, e := range entries {
+		if i > 0 {
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintf(w, "=== %s  actor=%s  history_id=%s\n", e.Ts, e.ActorSub, e.ID)
+		if e.AuditID != nil {
+			fmt.Fprintf(w, "    audit_id=%s\n", *e.AuditID)
+		} else {
+			fmt.Fprintln(w, "    audit_id=<seed>")
+		}
+
+		if e.BodyBefore == nil {
+			// CREATE row (or any other row with no prior state). Show
+			// the initial body as a + block so the trail visibly
+			// distinguishes the create from a body-replacing edit.
+			fmt.Fprintln(w, "--- /dev/null")
+			fmt.Fprintf(w, "+++ %s @ %s\n", slug, e.Ts)
+			for _, line := range strings.Split(strings.TrimRight(e.BodyAfter, "\r\n"), "\n") {
+				fmt.Fprintf(w, "+ %s\n", line)
+			}
+			continue
+		}
+
+		before := strings.TrimRight(*e.BodyBefore, "\r\n")
+		after := strings.TrimRight(e.BodyAfter, "\r\n")
+		if before == after {
+			// Title- or priority-only edit — body unchanged. The
+			// history row still exists (the substrate writes one per
+			// PATCH whether or not body changed), but the diff is
+			// empty. Surface that explicitly rather than printing a
+			// blank section.
+			fmt.Fprintln(w, "    (body unchanged — title/priority edit)")
+			continue
+		}
+		fmt.Fprintf(w, "--- %s @ <prev>\n", slug)
+		fmt.Fprintf(w, "+++ %s @ %s\n", slug, e.Ts)
+		writeUnifiedDiff(w, before, after)
+	}
+}
+
+// writeUnifiedDiff emits a simple line-oriented diff in unified
+// format. This is not a full LCS-quality diff (real `diff -u` quality
+// would require pulling in a 3rd-party library or implementing
+// Myers); it's a structural diff: lines present in `before` but not
+// `after` are `-`, lines present in `after` but not `before` are `+`,
+// shared lines are context. For typical convention edits (a small
+// number of rule lines edited at a time), the structural diff renders
+// cleanly enough for the operator to see "what changed". The `--json`
+// path stays as the escape valve for operators who need a precise
+// machine-readable diff.
+//
+// Implementation choice: we deliberately avoid a third-party diff
+// library to keep the CLI's dependency surface minimal — the binary
+// ships to operators who run it on laptops, in CI, and inside
+// containers; every transitive dependency adds maintenance debt and a
+// supply-chain edge.
+func writeUnifiedDiff(w io.Writer, before, after string) {
+	beforeLines := strings.Split(before, "\n")
+	afterLines := strings.Split(after, "\n")
+
+	// Build a map of after-lines for O(N) presence checks. We deliberately
+	// do NOT use a multiset because operationally-realistic convention
+	// bodies don't have many duplicated lines; the simple presence test
+	// is good enough.
+	afterSet := make(map[string]bool, len(afterLines))
+	for _, line := range afterLines {
+		afterSet[line] = true
+	}
+	beforeSet := make(map[string]bool, len(beforeLines))
+	for _, line := range beforeLines {
+		beforeSet[line] = true
+	}
+
+	// Walk before-lines, emitting `-` for lines not in after, ` ` for
+	// lines that are. Then walk after-lines for the `+` adds (lines
+	// not in before). This is the simplest diff that surfaces the
+	// shape of a change without the complexity of a real Myers
+	// implementation; for runbook-style Markdown bodies it reads
+	// fine. Operators wanting a real diff pipe `--json | jq -r
+	// '.[]|.body_after' | diff -u <(meho conventions history ... --json | jq...)`.
+	for _, line := range beforeLines {
+		if afterSet[line] {
+			fmt.Fprintf(w, "  %s\n", line)
+		} else {
+			fmt.Fprintf(w, "- %s\n", line)
+		}
+	}
+	for _, line := range afterLines {
+		if !beforeSet[line] {
+			fmt.Fprintf(w, "+ %s\n", line)
+		}
+	}
+}

--- a/cli/internal/cmd/conventions/list.go
+++ b/cli/internal/cmd/conventions/list.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package conventions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/url"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newListCmd returns the `meho conventions list` command.
+//
+//	meho conventions list [--kind K] [--json] [--backplane <url>]
+//
+// Role: operator. Lists the operator's tenant's conventions, sorted
+// `priority DESC, created_at ASC` (the same key the T4 preamble
+// assembler uses for packing — so the list view surfaces conventions
+// in the order T4 would consider them).
+//
+// --kind narrows by kind (operational | workflow | reference); when
+// omitted, all kinds are returned. The backend route's only filter is
+// --kind; for paginated browsing of a large tenant, the operator
+// scopes via the kind flag, not via limit/offset (the substrate does
+// not paginate; v0.2 list returns the full set, ordered).
+//
+// Acceptance criterion note (issue body): "lowest-priority slugs that
+// will be dropped when the tenant's operational set exceeds the
+// preamble budget" — that signal lives in the T4 preamble assembler
+// (sibling task #316), not in the T2 list endpoint. The list verb here
+// renders the priority column verbatim so an operator can spot
+// over-budget candidates manually; the dropped-slugs warning wires in
+// once T4 exposes that information. See `printOverBudgetWarning`
+// below for the structural placeholder.
+//
+// Exit codes:
+//   - 0   list returned cleanly (including zero rows)
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected response shape
+//   - 5   insufficient_role
+func newListCmd() *cobra.Command {
+	var (
+		kind              string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List tenant conventions, optionally filtered by kind",
+		Long: "list calls GET /api/v1/conventions and renders the " +
+			"conventions registered in the operator's tenant, sorted " +
+			"priority DESC, created_at ASC — the same order T4's preamble " +
+			"assembler uses. --kind filters by operational | workflow | " +
+			"reference. --json emits the raw ListResponse envelope for jq " +
+			"pipelines.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runList(cmd, listOptions{
+				Kind:              kind,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&kind, "kind", "",
+		"narrow entries by kind: operational | workflow | reference")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw ListResponse JSON instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type listOptions struct {
+	Kind              string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runList(cmd *cobra.Command, opts listOptions) error {
+	// Validate --kind locally so an operator typo surfaces immediately
+	// rather than as a remote 422 the user has to decode.
+	if opts.Kind != "" && !validKinds[opts.Kind] {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"--kind must be one of: operational, workflow, reference; got %q",
+				opts.Kind,
+			)),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	resp, err := getList(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp)
+	}
+	printListTable(cmd.OutOrStdout(), resp)
+	return nil
+}
+
+// buildListPath assembles the GET /api/v1/conventions query string from
+// the per-call options. Exposed for unit tests so the URL construction
+// stays unit-checkable without standing up an httptest.Server.
+func buildListPath(opts listOptions) string {
+	q := url.Values{}
+	if opts.Kind != "" {
+		q.Set("kind", opts.Kind)
+	}
+	path := "/api/v1/conventions"
+	if encoded := q.Encode(); encoded != "" {
+		path = path + "?" + encoded
+	}
+	return path
+}
+
+func getList(ctx context.Context, backplaneURL string, opts listOptions) (*ListResponse, error) {
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildListPath(opts), nil)
+	if err != nil {
+		return nil, err
+	}
+	var out ListResponse
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode conventions list response: %w", err)
+	}
+	return &out, nil
+}
+
+// printListTable renders the list as a compact, scannable table.
+// Columns: SLUG, KIND, PRIORITY, UPDATED, TITLE. The full ISO-8601
+// timestamp is kept verbatim (not truncated) because operators
+// correlating with audit-log rows want the precise updated_at.
+func printListTable(w io.Writer, r *ListResponse) {
+	if r == nil || len(r.Entries) == 0 {
+		fmt.Fprintln(w, "no conventions registered in this tenant")
+		return
+	}
+	fmt.Fprintf(w, "%-32s %-11s %-8s %-32s %s\n", "SLUG", "KIND", "PRIORITY", "UPDATED", "TITLE")
+	for _, e := range r.Entries {
+		fmt.Fprintf(w, "%-32s %-11s %-8d %-32s %s\n",
+			truncate(e.Slug, 32),
+			e.Kind,
+			e.Priority,
+			e.UpdatedAt,
+			truncate(e.Title, 60),
+		)
+	}
+}
+
+// truncate cuts s to maxLen runes, appending an ellipsis when
+// truncation happened. Rune-aware so multi-byte UTF-8 survives the
+// cut. Same shape as the sibling-package helpers.
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}

--- a/cli/internal/cmd/conventions/show.go
+++ b/cli/internal/cmd/conventions/show.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package conventions
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newShowCmd returns the `meho conventions show` command.
+//
+//	meho conventions show <slug> [--json] [--backplane <url>]
+//
+// Role: operator. Fetches one convention via
+// GET /api/v1/conventions/{slug} and renders the body as Markdown by
+// default (pipe through `glow`, `bat -l md`, etc. for prettified
+// rendering); --json wraps the full Convention shape.
+//
+// A 404 (`convention_not_found`) covers both genuine absence and
+// cross-tenant probes — the conflation prevents enumerating other
+// tenants via status-code differential.
+//
+// Exit codes:
+//   - 0   convention rendered cleanly
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (includes 404 slug-not-found)
+//   - 5   insufficient_role
+func newShowCmd() *cobra.Command {
+	var (
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "show <slug>",
+		Short: "Fetch one convention by slug",
+		Long: "show calls GET /api/v1/conventions/{slug} and renders the " +
+			"convention body as Markdown to stdout. Pipe through a Markdown " +
+			"renderer (glow, bat -l md, mdcat, etc.) for prettified output. " +
+			"--json wraps the convention in the full Convention envelope " +
+			"(id, slug, title, body, kind, priority, timestamps). A 404 " +
+			"means the slug doesn't exist in your tenant (the route " +
+			"conflates cross-tenant probes with genuine absence so existence " +
+			"is never leaked).",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runShow(cmd, showOptions{
+				Slug:              args[0],
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw Convention JSON instead of the Markdown body")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type showOptions struct {
+	Slug              string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runShow(cmd *cobra.Command, opts showOptions) error {
+	if opts.Slug == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("show requires a non-empty <slug> argument"),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	conv, err := getConvention(cmd.Context(), backplaneURL, opts.Slug)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), conv)
+	}
+	printConventionBody(cmd.OutOrStdout(), conv)
+	return nil
+}
+
+// buildShowPath assembles the GET path. Exposed for unit tests so URL
+// encoding of slugs stays covered (slugs are constrained to lowercase
+// ASCII + digits + hyphen server-side, but the escape is defensive).
+func buildShowPath(slug string) string {
+	return "/api/v1/conventions/" + pathEscape(slug)
+}
+
+func getConvention(ctx context.Context, backplaneURL, slug string) (*Convention, error) {
+	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildShowPath(slug), nil)
+	if err != nil {
+		return nil, err
+	}
+	var out Convention
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode conventions show response: %w", err)
+	}
+	return &out, nil
+}
+
+// printConventionBody writes the convention's Markdown body to stdout
+// verbatim with exactly one trailing newline. The substrate stores the
+// body unmodified, so a body that already ends in `\n` (the
+// conventional shape — most editors enforce a trailing LF on save)
+// would otherwise produce two newlines when Fprintln adds its own.
+// Trimming `\r` + `\n` from the right keeps the single-trailing-
+// newline contract regardless of whether the operator stored their
+// body with or without a trailing LF/CRLF.
+func printConventionBody(w io.Writer, c *Convention) {
+	if c == nil {
+		return
+	}
+	fmt.Fprintln(w, strings.TrimRight(c.Body, "\r\n"))
+}

--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/evoila/meho/cli/internal/cmd/bind9"
 	"github.com/evoila/meho/cli/internal/cmd/broadcast"
 	"github.com/evoila/meho/cli/internal/cmd/connector"
+	"github.com/evoila/meho/cli/internal/cmd/conventions"
 	"github.com/evoila/meho/cli/internal/cmd/gcloud"
 	"github.com/evoila/meho/cli/internal/cmd/harbor"
 	hetznerrobot "github.com/evoila/meho/cli/internal/cmd/hetzner-robot"
@@ -152,6 +153,16 @@ func newRootCmd() *cobra.Command {
 	// registerDynamicSubcommands so the backplane manifest cannot
 	// shadow the built-in `kb` parent.
 	root.AddCommand(kb.NewRootCmd())
+
+	// G7.1-T3 (#315) -- conventions verbs (list / show / create / edit /
+	// delete / history) for Initiative #229 (tenant conventions). Wraps
+	// the six /api/v1/conventions routes shipped by G7.1-T2 (#314).
+	// Read verbs are operator-level; write verbs require tenant_admin.
+	// The `edit` verb supports two modes — flag-driven PATCH (scripting)
+	// and $EDITOR interactive (operator conversational edit). Registered
+	// before registerDynamicSubcommands so the backplane manifest cannot
+	// shadow the built-in `conventions` parent.
+	root.AddCommand(conventions.NewRootCmd())
 
 	// G5.1-T4 (#424) -- top-level memory verbs (remember / recall /
 	// forget / list) for Initiative #332. Each verb is registered

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -48,6 +48,18 @@ names.
   the five `/api/v1/kb*` routes shipped by G4.1-T2 (#416) plus the
   `/api/v1/retrieve` route (G0.4-T5 #262, `source="kb"` scoped)
   for the search verb.
+- `meho conventions ...` (G7.1-T3 #315) — tenant-conventions
+  operator surface (`list`, `show`, `create`, `edit`, `delete`,
+  `history`) wrapping the six `/api/v1/conventions*` routes
+  shipped by G7.1-T2 (#314). `edit` ships in two modes: flag-driven
+  PATCH (scripting path) and `$EDITOR` interactive (operator
+  conversational-edit path; fetches current body, opens
+  $EDITOR/$VISUAL/vi on a `.md` tempfile, submits saved content as
+  a `body`-only PATCH). `history` renders unified-diff per row
+  (body_before → body_after); `--json` exposes raw history rows
+  for `jq`/`diff -u` pipelines. The dropped-slug warning the issue
+  body expected on `list` lives behind a T4 API surface that hasn't
+  shipped yet; the verb is structurally ready.
 - `meho remember / recall / forget / list` (G5.1-T4 #424) — memory
   operator surface, registered as **top-level** verbs (no `memory`
   parent — per consumer-needs.md §G5's ergonomic shape:
@@ -136,6 +148,16 @@ cli/
     │   │   ├── show_test.go      # path-escape + Markdown body to stdout + 404 slug_not_found tests.
     │   │   ├── add_test.go       # body-from-file / @- / inline + metadata parse + 422 surface tests.
     │   │   └── delete_test.go    # confirm-prompt + idempotent-204 + --json envelope tests.
+    │   ├── conventions/      # G7.1-T3 #315 — `meho conventions …` verb tree.
+    │   │   ├── conventions.go    # NewRootCmd + shared HTTP/auth helpers + body/confirm helpers + $EDITOR seam (runEditor var).
+    │   │   ├── list.go           # `meho conventions list [--kind K]` (GET /api/v1/conventions); table or --json.
+    │   │   ├── show.go           # `meho conventions show <slug>` (GET /api/v1/conventions/{slug}); Markdown body to stdout.
+    │   │   ├── create.go         # `meho conventions create --slug --kind --title --body @file [--priority]` (POST /api/v1/conventions).
+    │   │   ├── edit.go           # `meho conventions edit <slug>` (PATCH /api/v1/conventions/{slug}); flag-driven OR $EDITOR interactive.
+    │   │   ├── delete.go         # `meho conventions delete <slug> [--confirm]` (DELETE /api/v1/conventions/{slug}).
+    │   │   ├── history.go        # `meho conventions history <slug> [--limit N]` (GET /api/v1/conventions/{slug}/history); unified-diff per row.
+    │   │   ├── conventions_test.go # helpers + register-all-six-verbs + body/confirm/path-escape contract tests.
+    │   │   └── crud_test.go      # per-verb HTTP-server tests: list table + JSON, show 404, create 409/422-over-budget, edit flag/$EDITOR modes + 422 inline surface, delete confirm/decline/404, history diffs + --limit + --json.
     │   ├── memory/           # G5.1-T4 #424 — top-level `meho remember/recall/forget/list` (no parent).
     │   │   ├── memory.go         # Scope enum + Entry/ListResponse/RetrievalHit + shared HTTP/auth helpers + parseScope/parseTTL/parseTags/parseScopeSlugArg/loadBody/confirmPrompt.
     │   │   ├── remember.go       # `meho remember <body> [--scope --slug --target --tag --ttl --persist --json]` (POST /api/v1/memory). `--persist` (G5.2-T2 #624) sends explicit `expires_at: null` to opt out of the backend's default-7-day TTL on `memory-user` writes.

--- a/docs/codebase/tenant_conventions.md
+++ b/docs/codebase/tenant_conventions.md
@@ -10,9 +10,8 @@ models, and access patterns. Layer 2 lives in
 [docs/examples/consumer-onboarding/](../examples/consumer-onboarding/)
 (landed by sibling task #318).
 
-This document is current as of T2 (#314). Sibling tasks T3-T5 will
-extend it with the CLI, preamble assembler, and seed details as
-they land.
+This document is current as of T3 (#315). Sibling tasks T4-T5 will
+extend it with the preamble assembler and seed details as they land.
 
 ## Overview
 
@@ -203,6 +202,102 @@ The pre-allocation primitive is a small, additive chassis change
 v0.1 fresh-uuid behaviour). The alternative -- having the route
 write its own audit row (the topology-nodes pattern) -- would
 double-audit because the middleware also fires per HTTP request.
+
+## CLI surface (T3)
+
+T3 (#315) ships the `meho conventions ...` cobra subcommand tree
+[`cli/internal/cmd/conventions/`](../../cli/internal/cmd/conventions/).
+Each verb wraps exactly one T2 route; the audit log row + history
+row are written server-side, so the CLI is a thin HTTP client over
+the same JWT auth + bearer-refresh path the sibling `meho kb` /
+`meho agent` trees use.
+
+Six verbs:
+
+- **`meho conventions list [--kind K] [--json]`** -- GET
+  `/api/v1/conventions`. Renders a `SLUG | KIND | PRIORITY |
+  UPDATED | TITLE` table by default; `--json` emits the raw
+  `ConventionListResponse` envelope. `--kind` narrows by
+  `operational | workflow | reference` (CLI-side validation
+  rejects typos before the round-trip).
+- **`meho conventions show <slug> [--json]`** -- GET
+  `/api/v1/conventions/{slug}`. Writes the Markdown body to stdout
+  for `glow` / `bat -l md` pipelines; `--json` wraps the full
+  `Convention` shape.
+- **`meho conventions create --slug S --kind K --title T --body @file
+  [--priority N] [--json]`** -- POST `/api/v1/conventions`. `--body`
+  accepts inline text, `@<path>` to read a file, or `@-` for stdin;
+  the realistic shape is `@<path>` with a Markdown rule file. A
+  duplicate `(tenant, slug)` returns 409 with detail
+  `convention_already_exists`; an over-budget operational body
+  returns 422 with `estimated=X, budget=Y` surfaced verbatim.
+  `--priority` is omitted from the JSON body when unset so the
+  backend's default-0 server_default applies.
+- **`meho conventions edit <slug> [--title T] [--body @file]
+  [--priority N] [--json]`** -- PATCH `/api/v1/conventions/{slug}`,
+  two modes:
+  1. **Flag-driven PATCH** (any of `--title` / `--body` /
+     `--priority` set) -- sends only the explicitly-set fields,
+     mirroring pydantic's `model_fields_set` semantics on the
+     backend.
+  2. **`$EDITOR` interactive** (no field flag set) -- fetches the
+     current body (GET `/api/v1/conventions/{slug}`), opens
+     `$EDITOR` (or `$VISUAL`, fallback `vi`) on a `.md` tempfile
+     seeded with that body, and submits the saved content as a
+     `body`-only PATCH. Editor failure, empty saved buffer, or an
+     unchanged save aborts without an API call. A 422 over-budget
+     response surfaces inline (the operator sees `estimated=X,
+     budget=Y` before the buffer is discarded -- so they can
+     re-edit and retry without losing the work).
+- **`meho conventions delete <slug> [--confirm] [--json]`** --
+  DELETE `/api/v1/conventions/{slug}`. y/N prompt on stdin by
+  default; `--confirm` skips for scripted use. The substrate's
+  `body_after=<final body>` write into history preserves the
+  deleted convention for audit forensics.
+- **`meho conventions history <slug> [--limit N] [--json]`** -- GET
+  `/api/v1/conventions/{slug}/history`. Renders unified-diff
+  rendering of `body_before` -> `body_after` per row (the diff
+  shows what changed in that single edit; the CREATE row has no
+  body_before and renders the initial body as a `+`-block).
+  `--limit N` is a client-side cap; the route returns the full
+  trail. `--json` emits the raw history rows for `jq` pipelines or
+  for piping into a real `diff -u` if the unified view's
+  presence-set diff (a simplified renderer; see code comment for
+  why we don't ship Myers) isn't precise enough.
+
+Exit codes mirror the sibling verb trees:
+
+- `0` -- ok (including zero rows on `list`, declined prompt on
+  `delete`, no history on `history`).
+- `2` -- `auth_expired` (no stored token, refresh failed, bearer
+  rejected after refresh).
+- `3` -- `unreachable` (transport error against the backplane).
+- `4` -- `unexpected_response` (4xx / 5xx -- includes 404
+  `convention_not_found`, 409 `convention_already_exists`, 422
+  invalid / over-budget).
+- `5` -- `insufficient_role` (403 on write verbs without the
+  `tenant_admin` claim; the backend's detail naming the required
+  role surfaces in the error message).
+
+The CLI does **not** generate or mutate audit_log rows itself --
+those land server-side from the T2 routes via the audit middleware.
+
+**Dropped-slug warning (deferred to T4).** The issue body's
+acceptance criterion for `list` to surface "lowest-priority slugs
+that will be dropped when the tenant's operational set exceeds the
+preamble budget" depends on T4's preamble assembler returning
+`dropped_slugs` as part of an assembly pass. The T2 list endpoint
+returns only the `ConventionListResponse` envelope (entries +
+forward-compat fields); there is no `dropped_slugs` field on the
+GET surface today, so the CLI cannot synthesise the warning from a
+list call alone. T4 will either (a) add a query param to the list
+endpoint that runs a dry-run packing pass and returns
+`dropped_slugs`, or (b) expose a separate
+`GET /api/v1/conventions/preamble?dry_run=true` endpoint the CLI
+can call after `list`. The CLI verb's structural code path is
+ready -- once T4 ships the API surface, wiring the warning is a
+small additive PR (see `printOverBudgetWarning` placeholder
+discussion in `list.go`'s docstring).
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary
- Six `meho conventions ...` verbs wrapping G7.1-T2's REST surface — `list / show / create / edit / delete / history`.
- `edit` ships both a flag-driven PATCH (scripting) and a `$EDITOR` interactive mode (operator conversational-edit); $EDITOR/$VISUAL/vi precedence per issue body; editor failure / empty / unchanged buffer aborts without an API call; 422 over-budget surfaces inline before the buffer is discarded.
- `history` renders unified-diff per row (`body_before` → `body_after`); `--json` exposes raw rows for jq/diff -u pipelines.
- Follows the in-package HTTP helper pattern of `meho kb` / `meho agent` (no shared client package — cmd/* import-cycle reason every sibling cites).

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./internal/cmd/conventions/...` — all unit tests pass
- [x] `go test -race ./...` — full CLI suite passes with race detector
- [x] `golangci-lint run ./...` — 0 issues (v2.12.2, mirrors CI)
- [x] `gofmt -l` — clean
- [x] `meho conventions --help` — all six verbs listed; per-verb help renders correctly
- [x] AC1 (6 verbs work end-to-end): backed by per-verb httptest.Server unit tests covering happy-path round-trips through `doAuthedRequest` + bearer injection.
- [x] AC2 (`--json` works on every verb): explicit JSON-path tests for list / show / history + structural JSON-out flag on all verbs.
- [x] AC3 (`edit` invokes `$EDITOR`, saved → PATCH, aborted → no API): three editor-mode tests — happy path, empty-save abort, unchanged-save abort, editor-failure abort. PATCH never reached on abort (asserted by request-counter).
- [x] AC4 (`history --limit 5` bounded): test exercises `--limit 2` with three rows; only first two render; unified-diff format checked.
- [x] AC5 (403 surfaces "tenant_admin required"): `TestRunCreate403SurfacesInsufficientRole` confirms the backend's detail string flows through `insufficient_role` (exit 5).
- [x] AC6 (404 clean on show/edit/delete/history): four 404 tests confirm `convention_not_found` flows through `unexpected` (exit 4).
- [x] AC7 (409 clean on create duplicate): `TestRunCreate409SurfacesDuplicate` confirms `convention_already_exists` surfaces.

## Out of scope / deferred

- **Dropped-slugs warning on `list`** — the issue body's AC for `list` to "exit non-zero and print a warning naming the lowest-priority slugs that will be dropped when the tenant's operational set exceeds the preamble budget" requires T4's preamble assembler (sibling #316) to expose `dropped_slugs` via either a list query-param (`?include_preamble_drops=true`) or a separate dry-run endpoint. T2's list endpoint (`GET /api/v1/conventions`) returns only the `ConventionListResponse` envelope today; there is no `dropped_slugs` field to read. The CLI verb's structural path is ready — wiring the warning is a small additive PR once T4 ships the API surface. Documented in `docs/codebase/tenant_conventions.md` § CLI surface (T3) and in `list.go`'s docstring. (Also, on reflection, "exit non-zero when over-budget candidates exist" is an odd contract for a list verb — the list itself succeeded; over-budget is a per-tenant warning, not a list failure. Recommend revisiting that AC shape when T4 wires the surface.)
- Sibling tasks T4 (#316), T5 (#317) remain in their own PRs.
- Bulk-import from a Markdown directory, convention templates / scaffolding, cross-tenant ops, watch-for-external-edits — all per issue body's Out of scope.

## Notes

- Audit log rows are written **server-side** by the T2 routes via the audit middleware (the issue body acknowledges this). CLI does not generate audit rows.
- Editor precedence follows the issue body's sample code (`$EDITOR` → `$VISUAL` → `vi`), not POSIX (which is `VISUAL` → `EDITOR` → `vi`). Documented in `editor.go`'s docstring.
- `runEditor` is a package-level `var` so unit tests stub the editor seam without spawning real processes (same pattern the `readBodyFile` seam uses).
- The `history` verb's unified-diff is a simple presence-set diff, not a Myers / LCS implementation — small dependency surface for a CLI that ships to operator laptops. Documented in `writeUnifiedDiff`'s docstring; operators needing precise diffs pipe `--json` into real `diff -u`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #315
