### PR TITLE
feat(mcp): G6.4-T3 meho.broadcast.watch MCP tool (long-poll XREAD BLOCK ≤30s)

### DIFF
--- a/backend/src/meho_backplane/mcp/tools/broadcast.py
+++ b/backend/src/meho_backplane/mcp/tools/broadcast.py
@@ -102,6 +102,7 @@ References
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 from datetime import UTC, datetime
@@ -784,4 +785,371 @@ register_mcp_tool(
 
 # ===========================================================================
 # === end meho.broadcast.announce ===
+# ===========================================================================
+
+# ===========================================================================
+# === meho.broadcast.watch ===
+# ===========================================================================
+
+#: Default ``XREAD BLOCK`` window when the caller omits ``timeout_ms``. 10s
+#: balances "wait long enough that the average operator pause produces a
+#: hit" against "release the chassis worker before any HTTP intermediary
+#: idles the connection". Half the maximum so a default-shaped client has
+#: room for a per-call override without bumping into the cap.
+_WATCH_DEFAULT_TIMEOUT_MS: Final[int] = 10_000
+
+#: Lower bound on ``timeout_ms``. 100ms is the floor below which the
+#: long-poll degenerates into a non-blocking poll plus syscall overhead;
+#: clients that want strictly-non-blocking semantics should be using
+#: :func:`_handler_recent` instead.
+_WATCH_MIN_TIMEOUT_MS: Final[int] = 100
+
+#: Upper bound on ``timeout_ms``. 30s matches the SSE bridge's
+#: ``_XREAD_BLOCK_MS`` (:mod:`~meho_backplane.api.v1.feed`) and the
+#: common HTTP-intermediary keep-alive ceiling (nginx default
+#: ``proxy_read_timeout`` 60s; AWS ALB idle 60s). Allowing infinite-block
+#: (``block=0``) here would let a single misbehaving caller tie up a
+#: chassis worker for the lifetime of the process; the cap is a hard
+#: backpressure boundary, not a hint.
+_WATCH_MAX_TIMEOUT_MS: Final[int] = 30_000
+
+#: Upper bound on entries returned in one ``XREAD`` call. Mirrors
+#: :data:`meho_backplane.api.v1.feed._XREAD_COUNT` so a busy tenant
+#: doesn't surface a 10,000-event burst in a single tool response that
+#: would blow the agent's token budget. The caller paginates by calling
+#: again with the returned ``next_cursor``.
+_WATCH_XREAD_COUNT: Final[int] = 100
+
+
+def _validate_timeout_ms(raw: Any) -> int:
+    """Coerce *raw* into the ``timeout_ms`` integer and enforce the bounds.
+
+    ``raw`` may be absent (None) -- the default :data:`_WATCH_DEFAULT_TIMEOUT_MS`
+    applies. Anything other than a plain ``int`` (including ``bool``, which
+    Python's ``isinstance(..., int)`` would accept, and ``float``, which
+    would silently truncate via ``int(...)``) rejects with
+    :class:`McpInvalidParamsError`. Out-of-range integers reject for the
+    same reason -- the cap is non-negotiable; a caller cannot opt past it.
+
+    Surface area defence: even though :func:`_handler_watch`'s
+    ``inputSchema`` declares ``"type": "integer"`` plus
+    ``minimum`` / ``maximum``, the per-field re-check here is the
+    handler-side guarantee. A future schema relaxation or a registration
+    bug wouldn't quietly widen the contract; the handler would still
+    reject the bad input as ``-32602``.
+    """
+    if raw is None:
+        return _WATCH_DEFAULT_TIMEOUT_MS
+    if not isinstance(raw, int) or isinstance(raw, bool):
+        raise McpInvalidParamsError(
+            f"timeout_ms: must be an integer in [{_WATCH_MIN_TIMEOUT_MS}, {_WATCH_MAX_TIMEOUT_MS}]",
+        )
+    if raw < _WATCH_MIN_TIMEOUT_MS or raw > _WATCH_MAX_TIMEOUT_MS:
+        raise McpInvalidParamsError(
+            f"timeout_ms: must be in [{_WATCH_MIN_TIMEOUT_MS}, {_WATCH_MAX_TIMEOUT_MS}]",
+        )
+    return raw
+
+
+async def _xread_or_cancelled(
+    operator: Operator,
+    *,
+    stream_key: str,
+    since_cursor: str,
+    timeout_ms: int,
+) -> Any:
+    """Await ``XREAD BLOCK`` for *operator*'s stream; re-raise cancellation cleanly.
+
+    Wraps the single ``xread`` call so the ``except asyncio.CancelledError``
+    arm stays self-contained -- which both bounds the cancellation
+    contract to one shape (xread is the only awaitable in this leg of
+    :func:`_watch_events_impl`) and keeps the parent function under the
+    code-quality function-size ceiling.
+
+    Cancellation contract: when Starlette cancels the JSON-RPC request
+    mid-block (client hung up, transport closed, MCP dispatcher tore the
+    call down), the pending ``xread`` raises
+    :class:`asyncio.CancelledError`. We log the structured disconnect and
+    re-raise -- swallowing ``CancelledError`` breaks the task tree's
+    unwind invariants per the asyncio contract (Sonar S7497; Python 3.13+
+    re-issues cancellation if it goes unpropagated). The chassis worker
+    is released the moment the re-raise lands.
+
+    *since_cursor* is passed to ``xread`` verbatim; XREAD reads entries
+    strictly past the cursor (its "last id seen" semantics are
+    exclusive, unlike XRANGE's inclusive ``min``).
+    """
+    client = get_broadcast_client()
+    try:
+        return await client.xread(
+            {stream_key: since_cursor},
+            block=timeout_ms,
+            count=_WATCH_XREAD_COUNT,
+        )
+    except asyncio.CancelledError:
+        _log.info(
+            "broadcast_watch_cancelled",
+            stream_key=stream_key,
+            operator_sub=operator.sub,
+            since_cursor=since_cursor,
+        )
+        raise
+
+
+def _xread_items_or_none(
+    raw_response: Any,
+) -> list[tuple[str, dict[str, str]]] | None:
+    """Unwrap the redis-py ``XREAD`` envelope to the entry list, or ``None``.
+
+    XREAD's two distinguishable result shapes:
+
+    * ``None`` (timeout-with-no-entries) or an empty outer list -- the
+      "nothing for us" branch. The truthiness check collapses both into
+      the same return ``None`` here; the SSE bridge's
+      ``_feed_generator`` uses the same idiom.
+    * ``[[stream_key, [(entry_id, fields), ...]]]`` -- one outer tuple
+      per stream queried. We query exactly one stream (the operator's
+      tenant feed), so ``raw_response[0][1]`` is the
+      ``[(entry_id, fields_dict), ...]`` list. A defensive third branch
+      catches an outer tuple with an empty inner list (never observed
+      with redis-py 7.x in practice -- the client collapses to ``None``
+      -- but the branch keeps the response safe under a future redis-py
+      shape change).
+
+    Returning the inner list (or ``None``) collapses three branches in
+    the caller to one ``if items is None`` check.
+    """
+    if not raw_response:
+        return None
+    entries = cast(
+        "list[tuple[str, list[tuple[str, dict[str, str]]]]]",
+        raw_response,
+    )
+    _key, items = entries[0]
+    if not items:
+        return None
+    return items
+
+
+def _filter_xread_items(
+    items: list[tuple[str, dict[str, str]]],
+    *,
+    stream_key: str,
+    op_class: str | None,
+    principal: str | None,
+    target: str | None,
+) -> list[dict[str, Any]]:
+    """Parse + filter the XREAD batch into the wire-shape events list.
+
+    Each surviving entry carries ``id`` (the Valkey stream cursor, the
+    round-trip handle) plus every :class:`BroadcastEvent` field
+    (including the durable ``event_id`` UUID and the ``audit_id`` for
+    audit-log correlation). Entries that fail :func:`_parse_entry` (bad
+    field shape, malformed JSON) are logged + skipped inside the helper
+    so the watch handler never raises on a single bad entry.
+    """
+    matched: list[dict[str, Any]] = []
+    for entry_id, fields in items:
+        event = _parse_entry(entry_id, fields, stream_key=stream_key)
+        if event is None:
+            continue
+        if not _event_matches(
+            event,
+            op_class=op_class,
+            principal=principal,
+            target=target,
+        ):
+            continue
+        matched.append({"id": entry_id, **event.model_dump(mode="json")})
+    return matched
+
+
+async def _watch_events_impl(
+    operator: Operator,
+    *,
+    since_cursor: str,
+    op_class: str | None,
+    principal: str | None,
+    target: str | None,
+    timeout_ms: int,
+) -> dict[str, Any]:
+    """Long-poll the operator's tenant stream for entries strictly past *since_cursor*.
+
+    Issues a single ``XREAD BLOCK`` against ``meho:feed:{operator.tenant_id}``
+    with ``timeout_ms`` as the block window; the caller's chassis worker
+    is tied up for up to that long. When entries arrive, advances the
+    cursor to the **last fetched** entry id (NOT the last *matched* one --
+    same invariant as :func:`_list_recent_events_impl`) so a filter-heavy
+    page where every entry was dropped still advances the cursor and the
+    next call doesn't re-read the same batch.
+
+    No-events shape: returns ``{events: [], next_cursor: since_cursor}``.
+    The unchanged cursor signals "I waited; nothing landed" -- the caller
+    re-polls with the same cursor.
+
+    Implementation split across three helpers:
+
+    * :func:`_xread_or_cancelled` owns the ``xread`` await and the
+      :class:`asyncio.CancelledError` re-raise contract.
+    * :func:`_xread_items_or_none` unwraps the redis-py envelope.
+    * :func:`_filter_xread_items` parses + filters the batch.
+
+    The caller obtains an initial cursor from :func:`_handler_recent`'s
+    ``next_cursor`` field; from that point forward each watch call's
+    ``next_cursor`` feeds the next call's ``since_cursor``.
+    """
+    stream_key = _stream_key(operator.tenant_id)
+    raw_response = await _xread_or_cancelled(
+        operator,
+        stream_key=stream_key,
+        since_cursor=since_cursor,
+        timeout_ms=timeout_ms,
+    )
+    items = _xread_items_or_none(raw_response)
+    if items is None:
+        return {"events": [], "next_cursor": since_cursor}
+    # Advance to the LAST FETCHED entry id BEFORE filtering, mirroring
+    # the M2 fix on the SSE generator: a page where every entry is
+    # filtered out still moves the cursor forward so a busy-but-filtered
+    # tenant doesn't deliver the same batch on every poll. The cursor
+    # is the canonical "last id seen" -- the filter is the caller's
+    # post-fetch concern.
+    next_cursor = items[-1][0]
+    matched = _filter_xread_items(
+        items,
+        stream_key=stream_key,
+        op_class=op_class,
+        principal=principal,
+        target=target,
+    )
+    return {"events": matched, "next_cursor": next_cursor}
+
+
+async def _handler_watch(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """``meho.broadcast.watch`` handler.
+
+    Parses the wire arguments, then delegates to :func:`_watch_events_impl`.
+    The dispatcher's JSON-Schema validator catches the coarse shape errors
+    (missing ``since_cursor``, ``timeout_ms`` outside the integer range,
+    extra top-level keys); the per-field re-checks here are the typed
+    contract for the handler itself -- a future schema change wouldn't
+    silently widen what the handler accepts.
+
+    Tenant scoping is structural: ``arguments`` has no ``tenant_id`` field,
+    so the stream key is always ``meho:feed:{operator.tenant_id}``.
+    """
+    since_cursor = arguments.get("since_cursor")
+    if not isinstance(since_cursor, str) or not since_cursor:
+        raise McpInvalidParamsError(
+            "since_cursor: required, must be a non-empty Valkey stream cursor",
+        )
+    op_class, principal, target = _extract_filter(arguments)
+    timeout_ms = _validate_timeout_ms(arguments.get("timeout_ms"))
+    return await _watch_events_impl(
+        operator,
+        since_cursor=since_cursor,
+        op_class=op_class,
+        principal=principal,
+        target=target,
+        timeout_ms=timeout_ms,
+    )
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="meho.broadcast.watch",
+        description=(
+            "Long-poll the operator's tenant broadcast stream for new "
+            "events past 'since_cursor' (Initiative #1090, Task #1093). "
+            "Issues XREAD BLOCK against meho:feed:{tenant_id} with "
+            "'timeout_ms' as the block window (default 10000, cap "
+            "30000 -- the chassis worker is tied up for up to that long, "
+            "so the cap is a hard backpressure boundary, not a hint). "
+            "Returns {events, next_cursor}. When no events arrive within "
+            "the window: returns {events: [], next_cursor: <unchanged>} -- "
+            "re-poll with the same cursor. When events arrive: "
+            "'next_cursor' advances to the last *fetched* entry id (NOT "
+            "the last matched one) so a busy-but-filtered tenant still "
+            "progresses. Designed for the agent-side discipline loop: "
+            "'broadcast_watch -> process -> broadcast_watch with new "
+            "cursor'. Obtain the initial 'since_cursor' from "
+            "'meho.broadcast.recent's 'next_cursor'. The 'filter' object "
+            "narrows by exact-match op_class / principal (JWT 'sub') / "
+            "target (target_name). Tenant scoping is structural -- every "
+            "watch targets the operator's own tenant stream; there is no "
+            "input that could request another tenant's stream. Payloads "
+            "inherit the publisher-side redaction (credential_read + "
+            "audit_query events are already aggregate-only on the stream). "
+            "MCP 'resources/subscribe' (server-push) remains advertised "
+            "as 'false' per backend/src/meho_backplane/mcp/resources/kb.py; "
+            "this long-poll is the v0.2 pragmatic shape."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "since_cursor": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 64,
+                    "description": (
+                        "Valkey stream cursor ('1747800000000-0'). "
+                        "Required. Obtain initial value from "
+                        "meho.broadcast.recent's 'next_cursor'. "
+                        "XREAD reads entries strictly past this cursor."
+                    ),
+                },
+                "filter": {
+                    "type": "object",
+                    "properties": {
+                        "op_class": {
+                            "type": "string",
+                            "enum": list(_OP_CLASS_ENUM),
+                            "description": ("Exact-match filter on event op_class."),
+                        },
+                        "principal": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 256,
+                            "description": ("Exact-match filter on JWT 'sub' claim."),
+                        },
+                        "target": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 256,
+                            "description": ("Exact-match filter on event target_name."),
+                        },
+                    },
+                    "additionalProperties": False,
+                    "description": (
+                        "Filter narrows the result; all sub-keys "
+                        "optional. Each non-null sub-key is exact-match."
+                    ),
+                },
+                "timeout_ms": {
+                    "type": "integer",
+                    "minimum": _WATCH_MIN_TIMEOUT_MS,
+                    "maximum": _WATCH_MAX_TIMEOUT_MS,
+                    "default": _WATCH_DEFAULT_TIMEOUT_MS,
+                    "description": (
+                        "XREAD BLOCK window in milliseconds. Cap at "
+                        f"{_WATCH_MAX_TIMEOUT_MS} (long-poll, not "
+                        "infinite-block) to bound chassis worker tie-up."
+                    ),
+                },
+            },
+            "required": ["since_cursor"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.OPERATOR,
+        op_class="read",
+    ),
+    handler=_handler_watch,
+)
+
+
+# ===========================================================================
+# === end meho.broadcast.watch ===
 # ===========================================================================

--- a/backend/tests/test_mcp_tool_broadcast_watch.py
+++ b/backend/tests/test_mcp_tool_broadcast_watch.py
@@ -1,0 +1,1124 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for ``meho.broadcast.watch`` (G6.4-T3, #1093).
+
+Acceptance-criteria coverage:
+
+* ``meho.broadcast.watch`` is registered and visible on ``tools/list``
+  for an ``operator`` JWT; hidden from ``read_only``.
+* ``since_cursor`` is required at the schema layer -- missing surfaces as
+  JSON-RPC ``-32602`` Invalid Params.
+* ``timeout_ms`` is enforced at the input-schema AND handler layers:
+  values outside ``[100, 30000]`` reject with ``-32602``. The 30s cap is
+  the hard backpressure boundary; ``block=0`` (infinite) is not allowed.
+* No events within the block window returns
+  ``{events: [], next_cursor: <since_cursor>}`` (unchanged cursor signals
+  "I waited; nothing landed").
+* New events matching the filter arrive mid-block -> returned immediately
+  with ``next_cursor`` advanced to the **last fetched** entry id
+  (mirrors the SSE generator's M2 fix: a filter-heavy page still moves
+  the cursor forward).
+* Tenant boundary is structural -- the stream key passed to ``xread``
+  is always ``meho:feed:{operator.tenant_id}``, regardless of arguments.
+* ``filter.op_class`` / ``filter.principal`` / ``filter.target`` narrow
+  the result (one test per sub-key).
+* Cancellation: when Starlette cancels the request mid-block, the handler
+  raises :class:`asyncio.CancelledError` (chassis worker released).
+* Credential_read + audit_query events surface aggregate-only -- the
+  publisher already redacts at write time, so the tool surfaces what's
+  on the stream verbatim (no re-redaction, no leakage).
+
+The mocked-client tests cover the wire surface (registration, schema,
+validation, handler glue). The Docker-gated
+``TestBroadcastWatchIntegration`` suite spins up ``valkey/valkey:8`` via
+testcontainers and drives the full publisher -> XREAD -> handler seam,
+including the cursor round-trip and the watch-then-arrives cadence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from collections.abc import AsyncIterator, Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.broadcast import (
+    BroadcastEvent,
+    dispose_broadcast_client,
+    get_broadcast_client,
+    publish_event,
+    reset_broadcast_client_for_testing,
+)
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from meho_backplane.mcp.server import McpInvalidParamsError
+from meho_backplane.mcp.tools.broadcast import (
+    _WATCH_DEFAULT_TIMEOUT_MS,
+    _WATCH_MAX_TIMEOUT_MS,
+    _WATCH_MIN_TIMEOUT_MS,
+    _handler_watch,
+    _validate_timeout_ms,
+)
+from meho_backplane.settings import get_settings
+from tests.mcp_test_fixtures import (
+    OPERATOR_TENANT_ID,
+    build_operator,
+    client_with_operator,  # noqa: F401 -- pytest-discovered fixture
+    isolated_registry,  # noqa: F401 -- pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 -- pytest-discovered autouse fixture
+)
+
+_AUDIT_ID: UUID = UUID("55555555-5555-5555-5555-555555555555")
+
+#: A canonical Valkey stream cursor used as ``since_cursor`` in tests
+#: that don't exercise cursor-shape semantics directly. The bare-ms +
+#: sequence shape matches what :func:`_handler_recent`'s ``next_cursor``
+#: would hand the caller in production.
+_SINCE_FIXTURE: str = "1747800000000-0"
+
+
+# ---------------------------------------------------------------------------
+# Per-test broadcast-client isolation (mirrors test_mcp_tool_broadcast_recent)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolated_broadcast_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Clear the cached client + pin a stub URL around every test.
+
+    Pinning ``BROADCAST_REDIS_URL`` keeps the construction path free of
+    "URL not set" failures; per-test patches replace ``xread`` so no
+    socket ever opens.
+    """
+    monkeypatch.setenv("BROADCAST_REDIS_URL", "redis://broadcast.test:6379")
+    get_settings.cache_clear()
+    reset_broadcast_client_for_testing()
+    yield
+    reset_broadcast_client_for_testing()
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(
+    *,
+    tenant_id: UUID = OPERATOR_TENANT_ID,
+    op_id: str = "vsphere.vm.list",
+    op_class: str = "read",
+    principal_sub: str = "op-test",
+    target_name: str | None = None,
+    result_status: str = "ok",
+    payload: dict[str, Any] | None = None,
+) -> BroadcastEvent:
+    """Build a :class:`BroadcastEvent` shaped like one the publisher emits."""
+    return BroadcastEvent(
+        event_id=uuid4(),
+        ts=datetime(2026, 5, 25, 10, 0, tzinfo=UTC),
+        tenant_id=tenant_id,
+        principal_sub=principal_sub,
+        target_name=target_name,
+        op_id=op_id,
+        op_class=op_class,
+        result_status=result_status,
+        audit_id=_AUDIT_ID,
+        payload=payload or {"op_class": op_class, "params": {}, "result_status": result_status},
+    )
+
+
+def _xread_envelope(
+    stream_key: str,
+    items: list[tuple[BroadcastEvent, str]],
+) -> list[tuple[str, list[tuple[str, dict[str, str]]]]]:
+    """Build the redis-py ``XREAD`` return shape from event+id tuples.
+
+    redis-py returns ``[[stream_key, [(entry_id, fields), ...]]]``; the
+    handler unwraps it via ``entries[0][1]``. *items* pairs each event
+    with the stream entry id the publisher would have minted for it.
+    """
+    fields_list = [(entry_id, {"event": event.model_dump_json()}) for event, entry_id in items]
+    return [(stream_key, fields_list)]
+
+
+def _result_dict(response: Any) -> dict[str, Any]:
+    """Extract the JSON-decoded tool result from a JSON-RPC response."""
+    body = response.json()
+    assert "error" not in body, body
+    content = body["result"]["content"]
+    return json.loads(content[0]["text"])
+
+
+def _tools_call(name: str, arguments: dict[str, Any], call_id: int = 1) -> dict[str, Any]:
+    """Build a ``tools/call`` JSON-RPC envelope."""
+    return {
+        "jsonrpc": "2.0",
+        "id": call_id,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registration shape + role visibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_list_exposes_watch_for_operator(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``operator`` role sees ``meho.broadcast.watch`` on tools/list."""
+    client, _op = client_with_operator
+    resp = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    assert resp.status_code == 200
+    body = resp.json()
+    names = {t["name"] for t in body["result"]["tools"]}
+    assert "meho.broadcast.watch" in names
+    # MEHO-internal RBAC fields stripped from the wire shape.
+    watch_def = next(t for t in body["result"]["tools"] if t["name"] == "meho.broadcast.watch")
+    assert "required_role" not in watch_def
+    assert "op_class" not in watch_def
+    # Schema contract surfaces on the wire.
+    schema = watch_def["inputSchema"]
+    assert schema["type"] == "object"
+    assert schema["additionalProperties"] is False
+    assert "since_cursor" in schema["properties"]
+    assert "filter" in schema["properties"]
+    assert "timeout_ms" in schema["properties"]
+    # ``since_cursor`` is required at the schema layer.
+    assert schema["required"] == ["since_cursor"]
+    # ``timeout_ms`` bounds are wired.
+    assert schema["properties"]["timeout_ms"]["minimum"] == _WATCH_MIN_TIMEOUT_MS
+    assert schema["properties"]["timeout_ms"]["maximum"] == _WATCH_MAX_TIMEOUT_MS
+    assert schema["properties"]["timeout_ms"]["default"] == _WATCH_DEFAULT_TIMEOUT_MS
+
+
+def test_tools_list_hides_watch_from_read_only(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``read_only`` operator does NOT see the operator-gated tool."""
+    client, _op = client_with_operator  # default fixture role is READ_ONLY
+    resp = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    body = resp.json()
+    names = {t["name"] for t in body["result"]["tools"]}
+    assert "meho.broadcast.watch" not in names
+
+
+def test_read_only_tools_call_watch_is_rejected(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A direct ``tools/call`` from below ``operator`` rejects with -32602.
+
+    The registry filter hides the tool from ``tools/list``; the
+    dispatcher's call-time RBAC re-check is the load-bearing second
+    gate against a client that knows the name and posts anyway.
+    """
+    client, _op = client_with_operator  # default fixture role is READ_ONLY
+    resp = post_mcp(client, _tools_call("meho.broadcast.watch", {"since_cursor": _SINCE_FIXTURE}))
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "forbidden" in body["error"]["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# since_cursor required (schema + handler enforcement)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_missing_since_cursor_rejects_with_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Omitting ``since_cursor`` surfaces as JSON-RPC -32602.
+
+    The dispatcher's JSON Schema validator catches the ``required`` violation
+    before the handler runs; either path is acceptable as long as the wire
+    error is INVALID_PARAMS.
+    """
+    client, _op = client_with_operator
+    resp = post_mcp(client, _tools_call("meho.broadcast.watch", {}))
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_empty_since_cursor_rejects_with_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """An empty ``since_cursor`` rejects -- the schema's ``minLength: 1`` guards it."""
+    client, _op = client_with_operator
+    resp = post_mcp(client, _tools_call("meho.broadcast.watch", {"since_cursor": ""}))
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+async def test_handler_directly_rejects_non_string_since_cursor() -> None:
+    """Handler-side typed-contract: non-string ``since_cursor`` raises -32602.
+
+    Belt-and-suspenders over the schema -- a future schema relaxation
+    wouldn't silently widen what the handler accepts.
+    """
+    op = build_operator(TenantRole.OPERATOR)
+    with pytest.raises(McpInvalidParamsError, match="since_cursor"):
+        await _handler_watch(op, {"since_cursor": 12345})
+
+
+# ---------------------------------------------------------------------------
+# timeout_ms cap (schema + handler validation)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator,bad_timeout",
+    [
+        (TenantRole.OPERATOR, 0),  # infinite-block not allowed
+        (TenantRole.OPERATOR, 99),  # below 100ms floor
+        (TenantRole.OPERATOR, -5),  # negative
+        (TenantRole.OPERATOR, 30_001),  # one ms past the cap
+        (TenantRole.OPERATOR, 60_000),  # well past
+        (TenantRole.OPERATOR, 1_000_000),  # absurd
+    ],
+    indirect=["client_with_operator"],
+)
+def test_out_of_range_timeout_ms_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    bad_timeout: int,
+) -> None:
+    """``timeout_ms`` outside [100, 30000] rejects with JSON-RPC -32602.
+
+    The dispatcher's JSON-Schema validator runs against ``inputSchema``
+    before the handler -- a value below ``minimum`` or above ``maximum``
+    surfaces as Invalid Params. Explicitly covers the ``block=0`` case
+    (infinite-block) which would otherwise tie up the chassis worker
+    until process death.
+    """
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        _tools_call(
+            "meho.broadcast.watch",
+            {"since_cursor": _SINCE_FIXTURE, "timeout_ms": bad_timeout},
+        ),
+    )
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_non_integer_timeout_ms_returns_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``timeout_ms`` of the wrong JSON type rejects with -32602."""
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        _tools_call(
+            "meho.broadcast.watch",
+            {"since_cursor": _SINCE_FIXTURE, "timeout_ms": "5000"},
+        ),
+    )
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+def test_handler_timeout_validator_rejects_bool() -> None:
+    """``bool`` is a subclass of ``int`` in Python; the validator rejects it explicitly.
+
+    Without the explicit ``bool`` rejection, a caller could pass
+    ``timeout_ms=True`` (interpreted as 1ms) or ``timeout_ms=False`` (0ms)
+    and silently degrade the long-poll into a non-blocking poll or
+    instant-return. The validator catches both.
+    """
+    with pytest.raises(McpInvalidParamsError, match="timeout_ms"):
+        _validate_timeout_ms(True)
+    with pytest.raises(McpInvalidParamsError, match="timeout_ms"):
+        _validate_timeout_ms(False)
+
+
+def test_handler_timeout_validator_returns_default_for_none() -> None:
+    """``None`` -> the documented default of 10000ms."""
+    assert _validate_timeout_ms(None) == _WATCH_DEFAULT_TIMEOUT_MS
+
+
+@pytest.mark.parametrize(
+    "good_timeout",
+    [_WATCH_MIN_TIMEOUT_MS, 500, 10_000, _WATCH_MAX_TIMEOUT_MS],
+)
+def test_handler_timeout_validator_accepts_in_range(good_timeout: int) -> None:
+    """Boundary + interior in-range values pass through unchanged."""
+    assert _validate_timeout_ms(good_timeout) == good_timeout
+
+
+# ---------------------------------------------------------------------------
+# No events within timeout -> {events: [], next_cursor: unchanged}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_xread_timeout_none_returns_empty_with_unchanged_cursor(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``XREAD`` returning ``None`` (timeout) -> empty + unchanged cursor.
+
+    redis-py's documented "no new messages within block window" shape is
+    a ``None`` return value. The handler MUST surface
+    ``{events: [], next_cursor: <since_cursor>}`` so the caller knows to
+    re-poll with the same cursor.
+    """
+    client, _op = client_with_operator
+    bc = get_broadcast_client()
+    with patch.object(bc, "xread", new=AsyncMock(return_value=None)) as xr:
+        resp = post_mcp(
+            client,
+            _tools_call(
+                "meho.broadcast.watch",
+                {"since_cursor": _SINCE_FIXTURE, "timeout_ms": 200},
+            ),
+        )
+    result = _result_dict(resp)
+    assert result == {"events": [], "next_cursor": _SINCE_FIXTURE}
+    # And xread was invoked with the right block window.
+    assert xr.await_args.kwargs["block"] == 200
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_xread_empty_list_returns_empty_with_unchanged_cursor(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """An empty outer list from XREAD is also a "nothing for us" shape.
+
+    Defensive against a future redis-py shape change -- the truthiness
+    check collapses ``None`` and ``[]`` into the same branch.
+    """
+    client, _op = client_with_operator
+    bc = get_broadcast_client()
+    with patch.object(bc, "xread", new=AsyncMock(return_value=[])):
+        resp = post_mcp(
+            client,
+            _tools_call(
+                "meho.broadcast.watch",
+                {"since_cursor": _SINCE_FIXTURE},
+            ),
+        )
+    result = _result_dict(resp)
+    assert result == {"events": [], "next_cursor": _SINCE_FIXTURE}
+
+
+# ---------------------------------------------------------------------------
+# New events arrive -> returned immediately, cursor advanced
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_new_events_returned_with_advanced_cursor(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """Entries arriving within the block window surface immediately.
+
+    The handler advances ``next_cursor`` to the LAST FETCHED entry id
+    (the M2 invariant: filter-heavy pages still move the cursor forward).
+    """
+    client, op = client_with_operator
+    stream_key = f"meho:feed:{op.tenant_id}"
+    e1 = _make_event(op_id="vsphere.vm.list")
+    e2 = _make_event(op_id="vsphere.vm.create", op_class="write")
+    e3 = _make_event(op_id="vsphere.vm.delete", op_class="write")
+    envelope = _xread_envelope(
+        stream_key,
+        [(e1, "1747800000100-0"), (e2, "1747800000200-0"), (e3, "1747800000300-0")],
+    )
+    bc = get_broadcast_client()
+    with patch.object(bc, "xread", new=AsyncMock(return_value=envelope)):
+        resp = post_mcp(
+            client,
+            _tools_call(
+                "meho.broadcast.watch",
+                {"since_cursor": _SINCE_FIXTURE},
+            ),
+        )
+    result = _result_dict(resp)
+    op_ids = [e["op_id"] for e in result["events"]]
+    assert op_ids == ["vsphere.vm.list", "vsphere.vm.create", "vsphere.vm.delete"]
+    assert result["next_cursor"] == "1747800000300-0"
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_cursor_advances_past_filtered_out_entries(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A page where every entry is filtered out still moves the cursor.
+
+    Without this, a busy-but-filtered tenant would loop forever re-reading
+    the same XREAD batch on every poll -- the M2 fix the SSE generator
+    documents explicitly. ``events`` is empty (filter dropped both), but
+    ``next_cursor`` reflects the last *fetched* entry id.
+    """
+    client, op = client_with_operator
+    stream_key = f"meho:feed:{op.tenant_id}"
+    read_event = _make_event(op_id="vsphere.vm.list", op_class="read")
+    write_event = _make_event(op_id="vsphere.vm.create", op_class="write")
+    envelope = _xread_envelope(
+        stream_key,
+        [(read_event, "1747800000100-0"), (write_event, "1747800000200-0")],
+    )
+    bc = get_broadcast_client()
+    with patch.object(bc, "xread", new=AsyncMock(return_value=envelope)):
+        resp = post_mcp(
+            client,
+            _tools_call(
+                "meho.broadcast.watch",
+                {
+                    "since_cursor": _SINCE_FIXTURE,
+                    "filter": {"op_class": "credential_read"},  # matches nothing
+                },
+            ),
+        )
+    result = _result_dict(resp)
+    assert result["events"] == []
+    assert result["next_cursor"] == "1747800000200-0"  # advanced past both
+
+
+# ---------------------------------------------------------------------------
+# Filter narrowing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_filter_op_class_narrows_result(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``filter.op_class`` keeps only matching events."""
+    client, op = client_with_operator
+    stream_key = f"meho:feed:{op.tenant_id}"
+    read_event = _make_event(op_id="vsphere.vm.list", op_class="read")
+    write_event = _make_event(op_id="vsphere.vm.create", op_class="write")
+    envelope = _xread_envelope(
+        stream_key,
+        [(read_event, "1747800000100-0"), (write_event, "1747800000200-0")],
+    )
+    bc = get_broadcast_client()
+    with patch.object(bc, "xread", new=AsyncMock(return_value=envelope)):
+        resp = post_mcp(
+            client,
+            _tools_call(
+                "meho.broadcast.watch",
+                {"since_cursor": _SINCE_FIXTURE, "filter": {"op_class": "write"}},
+            ),
+        )
+    result = _result_dict(resp)
+    op_ids = [e["op_id"] for e in result["events"]]
+    assert op_ids == ["vsphere.vm.create"]
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_filter_principal_narrows_result(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``filter.principal`` keeps only events from the named JWT 'sub'."""
+    client, op = client_with_operator
+    stream_key = f"meho:feed:{op.tenant_id}"
+    alice = _make_event(op_id="vsphere.vm.list", principal_sub="op-alice")
+    bob = _make_event(op_id="vsphere.vm.list", principal_sub="op-bob")
+    envelope = _xread_envelope(
+        stream_key,
+        [(alice, "1747800000100-0"), (bob, "1747800000200-0")],
+    )
+    bc = get_broadcast_client()
+    with patch.object(bc, "xread", new=AsyncMock(return_value=envelope)):
+        resp = post_mcp(
+            client,
+            _tools_call(
+                "meho.broadcast.watch",
+                {"since_cursor": _SINCE_FIXTURE, "filter": {"principal": "op-alice"}},
+            ),
+        )
+    result = _result_dict(resp)
+    principals = [e["principal_sub"] for e in result["events"]]
+    assert principals == ["op-alice"]
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_filter_target_narrows_result(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``filter.target`` keeps only events with matching ``target_name``.
+
+    Asserts both:
+
+    1. The matching event survives.
+    2. Events with ``target_name=None`` are dropped (the caller asked
+       for a specific target; an untagged event doesn't qualify).
+    """
+    client, op = client_with_operator
+    stream_key = f"meho:feed:{op.tenant_id}"
+    prod = _make_event(target_name="prod-vc-1")
+    staging = _make_event(target_name="staging-vc-1")
+    untagged = _make_event(target_name=None)
+    envelope = _xread_envelope(
+        stream_key,
+        [
+            (prod, "1747800000100-0"),
+            (staging, "1747800000200-0"),
+            (untagged, "1747800000300-0"),
+        ],
+    )
+    bc = get_broadcast_client()
+    with patch.object(bc, "xread", new=AsyncMock(return_value=envelope)):
+        resp = post_mcp(
+            client,
+            _tools_call(
+                "meho.broadcast.watch",
+                {"since_cursor": _SINCE_FIXTURE, "filter": {"target": "prod-vc-1"}},
+            ),
+        )
+    result = _result_dict(resp)
+    targets = [e["target_name"] for e in result["events"]]
+    assert targets == ["prod-vc-1"]
+
+
+# ---------------------------------------------------------------------------
+# Tenant boundary (structural -- no input that could ask for another tenant)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_stream_key_derived_from_operator_tenant_id(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """The handler ALWAYS reads ``meho:feed:{operator.tenant_id}``.
+
+    Tenant isolation here is structural: the input schema has no
+    ``tenant_id`` field, so a malicious caller has no way to ask for
+    another tenant's stream. Asserting the read key is the right shape
+    proves the structural property holds.
+    """
+    client, op = client_with_operator
+    bc = get_broadcast_client()
+    with patch.object(bc, "xread", new=AsyncMock(return_value=None)) as xr:
+        post_mcp(
+            client,
+            _tools_call("meho.broadcast.watch", {"since_cursor": _SINCE_FIXTURE}),
+        )
+    streams_arg = xr.await_args.args[0]
+    expected_key = f"meho:feed:{op.tenant_id}"
+    assert expected_key in streams_arg
+    # And the cursor we passed forward is the one the caller sent.
+    assert streams_arg[expected_key] == _SINCE_FIXTURE
+
+
+async def test_handler_with_distinct_operator_reads_distinct_stream() -> None:
+    """Two operators on different tenants read their own streams only.
+
+    Directly exercises the handler (bypassing the FastAPI dispatcher)
+    with two operators bound to two different tenant ids; asserts each
+    call resolves to its own stream key. The mocked client always
+    returns ``None`` -- the assertion is on the key passed to xread,
+    not on what came back.
+    """
+    tenant_a = UUID("aaaa0000-0000-0000-0000-000000000001")
+    tenant_b = UUID("bbbb0000-0000-0000-0000-000000000002")
+    op_a = Operator(
+        sub="op-a",
+        raw_jwt="x",
+        tenant_id=tenant_a,
+        tenant_role=TenantRole.OPERATOR,
+    )
+    op_b = Operator(
+        sub="op-b",
+        raw_jwt="x",
+        tenant_id=tenant_b,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+    bc = get_broadcast_client()
+    with patch.object(bc, "xread", new=AsyncMock(return_value=None)) as xr:
+        await _handler_watch(op_a, {"since_cursor": _SINCE_FIXTURE})
+        await _handler_watch(op_b, {"since_cursor": _SINCE_FIXTURE})
+
+    keys_read = [next(iter(call.args[0].keys())) for call in xr.await_args_list]
+    assert keys_read == [f"meho:feed:{tenant_a}", f"meho:feed:{tenant_b}"]
+
+
+# ---------------------------------------------------------------------------
+# Cancellation: client disconnects mid-block -> CancelledError re-raised
+# ---------------------------------------------------------------------------
+
+
+async def test_handler_re_raises_cancelled_error_from_xread() -> None:
+    """When ``xread`` raises ``asyncio.CancelledError``, the handler re-raises.
+
+    Swallowing ``CancelledError`` breaks the task tree's unwind invariants
+    per the asyncio cancellation contract (Sonar S7497; Python 3.13+
+    re-issues cancellation if it goes unpropagated). The handler logs the
+    structured disconnect and re-raises so the chassis worker is released
+    the moment Starlette cancels the request.
+    """
+    op = build_operator(TenantRole.OPERATOR)
+
+    async def _cancelled_xread(*_args: object, **_kwargs: object) -> Any:
+        raise asyncio.CancelledError
+
+    bc = get_broadcast_client()
+    with (
+        patch.object(bc, "xread", new=_cancelled_xread),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await _handler_watch(op, {"since_cursor": _SINCE_FIXTURE})
+
+
+async def test_handler_cancellation_during_real_block_releases_worker() -> None:
+    """An asyncio-driven cancellation during a real block window propagates cleanly.
+
+    Models the full Starlette cancellation path: a long-poll call is in
+    progress, the client transport closes, ``asyncio.Task.cancel()`` lands
+    on the awaiting task, and the handler must release the chassis worker
+    without swallowing the signal. Drives this with ``asyncio.wait_for``
+    against a never-completing fake xread.
+
+    A "release the worker" guarantee that swallowed cancellation would
+    fail this test by leaking past the ``asyncio.TimeoutError`` raise --
+    that mechanism is exactly the one asyncio uses to escalate a
+    cancellation that the awaitee swallows.
+    """
+    op = build_operator(TenantRole.OPERATOR)
+
+    async def _never_returns(*_args: object, **_kwargs: object) -> Any:
+        await asyncio.sleep(3600)  # never completes within the test window
+        return None
+
+    bc = get_broadcast_client()
+    with (
+        patch.object(bc, "xread", new=_never_returns),
+        pytest.raises((asyncio.TimeoutError, asyncio.CancelledError)),
+    ):
+        await asyncio.wait_for(
+            _handler_watch(op, {"since_cursor": _SINCE_FIXTURE}),
+            timeout=0.1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# PII inheritance: aggregate-only payloads pass through verbatim
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_credential_read_payload_surfaces_aggregate_only(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``credential_read`` events return whatever the publisher redacted to.
+
+    The tool MUST NOT re-derive or mutate ``payload``; it surfaces the
+    on-stream view verbatim. Feeding an aggregate-shaped payload
+    asserts the tool doesn't accidentally expand it back to full.
+    """
+    client, op = client_with_operator
+    stream_key = f"meho:feed:{op.tenant_id}"
+    aggregate_payload = {"op_class": "credential_read", "result_status": "ok"}
+    event = _make_event(
+        op_id="vault.kv.read",
+        op_class="credential_read",
+        payload=aggregate_payload,
+    )
+    envelope = _xread_envelope(stream_key, [(event, "1747800000100-0")])
+    bc = get_broadcast_client()
+    with patch.object(bc, "xread", new=AsyncMock(return_value=envelope)):
+        resp = post_mcp(
+            client,
+            _tools_call("meho.broadcast.watch", {"since_cursor": _SINCE_FIXTURE}),
+        )
+    result = _result_dict(resp)
+    assert result["events"][0]["payload"] == aggregate_payload
+    # And no path / key / value leak from any earlier-rendered shape.
+    assert "params" not in result["events"][0]["payload"]
+    assert "path" not in result["events"][0]["payload"]
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_audit_query_payload_surfaces_aggregate_with_row_count(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``audit_query`` events surface the ``row_count`` aggregate verbatim."""
+    client, op = client_with_operator
+    stream_key = f"meho:feed:{op.tenant_id}"
+    aggregate_payload = {
+        "op_class": "audit_query",
+        "result_status": "ok",
+        "row_count": 17,
+    }
+    event = _make_event(
+        op_id="meho.audit.replay",
+        op_class="audit_query",
+        payload=aggregate_payload,
+    )
+    envelope = _xread_envelope(stream_key, [(event, "1747800000100-0")])
+    bc = get_broadcast_client()
+    with patch.object(bc, "xread", new=AsyncMock(return_value=envelope)):
+        resp = post_mcp(
+            client,
+            _tools_call("meho.broadcast.watch", {"since_cursor": _SINCE_FIXTURE}),
+        )
+    result = _result_dict(resp)
+    assert result["events"][0]["payload"] == aggregate_payload
+
+
+# ---------------------------------------------------------------------------
+# Deserialisation safety net (skip malformed entries, don't raise)
+# ---------------------------------------------------------------------------
+
+
+async def test_handler_skips_unknown_field_shape() -> None:
+    """An entry without an ``event`` field is logged + skipped, not raised."""
+    op = build_operator(TenantRole.OPERATOR)
+    stream_key = f"meho:feed:{op.tenant_id}"
+    good = _make_event()
+    envelope = [
+        (
+            stream_key,
+            [
+                ("1747800000100-0", {"unexpected_key": "nothing-useful"}),
+                ("1747800000200-0", {"event": good.model_dump_json()}),
+            ],
+        ),
+    ]
+    bc = get_broadcast_client()
+    with patch.object(bc, "xread", new=AsyncMock(return_value=envelope)):
+        result = await _handler_watch(op, {"since_cursor": _SINCE_FIXTURE})
+    assert len(result["events"]) == 1
+    assert result["events"][0]["event_id"] == str(good.event_id)
+    # Cursor still advances past the malformed entry.
+    assert result["next_cursor"] == "1747800000200-0"
+
+
+async def test_handler_skips_malformed_event_json() -> None:
+    """An entry whose ``event`` field doesn't parse as BroadcastEvent is skipped."""
+    op = build_operator(TenantRole.OPERATOR)
+    stream_key = f"meho:feed:{op.tenant_id}"
+    good = _make_event()
+    envelope = [
+        (
+            stream_key,
+            [
+                ("1747800000100-0", {"event": '{"not": "a BroadcastEvent"}'}),
+                ("1747800000200-0", {"event": good.model_dump_json()}),
+            ],
+        ),
+    ]
+    bc = get_broadcast_client()
+    with patch.object(bc, "xread", new=AsyncMock(return_value=envelope)):
+        result = await _handler_watch(op, {"since_cursor": _SINCE_FIXTURE})
+    assert len(result["events"]) == 1
+    assert result["events"][0]["event_id"] == str(good.event_id)
+
+
+# ---------------------------------------------------------------------------
+# Filter input-shape validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_filter_with_unknown_sub_key_rejected(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``filter`` rejects unknown sub-keys via ``additionalProperties: false``."""
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        _tools_call(
+            "meho.broadcast.watch",
+            {"since_cursor": _SINCE_FIXTURE, "filter": {"unknown": "value"}},
+        ),
+    )
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_filter_op_class_outside_enum_rejected(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``filter.op_class`` outside the enum rejects with -32602."""
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        _tools_call(
+            "meho.broadcast.watch",
+            {"since_cursor": _SINCE_FIXTURE, "filter": {"op_class": "made_up"}},
+        ),
+    )
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_unknown_top_level_argument_rejected(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``additionalProperties: false`` at the top level rejects stray keys.
+
+    Defends against a future-caller typo (e.g. ``tenant_id`` smuggled in
+    as a hopeful escape hatch) -- the schema rejects it before the
+    handler runs.
+    """
+    client, _op = client_with_operator
+    resp = post_mcp(
+        client,
+        _tools_call(
+            "meho.broadcast.watch",
+            {"since_cursor": _SINCE_FIXTURE, "tenant_id": "00000000-0000-0000-0000-000000000bad"},
+        ),
+    )
+    body = resp.json()
+    assert "error" in body
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+# ---------------------------------------------------------------------------
+# Optional testcontainers integration suite
+# ---------------------------------------------------------------------------
+
+
+def _docker_socket_present() -> bool:
+    return Path("/var/run/docker.sock").exists() or os.environ.get("DOCKER_HOST") is not None
+
+
+_DOCKER_AVAILABLE = _docker_socket_present()
+_SKIP_REASON = (
+    "Docker socket unavailable in this sandbox; runs in CI where containers are provisioned."
+)
+
+
+@pytest.mark.skipif(not _DOCKER_AVAILABLE, reason=_SKIP_REASON)
+class TestBroadcastWatchIntegration:
+    """End-to-end suite against a real Valkey container.
+
+    Drives the same publisher (``publish_event``) the production
+    publish-on-write hook uses so the integration covers the full
+    XADD -> XREAD -> handler seam, including the cursor round-trip
+    and the watch-then-arrives cadence.
+    """
+
+    @pytest.fixture
+    async def valkey_url(self, monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[str]:
+        from testcontainers.redis import RedisContainer
+
+        image = os.environ.get("MEHO_TEST_VALKEY_IMAGE", "valkey/valkey:8")
+        with RedisContainer(image) as container:
+            host = container.get_container_host_ip()
+            port = container.get_exposed_port(6379)
+            url = f"redis://{host}:{port}"
+            monkeypatch.setenv("BROADCAST_REDIS_URL", url)
+            get_settings.cache_clear()
+            reset_broadcast_client_for_testing()
+            try:
+                yield url
+            finally:
+                await dispose_broadcast_client()
+                get_settings.cache_clear()
+
+    async def test_watch_returns_immediately_when_event_already_present(
+        self,
+        valkey_url: str,
+    ) -> None:
+        """Pre-existing entries past the cursor surface on the first call.
+
+        Sets up: publish entry A, get its id; publish entry B; call watch
+        with since_cursor=A.id. Expect entry B in the response without
+        blocking.
+        """
+        op = build_operator(TenantRole.OPERATOR)
+        event_a = _make_event(op_id="vsphere.vm.list")
+        event_b = _make_event(op_id="vsphere.vm.create")
+        await publish_event(event_a)
+        # Wait so the two events get distinct ids -- Valkey's monotonic
+        # ms+seq guarantees ordering, but the cursor round-trip is the
+        # contract under test.
+        await asyncio.sleep(0.01)
+        await publish_event(event_b)
+
+        client = get_broadcast_client()
+        stream_key = f"meho:feed:{op.tenant_id}"
+        # Get the first event's id by XRANGE on the stream.
+        first = await client.xrange(stream_key, count=1)
+        assert first, "publisher seeded entry A but XRANGE returned empty"
+        a_id = first[0][0]
+
+        result = await _handler_watch(
+            op,
+            {"since_cursor": a_id, "timeout_ms": 1000},
+        )
+        op_ids = [e["op_id"] for e in result["events"]]
+        assert op_ids == ["vsphere.vm.create"]
+        assert result["next_cursor"] != a_id
+
+    async def test_watch_returns_empty_after_timeout_no_events(
+        self,
+        valkey_url: str,
+    ) -> None:
+        """No events arrive within the window -> empty + unchanged cursor.
+
+        Uses the smallest allowed timeout to keep the test fast (~100ms).
+        """
+        op = build_operator(TenantRole.OPERATOR)
+        # No publishes -- the stream may not exist yet. XREAD against a
+        # missing stream returns the same "no entries" shape.
+        result = await _handler_watch(
+            op,
+            {"since_cursor": "0-0", "timeout_ms": _WATCH_MIN_TIMEOUT_MS},
+        )
+        assert result == {"events": [], "next_cursor": "0-0"}
+
+    async def test_two_tenants_see_only_their_own_events(
+        self,
+        valkey_url: str,
+    ) -> None:
+        """Two operators on two tenants each read only their own stream.
+
+        The structural tenant guarantee verified end-to-end: tenant-A's
+        operator never sees tenant-B's events even when both streams sit
+        on the same Valkey instance.
+        """
+        tenant_a = UUID("aaaa0000-0000-0000-0000-000000000001")
+        tenant_b = UUID("bbbb0000-0000-0000-0000-000000000002")
+        op_a = Operator(
+            sub="op-a",
+            raw_jwt="x",
+            tenant_id=tenant_a,
+            tenant_role=TenantRole.OPERATOR,
+        )
+        op_b = Operator(
+            sub="op-b",
+            raw_jwt="x",
+            tenant_id=tenant_b,
+            tenant_role=TenantRole.OPERATOR,
+        )
+
+        await publish_event(_make_event(tenant_id=tenant_a, op_id="tenant-a.op"))
+        await publish_event(_make_event(tenant_id=tenant_b, op_id="tenant-b.op"))
+
+        # Watch with since_cursor=0-0 to fetch the first batch on each
+        # stream regardless of pre-existing data.
+        result_a = await _handler_watch(
+            op_a,
+            {"since_cursor": "0-0", "timeout_ms": _WATCH_MIN_TIMEOUT_MS},
+        )
+        result_b = await _handler_watch(
+            op_b,
+            {"since_cursor": "0-0", "timeout_ms": _WATCH_MIN_TIMEOUT_MS},
+        )
+
+        a_op_ids = [e["op_id"] for e in result_a["events"]]
+        b_op_ids = [e["op_id"] for e in result_b["events"]]
+        assert a_op_ids == ["tenant-a.op"]
+        assert b_op_ids == ["tenant-b.op"]
+
+    async def test_watch_then_publish_during_block(self, valkey_url: str) -> None:
+        """A publish landing mid-block surfaces to the waiting watcher.
+
+        Schedules a publish for ~50ms after the watch starts; the watch
+        with a 5s timeout should return well before the timeout fires.
+        """
+        op = build_operator(TenantRole.OPERATOR)
+
+        async def _delayed_publish() -> None:
+            await asyncio.sleep(0.05)
+            await publish_event(_make_event(op_id="vsphere.vm.late"))
+
+        publish_task = asyncio.create_task(_delayed_publish())
+        try:
+            result = await _handler_watch(
+                op,
+                {"since_cursor": "0-0", "timeout_ms": 5000},
+            )
+        finally:
+            await publish_task
+
+        op_ids = [e["op_id"] for e in result["events"]]
+        assert "vsphere.vm.late" in op_ids

--- a/docs/cross-repo/broadcast-onboarding.md
+++ b/docs/cross-repo/broadcast-onboarding.md
@@ -38,6 +38,7 @@ Every transport reads the same per-tenant stream. Pick by use case:
 | `meho://tenant/{tenant_id}/feed` MCP resource | LLM clients (Claude, MCP-aware agents) that poll a snapshot | G6.1-T6 (this task) |
 | `meho.broadcast.recent` MCP tool | LLM clients that need filter / since / cursor pagination over the same stream | G6.4-T1 (#1091) |
 | `meho.broadcast.announce` MCP tool | Agents publishing intent / progress / completion narratives that other operators can read | G6.4-T2 (#1092) |
+| `meho.broadcast.watch` MCP tool | LLM clients that need long-poll "wait for the next batch" without an SSE socket | G6.4-T3 (#1093) |
 
 The Slack mirror (G6.2 #333) and any future web admin UI subscribe
 the same way — XREAD against the per-tenant stream key.
@@ -297,6 +298,110 @@ saw it.
 Tenant scoping is **structural**: the input schema has no `tenant_id`
 argument; the announcement always writes to the operator's own tenant
 stream. RBAC: `operator` role minimum.
+
+## MCP tool: `meho.broadcast.watch`
+
+The long-poll equivalent of "subscribe to the feed" for clients that
+don't speak SSE. Where `meho.broadcast.recent` returns whatever's
+already on the stream past `since`, `meho.broadcast.watch` uses Valkey
+`XREAD BLOCK <timeout_ms>` to **wait** for new entries past
+`since_cursor` and returns them as soon as they arrive — or returns
+empty when the block window expires.
+
+```json
+{
+  "name": "meho.broadcast.watch",
+  "arguments": {
+    "since_cursor": "1747800099000-0",
+    "filter": {"op_class": "write"},
+    "timeout_ms": 10000
+  }
+}
+```
+
+Response shape (events arrived):
+
+```json
+{
+  "events": [
+    {
+      "id": "1747800100200-0",
+      "event_id": "...",
+      "op_id": "vsphere.vm.create",
+      "principal_sub": "op-alice",
+      "result_status": "ok",
+      "ts": "2026-05-25T10:01:40Z",
+      "payload": {...},
+      "audit_id": "..."
+    }
+  ],
+  "next_cursor": "1747800100200-0"
+}
+```
+
+Response shape (window expired with no events):
+
+```json
+{
+  "events": [],
+  "next_cursor": "1747800099000-0"
+}
+```
+
+The **unchanged `next_cursor` is the "I waited; nothing landed" signal**.
+The caller re-polls with the same cursor.
+
+Arguments:
+
+* `since_cursor` (**required**) — Valkey stream cursor (`1747800000000-0`).
+  Obtain the initial value from `meho.broadcast.recent`'s `next_cursor`;
+  from that point forward the watch loop feeds itself.
+* `filter.op_class` / `filter.principal` / `filter.target` — same
+  semantics as `meho.broadcast.recent`. Filtered-out entries still
+  advance the cursor so the walk progresses even on busy-but-filtered
+  tenants.
+* `timeout_ms` — integer in `[100, 30000]`, default `10000` (10s).
+  The 30s cap is a **hard backpressure boundary**, not a hint: each
+  watch call ties up one chassis worker for the block window, so an
+  infinite-block call would let one bad actor exhaust the worker pool.
+  Values outside the range return JSON-RPC `INVALID_PARAMS` (-32602).
+
+Pagination contract — the watch loop is the agent-side broadcast
+discipline:
+
+```javascript
+let {events: initial, next_cursor: cursor} = await callTool(
+  "meho.broadcast.recent", {limit: 100}
+);
+for (const e of initial) handle(e);
+
+while (running) {
+  const {events, next_cursor} = await callTool(
+    "meho.broadcast.watch",
+    {since_cursor: cursor, timeout_ms: 10000}
+  );
+  for (const e of events) handle(e);
+  cursor = next_cursor;  // advances on hit; stays the same on timeout
+}
+```
+
+Tenant scoping is **structural** (identical to `meho.broadcast.recent`):
+the input schema has no `tenant_id` argument; the stream key is
+derived exclusively from `operator.tenant_id`. RBAC: `operator` role
+minimum.
+
+**Why long-poll, not MCP `resources/subscribe`:** the MCP server's
+`initialize` response advertises `subscribe: false` (per
+[`backend/src/meho_backplane/mcp/resources/kb.py`](../../backend/src/meho_backplane/mcp/resources/kb.py)),
+deferring server-push to v0.2.next. Long-poll is the pragmatic v0.2
+shape — same caller pattern as a subscribe-loop, same per-tenant
+isolation, no extra capability on the wire.
+
+Cancellation: when the MCP client closes the transport mid-block (or
+the dispatcher tears the call down), Starlette propagates
+`asyncio.CancelledError` into the pending `xread` and the handler
+re-raises it after logging — the chassis worker is released on the
+next event-loop tick.
 
 ## PII defaults (decision #3)
 


### PR DESCRIPTION
## Summary
- Register `meho.broadcast.watch` MCP tool: long-poll batch read via Valkey `XREAD BLOCK` (timeout 100..30000 ms, default 10s) for the per-tenant `meho:feed:{operator.tenant_id}` stream past a caller-supplied `since_cursor`.
- 30s cap on `timeout_ms` is the hard backpressure boundary (one chassis worker tied up per outstanding watch); infinite-block (`block=0`) explicitly rejected as `-32602`.
- Cursor advancement matches the SSE generator's M2 fix: `next_cursor` advances to the LAST FETCHED entry id so filter-heavy pages still progress; cursor stays unchanged on timeout so the caller's re-poll picks up from the same point.
- Cancellation propagates `asyncio.CancelledError` per the Sonar S7497 contract — Starlette cancelling mid-block releases the chassis worker on the next event-loop tick.
- Tenant isolation is structural (no `tenant_id` argument); PII inheritance is structural (publisher already redacted credential_read / audit_query payloads at write time).
- Fallback for the MCP `resources/subscribe` gate (still advertised as `false` per `kb.py`); long-poll is the pragmatic v0.2 shape.

## Test plan
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy backend/src/meho_backplane/mcp/tools/broadcast.py` — clean
- [x] `pytest tests/test_mcp_tool_broadcast_watch.py` — 37 passed, 4 skipped (Docker-gated integration suite runs in CI)
- [x] `pytest tests/test_mcp_tool_broadcast_recent.py` — 30 passed, 4 skipped (T1 regression check)
- [x] `pytest -k "mcp_ or broadcast"` — 633 passed, 38 skipped (broader regression sweep, no failures)
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (pre-existing file-size + T1 function-size warnings only)
- [x] AC: `meho.broadcast.watch` registered, `tools/list` exposes it for `operator`, hidden from `read_only`
- [x] AC: `since_cursor` required; missing → `-32602`
- [x] AC: `timeout_ms` outside `[100, 30000]` → `-32602` (parametrized over 0 / 99 / -5 / 30001 / 60000 / 1_000_000)
- [x] AC: no events within timeout → `{events: [], next_cursor: <unchanged>}` (covered for both `None` and `[]` XREAD shapes)
- [x] AC: new events returned immediately, `next_cursor` advanced to last fetched id
- [x] AC: filter narrowing for `op_class` / `principal` / `target` (one test each, plus the busy-but-filtered cursor-advance invariant)
- [x] AC: tenant boundary structural (stream key always `meho:feed:{operator.tenant_id}` regardless of arguments; cross-operator handler test asserts two distinct tenants read two distinct keys)
- [x] AC: cancellation releases the chassis worker (direct `CancelledError` raise + `asyncio.wait_for` cancellation propagation test)
- [x] AC: credential_read + audit_query payloads pass through verbatim (publisher-side redaction inherited)

## Out of scope
- T2 (#1092) `broadcast_announce` — being implemented in parallel by another agent on `feat/1092-broadcast-announce-mcp`.
- MCP `resources/subscribe` server-push — chassis still advertises `subscribe:false` per `backend/src/meho_backplane/mcp/resources/kb.py`. Deferred to v0.2.next.
- Server-side cursor persistence — caller manages, per the issue body.
- Multi-tenant fan-out — out per the G6.1 tenant-isolation contract.

## Notes for review
- The shared `_list_recent_events_impl` helper from T1 is untouched; T3 adds its own `_watch_events_impl` plus three private helpers (`_xread_or_cancelled` / `_xread_items_or_none` / `_filter_xread_items`) to keep the parallel-merge surface against T2 minimal. All T3 additions are appended after T1's `# === end meho.broadcast.recent ===` marker with matching `# === <tool-name> ===` bounded-section discipline.
- Long-poll cadence + worker-tie-up cost is documented in `docs/cross-repo/broadcast-onboarding.md` so operators can reason about the fan-out shape before adopting the watch loop.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1093
