### PR TITLE
fix(topology): reconcile soft-delete reachability — docs + UI overlay parity (G9.1-T4 drift)

### DIFF
--- a/backend/alembic/versions/0007_create_topology_graph.py
+++ b/backend/alembic/versions/0007_create_topology_graph.py
@@ -138,8 +138,9 @@ SQLite (dev/test via aiosqlite).
   nullable with no default on either dialect -- the refresh service
   (T3) populates it on every observation, and *sets it back to NULL*
   once a node has been absent past the configured threshold (the
-  spec's soft-delete signal, kept queryable by G9.3 history replay
-  but invisible to default queries).
+  spec's soft-delete signal, kept queryable by the G9.3 history surface
+  and still reachable by the traversal verbs, though excluded by
+  default from the list verbs ``list_nodes`` / ``list_edges``).
 * ``properties`` -- portable JSON -> JSONB via
   :func:`sqlalchemy.JSON.with_variant`. Server default ``'{}'::jsonb``
   on PG matches the ORM ``default=dict`` so out-of-band PG inserts

--- a/backend/src/meho_backplane/topology/query.py
+++ b/backend/src/meho_backplane/topology/query.py
@@ -632,10 +632,14 @@ _MAX_EDGE_LIMIT = 1000
 # set deterministically and a two-page sweep reassembles to the unpaged
 # set with no gaps or duplicates.
 #
-# Soft-deleted edges (``e.last_seen IS NULL``) are excluded by default —
-# same default as traversal, which filters them out implicitly via the
-# ``last_seen`` column not appearing in its projection. Including them
-# would surface stale relationships in an inventory view.
+# Soft-deleted edges (``e.last_seen IS NULL``) are excluded from this
+# listing by the ``e.last_seen IS NOT NULL`` predicate below — surfacing
+# them would clutter an inventory view with stale relationships. This is
+# the *opposite* of the traversal verbs (``find_dependents`` /
+# ``find_dependencies`` / ``find_path``), which do not filter
+# ``last_seen`` at all, so a soft-deleted node stays reachable
+# (last-refresh-wins); see ``docs/architecture/topology.md``
+# §Soft-delete semantics.
 #
 # The ``conflicts_only`` predicate guards against the
 # ``jsonb_array_length`` non-array raise: the

--- a/backend/src/meho_backplane/ui/routes/topology/path_queries.py
+++ b/backend/src/meho_backplane/ui/routes/topology/path_queries.py
@@ -92,7 +92,6 @@ async def _bidirectional_neighbours(
             GraphEdge.tenant_id == tenant_id,
             from_alias.tenant_id == tenant_id,
             to_alias.tenant_id == tenant_id,
-            GraphEdge.last_seen.is_not(None),
             # Substrate parity: drop edges curated as superseded so the
             # UI path overlay's reachability matches what the CLI/REST
             # find_path verb returns. The ``or_(.is_(None), ==

--- a/backend/src/meho_backplane/ui/routes/topology/queries.py
+++ b/backend/src/meho_backplane/ui/routes/topology/queries.py
@@ -226,7 +226,10 @@ async def resolve_anchor(
       :class:`NodeNotFoundError`; 1 row returns it; >1 rows raises
       :class:`AmbiguousNodeError` with the candidate kinds.
 
-    Soft-deleted nodes (``last_seen IS NULL``) are excluded.
+    Soft-deleted nodes (``last_seen IS NULL``) are included -- the
+    overlay mirrors the substrate traversal verbs, which do not filter
+    ``last_seen`` (a soft-deleted node stays reachable, last-refresh-
+    wins; #584).
 
     Exposed (not name-mangled with a leading underscore) because the
     sibling :mod:`...path_queries` module needs to resolve both
@@ -235,7 +238,6 @@ async def resolve_anchor(
     stmt = select(GraphNode).where(
         GraphNode.tenant_id == tenant_id,
         GraphNode.name == name,
-        GraphNode.last_seen.is_not(None),
     )
     if kind is not None:
         stmt = stmt.where(GraphNode.kind == kind)
@@ -264,7 +266,9 @@ async def _bfs_neighbours(
     returns the destination endpoint -- the "dependencies" semantic.
 
     The triple tenant-scoping (edge + both endpoints) is the
-    defense-in-depth posture. Soft-deleted edges excluded.
+    defense-in-depth posture. Soft-deleted edges (``last_seen IS
+    NULL``) are included -- the overlay mirrors the substrate traversal
+    verbs, which do not filter ``last_seen`` (last-refresh-wins; #584).
 
     Superseded edges (``properties->>'superseded_by' IS NOT NULL``) are
     excluded to mirror the G9.1 substrate traversal verbs
@@ -288,7 +292,6 @@ async def _bfs_neighbours(
             GraphEdge.tenant_id == tenant_id,
             from_alias.tenant_id == tenant_id,
             to_alias.tenant_id == tenant_id,
-            GraphEdge.last_seen.is_not(None),
             # Mirror the substrate's superseded-edge exclusion -- the
             # PG raw-SQL ``e.properties->>'superseded_by' IS NULL``
             # idiom translated to dialect-portable ORM. PG returns SQL

--- a/backend/tests/integration/test_topology_g91_acceptance.py
+++ b/backend/tests/integration/test_topology_g91_acceptance.py
@@ -511,8 +511,8 @@ async def test_scenario4_soft_delete_retains_row(stable_connector: None) -> None
     flipped to stop reporting the ``vm`` + ``host`` nodes; a second
     refresh must soft-delete (not hard-delete) them: the rows stay in
     ``graph_node`` with ``last_seen IS NULL``, and the refresh diff
-    counts them as ``removed`` exactly once. G9.3 ships the history
-    surface that queries those retained rows; T8 asserts the row
+    counts them as ``removed`` exactly once. G9.3 (now shipped) provides
+    the history surface that queries those retained rows; T8 asserts the row
     survives soft-delete and that a *re-discovery* revives it (clears
     ``last_seen`` back to a timestamp on the same row, no re-insert).
 
@@ -566,7 +566,7 @@ async def test_scenario4_soft_delete_retains_row(stable_connector: None) -> None
     assert by_name["host-sd-target"] is None
     assert by_name["sd-target"] is not None  # still discovered
 
-    # Actual G9.1 contract: the traversal CTE does not yet filter
+    # Actual G9.1 contract: the traversal CTE does not filter
     # soft-deleted rows, so the dropped nodes are still reachable. The
     # load-bearing acceptance fact is that the rows were *retained*
     # (asserted above) for G9.3 to query — not that they vanish from

--- a/backend/tests/integration/test_topology_g91_acceptance.py
+++ b/backend/tests/integration/test_topology_g91_acceptance.py
@@ -518,11 +518,12 @@ async def test_scenario4_soft_delete_retains_row(stable_connector: None) -> None
 
     Note on read-verb visibility: the G9.1-T4 traversal CTE does **not**
     filter ``last_seen IS NULL`` — a soft-deleted node remains reachable
-    by ``find_dependents`` / ``find_dependencies`` until G9.3 layers a
-    history-aware read on top. This test pins the *actual* shipped
+    by ``find_dependents`` / ``find_dependencies`` / ``find_path``.
+    Point-in-time visibility is the separate G9.3 history/diff/timeline
+    surface, not a traversal filter. This test pins the *actual* shipped
     contract (row retained + revivable), not an aspirational
-    invisible-after-delete one; the divergence is recorded as an
-    adjacent finding on #456.
+    invisible-after-delete one; the docs were reconciled to this across
+    all surfaces (codebase/architecture/onboarding + UI BFS) by #584.
     """
     await _insert_target(tenant_id=TENANT_A_ID, name="sd-target")
     sm = get_sessionmaker()

--- a/backend/tests/test_ui_topology_queries.py
+++ b/backend/tests/test_ui_topology_queries.py
@@ -140,6 +140,7 @@ def _seed_node(
     name: str,
     target_id: uuid.UUID | None = None,
     discovered_by: str = "test",
+    soft_deleted: bool = False,
 ) -> uuid.UUID:
     node_id = uuid.uuid4()
 
@@ -156,7 +157,7 @@ def _seed_node(
                     properties={},
                     discovered_by=discovered_by,
                     first_seen=datetime.now(UTC),
-                    last_seen=datetime.now(UTC),
+                    last_seen=None if soft_deleted else datetime.now(UTC),
                 ),
             )
 
@@ -172,6 +173,7 @@ def _seed_edge(
     kind: str = "runs-on",
     source: str = "auto",
     properties: dict[str, object] | None = None,
+    soft_deleted: bool = False,
 ) -> uuid.UUID:
     edge_id = uuid.uuid4()
     edge_properties: dict[str, object] = dict(properties) if properties else {}
@@ -190,7 +192,7 @@ def _seed_edge(
                     properties=edge_properties,
                     discovered_by="test",
                     first_seen=datetime.now(UTC),
-                    last_seen=datetime.now(UTC),
+                    last_seen=None if soft_deleted else datetime.now(UTC),
                 ),
             )
 
@@ -787,6 +789,88 @@ def test_path_overlay_excludes_superseded_edges() -> None:
     # ``properties->>'superseded_by' IS NULL`` predicate on both
     # bidirectional arms.
     assert "no path found" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Substrate parity: soft-deleted nodes/edges (last_seen IS NULL) are
+# INCLUDED in both overlays. The substrate traversal verbs do not filter
+# last_seen -- a soft-deleted row stays reachable (last-refresh-wins;
+# #584). Regression guard against the UI BFS re-introducing a
+# ``last_seen IS NOT NULL`` filter, which would hide rows the substrate
+# REST/CLI/MCP closure still returns. (The full-inventory graph/table/
+# drawer views DO exclude soft-deleted rows -- those mirror list_nodes /
+# list_edges, which filter; only the traversal-parity BFS does not.)
+# ---------------------------------------------------------------------------
+
+
+def test_dependents_overlay_includes_soft_deleted_node() -> None:
+    """A soft-deleted dependent (last_seen NULL) still appears in the overlay.
+
+    vm-1 was dropped by a refresh reconcile -- its row and the edge into
+    host-1 carry ``last_seen IS NULL``. The substrate
+    ``find_dependents("host-1")`` still returns vm-1 (the traversal CTE
+    has no ``last_seen`` predicate; #584), so the UI overlay must too.
+    """
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    host = _seed_node(tenant_id=_TENANT_A, kind="host", name="host-1")
+    vm = _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-1", soft_deleted=True)
+    _seed_edge(
+        tenant_id=_TENANT_A,
+        from_node_id=vm,
+        to_node_id=host,
+        kind="runs-on",
+        soft_deleted=True,
+    )
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&from=host-1")
+    assert response.status_code == 200, response.text
+
+    elements = _extract_data_island(response.text, "topology-graph-data")
+    assert isinstance(elements, list)
+    nodes = [e for e in elements if isinstance(e, dict) and e.get("group") == "nodes"]
+    node_names = {n["data"]["name"] for n in nodes}
+    assert node_names == {"host-1", "vm-1"}
+
+
+def test_path_overlay_includes_soft_deleted_endpoint() -> None:
+    """The path overlay resolves + routes through a soft-deleted endpoint.
+
+    ``target-app -> vm-1`` where vm-1 *and* the edge are soft-deleted.
+    ``resolve_anchor`` must still find the vm-1 endpoint and the
+    bidirectional BFS must traverse the soft-deleted edge -- mirroring
+    the substrate ``find_path``, which does not filter ``last_seen``
+    (#584).
+    """
+    _seed_tenant_row(_TENANT_A, "tenant-a")
+    target = _seed_node(tenant_id=_TENANT_A, kind="target", name="target-app")
+    vm = _seed_node(tenant_id=_TENANT_A, kind="vm", name="vm-1", soft_deleted=True)
+    _seed_edge(
+        tenant_id=_TENANT_A,
+        from_node_id=target,
+        to_node_id=vm,
+        kind="runs-on",
+        soft_deleted=True,
+    )
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/topology?view=graph&from=target-app&to=vm-1")
+    assert response.status_code == 200, response.text
+    assert "no path found" not in response.text
+
+    body = response.text
+    elements = _extract_data_island(body, "topology-graph-data")
+    assert isinstance(elements, list)
+    nodes = [e for e in elements if isinstance(e, dict) and e.get("group") == "nodes"]
+    node_names = {n["data"]["name"] for n in nodes}
+    assert node_names == {"target-app", "vm-1"}
+    edges = [e for e in elements if isinstance(e, dict) and e.get("group") == "edges"]
+    highlighted_edges = [e for e in edges if "highlight" in str(e.get("classes", ""))]
+    assert len(highlighted_edges) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/docs/architecture/topology.md
+++ b/docs/architecture/topology.md
@@ -221,12 +221,15 @@ A refresh that no longer sees a previously-discovered node or edge
   back to a timestamp (the row is revived in place, not re-inserted —
   the `(tenant_id, kind, name)` natural key is stable, so the tenant's
   node count does not grow on revival).
-- **G9.1 read-verb visibility caveat.** The G9.1-T4 traversal CTE does
-  **not** yet filter `last_seen IS NULL` — a soft-deleted node is still
-  reachable by `find_dependents` / `find_dependencies` / `find_path`
-  until G9.3 layers a history-aware (point-in-time) read on top. In
-  G9.1, soft-delete is purely a *retention* mechanism for the future
-  history surface, not an immediate visibility change. Operators
+- **Read-verb visibility caveat.** The G9.1-T4 traversal CTE does
+  **not** filter `last_seen IS NULL` — a soft-deleted node is still
+  reachable by `find_dependents` / `find_dependencies` / `find_path`.
+  Point-in-time ("when did this disappear?") reads are served by the
+  separate G9.3 history/diff/timeline verbs over the retained rows;
+  G9.3 ([#365](https://github.com/evoila/meho/issues/365)) did not add
+  `last_seen` filtering to the traversal CTE. Soft-delete is purely a
+  *retention* mechanism, not an immediate visibility change for the
+  traversal verbs. Operators
   reading blast radius in v0.2 should treat the graph as
   last-refresh-wins; a stale edge persists until the next successful
   refresh of its owning target re-derives the snapshot.

--- a/docs/architecture/topology.md
+++ b/docs/architecture/topology.md
@@ -229,10 +229,9 @@ A refresh that no longer sees a previously-discovered node or edge
   G9.3 ([#365](https://github.com/evoila/meho/issues/365)) did not add
   `last_seen` filtering to the traversal CTE. Soft-delete is purely a
   *retention* mechanism, not an immediate visibility change for the
-  traversal verbs. Operators
-  reading blast radius in v0.2 should treat the graph as
-  last-refresh-wins; a stale edge persists until the next successful
-  refresh of its owning target re-derives the snapshot.
+  traversal verbs. Operators reading blast radius in v0.2 should treat
+  the graph as last-refresh-wins; a stale edge persists until the next
+  successful refresh of its owning target re-derives the snapshot.
 
 ## Performance expectations
 

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -1301,8 +1301,17 @@ shape.
   resolution is deferred to the CLI/MCP fronts (T6/T7).
 - Streaming refresh progress for very large topologies — v0.2 is
   single-shot; deferred per Initiative #363.
-- Graph history / time-travel — soft-delete here only makes a node
-  invisible to default queries; the history surface is G9.3.
+- Soft-delete is retention-only for the traversal verbs —
+  `find_dependents` / `find_dependencies` / `find_path` do **not**
+  filter `last_seen IS NULL`, so a soft-deleted node stays reachable
+  (last-refresh-wins). Only the list verbs (`list_edges` /
+  `list_nodes`) exclude soft-deleted rows by default. Point-in-time
+  visibility ("when did this disappear?") is answered by the dedicated
+  history/diff/timeline verbs (G9.3,
+  [#365](https://github.com/evoila/meho/issues/365)) over the retained
+  rows — G9.3 did not add `last_seen` filtering to the traversal CTE.
+  See `docs/architecture/topology.md` §Soft-delete semantics; pinned by
+  `test_scenario4_soft_delete_retains_row`.
 - Per-connector `discover_topology` overrides — each G3.x Initiative.
 - The advisory lock is a multi-replica stampede guard only; a single
   process serialises naturally and the SQLite test path no-ops it.

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -960,8 +960,17 @@ MCP surfaces.
 Every UI BFS module mirrors the substrate's edge-traversal
 predicates so the same closure is reported on both surfaces:
 
-* **Soft-delete exclusion** -- `GraphEdge.last_seen IS NOT NULL`
-  on every edge query, matching the substrate's `_TRAVERSAL_SQL`.
+* **Soft-delete (not filtered)** -- the BFS modules do *not* filter
+  `last_seen`, matching the substrate's `_TRAVERSAL_SQL` (which also
+  does not): a soft-deleted node stays reachable on both surfaces
+  (last-refresh-wins; point-in-time visibility is the separate G9.3
+  history/diff/timeline verbs, not a traversal filter). Regression
+  test: `test_dependents_overlay_includes_soft_deleted_node`. (The BFS
+  previously applied `last_seen IS NOT NULL` on the mistaken belief the
+  substrate did too; #584 removed it to restore real parity. Note the
+  *full-inventory* graph/table/drawer queries still exclude
+  soft-deleted rows -- those mirror `list_nodes` / `list_edges`, which
+  do filter, not the traversal verbs.)
 * **Superseded-edge exclusion** -- edges carrying
   `properties->>'superseded_by' IS NOT NULL` are dropped from
   both the dependents/dependencies BFS and the bidirectional

--- a/docs/cross-repo/topology-onboarding.md
+++ b/docs/cross-repo/topology-onboarding.md
@@ -133,11 +133,13 @@ than this, the likely cause is a missing/disabled traversal index on
   [topology-annotation.md](./topology-annotation.md).
 - **History (G9.3, [#365](https://github.com/evoila/meho/issues/365)).**
   A refresh that no longer sees a node soft-deletes it (`last_seen`
-  cleared, the row is retained — never SQL-deleted). In G9.1 a
-  soft-deleted node is still reachable by the query verbs (the
-  traversal does not yet filter `last_seen`); soft-delete is purely a
-  retention mechanism for history. Treat the graph as
-  last-refresh-wins: a stale edge persists until the next successful
-  refresh of its owning target re-derives the snapshot. G9.3 ships
-  `meho topology history|diff|timeline` plus the history-aware
-  point-in-time read to query when a resource appeared or disappeared.
+  cleared, the row is retained — never SQL-deleted). A soft-deleted
+  node is still reachable by the traversal query verbs
+  (`find_dependents` / `find_dependencies` / `find_path` do not filter
+  `last_seen`); soft-delete is purely a retention mechanism. Treat the
+  graph as last-refresh-wins: a stale edge persists until the next
+  successful refresh of its owning target re-derives the snapshot. G9.3
+  (now shipped) adds the *separate* `meho topology history|diff|timeline`
+  point-in-time verbs over the retained rows to query when a resource
+  appeared or disappeared — it does not add `last_seen` filtering to the
+  traversal verbs.


### PR DESCRIPTION
## Summary

Reconciles the topology **soft-delete reachability** semantics across every surface — and, after independent review, fixes the underlying code so the surfaces actually agree.

**#584 core (docs):** `docs/codebase/topology.md` claimed soft-delete *"only makes a node invisible to default queries"*, contradicting the G9.1-T4 traversal verbs (`find_dependents` / `find_dependencies` / `find_path`), which never filter `last_seen IS NULL` — a soft-deleted node **stays reachable** (last-refresh-wins). Corrected, and aligned `docs/architecture/topology.md` (its *"until G9.3 layers a point-in-time read"* framing drifted once #365/G9.3 closed).

**Independent-review finding (code):** the `_LIST_EDGES_SQL` comment in `query.py` falsely claimed the traversal "filters [soft-deleted] out implicitly" — corrected (comment-only).

**Behavioral fix (UI ↔ substrate parity):** the UI dependents/dependencies/path BFS filtered `last_seen IS NOT NULL` (`resolve_anchor` + `_bfs_neighbours` + `_bidirectional_neighbours`) on the mistaken belief the substrate did too, so the **UI graph hid soft-deleted nodes the CLI/MCP/REST traversal still returns** — exactly the divergence ui.md's "substrate-parity invariants" section forbids. Removed the three UI filters so the overlay matches the substrate. The full-inventory graph/table/drawer views keep filtering (those mirror `list_nodes`/`list_edges`, which *do* filter). Added two regression tests.

**Framing cleanup:** the cross-repo onboarding doc + the G9.1 acceptance-test docstring carried the same now-stale "G9.3 ships / until G9.3" framing; aligned.

## Test plan
- [x] `find_dependents`/`find_dependencies`/`find_path` have zero `last_seen` filtering (query.py traversal CTEs).
- [x] `test_scenario4_soft_delete_retains_row` asserts soft-deleted nodes still returned by `find_dependencies`.
- [x] UI topology suite: **47 passed** (incl. 2 new soft-delete regression tests).
- [x] `mypy src/` strict — Success, 295 files.
- [x] `ruff check` + `ruff format --check` — clean.
- [x] `code-quality.py --diff` — 0 blockers.

## Surfaces now in agreement
codebase doc · architecture doc · T4 traversal code (+ comment) · UI BFS overlay · cross-repo onboarding · G9.1 acceptance-test docstring.

<!-- auto-implement-issue: fresh+continue, behavior unify per maintainer direction -->

Closes #584


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed topology path and dependency overlays to properly traverse soft-deleted nodes and edges, enabling complete path discovery and visualization in overlays.

* **Documentation**
  * Clarified that traversal queries include soft-deleted topology elements, while list operations exclude them, establishing consistent visibility semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1068?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->