### PR TITLE
refactor(agents): G11.2-T9 polish identity_ref docstring + structured log + extract validator

### DIFF
--- a/backend/src/meho_backplane/agents/identity_ref.py
+++ b/backend/src/meho_backplane/agents/identity_ref.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Write-boundary validator for ``AgentDefinition.identity_ref``.
+
+G11.2-T8 (#1099) under Initiative #803. Extracted out of
+:mod:`meho_backplane.agents.service` (G11.2-T9 #1112) as a sibling of
+:func:`meho_backplane.agents.schemas.validate_name`: both are pure
+write-boundary gates that the service layer applies before a row lands.
+``validate_name`` is fully synchronous (a regex check) so it lives next
+to the Pydantic models in :mod:`~meho_backplane.agents.schemas`;
+``validate_identity_ref`` needs an
+:class:`~sqlalchemy.ext.asyncio.AsyncSession` to look up
+:class:`~meho_backplane.db.models.AgentPrincipal` rows, so it lives in
+its own module rather than dragging an SQLAlchemy import into
+``schemas.py``.
+
+The function is re-exported from
+:mod:`meho_backplane.agents.service` under the original
+``_validate_identity_ref`` name so existing call sites (and the test
+matrix that targets them) don't need to change.
+
+Isolation level note
+--------------------
+
+The validator runs inside the caller's session, so the SELECT and the
+subsequent INSERT/UPDATE share one transaction. Under PostgreSQL's
+default :pep:`READ COMMITTED <PEP-0008>`-equivalent isolation level
+(each statement gets its own snapshot, the chassis does not configure
+``REPEATABLE READ``), a revoke that lands between the SELECT and the
+write *is* visible to the write statement — there is a small TOCTOU
+window between the validate and the write. The runtime-time check in
+G11.3's ``run_scheduled`` (which enforces ``identity_ref ==
+agent_client_id`` under the ``client_credentials`` grant) is the
+authoritative gate; this validator is the write-time hygiene check that
+keeps a typo'd or never-existed ``identity_ref`` from landing in the
+first place.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.models import AgentPrincipal
+
+__all__ = [
+    "AgentIdentityRefInvalidError",
+    "validate_identity_ref",
+]
+
+
+class AgentIdentityRefInvalidError(Exception):
+    """Raised when ``identity_ref`` does not resolve to a tenant-scoped principal.
+
+    The :attr:`identity_ref` attribute carries the rejected value so the
+    boundary layer can echo it back; the :attr:`reason` attribute
+    distinguishes the failure mode (``unknown`` -- no row matches;
+    ``revoked`` -- a row matches but its kill switch has been pulled)
+    for the structlog breadcrumb. Both the REST route and the MCP tool
+    map this exception to a structured 4xx with detail
+    ``identity_ref_unknown`` -- a single code is intentional: leaking
+    ``revoked`` vs ``unknown`` to an unauthenticated caller would expose
+    whether a specific Keycloak client id ever existed in the tenant,
+    which is exactly the cross-tenant existence leak ``agent:test-bot``
+    reconnaissance would exploit. Operators see the structured
+    ``reason`` in the :event:`identity_ref_invalid` warning emitted just
+    before this exception is raised.
+    """
+
+    def __init__(self, identity_ref: str, reason: str) -> None:
+        self.identity_ref = identity_ref
+        self.reason = reason
+        super().__init__(
+            f"identity_ref {identity_ref!r} does not resolve to a registered "
+            f"non-revoked agent principal in this tenant (reason={reason})"
+        )
+
+
+async def validate_identity_ref(
+    session: AsyncSession,
+    tenant_id: uuid.UUID,
+    identity_ref: str,
+) -> None:
+    """Reject *identity_ref* unless it names a non-revoked tenant-scoped principal.
+
+    Matches exactly against :attr:`AgentPrincipal.keycloak_client_id`
+    (no wildcards, no case-folding) inside a tenant-scoped WHERE so a
+    cross-tenant probe is invisible to the query and rejected as
+    ``unknown`` -- the existence of another tenant's principal is never
+    leaked. ``revoked`` rows are rejected with ``reason="revoked"``;
+    the boundary collapses both reasons into a single
+    ``identity_ref_unknown`` code (to avoid leaking whether a specific
+    clientId ever existed), but operators see the precise reason on
+    the :event:`identity_ref_invalid` warning emitted before each raise.
+
+    The query runs inside the *caller's* session so validate + write
+    share one transaction; see the module docstring for the TOCTOU
+    window note. The logger is resolved per-call via
+    :func:`structlog.get_logger` to stay capturable under
+    :func:`structlog.testing.capture_logs` -- same precedent + rationale
+    as :mod:`meho_backplane.auth.rbac` and :mod:`meho_backplane.auth.jwt`.
+    """
+    result = await session.execute(
+        select(AgentPrincipal.revoked).where(
+            AgentPrincipal.tenant_id == tenant_id,
+            AgentPrincipal.keycloak_client_id == identity_ref,
+        )
+    )
+    revoked = result.scalar_one_or_none()
+    if revoked is None:
+        structlog.get_logger(__name__).warning(
+            "identity_ref_invalid",
+            identity_ref=identity_ref,
+            reason="unknown",
+            tenant_id=str(tenant_id),
+        )
+        raise AgentIdentityRefInvalidError(identity_ref, reason="unknown")
+    if revoked:
+        structlog.get_logger(__name__).warning(
+            "identity_ref_invalid",
+            identity_ref=identity_ref,
+            reason="revoked",
+            tenant_id=str(tenant_id),
+        )
+        raise AgentIdentityRefInvalidError(identity_ref, reason="revoked")

--- a/backend/src/meho_backplane/agents/mapping.py
+++ b/backend/src/meho_backplane/agents/mapping.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Payload -> ORM mappers for ``AgentDefinition`` write paths.
+
+G11.2-T9 (#1112) extracted these out of
+:mod:`meho_backplane.agents.service` so the service module stays
+inside the per-file size budget. Both helpers are pure: they
+translate Pydantic-validated create/update payloads onto SQLAlchemy
+rows. ``model_tier`` is round-tripped through its ``StrEnum``
+``.value`` on both paths so the column stores the wire string
+(``"deep"``) rather than the enum repr (``"AgentModelTier.DEEP"``).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from meho_backplane.agents.schemas import AgentDefinitionCreate
+from meho_backplane.db.models import AgentDefinition
+
+__all__ = [
+    "apply_changes",
+    "build_definition_row",
+]
+
+
+def build_definition_row(
+    tenant_id: uuid.UUID,
+    created_by_sub: str,
+    payload: AgentDefinitionCreate,
+) -> AgentDefinition:
+    """Map a validated create payload onto a fresh :class:`AgentDefinition` row."""
+    return AgentDefinition(
+        tenant_id=tenant_id,
+        name=payload.name,
+        identity_ref=payload.identity_ref,
+        model_tier=payload.model_tier.value,
+        system_prompt=payload.system_prompt,
+        toolset=payload.toolset,
+        turn_budget=payload.turn_budget,
+        output_schema=payload.output_schema,
+        enabled=payload.enabled,
+        created_by_sub=created_by_sub,
+    )
+
+
+def apply_changes(row: AgentDefinition, changes: dict[str, object]) -> None:
+    """Apply a validated PATCH body to *row* (``model_tier`` -> ``.value``)."""
+    for field, value in changes.items():
+        if field == "model_tier" and value is not None:
+            value = value.value if hasattr(value, "value") else value
+        setattr(row, field, value)

--- a/backend/src/meho_backplane/agents/service.py
+++ b/backend/src/meho_backplane/agents/service.py
@@ -73,8 +73,14 @@ import uuid
 import structlog
 from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.ext.asyncio import AsyncSession
 
+from meho_backplane.agents.identity_ref import (
+    AgentIdentityRefInvalidError,
+)
+from meho_backplane.agents.identity_ref import (
+    validate_identity_ref as _validate_identity_ref,
+)
+from meho_backplane.agents.mapping import apply_changes, build_definition_row
 from meho_backplane.agents.schemas import (
     AgentDefinitionCreate,
     AgentDefinitionRead,
@@ -82,11 +88,16 @@ from meho_backplane.agents.schemas import (
     validate_name,
 )
 from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import AgentDefinition, AgentPrincipal
+from meho_backplane.db.models import AgentDefinition
 
 __all__ = [
     "AgentDefinitionExistsError",
     "AgentDefinitionService",
+    # Re-exported from :mod:`meho_backplane.agents.identity_ref` so existing
+    # callers (REST routes, MCP tools, tests) keep their
+    # ``from meho_backplane.agents.service import AgentIdentityRefInvalidError``
+    # import path; the validator was extracted in G11.2-T9 (#1112) and
+    # ``_validate_identity_ref`` below is the alias internal call sites use.
     "AgentIdentityRefInvalidError",
 ]
 
@@ -110,31 +121,6 @@ class AgentDefinitionExistsError(Exception):
     def __init__(self, name: str) -> None:
         self.name = name
         super().__init__(f"agent definition {name!r} already exists for this tenant")
-
-
-class AgentIdentityRefInvalidError(Exception):
-    """Raised when ``identity_ref`` does not resolve to a tenant-scoped principal.
-
-    The :attr:`identity_ref` attribute carries the rejected value so the
-    boundary layer can echo it back; the *reason* attribute distinguishes
-    the failure mode (``unknown`` -- no row matches; ``revoked`` -- a row
-    matches but its kill switch has been pulled) for the structlog
-    breadcrumb. Both the REST route and the MCP tool map this exception
-    to a structured 4xx with detail ``identity_ref_unknown`` -- a single
-    code is intentional: leaking ``revoked`` vs ``unknown`` to an
-    unauthenticated caller would expose whether a specific Keycloak
-    client id ever existed in the tenant, which is exactly the
-    cross-tenant existence leak ``agent:test-bot`` reconnaissance would
-    exploit. Operators see the structured ``reason`` in the log event.
-    """
-
-    def __init__(self, identity_ref: str, reason: str) -> None:
-        self.identity_ref = identity_ref
-        self.reason = reason
-        super().__init__(
-            f"identity_ref {identity_ref!r} does not resolve to a registered "
-            f"non-revoked agent principal in this tenant (reason={reason})"
-        )
 
 
 def _is_unique_violation(exc: IntegrityError) -> bool:
@@ -170,44 +156,6 @@ class AgentDefinitionService:
     def __init__(self) -> None:
         self._log = structlog.get_logger()
 
-    async def _validate_identity_ref(
-        self,
-        session: AsyncSession,
-        tenant_id: uuid.UUID,
-        identity_ref: str,
-    ) -> None:
-        """Reject *identity_ref* unless it names a non-revoked tenant-scoped principal.
-
-        Matches against :attr:`AgentPrincipal.keycloak_client_id` -- the
-        agent-principal convention from T1 (#815) is that an agent's
-        Keycloak clientId is ``agent:<name>`` and that is the value stored
-        on ``AgentDefinition.identity_ref`` by every existing flow. The
-        match is exact (no wildcards, no case-folding) so two principals
-        with names differing only in case stay distinct.
-
-        Tenant scoping is the first WHERE clause: a cross-tenant probe
-        (a tenant A operator trying to bind a tenant B's principal) is
-        invisible to the query and rejected as ``unknown`` -- the
-        existence of tenant B's principal is never leaked across the
-        tenant boundary. ``revoked`` rows are also rejected with
-        ``reason="revoked"`` (logged; the boundary collapses both reasons
-        into a single ``identity_ref_unknown`` code to avoid leaking
-        whether a specific clientId ever existed). Read-only query
-        running inside the *caller's* session so the validate + write
-        happen in the same transaction.
-        """
-        result = await session.execute(
-            select(AgentPrincipal.revoked).where(
-                AgentPrincipal.tenant_id == tenant_id,
-                AgentPrincipal.keycloak_client_id == identity_ref,
-            )
-        )
-        revoked = result.scalar_one_or_none()
-        if revoked is None:
-            raise AgentIdentityRefInvalidError(identity_ref, reason="unknown")
-        if revoked:
-            raise AgentIdentityRefInvalidError(identity_ref, reason="revoked")
-
     async def create(
         self,
         tenant_id: uuid.UUID,
@@ -234,26 +182,15 @@ class AgentDefinitionService:
             When *name* contains characters outside the safe set.
         """
         validate_name(payload.name)
-        row = AgentDefinition(
-            tenant_id=tenant_id,
-            name=payload.name,
-            identity_ref=payload.identity_ref,
-            model_tier=payload.model_tier.value,
-            system_prompt=payload.system_prompt,
-            toolset=payload.toolset,
-            turn_budget=payload.turn_budget,
-            output_schema=payload.output_schema,
-            enabled=payload.enabled,
-            created_by_sub=created_by_sub,
-        )
+        row = build_definition_row(tenant_id, created_by_sub, payload)
         sessionmaker = get_sessionmaker()
         async with sessionmaker() as session:
-            # Validate the identity_ref before the INSERT lands. Doing it
-            # inside the same session ensures the FK-like guarantee under
-            # PostgreSQL REPEATABLE READ: a concurrent revoke between
-            # the select and the insert can't make the validation stale
-            # within this transaction's snapshot.
-            await self._validate_identity_ref(session, tenant_id, payload.identity_ref)
+            # Validate identity_ref inside the caller's session so the
+            # SELECT and the write share one transaction. The TOCTOU
+            # window (READ COMMITTED, not REPEATABLE READ) and the
+            # authoritative runtime gate are explained in the new
+            # :mod:`meho_backplane.agents.identity_ref` module docstring.
+            await _validate_identity_ref(session, tenant_id, payload.identity_ref)
             session.add(row)
             try:
                 await session.flush()
@@ -347,25 +284,20 @@ class AgentDefinitionService:
         """Apply a partial update to ``(tenant_id, name)``; ``None`` if absent.
 
         Only fields the caller explicitly set are applied
-        (``model_dump(exclude_unset=True)``), so a PATCH can change one
-        field without clobbering the rest. ``name`` is not updatable (it
-        is the natural key) -- the field is absent from
-        :class:`AgentDefinitionUpdate`. ``model_tier`` is stored as its
-        string value.
-
+        (``model_dump(exclude_unset=True)``); ``name`` is not updatable
+        (it is the natural key, absent from :class:`AgentDefinitionUpdate`).
         Returns ``None`` when no row matches (absent or cross-tenant) so
-        the boundary renders 404. The ``onupdate`` ORM hook bumps
+        the boundary renders 404; the ``onupdate`` ORM hook bumps
         ``updated_at`` on any column change.
 
-        Raises
-        ------
-        AgentIdentityRefInvalidError
-            When the PATCH body includes a new ``identity_ref`` that
-            does not resolve to a registered, non-revoked agent
-            principal in *tenant_id* (G11.2-T8 #1099). Updates that
-            don't touch ``identity_ref`` skip the validation -- the
-            existing value was already validated when the definition
-            was created or last identity-ref'd.
+        Raises :class:`AgentIdentityRefInvalidError` when the PATCH body
+        includes a new ``identity_ref`` that does not resolve to a
+        registered, non-revoked agent principal in *tenant_id*
+        (G11.2-T8 #1099). Updates that don't touch ``identity_ref`` skip
+        the validation -- the existing value was already validated when
+        the definition was created or last identity-ref'd. The runtime
+        check that the principal is still live at invocation time is
+        G11.3's responsibility, not this validator's.
         """
         changes = payload.model_dump(exclude_unset=True)
         sessionmaker = get_sessionmaker()
@@ -380,20 +312,10 @@ class AgentDefinitionService:
             if row is None:
                 return None
             # Re-validate identity_ref only when the PATCH body sets it.
-            # Untouched identity_ref keeps the existing (already-validated)
-            # value. The runtime-time check that the principal is still
-            # live at invocation time is G11.3's responsibility (the
-            # scheduler enforces identity_ref == agent_client_id under
-            # the client_credentials grant).
             new_identity_ref = changes.get("identity_ref")
             if new_identity_ref is not None:
-                await self._validate_identity_ref(session, tenant_id, new_identity_ref)
-            for field, value in changes.items():
-                # model_tier round-trips through the enum's .value so the
-                # column stores the wire string, not "AgentModelTier.X".
-                if field == "model_tier" and value is not None:
-                    value = value.value if hasattr(value, "value") else value
-                setattr(row, field, value)
+                await _validate_identity_ref(session, tenant_id, new_identity_ref)
+            apply_changes(row, changes)
             await session.flush()
             await session.refresh(row)
             entry = AgentDefinitionRead.model_validate(row)

--- a/backend/tests/test_agents_service.py
+++ b/backend/tests/test_agents_service.py
@@ -31,6 +31,7 @@ from collections.abc import Iterator
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
+from structlog.testing import capture_logs
 
 from meho_backplane.agents.schemas import (
     AgentDefinitionCreate,
@@ -367,3 +368,108 @@ async def test_update_other_fields_skips_identity_ref_revalidation() -> None:
     )
     assert updated is not None
     assert updated.turn_budget == 99
+
+
+# ---------------------------------------------------------------------------
+# G11.2-T9 (#1112) -- identity_ref_invalid structured log breadcrumb
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_identity_ref_invalid_unknown_emits_structured_warning() -> None:
+    """``unknown`` rejection emits ``identity_ref_invalid`` with structured fields.
+
+    Operators tail logs against the structured ``reason`` to spot a typo'd
+    or never-registered ``identity_ref``. The breadcrumb mirrors the
+    ``agent_definition_create`` / ``agent_definition_update`` info events
+    the service emits on the happy path: same event-name shape, same
+    ``tenant_id`` field.
+    """
+    async with get_sessionmaker()() as session:
+        tenant_id = await _seed_tenant(session, "t9-warn-unknown")
+        # No principal seeded -- the create below resolves to "unknown".
+    service = AgentDefinitionService()
+    with capture_logs() as captured, pytest.raises(AgentIdentityRefInvalidError):
+        await service.create(tenant_id, "op-1", _create_body("ghost"))
+
+    events = [line for line in captured if line.get("event") == "identity_ref_invalid"]
+    assert len(events) == 1
+    line = events[0]
+    assert line["identity_ref"] == "agent:ghost"
+    assert line["reason"] == "unknown"
+    assert line["tenant_id"] == str(tenant_id)
+    assert line["log_level"] == "warning"
+
+
+@pytest.mark.asyncio
+async def test_identity_ref_invalid_revoked_emits_structured_warning() -> None:
+    """``revoked`` rejection emits ``identity_ref_invalid`` with ``reason='revoked'``.
+
+    The boundary collapses ``revoked`` into ``identity_ref_unknown`` to
+    avoid leaking whether a specific clientId ever existed, but the
+    structured event must keep the precise reason so on-call can
+    distinguish a stale ``identity_ref`` referencing a revoked principal
+    from a typo.
+    """
+    async with get_sessionmaker()() as session:
+        tenant_id = await _seed_tenant(session, "t9-warn-revoked")
+        await _seed_principal(session, tenant_id, "killed-bot", revoked=True)
+    service = AgentDefinitionService()
+    with capture_logs() as captured, pytest.raises(AgentIdentityRefInvalidError):
+        await service.create(tenant_id, "op-1", _create_body("killed-bot"))
+
+    events = [line for line in captured if line.get("event") == "identity_ref_invalid"]
+    assert len(events) == 1
+    line = events[0]
+    assert line["identity_ref"] == "agent:killed-bot"
+    assert line["reason"] == "revoked"
+    assert line["tenant_id"] == str(tenant_id)
+    assert line["log_level"] == "warning"
+
+
+@pytest.mark.asyncio
+async def test_identity_ref_invalid_on_update_emits_structured_warning() -> None:
+    """An update that points at an unknown principal emits the same warning.
+
+    Covers the second call site of the validator: ``update`` re-runs it
+    only when the PATCH body sets ``identity_ref``. The structured event
+    is identical to the create path.
+    """
+    async with get_sessionmaker()() as session:
+        tenant_id = await _seed_tenant(session, "t9-warn-update")
+        await _seed_principal(session, tenant_id, "agent-a")
+    service = AgentDefinitionService()
+    await service.create(tenant_id, "op-1", _create_body("agent-a"))
+
+    with capture_logs() as captured, pytest.raises(AgentIdentityRefInvalidError):
+        await service.update(
+            tenant_id,
+            "agent-a",
+            AgentDefinitionUpdate(identity_ref="agent:does-not-exist"),
+        )
+
+    events = [line for line in captured if line.get("event") == "identity_ref_invalid"]
+    assert len(events) == 1
+    line = events[0]
+    assert line["identity_ref"] == "agent:does-not-exist"
+    assert line["reason"] == "unknown"
+    assert line["tenant_id"] == str(tenant_id)
+    assert line["log_level"] == "warning"
+
+
+def test_identity_ref_module_re_exports_match_service_module() -> None:
+    """``service`` re-exports ``AgentIdentityRefInvalidError`` from ``identity_ref``.
+
+    Boundary code (REST routes, MCP tools) imports the exception from
+    ``meho_backplane.agents.service``; the T9 extraction moved its
+    definition to ``meho_backplane.agents.identity_ref`` but kept the
+    re-export so no boundary import had to change. This pins that
+    contract so a future cleanup pass can't silently break it.
+    """
+    from meho_backplane.agents import identity_ref as identity_ref_module
+    from meho_backplane.agents import service as service_module
+
+    assert (
+        service_module.AgentIdentityRefInvalidError
+        is identity_ref_module.AgentIdentityRefInvalidError
+    )

--- a/docs/codebase/agent-definition.md
+++ b/docs/codebase/agent-definition.md
@@ -76,26 +76,36 @@ cross-tenant rows are structurally invisible: `get` / `update` /
 `AgentDefinitionExistsError` (narrowed from the unique-index
 `IntegrityError`).
 
-**`identity_ref` validation (G11.2-T8 #1099)**: `create` and any
-`update` that touches `identity_ref` validate the value against
-`agent_principal.keycloak_client_id` scoped to the operator's tenant
-and require `revoked=False` — raising `AgentIdentityRefInvalidError`
-otherwise (REST: 422 `identity_ref_unknown`; MCP: Invalid Params
-`identity_ref_unknown`). The validator runs inside the same session
-as the write so a concurrent revoke can't make the check stale
-within the same transaction's snapshot. The reason (`unknown` /
-`revoked`) is collapsed into one boundary code so cross-tenant
-existence isn't leaked; operators see the structured reason in the
-structlog event. A PATCH that doesn't include `identity_ref` skips
-the validation — the runtime-time check that the principal is still
-live at invocation time is G11.3's responsibility (the scheduler's
-`run_scheduled` enforces `identity_ref == agent_client_id` under the
-`client_credentials` grant). Validating at the write boundary makes
-the G11.2-T2 (#816) contracts — `actor_sub = identity_ref` on
-user-initiated runs, `identity_ref == agent_client_id` enforcement on
-`run_scheduled` — well-formed by construction: a typo'd
-`identity_ref` can never produce a meaningless `actor_sub` or a
-confusing scheduled-run rejection later.
+**`identity_ref` validation (G11.2-T8 #1099, refined in G11.2-T9
+#1112)**: `create` and any `update` that touches `identity_ref`
+validate the value against `agent_principal.keycloak_client_id`
+scoped to the operator's tenant and require `revoked=False` — raising
+`AgentIdentityRefInvalidError` otherwise (REST: 422
+`identity_ref_unknown`; MCP: Invalid Params `identity_ref_unknown`).
+The validator (`meho_backplane.agents.identity_ref.validate_identity_ref`,
+re-exported from `service` as `_validate_identity_ref`) runs inside
+the caller's session, so the SELECT and the write share one
+transaction. The chassis does not configure `REPEATABLE READ` —
+PostgreSQL defaults to `READ COMMITTED`, where each statement gets
+its own snapshot — so a revoke that lands between the SELECT and the
+write *is* visible to the write statement: the TOCTOU window is
+small but real. The authoritative gate against a principal being
+revoked between validation and use is the runtime check in G11.3's
+`run_scheduled`, which enforces `identity_ref == agent_client_id`
+under the `client_credentials` grant. The write-boundary validator
+is the hygiene check that keeps a typo'd or never-existed
+`identity_ref` from ever landing in the first place.
+The reason (`unknown` / `revoked`) is collapsed into one boundary
+code so cross-tenant existence isn't leaked; operators see the
+precise reason on the `identity_ref_invalid` structlog `warning`
+event emitted before each raise (carries `identity_ref`, `reason`,
+`tenant_id`). A PATCH that doesn't include `identity_ref` skips the
+validation. Validating at the write boundary makes the G11.2-T2
+(#816) contracts — `actor_sub = identity_ref` on user-initiated runs,
+`identity_ref == agent_client_id` enforcement on `run_scheduled` —
+well-formed by construction: a typo'd `identity_ref` can never
+produce a meaningless `actor_sub` or a confusing scheduled-run
+rejection later.
 
 ## Control flow
 


### PR DESCRIPTION
## Summary

Three polish items deferred from G11.2-T7/T8 (#1099 / PR #1108) bundled as one post-merge cleanup so `service.py` stays inside its size budget before the next G11.2 feature push:

- **(A) Docstring honesty.** Drops the incorrect "REPEATABLE READ" claim from the validator's docstring, `create()`'s inline comment, and `docs/codebase/agent-definition.md`. The chassis runs PostgreSQL's default READ COMMITTED, so a revoke that lands between the validator's SELECT and the write IS visible to the write — the TOCTOU window is small but real. The authoritative gate is G11.3's `run_scheduled` enforcing `identity_ref == agent_client_id` under the `client_credentials` grant; this validator is the write-time hygiene check.

- **(B) Structured log breadcrumb.** Emits `identity_ref_invalid` structlog `warning` carrying `identity_ref`, `reason`, `tenant_id` before each `AgentIdentityRefInvalidError` raise — mirroring the `agent_definition_create` / `..._update` info events on the happy path so operators can grep structured fields for stale-principal events. Logger is resolved per-call via `structlog.get_logger(__name__)` (same precedent as `auth/rbac` and `auth/jwt`) to stay capturable under `capture_logs` — `cache_logger_on_first_use=True` orphans module-level proxies after `configure` calls.

- **(C) Validator extracted to a sibling module.** `_validate_identity_ref` moves to `agents/identity_ref.py` (re-exported from `service.py` so callers don't change); Pydantic-to-ORM mappers (`build_definition_row`, `apply_changes`) move to `agents/mapping.py`. `service.py` drops from **446 → 367 lines**; `code-quality.py --diff` warnings on `service.py` go to **0**.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/meho_backplane/agents/` — clean
- [x] `pytest tests/test_agents_service.py` — 15 passed (12 pre-existing + 3 new `capture_logs` assertions on unknown/revoked/update paths + 1 re-export contract pin)
- [x] `pytest tests/test_api_v1_agents.py tests/test_mcp_tools_agents.py tests/test_agents_schemas.py` — 47 passed (boundary code unchanged, re-export keeps imports stable)
- [x] `pytest -k agent` (unit-test subset) — 257 passed
- [x] `code-quality.py --diff` — 0 warnings on `service.py` (previously 3: file-size + create + update); 0 blockers overall

## Acceptance criteria

- [x] Docstring in `_validate_identity_ref` no longer claims REPEATABLE READ semantics that the codebase doesn't enforce.
- [x] `AgentIdentityRefInvalidError` is preceded by a `structlog` `warning("identity_ref_invalid", ...)` event carrying `identity_ref`, `reason`, `tenant_id` — three new tests use `structlog.testing.capture_logs()` to assert the fields land on `unknown`, `revoked`, and the update-path call site.
- [x] `backend/src/meho_backplane/agents/service.py` drops under 400 lines after the validator extraction; `create()` / `update()` size warnings cleared via additional mapper extraction.
- [x] `Python (ruff + mypy + pytest)` green; `code-quality.py --diff` warning count drops to 0 on `service.py`.

## Out of scope

- Splitting `backend/src/meho_backplane/mcp/tools/agents.py` (433 lines) — separate concern per the issue.
- Reworking TOCTOU semantics (REPEATABLE READ would close the window; that's a chassis-wide config change, not this Task's scope).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1112
