### PR TITLE
feat(migrations): G0.11 UUID audit + drift-guard for str(uuid) vs value.hex (#1095)

### DIFF
--- a/backend/tests/test_alembic_uuid_param_consistency.py
+++ b/backend/tests/test_alembic_uuid_param_consistency.py
@@ -1,0 +1,345 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Drift-guard: every Alembic migration must use ``value.hex`` (not ``str(value)``) for UUID binds.
+
+Initiative #956 (G0.11 CI + test-infra hardening), Task #1095. PR
+#1045's fix to ``0018_seed_rdc_internal_conventions.py`` replaced
+``str(value)`` with ``value.hex`` in ``_uuid_param`` after 88 test
+failures caused by ORM FK lookups failing bytewise against a row
+the migration had stored in 36-char canonical form.
+
+The root cause: SQLAlchemy's ``Uuid(as_uuid=True)`` column type binds
+UUID values as 32-char hex (``value.hex``) on SQLite. A data migration
+that writes ``str(uuid_value)`` (36-char ``fc8c7b96-89f9-...``) stores
+a string the ORM's FK lookup never matches (it looks for
+``fc8c7b9689f9...``). The mismatch is silently invisible at the
+migration level but cascades into FK failures at test time.
+
+This module provides two guards:
+
+1. **AST scan** — :func:`check_migration_file` inspects every
+   ``backend/alembic/versions/*.py`` file at the AST level, looking
+   for ``str(<expr>)`` call patterns inside assignment-like contexts
+   (dict values, function arguments) that are named in a way consistent
+   with UUID binding (variable names ending in ``_id``, ``_uuid``,
+   containing ``uuid``, or the argument itself being a ``uuid.*`` call).
+   This is a conservative scan: it flags on names likely to be UUIDs;
+   it does *not* flag arbitrary ``str(...)`` calls.
+
+2. **Regression fixture** — :func:`test_regression_fixture_fails` injects
+   a synthetic migration that commits the bug (``str(uuid_value)``) and
+   asserts the AST scan catches it, proving the guard is live.
+
+Audit results as of Task #1095 (2026-05-26)
+--------------------------------------------
+
+Migrations 0001-0024 inspected:
+
+* 0001-0010: DDL-only or no UUID bind parameters (no hand-rolled INSERT
+  with UUID values).
+* 0011: backfill migration (UPDATE via SQLAlchemy Core); no UUID bind
+  params -- the WHERE clause uses text columns.
+* 0012-0017, 0019-0024: DDL-only schema migrations; no data seeding.
+* 0018: the only data migration with hand-rolled UUID binding.
+  Already fixed in PR #1045: ``_uuid_param`` returns ``value.hex``
+  on SQLite, ``uuid.UUID`` object on PostgreSQL. **No further fix
+  needed.**
+
+No migration currently uses ``str(uuid_value)`` in a UUID bind context.
+The drift-guard below fails if a future migration introduces the pattern.
+"""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+#: Directory containing the migration files to audit.
+#: parents[0] = backend/tests, parents[1] = backend
+_VERSIONS_DIR: Path = Path(__file__).resolve().parents[1] / "alembic" / "versions"
+
+# ---------------------------------------------------------------------------
+# AST-based scanner
+# ---------------------------------------------------------------------------
+
+#: Variable name substrings that suggest a UUID value is being bound.
+#: Conservative: we flag when the name *ends with* one of these, or
+#: when it *contains* ``uuid`` (case-insensitive).
+_UUID_NAME_HINTS: frozenset[str] = frozenset(
+    {"_id", "_uuid", "tenant_id", "convention_id", "run_id", "principal_id"}
+)
+
+
+def _looks_like_uuid_name(name: str) -> bool:
+    """Return True when *name* suggests a UUID value (heuristic)."""
+    lower = name.lower()
+    if "uuid" in lower:
+        return True
+    return any(lower.endswith(hint) for hint in _UUID_NAME_HINTS)
+
+
+def _is_str_call(node: ast.expr) -> bool:
+    """Return True when *node* is a ``str(...)`` call (builtin str)."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "str"
+        and len(node.args) == 1
+        and not node.keywords
+    )
+
+
+def _arg_looks_like_uuid(arg: ast.expr) -> bool:
+    """Heuristic: does the ``str(...)`` argument look like a UUID value?
+
+    True when the argument is:
+    * A name that matches a UUID hint (e.g. ``str(tenant_id)``).
+    * An attribute on a name that matches a UUID hint
+      (e.g. ``str(tenant.id)``).
+    * A ``uuid.uuid4()`` call.
+    * An ``attr`` access on a uuid module call (e.g. ``str(uuid.uuid4())``).
+    """
+    if isinstance(arg, ast.Name) and _looks_like_uuid_name(arg.id):
+        return True
+    if isinstance(arg, ast.Attribute):
+        # str(obj.id) or str(something.uuid)
+        if _looks_like_uuid_name(arg.attr):
+            return True
+        # str(value.something) where value is a UUID-hinted name
+        if isinstance(arg.value, ast.Name) and _looks_like_uuid_name(arg.value.id):
+            return True
+    # str(uuid.uuid4()) or str(uuid4())
+    if isinstance(arg, ast.Call):
+        func = arg.func
+        if isinstance(func, ast.Attribute) and func.attr in ("uuid4", "UUID", "uuid1"):
+            return True
+        if isinstance(func, ast.Name) and func.id in ("uuid4", "UUID"):
+            return True
+    return False
+
+
+def _find_str_uuid_violations(tree: ast.AST) -> list[int]:
+    """Walk *tree* and return line numbers of ``str(<uuid-ish>)`` patterns.
+
+    Specifically looks for dict values (the ``{...: str(uuid_val), ...}``
+    pattern used in migration ``execute()`` binds) and keyword arguments.
+    """
+    violations: list[int] = []
+    for node in ast.walk(tree):
+        # Pattern 1: dict literal value -- {key: str(uuid_val)}
+        if isinstance(node, ast.Dict):
+            for value in node.values:
+                if not isinstance(value, ast.Call):
+                    continue
+                if _is_str_call(value) and _arg_looks_like_uuid(value.args[0]):
+                    violations.append(value.lineno)
+        # Pattern 2: keyword argument -- func(param=str(uuid_val))
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                kw_val = kw.value
+                if not isinstance(kw_val, ast.Call):
+                    continue
+                if _is_str_call(kw_val) and _arg_looks_like_uuid(kw_val.args[0]):
+                    violations.append(kw_val.lineno)
+    return violations
+
+
+def check_migration_file(path: Path) -> list[str]:
+    """Scan *path* for ``str(<uuid-ish>)`` bind patterns.
+
+    Returns a (possibly empty) list of human-readable violation strings.
+    Returns an empty list when the file is clean.
+    Raises ``SyntaxError`` if the file cannot be parsed (broken migration).
+    """
+    source = path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(path))
+    line_numbers = _find_str_uuid_violations(tree)
+    return [
+        f"{path.name}:{lineno}: str(<uuid-value>) found — use value.hex on SQLite "
+        f"(see PR #1045 incident and docs/codebase/migrations.md)"
+        for lineno in line_numbers
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Live audit: all shipped migrations must be clean
+# ---------------------------------------------------------------------------
+
+
+def test_no_str_uuid_binding_in_any_migration() -> None:
+    """All migrations in ``backend/alembic/versions/`` are free of ``str(uuid-ish)`` binds.
+
+    This test fails when a new migration introduces the pattern that
+    caused PR #1045's 88-test cascade: storing a UUID as the 36-char
+    canonical ``str(value)`` form in a column that SQLAlchemy's
+    ``Uuid(as_uuid=True)`` type stores as 32-char hex on SQLite.
+
+    Audit summary (Task #1095, 2026-05-26): migrations 0001-0024 were
+    inspected; none use the forbidden pattern. Migration 0018 fixed the
+    pattern in PR #1045; subsequent migrations follow the convention
+    established there (``_uuid_param`` helper / ``value.hex`` on SQLite).
+    """
+    migration_files = sorted(_VERSIONS_DIR.glob("*.py"))
+    assert migration_files, (
+        f"no migration files found in {_VERSIONS_DIR} — check the path is correct"
+    )
+
+    all_violations: list[str] = []
+    for migration_file in migration_files:
+        violations = check_migration_file(migration_file)
+        all_violations.extend(violations)
+
+    assert not all_violations, (
+        "UUID bind consistency violations found in Alembic migrations.\n"
+        "Use ``value.hex`` (SQLite) / ``uuid.UUID`` object (PG) via a dialect-aware "
+        "helper like ``_uuid_param`` — not ``str(uuid_value)``.\n"
+        "See docs/codebase/migrations.md for the convention.\n\n" + "\n".join(all_violations)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression fixture: prove the guard is live
+# ---------------------------------------------------------------------------
+
+
+def test_regression_fixture_detected_by_guard(tmp_path: Path) -> None:
+    """The AST guard catches a synthetic migration that commits the bug.
+
+    A temporary migration is written into ``tmp_path`` with the exact
+    pattern that broke PR #1045: a dict value ``str(tenant_id)`` in
+    a bind parameter dict. The guard must flag it; if it returns clean,
+    the guard has a false-negative and this test fails.
+
+    This test does *not* run ``alembic upgrade`` — it exercises only
+    the AST scanner, so it runs fast and without a live DB.
+    """
+    bad_migration = tmp_path / "9999_bad_uuid_binding.py"
+    bad_migration.write_text(
+        textwrap.dedent(
+            """\
+            # Synthetic regression fixture — NOT a real migration.
+            import uuid
+            import sqlalchemy as sa
+            from alembic import op
+
+            revision = "9999"
+            down_revision = None
+
+
+            def upgrade() -> None:
+                tenant_id = uuid.uuid4()
+                bind = op.get_bind()
+                bind.execute(
+                    sa.text("INSERT INTO tenant (id, slug) VALUES (:id, :slug)"),
+                    {
+                        "id": str(tenant_id),   # BUG: should be tenant_id.hex
+                        "slug": "test-tenant",
+                    },
+                )
+
+
+            def downgrade() -> None:
+                pass
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    violations = check_migration_file(bad_migration)
+    assert violations, (
+        "The AST drift-guard should have flagged str(tenant_id) in the "
+        "regression fixture but returned no violations. "
+        "The guard has a false-negative — review _find_str_uuid_violations()."
+    )
+    # Confirm the violation message names the offending file.
+    assert any("9999_bad_uuid_binding.py" in v for v in violations), (
+        f"expected the violation to name the file; got: {violations!r}"
+    )
+
+
+def test_correct_hex_binding_is_not_flagged(tmp_path: Path) -> None:
+    """A migration that uses ``value.hex`` is not flagged by the guard.
+
+    Asserts the guard has no false-positives on the correct pattern
+    (``tenant_id.hex`` as a dict value), which is what migration 0018
+    does after the PR #1045 fix.
+    """
+    good_migration = tmp_path / "9998_correct_uuid_binding.py"
+    good_migration.write_text(
+        textwrap.dedent(
+            """\
+            # Synthetic correct migration — NOT a real migration.
+            import uuid
+            import sqlalchemy as sa
+            from alembic import op
+
+            revision = "9998"
+            down_revision = None
+
+            IS_POSTGRES = False  # simplified for fixture
+
+
+            def upgrade() -> None:
+                tenant_id = uuid.uuid4()
+                bind = op.get_bind()
+                bind.execute(
+                    sa.text("INSERT INTO tenant (id, slug) VALUES (:id, :slug)"),
+                    {
+                        "id": tenant_id if IS_POSTGRES else tenant_id.hex,
+                        "slug": "test-tenant",
+                    },
+                )
+
+
+            def downgrade() -> None:
+                pass
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    violations = check_migration_file(good_migration)
+    assert not violations, (
+        f"The correct ``value.hex`` pattern should not be flagged; got: {violations!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parametrised per-migration audit for granular failure reporting
+# ---------------------------------------------------------------------------
+
+
+def _collect_migration_params() -> list[Any]:
+    """Return a pytest.param per migration file for parametrised testing.
+
+    Evaluated at collection time so the param list is visible in
+    ``pytest --collect-only`` output. Returns an empty list when the
+    versions directory doesn't exist (boot-strap environment).
+    """
+    if not _VERSIONS_DIR.exists():
+        return []
+    return [
+        pytest.param(p, id=p.name)
+        for p in sorted(_VERSIONS_DIR.glob("*.py"))
+        if p.name != "__init__.py"
+    ]
+
+
+@pytest.mark.parametrize("migration_file", _collect_migration_params())
+def test_individual_migration_clean(migration_file: Path) -> None:
+    """Each migration file passes the UUID bind consistency check individually.
+
+    Parametrised so a failure names the specific file rather than
+    lumping all violations into the aggregate test above. Both tests
+    run: the aggregate provides a summary, the parametrised form
+    provides per-file granularity in CI's test-results matrix.
+    """
+    violations = check_migration_file(migration_file)
+    assert not violations, f"UUID bind violation in {migration_file.name}:\n" + "\n".join(
+        violations
+    )

--- a/docs/codebase/migrations.md
+++ b/docs/codebase/migrations.md
@@ -1,0 +1,167 @@
+# Alembic migrations
+
+## Overview
+
+MEHO uses [Alembic](https://alembic.sqlalchemy.org/) for database schema
+management. Migrations live in `backend/alembic/versions/` as numbered Python
+files (`0001_*.py`, `0002_*.py`, …). The chain runs against both SQLite
+(development and unit tests) and PostgreSQL (staging and production).
+
+The Alembic environment (`backend/alembic/env.py`) uses an async cookbook so
+migrations run via the same `asyncio`-aware engine the application uses. Each
+migration file's `upgrade()` and `downgrade()` functions run synchronously
+inside an `asyncio.run()` call made by Alembic — do not `await` in migration
+bodies; use synchronous SQLAlchemy Core (`op.get_bind()` / `bind.execute()`).
+
+## File naming
+
+```
+<sequence>_<slug>.py
+```
+
+Sequence is zero-padded to four digits (`0001`, `0018`, …). The slug is
+lower-case with underscores. Every new migration increments the sequence by one.
+
+## UUID binding convention
+
+**The most important rule for data migrations.**
+
+SQLAlchemy's `Uuid(as_uuid=True)` column type (the project-wide default for
+every UUID primary key and UUID foreign key) stores values differently per
+dialect:
+
+| Dialect    | Storage format         | Example                                |
+|------------|------------------------|----------------------------------------|
+| PostgreSQL | Native `uuid` type     | `fc8c7b96-89f9-4d0d-b164-7f3e8f29bd8d` |
+| SQLite     | `CHAR(32)` hex string  | `fc8c7b9689f94d0db1647f3e8f29bd8d`      |
+
+SQLite's bind processor calls `value.hex` — the 32-character hex form without
+dashes. A data migration that writes `str(uuid_value)` (the 36-character
+canonical dashed form) stores a string the ORM's FK lookup never matches,
+because the ORM issues `WHERE id = <value.hex>` against SQLite rows.
+
+**Always use `value.hex` on SQLite, not `str(uuid_value)`.**
+
+### Canonical pattern
+
+Every data migration that writes a UUID bind parameter must detect the dialect
+and pass the right form:
+
+```python
+def _uuid_param(value: uuid.UUID, *, is_postgres: bool) -> object:
+    """Return the correct bind type for a UUID on each dialect.
+
+    On PostgreSQL the asyncpg driver accepts ``uuid.UUID`` objects
+    directly.  On SQLite the stdlib sqlite3 driver does not register a
+    UUID adapter, so pass the 32-char hex string (``value.hex``) to
+    match the ``Uuid(as_uuid=True)`` bind processor's output.
+    """
+    return value if is_postgres else value.hex
+```
+
+Detect the dialect inside `upgrade()`:
+
+```python
+def upgrade() -> None:
+    bind = op.get_bind()
+    is_postgres: bool = bind.dialect.name == "postgresql"
+    tenant_id = uuid.uuid4()
+    bind.execute(
+        sa.text("INSERT INTO tenant (id, slug) VALUES (:id, :slug)"),
+        {"id": _uuid_param(tenant_id, is_postgres=is_postgres), "slug": "rdc-internal"},
+    )
+```
+
+### Why `value.hex` not `str(value)`
+
+`str(uuid.UUID(...))` produces the 36-char dashed form (`fc8c7b96-89f9-...`).
+SQLAlchemy's bind processor for `Uuid(as_uuid=True)` on SQLite calls
+`value.hex`, yielding the 32-char compact form (`fc8c7b9689f9...`). When a
+migration stores the dashed form in a `CHAR(32)` column, ORM-issued FK joins
+compare `fc8c7b96-89f9-4d0d-b164-7f3e8f29bd8d` against
+`fc8c7b9689f94d0db1647f3e8f29bd8d` — bytewise mismatch, silently no rows
+found.
+
+This caused 88 cascading test failures in PR #1045 (G7.1-T5). The fix was a
+one-line change in `0018_seed_rdc_internal_conventions.py`.
+
+### Reading UUIDs back from the DB
+
+SQLite via aiosqlite returns UUID-column values as plain strings (the `CHAR(32)`
+storage value). PostgreSQL returns `uuid.UUID` objects. Normalise before
+passing back as bind params:
+
+```python
+def _coerce_uuid(value: object) -> uuid.UUID:
+    if isinstance(value, uuid.UUID):
+        return value
+    return uuid.UUID(str(value))  # str() here is safe: converting a str to UUID object
+```
+
+The `uuid.UUID(str(value))` call accepts both the 32-char hex and the 36-char
+dashed forms and returns a proper `uuid.UUID` object; the returned object is
+then passed to `_uuid_param` to get the dialect-correct bind value.
+
+### Drift guard
+
+`backend/tests/test_alembic_uuid_param_consistency.py` contains an AST-based
+scanner that runs on every CI push and fails when any migration uses
+`str(<uuid-ish>)` as a dict value in a bind parameter context. It also
+contains a parametrised audit that checks each migration file individually
+for granular CI failure attribution.
+
+## Migration types
+
+### Schema migrations (DDL-only)
+
+The common case: `op.create_table()`, `op.add_column()`, `op.create_index()`,
+`op.create_foreign_key()`. No data operations, no UUID bind params.
+
+### Data migrations (seed / backfill)
+
+Migrations that INSERT, UPDATE, or DELETE rows. Rules:
+
+1. **Self-contained.** Do not import ORM models — models can change; the
+   migration must be a frozen snapshot of the schema at the revision's
+   point in time. Use `sa.table()` / `sa.column()` to reflect tables.
+2. **Parameterised SQL.** Use `sa.text("... :param ...")` with named bind
+   parameters — never f-string interpolation.
+3. **UUID bind convention.** Use `_uuid_param(value, is_postgres=is_postgres)`
+   (see above).
+4. **Timestamps.** `now()` is PG-only. For SQLite, pass a Python
+   `datetime.now(UTC).isoformat()` string as a bind parameter.
+5. **Idempotent.** `ON CONFLICT DO NOTHING` / `ON CONFLICT DO UPDATE` so a
+   re-run on an already-migrated DB is a no-op.
+6. **Reversible.** `downgrade()` must undo the data (delete seeded rows by a
+   stable discriminant such as `actor_sub` or slug) without touching rows the
+   operator authored independently.
+
+## Additive-only constraint
+
+Migrations in `upgrade()` must be additive: `create_table`, `add_column`,
+`create_index`, `create_foreign_key`, or data backfills. Destructive DDL
+(`drop_column`, `drop_table`, `rename_table`, `alter_column nullable=False`,
+raw `DROP …` / `RENAME …` / `SET NOT NULL` SQL) is forbidden in `upgrade()`.
+
+The CI script `scripts/ci/check_migration_compat.py` enforces this at the AST
+level. Running `alembic downgrade` in production is the rollback path; the
+schema must survive a rollback without manual DB intervention (`helm rollback`
+contract, Goal #11 DoD).
+
+## Async and sync engine interaction
+
+`backend/alembic/env.py` provides an async runner that wraps `upgrade()` and
+`downgrade()` in `asyncio.run()`. Tests that call `alembic.command.upgrade()`
+must therefore be synchronous (`def test_...`, not `async def test_...`) to
+avoid "event loop already running" errors.
+
+## References
+
+- PR #1045: the UUID `str()` vs `.hex` incident (G7.1-T5).
+- Task #1095: UUID audit + drift-guard (G0.11 CI hardening).
+- `backend/alembic/versions/0018_seed_rdc_internal_conventions.py`: the
+  canonical data-migration reference implementation with `_uuid_param` and
+  `_coerce_uuid` helpers.
+- `backend/tests/test_alembic_uuid_param_consistency.py`: drift-guard test.
+- `backend/tests/test_alembic_seed_rdc_conventions.py`: 0018 behavioural tests.
+- `backend/tests/test_migration_compat.py`: additive-only CI guard tests.


### PR DESCRIPTION
## Summary

- Audited all 24 Alembic migrations (0001–0024) for the `str(uuid)` vs `value.hex` inconsistency that caused 88 cascading test failures in PR #1045 (G7.1-T5). Findings: only migration 0018 hand-rolls UUID binding; already fixed in PR #1045 via `_uuid_param()` returning `value.hex` on SQLite. No further migration fixes needed.
- Adds `backend/tests/test_alembic_uuid_param_consistency.py` — AST-based drift-guard that fails if any future migration uses `str(<uuid-ish>)` in a dict bind-param context. Includes a synthetic regression fixture proving the guard is live and per-migration parametrised tests for granular CI attribution.
- Adds `docs/codebase/migrations.md` — new codebase doc covering the UUID binding convention, dialect portability rules (SQLite 32-char hex vs PG native uuid), additive-only constraint, and data migration patterns.

## Audit report

| Migration | Data ops | UUID binding | Status |
|-----------|----------|--------------|--------|
| 0001–0010 | DDL-only or no UUID binds | — | Clean |
| 0011 | UPDATE (text columns only) | None | Clean |
| 0012–0017, 0019–0024 | DDL-only | — | Clean |
| 0018 | INSERT (tenant + conventions) | `_uuid_param()` → `value.hex` ✓ | Clean (fixed PR #1045) |

Helper extraction criterion: only 1 migration hand-rolls UUID binding → no shared `uuid_param` helper extraction required per issue acceptance criteria ("0–1 migrations → no extraction").

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (645 files)
- [x] `mypy src/ --ignore-missing-imports` — clean (313 files)
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0
- [x] `pytest tests/test_alembic_uuid_param_consistency.py -x -q` — 27 passed
  - `test_no_str_uuid_binding_in_any_migration` — passes (no violations in 0001–0024)
  - `test_regression_fixture_detected_by_guard` — passes (guard catches synthetic `str(tenant_id)`)
  - `test_correct_hex_binding_is_not_flagged` — passes (no false positive on `value.hex`)
  - 24 parametrised per-migration tests — all pass
- [x] `pytest tests/ -x -q` (excluding integration/acceptance) — 4658 passed, 13 skipped

## Out of scope

- Switching ORM UUID storage from `Uuid(as_uuid=False)` to native UUID — chassis-wide, explicitly out for v0.2
- PostgreSQL-side audit — bytewise strictness is SQLite-specific
- Backfilling fixes into already-applied production migrations — rows are stable

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1095
