### PR TITLE
chore(ci): G0.11 adopt GitHub merge queue — merge_group trigger + cancel-in-progress guard (#769)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,17 @@
 # human-readable tag in a trailing comment (devops_best_practices:
 # SHA-pin every action). Same SHAs as the publish workflows where the
 # action overlaps, so a single supply-chain audit covers all of CI.
+#
+# Merge queue (#769): the `merge_group` event fires when a PR is admitted
+# to the GitHub merge queue. Required checks configured in the merge-queue
+# ruleset run against the actual merge result (PR head + current main +
+# any ahead-in-queue PRs), so a semantically-broken combination is caught
+# before it reaches main — ending the inherited-red episodes from
+# 2026-05-20/21. The concurrency group is intentionally NOT set to
+# cancel-in-progress on merge_group runs: a cancelled queue check fails
+# the merge attempt and defeats the queue's purpose. cancel-in-progress
+# is scoped to pull_request / push refs only so PR force-pushes and rapid
+# main pushes still cancel their predecessors cleanly.
 
 name: CI
 
@@ -65,6 +76,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Fires when a PR enters the merge queue. Runs the full check matrix
+  # against the synthesised merge commit (PR + current main tip +
+  # any ahead-in-queue PRs). This is the gate that prevents a
+  # stale-but-green PR from landing a broken combination on main.
+  merge_group:
 
 permissions:
   contents: read
@@ -74,8 +90,14 @@ concurrency:
   # commit cancels its predecessor. On PRs: scoped per PR ref so an
   # author force-push cancels its own prior CI run cleanly. Mirrors
   # the pattern used by image.yml, chart.yml, and cli-release.yml.
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  #
+  # IMPORTANT: merge_group runs must NEVER be cancelled. A cancelled
+  # queue check causes the merge attempt to fail and the PR falls out
+  # of the queue — defeating the whole point of the merge queue. The
+  # conditional below restricts cancel-in-progress to pull_request /
+  # push contexts only.
+  group: ci-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   python-lint-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,12 @@ concurrency:
   # author force-push cancels its own prior CI run cleanly. Mirrors
   # the pattern used by image.yml, chart.yml, and cli-release.yml.
   #
-  # IMPORTANT: merge_group runs must NEVER be cancelled. A cancelled
-  # queue check causes the merge attempt to fail and the PR falls out
-  # of the queue — defeating the whole point of the merge queue. The
-  # conditional below restricts cancel-in-progress to pull_request /
-  # push contexts only.
+  # IMPORTANT: already-running merge_group jobs must NEVER be cancelled.
+  # A cancelled queue check causes the merge attempt to fail and the PR
+  # falls out of the queue — defeating the whole point of the merge queue.
+  # The conditional below restricts cancel-in-progress to pull_request /
+  # push contexts only. Queued (not-yet-started) merge_group runs can
+  # still be displaced by newer queue entries; that is expected behaviour.
   group: ci-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 

--- a/.github/workflows/dependency-license-check.yml
+++ b/.github/workflows/dependency-license-check.yml
@@ -36,11 +36,28 @@ on:
       - '**/package.json'
       - '**/package-lock.json'
       - '.github/workflows/dependency-license-check.yml'
+  # Fires when a PR enters the GitHub merge queue. Required so the
+  # `Python License Check` and `NPM License Check` status contexts —
+  # required checks in branch protection — report against the
+  # synthesised merge commit, not just the PR head. Bare `merge_group:`
+  # is intentional: the `merge_group` event does not support `paths:`
+  # filtering (GitHub docs only allow `types:`), so the license jobs
+  # run on every queue admission. The `hashFiles()` guards on each
+  # step already make the jobs no-op when manifests are unchanged, so
+  # the redundant runs are cheap. Same rationale as ci.yml's
+  # merge_group trigger (#769).
+  merge_group:
   workflow_dispatch:
 
 concurrency:
-  group: dependency-license-check-${{ github.ref }}
-  cancel-in-progress: true
+  # Mirrors ci.yml's pattern (#769): event-suffixed group key so
+  # pull_request / push / merge_group runs don't collide, and
+  # cancel-in-progress is scoped OFF for merge_group because a
+  # cancelled queue check fails the merge attempt and defeats the
+  # queue. Workflow-name-specific group prefix so this workflow's
+  # cancellation domain stays distinct from ci.yml's.
+  group: dependency-license-check-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 permissions:
   contents: read

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -19,13 +19,27 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Fires when a PR enters the GitHub merge queue. Required so the
+  # `TruffleHog Secret Scan` status context — a required check in
+  # branch protection — reports against the synthesised merge commit,
+  # not just the PR head. Without this, merge-queue runs would never
+  # receive the secret-scan signal and queued PRs would hang on the
+  # missing required context. Same rationale as ci.yml's merge_group
+  # trigger (#769).
+  merge_group:
 
 permissions:
   contents: read
 
 concurrency:
-  group: secret-scan-${{ github.ref }}
-  cancel-in-progress: true
+  # Mirrors ci.yml's pattern (#769): event-suffixed group key so
+  # pull_request / push / merge_group runs don't collide, and
+  # cancel-in-progress is scoped OFF for merge_group because a
+  # cancelled queue check fails the merge attempt and defeats the
+  # queue. Workflow-name-specific group prefix so this workflow's
+  # cancellation domain stays distinct from ci.yml's.
+  group: secret-scan-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   trufflehog:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -28,10 +28,24 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Fires when a PR enters the GitHub merge queue. Required so the
+  # `Semgrep SAST` status context — a required check in branch
+  # protection — reports against the synthesised merge commit, not
+  # just the PR head. Without this, merge-queue runs would never
+  # receive the SAST signal and queued PRs would hang on the missing
+  # required context. Same rationale as ci.yml's merge_group trigger
+  # (#769).
+  merge_group:
 
 concurrency:
-  group: security-scan-${{ github.ref }}
-  cancel-in-progress: true
+  # Mirrors ci.yml's pattern (#769): event-suffixed group key so
+  # pull_request / push / merge_group runs don't collide, and
+  # cancel-in-progress is scoped OFF for merge_group because a
+  # cancelled queue check fails the merge attempt and defeats the
+  # queue. Workflow-name-specific group prefix so this workflow's
+  # cancellation domain stays distinct from ci.yml's.
+  group: security-scan-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 permissions:
   contents: read

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -622,16 +622,26 @@ Merge-queue setup (admin action, separate from this code change):
    ruleset for `main` (Settings → Rules → Branches → protect main →
    add "Require merge queue" rule, or via
    `gh api -X PUT repos/evoila/meho/rulesets/14556458 ...`).
-2. Configure merge-queue required checks: `Python (ruff + mypy +
-   pytest)`, `Python (integration testcontainers)`,
-   `Go (golangci-lint + go test)`, `Helm (lint + template +
-   kubeconform)`. These are the same contexts already required by the
-   `pull_request` gate; enabling them as merge-queue required checks
-   means the queue enforces the same bar against the actual merge
-   result, not just the PR's own head.
-3. The `ci.yml` `merge_group` trigger in this PR is the code-side
-   prerequisite for step 2 — without it, the queue would have no CI
-   signal to block on.
+2. Configure merge-queue required checks. The full set required by
+   branch protection on `main` spans four workflows; mirror the same
+   set in the merge-queue ruleset so the queue enforces the same bar
+   against the actual merge result, not just the PR's own head:
+   - From `ci.yml`: `Python (ruff + mypy + pytest)`,
+     `Python (integration testcontainers)`,
+     `Go (golangci-lint + go test)`,
+     `Helm (lint + template + kubeconform)`.
+   - From `security-scan.yml`: `Semgrep SAST`.
+   - From `secret-scan.yml`: `TruffleHog Secret Scan`.
+   - From `dependency-license-check.yml`: `Python License Check`,
+     `NPM License Check`. Both jobs no-op via `hashFiles()` when the
+     PR doesn't touch a manifest, so they report cheap green on
+     unrelated PRs — but they MUST run on every queue admission so
+     branch protection's required-context list stays satisfiable.
+3. The `merge_group` triggers in `ci.yml`, `security-scan.yml`,
+   `secret-scan.yml`, and `dependency-license-check.yml` are the
+   code-side prerequisite for step 2 — without each sibling workflow
+   subscribing to `merge_group`, its required context would never
+   report on queue runs and the queue would hang on missing checks.
 
 Concurrency note: `cancel-in-progress` is conditional on
 `github.event_name != 'merge_group'`. A cancelled queue check causes

--- a/docs/codebase/devops.md
+++ b/docs/codebase/devops.md
@@ -605,6 +605,40 @@ re-verified after the 2026-05-20 #698 promotion of the integration
 lane, the structural corrective to the v0.2 / G3.4 green-but-hollow
 incidents #634 / #697).
 
+### Merge queue (#769)
+
+`ci.yml` triggers on `merge_group` in addition to `pull_request` and
+`push`. The `merge_group` event fires when a PR is admitted to the
+GitHub merge queue and runs the full check matrix against the
+**synthesised merge commit** — PR head + current `main` tip + any
+PRs ahead in the queue. A merge that would break `main` fails in the
+queue and never reaches `main`, ending the inherited-red episodes from
+2026-05-20/21 where cancelled post-merge CI allowed broken combinations
+to land silently.
+
+Merge-queue setup (admin action, separate from this code change):
+
+1. Enable "Require merge queue" in the repository's branch-protection
+   ruleset for `main` (Settings → Rules → Branches → protect main →
+   add "Require merge queue" rule, or via
+   `gh api -X PUT repos/evoila/meho/rulesets/14556458 ...`).
+2. Configure merge-queue required checks: `Python (ruff + mypy +
+   pytest)`, `Python (integration testcontainers)`,
+   `Go (golangci-lint + go test)`, `Helm (lint + template +
+   kubeconform)`. These are the same contexts already required by the
+   `pull_request` gate; enabling them as merge-queue required checks
+   means the queue enforces the same bar against the actual merge
+   result, not just the PR's own head.
+3. The `ci.yml` `merge_group` trigger in this PR is the code-side
+   prerequisite for step 2 — without it, the queue would have no CI
+   signal to block on.
+
+Concurrency note: `cancel-in-progress` is conditional on
+`github.event_name != 'merge_group'`. A cancelled queue check causes
+the merge attempt to fail and the PR falls out of the queue — so
+merge-queue runs are never cancelled. PR force-pushes and rapid main
+commits still cancel their own prior runs as before.
+
 ### Matrix
 
 | Job | Surface | Steps |


### PR DESCRIPTION
## Summary

- Adds the `merge_group` event to the `ci.yml` trigger list, so GitHub's
  merge queue runs the full check matrix against the **synthesised merge
  commit** (PR head + current `main` tip + any PRs ahead in the queue)
  before anything reaches `main`.
- Scopes `cancel-in-progress` to non-queue events only
  (`${{ github.event_name != 'merge_group' }}`). A cancelled queue check
  fails the merge attempt and causes the PR to fall out of the queue —
  exactly the wrong outcome. PR force-pushes and rapid main commits still
  cancel their own predecessors as before.
- Appends `github.event_name` to the concurrency group key so
  `pull_request`, `push`, and `merge_group` runs never share a group and
  cannot cancel each other across event types.

The four inherited-red episodes on 2026-05-20/21 (#722, #746, #767)
traced to a single root cause: `cancel-in-progress: true` on a shared
concurrency group plus no "require branches up to date" gate let PR-B's
merge cancel PR-A's post-merge main CI run, silently burying a broken
merge combination in `main`. The merge queue eliminates this class of
failure by building and gating on the actual merge result before landing.

## Test plan

- [x] `ci.yml` YAML validates cleanly (ruby YAML parser)
- [x] Code-quality gate: `python3 .claude/hooks/code-quality.py --diff` — exit 0
- [x] `merge_group:` trigger present and syntactically correct
- [x] Concurrency `cancel-in-progress` uses the conditional expression
      `${{ github.event_name != 'merge_group' }}` (not a static `true`)
- [x] Concurrency group key includes `github.event_name` suffix
- [x] All job-level fork-PR guards (`github.event_name != 'pull_request'`)
      already pass for `merge_group` without change — verified by reading
      each `if:` condition: `event_name` is `'merge_group'`, not
      `'pull_request'`, so the OR short-circuits to `true`
- [x] `docs/codebase/devops.md` updated with merge-queue section including
      the admin-side setup steps required to activate the queue

## Admin action still required (not in this PR)

After this PR merges, a repo admin must enable "Require merge queue" in
the `protect-main` ruleset (Settings → Rules → Branches → protect main
→ add "Require merge queue") and configure the same required checks that
already gate `pull_request` as merge-queue required checks. Without that
admin step, the queue is not active and `merge_group` runs will not be
triggered — this PR only ships the code-side prerequisite.

See `docs/codebase/devops.md` § "Merge queue (#769)" for the exact steps.

## Out of scope

- Speeding up the unit job (#761 + follow-ups) — merge queue prevents
  broken merges, does not make CI faster
- Auto-rebase / auto-merge bot configuration beyond native queue
- Ruleset admin action (requires interactive repo-settings access)

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #769

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-26)

Addressed review findings from `.claude/auto/review-results/pr-1107-iter-1.json`:

- **B1** `5a0f81a` — Added `Signed-off-by: WorldWideWest <ddzafic@evoila.com>` trailer via `git rebase HEAD~1 --signoff`; DCO check now satisfied
- **m1** `ee6fc5a` — Clarified `cancel-in-progress` comment: "already-running merge_group jobs must NEVER be cancelled" + noted queued runs can still be displaced (expected queue behaviour)

Disputed:

- (none)

Deferred (recorded as adjacent findings; orchestrator may file follow-up issues):

- (none)

<!-- auto-implement-issue: continue, iteration 1 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to support merge-queue runs; concurrency behavior adjusted so merge-queue jobs are never cancelled while other event types keep existing cancellation behavior.

* **Documentation**
  * New docs describing merge-queue support, that checks run against the synthesized merge commit, and required setup steps to ensure CI job contexts and concurrency behave as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->