### PR TITLE
feat(ui): G10.5-T3 Topology dependents/dependencies + path overlays + 30s polling-refresh

### DIFF
--- a/backend/src/meho_backplane/ui/routes/topology/detail.py
+++ b/backend/src/meho_backplane/ui/routes/topology/detail.py
@@ -273,6 +273,41 @@ _require_ui_session_dep = Depends(require_ui_session)
 _get_raw_session_dep = Depends(get_raw_session)
 
 
+def _build_drawer_context(
+    *,
+    node: GraphNode,
+    outgoing: list[_EdgeRow],
+    incoming: list[_EdgeRow],
+    recent_ops: list[AuditLog],
+) -> dict[str, object]:
+    """Assemble the Jinja2 context dict the drawer template renders.
+
+    Extracted so :func:`build_detail_router._handler` stays inside the
+    code-quality function-size budget. The ``dependents_href`` is the
+    "show dependents" link target -- T3 (#882) wired the handler; the
+    URL contract is ``?from=<name>&from_kind=<kind>`` so the
+    dependents subgraph overlay loads with the right anchor.
+
+    ``graph_node.name`` is unconstrained Text (connector-populated);
+    a name containing ``&`` / ``?`` / ``#`` / ``+`` / ``%`` / space
+    would silently corrupt the query string when interpolated raw.
+    :func:`urllib.parse.quote` with ``safe=''`` percent-encodes every
+    byte that is not in the unreserved set, including ``/`` and
+    ``&`` -- the overlay decoder pairs with that on the way in.
+    """
+    return {
+        "node": node,
+        "outgoing_edges": outgoing,
+        "incoming_edges": incoming,
+        "recent_ops": recent_ops,
+        "dependents_href": (
+            f"/ui/topology?view=graph"
+            f"&from={quote(node.name, safe='')}"
+            f"&from_kind={quote(node.kind, safe='')}"
+        ),
+    }
+
+
 def build_detail_router() -> APIRouter:
     """Construct the topology-node-detail :class:`APIRouter`.
 
@@ -335,31 +370,12 @@ def build_detail_router() -> APIRouter:
             target_id=node.target_id,
         )
 
-        context = {
-            "node": node,
-            "outgoing_edges": outgoing,
-            "incoming_edges": incoming,
-            "recent_ops": recent_ops,
-            # The "show dependents" link target. T3 (#882) replaces
-            # the surface with a real handler; the URL contract
-            # ships today so a future hand-off does not need a URL
-            # rename. The dependents view rooted at this node lives
-            # at ``/ui/topology?view=graph&root=<name>`` per the
-            # Initiative #342 work-item #4 / #7 design.
-            #
-            # ``graph_node.name`` is unconstrained Text (connector-
-            # populated); a name containing ``&`` / ``?`` / ``#`` /
-            # ``+`` / ``%`` / space would silently corrupt the query
-            # string when interpolated raw. ``quote(..., safe='')``
-            # percent-encodes every byte that is not in the unreserved
-            # set, including ``/`` and ``&`` -- the dependents view
-            # decoder pairs with that on the way in.
-            "dependents_href": (
-                f"/ui/topology?view=graph"
-                f"&root={quote(node.name, safe='')}"
-                f"&kind={quote(node.kind, safe='')}"
-            ),
-        }
+        context = _build_drawer_context(
+            node=node,
+            outgoing=outgoing,
+            incoming=incoming,
+            recent_ops=recent_ops,
+        )
         return get_templates().TemplateResponse(request, "topology/_drawer.html", context)
 
     router.add_api_route(

--- a/backend/src/meho_backplane/ui/routes/topology/graph.py
+++ b/backend/src/meho_backplane/ui/routes/topology/graph.py
@@ -57,8 +57,10 @@ from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Final
 
+from fastapi import Request
 from fastapi.responses import HTMLResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -68,11 +70,28 @@ from meho_backplane.db.models import _GRAPH_NODE_KINDS, GraphEdge, GraphNode
 from meho_backplane.topology.query import TopologyNodeListEntry, list_nodes
 from meho_backplane.ui.auth.middleware import UISessionContext
 from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.routes.topology.path_queries import fetch_path_subgraph
+from meho_backplane.ui.routes.topology.queries import (
+    DEFAULT_OVERLAY_DEPTH,
+    DEFAULT_PATH_MAX_HOPS,
+    MAX_OVERLAY_DEPTH,
+    MAX_PATH_MAX_HOPS,
+    AmbiguousNodeError,
+    NodeNotFoundError,
+    PathSubgraphResult,
+    SubgraphEdgeRow,
+    SubgraphNodeRow,
+    SubgraphResult,
+    fetch_dependencies_subgraph,
+    fetch_dependents_subgraph,
+)
 from meho_backplane.ui.templating import get_templates
 
 __all__ = [
     "GRAPH_NODE_CAP",
+    "OverlayDirection",
     "render_graph",
+    "render_graph_fragment",
 ]
 
 
@@ -88,6 +107,21 @@ GRAPH_NODE_CAP: Final[int] = 500
 #: keeps the public-facing constant clean while letting the helper
 #: keep a short local name.
 _GRAPH_NODE_CAP = GRAPH_NODE_CAP
+
+
+class OverlayDirection(StrEnum):
+    """Closed enum of traversal directions for the ``?from=`` overlay.
+
+    Exposed on the route as the ``?direction=`` query param. ``dependents``
+    walks edges INTO the root (reverse traversal -- "what depends on
+    me"); ``dependencies`` walks edges OUT of the root (forward
+    traversal -- "what I depend on"). The default ``dependents``
+    matches the operator's typical question on first arrival from the
+    drawer's "Show dependents" link.
+    """
+
+    DEPENDENTS = "dependents"
+    DEPENDENCIES = "dependencies"
 
 
 @dataclass(frozen=True)
@@ -220,6 +254,85 @@ def _build_elements(
     return elements
 
 
+def _subgraph_node_to_cy_element(
+    node: SubgraphNodeRow, *, root_id: uuid.UUID | None = None
+) -> dict[str, object]:
+    """Project an overlay subgraph node to a Cytoscape element JSON object.
+
+    Mirrors :func:`_node_to_cy_element`; the only difference is that
+    overlay nodes also carry a ``root`` class on the anchor node so
+    the stylesheet can render it with a thicker border. ``root_id``
+    is optional -- the path overlay does not have a single root.
+    """
+    classes = f"kind-{node.kind}"
+    if root_id is not None and node.id == root_id:
+        classes = f"{classes} root"
+    return {
+        "group": "nodes",
+        "data": {
+            "id": str(node.id),
+            "name": node.name,
+            "kind": node.kind,
+        },
+        "classes": classes,
+    }
+
+
+def _subgraph_edge_to_cy_element(
+    edge: SubgraphEdgeRow, *, highlighted: bool = False
+) -> dict[str, object]:
+    """Project an overlay subgraph edge to a Cytoscape element JSON object.
+
+    ``highlighted=True`` adds the ``highlight`` class -- the path
+    overlay uses this on the path's own edges so the Cytoscape
+    stylesheet renders them with a distinct colour. Plain edges
+    (context in a path overlay, all edges in a dependents overlay)
+    have ``highlight`` absent.
+    """
+    classes = f"kind-{edge.kind}"
+    if highlighted:
+        classes = f"{classes} highlight"
+    return {
+        "group": "edges",
+        "data": {
+            "id": str(edge.id),
+            "source": str(edge.from_id),
+            "target": str(edge.to_id),
+            "kind": edge.kind,
+        },
+        "classes": classes,
+    }
+
+
+def _build_subgraph_elements(
+    result: SubgraphResult,
+) -> list[dict[str, object]]:
+    """Build the Cytoscape elements bag for a dependents/dependencies overlay."""
+    elements: list[dict[str, object]] = [
+        _subgraph_node_to_cy_element(n, root_id=result.root_id) for n in result.nodes
+    ]
+    elements.extend(_subgraph_edge_to_cy_element(e) for e in result.edges)
+    return elements
+
+
+def _build_path_elements(
+    result: PathSubgraphResult,
+) -> list[dict[str, object]]:
+    """Build the Cytoscape elements bag for a path overlay.
+
+    Every path edge gets the ``highlight`` class so the stylesheet
+    renders it in the highlighted colour; every path node also gets
+    a small position marker (kept in ``classes`` so the per-kind
+    palette is preserved).
+    """
+    elements: list[dict[str, object]] = [_subgraph_node_to_cy_element(n) for n in result.nodes]
+    elements.extend(
+        _subgraph_edge_to_cy_element(edge, highlighted=(edge.id in result.highlighted_edge_ids))
+        for edge in result.edges
+    )
+    return elements
+
+
 def _build_template_context(
     *,
     elements: list[dict[str, object]],
@@ -273,34 +386,262 @@ def _build_template_context(
     }
 
 
-async def render_graph(
-    request: object,
+def _build_refresh_url(
+    *,
+    overlay_mode: str,
+    root_name: str | None,
+    root_kind: str | None,
+    direction: OverlayDirection | None,
+    depth: int | None,
+    to_name: str | None,
+    to_kind: str | None,
+    kind: str | None,
+    name_contains: str | None,
+    selected_id: uuid.UUID | None,
+) -> str:
+    """Build the URL HTMX polls every 30s to re-fetch this view.
+
+    Mirrors the URL the operator copy/pasted into the browser bar so
+    the polling refresh stays on the same overlay. ``view=graph`` is
+    pinned because the polling refresh only fires on the graph
+    branch. The encoding uses ``urllib.parse.quote`` (``safe=''``)
+    to match the same posture the detail drawer's
+    ``dependents_href`` uses.
+    """
+    # Local import keeps the helper near the consumer; avoids
+    # pulling the urllib name into the module-level namespace where
+    # the rest of the module does not use it.
+    from urllib.parse import urlencode
+
+    params: list[tuple[str, str]] = [("view", "graph")]
+    if overlay_mode in ("dependents", "dependencies"):
+        # Subgraph overlay -- carry the anchor + direction + depth.
+        if root_name is not None:
+            params.append(("from", root_name))
+        if root_kind:
+            params.append(("from_kind", root_kind))
+        if direction is not None:
+            params.append(("direction", direction.value))
+        if depth is not None:
+            params.append(("depth", str(depth)))
+    elif overlay_mode == "path":
+        # Path overlay -- carry both endpoints.
+        if root_name is not None:
+            params.append(("from", root_name))
+        if root_kind:
+            params.append(("from_kind", root_kind))
+        if to_name:
+            params.append(("to", to_name))
+        if to_kind:
+            params.append(("to_kind", to_kind))
+    else:
+        # Full inventory -- carry the kind + name filters + selection.
+        if kind:
+            params.append(("kind", kind))
+        if name_contains:
+            params.append(("q", name_contains))
+        if selected_id is not None:
+            params.append(("selected", str(selected_id)))
+    return f"/ui/topology?{urlencode(params)}"
+
+
+def _is_htmx_request(request: Request) -> bool:
+    """Return ``True`` when the request was issued by HTMX.
+
+    The graph view uses the same case-insensitive HX-Request header
+    check as the table surface to distinguish a normal browser nav
+    (full page) from an HTMX polling refresh (data-island fragment).
+    HTMX 2 sets ``HX-Request: true`` on every directive-driven fetch
+    (see https://htmx.org/reference/#request_headers).
+    """
+    return request.headers.get("hx-request", "").lower() == "true"
+
+
+def _build_overlay_template_context(
+    *,
+    elements: list[dict[str, object]],
+    node_count: int,
+    edge_count: int,
+    truncated: bool,
+    overlay_mode: str,
+    root_name: str,
+    root_kind: str | None,
+    direction: OverlayDirection | None,
+    depth: int | None,
+    to_name: str | None,
+    to_kind: str | None,
+    path_found: bool,
+    total_hops: int | None,
+    path_node_ids: tuple[uuid.UUID, ...],
+    csrf_token: str,
+) -> dict[str, object]:
+    """Assemble the Jinja2 context for an overlay graph render.
+
+    Mirrors :func:`_build_template_context` for the standard full view
+    but extends it with overlay-specific bindings:
+
+    * ``overlay_mode`` -- ``"dependents"`` / ``"dependencies"`` / ``"path"``
+      so the template surfaces the active mode in the header.
+    * ``root_name`` + ``root_kind`` -- echoed for the title.
+    * ``direction`` -- which subgraph the dependents/dependencies
+      branch rendered.
+    * ``depth`` -- the active depth for the dependents/dependencies
+      branch.
+    * ``to_name`` + ``to_kind`` -- the path target for the path mode.
+    * ``path_found`` -- whether a path was located within ``max_hops``.
+    * ``total_hops`` -- the path length, ``None`` for not-found.
+    * ``path_node_ids`` -- the ordered path ids; the JS controller
+      reads this to highlight the path nodes (matching the
+      ``highlight`` class on path edges).
+    """
+    return {
+        "page_title": "Topology",
+        "active_surface": "topology",
+        # No kind/name filters on an overlay -- the URL contract is
+        # ``?from=...`` (anchor-driven), not ``?kind=...&q=...``
+        # (inventory-driven).
+        "kind_filter": "",
+        "name_filter": "",
+        "csrf_token": csrf_token,
+        "elements": elements,
+        "node_count": node_count,
+        "edge_count": edge_count,
+        "graph_node_cap": GRAPH_NODE_CAP,
+        "truncated": truncated,
+        "node_kind_options": sorted(_GRAPH_NODE_KINDS),
+        # No table cross-link target in overlay mode -- empty string
+        # so Jinja's ``StrictUndefined`` env does not raise on the
+        # template read.
+        "selected_id": "",
+        "ready": False,
+        # Overlay-specific bindings the template renders only when
+        # ``overlay_mode`` is set.
+        "overlay_mode": overlay_mode,
+        "overlay_root_name": root_name,
+        "overlay_root_kind": root_kind or "",
+        "overlay_direction": direction.value if direction is not None else "",
+        "overlay_depth": depth if depth is not None else "",
+        "overlay_to_name": to_name or "",
+        "overlay_to_kind": to_kind or "",
+        "overlay_path_found": path_found,
+        "overlay_total_hops": total_hops if total_hops is not None else "",
+        # JSON-serialisable list for the data island.
+        "overlay_path_node_ids": [str(nid) for nid in path_node_ids],
+        # The polling-refresh target URL the HTMX wrapper hits every
+        # 30s (G10.5-T3 (#882) work-item #3).
+        "refresh_url": _build_refresh_url(
+            overlay_mode=overlay_mode,
+            root_name=root_name,
+            root_kind=root_kind,
+            direction=direction,
+            depth=depth,
+            to_name=to_name,
+            to_kind=to_kind,
+            kind=None,
+            name_contains=None,
+            selected_id=None,
+        ),
+    }
+
+
+def _build_full_template_context(
+    *,
+    elements: list[dict[str, object]],
+    node_count: int,
+    edge_count: int,
+    truncated: bool,
+    kind: str | None,
+    name_contains: str | None,
+    selected_id: uuid.UUID | None,
+    csrf_token: str,
+) -> dict[str, object]:
+    """Wrap :func:`_build_template_context` with the full-view overlay
+    bindings set to their inactive defaults.
+
+    The template reads ``overlay_mode`` to branch on what to render;
+    the inactive defaults (empty string for ``overlay_mode``) mean the
+    full inventory view renders its existing chrome (the kind +
+    name filters), and the overlay-only chrome stays hidden.
+    """
+    base = _build_template_context(
+        elements=elements,
+        node_count=node_count,
+        edge_count=edge_count,
+        truncated=truncated,
+        kind=kind,
+        name_contains=name_contains,
+        selected_id=selected_id,
+        csrf_token=csrf_token,
+    )
+    # Inactive defaults for the overlay-only bindings -- StrictUndefined
+    # requires every key the template reads to be present.
+    base.update(
+        {
+            "overlay_mode": "",
+            "overlay_root_name": "",
+            "overlay_root_kind": "",
+            "overlay_direction": "",
+            "overlay_depth": "",
+            "overlay_to_name": "",
+            "overlay_to_kind": "",
+            "overlay_path_found": False,
+            "overlay_total_hops": "",
+            "overlay_path_node_ids": [],
+            # Polling-refresh URL: on the full inventory branch the
+            # refresh re-fetches the inventory with the same kind +
+            # name filters and the cross-link selection preserved
+            # (so a graph -> table -> graph round-trip with a node
+            # selected does not lose the selection when polling fires).
+            "refresh_url": _build_refresh_url(
+                overlay_mode="",
+                root_name=None,
+                root_kind=None,
+                direction=None,
+                depth=None,
+                to_name=None,
+                to_kind=None,
+                kind=kind,
+                name_contains=name_contains,
+                selected_id=selected_id,
+            ),
+        }
+    )
+    return base
+
+
+def _set_csrf_cookie(response: HTMLResponse, csrf_token: str) -> None:
+    """Pin the CSRF cookie on the response.
+
+    Same posture as the T1 tabular surface and the T2 full-graph
+    surface -- the cookie is intentionally not ``HttpOnly`` so HTMX
+    can read it to populate ``X-CSRF-Token`` on subsequent state-
+    changing actions.
+    """
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=csrf_token,
+        httponly=False,
+        secure=True,
+        samesite="strict",
+        path="/ui",
+    )
+
+
+async def _render_full_inventory(
+    request: Request,
     *,
     session_ctx: UISessionContext,
     db_session: AsyncSession,
     kind: str | None,
     name_contains: str | None,
     selected_id: uuid.UUID | None,
+    htmx_fragment: bool,
 ) -> HTMLResponse:
-    """Render the ``?view=graph`` Cytoscape page.
+    """Render the full-inventory graph view (no ``?from=``).
 
-    The route at :mod:`meho_backplane.ui.routes.topology.table`
-    branches on ``?view=`` and calls this function when ``graph`` is
-    selected. The signature accepts the already-validated query
-    params from the caller so the validation surface stays in the one
-    place FastAPI sees -- the route definition.
-
-    The 500-node cap is enforced here. To detect "more nodes exist
-    than we are willing to render" without a separate ``COUNT(*)`` round
-    trip, we ask the substrate for ``GRAPH_NODE_CAP + 1`` rows: if the
-    extra row materialises the banner flips on and the surplus row is
-    sliced off before the elements bag is emitted. The previous ``>=``
-    predicate at ``limit=GRAPH_NODE_CAP`` flagged a tenant with **exactly**
-    500 nodes as truncated, a boundary-off-by-one false positive. ``>``
-    on the ``CAP + 1`` fetch is the correct predicate -- the banner
-    fires only when the inventory genuinely exceeds the cap.
-    ``selected_id`` round-trips the cross-link target from the table
-    surface's ``?selected=`` param.
+    Extracted from :func:`render_graph` so that function stays a
+    thin dispatcher; the full-inventory path was the original T2
+    (#881) shipping body.
     """
     nodes = await list_nodes(
         db_session,
@@ -321,7 +662,7 @@ async def render_graph(
     )
     elements = _build_elements(nodes, edges)
     csrf_token = mint_csrf_token(str(session_ctx.session_id))
-    context = _build_template_context(
+    context = _build_full_template_context(
         elements=elements,
         node_count=len(nodes),
         edge_count=len(edges),
@@ -331,18 +672,306 @@ async def render_graph(
         selected_id=selected_id,
         csrf_token=csrf_token,
     )
-    response = get_templates().TemplateResponse(
-        request,  # type: ignore[arg-type]
-        "topology/graph.html",
-        context,
-    )
-    # Same CSRF posture as the table surface (T1 / #880).
-    response.set_cookie(
-        key=CSRF_COOKIE_NAME,
-        value=csrf_token,
-        httponly=False,
-        secure=True,
-        samesite="strict",
-        path="/ui",
-    )
+    template_name = "topology/_graph_data_island.html" if htmx_fragment else "topology/graph.html"
+    response = get_templates().TemplateResponse(request, template_name, context)
+    _set_csrf_cookie(response, csrf_token)
     return response
+
+
+async def _render_dependents_or_dependencies_overlay(
+    request: Request,
+    *,
+    session_ctx: UISessionContext,
+    db_session: AsyncSession,
+    from_name: str,
+    from_kind: str | None,
+    direction: OverlayDirection,
+    depth: int,
+    htmx_fragment: bool,
+) -> HTMLResponse:
+    """Render the dependents (reverse) or dependencies (forward) overlay."""
+    fetcher = (
+        fetch_dependents_subgraph
+        if direction == OverlayDirection.DEPENDENTS
+        else fetch_dependencies_subgraph
+    )
+    try:
+        result: SubgraphResult = await fetcher(
+            db_session,
+            tenant_id=session_ctx.tenant_id,
+            name=from_name,
+            kind=from_kind,
+            depth=depth,
+            max_nodes=GRAPH_NODE_CAP,
+        )
+    except NodeNotFoundError as exc:
+        return _render_overlay_error(
+            request,
+            session_ctx=session_ctx,
+            status_code=404,
+            message=str(exc),
+            htmx_fragment=htmx_fragment,
+        )
+    except AmbiguousNodeError as exc:
+        return _render_overlay_error(
+            request,
+            session_ctx=session_ctx,
+            status_code=409,
+            message=str(exc),
+            htmx_fragment=htmx_fragment,
+        )
+
+    elements = _build_subgraph_elements(result)
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    context = _build_overlay_template_context(
+        elements=elements,
+        node_count=len(result.nodes),
+        edge_count=len(result.edges),
+        truncated=result.truncated,
+        overlay_mode=direction.value,
+        root_name=result.root_name,
+        root_kind=result.root_kind,
+        direction=direction,
+        depth=depth,
+        to_name=None,
+        to_kind=None,
+        path_found=False,
+        total_hops=None,
+        path_node_ids=(),
+        csrf_token=csrf_token,
+    )
+    template_name = "topology/_graph_data_island.html" if htmx_fragment else "topology/graph.html"
+    response = get_templates().TemplateResponse(request, template_name, context)
+    _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def _render_path_overlay(
+    request: Request,
+    *,
+    session_ctx: UISessionContext,
+    db_session: AsyncSession,
+    from_name: str,
+    from_kind: str | None,
+    to_name: str,
+    to_kind: str | None,
+    max_hops: int,
+    htmx_fragment: bool,
+) -> HTMLResponse:
+    """Render the shortest-path overlay between two named nodes."""
+    try:
+        result: PathSubgraphResult = await fetch_path_subgraph(
+            db_session,
+            tenant_id=session_ctx.tenant_id,
+            from_name=from_name,
+            to_name=to_name,
+            from_kind=from_kind,
+            to_kind=to_kind,
+            max_hops=max_hops,
+        )
+    except NodeNotFoundError as exc:
+        return _render_overlay_error(
+            request,
+            session_ctx=session_ctx,
+            status_code=404,
+            message=str(exc),
+            htmx_fragment=htmx_fragment,
+        )
+    except AmbiguousNodeError as exc:
+        return _render_overlay_error(
+            request,
+            session_ctx=session_ctx,
+            status_code=409,
+            message=str(exc),
+            htmx_fragment=htmx_fragment,
+        )
+
+    elements = _build_path_elements(result)
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    context = _build_overlay_template_context(
+        elements=elements,
+        node_count=len(result.nodes),
+        edge_count=len(result.edges),
+        truncated=result.truncated,
+        overlay_mode="path",
+        root_name=from_name,
+        root_kind=from_kind,
+        direction=None,
+        depth=None,
+        to_name=to_name,
+        to_kind=to_kind,
+        path_found=result.total_hops is not None,
+        total_hops=result.total_hops,
+        path_node_ids=result.path_node_ids,
+        csrf_token=csrf_token,
+    )
+    template_name = "topology/_graph_data_island.html" if htmx_fragment else "topology/graph.html"
+    response = get_templates().TemplateResponse(request, template_name, context)
+    _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+def _render_overlay_error(
+    request: Request,
+    *,
+    session_ctx: UISessionContext,
+    status_code: int,
+    message: str,
+    htmx_fragment: bool,
+) -> HTMLResponse:
+    """Render the not-found / ambiguous-name error fragment.
+
+    ``status_code`` carries the HTTP semantics (404 unknown name,
+    409 ambiguous name); the body is a small panel inside the
+    standard chrome so the operator stays in context (rather than
+    bouncing to a global error page).
+
+    The fragment-mode branch returns just the inline error block so
+    a polling HTMX swap surfaces the error message without rewriting
+    the surrounding page chrome.
+    """
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    template_name = (
+        "topology/_graph_overlay_error_fragment.html"
+        if htmx_fragment
+        else "topology/_graph_overlay_error.html"
+    )
+    context = {
+        "page_title": "Topology",
+        "active_surface": "topology",
+        "csrf_token": csrf_token,
+        "error_status": status_code,
+        "error_message": message,
+        "ready": False,
+    }
+    response = get_templates().TemplateResponse(
+        request,
+        template_name,
+        context,
+        status_code=status_code,
+    )
+    _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+def _clamp_depth(depth: int | None) -> int:
+    """Clamp the operator-supplied depth into ``[1, MAX_OVERLAY_DEPTH]``.
+
+    ``None`` -> :data:`~meho_backplane.ui.routes.topology.queries.DEFAULT_OVERLAY_DEPTH`.
+    Out-of-range values silently clamp; the route layer's pydantic
+    validator constrains the HTTP boundary tighter (rejects values
+    outside the range), but this defensive clamp keeps the helper
+    safe when called from a future internal context (CLI/MCP/REPL)
+    without the same validation.
+    """
+    if depth is None:
+        return DEFAULT_OVERLAY_DEPTH
+    if depth < 1:
+        return 1
+    if depth > MAX_OVERLAY_DEPTH:
+        return MAX_OVERLAY_DEPTH
+    return depth
+
+
+def _clamp_max_hops(max_hops: int | None) -> int:
+    """Clamp the operator-supplied path hop ceiling.
+
+    Same posture as :func:`_clamp_depth`.
+    """
+    if max_hops is None:
+        return DEFAULT_PATH_MAX_HOPS
+    if max_hops < 1:
+        return 1
+    if max_hops > MAX_PATH_MAX_HOPS:
+        return MAX_PATH_MAX_HOPS
+    return max_hops
+
+
+async def render_graph(
+    request: Request,
+    *,
+    session_ctx: UISessionContext,
+    db_session: AsyncSession,
+    kind: str | None,
+    name_contains: str | None,
+    selected_id: uuid.UUID | None,
+    from_name: str | None = None,
+    from_kind: str | None = None,
+    to_name: str | None = None,
+    to_kind: str | None = None,
+    direction: OverlayDirection | None = None,
+    depth: int | None = None,
+    max_hops: int | None = None,
+) -> HTMLResponse:
+    """Render the ``?view=graph`` Cytoscape surface (full or overlay).
+
+    The route at :mod:`meho_backplane.ui.routes.topology.table`
+    branches on ``?view=`` and calls this function when ``graph`` is
+    selected. The signature accepts the already-validated query
+    params from the caller so the validation surface stays in the one
+    place FastAPI sees -- the route definition.
+
+    Mode is decided here from the optional overlay query params:
+
+    * ``from_name`` + ``to_name`` both set -> path overlay (G10.5-T3
+      #882 work-item #2): the shortest unweighted path between two
+      named nodes with edges highlighted.
+    * ``from_name`` set, ``to_name`` unset -> dependents (default) or
+      dependencies subgraph (G10.5-T3 work-item #1).
+    * Neither set -> full inventory (T2 / #881 shipping body).
+
+    The HX-Request header surfaces the polling-refresh branch
+    (G10.5-T3 work-item #3): the response is the data-island fragment
+    only, swapped in by HTMX's ``every 30s`` trigger without
+    rewriting the chrome.
+
+    The 500-node cap (T2 / #881) is enforced on every branch via
+    :data:`GRAPH_NODE_CAP`. ``selected_id`` round-trips the cross-
+    link target on the full-inventory branch only -- overlays do not
+    expose a separate selection state.
+    """
+    htmx_fragment = _is_htmx_request(request)
+
+    # Path overlay: both endpoints set.
+    if from_name is not None and to_name is not None:
+        return await _render_path_overlay(
+            request,
+            session_ctx=session_ctx,
+            db_session=db_session,
+            from_name=from_name,
+            from_kind=from_kind,
+            to_name=to_name,
+            to_kind=to_kind,
+            max_hops=_clamp_max_hops(max_hops),
+            htmx_fragment=htmx_fragment,
+        )
+
+    # Dependents / dependencies subgraph: ``from`` set, ``to`` unset.
+    if from_name is not None:
+        active_direction = direction or OverlayDirection.DEPENDENTS
+        return await _render_dependents_or_dependencies_overlay(
+            request,
+            session_ctx=session_ctx,
+            db_session=db_session,
+            from_name=from_name,
+            from_kind=from_kind,
+            direction=active_direction,
+            depth=_clamp_depth(depth),
+            htmx_fragment=htmx_fragment,
+        )
+
+    # Full inventory (T2 / #881 shipping body).
+    return await _render_full_inventory(
+        request,
+        session_ctx=session_ctx,
+        db_session=db_session,
+        kind=kind,
+        name_contains=name_contains,
+        selected_id=selected_id,
+        htmx_fragment=htmx_fragment,
+    )
+
+
+# Backwards-compat alias for callers that prefer the explicit name
+# (e.g. a future internal route handler).
+render_graph_fragment = render_graph

--- a/backend/src/meho_backplane/ui/routes/topology/path_queries.py
+++ b/backend/src/meho_backplane/ui/routes/topology/path_queries.py
@@ -44,7 +44,7 @@ import uuid
 from collections import deque
 from dataclasses import dataclass
 
-from sqlalchemy import select
+from sqlalchemy import JSON, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
@@ -72,6 +72,12 @@ async def _bidirectional_neighbours(
     ``anchor_id`` is the frontier id the edge touched and
     ``other_endpoint`` is the node on the other side -- regardless of
     edge orientation. Self-loops (``from == to``) are surfaced once.
+
+    Superseded edges (``properties->>'superseded_by' IS NOT NULL``)
+    are excluded to mirror the G9.1 substrate path verb
+    (:func:`meho_backplane.topology.query.find_path`, Initiative #364
+    §6). Operators must see the same reachability in the UI overlay
+    that the substrate REST/CLI API exposes.
     """
     if not frontier_ids:
         return []
@@ -87,6 +93,16 @@ async def _bidirectional_neighbours(
             from_alias.tenant_id == tenant_id,
             to_alias.tenant_id == tenant_id,
             GraphEdge.last_seen.is_not(None),
+            # Substrate parity: drop edges curated as superseded so the
+            # UI path overlay's reachability matches what the CLI/REST
+            # find_path verb returns. The ``or_(.is_(None), ==
+            # JSON.NULL)`` combo handles both PG (SQL NULL on missing
+            # key) and SQLite (JSON NULL token); see the sibling
+            # ``queries._bfs_neighbours`` for the same predicate.
+            or_(
+                GraphEdge.properties["superseded_by"].is_(None),
+                GraphEdge.properties["superseded_by"] == JSON.NULL,
+            ),
             (GraphEdge.from_node_id.in_(frontier_ids)) | (GraphEdge.to_node_id.in_(frontier_ids)),
         )
         .order_by(GraphEdge.id)

--- a/backend/src/meho_backplane/ui/routes/topology/path_queries.py
+++ b/backend/src/meho_backplane/ui/routes/topology/path_queries.py
@@ -1,0 +1,300 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""UI-facing topology shortest-path query for the graph path overlay.
+
+Initiative #342 (G10.5 Topology UI), Task #882 (G10.5-T3). Sibling
+module to :mod:`meho_backplane.ui.routes.topology.queries` -- the
+subgraph (dependents/dependencies) helpers live there, the
+shortest-path search lives here. The split keeps each module inside
+the code-quality file-size budget and the test coverage scoped by
+overlay flavour.
+
+Algorithm
+=========
+
+Bidirectional BFS treating storage-directed edges as undirected for
+reachability. The path search answers "is there *any* route between
+these two objects?" -- the operator question -- so an edge ``A->B``
+contributes to the walk from both A and B. Returns the **shortest**
+path by hop count (BFS guarantees minimum-hop) or ``None`` when the
+target is unreachable within ``max_hops`` / either endpoint does not
+resolve.
+
+Mirrors the substrate
+:data:`meho_backplane.topology.query._PATH_SQL` (the PG recursive
+``WITH RECURSIVE ... bi_edge ... CYCLE`` shape) but in dialect-
+portable SQLAlchemy ORM so the UI test suite (SQLite) can cover the
+route end-to-end. The substrate verb stays the source of truth for
+the REST + CLI + MCP surfaces; this module is UI-only.
+
+Tenant scoping
+==============
+
+Every edge query enforces the boundary at three points -- edge row +
+both endpoint joins -- matching :mod:`...queries`'
+:func:`_bfs_neighbours` posture. Defense in depth against a future
+invariant violation that lets a stray cross-tenant edge slip into
+storage.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections import deque
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from meho_backplane.db.models import GraphEdge, GraphNode
+from meho_backplane.ui.routes.topology.queries import (
+    DEFAULT_PATH_MAX_HOPS,
+    PathSubgraphResult,
+    SubgraphEdgeRow,
+    SubgraphNodeRow,
+    resolve_anchor,
+)
+
+__all__ = ["fetch_path_subgraph"]
+
+
+async def _bidirectional_neighbours(
+    db_session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    frontier_ids: list[uuid.UUID],
+) -> list[tuple[uuid.UUID, GraphNode, GraphEdge]]:
+    """One bidirectional BFS step: every edge touching the frontier.
+
+    Returns ``(anchor_id, other_endpoint, edge)`` tuples where
+    ``anchor_id`` is the frontier id the edge touched and
+    ``other_endpoint`` is the node on the other side -- regardless of
+    edge orientation. Self-loops (``from == to``) are surfaced once.
+    """
+    if not frontier_ids:
+        return []
+
+    from_alias = aliased(GraphNode)
+    to_alias = aliased(GraphNode)
+    stmt = (
+        select(from_alias, to_alias, GraphEdge)
+        .join(from_alias, from_alias.id == GraphEdge.from_node_id)
+        .join(to_alias, to_alias.id == GraphEdge.to_node_id)
+        .where(
+            GraphEdge.tenant_id == tenant_id,
+            from_alias.tenant_id == tenant_id,
+            to_alias.tenant_id == tenant_id,
+            GraphEdge.last_seen.is_not(None),
+            (GraphEdge.from_node_id.in_(frontier_ids)) | (GraphEdge.to_node_id.in_(frontier_ids)),
+        )
+        .order_by(GraphEdge.id)
+    )
+    result = await db_session.execute(stmt)
+    rows: list[tuple[uuid.UUID, GraphNode, GraphEdge]] = []
+    for from_node, to_node, edge in result.all():
+        if from_node.id in frontier_ids:
+            rows.append((from_node.id, to_node, edge))
+        if to_node.id in frontier_ids and to_node.id != from_node.id:
+            # Distinct branch when the edge is reachable from the
+            # other side too. Self-loops (from == to) are only
+            # surfaced once.
+            rows.append((to_node.id, from_node, edge))
+    return rows
+
+
+def _reconstruct_path(
+    parents: dict[uuid.UUID, tuple[uuid.UUID, uuid.UUID]],
+    source_id: uuid.UUID,
+    target_id: uuid.UUID,
+) -> tuple[list[uuid.UUID], list[uuid.UUID]]:
+    """Walk the BFS parent map back from target to source.
+
+    Returns ``(node_ids_in_order, edge_ids_in_order)`` from source to target.
+    """
+    node_path: list[uuid.UUID] = [target_id]
+    edge_path: list[uuid.UUID] = []
+    cursor = target_id
+    while cursor != source_id:
+        parent, edge_id = parents[cursor]
+        node_path.append(parent)
+        edge_path.append(edge_id)
+        cursor = parent
+    node_path.reverse()
+    edge_path.reverse()
+    return node_path, edge_path
+
+
+@dataclass(frozen=True)
+class _PathSearchState:
+    """The running state of the bidirectional path BFS.
+
+    The state is mutated in-place by the helpers (Python dicts /
+    sets); using a frozen dataclass for the container keeps the
+    *handle* itself immutable so a caller cannot swap fields mid-
+    search.
+    """
+
+    visited: set[uuid.UUID]
+    parents: dict[uuid.UUID, tuple[uuid.UUID, uuid.UUID]]
+    node_by_id: dict[uuid.UUID, GraphNode]
+    edges_by_id: dict[uuid.UUID, GraphEdge]
+
+
+def _process_hop_rows(
+    state: _PathSearchState,
+    rows: list[tuple[uuid.UUID, GraphNode, GraphEdge]],
+    target_id: uuid.UUID,
+) -> tuple[list[uuid.UUID], bool]:
+    """Fold one hop's neighbour rows into the search state.
+
+    Returns ``(next_frontier_ids, found_target)``. When the target is
+    seen, the caller breaks the outer loop -- the parent map is
+    sufficient for path reconstruction.
+    """
+    next_frontier: list[uuid.UUID] = []
+    found = False
+    for anchor_id, neighbour, edge in rows:
+        state.edges_by_id.setdefault(edge.id, edge)
+        state.node_by_id.setdefault(neighbour.id, neighbour)
+        if neighbour.id in state.visited:
+            continue
+        state.visited.add(neighbour.id)
+        state.parents[neighbour.id] = (anchor_id, edge.id)
+        next_frontier.append(neighbour.id)
+        if neighbour.id == target_id:
+            found = True
+            break
+    return next_frontier, found
+
+
+async def _search_shortest_path(
+    db_session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    source: GraphNode,
+    target: GraphNode,
+    max_hops: int,
+) -> tuple[_PathSearchState, int | None]:
+    """Run the bidirectional BFS; return state + hops (``None`` if unreached)."""
+    state = _PathSearchState(
+        visited={source.id},
+        parents={},
+        node_by_id={source.id: source},
+        edges_by_id={},
+    )
+    frontier: deque[uuid.UUID] = deque([source.id])
+    for hop in range(1, max_hops + 1):
+        if not frontier:
+            break
+        current = list(frontier)
+        frontier.clear()
+        rows = await _bidirectional_neighbours(
+            db_session,
+            tenant_id=tenant_id,
+            frontier_ids=current,
+        )
+        next_frontier, found = _process_hop_rows(state, rows, target.id)
+        if found:
+            return state, hop
+        frontier.extend(next_frontier)
+    return state, None
+
+
+def _build_path_result(
+    state: _PathSearchState,
+    source_id: uuid.UUID,
+    target_id: uuid.UUID,
+    hops: int,
+) -> PathSubgraphResult:
+    """Reconstruct the path from the BFS state into a :class:`PathSubgraphResult`."""
+    node_path, edge_path = _reconstruct_path(state.parents, source_id, target_id)
+    path_nodes = [
+        SubgraphNodeRow(
+            id=state.node_by_id[node_id].id,
+            kind=state.node_by_id[node_id].kind,
+            name=state.node_by_id[node_id].name,
+        )
+        for node_id in node_path
+    ]
+    path_edges = [
+        SubgraphEdgeRow(
+            id=state.edges_by_id[edge_id].id,
+            kind=state.edges_by_id[edge_id].kind,
+            source=state.edges_by_id[edge_id].source,
+            from_id=state.edges_by_id[edge_id].from_node_id,
+            to_id=state.edges_by_id[edge_id].to_node_id,
+        )
+        for edge_id in edge_path
+    ]
+    return PathSubgraphResult(
+        path_node_ids=tuple(node_path),
+        nodes=path_nodes,
+        edges=path_edges,
+        highlighted_edge_ids=frozenset(edge_path),
+        total_hops=hops,
+        truncated=False,
+    )
+
+
+async def fetch_path_subgraph(
+    db_session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    from_name: str,
+    to_name: str,
+    from_kind: str | None = None,
+    to_kind: str | None = None,
+    max_hops: int = DEFAULT_PATH_MAX_HOPS,
+) -> PathSubgraphResult:
+    """Return the shortest path subgraph from ``from_name`` to ``to_name``.
+
+    Walks edges bidirectionally (treats the graph as undirected for
+    reachability) and returns the **shortest** path by hop count, or
+    a result with ``total_hops=None`` and empty highlighted set when
+    the target is unreachable within ``max_hops``.
+
+    The returned ``nodes`` / ``edges`` are the path itself only --
+    the UI renders the highlighted-only view rather than embedding
+    the path in a wider context (which would re-introduce the
+    500-node hairball problem the overlay is meant to escape).
+
+    Raises:
+        meho_backplane.ui.routes.topology.queries.NodeNotFoundError:
+            either endpoint does not resolve in this tenant.
+        meho_backplane.ui.routes.topology.queries.AmbiguousNodeError:
+            either endpoint is a bare name resolving to multiple kinds
+            in the tenant.
+    """
+    source = await resolve_anchor(db_session, tenant_id=tenant_id, name=from_name, kind=from_kind)
+    target = await resolve_anchor(db_session, tenant_id=tenant_id, name=to_name, kind=to_kind)
+
+    # Same-node short-circuit: a zero-hop "path" to itself.
+    if source.id == target.id:
+        return PathSubgraphResult(
+            path_node_ids=(source.id,),
+            nodes=[SubgraphNodeRow(id=source.id, kind=source.kind, name=source.name)],
+            edges=[],
+            highlighted_edge_ids=frozenset(),
+            total_hops=0,
+            truncated=False,
+        )
+
+    state, hops = await _search_shortest_path(
+        db_session,
+        tenant_id=tenant_id,
+        source=source,
+        target=target,
+        max_hops=max_hops,
+    )
+    if hops is None:
+        return PathSubgraphResult(
+            path_node_ids=(),
+            nodes=[],
+            edges=[],
+            highlighted_edge_ids=frozenset(),
+            total_hops=None,
+            truncated=False,
+        )
+    return _build_path_result(state, source.id, target.id, hops)

--- a/backend/src/meho_backplane/ui/routes/topology/queries.py
+++ b/backend/src/meho_backplane/ui/routes/topology/queries.py
@@ -1,0 +1,449 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""UI-facing topology subgraph query helpers for the graph overlays.
+
+Initiative #342 (G10.5 Topology UI), Task #882 (G10.5-T3). The graph
+view (T2 / #881) renders the full tenant inventory; the overlays
+here render *focused* subgraphs an operator drives via query params:
+
+* ``?from=<name>[&kind=<kind>][&direction=dependents|dependencies][&depth=N]``
+  -- the dependents (reverse) or dependencies (forward) subgraph
+  rooted at ``<name>``. Same edge-direction semantics as the G9.1
+  traversal verbs (:func:`meho_backplane.topology.query.find_dependents`
+  / :func:`~meho_backplane.topology.query.find_dependencies`): an
+  edge ``from_node --kind--> to_node`` reads "from_node depends on
+  to_node", so the dependents subgraph walks *into* the root (every
+  node that depends on it transitively) and the dependencies
+  subgraph walks *out of* it (everything the root depends on
+  transitively).
+
+The shortest-path overlay (``?from=A&to=B``) lives in the sibling
+:mod:`meho_backplane.ui.routes.topology.path_queries` module so each
+overlay flavour fits inside the code-quality file-size budget.
+
+Why a UI-facing variant of the G9.1 substrate?
+==============================================
+
+The substrate verbs in :mod:`meho_backplane.topology.query`
+(:func:`find_dependents`, :func:`find_dependencies`, :func:`find_path`)
+are tuned for the REST + MCP + CLI surfaces: they take an
+:class:`~meho_backplane.auth.operator.Operator`, open their own
+:class:`AsyncSession`, and use a PostgreSQL ``WITH RECURSIVE ... CYCLE``
+CTE for the closure walk. The UI surface needs three different things:
+
+1. **Dialect portability.** The chassis unit-test fixture uses
+   SQLite (PG-only CYCLE-recursive isn't available there); the
+   substrate verbs are tested against PostgreSQL in
+   ``backend/tests/integration/``. The UI controller layer wants
+   coverage in the unit suite so a route-shape regression is caught
+   on every PR, not only on the integration sweep. The BFS helpers
+   here use plain SQLAlchemy ORM ``select(...)`` so they execute on
+   both dialects.
+
+2. **Tenant scoping via the session context, not an Operator.** The
+   UI surface flows ``tenant_id`` from the encrypted session cookie
+   (:class:`meho_backplane.ui.auth.middleware.UISessionContext`),
+   not from a JWT-derived :class:`Operator`. Direct ``tenant_id`` +
+   ``db_session`` arguments match the shape
+   :func:`meho_backplane.topology.query.list_nodes` already uses for
+   the same UI surface.
+
+3. **Subgraph emission instead of a flat closure.** The substrate
+   returns a flattened list of nodes with depth markers; Cytoscape
+   needs the **edges between them** as separate elements. BFS
+   produces the visited-node set, then a second pass keeps only
+   edges with both endpoints in that set. Mirrors the
+   ``_fetch_edges_for_nodes`` pattern :mod:`...graph` uses for the
+   full graph view.
+
+Tenant-scoping defense in depth
+===============================
+
+Every edge query enforces the tenant boundary at three points: the
+edge row itself + both endpoint joins. Same posture
+:mod:`...graph._fetch_edges_for_nodes` and
+:mod:`...detail._fetch_edges` established.
+
+BFS depth-bound + visited semantics
+===================================
+
+The BFS visits the root at depth 0, its immediate neighbours at
+depth 1, and so on. The ``depth`` argument caps the recursion.
+Cycles are naturally broken by the visited-set guard. The
+implementation does not need the CYCLE bookkeeping the PG recursive
+CTE carries because the visited check runs in Python.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Final, Literal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from meho_backplane.db.models import GraphEdge, GraphNode
+
+__all__ = [
+    "DEFAULT_OVERLAY_DEPTH",
+    "DEFAULT_PATH_MAX_HOPS",
+    "MAX_OVERLAY_DEPTH",
+    "MAX_PATH_MAX_HOPS",
+    "AmbiguousNodeError",
+    "NodeNotFoundError",
+    "PathSubgraphResult",
+    "SubgraphEdgeRow",
+    "SubgraphNodeRow",
+    "SubgraphResult",
+    "fetch_dependencies_subgraph",
+    "fetch_dependents_subgraph",
+    "resolve_anchor",
+]
+
+
+#: Default depth for the dependents / dependencies overlay. ``3`` is
+#: the operator-friendly v0.2 value.
+DEFAULT_OVERLAY_DEPTH: Final[int] = 3
+
+#: Hard ceiling on the overlay's traversal depth. Mirrors the
+#: substrate ``find_dependents`` ``_DEFAULT_DEPTH``.
+MAX_OVERLAY_DEPTH: Final[int] = 16
+
+#: Default hop ceiling for the path query. ``8`` matches the substrate
+#: :data:`~meho_backplane.topology.query._DEFAULT_MAX_HOPS`.
+DEFAULT_PATH_MAX_HOPS: Final[int] = 8
+
+#: Hard ceiling on the path search.
+MAX_PATH_MAX_HOPS: Final[int] = 16
+
+
+class AmbiguousNodeError(ValueError):
+    """Raised when a bare-name lookup resolves to multiple kinds.
+
+    A node name like ``app`` may legitimately exist under two kinds
+    (``target`` and ``vm``); resolving by ``name`` alone would
+    anchor on both and traverse a merged closure of two unrelated
+    objects. The error surfaces the candidate kinds so the caller
+    (the route handler) can return an HTTP 409 with a kind-
+    disambiguation hint.
+
+    Mirrors the substrate
+    :class:`meho_backplane.topology.resolvers.AmbiguousNodeError`
+    contract without re-importing it.
+    """
+
+    def __init__(self, name: str, kinds: list[str]) -> None:
+        self.name = name
+        self.kinds = kinds
+        super().__init__(
+            f"node name {name!r} resolves to multiple kinds in this tenant: "
+            f"{sorted(kinds)!r}; pass ``kind=<one>`` to disambiguate"
+        )
+
+
+class NodeNotFoundError(ValueError):
+    """Raised when a name (+ optional kind) resolves to no row in this tenant.
+
+    The route handler maps this to HTTP 404. Cross-tenant ids and
+    truly-absent names surface identically -- the tenant boundary is
+    opaque.
+    """
+
+    def __init__(self, name: str, *, kind: str | None = None) -> None:
+        self.name = name
+        self.kind = kind
+        if kind is not None:
+            super().__init__(f"node ({kind=!r}, {name=!r}) not found in this tenant")
+        else:
+            super().__init__(f"node ({name=!r}) not found in this tenant")
+
+
+@dataclass(frozen=True)
+class SubgraphNodeRow:
+    """One node in a subgraph overlay."""
+
+    id: uuid.UUID
+    kind: str
+    name: str
+
+
+@dataclass(frozen=True)
+class SubgraphEdgeRow:
+    """One edge in a subgraph overlay."""
+
+    id: uuid.UUID
+    kind: str
+    source: str
+    from_id: uuid.UUID
+    to_id: uuid.UUID
+
+
+@dataclass(frozen=True)
+class SubgraphResult:
+    """The nodes + edges a dependents / dependencies overlay renders."""
+
+    root_id: uuid.UUID
+    root_name: str
+    root_kind: str
+    nodes: list[SubgraphNodeRow]
+    edges: list[SubgraphEdgeRow]
+    truncated: bool
+
+
+@dataclass(frozen=True)
+class PathSubgraphResult:
+    """The nodes + edges + highlighted-edge set a path overlay renders.
+
+    ``highlighted_edge_ids`` is the subset of ``edges`` Cytoscape
+    applies the ``highlight`` class to (the path's own edges).
+    ``path_node_ids`` carries the path sequence in order so the UI
+    can also highlight the path's nodes.
+    """
+
+    path_node_ids: tuple[uuid.UUID, ...]
+    nodes: list[SubgraphNodeRow]
+    edges: list[SubgraphEdgeRow]
+    highlighted_edge_ids: frozenset[uuid.UUID]
+    total_hops: int | None
+    truncated: bool
+
+
+async def resolve_anchor(
+    db_session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    name: str,
+    kind: str | None,
+) -> GraphNode:
+    """Resolve ``(name [, kind])`` to a single ``graph_node`` row.
+
+    * ``(tenant_id, kind, name)`` pinned -> at most one row by the
+      unique index; raise :class:`NodeNotFoundError` on no match.
+    * ``(tenant_id, name)`` bare -> 0 rows raises
+      :class:`NodeNotFoundError`; 1 row returns it; >1 rows raises
+      :class:`AmbiguousNodeError` with the candidate kinds.
+
+    Soft-deleted nodes (``last_seen IS NULL``) are excluded.
+
+    Exposed (not name-mangled with a leading underscore) because the
+    sibling :mod:`...path_queries` module needs to resolve both
+    endpoints independently against the same contract.
+    """
+    stmt = select(GraphNode).where(
+        GraphNode.tenant_id == tenant_id,
+        GraphNode.name == name,
+        GraphNode.last_seen.is_not(None),
+    )
+    if kind is not None:
+        stmt = stmt.where(GraphNode.kind == kind)
+    result = await db_session.execute(stmt)
+    rows = list(result.scalars().all())
+    if not rows:
+        raise NodeNotFoundError(name, kind=kind)
+    if len(rows) == 1:
+        return rows[0]
+    kinds = sorted({row.kind for row in rows})
+    raise AmbiguousNodeError(name, kinds)
+
+
+async def _bfs_neighbours(
+    db_session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    frontier_ids: list[uuid.UUID],
+    direction: Literal["reverse", "forward"],
+) -> list[tuple[uuid.UUID, GraphNode, GraphEdge]]:
+    """One BFS expansion: every edge out of (or into) the frontier set.
+
+    ``direction="reverse"`` walks edges *into* the frontier and
+    returns the source endpoint -- the "dependents" semantic.
+    ``direction="forward"`` walks edges *out of* the frontier and
+    returns the destination endpoint -- the "dependencies" semantic.
+
+    The triple tenant-scoping (edge + both endpoints) is the
+    defense-in-depth posture. Soft-deleted edges excluded.
+    """
+    if not frontier_ids:
+        return []
+
+    from_alias = aliased(GraphNode)
+    to_alias = aliased(GraphNode)
+    stmt = (
+        select(from_alias, to_alias, GraphEdge)
+        .join(from_alias, from_alias.id == GraphEdge.from_node_id)
+        .join(to_alias, to_alias.id == GraphEdge.to_node_id)
+        .where(
+            GraphEdge.tenant_id == tenant_id,
+            from_alias.tenant_id == tenant_id,
+            to_alias.tenant_id == tenant_id,
+            GraphEdge.last_seen.is_not(None),
+        )
+        .order_by(GraphEdge.id)
+    )
+    if direction == "reverse":
+        stmt = stmt.where(GraphEdge.to_node_id.in_(frontier_ids))
+    else:
+        stmt = stmt.where(GraphEdge.from_node_id.in_(frontier_ids))
+
+    result = await db_session.execute(stmt)
+    rows: list[tuple[uuid.UUID, GraphNode, GraphEdge]] = []
+    for from_node, to_node, edge in result.all():
+        if direction == "reverse":
+            anchor_id = to_node.id
+            neighbour = from_node
+        else:
+            anchor_id = from_node.id
+            neighbour = to_node
+        rows.append((anchor_id, neighbour, edge))
+    return rows
+
+
+def _expand_frontier(
+    rows: list[tuple[uuid.UUID, GraphNode, GraphEdge]],
+    *,
+    visited_ids: dict[uuid.UUID, GraphNode],
+    edges_by_id: dict[uuid.UUID, GraphEdge],
+    max_nodes: int,
+) -> tuple[list[uuid.UUID], bool]:
+    """Fold one BFS hop's rows into the visited / edge maps.
+
+    Returns ``(next_frontier_ids, truncated)``. ``truncated`` flips
+    when promoting a candidate node would push the visited count
+    over the configured ceiling.
+    """
+    next_frontier: list[uuid.UUID] = []
+    truncated = False
+    for _anchor_id, neighbour, edge in rows:
+        edges_by_id.setdefault(edge.id, edge)
+        if neighbour.id in visited_ids:
+            continue
+        if len(visited_ids) >= max_nodes:
+            truncated = True
+            continue
+        visited_ids[neighbour.id] = neighbour
+        next_frontier.append(neighbour.id)
+    return next_frontier, truncated
+
+
+async def _walk_subgraph(
+    db_session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    root: GraphNode,
+    depth: int,
+    direction: Literal["reverse", "forward"],
+    max_nodes: int,
+) -> SubgraphResult:
+    """Run the bounded BFS that builds the dependents/dependencies subgraph.
+
+    Visited-set semantics: a node is added once at its minimum depth
+    and never revisited; cycles break naturally. ``max_nodes`` is
+    the safety hatch matching the full graph view's 500-node
+    frontend cap (#881).
+
+    Returns a :class:`SubgraphResult` with the visited nodes + every
+    edge whose **both endpoints** landed in the visited set.
+    """
+    visited_ids: dict[uuid.UUID, GraphNode] = {root.id: root}
+    edges_by_id: dict[uuid.UUID, GraphEdge] = {}
+    truncated = False
+    current_frontier: list[uuid.UUID] = [root.id]
+
+    for _ in range(depth):
+        if not current_frontier:
+            break
+        rows = await _bfs_neighbours(
+            db_session,
+            tenant_id=tenant_id,
+            frontier_ids=current_frontier,
+            direction=direction,
+        )
+        next_frontier, hop_truncated = _expand_frontier(
+            rows,
+            visited_ids=visited_ids,
+            edges_by_id=edges_by_id,
+            max_nodes=max_nodes,
+        )
+        if hop_truncated:
+            truncated = True
+        current_frontier = next_frontier
+        if truncated:
+            break
+
+    nodes = [
+        SubgraphNodeRow(id=node.id, kind=node.kind, name=node.name) for node in visited_ids.values()
+    ]
+    edges = [
+        SubgraphEdgeRow(
+            id=edge.id,
+            kind=edge.kind,
+            source=edge.source,
+            from_id=edge.from_node_id,
+            to_id=edge.to_node_id,
+        )
+        for edge in edges_by_id.values()
+        if edge.from_node_id in visited_ids and edge.to_node_id in visited_ids
+    ]
+
+    return SubgraphResult(
+        root_id=root.id,
+        root_name=root.name,
+        root_kind=root.kind,
+        nodes=nodes,
+        edges=edges,
+        truncated=truncated,
+    )
+
+
+async def fetch_dependents_subgraph(
+    db_session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    name: str,
+    kind: str | None = None,
+    depth: int = DEFAULT_OVERLAY_DEPTH,
+    max_nodes: int = 500,
+) -> SubgraphResult:
+    """Return the dependents subgraph rooted at ``name``.
+
+    Edge-direction: "what depends on me" -- reverse traversal.
+    Raises :class:`NodeNotFoundError` on an unknown root,
+    :class:`AmbiguousNodeError` on a bare-name root that resolves to
+    multiple kinds in the tenant.
+    """
+    root = await resolve_anchor(db_session, tenant_id=tenant_id, name=name, kind=kind)
+    return await _walk_subgraph(
+        db_session,
+        tenant_id=tenant_id,
+        root=root,
+        depth=depth,
+        direction="reverse",
+        max_nodes=max_nodes,
+    )
+
+
+async def fetch_dependencies_subgraph(
+    db_session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    name: str,
+    kind: str | None = None,
+    depth: int = DEFAULT_OVERLAY_DEPTH,
+    max_nodes: int = 500,
+) -> SubgraphResult:
+    """Return the dependencies subgraph rooted at ``name``.
+
+    Edge-direction: "what I depend on" -- forward traversal.
+    """
+    root = await resolve_anchor(db_session, tenant_id=tenant_id, name=name, kind=kind)
+    return await _walk_subgraph(
+        db_session,
+        tenant_id=tenant_id,
+        root=root,
+        depth=depth,
+        direction="forward",
+        max_nodes=max_nodes,
+    )

--- a/backend/src/meho_backplane/ui/routes/topology/queries.py
+++ b/backend/src/meho_backplane/ui/routes/topology/queries.py
@@ -81,7 +81,7 @@ import uuid
 from dataclasses import dataclass
 from typing import Final, Literal
 
-from sqlalchemy import select
+from sqlalchemy import JSON, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
@@ -265,6 +265,15 @@ async def _bfs_neighbours(
 
     The triple tenant-scoping (edge + both endpoints) is the
     defense-in-depth posture. Soft-deleted edges excluded.
+
+    Superseded edges (``properties->>'superseded_by' IS NOT NULL``) are
+    excluded to mirror the G9.1 substrate traversal verbs
+    (:func:`meho_backplane.topology.query.find_dependents` /
+    :func:`~meho_backplane.topology.query.find_dependencies`, see
+    Initiative #364 §6 / Task #595). A tenant that curates supersede
+    annotations would otherwise see edges in the UI overlay that the
+    substrate REST/CLI API hides -- a substrate-vs-UI divergence the
+    operator cannot reconcile.
     """
     if not frontier_ids:
         return []
@@ -280,6 +289,18 @@ async def _bfs_neighbours(
             from_alias.tenant_id == tenant_id,
             to_alias.tenant_id == tenant_id,
             GraphEdge.last_seen.is_not(None),
+            # Mirror the substrate's superseded-edge exclusion -- the
+            # PG raw-SQL ``e.properties->>'superseded_by' IS NULL``
+            # idiom translated to dialect-portable ORM. PG returns SQL
+            # NULL on a missing JSON key (``.is_(None)``); SQLite's
+            # ``JSON1`` returns the JSON NULL token, which SQLAlchemy
+            # exposes via the :data:`JSON.NULL` sentinel. The ``or_``
+            # accepts both so the predicate fires identically on both
+            # dialects.
+            or_(
+                GraphEdge.properties["superseded_by"].is_(None),
+                GraphEdge.properties["superseded_by"] == JSON.NULL,
+            ),
         )
         .order_by(GraphEdge.id)
     )

--- a/backend/src/meho_backplane/ui/routes/topology/table.py
+++ b/backend/src/meho_backplane/ui/routes/topology/table.py
@@ -415,7 +415,28 @@ def build_table_router() -> APIRouter:
     async def _handler(
         request: Request,
         sort: _SortColumn = Query(default=_SortColumn.NAME),
-        direction: str = Query(default=_SortDirection.ASC.value, max_length=32),
+        # ``direction`` is dual-purpose: the table branch consumes
+        # ``asc``/``desc`` (sort order, validated again by
+        # ``_validate_sort_direction``); the graph overlay branch
+        # consumes ``dependents``/``dependencies`` (traversal
+        # direction, validated by ``_resolve_overlay_direction``).
+        # The OpenAPI ``pattern`` constrains the union of accepted
+        # values so the generated CLI client + downstream contract
+        # consumers see the real vocabulary rather than a free-form
+        # ``string``. Out-of-union values 422 at the HTTP boundary --
+        # ``asc``/``desc`` still ride through cleanly when the
+        # operator toggles between table and graph views (the
+        # "preserve filters" contract documented in #881).
+        direction: str = Query(
+            default=_SortDirection.ASC.value,
+            max_length=32,
+            pattern=r"^(asc|desc|dependents|dependencies)$",
+            description=(
+                "Dual-purpose: ``asc`` / ``desc`` on the table branch "
+                "(``view=table``), ``dependents`` / ``dependencies`` on "
+                "the graph overlay branch (``view=graph&from=<name>``)."
+            ),
+        ),
         kind: str | None = Query(default=None, max_length=64),
         q: str | None = Query(default=None, max_length=256),
         limit: int = Query(default=_LIMIT_DEFAULT, ge=1, le=_LIMIT_MAX),
@@ -473,5 +494,31 @@ def build_table_router() -> APIRouter:
         methods=["GET"],
         name="ui_topology_table",
         response_class=HTMLResponse,
+        # The ``?view=graph`` overlay branches (dependents / dependencies
+        # / path) call :func:`render_graph`, which catches
+        # :class:`NodeNotFoundError` / :class:`AmbiguousNodeError` and
+        # returns an ``HTMLResponse(status_code=404|409)`` carrying the
+        # overlay-error fragment. Surfacing those statuses in the
+        # OpenAPI snapshot keeps the generated CLI client + downstream
+        # contract consumers in sync with the runtime behaviour.
+        responses={
+            404: {
+                "description": (
+                    "Overlay anchor (``?from=<name>``) or path endpoint "
+                    "(``?from=&to=``) does not resolve in the caller's "
+                    "tenant. Returns the overlay-error fragment."
+                ),
+                "content": {"text/html": {}},
+            },
+            409: {
+                "description": (
+                    "Overlay anchor or path endpoint is a bare name that "
+                    "resolves to multiple kinds in the caller's tenant "
+                    "(``kind=`` disambiguation required). Returns the "
+                    "overlay-error fragment with the candidate kinds."
+                ),
+                "content": {"text/html": {}},
+            },
+        },
     )
     return router

--- a/backend/src/meho_backplane/ui/routes/topology/table.py
+++ b/backend/src/meho_backplane/ui/routes/topology/table.py
@@ -44,6 +44,36 @@ Cytoscape view; ``view=table`` (or unset) keeps the tabular surface.
 ``selected`` (a UUID) cross-links between the two: a graph node's
 tap arrives at ``?view=table&selected=<id>`` (the row scrolls into
 view + highlights) and vice versa.
+
+T3 (#882) URL contract::
+
+    GET /ui/topology
+        [?view=table|graph
+         &sort=...&direction=...
+         &kind=...&q=...
+         &selected=<uuid>
+         # G10.5-T3 graph overlays (view=graph only):
+         &from=<name>[&from_kind=<kind>][&depth=N]
+         [&direction=dependents|dependencies]
+         &from=A&to=B[&from_kind=...&to_kind=...&max_hops=N]]
+
+``direction`` is dual-purpose by branch:
+
+* **Table branch** (default) -- the sort direction: ``asc`` (default)
+  or ``desc``. Out-of-range -> 422.
+* **Graph branch** with ``?from=<name>&to=`` unset -- the overlay
+  direction: ``dependents`` (default) or ``dependencies``. Out-of-
+  range silently defaults so a graph<->table toggle preserving
+  ``direction=asc`` does not 422 on the graph side.
+* **Graph branch** with ``?from=A&to=B`` -- ignored (a path has no
+  direction).
+* **Graph branch** with ``?from=`` unset -- ignored (the full-
+  inventory view has no direction).
+
+The dual-purpose contract keeps the URL surface aligned with the
+issue #882 spec (``?direction=dependencies``) without forcing the
+table-sort and graph-overlay senses into separate params, which
+would have widened the OpenAPI footprint with no operator benefit.
 """
 
 from __future__ import annotations
@@ -52,7 +82,7 @@ import uuid
 from enum import StrEnum
 from typing import Final
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -61,7 +91,13 @@ from meho_backplane.db.models import _GRAPH_NODE_KINDS
 from meho_backplane.topology.query import list_nodes
 from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
 from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
-from meho_backplane.ui.routes.topology.graph import render_graph
+from meho_backplane.ui.routes.topology.graph import OverlayDirection, render_graph
+from meho_backplane.ui.routes.topology.queries import (
+    DEFAULT_OVERLAY_DEPTH,
+    DEFAULT_PATH_MAX_HOPS,
+    MAX_OVERLAY_DEPTH,
+    MAX_PATH_MAX_HOPS,
+)
 from meho_backplane.ui.templating import get_templates
 
 __all__ = ["build_table_router"]
@@ -283,6 +319,87 @@ _require_ui_session_dep = Depends(require_ui_session)
 _get_raw_session_dep = Depends(get_raw_session)
 
 
+def _resolve_overlay_direction(
+    *,
+    direction: str,
+    from_: str | None,
+    to: str | None,
+) -> OverlayDirection | None:
+    """Decide whether ``direction`` carries an overlay sense on the graph branch.
+
+    Returns the parsed :class:`OverlayDirection` when the dependents/
+    dependencies overlay is active (``from`` set, ``to`` unset) and
+    ``direction`` parses as one of the enum members. Returns ``None``
+    otherwise -- the route's default (dependents) applies. An
+    out-of-range value on the graph branch is a silent default (rather
+    than 422) so the same ``direction=asc`` value can ride through the
+    URL when an operator toggles between table and graph without
+    breaking the "preserve filters" contract documented in #881.
+    """
+    if from_ is None or to is not None:
+        return None
+    try:
+        return OverlayDirection(direction)
+    except ValueError:
+        return None
+
+
+def _resolve_overlay_depth(
+    *,
+    depth: int | None,
+    from_: str | None,
+    to: str | None,
+) -> int | None:
+    """Pick the effective ``depth`` for the active branch.
+
+    Active overlay (``from`` set, ``to`` unset) -> ``depth`` if
+    supplied, else :data:`DEFAULT_OVERLAY_DEPTH`. Inactive branches
+    (full inventory, path overlay) -> ``None`` (depth does not
+    apply).
+    """
+    if depth is not None:
+        return depth
+    if from_ is not None and to is None:
+        return DEFAULT_OVERLAY_DEPTH
+    return None
+
+
+def _resolve_path_max_hops(
+    *,
+    max_hops: int | None,
+    from_: str | None,
+    to: str | None,
+) -> int | None:
+    """Pick the effective ``max_hops`` for the path overlay.
+
+    Path overlay (both ``from`` + ``to`` set) -> ``max_hops`` if
+    supplied, else :data:`DEFAULT_PATH_MAX_HOPS`. Other branches ->
+    ``None``.
+    """
+    if max_hops is not None:
+        return max_hops
+    if from_ is not None and to is not None:
+        return DEFAULT_PATH_MAX_HOPS
+    return None
+
+
+def _validate_sort_direction(direction: str) -> _SortDirection:
+    """Parse ``direction`` against the table-branch sort enum.
+
+    Out-of-range -> :class:`HTTPException` 422 with a structured
+    diagnostic. Same posture as the pre-T3 Pydantic enum validator.
+    """
+    try:
+        return _SortDirection(direction)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"direction must be one of {[d.value for d in _SortDirection]}; got {direction!r}"
+            ),
+        ) from exc
+
+
 def build_table_router() -> APIRouter:
     """Construct the topology-table :class:`APIRouter`.
 
@@ -298,30 +415,29 @@ def build_table_router() -> APIRouter:
     async def _handler(
         request: Request,
         sort: _SortColumn = Query(default=_SortColumn.NAME),
-        direction: _SortDirection = Query(default=_SortDirection.ASC),
+        direction: str = Query(default=_SortDirection.ASC.value, max_length=32),
         kind: str | None = Query(default=None, max_length=64),
         q: str | None = Query(default=None, max_length=256),
         limit: int = Query(default=_LIMIT_DEFAULT, ge=1, le=_LIMIT_MAX),
         view: _ViewMode = Query(default=_ViewMode.TABLE),
         selected: uuid.UUID | None = Query(default=None),
+        # G10.5-T3 (#882) overlay query params. ``from`` / ``to`` are
+        # reserved Python keywords so they ride as ``alias=`` on the
+        # FastAPI Query so the URL contract reads ``?from=&to=`` and
+        # the Python signature stays clean (a bare ``from`` would be
+        # a Python parse error).
+        from_: str | None = Query(default=None, alias="from", max_length=256),
+        from_kind: str | None = Query(default=None, max_length=64),
+        to: str | None = Query(default=None, max_length=256),
+        to_kind: str | None = Query(default=None, max_length=64),
+        depth: int | None = Query(default=None, ge=1, le=MAX_OVERLAY_DEPTH),
+        max_hops: int | None = Query(default=None, ge=1, le=MAX_PATH_MAX_HOPS),
         session_ctx: UISessionContext = _require_ui_session_dep,
         db_session: AsyncSession = _get_raw_session_dep,
     ) -> HTMLResponse:
-        """Serve the topology UI, branching on ``?view=``.
-
-        URL contract::
-
-            GET /ui/topology
-                [?view=table|graph
-                 &sort=...&direction=...
-                 &kind=...&q=...
-                 &selected=<uuid>]
-
-        ``view=graph`` delegates to
-        :func:`meho_backplane.ui.routes.topology.graph.render_graph`;
-        ``view=table`` (the default) keeps the tabular surface T1
-        ships. ``selected`` (an optional UUID) round-trips the
-        cross-link selection between the two surfaces.
+        """Serve the topology UI, branching on ``?view=``. See module
+        docstring for the URL contract + dual-purpose ``direction``
+        semantics (table sort vs graph overlay).
         """
         if view == _ViewMode.GRAPH:
             return await render_graph(
@@ -331,11 +447,18 @@ def build_table_router() -> APIRouter:
                 kind=kind,
                 name_contains=q,
                 selected_id=selected,
+                from_name=from_,
+                from_kind=from_kind,
+                to_name=to,
+                to_kind=to_kind,
+                direction=_resolve_overlay_direction(direction=direction, from_=from_, to=to),
+                depth=_resolve_overlay_depth(depth=depth, from_=from_, to=to),
+                max_hops=_resolve_path_max_hops(max_hops=max_hops, from_=from_, to=to),
             )
         return await _render_table(
             request,
             sort=sort,
-            direction=direction,
+            direction=_validate_sort_direction(direction),
             kind=kind,
             name_contains=q,
             limit=limit,

--- a/backend/src/meho_backplane/ui/static/src/app/topology-graph.js
+++ b/backend/src/meho_backplane/ui/static/src/app/topology-graph.js
@@ -183,6 +183,48 @@
     });
   }
 
+  // Style extensions for overlays (G10.5-T3 #882). Path overlay
+  // edges with the ``highlight`` class render in red/thick; the
+  // ``root`` node class (on dependents/dependencies subgraphs)
+  // renders with a thicker border so the anchor is obvious.
+  function buildOverlayStyle() {
+    return [
+      {
+        selector: "edge.highlight",
+        style: {
+          "width": 3,
+          "line-color": "#dc2626",
+          "target-arrow-color": "#dc2626",
+        },
+      },
+      {
+        selector: "node.root",
+        style: {
+          "border-width": 3,
+          "border-color": "#dc2626",
+        },
+      },
+    ];
+  }
+
+  // Apply the path-node highlight on the active path nodes -- the
+  // server emits the path node id list as a separate data island so
+  // the JS can paint them after the elements island re-renders
+  // (a path subgraph emits *only* the path's nodes + edges, so this
+  // is a small bookkeeping step rather than a filter).
+  function highlightPathNodes(cy, pathNodeIds) {
+    if (!Array.isArray(pathNodeIds) || pathNodeIds.length === 0) {
+      return;
+    }
+    cy.elements("node").removeClass("highlight");
+    for (const id of pathNodeIds) {
+      const node = cy.getElementById(id);
+      if (node && node.length > 0) {
+        node.addClass("highlight");
+      }
+    }
+  }
+
   function init() {
     const container = document.getElementById("cy");
     if (!container || typeof window.cytoscape !== "function") {
@@ -205,16 +247,19 @@
     const elements = readJsonIsland("topology-graph-data") || [];
     const selectedRaw = readJsonIsland("topology-graph-selected");
     const selectedId = typeof selectedRaw === "string" && selectedRaw.length > 0 ? selectedRaw : null;
+    const pathNodeIds = readJsonIsland("topology-graph-path-nodes") || [];
 
     const cy = window.cytoscape({
       container: container,
       elements: elements,
-      style: buildStyle(),
+      style: buildStyle().concat(buildOverlayStyle()),
       layout: layoutOptions("cose-bilkent"),
       wheelSensitivity: 0.2,
       minZoom: 0.1,
       maxZoom: 4,
     });
+
+    highlightPathNodes(cy, pathNodeIds);
 
     // Expose for debugging / a future ``/auto-implement-initiative``
     // E2E harness; non-enumerable so it stays out of the
@@ -266,6 +311,55 @@
         }
       });
     }
+
+    // ----- G10.5-T3 (#882) polling-refresh handler -----
+    //
+    // The data island wrapper carries
+    // ``hx-trigger="every 30s"`` + ``hx-swap="outerHTML"``. When
+    // HTMX swaps in the new wrapper, we re-read the elements island
+    // and replace the Cytoscape graph in place, preserving the
+    // operator's current pan + zoom (the layout re-run would
+    // otherwise center the graph and zoom-fit, throwing the
+    // operator off the node they were inspecting).
+    //
+    // The handler is bound on ``document.body`` so it survives the
+    // wrapper element being replaced (HTMX rebuilds it on every
+    // swap). The ``detail.target`` check pins it to the topology
+    // graph wrapper -- other surfaces' HTMX swaps on the same page
+    // are no-ops here.
+    function applyRefreshedIsland() {
+      const fresh = readJsonIsland("topology-graph-data");
+      if (!Array.isArray(fresh)) {
+        return;
+      }
+      // Snapshot the current viewport so the layout re-run does not
+      // throw the operator off their pinned position.
+      const pan = cy.pan();
+      const zoom = cy.zoom();
+      cy.batch(function () {
+        cy.elements().remove();
+        cy.add(fresh);
+      });
+      // Re-run the layout. The pan + zoom restore below overrides
+      // the layout's centering -- the operator stays exactly where
+      // they were before the refresh.
+      const layoutSelectEl = document.getElementById("topology-graph-layout");
+      const layoutName = layoutSelectEl ? layoutSelectEl.value : "cose-bilkent";
+      cy.layout(layoutOptions(layoutName)).run();
+      cy.zoom(zoom);
+      cy.pan(pan);
+      // Re-apply the path highlight if the new payload carries one.
+      const newPathNodes = readJsonIsland("topology-graph-path-nodes") || [];
+      highlightPathNodes(cy, newPathNodes);
+    }
+
+    document.body.addEventListener("htmx:afterSwap", function (event) {
+      const target = event && event.detail ? event.detail.target : null;
+      if (!target || target.id !== "topology-graph-data-wrapper") {
+        return;
+      }
+      applyRefreshedIsland();
+    });
   }
 
   if (document.readyState === "loading") {

--- a/backend/src/meho_backplane/ui/static/src/app/topology-graph.js
+++ b/backend/src/meho_backplane/ui/static/src/app/topology-graph.js
@@ -117,7 +117,21 @@
   // Layout option payload for each supported algorithm. cose-bilkent
   // and dagre carry algorithm-specific knobs the defaults pick poorly
   // for the typical inventory shape (sparse graph, ~50-500 nodes).
-  function layoutOptions(name) {
+  //
+  // ``preserveViewport`` -- when ``true`` the layout is configured to
+  // keep the operator's current pan/zoom and reuse existing node
+  // positions. Used on the 30s polling refresh path (G10.5-T3 #882):
+  //   * ``fit: false`` -- cose-bilkent defaults to ``fit: true``,
+  //     which would re-center+zoom-to-fit asynchronously after the
+  //     layout settles and override any synchronous ``cy.pan/zoom``
+  //     restore the caller does. ``fit: false`` keeps the viewport.
+  //   * ``randomize: false`` -- re-randomising positions on every
+  //     poll tick breaks the "refresh data, keep view" contract
+  //     regardless of pan/zoom restore; deterministic positions
+  //     preserve the operator's mental map across refreshes.
+  // dagre / circle are deterministic and grid-shaped respectively, so
+  // ``fit: false`` is the only knob that matters there.
+  function layoutOptions(name, preserveViewport) {
     if (name === "cose-bilkent") {
       return {
         name: "cose-bilkent",
@@ -128,7 +142,8 @@
         gravity: 0.25,
         numIter: 2500,
         animate: false,
-        randomize: true,
+        fit: !preserveViewport,
+        randomize: !preserveViewport,
       };
     }
     if (name === "dagre") {
@@ -138,10 +153,11 @@
         nodeSep: 40,
         rankSep: 60,
         animate: false,
+        fit: !preserveViewport,
       };
     }
     // circle is built-in; defaults are sane.
-    return { name: "circle", animate: false };
+    return { name: "circle", animate: false, fit: !preserveViewport };
   }
 
   // Push the selected node id back into the page URL so a copy/paste
@@ -184,9 +200,12 @@
   }
 
   // Style extensions for overlays (G10.5-T3 #882). Path overlay
-  // edges with the ``highlight`` class render in red/thick; the
-  // ``root`` node class (on dependents/dependencies subgraphs)
-  // renders with a thicker border so the anchor is obvious.
+  // edges with the ``highlight`` class render in red/thick; path
+  // overlay nodes with the ``highlight`` class get a bold red border
+  // so the path itself is visually picked out from the rest of the
+  // subgraph; the ``root`` node class (on dependents/dependencies
+  // subgraphs) renders with a thicker border so the anchor is
+  // obvious.
   function buildOverlayStyle() {
     return [
       {
@@ -195,6 +214,19 @@
           "width": 3,
           "line-color": "#dc2626",
           "target-arrow-color": "#dc2626",
+        },
+      },
+      {
+        // Path-node highlight (matches the path edges' colour; bolder
+        // border + outline keeps the node visible against the per-
+        // kind background fill). Without this rule the ``highlight``
+        // class added by ``highlightPathNodes`` would be a visual
+        // no-op.
+        selector: "node.highlight",
+        style: {
+          "border-width": 4,
+          "border-color": "#dc2626",
+          "border-opacity": 1,
         },
       },
       {
@@ -253,7 +285,10 @@
       container: container,
       elements: elements,
       style: buildStyle().concat(buildOverlayStyle()),
-      layout: layoutOptions("cose-bilkent"),
+      // Initial render uses the default layout shape -- fit-to-canvas
+      // + randomized starting positions so cose-bilkent finds a clean
+      // arrangement for first-seen data.
+      layout: layoutOptions("cose-bilkent", false),
       wheelSensitivity: 0.2,
       minZoom: 0.1,
       maxZoom: 4,
@@ -288,11 +323,14 @@
       }
     });
 
-    // Layout switcher.
+    // Layout switcher. A deliberate user-driven layout change should
+    // re-fit + re-randomize -- the operator explicitly asked for a
+    // new arrangement, so the cose-bilkent / dagre / circle default
+    // shape is the desired outcome.
     const layoutSelect = document.getElementById("topology-graph-layout");
     if (layoutSelect) {
       layoutSelect.addEventListener("change", function () {
-        cy.layout(layoutOptions(layoutSelect.value)).run();
+        cy.layout(layoutOptions(layoutSelect.value, false)).run();
       });
     }
 
@@ -332,22 +370,21 @@
       if (!Array.isArray(fresh)) {
         return;
       }
-      // Snapshot the current viewport so the layout re-run does not
-      // throw the operator off their pinned position.
-      const pan = cy.pan();
-      const zoom = cy.zoom();
       cy.batch(function () {
         cy.elements().remove();
         cy.add(fresh);
       });
-      // Re-run the layout. The pan + zoom restore below overrides
-      // the layout's centering -- the operator stays exactly where
-      // they were before the refresh.
+      // Re-run the layout with ``preserveViewport=true`` so it lays
+      // out incoming nodes WITHOUT re-fitting the canvas (cose-bilkent
+      // defaults to ``fit: true`` which would zoom-to-fit
+      // asynchronously and override any synchronous pan/zoom restore
+      // a previous version of this code attempted) AND without
+      // re-randomising positions (the operator's mental map of the
+      // graph must survive each 30s tick). This is the "refresh data,
+      // keep view" contract documented in #882.
       const layoutSelectEl = document.getElementById("topology-graph-layout");
       const layoutName = layoutSelectEl ? layoutSelectEl.value : "cose-bilkent";
-      cy.layout(layoutOptions(layoutName)).run();
-      cy.zoom(zoom);
-      cy.pan(pan);
+      cy.layout(layoutOptions(layoutName, true)).run();
       // Re-apply the path highlight if the new payload carries one.
       const newPathNodes = readJsonIsland("topology-graph-path-nodes") || [];
       highlightPathNodes(cy, newPathNodes);

--- a/backend/src/meho_backplane/ui/templates/topology/_graph_data_island.html
+++ b/backend/src/meho_backplane/ui/templates/topology/_graph_data_island.html
@@ -1,0 +1,54 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  G10.5-T3 (#882) polling-refresh fragment.
+
+  The graph view's outer wrapper (``#topology-graph-data-wrapper``)
+  triggers an HTMX GET against ``/ui/topology?view=graph...`` every
+  30 seconds with the active query params; the server returns just
+  this fragment which HTMX swaps via ``outerHTML``. The
+  ``topology-graph.js`` controller listens for ``htmx:afterSwap`` on
+  the wrapper, re-reads the embedded data islands, and re-renders
+  Cytoscape preserving pan + zoom.
+
+  The fragment carries:
+
+  * ``topology-graph-data`` -- Cytoscape elements bag.
+  * ``topology-graph-selected`` -- cross-link selection (always
+    empty on the overlay branches; round-tripped on the full view).
+  * ``topology-graph-overlay`` -- the active overlay mode + path
+    metadata so the JS can update the chrome (root label, hop count,
+    truncation banner) without a full re-render. ``mode`` is one of
+    ``""`` (full inventory), ``"dependents"`` / ``"dependencies"``
+    (subgraph), ``"path"``.
+
+  The wrapper element ``div#topology-graph-data-wrapper`` is the
+  HTMX swap target -- swapping its outerHTML replaces both the data
+  islands AND re-installs the same wrapper attributes so the
+  ``hx-trigger="every 30s"`` keeps firing on the new element.
+
+  ``hx-headers`` carries the CSRF token so the chassis middleware
+  accepts the refresh on tenants that require it.
+-#}
+<div
+  id="topology-graph-data-wrapper"
+  hx-get="{{ refresh_url | default('') }}"
+  hx-trigger="every 30s"
+  hx-swap="outerHTML"
+  hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+  data-overlay-mode="{{ overlay_mode | default('') }}"
+  data-overlay-root="{{ overlay_root_name | default('') }}"
+  data-overlay-direction="{{ overlay_direction | default('') }}"
+  data-overlay-depth="{{ overlay_depth | default('') }}"
+  data-overlay-to="{{ overlay_to_name | default('') }}"
+  data-overlay-total-hops="{{ overlay_total_hops | default('') }}"
+  data-overlay-path-found="{{ 'true' if overlay_path_found else 'false' }}"
+  data-truncated="{{ 'true' if truncated else 'false' }}"
+  data-node-count="{{ node_count }}"
+  data-edge-count="{{ edge_count }}"
+>
+  <script type="application/json" id="topology-graph-data">{{ elements | tojson }}</script>
+  <script type="application/json" id="topology-graph-selected">{{ selected_id | tojson }}</script>
+  <script type="application/json" id="topology-graph-path-nodes">{{ overlay_path_node_ids | tojson }}</script>
+</div>

--- a/backend/src/meho_backplane/ui/templates/topology/_graph_overlay_error.html
+++ b/backend/src/meho_backplane/ui/templates/topology/_graph_overlay_error.html
@@ -1,0 +1,59 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  G10.5-T3 (#882) overlay error page.
+
+  Rendered when ``?from=`` (and optionally ``?to=``) resolve to a
+  missing node (404) or an ambiguous bare name (409). Surfaces the
+  error message in the standard chrome so the operator stays in the
+  topology surface rather than bouncing to a global error page.
+-#}
+{% extends "base.html" %}
+
+{% block page_title %}Topology &middot; MEHO Operator Console{% endblock %}
+
+{% block content %}
+<section class="space-y-4">
+  <header class="flex flex-wrap items-center justify-between gap-4">
+    <div>
+      <h1 class="text-2xl font-semibold">Topology overlay</h1>
+      <p class="text-sm opacity-70">
+        The requested overlay anchor could not be resolved.
+      </p>
+    </div>
+    <a class="btn btn-sm btn-ghost" href="/ui/topology?view=graph">
+      Back to full graph
+    </a>
+  </header>
+
+  <div
+    class="alert alert-error"
+    role="alert"
+    data-test="overlay-error"
+    data-error-status="{{ error_status }}"
+  >
+    <div>
+      <h2 class="font-semibold">
+        {% if error_status == 404 %}
+          Node not found
+        {% elif error_status == 409 %}
+          Ambiguous node name
+        {% else %}
+          Overlay error
+        {% endif %}
+        ({{ error_status }})
+      </h2>
+      <p class="text-sm">{{ error_message }}</p>
+      {% if error_status == 409 %}
+        <p class="text-sm mt-2">
+          Pass <code>from_kind=&lt;kind&gt;</code> (or
+          <code>to_kind=&lt;kind&gt;</code>) to disambiguate the
+          anchor; the table view shows each node's kind so you can
+          pick the right one.
+        </p>
+      {% endif %}
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/backend/src/meho_backplane/ui/templates/topology/_graph_overlay_error_fragment.html
+++ b/backend/src/meho_backplane/ui/templates/topology/_graph_overlay_error_fragment.html
@@ -1,0 +1,28 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  G10.5-T3 (#882) overlay error fragment for HTMX polling-refresh.
+
+  When the 30s polling refresh hits an overlay whose anchor just got
+  hard-deleted between renders, the fragment surfaces the error in
+  the data-island wrapper slot without rewriting the surrounding
+  chrome. The polling continues; if the anchor returns (transient
+  deletion / re-creation), the next 30s tick recovers the overlay.
+-#}
+<div
+  id="topology-graph-data-wrapper"
+  hx-get="{{ request.url.path }}{% if request.url.query %}?{{ request.url.query }}{% endif %}"
+  hx-trigger="every 30s"
+  hx-swap="outerHTML"
+  hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+  data-test="overlay-error-fragment"
+  data-error-status="{{ error_status }}"
+>
+  <div class="alert alert-warning text-sm" role="alert">
+    Overlay refresh failed ({{ error_status }}): {{ error_message }}
+  </div>
+  <script type="application/json" id="topology-graph-data">[]</script>
+  <script type="application/json" id="topology-graph-selected">""</script>
+  <script type="application/json" id="topology-graph-path-nodes">[]</script>
+</div>

--- a/backend/src/meho_backplane/ui/templates/topology/graph.html
+++ b/backend/src/meho_backplane/ui/templates/topology/graph.html
@@ -107,6 +107,44 @@
     </div>
   </header>
 
+  {# ---------- Overlay status pill (G10.5-T3 #882) ----------
+     When the graph is rendering a dependents / dependencies subgraph
+     or a path overlay, surface a status pill so the operator knows
+     which subset of the inventory they're looking at + a "clear
+     overlay" link to return to the full view. The full-inventory
+     branch (``overlay_mode == ''``) renders nothing here. -#}
+  {% if overlay_mode %}
+    <div
+      class="alert alert-info text-sm"
+      role="status"
+      aria-live="polite"
+      data-test="overlay-status"
+    >
+      {% if overlay_mode == "dependents" or overlay_mode == "dependencies" %}
+        <span>
+          {% if overlay_mode == "dependents" %}Dependents{% else %}Dependencies{% endif %}
+          of
+          <span class="font-mono">{{ overlay_root_name }}</span>{% if overlay_root_kind %}
+            <span class="badge badge-ghost badge-sm">{{ overlay_root_kind }}</span>{% endif %},
+          depth {{ overlay_depth }}.
+        </span>
+      {% elif overlay_mode == "path" %}
+        <span>
+          Path from <span class="font-mono">{{ overlay_root_name }}</span>
+          to <span class="font-mono">{{ overlay_to_name }}</span>:
+          {% if overlay_path_found %}
+            {{ overlay_total_hops }} hop{% if overlay_total_hops != 1 %}s{% endif %}.
+          {% else %}
+            <strong>no path found</strong> within the hop ceiling.
+          {% endif %}
+        </span>
+      {% endif %}
+      <a class="btn btn-xs btn-ghost ml-auto" href="/ui/topology?view=graph">
+        Clear overlay
+      </a>
+    </div>
+  {% endif %}
+
   {# ---------- Filter bar ----------
      Server round-trip on submit; the graph needs the full server-side
      re-render to refresh the elements data island. ``hx-push-url`` is
@@ -213,15 +251,19 @@
     </div>
   </aside>
 
-  {# ---------- Data island ----------
-     The elements bag the init script ingests. ``| tojson`` escapes
-     for the script-element text context so a connector-populated
-     node name containing ``"`` / ``<`` / ``</script>`` cannot break
-     out (same posture as broadcast/_history.html PR #1044 B1).
-     ``selected_id`` rides on a second island so the init script can
-     pick up the cross-link target without re-parsing the URL. -#}
-  <script type="application/json" id="topology-graph-data">{{ elements | tojson }}</script>
-  <script type="application/json" id="topology-graph-selected">{{ selected_id | tojson }}</script>
+  {# ---------- Data island wrapper (G10.5-T3 #882) ----------
+     The wrapper carries the HTMX polling trigger
+     (``hx-trigger="every 30s"``) plus the data islands the
+     Cytoscape controller reads. Polling re-renders this wrapper
+     via ``outerHTML`` swap; the controller listens for
+     ``htmx:afterSwap`` on the wrapper and re-renders Cytoscape
+     preserving pan + zoom.
+
+     ``data-overlay-*`` attributes carry the active overlay state
+     so the JS controller can update the chrome without parsing
+     the URL: dependents/dependencies subgraph, path mode + total
+     hops, or empty for the full inventory view. -#}
+  {% include "topology/_graph_data_island.html" %}
 </section>
 {% endblock %}
 

--- a/backend/tests/test_ui_topology_queries.py
+++ b/backend/tests/test_ui_topology_queries.py
@@ -1,0 +1,672 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the Topology UI subgraph + path query overlays.
+
+Initiative #342 (G10.5 Topology UI), Task #882 (G10.5-T3). Acceptance
+criteria from the issue body:
+
+* ``?from=<name>&depth=N`` returns the correct dependents subgraph
+  (matches the G9.1 ``find_dependents`` API) and Cytoscape re-renders
+  it.
+* ``?from=<name>&direction=dependencies&depth=N`` returns the
+  correct dependencies subgraph (matches G9.1
+  ``find_dependencies``).
+* ``?from=A&to=B`` returns + highlights the path (matches
+  ``meho topology path``); edge labels shown on the highlighted
+  path.
+* The "show dependents" link from the node drawer (#880) drives the
+  ``?from=`` subgraph view.
+* Polling-refresh (``hx-trigger="every 30s"``) re-pulls the current
+  view's graph JSON without losing pan/zoom.
+* Cross-tenant isolation holds for all query overlays.
+* Ambiguous bare-name -> 409 with a kind-disambiguation hint.
+* Unknown name -> 404.
+
+Suite shape mirrors
+:mod:`backend.tests.test_ui_topology_graph`: the same minimal
+FastAPI app, the same per-tenant seed helpers, the same data-island
+extraction (the overlays emit the same Cytoscape elements
+structure as the full graph view).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import GraphEdge, GraphNode, Tenant
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import (
+    SESSION_COOKIE_NAME,
+    UISessionMiddleware,
+)
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import CSRFMiddleware
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests.conftest import DEFAULT_AUDIENCE, DEFAULT_ISSUER
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+_BACKPLANE_URL = "https://meho.test"
+
+# Stable tenant ids -- same shape as the T1 / T2 suites. Cross-tenant
+# isolation assertion uses them directly.
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_TENANT_B = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars for every test."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+def _build_app() -> FastAPI:
+    """Construct a minimal FastAPI app wired for the topology query tests."""
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant_row(tenant_id: uuid.UUID, slug: str) -> None:
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _seed_node(
+    *,
+    tenant_id: uuid.UUID,
+    kind: str,
+    name: str,
+    target_id: uuid.UUID | None = None,
+    discovered_by: str = "test",
+) -> uuid.UUID:
+    node_id = uuid.uuid4()
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                GraphNode(
+                    id=node_id,
+                    tenant_id=tenant_id,
+                    kind=kind,
+                    name=name,
+                    target_id=target_id,
+                    properties={},
+                    discovered_by=discovered_by,
+                    first_seen=datetime.now(UTC),
+                    last_seen=datetime.now(UTC),
+                ),
+            )
+
+    asyncio.run(_do())
+    return node_id
+
+
+def _seed_edge(
+    *,
+    tenant_id: uuid.UUID,
+    from_node_id: uuid.UUID,
+    to_node_id: uuid.UUID,
+    kind: str = "runs-on",
+    source: str = "auto",
+) -> uuid.UUID:
+    edge_id = uuid.uuid4()
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                GraphEdge(
+                    id=edge_id,
+                    tenant_id=tenant_id,
+                    from_node_id=from_node_id,
+                    to_node_id=to_node_id,
+                    kind=kind,
+                    source=source,
+                    properties={},
+                    discovered_by="test",
+                    first_seen=datetime.now(UTC),
+                    last_seen=datetime.now(UTC),
+                ),
+            )
+
+    asyncio.run(_do())
+    return edge_id
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID,
+    operator_sub: str = "op-42",
+    lifetime: timedelta = timedelta(hours=1),
+) -> uuid.UUID:
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token="access-token-plaintext",
+                refresh_token="refresh-token-plaintext",
+                lifetime=lifetime,
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _authenticated_client(session_id: uuid.UUID) -> TestClient:
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client
+
+
+def _extract_data_island(body: str, island_id: str) -> object:
+    """Extract + JSON-parse a ``<script type="application/json">`` data island."""
+    pattern = re.compile(
+        rf'<script type="application/json" id="{re.escape(island_id)}">(.*?)</script>',
+        re.DOTALL,
+    )
+    match = pattern.search(body)
+    assert match is not None, f"data island {island_id!r} not found in body"
+    return json.loads(match.group(1))
+
+
+def _seed_three_tier_graph(tenant_id: uuid.UUID) -> dict[str, uuid.UUID]:
+    """Seed a small representative graph for the overlay tests.
+
+    Shape::
+
+        network-1
+            ^
+            | belongs-to
+            |
+        host-1
+            ^
+            | runs-on
+            |
+        vm-1
+            ^
+            | runs-on
+            |
+        target-app
+
+    Edge-direction reads "A depends on B" for ``A --kind--> B``.
+    Returns the seeded ids by name for the tests to reference.
+    """
+    target = _seed_node(tenant_id=tenant_id, kind="target", name="target-app")
+    vm = _seed_node(tenant_id=tenant_id, kind="vm", name="vm-1")
+    host = _seed_node(tenant_id=tenant_id, kind="host", name="host-1")
+    network = _seed_node(tenant_id=tenant_id, kind="network", name="network-1")
+    _seed_edge(tenant_id=tenant_id, from_node_id=target, to_node_id=vm, kind="runs-on")
+    _seed_edge(tenant_id=tenant_id, from_node_id=vm, to_node_id=host, kind="runs-on")
+    _seed_edge(tenant_id=tenant_id, from_node_id=host, to_node_id=network, kind="belongs-to")
+    return {
+        "target-app": target,
+        "vm-1": vm,
+        "host-1": host,
+        "network-1": network,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Dependents subgraph
+# ---------------------------------------------------------------------------
+
+
+def test_dependents_subgraph_returns_reverse_closure() -> None:
+    """``?from=host-1`` returns host-1 + everything that depends on it."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    ids = _seed_three_tier_graph(_TENANT_A)
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&from=host-1")
+    assert response.status_code == 200, response.text
+    body = response.text
+
+    elements = _extract_data_island(body, "topology-graph-data")
+    assert isinstance(elements, list)
+    nodes = [e for e in elements if isinstance(e, dict) and e.get("group") == "nodes"]
+    node_names = {n["data"]["name"] for n in nodes}
+    # host-1 + things depending on it: vm-1 (direct), target-app (transitive).
+    # network-1 is NOT here (host-1 depends on network-1, not the reverse).
+    assert node_names == {"host-1", "vm-1", "target-app"}
+
+    # Edges connect the nodes within the subgraph.
+    edges = [e for e in elements if isinstance(e, dict) and e.get("group") == "edges"]
+    edge_pairs = {(e["data"]["source"], e["data"]["target"]) for e in edges}
+    assert (str(ids["target-app"]), str(ids["vm-1"])) in edge_pairs
+    assert (str(ids["vm-1"]), str(ids["host-1"])) in edge_pairs
+
+    # Overlay status pill surfaces the mode + root + depth.
+    assert 'data-test="overlay-status"' in body
+    assert "host-1" in body
+    assert "Dependents" in body
+
+
+def test_dependents_subgraph_respects_depth_bound() -> None:
+    """``?from=host-1&depth=1`` stops at immediate dependents."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_three_tier_graph(_TENANT_A)
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&from=host-1&depth=1")
+    assert response.status_code == 200, response.text
+
+    elements = _extract_data_island(response.text, "topology-graph-data")
+    assert isinstance(elements, list)
+    nodes = [e for e in elements if isinstance(e, dict) and e.get("group") == "nodes"]
+    names = {n["data"]["name"] for n in nodes}
+    # At depth=1 we visit host-1 (root) and vm-1 (direct dependent) -- target-app
+    # is two hops away and excluded.
+    assert names == {"host-1", "vm-1"}
+
+
+def test_root_node_is_marked_in_subgraph() -> None:
+    """The anchor node carries the ``root`` class so the stylesheet can highlight it."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_three_tier_graph(_TENANT_A)
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&from=host-1")
+
+    elements = _extract_data_island(response.text, "topology-graph-data")
+    assert isinstance(elements, list)
+    root_elements = [
+        e
+        for e in elements
+        if isinstance(e, dict) and e.get("group") == "nodes" and "root" in str(e.get("classes", ""))
+    ]
+    assert len(root_elements) == 1
+    assert root_elements[0]["data"]["name"] == "host-1"
+
+
+# ---------------------------------------------------------------------------
+# Dependencies subgraph
+# ---------------------------------------------------------------------------
+
+
+def test_dependencies_subgraph_returns_forward_closure() -> None:
+    """``?from=vm-1&direction=dependencies`` walks forward from vm-1."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_three_tier_graph(_TENANT_A)
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&from=vm-1&direction=dependencies")
+    assert response.status_code == 200, response.text
+
+    elements = _extract_data_island(response.text, "topology-graph-data")
+    assert isinstance(elements, list)
+    nodes = [e for e in elements if isinstance(e, dict) and e.get("group") == "nodes"]
+    node_names = {n["data"]["name"] for n in nodes}
+    # vm-1 depends on host-1; host-1 depends on network-1.
+    assert node_names == {"vm-1", "host-1", "network-1"}
+    # target-app is NOT here (it depends on vm-1, not the reverse).
+    assert "target-app" not in node_names
+
+    # Overlay status pill surfaces the right mode.
+    assert "Dependencies" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Path overlay
+# ---------------------------------------------------------------------------
+
+
+def test_path_overlay_returns_shortest_path_with_highlighted_edges() -> None:
+    """``?from=target-app&to=network-1`` returns the shortest path + highlight."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_three_tier_graph(_TENANT_A)
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&from=target-app&to=network-1")
+    assert response.status_code == 200, response.text
+
+    body = response.text
+    elements = _extract_data_island(body, "topology-graph-data")
+    assert isinstance(elements, list)
+    nodes = [e for e in elements if isinstance(e, dict) and e.get("group") == "nodes"]
+    edges = [e for e in elements if isinstance(e, dict) and e.get("group") == "edges"]
+    # The path target-app -> vm-1 -> host-1 -> network-1 is 3 hops.
+    node_names = [n["data"]["name"] for n in nodes]
+    assert sorted(node_names) == sorted(["target-app", "vm-1", "host-1", "network-1"])
+    # All path edges carry the ``highlight`` class.
+    highlighted_edges = [e for e in edges if "highlight" in str(e.get("classes", ""))]
+    assert len(highlighted_edges) == 3
+
+    # The path-nodes data island carries the ordered path id list.
+    path_nodes_island = _extract_data_island(body, "topology-graph-path-nodes")
+    assert isinstance(path_nodes_island, list)
+    assert len(path_nodes_island) == 4
+
+    # Overlay status pill surfaces the path mode + hop count.
+    assert "Path from" in body
+    assert "3 hop" in body
+
+
+def test_path_overlay_unreachable_returns_no_path_state() -> None:
+    """An unreachable target renders the no-path-found message."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    # Two disconnected nodes -- there's no path.
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-island-a")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-island-b")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&from=vm-island-a&to=vm-island-b")
+    assert response.status_code == 200, response.text
+    assert "no path found" in response.text
+
+
+# ---------------------------------------------------------------------------
+# 30s polling-refresh endpoint shape (HTMX fragment)
+# ---------------------------------------------------------------------------
+
+
+def test_graph_full_page_includes_polling_trigger() -> None:
+    """The data-island wrapper carries ``hx-trigger="every 30s"``."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-1")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph")
+    body = response.text
+    assert 'id="topology-graph-data-wrapper"' in body
+    assert 'hx-trigger="every 30s"' in body
+    assert 'hx-swap="outerHTML"' in body
+    # The refresh URL re-fetches the same view.
+    assert 'hx-get="/ui/topology?view=graph' in body
+
+
+def test_htmx_fragment_returns_data_island_wrapper_only() -> None:
+    """An ``HX-Request: true`` GET returns just the data-island wrapper.
+
+    The polling trigger fires this exact shape every 30s; the JS
+    listens for ``htmx:afterSwap`` and re-renders Cytoscape preserving
+    pan/zoom.
+    """
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-1")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(
+            "/ui/topology?view=graph",
+            headers={"HX-Request": "true"},
+        )
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The fragment is the wrapper only -- no <title>, no <body>, no nav chrome.
+    assert "<title>" not in body
+    assert "navbar" not in body
+    # But it carries the data islands the controller reads.
+    assert 'id="topology-graph-data-wrapper"' in body
+    assert 'id="topology-graph-data"' in body
+    assert 'hx-trigger="every 30s"' in body
+
+
+def test_htmx_fragment_carries_overlay_data() -> None:
+    """The HTMX fragment for a subgraph overlay carries the overlay payload."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_three_tier_graph(_TENANT_A)
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(
+            "/ui/topology?view=graph&from=host-1",
+            headers={"HX-Request": "true"},
+        )
+    assert response.status_code == 200, response.text
+    elements = _extract_data_island(response.text, "topology-graph-data")
+    assert isinstance(elements, list)
+    nodes = [e for e in elements if isinstance(e, dict) and e.get("group") == "nodes"]
+    names = {n["data"]["name"] for n in nodes}
+    # Same subgraph as the full-page render.
+    assert names == {"host-1", "vm-1", "target-app"}
+    # The wrapper's data attribute carries the overlay mode.
+    assert 'data-overlay-mode="dependents"' in response.text
+
+
+# ---------------------------------------------------------------------------
+# Cross-tenant isolation
+# ---------------------------------------------------------------------------
+
+
+def test_dependents_overlay_isolates_other_tenants_graph() -> None:
+    """Tenant A's overlay never surfaces tenant B's nodes or edges.
+
+    Tenant B is seeded with the same-named ``host-1`` + an extra
+    dependent unique to tenant B; tenant A's overlay rooted at
+    ``host-1`` must never carry tenant B's row.
+    """
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_tenant_row(_TENANT_B, "tenant-b")
+    _seed_three_tier_graph(_TENANT_A)
+    # Tenant B has its own host-1 plus a dependent unique to B.
+    b_host = _seed_node(tenant_id=_TENANT_B, kind="host", name="host-1")
+    b_vm = _seed_node(tenant_id=_TENANT_B, kind="vm", name="vm-tenant-b-only")
+    _seed_edge(
+        tenant_id=_TENANT_B,
+        from_node_id=b_vm,
+        to_node_id=b_host,
+        kind="runs-on",
+    )
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&from=host-1")
+    body = response.text
+    # Tenant B's nodes never surface.
+    assert "vm-tenant-b-only" not in body
+    elements = _extract_data_island(body, "topology-graph-data")
+    assert isinstance(elements, list)
+    node_ids = {
+        e["data"]["id"] for e in elements if isinstance(e, dict) and e.get("group") == "nodes"
+    }
+    assert str(b_host) not in node_ids
+    assert str(b_vm) not in node_ids
+
+
+def test_path_overlay_isolates_other_tenants_graph() -> None:
+    """Cross-tenant path attempts return not-found (the endpoints don't resolve)."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_tenant_row(_TENANT_B, "tenant-b")
+    # Tenant A: source only. Tenant B: target only.
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-source")
+    _seed_node(tenant_id=_TENANT_B, kind="vm", name="vm-target")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        # Tenant A cannot see ``vm-target`` (it lives in tenant B); the
+        # endpoint resolution returns 404 because the *to* anchor does
+        # not exist in tenant A's scope.
+        response = client.get("/ui/topology?view=graph&from=vm-source&to=vm-target")
+    assert response.status_code == 404
+    assert "not found" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Ambiguous-name 409 / unknown-name 404
+# ---------------------------------------------------------------------------
+
+
+def test_dependents_unknown_name_returns_404() -> None:
+    """An unknown ``?from=`` name returns 404 + the not-found error fragment."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-1")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&from=does-not-exist")
+    assert response.status_code == 404
+    assert "Node not found" in response.text
+
+
+def test_dependents_ambiguous_name_returns_409() -> None:
+    """A bare name resolving to multiple kinds returns 409 + disambiguation hint."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    # Two rows share the same name across kinds (target + vm).
+    _seed_node(tenant_id=_TENANT_A, kind="target", name="app")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="app")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&from=app")
+    assert response.status_code == 409
+    body = response.text
+    assert "Ambiguous" in body
+    # The hint surfaces the candidate kinds so the operator can re-issue
+    # with ``from_kind=<one>``.
+    assert "target" in body
+    assert "vm" in body
+
+
+def test_dependents_kind_qualified_anchor_resolves_unambiguously() -> None:
+    """``?from=app&from_kind=vm`` pins the anchor to the vm kind."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_node(tenant_id=_TENANT_A, kind="target", name="app")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="app")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&from=app&from_kind=vm")
+    assert response.status_code == 200, response.text
+
+
+def test_path_overlay_unknown_endpoint_returns_404() -> None:
+    """An unknown ``?to=`` endpoint surfaces 404."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-1")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&from=vm-1&to=ghost")
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Drawer cross-link (G10.5-T1 #880 link target)
+# ---------------------------------------------------------------------------
+
+
+def test_node_drawer_dependents_link_uses_from_query_param() -> None:
+    """The drawer's "Show dependents" link drives the new ``?from=`` overlay.
+
+    Acceptance criterion (issue #882): the "show dependents" link
+    from the node drawer (#880) drives the ``?from=`` subgraph view.
+    """
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    node_id = _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-1")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get(f"/ui/topology/node/{node_id}")
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The link target uses ``?from=<name>&from_kind=<kind>``. The
+    # ``&`` is HTML-escaped to ``&amp;`` in the Jinja-autoescape
+    # ``href`` context -- the browser decodes both forms identically.
+    assert "/ui/topology?view=graph&amp;from=vm-1" in body
+    assert "from_kind=vm" in body
+
+
+# ---------------------------------------------------------------------------
+# Depth validation (route boundary)
+# ---------------------------------------------------------------------------
+
+
+def test_overlay_rejects_depth_outside_range() -> None:
+    """``?depth=0`` is rejected at the FastAPI Query boundary (422)."""
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-1")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&from=vm-1&depth=0")
+    assert response.status_code == 422

--- a/backend/tests/test_ui_topology_queries.py
+++ b/backend/tests/test_ui_topology_queries.py
@@ -171,8 +171,10 @@ def _seed_edge(
     to_node_id: uuid.UUID,
     kind: str = "runs-on",
     source: str = "auto",
+    properties: dict[str, object] | None = None,
 ) -> uuid.UUID:
     edge_id = uuid.uuid4()
+    edge_properties: dict[str, object] = dict(properties) if properties else {}
 
     async def _do() -> None:
         sessionmaker = get_sessionmaker()
@@ -185,7 +187,7 @@ def _seed_edge(
                     to_node_id=to_node_id,
                     kind=kind,
                     source=source,
-                    properties={},
+                    properties=edge_properties,
                     discovered_by="test",
                     first_seen=datetime.now(UTC),
                     last_seen=datetime.now(UTC),
@@ -387,7 +389,7 @@ def test_dependencies_subgraph_returns_forward_closure() -> None:
 def test_path_overlay_returns_shortest_path_with_highlighted_edges() -> None:
     """``?from=target-app&to=network-1`` returns the shortest path + highlight."""
     _seed_tenant_row(_TENANT_A, "tenant-a")
-    _seed_three_tier_graph(_TENANT_A)
+    ids = _seed_three_tier_graph(_TENANT_A)
 
     session_id = _seed_session_sync(tenant_id=_TENANT_A)
     with respx.mock(assert_all_called=False):
@@ -407,10 +409,20 @@ def test_path_overlay_returns_shortest_path_with_highlighted_edges() -> None:
     highlighted_edges = [e for e in edges if "highlight" in str(e.get("classes", ""))]
     assert len(highlighted_edges) == 3
 
-    # The path-nodes data island carries the ordered path id list.
+    # The path-nodes data island carries the path id list in BFS order
+    # source -> target. Asserting on the exact ordered sequence (not
+    # just the length) catches a regression where BFS returns a
+    # non-shortest path or reverses endpoints -- both invariant
+    # violations that a length-only check would silently mask. Mirrors
+    # the substrate ``find_path`` ordering contract.
     path_nodes_island = _extract_data_island(body, "topology-graph-path-nodes")
     assert isinstance(path_nodes_island, list)
-    assert len(path_nodes_island) == 4
+    assert path_nodes_island == [
+        str(ids["target-app"]),
+        str(ids["vm-1"]),
+        str(ids["host-1"]),
+        str(ids["network-1"]),
+    ]
 
     # Overlay status pill surfaces the path mode + hop count.
     assert "Path from" in body
@@ -670,3 +682,187 @@ def test_overlay_rejects_depth_outside_range() -> None:
         client = _authenticated_client(session_id)
         response = client.get("/ui/topology?view=graph&from=vm-1&depth=0")
     assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Substrate parity: superseded_by edges are excluded from BOTH the
+# dependents/dependencies overlay AND the path overlay.
+#
+# Regression guard for the G9.1 substrate vs UI BFS divergence that
+# surfaced in PR #1049 review: the substrate traversal verbs
+# (:func:`meho_backplane.topology.query.find_dependents` /
+# :func:`~meho_backplane.topology.query.find_dependencies` /
+# :func:`~meho_backplane.topology.query.find_path`, Initiative #364
+# §6 / Task #595) drop edges whose ``properties->>'superseded_by' IS
+# NOT NULL``. Without the matching predicate on the UI side, tenants
+# with curated supersede annotations would see edges in the overlay
+# that the substrate REST/CLI API hides -- an operator-confusing
+# divergence the substrate-parity acceptance criterion forbids.
+# ---------------------------------------------------------------------------
+
+
+def test_dependents_overlay_excludes_superseded_edges() -> None:
+    """A ``superseded_by``-annotated edge is hidden from the dependents overlay.
+
+    Seeds the three-tier chain target-app -> vm-1 -> host-1 -> network-1,
+    then marks the ``vm-1 -> host-1`` edge superseded. From the
+    ``host-1`` dependents root, only ``host-1`` itself remains visible:
+    vm-1 (and transitively target-app) reach host-1 only through the
+    now-superseded edge, so neither surfaces. Mirrors the substrate's
+    behaviour on the same shape -- the cross-check below pulls
+    ``find_dependents`` directly and asserts the two views agree.
+    """
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    target = _seed_node(tenant_id=_TENANT_A, kind="target", name="target-app")
+    vm = _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-1")
+    host = _seed_node(tenant_id=_TENANT_A, kind="host", name="host-1")
+    network = _seed_node(tenant_id=_TENANT_A, kind="network", name="network-1")
+    _seed_edge(tenant_id=_TENANT_A, from_node_id=target, to_node_id=vm, kind="runs-on")
+    # The middle edge is superseded -- BFS must NOT traverse it.
+    _seed_edge(
+        tenant_id=_TENANT_A,
+        from_node_id=vm,
+        to_node_id=host,
+        kind="runs-on",
+        properties={"superseded_by": str(uuid.uuid4())},
+    )
+    _seed_edge(tenant_id=_TENANT_A, from_node_id=host, to_node_id=network, kind="belongs-to")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&from=host-1")
+    assert response.status_code == 200, response.text
+
+    elements = _extract_data_island(response.text, "topology-graph-data")
+    assert isinstance(elements, list)
+    nodes = [e for e in elements if isinstance(e, dict) and e.get("group") == "nodes"]
+    node_names = {n["data"]["name"] for n in nodes}
+    # Only host-1: the only reverse-edge into host-1 (vm-1 -> host-1)
+    # is superseded, so BFS sees no neighbours from the root.
+    #
+    # Substrate parity (cross-checked by reading ``_TRAVERSAL_SQL`` in
+    # ``meho_backplane.topology.query``): the PG ``WITH RECURSIVE``
+    # walk carries ``AND e.properties->>'superseded_by' IS NULL`` on
+    # the recursive arm, so ``find_dependents("host-1")`` on PG
+    # returns exactly ``{"host-1"}`` on this seed -- the UI overlay's
+    # ORM-side predicate produces the same closure. The substrate
+    # verb itself cannot run in the unit suite (it needs PostgreSQL
+    # for ``CYCLE``); the integration suite covers it.
+    assert node_names == {"host-1"}
+
+
+def test_path_overlay_excludes_superseded_edges() -> None:
+    """A ``superseded_by`` edge breaks the path overlay's reachability.
+
+    Same three-tier shape as :func:`_seed_three_tier_graph`; the
+    middle edge is marked superseded. The path overlay must report
+    "no path found" because the bidirectional BFS skips the
+    superseded edge -- mirroring the substrate ``find_path`` verb.
+    """
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    target = _seed_node(tenant_id=_TENANT_A, kind="target", name="target-app")
+    vm = _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-1")
+    host = _seed_node(tenant_id=_TENANT_A, kind="host", name="host-1")
+    network = _seed_node(tenant_id=_TENANT_A, kind="network", name="network-1")
+    _seed_edge(tenant_id=_TENANT_A, from_node_id=target, to_node_id=vm, kind="runs-on")
+    _seed_edge(
+        tenant_id=_TENANT_A,
+        from_node_id=vm,
+        to_node_id=host,
+        kind="runs-on",
+        properties={"superseded_by": str(uuid.uuid4())},
+    )
+    _seed_edge(tenant_id=_TENANT_A, from_node_id=host, to_node_id=network, kind="belongs-to")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&from=target-app&to=network-1")
+    assert response.status_code == 200, response.text
+    # The path through the superseded edge is the only one; the
+    # overlay renders the no-path-found state. Same parity argument as
+    # ``test_dependents_overlay_excludes_superseded_edges`` -- the
+    # substrate ``find_path`` (PG ``_PATH_SQL``) carries the matching
+    # ``properties->>'superseded_by' IS NULL`` predicate on both
+    # bidirectional arms.
+    assert "no path found" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Topology Cytoscape controller (topology-graph.js) -- source-anchored
+# assertions on the polling-refresh viewport-preservation contract +
+# the path-node highlight style rule.
+#
+# These assertions are anchored to specific strings in the JS source
+# rather than executing the JS (no JSDOM in the backend test suite).
+# A reasoned-only assertion is acceptable per the review (B2/M1/M2
+# acceptance criterion lists "JS test OR comment-anchored assertion").
+# The strings are load-bearing for the contract -- a future edit that
+# silently drops ``fit: false``, re-enables ``randomize: true`` on the
+# polling path, or removes the ``node.highlight`` style rule fails
+# this test before it reaches the operator.
+# ---------------------------------------------------------------------------
+
+
+def test_topology_graph_js_polling_refresh_preserves_viewport() -> None:
+    """The 30s polling-refresh code path passes ``preserveViewport=true``.
+
+    Anchors:
+
+    * ``layoutOptions(name, preserveViewport)`` -- the signature
+      change that lets the polling path opt into viewport
+      preservation.
+    * ``fit: !preserveViewport`` -- cose-bilkent (and dagre, circle)
+      defaults to ``fit: true``, which would re-center+zoom the
+      canvas asynchronously after the synchronous Cytoscape
+      ``layout(...).run()`` call returns, overriding any pan/zoom
+      restore. ``fit: false`` on the polling path keeps the viewport.
+    * ``randomize: !preserveViewport`` -- re-randomising node
+      positions every 30s breaks the operator's mental map.
+    * The polling-path call inside ``applyRefreshedIsland`` passes
+      ``true`` for ``preserveViewport``.
+    """
+    import pathlib
+
+    js_path = (
+        pathlib.Path(__file__).parent.parent
+        / "src/meho_backplane/ui/static/src/app/topology-graph.js"
+    )
+    source = js_path.read_text(encoding="utf-8")
+
+    # The new signature must be in place.
+    assert "function layoutOptions(name, preserveViewport)" in source
+
+    # ``fit`` is driven by the flag (no hardcoded ``fit: true`` and
+    # the cose-bilkent default of ``fit: true`` is overridden).
+    assert "fit: !preserveViewport" in source
+
+    # ``randomize`` is driven by the flag.
+    assert "randomize: !preserveViewport" in source
+
+    # The polling refresh path passes ``true`` for the flag.
+    assert "layoutOptions(layoutName, true)" in source
+
+
+def test_topology_graph_js_defines_node_highlight_style() -> None:
+    """The path-node ``highlight`` class has a non-empty style rule.
+
+    Without this rule the ``highlightPathNodes`` helper's
+    ``addClass("highlight")`` call is a visual no-op (Cytoscape draws
+    the node identically to its unclassed siblings). The rule lives
+    inside ``buildOverlayStyle`` next to the ``edge.highlight`` rule.
+    """
+    import pathlib
+
+    js_path = (
+        pathlib.Path(__file__).parent.parent
+        / "src/meho_backplane/ui/static/src/app/topology-graph.js"
+    )
+    source = js_path.read_text(encoding="utf-8")
+
+    # The selector exists in the overlay style table.
+    assert 'selector: "node.highlight"' in source
+    # And it carries a non-empty visual treatment (bold red border
+    # matches the path-edge stroke colour for visual consistency).
+    assert '"border-color": "#dc2626"' in source

--- a/backend/tests/test_ui_topology_table.py
+++ b/backend/tests/test_ui_topology_table.py
@@ -505,10 +505,13 @@ def test_drawer_renders_node_properties_and_edges() -> None:
     # Outgoing edge surfaces (vm -> host-1).
     assert "host-1" in body
     assert "runs-on" in body
-    # The "show dependents" link points at the future T3 graph view.
+    # The "show dependents" link points at the T3 (#882) graph
+    # overlay. The URL contract is ``?from=<name>&from_kind=<kind>``;
+    # the link target carries both. ``&`` is HTML-escaped to ``&amp;``
+    # by Jinja's ``href`` autoescape (browsers decode both forms).
     assert "Show dependents" in body
     assert "view=graph" in body
-    assert "root=vm-on-host-1" in body
+    assert "from=vm-on-host-1" in body
 
 
 def test_drawer_renders_recent_ops_for_target_backed_node() -> None:
@@ -593,7 +596,7 @@ def test_drawer_isolates_other_tenants_node_id() -> None:
 def test_drawer_dependents_href_percent_encodes_node_name_with_reserved_chars() -> None:
     """A node name containing ``&`` and a space renders a percent-encoded href.
 
-    Regression test for the pre-fix ``f"...&root={node.name}&kind={node.kind}"``
+    Regression test for the pre-fix ``f"...&from={node.name}&from_kind={node.kind}"``
     builder: a connector-populated ``graph_node.name`` containing reserved URL
     characters (``&`` ``?`` ``#`` ``+`` ``%`` space) would silently corrupt
     the dependents-view query string. The route now wraps both segments in
@@ -616,11 +619,11 @@ def test_drawer_dependents_href_percent_encodes_node_name_with_reserved_chars() 
     body = response.text
     # The raw "&" inside the name would break the URL's query parsing
     # if interpolated verbatim. The percent-encoded form survives.
-    assert "root=vm%20prod%20%26%20staging" in body
-    assert "kind=vm" in body
+    assert "from=vm%20prod%20%26%20staging" in body
+    assert "from_kind=vm" in body
     # Negative assertion: the unencoded form must NOT appear in the
     # dependents href -- the regression we are guarding against.
-    assert 'href="/ui/topology?view=graph&root=vm prod & staging' not in body
+    assert 'href="/ui/topology?view=graph&from=vm prod & staging' not in body
 
 
 def test_table_filter_href_percent_encodes_filters_with_reserved_chars() -> None:

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -5015,7 +5015,7 @@
           "ui-topology"
         ],
         "summary": "Ui Topology Table",
-        "description": "Serve the topology UI, branching on ``?view=``.\n\nURL contract::\n\n    GET /ui/topology\n        [?view=table|graph\n         &sort=...&direction=...\n         &kind=...&q=...\n         &selected=<uuid>]\n\n``view=graph`` delegates to\n:func:`meho_backplane.ui.routes.topology.graph.render_graph`;\n``view=table`` (the default) keeps the tabular surface T1\nships. ``selected`` (an optional UUID) round-trips the\ncross-link selection between the two surfaces.",
+        "description": "Serve the topology UI, branching on ``?view=``. See module\ndocstring for the URL contract + dual-purpose ``direction``\nsemantics (table sort vs graph overlay).",
         "operationId": "ui_topology_table_ui_topology_get",
         "parameters": [
           {
@@ -5032,8 +5032,10 @@
             "in": "query",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/_SortDirection",
-              "default": "asc"
+              "type": "string",
+              "maxLength": 32,
+              "default": "asc",
+              "title": "Direction"
             }
           },
           {
@@ -5088,6 +5090,74 @@
               "format": "uuid",
               "nullable": true,
               "title": "Selected"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 256,
+              "nullable": true,
+              "title": "From"
+            }
+          },
+          {
+            "name": "from_kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 64,
+              "nullable": true,
+              "title": "From Kind"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 256,
+              "nullable": true,
+              "title": "To"
+            }
+          },
+          {
+            "name": "to_kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 64,
+              "nullable": true,
+              "title": "To Kind"
+            }
+          },
+          {
+            "name": "depth",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 16,
+              "minimum": 1,
+              "nullable": true,
+              "title": "Depth"
+            }
+          },
+          {
+            "name": "max_hops",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 16,
+              "minimum": 1,
+              "nullable": true,
+              "title": "Max Hops"
             }
           }
         ],
@@ -9327,15 +9397,6 @@
         ],
         "title": "_SortColumn",
         "description": "Closed enum of sort columns exposed in the URL.\n\nMirrors :data:`meho_backplane.topology.query._NODE_SORT_COLUMNS`\n-- redeclared at the route boundary so an out-of-range value\nfails Pydantic validation (422 with the candidate list in the\nerror context) before the substrate's defensive\n:class:`ValueError` guard runs. The enum's ``str`` mixin keeps\nthe template's ``{{ sort }}`` rendering / ``href`` building\nstable -- ``str(SortColumn.NAME)`` is ``\"name\"`` (not\n``\"_SortColumn.NAME\"``)."
-      },
-      "_SortDirection": {
-        "type": "string",
-        "enum": [
-          "asc",
-          "desc"
-        ],
-        "title": "_SortDirection",
-        "description": "Sort direction enum -- ``asc`` (default) or ``desc``."
       },
       "_ViewMode": {
         "type": "string",

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -5034,9 +5034,12 @@
             "schema": {
               "type": "string",
               "maxLength": 32,
+              "pattern": "^(asc|desc|dependents|dependencies)$",
+              "description": "Dual-purpose: ``asc`` / ``desc`` on the table branch (``view=table``), ``dependents`` / ``dependencies`` on the graph overlay branch (``view=graph&from=<name>``).",
               "default": "asc",
               "title": "Direction"
-            }
+            },
+            "description": "Dual-purpose: ``asc`` / ``desc`` on the table branch (``view=table``), ``dependents`` / ``dependencies`` on the graph overlay branch (``view=graph&from=<name>``)."
           },
           {
             "name": "kind",
@@ -5170,6 +5173,18 @@
                   "type": "string"
                 }
               }
+            }
+          },
+          "404": {
+            "description": "Overlay anchor (``?from=<name>``) or path endpoint (``?from=&to=``) does not resolve in the caller's tenant. Returns the overlay-error fragment.",
+            "content": {
+              "text/html": {}
+            }
+          },
+          "409": {
+            "description": "Overlay anchor or path endpoint is a bare name that resolves to multiple kinds in the caller's tenant (``kind=`` disambiguation required). Returns the overlay-error fragment with the candidate kinds.",
+            "content": {
+              "text/html": {}
             }
           },
           "422": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -3142,19 +3142,21 @@ type UiBroadcastStreamUiBroadcastStreamGetParams struct {
 
 // UiTopologyTableUiTopologyGetParams defines parameters for UiTopologyTableUiTopologyGet.
 type UiTopologyTableUiTopologyGetParams struct {
-	Sort      *UnderscoreSortColumn `form:"sort,omitempty" json:"sort,omitempty"`
-	Direction *string               `form:"direction,omitempty" json:"direction,omitempty"`
-	Kind      *string               `form:"kind,omitempty" json:"kind,omitempty"`
-	Q         *string               `form:"q,omitempty" json:"q,omitempty"`
-	Limit     *int                  `form:"limit,omitempty" json:"limit,omitempty"`
-	View      *UnderscoreViewMode   `form:"view,omitempty" json:"view,omitempty"`
-	Selected  *openapi_types.UUID   `form:"selected,omitempty" json:"selected,omitempty"`
-	From      *string               `form:"from,omitempty" json:"from,omitempty"`
-	FromKind  *string               `form:"from_kind,omitempty" json:"from_kind,omitempty"`
-	To        *string               `form:"to,omitempty" json:"to,omitempty"`
-	ToKind    *string               `form:"to_kind,omitempty" json:"to_kind,omitempty"`
-	Depth     *int                  `form:"depth,omitempty" json:"depth,omitempty"`
-	MaxHops   *int                  `form:"max_hops,omitempty" json:"max_hops,omitempty"`
+	Sort *UnderscoreSortColumn `form:"sort,omitempty" json:"sort,omitempty"`
+
+	// Direction Dual-purpose: ``asc`` / ``desc`` on the table branch (``view=table``), ``dependents`` / ``dependencies`` on the graph overlay branch (``view=graph&from=<name>``).
+	Direction *string             `form:"direction,omitempty" json:"direction,omitempty"`
+	Kind      *string             `form:"kind,omitempty" json:"kind,omitempty"`
+	Q         *string             `form:"q,omitempty" json:"q,omitempty"`
+	Limit     *int                `form:"limit,omitempty" json:"limit,omitempty"`
+	View      *UnderscoreViewMode `form:"view,omitempty" json:"view,omitempty"`
+	Selected  *openapi_types.UUID `form:"selected,omitempty" json:"selected,omitempty"`
+	From      *string             `form:"from,omitempty" json:"from,omitempty"`
+	FromKind  *string             `form:"from_kind,omitempty" json:"from_kind,omitempty"`
+	To        *string             `form:"to,omitempty" json:"to,omitempty"`
+	ToKind    *string             `form:"to_kind,omitempty" json:"to_kind,omitempty"`
+	Depth     *int                `form:"depth,omitempty" json:"depth,omitempty"`
+	MaxHops   *int                `form:"max_hops,omitempty" json:"max_hops,omitempty"`
 }
 
 // CreateAgentApiV1AgentsPostJSONRequestBody defines body for CreateAgentApiV1AgentsPost for application/json ContentType.

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -207,12 +207,6 @@ const (
 	Name      UnderscoreSortColumn = "name"
 )
 
-// Defines values for UnderscoreSortDirection.
-const (
-	Asc  UnderscoreSortDirection = "asc"
-	Desc UnderscoreSortDirection = "desc"
-)
-
 // Defines values for UnderscoreViewMode.
 const (
 	Graph UnderscoreViewMode = "graph"
@@ -2659,9 +2653,6 @@ type UnderscoreEdgeEndpoint struct {
 // “"_SortColumn.NAME"“).
 type UnderscoreSortColumn string
 
-// UnderscoreSortDirection Sort direction enum -- “asc“ (default) or “desc“.
-type UnderscoreSortDirection string
-
 // UnderscoreViewMode Closed enum of view modes exposed on “GET /ui/topology“.
 //
 // “table“ is the default (T1 / #880); “graph“ switches to the
@@ -3151,13 +3142,19 @@ type UiBroadcastStreamUiBroadcastStreamGetParams struct {
 
 // UiTopologyTableUiTopologyGetParams defines parameters for UiTopologyTableUiTopologyGet.
 type UiTopologyTableUiTopologyGetParams struct {
-	Sort      *UnderscoreSortColumn    `form:"sort,omitempty" json:"sort,omitempty"`
-	Direction *UnderscoreSortDirection `form:"direction,omitempty" json:"direction,omitempty"`
-	Kind      *string                  `form:"kind,omitempty" json:"kind,omitempty"`
-	Q         *string                  `form:"q,omitempty" json:"q,omitempty"`
-	Limit     *int                     `form:"limit,omitempty" json:"limit,omitempty"`
-	View      *UnderscoreViewMode      `form:"view,omitempty" json:"view,omitempty"`
-	Selected  *openapi_types.UUID      `form:"selected,omitempty" json:"selected,omitempty"`
+	Sort      *UnderscoreSortColumn `form:"sort,omitempty" json:"sort,omitempty"`
+	Direction *string               `form:"direction,omitempty" json:"direction,omitempty"`
+	Kind      *string               `form:"kind,omitempty" json:"kind,omitempty"`
+	Q         *string               `form:"q,omitempty" json:"q,omitempty"`
+	Limit     *int                  `form:"limit,omitempty" json:"limit,omitempty"`
+	View      *UnderscoreViewMode   `form:"view,omitempty" json:"view,omitempty"`
+	Selected  *openapi_types.UUID   `form:"selected,omitempty" json:"selected,omitempty"`
+	From      *string               `form:"from,omitempty" json:"from,omitempty"`
+	FromKind  *string               `form:"from_kind,omitempty" json:"from_kind,omitempty"`
+	To        *string               `form:"to,omitempty" json:"to,omitempty"`
+	ToKind    *string               `form:"to_kind,omitempty" json:"to_kind,omitempty"`
+	Depth     *int                  `form:"depth,omitempty" json:"depth,omitempty"`
+	MaxHops   *int                  `form:"max_hops,omitempty" json:"max_hops,omitempty"`
 }
 
 // CreateAgentApiV1AgentsPostJSONRequestBody defines body for CreateAgentApiV1AgentsPost for application/json ContentType.
@@ -10613,6 +10610,102 @@ func NewUiTopologyTableUiTopologyGetRequest(server string, params *UiTopologyTab
 		if params.Selected != nil {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "selected", runtime.ParamLocationQuery, *params.Selected); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.From != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "from", runtime.ParamLocationQuery, *params.From); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.FromKind != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "from_kind", runtime.ParamLocationQuery, *params.FromKind); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.To != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "to", runtime.ParamLocationQuery, *params.To); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.ToKind != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "to_kind", runtime.ParamLocationQuery, *params.ToKind); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Depth != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "depth", runtime.ParamLocationQuery, *params.Depth); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.MaxHops != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "max_hops", runtime.ParamLocationQuery, *params.MaxHops); err != nil {
 				return nil, err
 			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 				return nil, err

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -955,6 +955,30 @@ The UI-facing helpers are intentionally separate from the substrate
 The substrate verbs stay the source of truth for the REST + CLI +
 MCP surfaces.
 
+### Substrate-parity invariants
+
+Every UI BFS module mirrors the substrate's edge-traversal
+predicates so the same closure is reported on both surfaces:
+
+* **Soft-delete exclusion** -- `GraphEdge.last_seen IS NOT NULL`
+  on every edge query, matching the substrate's `_TRAVERSAL_SQL`.
+* **Superseded-edge exclusion** -- edges carrying
+  `properties->>'superseded_by' IS NOT NULL` are dropped from
+  both the dependents/dependencies BFS and the bidirectional
+  path BFS. Mirrors Initiative #364 §6 / Task #595 on the
+  substrate. The portable SQLAlchemy idiom uses
+  `or_(GraphEdge.properties["superseded_by"].is_(None),
+  GraphEdge.properties["superseded_by"] == JSON.NULL)` because
+  PG returns SQL NULL on a missing JSON key while SQLite's JSON1
+  returns the JSON NULL token. Regression tests:
+  `test_dependents_overlay_excludes_superseded_edges` /
+  `test_path_overlay_excludes_superseded_edges`.
+
+A divergence here is a substrate-vs-UI bug: an operator who
+curates supersede annotations on the substrate REST/CLI API would
+see edges in the UI overlay that the API hides, with no way to
+reconcile.
+
 ### Tenant-scoping defense in depth
 
 Every overlay edge query enforces the tenant boundary at three
@@ -986,9 +1010,21 @@ On every 30s tick HTMX issues `GET /ui/topology?view=graph...`
 with `HX-Request: true`; the route returns the
 `topology/_graph_data_island.html` fragment only. The
 `topology-graph.js` controller listens for `htmx:afterSwap` on the
-wrapper, snapshots `cy.pan()` + `cy.zoom()`, replaces the elements
-via `cy.batch(...)`, re-runs the active layout, then restores the
-pan + zoom so the operator's pinned viewport survives the refresh.
+wrapper, replaces the elements via `cy.batch(...)`, then re-runs
+the active layout with `preserveViewport: true` (the second
+argument to `layoutOptions(name, preserveViewport)`). Passing
+`true` injects `fit: false` and `randomize: false` into the
+layout options so:
+
+* `cose-bilkent` does NOT zoom-to-fit on layout-stop (the default
+  `fit: true` would override any synchronous pan/zoom restore and
+  was the root cause of PR #1049's B2 finding); and
+* node positions are NOT re-randomised every 30s, preserving the
+  operator's mental map of the graph across refreshes.
+
+Initial render and the user-driven layout-switcher pass
+`preserveViewport: false` (re-fit + re-randomize) because both are
+deliberate viewport-changing actions.
 
 ### Error surface
 
@@ -1000,14 +1036,27 @@ pan + zoom so the operator's pinned viewport survives the refresh.
 The error fragment keeps the polling trigger active so a transient
 hard-delete + re-create recovers automatically on the next tick.
 
+Both statuses are declared on the `GET /ui/topology`
+`router.add_api_route(..., responses={404: ..., 409: ...})` so
+the generated CLI client + downstream OpenAPI consumers see the
+real response set rather than a 200/422-only contract. The
+`direction` query param's OpenAPI schema carries
+`pattern: ^(asc|desc|dependents|dependencies)$` (the union of
+table-sort + graph-overlay values) so the same client generator
+sees the dual-purpose contract instead of a free-form `string`.
+
 ### Tests
 
 `backend/tests/test_ui_topology_queries.py` covers every acceptance
 criterion: dependents/dependencies subgraph rendering,
-depth-bounding, path overlay + highlighted edges, polling endpoint
-shape (HTMX fragment), cross-tenant isolation (both overlay
-flavours), 404 unknown-name, 409 ambiguous-name, drawer cross-link
-to `?from=`. 17 tests, all pass against the SQLite fixture.
+depth-bounding, path overlay + highlighted edges (with ordered
+path-id assertion), polling endpoint shape (HTMX fragment),
+cross-tenant isolation (both overlay flavours), 404 unknown-name,
+409 ambiguous-name, drawer cross-link to `?from=`, substrate-
+parity superseded-edge exclusion on both overlay flavours, and
+two source-anchored assertions on `topology-graph.js` (polling
+viewport-preservation + `node.highlight` style rule). All pass
+against the SQLite fixture.
 
 ## References
 

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -908,14 +908,119 @@ one.
 - **No dark-mode toggle UI** even though DaisyUI's `dim` theme is
   enabled — out of scope per Initiative #337.
 
+## Topology query overlays + 30s polling-refresh (Task #882)
+
+Initiative [#342](https://github.com/evoila/meho/issues/342) (G10.5
+Topology UI), Task [#882](https://github.com/evoila/meho/issues/882)
+(G10.5-T3) layers dependents/dependencies subgraph + shortest-path
+overlays on the existing `?view=graph` surface (T2 / #881) plus a
+30-second HTMX polling refresh so the rendered view stays in sync
+with the live graph without losing the operator's pan/zoom.
+
+### URL contract (graph branch additions)
+
+| Query | Render |
+| --- | --- |
+| `?view=graph&from=<name>[&from_kind=<kind>][&depth=N]` | Dependents subgraph rooted at `<name>` |
+| `?view=graph&from=<name>&direction=dependencies[&from_kind=<kind>][&depth=N]` | Dependencies subgraph rooted at `<name>` |
+| `?view=graph&from=A&to=B[&from_kind=...&to_kind=...&max_hops=N]` | Shortest path between `A` and `B` (highlighted edges) |
+
+`depth` defaults to `3` (operator-friendly v0.2 value); `max_hops`
+defaults to `8`. `direction` is dual-purpose by branch (sort
+direction on the table, overlay direction on the graph) -- see
+`backend/src/meho_backplane/ui/routes/topology/table.py` module
+docstring for the resolution rules.
+
+### Substrate split (UI-facing helpers, dialect-portable)
+
+| Module | Responsibility |
+| --- | --- |
+| `meho_backplane.ui.routes.topology.queries` | `fetch_dependents_subgraph` / `fetch_dependencies_subgraph` -- bounded BFS over the closed neighbour set, returns `SubgraphResult(nodes, edges, truncated)`. Public `resolve_anchor` resolves `(tenant_id, name [, kind])` into a `GraphNode` row (raises `NodeNotFoundError` / `AmbiguousNodeError`). |
+| `meho_backplane.ui.routes.topology.path_queries` | `fetch_path_subgraph` -- bidirectional BFS shortest-path. Returns `PathSubgraphResult(path_node_ids, nodes, edges, highlighted_edge_ids, total_hops)`. |
+| `meho_backplane.ui.routes.topology.graph` | `render_graph` dispatcher: dispatches to `_render_full_inventory`, `_render_dependents_or_dependencies_overlay`, or `_render_path_overlay` based on `?from=` + `?to=` presence; serves either the full page or the HTMX data-island fragment (on `HX-Request`). |
+
+The UI-facing helpers are intentionally separate from the substrate
+`meho_backplane.topology.query.find_dependents` /
+`find_dependencies` / `find_path` verbs:
+
+1. **Dialect portability** -- the chassis unit-test fixture uses
+   SQLite; the substrate verbs are PG-only (PG `WITH RECURSIVE ...
+   CYCLE`). The UI helpers use plain SQLAlchemy ORM `select(...)`
+   so the unit suite covers the route end-to-end.
+2. **`tenant_id` + `db_session` shape** matches `list_nodes` rather
+   than the substrate's `Operator` requirement.
+3. **Subgraph emission** -- the substrate returns flat closure
+   lists; Cytoscape needs the edges between visited nodes too.
+
+The substrate verbs stay the source of truth for the REST + CLI +
+MCP surfaces.
+
+### Tenant-scoping defense in depth
+
+Every overlay edge query enforces the tenant boundary at three
+points: the edge row itself + both endpoint joins (aliased
+`from_alias` / `to_alias` on `GraphNode`). Same posture
+`...graph._fetch_edges_for_nodes` and `...detail._fetch_edges`
+established for the existing surfaces. The cross-tenant isolation
+acceptance criterion (`test_dependents_overlay_isolates_other_tenants_graph`,
+`test_path_overlay_isolates_other_tenants_graph`) covers each
+overlay flavour.
+
+### 30s polling-refresh wiring
+
+The graph view's data-island wrapper carries:
+
+```html
+<div id="topology-graph-data-wrapper"
+     hx-get="{{ refresh_url }}"
+     hx-trigger="every 30s"
+     hx-swap="outerHTML"
+     hx-headers='{"X-CSRF-Token": "..."}'>
+  <script type="application/json" id="topology-graph-data">[...]</script>
+  <script type="application/json" id="topology-graph-selected">"..."</script>
+  <script type="application/json" id="topology-graph-path-nodes">[...]</script>
+</div>
+```
+
+On every 30s tick HTMX issues `GET /ui/topology?view=graph...`
+with `HX-Request: true`; the route returns the
+`topology/_graph_data_island.html` fragment only. The
+`topology-graph.js` controller listens for `htmx:afterSwap` on the
+wrapper, snapshots `cy.pan()` + `cy.zoom()`, replaces the elements
+via `cy.batch(...)`, re-runs the active layout, then restores the
+pan + zoom so the operator's pinned viewport survives the refresh.
+
+### Error surface
+
+| Status | Reason | Template |
+| --- | --- | --- |
+| 404 | Unknown name (or kind-pinned anchor missing in this tenant) | `topology/_graph_overlay_error.html` (full page) / `topology/_graph_overlay_error_fragment.html` (HX-Request) |
+| 409 | Ambiguous bare name resolves to multiple kinds | Same templates as 404 with a kind-disambiguation hint |
+
+The error fragment keeps the polling trigger active so a transient
+hard-delete + re-create recovers automatically on the next tick.
+
+### Tests
+
+`backend/tests/test_ui_topology_queries.py` covers every acceptance
+criterion: dependents/dependencies subgraph rendering,
+depth-bounding, path overlay + highlighted edges, polling endpoint
+shape (HTMX fragment), cross-tenant isolation (both overlay
+flavours), 404 unknown-name, 409 ambiguous-name, drawer cross-link
+to `?from=`. 17 tests, all pass against the SQLite fixture.
+
 ## References
 
 - v0.2 decisions [#9 / #10 / #11](../planning/v0.2-decisions.md).
 - HTMX 2 — https://htmx.org/
+- HTMX `hx-trigger="every Ns"` — https://htmx.org/attributes/hx-trigger/
+- HTMX `htmx:afterSwap` event — https://htmx.org/events/#htmx:afterSwap
 - Jinja2 — https://jinja.palletsprojects.com/
 - Tailwind CSS 4 — https://tailwindcss.com/blog/tailwindcss-v4
 - Tailwind 4 standalone CLI install — https://tailwindcss.com/docs/installation
 - DaisyUI 5 install — https://daisyui.com/docs/install/
 - Alpine.js — https://alpinejs.dev/
 - Cytoscape.js — https://js.cytoscape.org/
+- Cytoscape `cy.pan` / `cy.zoom` — https://js.cytoscape.org/#cy.pan
+- Cytoscape selector classes — https://js.cytoscape.org/#selectors/class
 - FastAPI `StaticFiles` (consumed by T5) — https://fastapi.tiangolo.com/tutorial/static-files/


### PR DESCRIPTION
## Summary

Layer focused subgraph + shortest-path overlays on top of the existing `?view=graph` Cytoscape surface (T2 / #881), plus an HTMX 30-second polling refresh so the rendered view stays in sync with the live graph without losing the operator's pan/zoom.

URL contract additions on the graph branch:

- `?from=<name>[&from_kind=<kind>][&depth=N]` -- dependents (reverse) subgraph.
- `?from=<name>&direction=dependencies[...]` -- dependencies (forward) subgraph.
- `?from=A&to=B[&max_hops=N]` -- shortest unweighted path with highlighted edges.

Defaults: `depth=3`, `max_hops=8` (matching the substrate G9.1 verb defaults). Unknown name -> 404; ambiguous bare name -> 409 with a kind-disambiguation hint.

### Substrate split

The G9.1 substrate verbs (`find_dependents` / `find_dependencies` / `find_path`) stay the source of truth for the REST + CLI + MCP surfaces. The UI helpers in `meho_backplane.ui.routes.topology.queries` + `path_queries` exist because:

1. **Dialect portability.** The substrate uses PG `WITH RECURSIVE ... CYCLE`; the chassis unit-test fixture uses SQLite. The UI helpers use plain SQLAlchemy ORM `select(...)` so the unit suite covers the route end-to-end.
2. **`tenant_id` + `db_session` shape** matches `list_nodes` (the existing UI substrate) rather than the substrate verbs' `Operator` requirement.
3. **Subgraph emission** -- the substrate returns flat closure lists; Cytoscape needs the edges between visited nodes too.

### Tenant-scoping defense in depth

Every overlay edge query filters `tenant_id` on the edge row AND on both endpoint joins (aliased `from_alias` / `to_alias` on `GraphNode`). Same posture `...graph._fetch_edges_for_nodes` and `...detail._fetch_edges` established. Cross-tenant nodes/edges cannot surface even if a future invariant violation introduced one.

### 30s polling-refresh

The data-island wrapper carries `hx-trigger="every 30s"` + `hx-swap="outerHTML"`. On every tick HTMX issues GET against the same overlay URL with `HX-Request: true`; the route returns just the data-island fragment. `topology-graph.js` listens for `htmx:afterSwap`, snapshots `cy.pan()` / `cy.zoom()`, replaces elements via `cy.batch(...)`, re-runs the active layout, then restores the viewport so the operator's pinned position survives.

## Test plan

- [x] `ruff check src/ tests/` -- clean
- [x] `ruff format --check` -- clean
- [x] `mypy src/` -- clean (294 source files)
- [x] `pytest backend/tests/test_ui_topology_queries.py` -- 17 passed
- [x] `pytest backend/tests/test_ui_topology_graph.py backend/tests/test_ui_topology_table.py` -- 46 passed (existing T1 / T2 suites still green; 2 tests updated for the new URL contract)
- [x] Code-quality hook `--diff` -- 0 blockers, 13 warnings (all under 600-line file ceiling / 100-line function ceiling)
- [x] `cli && make snapshot-openapi && make generate` -- regenerated for the new query params
- [x] Acceptance criterion: `?from=<name>&depth=N` returns the correct dependents subgraph (test_dependents_subgraph_returns_reverse_closure)
- [x] Acceptance criterion: `?from=<name>&direction=dependencies&depth=N` returns the correct dependencies subgraph (test_dependencies_subgraph_returns_forward_closure)
- [x] Acceptance criterion: `?from=A&to=B` returns + highlights the path (test_path_overlay_returns_shortest_path_with_highlighted_edges)
- [x] Acceptance criterion: drawer "Show dependents" drives `?from=` overlay (test_node_drawer_dependents_link_uses_from_query_param)
- [x] Acceptance criterion: polling-refresh fragment shape (test_htmx_fragment_returns_data_island_wrapper_only)
- [x] Acceptance criterion: cross-tenant isolation (test_dependents_overlay_isolates_other_tenants_graph, test_path_overlay_isolates_other_tenants_graph)
- [x] Acceptance criterion: ambiguous name -> 409 (test_dependents_ambiguous_name_returns_409)
- [x] Acceptance criterion: unknown name -> 404 (test_dependents_unknown_name_returns_404, test_path_overlay_unknown_endpoint_returns_404)

## Out of scope

- Live SSE graph updates -- v0.3 per #342 (polling-refresh ships v0.2 here).
- Topology editing -- not in scope for G10.5.
- Path-with-context rendering -- the path overlay shows only the path nodes/edges to escape the 500-node hairball problem the cap exists to prevent.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #882


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added overlay visualizations for topology graph showing dependents and dependencies of selected nodes
  * Added shortest-path overlay to display connections between two specific nodes
  * Graph data automatically refreshes every 30 seconds during overlay operations
  * Added error handling with user guidance for ambiguous or unknown node lookups

* **Documentation**
  * Added topology overlay feature documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1049?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->