### PR TITLE
feat(agent-runtime): G11.1-T7 wire agent-invokes-agent into the live AgentInvoker

### DIFF
--- a/backend/src/meho_backplane/agent/invocation.py
+++ b/backend/src/meho_backplane/agent/invocation.py
@@ -61,6 +61,13 @@ the operator's tenant owns (cross-tenant run ids surface as
 :class:`AgentRunNotFoundError`).
 """
 
+# code-quality-allow: file-size — this is the agent-runtime orchestration
+# module. The T7 #1067 composition wiring (_resolve_child_definition /
+# _record_child_run) reuses the invoker's _to_agent_definition + the module's
+# _split_model_id, so it belongs here; pulling it (or the pre-existing error
+# classes / dataclasses) into a separate file fragments a cohesive unit or
+# introduces an import cycle with no readability gain.
+
 from __future__ import annotations
 
 import asyncio
@@ -71,6 +78,7 @@ from typing import Final
 
 import structlog
 
+from meho_backplane.agent.invoke import current_agent_run_id_var
 from meho_backplane.agent.run import (
     AgentDefinition,
     AgentRun,
@@ -231,7 +239,18 @@ class AgentInvoker:
     """
 
     def __init__(self, *, runtime: AgentRun | None = None) -> None:
-        self._runtime: AgentRun = runtime if runtime is not None else PydanticAgentRun()
+        # The default runtime wires agent-invokes-agent composition (G11.1-T7
+        # #1067): the live surface owns the tenant-scoped child resolver + the
+        # child-run recorder, so a run started here can invoke another agent.
+        # An injected runtime (tests) controls its own wiring.
+        self._runtime: AgentRun = (
+            runtime
+            if runtime is not None
+            else PydanticAgentRun(
+                child_agent_resolver=_resolve_child_definition,
+                child_run_recorder=_record_child_run,
+            )
+        )
         self._store: dict[uuid.UUID, _RunState] = {}
 
     # -- definition resolution -------------------------------------------
@@ -361,21 +380,31 @@ class AgentInvoker:
         re-raises — a failed run is a recorded ``failed`` row, not a crashed
         background task (an unhandled task exception would surface only as a
         log warning at GC time).
+
+        Binds :data:`~meho_backplane.agent.invoke.current_agent_run_id_var` to
+        this run's id for the loop's duration, so the first ``invoke_agent``
+        call records its child with this run as the parent (the lineage key).
+        The task carries its own contextvar copy (``asyncio.create_task``
+        snapshots the context), so the bind is isolated to this run.
         """
+        run_token = current_agent_run_id_var.set(run_id)
         try:
-            handle = self._runtime.start(definition, operator, inputs)
-            result = await self._runtime.result(handle)
-        except AgentRunError as exc:
-            await self._finalize_run(run_id, output=None, error=str(exc))
-            return
-        except asyncio.CancelledError:
-            # A cancel writes its own terminal row via cancel_run; leave it.
-            raise
-        except Exception as exc:
-            _log.warning("agent_invoke_unexpected_failure", run_id=str(run_id), error=str(exc))
-            await self._finalize_run(run_id, output=None, error=str(exc))
-            return
-        await self._finalize_run(run_id, output=_project_output(result.output), error=None)
+            try:
+                handle = self._runtime.start(definition, operator, inputs)
+                result = await self._runtime.result(handle)
+            except AgentRunError as exc:
+                await self._finalize_run(run_id, output=None, error=str(exc))
+                return
+            except asyncio.CancelledError:
+                # A cancel writes its own terminal row via cancel_run; leave it.
+                raise
+            except Exception as exc:
+                _log.warning("agent_invoke_unexpected_failure", run_id=str(run_id), error=str(exc))
+                await self._finalize_run(run_id, output=None, error=str(exc))
+                return
+            await self._finalize_run(run_id, output=_project_output(result.output), error=None)
+        finally:
+            current_agent_run_id_var.reset(run_token)
 
     # -- public surface ---------------------------------------------------
 
@@ -517,6 +546,11 @@ class AgentInvoker:
 
         terminal_output: dict[str, object] | None = None
         terminal_error: str | None = None
+        # Bind the lineage contextvar so an ``invoke_agent`` call inside the
+        # streamed run records its child against this run (G11.1-T7 #1067). The
+        # stream runs inline in the SSE response coroutine, so the token reset
+        # in ``finally`` keeps the bind from leaking past the stream.
+        run_token = current_agent_run_id_var.set(run_id)
         try:
             async for event in self._runtime.stream_events(definition, operator, inputs, run_id):
                 if event.kind is AgentRunEventKind.FINAL:
@@ -525,7 +559,79 @@ class AgentInvoker:
                     terminal_error = str(event.data.get("error"))
                 yield run_id, event
         finally:
+            current_agent_run_id_var.reset(run_token)
             await self._finalize_run(run_id, output=terminal_output, error=terminal_error)
+
+
+async def _resolve_child_definition(
+    operator: Operator,
+    agent_name: str,
+) -> AgentDefinition | None:
+    """Resolve a child agent name to a runnable seam definition, or ``None``.
+
+    The :class:`~meho_backplane.agent.invoke.ChildAgentResolver` the live
+    invoker injects into the seam (G11.1-T7 #1067). Looks the definition up
+    scoped to the operator's tenant via :class:`AgentDefinitionService`, so a
+    cross-tenant or unknown name simply does not resolve; a ``enabled=False``
+    definition also returns ``None``. ``invoke_agent`` surfaces a ``None`` as a
+    structured :class:`~pydantic_ai.ModelRetry`. Mirrors
+    :meth:`AgentInvoker._load_definition` but returns ``None`` instead of
+    raising, per the resolver protocol.
+    """
+    service = AgentDefinitionService()
+    entry = await service.get(operator.tenant_id, agent_name)
+    if entry is None or not entry.enabled:
+        return None
+    return AgentInvoker._to_agent_definition(entry)
+
+
+async def _record_child_run(
+    *,
+    operator: Operator,
+    definition: AgentDefinition,
+    parent_run_id: uuid.UUID | None,
+) -> uuid.UUID:
+    """Persist a child ``agent_run`` row linked to its parent; return its id.
+
+    The :class:`~meho_backplane.agent.invoke.ChildRunRecorder` the live invoker
+    injects (G11.1-T7 #1067). The seam value object carries neither the
+    persisted ``agent_definition_id`` nor the ``model_tier`` the run row
+    records, so the definition is re-resolved by ``(tenant, name)`` to recover
+    them; the row is then created with ``trigger=agent-invoked`` + the parent
+    linkage and transitioned to ``running``, committed in its own transaction
+    so the child run is inspectable while it executes (mirrors
+    :meth:`AgentInvoker._create_run_row`).
+
+    The row's *terminal* state is deliberately not written here: the
+    ``ChildRunRecorder`` protocol returns only the new id, and the child loop's
+    success/failure surfaces through the parent run. Finalizing child rows to
+    ``succeeded`` / ``failed`` is a follow-up — it needs a protocol extension
+    (a finalizer hook), out of #1067's "wire the existing mechanism" scope. A
+    definition deleted between resolution and recording raises
+    :class:`~meho_backplane.agent.run.AgentRunError`, surfaced by
+    ``invoke_agent`` as a ``ModelRetry``.
+    """
+    service = AgentDefinitionService()
+    entry = await service.get(operator.tenant_id, definition.name)
+    if entry is None:
+        raise AgentRunError(f"agent definition {definition.name!r} no longer exists")
+    settings = get_settings()
+    provider, model = _split_model_id(settings.agent_default_model)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = await run_lifecycle.create_run(
+            session,
+            tenant_id=operator.tenant_id,
+            identity_sub=operator.sub,
+            trigger=AgentRunTrigger.AGENT_INVOKED,
+            model_tier=entry.model_tier,
+            agent_definition_id=entry.id,
+            parent_run_id=parent_run_id,
+        )
+        await run_lifecycle.start_run(session, row, provider=provider, model=model)
+        child_run_id = row.id
+        await session.commit()
+    return child_run_id
 
 
 def _row_to_view(row: AgentRunRow) -> AgentRunStatusView:

--- a/backend/tests/test_agent_invocation.py
+++ b/backend/tests/test_agent_invocation.py
@@ -38,12 +38,15 @@ from uuid import UUID, uuid4
 import pytest
 from pydantic_ai.messages import ModelMessage, ModelRequest, ModelResponse, TextPart, ToolCallPart
 from pydantic_ai.models.function import AgentInfo, FunctionModel
+from sqlalchemy import select
 
 from meho_backplane.agent.invocation import (
     AgentDisabledError,
     AgentInvoker,
     AgentNotFoundError,
     AgentRunNotFoundError,
+    _record_child_run,
+    _resolve_child_definition,
 )
 from meho_backplane.agent.run import AgentDefinition, AgentRunEventKind, PydanticAgentRun
 from meho_backplane.agents.schemas import AgentDefinitionCreate, AgentModelTier
@@ -53,7 +56,8 @@ from meho_backplane.connectors.base import Connector
 from meho_backplane.connectors.registry import clear_registry, register_connector_v2
 from meho_backplane.connectors.schemas import FingerprintResult, OperationResult, ProbeResult
 from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import AgentRunStatus, Tenant
+from meho_backplane.db.models import AgentRun as AgentRunRow
+from meho_backplane.db.models import AgentRunStatus, AgentRunTrigger, Tenant
 from meho_backplane.operations import register_typed_operation, reset_dispatcher_caches
 from meho_backplane.retrieval.embedding import EMBEDDING_DIMENSION
 from meho_backplane.settings import get_settings
@@ -127,6 +131,8 @@ async def _seed_definition(
     tenant_id: UUID = _TENANT_A,
     enabled: bool = True,
     toolset: dict[str, Any] | None = None,
+    system_prompt: str = "You read secrets via MEHO operations.",
+    turn_budget: int = 5,
 ) -> None:
     """Insert an agent definition for *tenant_id* via the CRUD service."""
     await _seed_tenants()
@@ -138,9 +144,9 @@ async def _seed_definition(
             name=name,
             identity_ref=f"agent:{name}",
             model_tier=AgentModelTier.STANDARD,
-            system_prompt="You read secrets via MEHO operations.",
+            system_prompt=system_prompt,
             toolset=toolset or {},
-            turn_budget=5,
+            turn_budget=turn_budget,
             enabled=enabled,
         ),
     )
@@ -437,3 +443,170 @@ async def test_failed_loop_records_failed_run() -> None:
     outcome = await invoker.run(_make_operator(), "reader", "go")
     assert outcome.status is AgentRunStatus.FAILED
     assert outcome.error is not None
+
+
+# ---------------------------------------------------------------------------
+# Composition wiring (G11.1-T7 #1067) — agent invokes agent via the live invoker
+# ---------------------------------------------------------------------------
+
+
+def _composing_invoker_with(model: FunctionModel) -> AgentInvoker:
+    """An invoker whose seam carries the FunctionModel *and* the real (DB-backed)
+    child resolver + recorder — exercises the live composition wiring end to end
+    (the default invoker wires the same two callables)."""
+    return AgentInvoker(
+        runtime=PydanticAgentRun(
+            model_factory=lambda: model,
+            child_agent_resolver=_resolve_child_definition,
+            child_run_recorder=_record_child_run,
+        )
+    )
+
+
+def _parent_invokes_child_once(child_name: str, *, child_marker: str) -> FunctionModel:
+    """A model that, as the parent, invokes *child_name* once then answers; as the
+    child (detected by *child_marker* in its system prompt) answers directly."""
+
+    def fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        is_child = any(
+            getattr(part, "part_kind", "") == "system-prompt"
+            and child_marker in getattr(part, "content", "")
+            for message in messages
+            if isinstance(message, ModelRequest)
+            for part in message.parts
+        )
+        if is_child:
+            return ModelResponse(parts=[TextPart("child done")])
+        has_tool_return = any(
+            getattr(part, "part_kind", "") == "tool-return"
+            for message in messages
+            if isinstance(message, ModelRequest)
+            for part in message.parts
+        )
+        if not has_tool_return:
+            return ModelResponse(
+                parts=[ToolCallPart("invoke_agent", {"agent_name": child_name, "inputs": "sub"})]
+            )
+        return ModelResponse(parts=[TextPart("parent done")])
+
+    return FunctionModel(fn)
+
+
+def _always_invoke_model(child_name: str) -> FunctionModel:
+    """A model that calls ``invoke_agent`` every turn — a self-recursive cascade
+    only the depth cap or the shared budget can terminate."""
+
+    def fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[ToolCallPart("invoke_agent", {"agent_name": child_name, "inputs": "recurse"})]
+        )
+
+    return FunctionModel(fn)
+
+
+async def _agent_invoked_rows(tenant_id: UUID) -> list[AgentRunRow]:
+    """All ``agent_run`` rows with ``trigger=agent-invoked`` for *tenant_id*."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(AgentRunRow).where(
+                AgentRunRow.tenant_id == tenant_id,
+                AgentRunRow.trigger == AgentRunTrigger.AGENT_INVOKED.value,
+            )
+        )
+        return list(result.scalars().all())
+
+
+async def test_default_invoker_wires_composition() -> None:
+    """The default invoker builds a runtime with composition wired (#1067).
+
+    The gap #1067 closes: before this, ``AgentInvoker()`` built a bare
+    ``PydanticAgentRun()`` with no child hooks, so ``invoke_agent`` was never
+    registered for a run started via the live surface.
+    """
+    invoker = AgentInvoker()
+    runtime = invoker._runtime
+    assert isinstance(runtime, PydanticAgentRun)
+    assert runtime.child_agent_resolver is _resolve_child_definition
+    assert runtime.child_run_recorder is _record_child_run
+
+
+async def test_resolver_scopes_to_tenant_and_enabled() -> None:
+    """The child resolver returns a definition only for an enabled, same-tenant
+    name; disabled / unknown / cross-tenant names resolve to ``None``."""
+    await _seed_definition(name="reader", tenant_id=_TENANT_A, enabled=True)
+    await _seed_definition(name="parked", tenant_id=_TENANT_A, enabled=False)
+    op_a = _make_operator(tenant_id=_TENANT_A)
+
+    resolved = await _resolve_child_definition(op_a, "reader")
+    assert resolved is not None
+    assert resolved.name == "reader"
+
+    assert await _resolve_child_definition(op_a, "parked") is None  # disabled
+    assert await _resolve_child_definition(op_a, "ghost") is None  # unknown
+
+    op_b = _make_operator(tenant_id=_TENANT_B, sub="op-b")
+    assert await _resolve_child_definition(op_b, "reader") is None  # cross-tenant
+
+
+async def test_invoker_composition_persists_child_run_with_lineage() -> None:
+    """A parent run invoked through the live surface invokes a child; the child
+    ``agent_run`` row is persisted with ``trigger=agent-invoked`` and a
+    ``parent_run_id`` pointing at the parent run (cascade tree reconstructable)."""
+    await _seed_definition(
+        name="parent", toolset={"meta_tools": []}, system_prompt="You are the PARENT."
+    )
+    await _seed_definition(
+        name="child", toolset={"meta_tools": []}, system_prompt="You are the CHILD-AGENT."
+    )
+    invoker = _composing_invoker_with(
+        _parent_invokes_child_once("child", child_marker="CHILD-AGENT")
+    )
+
+    outcome = await invoker.run(_make_operator(), "parent", "delegate")
+
+    assert outcome.status is AgentRunStatus.SUCCEEDED
+    assert outcome.output == {"text": "parent done"}
+
+    children = await _agent_invoked_rows(_TENANT_A)
+    assert len(children) == 1
+    child_row = children[0]
+    assert child_row.parent_run_id == outcome.run_id
+    assert child_row.trigger == AgentRunTrigger.AGENT_INVOKED.value
+    assert child_row.agent_definition_id is not None
+
+
+async def test_invoker_composition_depth_capped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A self-invoking cascade through the live surface is bounded by
+    ``agent_invoke_max_depth`` — the over-depth call never reaches the recorder."""
+    monkeypatch.setenv("AGENT_INVOKE_MAX_DEPTH", "2")
+    get_settings.cache_clear()
+    await _seed_definition(name="loop", toolset={"meta_tools": []})
+    invoker = _composing_invoker_with(_always_invoke_model("loop"))
+
+    outcome = await invoker.run(_make_operator(), "loop", "start")
+
+    assert outcome.status is AgentRunStatus.FAILED
+    children = await _agent_invoked_rows(_TENANT_A)
+    # depth-1 + depth-2 invocations each recorded a child row; the depth-3
+    # invocation was rejected at the depth check, before the recorder ran
+    # (mirrors the seam-level invariant in test_agent_invoke.py).
+    assert len(children) == 2
+    assert all(c.parent_run_id is not None for c in children)
+
+
+async def test_invoker_composition_budget_capped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With a high depth cap, the shared turn budget terminates the cascade — the
+    run fails and the cascade stops well before the depth cap."""
+    monkeypatch.setenv("AGENT_INVOKE_MAX_DEPTH", "8")
+    get_settings.cache_clear()
+    await _seed_definition(name="loop", toolset={"meta_tools": []}, turn_budget=1)
+    invoker = _composing_invoker_with(_always_invoke_model("loop"))
+
+    outcome = await invoker.run(_make_operator(), "loop", "start")
+
+    assert outcome.status is AgentRunStatus.FAILED
+    children = await _agent_invoked_rows(_TENANT_A)
+    # The shared budget (turn_budget=1) tripped far below the depth cap of 8 —
+    # budget, not depth, bounded the cascade.
+    assert len(children) < 8

--- a/docs/codebase/agent-runtime.md
+++ b/docs/codebase/agent-runtime.md
@@ -249,9 +249,13 @@ escalate a cheap-tier agent to a deep-tier agent, but MEHO sees one agent run
 invoking another.
 
 `invoke_agent` is **off by default**. It is appended to a built agent only when
-the `PydanticAgentRun` carries a `child_agent_resolver` (injected at the edge by
-the T4 invocation surface, which owns the tenant-scoped definition lookup). With
-no resolver, the T1/T3 surface is unchanged.
+the `PydanticAgentRun` carries a `child_agent_resolver`. The live `AgentInvoker`
+(T7 #1067) wires it: its default runtime injects `_resolve_child_definition`
+(the tenant-scoped `AgentDefinitionService` lookup) and `_record_child_run` (the
+`agent_run` lineage recorder), and binds `current_agent_run_id_var` to each run's
+id, so a run started from the deployed REST/MCP/CLI surface can invoke another
+agent and the child is recorded against its parent. A runtime built without a
+resolver (the T1/T3 surface, and tests that don't opt in) is unchanged.
 
 ### Two independent bounds keep a cascade from escaping
 
@@ -392,15 +396,13 @@ Foundation) is G11.5.
   work cross-worker. Cancellation of an in-flight loop is the T6
   `cancel_run` path (records durable intent); wiring the loop to observe it
   at a turn boundary is future work.
-- The `invoke_agent` composition tool (T5 #812) is present but **not yet
-  wired into the live T4 invocation surface**: `AgentInvoker` does not inject
-  the `child_agent_resolver` / `ChildRunRecorder` at the edge (T4 #811 and T5
-  #812 were built in parallel), so agent-invokes-agent is reachable via direct
-  seam injection (the T5 tests) but not yet from a deployed run. Wiring the
-  tenant-scoped `AgentDefinitionService` resolver + the `agent_run` lifecycle
-  recorder into the invoker is a follow-up; until then the depth + shared-budget
-  bounds still hold and a recorder-less child run does not persist its lineage
-  row.
+- The child `agent_run` rows the recorder writes (T7 #1067) are created +
+  transitioned to `running` but **not finalized** (`succeeded` / `failed`):
+  the `ChildRunRecorder` protocol returns only the new id, and the child
+  loop's outcome surfaces through the parent run. Finalizing child rows needs
+  a protocol extension (a finalizer hook) — a follow-up. The lineage
+  (`parent_run_id` + `trigger=agent-invoked`) is recorded, so the cascade tree
+  is reconstructable regardless.
 - The identity-permission side of the intersection is the tenant role today.
   When the G11.2 per-op permission model lands, the resolver's role gate is
   the seam to extend (or replace) with the real per-op grant check — the


### PR DESCRIPTION
## Summary

- Wires agent-invokes-agent (T5 #812) into the **live** invocation surface (T4 #811), closing the G11.1 integration gap that #1067 captured: the two were built in parallel, so `AgentInvoker` never injected T5's hooks and `invoke_agent` was unreachable from a deployed run.
- `AgentInvoker`'s default runtime now injects a tenant-scoped child resolver (`_resolve_child_definition`, via `AgentDefinitionService`) and a child-run recorder (`_record_child_run`, via the `agent_run` lifecycle service), and binds `current_agent_run_id_var` to each run's id on every entry point (`run` sync + async, `stream_events`) so a child links to its parent.
- A running agent started via REST/MCP/CLI can now invoke another enabled agent in its tenant; the child is recorded as an `agent_run` row with `trigger=agent-invoked` + `parent_run_id`, and the existing depth (`agent_invoke_max_depth`) + shared-budget bounds hold on the live path.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/` — clean (295 files)
- [x] `test_default_invoker_wires_composition` — the default invoker wires `child_agent_resolver` + `child_run_recorder` (the regression #1067 guards)
- [x] `test_resolver_scopes_to_tenant_and_enabled` — resolver returns a def for an enabled same-tenant name; `None` for disabled / unknown / cross-tenant
- [x] `test_invoker_composition_persists_child_run_with_lineage` — parent invokes child via the live surface; child `agent_run` row persisted with `trigger=agent-invoked` + `parent_run_id == parent.run_id`
- [x] `test_invoker_composition_depth_capped` — self-invoking cascade bounded by `agent_invoke_max_depth=2` (exactly 2 child rows recorded; run fails)
- [x] `test_invoker_composition_budget_capped` — high depth cap + `turn_budget=1`: the shared budget terminates the cascade well below the depth cap
- [x] REST + MCP + lifecycle suites green (64 passed) — no regression in the invoker's consumers

## Out of scope

- **Child-run finalization.** The `ChildRunRecorder` protocol returns only the new id, so child `agent_run` rows are created + set `running` but not transitioned to `succeeded`/`failed` (the child's outcome surfaces through the parent run). A finalizer hook is a follow-up — documented in `docs/codebase/agent-runtime.md`.
- The depth/budget mechanism itself (shipped by #812) — this PR only wires it to the live surface.
- Structured `output_type` from a stored `output_schema` (a separate documented seam-contract follow-up).

Closes #1067
