### PR TITLE
feat(mcp): G6.4-T1 meho.broadcast.recent MCP tool

### DIFF
--- a/backend/src/meho_backplane/mcp/tools/broadcast.py
+++ b/backend/src/meho_backplane/mcp/tools/broadcast.py
@@ -1,0 +1,516 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Agent-facing MCP tools backed by the per-tenant broadcast stream.
+
+G6.4 Initiative (#1090) ships three agent-facing MCP tools that mirror
+the four-step ``broadcast discipline`` documented in the Layer-2
+consumer-onboarding template (PR #1028 / Initiative #229 G7.1):
+
+* T1 (#1091, this module) -- ``meho.broadcast.recent``: read the last
+  N events from ``meho:feed:{tenant_id}`` with optional time-window
+  and filter narrowing. Returns ``{events, next_cursor}``; the cursor
+  round-trips back as ``since`` to walk forward without overlap or
+  gaps.
+* T2 (#1092, follow-on) -- ``meho.broadcast.announce``: agent-authored
+  intent / completion publish.
+* T3 (#1093, follow-on) -- ``meho.broadcast.watch``: long-poll batch
+  read (caller passes ``since_cursor``, server returns ``{events,
+  next_cursor}`` capped at N events).
+
+File-layout convention
+======================
+
+All three tools share this file by design (mirroring the precedent set
+by :mod:`~meho_backplane.mcp.tools.broadcast_overrides` -- three
+broadcast-namespaced tools in one file). Each tool's section is bounded
+by ``# === <tool-name> ===`` / ``# === end <tool-name> ===`` markers so
+T2 and T3 can land in parallel branches with minimal merge-conflict
+surface against this file's body.
+
+Shared helpers (``_default_since_ms`` / ``_parse_since`` /
+``_event_matches`` / ``_list_recent_events_impl``) live above the
+per-tool sections; they're designed for re-use by T2's announce-on-write
+(no read) and T3's watch (same xrange shape, different cursor framing
+contract).
+
+Why the helper isn't shared with the UI history route
+=====================================================
+
+:mod:`~meho_backplane.ui.routes.broadcast.history` ALSO does an
+``xrange`` over ``meho:feed:{tenant_id}``, but its surrounding contract
+differs in two load-bearing ways:
+
+1. **Failure shape.** The UI history route is fail-soft -- a Valkey
+   error returns an empty list so the page degrades to the empty
+   state rather than 500-ing. The MCP tool is fail-loud: invalid
+   ``since`` / ``filter`` / ``limit`` surfaces as JSON-RPC
+   ``-32602`` Invalid Params, and a Valkey teardown bubbles up to
+   the dispatcher's ``-32603`` Internal Error path.
+2. **Window + cursor semantics.** The UI route always fetches a fixed
+   ``now - retention_hours`` window with no filter and no cursor.
+   The MCP tool accepts arbitrary ``since`` (ISO-8601 OR Valkey
+   cursor), enforces a ``[1, 1000]`` limit, and returns a
+   ``next_cursor`` for pagination round-trips.
+
+A shared helper would either compromise the UI's fail-soft contract
+(adding exceptions to the call-site) or compromise the MCP tool's
+strict-failure contract (swallowing invalid input as empty results).
+The duplication cost (one ``xrange`` + parse loop) is small; the
+contract-erosion cost would be larger. The UI route stays as-is; this
+helper serves T1/T2/T3 only. A future tightening that re-unifies the
+two reads MUST first reconcile the failure-shape contract.
+
+PII inheritance
+===============
+
+Every entry on ``meho:feed:{tenant_id}`` was already redacted by
+:func:`~meho_backplane.broadcast.events.redact_payload` at publish
+time (T3, the ``publish-on-write`` hook). This tool reads what's on
+the stream verbatim -- it does NOT re-redact, does NOT mutate the
+payload field, and does NOT call ``redact_payload``. The contract
+flows: publisher redacts -> stream stores redacted -> every reader
+(SSE, UI history, MCP resource, THIS tool) surfaces redacted-as-is.
+
+Tenant scoping is structural
+============================
+
+The stream key is derived exclusively from ``operator.tenant_id``
+(the verified JWT claim). The MCP tool's input schema has NO
+``tenant_id`` argument; cross-tenant reads are structurally
+impossible -- not "checked then rejected" but "no surface that could
+ask for another tenant's stream in the first place". A tenant-A
+operator's call always reads ``meho:feed:{A}``; the path that would
+read ``meho:feed:{B}`` does not exist.
+
+References
+----------
+
+* Parent Initiative: #1090.
+* Parent Goal: #217.
+* Stream key + redaction contract:
+  :mod:`~meho_backplane.broadcast.events`.
+* Sibling tool registration shape:
+  :mod:`~meho_backplane.mcp.tools.broadcast_overrides`.
+* Sibling resource (poll-only snapshot of latest 50):
+  :mod:`~meho_backplane.mcp.resources.tenant_feed`.
+* MCP 2025-06-18 Tools:
+  https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+* Valkey XRANGE (cursor + exclusive ``(`` syntax):
+  https://valkey.io/commands/xrange/
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import UTC, datetime
+from typing import Any, Final, cast
+
+import structlog
+from pydantic import ValidationError
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import BroadcastEvent, get_broadcast_client
+from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
+from meho_backplane.mcp.server import McpInvalidParamsError
+
+__all__: list[str] = []
+
+_log = structlog.get_logger(__name__)
+
+
+# ===========================================================================
+# === shared helpers (T1/T2/T3) ===
+# ===========================================================================
+
+#: Milliseconds per minute. The default ``since`` window is the last 30m;
+#: derived from ``now`` at call time as ``now_ms - 30 * _MS_PER_MINUTE``.
+_MS_PER_MINUTE: Final[int] = 60_000
+
+#: Default look-back window when the caller omits ``since``. Pinned to
+#: 30 minutes per the task body. Smaller than the 24h retention
+#: ceiling so the default response stays bounded even on a busy tenant.
+_DEFAULT_WINDOW_MINUTES: Final[int] = 30
+
+#: ``XRANGE`` end anchor. ``"+"`` is Valkey's "latest available entry"
+#: sentinel, so the pull spans from the ``since`` cursor to the live
+#: tail. Mirrors :mod:`~meho_backplane.ui.routes.broadcast.history`.
+_XRANGE_END: Final[str] = "+"
+
+#: Allowed ``op_class`` filter values. Superset of the four values the
+#: G6.4-T1 issue body example listed (``read|write|credential_read|
+#: audit_query``); we additionally allow ``credential_mint`` and
+#: ``other`` because :func:`~meho_backplane.broadcast.events.classify_op`
+#: emits those too. Restricting to the four would force the agent to
+#: omit the filter when chasing a freshly-minted credential
+#: (``harbor.robot.create``) or an unmapped HTTP route, which defeats
+#: the filter's purpose.
+_OP_CLASS_ENUM: Final[tuple[str, ...]] = (
+    "read",
+    "write",
+    "credential_read",
+    "credential_mint",
+    "audit_query",
+    "other",
+)
+
+
+def _stream_key(tenant_id: object) -> str:
+    """Build the per-tenant Valkey stream key.
+
+    Mirrors :func:`meho_backplane.broadcast.publisher._stream_key` and
+    every reader-side helper (SSE generator, UI history, MCP resource)
+    so the tool reads the same key the publisher writes.
+    """
+    return f"meho:feed:{tenant_id}"
+
+
+def _default_since_ms() -> int:
+    """Return the inclusive bare-millisecond cursor for the default window.
+
+    Default window is :data:`_DEFAULT_WINDOW_MINUTES` minutes before
+    ``now``. A bare ms timestamp as the ``XRANGE`` ``min`` auto-completes
+    the sequence to ``0`` (Valkey semantics), so the range is inclusive
+    of every entry from that millisecond onward. Clamped at ``0`` so a
+    clock skew producing a negative start never reaches Valkey.
+    """
+    now_ms = int(time.time() * 1000)
+    return max(now_ms - _DEFAULT_WINDOW_MINUTES * _MS_PER_MINUTE, 0)
+
+
+def _parse_since(raw: str | None) -> str:
+    """Translate the caller-supplied ``since`` into an ``XRANGE`` ``min``.
+
+    Three shapes accepted:
+
+    * ``None`` -- the default 30-minute window. Returns the bare
+      millisecond timestamp for ``now - 30m`` (inclusive lower bound,
+      Valkey auto-completes to sequence ``0``).
+    * A Valkey stream cursor (``"<ms>-<seq>"``) -- when the caller is
+      paginating a previous response's ``next_cursor``. Returned as
+      ``"(<cursor>"`` to make the lower bound EXCLUSIVE, which is the
+      Valkey-blessed pagination shape (https://valkey.io/commands/xrange/
+      under "Iterating a stream"). Without the ``(``, the next call
+      would re-fetch the last event of the previous page.
+    * An ISO-8601 timestamp (``"2026-05-25T10:00:00Z"`` or any value
+      :meth:`datetime.fromisoformat` accepts on 3.13) -- converted to
+      bare milliseconds (inclusive). The caller's first wall-clock
+      query uses this shape; subsequent paginated calls use the
+      cursor.
+
+    A trailing ``Z`` is normalised to ``+00:00`` for
+    :meth:`datetime.fromisoformat` (the stdlib parser accepts the
+    ``Z`` suffix only from 3.11 onwards; the explicit replace makes
+    the contract version-independent and reads consistently in tests).
+
+    Invalid inputs raise :class:`McpInvalidParamsError`.
+    """
+    if raw is None:
+        return str(_default_since_ms())
+    if _looks_like_stream_cursor(raw):
+        return f"({raw}"
+    return _iso8601_to_min_cursor(raw)
+
+
+def _looks_like_stream_cursor(raw: str) -> bool:
+    """Match the Valkey stream entry id shape ``"<ms>-<seq>"``.
+
+    A stream id is always two integers joined by ``-``. ISO-8601
+    timestamps contain ``T`` / ``:`` / ``Z`` / ``+`` characters that
+    a cursor never carries, so the discriminant is a simple
+    ``<digits>-<digits>`` pattern. Loose enough to accept the
+    bare-ms form when a caller copy-pastes one back, strict enough
+    to reject any ISO-8601 shape.
+    """
+    if "-" not in raw:
+        return False
+    ms_part, sep, seq_part = raw.partition("-")
+    return bool(sep) and ms_part.isdigit() and seq_part.isdigit()
+
+
+def _iso8601_to_min_cursor(raw: str) -> str:
+    """Convert an ISO-8601 timestamp string to a bare-ms inclusive cursor."""
+    iso_normalised = raw.replace("Z", "+00:00") if raw.endswith("Z") else raw
+    try:
+        parsed = datetime.fromisoformat(iso_normalised)
+    except ValueError as exc:
+        raise McpInvalidParamsError(
+            f"since: not a valid ISO-8601 timestamp or Valkey stream cursor: {raw!r}",
+        ) from exc
+    if parsed.tzinfo is None:
+        # Treat a naive timestamp as UTC explicitly; otherwise
+        # ``.timestamp()`` would interpret it in the worker's local
+        # timezone and produce off-by-hours window starts.
+        parsed = parsed.replace(tzinfo=UTC)
+    return str(int(parsed.timestamp() * 1000))
+
+
+def _event_matches(
+    event: BroadcastEvent,
+    *,
+    op_class: str | None,
+    principal: str | None,
+    target: str | None,
+) -> bool:
+    """Return ``True`` iff *event* matches every non-``None`` filter.
+
+    Exact-match semantics on each non-``None`` field; mirrors
+    :func:`meho_backplane.api.v1.feed._passes_filter`. ``target_name`` is
+    nullable on :class:`BroadcastEvent`; an event with no target
+    attribution never passes a non-``None`` *target* filter (the
+    caller explicitly asked for a target -- an untagged event doesn't
+    qualify).
+    """
+    if op_class is not None and event.op_class != op_class:
+        return False
+    if principal is not None and event.principal_sub != principal:
+        return False
+    return not (target is not None and event.target_name != target)
+
+
+def _parse_entry(
+    entry_id: str,
+    fields: dict[str, str],
+    *,
+    stream_key: str,
+) -> BroadcastEvent | None:
+    """Deserialise one ``XRANGE`` entry; log + skip on shape failure.
+
+    Mirrors the safety net in
+    :func:`meho_backplane.mcp.resources.tenant_feed._parse_entry`. The
+    publisher always emits ``{"event": <json>}`` today; this branch
+    is the forward-compat guard against a future Slack-mirror or
+    third-party writer XADD'ing a different shape onto the same key.
+    """
+    raw_event_json = fields.get("event")
+    if not isinstance(raw_event_json, str):
+        _log.warning(
+            "broadcast_recent_skipped_unknown_field_shape",
+            stream_key=stream_key,
+            entry_id=entry_id,
+            fields=list(fields.keys()),
+        )
+        return None
+    try:
+        return BroadcastEvent.model_validate_json(raw_event_json)
+    except ValidationError:
+        _log.warning(
+            "broadcast_recent_skipped_malformed_event",
+            stream_key=stream_key,
+            entry_id=entry_id,
+        )
+        return None
+
+
+async def _list_recent_events_impl(
+    operator: Operator,
+    *,
+    since: str | None,
+    op_class: str | None,
+    principal: str | None,
+    target: str | None,
+    limit: int,
+) -> dict[str, Any]:
+    """Read recent events for *operator*'s tenant; the shared helper T1/T2/T3 call.
+
+    Issues a single ``XRANGE`` over ``meho:feed:{operator.tenant_id}``
+    from the resolved ``since`` lower bound to ``"+"`` (latest),
+    capped at ``limit``. Filters the result in-process (the filter
+    surface area is small; per-event server-side filtering would
+    require a Lua script and isn't worth the complexity for ``limit
+    <= 1000``).
+
+    Returns ``{"events": [<event dict with id>, ...], "next_cursor":
+    <str or None>}``. ``next_cursor`` is the **stream entry id of the
+    last fetched entry** (NOT the last *matched* one) -- the caller
+    can pass it back as ``since`` to walk forward without overlap or
+    gaps even when the filter dropped every entry in this page. The
+    cursor is ``None`` when the stream returned fewer entries than
+    ``limit`` (caller has reached the live tail).
+    """
+    client = get_broadcast_client()
+    stream_key = _stream_key(operator.tenant_id)
+    min_cursor = _parse_since(since)
+    raw_entries = cast(
+        "list[tuple[str, dict[str, str]]]",
+        await client.xrange(
+            stream_key,
+            min=min_cursor,
+            max=_XRANGE_END,
+            count=limit,
+        ),
+    )
+
+    matched: list[dict[str, Any]] = []
+    for entry_id, fields in raw_entries:
+        event = _parse_entry(entry_id, fields, stream_key=stream_key)
+        if event is None:
+            continue
+        if not _event_matches(
+            event,
+            op_class=op_class,
+            principal=principal,
+            target=target,
+        ):
+            continue
+        # ``id`` is the Valkey stream entry id; the cursor a caller
+        # round-trips. The remaining fields come from BroadcastEvent
+        # (including ``event_id`` as the durable UUID). Both coexist
+        # so the agent can correlate a stream-cursor-driven walk
+        # with the canonical audit row via ``event_id`` / ``audit_id``.
+        matched.append({"id": entry_id, **event.model_dump(mode="json")})
+
+    # next_cursor pages forward from the LAST FETCHED entry, not the
+    # last matched one -- a page where every entry was filtered out
+    # still produces a non-null cursor so the caller can keep
+    # walking. When fewer entries came back than the limit, the
+    # caller has reached the live tail; ``None`` signals "no more
+    # pages right now" without precluding a later call.
+    next_cursor: str | None = raw_entries[-1][0] if len(raw_entries) == limit else None
+    return {"events": matched, "next_cursor": next_cursor}
+
+
+# ===========================================================================
+# === meho.broadcast.recent ===
+# ===========================================================================
+
+
+def _extract_filter(arguments: dict[str, Any]) -> tuple[str | None, str | None, str | None]:
+    """Extract the three ``filter.*`` sub-keys, asserting string-or-absent.
+
+    The wire schema's ``filter`` object permits each sub-key to be
+    omitted entirely OR set to a string. Anything else (a number, a
+    list, an object) surfaces as JSON-RPC ``-32602`` -- the JSON
+    Schema validator at the dispatcher layer catches structural
+    violations; this helper picks the typed view for the handler.
+    """
+    filter_obj = arguments.get("filter") or {}
+    if not isinstance(filter_obj, dict):
+        raise McpInvalidParamsError("filter: must be an object when provided")
+    op_class = filter_obj.get("op_class")
+    principal = filter_obj.get("principal")
+    target = filter_obj.get("target")
+    for name, value in (("op_class", op_class), ("principal", principal), ("target", target)):
+        if value is not None and not isinstance(value, str):
+            raise McpInvalidParamsError(f"filter.{name}: must be a string when provided")
+    return op_class, principal, target
+
+
+async def _handler_recent(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """``meho.broadcast.recent`` handler.
+
+    Parses the wire arguments, delegates to
+    :func:`_list_recent_events_impl`, and returns the JSON-shaped
+    response the dispatcher wraps in the MCP ``content`` envelope.
+    Errors surface as :class:`McpInvalidParamsError` (-32602); the
+    JSON Schema validator at the dispatcher already enforces the
+    coarse shape (``limit`` range, ``filter`` object type) so the
+    per-field re-checks here are belt-and-suspenders for the
+    handler's typed contract.
+    """
+    since = arguments.get("since")
+    if since is not None and not isinstance(since, str):
+        raise McpInvalidParamsError("since: must be a string when provided")
+    op_class, principal, target = _extract_filter(arguments)
+    raw_limit = arguments.get("limit", 100)
+    if not isinstance(raw_limit, int) or isinstance(raw_limit, bool):
+        raise McpInvalidParamsError("limit: must be an integer in [1, 1000]")
+    if raw_limit < 1 or raw_limit > 1000:
+        raise McpInvalidParamsError("limit: must be in [1, 1000]")
+    return await _list_recent_events_impl(
+        operator,
+        since=since,
+        op_class=op_class,
+        principal=principal,
+        target=target,
+        limit=raw_limit,
+    )
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="meho.broadcast.recent",
+        description=(
+            "Read the operator's tenant's recent broadcast events from "
+            "meho:feed:{tenant_id} (Initiative #1090, Task #1091). "
+            "Returns {events, next_cursor}. Default window is the last "
+            "30 minutes when 'since' is omitted; pass an ISO-8601 "
+            "timestamp ('2026-05-25T10:00:00Z') or a Valkey stream "
+            "cursor ('1747800000000-0') to override. The 'filter' "
+            "object narrows by exact-match op_class / principal "
+            "(JWT 'sub') / target (target_name). 'limit' caps the "
+            "page at 1..1000 (default 100); the response's "
+            "'next_cursor' round-trips as the next call's 'since' "
+            "for gap-free pagination. Tenant scoping is structural -- "
+            "every read targets the operator's own tenant stream; "
+            "there is no input that could request another tenant's "
+            "events. Payloads inherit the publisher-side redaction "
+            "(credential_read + audit_query events are already "
+            "aggregate-only on the stream)."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "since": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 64,
+                    "description": (
+                        "ISO-8601 timestamp ('2026-05-25T10:00:00Z') "
+                        "OR Valkey stream cursor ('1747800000000-0'). "
+                        "Omit for the last 30 minutes."
+                    ),
+                },
+                "filter": {
+                    "type": "object",
+                    "properties": {
+                        "op_class": {
+                            "type": "string",
+                            "enum": list(_OP_CLASS_ENUM),
+                            "description": ("Exact-match filter on event op_class."),
+                        },
+                        "principal": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 256,
+                            "description": ("Exact-match filter on JWT 'sub' claim."),
+                        },
+                        "target": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 256,
+                            "description": ("Exact-match filter on event target_name."),
+                        },
+                    },
+                    "additionalProperties": False,
+                    "description": (
+                        "Filter narrows the result; all sub-keys "
+                        "optional. Each non-null sub-key is exact-match."
+                    ),
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 1000,
+                    "default": 100,
+                    "description": (
+                        "Max events returned in one page. The XRANGE "
+                        "fetch is capped at this value before filtering."
+                    ),
+                },
+            },
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.OPERATOR,
+        op_class="read",
+    ),
+    handler=_handler_recent,
+)
+
+
+# ===========================================================================
+# === end meho.broadcast.recent ===
+# ===========================================================================

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -159,6 +159,7 @@ def isolated_registry() -> Iterator[None]:
         topology,
         topology_create_node,
     )
+    from meho_backplane.mcp.tools import broadcast as broadcast_tools
     from meho_backplane.mcp.tools import memory as memory_tools
     from meho_backplane.mcp.tools import memory_promote as memory_promote_tool
 
@@ -168,6 +169,11 @@ def isolated_registry() -> Iterator[None]:
     importlib.reload(connector_admin)
     importlib.reload(audit)
     importlib.reload(broadcast_overrides)
+    # G6.4-T1 (#1091): meho.broadcast.recent (agent-facing read of recent
+    # broadcast events). T2 (announce, #1092) and T3 (watch, #1093) will
+    # land additional tools in this module; the single reload covers all
+    # three because they share one file by design.
+    importlib.reload(broadcast_tools)
     importlib.reload(knowledge)
     importlib.reload(topology)
     importlib.reload(topology_create_node)

--- a/backend/tests/test_mcp_tool_broadcast_recent.py
+++ b/backend/tests/test_mcp_tool_broadcast_recent.py
@@ -940,9 +940,9 @@ class TestBroadcastRecentIntegration:
         op = build_operator(TenantRole.OPERATOR)
         # Publish three events; sleep between to ensure distinct ms timestamps.
         await publish_event(_make_event(op_id="vsphere.vm.op_before"))
-        await __aio_sleep(0.05)
+        await _aio_sleep(0.05)
         cutoff = datetime.now(UTC) - timedelta(milliseconds=10)
-        await __aio_sleep(0.05)
+        await _aio_sleep(0.05)
         await publish_event(_make_event(op_id="vsphere.vm.op_after_1"))
         await publish_event(_make_event(op_id="vsphere.vm.op_after_2"))
 
@@ -957,8 +957,15 @@ class TestBroadcastRecentIntegration:
         assert "vsphere.vm.op_after_2" in op_ids
 
 
-async def __aio_sleep(seconds: float) -> None:
-    """Async sleep used by the integration suite (kept local for clarity)."""
+async def _aio_sleep(seconds: float) -> None:
+    """Async sleep used by the integration suite (kept local for clarity).
+
+    Single-underscore prefix is deliberate: a dunder prefix triggers Python's
+    class-level name mangling (``__foo`` → ``_ClassName__foo``) at the call
+    site, which made this module-level helper unreachable from
+    ``TestBroadcastRecentIntegration`` and raised ``NameError`` in CI before
+    the rename. See: https://docs.python.org/3/reference/expressions.html#atom-identifiers
+    """
     import asyncio
 
     await asyncio.sleep(seconds)

--- a/backend/tests/test_mcp_tool_broadcast_recent.py
+++ b/backend/tests/test_mcp_tool_broadcast_recent.py
@@ -1,0 +1,964 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for ``meho.broadcast.recent`` (G6.4-T1, #1091).
+
+Acceptance-criteria coverage:
+
+* ``meho.broadcast.recent`` is registered and visible on ``tools/list``
+  for an ``operator`` JWT; hidden from ``read_only``.
+* Default 30m window when ``since`` is omitted; explicit ``since``
+  honoured for both ISO-8601 and Valkey-cursor shapes.
+* ``filter.op_class`` / ``filter.principal`` / ``filter.target``
+  narrow the result (one test per sub-key).
+* ``limit`` is enforced at the input-schema level: out-of-range
+  values rejected with ``-32602`` Invalid Params; the in-range
+  ``count`` is propagated to ``xrange``.
+* Tenant boundary is structural -- the stream key passed to
+  ``xrange`` is always ``meho:feed:{operator.tenant_id}``, regardless
+  of arguments. The integration test seeds two tenants' streams and
+  asserts each operator reads only their own.
+* ``next_cursor`` round-trip: feeding the response's ``next_cursor``
+  back as ``since`` reaches the next page with no overlap, no gaps
+  (validated against a real Valkey container).
+* Credential_read + audit_query events surface aggregate-only -- the
+  publisher already redacts at write time, so the tool surfaces what's
+  on the stream verbatim (no re-redaction, no leakage).
+
+The mocked-client tests cover the wire surface (registration, schema,
+validation, handler glue). The Docker-gated ``TestBroadcastRecentIntegration``
+suite spins up ``valkey/valkey:8`` via testcontainers and drives the
+full publisher -> xrange -> tool-handler seam, including the cursor
+round-trip and the two-tenant isolation guarantee.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import (
+    BroadcastEvent,
+    dispose_broadcast_client,
+    get_broadcast_client,
+    publish_event,
+    reset_broadcast_client_for_testing,
+)
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from meho_backplane.mcp.tools.broadcast import (
+    _default_since_ms,
+    _handler_recent,
+    _parse_since,
+)
+from meho_backplane.settings import get_settings
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    build_operator,
+    client_with_operator,  # noqa: F401 -- pytest-discovered fixture
+    isolated_registry,  # noqa: F401 -- pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 -- pytest-discovered autouse fixture
+)
+
+_AUDIT_ID: UUID = UUID("44444444-4444-4444-4444-444444444444")
+
+
+# ---------------------------------------------------------------------------
+# Per-test broadcast-client isolation (mirrors test_mcp_resource_tenant_feed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_broadcast_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Clear the cached client + pin a stub URL around every test.
+
+    Pinning ``BROADCAST_REDIS_URL`` keeps the construction path free of
+    "URL not set" failures; per-test patches replace ``xrange`` so no
+    socket ever opens.
+    """
+    monkeypatch.setenv("BROADCAST_REDIS_URL", "redis://broadcast.test:6379")
+    get_settings.cache_clear()
+    reset_broadcast_client_for_testing()
+    yield
+    reset_broadcast_client_for_testing()
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(
+    *,
+    tenant_id: UUID = OPERATOR_TENANT_ID,
+    op_id: str = "vsphere.vm.list",
+    op_class: str = "read",
+    principal_sub: str = "op-test",
+    target_name: str | None = None,
+    result_status: str = "ok",
+    payload: dict[str, Any] | None = None,
+) -> BroadcastEvent:
+    """Build a :class:`BroadcastEvent` shaped like one the publisher emits.
+
+    The ``payload`` defaults to the FULL shape the publisher emits for
+    non-sensitive ops; sensitive-class tests pass the aggregate shape
+    explicitly so the assertion targets the on-stream contract.
+    """
+    return BroadcastEvent(
+        event_id=uuid4(),
+        ts=datetime(2026, 5, 25, 10, 0, tzinfo=UTC),
+        tenant_id=tenant_id,
+        principal_sub=principal_sub,
+        target_name=target_name,
+        op_id=op_id,
+        op_class=op_class,
+        result_status=result_status,
+        audit_id=_AUDIT_ID,
+        payload=payload or {"op_class": op_class, "params": {}, "result_status": result_status},
+    )
+
+
+def _xrange_entry(event: BroadcastEvent, entry_id: str) -> tuple[str, dict[str, str]]:
+    """Build one ``XRANGE``-shaped entry tuple from a :class:`BroadcastEvent`."""
+    return entry_id, {"event": event.model_dump_json()}
+
+
+def _result_dict(response: Any) -> dict[str, Any]:
+    """Extract the JSON-decoded tool result from a JSON-RPC response."""
+    body = response.json()
+    assert "error" not in body, body
+    content = body["result"]["content"]
+    return json.loads(content[0]["text"])
+
+
+def _tools_call(name: str, arguments: dict[str, Any], call_id: int = 1) -> dict[str, Any]:
+    """Build a ``tools/call`` JSON-RPC envelope."""
+    return {
+        "jsonrpc": "2.0",
+        "id": call_id,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registration shape + role visibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_list_exposes_recent_for_operator(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``operator`` role sees ``meho.broadcast.recent`` on tools/list."""
+    client, _op = client_with_operator
+    resp = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    assert resp.status_code == 200
+    body = resp.json()
+    names = {t["name"] for t in body["result"]["tools"]}
+    assert "meho.broadcast.recent" in names
+    # MEHO-internal RBAC fields stripped from the wire shape.
+    recent_def = next(t for t in body["result"]["tools"] if t["name"] == "meho.broadcast.recent")
+    assert "required_role" not in recent_def
+    assert "op_class" not in recent_def
+    # Schema contract surfaces on the wire.
+    schema = recent_def["inputSchema"]
+    assert schema["type"] == "object"
+    assert schema["additionalProperties"] is False
+    assert "since" in schema["properties"]
+    assert "filter" in schema["properties"]
+    assert "limit" in schema["properties"]
+    assert schema["properties"]["limit"]["minimum"] == 1
+    assert schema["properties"]["limit"]["maximum"] == 1000
+
+
+def test_tools_list_hides_recent_from_read_only(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``read_only`` operator does NOT see the operator-gated tool."""
+    client, _op = client_with_operator  # default fixture role is READ_ONLY
+    resp = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    body = resp.json()
+    names = {t["name"] for t in body["result"]["tools"]}
+    assert "meho.broadcast.recent" not in names
+
+
+def test_read_only_tools_call_recent_is_rejected(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A direct ``tools/call`` from below ``operator`` rejects with -32602.
+
+    The registry filter hides the tool from ``tools/list``; the
+    dispatcher's call-time RBAC re-check is the load-bearing second
+    gate against a client that knows the name and posts anyway.
+    """
+    client, _op = client_with_operator  # default fixture role is READ_ONLY
+    resp = post_mcp(client, _tools_call("meho.broadcast.recent", {}))
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "forbidden" in body["error"]["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Default 30m window + explicit `since`
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_default_since_uses_30_minute_window(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """No ``since`` -> xrange ``min`` is now - 30 min (bare-ms cursor)."""
+    client, op = client_with_operator
+    before_ms = int(time.time() * 1000)
+    bc = get_broadcast_client()
+    with patch.object(bc, "xrange", new=AsyncMock(return_value=[])) as xr:
+        post_mcp(client, _tools_call("meho.broadcast.recent", {}))
+    after_ms = int(time.time() * 1000)
+
+    xr.assert_awaited_once()
+    args, kwargs = xr.await_args.args, xr.await_args.kwargs
+    assert args[0] == f"meho:feed:{op.tenant_id}"
+    assert kwargs["max"] == "+"
+    assert kwargs["count"] == 100  # default limit
+    min_cursor_ms = int(kwargs["min"])
+    # The min cursor must fall in the [before - 30m, after - 30m] window.
+    assert before_ms - 30 * 60_000 <= min_cursor_ms <= after_ms - 30 * 60_000
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_since_iso8601_normalised_to_bare_ms(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """An ISO-8601 ``since`` is converted to bare-ms (inclusive)."""
+    client, _op = client_with_operator
+    bc = get_broadcast_client()
+    with patch.object(bc, "xrange", new=AsyncMock(return_value=[])) as xr:
+        post_mcp(
+            client,
+            _tools_call("meho.broadcast.recent", {"since": "2026-05-25T10:00:00Z"}),
+        )
+    kwargs = xr.await_args.kwargs
+    expected_ms = int(datetime(2026, 5, 25, 10, 0, tzinfo=UTC).timestamp() * 1000)
+    assert kwargs["min"] == str(expected_ms)
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_since_cursor_form_becomes_exclusive_lower_bound(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A Valkey-cursor ``since`` is wrapped in ``(`` for exclusive-min.
+
+    This is the load-bearing pagination contract: without the
+    exclusive prefix, a next-page call would re-fetch the entry the
+    previous page's ``next_cursor`` pointed at.
+    """
+    client, _op = client_with_operator
+    bc = get_broadcast_client()
+    with patch.object(bc, "xrange", new=AsyncMock(return_value=[])) as xr:
+        post_mcp(
+            client,
+            _tools_call("meho.broadcast.recent", {"since": "1747800000000-0"}),
+        )
+    kwargs = xr.await_args.kwargs
+    assert kwargs["min"] == "(1747800000000-0"
+
+
+def test_since_invalid_iso_rejects_with_invalid_params() -> None:
+    """A garbled ``since`` raises ``McpInvalidParamsError`` at parse time."""
+    from meho_backplane.mcp.server import McpInvalidParamsError
+
+    with pytest.raises(McpInvalidParamsError, match="not a valid ISO-8601"):
+        _parse_since("not-a-real-timestamp")
+
+
+def test_parse_since_default_is_now_minus_30m() -> None:
+    """``_parse_since(None)`` returns a bare-ms ~30 minutes in the past."""
+    before_ms = int(time.time() * 1000)
+    cursor = _parse_since(None)
+    after_ms = int(time.time() * 1000)
+    assert cursor.isdigit()
+    cursor_ms = int(cursor)
+    assert before_ms - 30 * 60_000 <= cursor_ms <= after_ms - 30 * 60_000
+
+
+def test_default_since_ms_handles_clock_underflow(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A clock skew producing a negative bare-ms clamps to 0.
+
+    Documented contract; without the clamp, a misconfigured clock
+    would send a negative ``min`` to Valkey and the server would
+    reject the command, breaking every call until the clock recovers.
+    """
+    monkeypatch.setattr(time, "time", lambda: 60.0)  # ts*1000 = 60_000 ms; minus 30m = -ve
+    assert _default_since_ms() == 0
+
+
+# ---------------------------------------------------------------------------
+# Filter narrowing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_filter_op_class_narrows_result(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``filter.op_class`` keeps only matching events."""
+    client, _op = client_with_operator
+    read_event = _make_event(op_id="vsphere.vm.list", op_class="read")
+    write_event = _make_event(op_id="vsphere.vm.create", op_class="write")
+    bc = get_broadcast_client()
+    with patch.object(
+        bc,
+        "xrange",
+        new=AsyncMock(
+            return_value=[
+                _xrange_entry(read_event, "1747800000000-0"),
+                _xrange_entry(write_event, "1747800001000-0"),
+            ],
+        ),
+    ):
+        resp = post_mcp(
+            client,
+            _tools_call("meho.broadcast.recent", {"filter": {"op_class": "write"}}),
+        )
+    result = _result_dict(resp)
+    op_ids = [e["op_id"] for e in result["events"]]
+    assert op_ids == ["vsphere.vm.create"]
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_filter_principal_narrows_result(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``filter.principal`` keeps only events from the named JWT 'sub'."""
+    client, _op = client_with_operator
+    alice = _make_event(op_id="vsphere.vm.list", principal_sub="op-alice")
+    bob = _make_event(op_id="vsphere.vm.list", principal_sub="op-bob")
+    bc = get_broadcast_client()
+    with patch.object(
+        bc,
+        "xrange",
+        new=AsyncMock(
+            return_value=[
+                _xrange_entry(alice, "1747800000000-0"),
+                _xrange_entry(bob, "1747800001000-0"),
+            ],
+        ),
+    ):
+        resp = post_mcp(
+            client,
+            _tools_call("meho.broadcast.recent", {"filter": {"principal": "op-alice"}}),
+        )
+    result = _result_dict(resp)
+    principals = [e["principal_sub"] for e in result["events"]]
+    assert principals == ["op-alice"]
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_filter_target_narrows_result(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``filter.target`` keeps only events with matching ``target_name``.
+
+    Asserts both:
+
+    1. The matching event survives.
+    2. Events with ``target_name=None`` are dropped (the caller asked
+       for a specific target; an untagged event doesn't qualify).
+    """
+    client, _op = client_with_operator
+    prod = _make_event(target_name="prod-vc-1")
+    staging = _make_event(target_name="staging-vc-1")
+    untagged = _make_event(target_name=None)
+    bc = get_broadcast_client()
+    with patch.object(
+        bc,
+        "xrange",
+        new=AsyncMock(
+            return_value=[
+                _xrange_entry(prod, "1747800000000-0"),
+                _xrange_entry(staging, "1747800001000-0"),
+                _xrange_entry(untagged, "1747800002000-0"),
+            ],
+        ),
+    ):
+        resp = post_mcp(
+            client,
+            _tools_call("meho.broadcast.recent", {"filter": {"target": "prod-vc-1"}}),
+        )
+    result = _result_dict(resp)
+    targets = [e["target_name"] for e in result["events"]]
+    assert targets == ["prod-vc-1"]
+
+
+# ---------------------------------------------------------------------------
+# limit cap + invalid limit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_explicit_limit_propagates_to_xrange_count(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """An in-range ``limit`` is passed through to ``xrange(count=...)``."""
+    client, _op = client_with_operator
+    bc = get_broadcast_client()
+    with patch.object(bc, "xrange", new=AsyncMock(return_value=[])) as xr:
+        post_mcp(client, _tools_call("meho.broadcast.recent", {"limit": 250}))
+    assert xr.await_args.kwargs["count"] == 250
+
+
+@pytest.mark.parametrize(
+    "client_with_operator,bad_limit",
+    [
+        (TenantRole.OPERATOR, 0),
+        (TenantRole.OPERATOR, -5),
+        (TenantRole.OPERATOR, 1001),
+        (TenantRole.OPERATOR, 100_000),
+    ],
+    indirect=["client_with_operator"],
+)
+def test_out_of_range_limit_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    bad_limit: int,
+) -> None:
+    """``limit`` outside [1, 1000] rejects with JSON-RPC -32602.
+
+    The dispatcher's JSON-Schema validator runs against ``inputSchema``
+    before the handler -- a value below ``minimum`` or above
+    ``maximum`` surfaces as Invalid Params with the schema error
+    embedded in the message.
+    """
+    client, _op = client_with_operator
+    resp = post_mcp(client, _tools_call("meho.broadcast.recent", {"limit": bad_limit}))
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_non_integer_limit_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``limit`` of the wrong JSON type rejects with -32602."""
+    client, _op = client_with_operator
+    resp = post_mcp(client, _tools_call("meho.broadcast.recent", {"limit": "100"}))
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+# ---------------------------------------------------------------------------
+# Tenant boundary (structural -- no input that could ask for another tenant)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_stream_key_derived_from_operator_tenant_id(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """The handler ALWAYS reads ``meho:feed:{operator.tenant_id}``.
+
+    Tenant isolation here is structural: the input schema has no
+    ``tenant_id`` field, so a malicious caller has no way to ask for
+    another tenant's stream. Asserting the read key is the right
+    shape proves the structural property holds.
+    """
+    client, op = client_with_operator
+    bc = get_broadcast_client()
+    with patch.object(bc, "xrange", new=AsyncMock(return_value=[])) as xr:
+        post_mcp(client, _tools_call("meho.broadcast.recent", {}))
+    assert xr.await_args.args[0] == f"meho:feed:{op.tenant_id}"
+
+
+async def test_handler_with_distinct_operator_reads_distinct_stream() -> None:
+    """Two operators on different tenants read their own streams only.
+
+    Directly exercises the handler (bypassing the FastAPI dispatcher)
+    with two operators bound to two different tenant ids; asserts each
+    call resolves to its own stream key. The mocked client always
+    returns ``[]`` -- the assertion is on the key passed to xrange,
+    not on what came back.
+    """
+    tenant_a = UUID("aaaa0000-0000-0000-0000-000000000001")
+    tenant_b = UUID("bbbb0000-0000-0000-0000-000000000002")
+    op_a = Operator(
+        sub="op-a",
+        raw_jwt="x",
+        tenant_id=tenant_a,
+        tenant_role=TenantRole.OPERATOR,
+    )
+    op_b = Operator(
+        sub="op-b",
+        raw_jwt="x",
+        tenant_id=tenant_b,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+    bc = get_broadcast_client()
+    with patch.object(bc, "xrange", new=AsyncMock(return_value=[])) as xr:
+        await _handler_recent(op_a, {})
+        await _handler_recent(op_b, {})
+
+    keys_read = [call.args[0] for call in xr.await_args_list]
+    assert keys_read == [f"meho:feed:{tenant_a}", f"meho:feed:{tenant_b}"]
+
+
+# ---------------------------------------------------------------------------
+# next_cursor shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_next_cursor_is_last_fetched_entry_id_when_page_full(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A full page returns the last *fetched* entry id as ``next_cursor``.
+
+    The cursor is the last entry id from the xrange response (NOT the
+    last matched-after-filter id), so a page where every entry was
+    filtered out still produces a non-null cursor and the caller can
+    keep walking without an infinite-loop risk.
+    """
+    client, _op = client_with_operator
+    entries = [
+        _xrange_entry(_make_event(op_id="vsphere.vm.list"), f"17478{i:08d}-0") for i in range(3)
+    ]
+    bc = get_broadcast_client()
+    with patch.object(bc, "xrange", new=AsyncMock(return_value=entries)):
+        resp = post_mcp(client, _tools_call("meho.broadcast.recent", {"limit": 3}))
+    result = _result_dict(resp)
+    assert result["next_cursor"] == "1747800000002-0"
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_next_cursor_is_null_when_short_page(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A page shorter than ``limit`` returns ``next_cursor=null``.
+
+    Signals "you've reached the live tail"; the caller can stop
+    paginating until new events arrive.
+    """
+    client, _op = client_with_operator
+    entries = [_xrange_entry(_make_event(), "1747800000000-0")]
+    bc = get_broadcast_client()
+    with patch.object(bc, "xrange", new=AsyncMock(return_value=entries)):
+        resp = post_mcp(client, _tools_call("meho.broadcast.recent", {"limit": 10}))
+    result = _result_dict(resp)
+    assert result["next_cursor"] is None
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_empty_stream_returns_empty_events_null_cursor(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Empty stream returns ``events=[]`` + ``next_cursor=null``."""
+    client, _op = client_with_operator
+    bc = get_broadcast_client()
+    with patch.object(bc, "xrange", new=AsyncMock(return_value=[])):
+        resp = post_mcp(client, _tools_call("meho.broadcast.recent", {}))
+    result = _result_dict(resp)
+    assert result == {"events": [], "next_cursor": None}
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_event_dict_carries_stream_entry_id_and_event_fields(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Each event surfaces both ``id`` (stream cursor) and BroadcastEvent fields.
+
+    ``id`` is the Valkey stream entry id (the cursor a caller
+    round-trips); ``event_id`` / ``ts`` / ``audit_id`` / ``payload``
+    are the durable fields from :class:`BroadcastEvent`.
+    """
+    client, op = client_with_operator
+    event = _make_event(op_id="vsphere.vm.list")
+    bc = get_broadcast_client()
+    with patch.object(
+        bc,
+        "xrange",
+        new=AsyncMock(return_value=[_xrange_entry(event, "1747800000000-0")]),
+    ):
+        resp = post_mcp(client, _tools_call("meho.broadcast.recent", {}))
+    result = _result_dict(resp)
+    assert len(result["events"]) == 1
+    e = result["events"][0]
+    assert e["id"] == "1747800000000-0"
+    assert e["event_id"] == str(event.event_id)
+    assert e["tenant_id"] == str(op.tenant_id)
+    assert e["op_id"] == "vsphere.vm.list"
+    assert e["audit_id"] == str(_AUDIT_ID)
+    assert "ts" in e
+    assert "payload" in e
+
+
+# ---------------------------------------------------------------------------
+# PII inheritance: aggregate-only payloads pass through verbatim
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_credential_read_payload_surfaces_aggregate_only(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``credential_read`` events return whatever the publisher redacted to.
+
+    The tool MUST NOT re-derive or mutate ``payload``; it surfaces the
+    on-stream view verbatim. Feeding an aggregate-shaped payload
+    asserts the tool doesn't accidentally expand it back to full.
+    """
+    client, _op = client_with_operator
+    aggregate_payload = {"op_class": "credential_read", "result_status": "ok"}
+    event = _make_event(
+        op_id="vault.kv.read",
+        op_class="credential_read",
+        payload=aggregate_payload,
+    )
+    bc = get_broadcast_client()
+    with patch.object(
+        bc,
+        "xrange",
+        new=AsyncMock(return_value=[_xrange_entry(event, "1747800000000-0")]),
+    ):
+        resp = post_mcp(client, _tools_call("meho.broadcast.recent", {}))
+    result = _result_dict(resp)
+    assert result["events"][0]["payload"] == aggregate_payload
+    # And no path / key / value leak from any earlier-rendered shape.
+    assert "params" not in result["events"][0]["payload"]
+    assert "path" not in result["events"][0]["payload"]
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_audit_query_payload_surfaces_aggregate_with_row_count(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``audit_query`` events surface the ``row_count`` aggregate verbatim."""
+    client, _op = client_with_operator
+    aggregate_payload = {
+        "op_class": "audit_query",
+        "result_status": "ok",
+        "row_count": 17,
+    }
+    event = _make_event(
+        op_id="meho.audit.replay",
+        op_class="audit_query",
+        payload=aggregate_payload,
+    )
+    bc = get_broadcast_client()
+    with patch.object(
+        bc,
+        "xrange",
+        new=AsyncMock(return_value=[_xrange_entry(event, "1747800000000-0")]),
+    ):
+        resp = post_mcp(client, _tools_call("meho.broadcast.recent", {}))
+    result = _result_dict(resp)
+    assert result["events"][0]["payload"] == aggregate_payload
+
+
+# ---------------------------------------------------------------------------
+# Deserialisation safety net (skip malformed entries, don't raise)
+# ---------------------------------------------------------------------------
+
+
+async def test_handler_skips_unknown_field_shape() -> None:
+    """An entry without an ``event`` field is logged + skipped, not raised."""
+    op = build_operator(TenantRole.OPERATOR)
+    good = _make_event()
+    raw_entries = [
+        ("1747800000000-0", {"unexpected_key": "nothing-useful"}),
+        _xrange_entry(good, "1747800001000-0"),
+    ]
+    bc = get_broadcast_client()
+    with patch.object(bc, "xrange", new=AsyncMock(return_value=raw_entries)):
+        result = await _handler_recent(op, {})
+    assert len(result["events"]) == 1
+    assert result["events"][0]["event_id"] == str(good.event_id)
+
+
+async def test_handler_skips_malformed_event_json() -> None:
+    """An entry whose ``event`` field doesn't parse as BroadcastEvent is skipped."""
+    op = build_operator(TenantRole.OPERATOR)
+    good = _make_event()
+    raw_entries = [
+        ("1747800000000-0", {"event": '{"not": "a BroadcastEvent"}'}),
+        _xrange_entry(good, "1747800001000-0"),
+    ]
+    bc = get_broadcast_client()
+    with patch.object(bc, "xrange", new=AsyncMock(return_value=raw_entries)):
+        result = await _handler_recent(op, {})
+    assert len(result["events"]) == 1
+    assert result["events"][0]["event_id"] == str(good.event_id)
+
+
+# ---------------------------------------------------------------------------
+# Filter input-shape validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_filter_with_unknown_sub_key_rejected(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``filter`` rejects unknown sub-keys via ``additionalProperties: false``."""
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        _tools_call("meho.broadcast.recent", {"filter": {"unknown": "value"}}),
+    )
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_filter_op_class_outside_enum_rejected(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``filter.op_class`` outside the enum rejects with -32602."""
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        _tools_call("meho.broadcast.recent", {"filter": {"op_class": "made_up"}}),
+    )
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+# ---------------------------------------------------------------------------
+# Optional testcontainers integration suite
+# ---------------------------------------------------------------------------
+
+
+def _docker_socket_present() -> bool:
+    return Path("/var/run/docker.sock").exists() or os.environ.get("DOCKER_HOST") is not None
+
+
+_DOCKER_AVAILABLE = _docker_socket_present()
+_SKIP_REASON = (
+    "Docker socket unavailable in this sandbox; runs in CI where containers are provisioned."
+)
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason=_SKIP_REASON)
+class TestBroadcastRecentIntegration:
+    """End-to-end suite against a real Valkey container.
+
+    Drives the same publisher (``publish_event``) the production
+    publish-on-write hook uses so the integration covers the full
+    XADD -> XRANGE -> handler seam, the cursor round-trip, and the
+    two-tenant isolation contract.
+    """
+
+    @pytest.fixture
+    async def valkey_url(self, monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[str]:
+        from testcontainers.redis import RedisContainer
+
+        image = os.environ.get("MEHO_TEST_VALKEY_IMAGE", "valkey/valkey:8")
+        with RedisContainer(image) as container:
+            host = container.get_container_host_ip()
+            port = container.get_exposed_port(6379)
+            url = f"redis://{host}:{port}"
+            monkeypatch.setenv("BROADCAST_REDIS_URL", url)
+            get_settings.cache_clear()
+            reset_broadcast_client_for_testing()
+            try:
+                yield url
+            finally:
+                await dispose_broadcast_client()
+                get_settings.cache_clear()
+
+    async def test_publish_then_recent_round_trip(self, valkey_url: str) -> None:
+        """Publish two events; the handler reads them back oldest-first."""
+        op = build_operator(TenantRole.OPERATOR)
+        e_old = _make_event(op_id="vsphere.vm.list")
+        e_new = _make_event(op_id="vsphere.vm.create")
+        await publish_event(e_old)
+        await publish_event(e_new)
+
+        result = await _handler_recent(op, {})
+        op_ids = [e["op_id"] for e in result["events"]]
+        assert op_ids == ["vsphere.vm.list", "vsphere.vm.create"]
+
+    async def test_cursor_round_trip_walks_forward_without_overlap(
+        self,
+        valkey_url: str,
+    ) -> None:
+        """``next_cursor`` from page 1, passed as ``since`` to page 2, yields page 2.
+
+        Three events published; ``limit=2`` slices into two pages. The
+        cursor returned by page 1 MUST land page 2 starting strictly
+        after the page-1 boundary (no overlap, no gap). This is the
+        load-bearing pagination invariant the issue's "round-trip"
+        criterion gates on.
+        """
+        op = build_operator(TenantRole.OPERATOR)
+        events = [_make_event(op_id=f"vsphere.vm.op{i}") for i in range(3)]
+        for event in events:
+            await publish_event(event)
+
+        page1 = await _handler_recent(op, {"limit": 2})
+        assert [e["op_id"] for e in page1["events"]] == ["vsphere.vm.op0", "vsphere.vm.op1"]
+        assert page1["next_cursor"] is not None
+
+        page2 = await _handler_recent(op, {"limit": 2, "since": page1["next_cursor"]})
+        assert [e["op_id"] for e in page2["events"]] == ["vsphere.vm.op2"]
+        assert page2["next_cursor"] is None  # reached the tail
+
+        # Page1's last event id must NOT recur in page2.
+        page1_ids = {e["id"] for e in page1["events"]}
+        page2_ids = {e["id"] for e in page2["events"]}
+        assert not (page1_ids & page2_ids), "cursor pagination must not double-deliver"
+
+    async def test_two_tenants_see_only_their_own_events(
+        self,
+        valkey_url: str,
+    ) -> None:
+        """Two operators on two tenants each read only their own stream.
+
+        The structural tenant guarantee verified end-to-end: tenant-A's
+        operator never sees tenant-B's events even when both streams
+        sit on the same Valkey instance.
+        """
+        tenant_a = UUID("aaaa0000-0000-0000-0000-000000000001")
+        tenant_b = UUID("bbbb0000-0000-0000-0000-000000000002")
+        op_a = Operator(
+            sub="op-a",
+            raw_jwt="x",
+            tenant_id=tenant_a,
+            tenant_role=TenantRole.OPERATOR,
+        )
+        op_b = Operator(
+            sub="op-b",
+            raw_jwt="x",
+            tenant_id=tenant_b,
+            tenant_role=TenantRole.OPERATOR,
+        )
+
+        await publish_event(_make_event(tenant_id=tenant_a, op_id="tenant-a.op"))
+        await publish_event(_make_event(tenant_id=tenant_b, op_id="tenant-b.op"))
+
+        result_a = await _handler_recent(op_a, {})
+        result_b = await _handler_recent(op_b, {})
+
+        a_op_ids = [e["op_id"] for e in result_a["events"]]
+        b_op_ids = [e["op_id"] for e in result_b["events"]]
+        assert a_op_ids == ["tenant-a.op"]
+        assert b_op_ids == ["tenant-b.op"]
+
+    async def test_iso8601_since_filters_to_window(
+        self,
+        valkey_url: str,
+    ) -> None:
+        """An ISO-8601 ``since`` slices the stream at the wall-clock cutoff."""
+        op = build_operator(TenantRole.OPERATOR)
+        # Publish three events; sleep between to ensure distinct ms timestamps.
+        await publish_event(_make_event(op_id="vsphere.vm.op_before"))
+        await __aio_sleep(0.05)
+        cutoff = datetime.now(UTC) - timedelta(milliseconds=10)
+        await __aio_sleep(0.05)
+        await publish_event(_make_event(op_id="vsphere.vm.op_after_1"))
+        await publish_event(_make_event(op_id="vsphere.vm.op_after_2"))
+
+        result = await _handler_recent(
+            op,
+            {"since": cutoff.isoformat().replace("+00:00", "Z")},
+        )
+        op_ids = [e["op_id"] for e in result["events"]]
+        # Cutoff-relative: only the two "after" events surface.
+        assert "vsphere.vm.op_before" not in op_ids
+        assert "vsphere.vm.op_after_1" in op_ids
+        assert "vsphere.vm.op_after_2" in op_ids
+
+
+async def __aio_sleep(seconds: float) -> None:
+    """Async sleep used by the integration suite (kept local for clarity)."""
+    import asyncio
+
+    await asyncio.sleep(seconds)

--- a/docs/cross-repo/broadcast-onboarding.md
+++ b/docs/cross-repo/broadcast-onboarding.md
@@ -36,6 +36,7 @@ Every transport reads the same per-tenant stream. Pick by use case:
 | `meho status --watch` CLI | Terminal-resident operator triage | G6.1-T5 (#311) |
 | `GET /api/v1/feed` SSE | Custom dashboards, browser-side viewers, scripts that need live push | G6.1-T4 (#310) |
 | `meho://tenant/{tenant_id}/feed` MCP resource | LLM clients (Claude, MCP-aware agents) that poll a snapshot | G6.1-T6 (this task) |
+| `meho.broadcast.recent` MCP tool | LLM clients that need filter / since / cursor pagination over the same stream | G6.4-T1 (#1091) |
 
 The Slack mirror (G6.2 #333) and any future web admin UI subscribe
 the same way — XREAD against the per-tenant stream key.
@@ -124,6 +125,89 @@ that don't speak SSE (most pure JSON-RPC LLM tooling).
 Cross-tenant reads (`meho://tenant/<someone-else>/feed`) reject
 with JSON-RPC `INVALID_PARAMS` (-32602). The bound `tenant_id` must
 match the operator's JWT-derived tenant.
+
+## MCP tool: `meho.broadcast.recent`
+
+The agent-facing read surface. Where `meho://tenant/{id}/feed`
+returns the last 50 events in chronological order with no filter or
+cursor control, `meho.broadcast.recent` is a JSON-RPC `tools/call`
+that accepts a `since` cursor, optional filters, and a tunable
+page size:
+
+```json
+{
+  "name": "meho.broadcast.recent",
+  "arguments": {
+    "since": "2026-05-25T10:00:00Z",
+    "filter": {"op_class": "write", "principal": "op-alice"},
+    "limit": 100
+  }
+}
+```
+
+Response shape:
+
+```json
+{
+  "events": [
+    {
+      "id": "1747800000000-0",
+      "event_id": "...",
+      "tenant_id": "...",
+      "op_class": "write",
+      "op_id": "vsphere.vm.create",
+      "principal_sub": "op-alice",
+      "target_name": "prod-vc-1",
+      "result_status": "ok",
+      "ts": "2026-05-25T10:00:00Z",
+      "payload": {"op_class": "write", "params": {...}, "result_status": "ok"},
+      "audit_id": "..."
+    }
+  ],
+  "next_cursor": "1747800099000-0"
+}
+```
+
+Arguments (all optional):
+
+* `since` — ISO-8601 timestamp (`2026-05-25T10:00:00Z`) OR a Valkey
+  stream cursor (`1747800000000-0`). Omit for the last 30 minutes.
+  Cursors are treated as **exclusive** lower bounds so paginating
+  forward via `next_cursor` never double-delivers the boundary event.
+* `filter.op_class` — one of `read`, `write`, `credential_read`,
+  `credential_mint`, `audit_query`, `other`.
+* `filter.principal` — JWT `sub` claim (operator identifier).
+* `filter.target` — target name (when the op operates on a specific
+  target). Events with no target attribution (`target_name: null`)
+  never satisfy a non-null `target` filter.
+* `limit` — integer in `[1, 1000]`, default 100. Values outside the
+  range return JSON-RPC `INVALID_PARAMS` (-32602).
+
+Pagination contract:
+
+```javascript
+let cursor = null;
+while (true) {
+  const args = cursor ? {since: cursor, limit: 100} : {limit: 100};
+  const {events, next_cursor} = await callTool("meho.broadcast.recent", args);
+  for (const e of events) handle(e);
+  if (next_cursor === null) break;  // reached the live tail
+  cursor = next_cursor;
+}
+```
+
+`next_cursor` is the **last fetched** stream entry id (NOT the last
+*matched* one) so a page where every entry was filtered out still
+produces a non-null cursor and the walk progresses. `null` signals
+"this page was shorter than `limit` — you've reached the live tail".
+
+Tenant scoping is **structural**: the input schema has no `tenant_id`
+argument, so the stream key is derived exclusively from the operator's
+JWT-bound tenant. A cross-tenant request is not "checked then
+rejected" but "no surface that could ask for another tenant's stream
+in the first place". RBAC: `operator` role minimum (same as the SSE
+feed); `read_only` operators do not see the tool on `tools/list`
+and a direct call rejects with `forbidden`.
 
 ## PII defaults (decision #3)
 
@@ -274,6 +358,8 @@ replay. The load-test acceptance for the chaos case ships in
   [`backend/src/meho_backplane/api/v1/feed.py`](../../backend/src/meho_backplane/api/v1/feed.py).
 * MCP resource:
   [`backend/src/meho_backplane/mcp/resources/tenant_feed.py`](../../backend/src/meho_backplane/mcp/resources/tenant_feed.py).
+* MCP tools (broadcast namespace):
+  [`backend/src/meho_backplane/mcp/tools/broadcast.py`](../../backend/src/meho_backplane/mcp/tools/broadcast.py).
 * CLI verb:
   [`cli/internal/cmd/status_watch.go`](../../cli/internal/cmd/status_watch.go).
 * Decision #3 (PII defaults): `docs/planning/v0.2-decisions.md`.


### PR DESCRIPTION
## Summary

- Registers `meho.broadcast.recent` MCP tool — agent-facing read of recent broadcast events from the per-tenant Valkey stream `meho:feed:{tenant_id}` (G6.4-T1, Initiative #1090).
- Cursor-paginated, filterable snapshot via JSON-RPC `tools/call` — accepts `since` (ISO-8601 OR Valkey stream cursor), `filter.{op_class,principal,target}`, and `limit` (1..1000, default 100); returns `{events, next_cursor}`.
- Tenant scoping is **structural** (no `tenant_id` argument; stream key derived from operator's JWT-bound tenant). PII inheritance from publisher-side redaction — no re-derivation, no mutation.
- New file `backend/src/meho_backplane/mcp/tools/broadcast.py` houses T1 with shared helpers (`_parse_since`, `_event_matches`, `_list_recent_events_impl`) factored above per-tool sections so T2 (#1092) and T3 (#1093) can land in parallel branches with minimal merge-conflict surface.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (622 files)
- [x] `mypy src/ --ignore-missing-imports` — clean (302 source files)
- [x] `pytest tests/test_mcp_tool_broadcast_recent.py -x -q` — **30 passed, 4 skipped** (Docker-gated integration suite runs in CI)
- [x] `pytest tests/test_mcp_broadcast_overrides_tools.py tests/test_mcp_resource_tenant_feed.py tests/test_mcp_registry.py tests/test_broadcast_events.py tests/test_broadcast_publisher.py -x -q` — **128 passed, 3 skipped** (no regressions to sibling tests)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers, 2 warnings (file size 517/600 — intentional, T1/T2/T3 share this file by design; function-size warning for `_list_recent_events_impl` is mostly docstring)
- [x] Acceptance criteria coverage (one-to-one with the issue body):
  - [x] `meho.broadcast.recent` registered + `tools/list` returns it for `operator` (test_tools_list_exposes_recent_for_operator).
  - [x] Default 30m window when `since` omitted (test_default_since_uses_30_minute_window).
  - [x] Explicit `since` honoured — ISO-8601 + Valkey-cursor forms parsed (test_since_iso8601_normalised_to_bare_ms, test_since_cursor_form_becomes_exclusive_lower_bound).
  - [x] Filter narrows result, one test per sub-key (test_filter_op_class_narrows_result, test_filter_principal_narrows_result, test_filter_target_narrows_result).
  - [x] `limit` capped at 1000; out-of-range → JSON-RPC -32602 (test_out_of_range_limit_returns_invalid_params, parametrized: 0, -5, 1001, 100_000; plus test_non_integer_limit_returns_invalid_params).
  - [x] Tenant boundary — structural; test_stream_key_derived_from_operator_tenant_id + test_handler_with_distinct_operator_reads_distinct_stream + Docker-gated test_two_tenants_see_only_their_own_events.
  - [x] `next_cursor` round-trips no overlap/no gaps (test_next_cursor_is_last_fetched_entry_id_when_page_full + Docker-gated test_cursor_round_trip_walks_forward_without_overlap).
  - [x] credential_read + audit_query events return aggregate-only payload (test_credential_read_payload_surfaces_aggregate_only, test_audit_query_payload_surfaces_aggregate_with_row_count).

## Design notes

**Why the helper isn't shared with the UI history route.** `ui/routes/broadcast/history.py` also does `xrange` over the same key, but its surrounding contract differs in two load-bearing ways: it's fail-soft (Valkey error → empty list so the page degrades) and it uses a fixed 24h window with no filter. The MCP tool is fail-loud (-32602 / -32603) and accepts parametric `since` + filters + `limit` + returns a cursor for pagination. A shared helper would compromise one of those contracts. The duplication cost (one `xrange` + parse loop) is small; the contract-erosion cost would be larger. Documented in the module docstring; the helper serves T1/T2/T3 only.

**op_class enum is broader than the issue's example.** The issue body example listed 4 values (`read|write|credential_read|audit_query`); we accept all 6 that `classify_op` emits (adding `credential_mint` + `other`). Restricting to 4 would force the agent to omit the filter when chasing a freshly-minted credential (`harbor.robot.create` → `credential_mint`) or an unmapped HTTP route. The wider enum is the safer default for agent observability.

## Out of scope

- T2 (`meho.broadcast.announce`, #1092) and T3 (`meho.broadcast.watch`, #1093). File layout reserves comment-marker blocks so both can land in parallel.
- DRYing the UI history route against the new helper. Recorded as adjacent finding; a future refactor that re-unifies the two reads MUST first reconcile the failure-shape contract.
- Updating `docs/examples/consumer-onboarding/CLAUDE.md`'s "Tooling status" footnote — that paragraph names all three tools and gets updated when the full set has landed.

Closes #1091

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-25)

Addressed review findings from PR #1097 iteration-1 review (`.claude/auto/review-results/pr-1097-iter-1.json`):

- **B1** `10dbc4b` — Renamed module-level helper `__aio_sleep` → `_aio_sleep` and updated the two call sites inside `TestBroadcastRecentIntegration`. Dunder prefix triggered Python's class-level name mangling (`__foo` → `_ClassName__foo`), making the module-level helper unreachable from the class scope and raising `NameError` in CI's Python unit job. Added a docstring note on the rename so the next person doesn't reintroduce the dunder form.

Deferred (recorded as adjacent finding; out-of-scope for this iteration):

- **M1** — Shared `_list_recent_events_impl` helper deliberately NOT wired into `ui/routes/broadcast/history.py`. The deviation is intentional and is documented in the module docstring of `backend/src/meho_backplane/mcp/tools/broadcast.py` and in the "Design notes" + "Out of scope" sections of this PR body (above). The UI history route's fail-soft contract is incompatible with the MCP tool's fail-loud contract; a future re-unification must first reconcile both surfaces. The reviewer marked this as "doesn't need to block merge but should be on record" — explicitly confirming intentional deviation here.

<!-- auto-implement-issue: continue, iteration 1 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced broadcast event retrieval capability with cursor-based pagination, ISO-8601 timestamp filtering, and optional filtering by event properties. Access restricted to operator role users.

* **Documentation**
  * Added broadcast tool onboarding guide covering tool usage, response formats, pagination behavior, and role-based access control requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1097?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->