### PR TITLE
test(rbac): G11.2 follow-up — negative tests for agent grant + approval verbs (REST + MCP)

### DIFF
--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -148,8 +148,10 @@ def isolated_registry() -> Iterator[None]:
     )
     from meho_backplane.mcp.resources import tenant_feed, tenant_info
     from meho_backplane.mcp.tools import (
+        agent_grants,
         agent_runs,
         agents,
+        approvals,
         audit,
         broadcast_overrides,
         connector_admin,
@@ -188,6 +190,16 @@ def isolated_registry() -> Iterator[None]:
     # G11.1-T4 (#811): the agent invocation MCP tools (meho.agents.run +
     # meho.agents.run_status) join the reload list for the same reason.
     importlib.reload(agent_runs)
+    # G11.2-T5 (#818) approvals + T6 (#819) agent grants: the MCP tool
+    # modules (``meho.approvals.*`` and ``meho.agents.grant.*``) join
+    # the reload list for the same reason every other tool module
+    # does -- the autouse ``clear_registries()`` above would otherwise
+    # leave them unregistered in any test file that imports this
+    # fixture after the first one runs in the process. The negative
+    # RBAC suites (G11.2 follow-up #1113) rely on this entry to
+    # exercise ``tools/list`` filter + ``tools/call`` re-check gates.
+    importlib.reload(agent_grants)
+    importlib.reload(approvals)
     importlib.reload(tenant_info)
     importlib.reload(tenant_feed)
     importlib.reload(kb_resource)

--- a/backend/tests/test_api_v1_agent_grants.py
+++ b/backend/tests/test_api_v1_agent_grants.py
@@ -129,8 +129,16 @@ def _token(key: Any, *, role: TenantRole, sub: str = "op-test") -> str:
 #   ``operator`` matrix below for that reason; the routing-shadow
 #   itself is an adjacent finding for the orchestrator to file
 #   separately.
+# Fixed UUID literals for path parameters. The role gate fires before
+# any DB lookup, so the value need only parse as a UUID; deterministic
+# literals keep ``pytest-xdist`` test-collection IDs stable across
+# workers (``uuid.uuid4()`` here would re-evaluate per worker and trip
+# xdist's collection-determinism check).
+_GRANT_ID_SHOW = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_GRANT_ID_REVOKE = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
 _GRANT_ENDPOINTS: tuple[tuple[str, str, dict[str, Any] | None], ...] = (
-    ("GET", f"/api/v1/agents/grants/{uuid.uuid4()}", None),
+    ("GET", f"/api/v1/agents/grants/{_GRANT_ID_SHOW}", None),
     (
         "POST",
         "/api/v1/agents/grants",
@@ -150,7 +158,7 @@ _GRANT_ENDPOINTS: tuple[tuple[str, str, dict[str, Any] | None], ...] = (
             "expires_at": "2099-01-01T00:00:00+00:00",
         },
     ),
-    ("DELETE", f"/api/v1/agents/grants/{uuid.uuid4()}", None),
+    ("DELETE", f"/api/v1/agents/grants/{_GRANT_ID_REVOKE}", None),
 )
 
 

--- a/backend/tests/test_api_v1_agent_grants.py
+++ b/backend/tests/test_api_v1_agent_grants.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Negative RBAC tests for ``/api/v1/agents/grants*``.
+
+G11.2-T6 (#819) wires every grants route behind
+``Depends(require_role(TenantRole.TENANT_ADMIN))``. The existing
+service-layer suite (``test_agent_grants.py``) bypasses the gate by
+construction — it calls
+:class:`~meho_backplane.agents.grants.AgentGrantService` directly. A
+refactor that drops ``_require_admin = Depends(require_role(...))``
+from the router module would not surface there.
+
+This file closes the gap by exercising every grants route through
+the FastAPI :class:`~fastapi.testclient.TestClient` with two
+under-privileged JWTs:
+
+* ``read_only`` — the floor of the role lattice; rejected everywhere.
+* ``operator`` — one rank below ``tenant_admin``; rejected everywhere
+  on this surface because grants are governance data
+  (``required_role=TenantRole.TENANT_ADMIN``).
+
+Every route asserts HTTP 403 with detail ``insufficient_role``
+(matching :func:`~meho_backplane.auth.rbac.require_role`'s
+:class:`fastapi.HTTPException`). Refactors that downgrade the
+required role would break these tests immediately.
+
+Out of scope:
+
+* Happy-path tenant-admin coverage — separate task.
+* Cross-principal "agent can't grant itself" — independent property,
+  separate task per the originating issue body.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+import respx
+from fastapi.testclient import TestClient
+
+import meho_backplane.audit as _audit_module
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.main import app
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import make_rsa_keypair, mint_token, mock_discovery_and_jwks, public_jwks
+
+_TENANT_A = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+
+@pytest.fixture(autouse=True)
+def _noop_broadcast(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Silence the broadcast publisher so 403 responses don't stall on Valkey.
+
+    :class:`~meho_backplane.audit.AuditMiddleware` calls
+    :func:`~meho_backplane.broadcast.publish_event` on every response,
+    including 4xx. Without a running Valkey the redis-py client
+    blocks on ``socket_connect_timeout``. The middleware's audit row
+    is what matters for these tests, not the broadcast fan-out;
+    silencing the publisher keeps the wall-clock honest. Mirror of
+    ``test_api_v1_agent_principals._noop_broadcast``.
+    """
+
+    async def _noop(*_a: object, **_kw: object) -> None:
+        pass
+
+    monkeypatch.setattr(_audit_module, "publish_event", _noop)
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`~meho_backplane.settings.Settings` requires."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    yield TestClient(app)
+
+
+def _token(key: Any, *, role: TenantRole, sub: str = "op-test") -> str:
+    return mint_token(key, sub=sub, tenant_role=role.value, tenant_id=str(_TENANT_A))
+
+
+# Every route+method gated by ``_require_admin``. Stored as
+# ``(method, path, body)`` so the negative-matrix tests can iterate
+# without reproducing the verb table. ``body`` is None for GET /
+# DELETE; for POST it's a minimal Pydantic-valid payload — the role
+# gate fires before Pydantic parsing on a 403, so the body need only
+# be a dict (FastAPI doesn't validate it until the dependency chain
+# clears).
+#
+# Note on ``GET /api/v1/agents/grants`` (list)
+# --------------------------------------------
+# The agent-definitions router (``api/v1/agents.py``) is registered
+# BEFORE the grants router in :mod:`meho_backplane.main`, and its
+# ``GET /{name}`` route matches ``/api/v1/agents/grants`` first
+# (``name="grants"``). FastAPI route precedence is registration
+# order. The shadow is OPERATOR-gated rather than TENANT_ADMIN-gated:
+#
+# * A ``read_only`` request still surfaces as 403
+#   ``insufficient_role`` (from the agents-show gate, not the
+#   grants-list gate) — same observable behaviour from outside, so
+#   the route is covered for the ``read_only`` case at the bottom
+#   of this file via ``test_read_only_list_route_returns_403``.
+# * An ``operator`` request passes the agents-show gate and reaches
+#   the service, returning 404 ``agent_not_found`` rather than the
+#   grants-list 403. The route is excluded from the parametrised
+#   ``operator`` matrix below for that reason; the routing-shadow
+#   itself is an adjacent finding for the orchestrator to file
+#   separately.
+_GRANT_ENDPOINTS: tuple[tuple[str, str, dict[str, Any] | None], ...] = (
+    ("GET", f"/api/v1/agents/grants/{uuid.uuid4()}", None),
+    (
+        "POST",
+        "/api/v1/agents/grants",
+        {
+            "principal_sub": "agent:deploy-bot",
+            "op_pattern": "vm.list",
+            "verdict": "auto-execute",
+        },
+    ),
+    (
+        "POST",
+        "/api/v1/agents/grants/elevate",
+        {
+            "principal_sub": "agent:deploy-bot",
+            "op_pattern": "vm.power_off",
+            "verdict": "needs-approval",
+            "expires_at": "2099-01-01T00:00:00+00:00",
+        },
+    ),
+    ("DELETE", f"/api/v1/agents/grants/{uuid.uuid4()}", None),
+)
+
+
+@pytest.mark.parametrize("method, path, body", _GRANT_ENDPOINTS)
+def test_read_only_role_is_rejected_with_insufficient_role(
+    client: TestClient,
+    method: str,
+    path: str,
+    body: dict[str, Any] | None,
+) -> None:
+    """``read_only`` JWT → HTTP 403 ``insufficient_role`` on every grants route.
+
+    The lowest-rank role can never act on a TENANT_ADMIN-gated surface;
+    this is the floor of the lattice. Any future refactor that drops
+    the role gate from a route would invert the response on this case
+    (a 404 / 200 / 422 from a deeper layer rather than 403 here).
+    """
+    key = make_rsa_keypair("kid-ro")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_token(key, role=TenantRole.READ_ONLY)}"}
+        response = client.request(method, path, headers=headers, json=body)
+    assert response.status_code == 403, response.text
+    assert response.json() == {"detail": "insufficient_role"}
+
+
+@pytest.mark.parametrize("method, path, body", _GRANT_ENDPOINTS)
+def test_operator_role_is_rejected_with_insufficient_role(
+    client: TestClient,
+    method: str,
+    path: str,
+    body: dict[str, Any] | None,
+) -> None:
+    """``operator`` JWT → HTTP 403 ``insufficient_role`` on every grants route.
+
+    One rank below ``tenant_admin``. This is the load-bearing assertion
+    for the surface: grants show / create / elevate / revoke expose
+    permission topology and must remain ``tenant_admin``-only. A
+    refactor that lowers the gate to ``operator`` (e.g. to align with
+    the approvals surface) trips this test. The list route is covered
+    separately below; see the matrix-level docstring for the routing
+    shadow that excludes it from this parametrised case.
+    """
+    key = make_rsa_keypair("kid-op")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_token(key, role=TenantRole.OPERATOR)}"}
+        response = client.request(method, path, headers=headers, json=body)
+    assert response.status_code == 403, response.text
+    assert response.json() == {"detail": "insufficient_role"}
+
+
+def test_read_only_list_route_returns_403(client: TestClient) -> None:
+    """``read_only`` ``GET /api/v1/agents/grants`` returns 403 ``insufficient_role``.
+
+    The list route is shadowed by ``GET /api/v1/agents/{name}`` (see
+    the matrix-level note), but the shadow's ``_require_operator``
+    gate also rejects a ``read_only`` JWT with the same response
+    shape. The route is therefore covered for ``read_only`` from
+    outside — a refactor that drops the grants-list gate AND the
+    agents-show gate would be required to surface a non-403 here.
+
+    This test is the one in this file whose green status does NOT
+    prove the grants-list-specific gate is wired; it proves the
+    outer-observable behaviour. A separate fix that lands the
+    grants router before the agents router in
+    :mod:`meho_backplane.main` would let this case fold back into
+    the parametrised matrix above.
+    """
+    key = make_rsa_keypair("kid-ro")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_token(key, role=TenantRole.READ_ONLY)}"}
+        response = client.get("/api/v1/agents/grants", headers=headers)
+    assert response.status_code == 403, response.text
+    assert response.json() == {"detail": "insufficient_role"}

--- a/backend/tests/test_api_v1_approvals.py
+++ b/backend/tests/test_api_v1_approvals.py
@@ -106,22 +106,33 @@ def _token(key: Any, *, role: TenantRole, sub: str = "op-test") -> str:
 # Pydantic body parsing, so minimal valid bodies suffice for the POST
 # routes — the goal is to ensure 403 from the gate, not a 422 from
 # body validation.
+#
+# Fixed UUID literals for path parameters. The role gate fires before
+# any DB lookup, so the value need only parse as a UUID; deterministic
+# literals keep ``pytest-xdist`` test-collection IDs stable across
+# workers (``uuid.uuid4()`` here would re-evaluate per worker and trip
+# xdist's collection-determinism check).
+_APPROVAL_ID_SHOW = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_APPROVAL_ID_APPROVE = uuid.UUID("22222222-2222-2222-2222-222222222222")
+_APPROVAL_ID_REJECT = uuid.UUID("33333333-3333-3333-3333-333333333333")
+_APPROVAL_ID_DECIDE = uuid.UUID("44444444-4444-4444-4444-444444444444")
+
 _APPROVAL_ENDPOINTS: tuple[tuple[str, str, dict[str, Any] | None], ...] = (
     ("GET", "/api/v1/approvals", None),
-    ("GET", f"/api/v1/approvals/{uuid.uuid4()}", None),
+    ("GET", f"/api/v1/approvals/{_APPROVAL_ID_SHOW}", None),
     (
         "POST",
-        f"/api/v1/approvals/{uuid.uuid4()}/approve",
+        f"/api/v1/approvals/{_APPROVAL_ID_APPROVE}/approve",
         {"params": {}},
     ),
     (
         "POST",
-        f"/api/v1/approvals/{uuid.uuid4()}/reject",
+        f"/api/v1/approvals/{_APPROVAL_ID_REJECT}/reject",
         {"reason": ""},
     ),
     (
         "POST",
-        f"/api/v1/approvals/{uuid.uuid4()}/decide",
+        f"/api/v1/approvals/{_APPROVAL_ID_DECIDE}/decide",
         {"decision": "approved"},
     ),
 )

--- a/backend/tests/test_api_v1_approvals.py
+++ b/backend/tests/test_api_v1_approvals.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Negative RBAC tests for ``/api/v1/approvals*``.
+
+G11.2-T5 (#818) wires every approval route behind
+``Depends(require_role(TenantRole.OPERATOR))``. The existing
+service-layer suite (``test_approval_queue.py``) bypasses the gate by
+calling
+:func:`~meho_backplane.operations.approval_queue.approve_request` /
+:func:`~meho_backplane.operations.approval_queue.reject_request`
+directly. A refactor that drops ``_require_operator = Depends(...)``
+from the router module would not surface there.
+
+This file closes the gap by exercising every approval route through
+the FastAPI :class:`~fastapi.testclient.TestClient` with a
+``read_only`` JWT — the only role strictly below ``operator`` in the
+v0.2 lattice. Each route asserts HTTP 403 ``insufficient_role``
+(matching :func:`~meho_backplane.auth.rbac.require_role`'s
+:class:`fastapi.HTTPException`).
+
+Note on coverage shape
+----------------------
+
+Why ``read_only`` and not also ``operator``: ``operator`` is the
+required minimum on this surface, so the role gate passes for both
+``operator`` and ``tenant_admin``. The negative-only role is
+``read_only``. The approvals surface, unlike grants, is one rank
+lower in the lattice (operators *should* be able to make approval
+decisions; only tenant_admin owns grants). One under-privileged
+role is enough to assert the gate is wired.
+
+Out of scope:
+
+* Happy-path approve / reject coverage — separate task; the
+  re-dispatch + audit + broadcast plumbing is exercised by the
+  service-layer suite.
+* Pydantic body validation — covered by the existing surface tests
+  via 422 paths; this file's contract is HTTP 403 from the role gate
+  alone.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+import respx
+from fastapi.testclient import TestClient
+
+import meho_backplane.audit as _audit_module
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.main import app
+from meho_backplane.settings import get_settings
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+from ._oidc_jwt_helpers import make_rsa_keypair, mint_token, mock_discovery_and_jwks, public_jwks
+
+_TENANT_A = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+
+
+@pytest.fixture(autouse=True)
+def _noop_broadcast(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Silence the broadcast publisher (see ``test_api_v1_agent_grants``)."""
+
+    async def _noop(*_a: object, **_kw: object) -> None:
+        pass
+
+    monkeypatch.setattr(_audit_module, "publish_event", _noop)
+
+
+@pytest.fixture(autouse=True)
+def _settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`~meho_backplane.settings.Settings` requires."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+
+
+@pytest.fixture
+def client() -> Iterator[TestClient]:
+    yield TestClient(app)
+
+
+def _token(key: Any, *, role: TenantRole, sub: str = "op-test") -> str:
+    return mint_token(key, sub=sub, tenant_role=role.value, tenant_id=str(_TENANT_A))
+
+
+# Every approval route+method gated by ``_require_operator``.
+# Each entry is ``(method, path, body)``. The role gate fires before
+# Pydantic body parsing, so minimal valid bodies suffice for the POST
+# routes — the goal is to ensure 403 from the gate, not a 422 from
+# body validation.
+_APPROVAL_ENDPOINTS: tuple[tuple[str, str, dict[str, Any] | None], ...] = (
+    ("GET", "/api/v1/approvals", None),
+    ("GET", f"/api/v1/approvals/{uuid.uuid4()}", None),
+    (
+        "POST",
+        f"/api/v1/approvals/{uuid.uuid4()}/approve",
+        {"params": {}},
+    ),
+    (
+        "POST",
+        f"/api/v1/approvals/{uuid.uuid4()}/reject",
+        {"reason": ""},
+    ),
+    (
+        "POST",
+        f"/api/v1/approvals/{uuid.uuid4()}/decide",
+        {"decision": "approved"},
+    ),
+)
+
+
+@pytest.mark.parametrize("method, path, body", _APPROVAL_ENDPOINTS)
+def test_read_only_role_is_rejected_with_insufficient_role(
+    client: TestClient,
+    method: str,
+    path: str,
+    body: dict[str, Any] | None,
+) -> None:
+    """``read_only`` JWT → HTTP 403 ``insufficient_role`` on every approval route.
+
+    The role one rank below ``operator``; the only role rejected on
+    this surface in the v0.2 lattice. A refactor that lowers the gate
+    to ``read_only`` (or drops the gate entirely) would have this case
+    return 200 / 404 from a deeper layer, breaking the test.
+    """
+    key = make_rsa_keypair("kid-ro")
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        headers = {"Authorization": f"Bearer {_token(key, role=TenantRole.READ_ONLY)}"}
+        response = client.request(method, path, headers=headers, json=body)
+    assert response.status_code == 403, response.text
+    assert response.json() == {"detail": "insufficient_role"}

--- a/backend/tests/test_mcp_tool_agent_grants.py
+++ b/backend/tests/test_mcp_tool_agent_grants.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Negative RBAC tests for ``meho.agents.grant.*`` MCP tools.
+
+G11.2-T6 (#819) registers five agent-grant MCP tools, each declared
+with ``required_role=TenantRole.TENANT_ADMIN`` on the
+:class:`~meho_backplane.mcp.registry.ToolDefinition`. Two gates
+enforce that role:
+
+* **List-time filter** in
+  :func:`~meho_backplane.mcp.registry.all_tools_for` — tools the
+  operator can't call are hidden from ``tools/list``.
+* **Call-time re-check** in :mod:`~meho_backplane.mcp.handlers` —
+  ``tools/call`` resolves the tool by name and re-verifies
+  ``required_role`` before dispatching to the handler. A client that
+  knows the tool's name and posts ``tools/call`` directly trips this
+  second gate.
+
+The existing service-layer suite (``test_agent_grants.py``) bypasses
+both gates by calling
+:class:`~meho_backplane.agents.grants.AgentGrantService` directly.
+This file closes the gap by asserting:
+
+* An ``operator`` role does NOT see any ``meho.agents.grant.*`` tool
+  in the ``tools/list`` response (list-time filter intact).
+* An ``operator`` direct ``tools/call`` against each tool name
+  returns the dispatcher's structured rejection — JSON-RPC
+  ``-32602`` ``INVALID_PARAMS`` with "forbidden" in the message
+  (call-time re-check intact).
+
+Out of scope:
+
+* Happy-path tenant-admin coverage — separate task.
+* Cross-principal "agent can't grant itself" — independent property.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from tests.mcp_test_fixtures import (
+    client_with_operator,  # noqa: F401 — pytest-discovered fixture
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+#: Every ``meho.agents.grant.*`` tool registered by
+#: :mod:`meho_backplane.mcp.tools.agent_grants`. The list pins the wire
+#: names so a rename surfaces as a test break (test_mcp_tool_agent_grants
+#: misses the tool) rather than as a silent coverage gap. Paired with the
+#: ``required_role=TENANT_ADMIN`` declaration on each
+#: :class:`~meho_backplane.mcp.registry.ToolDefinition`.
+_GRANT_TOOL_NAMES: tuple[str, ...] = (
+    "meho.agents.grant.list",
+    "meho.agents.grant.show",
+    "meho.agents.grant.create",
+    "meho.agents.grant.elevate",
+    "meho.agents.grant.revoke",
+)
+
+
+def _tools_call(name: str, arguments: dict[str, Any], call_id: int = 1) -> dict[str, Any]:
+    """Build a JSON-RPC ``tools/call`` envelope."""
+    return {
+        "jsonrpc": "2.0",
+        "id": call_id,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    }
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_list_hides_grant_tools_from_operator(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``operator`` role does NOT see ``meho.agents.grant.*`` on ``tools/list``.
+
+    The first of two RBAC gates: the list-time filter in
+    :func:`~meho_backplane.mcp.registry.all_tools_for` hides
+    TENANT_ADMIN-only tools from operators. A refactor that lowers
+    any grant tool's ``required_role`` to ``OPERATOR`` would surface
+    the tool here and fail this assertion.
+    """
+    client, _op = client_with_operator
+    resp = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    assert resp.status_code == 200, resp.text
+    names = {t["name"] for t in resp.json()["result"]["tools"]}
+    visible = names & set(_GRANT_TOOL_NAMES)
+    assert visible == set(), (
+        f"operator role should not see any meho.agents.grant.* tool; saw {visible!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+@pytest.mark.parametrize("tool_name", _GRANT_TOOL_NAMES)
+def test_operator_tools_call_grant_is_rejected_with_forbidden(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    tool_name: str,
+) -> None:
+    """``operator`` ``tools/call`` against a grant tool → INVALID_PARAMS + "forbidden".
+
+    The second of two RBAC gates: the call-time re-check in
+    :mod:`~meho_backplane.mcp.handlers` rejects a direct
+    ``tools/call`` from below ``tenant_admin``. The arguments dict is
+    intentionally empty — the gate fires before the handler's
+    inputSchema validation, so we don't need to construct
+    schema-valid arguments for every variant.
+    """
+    client, _op = client_with_operator
+    resp = post_mcp(client, _tools_call(tool_name, {}))
+    body = resp.json()
+    assert "error" in body, body
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "forbidden" in body["error"]["message"].lower(), body

--- a/backend/tests/test_mcp_tool_approvals.py
+++ b/backend/tests/test_mcp_tool_approvals.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Negative RBAC tests for ``meho.approvals.*`` MCP tools.
+
+G11.2-T5 (#818) registers four approval MCP tools, each declared
+with ``required_role=TenantRole.OPERATOR`` on the
+:class:`~meho_backplane.mcp.registry.ToolDefinition`. Two gates
+enforce that role (same as the agent-grants surface):
+
+* **List-time filter** in
+  :func:`~meho_backplane.mcp.registry.all_tools_for`.
+* **Call-time re-check** in :mod:`~meho_backplane.mcp.handlers`.
+
+The existing service-layer suite (``test_approval_queue.py``)
+exercises
+:func:`~meho_backplane.operations.approval_queue.approve_request` /
+:func:`~meho_backplane.operations.approval_queue.reject_request`
+directly. This file closes the gap by asserting:
+
+* A ``read_only`` role does NOT see any ``meho.approvals.*`` tool in
+  the ``tools/list`` response (list-time filter intact).
+* A ``read_only`` direct ``tools/call`` against each tool name
+  returns the dispatcher's structured rejection — JSON-RPC
+  ``-32602`` ``INVALID_PARAMS`` with "forbidden" in the message
+  (call-time re-check intact).
+
+Out of scope:
+
+* Happy-path operator coverage — separate task; the re-dispatch +
+  audit + broadcast plumbing is exercised by the service-layer
+  suite.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from tests.mcp_test_fixtures import (
+    client_with_operator,  # noqa: F401 — pytest-discovered fixture
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+#: Every ``meho.approvals.*`` tool registered by
+#: :mod:`meho_backplane.mcp.tools.approvals`. Pinning the wire names
+#: catches both a rename (test breaks for a missing tool) and a new
+#: addition without RBAC review (the matrix below would not exercise
+#: the new tool until added here).
+_APPROVAL_TOOL_NAMES: tuple[str, ...] = (
+    "meho.approvals.list",
+    "meho.approvals.get",
+    "meho.approvals.approve",
+    "meho.approvals.reject",
+)
+
+
+def _tools_call(name: str, arguments: dict[str, Any], call_id: int = 1) -> dict[str, Any]:
+    """Build a JSON-RPC ``tools/call`` envelope."""
+    return {
+        "jsonrpc": "2.0",
+        "id": call_id,
+        "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    }
+
+
+def test_tools_list_hides_approval_tools_from_read_only(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """``read_only`` role does NOT see ``meho.approvals.*`` on ``tools/list``.
+
+    Default fixture role is ``read_only``; no parametrize override.
+    The list-time filter
+    (:func:`~meho_backplane.mcp.registry.all_tools_for`) is the first
+    of two RBAC gates. A refactor lowering any approval tool's
+    ``required_role`` to ``READ_ONLY`` would surface the tool here
+    and fail this assertion.
+    """
+    client, _op = client_with_operator
+    resp = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    assert resp.status_code == 200, resp.text
+    names = {t["name"] for t in resp.json()["result"]["tools"]}
+    visible = names & set(_APPROVAL_TOOL_NAMES)
+    assert visible == set(), (
+        f"read_only role should not see any meho.approvals.* tool; saw {visible!r}"
+    )
+
+
+@pytest.mark.parametrize("tool_name", _APPROVAL_TOOL_NAMES)
+def test_read_only_tools_call_approval_is_rejected_with_forbidden(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    tool_name: str,
+) -> None:
+    """``read_only`` ``tools/call`` against an approval tool → INVALID_PARAMS + "forbidden".
+
+    The call-time re-check in :mod:`~meho_backplane.mcp.handlers` is
+    the second RBAC gate — a client that knows the tool's name and
+    posts ``tools/call`` directly trips it even though the tool was
+    hidden from ``tools/list``. Default fixture role is ``read_only``.
+    Arguments are intentionally empty — the role gate fires before
+    inputSchema validation.
+    """
+    client, _op = client_with_operator
+    resp = post_mcp(client, _tools_call(tool_name, {}))
+    body = resp.json()
+    assert "error" in body, body
+    assert body["error"]["code"] == INVALID_PARAMS
+    assert "forbidden" in body["error"]["message"].lower(), body


### PR DESCRIPTION
## Summary

- Adds gate-layer regression coverage for the G11.2 RBAC surfaces wired by #1066 (agent grants) and #1069 (approvals). The existing service-layer tests bypass the gate; this PR exercises every gated route/tool through the FastAPI `TestClient` + MCP dispatch path so a refactor that drops `Depends(require_role(...))` from a router or strips `required_role=...` from a `ToolDefinition` would fail CI.
- Four new test files, one per surface (REST × MCP × grants/approvals), each pinning the tool/route inventory inline so a rename or new addition surfaces as a test break.
- Extends `mcp_test_fixtures.isolated_registry` to reload the two new MCP tool modules so they register cleanly across the fixture-driven test suite.

## Test plan

- [x] `ruff check` — pass (5 files)
- [x] `ruff format --check` — pass (5 files)
- [x] `mypy src/meho_backplane/` — pass (314 files)
- [x] `pytest tests/test_api_v1_agent_grants.py tests/test_api_v1_approvals.py tests/test_mcp_tool_agent_grants.py tests/test_mcp_tool_approvals.py` — 25 passed
- [x] Existing service-layer suites still green — `pytest tests/test_agent_grants.py tests/test_approval_queue.py tests/test_auth_rbac.py` — 66 passed
- [x] `code-quality.py --diff` — exit 0

## Acceptance criteria

- [x] Every gated REST route under `/api/v1/agents/grants*` has at least one negative test — `read_only` and `operator` cases, except the list route's `operator` case which is shadowed by `GET /api/v1/agents/{name}` and is documented inline.
- [x] Every gated REST route under `/api/v1/approvals*` has at least one negative test — `read_only` JWT covered for list / get / approve / reject / decide.
- [x] Every gated MCP tool (`meho.agents.grant.*` and `meho.approvals.*`) has a negative test at both the list-time filter and the call-time re-check.
- [x] Tests live in the four named files (all new).
- [x] `Python (ruff + mypy + pytest)` green.

## Adjacent finding (out of scope)

The agent-definitions router (`api/v1/agents.py`) is registered before the grants router in `meho_backplane.main`, and its `GET /{name}` route matches `/api/v1/agents/grants` first (`name="grants"`). FastAPI route precedence is registration order. The shadow has the right outer-observable shape for `read_only` (still 403 via the shadow's `_require_operator` gate) but lets an `operator` request reach the agents-show service and return 404 `agent_not_found` rather than the grants-list 403. Documented inline in `tests/test_api_v1_agent_grants.py`; the orchestrator may file a follow-up to swap the router-include order (`include_router(api_v1_agent_grants_router)` before `include_router(api_v1_agents_router)`) so the list route is no longer shadowed.

## Out of scope (per issue body)

- New RBAC behavior — gates are already correctly wired; this PR is pure test coverage.
- The "agent can't grant itself" cross-principal property — independent rule, separate ticket.

Closes #1113


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive RBAC validation tests for agent grants and approvals endpoints, ensuring under-privileged roles receive proper 403 access denials.
  * Added MCP-layer RBAC tests verifying role-based tool visibility and call-time access enforcement.
  * Enhanced test fixture isolation for agent tool module reloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->