### PR TITLE
docs(conventions): add freshness section to consumer ONBOARDING.md (G7.1 AC8)

### DIFF
--- a/docs/examples/consumer-onboarding/ONBOARDING.md
+++ b/docs/examples/consumer-onboarding/ONBOARDING.md
@@ -208,6 +208,53 @@ Patterns to follow:
   things that genuinely apply only to operators working in this
   repo's checkout.
 
+## Convention freshness — static-at-connect, reconnect-to-refresh
+
+Tenant conventions are loaded into the session preamble **at session
+connect time**, not continuously. The MCP `initialize` response on
+each new connection assembles the preamble from the current
+`tenant_conventions` rows and ships it as the spec-optional
+`instructions` field (per
+[MCP 2025-06-18 Lifecycle](https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle)).
+After that, the session holds the preamble snapshot it received at
+connect; subsequent edits do not retroactively reach already-
+connected sessions.
+
+What this means in practice:
+
+* A `tenant_admin` who edits a convention via
+  `meho conventions edit <slug>` while another operator's agent
+  session is already running will **not** see that edit reflected in
+  the running session. The edited convention reaches the running
+  session only after the agent reconnects (e.g. the consumer harness
+  restarts the MCP client, or the operator opens a new Claude
+  session).
+* New sessions opened after the edit see the new convention
+  immediately, via their own `initialize` assembly.
+* Audit-trail integrity is preserved either way — every edit writes
+  one `audit_log` row and one `tenant_convention_history` row in the
+  same DB transaction, regardless of whether any live session sees
+  the change mid-run.
+
+This is the **v0.2 baseline** behaviour. A mid-session refresh path
+is specified but conditional on MCP's
+`capabilities.resources.subscribe` being advertised as `true`. When
+that capability is enabled, edits emit
+`notifications/resources/updated` for the
+`meho://tenant/{tenant_id}/conventions/{slug}` resource, and
+subscribing clients re-read the resource to refresh their preamble
+mid-session.
+
+**Current posture:** v0.2 ships `resources.subscribe: false` — the
+`_initialize` capabilities envelope advertises `subscribe: false`,
+and the helper that wraps every convention write
+(`_maybe_emit_resource_updated`) is a no-op. v0.2.next flips both
+halves together (capability advertisement + emit on write), kept in
+sync by a single constant
+(`RESOURCES_SUBSCRIBE_ENABLED` in
+[`backend/src/meho_backplane/mcp/server.py`](https://github.com/evoila/meho/blob/main/backend/src/meho_backplane/mcp/server.py)).
+Until then, **reconnect-to-refresh** above is the documented contract.
+
 ## Step 4 — Refresh when MEHO ships a new minor version
 
 `meho version` reports the CLI version; `meho status` reports the

--- a/docs/examples/consumer-onboarding/ONBOARDING.md
+++ b/docs/examples/consumer-onboarding/ONBOARDING.md
@@ -232,9 +232,13 @@ What this means in practice:
 * New sessions opened after the edit see the new convention
   immediately, via their own `initialize` assembly.
 * Audit-trail integrity is preserved either way — every edit writes
-  one `audit_log` row and one `tenant_convention_history` row in the
-  same DB transaction, regardless of whether any live session sees
-  the change mid-run.
+  the convention mutation + a `tenant_convention_history` row inside
+  the route's DB transaction, while the audit middleware writes its
+  `audit_log` row in its own session in the same response cycle. The
+  two are linked by a pre-allocated `audit_id` soft-FK on the history
+  row, so the diff trail joins back to the operator-attributed audit
+  entry by exact uuid match — regardless of whether any live session
+  sees the change mid-run.
 
 This is the **v0.2 baseline** behaviour. A mid-session refresh path
 is specified but conditional on MCP's


### PR DESCRIPTION
## Summary

- Closes the last remaining gap in [#229](https://github.com/evoila/meho/issues/229) G7.1 DoD: AC8 (freshness behaviour documented in consumer-facing `ONBOARDING.md`).
- Mirrors what `docs/codebase/tenant_conventions.md` already documents from the backend's perspective — static-at-connect baseline, reconnect-to-refresh, conditional `notifications/resources/updated` gated on `capabilities.resources.subscribe`.
- Operator-focused framing: starts with "what this means in practice" so a `tenant_admin` editing a convention understands why their change doesn't reach running sessions until reconnect.

## Test plan

- [x] `git diff --stat` shows one file changed, 47 insertions, 0 deletions.
- [x] `markdownlint docs/examples/consumer-onboarding/ONBOARDING.md` (if configured) — clean.
- [x] No code/test changes — pure doc add, between "Tenant-specific rules" and "Step 4 — Refresh".
- [x] AC8 mapping verified: section names static-at-connect (¶1), reconnect-to-refresh (¶2, "Current posture"), `notifications/resources/updated` gated on `resources.subscribe` (¶3+¶4).

## Out of scope

- AC4 wording mismatch on [#229](https://github.com/evoila/meho/issues/229) — handled separately via an issue-body amendment (the `meho status.tenant_preamble` field originally scoped was de-scoped during T4 in favour of the single MCP `initialize.instructions` carrier).

Refs #229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated onboarding guide with new "Convention freshness" section explaining how tenant conventions are loaded at session start, the impact of editing conventions during active sessions, and v0.2 features for live refresh capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->