### PR TITLE
feat(conventions): G7.1-T7 surface BudgetStatus on list + exit 5 on overflow

### DIFF
--- a/backend/src/meho_backplane/api/v1/conventions.py
+++ b/backend/src/meho_backplane/api/v1/conventions.py
@@ -60,8 +60,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from meho_backplane.audit import bind_preallocated_audit_id
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
+from meho_backplane.conventions.preamble import assemble_preamble
 from meho_backplane.conventions.schemas import (
     DEFAULT_MAX_PREAMBLE_TOKENS,
+    BudgetStatus,
     Convention,
     ConventionCreate,
     ConventionHistoryEntry,
@@ -294,6 +296,17 @@ async def list_conventions(
     ``body``). Ordering is ``priority DESC, created_at ASC`` --
     the same key T4's preamble assembler uses for packing, so the
     list view surfaces conventions in T4's consideration order.
+
+    The response also carries ``budget_status`` (T7 #1094): the
+    preamble budget arithmetic for the operator's tenant, computed
+    by a call to :func:`~meho_backplane.conventions.preamble.assemble_preamble`.
+    The ``--kind`` query filter narrows the ``entries`` list only;
+    ``budget_status`` always reflects the full ``operational``
+    set (a ``--kind=workflow`` list call still wants the truthful
+    budget signal). The assembler runs an indexed SELECT + an
+    in-memory pack -- O(N) per call where N is the tenant's
+    operational-convention count (~10-20 in practice), so the
+    cost is negligible against the list round-trip.
     """
     structlog.contextvars.bind_contextvars(
         audit_op_id=_OP_ID_LIST,
@@ -309,8 +322,27 @@ async def list_conventions(
         TenantConvention.created_at.asc(),
     )
     rows = (await session.execute(stmt)).scalars().all()
+
+    # Compute the budget status via the same primitive T4's MCP
+    # ``initialize`` handler uses, so a tenant's
+    # ``estimated_tokens`` on the list response and the preamble
+    # actually delivered to agent sessions cannot drift. The
+    # assembler opens its own DB session (it has to: the MCP
+    # ``initialize`` path is not a FastAPI request handler), which
+    # adds one round-trip on top of the list query above; that is
+    # acceptable for the v0.2 budget contract and the natural unit
+    # for "what the preamble actually weighs".
+    preamble = await assemble_preamble(operator.tenant_id)
+    budget_status = BudgetStatus(
+        max_tokens=DEFAULT_MAX_PREAMBLE_TOKENS,
+        estimated_tokens=estimate_tokens(preamble.text),
+        over_budget=bool(preamble.dropped_slugs),
+        dropped_slugs=preamble.dropped_slugs,
+    )
+
     return ConventionListResponse(
         entries=[ConventionSummary.model_validate(row) for row in rows],
+        budget_status=budget_status,
     )
 
 

--- a/backend/src/meho_backplane/conventions/__init__.py
+++ b/backend/src/meho_backplane/conventions/__init__.py
@@ -38,6 +38,7 @@ from meho_backplane.conventions.preamble import (
 )
 from meho_backplane.conventions.schemas import (
     DEFAULT_MAX_PREAMBLE_TOKENS,
+    BudgetStatus,
     Convention,
     ConventionCreate,
     ConventionHistoryEntry,
@@ -53,6 +54,7 @@ __all__ = [
     "BLOCK_START",
     "DEFAULT_MAX_PREAMBLE_TOKENS",
     "GUARD_PREFIX",
+    "BudgetStatus",
     "Convention",
     "ConventionCreate",
     "ConventionHistoryEntry",

--- a/backend/src/meho_backplane/conventions/schemas.py
+++ b/backend/src/meho_backplane/conventions/schemas.py
@@ -61,6 +61,7 @@ from pydantic import BaseModel, ConfigDict, Field
 __all__ = [
     "DEFAULT_MAX_PREAMBLE_TOKENS",
     "TOKEN_CHAR_RATIO",
+    "BudgetStatus",
     "Convention",
     "ConventionCreate",
     "ConventionHistoryEntry",
@@ -277,6 +278,62 @@ class Convention(BaseModel):
     updated_at: datetime
 
 
+class BudgetStatus(BaseModel):
+    """Preamble budget status for the operator's tenant.
+
+    Surfaced as a sub-document on every ``GET /api/v1/conventions``
+    call so the CLI's ``meho conventions list`` (T7 #1094) can warn
+    when the tenant's ``kind='operational'`` set overflows the
+    preamble budget and name the slugs that will be dropped from the
+    agent session preamble. Without this surface, T3 #315's
+    "lowest-priority slugs that will be dropped" acceptance
+    criterion is unsatisfiable from a single list call -- the
+    deferred AC the issue body folds back in.
+
+    All four fields are populated by a single call to
+    :func:`~meho_backplane.conventions.preamble.assemble_preamble`
+    against the operator's tenant, so the budget arithmetic is
+    end-to-end consistent with T4's preamble assembler (the same
+    helper that produces the MCP ``initialize`` ``instructions``
+    field). A divergence between the list surface's
+    ``estimated_tokens`` and the preamble actually delivered to
+    agent sessions would be a silent contract drift; sharing the
+    primitive eliminates it by construction.
+
+    Fields:
+
+    * ``max_tokens`` -- the budget the preamble assembler enforces.
+      Currently :data:`DEFAULT_MAX_PREAMBLE_TOKENS` (a module-level
+      constant; configurable via the assembler's ``max_tokens``
+      parameter in tests). Exposed on the list response so
+      operators can do the budget math without grepping the source.
+    * ``estimated_tokens`` -- :func:`estimate_tokens` over the
+      assembled preamble text (header + guard + delimited kept
+      blocks). Empty tenant: 0. Fitting tenant: positive integer
+      below ``max_tokens``. Over-budget tenant: positive integer
+      below ``max_tokens`` (the packer dropped slugs whole until it
+      fit), but ``over_budget=True`` and ``dropped_slugs`` is
+      non-empty.
+    * ``over_budget`` -- convenience flag derived from
+      ``len(dropped_slugs) > 0``. Cheap derived value but worth
+      surfacing as a boolean so CLI / dashboard consumers branch on
+      one bit rather than a length-of-list check.
+    * ``dropped_slugs`` -- slugs that did not fit, in the packer's
+      drop order (lowest-priority-first, ties broken by oldest-
+      first). The CLI prints these on stderr with an
+      "insufficient_budget" exit-code-5 warning so the operator
+      knows exactly which conventions never reach an agent
+      session.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    max_tokens: int = Field(ge=0)
+    estimated_tokens: int = Field(ge=0)
+    over_budget: bool
+    dropped_slugs: list[str]
+
+
 class ConventionListResponse(BaseModel):
     """Response envelope for ``GET /api/v1/conventions``.
 
@@ -284,11 +341,22 @@ class ConventionListResponse(BaseModel):
     field can land non-breakingly. Same shape the kb + memory list
     surfaces adopted; consistency across the v0.2 read APIs keeps
     the CLI's list renderer one switch statement, not three.
+
+    ``budget_status`` (T7 #1094) carries the preamble budget
+    arithmetic for the operator's tenant. Always populated; the
+    underlying :func:`~meho_backplane.conventions.preamble.assemble_preamble`
+    call is one indexed SELECT + an in-memory pack -- cheap enough
+    to run on every list request. Exposing it on the list
+    response (rather than on a separate
+    ``/api/v1/conventions/budget-status`` route the issue body
+    explicitly rejects) keeps the CLI / dashboard consumer paths
+    to one HTTP round-trip.
     """
 
     model_config = ConfigDict(frozen=True)
 
     entries: list[ConventionSummary]
+    budget_status: BudgetStatus
 
 
 class ConventionHistoryEntry(BaseModel):

--- a/backend/tests/test_api_v1_conventions.py
+++ b/backend/tests/test_api_v1_conventions.py
@@ -756,7 +756,18 @@ async def test_get_does_not_leak_cross_tenant(client: TestClient) -> None:
             headers={"Authorization": f"Bearer {token_b}"},
         )
     assert resp.status_code == 200
-    assert resp.json() == {"entries": []}
+    body = resp.json()
+    # T7 #1094: list now carries ``budget_status`` alongside entries.
+    # Tenant B's view sees its own empty preamble budget -- tenant A's
+    # convention does not bleed across (the cross-tenant assertion this
+    # test originated to guard).
+    assert body["entries"] == []
+    assert body["budget_status"] == {
+        "max_tokens": DEFAULT_MAX_PREAMBLE_TOKENS,
+        "estimated_tokens": 0,
+        "over_budget": False,
+        "dropped_slugs": [],
+    }
 
 
 @pytest.mark.asyncio
@@ -1005,3 +1016,210 @@ async def test_audit_payload_carries_op_id_and_slug(client: TestClient) -> None:
     assert payload["op_id"] == "conventions.create"
     assert payload["op_class"] == "write"
     assert payload["slug"] == "audit-payload"
+
+
+# ---------------------------------------------------------------------------
+# T7 #1094 -- BudgetStatus surfacing on GET /api/v1/conventions
+# ---------------------------------------------------------------------------
+
+
+def _near_budget_body(target_tokens: int = 400) -> str:
+    """A body whose token estimate is close to ``target_tokens``.
+
+    Stays well under :data:`DEFAULT_MAX_PREAMBLE_TOKENS` so the
+    per-entry POST 422 gate accepts it (the single-entry overflow
+    check at write time is independent of the cumulative pack-
+    budget check at preamble-assembly time). Three of these
+    together overflow the cumulative budget and exercise the
+    packer's drop-lowest-priority-first behaviour.
+
+    Math: ``estimate_tokens`` is ``ceil(len / 3.3)``. For
+    ``target_tokens=400`` we need ``len >= 1320``; we use 1400 for
+    headroom.
+    """
+    chars = max(target_tokens * 4, 1400)
+    return "x " * (chars // 2)
+
+
+@pytest.mark.asyncio
+async def test_list_budget_status_empty_tenant(client: TestClient) -> None:
+    """Empty tenant: ``estimated_tokens=0``, ``over_budget=False``, ``dropped_slugs=[]``."""
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-budget-empty")
+    token = _token(key)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = client.get(
+            "/api/v1/conventions",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["entries"] == []
+    bs = body["budget_status"]
+    assert bs["max_tokens"] == DEFAULT_MAX_PREAMBLE_TOKENS
+    assert bs["estimated_tokens"] == 0
+    assert bs["over_budget"] is False
+    assert bs["dropped_slugs"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_budget_status_fitting_tenant(client: TestClient) -> None:
+    """Fitting tenant: ``over_budget=False``, ``dropped_slugs=[]``, ``estimated_tokens > 0``."""
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-budget-fits")
+    token = _token(key)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        # Two small operational conventions -- both fit the 600-
+        # token budget with room to spare.
+        _post_convention(client, token, slug="rule-one", body="Short rule one.", priority=10)
+        _post_convention(client, token, slug="rule-two", body="Short rule two.", priority=5)
+        # And a workflow / reference each -- preamble-unbound; should
+        # not affect ``budget_status`` since the packer reads only
+        # ``operational``.
+        _post_convention(client, token, slug="wf", body="Workflow note.", kind="workflow")
+        _post_convention(client, token, slug="ref", body="Reference note.", kind="reference")
+        resp = client.get(
+            "/api/v1/conventions",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert len(body["entries"]) == 4  # all four rows
+    bs = body["budget_status"]
+    assert bs["max_tokens"] == DEFAULT_MAX_PREAMBLE_TOKENS
+    assert bs["estimated_tokens"] > 0
+    assert bs["estimated_tokens"] < DEFAULT_MAX_PREAMBLE_TOKENS
+    assert bs["over_budget"] is False
+    assert bs["dropped_slugs"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_budget_status_over_budget_tenant(client: TestClient) -> None:
+    """Over-budget tenant: ``over_budget=True``, ``dropped_slugs`` lowest-priority-first."""
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-budget-over")
+    token = _token(key)
+    body_near = _near_budget_body(target_tokens=400)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        # Three operational conventions each ~400 tokens; cumulative
+        # ~1200 tokens against a 600 budget -> the lowest-priority
+        # entries must drop. Priorities are distinct so the drop
+        # order is deterministic.
+        _post_convention(client, token, slug="high-prio", body=body_near, priority=10)
+        _post_convention(client, token, slug="mid-prio", body=body_near, priority=5)
+        _post_convention(client, token, slug="low-prio", body=body_near, priority=1)
+        resp = client.get(
+            "/api/v1/conventions",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # ``entries`` returns the full set -- packing does not filter
+    # the list view; budget_status is the signal.
+    assert {row["slug"] for row in body["entries"]} == {"high-prio", "mid-prio", "low-prio"}
+    bs = body["budget_status"]
+    assert bs["over_budget"] is True
+    # Lowest priorities drop first (priority DESC order, then
+    # created_at ASC; the packer drops once cumulative + next
+    # would exceed the budget). The first one to overflow is
+    # mid-prio or low-prio depending on header overhead -- both
+    # must be in the dropped list and low-prio must precede none
+    # of the higher priorities.
+    assert "low-prio" in bs["dropped_slugs"]
+    # The dropped order respects the packer's iteration: lower
+    # priority appears later in iteration, so it lands later in
+    # ``dropped_slugs``. Mid-prio (priority=5) ranks above low-
+    # prio (priority=1), so any drop list containing mid-prio
+    # must have it before low-prio.
+    if "mid-prio" in bs["dropped_slugs"]:
+        assert bs["dropped_slugs"].index("mid-prio") < bs["dropped_slugs"].index(
+            "low-prio",
+        )
+    # High-prio (priority=10) is the first packed; it must not
+    # appear in the dropped list -- the packer fills from highest
+    # priority down.
+    assert "high-prio" not in bs["dropped_slugs"]
+
+
+@pytest.mark.asyncio
+async def test_list_budget_status_cross_tenant_isolation(client: TestClient) -> None:
+    """Tenant A's list call reflects only A's budget; B's conventions don't affect A."""
+    await _seed_tenants()
+    key_a = make_rsa_keypair("kid-budget-xt-a")
+    key_b = make_rsa_keypair("kid-budget-xt-b")
+    token_a = _token(key_a, tenant_id=_TENANT_A)
+    token_b = _token(key_b, sub="op-b", tenant_id=_TENANT_B)
+    body_near = _near_budget_body(target_tokens=400)
+    with respx.mock as r:
+        combined_jwks = {
+            "keys": [public_jwks(key_a)["keys"][0], public_jwks(key_b)["keys"][0]],
+        }
+        mock_discovery_and_jwks(r, combined_jwks)
+        # Tenant A: one tiny convention -> easily fits.
+        _post_convention(client, token_a, slug="a-small", body="Tiny rule.", priority=10)
+        # Tenant B: three near-budget conventions -> overflows.
+        _post_convention(client, token_b, slug="b-high", body=body_near, priority=10)
+        _post_convention(client, token_b, slug="b-mid", body=body_near, priority=5)
+        _post_convention(client, token_b, slug="b-low", body=body_near, priority=1)
+
+        resp_a = client.get(
+            "/api/v1/conventions",
+            headers={"Authorization": f"Bearer {token_a}"},
+        )
+        resp_b = client.get(
+            "/api/v1/conventions",
+            headers={"Authorization": f"Bearer {token_b}"},
+        )
+    assert resp_a.status_code == 200
+    assert resp_b.status_code == 200
+    body_a = resp_a.json()
+    body_b = resp_b.json()
+    # Tenant A: own entries only + fitting budget. Tenant B's bulk
+    # of conventions must not influence A's ``over_budget``.
+    assert {row["slug"] for row in body_a["entries"]} == {"a-small"}
+    assert body_a["budget_status"]["over_budget"] is False
+    assert body_a["budget_status"]["dropped_slugs"] == []
+    # Tenant B: own entries + over-budget; A's tiny convention must
+    # not have crossed into B's budget arithmetic.
+    assert {row["slug"] for row in body_b["entries"]} == {"b-high", "b-mid", "b-low"}
+    assert body_b["budget_status"]["over_budget"] is True
+    assert "a-small" not in body_b["budget_status"]["dropped_slugs"]
+    assert "b-low" in body_b["budget_status"]["dropped_slugs"]
+
+
+@pytest.mark.asyncio
+async def test_list_budget_status_kind_filter_does_not_narrow_budget(
+    client: TestClient,
+) -> None:
+    """``?kind=`` narrows entries only; ``budget_status`` reflects the full operational set."""
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-budget-kind-filter")
+    token = _token(key)
+    body_near = _near_budget_body(target_tokens=400)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        _post_convention(client, token, slug="op-a", body=body_near, priority=10)
+        _post_convention(client, token, slug="op-b", body=body_near, priority=5)
+        _post_convention(client, token, slug="op-c", body=body_near, priority=1)
+        _post_convention(client, token, slug="wf-x", body="WF.", kind="workflow")
+        # Narrow the list with ?kind=workflow -- entries collapse to
+        # the single workflow row, but budget_status still reflects
+        # the cumulative operational set (which is over budget).
+        resp = client.get(
+            "/api/v1/conventions?kind=workflow",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert {row["slug"] for row in body["entries"]} == {"wf-x"}
+    # ``budget_status`` is computed off the full operational set
+    # (the packer reads only ``operational`` regardless of the
+    # query filter), so a ``--kind=workflow`` list still surfaces
+    # the truthful overflow signal -- the operator can't hide an
+    # over-budget tenant by narrowing the kind.
+    bs = body["budget_status"]
+    assert bs["over_budget"] is True
+    assert "op-c" in bs["dropped_slugs"]

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -4873,7 +4873,7 @@
           "conventions"
         ],
         "summary": "List Conventions",
-        "description": "List the operator's tenant's conventions, optionally filtered by kind.\n\nReturns the lighter :class:`ConventionSummary` shape (no full\n``body``). Ordering is ``priority DESC, created_at ASC`` --\nthe same key T4's preamble assembler uses for packing, so the\nlist view surfaces conventions in T4's consideration order.",
+        "description": "List the operator's tenant's conventions, optionally filtered by kind.\n\nReturns the lighter :class:`ConventionSummary` shape (no full\n``body``). Ordering is ``priority DESC, created_at ASC`` --\nthe same key T4's preamble assembler uses for packing, so the\nlist view surfaces conventions in T4's consideration order.\n\nThe response also carries ``budget_status`` (T7 #1094): the\npreamble budget arithmetic for the operator's tenant, computed\nby a call to :func:`~meho_backplane.conventions.preamble.assemble_preamble`.\nThe ``--kind`` query filter narrows the ``entries`` list only;\n``budget_status`` always reflects the full ``operational``\nset (a ``--kind=workflow`` list call still wants the truthful\nbudget signal). The assembler runs an indexed SELECT + an\nin-memory pack -- O(N) per call where N is the tenant's\noperational-convention count (~10-20 in practice), so the\ncost is negligible against the list round-trip.",
         "operationId": "list_conventions_api_v1_conventions_get",
         "parameters": [
           {
@@ -7248,6 +7248,40 @@
         "title": "BroadcastOverrideRead",
         "description": "Outgoing row representation.\n\n``model_config = ConfigDict(from_attributes=True)`` lets the\nhandler return the SQLAlchemy ORM object directly; FastAPI\nserialises via this model rather than the ORM's ``__dict__``."
       },
+      "BudgetStatus": {
+        "properties": {
+          "max_tokens": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Max Tokens"
+          },
+          "estimated_tokens": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Estimated Tokens"
+          },
+          "over_budget": {
+            "type": "boolean",
+            "title": "Over Budget"
+          },
+          "dropped_slugs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Dropped Slugs"
+          }
+        },
+        "type": "object",
+        "required": [
+          "max_tokens",
+          "estimated_tokens",
+          "over_budget",
+          "dropped_slugs"
+        ],
+        "title": "BudgetStatus",
+        "description": "Preamble budget status for the operator's tenant.\n\nSurfaced as a sub-document on every ``GET /api/v1/conventions``\ncall so the CLI's ``meho conventions list`` (T7 #1094) can warn\nwhen the tenant's ``kind='operational'`` set overflows the\npreamble budget and name the slugs that will be dropped from the\nagent session preamble. Without this surface, T3 #315's\n\"lowest-priority slugs that will be dropped\" acceptance\ncriterion is unsatisfiable from a single list call -- the\ndeferred AC the issue body folds back in.\n\nAll four fields are populated by a single call to\n:func:`~meho_backplane.conventions.preamble.assemble_preamble`\nagainst the operator's tenant, so the budget arithmetic is\nend-to-end consistent with T4's preamble assembler (the same\nhelper that produces the MCP ``initialize`` ``instructions``\nfield). A divergence between the list surface's\n``estimated_tokens`` and the preamble actually delivered to\nagent sessions would be a silent contract drift; sharing the\nprimitive eliminates it by construction.\n\nFields:\n\n* ``max_tokens`` -- the budget the preamble assembler enforces.\n  Currently :data:`DEFAULT_MAX_PREAMBLE_TOKENS` (a module-level\n  constant; configurable via the assembler's ``max_tokens``\n  parameter in tests). Exposed on the list response so\n  operators can do the budget math without grepping the source.\n* ``estimated_tokens`` -- :func:`estimate_tokens` over the\n  assembled preamble text (header + guard + delimited kept\n  blocks). Empty tenant: 0. Fitting tenant: positive integer\n  below ``max_tokens``. Over-budget tenant: positive integer\n  below ``max_tokens`` (the packer dropped slugs whole until it\n  fit), but ``over_budget=True`` and ``dropped_slugs`` is\n  non-empty.\n* ``over_budget`` -- convenience flag derived from\n  ``len(dropped_slugs) > 0``. Cheap derived value but worth\n  surfacing as a boolean so CLI / dashboard consumers branch on\n  one bit rather than a length-of-list check.\n* ``dropped_slugs`` -- slugs that did not fit, in the packer's\n  drop order (lowest-priority-first, ties broken by oldest-\n  first). The CLI prints these on stderr with an\n  \"insufficient_budget\" exit-code-5 warning so the operator\n  knows exactly which conventions never reach an agent\n  session."
+      },
       "CallOperationBody": {
         "properties": {
           "connector_id": {
@@ -7723,14 +7757,18 @@
             },
             "type": "array",
             "title": "Entries"
+          },
+          "budget_status": {
+            "$ref": "#/components/schemas/BudgetStatus"
           }
         },
         "type": "object",
         "required": [
-          "entries"
+          "entries",
+          "budget_status"
         ],
         "title": "ConventionListResponse",
-        "description": "Response envelope for ``GET /api/v1/conventions``.\n\nWrapped in ``{\"entries\": [...]}`` so a future cursor / total\nfield can land non-breakingly. Same shape the kb + memory list\nsurfaces adopted; consistency across the v0.2 read APIs keeps\nthe CLI's list renderer one switch statement, not three."
+        "description": "Response envelope for ``GET /api/v1/conventions``.\n\nWrapped in ``{\"entries\": [...]}`` so a future cursor / total\nfield can land non-breakingly. Same shape the kb + memory list\nsurfaces adopted; consistency across the v0.2 read APIs keeps\nthe CLI's list renderer one switch statement, not three.\n\n``budget_status`` (T7 #1094) carries the preamble budget\narithmetic for the operator's tenant. Always populated; the\nunderlying :func:`~meho_backplane.conventions.preamble.assemble_preamble`\ncall is one indexed SELECT + an in-memory pack -- cheap enough\nto run on every list request. Exposing it on the list\nresponse (rather than on a separate\n``/api/v1/conventions/budget-status`` route the issue body\nexplicitly rejects) keeps the CLI / dashboard consumer paths\nto one HTTP round-trip."
       },
       "ConventionSummary": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -882,6 +882,58 @@ type BroadcastOverrideRead struct {
 	UpdatedAt    time.Time          `json:"updated_at"`
 }
 
+// BudgetStatus Preamble budget status for the operator's tenant.
+//
+// Surfaced as a sub-document on every “GET /api/v1/conventions“
+// call so the CLI's “meho conventions list“ (T7 #1094) can warn
+// when the tenant's “kind='operational'“ set overflows the
+// preamble budget and name the slugs that will be dropped from the
+// agent session preamble. Without this surface, T3 #315's
+// "lowest-priority slugs that will be dropped" acceptance
+// criterion is unsatisfiable from a single list call -- the
+// deferred AC the issue body folds back in.
+//
+// All four fields are populated by a single call to
+// :func:`~meho_backplane.conventions.preamble.assemble_preamble`
+// against the operator's tenant, so the budget arithmetic is
+// end-to-end consistent with T4's preamble assembler (the same
+// helper that produces the MCP “initialize“ “instructions“
+// field). A divergence between the list surface's
+// “estimated_tokens“ and the preamble actually delivered to
+// agent sessions would be a silent contract drift; sharing the
+// primitive eliminates it by construction.
+//
+// Fields:
+//
+//   - “max_tokens“ -- the budget the preamble assembler enforces.
+//     Currently :data:`DEFAULT_MAX_PREAMBLE_TOKENS` (a module-level
+//     constant; configurable via the assembler's “max_tokens“
+//     parameter in tests). Exposed on the list response so
+//     operators can do the budget math without grepping the source.
+//   - “estimated_tokens“ -- :func:`estimate_tokens` over the
+//     assembled preamble text (header + guard + delimited kept
+//     blocks). Empty tenant: 0. Fitting tenant: positive integer
+//     below “max_tokens“. Over-budget tenant: positive integer
+//     below “max_tokens“ (the packer dropped slugs whole until it
+//     fit), but “over_budget=True“ and “dropped_slugs“ is
+//     non-empty.
+//   - “over_budget“ -- convenience flag derived from
+//     “len(dropped_slugs) > 0“. Cheap derived value but worth
+//     surfacing as a boolean so CLI / dashboard consumers branch on
+//     one bit rather than a length-of-list check.
+//   - “dropped_slugs“ -- slugs that did not fit, in the packer's
+//     drop order (lowest-priority-first, ties broken by oldest-
+//     first). The CLI prints these on stderr with an
+//     "insufficient_budget" exit-code-5 warning so the operator
+//     knows exactly which conventions never reach an agent
+//     session.
+type BudgetStatus struct {
+	DroppedSlugs    []string `json:"dropped_slugs"`
+	EstimatedTokens int      `json:"estimated_tokens"`
+	MaxTokens       int      `json:"max_tokens"`
+	OverBudget      bool     `json:"over_budget"`
+}
+
 // CallOperationBody Request body for the “POST /api/v1/operations/call“ route.
 //
 // Mirrors the :func:`call_operation` “arguments“ shape so the route
@@ -1142,8 +1194,64 @@ type ConventionKind string
 // field can land non-breakingly. Same shape the kb + memory list
 // surfaces adopted; consistency across the v0.2 read APIs keeps
 // the CLI's list renderer one switch statement, not three.
+//
+// “budget_status“ (T7 #1094) carries the preamble budget
+// arithmetic for the operator's tenant. Always populated; the
+// underlying :func:`~meho_backplane.conventions.preamble.assemble_preamble`
+// call is one indexed SELECT + an in-memory pack -- cheap enough
+// to run on every list request. Exposing it on the list
+// response (rather than on a separate
+// “/api/v1/conventions/budget-status“ route the issue body
+// explicitly rejects) keeps the CLI / dashboard consumer paths
+// to one HTTP round-trip.
 type ConventionListResponse struct {
-	Entries []ConventionSummary `json:"entries"`
+	// BudgetStatus Preamble budget status for the operator's tenant.
+	//
+	// Surfaced as a sub-document on every ``GET /api/v1/conventions``
+	// call so the CLI's ``meho conventions list`` (T7 #1094) can warn
+	// when the tenant's ``kind='operational'`` set overflows the
+	// preamble budget and name the slugs that will be dropped from the
+	// agent session preamble. Without this surface, T3 #315's
+	// "lowest-priority slugs that will be dropped" acceptance
+	// criterion is unsatisfiable from a single list call -- the
+	// deferred AC the issue body folds back in.
+	//
+	// All four fields are populated by a single call to
+	// :func:`~meho_backplane.conventions.preamble.assemble_preamble`
+	// against the operator's tenant, so the budget arithmetic is
+	// end-to-end consistent with T4's preamble assembler (the same
+	// helper that produces the MCP ``initialize`` ``instructions``
+	// field). A divergence between the list surface's
+	// ``estimated_tokens`` and the preamble actually delivered to
+	// agent sessions would be a silent contract drift; sharing the
+	// primitive eliminates it by construction.
+	//
+	// Fields:
+	//
+	// * ``max_tokens`` -- the budget the preamble assembler enforces.
+	//   Currently :data:`DEFAULT_MAX_PREAMBLE_TOKENS` (a module-level
+	//   constant; configurable via the assembler's ``max_tokens``
+	//   parameter in tests). Exposed on the list response so
+	//   operators can do the budget math without grepping the source.
+	// * ``estimated_tokens`` -- :func:`estimate_tokens` over the
+	//   assembled preamble text (header + guard + delimited kept
+	//   blocks). Empty tenant: 0. Fitting tenant: positive integer
+	//   below ``max_tokens``. Over-budget tenant: positive integer
+	//   below ``max_tokens`` (the packer dropped slugs whole until it
+	//   fit), but ``over_budget=True`` and ``dropped_slugs`` is
+	//   non-empty.
+	// * ``over_budget`` -- convenience flag derived from
+	//   ``len(dropped_slugs) > 0``. Cheap derived value but worth
+	//   surfacing as a boolean so CLI / dashboard consumers branch on
+	//   one bit rather than a length-of-list check.
+	// * ``dropped_slugs`` -- slugs that did not fit, in the packer's
+	//   drop order (lowest-priority-first, ties broken by oldest-
+	//   first). The CLI prints these on stderr with an
+	//   "insufficient_budget" exit-code-5 warning so the operator
+	//   knows exactly which conventions never reach an agent
+	//   session.
+	BudgetStatus BudgetStatus        `json:"budget_status"`
+	Entries      []ConventionSummary `json:"entries"`
 }
 
 // ConventionSummary List-row representation returned by “GET /api/v1/conventions“.

--- a/cli/internal/cmd/conventions/conventions.go
+++ b/cli/internal/cmd/conventions/conventions.go
@@ -122,11 +122,37 @@ type Summary struct {
 	UpdatedAt    string  `json:"updated_at"`
 }
 
+// BudgetStatus mirrors the backend BudgetStatus pydantic model — the
+// preamble budget arithmetic the GET /api/v1/conventions list response
+// surfaces on every call (T7 #1094). MaxTokens is the budget the
+// preamble assembler enforces; EstimatedTokens is the actual weight of
+// the assembled preamble text; OverBudget is True iff DroppedSlugs is
+// non-empty; DroppedSlugs lists the slugs the packer omitted, in
+// lowest-priority-first drop order.
+//
+// The list verb consults DroppedSlugs: when non-empty (and not in --json
+// mode), it prints a stderr warning naming the dropped slugs and exits
+// with code 5 (insufficient_budget). --json mode emits the full envelope
+// and exits 0 — JSON consumers parse the field themselves.
+type BudgetStatus struct {
+	MaxTokens       int      `json:"max_tokens"`
+	EstimatedTokens int      `json:"estimated_tokens"`
+	OverBudget      bool     `json:"over_budget"`
+	DroppedSlugs    []string `json:"dropped_slugs"`
+}
+
 // ListResponse mirrors the backend ConventionListResponse envelope —
 // wrapped in `{"entries": [...]}` for forward-compat with future paging
 // fields. Same shape kb / agent adopted.
+//
+// BudgetStatus (T7 #1094) is always populated; the backend computes it
+// from the tenant's full operational-conventions set on every list
+// call. The --kind query filter narrows Entries only; BudgetStatus
+// always reflects the full operational set so an operator scoping
+// the list by kind cannot mask an over-budget tenant.
 type ListResponse struct {
-	Entries []Summary `json:"entries"`
+	Entries      []Summary    `json:"entries"`
+	BudgetStatus BudgetStatus `json:"budget_status"`
 }
 
 // HistoryEntry mirrors the backend ConventionHistoryEntry pydantic

--- a/cli/internal/cmd/conventions/crud_test.go
+++ b/cli/internal/cmd/conventions/crud_test.go
@@ -118,6 +118,137 @@ func TestPrintListTableEmpty(t *testing.T) {
 	}
 }
 
+// TestRunListOverBudgetExitsFive — G7.1-T7 (#1094) the deferred AC.
+// Table-mode list against an over-budget tenant prints the stderr
+// warning naming the dropped slugs, exits with code 5
+// (insufficient_budget), and still writes the table to stdout so
+// scripted consumers redirecting stdout still see the data.
+func TestRunListOverBudgetExitsFive(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(ListResponse{
+			Entries: []Summary{sampleSummary()},
+			BudgetStatus: BudgetStatus{
+				MaxTokens:       600,
+				EstimatedTokens: 920,
+				OverBudget:      true,
+				DroppedSlugs:    []string{"low-priority-rule", "lower-priority-rule"},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runList(cmd, listOptions{BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected non-nil error for over-budget tenant; stdout=%q stderr=%q",
+			stdout.String(), stderr.String())
+	}
+	// Exit code: must be 5 (insufficient_budget).
+	exitCoder, ok := err.(interface{ ExitCode() int })
+	if !ok {
+		t.Fatalf("error does not implement ExitCode(): %T", err)
+	}
+	if got := exitCoder.ExitCode(); got != 5 {
+		t.Errorf("exit code = %d; want 5 (insufficient_budget)", got)
+	}
+	// Table goes to stdout — even when over-budget, the operator
+	// wants to see what's actually registered.
+	if !strings.Contains(stdout.String(), "vault-canonical") {
+		t.Errorf("stdout missing table content; got %q", stdout.String())
+	}
+	// Warning + structured error envelope go to stderr together.
+	for _, want := range []string{
+		"WARNING",
+		"max_tokens=600",
+		"estimated=920",
+		"DROPPED",
+		"low-priority-rule",
+		"lower-priority-rule",
+		"insufficient_budget",
+	} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("stderr missing %q in %q", want, stderr.String())
+		}
+	}
+}
+
+// TestRunListOverBudgetJSONExitsZero — `--json` mode is the agent /
+// scripting surface; the entire envelope (entries + budget_status)
+// goes to stdout and the exit code is 0 regardless of over-budget
+// state. JSON consumers parse budget_status themselves.
+func TestRunListOverBudgetJSONExitsZero(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(ListResponse{
+			Entries: []Summary{sampleSummary()},
+			BudgetStatus: BudgetStatus{
+				MaxTokens:       600,
+				EstimatedTokens: 920,
+				OverBudget:      true,
+				DroppedSlugs:    []string{"low-priority-rule"},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	if err := runList(cmd, listOptions{BackplaneOverride: srv.URL, JSONOut: true}); err != nil {
+		t.Fatalf("runList --json over budget: %v; stderr=%q", err, stderr.String())
+	}
+	// stderr stays clean — no human warning under --json.
+	if stderr.Len() != 0 {
+		t.Errorf("expected clean stderr under --json; got %q", stderr.String())
+	}
+	// stdout carries the full envelope including budget_status.
+	var got ListResponse
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode stdout JSON: %v; raw=%s", err, stdout.String())
+	}
+	if !got.BudgetStatus.OverBudget {
+		t.Errorf("decoded JSON missing over_budget=true; got %+v", got.BudgetStatus)
+	}
+	if len(got.BudgetStatus.DroppedSlugs) != 1 || got.BudgetStatus.DroppedSlugs[0] != "low-priority-rule" {
+		t.Errorf("decoded JSON dropped_slugs wrong: %+v", got.BudgetStatus.DroppedSlugs)
+	}
+}
+
+// TestRunListFittingTenantExitsZero — sanity check that the table
+// path is unchanged for the fitting (default) case: stdout carries
+// the table, stderr is clean, exit code 0.
+func TestRunListFittingTenantExitsZero(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(ListResponse{
+			Entries: []Summary{sampleSummary()},
+			BudgetStatus: BudgetStatus{
+				MaxTokens:       600,
+				EstimatedTokens: 120,
+				OverBudget:      false,
+				DroppedSlugs:    []string{},
+			},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	if err := runList(cmd, listOptions{BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runList fitting tenant: %v; stderr=%q", err, stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("expected clean stderr for fitting tenant; got %q", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "vault-canonical") {
+		t.Errorf("stdout missing table content; got %q", stdout.String())
+	}
+}
+
 // --- show ---
 
 func TestBuildShowPath(t *testing.T) {

--- a/cli/internal/cmd/conventions/list.go
+++ b/cli/internal/cmd/conventions/list.go
@@ -31,21 +31,27 @@ import (
 // scopes via the kind flag, not via limit/offset (the substrate does
 // not paginate; v0.2 list returns the full set, ordered).
 //
-// Acceptance criterion note (issue body): "lowest-priority slugs that
-// will be dropped when the tenant's operational set exceeds the
-// preamble budget" — that signal lives in the T4 preamble assembler
-// (sibling task #316), not in the T2 list endpoint. The list verb here
-// renders the priority column verbatim so an operator can spot
-// over-budget candidates manually; the dropped-slugs warning wires in
-// once T4 exposes that information. See `printOverBudgetWarning`
-// below for the structural placeholder.
+// Over-budget warning (G7.1-T7 #1094): the response carries
+// `budget_status` -- the preamble budget arithmetic for the tenant.
+// When `budget_status.over_budget == true`, this verb writes a prose
+// warning to stderr naming the dropped slugs (the conventions that
+// will NOT reach an agent session) and exits with code 5
+// (insufficient_budget). The table still goes to stdout cleanly so a
+// scripted consumer redirecting stdout to a file still gets the data,
+// just with a non-zero return code. `--json` mode is the scripting
+// surface: it emits the full envelope (entries + budget_status) and
+// exits 0 regardless -- JSON consumers parse budget_status
+// themselves.
 //
 // Exit codes:
-//   - 0   list returned cleanly (including zero rows)
+//   - 0   list returned cleanly (including zero rows, or --json over
+//     an over-budget tenant)
 //   - 2   auth_expired
 //   - 3   unreachable
 //   - 4   unexpected response shape
-//   - 5   insufficient_role
+//   - 5   insufficient_role (HTTP 403) OR insufficient_budget (table
+//     mode on an over-budget tenant; the error code in the JSON
+//     envelope distinguishes the two)
 func newListCmd() *cobra.Command {
 	var (
 		kind              string
@@ -109,10 +115,80 @@ func runList(cmd *cobra.Command, opts listOptions) error {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
 	if opts.JSONOut {
+		// --json mode is the agent / scripting surface: emit the full
+		// envelope (entries + budget_status) and exit 0 regardless of
+		// over-budget state. JSON consumers parse budget_status
+		// themselves; the human warning + exit-code-5 branch is for
+		// the table mode below.
 		return output.PrintJSON(cmd.OutOrStdout(), resp)
 	}
 	printListTable(cmd.OutOrStdout(), resp)
+	// G7.1-T7 (#1094): when the tenant is over budget, the table is
+	// still useful (it shows what's there), so we always print it.
+	// But we also need to alert the operator that some conventions
+	// will NOT reach agent sessions. The warning goes to stderr (not
+	// stdout) so stdout-piping consumers (less, glow, jq via --json)
+	// don't see it mid-stream; the exit code (5 = insufficient_budget)
+	// makes the failure machine-detectable. T3 #315 deferred this AC
+	// because the list endpoint had no dropped_slugs surface; T7 is
+	// the plumbing that finally satisfies it.
+	if resp != nil && resp.BudgetStatus.OverBudget {
+		printOverBudgetWarning(cmd.ErrOrStderr(), &resp.BudgetStatus)
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.InsufficientBudget(formatBudgetDetail(&resp.BudgetStatus)),
+			false, // JSON mode exited earlier; this path is human-only
+		)
+	}
 	return nil
+}
+
+// printOverBudgetWarning writes the prose warning block to stderr.
+// Kept separate from the structured-error envelope so the operator
+// sees the full context (what's dropped, why, how to fix) on stderr
+// even when scripts route only the StructuredError JSON envelope.
+// The exact wording mirrors the issue body's specimen:
+//
+//	WARNING: tenant operational conventions exceed preamble budget
+//	  (max_tokens=N; estimated=M).
+//	The following conventions will be DROPPED from the agent
+//	session preamble (lowest priority first):
+//	  - slug-one
+//	  - slug-two
+//	Resolve: PATCH the dropped conventions to a higher priority, or
+//	shorten / split high-priority entries.
+//
+// The remediation hint is concrete — operators routinely run `meho
+// conventions edit <slug>` after seeing this, so the message points
+// them at the right next action.
+func printOverBudgetWarning(stderrW io.Writer, bs *BudgetStatus) {
+	fmt.Fprintf(stderrW,
+		"WARNING: tenant operational conventions exceed preamble budget "+
+			"(max_tokens=%d; estimated=%d).\n",
+		bs.MaxTokens, bs.EstimatedTokens,
+	)
+	fmt.Fprintln(stderrW,
+		"The following conventions will be DROPPED from the agent session "+
+			"preamble (lowest priority first):")
+	for _, slug := range bs.DroppedSlugs {
+		fmt.Fprintf(stderrW, "  - %s\n", slug)
+	}
+	fmt.Fprintln(stderrW,
+		"Resolve: PATCH the dropped conventions to a higher priority, or "+
+			"shorten / split high-priority entries.")
+}
+
+// formatBudgetDetail produces the short detail string the JSON error
+// envelope carries. The prose warning above is for human eyes; this
+// is the structured detail jq-style consumers see in the JSON
+// envelope's "detail" field. Compact + machine-friendly: names the
+// slug count and the overflow magnitude.
+func formatBudgetDetail(bs *BudgetStatus) string {
+	return fmt.Sprintf(
+		"%d operational convention(s) will be dropped from the agent preamble "+
+			"(estimated=%d, max_tokens=%d): %v",
+		len(bs.DroppedSlugs), bs.EstimatedTokens, bs.MaxTokens, bs.DroppedSlugs,
+	)
 }
 
 // buildListPath assembles the GET /api/v1/conventions query string from

--- a/cli/internal/output/format.go
+++ b/cli/internal/output/format.go
@@ -56,7 +56,24 @@ const (
 	// feed needs operator role, read_only is rejected. Distinct
 	// from auth_expired because `meho login` won't fix it; the
 	// remedy is a tenant-admin role grant.
+	//
+	// Exit 5 is also overloaded for InsufficientBudget (see
+	// ExitInsufficientBudget), since both states are
+	// "authenticated, but the action couldn't complete because of
+	// a configured limit the operator's tenant_admin must change."
+	// The error code in the JSON envelope distinguishes the two.
 	ExitInsufficientRole = 5
+	// ExitInsufficientBudget indicates the operator's tenant has
+	// over-budget operational conventions that exceed the preamble
+	// token budget — some conventions will be dropped from agent
+	// sessions until the tenant_admin resolves the overflow (raise
+	// priority, shorten, or split entries). Surfaced by `meho
+	// conventions list` (G7.1-T7 #1094) when the GET
+	// /api/v1/conventions response carries non-empty
+	// budget_status.dropped_slugs. Shares the integer value with
+	// ExitInsufficientRole (both are "tenant_admin must act");
+	// callers branch on the error code string, not the integer.
+	ExitInsufficientBudget = 5
 )
 
 // Error codes (the "error" field in the JSON error envelope). The
@@ -79,6 +96,13 @@ const (
 	// endpoint's minimum (HTTP 403). Remedy: tenant-admin role
 	// grant, not a re-login.
 	ErrCodeInsufficientRole = "insufficient_role"
+	// ErrCodeInsufficientBudget pairs with ExitInsufficientBudget.
+	// The operator's tenant has over-budget operational
+	// conventions; some will be dropped from agent sessions until
+	// the tenant_admin raises a priority, shortens a body, or
+	// splits an entry. Surfaced by `meho conventions list` per
+	// G7.1-T7 #1094.
+	ErrCodeInsufficientBudget = "insufficient_budget"
 )
 
 // StructuredError is the error shape produced by every meho
@@ -178,6 +202,20 @@ func InsufficientRole(detail string) *StructuredError {
 		Code:   ErrCodeInsufficientRole,
 		Detail: detail,
 		Exit:   ExitInsufficientRole,
+	}
+}
+
+// InsufficientBudget builds the canonical insufficient_budget
+// StructuredError for the over-budget preamble case (G7.1-T7 #1094).
+// Detail should name the dropped slugs and the tenant's max / estimated
+// token counts so the operator (or tenant_admin they alert) can act
+// without re-running another command. The same exit code 5 surfaces as
+// for insufficient_role; the error code string distinguishes them.
+func InsufficientBudget(detail string) *StructuredError {
+	return &StructuredError{
+		Code:   ErrCodeInsufficientBudget,
+		Detail: detail,
+		Exit:   ExitInsufficientBudget,
 	}
 }
 

--- a/docs/codebase/tenant_conventions.md
+++ b/docs/codebase/tenant_conventions.md
@@ -10,8 +10,9 @@ models, and access patterns. Layer 2 lives in
 [docs/examples/consumer-onboarding/](../examples/consumer-onboarding/)
 (landed by sibling task #318).
 
-This document is current as of T4 (#316) and T3 (#315). Sibling task
-T5 (#317) will extend it with the seed details as it lands.
+This document is current as of T7 (#1094), T6 (#318), T5 (#317),
+T4 (#316), T3 (#315), T2 (#314), and T1 (#313) -- all execution
+tasks under Initiative #229 have landed.
 
 ## Overview
 
@@ -326,7 +327,13 @@ Six verbs:
   UPDATED | TITLE` table by default; `--json` emits the raw
   `ConventionListResponse` envelope. `--kind` narrows by
   `operational | workflow | reference` (CLI-side validation
-  rejects typos before the round-trip).
+  rejects typos before the round-trip). The response also carries
+  `budget_status` (T7 #1094): on an over-budget tenant the table
+  still goes to stdout, a stderr warning names the dropped slugs
+  (the conventions that will NOT reach an agent session), and the
+  verb exits with code 5 (`insufficient_budget`). `--json` mode
+  emits the full envelope and exits 0 regardless -- JSON consumers
+  parse `budget_status` themselves.
 - **`meho conventions show <slug> [--json]`** -- GET
   `/api/v1/conventions/{slug}`. Writes the Markdown body to stdout
   for `glow` / `bat -l md` pipelines; `--json` wraps the full
@@ -384,27 +391,41 @@ Exit codes mirror the sibling verb trees:
   invalid / over-budget).
 - `5` -- `insufficient_role` (403 on write verbs without the
   `tenant_admin` claim; the backend's detail naming the required
-  role surfaces in the error message).
+  role surfaces in the error message) **OR** `insufficient_budget`
+  (table mode of `meho conventions list` on a tenant whose
+  operational set overflows the preamble budget -- see
+  "Dropped-slug warning" below). The two codes share exit `5`
+  because both states are "authenticated, but the action couldn't
+  complete because a configured limit needs a tenant_admin to
+  act"; the JSON error envelope's `error` field distinguishes
+  them (`insufficient_role` vs `insufficient_budget`).
 
 The CLI does **not** generate or mutate audit_log rows itself --
 those land server-side from the T2 routes via the audit middleware.
 
-**Dropped-slug warning (deferred to T4).** The issue body's
-acceptance criterion for `list` to surface "lowest-priority slugs
-that will be dropped when the tenant's operational set exceeds the
-preamble budget" depends on T4's preamble assembler returning
-`dropped_slugs` as part of an assembly pass. The T2 list endpoint
-returns only the `ConventionListResponse` envelope (entries +
-forward-compat fields); there is no `dropped_slugs` field on the
-GET surface today, so the CLI cannot synthesise the warning from a
-list call alone. T4 will either (a) add a query param to the list
-endpoint that runs a dry-run packing pass and returns
-`dropped_slugs`, or (b) expose a separate
-`GET /api/v1/conventions/preamble?dry_run=true` endpoint the CLI
-can call after `list`. The CLI verb's structural code path is
-ready -- once T4 ships the API surface, wiring the warning is a
-small additive PR (see `printOverBudgetWarning` placeholder
-discussion in `list.go`'s docstring).
+**Dropped-slug warning (T7 #1094).** `meho conventions list`
+honours the over-budget warning AC. The
+`GET /api/v1/conventions` response carries a `budget_status`
+sub-document (`max_tokens`, `estimated_tokens`, `over_budget`,
+`dropped_slugs`) computed by a call to
+`assemble_preamble(operator.tenant_id)` on every list call.
+When the tenant is over budget:
+
+- **Table mode** (default): the table still prints to stdout (the
+  operator wants to see what's there), a prose warning prints to
+  stderr naming the dropped slugs in lowest-priority-first drop
+  order, and the verb exits with code `5`
+  (`insufficient_budget`). The remediation hint points at the
+  natural next action (`meho conventions edit <slug>` to bump a
+  priority or shorten the body).
+- **`--json` mode**: the full `ConventionListResponse` envelope
+  (entries + budget_status) goes to stdout and the verb exits 0
+  regardless of over-budget state. JSON / agent consumers branch
+  on `budget_status.over_budget` themselves.
+
+The `--kind` query filter narrows `entries` only;
+`budget_status` always reflects the full operational set so an
+operator cannot mask an over-budget tenant by scoping the list.
 
 ## Dependencies
 
@@ -417,13 +438,17 @@ Downstream consumers:
 
 - **T2 (#314)** -- Pydantic schemas + 6 API routes. **Landed.**
 - **T3 (#315)** -- CLI verbs (`meho conventions list / show / edit /
-  history`).
+  history`). **Landed.**
 - **T4 (#316)** -- session-preamble assembler + MCP `initialize`
   integration + `meho://tenant/{tenant_id}/conventions/{slug}`
-  resource. **Landed** (this task).
+  resource. **Landed.**
 - **T5 (#317)** -- seed migration for `rdc-internal` tenant.
+  **Landed.**
 - **T6 (#318)** -- Layer 2 starter doc
   (`docs/examples/consumer-onboarding/CLAUDE.md`). **Landed.**
+- **T7 (#1094)** -- `BudgetStatus` surfacing on
+  `GET /api/v1/conventions` + `meho conventions list` exit-code-5
+  warning. **Landed** (this task).
 
 ## Migration
 


### PR DESCRIPTION
## Summary

- Adds `BudgetStatus(max_tokens, estimated_tokens, over_budget, dropped_slugs)` to `GET /api/v1/conventions` so the list endpoint carries the same overflow signal the MCP `initialize` preamble already uses (single shared `assemble_preamble(tenant_id)` call — the two sites cannot drift).
- Wires `meho conventions list` to honour the over-budget warning G7.1-T3 (#315) structurally deferred: table mode prints to stdout, a stderr warning names the dropped slugs in lowest-priority-first order, exit code 5 (new `insufficient_budget` error code overloading the existing `insufficient_role` exit-5 — JSON envelope's `error` field distinguishes them). `--json` mode emits the full envelope and exits 0.
- Regenerates `cli/api/openapi.json` + `cli/internal/api/client.gen.go` for the new response shape.

## Test plan

- [x] `uv run pytest tests/test_api_v1_conventions.py` — 44 passed (5 new T7 tests + existing 39).
- [x] `uv run pytest tests/ -k convention` — 75 passed, no regressions on adjacent convention tests.
- [x] `ruff check src/ tests/` + `ruff format --check` — clean.
- [x] `mypy src/meho_backplane/conventions/ src/meho_backplane/api/v1/conventions.py` — clean.
- [x] `go test ./...` (full CLI suite) — all packages pass; 3 new T7 tests for the over-budget exit-5 / `--json` exit-0 / fitting-sanity paths.
- [x] `go vet ./...` — clean. `gofmt -l .` — clean. `golangci-lint run` — 0 issues.
- [x] Acceptance criteria mapping (all 12 boxes from the issue body):
  - `budget_status` populated by `assemble_preamble(operator.tenant_id)` — `test_list_budget_status_*` set
  - Empty tenant: `estimated_tokens=0`, `over_budget=False`, `dropped_slugs=[]` — `test_list_budget_status_empty_tenant`
  - Fitting tenant: `over_budget=False`, `dropped_slugs=[]`, `estimated_tokens>0` — `test_list_budget_status_fitting_tenant`
  - Over-budget tenant: `over_budget=True`, `dropped_slugs` lowest-priority-first — `test_list_budget_status_over_budget_tenant`
  - `meho conventions list` exits 5 + stderr warning on over-budget — `TestRunListOverBudgetExitsFive`
  - `--json` exits 0 regardless — `TestRunListOverBudgetJSONExitsZero`
  - OpenAPI snapshot regenerated — `cli/api/openapi.json` + `cli/internal/api/client.gen.go` in this PR
  - Cross-tenant isolation — `test_list_budget_status_cross_tenant_isolation`
  - 3+ backend tests added (5 in this PR)
  - 2 CLI tests added (3 in this PR, +1 fitting sanity)
  - `docs/codebase/tenant_conventions.md` § CLI surface updated — deferral note removed, live behaviour documented
  - Parent Initiative #229 body checkbox ticked

## Out of scope

- A separate `/api/v1/conventions/budget-status` route — folded into list per issue body.
- Budget-status on `meho conventions show <slug>` — single-convention view doesn't drive packing decisions.
- Server-side mitigation suggestions ("automatically lower priority X to fit") — operator-driven UX per the issue body.
- MCP-tool wrapper around `budget_status` — agents already see the preamble at `initialize`; aggregate budget queries are admin tooling.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1094
