### PR TITLE
feat(ui): G10.5-T2 Topology Cytoscape graph view + cross-link + 500-node cap

### DIFF
--- a/backend/src/meho_backplane/ui/routes/topology/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/topology/__init__.py
@@ -1,27 +1,35 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Topology UI routes: tabular view + node detail drawer.
+"""Topology UI routes: tabular view + Cytoscape graph + node detail drawer.
 
-Initiative #342 (G10.5 Topology UI), Task #880 (G10.5-T1). This subpackage
-ships the read-only tabular surface plus the per-node drawer the
-chassis stub (#866) placeholders for. The Cytoscape.js graph view + the
-table-graph cross-link land in T2 (#881); the dependents / path query
-overlays land in T3 (#882).
+Initiative #342 (G10.5 Topology UI). Task #880 (G10.5-T1) shipped the
+tabular surface + drawer; Task #881 (G10.5-T2) layered the Cytoscape.js
+graph view on the same ``/ui/topology`` path via the ``?view=graph``
+branch. T3 (#882) adds dependents / path query overlays on top of the
+graph.
 
 Module layout:
 
 * :mod:`~meho_backplane.ui.routes.topology.table` -- the
-  ``GET /ui/topology`` route. Renders the full HTML page on a normal
-  GET and an HTMX fragment of just the table body on an
-  ``HX-Request`` round trip so sort / filter changes swap into the
-  same DOM tree without a full re-render.
+  ``GET /ui/topology`` route. One handler serves three response
+  shapes: the full tabular page (browser nav, ``view=table``), the
+  ``_table_rows.html`` HTMX fragment (sort / filter swap), and the
+  Cytoscape graph full page (``view=graph``). The graph branch
+  delegates to ``graph.render_graph``.
+* :mod:`~meho_backplane.ui.routes.topology.graph` -- the
+  ``?view=graph`` render. Pulls nodes via the substrate
+  :func:`list_nodes` (capped at 500 per Initiative #342 work item
+  #6) and edges via a local SQLite-portable ORM query, then emits
+  the Cytoscape elements as a ``<script type="application/json">``
+  data island the ``topology-graph.js`` Alpine controller reads on
+  init.
 * :mod:`~meho_backplane.ui.routes.topology.detail` -- the
   ``GET /ui/topology/node/{node_id}`` route. Renders the side-drawer
-  fragment with node properties, incoming/outgoing edges, recent
-  audit operations on the node's target (when one is attached), and
-  a "show dependents" link that hands off to the future T3 graph
-  view.
+  fragment shared by both the table view (HTMX row "View" button)
+  and the graph view (HTMX node-tap handler) with node properties,
+  incoming/outgoing edges, recent audit operations on the node's
+  target (when one is attached), and a "show dependents" link.
 
 The umbrella :func:`build_router` aggregates both. It is mounted
 **before** :func:`meho_backplane.ui.routes.stubs.build_stubs_router`
@@ -29,7 +37,7 @@ in :func:`meho_backplane.ui.routes.build_router` so the real
 ``/ui/topology`` handler wins the first-match-wins lookup -- a later
 ``include_router`` for the stub does **not** override an earlier
 registration (verified at construction time with a FastAPI test
-client). The remaining four stub surfaces stay placeholder routes
+client). The remaining three stub surfaces stay placeholder routes
 until their own G10.x Initiatives land.
 """
 

--- a/backend/src/meho_backplane/ui/routes/topology/graph.py
+++ b/backend/src/meho_backplane/ui/routes/topology/graph.py
@@ -1,0 +1,329 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``GET /ui/topology?view=graph`` -- the tenant topology Cytoscape graph view.
+
+Initiative #342 (G10.5 Topology UI), Task #881 (G10.5-T2). Renders an
+interactive node-link visualisation of the tenant's graph as a
+Cytoscape.js island the operator can pan, zoom, and click. Reuses the
+T1 (#880) :func:`meho_backplane.topology.query.list_nodes` substrate
+plus a local SQLite-portable edge query (the substrate's
+:func:`~meho_backplane.topology.query.list_edges` leans on PostgreSQL
+``jsonb_typeof`` for the conflict predicate; the graph view does not
+need conflict info so a leaner ORM query that runs on both dialects is
+the right factoring -- same call as the T1 drawer's ``_fetch_edges``).
+
+The route is the same handler as
+:mod:`meho_backplane.ui.routes.topology.table` -- both modes share the
+``GET /ui/topology`` path and branch on ``?view=`` so the URL contract
+holds across the table/graph toggle and copy/paste reproduces either
+mode. ``view`` is plumbed through :mod:`...topology.table` (the
+shipped handler since T1) which delegates the graph branch here.
+
+Layout strategy
+---------------
+
+The graph emits node + edge JSON into a ``<script type="application/json">``
+data island; the Cytoscape init (``topology-graph.js``) reads it on
+init and registers the two extension layouts (``cose-bilkent`` /
+``dagre``) plus the built-in ``circle``. Server-side this module owns
+only the data + the layout switcher chrome; layout selection is
+client-state-only (an Alpine ``<select>`` calls
+``cy.layout({name}).run()``).
+
+500-node frontend cap
+---------------------
+
+Per Initiative #342 work item #6, the frontend renders at most
+:data:`_GRAPH_NODE_CAP` (500) nodes. Beyond that the operator is
+prompted to narrow the inventory or hand off to the T3 (#882) subgraph
+query. The cap is enforced at the route by passing ``limit=500`` into
+:func:`list_nodes`; the template surfaces a truncation banner when the
+returned list is at the cap so an operator knows the rendered view is
+incomplete.
+
+Tenant scoping
+--------------
+
+Every read goes through :func:`list_nodes` (substrate-level
+``WHERE graph_node.tenant_id = :tenant_id`` first clause, no override
+path) plus the local :func:`_fetch_edges_for_nodes` (same
+defence-in-depth as the T1 detail route: edge ``tenant_id`` + both
+endpoint ``tenant_id`` joined explicitly). Cross-tenant nodes/edges
+cannot surface even if a future invariant violation introduced one.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Final
+
+from fastapi.responses import HTMLResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from meho_backplane.db.models import GraphEdge, GraphNode
+from meho_backplane.topology.query import TopologyNodeListEntry, list_nodes
+from meho_backplane.ui.auth.middleware import UISessionContext
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.templating import get_templates
+
+__all__ = [
+    "GRAPH_NODE_CAP",
+    "render_graph",
+]
+
+
+#: Frontend-side render cap. Cytoscape comfortably handles ~1k nodes,
+#: but legibility past 500 collapses to a hairball. Beyond this number
+#: the page surfaces a truncation banner and routes the operator at
+#: the T3 (#882) subgraph query. Pinned per Initiative #342 work item
+#: #6 ("Performance discipline. ... v0.2 caps frontend-side rendering
+#: at 500 nodes").
+GRAPH_NODE_CAP: Final[int] = 500
+
+#: Module-private alias for use inside ``_fetch_edges_for_nodes`` --
+#: keeps the public-facing constant clean while letting the helper
+#: keep a short local name.
+_GRAPH_NODE_CAP = GRAPH_NODE_CAP
+
+
+@dataclass(frozen=True)
+class _GraphEdgeRow:
+    """One edge the graph view renders.
+
+    Frozen dataclass because the rows are immutable projections of the
+    query result. The Pydantic :class:`TopologyEdge` (in the substrate
+    schema module) carries a deep-frozen ``properties`` map that the
+    graph view does not need -- the lighter dataclass keeps the per-row
+    allocation small for the up-to-500-node ceiling.
+    """
+
+    id: uuid.UUID
+    kind: str
+    source: str
+    from_id: uuid.UUID
+    to_id: uuid.UUID
+
+
+async def _fetch_edges_for_nodes(
+    db_session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    node_ids: list[uuid.UUID],
+) -> list[_GraphEdgeRow]:
+    """Return the live edges with both endpoints in *node_ids*.
+
+    Tenant-scoped on the edge AND on both endpoint joins
+    (defence-in-depth, matching the T1 drawer ``_fetch_edges`` shape).
+    Soft-deleted edges (``last_seen IS NULL``) are excluded so the
+    view shows the live snapshot, not stale relationships.
+
+    The endpoint filter (``IN node_ids``) keeps the returned set
+    bounded by the table-cap ceiling: with ``len(node_ids) <= 500``
+    the worst-case edge count is bounded by the per-tenant graph
+    density, which the production tenants stay well under the
+    in-memory ceiling for.
+    """
+    if not node_ids:
+        return []
+
+    from_alias = aliased(GraphNode)
+    to_alias = aliased(GraphNode)
+    stmt = (
+        select(
+            GraphEdge.id.label("edge_id"),
+            GraphEdge.kind.label("edge_kind"),
+            GraphEdge.source.label("edge_source"),
+            GraphEdge.from_node_id.label("from_id"),
+            GraphEdge.to_node_id.label("to_id"),
+        )
+        .join(from_alias, from_alias.id == GraphEdge.from_node_id)
+        .join(to_alias, to_alias.id == GraphEdge.to_node_id)
+        .where(
+            GraphEdge.tenant_id == tenant_id,
+            from_alias.tenant_id == tenant_id,
+            to_alias.tenant_id == tenant_id,
+            GraphEdge.last_seen.is_not(None),
+            GraphEdge.from_node_id.in_(node_ids),
+            GraphEdge.to_node_id.in_(node_ids),
+        )
+        .order_by(GraphEdge.id)
+    )
+    result = await db_session.execute(stmt)
+    return [
+        _GraphEdgeRow(
+            id=row.edge_id,
+            kind=row.edge_kind,
+            source=row.edge_source,
+            from_id=row.from_id,
+            to_id=row.to_id,
+        )
+        for row in result.all()
+    ]
+
+
+def _node_to_cy_element(node: TopologyNodeListEntry) -> dict[str, object]:
+    """Project one node to a Cytoscape element JSON object.
+
+    Cytoscape element shape: ``{"data": {"id": str, ...}, "group": "nodes"}``
+    (see https://js.cytoscape.org/#notation/elements-json). ``id`` must
+    be a string for Cytoscape's selector engine; the UUID renders via
+    ``str(uuid)``. ``kind`` doubles as the class for per-kind styling
+    in the template (square = host, ellipse = vm, etc.).
+    """
+    return {
+        "group": "nodes",
+        "data": {
+            "id": str(node.id),
+            "name": node.name,
+            "kind": node.kind,
+        },
+        "classes": f"kind-{node.kind}",
+    }
+
+
+def _edge_to_cy_element(edge: _GraphEdgeRow) -> dict[str, object]:
+    """Project one edge to a Cytoscape element JSON object.
+
+    Cytoscape edge data needs ``source`` + ``target`` plus an ``id``
+    distinct from any node id (using the edge's own UUID keeps it
+    unambiguous). ``kind`` rides along so the template can label
+    edges by relationship type.
+    """
+    return {
+        "group": "edges",
+        "data": {
+            "id": str(edge.id),
+            "source": str(edge.from_id),
+            "target": str(edge.to_id),
+            "kind": edge.kind,
+        },
+        "classes": f"kind-{edge.kind}",
+    }
+
+
+def _build_elements(
+    nodes: list[TopologyNodeListEntry],
+    edges: list[_GraphEdgeRow],
+) -> list[dict[str, object]]:
+    """Build the Cytoscape elements bag from nodes + edges.
+
+    The list shape matches ``cytoscape({ elements: [...] })`` (see
+    https://js.cytoscape.org/#init-opts/elements); the init script
+    passes it straight in.
+    """
+    elements: list[dict[str, object]] = [_node_to_cy_element(n) for n in nodes]
+    elements.extend(_edge_to_cy_element(e) for e in edges)
+    return elements
+
+
+def _build_template_context(
+    *,
+    elements: list[dict[str, object]],
+    node_count: int,
+    edge_count: int,
+    truncated: bool,
+    kind: str | None,
+    name_contains: str | None,
+    selected_id: uuid.UUID | None,
+    csrf_token: str,
+) -> dict[str, object]:
+    """Assemble the Jinja2 context dict the graph template renders against.
+
+    Pulled out of :func:`render_graph` so the rendering function stays
+    inside the code-quality function-size budget (the docstring +
+    context literal pushed it over). The shape is documented inline
+    -- every key is consumed by ``topology/graph.html``.
+    """
+    return {
+        "page_title": "Topology",
+        "active_surface": "topology",
+        "kind_filter": kind or "",
+        "name_filter": name_contains or "",
+        "csrf_token": csrf_token,
+        "elements": elements,
+        "node_count": node_count,
+        "edge_count": edge_count,
+        "graph_node_cap": GRAPH_NODE_CAP,
+        "truncated": truncated,
+        # ``selected_id`` is the cross-link payload: when the operator
+        # clicks a table row's "Show in graph" button (or arrived via
+        # ``?view=graph&selected=<id>`` from any source), the init
+        # script centers + selects the matching Cytoscape node.
+        # ``None`` surfaces to the template as an empty string --
+        # Jinja's ``StrictUndefined`` env requires the key present.
+        "selected_id": str(selected_id) if selected_id is not None else "",
+        # ``ready=False`` so ``base.html``'s footer pill stays the
+        # same colour as the table surface (the dashboard owns the
+        # readiness signal).
+        "ready": False,
+    }
+
+
+async def render_graph(
+    request: object,
+    *,
+    session_ctx: UISessionContext,
+    db_session: AsyncSession,
+    kind: str | None,
+    name_contains: str | None,
+    selected_id: uuid.UUID | None,
+) -> HTMLResponse:
+    """Render the ``?view=graph`` Cytoscape page.
+
+    The route at :mod:`meho_backplane.ui.routes.topology.table`
+    branches on ``?view=`` and calls this function when ``graph`` is
+    selected. The signature accepts the already-validated query
+    params from the caller so the validation surface stays in the one
+    place FastAPI sees -- the route definition.
+
+    The 500-node cap is enforced here (``limit=GRAPH_NODE_CAP``); a
+    returned list at the cap drives the truncation banner in the
+    template via ``truncated=True``. ``selected_id`` round-trips the
+    cross-link target from the table surface's ``?selected=`` param.
+    """
+    nodes = await list_nodes(
+        db_session,
+        session_ctx.tenant_id,
+        kind=kind,
+        name_contains=name_contains,
+        sort="name",
+        direction="asc",
+        limit=GRAPH_NODE_CAP,
+    )
+    truncated = len(nodes) >= GRAPH_NODE_CAP
+    edges = await _fetch_edges_for_nodes(
+        db_session,
+        tenant_id=session_ctx.tenant_id,
+        node_ids=[node.id for node in nodes],
+    )
+    elements = _build_elements(nodes, edges)
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    context = _build_template_context(
+        elements=elements,
+        node_count=len(nodes),
+        edge_count=len(edges),
+        truncated=truncated,
+        kind=kind,
+        name_contains=name_contains,
+        selected_id=selected_id,
+        csrf_token=csrf_token,
+    )
+    response = get_templates().TemplateResponse(
+        request,  # type: ignore[arg-type]
+        "topology/graph.html",
+        context,
+    )
+    # Same CSRF posture as the table surface (T1 / #880).
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=csrf_token,
+        httponly=False,
+        secure=True,
+        samesite="strict",
+        path="/ui",
+    )
+    return response

--- a/backend/src/meho_backplane/ui/routes/topology/graph.py
+++ b/backend/src/meho_backplane/ui/routes/topology/graph.py
@@ -64,7 +64,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
-from meho_backplane.db.models import GraphEdge, GraphNode
+from meho_backplane.db.models import _GRAPH_NODE_KINDS, GraphEdge, GraphNode
 from meho_backplane.topology.query import TopologyNodeListEntry, list_nodes
 from meho_backplane.ui.auth.middleware import UISessionContext
 from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
@@ -237,6 +237,13 @@ def _build_template_context(
     inside the code-quality function-size budget (the docstring +
     context literal pushed it over). The shape is documented inline
     -- every key is consumed by ``topology/graph.html``.
+
+    ``node_kind_options`` mirrors the T1 (#880) ``table.py`` pattern of
+    sourcing the kind filter dropdown from the closed enum
+    (:data:`meho_backplane.db.models._GRAPH_NODE_KINDS`) rather than
+    hard-coding the vocabulary in the template. When the closed enum
+    widens (a new connector contributes a new ``kind``), both the
+    table and graph dropdowns pick up the new option for free.
     """
     return {
         "page_title": "Topology",
@@ -249,6 +256,9 @@ def _build_template_context(
         "edge_count": edge_count,
         "graph_node_cap": GRAPH_NODE_CAP,
         "truncated": truncated,
+        # Sourced from the closed enum -- single source of truth shared
+        # with the T1 tabular surface (``table.py._node_kind_options``).
+        "node_kind_options": sorted(_GRAPH_NODE_KINDS),
         # ``selected_id`` is the cross-link payload: when the operator
         # clicks a table row's "Show in graph" button (or arrived via
         # ``?view=graph&selected=<id>`` from any source), the init
@@ -280,10 +290,17 @@ async def render_graph(
     params from the caller so the validation surface stays in the one
     place FastAPI sees -- the route definition.
 
-    The 500-node cap is enforced here (``limit=GRAPH_NODE_CAP``); a
-    returned list at the cap drives the truncation banner in the
-    template via ``truncated=True``. ``selected_id`` round-trips the
-    cross-link target from the table surface's ``?selected=`` param.
+    The 500-node cap is enforced here. To detect "more nodes exist
+    than we are willing to render" without a separate ``COUNT(*)`` round
+    trip, we ask the substrate for ``GRAPH_NODE_CAP + 1`` rows: if the
+    extra row materialises the banner flips on and the surplus row is
+    sliced off before the elements bag is emitted. The previous ``>=``
+    predicate at ``limit=GRAPH_NODE_CAP`` flagged a tenant with **exactly**
+    500 nodes as truncated, a boundary-off-by-one false positive. ``>``
+    on the ``CAP + 1`` fetch is the correct predicate -- the banner
+    fires only when the inventory genuinely exceeds the cap.
+    ``selected_id`` round-trips the cross-link target from the table
+    surface's ``?selected=`` param.
     """
     nodes = await list_nodes(
         db_session,
@@ -292,9 +309,11 @@ async def render_graph(
         name_contains=name_contains,
         sort="name",
         direction="asc",
-        limit=GRAPH_NODE_CAP,
+        limit=GRAPH_NODE_CAP + 1,
     )
-    truncated = len(nodes) >= GRAPH_NODE_CAP
+    truncated = len(nodes) > GRAPH_NODE_CAP
+    if truncated:
+        nodes = nodes[:GRAPH_NODE_CAP]
     edges = await _fetch_edges_for_nodes(
         db_session,
         tenant_id=session_ctx.tenant_id,

--- a/backend/src/meho_backplane/ui/routes/topology/table.py
+++ b/backend/src/meho_backplane/ui/routes/topology/table.py
@@ -1,46 +1,54 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""``GET /ui/topology`` -- the tenant topology tabular surface.
+"""``GET /ui/topology`` -- the tenant topology tabular + graph surface.
 
-Initiative #342 (G10.5 Topology UI), Task #880 (G10.5-T1) work item
-#1. Renders the per-tenant node inventory as a server-side sortable +
-HTMX-filterable table with multi-row checkbox select.
+Initiative #342 (G10.5 Topology UI), Task #880 (G10.5-T1) shipped the
+tabular view; Task #881 (G10.5-T2) layered the Cytoscape graph view on
+top of the same path via the ``?view=graph`` branch.
 
-Two response shapes share one handler:
+Three response shapes share one handler:
 
-* **Full page** -- a normal browser navigation to ``/ui/topology``
-  (no ``HX-Request`` header) returns the full ``topology/table.html``
-  page (extends ``base.html``; renders the navbar, sidebar, filter
-  bar, sort headers, table body, and the empty ``#node-drawer``
-  slot the per-node drawer swaps into).
+* **Tabular full page** (``?view=table`` or unset) -- a normal browser
+  navigation returns the full ``topology/table.html`` page (extends
+  ``base.html``; navbar, sidebar, filter bar, sort headers, table
+  body, and the empty ``#node-drawer`` slot the per-node drawer
+  swaps into).
 
-* **Fragment** -- an HTMX-driven sort / filter
-  (``hx-get="/ui/topology" hx-target="#topology-table-body"`` plus
-  ``hx-trigger="input changed delay:300ms, keyup changed delay:300ms"``
-  on the filter inputs) carries ``HX-Request: true`` and the handler
-  returns the ``topology/_table_rows.html`` partial -- just the
-  ``<tbody>`` content swapped into the existing table without a
-  full-page reload.
+* **Tabular HTMX fragment** (``?view=table`` or unset with
+  ``HX-Request: true``) -- a sort / filter swap returns the
+  ``topology/_table_rows.html`` partial swapped into the existing
+  table without a full-page reload.
+
+* **Graph full page** (``?view=graph``) -- returns the
+  ``topology/graph.html`` page with a server-rendered Cytoscape.js
+  island; elements + cross-link selection ride into the page as a
+  ``<script type="application/json">`` data island the init script
+  reads on load. The graph view does not have an HTMX-fragment
+  variant: layout switches happen client-side via
+  ``cy.layout({name}).run()``; filter / kind changes round-trip to
+  the server (full-page reload) so the URL captures the active mode
+  for copy/paste.
 
 Tenant scoping is non-overrideable. Every call to
-:func:`meho_backplane.topology.query.list_nodes` passes
-``operator.tenant_id`` from the session-bound
-:class:`UISessionContext`; no query parameter or body field carries
-a tenant id. Another tenant's node never renders -- the acceptance
-criterion is enforced at the substrate layer (the listing SQL's
-first ``WHERE`` clause), not the template.
+:func:`meho_backplane.topology.query.list_nodes` (table) and the
+graph-route's edge-and-node fetch passes ``operator.tenant_id`` from
+the session-bound :class:`UISessionContext`; no query parameter or
+body field carries a tenant id. Another tenant's node never renders
+-- the acceptance criterion is enforced at the substrate layer (the
+listing SQL's first ``WHERE`` clause), not the template.
 
 Sort column + direction defaults are the ``name`` column ascending
--- a stable, human-meaningful order. ``view=table`` in the query
-string is currently a no-op (T2 (#881) will introduce ``view=graph``
-and switch routing accordingly); the route accepts but does not
-require it so a future graph view can land without an external URL
-contract change.
+-- a stable, human-meaningful order. ``view=graph`` switches to the
+Cytoscape view; ``view=table`` (or unset) keeps the tabular surface.
+``selected`` (a UUID) cross-links between the two: a graph node's
+tap arrives at ``?view=table&selected=<id>`` (the row scrolls into
+view + highlights) and vice versa.
 """
 
 from __future__ import annotations
 
+import uuid
 from enum import StrEnum
 from typing import Final
 
@@ -53,9 +61,25 @@ from meho_backplane.db.models import _GRAPH_NODE_KINDS
 from meho_backplane.topology.query import list_nodes
 from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
 from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.routes.topology.graph import render_graph
 from meho_backplane.ui.templating import get_templates
 
 __all__ = ["build_table_router"]
+
+
+class _ViewMode(StrEnum):
+    """Closed enum of view modes exposed on ``GET /ui/topology``.
+
+    ``table`` is the default (T1 / #880); ``graph`` switches to the
+    Cytoscape.js surface (T2 / #881). The enum's ``str`` mixin keeps
+    template URL building stable -- ``str(_ViewMode.GRAPH)`` is
+    ``"graph"`` (not ``"_ViewMode.GRAPH"``). An out-of-range value
+    fails Pydantic validation (422) at the HTTP boundary so the route
+    body never sees an unknown mode.
+    """
+
+    TABLE = "table"
+    GRAPH = "graph"
 
 
 class _SortColumn(StrEnum):
@@ -131,10 +155,11 @@ async def _render_table(
     kind: str | None = None,
     name_contains: str | None = None,
     limit: int = _LIMIT_DEFAULT,
+    selected_id: uuid.UUID | None = None,
     session_ctx: UISessionContext = Depends(require_ui_session),
     db_session: AsyncSession = Depends(get_raw_session),
 ) -> HTMLResponse:
-    """Render ``GET /ui/topology``.
+    """Render ``GET /ui/topology[?view=table]``.
 
     Pulls the tenant's nodes via :func:`list_nodes` and renders
     either the full page (browser nav) or the table-body fragment
@@ -146,6 +171,13 @@ async def _render_table(
     active-direction arrow, the filter input keeps its text). Both
     the page and the fragment receive the same context shape so the
     template fragments stay interchangeable.
+
+    ``selected_id`` is the cross-link payload from the graph view's
+    node tap: when present, the matching row is marked with
+    ``data-selected="true"`` so a small inline script can scroll it
+    into view + highlight it. Cross-tenant ids decay safely: the row
+    simply does not exist in the rendered fragment, so the
+    ``data-selected`` marker no-ops.
     """
     nodes = await list_nodes(
         db_session,
@@ -159,6 +191,7 @@ async def _render_table(
     csrf_token = mint_csrf_token(str(session_ctx.session_id))
     context = {
         "page_title": "Topology",
+        "active_surface": "topology",
         "nodes": nodes,
         "sort": sort,
         "direction": direction,
@@ -167,6 +200,11 @@ async def _render_table(
         "csrf_token": csrf_token,
         "next_direction_for": _next_direction_factory(sort, direction),
         "node_kind_options": _node_kind_options(),
+        # ``selected_id`` is the cross-link payload from the graph
+        # surface ("show in table" / a Cytoscape node tap). The empty
+        # string represents "no selection" so Jinja's ``StrictUndefined``
+        # env does not raise on a missing-key read in the template.
+        "selected_id": str(selected_id) if selected_id is not None else "",
         # The footer in ``base.html`` reads ``ready`` to colour the
         # readiness pill; topology does not poll readiness itself
         # (the dashboard owns that surface), so ship ``False`` so
@@ -248,8 +286,9 @@ _get_raw_session_dep = Depends(get_raw_session)
 def build_table_router() -> APIRouter:
     """Construct the topology-table :class:`APIRouter`.
 
-    Registers the single ``GET /ui/topology`` route that serves both
-    the full page and the HTMX fragment from one handler. The route
+    Registers the single ``GET /ui/topology`` route that serves the
+    full page, the HTMX table fragment, and the Cytoscape graph
+    surface from one handler -- branching on ``?view=``. The route
     name (``ui_topology_table``) is referenced by ``url_for`` in the
     chassis sidebar template -- a future rename here must update the
     sidebar in lockstep.
@@ -263,17 +302,36 @@ def build_table_router() -> APIRouter:
         kind: str | None = Query(default=None, max_length=64),
         q: str | None = Query(default=None, max_length=256),
         limit: int = Query(default=_LIMIT_DEFAULT, ge=1, le=_LIMIT_MAX),
-        view: str | None = Query(default=None, max_length=16),
+        view: _ViewMode = Query(default=_ViewMode.TABLE),
+        selected: uuid.UUID | None = Query(default=None),
         session_ctx: UISessionContext = _require_ui_session_dep,
         db_session: AsyncSession = _get_raw_session_dep,
     ) -> HTMLResponse:
-        """``GET /ui/topology[?view=table&sort=...&direction=...&kind=...&q=...]``.
+        """Serve the topology UI, branching on ``?view=``.
 
-        ``view`` is accepted but unused in T1 (the only mode is the
-        table); T2 (#881) will branch on ``view`` to render the
-        Cytoscape graph instead. Documenting the param in the
-        signature now keeps the URL contract forward-compatible.
+        URL contract::
+
+            GET /ui/topology
+                [?view=table|graph
+                 &sort=...&direction=...
+                 &kind=...&q=...
+                 &selected=<uuid>]
+
+        ``view=graph`` delegates to
+        :func:`meho_backplane.ui.routes.topology.graph.render_graph`;
+        ``view=table`` (the default) keeps the tabular surface T1
+        ships. ``selected`` (an optional UUID) round-trips the
+        cross-link selection between the two surfaces.
         """
+        if view == _ViewMode.GRAPH:
+            return await render_graph(
+                request,
+                session_ctx=session_ctx,
+                db_session=db_session,
+                kind=kind,
+                name_contains=q,
+                selected_id=selected,
+            )
         return await _render_table(
             request,
             sort=sort,
@@ -281,6 +339,7 @@ def build_table_router() -> APIRouter:
             kind=kind,
             name_contains=q,
             limit=limit,
+            selected_id=selected,
             session_ctx=session_ctx,
             db_session=db_session,
         )

--- a/backend/src/meho_backplane/ui/static/src/app/topology-graph.js
+++ b/backend/src/meho_backplane/ui/static/src/app/topology-graph.js
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+//
+// Topology Cytoscape.js graph controller (Initiative #342; Task #881).
+//
+// Loaded via ``<script src=... defer>`` from ``topology/graph.html``'s
+// ``{% block scripts %}`` (NOT inline) so a future nonce-based CSP needs
+// no inline-script exception -- matching the chassis ``base.html``
+// "zero inline script" posture.
+//
+// Responsibilities:
+//   * Register the two extension layouts (``cose-bilkent`` /
+//     ``dagre``) onto the global ``cytoscape`` factory once.
+//     ``cytoscape.use(extension)`` is the official plugin API (see
+//     https://js.cytoscape.org/#extensions).
+//   * Read the server-emitted elements from the
+//     ``#topology-graph-data`` data island (Jinja ``| tojson`` -- safe
+//     for the script-element text context) and instantiate Cytoscape
+//     into ``#cy``.
+//   * On node tap, issue ``htmx.ajax`` GET
+//     ``/ui/topology/node/<id>`` into ``#node-drawer`` (the same
+//     drawer fragment the tabular view uses, per the T1 (#880)
+//     contract). Center + visually select the tapped node.
+//   * Layout-switcher: the ``#topology-graph-layout`` ``<select>``
+//     drives ``cy.layout({name}).run()`` on change.
+//   * Cross-link from the table: ``?selected=<id>`` lands as a
+//     non-empty ``#topology-graph-selected`` island; on init the
+//     controller centers + selects the matching node, then issues
+//     the same drawer ``htmx.ajax`` as a tap would.
+//   * Tabular cross-link: a tap also rewrites the page URL via
+//     ``history.replaceState`` so a copy/paste reproduces the
+//     selected node, AND the table-view link in the page header
+//     picks up the latest selection without a re-render.
+//
+// All work happens on ``DOMContentLoaded`` so every vendored script
+// in the ``defer`` chain has executed (the chain is order-load-
+// bearing -- see VENDOR.md + graph.html script-block comments).
+
+(function () {
+  "use strict";
+
+  function readJsonIsland(id) {
+    const el = document.getElementById(id);
+    if (!el) {
+      return null;
+    }
+    try {
+      return JSON.parse(el.textContent || "");
+    } catch (e) {
+      // A malformed island leaves the controller idle rather than
+      // throwing during init -- the page still renders, the graph is
+      // simply empty.
+      return null;
+    }
+  }
+
+  // Cytoscape style sheet. Per-kind colouring uses generic Tailwind
+  // colour values rather than DaisyUI semantic tokens because the
+  // canvas-rendered nodes can't read CSS custom properties resolved
+  // by DaisyUI's theme system. Hard-coded hex keeps the colour
+  // deterministic regardless of active theme.
+  function buildStyle() {
+    return [
+      {
+        selector: "node",
+        style: {
+          "background-color": "#6366f1", // indigo-500 fallback
+          "label": "data(name)",
+          "color": "#1f2937",
+          "font-size": 10,
+          "text-valign": "bottom",
+          "text-halign": "center",
+          "text-margin-y": 4,
+          "text-wrap": "ellipsis",
+          "text-max-width": 100,
+          "border-width": 1,
+          "border-color": "#1f2937",
+          "width": 28,
+          "height": 28,
+        },
+      },
+      // Per-kind shape/colour overrides. Cytoscape selectors match
+      // the ``classes`` field on the element JSON
+      // (see _node_to_cy_element).
+      { selector: "node.kind-target", style: { "background-color": "#0ea5e9", "shape": "round-rectangle" } },
+      { selector: "node.kind-vm", style: { "background-color": "#22c55e", "shape": "ellipse" } },
+      { selector: "node.kind-host", style: { "background-color": "#f97316", "shape": "rectangle" } },
+      { selector: "node.kind-cluster", style: { "background-color": "#a855f7", "shape": "hexagon" } },
+      { selector: "node.kind-datastore", style: { "background-color": "#facc15", "shape": "barrel" } },
+      { selector: "node.kind-network", style: { "background-color": "#14b8a6", "shape": "diamond" } },
+      {
+        selector: "node:selected",
+        style: {
+          "border-width": 3,
+          "border-color": "#dc2626",
+        },
+      },
+      {
+        selector: "edge",
+        style: {
+          "width": 1,
+          "line-color": "#94a3b8",
+          "target-arrow-color": "#94a3b8",
+          "target-arrow-shape": "triangle",
+          "curve-style": "bezier",
+          "label": "data(kind)",
+          "font-size": 8,
+          "color": "#475569",
+          "text-background-color": "#f8fafc",
+          "text-background-opacity": 0.85,
+          "text-background-padding": 2,
+        },
+      },
+    ];
+  }
+
+  // Layout option payload for each supported algorithm. cose-bilkent
+  // and dagre carry algorithm-specific knobs the defaults pick poorly
+  // for the typical inventory shape (sparse graph, ~50-500 nodes).
+  function layoutOptions(name) {
+    if (name === "cose-bilkent") {
+      return {
+        name: "cose-bilkent",
+        nodeRepulsion: 4500,
+        idealEdgeLength: 80,
+        edgeElasticity: 0.45,
+        nestingFactor: 0.1,
+        gravity: 0.25,
+        numIter: 2500,
+        animate: false,
+        randomize: true,
+      };
+    }
+    if (name === "dagre") {
+      return {
+        name: "dagre",
+        rankDir: "TB",
+        nodeSep: 40,
+        rankSep: 60,
+        animate: false,
+      };
+    }
+    // circle is built-in; defaults are sane.
+    return { name: "circle", animate: false };
+  }
+
+  // Push the selected node id back into the page URL so a copy/paste
+  // reproduces the view. ``history.replaceState`` (NOT pushState) so a
+  // back-button does not need to reverse through every tap.
+  function updateSelectedInUrl(nodeId) {
+    const url = new URL(window.location.href);
+    if (nodeId) {
+      url.searchParams.set("selected", nodeId);
+    } else {
+      url.searchParams.delete("selected");
+    }
+    window.history.replaceState({}, "", url.toString());
+  }
+
+  // Sync the "Show in table" header link's ``?selected=`` so a click
+  // from the header takes the operator to the matching row.
+  function updateTableLink(nodeId) {
+    const link = document.querySelector('a[href^="/ui/topology?view=table"]');
+    if (!link) {
+      return;
+    }
+    const href = new URL(link.href, window.location.origin);
+    if (nodeId) {
+      href.searchParams.set("selected", nodeId);
+    } else {
+      href.searchParams.delete("selected");
+    }
+    link.href = href.pathname + href.search;
+  }
+
+  function openDrawerForNode(nodeId) {
+    if (!nodeId || typeof window.htmx === "undefined") {
+      return;
+    }
+    window.htmx.ajax("GET", "/ui/topology/node/" + encodeURIComponent(nodeId), {
+      target: "#node-drawer",
+      swap: "outerHTML",
+    });
+  }
+
+  function init() {
+    const container = document.getElementById("cy");
+    if (!container || typeof window.cytoscape !== "function") {
+      return;
+    }
+
+    // Register the layout extensions exactly once. ``cytoscape.use``
+    // is idempotent on the official API, but guarding against a
+    // re-init (e.g. browser back-forward cache restore) keeps the
+    // console clean.
+    if (window.cytoscapeCoseBilkent && !window.__mehoCoseBilkentRegistered) {
+      window.cytoscape.use(window.cytoscapeCoseBilkent);
+      window.__mehoCoseBilkentRegistered = true;
+    }
+    if (window.cytoscapeDagre && !window.__mehoDagreRegistered) {
+      window.cytoscape.use(window.cytoscapeDagre);
+      window.__mehoDagreRegistered = true;
+    }
+
+    const elements = readJsonIsland("topology-graph-data") || [];
+    const selectedRaw = readJsonIsland("topology-graph-selected");
+    const selectedId = typeof selectedRaw === "string" && selectedRaw.length > 0 ? selectedRaw : null;
+
+    const cy = window.cytoscape({
+      container: container,
+      elements: elements,
+      style: buildStyle(),
+      layout: layoutOptions("cose-bilkent"),
+      wheelSensitivity: 0.2,
+      minZoom: 0.1,
+      maxZoom: 4,
+    });
+
+    // Expose for debugging / a future ``/auto-implement-initiative``
+    // E2E harness; non-enumerable so it stays out of the
+    // operator-visible globals listing.
+    Object.defineProperty(window, "__mehoCy", { value: cy, configurable: true });
+
+    // Node-tap -> drawer swap + URL sync + table-link sync.
+    cy.on("tap", "node", function (event) {
+      const node = event.target;
+      const nodeId = node.id();
+      cy.elements("node:selected").unselect();
+      node.select();
+      openDrawerForNode(nodeId);
+      updateSelectedInUrl(nodeId);
+      updateTableLink(nodeId);
+    });
+
+    // Background tap clears the selection (consistent with macOS Finder
+    // / most graph editors). The drawer slot keeps its last content so
+    // the operator can still scroll the previously-opened detail.
+    cy.on("tap", function (event) {
+      if (event.target === cy) {
+        cy.elements("node:selected").unselect();
+        updateSelectedInUrl(null);
+        updateTableLink(null);
+      }
+    });
+
+    // Layout switcher.
+    const layoutSelect = document.getElementById("topology-graph-layout");
+    if (layoutSelect) {
+      layoutSelect.addEventListener("change", function () {
+        cy.layout(layoutOptions(layoutSelect.value)).run();
+      });
+    }
+
+    // Cross-link from the table: if the page arrived with
+    // ``?selected=<id>``, center + visually select that node + open
+    // its drawer once the layout is settled. ``layoutstop`` fires
+    // after the initial cose-bilkent pass so the node has a final
+    // position to center on.
+    if (selectedId) {
+      cy.one("layoutstop", function () {
+        const node = cy.getElementById(selectedId);
+        if (node && node.length > 0) {
+          node.select();
+          cy.center(node);
+          openDrawerForNode(selectedId);
+        }
+      });
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/backend/src/meho_backplane/ui/static/src/app/topology-table.js
+++ b/backend/src/meho_backplane/ui/static/src/app/topology-table.js
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+//
+// Topology table cross-link helper (Initiative #342; Task #881).
+//
+// Loaded via ``<script src=... defer>`` from ``topology/table.html``'s
+// ``{% block scripts %}`` (NOT inline) so the chassis CSP posture
+// (zero inline JS) needs no exception.
+//
+// Single responsibility: when the table is rendered with a
+// ``?selected=<id>`` cross-link payload from the graph view, find the
+// ``<tr data-selected="true">`` row (T2 / #881; emitted by
+// ``_table_rows.html`` when ``selected_id`` matches), scroll it into
+// view, and apply a brief highlight pulse so the operator's eye
+// catches it. No-ops cleanly when nothing matches (the operator
+// arrived on the table view without a selection, or the selected id
+// belongs to another tenant and the row therefore did not render).
+
+(function () {
+  "use strict";
+
+  function highlightSelectedRow() {
+    const row = document.querySelector('tr[data-selected="true"]');
+    if (!row) {
+      return;
+    }
+    // ``scrollIntoView({block: "center"})`` matches the same UX as
+    // most search-result navigation -- the row lands roughly mid-screen
+    // so the operator can see its neighbours, not at the top edge.
+    row.scrollIntoView({ block: "center", behavior: "smooth" });
+    // Brief outline pulse via a one-shot CSS animation. The class is
+    // removed after 2s so a re-render does not stack copies.
+    row.classList.add("ring", "ring-primary", "ring-offset-2");
+    window.setTimeout(function () {
+      row.classList.remove("ring", "ring-primary", "ring-offset-2");
+    }, 2000);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", highlightSelectedRow);
+  } else {
+    highlightSelectedRow();
+  }
+})();

--- a/backend/src/meho_backplane/ui/static/src/vendor/VENDOR.md
+++ b/backend/src/meho_backplane/ui/static/src/vendor/VENDOR.md
@@ -26,7 +26,7 @@ loaded plugin (`@plugin "./vendor/daisyui.js"` in
 | `sse.min.js` | htmx-ext-sse | 2.2.4 | `98a46496de0c3605fbffdce9167ba427bdd9553184f83f149c261891a92c0136` | https://cdn.jsdelivr.net/npm/htmx-ext-sse@2.2.4/dist/sse.min.js |
 | `alpine.min.js` | Alpine.js | 3.15.12 | `57b37d7cae9a27d965fdae4adcc844245dfdc407e655aee85dcfff3a08036a3f` | https://cdn.jsdelivr.net/npm/alpinejs@3.15.12/dist/cdn.min.js |
 | `cytoscape.min.js` | Cytoscape.js | 3.33.4 | `bcd83f0e31eb175026a811db6dc1f24b4326000edffa402a10d0748c5be557b4` | https://cdn.jsdelivr.net/npm/cytoscape@3.33.4/dist/cytoscape.min.js |
-| `layout-base.js` | layout-base | 2.0.1 | `ec15ab5df9af3f20708f4faab994accf91cda71848cd5bb10a23432cc50b6745` | https://cdn.jsdelivr.net/npm/layout-base@2.0.1/layout-base.js |
+| `layout-base.js` | layout-base | 2.0.1 | `f5c66be21c9cca16c4f25a576bffbd16ed1a48181c1c2dcbb8d905ec822e76b5` | https://cdn.jsdelivr.net/npm/layout-base@2.0.1/layout-base.js |
 | `cose-base.js` | cose-base | 2.2.0 | `7cae9509bd36235a63a85e71c8d9fa2cd0bc1d0c1ecc5b5a737976f39d040ddf` | https://cdn.jsdelivr.net/npm/cose-base@2.2.0/cose-base.js |
 | `cytoscape-cose-bilkent.js` | cytoscape-cose-bilkent | 4.1.0 | `9297c5b4245efd314941c622cb045fb96ffbfde3268985463745311699cae0b2` | https://cdn.jsdelivr.net/npm/cytoscape-cose-bilkent@4.1.0/cytoscape-cose-bilkent.js |
 | `cytoscape-dagre.js` | cytoscape-dagre | 3.0.0 | `1b060e1ffec6355e208d5ec4d49aa573000e8069eafbe01b1719a3bd630da290` | https://cdn.jsdelivr.net/npm/cytoscape-dagre@3.0.0/cytoscape-dagre.js |
@@ -81,6 +81,24 @@ cd backend/src/meho_backplane/ui/static/src/vendor/
 sha256sum -c <(awk -F'`' '/^\|/ && NF >= 8 {print $4 "  " $2}' VENDOR.md \
               | grep -v '^SHA256')
 ```
+
+**Line endings.** SHA256 values above are computed against the **committed
+git-blob bytes** (LF endings), which is what a fresh CI checkout on Linux
+sees and what the supply-chain audit trail tracks. The upstream npm
+tarball for `layout-base@2.0.1` ships CRLF endings, so on a developer's
+machine with `core.autocrlf=input` the working-tree checkout may have
+CRLFs restored; in that case the local `sha256sum -c` would diff against
+the recorded value despite the committed blob being correct. To re-verify
+against the committed bytes specifically:
+
+```bash
+git cat-file -p HEAD:backend/src/meho_backplane/ui/static/src/vendor/layout-base.js \
+  | sha256sum
+```
+
+CI verifies committed blobs (which is the boundary that matters); the
+working-tree recipe above is the human-friendly path that works as-is
+for the other three layout files (they ship LF-only upstream).
 
 ## Refresh procedure
 

--- a/backend/src/meho_backplane/ui/static/src/vendor/VENDOR.md
+++ b/backend/src/meho_backplane/ui/static/src/vendor/VENDOR.md
@@ -26,6 +26,10 @@ loaded plugin (`@plugin "./vendor/daisyui.js"` in
 | `sse.min.js` | htmx-ext-sse | 2.2.4 | `98a46496de0c3605fbffdce9167ba427bdd9553184f83f149c261891a92c0136` | https://cdn.jsdelivr.net/npm/htmx-ext-sse@2.2.4/dist/sse.min.js |
 | `alpine.min.js` | Alpine.js | 3.15.12 | `57b37d7cae9a27d965fdae4adcc844245dfdc407e655aee85dcfff3a08036a3f` | https://cdn.jsdelivr.net/npm/alpinejs@3.15.12/dist/cdn.min.js |
 | `cytoscape.min.js` | Cytoscape.js | 3.33.4 | `bcd83f0e31eb175026a811db6dc1f24b4326000edffa402a10d0748c5be557b4` | https://cdn.jsdelivr.net/npm/cytoscape@3.33.4/dist/cytoscape.min.js |
+| `layout-base.js` | layout-base | 2.0.1 | `ec15ab5df9af3f20708f4faab994accf91cda71848cd5bb10a23432cc50b6745` | https://cdn.jsdelivr.net/npm/layout-base@2.0.1/layout-base.js |
+| `cose-base.js` | cose-base | 2.2.0 | `7cae9509bd36235a63a85e71c8d9fa2cd0bc1d0c1ecc5b5a737976f39d040ddf` | https://cdn.jsdelivr.net/npm/cose-base@2.2.0/cose-base.js |
+| `cytoscape-cose-bilkent.js` | cytoscape-cose-bilkent | 4.1.0 | `9297c5b4245efd314941c622cb045fb96ffbfde3268985463745311699cae0b2` | https://cdn.jsdelivr.net/npm/cytoscape-cose-bilkent@4.1.0/cytoscape-cose-bilkent.js |
+| `cytoscape-dagre.js` | cytoscape-dagre | 3.0.0 | `1b060e1ffec6355e208d5ec4d49aa573000e8069eafbe01b1719a3bd630da290` | https://cdn.jsdelivr.net/npm/cytoscape-dagre@3.0.0/cytoscape-dagre.js |
 | `daisyui.js` | DaisyUI | 5.5.20 | `a92e663a1f150d6db47920967b0485ee34f87bfe74d0a80045c3a3a73afbc657` | https://github.com/saadeghi/daisyui/releases/download/v5.5.20/daisyui.js |
 
 ## Why these sources
@@ -41,6 +45,26 @@ byte-for-byte through jsDelivr at the pinned `@<version>` path. The
 jsDelivr and unpkg before pinning. The SHA256 below covers the same
 byte sequence either way — vendoring + pinning is the actual security
 boundary, not the URL scheme.
+
+## Cytoscape layout plugins (Task #881)
+
+The graph view (`/ui/topology?view=graph`) needs two non-built-in
+layouts: `cose-bilkent` (default, organic) and `dagre` (DAG-tidy).
+Cytoscape.js extensions are UMD bundles that register themselves via
+`cytoscape.use(extensionFn)` at load. Browser globals chain as:
+
+* `cytoscape-cose-bilkent@4.1.0` factory requires `coseBase` global.
+* `cose-base@2.2.0` factory requires `layoutBase` global.
+* `layout-base@2.0.1` is self-contained.
+* `cytoscape-dagre@3.0.0` bundles dagre internally (the 2.x line
+  required a separate `dagre` vendored file; 3.0.0 inlines it).
+
+Load order in `topology/graph.html`'s `{% block scripts %}` is
+load-bearing — `layout-base.js` → `cose-base.js` →
+`cytoscape-cose-bilkent.js` → `cytoscape-dagre.js` → app init. The
+`defer` attribute preserves document order while letting the browser
+fetch in parallel; the registration runs inside the app init script
+once all four globals are present.
 
 `sse.min.js` is the SSE extension HTMX 2 split out of core (HTMX 1
 bundled it; HTMX 2 ships it as a separate `hx-ext="sse"` plugin). It is

--- a/backend/src/meho_backplane/ui/static/src/vendor/cose-base.js
+++ b/backend/src/meho_backplane/ui/static/src/vendor/cose-base.js
@@ -1,0 +1,3214 @@
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory(require("layout-base"));
+	else if(typeof define === 'function' && define.amd)
+		define(["layout-base"], factory);
+	else if(typeof exports === 'object')
+		exports["coseBase"] = factory(require("layout-base"));
+	else
+		root["coseBase"] = factory(root["layoutBase"]);
+})(this, function(__WEBPACK_EXTERNAL_MODULE__551__) {
+return /******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 45:
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+
+
+var coseBase = {};
+
+coseBase.layoutBase = __webpack_require__(551);
+coseBase.CoSEConstants = __webpack_require__(806);
+coseBase.CoSEEdge = __webpack_require__(767);
+coseBase.CoSEGraph = __webpack_require__(880);
+coseBase.CoSEGraphManager = __webpack_require__(578);
+coseBase.CoSELayout = __webpack_require__(765);
+coseBase.CoSENode = __webpack_require__(991);
+coseBase.ConstraintHandler = __webpack_require__(902);
+
+module.exports = coseBase;
+
+/***/ }),
+
+/***/ 806:
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+
+
+var FDLayoutConstants = __webpack_require__(551).FDLayoutConstants;
+
+function CoSEConstants() {}
+
+//CoSEConstants inherits static props in FDLayoutConstants
+for (var prop in FDLayoutConstants) {
+  CoSEConstants[prop] = FDLayoutConstants[prop];
+}
+
+CoSEConstants.DEFAULT_USE_MULTI_LEVEL_SCALING = false;
+CoSEConstants.DEFAULT_RADIAL_SEPARATION = FDLayoutConstants.DEFAULT_EDGE_LENGTH;
+CoSEConstants.DEFAULT_COMPONENT_SEPERATION = 60;
+CoSEConstants.TILE = true;
+CoSEConstants.TILING_PADDING_VERTICAL = 10;
+CoSEConstants.TILING_PADDING_HORIZONTAL = 10;
+CoSEConstants.TRANSFORM_ON_CONSTRAINT_HANDLING = true;
+CoSEConstants.ENFORCE_CONSTRAINTS = true;
+CoSEConstants.APPLY_LAYOUT = true;
+CoSEConstants.RELAX_MOVEMENT_ON_CONSTRAINTS = true;
+CoSEConstants.TREE_REDUCTION_ON_INCREMENTAL = true; // this should be set to false if there will be a constraint
+// This constant is for differentiating whether actual layout algorithm that uses cose-base wants to apply only incremental layout or 
+// an incremental layout on top of a randomized layout. If it is only incremental layout, then this constant should be true.
+CoSEConstants.PURE_INCREMENTAL = CoSEConstants.DEFAULT_INCREMENTAL;
+
+module.exports = CoSEConstants;
+
+/***/ }),
+
+/***/ 767:
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+
+
+var FDLayoutEdge = __webpack_require__(551).FDLayoutEdge;
+
+function CoSEEdge(source, target, vEdge) {
+  FDLayoutEdge.call(this, source, target, vEdge);
+}
+
+CoSEEdge.prototype = Object.create(FDLayoutEdge.prototype);
+for (var prop in FDLayoutEdge) {
+  CoSEEdge[prop] = FDLayoutEdge[prop];
+}
+
+module.exports = CoSEEdge;
+
+/***/ }),
+
+/***/ 880:
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+
+
+var LGraph = __webpack_require__(551).LGraph;
+
+function CoSEGraph(parent, graphMgr, vGraph) {
+  LGraph.call(this, parent, graphMgr, vGraph);
+}
+
+CoSEGraph.prototype = Object.create(LGraph.prototype);
+for (var prop in LGraph) {
+  CoSEGraph[prop] = LGraph[prop];
+}
+
+module.exports = CoSEGraph;
+
+/***/ }),
+
+/***/ 578:
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+
+
+var LGraphManager = __webpack_require__(551).LGraphManager;
+
+function CoSEGraphManager(layout) {
+  LGraphManager.call(this, layout);
+}
+
+CoSEGraphManager.prototype = Object.create(LGraphManager.prototype);
+for (var prop in LGraphManager) {
+  CoSEGraphManager[prop] = LGraphManager[prop];
+}
+
+module.exports = CoSEGraphManager;
+
+/***/ }),
+
+/***/ 765:
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+
+
+var FDLayout = __webpack_require__(551).FDLayout;
+var CoSEGraphManager = __webpack_require__(578);
+var CoSEGraph = __webpack_require__(880);
+var CoSENode = __webpack_require__(991);
+var CoSEEdge = __webpack_require__(767);
+var CoSEConstants = __webpack_require__(806);
+var ConstraintHandler = __webpack_require__(902);
+var FDLayoutConstants = __webpack_require__(551).FDLayoutConstants;
+var LayoutConstants = __webpack_require__(551).LayoutConstants;
+var Point = __webpack_require__(551).Point;
+var PointD = __webpack_require__(551).PointD;
+var DimensionD = __webpack_require__(551).DimensionD;
+var Layout = __webpack_require__(551).Layout;
+var Integer = __webpack_require__(551).Integer;
+var IGeometry = __webpack_require__(551).IGeometry;
+var LGraph = __webpack_require__(551).LGraph;
+var Transform = __webpack_require__(551).Transform;
+var LinkedList = __webpack_require__(551).LinkedList;
+
+function CoSELayout() {
+  FDLayout.call(this);
+
+  this.toBeTiled = {}; // Memorize if a node is to be tiled or is tiled
+  this.constraints = {}; // keep layout constraints
+}
+
+CoSELayout.prototype = Object.create(FDLayout.prototype);
+
+for (var prop in FDLayout) {
+  CoSELayout[prop] = FDLayout[prop];
+}
+
+CoSELayout.prototype.newGraphManager = function () {
+  var gm = new CoSEGraphManager(this);
+  this.graphManager = gm;
+  return gm;
+};
+
+CoSELayout.prototype.newGraph = function (vGraph) {
+  return new CoSEGraph(null, this.graphManager, vGraph);
+};
+
+CoSELayout.prototype.newNode = function (vNode) {
+  return new CoSENode(this.graphManager, vNode);
+};
+
+CoSELayout.prototype.newEdge = function (vEdge) {
+  return new CoSEEdge(null, null, vEdge);
+};
+
+CoSELayout.prototype.initParameters = function () {
+  FDLayout.prototype.initParameters.call(this, arguments);
+  if (!this.isSubLayout) {
+    if (CoSEConstants.DEFAULT_EDGE_LENGTH < 10) {
+      this.idealEdgeLength = 10;
+    } else {
+      this.idealEdgeLength = CoSEConstants.DEFAULT_EDGE_LENGTH;
+    }
+
+    this.useSmartIdealEdgeLengthCalculation = CoSEConstants.DEFAULT_USE_SMART_IDEAL_EDGE_LENGTH_CALCULATION;
+    this.gravityConstant = FDLayoutConstants.DEFAULT_GRAVITY_STRENGTH;
+    this.compoundGravityConstant = FDLayoutConstants.DEFAULT_COMPOUND_GRAVITY_STRENGTH;
+    this.gravityRangeFactor = FDLayoutConstants.DEFAULT_GRAVITY_RANGE_FACTOR;
+    this.compoundGravityRangeFactor = FDLayoutConstants.DEFAULT_COMPOUND_GRAVITY_RANGE_FACTOR;
+
+    // variables for tree reduction support
+    this.prunedNodesAll = [];
+    this.growTreeIterations = 0;
+    this.afterGrowthIterations = 0;
+    this.isTreeGrowing = false;
+    this.isGrowthFinished = false;
+  }
+};
+
+// This method is used to set CoSE related parameters used by spring embedder.
+CoSELayout.prototype.initSpringEmbedder = function () {
+  FDLayout.prototype.initSpringEmbedder.call(this);
+
+  // variables for cooling
+  this.coolingCycle = 0;
+  this.maxCoolingCycle = this.maxIterations / FDLayoutConstants.CONVERGENCE_CHECK_PERIOD;
+  this.finalTemperature = 0.04;
+  this.coolingAdjuster = 1;
+};
+
+CoSELayout.prototype.layout = function () {
+  var createBendsAsNeeded = LayoutConstants.DEFAULT_CREATE_BENDS_AS_NEEDED;
+  if (createBendsAsNeeded) {
+    this.createBendpoints();
+    this.graphManager.resetAllEdges();
+  }
+
+  this.level = 0;
+  return this.classicLayout();
+};
+
+CoSELayout.prototype.classicLayout = function () {
+  this.nodesWithGravity = this.calculateNodesToApplyGravitationTo();
+  this.graphManager.setAllNodesToApplyGravitation(this.nodesWithGravity);
+  this.calcNoOfChildrenForAllNodes();
+  this.graphManager.calcLowestCommonAncestors();
+  this.graphManager.calcInclusionTreeDepths();
+  this.graphManager.getRoot().calcEstimatedSize();
+  this.calcIdealEdgeLengths();
+
+  if (!this.incremental) {
+    var forest = this.getFlatForest();
+
+    // The graph associated with this layout is flat and a forest
+    if (forest.length > 0) {
+      this.positionNodesRadially(forest);
+    }
+    // The graph associated with this layout is not flat or a forest
+    else {
+        // Reduce the trees when incremental mode is not enabled and graph is not a forest 
+        this.reduceTrees();
+        // Update nodes that gravity will be applied
+        this.graphManager.resetAllNodesToApplyGravitation();
+        var allNodes = new Set(this.getAllNodes());
+        var intersection = this.nodesWithGravity.filter(function (x) {
+          return allNodes.has(x);
+        });
+        this.graphManager.setAllNodesToApplyGravitation(intersection);
+
+        this.positionNodesRandomly();
+      }
+  } else {
+    if (CoSEConstants.TREE_REDUCTION_ON_INCREMENTAL) {
+      // Reduce the trees in incremental mode if only this constant is set to true 
+      this.reduceTrees();
+      // Update nodes that gravity will be applied
+      this.graphManager.resetAllNodesToApplyGravitation();
+      var allNodes = new Set(this.getAllNodes());
+      var intersection = this.nodesWithGravity.filter(function (x) {
+        return allNodes.has(x);
+      });
+      this.graphManager.setAllNodesToApplyGravitation(intersection);
+    }
+  }
+
+  if (Object.keys(this.constraints).length > 0) {
+    ConstraintHandler.handleConstraints(this);
+    this.initConstraintVariables();
+  }
+
+  this.initSpringEmbedder();
+  if (CoSEConstants.APPLY_LAYOUT) {
+    this.runSpringEmbedder();
+  }
+
+  return true;
+};
+
+CoSELayout.prototype.tick = function () {
+  this.totalIterations++;
+
+  if (this.totalIterations === this.maxIterations && !this.isTreeGrowing && !this.isGrowthFinished) {
+    if (this.prunedNodesAll.length > 0) {
+      this.isTreeGrowing = true;
+    } else {
+      return true;
+    }
+  }
+
+  if (this.totalIterations % FDLayoutConstants.CONVERGENCE_CHECK_PERIOD == 0 && !this.isTreeGrowing && !this.isGrowthFinished) {
+    if (this.isConverged()) {
+      if (this.prunedNodesAll.length > 0) {
+        this.isTreeGrowing = true;
+      } else {
+        return true;
+      }
+    }
+
+    this.coolingCycle++;
+
+    if (this.layoutQuality == 0) {
+      // quality - "draft"
+      this.coolingAdjuster = this.coolingCycle;
+    } else if (this.layoutQuality == 1) {
+      // quality - "default"
+      this.coolingAdjuster = this.coolingCycle / 3;
+    }
+
+    // cooling schedule is based on http://www.btluke.com/simanf1.html -> cooling schedule 3
+    this.coolingFactor = Math.max(this.initialCoolingFactor - Math.pow(this.coolingCycle, Math.log(100 * (this.initialCoolingFactor - this.finalTemperature)) / Math.log(this.maxCoolingCycle)) / 100 * this.coolingAdjuster, this.finalTemperature);
+    this.animationPeriod = Math.ceil(this.initialAnimationPeriod * Math.sqrt(this.coolingFactor));
+  }
+  // Operations while tree is growing again 
+  if (this.isTreeGrowing) {
+    if (this.growTreeIterations % 10 == 0) {
+      if (this.prunedNodesAll.length > 0) {
+        this.graphManager.updateBounds();
+        this.updateGrid();
+        this.growTree(this.prunedNodesAll);
+        // Update nodes that gravity will be applied
+        this.graphManager.resetAllNodesToApplyGravitation();
+        var allNodes = new Set(this.getAllNodes());
+        var intersection = this.nodesWithGravity.filter(function (x) {
+          return allNodes.has(x);
+        });
+        this.graphManager.setAllNodesToApplyGravitation(intersection);
+
+        this.graphManager.updateBounds();
+        this.updateGrid();
+        if (CoSEConstants.PURE_INCREMENTAL) this.coolingFactor = FDLayoutConstants.DEFAULT_COOLING_FACTOR_INCREMENTAL / 2;else this.coolingFactor = FDLayoutConstants.DEFAULT_COOLING_FACTOR_INCREMENTAL;
+      } else {
+        this.isTreeGrowing = false;
+        this.isGrowthFinished = true;
+      }
+    }
+    this.growTreeIterations++;
+  }
+  // Operations after growth is finished
+  if (this.isGrowthFinished) {
+    if (this.isConverged()) {
+      return true;
+    }
+    if (this.afterGrowthIterations % 10 == 0) {
+      this.graphManager.updateBounds();
+      this.updateGrid();
+    }
+    if (CoSEConstants.PURE_INCREMENTAL) this.coolingFactor = FDLayoutConstants.DEFAULT_COOLING_FACTOR_INCREMENTAL / 2 * ((100 - this.afterGrowthIterations) / 100);else this.coolingFactor = FDLayoutConstants.DEFAULT_COOLING_FACTOR_INCREMENTAL * ((100 - this.afterGrowthIterations) / 100);
+    this.afterGrowthIterations++;
+  }
+
+  var gridUpdateAllowed = !this.isTreeGrowing && !this.isGrowthFinished;
+  var forceToNodeSurroundingUpdate = this.growTreeIterations % 10 == 1 && this.isTreeGrowing || this.afterGrowthIterations % 10 == 1 && this.isGrowthFinished;
+
+  this.totalDisplacement = 0;
+  this.graphManager.updateBounds();
+  this.calcSpringForces();
+  this.calcRepulsionForces(gridUpdateAllowed, forceToNodeSurroundingUpdate);
+  this.calcGravitationalForces();
+  this.moveNodes();
+  this.animate();
+
+  return false; // Layout is not ended yet return false
+};
+
+CoSELayout.prototype.getPositionsData = function () {
+  var allNodes = this.graphManager.getAllNodes();
+  var pData = {};
+  for (var i = 0; i < allNodes.length; i++) {
+    var rect = allNodes[i].rect;
+    var id = allNodes[i].id;
+    pData[id] = {
+      id: id,
+      x: rect.getCenterX(),
+      y: rect.getCenterY(),
+      w: rect.width,
+      h: rect.height
+    };
+  }
+
+  return pData;
+};
+
+CoSELayout.prototype.runSpringEmbedder = function () {
+  this.initialAnimationPeriod = 25;
+  this.animationPeriod = this.initialAnimationPeriod;
+  var layoutEnded = false;
+
+  // If aminate option is 'during' signal that layout is supposed to start iterating
+  if (FDLayoutConstants.ANIMATE === 'during') {
+    this.emit('layoutstarted');
+  } else {
+    // If aminate option is 'during' tick() function will be called on index.js
+    while (!layoutEnded) {
+      layoutEnded = this.tick();
+    }
+
+    this.graphManager.updateBounds();
+  }
+};
+
+// overrides moveNodes method in FDLayout
+CoSELayout.prototype.moveNodes = function () {
+  var lNodes = this.getAllNodes();
+  var node;
+
+  // calculate displacement for each node 
+  for (var i = 0; i < lNodes.length; i++) {
+    node = lNodes[i];
+    node.calculateDisplacement();
+  }
+
+  if (Object.keys(this.constraints).length > 0) {
+    this.updateDisplacements();
+  }
+
+  // move each node
+  for (var i = 0; i < lNodes.length; i++) {
+    node = lNodes[i];
+    node.move();
+  }
+};
+
+// constraint related methods: initConstraintVariables and updateDisplacements
+
+// initialize constraint related variables
+CoSELayout.prototype.initConstraintVariables = function () {
+  var self = this;
+  this.idToNodeMap = new Map();
+  this.fixedNodeSet = new Set();
+
+  var allNodes = this.graphManager.getAllNodes();
+
+  // fill idToNodeMap
+  for (var i = 0; i < allNodes.length; i++) {
+    var node = allNodes[i];
+    this.idToNodeMap.set(node.id, node);
+  }
+
+  // calculate fixed node weight for given compound node
+  var calculateCompoundWeight = function calculateCompoundWeight(compoundNode) {
+    var nodes = compoundNode.getChild().getNodes();
+    var node;
+    var fixedNodeWeight = 0;
+    for (var i = 0; i < nodes.length; i++) {
+      node = nodes[i];
+      if (node.getChild() == null) {
+        if (self.fixedNodeSet.has(node.id)) {
+          fixedNodeWeight += 100;
+        }
+      } else {
+        fixedNodeWeight += calculateCompoundWeight(node);
+      }
+    }
+    return fixedNodeWeight;
+  };
+
+  if (this.constraints.fixedNodeConstraint) {
+    // fill fixedNodeSet
+    this.constraints.fixedNodeConstraint.forEach(function (nodeData) {
+      self.fixedNodeSet.add(nodeData.nodeId);
+    });
+
+    // assign fixed node weights to compounds if they contain fixed nodes
+    var allNodes = this.graphManager.getAllNodes();
+    var node;
+
+    for (var i = 0; i < allNodes.length; i++) {
+      node = allNodes[i];
+      if (node.getChild() != null) {
+        var fixedNodeWeight = calculateCompoundWeight(node);
+        if (fixedNodeWeight > 0) {
+          node.fixedNodeWeight = fixedNodeWeight;
+        }
+      }
+    }
+  }
+
+  if (this.constraints.relativePlacementConstraint) {
+    var nodeToDummyForVerticalAlignment = new Map();
+    var nodeToDummyForHorizontalAlignment = new Map();
+    this.dummyToNodeForVerticalAlignment = new Map();
+    this.dummyToNodeForHorizontalAlignment = new Map();
+    this.fixedNodesOnHorizontal = new Set();
+    this.fixedNodesOnVertical = new Set();
+
+    // fill maps and sets
+    this.fixedNodeSet.forEach(function (nodeId) {
+      self.fixedNodesOnHorizontal.add(nodeId);
+      self.fixedNodesOnVertical.add(nodeId);
+    });
+
+    if (this.constraints.alignmentConstraint) {
+      if (this.constraints.alignmentConstraint.vertical) {
+        var verticalAlignment = this.constraints.alignmentConstraint.vertical;
+        for (var i = 0; i < verticalAlignment.length; i++) {
+          this.dummyToNodeForVerticalAlignment.set("dummy" + i, []);
+          verticalAlignment[i].forEach(function (nodeId) {
+            nodeToDummyForVerticalAlignment.set(nodeId, "dummy" + i);
+            self.dummyToNodeForVerticalAlignment.get("dummy" + i).push(nodeId);
+            if (self.fixedNodeSet.has(nodeId)) {
+              self.fixedNodesOnHorizontal.add("dummy" + i);
+            }
+          });
+        }
+      }
+      if (this.constraints.alignmentConstraint.horizontal) {
+        var horizontalAlignment = this.constraints.alignmentConstraint.horizontal;
+        for (var i = 0; i < horizontalAlignment.length; i++) {
+          this.dummyToNodeForHorizontalAlignment.set("dummy" + i, []);
+          horizontalAlignment[i].forEach(function (nodeId) {
+            nodeToDummyForHorizontalAlignment.set(nodeId, "dummy" + i);
+            self.dummyToNodeForHorizontalAlignment.get("dummy" + i).push(nodeId);
+            if (self.fixedNodeSet.has(nodeId)) {
+              self.fixedNodesOnVertical.add("dummy" + i);
+            }
+          });
+        }
+      }
+    }
+
+    if (CoSEConstants.RELAX_MOVEMENT_ON_CONSTRAINTS) {
+
+      this.shuffle = function (array) {
+        var j, x, i;
+        for (i = array.length - 1; i >= 2 * array.length / 3; i--) {
+          j = Math.floor(Math.random() * (i + 1));
+          x = array[i];
+          array[i] = array[j];
+          array[j] = x;
+        }
+        return array;
+      };
+
+      this.nodesInRelativeHorizontal = [];
+      this.nodesInRelativeVertical = [];
+      this.nodeToRelativeConstraintMapHorizontal = new Map();
+      this.nodeToRelativeConstraintMapVertical = new Map();
+      this.nodeToTempPositionMapHorizontal = new Map();
+      this.nodeToTempPositionMapVertical = new Map();
+
+      // fill arrays and maps
+      this.constraints.relativePlacementConstraint.forEach(function (constraint) {
+        if (constraint.left) {
+          var nodeIdLeft = nodeToDummyForVerticalAlignment.has(constraint.left) ? nodeToDummyForVerticalAlignment.get(constraint.left) : constraint.left;
+          var nodeIdRight = nodeToDummyForVerticalAlignment.has(constraint.right) ? nodeToDummyForVerticalAlignment.get(constraint.right) : constraint.right;
+
+          if (!self.nodesInRelativeHorizontal.includes(nodeIdLeft)) {
+            self.nodesInRelativeHorizontal.push(nodeIdLeft);
+            self.nodeToRelativeConstraintMapHorizontal.set(nodeIdLeft, []);
+            if (self.dummyToNodeForVerticalAlignment.has(nodeIdLeft)) {
+              self.nodeToTempPositionMapHorizontal.set(nodeIdLeft, self.idToNodeMap.get(self.dummyToNodeForVerticalAlignment.get(nodeIdLeft)[0]).getCenterX());
+            } else {
+              self.nodeToTempPositionMapHorizontal.set(nodeIdLeft, self.idToNodeMap.get(nodeIdLeft).getCenterX());
+            }
+          }
+          if (!self.nodesInRelativeHorizontal.includes(nodeIdRight)) {
+            self.nodesInRelativeHorizontal.push(nodeIdRight);
+            self.nodeToRelativeConstraintMapHorizontal.set(nodeIdRight, []);
+            if (self.dummyToNodeForVerticalAlignment.has(nodeIdRight)) {
+              self.nodeToTempPositionMapHorizontal.set(nodeIdRight, self.idToNodeMap.get(self.dummyToNodeForVerticalAlignment.get(nodeIdRight)[0]).getCenterX());
+            } else {
+              self.nodeToTempPositionMapHorizontal.set(nodeIdRight, self.idToNodeMap.get(nodeIdRight).getCenterX());
+            }
+          }
+
+          self.nodeToRelativeConstraintMapHorizontal.get(nodeIdLeft).push({ right: nodeIdRight, gap: constraint.gap });
+          self.nodeToRelativeConstraintMapHorizontal.get(nodeIdRight).push({ left: nodeIdLeft, gap: constraint.gap });
+        } else {
+          var nodeIdTop = nodeToDummyForHorizontalAlignment.has(constraint.top) ? nodeToDummyForHorizontalAlignment.get(constraint.top) : constraint.top;
+          var nodeIdBottom = nodeToDummyForHorizontalAlignment.has(constraint.bottom) ? nodeToDummyForHorizontalAlignment.get(constraint.bottom) : constraint.bottom;
+
+          if (!self.nodesInRelativeVertical.includes(nodeIdTop)) {
+            self.nodesInRelativeVertical.push(nodeIdTop);
+            self.nodeToRelativeConstraintMapVertical.set(nodeIdTop, []);
+            if (self.dummyToNodeForHorizontalAlignment.has(nodeIdTop)) {
+              self.nodeToTempPositionMapVertical.set(nodeIdTop, self.idToNodeMap.get(self.dummyToNodeForHorizontalAlignment.get(nodeIdTop)[0]).getCenterY());
+            } else {
+              self.nodeToTempPositionMapVertical.set(nodeIdTop, self.idToNodeMap.get(nodeIdTop).getCenterY());
+            }
+          }
+          if (!self.nodesInRelativeVertical.includes(nodeIdBottom)) {
+            self.nodesInRelativeVertical.push(nodeIdBottom);
+            self.nodeToRelativeConstraintMapVertical.set(nodeIdBottom, []);
+            if (self.dummyToNodeForHorizontalAlignment.has(nodeIdBottom)) {
+              self.nodeToTempPositionMapVertical.set(nodeIdBottom, self.idToNodeMap.get(self.dummyToNodeForHorizontalAlignment.get(nodeIdBottom)[0]).getCenterY());
+            } else {
+              self.nodeToTempPositionMapVertical.set(nodeIdBottom, self.idToNodeMap.get(nodeIdBottom).getCenterY());
+            }
+          }
+          self.nodeToRelativeConstraintMapVertical.get(nodeIdTop).push({ bottom: nodeIdBottom, gap: constraint.gap });
+          self.nodeToRelativeConstraintMapVertical.get(nodeIdBottom).push({ top: nodeIdTop, gap: constraint.gap });
+        }
+      });
+    } else {
+      var subGraphOnHorizontal = new Map(); // subgraph from vertical RP constraints
+      var subGraphOnVertical = new Map(); // subgraph from vertical RP constraints
+
+      // construct subgraphs from relative placement constraints 
+      this.constraints.relativePlacementConstraint.forEach(function (constraint) {
+        if (constraint.left) {
+          var left = nodeToDummyForVerticalAlignment.has(constraint.left) ? nodeToDummyForVerticalAlignment.get(constraint.left) : constraint.left;
+          var right = nodeToDummyForVerticalAlignment.has(constraint.right) ? nodeToDummyForVerticalAlignment.get(constraint.right) : constraint.right;
+          if (subGraphOnHorizontal.has(left)) {
+            subGraphOnHorizontal.get(left).push(right);
+          } else {
+            subGraphOnHorizontal.set(left, [right]);
+          }
+          if (subGraphOnHorizontal.has(right)) {
+            subGraphOnHorizontal.get(right).push(left);
+          } else {
+            subGraphOnHorizontal.set(right, [left]);
+          }
+        } else {
+          var top = nodeToDummyForHorizontalAlignment.has(constraint.top) ? nodeToDummyForHorizontalAlignment.get(constraint.top) : constraint.top;
+          var bottom = nodeToDummyForHorizontalAlignment.has(constraint.bottom) ? nodeToDummyForHorizontalAlignment.get(constraint.bottom) : constraint.bottom;
+          if (subGraphOnVertical.has(top)) {
+            subGraphOnVertical.get(top).push(bottom);
+          } else {
+            subGraphOnVertical.set(top, [bottom]);
+          }
+          if (subGraphOnVertical.has(bottom)) {
+            subGraphOnVertical.get(bottom).push(top);
+          } else {
+            subGraphOnVertical.set(bottom, [top]);
+          }
+        }
+      });
+
+      // function to construct components from a given graph 
+      // also returns an array that keeps whether each component contains fixed node
+      var constructComponents = function constructComponents(graph, fixedNodes) {
+        var components = [];
+        var isFixed = [];
+        var queue = new LinkedList();
+        var visited = new Set();
+        var count = 0;
+
+        graph.forEach(function (value, key) {
+          if (!visited.has(key)) {
+            components[count] = [];
+            isFixed[count] = false;
+            var currentNode = key;
+            queue.push(currentNode);
+            visited.add(currentNode);
+            components[count].push(currentNode);
+
+            while (queue.length != 0) {
+              currentNode = queue.shift();
+              if (fixedNodes.has(currentNode)) {
+                isFixed[count] = true;
+              }
+              var neighbors = graph.get(currentNode);
+              neighbors.forEach(function (neighbor) {
+                if (!visited.has(neighbor)) {
+                  queue.push(neighbor);
+                  visited.add(neighbor);
+                  components[count].push(neighbor);
+                }
+              });
+            }
+            count++;
+          }
+        });
+
+        return { components: components, isFixed: isFixed };
+      };
+
+      var resultOnHorizontal = constructComponents(subGraphOnHorizontal, self.fixedNodesOnHorizontal);
+      this.componentsOnHorizontal = resultOnHorizontal.components;
+      this.fixedComponentsOnHorizontal = resultOnHorizontal.isFixed;
+      var resultOnVertical = constructComponents(subGraphOnVertical, self.fixedNodesOnVertical);
+      this.componentsOnVertical = resultOnVertical.components;
+      this.fixedComponentsOnVertical = resultOnVertical.isFixed;
+    }
+  }
+};
+
+// updates node displacements based on constraints
+CoSELayout.prototype.updateDisplacements = function () {
+  var self = this;
+  if (this.constraints.fixedNodeConstraint) {
+    this.constraints.fixedNodeConstraint.forEach(function (nodeData) {
+      var fixedNode = self.idToNodeMap.get(nodeData.nodeId);
+      fixedNode.displacementX = 0;
+      fixedNode.displacementY = 0;
+    });
+  }
+
+  if (this.constraints.alignmentConstraint) {
+    if (this.constraints.alignmentConstraint.vertical) {
+      var allVerticalAlignments = this.constraints.alignmentConstraint.vertical;
+      for (var i = 0; i < allVerticalAlignments.length; i++) {
+        var totalDisplacementX = 0;
+        for (var j = 0; j < allVerticalAlignments[i].length; j++) {
+          if (this.fixedNodeSet.has(allVerticalAlignments[i][j])) {
+            totalDisplacementX = 0;
+            break;
+          }
+          totalDisplacementX += this.idToNodeMap.get(allVerticalAlignments[i][j]).displacementX;
+        }
+        var averageDisplacementX = totalDisplacementX / allVerticalAlignments[i].length;
+        for (var j = 0; j < allVerticalAlignments[i].length; j++) {
+          this.idToNodeMap.get(allVerticalAlignments[i][j]).displacementX = averageDisplacementX;
+        }
+      }
+    }
+    if (this.constraints.alignmentConstraint.horizontal) {
+      var allHorizontalAlignments = this.constraints.alignmentConstraint.horizontal;
+      for (var i = 0; i < allHorizontalAlignments.length; i++) {
+        var totalDisplacementY = 0;
+        for (var j = 0; j < allHorizontalAlignments[i].length; j++) {
+          if (this.fixedNodeSet.has(allHorizontalAlignments[i][j])) {
+            totalDisplacementY = 0;
+            break;
+          }
+          totalDisplacementY += this.idToNodeMap.get(allHorizontalAlignments[i][j]).displacementY;
+        }
+        var averageDisplacementY = totalDisplacementY / allHorizontalAlignments[i].length;
+        for (var j = 0; j < allHorizontalAlignments[i].length; j++) {
+          this.idToNodeMap.get(allHorizontalAlignments[i][j]).displacementY = averageDisplacementY;
+        }
+      }
+    }
+  }
+
+  if (this.constraints.relativePlacementConstraint) {
+
+    if (CoSEConstants.RELAX_MOVEMENT_ON_CONSTRAINTS) {
+      // shuffle array to randomize node processing order
+      if (this.totalIterations % 10 == 0) {
+        this.shuffle(this.nodesInRelativeHorizontal);
+        this.shuffle(this.nodesInRelativeVertical);
+      }
+
+      this.nodesInRelativeHorizontal.forEach(function (nodeId) {
+        if (!self.fixedNodesOnHorizontal.has(nodeId)) {
+          var displacement = 0;
+          if (self.dummyToNodeForVerticalAlignment.has(nodeId)) {
+            displacement = self.idToNodeMap.get(self.dummyToNodeForVerticalAlignment.get(nodeId)[0]).displacementX;
+          } else {
+            displacement = self.idToNodeMap.get(nodeId).displacementX;
+          }
+          self.nodeToRelativeConstraintMapHorizontal.get(nodeId).forEach(function (constraint) {
+            if (constraint.right) {
+              var diff = self.nodeToTempPositionMapHorizontal.get(constraint.right) - self.nodeToTempPositionMapHorizontal.get(nodeId) - displacement;
+              if (diff < constraint.gap) {
+                displacement -= constraint.gap - diff;
+              }
+            } else {
+              var diff = self.nodeToTempPositionMapHorizontal.get(nodeId) - self.nodeToTempPositionMapHorizontal.get(constraint.left) + displacement;
+              if (diff < constraint.gap) {
+                displacement += constraint.gap - diff;
+              }
+            }
+          });
+          self.nodeToTempPositionMapHorizontal.set(nodeId, self.nodeToTempPositionMapHorizontal.get(nodeId) + displacement);
+          if (self.dummyToNodeForVerticalAlignment.has(nodeId)) {
+            self.dummyToNodeForVerticalAlignment.get(nodeId).forEach(function (nodeId) {
+              self.idToNodeMap.get(nodeId).displacementX = displacement;
+            });
+          } else {
+            self.idToNodeMap.get(nodeId).displacementX = displacement;
+          }
+        }
+      });
+
+      this.nodesInRelativeVertical.forEach(function (nodeId) {
+        if (!self.fixedNodesOnHorizontal.has(nodeId)) {
+          var displacement = 0;
+          if (self.dummyToNodeForHorizontalAlignment.has(nodeId)) {
+            displacement = self.idToNodeMap.get(self.dummyToNodeForHorizontalAlignment.get(nodeId)[0]).displacementY;
+          } else {
+            displacement = self.idToNodeMap.get(nodeId).displacementY;
+          }
+          self.nodeToRelativeConstraintMapVertical.get(nodeId).forEach(function (constraint) {
+            if (constraint.bottom) {
+              var diff = self.nodeToTempPositionMapVertical.get(constraint.bottom) - self.nodeToTempPositionMapVertical.get(nodeId) - displacement;
+              if (diff < constraint.gap) {
+                displacement -= constraint.gap - diff;
+              }
+            } else {
+              var diff = self.nodeToTempPositionMapVertical.get(nodeId) - self.nodeToTempPositionMapVertical.get(constraint.top) + displacement;
+              if (diff < constraint.gap) {
+                displacement += constraint.gap - diff;
+              }
+            }
+          });
+          self.nodeToTempPositionMapVertical.set(nodeId, self.nodeToTempPositionMapVertical.get(nodeId) + displacement);
+          if (self.dummyToNodeForHorizontalAlignment.has(nodeId)) {
+            self.dummyToNodeForHorizontalAlignment.get(nodeId).forEach(function (nodeId) {
+              self.idToNodeMap.get(nodeId).displacementY = displacement;
+            });
+          } else {
+            self.idToNodeMap.get(nodeId).displacementY = displacement;
+          }
+        }
+      });
+    } else {
+      for (var i = 0; i < this.componentsOnHorizontal.length; i++) {
+        var component = this.componentsOnHorizontal[i];
+        if (this.fixedComponentsOnHorizontal[i]) {
+          for (var j = 0; j < component.length; j++) {
+            if (this.dummyToNodeForVerticalAlignment.has(component[j])) {
+              this.dummyToNodeForVerticalAlignment.get(component[j]).forEach(function (nodeId) {
+                self.idToNodeMap.get(nodeId).displacementX = 0;
+              });
+            } else {
+              this.idToNodeMap.get(component[j]).displacementX = 0;
+            }
+          }
+        } else {
+          var sum = 0;
+          var count = 0;
+          for (var j = 0; j < component.length; j++) {
+            if (this.dummyToNodeForVerticalAlignment.has(component[j])) {
+              var actualNodes = this.dummyToNodeForVerticalAlignment.get(component[j]);
+              sum += actualNodes.length * this.idToNodeMap.get(actualNodes[0]).displacementX;
+              count += actualNodes.length;
+            } else {
+              sum += this.idToNodeMap.get(component[j]).displacementX;
+              count++;
+            }
+          }
+          var averageDisplacement = sum / count;
+          for (var j = 0; j < component.length; j++) {
+            if (this.dummyToNodeForVerticalAlignment.has(component[j])) {
+              this.dummyToNodeForVerticalAlignment.get(component[j]).forEach(function (nodeId) {
+                self.idToNodeMap.get(nodeId).displacementX = averageDisplacement;
+              });
+            } else {
+              this.idToNodeMap.get(component[j]).displacementX = averageDisplacement;
+            }
+          }
+        }
+      }
+
+      for (var i = 0; i < this.componentsOnVertical.length; i++) {
+        var component = this.componentsOnVertical[i];
+        if (this.fixedComponentsOnVertical[i]) {
+          for (var j = 0; j < component.length; j++) {
+            if (this.dummyToNodeForHorizontalAlignment.has(component[j])) {
+              this.dummyToNodeForHorizontalAlignment.get(component[j]).forEach(function (nodeId) {
+                self.idToNodeMap.get(nodeId).displacementY = 0;
+              });
+            } else {
+              this.idToNodeMap.get(component[j]).displacementY = 0;
+            }
+          }
+        } else {
+          var sum = 0;
+          var count = 0;
+          for (var j = 0; j < component.length; j++) {
+            if (this.dummyToNodeForHorizontalAlignment.has(component[j])) {
+              var actualNodes = this.dummyToNodeForHorizontalAlignment.get(component[j]);
+              sum += actualNodes.length * this.idToNodeMap.get(actualNodes[0]).displacementY;
+              count += actualNodes.length;
+            } else {
+              sum += this.idToNodeMap.get(component[j]).displacementY;
+              count++;
+            }
+          }
+          var averageDisplacement = sum / count;
+          for (var j = 0; j < component.length; j++) {
+            if (this.dummyToNodeForHorizontalAlignment.has(component[j])) {
+              this.dummyToNodeForHorizontalAlignment.get(component[j]).forEach(function (nodeId) {
+                self.idToNodeMap.get(nodeId).displacementY = averageDisplacement;
+              });
+            } else {
+              this.idToNodeMap.get(component[j]).displacementY = averageDisplacement;
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+CoSELayout.prototype.calculateNodesToApplyGravitationTo = function () {
+  var nodeList = [];
+  var graph;
+
+  var graphs = this.graphManager.getGraphs();
+  var size = graphs.length;
+  var i;
+  for (i = 0; i < size; i++) {
+    graph = graphs[i];
+
+    graph.updateConnected();
+
+    if (!graph.isConnected) {
+      nodeList = nodeList.concat(graph.getNodes());
+    }
+  }
+
+  return nodeList;
+};
+
+CoSELayout.prototype.createBendpoints = function () {
+  var edges = [];
+  edges = edges.concat(this.graphManager.getAllEdges());
+  var visited = new Set();
+  var i;
+  for (i = 0; i < edges.length; i++) {
+    var edge = edges[i];
+
+    if (!visited.has(edge)) {
+      var source = edge.getSource();
+      var target = edge.getTarget();
+
+      if (source == target) {
+        edge.getBendpoints().push(new PointD());
+        edge.getBendpoints().push(new PointD());
+        this.createDummyNodesForBendpoints(edge);
+        visited.add(edge);
+      } else {
+        var edgeList = [];
+
+        edgeList = edgeList.concat(source.getEdgeListToNode(target));
+        edgeList = edgeList.concat(target.getEdgeListToNode(source));
+
+        if (!visited.has(edgeList[0])) {
+          if (edgeList.length > 1) {
+            var k;
+            for (k = 0; k < edgeList.length; k++) {
+              var multiEdge = edgeList[k];
+              multiEdge.getBendpoints().push(new PointD());
+              this.createDummyNodesForBendpoints(multiEdge);
+            }
+          }
+          edgeList.forEach(function (edge) {
+            visited.add(edge);
+          });
+        }
+      }
+    }
+
+    if (visited.size == edges.length) {
+      break;
+    }
+  }
+};
+
+CoSELayout.prototype.positionNodesRadially = function (forest) {
+  // We tile the trees to a grid row by row; first tree starts at (0,0)
+  var currentStartingPoint = new Point(0, 0);
+  var numberOfColumns = Math.ceil(Math.sqrt(forest.length));
+  var height = 0;
+  var currentY = 0;
+  var currentX = 0;
+  var point = new PointD(0, 0);
+
+  for (var i = 0; i < forest.length; i++) {
+    if (i % numberOfColumns == 0) {
+      // Start of a new row, make the x coordinate 0, increment the
+      // y coordinate with the max height of the previous row
+      currentX = 0;
+      currentY = height;
+
+      if (i != 0) {
+        currentY += CoSEConstants.DEFAULT_COMPONENT_SEPERATION;
+      }
+
+      height = 0;
+    }
+
+    var tree = forest[i];
+
+    // Find the center of the tree
+    var centerNode = Layout.findCenterOfTree(tree);
+
+    // Set the staring point of the next tree
+    currentStartingPoint.x = currentX;
+    currentStartingPoint.y = currentY;
+
+    // Do a radial layout starting with the center
+    point = CoSELayout.radialLayout(tree, centerNode, currentStartingPoint);
+
+    if (point.y > height) {
+      height = Math.floor(point.y);
+    }
+
+    currentX = Math.floor(point.x + CoSEConstants.DEFAULT_COMPONENT_SEPERATION);
+  }
+
+  this.transform(new PointD(LayoutConstants.WORLD_CENTER_X - point.x / 2, LayoutConstants.WORLD_CENTER_Y - point.y / 2));
+};
+
+CoSELayout.radialLayout = function (tree, centerNode, startingPoint) {
+  var radialSep = Math.max(this.maxDiagonalInTree(tree), CoSEConstants.DEFAULT_RADIAL_SEPARATION);
+  CoSELayout.branchRadialLayout(centerNode, null, 0, 359, 0, radialSep);
+  var bounds = LGraph.calculateBounds(tree);
+
+  var transform = new Transform();
+  transform.setDeviceOrgX(bounds.getMinX());
+  transform.setDeviceOrgY(bounds.getMinY());
+  transform.setWorldOrgX(startingPoint.x);
+  transform.setWorldOrgY(startingPoint.y);
+
+  for (var i = 0; i < tree.length; i++) {
+    var node = tree[i];
+    node.transform(transform);
+  }
+
+  var bottomRight = new PointD(bounds.getMaxX(), bounds.getMaxY());
+
+  return transform.inverseTransformPoint(bottomRight);
+};
+
+CoSELayout.branchRadialLayout = function (node, parentOfNode, startAngle, endAngle, distance, radialSeparation) {
+  // First, position this node by finding its angle.
+  var halfInterval = (endAngle - startAngle + 1) / 2;
+
+  if (halfInterval < 0) {
+    halfInterval += 180;
+  }
+
+  var nodeAngle = (halfInterval + startAngle) % 360;
+  var teta = nodeAngle * IGeometry.TWO_PI / 360;
+
+  // Make polar to java cordinate conversion.
+  var cos_teta = Math.cos(teta);
+  var x_ = distance * Math.cos(teta);
+  var y_ = distance * Math.sin(teta);
+
+  node.setCenter(x_, y_);
+
+  // Traverse all neighbors of this node and recursively call this
+  // function.
+  var neighborEdges = [];
+  neighborEdges = neighborEdges.concat(node.getEdges());
+  var childCount = neighborEdges.length;
+
+  if (parentOfNode != null) {
+    childCount--;
+  }
+
+  var branchCount = 0;
+
+  var incEdgesCount = neighborEdges.length;
+  var startIndex;
+
+  var edges = node.getEdgesBetween(parentOfNode);
+
+  // If there are multiple edges, prune them until there remains only one
+  // edge.
+  while (edges.length > 1) {
+    //neighborEdges.remove(edges.remove(0));
+    var temp = edges[0];
+    edges.splice(0, 1);
+    var index = neighborEdges.indexOf(temp);
+    if (index >= 0) {
+      neighborEdges.splice(index, 1);
+    }
+    incEdgesCount--;
+    childCount--;
+  }
+
+  if (parentOfNode != null) {
+    //assert edges.length == 1;
+    startIndex = (neighborEdges.indexOf(edges[0]) + 1) % incEdgesCount;
+  } else {
+    startIndex = 0;
+  }
+
+  var stepAngle = Math.abs(endAngle - startAngle) / childCount;
+
+  for (var i = startIndex; branchCount != childCount; i = ++i % incEdgesCount) {
+    var currentNeighbor = neighborEdges[i].getOtherEnd(node);
+
+    // Don't back traverse to root node in current tree.
+    if (currentNeighbor == parentOfNode) {
+      continue;
+    }
+
+    var childStartAngle = (startAngle + branchCount * stepAngle) % 360;
+    var childEndAngle = (childStartAngle + stepAngle) % 360;
+
+    CoSELayout.branchRadialLayout(currentNeighbor, node, childStartAngle, childEndAngle, distance + radialSeparation, radialSeparation);
+
+    branchCount++;
+  }
+};
+
+CoSELayout.maxDiagonalInTree = function (tree) {
+  var maxDiagonal = Integer.MIN_VALUE;
+
+  for (var i = 0; i < tree.length; i++) {
+    var node = tree[i];
+    var diagonal = node.getDiagonal();
+
+    if (diagonal > maxDiagonal) {
+      maxDiagonal = diagonal;
+    }
+  }
+
+  return maxDiagonal;
+};
+
+CoSELayout.prototype.calcRepulsionRange = function () {
+  // formula is 2 x (level + 1) x idealEdgeLength
+  return 2 * (this.level + 1) * this.idealEdgeLength;
+};
+
+// Tiling methods
+
+// Group zero degree members whose parents are not to be tiled, create dummy parents where needed and fill memberGroups by their dummp parent id's
+CoSELayout.prototype.groupZeroDegreeMembers = function () {
+  var self = this;
+  // array of [parent_id x oneDegreeNode_id]
+  var tempMemberGroups = {}; // A temporary map of parent node and its zero degree members
+  this.memberGroups = {}; // A map of dummy parent node and its zero degree members whose parents are not to be tiled
+  this.idToDummyNode = {}; // A map of id to dummy node 
+
+  var zeroDegree = []; // List of zero degree nodes whose parents are not to be tiled
+  var allNodes = this.graphManager.getAllNodes();
+
+  // Fill zero degree list
+  for (var i = 0; i < allNodes.length; i++) {
+    var node = allNodes[i];
+    var parent = node.getParent();
+    // If a node has zero degree and its parent is not to be tiled if exists add that node to zeroDegres list
+    if (this.getNodeDegreeWithChildren(node) === 0 && (parent.id == undefined || !this.getToBeTiled(parent))) {
+      zeroDegree.push(node);
+    }
+  }
+
+  // Create a map of parent node and its zero degree members
+  for (var i = 0; i < zeroDegree.length; i++) {
+    var node = zeroDegree[i]; // Zero degree node itself
+    var p_id = node.getParent().id; // Parent id
+
+    if (typeof tempMemberGroups[p_id] === "undefined") tempMemberGroups[p_id] = [];
+
+    tempMemberGroups[p_id] = tempMemberGroups[p_id].concat(node); // Push node to the list belongs to its parent in tempMemberGroups
+  }
+
+  // If there are at least two nodes at a level, create a dummy compound for them
+  Object.keys(tempMemberGroups).forEach(function (p_id) {
+    if (tempMemberGroups[p_id].length > 1) {
+      var dummyCompoundId = "DummyCompound_" + p_id; // The id of dummy compound which will be created soon
+      self.memberGroups[dummyCompoundId] = tempMemberGroups[p_id]; // Add dummy compound to memberGroups
+
+      var parent = tempMemberGroups[p_id][0].getParent(); // The parent of zero degree nodes will be the parent of new dummy compound
+
+      // Create a dummy compound with calculated id
+      var dummyCompound = new CoSENode(self.graphManager);
+      dummyCompound.id = dummyCompoundId;
+      dummyCompound.paddingLeft = parent.paddingLeft || 0;
+      dummyCompound.paddingRight = parent.paddingRight || 0;
+      dummyCompound.paddingBottom = parent.paddingBottom || 0;
+      dummyCompound.paddingTop = parent.paddingTop || 0;
+
+      self.idToDummyNode[dummyCompoundId] = dummyCompound;
+
+      var dummyParentGraph = self.getGraphManager().add(self.newGraph(), dummyCompound);
+      var parentGraph = parent.getChild();
+
+      // Add dummy compound to parent the graph
+      parentGraph.add(dummyCompound);
+
+      // For each zero degree node in this level remove it from its parent graph and add it to the graph of dummy parent
+      for (var i = 0; i < tempMemberGroups[p_id].length; i++) {
+        var node = tempMemberGroups[p_id][i];
+
+        parentGraph.remove(node);
+        dummyParentGraph.add(node);
+      }
+    }
+  });
+};
+
+CoSELayout.prototype.clearCompounds = function () {
+  var childGraphMap = {};
+  var idToNode = {};
+
+  // Get compound ordering by finding the inner one first
+  this.performDFSOnCompounds();
+
+  for (var i = 0; i < this.compoundOrder.length; i++) {
+
+    idToNode[this.compoundOrder[i].id] = this.compoundOrder[i];
+    childGraphMap[this.compoundOrder[i].id] = [].concat(this.compoundOrder[i].getChild().getNodes());
+
+    // Remove children of compounds
+    this.graphManager.remove(this.compoundOrder[i].getChild());
+    this.compoundOrder[i].child = null;
+  }
+
+  this.graphManager.resetAllNodes();
+
+  // Tile the removed children
+  this.tileCompoundMembers(childGraphMap, idToNode);
+};
+
+CoSELayout.prototype.clearZeroDegreeMembers = function () {
+  var self = this;
+  var tiledZeroDegreePack = this.tiledZeroDegreePack = [];
+
+  Object.keys(this.memberGroups).forEach(function (id) {
+    var compoundNode = self.idToDummyNode[id]; // Get the dummy compound
+
+    tiledZeroDegreePack[id] = self.tileNodes(self.memberGroups[id], compoundNode.paddingLeft + compoundNode.paddingRight);
+
+    // Set the width and height of the dummy compound as calculated
+    compoundNode.rect.width = tiledZeroDegreePack[id].width;
+    compoundNode.rect.height = tiledZeroDegreePack[id].height;
+    compoundNode.setCenter(tiledZeroDegreePack[id].centerX, tiledZeroDegreePack[id].centerY);
+
+    // compound left and top margings for labels
+    // when node labels are included, these values may be set to different values below and are used in tilingPostLayout,
+    // otherwise they stay as zero
+    compoundNode.labelMarginLeft = 0;
+    compoundNode.labelMarginTop = 0;
+
+    // Update compound bounds considering its label properties and set label margins for left and top
+    if (CoSEConstants.NODE_DIMENSIONS_INCLUDE_LABELS) {
+
+      var width = compoundNode.rect.width;
+      var height = compoundNode.rect.height;
+
+      if (compoundNode.labelWidth) {
+        if (compoundNode.labelPosHorizontal == "left") {
+          compoundNode.rect.x -= compoundNode.labelWidth;
+          compoundNode.setWidth(width + compoundNode.labelWidth);
+          compoundNode.labelMarginLeft = compoundNode.labelWidth;
+        } else if (compoundNode.labelPosHorizontal == "center" && compoundNode.labelWidth > width) {
+          compoundNode.rect.x -= (compoundNode.labelWidth - width) / 2;
+          compoundNode.setWidth(compoundNode.labelWidth);
+          compoundNode.labelMarginLeft = (compoundNode.labelWidth - width) / 2;
+        } else if (compoundNode.labelPosHorizontal == "right") {
+          compoundNode.setWidth(width + compoundNode.labelWidth);
+        }
+      }
+
+      if (compoundNode.labelHeight) {
+        if (compoundNode.labelPosVertical == "top") {
+          compoundNode.rect.y -= compoundNode.labelHeight;
+          compoundNode.setHeight(height + compoundNode.labelHeight);
+          compoundNode.labelMarginTop = compoundNode.labelHeight;
+        } else if (compoundNode.labelPosVertical == "center" && compoundNode.labelHeight > height) {
+          compoundNode.rect.y -= (compoundNode.labelHeight - height) / 2;
+          compoundNode.setHeight(compoundNode.labelHeight);
+          compoundNode.labelMarginTop = (compoundNode.labelHeight - height) / 2;
+        } else if (compoundNode.labelPosVertical == "bottom") {
+          compoundNode.setHeight(height + compoundNode.labelHeight);
+        }
+      }
+    }
+  });
+};
+
+CoSELayout.prototype.repopulateCompounds = function () {
+  for (var i = this.compoundOrder.length - 1; i >= 0; i--) {
+    var lCompoundNode = this.compoundOrder[i];
+    var id = lCompoundNode.id;
+    var horizontalMargin = lCompoundNode.paddingLeft;
+    var verticalMargin = lCompoundNode.paddingTop;
+    var labelMarginLeft = lCompoundNode.labelMarginLeft;
+    var labelMarginTop = lCompoundNode.labelMarginTop;
+
+    this.adjustLocations(this.tiledMemberPack[id], lCompoundNode.rect.x, lCompoundNode.rect.y, horizontalMargin, verticalMargin, labelMarginLeft, labelMarginTop);
+  }
+};
+
+CoSELayout.prototype.repopulateZeroDegreeMembers = function () {
+  var self = this;
+  var tiledPack = this.tiledZeroDegreePack;
+
+  Object.keys(tiledPack).forEach(function (id) {
+    var compoundNode = self.idToDummyNode[id]; // Get the dummy compound by its id
+    var horizontalMargin = compoundNode.paddingLeft;
+    var verticalMargin = compoundNode.paddingTop;
+    var labelMarginLeft = compoundNode.labelMarginLeft;
+    var labelMarginTop = compoundNode.labelMarginTop;
+
+    // Adjust the positions of nodes wrt its compound
+    self.adjustLocations(tiledPack[id], compoundNode.rect.x, compoundNode.rect.y, horizontalMargin, verticalMargin, labelMarginLeft, labelMarginTop);
+  });
+};
+
+CoSELayout.prototype.getToBeTiled = function (node) {
+  var id = node.id;
+  //firstly check the previous results
+  if (this.toBeTiled[id] != null) {
+    return this.toBeTiled[id];
+  }
+
+  //only compound nodes are to be tiled
+  var childGraph = node.getChild();
+  if (childGraph == null) {
+    this.toBeTiled[id] = false;
+    return false;
+  }
+
+  var children = childGraph.getNodes(); // Get the children nodes
+
+  //a compound node is not to be tiled if all of its compound children are not to be tiled
+  for (var i = 0; i < children.length; i++) {
+    var theChild = children[i];
+
+    if (this.getNodeDegree(theChild) > 0) {
+      this.toBeTiled[id] = false;
+      return false;
+    }
+
+    //pass the children not having the compound structure
+    if (theChild.getChild() == null) {
+      this.toBeTiled[theChild.id] = false;
+      continue;
+    }
+
+    if (!this.getToBeTiled(theChild)) {
+      this.toBeTiled[id] = false;
+      return false;
+    }
+  }
+  this.toBeTiled[id] = true;
+  return true;
+};
+
+// Get degree of a node depending of its edges and independent of its children
+CoSELayout.prototype.getNodeDegree = function (node) {
+  var id = node.id;
+  var edges = node.getEdges();
+  var degree = 0;
+
+  // For the edges connected
+  for (var i = 0; i < edges.length; i++) {
+    var edge = edges[i];
+    if (edge.getSource().id !== edge.getTarget().id) {
+      degree = degree + 1;
+    }
+  }
+  return degree;
+};
+
+// Get degree of a node with its children
+CoSELayout.prototype.getNodeDegreeWithChildren = function (node) {
+  var degree = this.getNodeDegree(node);
+  if (node.getChild() == null) {
+    return degree;
+  }
+  var children = node.getChild().getNodes();
+  for (var i = 0; i < children.length; i++) {
+    var child = children[i];
+    degree += this.getNodeDegreeWithChildren(child);
+  }
+  return degree;
+};
+
+CoSELayout.prototype.performDFSOnCompounds = function () {
+  this.compoundOrder = [];
+  this.fillCompexOrderByDFS(this.graphManager.getRoot().getNodes());
+};
+
+CoSELayout.prototype.fillCompexOrderByDFS = function (children) {
+  for (var i = 0; i < children.length; i++) {
+    var child = children[i];
+    if (child.getChild() != null) {
+      this.fillCompexOrderByDFS(child.getChild().getNodes());
+    }
+    if (this.getToBeTiled(child)) {
+      this.compoundOrder.push(child);
+    }
+  }
+};
+
+/**
+* This method places each zero degree member wrt given (x,y) coordinates (top left).
+*/
+CoSELayout.prototype.adjustLocations = function (organization, x, y, compoundHorizontalMargin, compoundVerticalMargin, compoundLabelMarginLeft, compoundLabelMarginTop) {
+  x += compoundHorizontalMargin + compoundLabelMarginLeft;
+  y += compoundVerticalMargin + compoundLabelMarginTop;
+
+  var left = x;
+
+  for (var i = 0; i < organization.rows.length; i++) {
+    var row = organization.rows[i];
+    x = left;
+    var maxHeight = 0;
+
+    for (var j = 0; j < row.length; j++) {
+      var lnode = row[j];
+
+      lnode.rect.x = x; // + lnode.rect.width / 2;
+      lnode.rect.y = y; // + lnode.rect.height / 2;
+
+      x += lnode.rect.width + organization.horizontalPadding;
+
+      if (lnode.rect.height > maxHeight) maxHeight = lnode.rect.height;
+    }
+
+    y += maxHeight + organization.verticalPadding;
+  }
+};
+
+CoSELayout.prototype.tileCompoundMembers = function (childGraphMap, idToNode) {
+  var self = this;
+  this.tiledMemberPack = [];
+
+  Object.keys(childGraphMap).forEach(function (id) {
+    // Get the compound node
+    var compoundNode = idToNode[id];
+
+    self.tiledMemberPack[id] = self.tileNodes(childGraphMap[id], compoundNode.paddingLeft + compoundNode.paddingRight);
+
+    compoundNode.rect.width = self.tiledMemberPack[id].width;
+    compoundNode.rect.height = self.tiledMemberPack[id].height;
+    compoundNode.setCenter(self.tiledMemberPack[id].centerX, self.tiledMemberPack[id].centerY);
+
+    // compound left and top margings for labels
+    // when node labels are included, these values may be set to different values below and are used in tilingPostLayout,
+    // otherwise they stay as zero
+    compoundNode.labelMarginLeft = 0;
+    compoundNode.labelMarginTop = 0;
+
+    // Update compound bounds considering its label properties and set label margins for left and top
+    if (CoSEConstants.NODE_DIMENSIONS_INCLUDE_LABELS) {
+
+      var width = compoundNode.rect.width;
+      var height = compoundNode.rect.height;
+
+      if (compoundNode.labelWidth) {
+        if (compoundNode.labelPosHorizontal == "left") {
+          compoundNode.rect.x -= compoundNode.labelWidth;
+          compoundNode.setWidth(width + compoundNode.labelWidth);
+          compoundNode.labelMarginLeft = compoundNode.labelWidth;
+        } else if (compoundNode.labelPosHorizontal == "center" && compoundNode.labelWidth > width) {
+          compoundNode.rect.x -= (compoundNode.labelWidth - width) / 2;
+          compoundNode.setWidth(compoundNode.labelWidth);
+          compoundNode.labelMarginLeft = (compoundNode.labelWidth - width) / 2;
+        } else if (compoundNode.labelPosHorizontal == "right") {
+          compoundNode.setWidth(width + compoundNode.labelWidth);
+        }
+      }
+
+      if (compoundNode.labelHeight) {
+        if (compoundNode.labelPosVertical == "top") {
+          compoundNode.rect.y -= compoundNode.labelHeight;
+          compoundNode.setHeight(height + compoundNode.labelHeight);
+          compoundNode.labelMarginTop = compoundNode.labelHeight;
+        } else if (compoundNode.labelPosVertical == "center" && compoundNode.labelHeight > height) {
+          compoundNode.rect.y -= (compoundNode.labelHeight - height) / 2;
+          compoundNode.setHeight(compoundNode.labelHeight);
+          compoundNode.labelMarginTop = (compoundNode.labelHeight - height) / 2;
+        } else if (compoundNode.labelPosVertical == "bottom") {
+          compoundNode.setHeight(height + compoundNode.labelHeight);
+        }
+      }
+    }
+  });
+};
+
+CoSELayout.prototype.tileNodes = function (nodes, minWidth) {
+  var horizontalOrg = this.tileNodesByFavoringDim(nodes, minWidth, true);
+  var verticalOrg = this.tileNodesByFavoringDim(nodes, minWidth, false);
+
+  var horizontalRatio = this.getOrgRatio(horizontalOrg);
+  var verticalRatio = this.getOrgRatio(verticalOrg);
+  var bestOrg;
+
+  // the best ratio is the one that is closer to 1 since the ratios are already normalized
+  // and the best organization is the one that has the best ratio
+  if (verticalRatio < horizontalRatio) {
+    bestOrg = verticalOrg;
+  } else {
+    bestOrg = horizontalOrg;
+  }
+
+  return bestOrg;
+};
+
+// get the width/height ratio of the organization that is normalized so that it will not be less than 1
+CoSELayout.prototype.getOrgRatio = function (organization) {
+  // get dimensions and calculate the initial ratio
+  var width = organization.width;
+  var height = organization.height;
+  var ratio = width / height;
+
+  // if the initial ratio is less then 1 then inverse it
+  if (ratio < 1) {
+    ratio = 1 / ratio;
+  }
+
+  // return the normalized ratio
+  return ratio;
+};
+
+/*
+ * Calculates the ideal width for the rows. This method assumes that
+ * each node has the same sizes and calculates the ideal row width that
+ * approximates a square shaped complex accordingly. However, since nodes would
+ * have different sizes some rows would have different sizes and the resulting
+ * shape would not be an exact square.
+ */
+CoSELayout.prototype.calcIdealRowWidth = function (members, favorHorizontalDim) {
+  // To approximate a square shaped complex we need to make complex width equal to complex height.
+  // To achieve this we need to solve the following equation system for hc:
+  // (x + bx) * hc - bx = (y + by) * vc - by, hc * vc = n
+  // where x is the avarage width of the nodes, y is the avarage height of nodes
+  // bx and by are the buffer sizes in horizontal and vertical dimensions accordingly,
+  // hc and vc are the number of rows in horizontal and vertical dimensions
+  // n is number of members.
+
+  var verticalPadding = CoSEConstants.TILING_PADDING_VERTICAL;
+  var horizontalPadding = CoSEConstants.TILING_PADDING_HORIZONTAL;
+
+  // number of members
+  var membersSize = members.length;
+
+  // sum of the width of all members
+  var totalWidth = 0;
+
+  // sum of the height of all members
+  var totalHeight = 0;
+
+  var maxWidth = 0;
+
+  // traverse all members to calculate total width and total height and get the maximum members width
+  members.forEach(function (node) {
+    totalWidth += node.getWidth();
+    totalHeight += node.getHeight();
+
+    if (node.getWidth() > maxWidth) {
+      maxWidth = node.getWidth();
+    }
+  });
+
+  // average width of the members
+  var averageWidth = totalWidth / membersSize;
+
+  // average height of the members
+  var averageHeight = totalHeight / membersSize;
+
+  // solving the initial equation system for the hc yields the following second degree equation:
+  // hc^2 * (x+bx) + hc * (by - bx) - n * (y + by) = 0
+
+  // the delta value to solve the equation above for hc
+  var delta = Math.pow(verticalPadding - horizontalPadding, 2) + 4 * (averageWidth + horizontalPadding) * (averageHeight + verticalPadding) * membersSize;
+
+  // solve the equation using delta value to calculate the horizontal count
+  // that represents the number of nodes in an ideal row
+  var horizontalCountDouble = (horizontalPadding - verticalPadding + Math.sqrt(delta)) / (2 * (averageWidth + horizontalPadding));
+  // round the calculated horizontal count up or down according to the favored dimension
+  var horizontalCount;
+
+  if (favorHorizontalDim) {
+    horizontalCount = Math.ceil(horizontalCountDouble);
+    // if horizontalCount count is not a float value then both of rounding to floor and ceil
+    // will yield the same values. Instead of repeating the same calculation try going up
+    // while favoring horizontal dimension in such cases
+    if (horizontalCount == horizontalCountDouble) {
+      horizontalCount++;
+    }
+  } else {
+    horizontalCount = Math.floor(horizontalCountDouble);
+  }
+
+  // ideal width to be calculated
+  var idealWidth = horizontalCount * (averageWidth + horizontalPadding) - horizontalPadding;
+
+  // if max width is bigger than calculated ideal width reset ideal width to it
+  if (maxWidth > idealWidth) {
+    idealWidth = maxWidth;
+  }
+
+  // add the left-right margins to the ideal row width
+  idealWidth += horizontalPadding * 2;
+
+  // return the ideal row width1
+  return idealWidth;
+};
+
+CoSELayout.prototype.tileNodesByFavoringDim = function (nodes, minWidth, favorHorizontalDim) {
+  var verticalPadding = CoSEConstants.TILING_PADDING_VERTICAL;
+  var horizontalPadding = CoSEConstants.TILING_PADDING_HORIZONTAL;
+  var tilingCompareBy = CoSEConstants.TILING_COMPARE_BY;
+  var organization = {
+    rows: [],
+    rowWidth: [],
+    rowHeight: [],
+    width: 0,
+    height: minWidth, // assume minHeight equals to minWidth
+    verticalPadding: verticalPadding,
+    horizontalPadding: horizontalPadding,
+    centerX: 0,
+    centerY: 0
+  };
+
+  if (tilingCompareBy) {
+    organization.idealRowWidth = this.calcIdealRowWidth(nodes, favorHorizontalDim);
+  }
+
+  var getNodeArea = function getNodeArea(n) {
+    return n.rect.width * n.rect.height;
+  };
+
+  var areaCompareFcn = function areaCompareFcn(n1, n2) {
+    return getNodeArea(n2) - getNodeArea(n1);
+  };
+
+  // Sort the nodes in descending order of their areas
+  nodes.sort(function (n1, n2) {
+    var cmpBy = areaCompareFcn;
+    if (organization.idealRowWidth) {
+      cmpBy = tilingCompareBy;
+      return cmpBy(n1.id, n2.id);
+    }
+    return cmpBy(n1, n2);
+  });
+
+  // Create the organization -> calculate compound center
+  var sumCenterX = 0;
+  var sumCenterY = 0;
+  for (var i = 0; i < nodes.length; i++) {
+    var lNode = nodes[i];
+
+    sumCenterX += lNode.getCenterX();
+    sumCenterY += lNode.getCenterY();
+  }
+
+  organization.centerX = sumCenterX / nodes.length;
+  organization.centerY = sumCenterY / nodes.length;
+
+  // Create the organization -> tile members
+  for (var i = 0; i < nodes.length; i++) {
+    var lNode = nodes[i];
+
+    if (organization.rows.length == 0) {
+      this.insertNodeToRow(organization, lNode, 0, minWidth);
+    } else if (this.canAddHorizontal(organization, lNode.rect.width, lNode.rect.height)) {
+      var rowIndex = organization.rows.length - 1;
+      if (!organization.idealRowWidth) {
+        rowIndex = this.getShortestRowIndex(organization);
+      }
+      this.insertNodeToRow(organization, lNode, rowIndex, minWidth);
+    } else {
+      this.insertNodeToRow(organization, lNode, organization.rows.length, minWidth);
+    }
+
+    this.shiftToLastRow(organization);
+  }
+
+  return organization;
+};
+
+CoSELayout.prototype.insertNodeToRow = function (organization, node, rowIndex, minWidth) {
+  var minCompoundSize = minWidth;
+
+  // Add new row if needed
+  if (rowIndex == organization.rows.length) {
+    var secondDimension = [];
+
+    organization.rows.push(secondDimension);
+    organization.rowWidth.push(minCompoundSize);
+    organization.rowHeight.push(0);
+  }
+
+  // Update row width
+  var w = organization.rowWidth[rowIndex] + node.rect.width;
+
+  if (organization.rows[rowIndex].length > 0) {
+    w += organization.horizontalPadding;
+  }
+
+  organization.rowWidth[rowIndex] = w;
+  // Update compound width
+  if (organization.width < w) {
+    organization.width = w;
+  }
+
+  // Update height
+  var h = node.rect.height;
+  if (rowIndex > 0) h += organization.verticalPadding;
+
+  var extraHeight = 0;
+  if (h > organization.rowHeight[rowIndex]) {
+    extraHeight = organization.rowHeight[rowIndex];
+    organization.rowHeight[rowIndex] = h;
+    extraHeight = organization.rowHeight[rowIndex] - extraHeight;
+  }
+
+  organization.height += extraHeight;
+
+  // Insert node
+  organization.rows[rowIndex].push(node);
+};
+
+//Scans the rows of an organization and returns the one with the min width
+CoSELayout.prototype.getShortestRowIndex = function (organization) {
+  var r = -1;
+  var min = Number.MAX_VALUE;
+
+  for (var i = 0; i < organization.rows.length; i++) {
+    if (organization.rowWidth[i] < min) {
+      r = i;
+      min = organization.rowWidth[i];
+    }
+  }
+  return r;
+};
+
+//Scans the rows of an organization and returns the one with the max width
+CoSELayout.prototype.getLongestRowIndex = function (organization) {
+  var r = -1;
+  var max = Number.MIN_VALUE;
+
+  for (var i = 0; i < organization.rows.length; i++) {
+
+    if (organization.rowWidth[i] > max) {
+      r = i;
+      max = organization.rowWidth[i];
+    }
+  }
+
+  return r;
+};
+
+/**
+* This method checks whether adding extra width to the organization violates
+* the aspect ratio(1) or not.
+*/
+CoSELayout.prototype.canAddHorizontal = function (organization, extraWidth, extraHeight) {
+
+  // if there is an ideal row width specified use it instead of checking the aspect ratio
+  if (organization.idealRowWidth) {
+    var lastRowIndex = organization.rows.length - 1;
+    var lastRowWidth = organization.rowWidth[lastRowIndex];
+
+    // check and return if ideal row width will be exceed if the node is added to the row
+    return lastRowWidth + extraWidth + organization.horizontalPadding <= organization.idealRowWidth;
+  }
+
+  var sri = this.getShortestRowIndex(organization);
+
+  if (sri < 0) {
+    return true;
+  }
+
+  var min = organization.rowWidth[sri];
+
+  if (min + organization.horizontalPadding + extraWidth <= organization.width) return true;
+
+  var hDiff = 0;
+
+  // Adding to an existing row
+  if (organization.rowHeight[sri] < extraHeight) {
+    if (sri > 0) hDiff = extraHeight + organization.verticalPadding - organization.rowHeight[sri];
+  }
+
+  var add_to_row_ratio;
+  if (organization.width - min >= extraWidth + organization.horizontalPadding) {
+    add_to_row_ratio = (organization.height + hDiff) / (min + extraWidth + organization.horizontalPadding);
+  } else {
+    add_to_row_ratio = (organization.height + hDiff) / organization.width;
+  }
+
+  // Adding a new row for this node
+  hDiff = extraHeight + organization.verticalPadding;
+  var add_new_row_ratio;
+  if (organization.width < extraWidth) {
+    add_new_row_ratio = (organization.height + hDiff) / extraWidth;
+  } else {
+    add_new_row_ratio = (organization.height + hDiff) / organization.width;
+  }
+
+  if (add_new_row_ratio < 1) add_new_row_ratio = 1 / add_new_row_ratio;
+
+  if (add_to_row_ratio < 1) add_to_row_ratio = 1 / add_to_row_ratio;
+
+  return add_to_row_ratio < add_new_row_ratio;
+};
+
+//If moving the last node from the longest row and adding it to the last
+//row makes the bounding box smaller, do it.
+CoSELayout.prototype.shiftToLastRow = function (organization) {
+  var longest = this.getLongestRowIndex(organization);
+  var last = organization.rowWidth.length - 1;
+  var row = organization.rows[longest];
+  var node = row[row.length - 1];
+
+  var diff = node.width + organization.horizontalPadding;
+
+  // Check if there is enough space on the last row
+  if (organization.width - organization.rowWidth[last] > diff && longest != last) {
+    // Remove the last element of the longest row
+    row.splice(-1, 1);
+
+    // Push it to the last row
+    organization.rows[last].push(node);
+
+    organization.rowWidth[longest] = organization.rowWidth[longest] - diff;
+    organization.rowWidth[last] = organization.rowWidth[last] + diff;
+    organization.width = organization.rowWidth[instance.getLongestRowIndex(organization)];
+
+    // Update heights of the organization
+    var maxHeight = Number.MIN_VALUE;
+    for (var i = 0; i < row.length; i++) {
+      if (row[i].height > maxHeight) maxHeight = row[i].height;
+    }
+    if (longest > 0) maxHeight += organization.verticalPadding;
+
+    var prevTotal = organization.rowHeight[longest] + organization.rowHeight[last];
+
+    organization.rowHeight[longest] = maxHeight;
+    if (organization.rowHeight[last] < node.height + organization.verticalPadding) organization.rowHeight[last] = node.height + organization.verticalPadding;
+
+    var finalTotal = organization.rowHeight[longest] + organization.rowHeight[last];
+    organization.height += finalTotal - prevTotal;
+
+    this.shiftToLastRow(organization);
+  }
+};
+
+CoSELayout.prototype.tilingPreLayout = function () {
+  if (CoSEConstants.TILE) {
+    // Find zero degree nodes and create a compound for each level
+    this.groupZeroDegreeMembers();
+    // Tile and clear children of each compound
+    this.clearCompounds();
+    // Separately tile and clear zero degree nodes for each level
+    this.clearZeroDegreeMembers();
+  }
+};
+
+CoSELayout.prototype.tilingPostLayout = function () {
+  if (CoSEConstants.TILE) {
+    this.repopulateZeroDegreeMembers();
+    this.repopulateCompounds();
+  }
+};
+
+// -----------------------------------------------------------------------------
+// Section: Tree Reduction methods
+// -----------------------------------------------------------------------------
+// Reduce trees 
+CoSELayout.prototype.reduceTrees = function () {
+  var prunedNodesAll = [];
+  var containsLeaf = true;
+  var node;
+
+  while (containsLeaf) {
+    var allNodes = this.graphManager.getAllNodes();
+    var prunedNodesInStepTemp = [];
+    containsLeaf = false;
+
+    for (var i = 0; i < allNodes.length; i++) {
+      node = allNodes[i];
+      if (node.getEdges().length == 1 && !node.getEdges()[0].isInterGraph && node.getChild() == null) {
+        if (CoSEConstants.PURE_INCREMENTAL) {
+          var otherEnd = node.getEdges()[0].getOtherEnd(node);
+          var relativePosition = new DimensionD(node.getCenterX() - otherEnd.getCenterX(), node.getCenterY() - otherEnd.getCenterY());
+          prunedNodesInStepTemp.push([node, node.getEdges()[0], node.getOwner(), relativePosition]);
+        } else {
+          prunedNodesInStepTemp.push([node, node.getEdges()[0], node.getOwner()]);
+        }
+        containsLeaf = true;
+      }
+    }
+    if (containsLeaf == true) {
+      var prunedNodesInStep = [];
+      for (var j = 0; j < prunedNodesInStepTemp.length; j++) {
+        if (prunedNodesInStepTemp[j][0].getEdges().length == 1) {
+          prunedNodesInStep.push(prunedNodesInStepTemp[j]);
+          prunedNodesInStepTemp[j][0].getOwner().remove(prunedNodesInStepTemp[j][0]);
+        }
+      }
+      prunedNodesAll.push(prunedNodesInStep);
+      this.graphManager.resetAllNodes();
+      this.graphManager.resetAllEdges();
+    }
+  }
+  this.prunedNodesAll = prunedNodesAll;
+};
+
+// Grow tree one step 
+CoSELayout.prototype.growTree = function (prunedNodesAll) {
+  var lengthOfPrunedNodesInStep = prunedNodesAll.length;
+  var prunedNodesInStep = prunedNodesAll[lengthOfPrunedNodesInStep - 1];
+
+  var nodeData;
+  for (var i = 0; i < prunedNodesInStep.length; i++) {
+    nodeData = prunedNodesInStep[i];
+
+    this.findPlaceforPrunedNode(nodeData);
+
+    nodeData[2].add(nodeData[0]);
+    nodeData[2].add(nodeData[1], nodeData[1].source, nodeData[1].target);
+  }
+
+  prunedNodesAll.splice(prunedNodesAll.length - 1, 1);
+  this.graphManager.resetAllNodes();
+  this.graphManager.resetAllEdges();
+};
+
+// Find an appropriate position to replace pruned node, this method can be improved
+CoSELayout.prototype.findPlaceforPrunedNode = function (nodeData) {
+
+  var gridForPrunedNode;
+  var nodeToConnect;
+  var prunedNode = nodeData[0];
+  if (prunedNode == nodeData[1].source) {
+    nodeToConnect = nodeData[1].target;
+  } else {
+    nodeToConnect = nodeData[1].source;
+  }
+
+  if (CoSEConstants.PURE_INCREMENTAL) {
+    prunedNode.setCenter(nodeToConnect.getCenterX() + nodeData[3].getWidth(), nodeToConnect.getCenterY() + nodeData[3].getHeight());
+  } else {
+    var startGridX = nodeToConnect.startX;
+    var finishGridX = nodeToConnect.finishX;
+    var startGridY = nodeToConnect.startY;
+    var finishGridY = nodeToConnect.finishY;
+
+    var upNodeCount = 0;
+    var downNodeCount = 0;
+    var rightNodeCount = 0;
+    var leftNodeCount = 0;
+    var controlRegions = [upNodeCount, rightNodeCount, downNodeCount, leftNodeCount];
+
+    if (startGridY > 0) {
+      for (var i = startGridX; i <= finishGridX; i++) {
+        controlRegions[0] += this.grid[i][startGridY - 1].length + this.grid[i][startGridY].length - 1;
+      }
+    }
+    if (finishGridX < this.grid.length - 1) {
+      for (var i = startGridY; i <= finishGridY; i++) {
+        controlRegions[1] += this.grid[finishGridX + 1][i].length + this.grid[finishGridX][i].length - 1;
+      }
+    }
+    if (finishGridY < this.grid[0].length - 1) {
+      for (var i = startGridX; i <= finishGridX; i++) {
+        controlRegions[2] += this.grid[i][finishGridY + 1].length + this.grid[i][finishGridY].length - 1;
+      }
+    }
+    if (startGridX > 0) {
+      for (var i = startGridY; i <= finishGridY; i++) {
+        controlRegions[3] += this.grid[startGridX - 1][i].length + this.grid[startGridX][i].length - 1;
+      }
+    }
+    var min = Integer.MAX_VALUE;
+    var minCount;
+    var minIndex;
+    for (var j = 0; j < controlRegions.length; j++) {
+      if (controlRegions[j] < min) {
+        min = controlRegions[j];
+        minCount = 1;
+        minIndex = j;
+      } else if (controlRegions[j] == min) {
+        minCount++;
+      }
+    }
+
+    if (minCount == 3 && min == 0) {
+      if (controlRegions[0] == 0 && controlRegions[1] == 0 && controlRegions[2] == 0) {
+        gridForPrunedNode = 1;
+      } else if (controlRegions[0] == 0 && controlRegions[1] == 0 && controlRegions[3] == 0) {
+        gridForPrunedNode = 0;
+      } else if (controlRegions[0] == 0 && controlRegions[2] == 0 && controlRegions[3] == 0) {
+        gridForPrunedNode = 3;
+      } else if (controlRegions[1] == 0 && controlRegions[2] == 0 && controlRegions[3] == 0) {
+        gridForPrunedNode = 2;
+      }
+    } else if (minCount == 2 && min == 0) {
+      var random = Math.floor(Math.random() * 2);
+      if (controlRegions[0] == 0 && controlRegions[1] == 0) {
+        ;
+        if (random == 0) {
+          gridForPrunedNode = 0;
+        } else {
+          gridForPrunedNode = 1;
+        }
+      } else if (controlRegions[0] == 0 && controlRegions[2] == 0) {
+        if (random == 0) {
+          gridForPrunedNode = 0;
+        } else {
+          gridForPrunedNode = 2;
+        }
+      } else if (controlRegions[0] == 0 && controlRegions[3] == 0) {
+        if (random == 0) {
+          gridForPrunedNode = 0;
+        } else {
+          gridForPrunedNode = 3;
+        }
+      } else if (controlRegions[1] == 0 && controlRegions[2] == 0) {
+        if (random == 0) {
+          gridForPrunedNode = 1;
+        } else {
+          gridForPrunedNode = 2;
+        }
+      } else if (controlRegions[1] == 0 && controlRegions[3] == 0) {
+        if (random == 0) {
+          gridForPrunedNode = 1;
+        } else {
+          gridForPrunedNode = 3;
+        }
+      } else {
+        if (random == 0) {
+          gridForPrunedNode = 2;
+        } else {
+          gridForPrunedNode = 3;
+        }
+      }
+    } else if (minCount == 4 && min == 0) {
+      var random = Math.floor(Math.random() * 4);
+      gridForPrunedNode = random;
+    } else {
+      gridForPrunedNode = minIndex;
+    }
+
+    if (gridForPrunedNode == 0) {
+      prunedNode.setCenter(nodeToConnect.getCenterX(), nodeToConnect.getCenterY() - nodeToConnect.getHeight() / 2 - FDLayoutConstants.DEFAULT_EDGE_LENGTH - prunedNode.getHeight() / 2);
+    } else if (gridForPrunedNode == 1) {
+      prunedNode.setCenter(nodeToConnect.getCenterX() + nodeToConnect.getWidth() / 2 + FDLayoutConstants.DEFAULT_EDGE_LENGTH + prunedNode.getWidth() / 2, nodeToConnect.getCenterY());
+    } else if (gridForPrunedNode == 2) {
+      prunedNode.setCenter(nodeToConnect.getCenterX(), nodeToConnect.getCenterY() + nodeToConnect.getHeight() / 2 + FDLayoutConstants.DEFAULT_EDGE_LENGTH + prunedNode.getHeight() / 2);
+    } else {
+      prunedNode.setCenter(nodeToConnect.getCenterX() - nodeToConnect.getWidth() / 2 - FDLayoutConstants.DEFAULT_EDGE_LENGTH - prunedNode.getWidth() / 2, nodeToConnect.getCenterY());
+    }
+  }
+};
+
+module.exports = CoSELayout;
+
+/***/ }),
+
+/***/ 991:
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+
+
+var FDLayoutNode = __webpack_require__(551).FDLayoutNode;
+var IMath = __webpack_require__(551).IMath;
+
+function CoSENode(gm, loc, size, vNode) {
+  FDLayoutNode.call(this, gm, loc, size, vNode);
+}
+
+CoSENode.prototype = Object.create(FDLayoutNode.prototype);
+for (var prop in FDLayoutNode) {
+  CoSENode[prop] = FDLayoutNode[prop];
+}
+
+CoSENode.prototype.calculateDisplacement = function () {
+  var layout = this.graphManager.getLayout();
+  // this check is for compound nodes that contain fixed nodes
+  if (this.getChild() != null && this.fixedNodeWeight) {
+    this.displacementX += layout.coolingFactor * (this.springForceX + this.repulsionForceX + this.gravitationForceX) / this.fixedNodeWeight;
+    this.displacementY += layout.coolingFactor * (this.springForceY + this.repulsionForceY + this.gravitationForceY) / this.fixedNodeWeight;
+  } else {
+    this.displacementX += layout.coolingFactor * (this.springForceX + this.repulsionForceX + this.gravitationForceX) / this.noOfChildren;
+    this.displacementY += layout.coolingFactor * (this.springForceY + this.repulsionForceY + this.gravitationForceY) / this.noOfChildren;
+  }
+
+  if (Math.abs(this.displacementX) > layout.coolingFactor * layout.maxNodeDisplacement) {
+    this.displacementX = layout.coolingFactor * layout.maxNodeDisplacement * IMath.sign(this.displacementX);
+  }
+
+  if (Math.abs(this.displacementY) > layout.coolingFactor * layout.maxNodeDisplacement) {
+    this.displacementY = layout.coolingFactor * layout.maxNodeDisplacement * IMath.sign(this.displacementY);
+  }
+
+  // non-empty compound node, propogate movement to children as well
+  if (this.child && this.child.getNodes().length > 0) {
+    this.propogateDisplacementToChildren(this.displacementX, this.displacementY);
+  }
+};
+
+CoSENode.prototype.propogateDisplacementToChildren = function (dX, dY) {
+  var nodes = this.getChild().getNodes();
+  var node;
+  for (var i = 0; i < nodes.length; i++) {
+    node = nodes[i];
+    if (node.getChild() == null) {
+      node.displacementX += dX;
+      node.displacementY += dY;
+    } else {
+      node.propogateDisplacementToChildren(dX, dY);
+    }
+  }
+};
+
+CoSENode.prototype.move = function () {
+  var layout = this.graphManager.getLayout();
+
+  // a simple node or an empty compound node, move it
+  if (this.child == null || this.child.getNodes().length == 0) {
+    this.moveBy(this.displacementX, this.displacementY);
+
+    layout.totalDisplacement += Math.abs(this.displacementX) + Math.abs(this.displacementY);
+  }
+
+  this.springForceX = 0;
+  this.springForceY = 0;
+  this.repulsionForceX = 0;
+  this.repulsionForceY = 0;
+  this.gravitationForceX = 0;
+  this.gravitationForceY = 0;
+  this.displacementX = 0;
+  this.displacementY = 0;
+};
+
+CoSENode.prototype.setPred1 = function (pred1) {
+  this.pred1 = pred1;
+};
+
+CoSENode.prototype.getPred1 = function () {
+  return pred1;
+};
+
+CoSENode.prototype.getPred2 = function () {
+  return pred2;
+};
+
+CoSENode.prototype.setNext = function (next) {
+  this.next = next;
+};
+
+CoSENode.prototype.getNext = function () {
+  return next;
+};
+
+CoSENode.prototype.setProcessed = function (processed) {
+  this.processed = processed;
+};
+
+CoSENode.prototype.isProcessed = function () {
+  return processed;
+};
+
+module.exports = CoSENode;
+
+/***/ }),
+
+/***/ 902:
+/***/ ((module, __unused_webpack_exports, __webpack_require__) => {
+
+
+
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
+var CoSEConstants = __webpack_require__(806);
+var LinkedList = __webpack_require__(551).LinkedList;
+var Matrix = __webpack_require__(551).Matrix;
+var SVD = __webpack_require__(551).SVD;
+
+function ConstraintHandler() {}
+
+ConstraintHandler.handleConstraints = function (layout) {
+  //  let layout = this.graphManager.getLayout();
+
+  // get constraints from layout
+  var constraints = {};
+  constraints.fixedNodeConstraint = layout.constraints.fixedNodeConstraint;
+  constraints.alignmentConstraint = layout.constraints.alignmentConstraint;
+  constraints.relativePlacementConstraint = layout.constraints.relativePlacementConstraint;
+
+  var idToNodeMap = new Map();
+  var nodeIndexes = new Map();
+  var xCoords = [];
+  var yCoords = [];
+
+  var allNodes = layout.getAllNodes();
+  var index = 0;
+  // fill index map and coordinates
+  for (var i = 0; i < allNodes.length; i++) {
+    var node = allNodes[i];
+    if (node.getChild() == null) {
+      nodeIndexes.set(node.id, index++);
+      xCoords.push(node.getCenterX());
+      yCoords.push(node.getCenterY());
+      idToNodeMap.set(node.id, node);
+    }
+  }
+
+  // if there exists relative placement constraint without gap value, set it to default 
+  if (constraints.relativePlacementConstraint) {
+    constraints.relativePlacementConstraint.forEach(function (constraint) {
+      if (!constraint.gap && constraint.gap != 0) {
+        if (constraint.left) {
+          constraint.gap = CoSEConstants.DEFAULT_EDGE_LENGTH + idToNodeMap.get(constraint.left).getWidth() / 2 + idToNodeMap.get(constraint.right).getWidth() / 2;
+        } else {
+          constraint.gap = CoSEConstants.DEFAULT_EDGE_LENGTH + idToNodeMap.get(constraint.top).getHeight() / 2 + idToNodeMap.get(constraint.bottom).getHeight() / 2;
+        }
+      }
+    });
+  }
+
+  /* auxiliary functions */
+
+  // calculate difference between two position objects
+  var calculatePositionDiff = function calculatePositionDiff(pos1, pos2) {
+    return { x: pos1.x - pos2.x, y: pos1.y - pos2.y };
+  };
+
+  // calculate average position of the nodes
+  var calculateAvgPosition = function calculateAvgPosition(nodeIdSet) {
+    var xPosSum = 0;
+    var yPosSum = 0;
+    nodeIdSet.forEach(function (nodeId) {
+      xPosSum += xCoords[nodeIndexes.get(nodeId)];
+      yPosSum += yCoords[nodeIndexes.get(nodeId)];
+    });
+
+    return { x: xPosSum / nodeIdSet.size, y: yPosSum / nodeIdSet.size };
+  };
+
+  // find an appropriate positioning for the nodes in a given graph according to relative placement constraints
+  // this function also takes the fixed nodes and alignment constraints into account
+  // graph: dag to be evaluated, direction: "horizontal" or "vertical", 
+  // fixedNodes: set of fixed nodes to consider during evaluation, dummyPositions: appropriate coordinates of the dummy nodes  
+  var findAppropriatePositionForRelativePlacement = function findAppropriatePositionForRelativePlacement(graph, direction, fixedNodes, dummyPositions, componentSources) {
+
+    // find union of two sets
+    function setUnion(setA, setB) {
+      var union = new Set(setA);
+      var _iteratorNormalCompletion = true;
+      var _didIteratorError = false;
+      var _iteratorError = undefined;
+
+      try {
+        for (var _iterator = setB[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+          var elem = _step.value;
+
+          union.add(elem);
+        }
+      } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion && _iterator.return) {
+            _iterator.return();
+          }
+        } finally {
+          if (_didIteratorError) {
+            throw _iteratorError;
+          }
+        }
+      }
+
+      return union;
+    }
+
+    // find indegree count for each node
+    var inDegrees = new Map();
+
+    graph.forEach(function (value, key) {
+      inDegrees.set(key, 0);
+    });
+    graph.forEach(function (value, key) {
+      value.forEach(function (adjacent) {
+        inDegrees.set(adjacent.id, inDegrees.get(adjacent.id) + 1);
+      });
+    });
+
+    var positionMap = new Map(); // keeps the position for each node
+    var pastMap = new Map(); // keeps the predecessors(past) of a node
+    var queue = new LinkedList();
+    inDegrees.forEach(function (value, key) {
+      if (value == 0) {
+        queue.push(key);
+        if (!fixedNodes) {
+          if (direction == "horizontal") {
+            positionMap.set(key, nodeIndexes.has(key) ? xCoords[nodeIndexes.get(key)] : dummyPositions.get(key));
+          } else {
+            positionMap.set(key, nodeIndexes.has(key) ? yCoords[nodeIndexes.get(key)] : dummyPositions.get(key));
+          }
+        }
+      } else {
+        positionMap.set(key, Number.NEGATIVE_INFINITY);
+      }
+      if (fixedNodes) {
+        pastMap.set(key, new Set([key]));
+      }
+    });
+
+    // align sources of each component in enforcement phase
+    if (fixedNodes) {
+      componentSources.forEach(function (component) {
+        var fixedIds = [];
+        component.forEach(function (nodeId) {
+          if (fixedNodes.has(nodeId)) {
+            fixedIds.push(nodeId);
+          }
+        });
+        if (fixedIds.length > 0) {
+          var position = 0;
+          fixedIds.forEach(function (fixedId) {
+            if (direction == "horizontal") {
+              positionMap.set(fixedId, nodeIndexes.has(fixedId) ? xCoords[nodeIndexes.get(fixedId)] : dummyPositions.get(fixedId));
+              position += positionMap.get(fixedId);
+            } else {
+              positionMap.set(fixedId, nodeIndexes.has(fixedId) ? yCoords[nodeIndexes.get(fixedId)] : dummyPositions.get(fixedId));
+              position += positionMap.get(fixedId);
+            }
+          });
+          position = position / fixedIds.length;
+          component.forEach(function (nodeId) {
+            if (!fixedNodes.has(nodeId)) {
+              positionMap.set(nodeId, position);
+            }
+          });
+        } else {
+          var _position = 0;
+          component.forEach(function (nodeId) {
+            if (direction == "horizontal") {
+              _position += nodeIndexes.has(nodeId) ? xCoords[nodeIndexes.get(nodeId)] : dummyPositions.get(nodeId);
+            } else {
+              _position += nodeIndexes.has(nodeId) ? yCoords[nodeIndexes.get(nodeId)] : dummyPositions.get(nodeId);
+            }
+          });
+          _position = _position / component.length;
+          component.forEach(function (nodeId) {
+            positionMap.set(nodeId, _position);
+          });
+        }
+      });
+    }
+
+    // calculate positions of the nodes
+
+    var _loop = function _loop() {
+      var currentNode = queue.shift();
+      var neighbors = graph.get(currentNode);
+      neighbors.forEach(function (neighbor) {
+        if (positionMap.get(neighbor.id) < positionMap.get(currentNode) + neighbor.gap) {
+          if (fixedNodes && fixedNodes.has(neighbor.id)) {
+            var fixedPosition = void 0;
+            if (direction == "horizontal") {
+              fixedPosition = nodeIndexes.has(neighbor.id) ? xCoords[nodeIndexes.get(neighbor.id)] : dummyPositions.get(neighbor.id);
+            } else {
+              fixedPosition = nodeIndexes.has(neighbor.id) ? yCoords[nodeIndexes.get(neighbor.id)] : dummyPositions.get(neighbor.id);
+            }
+            positionMap.set(neighbor.id, fixedPosition); // TODO: may do unnecessary work
+            if (fixedPosition < positionMap.get(currentNode) + neighbor.gap) {
+              var diff = positionMap.get(currentNode) + neighbor.gap - fixedPosition;
+              pastMap.get(currentNode).forEach(function (nodeId) {
+                positionMap.set(nodeId, positionMap.get(nodeId) - diff);
+              });
+            }
+          } else {
+            positionMap.set(neighbor.id, positionMap.get(currentNode) + neighbor.gap);
+          }
+        }
+        inDegrees.set(neighbor.id, inDegrees.get(neighbor.id) - 1);
+        if (inDegrees.get(neighbor.id) == 0) {
+          queue.push(neighbor.id);
+        }
+        if (fixedNodes) {
+          pastMap.set(neighbor.id, setUnion(pastMap.get(currentNode), pastMap.get(neighbor.id)));
+        }
+      });
+    };
+
+    while (queue.length != 0) {
+      _loop();
+    }
+
+    // readjust position of the nodes after enforcement
+    if (fixedNodes) {
+      // find indegree count for each node
+      var sinkNodes = new Set();
+
+      graph.forEach(function (value, key) {
+        if (value.length == 0) {
+          sinkNodes.add(key);
+        }
+      });
+
+      var _components = [];
+      pastMap.forEach(function (value, key) {
+        if (sinkNodes.has(key)) {
+          var isFixedComponent = false;
+          var _iteratorNormalCompletion2 = true;
+          var _didIteratorError2 = false;
+          var _iteratorError2 = undefined;
+
+          try {
+            for (var _iterator2 = value[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+              var nodeId = _step2.value;
+
+              if (fixedNodes.has(nodeId)) {
+                isFixedComponent = true;
+              }
+            }
+          } catch (err) {
+            _didIteratorError2 = true;
+            _iteratorError2 = err;
+          } finally {
+            try {
+              if (!_iteratorNormalCompletion2 && _iterator2.return) {
+                _iterator2.return();
+              }
+            } finally {
+              if (_didIteratorError2) {
+                throw _iteratorError2;
+              }
+            }
+          }
+
+          if (!isFixedComponent) {
+            var isExist = false;
+            var existAt = void 0;
+            _components.forEach(function (component, index) {
+              if (component.has([].concat(_toConsumableArray(value))[0])) {
+                isExist = true;
+                existAt = index;
+              }
+            });
+            if (!isExist) {
+              _components.push(new Set(value));
+            } else {
+              value.forEach(function (ele) {
+                _components[existAt].add(ele);
+              });
+            }
+          }
+        }
+      });
+
+      _components.forEach(function (component, index) {
+        var minBefore = Number.POSITIVE_INFINITY;
+        var minAfter = Number.POSITIVE_INFINITY;
+        var maxBefore = Number.NEGATIVE_INFINITY;
+        var maxAfter = Number.NEGATIVE_INFINITY;
+
+        var _iteratorNormalCompletion3 = true;
+        var _didIteratorError3 = false;
+        var _iteratorError3 = undefined;
+
+        try {
+          for (var _iterator3 = component[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+            var nodeId = _step3.value;
+
+            var posBefore = void 0;
+            if (direction == "horizontal") {
+              posBefore = nodeIndexes.has(nodeId) ? xCoords[nodeIndexes.get(nodeId)] : dummyPositions.get(nodeId);
+            } else {
+              posBefore = nodeIndexes.has(nodeId) ? yCoords[nodeIndexes.get(nodeId)] : dummyPositions.get(nodeId);
+            }
+            var posAfter = positionMap.get(nodeId);
+            if (posBefore < minBefore) {
+              minBefore = posBefore;
+            }
+            if (posBefore > maxBefore) {
+              maxBefore = posBefore;
+            }
+            if (posAfter < minAfter) {
+              minAfter = posAfter;
+            }
+            if (posAfter > maxAfter) {
+              maxAfter = posAfter;
+            }
+          }
+        } catch (err) {
+          _didIteratorError3 = true;
+          _iteratorError3 = err;
+        } finally {
+          try {
+            if (!_iteratorNormalCompletion3 && _iterator3.return) {
+              _iterator3.return();
+            }
+          } finally {
+            if (_didIteratorError3) {
+              throw _iteratorError3;
+            }
+          }
+        }
+
+        var diff = (minBefore + maxBefore) / 2 - (minAfter + maxAfter) / 2;
+
+        var _iteratorNormalCompletion4 = true;
+        var _didIteratorError4 = false;
+        var _iteratorError4 = undefined;
+
+        try {
+          for (var _iterator4 = component[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
+            var _nodeId = _step4.value;
+
+            positionMap.set(_nodeId, positionMap.get(_nodeId) + diff);
+          }
+        } catch (err) {
+          _didIteratorError4 = true;
+          _iteratorError4 = err;
+        } finally {
+          try {
+            if (!_iteratorNormalCompletion4 && _iterator4.return) {
+              _iterator4.return();
+            }
+          } finally {
+            if (_didIteratorError4) {
+              throw _iteratorError4;
+            }
+          }
+        }
+      });
+    }
+
+    return positionMap;
+  };
+
+  // find transformation based on rel. placement constraints if there are both alignment and rel. placement constraints
+  // or if there are only rel. placement contraints where the largest component isn't sufficiently large
+  var applyReflectionForRelativePlacement = function applyReflectionForRelativePlacement(relativePlacementConstraints) {
+    // variables to count votes
+    var reflectOnY = 0,
+        notReflectOnY = 0;
+    var reflectOnX = 0,
+        notReflectOnX = 0;
+
+    relativePlacementConstraints.forEach(function (constraint) {
+      if (constraint.left) {
+        xCoords[nodeIndexes.get(constraint.left)] - xCoords[nodeIndexes.get(constraint.right)] >= 0 ? reflectOnY++ : notReflectOnY++;
+      } else {
+        yCoords[nodeIndexes.get(constraint.top)] - yCoords[nodeIndexes.get(constraint.bottom)] >= 0 ? reflectOnX++ : notReflectOnX++;
+      }
+    });
+
+    if (reflectOnY > notReflectOnY && reflectOnX > notReflectOnX) {
+      for (var _i = 0; _i < nodeIndexes.size; _i++) {
+        xCoords[_i] = -1 * xCoords[_i];
+        yCoords[_i] = -1 * yCoords[_i];
+      }
+    } else if (reflectOnY > notReflectOnY) {
+      for (var _i2 = 0; _i2 < nodeIndexes.size; _i2++) {
+        xCoords[_i2] = -1 * xCoords[_i2];
+      }
+    } else if (reflectOnX > notReflectOnX) {
+      for (var _i3 = 0; _i3 < nodeIndexes.size; _i3++) {
+        yCoords[_i3] = -1 * yCoords[_i3];
+      }
+    }
+  };
+
+  // find weakly connected components in undirected graph
+  var findComponents = function findComponents(graph) {
+    // find weakly connected components in dag
+    var components = [];
+    var queue = new LinkedList();
+    var visited = new Set();
+    var count = 0;
+
+    graph.forEach(function (value, key) {
+      if (!visited.has(key)) {
+        components[count] = [];
+        var _currentNode = key;
+        queue.push(_currentNode);
+        visited.add(_currentNode);
+        components[count].push(_currentNode);
+
+        while (queue.length != 0) {
+          _currentNode = queue.shift();
+          var neighbors = graph.get(_currentNode);
+          neighbors.forEach(function (neighbor) {
+            if (!visited.has(neighbor.id)) {
+              queue.push(neighbor.id);
+              visited.add(neighbor.id);
+              components[count].push(neighbor.id);
+            }
+          });
+        }
+        count++;
+      }
+    });
+    return components;
+  };
+
+  // return undirected version of given dag
+  var dagToUndirected = function dagToUndirected(dag) {
+    var undirected = new Map();
+
+    dag.forEach(function (value, key) {
+      undirected.set(key, []);
+    });
+
+    dag.forEach(function (value, key) {
+      value.forEach(function (adjacent) {
+        undirected.get(key).push(adjacent);
+        undirected.get(adjacent.id).push({ id: key, gap: adjacent.gap, direction: adjacent.direction });
+      });
+    });
+
+    return undirected;
+  };
+
+  // return reversed (directions inverted) version of given dag
+  var dagToReversed = function dagToReversed(dag) {
+    var reversed = new Map();
+
+    dag.forEach(function (value, key) {
+      reversed.set(key, []);
+    });
+
+    dag.forEach(function (value, key) {
+      value.forEach(function (adjacent) {
+        reversed.get(adjacent.id).push({ id: key, gap: adjacent.gap, direction: adjacent.direction });
+      });
+    });
+
+    return reversed;
+  };
+
+  /****  apply transformation to the initial draft layout to better align with constrained nodes ****/
+  // solve the Orthogonal Procrustean Problem to rotate and/or reflect initial draft layout
+  // here we follow the solution in Chapter 20.2 of Borg, I. & Groenen, P. (2005) Modern Multidimensional Scaling: Theory and Applications 
+
+  /* construct source and target configurations */
+
+  var targetMatrix = []; // A - target configuration
+  var sourceMatrix = []; // B - source configuration 
+  var standardTransformation = false; // false for no transformation, true for standart (Procrustes) transformation (rotation and/or reflection)
+  var reflectionType = false; // false/true for reflection check, 'reflectOnX', 'reflectOnY' or 'reflectOnBoth' for reflection type if necessary
+  var fixedNodes = new Set();
+  var dag = new Map(); // adjacency list to keep directed acyclic graph (dag) that consists of relative placement constraints
+  var dagUndirected = new Map(); // undirected version of the dag
+  var components = []; // weakly connected components
+
+  // fill fixedNodes collection to use later
+  if (constraints.fixedNodeConstraint) {
+    constraints.fixedNodeConstraint.forEach(function (nodeData) {
+      fixedNodes.add(nodeData.nodeId);
+    });
+  }
+
+  // construct dag from relative placement constraints 
+  if (constraints.relativePlacementConstraint) {
+    // construct both directed and undirected version of the dag
+    constraints.relativePlacementConstraint.forEach(function (constraint) {
+      if (constraint.left) {
+        if (dag.has(constraint.left)) {
+          dag.get(constraint.left).push({ id: constraint.right, gap: constraint.gap, direction: "horizontal" });
+        } else {
+          dag.set(constraint.left, [{ id: constraint.right, gap: constraint.gap, direction: "horizontal" }]);
+        }
+        if (!dag.has(constraint.right)) {
+          dag.set(constraint.right, []);
+        }
+      } else {
+        if (dag.has(constraint.top)) {
+          dag.get(constraint.top).push({ id: constraint.bottom, gap: constraint.gap, direction: "vertical" });
+        } else {
+          dag.set(constraint.top, [{ id: constraint.bottom, gap: constraint.gap, direction: "vertical" }]);
+        }
+        if (!dag.has(constraint.bottom)) {
+          dag.set(constraint.bottom, []);
+        }
+      }
+    });
+
+    dagUndirected = dagToUndirected(dag);
+    components = findComponents(dagUndirected);
+  }
+
+  if (CoSEConstants.TRANSFORM_ON_CONSTRAINT_HANDLING) {
+    // first check fixed node constraint
+    if (constraints.fixedNodeConstraint && constraints.fixedNodeConstraint.length > 1) {
+      constraints.fixedNodeConstraint.forEach(function (nodeData, i) {
+        targetMatrix[i] = [nodeData.position.x, nodeData.position.y];
+        sourceMatrix[i] = [xCoords[nodeIndexes.get(nodeData.nodeId)], yCoords[nodeIndexes.get(nodeData.nodeId)]];
+      });
+      standardTransformation = true;
+    } else if (constraints.alignmentConstraint) {
+      (function () {
+        // then check alignment constraint
+        var count = 0;
+        if (constraints.alignmentConstraint.vertical) {
+          var verticalAlign = constraints.alignmentConstraint.vertical;
+
+          var _loop2 = function _loop2(_i4) {
+            var alignmentSet = new Set();
+            verticalAlign[_i4].forEach(function (nodeId) {
+              alignmentSet.add(nodeId);
+            });
+            var intersection = new Set([].concat(_toConsumableArray(alignmentSet)).filter(function (x) {
+              return fixedNodes.has(x);
+            }));
+            var xPos = void 0;
+            if (intersection.size > 0) xPos = xCoords[nodeIndexes.get(intersection.values().next().value)];else xPos = calculateAvgPosition(alignmentSet).x;
+
+            verticalAlign[_i4].forEach(function (nodeId) {
+              targetMatrix[count] = [xPos, yCoords[nodeIndexes.get(nodeId)]];
+              sourceMatrix[count] = [xCoords[nodeIndexes.get(nodeId)], yCoords[nodeIndexes.get(nodeId)]];
+              count++;
+            });
+          };
+
+          for (var _i4 = 0; _i4 < verticalAlign.length; _i4++) {
+            _loop2(_i4);
+          }
+          standardTransformation = true;
+        }
+        if (constraints.alignmentConstraint.horizontal) {
+          var horizontalAlign = constraints.alignmentConstraint.horizontal;
+
+          var _loop3 = function _loop3(_i5) {
+            var alignmentSet = new Set();
+            horizontalAlign[_i5].forEach(function (nodeId) {
+              alignmentSet.add(nodeId);
+            });
+            var intersection = new Set([].concat(_toConsumableArray(alignmentSet)).filter(function (x) {
+              return fixedNodes.has(x);
+            }));
+            var yPos = void 0;
+            if (intersection.size > 0) yPos = xCoords[nodeIndexes.get(intersection.values().next().value)];else yPos = calculateAvgPosition(alignmentSet).y;
+
+            horizontalAlign[_i5].forEach(function (nodeId) {
+              targetMatrix[count] = [xCoords[nodeIndexes.get(nodeId)], yPos];
+              sourceMatrix[count] = [xCoords[nodeIndexes.get(nodeId)], yCoords[nodeIndexes.get(nodeId)]];
+              count++;
+            });
+          };
+
+          for (var _i5 = 0; _i5 < horizontalAlign.length; _i5++) {
+            _loop3(_i5);
+          }
+          standardTransformation = true;
+        }
+        if (constraints.relativePlacementConstraint) {
+          reflectionType = true;
+        }
+      })();
+    } else if (constraints.relativePlacementConstraint) {
+      // finally check relative placement constraint
+      // find largest component in dag
+      var largestComponentSize = 0;
+      var largestComponentIndex = 0;
+      for (var _i6 = 0; _i6 < components.length; _i6++) {
+        if (components[_i6].length > largestComponentSize) {
+          largestComponentSize = components[_i6].length;
+          largestComponentIndex = _i6;
+        }
+      }
+      // if largest component isn't dominant, then take the votes for reflection
+      if (largestComponentSize < dagUndirected.size / 2) {
+        applyReflectionForRelativePlacement(constraints.relativePlacementConstraint);
+        standardTransformation = false;
+        reflectionType = false;
+      } else {
+        // use largest component for transformation
+        // construct horizontal and vertical subgraphs in the largest component
+        var subGraphOnHorizontal = new Map();
+        var subGraphOnVertical = new Map();
+        var constraintsInlargestComponent = [];
+
+        components[largestComponentIndex].forEach(function (nodeId) {
+          dag.get(nodeId).forEach(function (adjacent) {
+            if (adjacent.direction == "horizontal") {
+              if (subGraphOnHorizontal.has(nodeId)) {
+                subGraphOnHorizontal.get(nodeId).push(adjacent);
+              } else {
+                subGraphOnHorizontal.set(nodeId, [adjacent]);
+              }
+              if (!subGraphOnHorizontal.has(adjacent.id)) {
+                subGraphOnHorizontal.set(adjacent.id, []);
+              }
+              constraintsInlargestComponent.push({ left: nodeId, right: adjacent.id });
+            } else {
+              if (subGraphOnVertical.has(nodeId)) {
+                subGraphOnVertical.get(nodeId).push(adjacent);
+              } else {
+                subGraphOnVertical.set(nodeId, [adjacent]);
+              }
+              if (!subGraphOnVertical.has(adjacent.id)) {
+                subGraphOnVertical.set(adjacent.id, []);
+              }
+              constraintsInlargestComponent.push({ top: nodeId, bottom: adjacent.id });
+            }
+          });
+        });
+
+        applyReflectionForRelativePlacement(constraintsInlargestComponent);
+        reflectionType = false;
+
+        // calculate appropriate positioning for subgraphs
+        var positionMapHorizontal = findAppropriatePositionForRelativePlacement(subGraphOnHorizontal, "horizontal");
+        var positionMapVertical = findAppropriatePositionForRelativePlacement(subGraphOnVertical, "vertical");
+
+        // construct source and target configuration
+        components[largestComponentIndex].forEach(function (nodeId, i) {
+          sourceMatrix[i] = [xCoords[nodeIndexes.get(nodeId)], yCoords[nodeIndexes.get(nodeId)]];
+          targetMatrix[i] = [];
+          if (positionMapHorizontal.has(nodeId)) {
+            targetMatrix[i][0] = positionMapHorizontal.get(nodeId);
+          } else {
+            targetMatrix[i][0] = xCoords[nodeIndexes.get(nodeId)];
+          }
+          if (positionMapVertical.has(nodeId)) {
+            targetMatrix[i][1] = positionMapVertical.get(nodeId);
+          } else {
+            targetMatrix[i][1] = yCoords[nodeIndexes.get(nodeId)];
+          }
+        });
+
+        standardTransformation = true;
+      }
+    }
+
+    // if transformation is required, then calculate and apply transformation matrix
+    if (standardTransformation) {
+      /* calculate transformation matrix */
+      var transformationMatrix = void 0;
+      var targetMatrixTranspose = Matrix.transpose(targetMatrix); // A'
+      var sourceMatrixTranspose = Matrix.transpose(sourceMatrix); // B'
+
+      // centralize transpose matrices
+      for (var _i7 = 0; _i7 < targetMatrixTranspose.length; _i7++) {
+        targetMatrixTranspose[_i7] = Matrix.multGamma(targetMatrixTranspose[_i7]);
+        sourceMatrixTranspose[_i7] = Matrix.multGamma(sourceMatrixTranspose[_i7]);
+      }
+
+      // do actual calculation for transformation matrix
+      var tempMatrix = Matrix.multMat(targetMatrixTranspose, Matrix.transpose(sourceMatrixTranspose)); // tempMatrix = A'B
+      var SVDResult = SVD.svd(tempMatrix); // SVD(A'B) = USV', svd function returns U, S and V 
+      transformationMatrix = Matrix.multMat(SVDResult.V, Matrix.transpose(SVDResult.U)); // transformationMatrix = T = VU'
+
+      /* apply found transformation matrix to obtain final draft layout */
+      for (var _i8 = 0; _i8 < nodeIndexes.size; _i8++) {
+        var temp1 = [xCoords[_i8], yCoords[_i8]];
+        var temp2 = [transformationMatrix[0][0], transformationMatrix[1][0]];
+        var temp3 = [transformationMatrix[0][1], transformationMatrix[1][1]];
+        xCoords[_i8] = Matrix.dotProduct(temp1, temp2);
+        yCoords[_i8] = Matrix.dotProduct(temp1, temp3);
+      }
+
+      // applied only both alignment and rel. placement constraints exist
+      if (reflectionType) {
+        applyReflectionForRelativePlacement(constraints.relativePlacementConstraint);
+      }
+    }
+  }
+
+  if (CoSEConstants.ENFORCE_CONSTRAINTS) {
+    /****  enforce constraints on the transformed draft layout ****/
+
+    /* first enforce fixed node constraint */
+
+    if (constraints.fixedNodeConstraint && constraints.fixedNodeConstraint.length > 0) {
+      var translationAmount = { x: 0, y: 0 };
+      constraints.fixedNodeConstraint.forEach(function (nodeData, i) {
+        var posInTheory = { x: xCoords[nodeIndexes.get(nodeData.nodeId)], y: yCoords[nodeIndexes.get(nodeData.nodeId)] };
+        var posDesired = nodeData.position;
+        var posDiff = calculatePositionDiff(posDesired, posInTheory);
+        translationAmount.x += posDiff.x;
+        translationAmount.y += posDiff.y;
+      });
+      translationAmount.x /= constraints.fixedNodeConstraint.length;
+      translationAmount.y /= constraints.fixedNodeConstraint.length;
+
+      xCoords.forEach(function (value, i) {
+        xCoords[i] += translationAmount.x;
+      });
+
+      yCoords.forEach(function (value, i) {
+        yCoords[i] += translationAmount.y;
+      });
+
+      constraints.fixedNodeConstraint.forEach(function (nodeData) {
+        xCoords[nodeIndexes.get(nodeData.nodeId)] = nodeData.position.x;
+        yCoords[nodeIndexes.get(nodeData.nodeId)] = nodeData.position.y;
+      });
+    }
+
+    /* then enforce alignment constraint */
+
+    if (constraints.alignmentConstraint) {
+      if (constraints.alignmentConstraint.vertical) {
+        var xAlign = constraints.alignmentConstraint.vertical;
+
+        var _loop4 = function _loop4(_i9) {
+          var alignmentSet = new Set();
+          xAlign[_i9].forEach(function (nodeId) {
+            alignmentSet.add(nodeId);
+          });
+          var intersection = new Set([].concat(_toConsumableArray(alignmentSet)).filter(function (x) {
+            return fixedNodes.has(x);
+          }));
+          var xPos = void 0;
+          if (intersection.size > 0) xPos = xCoords[nodeIndexes.get(intersection.values().next().value)];else xPos = calculateAvgPosition(alignmentSet).x;
+
+          alignmentSet.forEach(function (nodeId) {
+            if (!fixedNodes.has(nodeId)) xCoords[nodeIndexes.get(nodeId)] = xPos;
+          });
+        };
+
+        for (var _i9 = 0; _i9 < xAlign.length; _i9++) {
+          _loop4(_i9);
+        }
+      }
+      if (constraints.alignmentConstraint.horizontal) {
+        var yAlign = constraints.alignmentConstraint.horizontal;
+
+        var _loop5 = function _loop5(_i10) {
+          var alignmentSet = new Set();
+          yAlign[_i10].forEach(function (nodeId) {
+            alignmentSet.add(nodeId);
+          });
+          var intersection = new Set([].concat(_toConsumableArray(alignmentSet)).filter(function (x) {
+            return fixedNodes.has(x);
+          }));
+          var yPos = void 0;
+          if (intersection.size > 0) yPos = yCoords[nodeIndexes.get(intersection.values().next().value)];else yPos = calculateAvgPosition(alignmentSet).y;
+
+          alignmentSet.forEach(function (nodeId) {
+            if (!fixedNodes.has(nodeId)) yCoords[nodeIndexes.get(nodeId)] = yPos;
+          });
+        };
+
+        for (var _i10 = 0; _i10 < yAlign.length; _i10++) {
+          _loop5(_i10);
+        }
+      }
+    }
+
+    /* finally enforce relative placement constraint */
+
+    if (constraints.relativePlacementConstraint) {
+      (function () {
+        var nodeToDummyForVerticalAlignment = new Map();
+        var nodeToDummyForHorizontalAlignment = new Map();
+        var dummyToNodeForVerticalAlignment = new Map();
+        var dummyToNodeForHorizontalAlignment = new Map();
+        var dummyPositionsForVerticalAlignment = new Map();
+        var dummyPositionsForHorizontalAlignment = new Map();
+        var fixedNodesOnHorizontal = new Set();
+        var fixedNodesOnVertical = new Set();
+
+        // fill maps and sets      
+        fixedNodes.forEach(function (nodeId) {
+          fixedNodesOnHorizontal.add(nodeId);
+          fixedNodesOnVertical.add(nodeId);
+        });
+
+        if (constraints.alignmentConstraint) {
+          if (constraints.alignmentConstraint.vertical) {
+            var verticalAlignment = constraints.alignmentConstraint.vertical;
+
+            var _loop6 = function _loop6(_i11) {
+              dummyToNodeForVerticalAlignment.set("dummy" + _i11, []);
+              verticalAlignment[_i11].forEach(function (nodeId) {
+                nodeToDummyForVerticalAlignment.set(nodeId, "dummy" + _i11);
+                dummyToNodeForVerticalAlignment.get("dummy" + _i11).push(nodeId);
+                if (fixedNodes.has(nodeId)) {
+                  fixedNodesOnHorizontal.add("dummy" + _i11);
+                }
+              });
+              dummyPositionsForVerticalAlignment.set("dummy" + _i11, xCoords[nodeIndexes.get(verticalAlignment[_i11][0])]);
+            };
+
+            for (var _i11 = 0; _i11 < verticalAlignment.length; _i11++) {
+              _loop6(_i11);
+            }
+          }
+          if (constraints.alignmentConstraint.horizontal) {
+            var horizontalAlignment = constraints.alignmentConstraint.horizontal;
+
+            var _loop7 = function _loop7(_i12) {
+              dummyToNodeForHorizontalAlignment.set("dummy" + _i12, []);
+              horizontalAlignment[_i12].forEach(function (nodeId) {
+                nodeToDummyForHorizontalAlignment.set(nodeId, "dummy" + _i12);
+                dummyToNodeForHorizontalAlignment.get("dummy" + _i12).push(nodeId);
+                if (fixedNodes.has(nodeId)) {
+                  fixedNodesOnVertical.add("dummy" + _i12);
+                }
+              });
+              dummyPositionsForHorizontalAlignment.set("dummy" + _i12, yCoords[nodeIndexes.get(horizontalAlignment[_i12][0])]);
+            };
+
+            for (var _i12 = 0; _i12 < horizontalAlignment.length; _i12++) {
+              _loop7(_i12);
+            }
+          }
+        }
+
+        // construct horizontal and vertical dags (subgraphs) from overall dag
+        var dagOnHorizontal = new Map();
+        var dagOnVertical = new Map();
+
+        var _loop8 = function _loop8(nodeId) {
+          dag.get(nodeId).forEach(function (adjacent) {
+            var sourceId = void 0;
+            var targetNode = void 0;
+            if (adjacent["direction"] == "horizontal") {
+              sourceId = nodeToDummyForVerticalAlignment.get(nodeId) ? nodeToDummyForVerticalAlignment.get(nodeId) : nodeId;
+              if (nodeToDummyForVerticalAlignment.get(adjacent.id)) {
+                targetNode = { id: nodeToDummyForVerticalAlignment.get(adjacent.id), gap: adjacent.gap, direction: adjacent.direction };
+              } else {
+                targetNode = adjacent;
+              }
+              if (dagOnHorizontal.has(sourceId)) {
+                dagOnHorizontal.get(sourceId).push(targetNode);
+              } else {
+                dagOnHorizontal.set(sourceId, [targetNode]);
+              }
+              if (!dagOnHorizontal.has(targetNode.id)) {
+                dagOnHorizontal.set(targetNode.id, []);
+              }
+            } else {
+              sourceId = nodeToDummyForHorizontalAlignment.get(nodeId) ? nodeToDummyForHorizontalAlignment.get(nodeId) : nodeId;
+              if (nodeToDummyForHorizontalAlignment.get(adjacent.id)) {
+                targetNode = { id: nodeToDummyForHorizontalAlignment.get(adjacent.id), gap: adjacent.gap, direction: adjacent.direction };
+              } else {
+                targetNode = adjacent;
+              }
+              if (dagOnVertical.has(sourceId)) {
+                dagOnVertical.get(sourceId).push(targetNode);
+              } else {
+                dagOnVertical.set(sourceId, [targetNode]);
+              }
+              if (!dagOnVertical.has(targetNode.id)) {
+                dagOnVertical.set(targetNode.id, []);
+              }
+            }
+          });
+        };
+
+        var _iteratorNormalCompletion5 = true;
+        var _didIteratorError5 = false;
+        var _iteratorError5 = undefined;
+
+        try {
+          for (var _iterator5 = dag.keys()[Symbol.iterator](), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
+            var nodeId = _step5.value;
+
+            _loop8(nodeId);
+          }
+
+          // find source nodes of each component in horizontal and vertical dags
+        } catch (err) {
+          _didIteratorError5 = true;
+          _iteratorError5 = err;
+        } finally {
+          try {
+            if (!_iteratorNormalCompletion5 && _iterator5.return) {
+              _iterator5.return();
+            }
+          } finally {
+            if (_didIteratorError5) {
+              throw _iteratorError5;
+            }
+          }
+        }
+
+        var undirectedOnHorizontal = dagToUndirected(dagOnHorizontal);
+        var undirectedOnVertical = dagToUndirected(dagOnVertical);
+        var componentsOnHorizontal = findComponents(undirectedOnHorizontal);
+        var componentsOnVertical = findComponents(undirectedOnVertical);
+        var reversedDagOnHorizontal = dagToReversed(dagOnHorizontal);
+        var reversedDagOnVertical = dagToReversed(dagOnVertical);
+        var componentSourcesOnHorizontal = [];
+        var componentSourcesOnVertical = [];
+
+        componentsOnHorizontal.forEach(function (component, index) {
+          componentSourcesOnHorizontal[index] = [];
+          component.forEach(function (nodeId) {
+            if (reversedDagOnHorizontal.get(nodeId).length == 0) {
+              componentSourcesOnHorizontal[index].push(nodeId);
+            }
+          });
+        });
+
+        componentsOnVertical.forEach(function (component, index) {
+          componentSourcesOnVertical[index] = [];
+          component.forEach(function (nodeId) {
+            if (reversedDagOnVertical.get(nodeId).length == 0) {
+              componentSourcesOnVertical[index].push(nodeId);
+            }
+          });
+        });
+
+        // calculate appropriate positioning for subgraphs
+        var positionMapHorizontal = findAppropriatePositionForRelativePlacement(dagOnHorizontal, "horizontal", fixedNodesOnHorizontal, dummyPositionsForVerticalAlignment, componentSourcesOnHorizontal);
+        var positionMapVertical = findAppropriatePositionForRelativePlacement(dagOnVertical, "vertical", fixedNodesOnVertical, dummyPositionsForHorizontalAlignment, componentSourcesOnVertical);
+
+        // update positions of the nodes based on relative placement constraints
+
+        var _loop9 = function _loop9(key) {
+          if (dummyToNodeForVerticalAlignment.get(key)) {
+            dummyToNodeForVerticalAlignment.get(key).forEach(function (nodeId) {
+              xCoords[nodeIndexes.get(nodeId)] = positionMapHorizontal.get(key);
+            });
+          } else {
+            xCoords[nodeIndexes.get(key)] = positionMapHorizontal.get(key);
+          }
+        };
+
+        var _iteratorNormalCompletion6 = true;
+        var _didIteratorError6 = false;
+        var _iteratorError6 = undefined;
+
+        try {
+          for (var _iterator6 = positionMapHorizontal.keys()[Symbol.iterator](), _step6; !(_iteratorNormalCompletion6 = (_step6 = _iterator6.next()).done); _iteratorNormalCompletion6 = true) {
+            var key = _step6.value;
+
+            _loop9(key);
+          }
+        } catch (err) {
+          _didIteratorError6 = true;
+          _iteratorError6 = err;
+        } finally {
+          try {
+            if (!_iteratorNormalCompletion6 && _iterator6.return) {
+              _iterator6.return();
+            }
+          } finally {
+            if (_didIteratorError6) {
+              throw _iteratorError6;
+            }
+          }
+        }
+
+        var _loop10 = function _loop10(key) {
+          if (dummyToNodeForHorizontalAlignment.get(key)) {
+            dummyToNodeForHorizontalAlignment.get(key).forEach(function (nodeId) {
+              yCoords[nodeIndexes.get(nodeId)] = positionMapVertical.get(key);
+            });
+          } else {
+            yCoords[nodeIndexes.get(key)] = positionMapVertical.get(key);
+          }
+        };
+
+        var _iteratorNormalCompletion7 = true;
+        var _didIteratorError7 = false;
+        var _iteratorError7 = undefined;
+
+        try {
+          for (var _iterator7 = positionMapVertical.keys()[Symbol.iterator](), _step7; !(_iteratorNormalCompletion7 = (_step7 = _iterator7.next()).done); _iteratorNormalCompletion7 = true) {
+            var key = _step7.value;
+
+            _loop10(key);
+          }
+        } catch (err) {
+          _didIteratorError7 = true;
+          _iteratorError7 = err;
+        } finally {
+          try {
+            if (!_iteratorNormalCompletion7 && _iterator7.return) {
+              _iterator7.return();
+            }
+          } finally {
+            if (_didIteratorError7) {
+              throw _iteratorError7;
+            }
+          }
+        }
+      })();
+    }
+  }
+
+  // assign new coordinates to nodes after constraint handling
+  for (var _i13 = 0; _i13 < allNodes.length; _i13++) {
+    var _node = allNodes[_i13];
+    if (_node.getChild() == null) {
+      _node.setCenter(xCoords[nodeIndexes.get(_node.id)], yCoords[nodeIndexes.get(_node.id)]);
+    }
+  }
+};
+
+module.exports = ConstraintHandler;
+
+/***/ }),
+
+/***/ 551:
+/***/ ((module) => {
+
+module.exports = __WEBPACK_EXTERNAL_MODULE__551__;
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __webpack_require__(45);
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});

--- a/backend/src/meho_backplane/ui/static/src/vendor/cytoscape-cose-bilkent.js
+++ b/backend/src/meho_backplane/ui/static/src/vendor/cytoscape-cose-bilkent.js
@@ -1,0 +1,458 @@
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory(require("cose-base"));
+	else if(typeof define === 'function' && define.amd)
+		define(["cose-base"], factory);
+	else if(typeof exports === 'object')
+		exports["cytoscapeCoseBilkent"] = factory(require("cose-base"));
+	else
+		root["cytoscapeCoseBilkent"] = factory(root["coseBase"]);
+})(this, function(__WEBPACK_EXTERNAL_MODULE_0__) {
+return /******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 1);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports) {
+
+module.exports = __WEBPACK_EXTERNAL_MODULE_0__;
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var LayoutConstants = __webpack_require__(0).layoutBase.LayoutConstants;
+var FDLayoutConstants = __webpack_require__(0).layoutBase.FDLayoutConstants;
+var CoSEConstants = __webpack_require__(0).CoSEConstants;
+var CoSELayout = __webpack_require__(0).CoSELayout;
+var CoSENode = __webpack_require__(0).CoSENode;
+var PointD = __webpack_require__(0).layoutBase.PointD;
+var DimensionD = __webpack_require__(0).layoutBase.DimensionD;
+
+var defaults = {
+  // Called on `layoutready`
+  ready: function ready() {},
+  // Called on `layoutstop`
+  stop: function stop() {},
+  // 'draft', 'default' or 'proof" 
+  // - 'draft' fast cooling rate 
+  // - 'default' moderate cooling rate 
+  // - "proof" slow cooling rate
+  quality: 'default',
+  // include labels in node dimensions
+  nodeDimensionsIncludeLabels: false,
+  // number of ticks per frame; higher is faster but more jerky
+  refresh: 30,
+  // Whether to fit the network view after when done
+  fit: true,
+  // Padding on fit
+  padding: 10,
+  // Whether to enable incremental mode
+  randomize: true,
+  // Node repulsion (non overlapping) multiplier
+  nodeRepulsion: 4500,
+  // Ideal edge (non nested) length
+  idealEdgeLength: 50,
+  // Divisor to compute edge forces
+  edgeElasticity: 0.45,
+  // Nesting factor (multiplier) to compute ideal edge length for nested edges
+  nestingFactor: 0.1,
+  // Gravity force (constant)
+  gravity: 0.25,
+  // Maximum number of iterations to perform
+  numIter: 2500,
+  // For enabling tiling
+  tile: true,
+  // Type of layout animation. The option set is {'during', 'end', false}
+  animate: 'end',
+  // Duration for animate:end
+  animationDuration: 500,
+  // Represents the amount of the vertical space to put between the zero degree members during the tiling operation(can also be a function)
+  tilingPaddingVertical: 10,
+  // Represents the amount of the horizontal space to put between the zero degree members during the tiling operation(can also be a function)
+  tilingPaddingHorizontal: 10,
+  // Gravity range (constant) for compounds
+  gravityRangeCompound: 1.5,
+  // Gravity force (constant) for compounds
+  gravityCompound: 1.0,
+  // Gravity range (constant)
+  gravityRange: 3.8,
+  // Initial cooling factor for incremental layout
+  initialEnergyOnIncremental: 0.5
+};
+
+function extend(defaults, options) {
+  var obj = {};
+
+  for (var i in defaults) {
+    obj[i] = defaults[i];
+  }
+
+  for (var i in options) {
+    obj[i] = options[i];
+  }
+
+  return obj;
+};
+
+function _CoSELayout(_options) {
+  this.options = extend(defaults, _options);
+  getUserOptions(this.options);
+}
+
+var getUserOptions = function getUserOptions(options) {
+  if (options.nodeRepulsion != null) CoSEConstants.DEFAULT_REPULSION_STRENGTH = FDLayoutConstants.DEFAULT_REPULSION_STRENGTH = options.nodeRepulsion;
+  if (options.idealEdgeLength != null) CoSEConstants.DEFAULT_EDGE_LENGTH = FDLayoutConstants.DEFAULT_EDGE_LENGTH = options.idealEdgeLength;
+  if (options.edgeElasticity != null) CoSEConstants.DEFAULT_SPRING_STRENGTH = FDLayoutConstants.DEFAULT_SPRING_STRENGTH = options.edgeElasticity;
+  if (options.nestingFactor != null) CoSEConstants.PER_LEVEL_IDEAL_EDGE_LENGTH_FACTOR = FDLayoutConstants.PER_LEVEL_IDEAL_EDGE_LENGTH_FACTOR = options.nestingFactor;
+  if (options.gravity != null) CoSEConstants.DEFAULT_GRAVITY_STRENGTH = FDLayoutConstants.DEFAULT_GRAVITY_STRENGTH = options.gravity;
+  if (options.numIter != null) CoSEConstants.MAX_ITERATIONS = FDLayoutConstants.MAX_ITERATIONS = options.numIter;
+  if (options.gravityRange != null) CoSEConstants.DEFAULT_GRAVITY_RANGE_FACTOR = FDLayoutConstants.DEFAULT_GRAVITY_RANGE_FACTOR = options.gravityRange;
+  if (options.gravityCompound != null) CoSEConstants.DEFAULT_COMPOUND_GRAVITY_STRENGTH = FDLayoutConstants.DEFAULT_COMPOUND_GRAVITY_STRENGTH = options.gravityCompound;
+  if (options.gravityRangeCompound != null) CoSEConstants.DEFAULT_COMPOUND_GRAVITY_RANGE_FACTOR = FDLayoutConstants.DEFAULT_COMPOUND_GRAVITY_RANGE_FACTOR = options.gravityRangeCompound;
+  if (options.initialEnergyOnIncremental != null) CoSEConstants.DEFAULT_COOLING_FACTOR_INCREMENTAL = FDLayoutConstants.DEFAULT_COOLING_FACTOR_INCREMENTAL = options.initialEnergyOnIncremental;
+
+  if (options.quality == 'draft') LayoutConstants.QUALITY = 0;else if (options.quality == 'proof') LayoutConstants.QUALITY = 2;else LayoutConstants.QUALITY = 1;
+
+  CoSEConstants.NODE_DIMENSIONS_INCLUDE_LABELS = FDLayoutConstants.NODE_DIMENSIONS_INCLUDE_LABELS = LayoutConstants.NODE_DIMENSIONS_INCLUDE_LABELS = options.nodeDimensionsIncludeLabels;
+  CoSEConstants.DEFAULT_INCREMENTAL = FDLayoutConstants.DEFAULT_INCREMENTAL = LayoutConstants.DEFAULT_INCREMENTAL = !options.randomize;
+  CoSEConstants.ANIMATE = FDLayoutConstants.ANIMATE = LayoutConstants.ANIMATE = options.animate;
+  CoSEConstants.TILE = options.tile;
+  CoSEConstants.TILING_PADDING_VERTICAL = typeof options.tilingPaddingVertical === 'function' ? options.tilingPaddingVertical.call() : options.tilingPaddingVertical;
+  CoSEConstants.TILING_PADDING_HORIZONTAL = typeof options.tilingPaddingHorizontal === 'function' ? options.tilingPaddingHorizontal.call() : options.tilingPaddingHorizontal;
+};
+
+_CoSELayout.prototype.run = function () {
+  var ready;
+  var frameId;
+  var options = this.options;
+  var idToLNode = this.idToLNode = {};
+  var layout = this.layout = new CoSELayout();
+  var self = this;
+
+  self.stopped = false;
+
+  this.cy = this.options.cy;
+
+  this.cy.trigger({ type: 'layoutstart', layout: this });
+
+  var gm = layout.newGraphManager();
+  this.gm = gm;
+
+  var nodes = this.options.eles.nodes();
+  var edges = this.options.eles.edges();
+
+  this.root = gm.addRoot();
+  this.processChildrenList(this.root, this.getTopMostNodes(nodes), layout);
+
+  for (var i = 0; i < edges.length; i++) {
+    var edge = edges[i];
+    var sourceNode = this.idToLNode[edge.data("source")];
+    var targetNode = this.idToLNode[edge.data("target")];
+    if (sourceNode !== targetNode && sourceNode.getEdgesBetween(targetNode).length == 0) {
+      var e1 = gm.add(layout.newEdge(), sourceNode, targetNode);
+      e1.id = edge.id();
+    }
+  }
+
+  var getPositions = function getPositions(ele, i) {
+    if (typeof ele === "number") {
+      ele = i;
+    }
+    var theId = ele.data('id');
+    var lNode = self.idToLNode[theId];
+
+    return {
+      x: lNode.getRect().getCenterX(),
+      y: lNode.getRect().getCenterY()
+    };
+  };
+
+  /*
+   * Reposition nodes in iterations animatedly
+   */
+  var iterateAnimated = function iterateAnimated() {
+    // Thigs to perform after nodes are repositioned on screen
+    var afterReposition = function afterReposition() {
+      if (options.fit) {
+        options.cy.fit(options.eles, options.padding);
+      }
+
+      if (!ready) {
+        ready = true;
+        self.cy.one('layoutready', options.ready);
+        self.cy.trigger({ type: 'layoutready', layout: self });
+      }
+    };
+
+    var ticksPerFrame = self.options.refresh;
+    var isDone;
+
+    for (var i = 0; i < ticksPerFrame && !isDone; i++) {
+      isDone = self.stopped || self.layout.tick();
+    }
+
+    // If layout is done
+    if (isDone) {
+      // If the layout is not a sublayout and it is successful perform post layout.
+      if (layout.checkLayoutSuccess() && !layout.isSubLayout) {
+        layout.doPostLayout();
+      }
+
+      // If layout has a tilingPostLayout function property call it.
+      if (layout.tilingPostLayout) {
+        layout.tilingPostLayout();
+      }
+
+      layout.isLayoutFinished = true;
+
+      self.options.eles.nodes().positions(getPositions);
+
+      afterReposition();
+
+      // trigger layoutstop when the layout stops (e.g. finishes)
+      self.cy.one('layoutstop', self.options.stop);
+      self.cy.trigger({ type: 'layoutstop', layout: self });
+
+      if (frameId) {
+        cancelAnimationFrame(frameId);
+      }
+
+      ready = false;
+      return;
+    }
+
+    var animationData = self.layout.getPositionsData(); // Get positions of layout nodes note that all nodes may not be layout nodes because of tiling
+
+    // Position nodes, for the nodes whose id does not included in data (because they are removed from their parents and included in dummy compounds)
+    // use position of their ancestors or dummy ancestors
+    options.eles.nodes().positions(function (ele, i) {
+      if (typeof ele === "number") {
+        ele = i;
+      }
+      // If ele is a compound node, then its position will be defined by its children
+      if (!ele.isParent()) {
+        var theId = ele.id();
+        var pNode = animationData[theId];
+        var temp = ele;
+        // If pNode is undefined search until finding position data of its first ancestor (It may be dummy as well)
+        while (pNode == null) {
+          pNode = animationData[temp.data('parent')] || animationData['DummyCompound_' + temp.data('parent')];
+          animationData[theId] = pNode;
+          temp = temp.parent()[0];
+          if (temp == undefined) {
+            break;
+          }
+        }
+        if (pNode != null) {
+          return {
+            x: pNode.x,
+            y: pNode.y
+          };
+        } else {
+          return {
+            x: ele.position('x'),
+            y: ele.position('y')
+          };
+        }
+      }
+    });
+
+    afterReposition();
+
+    frameId = requestAnimationFrame(iterateAnimated);
+  };
+
+  /*
+  * Listen 'layoutstarted' event and start animated iteration if animate option is 'during'
+  */
+  layout.addListener('layoutstarted', function () {
+    if (self.options.animate === 'during') {
+      frameId = requestAnimationFrame(iterateAnimated);
+    }
+  });
+
+  layout.runLayout(); // Run cose layout
+
+  /*
+   * If animate option is not 'during' ('end' or false) perform these here (If it is 'during' similar things are already performed)
+   */
+  if (this.options.animate !== "during") {
+    self.options.eles.nodes().not(":parent").layoutPositions(self, self.options, getPositions); // Use layout positions to reposition the nodes it considers the options parameter
+    ready = false;
+  }
+
+  return this; // chaining
+};
+
+//Get the top most ones of a list of nodes
+_CoSELayout.prototype.getTopMostNodes = function (nodes) {
+  var nodesMap = {};
+  for (var i = 0; i < nodes.length; i++) {
+    nodesMap[nodes[i].id()] = true;
+  }
+  var roots = nodes.filter(function (ele, i) {
+    if (typeof ele === "number") {
+      ele = i;
+    }
+    var parent = ele.parent()[0];
+    while (parent != null) {
+      if (nodesMap[parent.id()]) {
+        return false;
+      }
+      parent = parent.parent()[0];
+    }
+    return true;
+  });
+
+  return roots;
+};
+
+_CoSELayout.prototype.processChildrenList = function (parent, children, layout) {
+  var size = children.length;
+  for (var i = 0; i < size; i++) {
+    var theChild = children[i];
+    var children_of_children = theChild.children();
+    var theNode;
+
+    var dimensions = theChild.layoutDimensions({
+      nodeDimensionsIncludeLabels: this.options.nodeDimensionsIncludeLabels
+    });
+
+    if (theChild.outerWidth() != null && theChild.outerHeight() != null) {
+      theNode = parent.add(new CoSENode(layout.graphManager, new PointD(theChild.position('x') - dimensions.w / 2, theChild.position('y') - dimensions.h / 2), new DimensionD(parseFloat(dimensions.w), parseFloat(dimensions.h))));
+    } else {
+      theNode = parent.add(new CoSENode(this.graphManager));
+    }
+    // Attach id to the layout node
+    theNode.id = theChild.data("id");
+    // Attach the paddings of cy node to layout node
+    theNode.paddingLeft = parseInt(theChild.css('padding'));
+    theNode.paddingTop = parseInt(theChild.css('padding'));
+    theNode.paddingRight = parseInt(theChild.css('padding'));
+    theNode.paddingBottom = parseInt(theChild.css('padding'));
+
+    //Attach the label properties to compound if labels will be included in node dimensions  
+    if (this.options.nodeDimensionsIncludeLabels) {
+      if (theChild.isParent()) {
+        var labelWidth = theChild.boundingBox({ includeLabels: true, includeNodes: false }).w;
+        var labelHeight = theChild.boundingBox({ includeLabels: true, includeNodes: false }).h;
+        var labelPos = theChild.css("text-halign");
+        theNode.labelWidth = labelWidth;
+        theNode.labelHeight = labelHeight;
+        theNode.labelPos = labelPos;
+      }
+    }
+
+    // Map the layout node
+    this.idToLNode[theChild.data("id")] = theNode;
+
+    if (isNaN(theNode.rect.x)) {
+      theNode.rect.x = 0;
+    }
+
+    if (isNaN(theNode.rect.y)) {
+      theNode.rect.y = 0;
+    }
+
+    if (children_of_children != null && children_of_children.length > 0) {
+      var theNewGraph;
+      theNewGraph = layout.getGraphManager().add(layout.newGraph(), theNode);
+      this.processChildrenList(theNewGraph, children_of_children, layout);
+    }
+  }
+};
+
+/**
+ * @brief : called on continuous layouts to stop them before they finish
+ */
+_CoSELayout.prototype.stop = function () {
+  this.stopped = true;
+
+  return this; // chaining
+};
+
+var register = function register(cytoscape) {
+  //  var Layout = getLayout( cytoscape );
+
+  cytoscape('layout', 'cose-bilkent', _CoSELayout);
+};
+
+// auto reg for globals
+if (typeof cytoscape !== 'undefined') {
+  register(cytoscape);
+}
+
+module.exports = register;
+
+/***/ })
+/******/ ]);
+});

--- a/backend/src/meho_backplane/ui/static/src/vendor/cytoscape-dagre.js
+++ b/backend/src/meho_backplane/ui/static/src/vendor/cytoscape-dagre.js
@@ -1,0 +1,551 @@
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports["cytoscapeDagre"] = factory();
+	else
+		root["cytoscapeDagre"] = factory();
+})(this, () => {
+return /******/ (() => { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ 155
+(module, __unused_webpack_exports, __webpack_require__) {
+
+"use strict";
+var Ze=Object.create;var M=Object.defineProperty;var $e=Object.getOwnPropertyDescriptor;var en=Object.getOwnPropertyNames;var nn=Object.getPrototypeOf,tn=Object.prototype.hasOwnProperty;var rn=(e,n,t)=>n in e?M(e,n,{enumerable:!0,configurable:!0,writable:!0,value:t}):e[n]=t;var on=(e,n)=>{for(var t in n)M(e,t,{get:n[t],enumerable:!0})},ue=(e,n,t,r)=>{if(n&&typeof n=="object"||typeof n=="function")for(let o of en(n))!tn.call(e,o)&&o!==t&&M(e,o,{get:()=>n[o],enumerable:!(r=$e(n,o))||r.enumerable});return e};var an=(e,n,t)=>(t=e!=null?Ze(nn(e)):{},ue(n||!e||!e.__esModule?M(t,"default",{value:e,enumerable:!0}):t,e)),sn=e=>ue(M({},"__esModule",{value:!0}),e);var ce=(e,n,t)=>rn(e,typeof n!="symbol"?n+"":n,t);var It={};on(It,{Graph:()=>Qe.Graph,debug:()=>D,default:()=>St,graphlib:()=>Je,layout:()=>B,util:()=>Pt,version:()=>F});module.exports=sn(It);var Je=an(__webpack_require__(413));var p=__webpack_require__(413);function N(e,n,t,r){let o=r;for(;e.hasNode(o);)o=C(r);return t.dummy=n,e.setNode(o,t),o}function be(e){let n=new p.Graph().setGraph(e.graph());return e.nodes().forEach(t=>n.setNode(t,e.node(t))),e.edges().forEach(t=>{let r=n.edge(t.v,t.w)||{weight:0,minlen:1},o=e.edge(t);n.setEdge(t.v,t.w,{weight:r.weight+o.weight,minlen:Math.max(r.minlen,o.minlen)})}),n}function _(e){let n=new p.Graph({multigraph:e.isMultigraph()}).setGraph(e.graph());return e.nodes().forEach(t=>{e.children(t).length||n.setNode(t,e.node(t))}),e.edges().forEach(t=>{n.setEdge(t,e.edge(t))}),n}function Y(e,n){let t=e.x,r=e.y,o=n.x-t,i=n.y-r,a=e.width/2,s=e.height/2;if(!o&&!i)throw new Error("Not possible to find intersection inside of the rectangle");let d,l;return Math.abs(i)*a>Math.abs(o)*s?(i<0&&(s=-s),d=s*o/i,l=s):(o<0&&(a=-a),d=a,l=a*i/o),{x:t+d,y:r+l}}function G(e){let n=k(q(e)+1).map(()=>[]);return e.nodes().forEach(t=>{let r=e.node(t),o=r.rank;o!==void 0&&(n[o]||(n[o]=[]),n[o][r.order]=t)}),n}function fe(e){let n=e.nodes().map(r=>{let o=e.node(r).rank;return o===void 0?Number.MAX_VALUE:o}),t=E(Math.min,n);e.nodes().forEach(r=>{let o=e.node(r);Object.hasOwn(o,"rank")&&(o.rank-=t)})}function he(e){let n=e.nodes().map(a=>e.node(a).rank).filter(a=>a!==void 0),t=E(Math.min,n),r=[];e.nodes().forEach(a=>{let s=e.node(a).rank-t;r[s]||(r[s]=[]),r[s].push(a)});let o=0,i=e.graph().nodeRankFactor;Array.from(r).forEach((a,s)=>{a===void 0&&s%i!==0?--o:a!==void 0&&o&&a.forEach(d=>e.node(d).rank+=o)})}function H(e,n,t,r){let o={width:0,height:0};return arguments.length>=4&&(o.rank=t,o.order=r),N(e,"border",o,n)}function dn(e,n=ge){let t=[];for(let r=0;r<e.length;r+=n){let o=e.slice(r,r+n);t.push(o)}return t}var ge=65535;function E(e,n){if(n.length>ge){let t=dn(n);return e(...t.map(r=>e(...r)))}else return e(...n)}function q(e){let t=e.nodes().map(r=>{let o=e.node(r).rank;return o===void 0?Number.MIN_VALUE:o});return E(Math.max,t)}function pe(e,n){let t={lhs:[],rhs:[]};return e.forEach(r=>{n(r)?t.lhs.push(r):t.rhs.push(r)}),t}function S(e,n){let t=Date.now();try{return n()}finally{console.log(e+" time: "+(Date.now()-t)+"ms")}}function I(e,n){return n()}var ln=0;function C(e){let n=++ln;return e+(""+n)}function k(e,n,t=1){n==null&&(n=e,e=0);let r=i=>i<n;t<0&&(r=i=>n<i);let o=[];for(let i=e;r(i);i+=t)o.push(i);return o}function O(e,n){let t={};for(let r of n)e[r]!==void 0&&(t[r]=e[r]);return t}function R(e,n){let t;return typeof n=="string"?t=r=>r[n]:t=n,Object.entries(e).reduce((r,[o,i])=>(r[o]=t(i,o),r),{})}function me(e,n){return e.reduce((t,r,o)=>(t[r]=n[o],t),{})}var v="\0";var F="3.0.0";var z=class{constructor(){ce(this,"_sentinel");let n={};n._next=n._prev=n,this._sentinel=n}dequeue(){let n=this._sentinel,t=n._prev;if(t!==n)return Le(t),t}enqueue(n){let t=this._sentinel;n._prev&&n._next&&Le(n),n._next=t._next,t._next._prev=n,t._next=n,n._prev=t}toString(){let n=[],t=this._sentinel,r=t._prev;for(;r!==t;)n.push(JSON.stringify(r,un)),r=r._prev;return"["+n.join(", ")+"]"}};function Le(e){e._prev._next=e._next,e._next._prev=e._prev,delete e._next,delete e._prev}function un(e,n){if(e!=="_next"&&e!=="_prev")return n}var Ee=z;var cn=()=>1;function K(e,n){if(e.nodeCount()<=1)return[];let t=fn(e,n||cn);return bn(t.graph,t.buckets,t.zeroIdx).flatMap(o=>e.outEdges(o.v,o.w)||[])}function bn(e,n,t){var s;let r=[],o=n[n.length-1],i=n[0],a;for(;e.nodeCount();){for(;a=i.dequeue();)X(e,n,t,a);for(;a=o.dequeue();)X(e,n,t,a);if(e.nodeCount()){for(let d=n.length-2;d>0;--d)if(a=(s=n[d])==null?void 0:s.dequeue(),a){r=r.concat(X(e,n,t,a,!0)||[]);break}}}return r}function X(e,n,t,r,o){let i=[],a=o?i:void 0;return(e.inEdges(r.v)||[]).forEach(s=>{let d=e.edge(s),l=e.node(s.v);o&&i.push({v:s.v,w:s.w}),l.out-=d,U(n,t,l)}),(e.outEdges(r.v)||[]).forEach(s=>{let d=e.edge(s),l=s.w,u=e.node(l);u.in-=d,U(n,t,u)}),e.removeNode(r.v),a}function fn(e,n){let t=new p.Graph,r=0,o=0;e.nodes().forEach(s=>{t.setNode(s,{v:s,in:0,out:0})}),e.edges().forEach(s=>{let d=t.edge(s.v,s.w)||0,l=n(s),u=d+l;t.setEdge(s.v,s.w,u);let c=t.node(s.v),f=t.node(s.w);o=Math.max(o,c.out+=l),r=Math.max(r,f.in+=l)});let i=hn(o+r+3).map(()=>new Ee),a=r+1;return t.nodes().forEach(s=>{U(i,a,t.node(s))}),{graph:t,buckets:i,zeroIdx:a}}function U(e,n,t){var r,o,i;t.out?t.in?(i=e[t.out-t.in+n])==null||i.enqueue(t):(o=e[e.length-1])==null||o.enqueue(t):(r=e[0])==null||r.enqueue(t)}function hn(e){let n=[];for(let t=0;t<e;t++)n.push(t);return n}function ye(e){(e.graph().acyclicer==="greedy"?K(e,t(e)):gn(e)).forEach(r=>{let o=e.edge(r);e.removeEdge(r),o.forwardName=r.name,o.reversed=!0,e.setEdge(r.w,r.v,o,C("rev"))});function t(r){return o=>r.edge(o).weight}}function gn(e){let n=[],t={},r={};function o(i){Object.hasOwn(r,i)||(r[i]=!0,t[i]=!0,e.outEdges(i).forEach(a=>{Object.hasOwn(t,a.w)?n.push(a):o(a.w)}),delete t[i])}return e.nodes().forEach(o),n}function Ne(e){e.edges().forEach(n=>{let t=e.edge(n);if(t.reversed){e.removeEdge(n);let r=t.forwardName;delete t.reversed,delete t.forwardName,e.setEdge(n.w,n.v,t,r)}})}function Ge(e){e.graph().dummyChains=[],e.edges().forEach(n=>mn(e,n))}function mn(e,n){let t=n.v,r=e.node(t).rank,o=n.w,i=e.node(o).rank,a=n.name,s=e.edge(n),d=s.labelRank;if(i===r+1)return;e.removeEdge(n);let l,u,c;for(c=0,++r;r<i;++c,++r)s.points=[],u={width:0,height:0,edgeLabel:s,edgeObj:n,rank:r},l=N(e,"edge",u,"_d"),r===d&&(u.width=s.width,u.height=s.height,u.dummy="edge-label",u.labelpos=s.labelpos),e.setEdge(t,l,{weight:s.weight},a),c===0&&e.graph().dummyChains.push(l),t=l;e.setEdge(t,o,{weight:s.weight},a)}function we(e){e.graph().dummyChains.forEach(n=>{let t=e.node(n),r=t.edgeLabel,o;for(e.setEdge(t.edgeObj,r);t.dummy;)o=e.successors(n)[0],e.removeNode(n),r.points.push({x:t.x,y:t.y}),t.dummy==="edge-label"&&(r.x=t.x,r.y=t.y,r.width=t.width,r.height=t.height),n=o,t=e.node(n)})}function j(e){let n={};function t(r){let o=e.node(r);if(Object.hasOwn(n,r))return o.rank;n[r]=!0;let i=e.outEdges(r),a=i?i.map(d=>d==null?Number.POSITIVE_INFINITY:t(d.w)-e.edge(d).minlen):[],s=E(Math.min,a);return s===Number.POSITIVE_INFINITY&&(s=0),o.rank=s}e.sources().forEach(t)}function x(e,n){return e.node(n.w).rank-e.node(n.v).rank-e.edge(n).minlen}var A=En;function En(e){let n=new p.Graph({directed:!1}),t=e.nodes();if(t.length===0)throw new Error("Graph must have at least one node");let r=t[0],o=e.nodeCount();n.setNode(r,{});let i,a;for(;yn(n,e)<o&&(i=Nn(n,e),!!i);)a=n.hasNode(i.v)?x(e,i):-x(e,i),Gn(n,e,a);return n}function yn(e,n){function t(r){let o=n.nodeEdges(r);o&&o.forEach(i=>{let a=i.v,s=r===a?i.w:a;!e.hasNode(s)&&!x(n,i)&&(e.setNode(s,{}),e.setEdge(r,s,{}),t(s))})}return e.nodes().forEach(t),e.nodeCount()}function Nn(e,n){return n.edges().reduce((r,o)=>{let i=Number.POSITIVE_INFINITY;return e.hasNode(o.v)!==e.hasNode(o.w)&&(i=x(n,o)),i<r[0]?[i,o]:r},[Number.POSITIVE_INFINITY,null])[1]}function Gn(e,n,t){e.nodes().forEach(r=>n.node(r).rank+=t)}var{preorder:wn,postorder:kn}=p.alg,xe=T;T.initLowLimValues=Q;T.initCutValues=J;T.calcCutValue=ve;T.leaveEdge=Oe;T.enterEdge=Re;T.exchangeEdges=Pe;function T(e){e=be(e),j(e);let n=A(e);Q(n),J(n,e);let t,r;for(;t=Oe(n);)r=Re(n,e,t),Pe(n,e,t,r)}function J(e,n){let t=kn(e,e.nodes());t=t.slice(0,t.length-1),t.forEach(r=>xn(e,n,r))}function xn(e,n,t){let o=e.node(t).parent,i=e.edge(t,o);i.cutvalue=ve(e,n,t)}function ve(e,n,t){let o=e.node(t).parent,i=!0,a=n.edge(t,o),s=0;a||(i=!1,a=n.edge(o,t)),s=a.weight;let d=n.nodeEdges(t);return d&&d.forEach(l=>{let u=l.v===t,c=u?l.w:l.v;if(c!==o){let f=u===i,b=n.edge(l).weight;if(s+=f?b:-b,Tn(e,t,c)){let h=e.edge(t,c).cutvalue;s+=f?-h:h}}}),s}function Q(e,n){arguments.length<2&&(n=e.nodes()[0]),Te(e,{},1,n)}function Te(e,n,t,r,o){let i=t,a=e.node(r);n[r]=!0;let s=e.neighbors(r);return s&&s.forEach(d=>{Object.hasOwn(n,d)||(t=Te(e,n,t,d,r))}),a.low=i,a.lim=t++,o?a.parent=o:delete a.parent,t}function Oe(e){return e.edges().find(n=>e.edge(n).cutvalue<0)}function Re(e,n,t){let r=t.v,o=t.w;n.hasEdge(r,o)||(r=t.w,o=t.v);let i=e.node(r),a=e.node(o),s=i,d=!1;return i.lim>a.lim&&(s=a,d=!0),n.edges().filter(u=>d===ke(e,e.node(u.v),s)&&d!==ke(e,e.node(u.w),s)).reduce((u,c)=>x(n,c)<x(n,u)?c:u)}function Pe(e,n,t,r){let o=t.v,i=t.w;e.removeEdge(o,i),e.setEdge(r.v,r.w,{}),Q(e),J(e,n),vn(e,n)}function vn(e,n){let t=e.nodes().find(o=>!e.node(o).parent);if(!t)return;let r=wn(e,[t]);r=r.slice(1),r.forEach(o=>{let a=e.node(o).parent,s=n.edge(o,a),d=!1;s||(s=n.edge(a,o),d=!0),n.node(o).rank=n.node(a).rank+(d?s.minlen:-s.minlen)})}function Tn(e,n,t){return e.hasEdge(n,t)}function ke(e,n,t){return t.low<=n.lim&&n.lim<=t.lim}var Se=On;function On(e){let n=e.graph().ranker;if(typeof n=="function")return n(e);switch(n){case"network-simplex":Me(e);break;case"tight-tree":Pn(e);break;case"longest-path":Rn(e);break;case"none":break;default:Me(e)}}var Rn=j;function Pn(e){j(e),A(e)}function Me(e){xe(e)}var Ie=Mn;function Mn(e){let n=In(e);e.graph().dummyChains.forEach(t=>{let r=e.node(t),o=r.edgeObj,i=Sn(e,n,o.v,o.w),a=i.path,s=i.lca,d=0,l=a[d],u=!0;for(;t!==o.w;){if(r=e.node(t),u){for(;(l=a[d])!==s&&e.node(l).maxRank<r.rank;)d++;l===s&&(u=!1)}if(!u){for(;d<a.length-1&&e.node(a[d+1]).minRank<=r.rank;)d++;l=a[d]}l!==void 0&&e.setParent(t,l),t=e.successors(t)[0]}})}function Sn(e,n,t,r){let o=[],i=[],a=Math.min(n[t].low,n[r].low),s=Math.max(n[t].lim,n[r].lim),d;d=t;do d=e.parent(d),o.push(d);while(d&&(n[d].low>a||s>n[d].lim));let l=d,u=r;for(;(u=e.parent(u))!==l;)i.push(u);return{path:o.concat(i.reverse()),lca:l}}function In(e){let n={},t=0;function r(o){let i=t;e.children(o).forEach(r),n[o]={low:i,lim:t++}}return e.children(v).forEach(r),n}function Ce(e){let n=N(e,"root",{},"_root"),t=Cn(e),r=Object.values(t),o=E(Math.max,r)-1,i=2*o+1;e.graph().nestingRoot=n,e.edges().forEach(s=>e.edge(s).minlen*=i);let a=jn(e)+1;e.children(v).forEach(s=>je(e,n,i,a,o,t,s)),e.graph().nodeRankFactor=i}function je(e,n,t,r,o,i,a){var c;let s=e.children(a);if(!s.length){a!==n&&e.setEdge(n,a,{weight:0,minlen:t});return}let d=H(e,"_bt"),l=H(e,"_bb"),u=e.node(a);e.setParent(d,a),u.borderTop=d,e.setParent(l,a),u.borderBottom=l,s.forEach(f=>{var y;je(e,n,t,r,o,i,f);let b=e.node(f),g=b.borderTop?b.borderTop:f,h=b.borderBottom?b.borderBottom:f,m=b.borderTop?r:2*r,L=g!==h?1:o-((y=i[a])!=null?y:0)+1;e.setEdge(d,g,{weight:m,minlen:L,nestingEdge:!0}),e.setEdge(h,l,{weight:m,minlen:L,nestingEdge:!0})}),e.parent(a)||e.setEdge(n,d,{weight:0,minlen:o+((c=i[a])!=null?c:0)})}function Cn(e){let n={};function t(r,o){let i=e.children(r);i&&i.length&&i.forEach(a=>t(a,o+1)),n[r]=o}return e.children(v).forEach(r=>t(r,1)),n}function jn(e){return e.edges().reduce((n,t)=>n+e.edge(t).weight,0)}function _e(e){let n=e.graph();e.removeNode(n.nestingRoot),delete n.nestingRoot,e.edges().forEach(t=>{e.edge(t).nestingEdge&&e.removeEdge(t)})}var Ae=Fn;function Fn(e){function n(t){let r=e.children(t),o=e.node(t);if(r.length&&r.forEach(n),Object.hasOwn(o,"minRank")){o.borderLeft=[],o.borderRight=[];for(let i=o.minRank,a=o.maxRank+1;i<a;++i)Fe(e,"borderLeft","_bl",t,o,i),Fe(e,"borderRight","_br",t,o,i)}}e.children(v).forEach(n)}function Fe(e,n,t,r,o,i){let a={width:0,height:0,rank:i,borderType:n},s=o[n][i-1],d=N(e,"border",a,t);o[n][i]=d,e.setParent(d,r),s&&e.setEdge(s,d,{weight:1})}function We(e){var t;let n=(t=e.graph().rankdir)==null?void 0:t.toLowerCase();(n==="lr"||n==="rl")&&De(e)}function Be(e){var t;let n=(t=e.graph().rankdir)==null?void 0:t.toLowerCase();(n==="bt"||n==="rl")&&An(e),(n==="lr"||n==="rl")&&(Vn(e),De(e))}function De(e){e.nodes().forEach(n=>Ve(e.node(n))),e.edges().forEach(n=>Ve(e.edge(n)))}function Ve(e){let n=e.width;e.width=e.height,e.height=n}function An(e){e.nodes().forEach(n=>Z(e.node(n))),e.edges().forEach(n=>{var r;let t=e.edge(n);(r=t.points)==null||r.forEach(Z),Object.hasOwn(t,"y")&&Z(t)})}function Z(e){e.y=-e.y}function Vn(e){e.nodes().forEach(n=>$(e.node(n))),e.edges().forEach(n=>{var r;let t=e.edge(n);(r=t.points)==null||r.forEach($),Object.hasOwn(t,"x")&&$(t)})}function $(e){let n=e.x;e.x=e.y,e.y=n}function ee(e){let n={},t=e.nodes().filter(d=>!e.children(d).length),r=t.map(d=>e.node(d).rank),o=E(Math.max,r),i=k(o+1).map(()=>[]);function a(d){if(n[d])return;n[d]=!0;let l=e.node(d);i[l.rank].push(d);let u=e.successors(d);u&&u.forEach(a)}return t.sort((d,l)=>e.node(d).rank-e.node(l).rank).forEach(a),i}function ne(e,n){let t=0;for(let r=1;r<n.length;++r)t+=Bn(e,n[r-1],n[r]);return t}function Bn(e,n,t){let r=me(t,t.map((l,u)=>u)),o=n.flatMap(l=>{let u=e.outEdges(l);return u?u.map(c=>({pos:r[c.w],weight:e.edge(c).weight})).sort((c,f)=>c.pos-f.pos):[]}),i=1;for(;i<t.length;)i<<=1;let a=2*i-1;i-=1;let s=new Array(a).fill(0),d=0;return o.forEach(l=>{let u=l.pos+i;s[u]+=l.weight;let c=0;for(;u>0;)u%2&&(c+=s[u+1]),u=u-1>>1,s[u]+=l.weight;d+=l.weight*c}),d}function te(e,n=[]){return n.map(t=>{let r=e.inEdges(t);if(!r||!r.length)return{v:t};{let o=r.reduce((i,a)=>{let s=e.edge(a),d=e.node(a.v);return{sum:i.sum+s.weight*d.order,weight:i.weight+s.weight}},{sum:0,weight:0});return{v:t,barycenter:o.sum/o.weight,weight:o.weight}}})}function re(e,n){let t={};e.forEach((o,i)=>{let a={indegree:0,in:[],out:[],vs:[o.v],i};o.barycenter!==void 0&&(a.barycenter=o.barycenter,a.weight=o.weight),t[o.v]=a}),n.edges().forEach(o=>{let i=t[o.v],a=t[o.w];i!==void 0&&a!==void 0&&(a.indegree++,i.out.push(a))});let r=Object.values(t).filter(o=>!o.indegree);return Dn(r)}function Dn(e){let n=[];function t(o){return i=>{i.merged||(i.barycenter===void 0||o.barycenter===void 0||i.barycenter>=o.barycenter)&&Yn(o,i)}}function r(o){return i=>{i.in.push(o),--i.indegree===0&&e.push(i)}}for(;e.length;){let o=e.pop();n.push(o),o.in.reverse().forEach(t(o)),o.out.forEach(r(o))}return n.filter(o=>!o.merged).map(o=>O(o,["vs","i","barycenter","weight"]))}function Yn(e,n){let t=0,r=0;e.weight&&(t+=e.barycenter*e.weight,r+=e.weight),n.weight&&(t+=n.barycenter*n.weight,r+=n.weight),e.vs=n.vs.concat(e.vs),e.barycenter=t/r,e.weight=r,e.i=Math.min(n.i,e.i),n.merged=!0}function oe(e,n){let t=pe(e,u=>Object.hasOwn(u,"barycenter")),r=t.lhs,o=t.rhs.sort((u,c)=>c.i-u.i),i=[],a=0,s=0,d=0;r.sort(Hn(!!n)),d=Ye(i,o,d),r.forEach(u=>{d+=u.vs.length,i.push(u.vs),a+=u.barycenter*u.weight,s+=u.weight,d=Ye(i,o,d)});let l={vs:i.flat(1)};return s&&(l.barycenter=a/s,l.weight=s),l}function Ye(e,n,t){let r;for(;n.length&&(r=n[n.length-1]).i<=t;)n.pop(),e.push(r.vs),t++;return t}function Hn(e){return(n,t)=>n.barycenter<t.barycenter?-1:n.barycenter>t.barycenter?1:e?t.i-n.i:n.i-t.i}function V(e,n,t,r){let o=e.children(n),i=e.node(n),a=i?i.borderLeft:void 0,s=i?i.borderRight:void 0,d={};a&&(o=o.filter(f=>f!==a&&f!==s));let l=te(e,o);l.forEach(f=>{if(e.children(f.v).length){let b=V(e,f.v,t,r);d[f.v]=b,Object.hasOwn(b,"barycenter")&&zn(f,b)}});let u=re(l,t);qn(u,d);let c=oe(u,r);if(a&&s){c.vs=[a,c.vs,s].flat(1);let f=e.predecessors(a);if(f&&f.length){let b=e.node(f[0]),g=e.predecessors(s),h=e.node(g[0]);Object.hasOwn(c,"barycenter")||(c.barycenter=0,c.weight=0),c.barycenter=(c.barycenter*c.weight+b.order+h.order)/(c.weight+2),c.weight+=2}}return c}function qn(e,n){e.forEach(t=>{t.vs=t.vs.flatMap(r=>n[r]?n[r].vs:r)})}function zn(e,n){e.barycenter!==void 0?(e.barycenter=(e.barycenter*e.weight+n.barycenter*n.weight)/(e.weight+n.weight),e.weight+=n.weight):(e.barycenter=n.barycenter,e.weight=n.weight)}function ie(e,n,t,r){r||(r=e.nodes());let o=Xn(e),i=new p.Graph({compound:!0}).setGraph({root:o}).setDefaultNodeLabel(a=>e.node(a));return r.forEach(a=>{let s=e.node(a),d=e.parent(a);if(s.rank===n||s.minRank<=n&&n<=s.maxRank){i.setNode(a),i.setParent(a,d||o);let l=e[t](a);l&&l.forEach(u=>{let c=u.v===a?u.w:u.v,f=i.edge(c,a),b=f!==void 0?f.weight:0;i.setEdge(c,a,{weight:e.edge(u).weight+b})}),Object.hasOwn(s,"minRank")&&i.setNode(a,{borderLeft:s.borderLeft[n],borderRight:s.borderRight[n]})}}),i}function Xn(e){let n;for(;e.hasNode(n=C("_root")););return n}function ae(e,n,t){let r={},o;t.forEach(i=>{let a=e.parent(i),s,d;for(;a;){if(s=e.parent(a),s?(d=r[s],r[s]=a):(d=o,o=a),d&&d!==a){n.setEdge(d,a);return}a=s}})}function W(e,n={}){if(typeof n.customOrder=="function"){n.customOrder(e,W);return}let t=q(e),r=He(e,k(1,t+1),"inEdges"),o=He(e,k(t-1,-1,-1),"outEdges"),i=ee(e);if(qe(e,i),n.disableOptimalOrderHeuristic)return;let a=Number.POSITIVE_INFINITY,s,d=n.constraints||[];for(let l=0,u=0;u<4;++l,++u){Un(l%2?r:o,l%4>=2,d),i=G(e);let c=ne(e,i);c<a?(u=0,s=Object.assign({},i),a=c):c===a&&(s=structuredClone(i))}qe(e,s)}function He(e,n,t){let r=new Map,o=(i,a)=>{r.has(i)||r.set(i,[]),r.get(i).push(a)};for(let i of e.nodes()){let a=e.node(i);if(typeof a.rank=="number"&&o(a.rank,i),typeof a.minRank=="number"&&typeof a.maxRank=="number")for(let s=a.minRank;s<=a.maxRank;s++)s!==a.rank&&o(s,i)}return n.map(function(i){return ie(e,i,t,r.get(i)||[])})}function Un(e,n,t){let r=new p.Graph;e.forEach(function(o){t.forEach(s=>r.setEdge(s.left,s.right));let i=o.graph().root,a=V(o,i,r,n);a.vs.forEach((s,d)=>o.node(s).order=d),ae(o,r,a.vs)})}function qe(e,n){Object.values(n).forEach(t=>t.forEach((r,o)=>e.node(r).order=o))}function Kn(e,n){let t={};function r(o,i){let a=0,s=0,d=o.length,l=i[i.length-1];return i.forEach((u,c)=>{let f=Qn(e,u),b=f?e.node(f).order:d;(f||u===l)&&(i.slice(s,c+1).forEach(g=>{let h=e.predecessors(g);h&&h.forEach(m=>{let L=e.node(m),y=L.order;(y<a||b<y)&&!(L.dummy&&e.node(g).dummy)&&ze(t,m,g)})}),s=c+1,a=b)}),i}return n.length&&n.reduce(r),t}function Jn(e,n){let t={};function r(i,a,s,d,l){k(a,s).forEach(u=>{let c=i[u];if(c!==void 0&&e.node(c).dummy){let f=e.predecessors(c);f&&f.forEach(b=>{if(b===void 0)return;let g=e.node(b);g.dummy&&(g.order<d||g.order>l)&&ze(t,b,c)})}})}function o(i,a){let s=-1,d=-1,l=0;return a.forEach((u,c)=>{if(e.node(u).dummy==="border"){let f=e.predecessors(u);if(f&&f.length){let b=f[0];if(b===void 0)return;d=e.node(b).order,r(a,l,c,s,d),l=c,s=d}}r(a,l,a.length,d,i.length)}),a}return n.length&&n.reduce(o),t}function Qn(e,n){if(e.node(n).dummy){let t=e.predecessors(n);if(t)return t.find(r=>e.node(r).dummy)}}function ze(e,n,t){if(n>t){let o=n;n=t,t=o}let r=e[n];r||(e[n]=r={}),r[t]=!0}function Zn(e,n,t){if(n>t){let o=n;n=t,t=o}let r=e[n];return r!==void 0&&Object.hasOwn(r,t)}function $n(e,n,t,r){let o={},i={},a={};return n.forEach(s=>{s.forEach((d,l)=>{o[d]=d,i[d]=d,a[d]=l})}),n.forEach(s=>{let d=-1;s.forEach(l=>{let u=r(l);if(u&&u.length){let c=u.sort((b,g)=>{let h=a[b],m=a[g];return(h!==void 0?h:0)-(m!==void 0?m:0)}),f=(c.length-1)/2;for(let b=Math.floor(f),g=Math.ceil(f);b<=g;++b){let h=c[b];if(h===void 0)continue;let m=a[h];if(m!==void 0&&i[l]===l&&d<m&&!Zn(t,l,h)){let L=o[h];L!==void 0&&(i[h]=l,i[l]=o[l]=L,d=m)}}}})}),{root:o,align:i}}function et(e,n,t,r,o=!1){let i={},a=nt(e,n,t,o),s=o?"borderLeft":"borderRight";function d(b,g){let h=a.nodes().slice(),m={},L=h.pop();for(;L;){if(m[L])b(L);else{m[L]=!0,h.push(L);for(let y of g(L))h.push(y)}L=h.pop()}}function l(b){let g=a.inEdges(b);g?i[b]=g.reduce((h,m)=>{var P;let L=(P=i[m.v])!=null?P:0,y=a.edge(m);return Math.max(h,L+(y!==void 0?y:0))},0):i[b]=0}function u(b){let g=a.outEdges(b),h=Number.POSITIVE_INFINITY;g&&(h=g.reduce((L,y)=>{let P=i[y.w],le=a.edge(y);return Math.min(L,(P!==void 0?P:0)-(le!==void 0?le:0))},Number.POSITIVE_INFINITY));let m=e.node(b);h!==Number.POSITIVE_INFINITY&&m.borderType!==s&&(i[b]=Math.max(i[b]!==void 0?i[b]:0,h))}function c(b){return a.predecessors(b)||[]}function f(b){return a.successors(b)||[]}return d(l,c),d(u,f),Object.keys(r).forEach(b=>{var h;let g=t[b];g!==void 0&&(i[b]=(h=i[g])!=null?h:0)}),i}function nt(e,n,t,r){let o=new p.Graph,i=e.graph(),a=it(i.nodesep,i.edgesep,r);return n.forEach(s=>{let d;s.forEach(l=>{let u=t[l];if(u!==void 0){if(o.setNode(u),d!==void 0){let c=t[d];if(c!==void 0){let f=o.edge(c,u);o.setEdge(c,u,Math.max(a(e,l,d),f||0))}}d=l}})}),o}function tt(e,n){return Object.values(n).reduce((t,r)=>{let o=Number.NEGATIVE_INFINITY,i=Number.POSITIVE_INFINITY;Object.entries(r).forEach(([s,d])=>{let l=at(e,s)/2;o=Math.max(d+l,o),i=Math.min(d-l,i)});let a=o-i;return a<t[0]&&(t=[a,r]),t},[Number.POSITIVE_INFINITY,null])[1]}function rt(e,n){let t=Object.values(n),r=E(Math.min,t),o=E(Math.max,t);["u","d"].forEach(i=>{["l","r"].forEach(a=>{let s=i+a,d=e[s];if(!d||d===n)return;let l=Object.values(d),u=r-E(Math.min,l);a!=="l"&&(u=o-E(Math.max,l)),u&&(e[s]=R(d,c=>c+u))})})}function ot(e,n=void 0){let t=e.ul;return t?R(t,(r,o)=>{var a,s;if(n){let d=n.toLowerCase(),l=e[d];if(l&&l[o]!==void 0)return l[o]}let i=Object.values(e).map(d=>{let l=d[o];return l!==void 0?l:0}).sort((d,l)=>d-l);return(((a=i[1])!=null?a:0)+((s=i[2])!=null?s:0))/2}):{}}function Xe(e){let n=G(e),t=Object.assign(Kn(e,n),Jn(e,n)),r={},o;["u","d"].forEach(a=>{o=a==="u"?n:Object.values(n).reverse(),["l","r"].forEach(s=>{s==="r"&&(o=o.map(c=>Object.values(c).reverse()));let l=$n(e,o,t,c=>(a==="u"?e.predecessors(c):e.successors(c))||[]),u=et(e,o,l.root,l.align,s==="r");s==="r"&&(u=R(u,c=>-c)),r[a+s]=u})});let i=tt(e,r);return rt(r,i),ot(r,e.graph().align)}function it(e,n,t){return(r,o,i)=>{let a=r.node(o),s=r.node(i),d=0,l;if(d+=a.width/2,Object.hasOwn(a,"labelpos"))switch(a.labelpos.toLowerCase()){case"l":l=-a.width/2;break;case"r":l=a.width/2;break}if(l&&(d+=t?l:-l),l=void 0,d+=(a.dummy?n:e)/2,d+=(s.dummy?n:e)/2,d+=s.width/2,Object.hasOwn(s,"labelpos"))switch(s.labelpos.toLowerCase()){case"l":l=s.width/2;break;case"r":l=-s.width/2;break}return l&&(d+=t?l:-l),d}}function at(e,n){return e.node(n).width}function Ue(e){e=_(e),st(e),Object.entries(Xe(e)).forEach(([n,t])=>e.node(n).x=t)}function st(e){let n=G(e),t=e.graph(),r=t.ranksep,o=t.rankalign,i=0;n.forEach(a=>{let s=a.reduce((d,l)=>{var c;let u=(c=e.node(l).height)!=null?c:0;return d>u?d:u},0);a.forEach(d=>{let l=e.node(d);o==="top"?l.y=i+l.height/2:o==="bottom"?l.y=i+s-l.height/2:l.y=i+s/2}),i+=s+r})}function B(e,n={}){let t=n.debugTiming?S:I;return t("layout",()=>{let r=t("  buildLayoutGraph",()=>mt(e));return t("  runLayout",()=>dt(r,t,n)),t("  updateInputGraph",()=>lt(e,r)),r})}function dt(e,n,t){n("    makeSpaceForEdgeLabels",()=>Lt(e)),n("    removeSelfEdges",()=>Tt(e)),n("    acyclic",()=>ye(e)),n("    nestingGraph.run",()=>Ce(e)),n("    rank",()=>Se(_(e))),n("    injectEdgeLabelProxies",()=>Et(e)),n("    removeEmptyRanks",()=>he(e)),n("    nestingGraph.cleanup",()=>_e(e)),n("    normalizeRanks",()=>fe(e)),n("    assignRankMinMax",()=>yt(e)),n("    removeEdgeLabelProxies",()=>Nt(e)),n("    normalize.run",()=>Ge(e)),n("    parentDummyChains",()=>Ie(e)),n("    addBorderSegments",()=>Ae(e)),n("    order",()=>W(e,t)),n("    insertSelfEdges",()=>Ot(e)),n("    adjustCoordinateSystem",()=>We(e)),n("    position",()=>Ue(e)),n("    positionSelfEdges",()=>Rt(e)),n("    removeBorderNodes",()=>vt(e)),n("    normalize.undo",()=>we(e)),n("    fixupEdgeLabelCoords",()=>kt(e)),n("    undoCoordinateSystem",()=>Be(e)),n("    translateGraph",()=>Gt(e)),n("    assignNodeIntersects",()=>wt(e)),n("    reversePoints",()=>xt(e)),n("    acyclic.undo",()=>Ne(e))}function lt(e,n){e.nodes().forEach(t=>{let r=e.node(t),o=n.node(t);r&&(r.x=o.x,r.y=o.y,r.order=o.order,r.rank=o.rank,n.children(t).length&&(r.width=o.width,r.height=o.height))}),e.edges().forEach(t=>{let r=e.edge(t),o=n.edge(t);r.points=o.points,Object.hasOwn(o,"x")&&(r.x=o.x,r.y=o.y)}),e.graph().width=n.graph().width,e.graph().height=n.graph().height}var ut=["nodesep","edgesep","ranksep","marginx","marginy"],ct={ranksep:50,edgesep:20,nodesep:50,rankdir:"TB",rankalign:"center"},bt=["acyclicer","ranker","rankdir","align","rankalign"],ft=["width","height","rank"],Ke={width:0,height:0},ht=["minlen","weight","width","height","labeloffset"],gt={minlen:1,weight:1,width:0,height:0,labeloffset:10,labelpos:"r"},pt=["labelpos"];function mt(e){let n=new p.Graph({multigraph:!0,compound:!0}),t=de(e.graph());return n.setGraph(Object.assign({},ct,se(t,ut),O(t,bt))),e.nodes().forEach(r=>{let o=de(e.node(r)),i=se(o,ft);Object.keys(Ke).forEach(s=>{i[s]===void 0&&(i[s]=Ke[s])}),n.setNode(r,i);let a=e.parent(r);a!==void 0&&n.setParent(r,a)}),e.edges().forEach(r=>{let o=de(e.edge(r));n.setEdge(r,Object.assign({},gt,se(o,ht),O(o,pt)))}),n}function Lt(e){let n=e.graph();n.ranksep/=2,e.edges().forEach(t=>{let r=e.edge(t);r.minlen*=2,r.labelpos.toLowerCase()!=="c"&&(n.rankdir==="TB"||n.rankdir==="BT"?r.width+=r.labeloffset:r.height+=r.labeloffset)})}function Et(e){e.edges().forEach(n=>{let t=e.edge(n);if(t.width&&t.height){let r=e.node(n.v),i={rank:(e.node(n.w).rank-r.rank)/2+r.rank,e:n};N(e,"edge-proxy",i,"_ep")}})}function yt(e){let n=0;e.nodes().forEach(t=>{let r=e.node(t);r.borderTop&&(r.minRank=e.node(r.borderTop).rank,r.maxRank=e.node(r.borderBottom).rank,n=Math.max(n,r.maxRank))}),e.graph().maxRank=n}function Nt(e){e.nodes().forEach(n=>{let t=e.node(n);if(t.dummy==="edge-proxy"){let r=t;e.edge(r.e).labelRank=t.rank,e.removeNode(n)}})}function Gt(e){let n=Number.POSITIVE_INFINITY,t=0,r=Number.POSITIVE_INFINITY,o=0,i=e.graph(),a=i.marginx||0,s=i.marginy||0;function d(l){let u=l.x,c=l.y,f=l.width,b=l.height;n=Math.min(n,u-f/2),t=Math.max(t,u+f/2),r=Math.min(r,c-b/2),o=Math.max(o,c+b/2)}e.nodes().forEach(l=>d(e.node(l))),e.edges().forEach(l=>{let u=e.edge(l);Object.hasOwn(u,"x")&&d(u)}),n-=a,r-=s,e.nodes().forEach(l=>{let u=e.node(l);u.x-=n,u.y-=r}),e.edges().forEach(l=>{let u=e.edge(l);u.points.forEach(c=>{c.x-=n,c.y-=r}),Object.hasOwn(u,"x")&&(u.x-=n),Object.hasOwn(u,"y")&&(u.y-=r)}),i.width=t-n+a,i.height=o-r+s}function wt(e){e.edges().forEach(n=>{let t=e.edge(n),r=e.node(n.v),o=e.node(n.w),i,a;t.points?(i=t.points[0],a=t.points[t.points.length-1]):(t.points=[],i=o,a=r),t.points.unshift(Y(r,i)),t.points.push(Y(o,a))})}function kt(e){e.edges().forEach(n=>{let t=e.edge(n);if(Object.hasOwn(t,"x"))switch((t.labelpos==="l"||t.labelpos==="r")&&(t.width-=t.labeloffset),t.labelpos){case"l":t.x-=t.width/2+t.labeloffset;break;case"r":t.x+=t.width/2+t.labeloffset;break}})}function xt(e){e.edges().forEach(n=>{let t=e.edge(n);t.reversed&&t.points.reverse()})}function vt(e){e.nodes().forEach(n=>{if(e.children(n).length){let t=e.node(n),r=e.node(t.borderTop),o=e.node(t.borderBottom),i=e.node(t.borderLeft[t.borderLeft.length-1]),a=e.node(t.borderRight[t.borderRight.length-1]);t.width=Math.abs(a.x-i.x),t.height=Math.abs(o.y-r.y),t.x=i.x+t.width/2,t.y=r.y+t.height/2}}),e.nodes().forEach(n=>{e.node(n).dummy==="border"&&e.removeNode(n)})}function Tt(e){e.edges().forEach(n=>{if(n.v===n.w){let t=e.node(n.v);t.selfEdges||(t.selfEdges=[]),t.selfEdges.push({e:n,label:e.edge(n)}),e.removeEdge(n)}})}function Ot(e){G(e).forEach(t=>{let r=0;t.forEach((o,i)=>{let a=e.node(o);a.order=i+r,(a.selfEdges||[]).forEach(s=>{N(e,"selfedge",{width:s.label.width,height:s.label.height,rank:a.rank,order:i+ ++r,e:s.e,label:s.label},"_se")}),delete a.selfEdges})})}function Rt(e){e.nodes().forEach(n=>{let t=e.node(n);if(t.dummy==="selfedge"){let r=t,o=e.node(r.e.v),i=o.x+o.width/2,a=o.y,s=t.x-i,d=o.height/2;e.setEdge(r.e,r.label),e.removeNode(n),r.label.points=[{x:i+2*s/3,y:a-d},{x:i+5*s/6,y:a-d},{x:i+s,y:a},{x:i+5*s/6,y:a+d},{x:i+2*s/3,y:a+d}],r.label.x=t.x,r.label.y=t.y}})}function se(e,n){return R(O(e,n),Number)}function de(e){let n={};return e&&Object.entries(e).forEach(([t,r])=>{typeof t=="string"&&(t=t.toLowerCase()),n[t]=r}),n}function D(e){let n=G(e),t=new p.Graph({compound:!0,multigraph:!0}).setGraph({});return e.nodes().forEach(r=>{t.setNode(r,{label:r}),t.setParent(r,"layer"+e.node(r).rank)}),e.edges().forEach(r=>t.setEdge(r.v,r.w,{},r.name)),n.forEach((r,o)=>{let i="layer"+o;t.setNode(i,{rank:"same"}),r.reduce((a,s)=>(t.setEdge(a,s,{style:"invis"}),s))}),t}var Qe=__webpack_require__(413);var Pt={time:S,notime:I},Mt={graphlib:Je,version:F,layout:B,debug:D,util:{time:S,notime:I}},St=Mt;0&&(0);
+/*! For license information please see dagre.cjs.js.LEGAL.txt */
+//# sourceMappingURL=dagre.cjs.js.map
+
+
+/***/ },
+
+/***/ 413
+(module) {
+
+"use strict";
+var v=Object.defineProperty;var H=Object.getOwnPropertyDescriptor;var U=Object.getOwnPropertyNames;var Y=Object.prototype.hasOwnProperty;var F=(s,e)=>{for(var t in e)v(s,t,{get:e[t],enumerable:!0})},K=(s,e,t,r)=>{if(e&&typeof e=="object"||typeof e=="function")for(let i of U(e))!Y.call(s,i)&&i!==t&&v(s,i,{get:()=>e[i],enumerable:!(r=H(e,i))||r.enumerable});return s};var z=s=>K(v({},"__esModule",{value:!0}),s);var oe={};F(oe,{Graph:()=>l,alg:()=>G,json:()=>m,version:()=>P});module.exports=z(oe);var l=class{constructor(e){this._isDirected=!0;this._isMultigraph=!1;this._isCompound=!1;this._nodes={};this._in={};this._preds={};this._out={};this._sucs={};this._edgeObjs={};this._edgeLabels={};this._nodeCount=0;this._edgeCount=0;this._defaultNodeLabelFn=()=>{};this._defaultEdgeLabelFn=()=>{};e&&(this._isDirected="directed"in e?e.directed:!0,this._isMultigraph="multigraph"in e?e.multigraph:!1,this._isCompound="compound"in e?e.compound:!1),this._isCompound&&(this._parent={},this._children={},this._children["\0"]={})}isDirected(){return this._isDirected}isMultigraph(){return this._isMultigraph}isCompound(){return this._isCompound}setGraph(e){return this._label=e,this}graph(){return this._label}setDefaultNodeLabel(e){return typeof e!="function"?this._defaultNodeLabelFn=()=>e:this._defaultNodeLabelFn=e,this}nodeCount(){return this._nodeCount}nodes(){return Object.keys(this._nodes)}sources(){return this.nodes().filter(e=>Object.keys(this._in[e]).length===0)}sinks(){return this.nodes().filter(e=>Object.keys(this._out[e]).length===0)}setNodes(e,t){return e.forEach(r=>{t!==void 0?this.setNode(r,t):this.setNode(r)}),this}setNode(e,t){return e in this._nodes?(arguments.length>1&&(this._nodes[e]=t),this):(this._nodes[e]=arguments.length>1?t:this._defaultNodeLabelFn(e),this._isCompound&&(this._parent[e]="\0",this._children[e]={},this._children["\0"][e]=!0),this._in[e]={},this._preds[e]={},this._out[e]={},this._sucs[e]={},++this._nodeCount,this)}node(e){return this._nodes[e]}hasNode(e){return e in this._nodes}removeNode(e){if(e in this._nodes){let t=r=>this.removeEdge(this._edgeObjs[r]);delete this._nodes[e],this._isCompound&&(this._removeFromParentsChildList(e),delete this._parent[e],this.children(e).forEach(r=>{this.setParent(r)}),delete this._children[e]),Object.keys(this._in[e]).forEach(t),delete this._in[e],delete this._preds[e],Object.keys(this._out[e]).forEach(t),delete this._out[e],delete this._sucs[e],--this._nodeCount}return this}setParent(e,t){if(!this._isCompound)throw new Error("Cannot set parent in a non-compound graph");if(t===void 0)t="\0";else{t+="";for(let r=t;r!==void 0;r=this.parent(r))if(r===e)throw new Error("Setting "+t+" as parent of "+e+" would create a cycle");this.setNode(t)}return this.setNode(e),this._removeFromParentsChildList(e),this._parent[e]=t,this._children[t][e]=!0,this}parent(e){if(this._isCompound){let t=this._parent[e];if(t!=="\0")return t}}children(e="\0"){if(this._isCompound){let t=this._children[e];if(t)return Object.keys(t)}else{if(e==="\0")return this.nodes();if(this.hasNode(e))return[]}return[]}predecessors(e){let t=this._preds[e];if(t)return Object.keys(t)}successors(e){let t=this._sucs[e];if(t)return Object.keys(t)}neighbors(e){let t=this.predecessors(e);if(t){let r=new Set(t);for(let i of this.successors(e))r.add(i);return Array.from(r.values())}}isLeaf(e){let t;return this.isDirected()?t=this.successors(e):t=this.neighbors(e),t.length===0}filterNodes(e){let t=new this.constructor({directed:this._isDirected,multigraph:this._isMultigraph,compound:this._isCompound});t.setGraph(this.graph()),Object.entries(this._nodes).forEach(([n,o])=>{e(n)&&t.setNode(n,o)}),Object.values(this._edgeObjs).forEach(n=>{t.hasNode(n.v)&&t.hasNode(n.w)&&t.setEdge(n,this.edge(n))});let r={},i=n=>{let o=this.parent(n);return!o||t.hasNode(o)?(r[n]=o!=null?o:void 0,o!=null?o:void 0):o in r?r[o]:i(o)};return this._isCompound&&t.nodes().forEach(n=>t.setParent(n,i(n))),t}setDefaultEdgeLabel(e){return typeof e!="function"?this._defaultEdgeLabelFn=()=>e:this._defaultEdgeLabelFn=e,this}edgeCount(){return this._edgeCount}edges(){return Object.values(this._edgeObjs)}setPath(e,t){return e.reduce((r,i)=>(t!==void 0?this.setEdge(r,i,t):this.setEdge(r,i),i)),this}setEdge(e,t,r,i){let n,o,d,a,c=!1;typeof e=="object"&&e!==null&&"v"in e?(n=e.v,o=e.w,d=e.name,arguments.length===2&&(a=t,c=!0)):(n=e,o=t,d=i,arguments.length>2&&(a=r,c=!0)),n=""+n,o=""+o,d!==void 0&&(d=""+d);let h=b(this._isDirected,n,o,d);if(h in this._edgeLabels)return c&&(this._edgeLabels[h]=a),this;if(d!==void 0&&!this._isMultigraph)throw new Error("Cannot set a named edge when isMultigraph = false");this.setNode(n),this.setNode(o),this._edgeLabels[h]=c?a:this._defaultEdgeLabelFn(n,o,d);let u=Q(this._isDirected,n,o,d);return n=u.v,o=u.w,Object.freeze(u),this._edgeObjs[h]=u,x(this._preds[o],n),x(this._sucs[n],o),this._in[o][h]=u,this._out[n][h]=u,this._edgeCount++,this}edge(e,t,r){let i=arguments.length===1?k(this._isDirected,e):b(this._isDirected,e,t,r);return this._edgeLabels[i]}edgeAsObj(e,t,r){let i=arguments.length===1?this.edge(e):this.edge(e,t,r);return typeof i!="object"?{label:i}:i}hasEdge(e,t,r){return(arguments.length===1?k(this._isDirected,e):b(this._isDirected,e,t,r))in this._edgeLabels}removeEdge(e,t,r){let i=arguments.length===1?k(this._isDirected,e):b(this._isDirected,e,t,r),n=this._edgeObjs[i];if(n){let o=n.v,d=n.w;delete this._edgeLabels[i],delete this._edgeObjs[i],R(this._preds[d],o),R(this._sucs[o],d),delete this._in[d][i],delete this._out[o][i],this._edgeCount--}return this}inEdges(e,t){return this.isDirected()?this.filterEdges(this._in[e],e,t):this.nodeEdges(e,t)}outEdges(e,t){return this.isDirected()?this.filterEdges(this._out[e],e,t):this.nodeEdges(e,t)}nodeEdges(e,t){if(e in this._nodes)return this.filterEdges({...this._in[e],...this._out[e]},e,t)}_removeFromParentsChildList(e){delete this._children[this._parent[e]][e]}filterEdges(e,t,r){if(!e)return;let i=Object.values(e);return r?i.filter(n=>n.v===t&&n.w===r||n.v===r&&n.w===t):i}};function x(s,e){s[e]?s[e]++:s[e]=1}function R(s,e){s[e]!==void 0&&!--s[e]&&delete s[e]}function b(s,e,t,r){let i=""+e,n=""+t;if(!s&&i>n){let o=i;i=n,n=o}return i+""+n+""+(r===void 0?"\0":r)}function Q(s,e,t,r){let i=""+e,n=""+t;if(!s&&i>n){let d=i;i=n,n=d}let o={v:i,w:n};return r&&(o.name=r),o}function k(s,e){return b(s,e.v,e.w,e.name)}var P="4.0.1";var m={};F(m,{read:()=>X,write:()=>$});function $(s){let e={options:{directed:s.isDirected(),multigraph:s.isMultigraph(),compound:s.isCompound()},nodes:q(s),edges:B(s)},t=s.graph();return t!==void 0&&(e.value=structuredClone(t)),e}function q(s){return s.nodes().map(e=>{let t=s.node(e),r=s.parent(e),i={v:e};return t!==void 0&&(i.value=t),r!==void 0&&(i.parent=r),i})}function B(s){return s.edges().map(e=>{let t=s.edge(e),r={v:e.v,w:e.w};return e.name!==void 0&&(r.name=e.name),t!==void 0&&(r.value=t),r})}function X(s){let e=new l(s.options);return s.value!==void 0&&e.setGraph(s.value),s.nodes.forEach(t=>{e.setNode(t.v,t.value),t.parent&&e.setParent(t.v,t.parent)}),s.edges.forEach(t=>{e.setEdge({v:t.v,w:t.w,name:t.name},t.value)}),e}var G={};F(G,{CycleException:()=>p,bellmanFord:()=>y,components:()=>I,dijkstra:()=>E,dijkstraAll:()=>D,findCycles:()=>O,floydWarshall:()=>j,isAcyclic:()=>C,postorder:()=>W,preorder:()=>S,prim:()=>M,shortestPaths:()=>V,tarjan:()=>L,topsort:()=>w});var Z=()=>1;function y(s,e,t,r){return ee(s,String(e),t||Z,r||function(i){return s.outEdges(i)})}function ee(s,e,t,r){let i={},n,o=0,d=s.nodes(),a=function(u){let g=t(u);i[u.v].distance+g<i[u.w].distance&&(i[u.w]={distance:i[u.v].distance+g,predecessor:u.v},n=!0)},c=function(){d.forEach(function(u){r(u).forEach(function(g){let f=g.v===u?g.v:g.w,J=f===g.v?g.w:g.v;a({v:f,w:J})})})};d.forEach(function(u){let g=u===e?0:Number.POSITIVE_INFINITY;i[u]={distance:g,predecessor:""}});let h=d.length;for(let u=1;u<h&&(n=!1,o++,c(),!!n);u++);if(o===h-1&&(n=!1,c(),n))throw new Error("The graph contains a negative weight cycle");return i}function I(s){let e={},t=[],r;function i(n){n in e||(e[n]=!0,r.push(n),s.successors(n).forEach(i),s.predecessors(n).forEach(i))}return s.nodes().forEach(function(n){r=[],i(n),r.length&&t.push(r)}),t}var _=class{constructor(){this._arr=[];this._keyIndices={}}size(){return this._arr.length}keys(){return this._arr.map(e=>e.key)}has(e){return e in this._keyIndices}priority(e){let t=this._keyIndices[e];if(t!==void 0)return this._arr[t].priority}min(){if(this.size()===0)throw new Error("Queue underflow");return this._arr[0].key}add(e,t){let r=this._keyIndices,i=String(e);if(!(i in r)){let n=this._arr,o=n.length;return r[i]=o,n.push({key:i,priority:t}),this._decrease(o),!0}return!1}removeMin(){this._swap(0,this._arr.length-1);let e=this._arr.pop();return delete this._keyIndices[e.key],this._heapify(0),e.key}decrease(e,t){let r=this._keyIndices[e];if(r===void 0)throw new Error(`Key not found: ${e}`);let i=this._arr[r].priority;if(t>i)throw new Error(`New priority is greater than current priority. Key: ${e} Old: ${i} New: ${t}`);this._arr[r].priority=t,this._decrease(r)}_heapify(e){let t=this._arr,r=2*e,i=r+1,n=e;r<t.length&&(n=t[r].priority<t[n].priority?r:n,i<t.length&&(n=t[i].priority<t[n].priority?i:n),n!==e&&(this._swap(e,n),this._heapify(n)))}_decrease(e){let t=this._arr,r=t[e].priority,i;for(;e!==0&&(i=e>>1,!(t[i].priority<r));)this._swap(e,i),e=i}_swap(e,t){let r=this._arr,i=this._keyIndices,n=r[e],o=r[t];r[e]=o,r[t]=n,i[o.key]=e,i[n.key]=t}};var te=()=>1;function E(s,e,t,r){let i=function(n){return s.outEdges(n)};return re(s,String(e),t||te,r||i)}function re(s,e,t,r){let i={},n=new _,o,d,a=function(c){let h=c.v!==o?c.v:c.w,u=i[h],g=t(c),f=d.distance+g;if(g<0)throw new Error("dijkstra does not allow negative edge weights. Bad edge: "+c+" Weight: "+g);f<u.distance&&(u.distance=f,u.predecessor=o,n.decrease(h,f))};for(s.nodes().forEach(function(c){let h=c===e?0:Number.POSITIVE_INFINITY;i[c]={distance:h,predecessor:""},n.add(c,h)});n.size()>0&&(o=n.removeMin(),d=i[o],d.distance!==Number.POSITIVE_INFINITY);)r(o).forEach(a);return i}function D(s,e,t){return s.nodes().reduce(function(r,i){return r[i]=E(s,i,e,t),r},{})}function L(s){let e=0,t=[],r={},i=[];function n(o){let d=r[o]={onStack:!0,lowlink:e,index:e++};if(t.push(o),s.successors(o).forEach(function(a){a in r?r[a].onStack&&(d.lowlink=Math.min(d.lowlink,r[a].index)):(n(a),d.lowlink=Math.min(d.lowlink,r[a].lowlink))}),d.lowlink===d.index){let a=[],c;do c=t.pop(),r[c].onStack=!1,a.push(c);while(o!==c);i.push(a)}}return s.nodes().forEach(function(o){o in r||n(o)}),i}function O(s){return L(s).filter(function(e){return e.length>1||e.length===1&&s.hasEdge(e[0],e[0])})}var ne=()=>1;function j(s,e,t){return ie(s,e||ne,t||function(r){return s.outEdges(r)})}function ie(s,e,t){let r={},i=s.nodes();return i.forEach(function(n){r[n]={},r[n][n]={distance:0,predecessor:""},i.forEach(function(o){n!==o&&(r[n][o]={distance:Number.POSITIVE_INFINITY,predecessor:""})}),t(n).forEach(function(o){let d=o.v===n?o.w:o.v,a=e(o);r[n][d]={distance:a,predecessor:n}})}),i.forEach(function(n){let o=r[n];i.forEach(function(d){let a=r[d];i.forEach(function(c){let h=a[n],u=o[c],g=a[c],f=h.distance+u.distance;f<g.distance&&(g.distance=f,g.predecessor=u.predecessor)})})}),r}var p=class extends Error{constructor(...e){super(...e)}};function w(s){let e={},t={},r=[];function i(n){if(n in t)throw new p;n in e||(t[n]=!0,e[n]=!0,s.predecessors(n).forEach(i),delete t[n],r.push(n))}if(s.sinks().forEach(i),Object.keys(e).length!==s.nodeCount())throw new p;return r}function C(s){try{w(s)}catch(e){if(e instanceof p)return!1;throw e}return!0}function T(s,e,t,r,i){Array.isArray(e)||(e=[e]);let n=(d=>{var a;return(a=s.isDirected()?s.successors(d):s.neighbors(d))!=null?a:[]}),o={};return e.forEach(function(d){if(!s.hasNode(d))throw new Error("Graph does not have node: "+d);i=A(s,d,t==="post",o,n,r,i)}),i}function A(s,e,t,r,i,n,o){return e in r||(r[e]=!0,t||(o=n(o,e)),i(e).forEach(function(d){o=A(s,d,t,r,i,n,o)}),t&&(o=n(o,e))),o}function N(s,e,t){return T(s,e,t,function(r,i){return r.push(i),r},[])}function W(s,e){return N(s,e,"post")}function S(s,e){return N(s,e,"pre")}function M(s,e){let t=new l,r={},i=new _,n;function o(a){let c=a.v===n?a.w:a.v,h=i.priority(c);if(h!==void 0){let u=e(a);u<h&&(r[c]=n,i.decrease(c,u))}}if(s.nodeCount()===0)return t;s.nodes().forEach(function(a){i.add(a,Number.POSITIVE_INFINITY),t.setNode(a)}),i.decrease(s.nodes()[0],0);let d=!1;for(;i.size()>0;){if(n=i.removeMin(),n in r)t.setEdge(n,r[n]);else{if(d)throw new Error("Input graph is not connected: "+s);d=!0}s.nodeEdges(n).forEach(o)}return t}function V(s,e,t,r){return se(s,e,t,r!=null?r:(i=>{let n=s.outEdges(i);return n!=null?n:[]}))}function se(s,e,t,r){if(t===void 0)return E(s,e,t,r);let i=!1,n=s.nodes();for(let o=0;o<n.length;o++){let d=r(n[o]);for(let a=0;a<d.length;a++){let c=d[a],h=c.v===n[o]?c.v:c.w,u=h===c.v?c.w:c.v;t({v:h,w:u})<0&&(i=!0)}if(i)return y(s,e,t,r)}return E(s,e,t,r)}0&&(0);
+//# sourceMappingURL=graphlib.cjs.js.map
+
+
+/***/ },
+
+/***/ 432
+(module) {
+
+// Simple, internal Object.assign() polyfill for options objects etc.
+
+module.exports = Object.assign != null ? Object.assign.bind(Object) : function (tgt) {
+  for (var _len = arguments.length, srcs = new Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+    srcs[_key - 1] = arguments[_key];
+  }
+  srcs.forEach(function (src) {
+    Object.keys(src).forEach(function (k) {
+      return tgt[k] = src[k];
+    });
+  });
+  return tgt;
+};
+
+/***/ },
+
+/***/ 299
+(module) {
+
+/** 
+ * Dagre algorithmic options. The default value of dagre.js is used
+ * when the option is left undefined here.
+ */
+var defaults = {
+  /**
+   * the separation between adjacent nodes in the same rank
+   */
+  nodeSep: undefined,
+  /**
+   * The separation between adjacent edges in the same rank
+   */
+  edgeSep: undefined,
+  /**
+   * The separation between each rank in the layout
+   */
+  rankSep: undefined,
+  /**
+   * Direction in which ranks flow: `'TB'` for top to bottom flow, `'LR'` for left to right,
+   */
+  rankDir: undefined,
+  /**
+   * alignment for rank nodes. Can be `'UL'`, `'UR'`, `'DL'`, or `'DR'`, 
+   * where `U` = up, `D` = down, `L` = left, and `R` = right
+   */
+  align: undefined,
+  /**
+   * If set to `'greedy'`, uses a greedy heuristic for finding a feedback arc set for a graph.
+   * A feedback arc set is a set of edges that can be removed to make a graph acyclic.
+   */
+  acyclicer: undefined,
+  /**
+   * Type of algorithm to assigns a rank to each node in the input graph.
+   * Possible values: 
+   *    * `'network-simplex'`, 
+   *    * `'tight-tree'` or
+   *    * `'longest-path'`
+   */
+  ranker: undefined,
+  /**
+   * Number of ranks to keep between the source and target of the edge
+   */
+  minLen: function minLen(_edge) {
+    return 1;
+  },
+  /**
+   * Higher weight edges are generally made shorter and straighter than lower weight edges} _edge 
+   */
+  edgeWeight: function edgeWeight(_edge) {
+    return 1;
+  },
+  /* general layout options */
+  /**
+   * whether to fit to viewport
+   */
+  fit: true,
+  /**
+   * Fit padding
+   */
+  padding: 30,
+  /**
+   * Applies a multiplicative factor (>0) to expand or compress the overall area that the nodes take up
+   */
+  spacingFactor: undefined,
+  /**
+   * Whether labels should be included in determining the space used by a node
+   */
+  nodeDimensionsIncludeLabels: false,
+  /**
+   * Enables bezier curves using dagre's edge control points
+   */
+  useDagreEdgeControlPoints: false,
+  /**
+   * Automatically adds edge class '.useDagreEdgeControlPoints' to all edges and configure it with this.dagreEdgeStyle.
+   * If set to `false` and `useDagreEdgeControlPoints` is `true` then apply `this.dagreEdgeStyle` yourself.
+   */
+  automaticDagreEdgeStyle: this.useDagreEdgeControlPoints,
+  /**
+   * Defines the style for rendering dagre edge control points stored by the layout algorithm
+   * if `useDagreEdgeControlPoints` is `true` and `automaticDagreEdgeStyle` is `true`
+   */
+  dagreEdgeStyle: {
+    'curve-style': 'unbundled-bezier',
+    'control-point-weights': function controlPointWeights(ele) {
+      return ele.scratch('controlPointWeights');
+    },
+    'control-point-distances': function controlPointDistances(ele) {
+      return ele.scratch('controlPointDistances');
+    },
+    'edge-distances': 'intersection',
+    'edge-ends-overlap': false
+  },
+  /**
+   * Whether to transition the node positions
+   */
+  animate: false,
+  /**
+   * Whether to animate specific nodes when animation is on; non-animated nodes immediately go to their final positions
+   */
+  animateFilter: function animateFilter(_node, i) {
+    return true;
+  },
+  /**
+   * Duration of animation in ms if enabled
+   */
+  animationDuration: 500,
+  /**
+   * Easing of animation, if enabled
+   */
+  animationEasing: undefined,
+  /**
+   * Constrain outermost layout bounds; `{ x1, y1, x2, y2 }` or `{ x1, y1, w, h }`
+   */
+  boundingBox: undefined,
+  /**
+   * A function that applies a transform to the final node position
+   */
+  transform: function transform(node, pos) {
+    return pos;
+  },
+  /**
+   * On layoutready execute this function
+   */
+  ready: function ready() {},
+  /**
+   * A sorting function to order the nodes and edges; e.g. `function(a, b){ return a.data('weight') - b.data('weight')`. }
+   * Because cytoscape dagre creates a directed graph, and directed graphs use the node order as a tie breaker when
+   * defining the topology of a graph, this sort function can help ensure the correct order of the nodes/edges.
+   * This feature is most useful when adding and removing the same nodes and edges multiple times in a graph,
+   * but it can also help avoid sprurious edge crossings between ranks.
+   */
+  sort: undefined,
+  /**
+   * on layoutstop, execute this function
+   */
+  stop: function stop() {}
+};
+module.exports = defaults;
+
+/***/ },
+
+/***/ 497
+(module, __unused_webpack_exports, __webpack_require__) {
+
+var impl = __webpack_require__(539);
+
+// registers the extension on a cytoscape lib ref
+var register = function register(cytoscape) {
+  if (!cytoscape) {
+    return;
+  } // can't register if cytoscape unspecified
+
+  cytoscape('layout', 'dagre', impl); // register with cytoscape.js
+};
+if (typeof window !== 'undefined' && typeof window.cytoscape !== 'undefined') {
+  // expose to global cytoscape (i.e. window.cytoscape)
+  register(window.cytoscape);
+}
+module.exports = register;
+
+/***/ },
+
+/***/ 539
+(module, __unused_webpack_exports, __webpack_require__) {
+
+function _typeof(o) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (o) { return typeof o; } : function (o) { return o && "function" == typeof Symbol && o.constructor === Symbol && o !== Symbol.prototype ? "symbol" : typeof o; }, _typeof(o); }
+function _createForOfIteratorHelper(r, e) { var t = "undefined" != typeof Symbol && r[Symbol.iterator] || r["@@iterator"]; if (!t) { if (Array.isArray(r) || (t = _unsupportedIterableToArray(r)) || e && r && "number" == typeof r.length) { t && (r = t); var _n = 0, F = function F() {}; return { s: F, n: function n() { return _n >= r.length ? { done: !0 } : { done: !1, value: r[_n++] }; }, e: function e(r) { throw r; }, f: F }; } throw new TypeError("Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); } var o, a = !0, u = !1; return { s: function s() { t = t.call(r); }, n: function n() { var r = t.next(); return a = r.done, r; }, e: function e(r) { u = !0, o = r; }, f: function f() { try { a || null == t["return"] || t["return"](); } finally { if (u) throw o; } } }; }
+function _unsupportedIterableToArray(r, a) { if (r) { if ("string" == typeof r) return _arrayLikeToArray(r, a); var t = {}.toString.call(r).slice(8, -1); return "Object" === t && r.constructor && (t = r.constructor.name), "Map" === t || "Set" === t ? Array.from(r) : "Arguments" === t || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(t) ? _arrayLikeToArray(r, a) : void 0; } }
+function _arrayLikeToArray(r, a) { (null == a || a > r.length) && (a = r.length); for (var e = 0, n = Array(a); e < a; e++) n[e] = r[e]; return n; }
+var isFunction = function isFunction(o) {
+  return typeof o === 'function';
+};
+var defaults = __webpack_require__(299);
+var assign = __webpack_require__(432);
+var dagre = __webpack_require__(155);
+var EPSILON = 0.001; // what does it mean to be too close to 0?
+
+// constructor
+// options : object containing layout options
+function DagreLayout(options) {
+  this.options = assign({}, defaults, options);
+}
+function subtract(a, b) {
+  return {
+    x: noZero(a.x - b.x),
+    y: noZero(a.y - b.y)
+  };
+}
+function product(a, b) {
+  return noZero(a.x * b.x) + noZero(a.y * b.y);
+}
+function norm(v) {
+  var len = Math.hypot(v.x, v.y) || 1;
+  return {
+    x: v.x / len,
+    y: v.y / len,
+    len: len
+  };
+}
+function perp(v) {
+  return {
+    x: -v.y,
+    y: v.x
+  };
+}
+
+/* provides the context for mapping from dagre's x, y coordinate system
+ * for control points to cytoscapes coordinate system for control points
+ * which is relative to the straight vector from source to target node
+ */
+function buildEdgeFrame(src, tgt) {
+  var d = subtract(tgt, src);
+  var _norm = norm(d),
+    x = _norm.x,
+    y = _norm.y,
+    len = _norm.len;
+  var dir = {
+    x: x,
+    y: y
+  };
+  var normal = perp(dir);
+  return {
+    src: src,
+    tgt: tgt,
+    dir: dir,
+    normal: normal,
+    len: len
+  };
+}
+function noZero(x) {
+  if (Math.abs(x) < EPSILON) {
+    return x < 0 ? -EPSILON : EPSILON;
+  }
+  return x;
+}
+function toEdgeCoordinates(P, frame) {
+  var vector = subtract(P, frame.src);
+  var weight = noZero(product(vector, frame.dir) / frame.len);
+  var distance = noZero(product(vector, frame.normal));
+  return {
+    weight: weight,
+    distance: distance
+  };
+}
+function normalizeWeight(coords) {
+  var min = Infinity;
+  var max = -Infinity;
+  var _iterator = _createForOfIteratorHelper(coords),
+    _step;
+  try {
+    for (_iterator.s(); !(_step = _iterator.n()).done;) {
+      var p = _step.value;
+      if (p.weight < min) {
+        min = p.weight;
+      }
+      if (p.weight > max) {
+        max = p.weight;
+      }
+    }
+  } catch (err) {
+    _iterator.e(err);
+  } finally {
+    _iterator.f();
+  }
+  var range = max - min || 1;
+  return coords.map(function (p) {
+    return {
+      distance: p.distance,
+      weight: (p.weight - min) / range
+    };
+  });
+}
+
+/* First introduce new control points to bridge between the dagre list of 
+ * points and the centres of cytoscape nodes.
+ * Then we sanitize any empty or non-existing or degenerate control points
+ * And finally we map the Dagre coordinates to the Cytoscape coordinated which
+ * are relative to the original direction vector from source to target.
+ * These final coordinates are stored pairwise in two arrays cpw and cpd
+ * which are picked up by the Bezier construction code in cytoscape.
+ */
+function dagreEdgeToCytoscapeEdge(dEdge, cEdge) {
+  var fromNode = cEdge.source().position();
+  var toNode = cEdge.target().position();
+  var frame = buildEdgeFrame(fromNode, toNode);
+  var coords = normalizeWeight(dEdge.points.map(function (p) {
+    return toEdgeCoordinates(p, frame);
+  }));
+  var controlPointWeights = coords.slice(1, -1).map(function (c) {
+    return c.weight;
+  });
+  var controlPointDistances = coords.slice(1, -1).map(function (c) {
+    return c.distance;
+  });
+  var result = {
+    controlPointWeights: controlPointWeights,
+    controlPointDistances: controlPointDistances
+  };
+  return result;
+}
+
+// runs the layout
+DagreLayout.prototype.run = function () {
+  var options = this.options;
+  var layout = this;
+  var cy = options.cy; // cy is automatically populated for us in the constructor
+  var eles = options.eles;
+  var getVal = function getVal(ele, val) {
+    return isFunction(val) ? val.apply(ele, [ele]) : val;
+  };
+  var bb = options.boundingBox || {
+    x1: 0,
+    y1: 0,
+    w: cy.width(),
+    h: cy.height()
+  };
+  if (bb.x2 === undefined) {
+    bb.x2 = bb.x1 + bb.w;
+  }
+  if (bb.w === undefined) {
+    bb.w = bb.x2 - bb.x1;
+  }
+  if (bb.y2 === undefined) {
+    bb.y2 = bb.y1 + bb.h;
+  }
+  if (bb.h === undefined) {
+    bb.h = bb.y2 - bb.y1;
+  }
+  var g = new dagre.graphlib.Graph({
+    multigraph: true,
+    compound: true
+  });
+  var gObj = {};
+  var setGObj = function setGObj(name, val) {
+    if (val != null) {
+      gObj[name] = val;
+    }
+  };
+  setGObj('nodesep', options.nodeSep);
+  setGObj('edgesep', options.edgeSep);
+  setGObj('ranksep', options.rankSep);
+  setGObj('rankdir', options.rankDir);
+  setGObj('align', options.align);
+  setGObj('ranker', options.ranker);
+  setGObj('acyclicer', options.acyclicer);
+  g.setGraph(gObj);
+  g.setDefaultEdgeLabel(function () {
+    return {};
+  });
+  g.setDefaultNodeLabel(function () {
+    return {};
+  });
+
+  // add nodes to dagre
+  var nodes = eles.nodes();
+  if (isFunction(options.sort)) {
+    nodes = nodes.sort(options.sort);
+  }
+  for (var i = 0; i < nodes.length; i++) {
+    var node = nodes[i];
+    var nbb = node.layoutDimensions(options);
+    g.setNode(node.id(), {
+      width: nbb.w,
+      height: nbb.h,
+      shape: 'ellipse',
+      name: node.id()
+    });
+  }
+
+  // set compound parents
+  for (var _i = 0; _i < nodes.length; _i++) {
+    var _node = nodes[_i];
+    if (_node.isChild()) {
+      g.setParent(_node.id(), _node.parent().id());
+    }
+  }
+
+  // add edges to dagre
+  var edges = eles.edges().stdFilter(function (edge) {
+    return !edge.source().isParent() && !edge.target().isParent(); // dagre can't handle edges on compound nodes
+  });
+  if (isFunction(options.sort)) {
+    edges = edges.sort(options.sort);
+  }
+  for (var _i2 = 0; _i2 < edges.length; _i2++) {
+    var edge = edges[_i2];
+    g.setEdge(edge.source().id(), edge.target().id(), {
+      minlen: getVal(edge, options.minLen),
+      weight: getVal(edge, options.edgeWeight),
+      name: edge.id()
+    }, edge.id());
+  }
+  dagre.layout(g);
+  var gNodeIds = g.nodes();
+  for (var _i3 = 0; _i3 < gNodeIds.length; _i3++) {
+    var id = gNodeIds[_i3];
+    var n = g.node(id);
+    cy.getElementById(id).scratch().dagre = n;
+  }
+  var dagreBB;
+  if (options.boundingBox) {
+    dagreBB = {
+      x1: Infinity,
+      x2: -Infinity,
+      y1: Infinity,
+      y2: -Infinity
+    };
+    nodes.forEach(function (node) {
+      var dModel = node.scratch().dagre;
+      dagreBB.x1 = Math.min(dagreBB.x1, dModel.x);
+      dagreBB.x2 = Math.max(dagreBB.x2, dModel.x);
+      dagreBB.y1 = Math.min(dagreBB.y1, dModel.y);
+      dagreBB.y2 = Math.max(dagreBB.y2, dModel.y);
+    });
+    dagreBB.w = dagreBB.x2 - dagreBB.x1;
+    dagreBB.h = dagreBB.y2 - dagreBB.y1;
+  } else {
+    dagreBB = bb;
+  }
+  var constrainPos = function constrainPos(p) {
+    if (options.boundingBox) {
+      var xPct = dagreBB.w === 0 ? 0 : (p.x - dagreBB.x1) / dagreBB.w;
+      var yPct = dagreBB.h === 0 ? 0 : (p.y - dagreBB.y1) / dagreBB.h;
+      return {
+        x: bb.x1 + xPct * bb.w,
+        y: bb.y1 + yPct * bb.h
+      };
+    } else {
+      return p;
+    }
+  };
+  nodes.layoutPositions(layout, options, function (ele) {
+    ele = _typeof(ele) === "object" ? ele : this;
+    var dModel = ele.scratch().dagre;
+    return constrainPos({
+      x: dModel.x,
+      y: dModel.y
+    });
+  });
+  if (options.useDagreEdgeControlPoints) {
+    if (options.automaticDagreEdgeStyle) {
+      cy.edges().addClass('useDagreEdgeControlPoints');
+      cy.style().selector('edge.useDagreEdgeControlPoints').style(options.dagreEdgeStyle).update();
+    }
+    g.edges().forEach(function (id) {
+      var cyEdge = cy.getElementById(id.name);
+      var dEdge = g.edge(id);
+      if (dEdge && dEdge.points) {
+        cyEdge.scratch(dagreEdgeToCytoscapeEdge(dEdge, cyEdge));
+      }
+    });
+  }
+  return this; // chaining
+};
+module.exports = DagreLayout;
+
+/***/ }
+
+/******/ 	});
+/************************************************************************/
+/******/ 	// The module cache
+/******/ 	var __webpack_module_cache__ = {};
+/******/ 	
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/ 		// Check if module is in cache
+/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
+/******/ 		if (cachedModule !== undefined) {
+/******/ 			return cachedModule.exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = __webpack_module_cache__[moduleId] = {
+/******/ 			// no module.id needed
+/******/ 			// no module.loaded needed
+/******/ 			exports: {}
+/******/ 		};
+/******/ 	
+/******/ 		// Execute the module function
+/******/ 		__webpack_modules__[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/ 	
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/ 	
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module is referenced by other modules so it can't be inlined
+/******/ 	var __webpack_exports__ = __webpack_require__(497);
+/******/ 	
+/******/ 	return __webpack_exports__;
+/******/ })()
+;
+});

--- a/backend/src/meho_backplane/ui/static/src/vendor/layout-base.js
+++ b/backend/src/meho_backplane/ui/static/src/vendor/layout-base.js
@@ -1,0 +1,5230 @@
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports["layoutBase"] = factory();
+	else
+		root["layoutBase"] = factory();
+})(this, function() {
+return /******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 28);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+function LayoutConstants() {}
+
+/**
+ * Layout Quality: 0:draft, 1:default, 2:proof
+ */
+LayoutConstants.QUALITY = 1;
+
+/**
+ * Default parameters
+ */
+LayoutConstants.DEFAULT_CREATE_BENDS_AS_NEEDED = false;
+LayoutConstants.DEFAULT_INCREMENTAL = false;
+LayoutConstants.DEFAULT_ANIMATION_ON_LAYOUT = true;
+LayoutConstants.DEFAULT_ANIMATION_DURING_LAYOUT = false;
+LayoutConstants.DEFAULT_ANIMATION_PERIOD = 50;
+LayoutConstants.DEFAULT_UNIFORM_LEAF_NODE_SIZES = false;
+
+// -----------------------------------------------------------------------------
+// Section: General other constants
+// -----------------------------------------------------------------------------
+/*
+ * Margins of a graph to be applied on bouding rectangle of its contents. We
+ * assume margins on all four sides to be uniform.
+ */
+LayoutConstants.DEFAULT_GRAPH_MARGIN = 15;
+
+/*
+ * Whether to consider labels in node dimensions or not
+ */
+LayoutConstants.NODE_DIMENSIONS_INCLUDE_LABELS = false;
+
+/*
+ * Default dimension of a non-compound node.
+ */
+LayoutConstants.SIMPLE_NODE_SIZE = 40;
+
+/*
+ * Default dimension of a non-compound node.
+ */
+LayoutConstants.SIMPLE_NODE_HALF_SIZE = LayoutConstants.SIMPLE_NODE_SIZE / 2;
+
+/*
+ * Empty compound node size. When a compound node is empty, its both
+ * dimensions should be of this value.
+ */
+LayoutConstants.EMPTY_COMPOUND_NODE_SIZE = 40;
+
+/*
+ * Minimum length that an edge should take during layout
+ */
+LayoutConstants.MIN_EDGE_LENGTH = 1;
+
+/*
+ * World boundaries that layout operates on
+ */
+LayoutConstants.WORLD_BOUNDARY = 1000000;
+
+/*
+ * World boundaries that random positioning can be performed with
+ */
+LayoutConstants.INITIAL_WORLD_BOUNDARY = LayoutConstants.WORLD_BOUNDARY / 1000;
+
+/*
+ * Coordinates of the world center
+ */
+LayoutConstants.WORLD_CENTER_X = 1200;
+LayoutConstants.WORLD_CENTER_Y = 900;
+
+module.exports = LayoutConstants;
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var LGraphObject = __webpack_require__(2);
+var IGeometry = __webpack_require__(8);
+var IMath = __webpack_require__(9);
+
+function LEdge(source, target, vEdge) {
+  LGraphObject.call(this, vEdge);
+
+  this.isOverlapingSourceAndTarget = false;
+  this.vGraphObject = vEdge;
+  this.bendpoints = [];
+  this.source = source;
+  this.target = target;
+}
+
+LEdge.prototype = Object.create(LGraphObject.prototype);
+
+for (var prop in LGraphObject) {
+  LEdge[prop] = LGraphObject[prop];
+}
+
+LEdge.prototype.getSource = function () {
+  return this.source;
+};
+
+LEdge.prototype.getTarget = function () {
+  return this.target;
+};
+
+LEdge.prototype.isInterGraph = function () {
+  return this.isInterGraph;
+};
+
+LEdge.prototype.getLength = function () {
+  return this.length;
+};
+
+LEdge.prototype.isOverlapingSourceAndTarget = function () {
+  return this.isOverlapingSourceAndTarget;
+};
+
+LEdge.prototype.getBendpoints = function () {
+  return this.bendpoints;
+};
+
+LEdge.prototype.getLca = function () {
+  return this.lca;
+};
+
+LEdge.prototype.getSourceInLca = function () {
+  return this.sourceInLca;
+};
+
+LEdge.prototype.getTargetInLca = function () {
+  return this.targetInLca;
+};
+
+LEdge.prototype.getOtherEnd = function (node) {
+  if (this.source === node) {
+    return this.target;
+  } else if (this.target === node) {
+    return this.source;
+  } else {
+    throw "Node is not incident with this edge";
+  }
+};
+
+LEdge.prototype.getOtherEndInGraph = function (node, graph) {
+  var otherEnd = this.getOtherEnd(node);
+  var root = graph.getGraphManager().getRoot();
+
+  while (true) {
+    if (otherEnd.getOwner() == graph) {
+      return otherEnd;
+    }
+
+    if (otherEnd.getOwner() == root) {
+      break;
+    }
+
+    otherEnd = otherEnd.getOwner().getParent();
+  }
+
+  return null;
+};
+
+LEdge.prototype.updateLength = function () {
+  var clipPointCoordinates = new Array(4);
+
+  this.isOverlapingSourceAndTarget = IGeometry.getIntersection(this.target.getRect(), this.source.getRect(), clipPointCoordinates);
+
+  if (!this.isOverlapingSourceAndTarget) {
+    this.lengthX = clipPointCoordinates[0] - clipPointCoordinates[2];
+    this.lengthY = clipPointCoordinates[1] - clipPointCoordinates[3];
+
+    if (Math.abs(this.lengthX) < 1.0) {
+      this.lengthX = IMath.sign(this.lengthX);
+    }
+
+    if (Math.abs(this.lengthY) < 1.0) {
+      this.lengthY = IMath.sign(this.lengthY);
+    }
+
+    this.length = Math.sqrt(this.lengthX * this.lengthX + this.lengthY * this.lengthY);
+  }
+};
+
+LEdge.prototype.updateLengthSimple = function () {
+  this.lengthX = this.target.getCenterX() - this.source.getCenterX();
+  this.lengthY = this.target.getCenterY() - this.source.getCenterY();
+
+  if (Math.abs(this.lengthX) < 1.0) {
+    this.lengthX = IMath.sign(this.lengthX);
+  }
+
+  if (Math.abs(this.lengthY) < 1.0) {
+    this.lengthY = IMath.sign(this.lengthY);
+  }
+
+  this.length = Math.sqrt(this.lengthX * this.lengthX + this.lengthY * this.lengthY);
+};
+
+module.exports = LEdge;
+
+/***/ }),
+/* 2 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+function LGraphObject(vGraphObject) {
+  this.vGraphObject = vGraphObject;
+}
+
+module.exports = LGraphObject;
+
+/***/ }),
+/* 3 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var LGraphObject = __webpack_require__(2);
+var Integer = __webpack_require__(10);
+var RectangleD = __webpack_require__(13);
+var LayoutConstants = __webpack_require__(0);
+var RandomSeed = __webpack_require__(16);
+var PointD = __webpack_require__(5);
+
+function LNode(gm, loc, size, vNode) {
+  //Alternative constructor 1 : LNode(LGraphManager gm, Point loc, Dimension size, Object vNode)
+  if (size == null && vNode == null) {
+    vNode = loc;
+  }
+
+  LGraphObject.call(this, vNode);
+
+  //Alternative constructor 2 : LNode(Layout layout, Object vNode)
+  if (gm.graphManager != null) gm = gm.graphManager;
+
+  this.estimatedSize = Integer.MIN_VALUE;
+  this.inclusionTreeDepth = Integer.MAX_VALUE;
+  this.vGraphObject = vNode;
+  this.edges = [];
+  this.graphManager = gm;
+
+  if (size != null && loc != null) this.rect = new RectangleD(loc.x, loc.y, size.width, size.height);else this.rect = new RectangleD();
+}
+
+LNode.prototype = Object.create(LGraphObject.prototype);
+for (var prop in LGraphObject) {
+  LNode[prop] = LGraphObject[prop];
+}
+
+LNode.prototype.getEdges = function () {
+  return this.edges;
+};
+
+LNode.prototype.getChild = function () {
+  return this.child;
+};
+
+LNode.prototype.getOwner = function () {
+  //  if (this.owner != null) {
+  //    if (!(this.owner == null || this.owner.getNodes().indexOf(this) > -1)) {
+  //      throw "assert failed";
+  //    }
+  //  }
+
+  return this.owner;
+};
+
+LNode.prototype.getWidth = function () {
+  return this.rect.width;
+};
+
+LNode.prototype.setWidth = function (width) {
+  this.rect.width = width;
+};
+
+LNode.prototype.getHeight = function () {
+  return this.rect.height;
+};
+
+LNode.prototype.setHeight = function (height) {
+  this.rect.height = height;
+};
+
+LNode.prototype.getCenterX = function () {
+  return this.rect.x + this.rect.width / 2;
+};
+
+LNode.prototype.getCenterY = function () {
+  return this.rect.y + this.rect.height / 2;
+};
+
+LNode.prototype.getCenter = function () {
+  return new PointD(this.rect.x + this.rect.width / 2, this.rect.y + this.rect.height / 2);
+};
+
+LNode.prototype.getLocation = function () {
+  return new PointD(this.rect.x, this.rect.y);
+};
+
+LNode.prototype.getRect = function () {
+  return this.rect;
+};
+
+LNode.prototype.getDiagonal = function () {
+  return Math.sqrt(this.rect.width * this.rect.width + this.rect.height * this.rect.height);
+};
+
+/**
+ * This method returns half the diagonal length of this node.
+ */
+LNode.prototype.getHalfTheDiagonal = function () {
+  return Math.sqrt(this.rect.height * this.rect.height + this.rect.width * this.rect.width) / 2;
+};
+
+LNode.prototype.setRect = function (upperLeft, dimension) {
+  this.rect.x = upperLeft.x;
+  this.rect.y = upperLeft.y;
+  this.rect.width = dimension.width;
+  this.rect.height = dimension.height;
+};
+
+LNode.prototype.setCenter = function (cx, cy) {
+  this.rect.x = cx - this.rect.width / 2;
+  this.rect.y = cy - this.rect.height / 2;
+};
+
+LNode.prototype.setLocation = function (x, y) {
+  this.rect.x = x;
+  this.rect.y = y;
+};
+
+LNode.prototype.moveBy = function (dx, dy) {
+  this.rect.x += dx;
+  this.rect.y += dy;
+};
+
+LNode.prototype.getEdgeListToNode = function (to) {
+  var edgeList = [];
+  var edge;
+  var self = this;
+
+  self.edges.forEach(function (edge) {
+
+    if (edge.target == to) {
+      if (edge.source != self) throw "Incorrect edge source!";
+
+      edgeList.push(edge);
+    }
+  });
+
+  return edgeList;
+};
+
+LNode.prototype.getEdgesBetween = function (other) {
+  var edgeList = [];
+  var edge;
+
+  var self = this;
+  self.edges.forEach(function (edge) {
+
+    if (!(edge.source == self || edge.target == self)) throw "Incorrect edge source and/or target";
+
+    if (edge.target == other || edge.source == other) {
+      edgeList.push(edge);
+    }
+  });
+
+  return edgeList;
+};
+
+LNode.prototype.getNeighborsList = function () {
+  var neighbors = new Set();
+
+  var self = this;
+  self.edges.forEach(function (edge) {
+
+    if (edge.source == self) {
+      neighbors.add(edge.target);
+    } else {
+      if (edge.target != self) {
+        throw "Incorrect incidency!";
+      }
+
+      neighbors.add(edge.source);
+    }
+  });
+
+  return neighbors;
+};
+
+LNode.prototype.withChildren = function () {
+  var withNeighborsList = new Set();
+  var childNode;
+  var children;
+
+  withNeighborsList.add(this);
+
+  if (this.child != null) {
+    var nodes = this.child.getNodes();
+    for (var i = 0; i < nodes.length; i++) {
+      childNode = nodes[i];
+      children = childNode.withChildren();
+      children.forEach(function (node) {
+        withNeighborsList.add(node);
+      });
+    }
+  }
+
+  return withNeighborsList;
+};
+
+LNode.prototype.getNoOfChildren = function () {
+  var noOfChildren = 0;
+  var childNode;
+
+  if (this.child == null) {
+    noOfChildren = 1;
+  } else {
+    var nodes = this.child.getNodes();
+    for (var i = 0; i < nodes.length; i++) {
+      childNode = nodes[i];
+
+      noOfChildren += childNode.getNoOfChildren();
+    }
+  }
+
+  if (noOfChildren == 0) {
+    noOfChildren = 1;
+  }
+  return noOfChildren;
+};
+
+LNode.prototype.getEstimatedSize = function () {
+  if (this.estimatedSize == Integer.MIN_VALUE) {
+    throw "assert failed";
+  }
+  return this.estimatedSize;
+};
+
+LNode.prototype.calcEstimatedSize = function () {
+  if (this.child == null) {
+    return this.estimatedSize = (this.rect.width + this.rect.height) / 2;
+  } else {
+    this.estimatedSize = this.child.calcEstimatedSize();
+    this.rect.width = this.estimatedSize;
+    this.rect.height = this.estimatedSize;
+
+    return this.estimatedSize;
+  }
+};
+
+LNode.prototype.scatter = function () {
+  var randomCenterX;
+  var randomCenterY;
+
+  var minX = -LayoutConstants.INITIAL_WORLD_BOUNDARY;
+  var maxX = LayoutConstants.INITIAL_WORLD_BOUNDARY;
+  randomCenterX = LayoutConstants.WORLD_CENTER_X + RandomSeed.nextDouble() * (maxX - minX) + minX;
+
+  var minY = -LayoutConstants.INITIAL_WORLD_BOUNDARY;
+  var maxY = LayoutConstants.INITIAL_WORLD_BOUNDARY;
+  randomCenterY = LayoutConstants.WORLD_CENTER_Y + RandomSeed.nextDouble() * (maxY - minY) + minY;
+
+  this.rect.x = randomCenterX;
+  this.rect.y = randomCenterY;
+};
+
+LNode.prototype.updateBounds = function () {
+  if (this.getChild() == null) {
+    throw "assert failed";
+  }
+  if (this.getChild().getNodes().length != 0) {
+    // wrap the children nodes by re-arranging the boundaries
+    var childGraph = this.getChild();
+    childGraph.updateBounds(true);
+
+    this.rect.x = childGraph.getLeft();
+    this.rect.y = childGraph.getTop();
+
+    this.setWidth(childGraph.getRight() - childGraph.getLeft());
+    this.setHeight(childGraph.getBottom() - childGraph.getTop());
+
+    // Update compound bounds considering its label properties    
+    if (LayoutConstants.NODE_DIMENSIONS_INCLUDE_LABELS) {
+
+      var width = childGraph.getRight() - childGraph.getLeft();
+      var height = childGraph.getBottom() - childGraph.getTop();
+
+      if (this.labelWidth) {
+        if (this.labelPosHorizontal == "left") {
+          this.rect.x -= this.labelWidth;
+          this.setWidth(width + this.labelWidth);
+        } else if (this.labelPosHorizontal == "center" && this.labelWidth > width) {
+          this.rect.x -= (this.labelWidth - width) / 2;
+          this.setWidth(this.labelWidth);
+        } else if (this.labelPosHorizontal == "right") {
+          this.setWidth(width + this.labelWidth);
+        }
+      }
+
+      if (this.labelHeight) {
+        if (this.labelPosVertical == "top") {
+          this.rect.y -= this.labelHeight;
+          this.setHeight(height + this.labelHeight);
+        } else if (this.labelPosVertical == "center" && this.labelHeight > height) {
+          this.rect.y -= (this.labelHeight - height) / 2;
+          this.setHeight(this.labelHeight);
+        } else if (this.labelPosVertical == "bottom") {
+          this.setHeight(height + this.labelHeight);
+        }
+      }
+    }
+  }
+};
+
+LNode.prototype.getInclusionTreeDepth = function () {
+  if (this.inclusionTreeDepth == Integer.MAX_VALUE) {
+    throw "assert failed";
+  }
+  return this.inclusionTreeDepth;
+};
+
+LNode.prototype.transform = function (trans) {
+  var left = this.rect.x;
+
+  if (left > LayoutConstants.WORLD_BOUNDARY) {
+    left = LayoutConstants.WORLD_BOUNDARY;
+  } else if (left < -LayoutConstants.WORLD_BOUNDARY) {
+    left = -LayoutConstants.WORLD_BOUNDARY;
+  }
+
+  var top = this.rect.y;
+
+  if (top > LayoutConstants.WORLD_BOUNDARY) {
+    top = LayoutConstants.WORLD_BOUNDARY;
+  } else if (top < -LayoutConstants.WORLD_BOUNDARY) {
+    top = -LayoutConstants.WORLD_BOUNDARY;
+  }
+
+  var leftTop = new PointD(left, top);
+  var vLeftTop = trans.inverseTransformPoint(leftTop);
+
+  this.setLocation(vLeftTop.x, vLeftTop.y);
+};
+
+LNode.prototype.getLeft = function () {
+  return this.rect.x;
+};
+
+LNode.prototype.getRight = function () {
+  return this.rect.x + this.rect.width;
+};
+
+LNode.prototype.getTop = function () {
+  return this.rect.y;
+};
+
+LNode.prototype.getBottom = function () {
+  return this.rect.y + this.rect.height;
+};
+
+LNode.prototype.getParent = function () {
+  if (this.owner == null) {
+    return null;
+  }
+
+  return this.owner.getParent();
+};
+
+module.exports = LNode;
+
+/***/ }),
+/* 4 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var LayoutConstants = __webpack_require__(0);
+
+function FDLayoutConstants() {}
+
+//FDLayoutConstants inherits static props in LayoutConstants
+for (var prop in LayoutConstants) {
+  FDLayoutConstants[prop] = LayoutConstants[prop];
+}
+
+FDLayoutConstants.MAX_ITERATIONS = 2500;
+
+FDLayoutConstants.DEFAULT_EDGE_LENGTH = 50;
+FDLayoutConstants.DEFAULT_SPRING_STRENGTH = 0.45;
+FDLayoutConstants.DEFAULT_REPULSION_STRENGTH = 4500.0;
+FDLayoutConstants.DEFAULT_GRAVITY_STRENGTH = 0.4;
+FDLayoutConstants.DEFAULT_COMPOUND_GRAVITY_STRENGTH = 1.0;
+FDLayoutConstants.DEFAULT_GRAVITY_RANGE_FACTOR = 3.8;
+FDLayoutConstants.DEFAULT_COMPOUND_GRAVITY_RANGE_FACTOR = 1.5;
+FDLayoutConstants.DEFAULT_USE_SMART_IDEAL_EDGE_LENGTH_CALCULATION = true;
+FDLayoutConstants.DEFAULT_USE_SMART_REPULSION_RANGE_CALCULATION = true;
+FDLayoutConstants.DEFAULT_COOLING_FACTOR_INCREMENTAL = 0.3;
+FDLayoutConstants.COOLING_ADAPTATION_FACTOR = 0.33;
+FDLayoutConstants.ADAPTATION_LOWER_NODE_LIMIT = 1000;
+FDLayoutConstants.ADAPTATION_UPPER_NODE_LIMIT = 5000;
+FDLayoutConstants.MAX_NODE_DISPLACEMENT_INCREMENTAL = 100.0;
+FDLayoutConstants.MAX_NODE_DISPLACEMENT = FDLayoutConstants.MAX_NODE_DISPLACEMENT_INCREMENTAL * 3;
+FDLayoutConstants.MIN_REPULSION_DIST = FDLayoutConstants.DEFAULT_EDGE_LENGTH / 10.0;
+FDLayoutConstants.CONVERGENCE_CHECK_PERIOD = 100;
+FDLayoutConstants.PER_LEVEL_IDEAL_EDGE_LENGTH_FACTOR = 0.1;
+FDLayoutConstants.MIN_EDGE_LENGTH = 1;
+FDLayoutConstants.GRID_CALCULATION_CHECK_PERIOD = 10;
+
+module.exports = FDLayoutConstants;
+
+/***/ }),
+/* 5 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+function PointD(x, y) {
+  if (x == null && y == null) {
+    this.x = 0;
+    this.y = 0;
+  } else {
+    this.x = x;
+    this.y = y;
+  }
+}
+
+PointD.prototype.getX = function () {
+  return this.x;
+};
+
+PointD.prototype.getY = function () {
+  return this.y;
+};
+
+PointD.prototype.setX = function (x) {
+  this.x = x;
+};
+
+PointD.prototype.setY = function (y) {
+  this.y = y;
+};
+
+PointD.prototype.getDifference = function (pt) {
+  return new DimensionD(this.x - pt.x, this.y - pt.y);
+};
+
+PointD.prototype.getCopy = function () {
+  return new PointD(this.x, this.y);
+};
+
+PointD.prototype.translate = function (dim) {
+  this.x += dim.width;
+  this.y += dim.height;
+  return this;
+};
+
+module.exports = PointD;
+
+/***/ }),
+/* 6 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var LGraphObject = __webpack_require__(2);
+var Integer = __webpack_require__(10);
+var LayoutConstants = __webpack_require__(0);
+var LGraphManager = __webpack_require__(7);
+var LNode = __webpack_require__(3);
+var LEdge = __webpack_require__(1);
+var RectangleD = __webpack_require__(13);
+var Point = __webpack_require__(12);
+var LinkedList = __webpack_require__(11);
+
+function LGraph(parent, obj2, vGraph) {
+  LGraphObject.call(this, vGraph);
+  this.estimatedSize = Integer.MIN_VALUE;
+  this.margin = LayoutConstants.DEFAULT_GRAPH_MARGIN;
+  this.edges = [];
+  this.nodes = [];
+  this.isConnected = false;
+  this.parent = parent;
+
+  if (obj2 != null && obj2 instanceof LGraphManager) {
+    this.graphManager = obj2;
+  } else if (obj2 != null && obj2 instanceof Layout) {
+    this.graphManager = obj2.graphManager;
+  }
+}
+
+LGraph.prototype = Object.create(LGraphObject.prototype);
+for (var prop in LGraphObject) {
+  LGraph[prop] = LGraphObject[prop];
+}
+
+LGraph.prototype.getNodes = function () {
+  return this.nodes;
+};
+
+LGraph.prototype.getEdges = function () {
+  return this.edges;
+};
+
+LGraph.prototype.getGraphManager = function () {
+  return this.graphManager;
+};
+
+LGraph.prototype.getParent = function () {
+  return this.parent;
+};
+
+LGraph.prototype.getLeft = function () {
+  return this.left;
+};
+
+LGraph.prototype.getRight = function () {
+  return this.right;
+};
+
+LGraph.prototype.getTop = function () {
+  return this.top;
+};
+
+LGraph.prototype.getBottom = function () {
+  return this.bottom;
+};
+
+LGraph.prototype.isConnected = function () {
+  return this.isConnected;
+};
+
+LGraph.prototype.add = function (obj1, sourceNode, targetNode) {
+  if (sourceNode == null && targetNode == null) {
+    var newNode = obj1;
+    if (this.graphManager == null) {
+      throw "Graph has no graph mgr!";
+    }
+    if (this.getNodes().indexOf(newNode) > -1) {
+      throw "Node already in graph!";
+    }
+    newNode.owner = this;
+    this.getNodes().push(newNode);
+
+    return newNode;
+  } else {
+    var newEdge = obj1;
+    if (!(this.getNodes().indexOf(sourceNode) > -1 && this.getNodes().indexOf(targetNode) > -1)) {
+      throw "Source or target not in graph!";
+    }
+
+    if (!(sourceNode.owner == targetNode.owner && sourceNode.owner == this)) {
+      throw "Both owners must be this graph!";
+    }
+
+    if (sourceNode.owner != targetNode.owner) {
+      return null;
+    }
+
+    // set source and target
+    newEdge.source = sourceNode;
+    newEdge.target = targetNode;
+
+    // set as intra-graph edge
+    newEdge.isInterGraph = false;
+
+    // add to graph edge list
+    this.getEdges().push(newEdge);
+
+    // add to incidency lists
+    sourceNode.edges.push(newEdge);
+
+    if (targetNode != sourceNode) {
+      targetNode.edges.push(newEdge);
+    }
+
+    return newEdge;
+  }
+};
+
+LGraph.prototype.remove = function (obj) {
+  var node = obj;
+  if (obj instanceof LNode) {
+    if (node == null) {
+      throw "Node is null!";
+    }
+    if (!(node.owner != null && node.owner == this)) {
+      throw "Owner graph is invalid!";
+    }
+    if (this.graphManager == null) {
+      throw "Owner graph manager is invalid!";
+    }
+    // remove incident edges first (make a copy to do it safely)
+    var edgesToBeRemoved = node.edges.slice();
+    var edge;
+    var s = edgesToBeRemoved.length;
+    for (var i = 0; i < s; i++) {
+      edge = edgesToBeRemoved[i];
+
+      if (edge.isInterGraph) {
+        this.graphManager.remove(edge);
+      } else {
+        edge.source.owner.remove(edge);
+      }
+    }
+
+    // now the node itself
+    var index = this.nodes.indexOf(node);
+    if (index == -1) {
+      throw "Node not in owner node list!";
+    }
+
+    this.nodes.splice(index, 1);
+  } else if (obj instanceof LEdge) {
+    var edge = obj;
+    if (edge == null) {
+      throw "Edge is null!";
+    }
+    if (!(edge.source != null && edge.target != null)) {
+      throw "Source and/or target is null!";
+    }
+    if (!(edge.source.owner != null && edge.target.owner != null && edge.source.owner == this && edge.target.owner == this)) {
+      throw "Source and/or target owner is invalid!";
+    }
+
+    var sourceIndex = edge.source.edges.indexOf(edge);
+    var targetIndex = edge.target.edges.indexOf(edge);
+    if (!(sourceIndex > -1 && targetIndex > -1)) {
+      throw "Source and/or target doesn't know this edge!";
+    }
+
+    edge.source.edges.splice(sourceIndex, 1);
+
+    if (edge.target != edge.source) {
+      edge.target.edges.splice(targetIndex, 1);
+    }
+
+    var index = edge.source.owner.getEdges().indexOf(edge);
+    if (index == -1) {
+      throw "Not in owner's edge list!";
+    }
+
+    edge.source.owner.getEdges().splice(index, 1);
+  }
+};
+
+LGraph.prototype.updateLeftTop = function () {
+  var top = Integer.MAX_VALUE;
+  var left = Integer.MAX_VALUE;
+  var nodeTop;
+  var nodeLeft;
+  var margin;
+
+  var nodes = this.getNodes();
+  var s = nodes.length;
+
+  for (var i = 0; i < s; i++) {
+    var lNode = nodes[i];
+    nodeTop = lNode.getTop();
+    nodeLeft = lNode.getLeft();
+
+    if (top > nodeTop) {
+      top = nodeTop;
+    }
+
+    if (left > nodeLeft) {
+      left = nodeLeft;
+    }
+  }
+
+  // Do we have any nodes in this graph?
+  if (top == Integer.MAX_VALUE) {
+    return null;
+  }
+
+  if (nodes[0].getParent().paddingLeft != undefined) {
+    margin = nodes[0].getParent().paddingLeft;
+  } else {
+    margin = this.margin;
+  }
+
+  this.left = left - margin;
+  this.top = top - margin;
+
+  // Apply the margins and return the result
+  return new Point(this.left, this.top);
+};
+
+LGraph.prototype.updateBounds = function (recursive) {
+  // calculate bounds
+  var left = Integer.MAX_VALUE;
+  var right = -Integer.MAX_VALUE;
+  var top = Integer.MAX_VALUE;
+  var bottom = -Integer.MAX_VALUE;
+  var nodeLeft;
+  var nodeRight;
+  var nodeTop;
+  var nodeBottom;
+  var margin;
+
+  var nodes = this.nodes;
+  var s = nodes.length;
+  for (var i = 0; i < s; i++) {
+    var lNode = nodes[i];
+
+    if (recursive && lNode.child != null) {
+      lNode.updateBounds();
+    }
+    nodeLeft = lNode.getLeft();
+    nodeRight = lNode.getRight();
+    nodeTop = lNode.getTop();
+    nodeBottom = lNode.getBottom();
+
+    if (left > nodeLeft) {
+      left = nodeLeft;
+    }
+
+    if (right < nodeRight) {
+      right = nodeRight;
+    }
+
+    if (top > nodeTop) {
+      top = nodeTop;
+    }
+
+    if (bottom < nodeBottom) {
+      bottom = nodeBottom;
+    }
+  }
+
+  var boundingRect = new RectangleD(left, top, right - left, bottom - top);
+  if (left == Integer.MAX_VALUE) {
+    this.left = this.parent.getLeft();
+    this.right = this.parent.getRight();
+    this.top = this.parent.getTop();
+    this.bottom = this.parent.getBottom();
+  }
+
+  if (nodes[0].getParent().paddingLeft != undefined) {
+    margin = nodes[0].getParent().paddingLeft;
+  } else {
+    margin = this.margin;
+  }
+
+  this.left = boundingRect.x - margin;
+  this.right = boundingRect.x + boundingRect.width + margin;
+  this.top = boundingRect.y - margin;
+  this.bottom = boundingRect.y + boundingRect.height + margin;
+};
+
+LGraph.calculateBounds = function (nodes) {
+  var left = Integer.MAX_VALUE;
+  var right = -Integer.MAX_VALUE;
+  var top = Integer.MAX_VALUE;
+  var bottom = -Integer.MAX_VALUE;
+  var nodeLeft;
+  var nodeRight;
+  var nodeTop;
+  var nodeBottom;
+
+  var s = nodes.length;
+
+  for (var i = 0; i < s; i++) {
+    var lNode = nodes[i];
+    nodeLeft = lNode.getLeft();
+    nodeRight = lNode.getRight();
+    nodeTop = lNode.getTop();
+    nodeBottom = lNode.getBottom();
+
+    if (left > nodeLeft) {
+      left = nodeLeft;
+    }
+
+    if (right < nodeRight) {
+      right = nodeRight;
+    }
+
+    if (top > nodeTop) {
+      top = nodeTop;
+    }
+
+    if (bottom < nodeBottom) {
+      bottom = nodeBottom;
+    }
+  }
+
+  var boundingRect = new RectangleD(left, top, right - left, bottom - top);
+
+  return boundingRect;
+};
+
+LGraph.prototype.getInclusionTreeDepth = function () {
+  if (this == this.graphManager.getRoot()) {
+    return 1;
+  } else {
+    return this.parent.getInclusionTreeDepth();
+  }
+};
+
+LGraph.prototype.getEstimatedSize = function () {
+  if (this.estimatedSize == Integer.MIN_VALUE) {
+    throw "assert failed";
+  }
+  return this.estimatedSize;
+};
+
+LGraph.prototype.calcEstimatedSize = function () {
+  var size = 0;
+  var nodes = this.nodes;
+  var s = nodes.length;
+
+  for (var i = 0; i < s; i++) {
+    var lNode = nodes[i];
+    size += lNode.calcEstimatedSize();
+  }
+
+  if (size == 0) {
+    this.estimatedSize = LayoutConstants.EMPTY_COMPOUND_NODE_SIZE;
+  } else {
+    this.estimatedSize = size / Math.sqrt(this.nodes.length);
+  }
+
+  return this.estimatedSize;
+};
+
+LGraph.prototype.updateConnected = function () {
+  var self = this;
+  if (this.nodes.length == 0) {
+    this.isConnected = true;
+    return;
+  }
+
+  var queue = new LinkedList();
+  var visited = new Set();
+  var currentNode = this.nodes[0];
+  var neighborEdges;
+  var currentNeighbor;
+  var childrenOfNode = currentNode.withChildren();
+  childrenOfNode.forEach(function (node) {
+    queue.push(node);
+    visited.add(node);
+  });
+
+  while (queue.length !== 0) {
+    currentNode = queue.shift();
+
+    // Traverse all neighbors of this node
+    neighborEdges = currentNode.getEdges();
+    var size = neighborEdges.length;
+    for (var i = 0; i < size; i++) {
+      var neighborEdge = neighborEdges[i];
+      currentNeighbor = neighborEdge.getOtherEndInGraph(currentNode, this);
+
+      // Add unvisited neighbors to the list to visit
+      if (currentNeighbor != null && !visited.has(currentNeighbor)) {
+        var childrenOfNeighbor = currentNeighbor.withChildren();
+
+        childrenOfNeighbor.forEach(function (node) {
+          queue.push(node);
+          visited.add(node);
+        });
+      }
+    }
+  }
+
+  this.isConnected = false;
+
+  if (visited.size >= this.nodes.length) {
+    var noOfVisitedInThisGraph = 0;
+
+    visited.forEach(function (visitedNode) {
+      if (visitedNode.owner == self) {
+        noOfVisitedInThisGraph++;
+      }
+    });
+
+    if (noOfVisitedInThisGraph == this.nodes.length) {
+      this.isConnected = true;
+    }
+  }
+};
+
+module.exports = LGraph;
+
+/***/ }),
+/* 7 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var LGraph;
+var LEdge = __webpack_require__(1);
+
+function LGraphManager(layout) {
+  LGraph = __webpack_require__(6); // It may be better to initilize this out of this function but it gives an error (Right-hand side of 'instanceof' is not callable) now.
+  this.layout = layout;
+
+  this.graphs = [];
+  this.edges = [];
+}
+
+LGraphManager.prototype.addRoot = function () {
+  var ngraph = this.layout.newGraph();
+  var nnode = this.layout.newNode(null);
+  var root = this.add(ngraph, nnode);
+  this.setRootGraph(root);
+  return this.rootGraph;
+};
+
+LGraphManager.prototype.add = function (newGraph, parentNode, newEdge, sourceNode, targetNode) {
+  //there are just 2 parameters are passed then it adds an LGraph else it adds an LEdge
+  if (newEdge == null && sourceNode == null && targetNode == null) {
+    if (newGraph == null) {
+      throw "Graph is null!";
+    }
+    if (parentNode == null) {
+      throw "Parent node is null!";
+    }
+    if (this.graphs.indexOf(newGraph) > -1) {
+      throw "Graph already in this graph mgr!";
+    }
+
+    this.graphs.push(newGraph);
+
+    if (newGraph.parent != null) {
+      throw "Already has a parent!";
+    }
+    if (parentNode.child != null) {
+      throw "Already has a child!";
+    }
+
+    newGraph.parent = parentNode;
+    parentNode.child = newGraph;
+
+    return newGraph;
+  } else {
+    //change the order of the parameters
+    targetNode = newEdge;
+    sourceNode = parentNode;
+    newEdge = newGraph;
+    var sourceGraph = sourceNode.getOwner();
+    var targetGraph = targetNode.getOwner();
+
+    if (!(sourceGraph != null && sourceGraph.getGraphManager() == this)) {
+      throw "Source not in this graph mgr!";
+    }
+    if (!(targetGraph != null && targetGraph.getGraphManager() == this)) {
+      throw "Target not in this graph mgr!";
+    }
+
+    if (sourceGraph == targetGraph) {
+      newEdge.isInterGraph = false;
+      return sourceGraph.add(newEdge, sourceNode, targetNode);
+    } else {
+      newEdge.isInterGraph = true;
+
+      // set source and target
+      newEdge.source = sourceNode;
+      newEdge.target = targetNode;
+
+      // add edge to inter-graph edge list
+      if (this.edges.indexOf(newEdge) > -1) {
+        throw "Edge already in inter-graph edge list!";
+      }
+
+      this.edges.push(newEdge);
+
+      // add edge to source and target incidency lists
+      if (!(newEdge.source != null && newEdge.target != null)) {
+        throw "Edge source and/or target is null!";
+      }
+
+      if (!(newEdge.source.edges.indexOf(newEdge) == -1 && newEdge.target.edges.indexOf(newEdge) == -1)) {
+        throw "Edge already in source and/or target incidency list!";
+      }
+
+      newEdge.source.edges.push(newEdge);
+      newEdge.target.edges.push(newEdge);
+
+      return newEdge;
+    }
+  }
+};
+
+LGraphManager.prototype.remove = function (lObj) {
+  if (lObj instanceof LGraph) {
+    var graph = lObj;
+    if (graph.getGraphManager() != this) {
+      throw "Graph not in this graph mgr";
+    }
+    if (!(graph == this.rootGraph || graph.parent != null && graph.parent.graphManager == this)) {
+      throw "Invalid parent node!";
+    }
+
+    // first the edges (make a copy to do it safely)
+    var edgesToBeRemoved = [];
+
+    edgesToBeRemoved = edgesToBeRemoved.concat(graph.getEdges());
+
+    var edge;
+    var s = edgesToBeRemoved.length;
+    for (var i = 0; i < s; i++) {
+      edge = edgesToBeRemoved[i];
+      graph.remove(edge);
+    }
+
+    // then the nodes (make a copy to do it safely)
+    var nodesToBeRemoved = [];
+
+    nodesToBeRemoved = nodesToBeRemoved.concat(graph.getNodes());
+
+    var node;
+    s = nodesToBeRemoved.length;
+    for (var i = 0; i < s; i++) {
+      node = nodesToBeRemoved[i];
+      graph.remove(node);
+    }
+
+    // check if graph is the root
+    if (graph == this.rootGraph) {
+      this.setRootGraph(null);
+    }
+
+    // now remove the graph itself
+    var index = this.graphs.indexOf(graph);
+    this.graphs.splice(index, 1);
+
+    // also reset the parent of the graph
+    graph.parent = null;
+  } else if (lObj instanceof LEdge) {
+    edge = lObj;
+    if (edge == null) {
+      throw "Edge is null!";
+    }
+    if (!edge.isInterGraph) {
+      throw "Not an inter-graph edge!";
+    }
+    if (!(edge.source != null && edge.target != null)) {
+      throw "Source and/or target is null!";
+    }
+
+    // remove edge from source and target nodes' incidency lists
+
+    if (!(edge.source.edges.indexOf(edge) != -1 && edge.target.edges.indexOf(edge) != -1)) {
+      throw "Source and/or target doesn't know this edge!";
+    }
+
+    var index = edge.source.edges.indexOf(edge);
+    edge.source.edges.splice(index, 1);
+    index = edge.target.edges.indexOf(edge);
+    edge.target.edges.splice(index, 1);
+
+    // remove edge from owner graph manager's inter-graph edge list
+
+    if (!(edge.source.owner != null && edge.source.owner.getGraphManager() != null)) {
+      throw "Edge owner graph or owner graph manager is null!";
+    }
+    if (edge.source.owner.getGraphManager().edges.indexOf(edge) == -1) {
+      throw "Not in owner graph manager's edge list!";
+    }
+
+    var index = edge.source.owner.getGraphManager().edges.indexOf(edge);
+    edge.source.owner.getGraphManager().edges.splice(index, 1);
+  }
+};
+
+LGraphManager.prototype.updateBounds = function () {
+  this.rootGraph.updateBounds(true);
+};
+
+LGraphManager.prototype.getGraphs = function () {
+  return this.graphs;
+};
+
+LGraphManager.prototype.getAllNodes = function () {
+  if (this.allNodes == null) {
+    var nodeList = [];
+    var graphs = this.getGraphs();
+    var s = graphs.length;
+    for (var i = 0; i < s; i++) {
+      nodeList = nodeList.concat(graphs[i].getNodes());
+    }
+    this.allNodes = nodeList;
+  }
+  return this.allNodes;
+};
+
+LGraphManager.prototype.resetAllNodes = function () {
+  this.allNodes = null;
+};
+
+LGraphManager.prototype.resetAllEdges = function () {
+  this.allEdges = null;
+};
+
+LGraphManager.prototype.resetAllNodesToApplyGravitation = function () {
+  this.allNodesToApplyGravitation = null;
+};
+
+LGraphManager.prototype.getAllEdges = function () {
+  if (this.allEdges == null) {
+    var edgeList = [];
+    var graphs = this.getGraphs();
+    var s = graphs.length;
+    for (var i = 0; i < graphs.length; i++) {
+      edgeList = edgeList.concat(graphs[i].getEdges());
+    }
+
+    edgeList = edgeList.concat(this.edges);
+
+    this.allEdges = edgeList;
+  }
+  return this.allEdges;
+};
+
+LGraphManager.prototype.getAllNodesToApplyGravitation = function () {
+  return this.allNodesToApplyGravitation;
+};
+
+LGraphManager.prototype.setAllNodesToApplyGravitation = function (nodeList) {
+  if (this.allNodesToApplyGravitation != null) {
+    throw "assert failed";
+  }
+
+  this.allNodesToApplyGravitation = nodeList;
+};
+
+LGraphManager.prototype.getRoot = function () {
+  return this.rootGraph;
+};
+
+LGraphManager.prototype.setRootGraph = function (graph) {
+  if (graph.getGraphManager() != this) {
+    throw "Root not in this graph mgr!";
+  }
+
+  this.rootGraph = graph;
+  // root graph must have a root node associated with it for convenience
+  if (graph.parent == null) {
+    graph.parent = this.layout.newNode("Root node");
+  }
+};
+
+LGraphManager.prototype.getLayout = function () {
+  return this.layout;
+};
+
+LGraphManager.prototype.isOneAncestorOfOther = function (firstNode, secondNode) {
+  if (!(firstNode != null && secondNode != null)) {
+    throw "assert failed";
+  }
+
+  if (firstNode == secondNode) {
+    return true;
+  }
+  // Is second node an ancestor of the first one?
+  var ownerGraph = firstNode.getOwner();
+  var parentNode;
+
+  do {
+    parentNode = ownerGraph.getParent();
+
+    if (parentNode == null) {
+      break;
+    }
+
+    if (parentNode == secondNode) {
+      return true;
+    }
+
+    ownerGraph = parentNode.getOwner();
+    if (ownerGraph == null) {
+      break;
+    }
+  } while (true);
+  // Is first node an ancestor of the second one?
+  ownerGraph = secondNode.getOwner();
+
+  do {
+    parentNode = ownerGraph.getParent();
+
+    if (parentNode == null) {
+      break;
+    }
+
+    if (parentNode == firstNode) {
+      return true;
+    }
+
+    ownerGraph = parentNode.getOwner();
+    if (ownerGraph == null) {
+      break;
+    }
+  } while (true);
+
+  return false;
+};
+
+LGraphManager.prototype.calcLowestCommonAncestors = function () {
+  var edge;
+  var sourceNode;
+  var targetNode;
+  var sourceAncestorGraph;
+  var targetAncestorGraph;
+
+  var edges = this.getAllEdges();
+  var s = edges.length;
+  for (var i = 0; i < s; i++) {
+    edge = edges[i];
+
+    sourceNode = edge.source;
+    targetNode = edge.target;
+    edge.lca = null;
+    edge.sourceInLca = sourceNode;
+    edge.targetInLca = targetNode;
+
+    if (sourceNode == targetNode) {
+      edge.lca = sourceNode.getOwner();
+      continue;
+    }
+
+    sourceAncestorGraph = sourceNode.getOwner();
+
+    while (edge.lca == null) {
+      edge.targetInLca = targetNode;
+      targetAncestorGraph = targetNode.getOwner();
+
+      while (edge.lca == null) {
+        if (targetAncestorGraph == sourceAncestorGraph) {
+          edge.lca = targetAncestorGraph;
+          break;
+        }
+
+        if (targetAncestorGraph == this.rootGraph) {
+          break;
+        }
+
+        if (edge.lca != null) {
+          throw "assert failed";
+        }
+        edge.targetInLca = targetAncestorGraph.getParent();
+        targetAncestorGraph = edge.targetInLca.getOwner();
+      }
+
+      if (sourceAncestorGraph == this.rootGraph) {
+        break;
+      }
+
+      if (edge.lca == null) {
+        edge.sourceInLca = sourceAncestorGraph.getParent();
+        sourceAncestorGraph = edge.sourceInLca.getOwner();
+      }
+    }
+
+    if (edge.lca == null) {
+      throw "assert failed";
+    }
+  }
+};
+
+LGraphManager.prototype.calcLowestCommonAncestor = function (firstNode, secondNode) {
+  if (firstNode == secondNode) {
+    return firstNode.getOwner();
+  }
+  var firstOwnerGraph = firstNode.getOwner();
+
+  do {
+    if (firstOwnerGraph == null) {
+      break;
+    }
+    var secondOwnerGraph = secondNode.getOwner();
+
+    do {
+      if (secondOwnerGraph == null) {
+        break;
+      }
+
+      if (secondOwnerGraph == firstOwnerGraph) {
+        return secondOwnerGraph;
+      }
+      secondOwnerGraph = secondOwnerGraph.getParent().getOwner();
+    } while (true);
+
+    firstOwnerGraph = firstOwnerGraph.getParent().getOwner();
+  } while (true);
+
+  return firstOwnerGraph;
+};
+
+LGraphManager.prototype.calcInclusionTreeDepths = function (graph, depth) {
+  if (graph == null && depth == null) {
+    graph = this.rootGraph;
+    depth = 1;
+  }
+  var node;
+
+  var nodes = graph.getNodes();
+  var s = nodes.length;
+  for (var i = 0; i < s; i++) {
+    node = nodes[i];
+    node.inclusionTreeDepth = depth;
+
+    if (node.child != null) {
+      this.calcInclusionTreeDepths(node.child, depth + 1);
+    }
+  }
+};
+
+LGraphManager.prototype.includesInvalidEdge = function () {
+  var edge;
+  var edgesToRemove = [];
+
+  var s = this.edges.length;
+  for (var i = 0; i < s; i++) {
+    edge = this.edges[i];
+
+    if (this.isOneAncestorOfOther(edge.source, edge.target)) {
+      edgesToRemove.push(edge);
+    }
+  }
+
+  // Remove invalid edges from graph manager
+  for (var i = 0; i < edgesToRemove.length; i++) {
+    this.remove(edgesToRemove[i]);
+  }
+
+  // Invalid edges are cleared, so return false
+  return false;
+};
+
+module.exports = LGraphManager;
+
+/***/ }),
+/* 8 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+/**
+ * This class maintains a list of static geometry related utility methods.
+ *
+ *
+ * Copyright: i-Vis Research Group, Bilkent University, 2007 - present
+ */
+
+var Point = __webpack_require__(12);
+
+function IGeometry() {}
+
+/**
+ * This method calculates *half* the amount in x and y directions of the two
+ * input rectangles needed to separate them keeping their respective
+ * positioning, and returns the result in the input array. An input
+ * separation buffer added to the amount in both directions. We assume that
+ * the two rectangles do intersect.
+ */
+IGeometry.calcSeparationAmount = function (rectA, rectB, overlapAmount, separationBuffer) {
+  if (!rectA.intersects(rectB)) {
+    throw "assert failed";
+  }
+
+  var directions = new Array(2);
+
+  this.decideDirectionsForOverlappingNodes(rectA, rectB, directions);
+
+  overlapAmount[0] = Math.min(rectA.getRight(), rectB.getRight()) - Math.max(rectA.x, rectB.x);
+  overlapAmount[1] = Math.min(rectA.getBottom(), rectB.getBottom()) - Math.max(rectA.y, rectB.y);
+
+  // update the overlapping amounts for the following cases:
+  if (rectA.getX() <= rectB.getX() && rectA.getRight() >= rectB.getRight()) {
+    /* Case x.1:
+    *
+    * rectA
+    * 	|                       |
+    * 	|        _________      |
+    * 	|        |       |      |
+    * 	|________|_______|______|
+    * 			 |       |
+    *           |       |
+    *        rectB
+    */
+    overlapAmount[0] += Math.min(rectB.getX() - rectA.getX(), rectA.getRight() - rectB.getRight());
+  } else if (rectB.getX() <= rectA.getX() && rectB.getRight() >= rectA.getRight()) {
+    /* Case x.2:
+    *
+    * rectB
+    * 	|                       |
+    * 	|        _________      |
+    * 	|        |       |      |
+    * 	|________|_______|______|
+    * 			 |       |
+    *           |       |
+    *        rectA
+    */
+    overlapAmount[0] += Math.min(rectA.getX() - rectB.getX(), rectB.getRight() - rectA.getRight());
+  }
+  if (rectA.getY() <= rectB.getY() && rectA.getBottom() >= rectB.getBottom()) {
+    /* Case y.1:
+     *          ________ rectA
+     *         |
+     *         |
+     *   ______|____  rectB
+     *         |    |
+     *         |    |
+     *   ______|____|
+     *         |
+     *         |
+     *         |________
+     *
+     */
+    overlapAmount[1] += Math.min(rectB.getY() - rectA.getY(), rectA.getBottom() - rectB.getBottom());
+  } else if (rectB.getY() <= rectA.getY() && rectB.getBottom() >= rectA.getBottom()) {
+    /* Case y.2:
+    *          ________ rectB
+    *         |
+    *         |
+    *   ______|____  rectA
+    *         |    |
+    *         |    |
+    *   ______|____|
+    *         |
+    *         |
+    *         |________
+    *
+    */
+    overlapAmount[1] += Math.min(rectA.getY() - rectB.getY(), rectB.getBottom() - rectA.getBottom());
+  }
+
+  // find slope of the line passes two centers
+  var slope = Math.abs((rectB.getCenterY() - rectA.getCenterY()) / (rectB.getCenterX() - rectA.getCenterX()));
+  // if centers are overlapped
+  if (rectB.getCenterY() === rectA.getCenterY() && rectB.getCenterX() === rectA.getCenterX()) {
+    // assume the slope is 1 (45 degree)
+    slope = 1.0;
+  }
+
+  var moveByY = slope * overlapAmount[0];
+  var moveByX = overlapAmount[1] / slope;
+  if (overlapAmount[0] < moveByX) {
+    moveByX = overlapAmount[0];
+  } else {
+    moveByY = overlapAmount[1];
+  }
+  // return half the amount so that if each rectangle is moved by these
+  // amounts in opposite directions, overlap will be resolved
+  overlapAmount[0] = -1 * directions[0] * (moveByX / 2 + separationBuffer);
+  overlapAmount[1] = -1 * directions[1] * (moveByY / 2 + separationBuffer);
+};
+
+/**
+ * This method decides the separation direction of overlapping nodes
+ *
+ * if directions[0] = -1, then rectA goes left
+ * if directions[0] = 1,  then rectA goes right
+ * if directions[1] = -1, then rectA goes up
+ * if directions[1] = 1,  then rectA goes down
+ */
+IGeometry.decideDirectionsForOverlappingNodes = function (rectA, rectB, directions) {
+  if (rectA.getCenterX() < rectB.getCenterX()) {
+    directions[0] = -1;
+  } else {
+    directions[0] = 1;
+  }
+
+  if (rectA.getCenterY() < rectB.getCenterY()) {
+    directions[1] = -1;
+  } else {
+    directions[1] = 1;
+  }
+};
+
+/**
+ * This method calculates the intersection (clipping) points of the two
+ * input rectangles with line segment defined by the centers of these two
+ * rectangles. The clipping points are saved in the input double array and
+ * whether or not the two rectangles overlap is returned.
+ */
+IGeometry.getIntersection2 = function (rectA, rectB, result) {
+  //result[0-1] will contain clipPoint of rectA, result[2-3] will contain clipPoint of rectB
+  var p1x = rectA.getCenterX();
+  var p1y = rectA.getCenterY();
+  var p2x = rectB.getCenterX();
+  var p2y = rectB.getCenterY();
+
+  //if two rectangles intersect, then clipping points are centers
+  if (rectA.intersects(rectB)) {
+    result[0] = p1x;
+    result[1] = p1y;
+    result[2] = p2x;
+    result[3] = p2y;
+    return true;
+  }
+  //variables for rectA
+  var topLeftAx = rectA.getX();
+  var topLeftAy = rectA.getY();
+  var topRightAx = rectA.getRight();
+  var bottomLeftAx = rectA.getX();
+  var bottomLeftAy = rectA.getBottom();
+  var bottomRightAx = rectA.getRight();
+  var halfWidthA = rectA.getWidthHalf();
+  var halfHeightA = rectA.getHeightHalf();
+  //variables for rectB
+  var topLeftBx = rectB.getX();
+  var topLeftBy = rectB.getY();
+  var topRightBx = rectB.getRight();
+  var bottomLeftBx = rectB.getX();
+  var bottomLeftBy = rectB.getBottom();
+  var bottomRightBx = rectB.getRight();
+  var halfWidthB = rectB.getWidthHalf();
+  var halfHeightB = rectB.getHeightHalf();
+
+  //flag whether clipping points are found
+  var clipPointAFound = false;
+  var clipPointBFound = false;
+
+  // line is vertical
+  if (p1x === p2x) {
+    if (p1y > p2y) {
+      result[0] = p1x;
+      result[1] = topLeftAy;
+      result[2] = p2x;
+      result[3] = bottomLeftBy;
+      return false;
+    } else if (p1y < p2y) {
+      result[0] = p1x;
+      result[1] = bottomLeftAy;
+      result[2] = p2x;
+      result[3] = topLeftBy;
+      return false;
+    } else {
+      //not line, return null;
+    }
+  }
+  // line is horizontal
+  else if (p1y === p2y) {
+      if (p1x > p2x) {
+        result[0] = topLeftAx;
+        result[1] = p1y;
+        result[2] = topRightBx;
+        result[3] = p2y;
+        return false;
+      } else if (p1x < p2x) {
+        result[0] = topRightAx;
+        result[1] = p1y;
+        result[2] = topLeftBx;
+        result[3] = p2y;
+        return false;
+      } else {
+        //not valid line, return null;
+      }
+    } else {
+      //slopes of rectA's and rectB's diagonals
+      var slopeA = rectA.height / rectA.width;
+      var slopeB = rectB.height / rectB.width;
+
+      //slope of line between center of rectA and center of rectB
+      var slopePrime = (p2y - p1y) / (p2x - p1x);
+      var cardinalDirectionA = void 0;
+      var cardinalDirectionB = void 0;
+      var tempPointAx = void 0;
+      var tempPointAy = void 0;
+      var tempPointBx = void 0;
+      var tempPointBy = void 0;
+
+      //determine whether clipping point is the corner of nodeA
+      if (-slopeA === slopePrime) {
+        if (p1x > p2x) {
+          result[0] = bottomLeftAx;
+          result[1] = bottomLeftAy;
+          clipPointAFound = true;
+        } else {
+          result[0] = topRightAx;
+          result[1] = topLeftAy;
+          clipPointAFound = true;
+        }
+      } else if (slopeA === slopePrime) {
+        if (p1x > p2x) {
+          result[0] = topLeftAx;
+          result[1] = topLeftAy;
+          clipPointAFound = true;
+        } else {
+          result[0] = bottomRightAx;
+          result[1] = bottomLeftAy;
+          clipPointAFound = true;
+        }
+      }
+
+      //determine whether clipping point is the corner of nodeB
+      if (-slopeB === slopePrime) {
+        if (p2x > p1x) {
+          result[2] = bottomLeftBx;
+          result[3] = bottomLeftBy;
+          clipPointBFound = true;
+        } else {
+          result[2] = topRightBx;
+          result[3] = topLeftBy;
+          clipPointBFound = true;
+        }
+      } else if (slopeB === slopePrime) {
+        if (p2x > p1x) {
+          result[2] = topLeftBx;
+          result[3] = topLeftBy;
+          clipPointBFound = true;
+        } else {
+          result[2] = bottomRightBx;
+          result[3] = bottomLeftBy;
+          clipPointBFound = true;
+        }
+      }
+
+      //if both clipping points are corners
+      if (clipPointAFound && clipPointBFound) {
+        return false;
+      }
+
+      //determine Cardinal Direction of rectangles
+      if (p1x > p2x) {
+        if (p1y > p2y) {
+          cardinalDirectionA = this.getCardinalDirection(slopeA, slopePrime, 4);
+          cardinalDirectionB = this.getCardinalDirection(slopeB, slopePrime, 2);
+        } else {
+          cardinalDirectionA = this.getCardinalDirection(-slopeA, slopePrime, 3);
+          cardinalDirectionB = this.getCardinalDirection(-slopeB, slopePrime, 1);
+        }
+      } else {
+        if (p1y > p2y) {
+          cardinalDirectionA = this.getCardinalDirection(-slopeA, slopePrime, 1);
+          cardinalDirectionB = this.getCardinalDirection(-slopeB, slopePrime, 3);
+        } else {
+          cardinalDirectionA = this.getCardinalDirection(slopeA, slopePrime, 2);
+          cardinalDirectionB = this.getCardinalDirection(slopeB, slopePrime, 4);
+        }
+      }
+      //calculate clipping Point if it is not found before
+      if (!clipPointAFound) {
+        switch (cardinalDirectionA) {
+          case 1:
+            tempPointAy = topLeftAy;
+            tempPointAx = p1x + -halfHeightA / slopePrime;
+            result[0] = tempPointAx;
+            result[1] = tempPointAy;
+            break;
+          case 2:
+            tempPointAx = bottomRightAx;
+            tempPointAy = p1y + halfWidthA * slopePrime;
+            result[0] = tempPointAx;
+            result[1] = tempPointAy;
+            break;
+          case 3:
+            tempPointAy = bottomLeftAy;
+            tempPointAx = p1x + halfHeightA / slopePrime;
+            result[0] = tempPointAx;
+            result[1] = tempPointAy;
+            break;
+          case 4:
+            tempPointAx = bottomLeftAx;
+            tempPointAy = p1y + -halfWidthA * slopePrime;
+            result[0] = tempPointAx;
+            result[1] = tempPointAy;
+            break;
+        }
+      }
+      if (!clipPointBFound) {
+        switch (cardinalDirectionB) {
+          case 1:
+            tempPointBy = topLeftBy;
+            tempPointBx = p2x + -halfHeightB / slopePrime;
+            result[2] = tempPointBx;
+            result[3] = tempPointBy;
+            break;
+          case 2:
+            tempPointBx = bottomRightBx;
+            tempPointBy = p2y + halfWidthB * slopePrime;
+            result[2] = tempPointBx;
+            result[3] = tempPointBy;
+            break;
+          case 3:
+            tempPointBy = bottomLeftBy;
+            tempPointBx = p2x + halfHeightB / slopePrime;
+            result[2] = tempPointBx;
+            result[3] = tempPointBy;
+            break;
+          case 4:
+            tempPointBx = bottomLeftBx;
+            tempPointBy = p2y + -halfWidthB * slopePrime;
+            result[2] = tempPointBx;
+            result[3] = tempPointBy;
+            break;
+        }
+      }
+    }
+  return false;
+};
+
+/**
+ * This method returns in which cardinal direction does input point stays
+ * 1: North
+ * 2: East
+ * 3: South
+ * 4: West
+ */
+IGeometry.getCardinalDirection = function (slope, slopePrime, line) {
+  if (slope > slopePrime) {
+    return line;
+  } else {
+    return 1 + line % 4;
+  }
+};
+
+/**
+ * This method calculates the intersection of the two lines defined by
+ * point pairs (s1,s2) and (f1,f2).
+ */
+IGeometry.getIntersection = function (s1, s2, f1, f2) {
+  if (f2 == null) {
+    return this.getIntersection2(s1, s2, f1);
+  }
+
+  var x1 = s1.x;
+  var y1 = s1.y;
+  var x2 = s2.x;
+  var y2 = s2.y;
+  var x3 = f1.x;
+  var y3 = f1.y;
+  var x4 = f2.x;
+  var y4 = f2.y;
+  var x = void 0,
+      y = void 0; // intersection point
+  var a1 = void 0,
+      a2 = void 0,
+      b1 = void 0,
+      b2 = void 0,
+      c1 = void 0,
+      c2 = void 0; // coefficients of line eqns.
+  var denom = void 0;
+
+  a1 = y2 - y1;
+  b1 = x1 - x2;
+  c1 = x2 * y1 - x1 * y2; // { a1*x + b1*y + c1 = 0 is line 1 }
+
+  a2 = y4 - y3;
+  b2 = x3 - x4;
+  c2 = x4 * y3 - x3 * y4; // { a2*x + b2*y + c2 = 0 is line 2 }
+
+  denom = a1 * b2 - a2 * b1;
+
+  if (denom === 0) {
+    return null;
+  }
+
+  x = (b1 * c2 - b2 * c1) / denom;
+  y = (a2 * c1 - a1 * c2) / denom;
+
+  return new Point(x, y);
+};
+
+/**
+ * This method finds and returns the angle of the vector from the + x-axis
+ * in clockwise direction (compatible w/ Java coordinate system!).
+ */
+IGeometry.angleOfVector = function (Cx, Cy, Nx, Ny) {
+  var C_angle = void 0;
+
+  if (Cx !== Nx) {
+    C_angle = Math.atan((Ny - Cy) / (Nx - Cx));
+
+    if (Nx < Cx) {
+      C_angle += Math.PI;
+    } else if (Ny < Cy) {
+      C_angle += this.TWO_PI;
+    }
+  } else if (Ny < Cy) {
+    C_angle = this.ONE_AND_HALF_PI; // 270 degrees
+  } else {
+    C_angle = this.HALF_PI; // 90 degrees
+  }
+
+  return C_angle;
+};
+
+/**
+ * This method checks whether the given two line segments (one with point
+ * p1 and p2, the other with point p3 and p4) intersect at a point other
+ * than these points.
+ */
+IGeometry.doIntersect = function (p1, p2, p3, p4) {
+  var a = p1.x;
+  var b = p1.y;
+  var c = p2.x;
+  var d = p2.y;
+  var p = p3.x;
+  var q = p3.y;
+  var r = p4.x;
+  var s = p4.y;
+  var det = (c - a) * (s - q) - (r - p) * (d - b);
+
+  if (det === 0) {
+    return false;
+  } else {
+    var lambda = ((s - q) * (r - a) + (p - r) * (s - b)) / det;
+    var gamma = ((b - d) * (r - a) + (c - a) * (s - b)) / det;
+    return 0 < lambda && lambda < 1 && 0 < gamma && gamma < 1;
+  }
+};
+
+/**
+ * This method checks and calculates the intersection of 
+ * a line segment and a circle.
+ */
+IGeometry.findCircleLineIntersections = function (Ex, Ey, Lx, Ly, Cx, Cy, r) {
+
+  // E is the starting point of the ray,
+  // L is the end point of the ray,
+  // C is the center of sphere you're testing against
+  // r is the radius of that sphere
+
+  // Compute:
+  // d = L - E ( Direction vector of ray, from start to end )
+  // f = E - C ( Vector from center sphere to ray start )
+
+  // Then the intersection is found by..
+  // P = E + t * d
+  // This is a parametric equation:
+  // Px = Ex + tdx
+  // Py = Ey + tdy
+
+  // get a, b, c values
+  var a = (Lx - Ex) * (Lx - Ex) + (Ly - Ey) * (Ly - Ey);
+  var b = 2 * ((Ex - Cx) * (Lx - Ex) + (Ey - Cy) * (Ly - Ey));
+  var c = (Ex - Cx) * (Ex - Cx) + (Ey - Cy) * (Ey - Cy) - r * r;
+
+  // get discriminant
+  var disc = b * b - 4 * a * c;
+  if (disc >= 0) {
+    // insert into quadratic formula
+    var t1 = (-b + Math.sqrt(b * b - 4 * a * c)) / (2 * a);
+    var t2 = (-b - Math.sqrt(b * b - 4 * a * c)) / (2 * a);
+    var intersections = null;
+    if (t1 >= 0 && t1 <= 1) {
+      // t1 is the intersection, and it's closer than t2
+      // (since t1 uses -b - discriminant)
+      // Impale, Poke
+      return [t1];
+    }
+
+    // here t1 didn't intersect so we are either started
+    // inside the sphere or completely past it
+    if (t2 >= 0 && t2 <= 1) {
+      // ExitWound
+      return [t2];
+    }
+
+    return intersections;
+  } else return null;
+};
+
+// -----------------------------------------------------------------------------
+// Section: Class Constants
+// -----------------------------------------------------------------------------
+/**
+ * Some useful pre-calculated constants
+ */
+IGeometry.HALF_PI = 0.5 * Math.PI;
+IGeometry.ONE_AND_HALF_PI = 1.5 * Math.PI;
+IGeometry.TWO_PI = 2.0 * Math.PI;
+IGeometry.THREE_PI = 3.0 * Math.PI;
+
+module.exports = IGeometry;
+
+/***/ }),
+/* 9 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+function IMath() {}
+
+/**
+ * This method returns the sign of the input value.
+ */
+IMath.sign = function (value) {
+  if (value > 0) {
+    return 1;
+  } else if (value < 0) {
+    return -1;
+  } else {
+    return 0;
+  }
+};
+
+IMath.floor = function (value) {
+  return value < 0 ? Math.ceil(value) : Math.floor(value);
+};
+
+IMath.ceil = function (value) {
+  return value < 0 ? Math.floor(value) : Math.ceil(value);
+};
+
+module.exports = IMath;
+
+/***/ }),
+/* 10 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+function Integer() {}
+
+Integer.MAX_VALUE = 2147483647;
+Integer.MIN_VALUE = -2147483648;
+
+module.exports = Integer;
+
+/***/ }),
+/* 11 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var nodeFrom = function nodeFrom(value) {
+  return { value: value, next: null, prev: null };
+};
+
+var add = function add(prev, node, next, list) {
+  if (prev !== null) {
+    prev.next = node;
+  } else {
+    list.head = node;
+  }
+
+  if (next !== null) {
+    next.prev = node;
+  } else {
+    list.tail = node;
+  }
+
+  node.prev = prev;
+  node.next = next;
+
+  list.length++;
+
+  return node;
+};
+
+var _remove = function _remove(node, list) {
+  var prev = node.prev,
+      next = node.next;
+
+
+  if (prev !== null) {
+    prev.next = next;
+  } else {
+    list.head = next;
+  }
+
+  if (next !== null) {
+    next.prev = prev;
+  } else {
+    list.tail = prev;
+  }
+
+  node.prev = node.next = null;
+
+  list.length--;
+
+  return node;
+};
+
+var LinkedList = function () {
+  function LinkedList(vals) {
+    var _this = this;
+
+    _classCallCheck(this, LinkedList);
+
+    this.length = 0;
+    this.head = null;
+    this.tail = null;
+
+    if (vals != null) {
+      vals.forEach(function (v) {
+        return _this.push(v);
+      });
+    }
+  }
+
+  _createClass(LinkedList, [{
+    key: "size",
+    value: function size() {
+      return this.length;
+    }
+  }, {
+    key: "insertBefore",
+    value: function insertBefore(val, otherNode) {
+      return add(otherNode.prev, nodeFrom(val), otherNode, this);
+    }
+  }, {
+    key: "insertAfter",
+    value: function insertAfter(val, otherNode) {
+      return add(otherNode, nodeFrom(val), otherNode.next, this);
+    }
+  }, {
+    key: "insertNodeBefore",
+    value: function insertNodeBefore(newNode, otherNode) {
+      return add(otherNode.prev, newNode, otherNode, this);
+    }
+  }, {
+    key: "insertNodeAfter",
+    value: function insertNodeAfter(newNode, otherNode) {
+      return add(otherNode, newNode, otherNode.next, this);
+    }
+  }, {
+    key: "push",
+    value: function push(val) {
+      return add(this.tail, nodeFrom(val), null, this);
+    }
+  }, {
+    key: "unshift",
+    value: function unshift(val) {
+      return add(null, nodeFrom(val), this.head, this);
+    }
+  }, {
+    key: "remove",
+    value: function remove(node) {
+      return _remove(node, this);
+    }
+  }, {
+    key: "pop",
+    value: function pop() {
+      return _remove(this.tail, this).value;
+    }
+  }, {
+    key: "popNode",
+    value: function popNode() {
+      return _remove(this.tail, this);
+    }
+  }, {
+    key: "shift",
+    value: function shift() {
+      return _remove(this.head, this).value;
+    }
+  }, {
+    key: "shiftNode",
+    value: function shiftNode() {
+      return _remove(this.head, this);
+    }
+  }, {
+    key: "get_object_at",
+    value: function get_object_at(index) {
+      if (index <= this.length()) {
+        var i = 1;
+        var current = this.head;
+        while (i < index) {
+          current = current.next;
+          i++;
+        }
+        return current.value;
+      }
+    }
+  }, {
+    key: "set_object_at",
+    value: function set_object_at(index, value) {
+      if (index <= this.length()) {
+        var i = 1;
+        var current = this.head;
+        while (i < index) {
+          current = current.next;
+          i++;
+        }
+        current.value = value;
+      }
+    }
+  }]);
+
+  return LinkedList;
+}();
+
+module.exports = LinkedList;
+
+/***/ }),
+/* 12 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+/*
+ *This class is the javascript implementation of the Point.java class in jdk
+ */
+function Point(x, y, p) {
+  this.x = null;
+  this.y = null;
+  if (x == null && y == null && p == null) {
+    this.x = 0;
+    this.y = 0;
+  } else if (typeof x == 'number' && typeof y == 'number' && p == null) {
+    this.x = x;
+    this.y = y;
+  } else if (x.constructor.name == 'Point' && y == null && p == null) {
+    p = x;
+    this.x = p.x;
+    this.y = p.y;
+  }
+}
+
+Point.prototype.getX = function () {
+  return this.x;
+};
+
+Point.prototype.getY = function () {
+  return this.y;
+};
+
+Point.prototype.getLocation = function () {
+  return new Point(this.x, this.y);
+};
+
+Point.prototype.setLocation = function (x, y, p) {
+  if (x.constructor.name == 'Point' && y == null && p == null) {
+    p = x;
+    this.setLocation(p.x, p.y);
+  } else if (typeof x == 'number' && typeof y == 'number' && p == null) {
+    //if both parameters are integer just move (x,y) location
+    if (parseInt(x) == x && parseInt(y) == y) {
+      this.move(x, y);
+    } else {
+      this.x = Math.floor(x + 0.5);
+      this.y = Math.floor(y + 0.5);
+    }
+  }
+};
+
+Point.prototype.move = function (x, y) {
+  this.x = x;
+  this.y = y;
+};
+
+Point.prototype.translate = function (dx, dy) {
+  this.x += dx;
+  this.y += dy;
+};
+
+Point.prototype.equals = function (obj) {
+  if (obj.constructor.name == "Point") {
+    var pt = obj;
+    return this.x == pt.x && this.y == pt.y;
+  }
+  return this == obj;
+};
+
+Point.prototype.toString = function () {
+  return new Point().constructor.name + "[x=" + this.x + ",y=" + this.y + "]";
+};
+
+module.exports = Point;
+
+/***/ }),
+/* 13 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+function RectangleD(x, y, width, height) {
+  this.x = 0;
+  this.y = 0;
+  this.width = 0;
+  this.height = 0;
+
+  if (x != null && y != null && width != null && height != null) {
+    this.x = x;
+    this.y = y;
+    this.width = width;
+    this.height = height;
+  }
+}
+
+RectangleD.prototype.getX = function () {
+  return this.x;
+};
+
+RectangleD.prototype.setX = function (x) {
+  this.x = x;
+};
+
+RectangleD.prototype.getY = function () {
+  return this.y;
+};
+
+RectangleD.prototype.setY = function (y) {
+  this.y = y;
+};
+
+RectangleD.prototype.getWidth = function () {
+  return this.width;
+};
+
+RectangleD.prototype.setWidth = function (width) {
+  this.width = width;
+};
+
+RectangleD.prototype.getHeight = function () {
+  return this.height;
+};
+
+RectangleD.prototype.setHeight = function (height) {
+  this.height = height;
+};
+
+RectangleD.prototype.getRight = function () {
+  return this.x + this.width;
+};
+
+RectangleD.prototype.getBottom = function () {
+  return this.y + this.height;
+};
+
+RectangleD.prototype.intersects = function (a) {
+  if (this.getRight() < a.x) {
+    return false;
+  }
+
+  if (this.getBottom() < a.y) {
+    return false;
+  }
+
+  if (a.getRight() < this.x) {
+    return false;
+  }
+
+  if (a.getBottom() < this.y) {
+    return false;
+  }
+
+  return true;
+};
+
+RectangleD.prototype.getCenterX = function () {
+  return this.x + this.width / 2;
+};
+
+RectangleD.prototype.getMinX = function () {
+  return this.getX();
+};
+
+RectangleD.prototype.getMaxX = function () {
+  return this.getX() + this.width;
+};
+
+RectangleD.prototype.getCenterY = function () {
+  return this.y + this.height / 2;
+};
+
+RectangleD.prototype.getMinY = function () {
+  return this.getY();
+};
+
+RectangleD.prototype.getMaxY = function () {
+  return this.getY() + this.height;
+};
+
+RectangleD.prototype.getWidthHalf = function () {
+  return this.width / 2;
+};
+
+RectangleD.prototype.getHeightHalf = function () {
+  return this.height / 2;
+};
+
+module.exports = RectangleD;
+
+/***/ }),
+/* 14 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+function UniqueIDGeneretor() {}
+
+UniqueIDGeneretor.lastID = 0;
+
+UniqueIDGeneretor.createID = function (obj) {
+  if (UniqueIDGeneretor.isPrimitive(obj)) {
+    return obj;
+  }
+  if (obj.uniqueID != null) {
+    return obj.uniqueID;
+  }
+  obj.uniqueID = UniqueIDGeneretor.getString();
+  UniqueIDGeneretor.lastID++;
+  return obj.uniqueID;
+};
+
+UniqueIDGeneretor.getString = function (id) {
+  if (id == null) id = UniqueIDGeneretor.lastID;
+  return "Object#" + id + "";
+};
+
+UniqueIDGeneretor.isPrimitive = function (arg) {
+  var type = typeof arg === "undefined" ? "undefined" : _typeof(arg);
+  return arg == null || type != "object" && type != "function";
+};
+
+module.exports = UniqueIDGeneretor;
+
+/***/ }),
+/* 15 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
+var LayoutConstants = __webpack_require__(0);
+var LGraphManager = __webpack_require__(7);
+var LNode = __webpack_require__(3);
+var LEdge = __webpack_require__(1);
+var LGraph = __webpack_require__(6);
+var PointD = __webpack_require__(5);
+var Transform = __webpack_require__(17);
+var Emitter = __webpack_require__(29);
+
+function Layout(isRemoteUse) {
+  Emitter.call(this);
+
+  //Layout Quality: 0:draft, 1:default, 2:proof
+  this.layoutQuality = LayoutConstants.QUALITY;
+  //Whether layout should create bendpoints as needed or not
+  this.createBendsAsNeeded = LayoutConstants.DEFAULT_CREATE_BENDS_AS_NEEDED;
+  //Whether layout should be incremental or not
+  this.incremental = LayoutConstants.DEFAULT_INCREMENTAL;
+  //Whether we animate from before to after layout node positions
+  this.animationOnLayout = LayoutConstants.DEFAULT_ANIMATION_ON_LAYOUT;
+  //Whether we animate the layout process or not
+  this.animationDuringLayout = LayoutConstants.DEFAULT_ANIMATION_DURING_LAYOUT;
+  //Number iterations that should be done between two successive animations
+  this.animationPeriod = LayoutConstants.DEFAULT_ANIMATION_PERIOD;
+  /**
+   * Whether or not leaf nodes (non-compound nodes) are of uniform sizes. When
+   * they are, both spring and repulsion forces between two leaf nodes can be
+   * calculated without the expensive clipping point calculations, resulting
+   * in major speed-up.
+   */
+  this.uniformLeafNodeSizes = LayoutConstants.DEFAULT_UNIFORM_LEAF_NODE_SIZES;
+  /**
+   * This is used for creation of bendpoints by using dummy nodes and edges.
+   * Maps an LEdge to its dummy bendpoint path.
+   */
+  this.edgeToDummyNodes = new Map();
+  this.graphManager = new LGraphManager(this);
+  this.isLayoutFinished = false;
+  this.isSubLayout = false;
+  this.isRemoteUse = false;
+
+  if (isRemoteUse != null) {
+    this.isRemoteUse = isRemoteUse;
+  }
+}
+
+Layout.RANDOM_SEED = 1;
+
+Layout.prototype = Object.create(Emitter.prototype);
+
+Layout.prototype.getGraphManager = function () {
+  return this.graphManager;
+};
+
+Layout.prototype.getAllNodes = function () {
+  return this.graphManager.getAllNodes();
+};
+
+Layout.prototype.getAllEdges = function () {
+  return this.graphManager.getAllEdges();
+};
+
+Layout.prototype.getAllNodesToApplyGravitation = function () {
+  return this.graphManager.getAllNodesToApplyGravitation();
+};
+
+Layout.prototype.newGraphManager = function () {
+  var gm = new LGraphManager(this);
+  this.graphManager = gm;
+  return gm;
+};
+
+Layout.prototype.newGraph = function (vGraph) {
+  return new LGraph(null, this.graphManager, vGraph);
+};
+
+Layout.prototype.newNode = function (vNode) {
+  return new LNode(this.graphManager, vNode);
+};
+
+Layout.prototype.newEdge = function (vEdge) {
+  return new LEdge(null, null, vEdge);
+};
+
+Layout.prototype.checkLayoutSuccess = function () {
+  return this.graphManager.getRoot() == null || this.graphManager.getRoot().getNodes().length == 0 || this.graphManager.includesInvalidEdge();
+};
+
+Layout.prototype.runLayout = function () {
+  this.isLayoutFinished = false;
+
+  if (this.tilingPreLayout) {
+    this.tilingPreLayout();
+  }
+
+  this.initParameters();
+  var isLayoutSuccessfull;
+
+  if (this.checkLayoutSuccess()) {
+    isLayoutSuccessfull = false;
+  } else {
+    isLayoutSuccessfull = this.layout();
+  }
+
+  if (LayoutConstants.ANIMATE === 'during') {
+    // If this is a 'during' layout animation. Layout is not finished yet. 
+    // We need to perform these in index.js when layout is really finished.
+    return false;
+  }
+
+  if (isLayoutSuccessfull) {
+    if (!this.isSubLayout) {
+      this.doPostLayout();
+    }
+  }
+
+  if (this.tilingPostLayout) {
+    this.tilingPostLayout();
+  }
+
+  this.isLayoutFinished = true;
+
+  return isLayoutSuccessfull;
+};
+
+/**
+ * This method performs the operations required after layout.
+ */
+Layout.prototype.doPostLayout = function () {
+  //assert !isSubLayout : "Should not be called on sub-layout!";
+  // Propagate geometric changes to v-level objects
+  if (!this.incremental) {
+    this.transform();
+  }
+  this.update();
+};
+
+/**
+ * This method updates the geometry of the target graph according to
+ * calculated layout.
+ */
+Layout.prototype.update2 = function () {
+  // update bend points
+  if (this.createBendsAsNeeded) {
+    this.createBendpointsFromDummyNodes();
+
+    // reset all edges, since the topology has changed
+    this.graphManager.resetAllEdges();
+  }
+
+  // perform edge, node and root updates if layout is not called
+  // remotely
+  if (!this.isRemoteUse) {
+    // update all edges
+    var edge;
+    var allEdges = this.graphManager.getAllEdges();
+    for (var i = 0; i < allEdges.length; i++) {
+      edge = allEdges[i];
+      //      this.update(edge);
+    }
+
+    // recursively update nodes
+    var node;
+    var nodes = this.graphManager.getRoot().getNodes();
+    for (var i = 0; i < nodes.length; i++) {
+      node = nodes[i];
+      //      this.update(node);
+    }
+
+    // update root graph
+    this.update(this.graphManager.getRoot());
+  }
+};
+
+Layout.prototype.update = function (obj) {
+  if (obj == null) {
+    this.update2();
+  } else if (obj instanceof LNode) {
+    var node = obj;
+    if (node.getChild() != null) {
+      // since node is compound, recursively update child nodes
+      var nodes = node.getChild().getNodes();
+      for (var i = 0; i < nodes.length; i++) {
+        update(nodes[i]);
+      }
+    }
+
+    // if the l-level node is associated with a v-level graph object,
+    // then it is assumed that the v-level node implements the
+    // interface Updatable.
+    if (node.vGraphObject != null) {
+      // cast to Updatable without any type check
+      var vNode = node.vGraphObject;
+
+      // call the update method of the interface
+      vNode.update(node);
+    }
+  } else if (obj instanceof LEdge) {
+    var edge = obj;
+    // if the l-level edge is associated with a v-level graph object,
+    // then it is assumed that the v-level edge implements the
+    // interface Updatable.
+
+    if (edge.vGraphObject != null) {
+      // cast to Updatable without any type check
+      var vEdge = edge.vGraphObject;
+
+      // call the update method of the interface
+      vEdge.update(edge);
+    }
+  } else if (obj instanceof LGraph) {
+    var graph = obj;
+    // if the l-level graph is associated with a v-level graph object,
+    // then it is assumed that the v-level object implements the
+    // interface Updatable.
+
+    if (graph.vGraphObject != null) {
+      // cast to Updatable without any type check
+      var vGraph = graph.vGraphObject;
+
+      // call the update method of the interface
+      vGraph.update(graph);
+    }
+  }
+};
+
+/**
+ * This method is used to set all layout parameters to default values
+ * determined at compile time.
+ */
+Layout.prototype.initParameters = function () {
+  if (!this.isSubLayout) {
+    this.layoutQuality = LayoutConstants.QUALITY;
+    this.animationDuringLayout = LayoutConstants.DEFAULT_ANIMATION_DURING_LAYOUT;
+    this.animationPeriod = LayoutConstants.DEFAULT_ANIMATION_PERIOD;
+    this.animationOnLayout = LayoutConstants.DEFAULT_ANIMATION_ON_LAYOUT;
+    this.incremental = LayoutConstants.DEFAULT_INCREMENTAL;
+    this.createBendsAsNeeded = LayoutConstants.DEFAULT_CREATE_BENDS_AS_NEEDED;
+    this.uniformLeafNodeSizes = LayoutConstants.DEFAULT_UNIFORM_LEAF_NODE_SIZES;
+  }
+
+  if (this.animationDuringLayout) {
+    this.animationOnLayout = false;
+  }
+};
+
+Layout.prototype.transform = function (newLeftTop) {
+  if (newLeftTop == undefined) {
+    this.transform(new PointD(0, 0));
+  } else {
+    // create a transformation object (from Eclipse to layout). When an
+    // inverse transform is applied, we get upper-left coordinate of the
+    // drawing or the root graph at given input coordinate (some margins
+    // already included in calculation of left-top).
+
+    var trans = new Transform();
+    var leftTop = this.graphManager.getRoot().updateLeftTop();
+
+    if (leftTop != null) {
+      trans.setWorldOrgX(newLeftTop.x);
+      trans.setWorldOrgY(newLeftTop.y);
+
+      trans.setDeviceOrgX(leftTop.x);
+      trans.setDeviceOrgY(leftTop.y);
+
+      var nodes = this.getAllNodes();
+      var node;
+
+      for (var i = 0; i < nodes.length; i++) {
+        node = nodes[i];
+        node.transform(trans);
+      }
+    }
+  }
+};
+
+Layout.prototype.positionNodesRandomly = function (graph) {
+
+  if (graph == undefined) {
+    //assert !this.incremental;
+    this.positionNodesRandomly(this.getGraphManager().getRoot());
+    this.getGraphManager().getRoot().updateBounds(true);
+  } else {
+    var lNode;
+    var childGraph;
+
+    var nodes = graph.getNodes();
+    for (var i = 0; i < nodes.length; i++) {
+      lNode = nodes[i];
+      childGraph = lNode.getChild();
+
+      if (childGraph == null) {
+        lNode.scatter();
+      } else if (childGraph.getNodes().length == 0) {
+        lNode.scatter();
+      } else {
+        this.positionNodesRandomly(childGraph);
+        lNode.updateBounds();
+      }
+    }
+  }
+};
+
+/**
+ * This method returns a list of trees where each tree is represented as a
+ * list of l-nodes. The method returns a list of size 0 when:
+ * - The graph is not flat or
+ * - One of the component(s) of the graph is not a tree.
+ */
+Layout.prototype.getFlatForest = function () {
+  var flatForest = [];
+  var isForest = true;
+
+  // Quick reference for all nodes in the graph manager associated with
+  // this layout. The list should not be changed.
+  var allNodes = this.graphManager.getRoot().getNodes();
+
+  // First be sure that the graph is flat
+  var isFlat = true;
+
+  for (var i = 0; i < allNodes.length; i++) {
+    if (allNodes[i].getChild() != null) {
+      isFlat = false;
+    }
+  }
+
+  // Return empty forest if the graph is not flat.
+  if (!isFlat) {
+    return flatForest;
+  }
+
+  // Run BFS for each component of the graph.
+
+  var visited = new Set();
+  var toBeVisited = [];
+  var parents = new Map();
+  var unProcessedNodes = [];
+
+  unProcessedNodes = unProcessedNodes.concat(allNodes);
+
+  // Each iteration of this loop finds a component of the graph and
+  // decides whether it is a tree or not. If it is a tree, adds it to the
+  // forest and continued with the next component.
+
+  while (unProcessedNodes.length > 0 && isForest) {
+    toBeVisited.push(unProcessedNodes[0]);
+
+    // Start the BFS. Each iteration of this loop visits a node in a
+    // BFS manner.
+    while (toBeVisited.length > 0 && isForest) {
+      //pool operation
+      var currentNode = toBeVisited[0];
+      toBeVisited.splice(0, 1);
+      visited.add(currentNode);
+
+      // Traverse all neighbors of this node
+      var neighborEdges = currentNode.getEdges();
+
+      for (var i = 0; i < neighborEdges.length; i++) {
+        var currentNeighbor = neighborEdges[i].getOtherEnd(currentNode);
+
+        // If BFS is not growing from this neighbor.
+        if (parents.get(currentNode) != currentNeighbor) {
+          // We haven't previously visited this neighbor.
+          if (!visited.has(currentNeighbor)) {
+            toBeVisited.push(currentNeighbor);
+            parents.set(currentNeighbor, currentNode);
+          }
+          // Since we have previously visited this neighbor and
+          // this neighbor is not parent of currentNode, given
+          // graph contains a component that is not tree, hence
+          // it is not a forest.
+          else {
+              isForest = false;
+              break;
+            }
+        }
+      }
+    }
+
+    // The graph contains a component that is not a tree. Empty
+    // previously found trees. The method will end.
+    if (!isForest) {
+      flatForest = [];
+    }
+    // Save currently visited nodes as a tree in our forest. Reset
+    // visited and parents lists. Continue with the next component of
+    // the graph, if any.
+    else {
+        var temp = [].concat(_toConsumableArray(visited));
+        flatForest.push(temp);
+        //flatForest = flatForest.concat(temp);
+        //unProcessedNodes.removeAll(visited);
+        for (var i = 0; i < temp.length; i++) {
+          var value = temp[i];
+          var index = unProcessedNodes.indexOf(value);
+          if (index > -1) {
+            unProcessedNodes.splice(index, 1);
+          }
+        }
+        visited = new Set();
+        parents = new Map();
+      }
+  }
+
+  return flatForest;
+};
+
+/**
+ * This method creates dummy nodes (an l-level node with minimal dimensions)
+ * for the given edge (one per bendpoint). The existing l-level structure
+ * is updated accordingly.
+ */
+Layout.prototype.createDummyNodesForBendpoints = function (edge) {
+  var dummyNodes = [];
+  var prev = edge.source;
+
+  var graph = this.graphManager.calcLowestCommonAncestor(edge.source, edge.target);
+
+  for (var i = 0; i < edge.bendpoints.length; i++) {
+    // create new dummy node
+    var dummyNode = this.newNode(null);
+    dummyNode.setRect(new Point(0, 0), new Dimension(1, 1));
+
+    graph.add(dummyNode);
+
+    // create new dummy edge between prev and dummy node
+    var dummyEdge = this.newEdge(null);
+    this.graphManager.add(dummyEdge, prev, dummyNode);
+
+    dummyNodes.add(dummyNode);
+    prev = dummyNode;
+  }
+
+  var dummyEdge = this.newEdge(null);
+  this.graphManager.add(dummyEdge, prev, edge.target);
+
+  this.edgeToDummyNodes.set(edge, dummyNodes);
+
+  // remove real edge from graph manager if it is inter-graph
+  if (edge.isInterGraph()) {
+    this.graphManager.remove(edge);
+  }
+  // else, remove the edge from the current graph
+  else {
+      graph.remove(edge);
+    }
+
+  return dummyNodes;
+};
+
+/**
+ * This method creates bendpoints for edges from the dummy nodes
+ * at l-level.
+ */
+Layout.prototype.createBendpointsFromDummyNodes = function () {
+  var edges = [];
+  edges = edges.concat(this.graphManager.getAllEdges());
+  edges = [].concat(_toConsumableArray(this.edgeToDummyNodes.keys())).concat(edges);
+
+  for (var k = 0; k < edges.length; k++) {
+    var lEdge = edges[k];
+
+    if (lEdge.bendpoints.length > 0) {
+      var path = this.edgeToDummyNodes.get(lEdge);
+
+      for (var i = 0; i < path.length; i++) {
+        var dummyNode = path[i];
+        var p = new PointD(dummyNode.getCenterX(), dummyNode.getCenterY());
+
+        // update bendpoint's location according to dummy node
+        var ebp = lEdge.bendpoints.get(i);
+        ebp.x = p.x;
+        ebp.y = p.y;
+
+        // remove the dummy node, dummy edges incident with this
+        // dummy node is also removed (within the remove method)
+        dummyNode.getOwner().remove(dummyNode);
+      }
+
+      // add the real edge to graph
+      this.graphManager.add(lEdge, lEdge.source, lEdge.target);
+    }
+  }
+};
+
+Layout.transform = function (sliderValue, defaultValue, minDiv, maxMul) {
+  if (minDiv != undefined && maxMul != undefined) {
+    var value = defaultValue;
+
+    if (sliderValue <= 50) {
+      var minValue = defaultValue / minDiv;
+      value -= (defaultValue - minValue) / 50 * (50 - sliderValue);
+    } else {
+      var maxValue = defaultValue * maxMul;
+      value += (maxValue - defaultValue) / 50 * (sliderValue - 50);
+    }
+
+    return value;
+  } else {
+    var a, b;
+
+    if (sliderValue <= 50) {
+      a = 9.0 * defaultValue / 500.0;
+      b = defaultValue / 10.0;
+    } else {
+      a = 9.0 * defaultValue / 50.0;
+      b = -8 * defaultValue;
+    }
+
+    return a * sliderValue + b;
+  }
+};
+
+/**
+ * This method finds and returns the center of the given nodes, assuming
+ * that the given nodes form a tree in themselves.
+ */
+Layout.findCenterOfTree = function (nodes) {
+  var list = [];
+  list = list.concat(nodes);
+
+  var removedNodes = [];
+  var remainingDegrees = new Map();
+  var foundCenter = false;
+  var centerNode = null;
+
+  if (list.length == 1 || list.length == 2) {
+    foundCenter = true;
+    centerNode = list[0];
+  }
+
+  for (var i = 0; i < list.length; i++) {
+    var node = list[i];
+    var degree = node.getNeighborsList().size;
+    remainingDegrees.set(node, node.getNeighborsList().size);
+
+    if (degree == 1) {
+      removedNodes.push(node);
+    }
+  }
+
+  var tempList = [];
+  tempList = tempList.concat(removedNodes);
+
+  while (!foundCenter) {
+    var tempList2 = [];
+    tempList2 = tempList2.concat(tempList);
+    tempList = [];
+
+    for (var i = 0; i < list.length; i++) {
+      var node = list[i];
+
+      var index = list.indexOf(node);
+      if (index >= 0) {
+        list.splice(index, 1);
+      }
+
+      var neighbours = node.getNeighborsList();
+
+      neighbours.forEach(function (neighbour) {
+        if (removedNodes.indexOf(neighbour) < 0) {
+          var otherDegree = remainingDegrees.get(neighbour);
+          var newDegree = otherDegree - 1;
+
+          if (newDegree == 1) {
+            tempList.push(neighbour);
+          }
+
+          remainingDegrees.set(neighbour, newDegree);
+        }
+      });
+    }
+
+    removedNodes = removedNodes.concat(tempList);
+
+    if (list.length == 1 || list.length == 2) {
+      foundCenter = true;
+      centerNode = list[0];
+    }
+  }
+
+  return centerNode;
+};
+
+/**
+ * During the coarsening process, this layout may be referenced by two graph managers
+ * this setter function grants access to change the currently being used graph manager
+ */
+Layout.prototype.setGraphManager = function (gm) {
+  this.graphManager = gm;
+};
+
+module.exports = Layout;
+
+/***/ }),
+/* 16 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+function RandomSeed() {}
+// adapted from: https://stackoverflow.com/a/19303725
+RandomSeed.seed = 1;
+RandomSeed.x = 0;
+
+RandomSeed.nextDouble = function () {
+  RandomSeed.x = Math.sin(RandomSeed.seed++) * 10000;
+  return RandomSeed.x - Math.floor(RandomSeed.x);
+};
+
+module.exports = RandomSeed;
+
+/***/ }),
+/* 17 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var PointD = __webpack_require__(5);
+
+function Transform(x, y) {
+  this.lworldOrgX = 0.0;
+  this.lworldOrgY = 0.0;
+  this.ldeviceOrgX = 0.0;
+  this.ldeviceOrgY = 0.0;
+  this.lworldExtX = 1.0;
+  this.lworldExtY = 1.0;
+  this.ldeviceExtX = 1.0;
+  this.ldeviceExtY = 1.0;
+}
+
+Transform.prototype.getWorldOrgX = function () {
+  return this.lworldOrgX;
+};
+
+Transform.prototype.setWorldOrgX = function (wox) {
+  this.lworldOrgX = wox;
+};
+
+Transform.prototype.getWorldOrgY = function () {
+  return this.lworldOrgY;
+};
+
+Transform.prototype.setWorldOrgY = function (woy) {
+  this.lworldOrgY = woy;
+};
+
+Transform.prototype.getWorldExtX = function () {
+  return this.lworldExtX;
+};
+
+Transform.prototype.setWorldExtX = function (wex) {
+  this.lworldExtX = wex;
+};
+
+Transform.prototype.getWorldExtY = function () {
+  return this.lworldExtY;
+};
+
+Transform.prototype.setWorldExtY = function (wey) {
+  this.lworldExtY = wey;
+};
+
+/* Device related */
+
+Transform.prototype.getDeviceOrgX = function () {
+  return this.ldeviceOrgX;
+};
+
+Transform.prototype.setDeviceOrgX = function (dox) {
+  this.ldeviceOrgX = dox;
+};
+
+Transform.prototype.getDeviceOrgY = function () {
+  return this.ldeviceOrgY;
+};
+
+Transform.prototype.setDeviceOrgY = function (doy) {
+  this.ldeviceOrgY = doy;
+};
+
+Transform.prototype.getDeviceExtX = function () {
+  return this.ldeviceExtX;
+};
+
+Transform.prototype.setDeviceExtX = function (dex) {
+  this.ldeviceExtX = dex;
+};
+
+Transform.prototype.getDeviceExtY = function () {
+  return this.ldeviceExtY;
+};
+
+Transform.prototype.setDeviceExtY = function (dey) {
+  this.ldeviceExtY = dey;
+};
+
+Transform.prototype.transformX = function (x) {
+  var xDevice = 0.0;
+  var worldExtX = this.lworldExtX;
+  if (worldExtX != 0.0) {
+    xDevice = this.ldeviceOrgX + (x - this.lworldOrgX) * this.ldeviceExtX / worldExtX;
+  }
+
+  return xDevice;
+};
+
+Transform.prototype.transformY = function (y) {
+  var yDevice = 0.0;
+  var worldExtY = this.lworldExtY;
+  if (worldExtY != 0.0) {
+    yDevice = this.ldeviceOrgY + (y - this.lworldOrgY) * this.ldeviceExtY / worldExtY;
+  }
+
+  return yDevice;
+};
+
+Transform.prototype.inverseTransformX = function (x) {
+  var xWorld = 0.0;
+  var deviceExtX = this.ldeviceExtX;
+  if (deviceExtX != 0.0) {
+    xWorld = this.lworldOrgX + (x - this.ldeviceOrgX) * this.lworldExtX / deviceExtX;
+  }
+
+  return xWorld;
+};
+
+Transform.prototype.inverseTransformY = function (y) {
+  var yWorld = 0.0;
+  var deviceExtY = this.ldeviceExtY;
+  if (deviceExtY != 0.0) {
+    yWorld = this.lworldOrgY + (y - this.ldeviceOrgY) * this.lworldExtY / deviceExtY;
+  }
+  return yWorld;
+};
+
+Transform.prototype.inverseTransformPoint = function (inPoint) {
+  var outPoint = new PointD(this.inverseTransformX(inPoint.x), this.inverseTransformY(inPoint.y));
+  return outPoint;
+};
+
+module.exports = Transform;
+
+/***/ }),
+/* 18 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
+
+var Layout = __webpack_require__(15);
+var FDLayoutConstants = __webpack_require__(4);
+var LayoutConstants = __webpack_require__(0);
+var IGeometry = __webpack_require__(8);
+var IMath = __webpack_require__(9);
+
+function FDLayout() {
+  Layout.call(this);
+
+  this.useSmartIdealEdgeLengthCalculation = FDLayoutConstants.DEFAULT_USE_SMART_IDEAL_EDGE_LENGTH_CALCULATION;
+  this.gravityConstant = FDLayoutConstants.DEFAULT_GRAVITY_STRENGTH;
+  this.compoundGravityConstant = FDLayoutConstants.DEFAULT_COMPOUND_GRAVITY_STRENGTH;
+  this.gravityRangeFactor = FDLayoutConstants.DEFAULT_GRAVITY_RANGE_FACTOR;
+  this.compoundGravityRangeFactor = FDLayoutConstants.DEFAULT_COMPOUND_GRAVITY_RANGE_FACTOR;
+  this.displacementThresholdPerNode = 3.0 * FDLayoutConstants.DEFAULT_EDGE_LENGTH / 100;
+  this.coolingFactor = FDLayoutConstants.DEFAULT_COOLING_FACTOR_INCREMENTAL;
+  this.initialCoolingFactor = FDLayoutConstants.DEFAULT_COOLING_FACTOR_INCREMENTAL;
+  this.totalDisplacement = 0.0;
+  this.oldTotalDisplacement = 0.0;
+  this.maxIterations = FDLayoutConstants.MAX_ITERATIONS;
+}
+
+FDLayout.prototype = Object.create(Layout.prototype);
+
+for (var prop in Layout) {
+  FDLayout[prop] = Layout[prop];
+}
+
+FDLayout.prototype.initParameters = function () {
+  Layout.prototype.initParameters.call(this, arguments);
+
+  this.totalIterations = 0;
+  this.notAnimatedIterations = 0;
+
+  this.useFRGridVariant = FDLayoutConstants.DEFAULT_USE_SMART_REPULSION_RANGE_CALCULATION;
+
+  this.grid = [];
+};
+
+FDLayout.prototype.calcIdealEdgeLengths = function () {
+  var edge;
+  var originalIdealLength;
+  var lcaDepth;
+  var source;
+  var target;
+  var sizeOfSourceInLca;
+  var sizeOfTargetInLca;
+
+  var allEdges = this.getGraphManager().getAllEdges();
+  for (var i = 0; i < allEdges.length; i++) {
+    edge = allEdges[i];
+
+    originalIdealLength = edge.idealLength;
+
+    if (edge.isInterGraph) {
+      source = edge.getSource();
+      target = edge.getTarget();
+
+      sizeOfSourceInLca = edge.getSourceInLca().getEstimatedSize();
+      sizeOfTargetInLca = edge.getTargetInLca().getEstimatedSize();
+
+      if (this.useSmartIdealEdgeLengthCalculation) {
+        edge.idealLength += sizeOfSourceInLca + sizeOfTargetInLca - 2 * LayoutConstants.SIMPLE_NODE_SIZE;
+      }
+
+      lcaDepth = edge.getLca().getInclusionTreeDepth();
+
+      edge.idealLength += originalIdealLength * FDLayoutConstants.PER_LEVEL_IDEAL_EDGE_LENGTH_FACTOR * (source.getInclusionTreeDepth() + target.getInclusionTreeDepth() - 2 * lcaDepth);
+    }
+  }
+};
+
+FDLayout.prototype.initSpringEmbedder = function () {
+
+  var s = this.getAllNodes().length;
+  if (this.incremental) {
+    if (s > FDLayoutConstants.ADAPTATION_LOWER_NODE_LIMIT) {
+      this.coolingFactor = Math.max(this.coolingFactor * FDLayoutConstants.COOLING_ADAPTATION_FACTOR, this.coolingFactor - (s - FDLayoutConstants.ADAPTATION_LOWER_NODE_LIMIT) / (FDLayoutConstants.ADAPTATION_UPPER_NODE_LIMIT - FDLayoutConstants.ADAPTATION_LOWER_NODE_LIMIT) * this.coolingFactor * (1 - FDLayoutConstants.COOLING_ADAPTATION_FACTOR));
+    }
+    this.maxNodeDisplacement = FDLayoutConstants.MAX_NODE_DISPLACEMENT_INCREMENTAL;
+  } else {
+    if (s > FDLayoutConstants.ADAPTATION_LOWER_NODE_LIMIT) {
+      this.coolingFactor = Math.max(FDLayoutConstants.COOLING_ADAPTATION_FACTOR, 1.0 - (s - FDLayoutConstants.ADAPTATION_LOWER_NODE_LIMIT) / (FDLayoutConstants.ADAPTATION_UPPER_NODE_LIMIT - FDLayoutConstants.ADAPTATION_LOWER_NODE_LIMIT) * (1 - FDLayoutConstants.COOLING_ADAPTATION_FACTOR));
+    } else {
+      this.coolingFactor = 1.0;
+    }
+    this.initialCoolingFactor = this.coolingFactor;
+    this.maxNodeDisplacement = FDLayoutConstants.MAX_NODE_DISPLACEMENT;
+  }
+
+  this.maxIterations = Math.max(this.getAllNodes().length * 5, this.maxIterations);
+
+  // Reassign this attribute by using new constant value
+  this.displacementThresholdPerNode = 3.0 * FDLayoutConstants.DEFAULT_EDGE_LENGTH / 100;
+  this.totalDisplacementThreshold = this.displacementThresholdPerNode * this.getAllNodes().length;
+
+  this.repulsionRange = this.calcRepulsionRange();
+};
+
+FDLayout.prototype.calcSpringForces = function () {
+  var lEdges = this.getAllEdges();
+  var edge;
+
+  for (var i = 0; i < lEdges.length; i++) {
+    edge = lEdges[i];
+
+    this.calcSpringForce(edge, edge.idealLength);
+  }
+};
+
+FDLayout.prototype.calcRepulsionForces = function () {
+  var gridUpdateAllowed = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : true;
+  var forceToNodeSurroundingUpdate = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : false;
+
+  var i, j;
+  var nodeA, nodeB;
+  var lNodes = this.getAllNodes();
+  var processedNodeSet;
+
+  if (this.useFRGridVariant) {
+    if (this.totalIterations % FDLayoutConstants.GRID_CALCULATION_CHECK_PERIOD == 1 && gridUpdateAllowed) {
+      this.updateGrid();
+    }
+
+    processedNodeSet = new Set();
+
+    // calculate repulsion forces between each nodes and its surrounding
+    for (i = 0; i < lNodes.length; i++) {
+      nodeA = lNodes[i];
+      this.calculateRepulsionForceOfANode(nodeA, processedNodeSet, gridUpdateAllowed, forceToNodeSurroundingUpdate);
+      processedNodeSet.add(nodeA);
+    }
+  } else {
+    for (i = 0; i < lNodes.length; i++) {
+      nodeA = lNodes[i];
+
+      for (j = i + 1; j < lNodes.length; j++) {
+        nodeB = lNodes[j];
+
+        // If both nodes are not members of the same graph, skip.
+        if (nodeA.getOwner() != nodeB.getOwner()) {
+          continue;
+        }
+
+        this.calcRepulsionForce(nodeA, nodeB);
+      }
+    }
+  }
+};
+
+FDLayout.prototype.calcGravitationalForces = function () {
+  var node;
+  var lNodes = this.getAllNodesToApplyGravitation();
+
+  for (var i = 0; i < lNodes.length; i++) {
+    node = lNodes[i];
+    this.calcGravitationalForce(node);
+  }
+};
+
+FDLayout.prototype.moveNodes = function () {
+  var lNodes = this.getAllNodes();
+  var node;
+
+  for (var i = 0; i < lNodes.length; i++) {
+    node = lNodes[i];
+    node.move();
+  }
+};
+
+FDLayout.prototype.calcSpringForce = function (edge, idealLength) {
+  var sourceNode = edge.getSource();
+  var targetNode = edge.getTarget();
+
+  var length;
+  var springForce;
+  var springForceX;
+  var springForceY;
+
+  // Update edge length
+  if (this.uniformLeafNodeSizes && sourceNode.getChild() == null && targetNode.getChild() == null) {
+    edge.updateLengthSimple();
+  } else {
+    edge.updateLength();
+
+    if (edge.isOverlapingSourceAndTarget) {
+      return;
+    }
+  }
+
+  length = edge.getLength();
+
+  if (length == 0) return;
+
+  // Calculate spring forces
+  springForce = edge.edgeElasticity * (length - idealLength);
+
+  // Project force onto x and y axes
+  springForceX = springForce * (edge.lengthX / length);
+  springForceY = springForce * (edge.lengthY / length);
+
+  // Apply forces on the end nodes
+  sourceNode.springForceX += springForceX;
+  sourceNode.springForceY += springForceY;
+  targetNode.springForceX -= springForceX;
+  targetNode.springForceY -= springForceY;
+};
+
+FDLayout.prototype.calcRepulsionForce = function (nodeA, nodeB) {
+  var rectA = nodeA.getRect();
+  var rectB = nodeB.getRect();
+  var overlapAmount = new Array(2);
+  var clipPoints = new Array(4);
+  var distanceX;
+  var distanceY;
+  var distanceSquared;
+  var distance;
+  var repulsionForce;
+  var repulsionForceX;
+  var repulsionForceY;
+
+  if (rectA.intersects(rectB)) // two nodes overlap
+    {
+      // calculate separation amount in x and y directions
+      IGeometry.calcSeparationAmount(rectA, rectB, overlapAmount, FDLayoutConstants.DEFAULT_EDGE_LENGTH / 2.0);
+
+      repulsionForceX = 2 * overlapAmount[0];
+      repulsionForceY = 2 * overlapAmount[1];
+
+      var childrenConstant = nodeA.noOfChildren * nodeB.noOfChildren / (nodeA.noOfChildren + nodeB.noOfChildren);
+
+      // Apply forces on the two nodes
+      nodeA.repulsionForceX -= childrenConstant * repulsionForceX;
+      nodeA.repulsionForceY -= childrenConstant * repulsionForceY;
+      nodeB.repulsionForceX += childrenConstant * repulsionForceX;
+      nodeB.repulsionForceY += childrenConstant * repulsionForceY;
+    } else // no overlap
+    {
+      // calculate distance
+
+      if (this.uniformLeafNodeSizes && nodeA.getChild() == null && nodeB.getChild() == null) // simply base repulsion on distance of node centers
+        {
+          distanceX = rectB.getCenterX() - rectA.getCenterX();
+          distanceY = rectB.getCenterY() - rectA.getCenterY();
+        } else // use clipping points
+        {
+          IGeometry.getIntersection(rectA, rectB, clipPoints);
+
+          distanceX = clipPoints[2] - clipPoints[0];
+          distanceY = clipPoints[3] - clipPoints[1];
+        }
+
+      // No repulsion range. FR grid variant should take care of this.
+      if (Math.abs(distanceX) < FDLayoutConstants.MIN_REPULSION_DIST) {
+        distanceX = IMath.sign(distanceX) * FDLayoutConstants.MIN_REPULSION_DIST;
+      }
+
+      if (Math.abs(distanceY) < FDLayoutConstants.MIN_REPULSION_DIST) {
+        distanceY = IMath.sign(distanceY) * FDLayoutConstants.MIN_REPULSION_DIST;
+      }
+
+      distanceSquared = distanceX * distanceX + distanceY * distanceY;
+      distance = Math.sqrt(distanceSquared);
+
+      // Here we use half of the nodes' repulsion values for backward compatibility
+      repulsionForce = (nodeA.nodeRepulsion / 2 + nodeB.nodeRepulsion / 2) * nodeA.noOfChildren * nodeB.noOfChildren / distanceSquared;
+
+      // Project force onto x and y axes
+      repulsionForceX = repulsionForce * distanceX / distance;
+      repulsionForceY = repulsionForce * distanceY / distance;
+
+      // Apply forces on the two nodes    
+      nodeA.repulsionForceX -= repulsionForceX;
+      nodeA.repulsionForceY -= repulsionForceY;
+      nodeB.repulsionForceX += repulsionForceX;
+      nodeB.repulsionForceY += repulsionForceY;
+    }
+};
+
+FDLayout.prototype.calcGravitationalForce = function (node) {
+  var ownerGraph;
+  var ownerCenterX;
+  var ownerCenterY;
+  var distanceX;
+  var distanceY;
+  var absDistanceX;
+  var absDistanceY;
+  var estimatedSize;
+  ownerGraph = node.getOwner();
+
+  ownerCenterX = (ownerGraph.getRight() + ownerGraph.getLeft()) / 2;
+  ownerCenterY = (ownerGraph.getTop() + ownerGraph.getBottom()) / 2;
+  distanceX = node.getCenterX() - ownerCenterX;
+  distanceY = node.getCenterY() - ownerCenterY;
+  absDistanceX = Math.abs(distanceX) + node.getWidth() / 2;
+  absDistanceY = Math.abs(distanceY) + node.getHeight() / 2;
+
+  if (node.getOwner() == this.graphManager.getRoot()) // in the root graph
+    {
+      estimatedSize = ownerGraph.getEstimatedSize() * this.gravityRangeFactor;
+
+      if (absDistanceX > estimatedSize || absDistanceY > estimatedSize) {
+        node.gravitationForceX = -this.gravityConstant * distanceX;
+        node.gravitationForceY = -this.gravityConstant * distanceY;
+      }
+    } else // inside a compound
+    {
+      estimatedSize = ownerGraph.getEstimatedSize() * this.compoundGravityRangeFactor;
+
+      if (absDistanceX > estimatedSize || absDistanceY > estimatedSize) {
+        node.gravitationForceX = -this.gravityConstant * distanceX * this.compoundGravityConstant;
+        node.gravitationForceY = -this.gravityConstant * distanceY * this.compoundGravityConstant;
+      }
+    }
+};
+
+FDLayout.prototype.isConverged = function () {
+  var converged;
+  var oscilating = false;
+
+  if (this.totalIterations > this.maxIterations / 3) {
+    oscilating = Math.abs(this.totalDisplacement - this.oldTotalDisplacement) < 2;
+  }
+
+  converged = this.totalDisplacement < this.totalDisplacementThreshold;
+
+  this.oldTotalDisplacement = this.totalDisplacement;
+
+  return converged || oscilating;
+};
+
+FDLayout.prototype.animate = function () {
+  if (this.animationDuringLayout && !this.isSubLayout) {
+    if (this.notAnimatedIterations == this.animationPeriod) {
+      this.update();
+      this.notAnimatedIterations = 0;
+    } else {
+      this.notAnimatedIterations++;
+    }
+  }
+};
+
+//This method calculates the number of children (weight) for all nodes
+FDLayout.prototype.calcNoOfChildrenForAllNodes = function () {
+  var node;
+  var allNodes = this.graphManager.getAllNodes();
+
+  for (var i = 0; i < allNodes.length; i++) {
+    node = allNodes[i];
+    node.noOfChildren = node.getNoOfChildren();
+  }
+};
+
+// -----------------------------------------------------------------------------
+// Section: FR-Grid Variant Repulsion Force Calculation
+// -----------------------------------------------------------------------------
+
+FDLayout.prototype.calcGrid = function (graph) {
+
+  var sizeX = 0;
+  var sizeY = 0;
+
+  sizeX = parseInt(Math.ceil((graph.getRight() - graph.getLeft()) / this.repulsionRange));
+  sizeY = parseInt(Math.ceil((graph.getBottom() - graph.getTop()) / this.repulsionRange));
+
+  var grid = new Array(sizeX);
+
+  for (var i = 0; i < sizeX; i++) {
+    grid[i] = new Array(sizeY);
+  }
+
+  for (var i = 0; i < sizeX; i++) {
+    for (var j = 0; j < sizeY; j++) {
+      grid[i][j] = new Array();
+    }
+  }
+
+  return grid;
+};
+
+FDLayout.prototype.addNodeToGrid = function (v, left, top) {
+
+  var startX = 0;
+  var finishX = 0;
+  var startY = 0;
+  var finishY = 0;
+
+  startX = parseInt(Math.floor((v.getRect().x - left) / this.repulsionRange));
+  finishX = parseInt(Math.floor((v.getRect().width + v.getRect().x - left) / this.repulsionRange));
+  startY = parseInt(Math.floor((v.getRect().y - top) / this.repulsionRange));
+  finishY = parseInt(Math.floor((v.getRect().height + v.getRect().y - top) / this.repulsionRange));
+
+  for (var i = startX; i <= finishX; i++) {
+    for (var j = startY; j <= finishY; j++) {
+      this.grid[i][j].push(v);
+      v.setGridCoordinates(startX, finishX, startY, finishY);
+    }
+  }
+};
+
+FDLayout.prototype.updateGrid = function () {
+  var i;
+  var nodeA;
+  var lNodes = this.getAllNodes();
+
+  this.grid = this.calcGrid(this.graphManager.getRoot());
+
+  // put all nodes to proper grid cells
+  for (i = 0; i < lNodes.length; i++) {
+    nodeA = lNodes[i];
+    this.addNodeToGrid(nodeA, this.graphManager.getRoot().getLeft(), this.graphManager.getRoot().getTop());
+  }
+};
+
+FDLayout.prototype.calculateRepulsionForceOfANode = function (nodeA, processedNodeSet, gridUpdateAllowed, forceToNodeSurroundingUpdate) {
+
+  if (this.totalIterations % FDLayoutConstants.GRID_CALCULATION_CHECK_PERIOD == 1 && gridUpdateAllowed || forceToNodeSurroundingUpdate) {
+    var surrounding = new Set();
+    nodeA.surrounding = new Array();
+    var nodeB;
+    var grid = this.grid;
+
+    for (var i = nodeA.startX - 1; i < nodeA.finishX + 2; i++) {
+      for (var j = nodeA.startY - 1; j < nodeA.finishY + 2; j++) {
+        if (!(i < 0 || j < 0 || i >= grid.length || j >= grid[0].length)) {
+          for (var k = 0; k < grid[i][j].length; k++) {
+            nodeB = grid[i][j][k];
+
+            // If both nodes are not members of the same graph, 
+            // or both nodes are the same, skip.
+            if (nodeA.getOwner() != nodeB.getOwner() || nodeA == nodeB) {
+              continue;
+            }
+
+            // check if the repulsion force between
+            // nodeA and nodeB has already been calculated
+            if (!processedNodeSet.has(nodeB) && !surrounding.has(nodeB)) {
+              var distanceX = Math.abs(nodeA.getCenterX() - nodeB.getCenterX()) - (nodeA.getWidth() / 2 + nodeB.getWidth() / 2);
+              var distanceY = Math.abs(nodeA.getCenterY() - nodeB.getCenterY()) - (nodeA.getHeight() / 2 + nodeB.getHeight() / 2);
+
+              // if the distance between nodeA and nodeB 
+              // is less then calculation range
+              if (distanceX <= this.repulsionRange && distanceY <= this.repulsionRange) {
+                //then add nodeB to surrounding of nodeA
+                surrounding.add(nodeB);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    nodeA.surrounding = [].concat(_toConsumableArray(surrounding));
+  }
+  for (i = 0; i < nodeA.surrounding.length; i++) {
+    this.calcRepulsionForce(nodeA, nodeA.surrounding[i]);
+  }
+};
+
+FDLayout.prototype.calcRepulsionRange = function () {
+  return 0.0;
+};
+
+module.exports = FDLayout;
+
+/***/ }),
+/* 19 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var LEdge = __webpack_require__(1);
+var FDLayoutConstants = __webpack_require__(4);
+
+function FDLayoutEdge(source, target, vEdge) {
+  LEdge.call(this, source, target, vEdge);
+
+  // Ideal length and elasticity value for this edge
+  this.idealLength = FDLayoutConstants.DEFAULT_EDGE_LENGTH;
+  this.edgeElasticity = FDLayoutConstants.DEFAULT_SPRING_STRENGTH;
+}
+
+FDLayoutEdge.prototype = Object.create(LEdge.prototype);
+
+for (var prop in LEdge) {
+  FDLayoutEdge[prop] = LEdge[prop];
+}
+
+module.exports = FDLayoutEdge;
+
+/***/ }),
+/* 20 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var LNode = __webpack_require__(3);
+var FDLayoutConstants = __webpack_require__(4);
+
+function FDLayoutNode(gm, loc, size, vNode) {
+  // alternative constructor is handled inside LNode
+  LNode.call(this, gm, loc, size, vNode);
+
+  // Repulsion value of this node
+  this.nodeRepulsion = FDLayoutConstants.DEFAULT_REPULSION_STRENGTH;
+
+  //Spring, repulsion and gravitational forces acting on this node
+  this.springForceX = 0;
+  this.springForceY = 0;
+  this.repulsionForceX = 0;
+  this.repulsionForceY = 0;
+  this.gravitationForceX = 0;
+  this.gravitationForceY = 0;
+  //Amount by which this node is to be moved in this iteration
+  this.displacementX = 0;
+  this.displacementY = 0;
+
+  //Start and finish grid coordinates that this node is fallen into
+  this.startX = 0;
+  this.finishX = 0;
+  this.startY = 0;
+  this.finishY = 0;
+
+  //Geometric neighbors of this node
+  this.surrounding = [];
+}
+
+FDLayoutNode.prototype = Object.create(LNode.prototype);
+
+for (var prop in LNode) {
+  FDLayoutNode[prop] = LNode[prop];
+}
+
+FDLayoutNode.prototype.setGridCoordinates = function (_startX, _finishX, _startY, _finishY) {
+  this.startX = _startX;
+  this.finishX = _finishX;
+  this.startY = _startY;
+  this.finishY = _finishY;
+};
+
+module.exports = FDLayoutNode;
+
+/***/ }),
+/* 21 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+function DimensionD(width, height) {
+  this.width = 0;
+  this.height = 0;
+  if (width !== null && height !== null) {
+    this.height = height;
+    this.width = width;
+  }
+}
+
+DimensionD.prototype.getWidth = function () {
+  return this.width;
+};
+
+DimensionD.prototype.setWidth = function (width) {
+  this.width = width;
+};
+
+DimensionD.prototype.getHeight = function () {
+  return this.height;
+};
+
+DimensionD.prototype.setHeight = function (height) {
+  this.height = height;
+};
+
+module.exports = DimensionD;
+
+/***/ }),
+/* 22 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var UniqueIDGeneretor = __webpack_require__(14);
+
+function HashMap() {
+  this.map = {};
+  this.keys = [];
+}
+
+HashMap.prototype.put = function (key, value) {
+  var theId = UniqueIDGeneretor.createID(key);
+  if (!this.contains(theId)) {
+    this.map[theId] = value;
+    this.keys.push(key);
+  }
+};
+
+HashMap.prototype.contains = function (key) {
+  var theId = UniqueIDGeneretor.createID(key);
+  return this.map[key] != null;
+};
+
+HashMap.prototype.get = function (key) {
+  var theId = UniqueIDGeneretor.createID(key);
+  return this.map[theId];
+};
+
+HashMap.prototype.keySet = function () {
+  return this.keys;
+};
+
+module.exports = HashMap;
+
+/***/ }),
+/* 23 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var UniqueIDGeneretor = __webpack_require__(14);
+
+function HashSet() {
+  this.set = {};
+}
+;
+
+HashSet.prototype.add = function (obj) {
+  var theId = UniqueIDGeneretor.createID(obj);
+  if (!this.contains(theId)) this.set[theId] = obj;
+};
+
+HashSet.prototype.remove = function (obj) {
+  delete this.set[UniqueIDGeneretor.createID(obj)];
+};
+
+HashSet.prototype.clear = function () {
+  this.set = {};
+};
+
+HashSet.prototype.contains = function (obj) {
+  return this.set[UniqueIDGeneretor.createID(obj)] == obj;
+};
+
+HashSet.prototype.isEmpty = function () {
+  return this.size() === 0;
+};
+
+HashSet.prototype.size = function () {
+  return Object.keys(this.set).length;
+};
+
+//concats this.set to the given list
+HashSet.prototype.addAllTo = function (list) {
+  var keys = Object.keys(this.set);
+  var length = keys.length;
+  for (var i = 0; i < length; i++) {
+    list.push(this.set[keys[i]]);
+  }
+};
+
+HashSet.prototype.size = function () {
+  return Object.keys(this.set).length;
+};
+
+HashSet.prototype.addAll = function (list) {
+  var s = list.length;
+  for (var i = 0; i < s; i++) {
+    var v = list[i];
+    this.add(v);
+  }
+};
+
+module.exports = HashSet;
+
+/***/ }),
+/* 24 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+// Some matrix (1d and 2d array) operations
+function Matrix() {}
+
+/**
+ * matrix multiplication
+ * array1, array2 and result are 2d arrays
+ */
+Matrix.multMat = function (array1, array2) {
+  var result = [];
+
+  for (var i = 0; i < array1.length; i++) {
+    result[i] = [];
+    for (var j = 0; j < array2[0].length; j++) {
+      result[i][j] = 0;
+      for (var k = 0; k < array1[0].length; k++) {
+        result[i][j] += array1[i][k] * array2[k][j];
+      }
+    }
+  }
+  return result;
+};
+
+/**
+ * matrix transpose
+ * array and result are 2d arrays
+ */
+Matrix.transpose = function (array) {
+  var result = [];
+
+  for (var i = 0; i < array[0].length; i++) {
+    result[i] = [];
+    for (var j = 0; j < array.length; j++) {
+      result[i][j] = array[j][i];
+    }
+  }
+
+  return result;
+};
+
+/**
+ * multiply array with constant
+ * array and result are 1d arrays
+ */
+Matrix.multCons = function (array, constant) {
+  var result = [];
+
+  for (var i = 0; i < array.length; i++) {
+    result[i] = array[i] * constant;
+  }
+
+  return result;
+};
+
+/**
+ * substract two arrays
+ * array1, array2 and result are 1d arrays
+ */
+Matrix.minusOp = function (array1, array2) {
+  var result = [];
+
+  for (var i = 0; i < array1.length; i++) {
+    result[i] = array1[i] - array2[i];
+  }
+
+  return result;
+};
+
+/**
+ * dot product of two arrays with same size
+ * array1 and array2 are 1d arrays
+ */
+Matrix.dotProduct = function (array1, array2) {
+  var product = 0;
+
+  for (var i = 0; i < array1.length; i++) {
+    product += array1[i] * array2[i];
+  }
+
+  return product;
+};
+
+/**
+ * magnitude of an array
+ * array is 1d array
+ */
+Matrix.mag = function (array) {
+  return Math.sqrt(this.dotProduct(array, array));
+};
+
+/**
+ * normalization of an array
+ * array and result are 1d array
+ */
+Matrix.normalize = function (array) {
+  var result = [];
+  var magnitude = this.mag(array);
+
+  for (var i = 0; i < array.length; i++) {
+    result[i] = array[i] / magnitude;
+  }
+
+  return result;
+};
+
+/**
+ * multiply an array with centering matrix
+ * array and result are 1d array
+ */
+Matrix.multGamma = function (array) {
+  var result = [];
+  var sum = 0;
+
+  for (var i = 0; i < array.length; i++) {
+    sum += array[i];
+  }
+
+  sum *= -1 / array.length;
+
+  for (var _i = 0; _i < array.length; _i++) {
+    result[_i] = sum + array[_i];
+  }
+  return result;
+};
+
+/**
+ * a special matrix multiplication
+ * result = 0.5 * C * INV * C^T * array
+ * array and result are 1d, C and INV are 2d arrays
+ */
+Matrix.multL = function (array, C, INV) {
+  var result = [];
+  var temp1 = [];
+  var temp2 = [];
+
+  // multiply by C^T
+  for (var i = 0; i < C[0].length; i++) {
+    var sum = 0;
+    for (var j = 0; j < C.length; j++) {
+      sum += -0.5 * C[j][i] * array[j];
+    }
+    temp1[i] = sum;
+  }
+  // multiply the result by INV
+  for (var _i2 = 0; _i2 < INV.length; _i2++) {
+    var _sum = 0;
+    for (var _j = 0; _j < INV.length; _j++) {
+      _sum += INV[_i2][_j] * temp1[_j];
+    }
+    temp2[_i2] = _sum;
+  }
+  // multiply the result by C
+  for (var _i3 = 0; _i3 < C.length; _i3++) {
+    var _sum2 = 0;
+    for (var _j2 = 0; _j2 < C[0].length; _j2++) {
+      _sum2 += C[_i3][_j2] * temp2[_j2];
+    }
+    result[_i3] = _sum2;
+  }
+
+  return result;
+};
+
+module.exports = Matrix;
+
+/***/ }),
+/* 25 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+/**
+ * A classic Quicksort algorithm with Hoare's partition
+ * - Works also on LinkedList objects
+ *
+ * Copyright: i-Vis Research Group, Bilkent University, 2007 - present
+ */
+
+var LinkedList = __webpack_require__(11);
+
+var Quicksort = function () {
+    function Quicksort(A, compareFunction) {
+        _classCallCheck(this, Quicksort);
+
+        if (compareFunction !== null || compareFunction !== undefined) this.compareFunction = this._defaultCompareFunction;
+
+        var length = void 0;
+        if (A instanceof LinkedList) length = A.size();else length = A.length;
+
+        this._quicksort(A, 0, length - 1);
+    }
+
+    _createClass(Quicksort, [{
+        key: '_quicksort',
+        value: function _quicksort(A, p, r) {
+            if (p < r) {
+                var q = this._partition(A, p, r);
+                this._quicksort(A, p, q);
+                this._quicksort(A, q + 1, r);
+            }
+        }
+    }, {
+        key: '_partition',
+        value: function _partition(A, p, r) {
+            var x = this._get(A, p);
+            var i = p;
+            var j = r;
+            while (true) {
+                while (this.compareFunction(x, this._get(A, j))) {
+                    j--;
+                }while (this.compareFunction(this._get(A, i), x)) {
+                    i++;
+                }if (i < j) {
+                    this._swap(A, i, j);
+                    i++;
+                    j--;
+                } else return j;
+            }
+        }
+    }, {
+        key: '_get',
+        value: function _get(object, index) {
+            if (object instanceof LinkedList) return object.get_object_at(index);else return object[index];
+        }
+    }, {
+        key: '_set',
+        value: function _set(object, index, value) {
+            if (object instanceof LinkedList) object.set_object_at(index, value);else object[index] = value;
+        }
+    }, {
+        key: '_swap',
+        value: function _swap(A, i, j) {
+            var temp = this._get(A, i);
+            this._set(A, i, this._get(A, j));
+            this._set(A, j, temp);
+        }
+    }, {
+        key: '_defaultCompareFunction',
+        value: function _defaultCompareFunction(a, b) {
+            return b > a;
+        }
+    }]);
+
+    return Quicksort;
+}();
+
+module.exports = Quicksort;
+
+/***/ }),
+/* 26 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+// Singular Value Decomposition implementation
+function SVD() {};
+
+/* Below singular value decomposition (svd) code including hypot function is adopted from https://github.com/dragonfly-ai/JamaJS
+   Some changes are applied to make the code compatible with the fcose code and to make it independent from Jama.
+   Input matrix is changed to a 2D array instead of Jama matrix. Matrix dimensions are taken according to 2D array instead of using Jama functions.
+   An object that includes singular value components is created for return. 
+   The types of input parameters of the hypot function are removed. 
+   let is used instead of var for the variable initialization.
+*/
+/*
+                               Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+SVD.svd = function (A) {
+  this.U = null;
+  this.V = null;
+  this.s = null;
+  this.m = 0;
+  this.n = 0;
+  this.m = A.length;
+  this.n = A[0].length;
+  var nu = Math.min(this.m, this.n);
+  this.s = function (s) {
+    var a = [];
+    while (s-- > 0) {
+      a.push(0);
+    }return a;
+  }(Math.min(this.m + 1, this.n));
+  this.U = function (dims) {
+    var allocate = function allocate(dims) {
+      if (dims.length == 0) {
+        return 0;
+      } else {
+        var array = [];
+        for (var i = 0; i < dims[0]; i++) {
+          array.push(allocate(dims.slice(1)));
+        }
+        return array;
+      }
+    };
+    return allocate(dims);
+  }([this.m, nu]);
+  this.V = function (dims) {
+    var allocate = function allocate(dims) {
+      if (dims.length == 0) {
+        return 0;
+      } else {
+        var array = [];
+        for (var i = 0; i < dims[0]; i++) {
+          array.push(allocate(dims.slice(1)));
+        }
+        return array;
+      }
+    };
+    return allocate(dims);
+  }([this.n, this.n]);
+  var e = function (s) {
+    var a = [];
+    while (s-- > 0) {
+      a.push(0);
+    }return a;
+  }(this.n);
+  var work = function (s) {
+    var a = [];
+    while (s-- > 0) {
+      a.push(0);
+    }return a;
+  }(this.m);
+  var wantu = true;
+  var wantv = true;
+  var nct = Math.min(this.m - 1, this.n);
+  var nrt = Math.max(0, Math.min(this.n - 2, this.m));
+  for (var k = 0; k < Math.max(nct, nrt); k++) {
+    if (k < nct) {
+      this.s[k] = 0;
+      for (var i = k; i < this.m; i++) {
+        this.s[k] = SVD.hypot(this.s[k], A[i][k]);
+      }
+      ;
+      if (this.s[k] !== 0.0) {
+        if (A[k][k] < 0.0) {
+          this.s[k] = -this.s[k];
+        }
+        for (var _i = k; _i < this.m; _i++) {
+          A[_i][k] /= this.s[k];
+        }
+        ;
+        A[k][k] += 1.0;
+      }
+      this.s[k] = -this.s[k];
+    }
+    for (var j = k + 1; j < this.n; j++) {
+      if (function (lhs, rhs) {
+        return lhs && rhs;
+      }(k < nct, this.s[k] !== 0.0)) {
+        var t = 0;
+        for (var _i2 = k; _i2 < this.m; _i2++) {
+          t += A[_i2][k] * A[_i2][j];
+        }
+        ;
+        t = -t / A[k][k];
+        for (var _i3 = k; _i3 < this.m; _i3++) {
+          A[_i3][j] += t * A[_i3][k];
+        }
+        ;
+      }
+      e[j] = A[k][j];
+    }
+    ;
+    if (function (lhs, rhs) {
+      return lhs && rhs;
+    }(wantu, k < nct)) {
+      for (var _i4 = k; _i4 < this.m; _i4++) {
+        this.U[_i4][k] = A[_i4][k];
+      }
+      ;
+    }
+    if (k < nrt) {
+      e[k] = 0;
+      for (var _i5 = k + 1; _i5 < this.n; _i5++) {
+        e[k] = SVD.hypot(e[k], e[_i5]);
+      }
+      ;
+      if (e[k] !== 0.0) {
+        if (e[k + 1] < 0.0) {
+          e[k] = -e[k];
+        }
+        for (var _i6 = k + 1; _i6 < this.n; _i6++) {
+          e[_i6] /= e[k];
+        }
+        ;
+        e[k + 1] += 1.0;
+      }
+      e[k] = -e[k];
+      if (function (lhs, rhs) {
+        return lhs && rhs;
+      }(k + 1 < this.m, e[k] !== 0.0)) {
+        for (var _i7 = k + 1; _i7 < this.m; _i7++) {
+          work[_i7] = 0.0;
+        }
+        ;
+        for (var _j = k + 1; _j < this.n; _j++) {
+          for (var _i8 = k + 1; _i8 < this.m; _i8++) {
+            work[_i8] += e[_j] * A[_i8][_j];
+          }
+          ;
+        }
+        ;
+        for (var _j2 = k + 1; _j2 < this.n; _j2++) {
+          var _t = -e[_j2] / e[k + 1];
+          for (var _i9 = k + 1; _i9 < this.m; _i9++) {
+            A[_i9][_j2] += _t * work[_i9];
+          }
+          ;
+        }
+        ;
+      }
+      if (wantv) {
+        for (var _i10 = k + 1; _i10 < this.n; _i10++) {
+          this.V[_i10][k] = e[_i10];
+        };
+      }
+    }
+  };
+  var p = Math.min(this.n, this.m + 1);
+  if (nct < this.n) {
+    this.s[nct] = A[nct][nct];
+  }
+  if (this.m < p) {
+    this.s[p - 1] = 0.0;
+  }
+  if (nrt + 1 < p) {
+    e[nrt] = A[nrt][p - 1];
+  }
+  e[p - 1] = 0.0;
+  if (wantu) {
+    for (var _j3 = nct; _j3 < nu; _j3++) {
+      for (var _i11 = 0; _i11 < this.m; _i11++) {
+        this.U[_i11][_j3] = 0.0;
+      }
+      ;
+      this.U[_j3][_j3] = 1.0;
+    };
+    for (var _k = nct - 1; _k >= 0; _k--) {
+      if (this.s[_k] !== 0.0) {
+        for (var _j4 = _k + 1; _j4 < nu; _j4++) {
+          var _t2 = 0;
+          for (var _i12 = _k; _i12 < this.m; _i12++) {
+            _t2 += this.U[_i12][_k] * this.U[_i12][_j4];
+          };
+          _t2 = -_t2 / this.U[_k][_k];
+          for (var _i13 = _k; _i13 < this.m; _i13++) {
+            this.U[_i13][_j4] += _t2 * this.U[_i13][_k];
+          };
+        };
+        for (var _i14 = _k; _i14 < this.m; _i14++) {
+          this.U[_i14][_k] = -this.U[_i14][_k];
+        };
+        this.U[_k][_k] = 1.0 + this.U[_k][_k];
+        for (var _i15 = 0; _i15 < _k - 1; _i15++) {
+          this.U[_i15][_k] = 0.0;
+        };
+      } else {
+        for (var _i16 = 0; _i16 < this.m; _i16++) {
+          this.U[_i16][_k] = 0.0;
+        };
+        this.U[_k][_k] = 1.0;
+      }
+    };
+  }
+  if (wantv) {
+    for (var _k2 = this.n - 1; _k2 >= 0; _k2--) {
+      if (function (lhs, rhs) {
+        return lhs && rhs;
+      }(_k2 < nrt, e[_k2] !== 0.0)) {
+        for (var _j5 = _k2 + 1; _j5 < nu; _j5++) {
+          var _t3 = 0;
+          for (var _i17 = _k2 + 1; _i17 < this.n; _i17++) {
+            _t3 += this.V[_i17][_k2] * this.V[_i17][_j5];
+          };
+          _t3 = -_t3 / this.V[_k2 + 1][_k2];
+          for (var _i18 = _k2 + 1; _i18 < this.n; _i18++) {
+            this.V[_i18][_j5] += _t3 * this.V[_i18][_k2];
+          };
+        };
+      }
+      for (var _i19 = 0; _i19 < this.n; _i19++) {
+        this.V[_i19][_k2] = 0.0;
+      };
+      this.V[_k2][_k2] = 1.0;
+    };
+  }
+  var pp = p - 1;
+  var iter = 0;
+  var eps = Math.pow(2.0, -52.0);
+  var tiny = Math.pow(2.0, -966.0);
+  while (p > 0) {
+    var _k3 = void 0;
+    var kase = void 0;
+    for (_k3 = p - 2; _k3 >= -1; _k3--) {
+      if (_k3 === -1) {
+        break;
+      }
+      if (Math.abs(e[_k3]) <= tiny + eps * (Math.abs(this.s[_k3]) + Math.abs(this.s[_k3 + 1]))) {
+        e[_k3] = 0.0;
+        break;
+      }
+    };
+    if (_k3 === p - 2) {
+      kase = 4;
+    } else {
+      var ks = void 0;
+      for (ks = p - 1; ks >= _k3; ks--) {
+        if (ks === _k3) {
+          break;
+        }
+        var _t4 = (ks !== p ? Math.abs(e[ks]) : 0.0) + (ks !== _k3 + 1 ? Math.abs(e[ks - 1]) : 0.0);
+        if (Math.abs(this.s[ks]) <= tiny + eps * _t4) {
+          this.s[ks] = 0.0;
+          break;
+        }
+      };
+      if (ks === _k3) {
+        kase = 3;
+      } else if (ks === p - 1) {
+        kase = 1;
+      } else {
+        kase = 2;
+        _k3 = ks;
+      }
+    }
+    _k3++;
+    switch (kase) {
+      case 1:
+        {
+          var f = e[p - 2];
+          e[p - 2] = 0.0;
+          for (var _j6 = p - 2; _j6 >= _k3; _j6--) {
+            var _t5 = SVD.hypot(this.s[_j6], f);
+            var cs = this.s[_j6] / _t5;
+            var sn = f / _t5;
+            this.s[_j6] = _t5;
+            if (_j6 !== _k3) {
+              f = -sn * e[_j6 - 1];
+              e[_j6 - 1] = cs * e[_j6 - 1];
+            }
+            if (wantv) {
+              for (var _i20 = 0; _i20 < this.n; _i20++) {
+                _t5 = cs * this.V[_i20][_j6] + sn * this.V[_i20][p - 1];
+                this.V[_i20][p - 1] = -sn * this.V[_i20][_j6] + cs * this.V[_i20][p - 1];
+                this.V[_i20][_j6] = _t5;
+              };
+            }
+          };
+        };
+        break;
+      case 2:
+        {
+          var _f = e[_k3 - 1];
+          e[_k3 - 1] = 0.0;
+          for (var _j7 = _k3; _j7 < p; _j7++) {
+            var _t6 = SVD.hypot(this.s[_j7], _f);
+            var _cs = this.s[_j7] / _t6;
+            var _sn = _f / _t6;
+            this.s[_j7] = _t6;
+            _f = -_sn * e[_j7];
+            e[_j7] = _cs * e[_j7];
+            if (wantu) {
+              for (var _i21 = 0; _i21 < this.m; _i21++) {
+                _t6 = _cs * this.U[_i21][_j7] + _sn * this.U[_i21][_k3 - 1];
+                this.U[_i21][_k3 - 1] = -_sn * this.U[_i21][_j7] + _cs * this.U[_i21][_k3 - 1];
+                this.U[_i21][_j7] = _t6;
+              };
+            }
+          };
+        };
+        break;
+      case 3:
+        {
+          var scale = Math.max(Math.max(Math.max(Math.max(Math.abs(this.s[p - 1]), Math.abs(this.s[p - 2])), Math.abs(e[p - 2])), Math.abs(this.s[_k3])), Math.abs(e[_k3]));
+          var sp = this.s[p - 1] / scale;
+          var spm1 = this.s[p - 2] / scale;
+          var epm1 = e[p - 2] / scale;
+          var sk = this.s[_k3] / scale;
+          var ek = e[_k3] / scale;
+          var b = ((spm1 + sp) * (spm1 - sp) + epm1 * epm1) / 2.0;
+          var c = sp * epm1 * (sp * epm1);
+          var shift = 0.0;
+          if (function (lhs, rhs) {
+            return lhs || rhs;
+          }(b !== 0.0, c !== 0.0)) {
+            shift = Math.sqrt(b * b + c);
+            if (b < 0.0) {
+              shift = -shift;
+            }
+            shift = c / (b + shift);
+          }
+          var _f2 = (sk + sp) * (sk - sp) + shift;
+          var g = sk * ek;
+          for (var _j8 = _k3; _j8 < p - 1; _j8++) {
+            var _t7 = SVD.hypot(_f2, g);
+            var _cs2 = _f2 / _t7;
+            var _sn2 = g / _t7;
+            if (_j8 !== _k3) {
+              e[_j8 - 1] = _t7;
+            }
+            _f2 = _cs2 * this.s[_j8] + _sn2 * e[_j8];
+            e[_j8] = _cs2 * e[_j8] - _sn2 * this.s[_j8];
+            g = _sn2 * this.s[_j8 + 1];
+            this.s[_j8 + 1] = _cs2 * this.s[_j8 + 1];
+            if (wantv) {
+              for (var _i22 = 0; _i22 < this.n; _i22++) {
+                _t7 = _cs2 * this.V[_i22][_j8] + _sn2 * this.V[_i22][_j8 + 1];
+                this.V[_i22][_j8 + 1] = -_sn2 * this.V[_i22][_j8] + _cs2 * this.V[_i22][_j8 + 1];
+                this.V[_i22][_j8] = _t7;
+              };
+            }
+            _t7 = SVD.hypot(_f2, g);
+            _cs2 = _f2 / _t7;
+            _sn2 = g / _t7;
+            this.s[_j8] = _t7;
+            _f2 = _cs2 * e[_j8] + _sn2 * this.s[_j8 + 1];
+            this.s[_j8 + 1] = -_sn2 * e[_j8] + _cs2 * this.s[_j8 + 1];
+            g = _sn2 * e[_j8 + 1];
+            e[_j8 + 1] = _cs2 * e[_j8 + 1];
+            if (wantu && _j8 < this.m - 1) {
+              for (var _i23 = 0; _i23 < this.m; _i23++) {
+                _t7 = _cs2 * this.U[_i23][_j8] + _sn2 * this.U[_i23][_j8 + 1];
+                this.U[_i23][_j8 + 1] = -_sn2 * this.U[_i23][_j8] + _cs2 * this.U[_i23][_j8 + 1];
+                this.U[_i23][_j8] = _t7;
+              };
+            }
+          };
+          e[p - 2] = _f2;
+          iter = iter + 1;
+        };
+        break;
+      case 4:
+        {
+          if (this.s[_k3] <= 0.0) {
+            this.s[_k3] = this.s[_k3] < 0.0 ? -this.s[_k3] : 0.0;
+            if (wantv) {
+              for (var _i24 = 0; _i24 <= pp; _i24++) {
+                this.V[_i24][_k3] = -this.V[_i24][_k3];
+              };
+            }
+          }
+          while (_k3 < pp) {
+            if (this.s[_k3] >= this.s[_k3 + 1]) {
+              break;
+            }
+            var _t8 = this.s[_k3];
+            this.s[_k3] = this.s[_k3 + 1];
+            this.s[_k3 + 1] = _t8;
+            if (wantv && _k3 < this.n - 1) {
+              for (var _i25 = 0; _i25 < this.n; _i25++) {
+                _t8 = this.V[_i25][_k3 + 1];
+                this.V[_i25][_k3 + 1] = this.V[_i25][_k3];
+                this.V[_i25][_k3] = _t8;
+              };
+            }
+            if (wantu && _k3 < this.m - 1) {
+              for (var _i26 = 0; _i26 < this.m; _i26++) {
+                _t8 = this.U[_i26][_k3 + 1];
+                this.U[_i26][_k3 + 1] = this.U[_i26][_k3];
+                this.U[_i26][_k3] = _t8;
+              };
+            }
+            _k3++;
+          };
+          iter = 0;
+          p--;
+        };
+        break;
+    }
+  };
+  var result = { U: this.U, V: this.V, S: this.s };
+  return result;
+};
+
+// sqrt(a^2 + b^2) without under/overflow.
+SVD.hypot = function (a, b) {
+  var r = void 0;
+  if (Math.abs(a) > Math.abs(b)) {
+    r = b / a;
+    r = Math.abs(a) * Math.sqrt(1 + r * r);
+  } else if (b != 0) {
+    r = a / b;
+    r = Math.abs(b) * Math.sqrt(1 + r * r);
+  } else {
+    r = 0.0;
+  }
+  return r;
+};
+
+module.exports = SVD;
+
+/***/ }),
+/* 27 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+/**
+ *   Needleman-Wunsch algorithm is an procedure to compute the optimal global alignment of two string
+ *   sequences by S.B.Needleman and C.D.Wunsch (1970).
+ *
+ *   Aside from the inputs, you can assign the scores for,
+ *   - Match: The two characters at the current index are same.
+ *   - Mismatch: The two characters at the current index are different.
+ *   - Insertion/Deletion(gaps): The best alignment involves one letter aligning to a gap in the other string.
+ */
+
+var NeedlemanWunsch = function () {
+    function NeedlemanWunsch(sequence1, sequence2) {
+        var match_score = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 1;
+        var mismatch_penalty = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : -1;
+        var gap_penalty = arguments.length > 4 && arguments[4] !== undefined ? arguments[4] : -1;
+
+        _classCallCheck(this, NeedlemanWunsch);
+
+        this.sequence1 = sequence1;
+        this.sequence2 = sequence2;
+        this.match_score = match_score;
+        this.mismatch_penalty = mismatch_penalty;
+        this.gap_penalty = gap_penalty;
+
+        // Just the remove redundancy
+        this.iMax = sequence1.length + 1;
+        this.jMax = sequence2.length + 1;
+
+        // Grid matrix of scores
+        this.grid = new Array(this.iMax);
+        for (var i = 0; i < this.iMax; i++) {
+            this.grid[i] = new Array(this.jMax);
+
+            for (var j = 0; j < this.jMax; j++) {
+                this.grid[i][j] = 0;
+            }
+        }
+
+        // Traceback matrix (2D array, each cell is an array of boolean values for [`Diag`, `Up`, `Left`] positions)
+        this.tracebackGrid = new Array(this.iMax);
+        for (var _i = 0; _i < this.iMax; _i++) {
+            this.tracebackGrid[_i] = new Array(this.jMax);
+
+            for (var _j = 0; _j < this.jMax; _j++) {
+                this.tracebackGrid[_i][_j] = [null, null, null];
+            }
+        }
+
+        // The aligned sequences (return multiple possibilities)
+        this.alignments = [];
+
+        // Final alignment score
+        this.score = -1;
+
+        // Calculate scores and tracebacks
+        this.computeGrids();
+    }
+
+    _createClass(NeedlemanWunsch, [{
+        key: "getScore",
+        value: function getScore() {
+            return this.score;
+        }
+    }, {
+        key: "getAlignments",
+        value: function getAlignments() {
+            return this.alignments;
+        }
+
+        // Main dynamic programming procedure
+
+    }, {
+        key: "computeGrids",
+        value: function computeGrids() {
+            // Fill in the first row
+            for (var j = 1; j < this.jMax; j++) {
+                this.grid[0][j] = this.grid[0][j - 1] + this.gap_penalty;
+                this.tracebackGrid[0][j] = [false, false, true];
+            }
+
+            // Fill in the first column
+            for (var i = 1; i < this.iMax; i++) {
+                this.grid[i][0] = this.grid[i - 1][0] + this.gap_penalty;
+                this.tracebackGrid[i][0] = [false, true, false];
+            }
+
+            // Fill the rest of the grid
+            for (var _i2 = 1; _i2 < this.iMax; _i2++) {
+                for (var _j2 = 1; _j2 < this.jMax; _j2++) {
+                    // Find the max score(s) among [`Diag`, `Up`, `Left`]
+                    var diag = void 0;
+                    if (this.sequence1[_i2 - 1] === this.sequence2[_j2 - 1]) diag = this.grid[_i2 - 1][_j2 - 1] + this.match_score;else diag = this.grid[_i2 - 1][_j2 - 1] + this.mismatch_penalty;
+
+                    var up = this.grid[_i2 - 1][_j2] + this.gap_penalty;
+                    var left = this.grid[_i2][_j2 - 1] + this.gap_penalty;
+
+                    // If there exists multiple max values, capture them for multiple paths
+                    var maxOf = [diag, up, left];
+                    var indices = this.arrayAllMaxIndexes(maxOf);
+
+                    // Update Grids
+                    this.grid[_i2][_j2] = maxOf[indices[0]];
+                    this.tracebackGrid[_i2][_j2] = [indices.includes(0), indices.includes(1), indices.includes(2)];
+                }
+            }
+
+            // Update alignment score
+            this.score = this.grid[this.iMax - 1][this.jMax - 1];
+        }
+
+        // Gets all possible valid sequence combinations
+
+    }, {
+        key: "alignmentTraceback",
+        value: function alignmentTraceback() {
+            var inProcessAlignments = [];
+
+            inProcessAlignments.push({ pos: [this.sequence1.length, this.sequence2.length],
+                seq1: "",
+                seq2: ""
+            });
+
+            while (inProcessAlignments[0]) {
+                var current = inProcessAlignments[0];
+                var directions = this.tracebackGrid[current.pos[0]][current.pos[1]];
+
+                if (directions[0]) {
+                    inProcessAlignments.push({ pos: [current.pos[0] - 1, current.pos[1] - 1],
+                        seq1: this.sequence1[current.pos[0] - 1] + current.seq1,
+                        seq2: this.sequence2[current.pos[1] - 1] + current.seq2
+                    });
+                }
+                if (directions[1]) {
+                    inProcessAlignments.push({ pos: [current.pos[0] - 1, current.pos[1]],
+                        seq1: this.sequence1[current.pos[0] - 1] + current.seq1,
+                        seq2: '-' + current.seq2
+                    });
+                }
+                if (directions[2]) {
+                    inProcessAlignments.push({ pos: [current.pos[0], current.pos[1] - 1],
+                        seq1: '-' + current.seq1,
+                        seq2: this.sequence2[current.pos[1] - 1] + current.seq2
+                    });
+                }
+
+                if (current.pos[0] === 0 && current.pos[1] === 0) this.alignments.push({ sequence1: current.seq1,
+                    sequence2: current.seq2
+                });
+
+                inProcessAlignments.shift();
+            }
+
+            return this.alignments;
+        }
+
+        // Helper Functions
+
+    }, {
+        key: "getAllIndexes",
+        value: function getAllIndexes(arr, val) {
+            var indexes = [],
+                i = -1;
+            while ((i = arr.indexOf(val, i + 1)) !== -1) {
+                indexes.push(i);
+            }
+            return indexes;
+        }
+    }, {
+        key: "arrayAllMaxIndexes",
+        value: function arrayAllMaxIndexes(array) {
+            return this.getAllIndexes(array, Math.max.apply(null, array));
+        }
+    }]);
+
+    return NeedlemanWunsch;
+}();
+
+module.exports = NeedlemanWunsch;
+
+/***/ }),
+/* 28 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var layoutBase = function layoutBase() {
+  return;
+};
+
+layoutBase.FDLayout = __webpack_require__(18);
+layoutBase.FDLayoutConstants = __webpack_require__(4);
+layoutBase.FDLayoutEdge = __webpack_require__(19);
+layoutBase.FDLayoutNode = __webpack_require__(20);
+layoutBase.DimensionD = __webpack_require__(21);
+layoutBase.HashMap = __webpack_require__(22);
+layoutBase.HashSet = __webpack_require__(23);
+layoutBase.IGeometry = __webpack_require__(8);
+layoutBase.IMath = __webpack_require__(9);
+layoutBase.Integer = __webpack_require__(10);
+layoutBase.Point = __webpack_require__(12);
+layoutBase.PointD = __webpack_require__(5);
+layoutBase.RandomSeed = __webpack_require__(16);
+layoutBase.RectangleD = __webpack_require__(13);
+layoutBase.Transform = __webpack_require__(17);
+layoutBase.UniqueIDGeneretor = __webpack_require__(14);
+layoutBase.Quicksort = __webpack_require__(25);
+layoutBase.LinkedList = __webpack_require__(11);
+layoutBase.LGraphObject = __webpack_require__(2);
+layoutBase.LGraph = __webpack_require__(6);
+layoutBase.LEdge = __webpack_require__(1);
+layoutBase.LGraphManager = __webpack_require__(7);
+layoutBase.LNode = __webpack_require__(3);
+layoutBase.Layout = __webpack_require__(15);
+layoutBase.LayoutConstants = __webpack_require__(0);
+layoutBase.NeedlemanWunsch = __webpack_require__(27);
+layoutBase.Matrix = __webpack_require__(24);
+layoutBase.SVD = __webpack_require__(26);
+
+module.exports = layoutBase;
+
+/***/ }),
+/* 29 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+function Emitter() {
+  this.listeners = [];
+}
+
+var p = Emitter.prototype;
+
+p.addListener = function (event, callback) {
+  this.listeners.push({
+    event: event,
+    callback: callback
+  });
+};
+
+p.removeListener = function (event, callback) {
+  for (var i = this.listeners.length; i >= 0; i--) {
+    var l = this.listeners[i];
+
+    if (l.event === event && l.callback === callback) {
+      this.listeners.splice(i, 1);
+    }
+  }
+};
+
+p.emit = function (event, data) {
+  for (var i = 0; i < this.listeners.length; i++) {
+    var l = this.listeners[i];
+
+    if (event === l.event) {
+      l.callback(data);
+    }
+  }
+};
+
+module.exports = Emitter;
+
+/***/ })
+/******/ ]);
+});

--- a/backend/src/meho_backplane/ui/templates/topology/_table_rows.html
+++ b/backend/src/meho_backplane/ui/templates/topology/_table_rows.html
@@ -13,7 +13,19 @@
 <tbody id="topology-table-body">
   {% if nodes %}
     {% for node in nodes %}
-      <tr data-node-id="{{ node.id }}" data-node-kind="{{ node.kind }}">
+      {#- ``selected_id`` is the cross-link payload from the graph
+          view (T2 / #881): a graph node-tap navigates back to the
+          table with ``?selected=<id>``; the matching row gets a
+          ``data-selected="true"`` marker the page-level scroll-into-view
+          script picks up + a visual highlight class. Empty string =
+          no selection (the StrictUndefined-safe default the route
+          renders). -#}
+      {%- set is_selected = (selected_id and (node.id | string) == selected_id) -%}
+      <tr
+        data-node-id="{{ node.id }}"
+        data-node-kind="{{ node.kind }}"
+        {% if is_selected %}data-selected="true" class="bg-base-300/40"{% endif %}
+      >
         <td>
           <input
             type="checkbox"
@@ -58,7 +70,7 @@
           <span class="text-xs opacity-50">—</span>
         </td>
         <td class="text-right tabular-nums">{{ node.children_count }}</td>
-        <td>
+        <td class="flex items-center gap-1">
           <button
             type="button"
             class="btn btn-ghost btn-xs"
@@ -69,6 +81,18 @@
           >
             View
           </button>
+          {#- "Show in graph" cross-link -- plain anchor so a full-page
+              nav to the graph view re-renders Cytoscape with this node
+              selected (T2 / #881 cross-link). The graph view's init
+              script reads ``?selected=<id>`` and centers + selects
+              the matching node. -#}
+          <a
+            class="btn btn-ghost btn-xs"
+            href="/ui/topology?view=graph&selected={{ node.id }}{% if kind_filter %}&kind={{ kind_filter | urlencode }}{% endif %}{% if name_filter %}&q={{ name_filter | urlencode }}{% endif %}"
+            aria-label="Show {{ node.name }} in graph view"
+          >
+            Graph
+          </a>
         </td>
       </tr>
     {% endfor %}

--- a/backend/src/meho_backplane/ui/templates/topology/graph.html
+++ b/backend/src/meho_backplane/ui/templates/topology/graph.html
@@ -140,11 +140,10 @@
           aria-label="Filter nodes by kind"
         >
           <option value="">All kinds</option>
-          {%- set kind_options = [
-            "target", "vm", "host", "cluster", "datastore", "network",
-            "pod", "container", "service", "namespace",
-          ] -%}
-          {% for option in kind_options %}
+          {# ``node_kind_options`` is the closed enum
+             (``_GRAPH_NODE_KINDS``) the route handler ships -- single
+             source of truth shared with the T1 tabular surface. -#}
+          {% for option in node_kind_options %}
             <option value="{{ option }}" {% if option == kind_filter %}selected{% endif %}>
               {{ option }}
             </option>

--- a/backend/src/meho_backplane/ui/templates/topology/graph.html
+++ b/backend/src/meho_backplane/ui/templates/topology/graph.html
@@ -1,0 +1,242 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Topology Cytoscape.js graph view (Initiative #342 Task #881).
+  Extends ``base.html`` so the chrome (navbar, sidebar, footer) matches
+  the rest of the console; the tabular surface (table.html, T1 / #880)
+  is the sibling render the user toggles between.
+
+  Layout (top-down):
+    * Header -- title + view toggle (table | graph) + filter chips
+      surfaced as Alpine state. ``selected`` rides into the toggle's
+      table href so a graph -> table click preserves the active node.
+    * Filter bar -- kind <select> + free-text name search. Server
+      round-trips the filter (full-page reload, NOT an HTMX fragment),
+      because the graph re-render needs to re-emit the data island AND
+      the init script -- a tbody fragment swap would not refresh the
+      Cytoscape instance. ``hx-push-url`` keeps copy/paste reproducing
+      the filtered view.
+    * Graph container -- ``<div id="cy">`` Cytoscape mounts into.
+      Sized via Tailwind so it dominates the page; ``min-h`` keeps
+      it tall enough for an organic layout to breathe even on the
+      Cytoscape-default empty inventory state.
+    * Layout switcher -- Alpine ``<select>`` calls
+      ``cy.layout({name}).run()`` on change. Three options:
+      ``cose-bilkent`` (default, organic), ``dagre`` (DAG-tidy),
+      ``circle`` (built-in fallback).
+    * Drawer slot -- ``#node-drawer`` the node-tap HTMX swap fills.
+      Same id as the table view so the drawer fragment URL contract
+      stays identical across surfaces.
+    * Data island -- ``<script type="application/json"
+      id="topology-graph-data">`` carries the Cytoscape elements
+      JSON. ``| tojson`` escapes ``<`` / ``>`` / ``&`` / ``'`` /
+      U+2028/U+2029 (XSS-safe for the script-element text context).
+
+  HTMX wiring:
+    * Filter <select>/<input>: full-page navigation on submit so the
+      graph re-renders with a fresh data island. (HTMX fragment swap
+      would leave the existing Cytoscape instance running against
+      stale data.)
+    * Node tap (in topology-graph.js): ``htmx.ajax`` GET
+      ``/ui/topology/node/<id>`` into ``#node-drawer``.
+    * "Show in table" cross-link: plain ``<a href>`` to
+      ``/ui/topology?view=table&selected=<id>``. The table page's
+      inline script scrolls the matching row into view.
+
+  Script load order is load-bearing (see static/src/vendor/VENDOR.md):
+    1. ``cytoscape.min.js`` (chassis-provided, already in base via
+       ``{% block scripts %}`` extension only -- NOT base.html. The
+       block here loads all five graph-related JS files in order.)
+    2. ``layout-base.js`` -- exposes ``window.layoutBase``.
+    3. ``cose-base.js`` -- consumes ``layoutBase``, exposes
+       ``window.coseBase``.
+    4. ``cytoscape-cose-bilkent.js`` -- consumes ``coseBase``, exposes
+       ``window.cytoscapeCoseBilkent``.
+    5. ``cytoscape-dagre.js`` (3.0.0 bundles dagre internally so no
+       separate dagre vendored file is needed) -- exposes
+       ``window.cytoscapeDagre``.
+    6. ``topology-graph.js`` -- the app controller that registers the
+       extensions and initialises Cytoscape from the data island.
+
+  All scripts carry ``defer`` so they execute in document order after
+  HTML parse -- the chassis CSP posture (zero inline JS) remains
+  unchanged.
+-#}
+{% extends "base.html" %}
+
+{% block page_title %}Topology &middot; MEHO Operator Console{% endblock %}
+
+{% block content %}
+<section
+  class="space-y-4"
+  hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+>
+  <header class="flex flex-wrap items-center justify-between gap-4">
+    <div>
+      <h1 class="text-2xl font-semibold">Topology</h1>
+      <p class="text-sm opacity-70">
+        Interactive graph view: pan, zoom, click a node to inspect.
+      </p>
+    </div>
+    {# ---------- View toggle (table | graph) ----------
+       Plain anchor links -- a full-page nav re-renders the matching
+       view from scratch. The current view ('graph') is rendered as a
+       button-active style and the other view as a clickable link.
+       Active filters + the cross-link selection ride along so a
+       toggle preserves operator state.
+    -#}
+    <div class="join" role="tablist" aria-label="View mode">
+      <a
+        class="btn btn-sm join-item"
+        role="tab"
+        aria-selected="false"
+        href="/ui/topology?view=table{% if kind_filter %}&kind={{ kind_filter | urlencode }}{% endif %}{% if name_filter %}&q={{ name_filter | urlencode }}{% endif %}{% if selected_id %}&selected={{ selected_id }}{% endif %}"
+      >
+        Table
+      </a>
+      <button
+        type="button"
+        class="btn btn-sm btn-active join-item"
+        role="tab"
+        aria-selected="true"
+        disabled
+      >
+        Graph
+      </button>
+    </div>
+  </header>
+
+  {# ---------- Filter bar ----------
+     Server round-trip on submit; the graph needs the full server-side
+     re-render to refresh the elements data island. ``hx-push-url`` is
+     replaced by the form's natural ``action`` since this is a full
+     page reload. -#}
+  <form
+    class="card bg-base-100 border-base-300 border shadow-sm"
+    method="get"
+    action="/ui/topology"
+    role="search"
+    aria-label="Filter topology nodes"
+  >
+    <div class="card-body grid gap-3 md:grid-cols-4">
+      <input type="hidden" name="view" value="graph" />
+      <label class="form-control md:col-span-2">
+        <span class="label-text">Search by name</span>
+        <input
+          type="search"
+          name="q"
+          value="{{ name_filter }}"
+          placeholder="Substring match (case-insensitive)"
+          class="input input-bordered input-sm"
+          aria-label="Filter nodes by name"
+        />
+      </label>
+      <label class="form-control">
+        <span class="label-text">Kind</span>
+        <select
+          name="kind"
+          class="select select-bordered select-sm"
+          aria-label="Filter nodes by kind"
+        >
+          <option value="">All kinds</option>
+          {%- set kind_options = [
+            "target", "vm", "host", "cluster", "datastore", "network",
+            "pod", "container", "service", "namespace",
+          ] -%}
+          {% for option in kind_options %}
+            <option value="{{ option }}" {% if option == kind_filter %}selected{% endif %}>
+              {{ option }}
+            </option>
+          {% endfor %}
+        </select>
+      </label>
+      <div class="form-control">
+        <span class="label-text">&nbsp;</span>
+        <button type="submit" class="btn btn-sm btn-primary">Apply</button>
+      </div>
+    </div>
+  </form>
+
+  {# ---------- Status + layout switcher ----------
+     ``node_count`` / ``edge_count`` give the operator the rendered
+     size at a glance; ``truncated`` flashes the cap-reached banner. -#}
+  <div class="flex flex-wrap items-center justify-between gap-3 text-sm">
+    <div class="opacity-70">
+      Rendering <span class="font-mono">{{ node_count }}</span> nodes /
+      <span class="font-mono">{{ edge_count }}</span> edges
+      {%- if truncated %}
+        <span class="badge badge-warning badge-sm ml-2">
+          Capped at {{ graph_node_cap }} -- narrow the filter or use the dependents query (T3) for larger sets.
+        </span>
+      {%- endif %}
+    </div>
+    <label class="form-control flex flex-row items-center gap-2">
+      <span class="label-text whitespace-nowrap">Layout</span>
+      <select
+        id="topology-graph-layout"
+        class="select select-bordered select-sm"
+        aria-label="Graph layout algorithm"
+      >
+        <option value="cose-bilkent" selected>cose-bilkent (organic)</option>
+        <option value="dagre">dagre (hierarchical)</option>
+        <option value="circle">circle</option>
+      </select>
+    </label>
+  </div>
+
+  {# ---------- Cytoscape mount ----------
+     Fixed-ish height so the layout has room. The ``aria-label`` is
+     the screen-reader hint; Cytoscape itself is canvas-rendered so
+     the graph is not directly keyboard-accessible (operators use the
+     table view for that). -#}
+  <div
+    id="cy"
+    class="rounded-box border border-base-300 bg-base-100"
+    style="height: 600px; min-height: 480px;"
+    role="img"
+    aria-label="Topology graph -- click a node to open its detail drawer"
+  ></div>
+
+  {# ---------- Drawer slot ----------
+     Same id as the table view so the drawer fragment URL contract
+     stays identical across surfaces; the node-tap handler in
+     topology-graph.js issues ``htmx.ajax`` GET
+     ``/ui/topology/node/<id>`` into this slot. -#}
+  <aside
+    id="node-drawer"
+    class="card bg-base-100 border-base-300 border shadow-sm"
+    aria-live="polite"
+    aria-label="Node detail drawer"
+  >
+    <div class="card-body text-sm opacity-70">
+      Click a node in the graph to inspect it.
+    </div>
+  </aside>
+
+  {# ---------- Data island ----------
+     The elements bag the init script ingests. ``| tojson`` escapes
+     for the script-element text context so a connector-populated
+     node name containing ``"`` / ``<`` / ``</script>`` cannot break
+     out (same posture as broadcast/_history.html PR #1044 B1).
+     ``selected_id`` rides on a second island so the init script can
+     pick up the cross-link target without re-parsing the URL. -#}
+  <script type="application/json" id="topology-graph-data">{{ elements | tojson }}</script>
+  <script type="application/json" id="topology-graph-selected">{{ selected_id | tojson }}</script>
+</section>
+{% endblock %}
+
+{# Surface JS -- vendored Cytoscape layout plugins (load order load-bearing,
+   see static/src/vendor/VENDOR.md "Cytoscape layout plugins" section) plus
+   the per-page controller. All ``defer`` so they run after HTML parse in
+   document order; the controller (``topology-graph.js``) waits for
+   ``DOMContentLoaded`` before reading the data island so every
+   plugin is registered before ``cytoscape({...})`` is called. #}
+{% block scripts %}
+  <script src="/ui/static/src/vendor/cytoscape.min.js" defer></script>
+  <script src="/ui/static/src/vendor/layout-base.js" defer></script>
+  <script src="/ui/static/src/vendor/cose-base.js" defer></script>
+  <script src="/ui/static/src/vendor/cytoscape-cose-bilkent.js" defer></script>
+  <script src="/ui/static/src/vendor/cytoscape-dagre.js" defer></script>
+  <script src="/ui/static/src/app/topology-graph.js" defer></script>
+{% endblock %}

--- a/backend/src/meho_backplane/ui/templates/topology/table.html
+++ b/backend/src/meho_backplane/ui/templates/topology/table.html
@@ -124,9 +124,15 @@
         </select>
       </label>
       {# Hidden inputs carry the current sort + direction so the next
-         HTMX swap preserves them on top of the filter change. #}
+         HTMX swap preserves them on top of the filter change. The
+         ``selected`` hidden input carries the cross-link selection
+         (the graph surface's "show in table" payload) -- without it,
+         ``hx-include="closest form"`` + ``hx-push-url="true"`` would
+         drop ``?selected=`` from the URL on the first filter keystroke,
+         clearing the row highlight that the cross-link AC requires. #}
       <input type="hidden" name="sort" value="{{ sort.value }}" />
       <input type="hidden" name="direction" value="{{ direction.value }}" />
+      {% if selected_id %}<input type="hidden" name="selected" value="{{ selected_id }}" />{% endif %}
     </div>
   </form>
 

--- a/backend/src/meho_backplane/ui/templates/topology/table.html
+++ b/backend/src/meho_backplane/ui/templates/topology/table.html
@@ -52,8 +52,34 @@
         Tenant inventory of nodes (targets, VMs, hosts, clusters, networks, datastores, ...).
       </p>
     </div>
-    <div class="text-sm opacity-70">
-      <span x-text="'Selected: ' + selected.size" aria-live="polite"></span>
+    <div class="flex items-center gap-3">
+      <div class="text-sm opacity-70">
+        <span x-text="'Selected: ' + selected.size" aria-live="polite"></span>
+      </div>
+      {# ---------- View toggle (table | graph) ----------
+         The graph link carries the active filters + the cross-link
+         selection so a table -> graph toggle preserves operator
+         state. Active mode is rendered as a disabled active button
+         and the other mode as a clickable link. -#}
+      <div class="join" role="tablist" aria-label="View mode">
+        <button
+          type="button"
+          class="btn btn-sm btn-active join-item"
+          role="tab"
+          aria-selected="true"
+          disabled
+        >
+          Table
+        </button>
+        <a
+          class="btn btn-sm join-item"
+          role="tab"
+          aria-selected="false"
+          href="/ui/topology?view=graph{% if kind_filter %}&kind={{ kind_filter | urlencode }}{% endif %}{% if name_filter %}&q={{ name_filter | urlencode }}{% endif %}{% if selected_id %}&selected={{ selected_id }}{% endif %}"
+        >
+          Graph
+        </a>
+      </div>
     </div>
   </header>
 
@@ -142,8 +168,8 @@
                 ``urllib.parse.quote(safe='')`` does on the Python side. -#}
             <th>
               <a
-                href="/ui/topology?sort={{ col_value }}&direction={{ next_dir }}{% if kind_filter %}&kind={{ kind_filter | urlencode }}{% endif %}{% if name_filter %}&q={{ name_filter | urlencode }}{% endif %}"
-                hx-get="/ui/topology?sort={{ col_value }}&direction={{ next_dir }}{% if kind_filter %}&kind={{ kind_filter | urlencode }}{% endif %}{% if name_filter %}&q={{ name_filter | urlencode }}{% endif %}"
+                href="/ui/topology?sort={{ col_value }}&direction={{ next_dir }}{% if kind_filter %}&kind={{ kind_filter | urlencode }}{% endif %}{% if name_filter %}&q={{ name_filter | urlencode }}{% endif %}{% if selected_id %}&selected={{ selected_id }}{% endif %}"
+                hx-get="/ui/topology?sort={{ col_value }}&direction={{ next_dir }}{% if kind_filter %}&kind={{ kind_filter | urlencode }}{% endif %}{% if name_filter %}&q={{ name_filter | urlencode }}{% endif %}{% if selected_id %}&selected={{ selected_id }}{% endif %}"
                 hx-target="#topology-table-body"
                 hx-swap="outerHTML"
                 hx-push-url="true"
@@ -184,4 +210,11 @@
     </div>
   </aside>
 </section>
+{% endblock %}
+
+{# Surface JS -- scroll-into-view helper for the graph -> table
+   cross-link payload (T2 / #881). Loaded as an external deferred
+   script (not inline) so the chassis CSP posture stays zero-inline. #}
+{% block scripts %}
+  <script src="/ui/static/src/app/topology-table.js" defer></script>
 {% endblock %}

--- a/backend/tests/test_ui_templates.py
+++ b/backend/tests/test_ui_templates.py
@@ -90,6 +90,13 @@ def test_static_src_carries_vendored_assets() -> None:
     assert (vendor / "sse.min.js").is_file()
     assert (vendor / "alpine.min.js").is_file()
     assert (vendor / "cytoscape.min.js").is_file()
+    # Cytoscape layout-plugin chain shipped by G10.5-T2 (#881). Load
+    # order is layout-base -> cose-base -> cose-bilkent / dagre; the
+    # topology graph view depends on all four.
+    assert (vendor / "layout-base.js").is_file()
+    assert (vendor / "cose-base.js").is_file()
+    assert (vendor / "cytoscape-cose-bilkent.js").is_file()
+    assert (vendor / "cytoscape-dagre.js").is_file()
     assert (vendor / "daisyui.js").is_file()
     assert (vendor / "VENDOR.md").is_file()
 

--- a/backend/tests/test_ui_topology_graph.py
+++ b/backend/tests/test_ui_topology_graph.py
@@ -1,0 +1,733 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the Topology UI Cytoscape graph view.
+
+Initiative #342 (G10.5 Topology UI), Task #881 (G10.5-T2). The
+acceptance criteria on issue #881 are:
+
+* ``/ui/topology?view=graph`` renders a Cytoscape graph (vendored
+  Cytoscape + cose-bilkent + dagre, SHA256-pinned) for up to 500
+  nodes; pan + zoom + node-click work.
+* Node click opens the detail drawer (reusing the #880
+  ``/ui/topology/node/<id>`` partial).
+* Layout switcher toggles cose-bilkent / dagre / circle via
+  ``cy.layout(...).run()``.
+* Tabular <-> graph cross-link: selecting a table row centers +
+  selects the node in the graph; a graph tap navigates back to the
+  table with the row scrolled into view; selection preserved via
+  query params.
+* The 500-node cap is enforced (beyond it, the page prompts to
+  narrow via the T3 subgraph query) and documented.
+* Cross-tenant isolation holds; ``ruff`` + ``mypy`` clean;
+  ``pytest -n auto backend/tests/test_ui_topology_graph.py`` passes.
+
+Suite shape:
+
+* :func:`_build_app` constructs a minimal FastAPI app the same way
+  :mod:`backend.tests.test_ui_topology_table` does -- UI session +
+  CSRF middlewares, BFF auth router, UI router.
+* :func:`_seed_*` helpers populate two tenants with disjoint graph
+  nodes + edges so cross-tenant assertions have concrete state.
+* Test cases cover: full-page render, Cytoscape script wiring +
+  data-island shape, layout switcher options, node/edge JSON
+  emission, 500-node cap + truncation banner, view toggle preserves
+  filters, cross-link ``?selected=<id>`` round-trip, cross-tenant
+  isolation, drawer route (the existing T1 route) still reachable
+  from the graph context.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import GraphEdge, GraphNode, Tenant
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import (
+    SESSION_COOKIE_NAME,
+    UISessionMiddleware,
+)
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, CSRFMiddleware
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.routes.topology.graph import GRAPH_NODE_CAP
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests.conftest import DEFAULT_AUDIENCE, DEFAULT_ISSUER
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+_BACKPLANE_URL = "https://meho.test"
+
+# Two stable tenant ids -- same shape as the T1 suite. Cross-tenant
+# isolation assertion uses them directly.
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_TENANT_B = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars for every test.
+
+    Mirrors :func:`backend.tests.test_ui_topology_table._bff_env` so
+    cache + global-state resets happen on both setup + teardown.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+def _build_app() -> FastAPI:
+    """Construct a minimal FastAPI app wired for the topology graph tests."""
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant_row(tenant_id: uuid.UUID, slug: str) -> None:
+    """Insert one ``tenant`` row so the graph FKs resolve."""
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _seed_node(
+    *,
+    tenant_id: uuid.UUID,
+    kind: str,
+    name: str,
+    target_id: uuid.UUID | None = None,
+    discovered_by: str = "test",
+) -> uuid.UUID:
+    """Insert one ``graph_node`` row and return its id."""
+    node_id = uuid.uuid4()
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                GraphNode(
+                    id=node_id,
+                    tenant_id=tenant_id,
+                    kind=kind,
+                    name=name,
+                    target_id=target_id,
+                    properties={},
+                    discovered_by=discovered_by,
+                    first_seen=datetime.now(UTC),
+                    last_seen=datetime.now(UTC),
+                ),
+            )
+
+    asyncio.run(_do())
+    return node_id
+
+
+def _seed_edge(
+    *,
+    tenant_id: uuid.UUID,
+    from_node_id: uuid.UUID,
+    to_node_id: uuid.UUID,
+    kind: str = "runs-on",
+    source: str = "auto",
+) -> uuid.UUID:
+    """Insert one ``graph_edge`` row and return its id."""
+    edge_id = uuid.uuid4()
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                GraphEdge(
+                    id=edge_id,
+                    tenant_id=tenant_id,
+                    from_node_id=from_node_id,
+                    to_node_id=to_node_id,
+                    kind=kind,
+                    source=source,
+                    properties={},
+                    discovered_by="test",
+                    first_seen=datetime.now(UTC),
+                    last_seen=datetime.now(UTC),
+                ),
+            )
+
+    asyncio.run(_do())
+    return edge_id
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID,
+    operator_sub: str = "op-42",
+    lifetime: timedelta = timedelta(hours=1),
+) -> uuid.UUID:
+    """Create a ``web_session`` row directly and return its UUID."""
+
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token="access-token-plaintext",
+                refresh_token="refresh-token-plaintext",
+                lifetime=lifetime,
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _authenticated_client(session_id: uuid.UUID) -> TestClient:
+    """Return a TestClient with the session cookie pre-set."""
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client
+
+
+def _extract_data_island(body: str, island_id: str) -> object:
+    """Extract + JSON-parse a ``<script type="application/json">`` data island.
+
+    Each island in the graph template carries the elements (or the
+    selected-id payload) the controller reads on init. Tests rely on
+    the parsed JSON to verify the server-emitted shape independent of
+    HTML formatting whitespace.
+    """
+    pattern = re.compile(
+        rf'<script type="application/json" id="{re.escape(island_id)}">(.*?)</script>',
+        re.DOTALL,
+    )
+    match = pattern.search(body)
+    assert match is not None, f"data island {island_id!r} not found in body"
+    return json.loads(match.group(1))
+
+
+# ---------------------------------------------------------------------------
+# Authentication boundary
+# ---------------------------------------------------------------------------
+
+
+def test_graph_unauthenticated_redirects_to_login() -> None:
+    """``GET /ui/topology?view=graph`` without a session 302s to the BFF login."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/topology?view=graph")
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+
+
+# ---------------------------------------------------------------------------
+# Full-page render -- 200 + Cytoscape mount + script wiring
+# ---------------------------------------------------------------------------
+
+
+def test_graph_full_page_renders_cytoscape_mount() -> None:
+    """``view=graph`` returns the full page with the Cytoscape mount + script chain."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-1")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph")
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Page chrome.
+    assert "<title>Topology" in body
+    # Cytoscape mount div.
+    assert 'id="cy"' in body
+    # The vendored layout-plugin chain is wired in load-bearing order
+    # (see VENDOR.md "Cytoscape layout plugins"); each src appears
+    # exactly once.
+    assert "/ui/static/src/vendor/cytoscape.min.js" in body
+    assert "/ui/static/src/vendor/layout-base.js" in body
+    assert "/ui/static/src/vendor/cose-base.js" in body
+    assert "/ui/static/src/vendor/cytoscape-cose-bilkent.js" in body
+    assert "/ui/static/src/vendor/cytoscape-dagre.js" in body
+    # Per-page controller.
+    assert "/ui/static/src/app/topology-graph.js" in body
+    # CSRF cookie set by the route (matches the table route's posture).
+    assert CSRF_COOKIE_NAME in response.cookies
+
+
+def test_graph_full_page_emits_node_and_edge_elements() -> None:
+    """The Cytoscape elements data island carries seeded nodes + edges."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    host_id = _seed_node(tenant_id=_TENANT_A, kind="host", name="host-1")
+    vm_id = _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-1")
+    _seed_edge(tenant_id=_TENANT_A, from_node_id=vm_id, to_node_id=host_id, kind="runs-on")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph")
+    assert response.status_code == 200, response.text
+
+    elements = _extract_data_island(response.text, "topology-graph-data")
+    assert isinstance(elements, list)
+    # Two nodes + one edge.
+    nodes = [e for e in elements if isinstance(e, dict) and e.get("group") == "nodes"]
+    edges = [e for e in elements if isinstance(e, dict) and e.get("group") == "edges"]
+    assert len(nodes) == 2
+    assert len(edges) == 1
+    node_names = {n["data"]["name"] for n in nodes}
+    assert node_names == {"host-1", "vm-1"}
+    # Edge endpoints reference the node UUIDs by string.
+    edge = edges[0]
+    assert edge["data"]["source"] == str(vm_id)
+    assert edge["data"]["target"] == str(host_id)
+    assert edge["data"]["kind"] == "runs-on"
+    # Per-kind classes drive the Cytoscape stylesheet selectors.
+    host_element = next(n for n in nodes if n["data"]["name"] == "host-1")
+    assert host_element["classes"] == "kind-host"
+
+
+def test_graph_full_page_lists_node_and_edge_counts() -> None:
+    """The status row surfaces the rendered node + edge counts."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-1")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-2")
+    _seed_node(tenant_id=_TENANT_A, kind="host", name="host-1")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph")
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "Rendering" in body
+    # The status row shows "Rendering 3 nodes / 0 edges" (no edges seeded).
+    assert ">3</span>" in body
+    assert ">0</span>" in body
+
+
+# ---------------------------------------------------------------------------
+# Layout switcher
+# ---------------------------------------------------------------------------
+
+
+def test_graph_layout_switcher_offers_three_layouts() -> None:
+    """The layout ``<select>`` exposes cose-bilkent / dagre / circle."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph")
+    body = response.text
+    assert 'id="topology-graph-layout"' in body
+    assert '<option value="cose-bilkent"' in body
+    assert '<option value="dagre"' in body
+    assert '<option value="circle"' in body
+    # cose-bilkent is the default per the task body.
+    assert '<option value="cose-bilkent" selected>' in body
+
+
+# ---------------------------------------------------------------------------
+# 500-node cap + truncation banner
+# ---------------------------------------------------------------------------
+
+
+def test_graph_caps_render_at_500_nodes() -> None:
+    """The graph renders at most 500 nodes and surfaces a truncation banner.
+
+    Acceptance criterion: "The 500-node cap is enforced (beyond it,
+    the page prompts to narrow via the T3 subgraph query) and
+    documented" (issue #881). The cap is enforced by passing
+    ``limit=GRAPH_NODE_CAP`` into the substrate ``list_nodes``; the
+    banner is rendered when the returned list saturates the cap.
+    """
+    assert GRAPH_NODE_CAP == 500  # The contract; bumping it is a doc + perf review.
+
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    # Seed one row past the cap. The route caps at 500, so the
+    # 501st node is silently dropped and the banner flips on.
+    for index in range(GRAPH_NODE_CAP + 1):
+        _seed_node(tenant_id=_TENANT_A, kind="vm", name=f"vm-{index:04d}")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph")
+    assert response.status_code == 200, response.text
+    body = response.text
+
+    elements = _extract_data_island(body, "topology-graph-data")
+    assert isinstance(elements, list)
+    nodes = [e for e in elements if isinstance(e, dict) and e.get("group") == "nodes"]
+    assert len(nodes) == GRAPH_NODE_CAP, (
+        f"expected the cap to truncate to {GRAPH_NODE_CAP} nodes, got {len(nodes)}"
+    )
+    # Truncation banner copy.
+    assert f"Capped at {GRAPH_NODE_CAP}" in body
+    # And the call-out to T3.
+    assert "dependents query" in body or "dependents" in body
+
+
+def test_graph_does_not_show_truncation_banner_under_the_cap() -> None:
+    """Inventories below the cap render without the banner."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-1")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph")
+    assert response.status_code == 200, response.text
+    assert f"Capped at {GRAPH_NODE_CAP}" not in response.text
+
+
+# ---------------------------------------------------------------------------
+# Filters
+# ---------------------------------------------------------------------------
+
+
+def test_graph_filter_by_kind_narrows_results() -> None:
+    """``?view=graph&kind=vm`` returns only ``vm`` nodes."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-keep")
+    _seed_node(tenant_id=_TENANT_A, kind="target", name="target-hide")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&kind=vm")
+    assert response.status_code == 200, response.text
+
+    elements = _extract_data_island(response.text, "topology-graph-data")
+    assert isinstance(elements, list)
+    names = {
+        e["data"]["name"] for e in elements if isinstance(e, dict) and e.get("group") == "nodes"
+    }
+    assert names == {"vm-keep"}
+
+
+def test_graph_filter_by_name_substring_narrows_results() -> None:
+    """``?view=graph&q=prod`` returns only nodes whose name contains ``prod``."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-prod-01")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-staging-01")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&q=prod")
+
+    elements = _extract_data_island(response.text, "topology-graph-data")
+    assert isinstance(elements, list)
+    names = {
+        e["data"]["name"] for e in elements if isinstance(e, dict) and e.get("group") == "nodes"
+    }
+    assert names == {"vm-prod-01"}
+
+
+# ---------------------------------------------------------------------------
+# Cross-tenant isolation
+# ---------------------------------------------------------------------------
+
+
+def test_graph_isolates_other_tenants_nodes() -> None:
+    """Tenant A's graph view never carries tenant B's nodes."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_tenant_row(_TENANT_B, "tenant-b")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-tenant-a")
+    _seed_node(tenant_id=_TENANT_B, kind="vm", name="vm-tenant-b")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph")
+    body = response.text
+    assert "vm-tenant-a" in body
+    assert "vm-tenant-b" not in body
+
+
+def test_graph_excludes_cross_tenant_edges() -> None:
+    """Edges with cross-tenant endpoints never surface on the graph view.
+
+    Tenant A has its own host + vm + edge. Tenant B has a separate
+    edge tenant A's session should never see, even though both
+    tenants have nodes named identically.
+    """
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_tenant_row(_TENANT_B, "tenant-b")
+    a_host = _seed_node(tenant_id=_TENANT_A, kind="host", name="host-shared")
+    a_vm = _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-shared")
+    _seed_edge(
+        tenant_id=_TENANT_A,
+        from_node_id=a_vm,
+        to_node_id=a_host,
+        kind="runs-on",
+    )
+
+    b_host = _seed_node(tenant_id=_TENANT_B, kind="host", name="host-shared")
+    b_vm = _seed_node(tenant_id=_TENANT_B, kind="vm", name="vm-shared")
+    b_edge = _seed_edge(
+        tenant_id=_TENANT_B,
+        from_node_id=b_vm,
+        to_node_id=b_host,
+        kind="runs-on",
+    )
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph")
+    elements = _extract_data_island(response.text, "topology-graph-data")
+    assert isinstance(elements, list)
+    # Tenant A sees its own edge (one edge, source vm_a -> target host_a).
+    edges = [e for e in elements if isinstance(e, dict) and e.get("group") == "edges"]
+    assert len(edges) == 1
+    assert edges[0]["data"]["source"] == str(a_vm)
+    assert edges[0]["data"]["target"] == str(a_host)
+    # Tenant B's edge id never surfaces.
+    edge_ids = {e["data"]["id"] for e in edges}
+    assert str(b_edge) not in edge_ids
+
+
+# ---------------------------------------------------------------------------
+# View toggle (table <-> graph)
+# ---------------------------------------------------------------------------
+
+
+def test_graph_page_links_back_to_table_view() -> None:
+    """The graph page header renders a link to the tabular view."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph")
+    body = response.text
+    assert 'href="/ui/topology?view=table' in body
+
+
+def test_table_page_links_back_to_graph_view() -> None:
+    """The table page header renders a link to the graph view."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology")
+    body = response.text
+    assert 'href="/ui/topology?view=graph' in body
+
+
+def test_view_toggle_preserves_active_filter() -> None:
+    """A toggle from graph to table carries the active filter values."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&kind=vm&q=foo")
+    body = response.text
+    # The toggle link includes the active kind + name filter.
+    assert "view=table" in body
+    assert "kind=vm" in body
+    assert "q=foo" in body
+
+
+# ---------------------------------------------------------------------------
+# Cross-link (table <-> graph) via ?selected=<id>
+# ---------------------------------------------------------------------------
+
+
+def test_graph_selected_id_round_trips_into_data_island() -> None:
+    """``?selected=<id>`` lands as a non-empty data island the JS reads on init."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    node_id = _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-target")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(f"/ui/topology?view=graph&selected={node_id}")
+    assert response.status_code == 200, response.text
+    payload = _extract_data_island(response.text, "topology-graph-selected")
+    # Server emits a string id; the JS uses it to look up the
+    # matching Cytoscape node on init.
+    assert payload == str(node_id)
+
+
+def test_graph_without_selection_emits_empty_island() -> None:
+    """The selected-id island is empty when no ``?selected=`` is present."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph")
+    payload = _extract_data_island(response.text, "topology-graph-selected")
+    assert payload == ""
+
+
+def test_graph_invalid_selected_uuid_returns_422() -> None:
+    """A non-UUID ``?selected=`` value 422s at the Pydantic boundary.
+
+    The route declares ``selected: uuid.UUID | None`` so a malformed
+    payload is rejected with a 422 + diagnostic context, NOT silently
+    decayed to ``None`` (which would mask a misuse).
+    """
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&selected=not-a-uuid")
+    assert response.status_code == 422
+
+
+def test_table_marks_selected_row() -> None:
+    """``?view=table&selected=<id>`` marks the matching row for scroll-into-view."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-not-selected")
+    target_id = _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-target")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(f"/ui/topology?view=table&selected={target_id}")
+    body = response.text
+    # The matching row carries the marker the scroll-into-view helper picks up.
+    assert 'data-selected="true"' in body
+    # And only one row -- the one with the matching id.
+    selected_row_count = body.count('data-selected="true"')
+    assert selected_row_count == 1, f"expected exactly one selected row, got {selected_row_count}"
+    # The cross-link script tag is wired.
+    assert "/ui/static/src/app/topology-table.js" in body
+
+
+def test_table_rows_include_show_in_graph_link() -> None:
+    """Every table row carries a "Graph" cross-link to the graph view."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    node_id = _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-1")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology")
+    body = response.text
+    # The Graph link href targets the graph view with this node selected.
+    assert f"/ui/topology?view=graph&selected={node_id}" in body
+
+
+# ---------------------------------------------------------------------------
+# Drawer reuse -- the existing T1 route is the drawer target from the graph
+# ---------------------------------------------------------------------------
+
+
+def test_drawer_route_still_serves_node_detail_for_graph_tap() -> None:
+    """``GET /ui/topology/node/<id>`` (T1 #880) returns the drawer fragment.
+
+    The graph view's ``cy.on('tap', 'node', ...)`` handler issues
+    ``htmx.ajax`` GET against this exact path -- regression-pinning
+    here so a future refactor cannot break the cross-surface drawer
+    contract without taking the suite down.
+    """
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    node_id = _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-drawer-test")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(f"/ui/topology/node/{node_id}")
+    assert response.status_code == 200, response.text
+    assert "vm-drawer-test" in response.text
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI schema -- the view enum surfaces on the table route's schema
+# ---------------------------------------------------------------------------
+
+
+def test_view_enum_includes_graph_in_openapi_schema() -> None:
+    """The ``view`` query param's enum carries ``graph`` (T2 contract).
+
+    Regression-pin: a future refactor that drops the enum (e.g. swaps
+    to a bare ``str``) would mask invalid mode values; the OpenAPI
+    schema breaks on `view=bogus` returning 422 -- the test asserts
+    the generated schema documents the closed enum.
+    """
+    app = _build_app()
+    schema = app.openapi()
+    topology_op = schema["paths"]["/ui/topology"]["get"]
+    view_param = next(p for p in topology_op["parameters"] if p["name"] == "view")
+    # The schema for an enum query param either inlines the enum or
+    # references it via $ref -- accept both. The inlined form puts
+    # ``enum`` directly under ``schema``; the $ref form references a
+    # component schema. We assert at least one of the resolution paths
+    # carries the ``graph`` member.
+    schema_obj = view_param.get("schema", {})
+    enum_values: list[str] = []
+    if "enum" in schema_obj:
+        enum_values = list(schema_obj["enum"])
+    elif "$ref" in schema_obj:
+        ref_path = schema_obj["$ref"].lstrip("#/").split("/")
+        target = schema
+        for step in ref_path:
+            target = target[step]
+        enum_values = list(target.get("enum", []))
+    assert "graph" in enum_values
+    assert "table" in enum_values
+
+
+def test_invalid_view_mode_returns_422() -> None:
+    """An out-of-enum ``view`` value is rejected by Pydantic with 422."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=hologram")
+    assert response.status_code == 422

--- a/backend/tests/test_ui_topology_graph.py
+++ b/backend/tests/test_ui_topology_graph.py
@@ -434,6 +434,38 @@ def test_graph_does_not_show_truncation_banner_under_the_cap() -> None:
     assert f"Capped at {GRAPH_NODE_CAP}" not in response.text
 
 
+def test_graph_at_exactly_cap_does_not_show_truncation_banner() -> None:
+    """A tenant with exactly ``GRAPH_NODE_CAP`` nodes is NOT truncated.
+
+    Boundary regression. The pre-fix code used
+    ``limit=GRAPH_NODE_CAP`` + ``truncated = len(nodes) >= GRAPH_NODE_CAP``,
+    which fired the banner as a false-positive on tenants sitting at
+    exactly the cap. The fix asks the substrate for ``CAP + 1`` rows
+    and flips the predicate to ``>`` so the banner only fires when
+    the inventory genuinely exceeds the cap. This test seeds exactly
+    the cap and asserts the banner stays off + all rows render.
+    """
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    for index in range(GRAPH_NODE_CAP):
+        _seed_node(tenant_id=_TENANT_A, kind="vm", name=f"vm-{index:04d}")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph")
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Banner stays off at the exact cap.
+    assert f"Capped at {GRAPH_NODE_CAP}" not in body
+    # And every node renders.
+    elements = _extract_data_island(body, "topology-graph-data")
+    assert isinstance(elements, list)
+    nodes = [e for e in elements if isinstance(e, dict) and e.get("group") == "nodes"]
+    assert len(nodes) == GRAPH_NODE_CAP, (
+        f"expected all {GRAPH_NODE_CAP} nodes to render at the boundary, got {len(nodes)}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Filters
 # ---------------------------------------------------------------------------
@@ -476,6 +508,32 @@ def test_graph_filter_by_name_substring_narrows_results() -> None:
         e["data"]["name"] for e in elements if isinstance(e, dict) and e.get("group") == "nodes"
     }
     assert names == {"vm-prod-01"}
+
+
+def test_graph_kind_dropdown_matches_closed_enum() -> None:
+    """The graph view's kind dropdown sources its options from ``_GRAPH_NODE_KINDS``.
+
+    Regression for the previously hardcoded vocabulary in
+    ``graph.html``. T1's tabular surface already routes through
+    ``node_kind_options`` (sourced from the closed enum); the graph
+    surface now mirrors that, so a widening of the closed enum (a new
+    connector contributing a new kind) reaches both filter dropdowns
+    without a template edit. The test asserts every ``_GRAPH_NODE_KINDS``
+    member renders as an ``<option>`` in the graph view.
+    """
+    from meho_backplane.db.models import _GRAPH_NODE_KINDS
+
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph")
+    assert response.status_code == 200, response.text
+    body = response.text
+    for kind in _GRAPH_NODE_KINDS:
+        assert f'<option value="{kind}"' in body, (
+            f"closed-enum kind {kind!r} missing from graph view's filter dropdown"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ui_topology_table.py
+++ b/backend/tests/test_ui_topology_table.py
@@ -655,6 +655,48 @@ def test_table_filter_href_percent_encodes_filters_with_reserved_chars() -> None
 
 
 # ---------------------------------------------------------------------------
+# Filter form preserves the cross-link selection (?selected=) across keystrokes
+# ---------------------------------------------------------------------------
+
+
+def test_filter_form_preserves_selected_id_across_filter_keystrokes() -> None:
+    """The filter form carries ``selected`` as a hidden input.
+
+    Cross-link AC (issue #881): a graph -> table click sets
+    ``?selected=<id>``; the table page highlights + scrolls the
+    matching row. The filter form is HTMX-wired with
+    ``hx-include="closest form"`` + ``hx-push-url="true"``, so on
+    the first filter keystroke HTMX collects only the inputs that
+    live inside the form. Without an explicit ``selected`` hidden
+    input the cross-link payload is dropped from the rebuilt URL
+    and the row highlight is lost on the very first keystroke,
+    directly subverting the cross-link AC.
+
+    This test seeds a node, requests the table with the matching
+    ``?selected=`` payload, and asserts the rendered filter form
+    carries the id as a hidden input alongside ``sort`` / ``direction``
+    so HTMX picks it up on every swap.
+    """
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    target_id = _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-keep-selected")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(f"/ui/topology?selected={target_id}")
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The selected hidden input rides inside the filter form. The
+    # exact tag shape mirrors the existing sort/direction hidden
+    # inputs so HTMX collects it on every swap.
+    expected = f'<input type="hidden" name="selected" value="{target_id}" />'
+    assert expected in body, (
+        "filter form is missing the selected hidden input -- "
+        "cross-link will be dropped on first keystroke"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Kind-filter dropdown -- sourced from the closed enum, not the current page
 # ---------------------------------------------------------------------------
 

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -5015,7 +5015,7 @@
           "ui-topology"
         ],
         "summary": "Ui Topology Table",
-        "description": "``GET /ui/topology[?view=table&sort=...&direction=...&kind=...&q=...]``.\n\n``view`` is accepted but unused in T1 (the only mode is the\ntable); T2 (#881) will branch on ``view`` to render the\nCytoscape graph instead. Documenting the param in the\nsignature now keeps the URL contract forward-compatible.",
+        "description": "Serve the topology UI, branching on ``?view=``.\n\nURL contract::\n\n    GET /ui/topology\n        [?view=table|graph\n         &sort=...&direction=...\n         &kind=...&q=...\n         &selected=<uuid>]\n\n``view=graph`` delegates to\n:func:`meho_backplane.ui.routes.topology.graph.render_graph`;\n``view=table`` (the default) keeps the tabular surface T1\nships. ``selected`` (an optional UUID) round-trips the\ncross-link selection between the two surfaces.",
         "operationId": "ui_topology_table_ui_topology_get",
         "parameters": [
           {
@@ -5075,10 +5075,19 @@
             "in": "query",
             "required": false,
             "schema": {
+              "$ref": "#/components/schemas/_ViewMode",
+              "default": "table"
+            }
+          },
+          {
+            "name": "selected",
+            "in": "query",
+            "required": false,
+            "schema": {
               "type": "string",
-              "maxLength": 16,
+              "format": "uuid",
               "nullable": true,
-              "title": "View"
+              "title": "Selected"
             }
           }
         ],
@@ -9327,6 +9336,15 @@
         ],
         "title": "_SortDirection",
         "description": "Sort direction enum -- ``asc`` (default) or ``desc``."
+      },
+      "_ViewMode": {
+        "type": "string",
+        "enum": [
+          "table",
+          "graph"
+        ],
+        "title": "_ViewMode",
+        "description": "Closed enum of view modes exposed on ``GET /ui/topology``.\n\n``table`` is the default (T1 / #880); ``graph`` switches to the\nCytoscape.js surface (T2 / #881). The enum's ``str`` mixin keeps\ntemplate URL building stable -- ``str(_ViewMode.GRAPH)`` is\n``\"graph\"`` (not ``\"_ViewMode.GRAPH\"``). An out-of-range value\nfails Pydantic validation (422) at the HTTP boundary so the route\nbody never sees an unknown mode."
       }
     }
   }

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -213,6 +213,12 @@ const (
 	Desc UnderscoreSortDirection = "desc"
 )
 
+// Defines values for UnderscoreViewMode.
+const (
+	Graph UnderscoreViewMode = "graph"
+	Table UnderscoreViewMode = "table"
+)
+
 // Defines values for ListEndpointApiV1ConnectorsGetParamsStatus.
 const (
 	All      ListEndpointApiV1ConnectorsGetParamsStatus = "all"
@@ -2656,6 +2662,16 @@ type UnderscoreSortColumn string
 // UnderscoreSortDirection Sort direction enum -- “asc“ (default) or “desc“.
 type UnderscoreSortDirection string
 
+// UnderscoreViewMode Closed enum of view modes exposed on “GET /ui/topology“.
+//
+// “table“ is the default (T1 / #880); “graph“ switches to the
+// Cytoscape.js surface (T2 / #881). The enum's “str“ mixin keeps
+// template URL building stable -- “str(_ViewMode.GRAPH)“ is
+// “"graph"“ (not “"_ViewMode.GRAPH"“). An out-of-range value
+// fails Pydantic validation (422) at the HTTP boundary so the route
+// body never sees an unknown mode.
+type UnderscoreViewMode string
+
 // ListAgentsApiV1AgentsGetParams defines parameters for ListAgentsApiV1AgentsGet.
 type ListAgentsApiV1AgentsGetParams struct {
 	Limit         *int    `form:"limit,omitempty" json:"limit,omitempty"`
@@ -3140,7 +3156,8 @@ type UiTopologyTableUiTopologyGetParams struct {
 	Kind      *string                  `form:"kind,omitempty" json:"kind,omitempty"`
 	Q         *string                  `form:"q,omitempty" json:"q,omitempty"`
 	Limit     *int                     `form:"limit,omitempty" json:"limit,omitempty"`
-	View      *string                  `form:"view,omitempty" json:"view,omitempty"`
+	View      *UnderscoreViewMode      `form:"view,omitempty" json:"view,omitempty"`
+	Selected  *openapi_types.UUID      `form:"selected,omitempty" json:"selected,omitempty"`
 }
 
 // CreateAgentApiV1AgentsPostJSONRequestBody defines body for CreateAgentApiV1AgentsPost for application/json ContentType.
@@ -10580,6 +10597,22 @@ func NewUiTopologyTableUiTopologyGetRequest(server string, params *UiTopologyTab
 		if params.View != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "view", runtime.ParamLocationQuery, *params.View); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Selected != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "selected", runtime.ParamLocationQuery, *params.Selected); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -785,9 +785,114 @@ pin both invariants.
 * **Multi-row select is client-side only** — Alpine.js holds the
   selection set. T1 doesn't ship a bulk-action endpoint; the selection
   state is exposed for a future button to consume.
-* **No graph view yet** — `view=table` is the only mode T1 honours.
-  T2 (#881) adds `view=graph` and switches routing on the query
-  parameter.
+
+## Topology graph view (Task #881)
+
+Initiative [#342](https://github.com/evoila/meho/issues/342) (G10.5
+Topology UI), Task [#881](https://github.com/evoila/meho/issues/881)
+(G10.5-T2) layers an interactive Cytoscape.js graph view on top of the
+same `/ui/topology` path via the `?view=graph` branch. The same
+`GET /ui/topology` handler serves both surfaces; one of three response
+shapes is selected per request:
+
+| Query | Header | Response |
+| ----- | ------ | -------- |
+| `view=table` (default) | _none_ | `topology/table.html` full page |
+| `view=table` (default) | `HX-Request: true` | `topology/_table_rows.html` fragment |
+| `view=graph` | _none_ | `topology/graph.html` full page (Cytoscape island) |
+
+The graph view does not have an HTMX-fragment variant — layout
+switches happen client-side via `cy.layout({name}).run()`, and filter
+changes round-trip to the server as a full-page navigation so the URL
+captures the active mode for copy/paste.
+
+### Module layout
+
+| Module | Purpose |
+| ------ | ------- |
+| `meho_backplane.ui.routes.topology.table` | `GET /ui/topology` handler. Branches on `view=` and delegates the `graph` branch to `topology.graph.render_graph`; the `table` branch keeps the T1 tabular rendering. |
+| `meho_backplane.ui.routes.topology.graph` | The `?view=graph` render. Pulls nodes via the substrate `list_nodes` capped at 500 (`GRAPH_NODE_CAP`) and edges via a local SQLite-portable ORM query (the substrate `list_edges` relies on PG `jsonb_typeof` for its conflict predicate; the graph view does not need conflict info, so the local helper is the right factoring). Emits node + edge JSON as a `<script type="application/json">` data island the `topology-graph.js` controller reads on init. |
+
+### Vendored JS
+
+The graph view adds four vendored files alongside the chassis bundle
+(`htmx`, `sse`, `alpine`, `cytoscape`, `daisyui`). All four are
+SHA256-pinned in
+[`backend/src/meho_backplane/ui/static/src/vendor/VENDOR.md`](../../backend/src/meho_backplane/ui/static/src/vendor/VENDOR.md).
+
+| File | Library | Version | Notes |
+| ---- | ------- | ------- | ----- |
+| `layout-base.js` | layout-base | 2.0.1 | Shared layout primitive; exposes `window.layoutBase`. |
+| `cose-base.js` | cose-base | 2.2.0 | Consumes `layoutBase`, exposes `window.coseBase`. |
+| `cytoscape-cose-bilkent.js` | cytoscape-cose-bilkent | 4.1.0 | Default organic layout. Consumes `coseBase`; exposes `window.cytoscapeCoseBilkent`. |
+| `cytoscape-dagre.js` | cytoscape-dagre | 3.0.0 | Hierarchical layout; bundles dagre internally (the 2.x line required a separate `dagre` vendored file). |
+
+Script load order in `graph.html` is **load-bearing** (the UMD
+wrappers consume globals exposed by their predecessors):
+
+```
+cytoscape.min.js → layout-base.js → cose-base.js
+                → cytoscape-cose-bilkent.js
+                → cytoscape-dagre.js
+                → topology-graph.js   (the per-page controller)
+```
+
+All carry `defer` so they execute in document order after the HTML is
+parsed — the chassis CSP posture (zero inline JS) is unchanged.
+
+### Controllers
+
+| File | Purpose |
+| ---- | ------- |
+| `static/src/app/topology-graph.js` | Cytoscape init for the graph view. Registers the two layout plugins once (`cytoscape.use(...)`), reads the elements + selected-id data islands, mounts `<div id="cy">`, wires node-tap → HTMX drawer swap + URL sync, and drives the `cy.layout(...).run()` switcher off the `<select id="topology-graph-layout">` change event. |
+| `static/src/app/topology-table.js` | Cross-link helper for the tabular view. On `DOMContentLoaded` it finds any `<tr data-selected="true">` row (rendered by `_table_rows.html` when the route received `?selected=<id>`), scrolls it into view, and applies a brief outline pulse so the operator's eye catches it. No-op when no row matches. |
+
+### Cross-link contract (table ↔ graph)
+
+The `?selected=<uuid>` query param round-trips selection between the
+two surfaces.
+
+* **Graph → table**: `cy.on('tap', 'node', ...)` opens the drawer
+  (HTMX swap of `/ui/topology/node/<id>` into `#node-drawer`),
+  `history.replaceState`s `?selected=<id>` into the URL, and updates
+  the header's "Show in table" link `href` so a click takes the
+  operator to `/ui/topology?view=table&selected=<id>`. The table page
+  marks the matching row `data-selected="true"`, and
+  `topology-table.js` scrolls + highlights it.
+* **Table → graph**: each row carries a "Graph" link to
+  `/ui/topology?view=graph&selected=<id>`. The graph route emits the
+  id into `#topology-graph-selected`; `topology-graph.js` reads it,
+  centers the matching node on the first `layoutstop`, selects it,
+  and opens the same drawer.
+
+Both directions preserve active filters (`kind`, `q`) so the toggle
+keeps operator state.
+
+### 500-node render cap
+
+Per Initiative #342 work item #6 ("Performance discipline.
+Cytoscape handles ~1k nodes; v0.2 caps frontend-side rendering at
+500 nodes"), `graph.GRAPH_NODE_CAP = 500` and the route passes
+`limit=500` into `list_nodes`. When the returned list saturates the
+cap, the page surfaces a truncation banner ("Capped at 500 — narrow
+the filter or use the dependents query (T3) for larger sets"). Larger
+sets reach the operator via T3 (#882)'s subgraph query.
+
+### Templates
+
+| Template | Purpose |
+| -------- | ------- |
+| `topology/graph.html` | Full-page Cytoscape surface. Extends `base.html`; renders the view toggle, filter bar, status row + layout `<select>`, the `<div id="cy">` mount, the `#node-drawer` slot (shared with the table view), and two `<script type="application/json">` data islands carrying the elements + selected-id payloads. |
+
+### Cross-tenant isolation
+
+Same posture as the tabular surface: every read goes through
+`list_nodes` (substrate-level `WHERE graph_node.tenant_id = :tenant_id`
+first clause) plus a local `_fetch_edges_for_nodes` that joins both
+endpoints with explicit `tenant_id` predicates (defence-in-depth
+matching the T1 drawer's `_fetch_edges` shape). Cross-tenant nodes /
+edges cannot surface even if a future invariant violation introduced
+one.
 
 ## Known issues / open items
 


### PR DESCRIPTION
## Summary

- Layers the Cytoscape.js graph view on top of T1 (#880)'s tabular surface via the same `GET /ui/topology` handler branching on `?view=graph`.
- Adds the per-page controller (`topology-graph.js`) that registers the vendored `cose-bilkent` + `dagre` layout plugins, builds the Cytoscape instance from a server-emitted JSON data island, wires node-tap to the existing T1 drawer route via HTMX, and drives a layout `<select>` (cose-bilkent / dagre / circle) via `cy.layout(...).run()`.
- Adds the `?selected=<uuid>` cross-link that round-trips between the table and graph surfaces (table row "Graph" anchor → graph view centers + selects the node; graph node-tap → table view scrolls + highlights the row). Active filters (`kind`, `q`) are preserved on every toggle.
- Adds four SHA256-pinned vendored files (`layout-base.js` 2.0.1, `cose-base.js` 2.2.0, `cytoscape-cose-bilkent.js` 4.1.0, `cytoscape-dagre.js` 3.0.0; 3.0.0 bundles dagre internally so no separate dagre file is needed). Load order is documented in `VENDOR.md` per the UMD factory chain.
- Enforces the 500-node frontend cap per Initiative #342 work item #6 (`GRAPH_NODE_CAP`); beyond it the page surfaces a truncation banner pointing at the T3 (#882) subgraph query.

## Test plan

- [x] `ruff check src/meho_backplane/ui/ tests/test_ui_topology_graph.py` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/ui/ --ignore-missing-imports` — Success: no issues found in 22 source files
- [x] `pytest tests/test_ui_topology_graph.py` — 22 passed
- [x] `pytest tests/test_ui_topology_table.py tests/test_ui_templates.py tests/test_ui_chassis_smoke.py` — 48 passed (no regressions on the T1 / chassis suites)
- [x] `pytest tests/ -k ui_` — 168 passed (full UI suite green)
- [x] `code-quality.py --diff` — 0 blockers, 3 informational warnings on existing helpers
- [x] **AC1** — `/ui/topology?view=graph` renders Cytoscape graph (vendored + SHA-pinned) for ≤500 nodes; pan/zoom/click verified in tests (`test_graph_full_page_renders_cytoscape_mount`, `test_graph_caps_render_at_500_nodes`)
- [x] **AC2** — Node click opens drawer reusing the T1 `/ui/topology/node/<id>` route (`test_drawer_route_still_serves_node_detail_for_graph_tap`; the JS uses `htmx.ajax` against that exact path)
- [x] **AC3** — Layout switcher cose-bilkent / dagre / circle (`test_graph_layout_switcher_offers_three_layouts`)
- [x] **AC4** — Tabular ↔ graph cross-link (`test_graph_selected_id_round_trips_into_data_island`, `test_table_marks_selected_row`, `test_table_rows_include_show_in_graph_link`)
- [x] **AC5** — 500-node cap enforced + documented (`test_graph_caps_render_at_500_nodes`, `docs/codebase/ui.md` updated)
- [x] **AC6** — Cross-tenant isolation (`test_graph_isolates_other_tenants_nodes`, `test_graph_excludes_cross_tenant_edges`)

## Out of scope

- Dependents / path query overlays + polling-refresh — T3 (#882).
- Topology editing, time-travel, 3D — per #342 OOS.

## Notes

- The #974 iter-2 carry-over concern (stub-shadow on OpenAPI for `/ui/topology`) was already fixed on `main` before merge — `topology` and `broadcast` are no longer in `_SURFACE_STUBS` (`backend/src/meho_backplane/ui/routes/stubs.py:_SURFACE_STUBS`), and `test_topology_route_not_shadowed_in_openapi_schema` still passes. No follow-up work needed.
- The OpenAPI snapshot (`cli/api/openapi.json`) was regenerated via `cli/api/snapshot-openapi.py` to surface the new `view` enum (`table | graph`) and the optional `selected` UUID param on `GET /ui/topology`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #881


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graph visualization view for topology with interactive node selection and layout algorithm options
  * Cross-linking between table and graph views with shared selection state
  * Filter nodes by kind and name substring in graph view
  * Node detail drawer triggered from graph node interaction
  * View toggle preserves active filters across table/graph transitions

* **Documentation**
  * Updated API schema and codebase documentation to cover graph view behavior

* **Tests**
  * Added comprehensive test suite for graph view functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->