### PR TITLE
feat(scheduler): G11.3-T4 agent_run lease/heartbeat + reaper — no run silently lost

### DIFF
--- a/backend/alembic/versions/0025_add_agent_run_lease_reaper.py
+++ b/backend/alembic/versions/0025_add_agent_run_lease_reaper.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add lease / heartbeat / in_flight_policy columns to ``agent_run``.
+
+Revision ID: 0025
+Revises: 0024
+Create Date: 2026-05-26
+
+Initiative #804 (G11.3 Scheduler), Task #825 (T4). T1 (#822, 0020)
+landed the ``scheduled_trigger`` table including the
+``in_flight_policy`` column on the *trigger*. T4 wires the in-flight
+resume-or-fail-into-audit *mechanics*: a per-run lease + heartbeat the
+worker holds while it executes, and a reaper that detects expired
+leases (the worker died -- pod restart, OOM, network partition) and
+applies the policy. The per-run policy is a *snapshot* of the firing
+trigger's policy taken at run-start, so a mid-flight definition edit
+cannot flip behavior on a run that's already executing.
+
+Columns added to ``agent_run``
+------------------------------
+
+* ``lease_owner`` -- Text nullable. The worker process / replica
+  identifier holding the lease (e.g. ``"meho-backplane-pod-3:pid-42"``).
+  NULL whenever no worker is executing the run (``pending``,
+  ``awaiting_approval`` after a release, or any terminal state). The
+  lifecycle service keeps this column in lock-step with
+  ``lease_expires_at`` -- both set together on claim, both cleared
+  together on release.
+
+* ``lease_expires_at`` -- ``timestamptz`` nullable. The wall-clock
+  after which the lease is considered abandoned. The healthy worker
+  bumps it forward periodically via the lifecycle service's
+  ``heartbeat``; as long as heartbeats land the reaper never sees the
+  run. The reaper
+  (:mod:`meho_backplane.scheduler.reaper`) scans rows with
+  ``status='running' AND lease_expires_at < now()`` and applies
+  ``in_flight_policy``.
+
+* ``in_flight_policy`` -- Text NOT NULL DEFAULT ``'fail_into_audit'``
+  with a portable ``CHECK in_flight_policy IN (...)`` constraint
+  enforcing the closed
+  :class:`~meho_backplane.db.models.ScheduledTriggerInFlightPolicy`
+  vocabulary (``resume`` / ``fail_into_audit``). The default matches
+  the consumer doc's explicitly-accepted outcome
+  (``agent-runtime-for-ops-spec.md`` §P2): a killed run fails cleanly
+  into the audit log and the next trigger tick fires a fresh run.
+  ``resume`` is opt-in per agent definition; the scheduler copies the
+  policy onto the row at run-start. Existing rows (pre-migration)
+  backfill to the default via the server-side DEFAULT so the column
+  becomes NOT NULL without a separate backfill UPDATE.
+
+Index added
+-----------
+
+* ``agent_run_lease_expires_at_idx`` -- b-tree on
+  ``lease_expires_at``. On PG the index is partial
+  (``WHERE status = 'running'``) so it stays narrow -- terminal-state
+  and ``pending`` rows have ``lease_expires_at IS NULL`` anyway, but
+  the partial predicate prunes the index physically and matches the
+  reaper's query shape. SQLite ignores ``postgresql_where`` and
+  builds a full index; that is fine because SQLite is the dev / test
+  path and never sees production-scale data.
+
+Why per-run snapshot, not a join to the trigger
+-----------------------------------------------
+
+A run that's already executing must not flip its in-flight behavior
+because an operator changed the trigger's policy mid-flight. The
+clean way to fix that is to *copy* the policy onto the run row at
+run-start (T2 #823 / T3 #824 wire the copy when they fire a run).
+Joining back to ``scheduled_trigger.in_flight_policy`` at reap time
+would read the *current* value -- which can have changed during the
+run, breaking the policy contract. The copy is the substrate that
+makes the contract honourable; storing it on the row is the cheapest
+way to make every reader see the same answer for the life of the
+run.
+
+Dialect portability
+-------------------
+
+Mirrors the discipline migrations ``0017`` / ``0020`` follow:
+
+* ``ALTER TABLE ... ADD COLUMN`` -- portable on PG and SQLite (the
+  test path); ``server_default=sa.text("'fail_into_audit'")`` on
+  ``in_flight_policy`` lets the column flip to NOT NULL without a
+  backfill UPDATE on either dialect.
+* The ``CHECK (col IN (...))`` constraint compiles identically on PG
+  and SQLite -- the same portable enforcement
+  :class:`~meho_backplane.db.models.AgentRunStatus` /
+  :class:`~meho_backplane.db.models.AgentRunTrigger` use.
+* ``op.batch_alter_table`` is required on SQLite (which lacks native
+  ``ADD CONSTRAINT``); on PG the batch context is a no-op. Same
+  pattern migration ``0024`` (``agent_permission_expires_at``) uses.
+
+Reversibility contract
+----------------------
+
+``upgrade()`` adds the three columns + the partial index + the
+``CHECK`` constraint; ``downgrade()`` drops them in reverse order
+(constraint, index, columns). Explicit drops keep the inverse
+symmetric across dialects; the column drop preserves any data the
+caller wants to capture in a follow-up migration before reverting.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0025"
+down_revision: str | None = "0024"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+#: Closed ``agent_run.in_flight_policy`` vocabulary -- kept in lock-step
+#: with :class:`meho_backplane.db.models.ScheduledTriggerInFlightPolicy`
+#: (the per-run column is a snapshot of the trigger column's
+#: vocabulary). Duplicated here as a literal tuple (not imported) so the
+#: migration's recorded DDL is a frozen snapshot independent of any
+#: later edit to the model enum -- the same self-contained discipline
+#: migrations ``0017`` and ``0020`` follow. The drift guard in
+#: :mod:`tests.test_db_agent_run` asserts the model enum and the live
+#: ``CHECK`` constraint agree.
+_AGENT_RUN_IN_FLIGHT_POLICIES: tuple[str, ...] = (
+    "resume",
+    "fail_into_audit",
+)
+
+
+def _check_in(column: str, values: tuple[str, ...]) -> str:
+    """Render a portable ``column IN ('a', 'b', ...)`` CHECK body."""
+    quoted = ", ".join(f"'{v}'" for v in values)
+    return f"{column} IN ({quoted})"
+
+
+def upgrade() -> None:
+    """Add ``lease_owner`` / ``lease_expires_at`` / ``in_flight_policy``."""
+    # ``batch_alter_table`` lets SQLite (which lacks ``ALTER TABLE ADD
+    # CONSTRAINT``) recreate the table under the hood; PG passes
+    # straight through. Same pattern migration ``0024`` follows.
+    with op.batch_alter_table("agent_run") as batch:
+        batch.add_column(
+            sa.Column("lease_owner", sa.Text(), nullable=True),
+        )
+        batch.add_column(
+            sa.Column(
+                "lease_expires_at",
+                sa.DateTime(timezone=True),
+                nullable=True,
+            ),
+        )
+        # ``server_default`` is what lets the column flip to NOT NULL
+        # against an existing table without a separate backfill UPDATE:
+        # every pre-migration row picks up the default value, and the
+        # NOT NULL constraint is satisfied at the same moment the
+        # column lands.
+        batch.add_column(
+            sa.Column(
+                "in_flight_policy",
+                sa.Text(),
+                nullable=False,
+                server_default=sa.text("'fail_into_audit'"),
+            ),
+        )
+        batch.create_check_constraint(
+            "ck_agent_run_in_flight_policy",
+            _check_in("in_flight_policy", _AGENT_RUN_IN_FLIGHT_POLICIES),
+        )
+
+    # Partial index on PG (``WHERE status='running'``) -- terminal +
+    # ``pending`` rows have ``lease_expires_at IS NULL`` anyway, but
+    # the partial predicate prunes the index physically and matches
+    # the reaper's query shape. SQLite ignores ``postgresql_where``.
+    op.create_index(
+        "agent_run_lease_expires_at_idx",
+        "agent_run",
+        ["lease_expires_at"],
+        postgresql_using="btree",
+        postgresql_where=sa.text("status = 'running'"),
+    )
+
+
+def downgrade() -> None:
+    """Drop the index, the CHECK constraint, then the columns."""
+    op.drop_index("agent_run_lease_expires_at_idx", table_name="agent_run")
+    with op.batch_alter_table("agent_run") as batch:
+        batch.drop_constraint("ck_agent_run_in_flight_policy", type_="check")
+        batch.drop_column("in_flight_policy")
+        batch.drop_column("lease_expires_at")
+        batch.drop_column("lease_owner")

--- a/backend/src/meho_backplane/agent/reaper.py
+++ b/backend/src/meho_backplane/agent/reaper.py
@@ -1,0 +1,483 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""In-flight ``agent_run`` reaper — expired-lease policy enforcement.
+
+Initiative #804 (G11.3 Scheduler), Task #825 (T4). A scheduled or
+event-fired agent run that gets killed mid-flight (pod restart, OOM,
+network partition) must end in a terminal audited state -- never
+silently lost. This module owns the *reclaim* half of that contract:
+the trigger-firing path (T2 #823 / T3 #824) writes a lease + heartbeat
+on the run row as it executes; the healthy worker bumps the lease
+forward via :func:`meho_backplane.operations.agent_run.heartbeat`; the
+reaper here scans for ``status='running' AND lease_expires_at < now()``
+on a fixed cadence and applies :attr:`AgentRun.in_flight_policy`:
+
+* **``fail_into_audit``** -- transition the row to ``failed`` with an
+  interruption reason; write an internal audit row so operators can
+  see which run was reaped. The next trigger tick fires a fresh run
+  (the consumer doc ``agent-runtime-for-ops-spec.md`` §P2 explicitly
+  accepts this outcome as the default policy).
+* **``resume``** -- clear the lease columns (``lease_owner`` /
+  ``lease_expires_at`` to NULL) so the dispatcher's next sweep
+  re-claims the row and a fresh worker resumes from its recorded
+  state. Write an internal audit row noting the resume so the
+  interruption is durably visible. At-least-once semantics
+  documented; the underlying agent runtime should be
+  idempotent-friendly.
+
+Why ``asyncio.create_task`` and not APScheduler 4.x
+---------------------------------------------------
+
+Same reasoning as :mod:`meho_backplane.topology.scheduler` and
+:mod:`meho_backplane.memory.expiry`: APScheduler 4.x ships alpha
+releases the maintainer documents as "should NOT be used in
+production". The chassis follows a "no new substrate / minimal
+dependencies" discipline (``CLAUDE.md``); a stdlib ``asyncio`` loop in
+the lifespan is zero-dependency and is the same shape every other
+lifespan-owned background sweeper uses.
+
+Per-replica leader election (advisory lock)
+-------------------------------------------
+
+Two backplane replicas share one Postgres. Without coordination both
+would reap the same expired-lease row in the same tick, racing to mark
+it ``failed`` (idempotent under :func:`transition` -- the second move
+hits the terminal-state guard -- but still wasteful). A single
+session-level advisory lock on a fixed key, acquired non-blocking,
+elects one replica per tick. The replica that loses the race skips
+the sweep entirely; the next cadence is its chance to re-elect.
+
+On SQLite (the dev / test path) the lock is a no-op: the test process
+is single-replica so there is nothing to elect.
+
+Failure isolation
+-----------------
+
+Each tick runs inside its own ``try`` / ``except`` so one bad row
+(connector down mid-audit, transient DB blip, malformed payload)
+never stalls the loop. The exception is logged with ``structlog.warning``
+under ``agent_run_reaper_tick_failed`` and the loop waits for the next
+cadence. A single missed tick is recoverable on the next cadence; a
+crashed loop silently stops the reclaim contract until the next
+process restart -- which is exactly what we are protecting against.
+Loop survival dominates.
+
+Per-row reclaim is similarly isolated: one row failing to reap
+(audit-write error, transaction conflict) does not block the rest of
+the batch. The next tick picks up whatever is still expired.
+
+Reap batch size + per-tick LIMIT
+--------------------------------
+
+The reaper claims at most
+:attr:`Settings.agent_run_reaper_max_per_tick` rows per tick so a
+backlog (e.g. after a long outage where many leases expired
+simultaneously) does not pin a Postgres backend for an arbitrary
+amount of time. A large backlog is drained across several ticks; the
+LIMIT is purely a fairness / latency knob, not a correctness one.
+
+At-least-once semantics
+-----------------------
+
+The ``resume`` policy is at-least-once by construction: the original
+worker may still be alive (network-partitioned, garbage-collected,
+slow GC pause) and resume its own work after the reaper has cleared
+the lease. The reaper's first defense is the
+:func:`heartbeat`-conditional ``UPDATE`` (which raises
+:class:`LeaseLostError` so a partitioned worker stops on its next
+heartbeat); the agent runtime's second defense should be
+idempotent-friendly tool calls (G11.1's design constraint). T4 does
+not enforce idempotency at the substrate; it is the agent author's
+contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import time
+import uuid
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import structlog
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    AgentRun,
+    AgentRunStatus,
+    AuditLog,
+    ScheduledTriggerInFlightPolicy,
+)
+from meho_backplane.operations.agent_run import (
+    IllegalTransitionError,
+    release_lease,
+    transition,
+)
+from meho_backplane.settings import get_settings
+
+__all__ = [
+    "AGENT_RUN_REAPER_INTERRUPTION_REASON",
+    "start_agent_run_reaper",
+    "stop_agent_run_reaper",
+]
+
+
+_log = structlog.get_logger(__name__)
+
+#: The fixed advisory-lock key the reaper holds during a tick. Same
+#: hashing shape :mod:`meho_backplane.topology.scheduler` uses; a single
+#: scalar (no per-row key) because the reaper is a singleton sweep, not
+#: a per-row claimer. Computed once at module import for cheap reuse.
+_REAPER_ADVISORY_LOCK_KEY: int = (
+    int.from_bytes(
+        hashlib.blake2b(b"agent_run_reaper:v1", digest_size=8).digest(),
+        "big",
+    )
+    & 0x7FFF_FFFF_FFFF_FFFF
+)
+
+#: The synthetic operator ``sub`` recorded on reaper-driven audit rows.
+#: A stable prefix makes reaper events filterable in audit queries and
+#: distinct from operator-driven ones; mirrors the convention
+#: :mod:`meho_backplane.topology.scheduler` (``system:topology-scheduler``)
+#: and :mod:`meho_backplane.memory.expiry` (the internal-audit helper)
+#: use.
+_SYSTEM_OPERATOR_SUB = "system:agent-run-reaper"
+
+#: Audit ``method`` for reaper writes. Internal events are not HTTP;
+#: the chassis-wide convention is ``INTERNAL`` so audit filters can
+#: easily exclude them from operator activity.
+_AUDIT_METHOD = "INTERNAL"
+
+#: Audit ``path`` for reaper writes. Stable identifier so operators
+#: can grep / dashboard on it; distinct per policy outcome so the
+#: filter is precise.
+_AUDIT_PATH_FAIL = "internal/agent-run/reaper/fail-into-audit"
+_AUDIT_PATH_RESUME = "internal/agent-run/reaper/clear-for-resume"
+
+#: The human-readable ``error`` recorded on a ``failed`` run reaped by
+#: the ``fail_into_audit`` policy. Stable phrasing so dashboards and
+#: alerting can match on it; the audit row carries the lease metadata.
+AGENT_RUN_REAPER_INTERRUPTION_REASON = (
+    "interrupted: lease expired -- worker died mid-flight (reaped by agent_run_reaper)"
+)
+
+
+async def _try_advisory_lock(session: AsyncSession, key: int) -> bool:
+    """Acquire a session-level PG advisory lock; ``True`` on non-PG.
+
+    Returns ``True`` when the lock is held (or the dialect has no
+    advisory locks, i.e. the single-replica SQLite test path) and the
+    caller should proceed with the sweep; ``False`` when another
+    replica holds it and this tick should be skipped.
+
+    Same shape as
+    :func:`meho_backplane.topology.scheduler._try_advisory_lock` --
+    duplicated rather than imported so the reaper does not pull in
+    the topology package (different feature surface, different
+    lifespan ordering).
+    """
+    conn = await session.connection()
+    if conn.dialect.name != "postgresql":
+        return True
+    locked = await session.scalar(text("SELECT pg_try_advisory_lock(:k)"), {"k": key})
+    return bool(locked)
+
+
+async def _release_advisory_lock(session: AsyncSession, key: int) -> None:
+    """Release the session-level PG advisory lock; no-op on non-PG.
+
+    The advisory lock is released explicitly at the end of every tick
+    so the connection can be returned to the pool clean. PG would
+    release it on session close anyway, but the asyncpg pool may
+    reuse the connection before close.
+    """
+    conn = await session.connection()
+    if conn.dialect.name != "postgresql":
+        return
+    await session.execute(text("SELECT pg_advisory_unlock(:k)"), {"k": key})
+
+
+def _stage_audit_row(
+    *,
+    session: AsyncSession,
+    operator_sub: str,
+    tenant_id: uuid.UUID,
+    method: str,
+    path: str,
+    payload: dict[str, object],
+    agent_session_id: uuid.UUID,
+) -> None:
+    """Stage an :class:`AuditLog` row in *session*; do not commit.
+
+    The reaper's audit row must commit in the *same transaction* as the
+    lifecycle transition (or the lease release) so a crash between the
+    two cannot leave a reaped run without an audit row. The chassis's
+    shared writers (:func:`meho_backplane.audit._write_audit_row`,
+    :func:`meho_backplane.memory.audit.write_internal_audit_row`) both
+    open their own session and commit -- correct for the chassis HTTP
+    path and for the memory sweeper (which has already committed its
+    deletes by the time it audits), but wrong for the reaper, where
+    the lifecycle transition + the audit row must commit atomically.
+
+    This staging helper sits next to its one caller and writes the row
+    via :meth:`AsyncSession.add` (no autoflush -- the outer
+    :func:`session.commit` in :func:`_run_one_tick` is the single
+    flush + commit boundary).
+
+    The ``duration_ms`` column is :class:`Numeric`; the reaper has no
+    per-row wall-clock to record (the relevant duration is the *lease*
+    expiry, captured in the payload), so we record ``0`` -- a stable
+    value the audit-query layer can recognise as "internal
+    instantaneous event". Mirrors the convention the memory-expiry
+    sweeper uses for its per-tenant audit rows.
+    """
+    session.add(
+        AuditLog(
+            id=uuid.uuid4(),
+            occurred_at=datetime.now(UTC),
+            operator_sub=operator_sub,
+            tenant_id=tenant_id,
+            method=method,
+            path=path,
+            status_code=200,
+            duration_ms=Decimal("0"),
+            payload=payload,
+            agent_session_id=agent_session_id,
+        )
+    )
+
+
+async def _reap_one_row(
+    session: AsyncSession,
+    row: AgentRun,
+    *,
+    now: datetime,
+) -> tuple[str, str]:
+    """Apply the row's in-flight policy. Return ``(policy, outcome)``.
+
+    Called inside the tick's per-row ``try`` block so a single bad row
+    cannot stall the rest of the batch. The session commit is the
+    caller's responsibility -- this function only stages the
+    transition + audit so the caller can group multiple rows in one
+    transaction if it wants.
+
+    Args:
+        session: Open :class:`AsyncSession`; flushed, not committed.
+        row: The expired-lease :class:`AgentRun` being reaped.
+        now: The tick's "now" -- threaded in so all rows in one tick
+            share a single timestamp (cleaner audit + easier test
+            assertions).
+
+    Returns:
+        ``(policy_value, outcome_label)`` -- ``outcome_label`` is
+        ``"failed"`` for ``fail_into_audit`` and ``"cleared"`` for
+        ``resume``. Used for the structured log line.
+    """
+    policy_value = row.in_flight_policy
+    run_id = row.id
+    tenant_id = row.tenant_id
+    prior_owner = row.lease_owner
+    prior_expires_at = row.lease_expires_at
+
+    # Payload shape mirrors the audit writer's convention: stable
+    # field names so dashboards can index on them; the prior lease
+    # metadata is captured for forensics (which worker died, when
+    # the lease should have ended).
+    payload: dict[str, object] = {
+        "run_id": str(run_id),
+        "tenant_id": str(tenant_id),
+        "policy": policy_value,
+        "prior_lease_owner": prior_owner,
+        "prior_lease_expires_at": (
+            prior_expires_at.isoformat() if prior_expires_at is not None else None
+        ),
+        "reaped_at": now.isoformat(),
+    }
+
+    if policy_value == ScheduledTriggerInFlightPolicy.RESUME.value:
+        # Clear the lease so the next dispatcher sweep can re-claim
+        # the row. Status stays ``running`` -- the dispatcher's claim
+        # query already filters on ``lease_owner IS NULL`` for
+        # resume-eligible work (T2 / T3 will wire that filter when
+        # they fire runs). We do NOT transition status here; the
+        # row's current state IS the resume point.
+        await release_lease(session, row)
+        _stage_audit_row(
+            session=session,
+            operator_sub=_SYSTEM_OPERATOR_SUB,
+            tenant_id=tenant_id,
+            method=_AUDIT_METHOD,
+            path=_AUDIT_PATH_RESUME,
+            payload=payload,
+            agent_session_id=run_id,
+        )
+        return policy_value, "cleared"
+
+    # fail_into_audit -- the conservative default. Mark the row
+    # ``failed`` with a stable interruption reason; ``transition()``
+    # clears the lease as part of the terminal-state side effect.
+    # Status guard: the row could have transitioned between the
+    # claim query and this write (e.g. an operator cancel landed) --
+    # ``transition()`` raises :class:`IllegalTransitionError` on a
+    # bad edge; the outer per-row ``try`` catches and logs.
+    row.error = AGENT_RUN_REAPER_INTERRUPTION_REASON
+    await transition(session, row, AgentRunStatus.FAILED)
+    _stage_audit_row(
+        session=session,
+        operator_sub=_SYSTEM_OPERATOR_SUB,
+        tenant_id=tenant_id,
+        method=_AUDIT_METHOD,
+        path=_AUDIT_PATH_FAIL,
+        payload=payload,
+        agent_session_id=run_id,
+    )
+    return policy_value, "failed"
+
+
+async def _run_one_tick() -> None:
+    """One sweep: claim expired-lease rows, apply policy, audit.
+
+    Two-phase shape:
+
+    1. Acquire the single advisory lock (skip the tick on PG if
+       another replica won).
+    2. Select up to ``max_per_tick`` expired-lease ``running`` rows;
+       per-row, apply the policy in its own ``try`` so a bad row
+       does not stall the batch.
+
+    Commits once at the end so the entire tick's transitions + audit
+    rows land atomically. A per-row commit would force a per-row
+    transaction, which on a 100-row backlog is 100 round-trips; a
+    single commit per tick is the same correctness with N=1.
+    """
+    tick_started = time.perf_counter()
+    now = datetime.now(UTC)
+    settings = get_settings()
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        if not await _try_advisory_lock(session, _REAPER_ADVISORY_LOCK_KEY):
+            _log.debug("agent_run_reaper_tick_skipped_lock_held")
+            return
+        try:
+            # ``select ... where status='running' AND lease_expires_at < now``
+            # -- the partial index drives this on PG. The LIMIT bounds
+            # the per-tick work; a backlog is drained across multiple
+            # ticks rather than pinning one backend.
+            stmt = (
+                select(AgentRun)
+                .where(
+                    AgentRun.status == AgentRunStatus.RUNNING.value,
+                    AgentRun.lease_expires_at.is_not(None),
+                    AgentRun.lease_expires_at < now,
+                )
+                .order_by(AgentRun.lease_expires_at.asc())
+                .limit(settings.agent_run_reaper_max_per_tick)
+            )
+            result = await session.execute(stmt)
+            expired_rows = list(result.scalars().all())
+            if not expired_rows:
+                _log.debug("agent_run_reaper_tick_clean")
+                return
+
+            outcomes: dict[str, int] = {"failed": 0, "cleared": 0}
+            for row in expired_rows:
+                try:
+                    _policy, outcome = await _reap_one_row(session, row, now=now)
+                    outcomes[outcome] = outcomes.get(outcome, 0) + 1
+                except IllegalTransitionError:
+                    # The row's status changed between the claim query
+                    # and the reap (operator cancel, race with another
+                    # reaper instance that bypassed the advisory lock,
+                    # etc.). Skip this row -- the new status is
+                    # already terminal and another writer owns the
+                    # audit row for it.
+                    _log.info(
+                        "agent_run_reaper_row_skipped_status_changed",
+                        run_id=str(row.id),
+                    )
+                except Exception:
+                    # Per-row failure isolation -- log loud, continue.
+                    _log.exception(
+                        "agent_run_reaper_row_failed",
+                        run_id=str(row.id),
+                    )
+
+            await session.commit()
+            duration_ms = (time.perf_counter() - tick_started) * 1000.0
+            _log.info(
+                "agent_run_reaper_tick_done",
+                reaped_total=len(expired_rows),
+                failed=outcomes.get("failed", 0),
+                cleared_for_resume=outcomes.get("cleared", 0),
+                duration_ms=duration_ms,
+            )
+        finally:
+            await _release_advisory_lock(session, _REAPER_ADVISORY_LOCK_KEY)
+
+
+async def _reaper_loop() -> None:
+    """The forever loop: sleep one cadence, sweep, repeat.
+
+    Sleep-then-sweep (rather than sweep-then-sleep) so the first tick
+    after process start does not race the rest of the startup work
+    (eager engine init, embedding preload, typed-op registration). A
+    single cadence delay after startup is the cleanest signal that all
+    eager init has completed.
+
+    Per-tick ``try`` / ``except`` guards mean a transient DB blip
+    (connection lost, advisory-lock query failed) is logged and the
+    loop continues to the next cadence. ``CancelledError`` propagates
+    so lifespan shutdown can stop the task cleanly.
+    """
+    interval = get_settings().agent_run_reaper_tick_interval_seconds
+    _log.info(
+        "agent_run_reaper_started",
+        interval_seconds=interval,
+    )
+    while True:
+        await asyncio.sleep(get_settings().agent_run_reaper_tick_interval_seconds)
+        try:
+            await _run_one_tick()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _log.warning(
+                "agent_run_reaper_tick_failed",
+                exc_info=True,
+            )
+
+
+def start_agent_run_reaper() -> asyncio.Task[None]:
+    """Start the background reaper loop and return its task handle.
+
+    Registered in :func:`meho_backplane.main.lifespan` behind the
+    ``AGENT_RUN_REAPER_ENABLED`` setting. The returned task is
+    cancelled on lifespan shutdown; the caller awaits the cancellation
+    so the loop unwinds cleanly. Returning the task (rather than
+    fire-and-forgetting) keeps a strong reference alive -- an
+    un-referenced :class:`asyncio.Task` can be garbage-collected
+    mid-flight, producing the "Task was destroyed but it is pending!"
+    warnings the chassis bars under pytest-asyncio shutdown.
+    """
+    return asyncio.create_task(_reaper_loop(), name="agent-run-reaper")
+
+
+async def stop_agent_run_reaper(task: asyncio.Task[None]) -> None:
+    """Cancel the reaper task and await its unwind.
+
+    Swallows the expected :class:`asyncio.CancelledError`; any other
+    exception surfaced during unwind propagates so a broken shutdown
+    is visible rather than silently swallowed. The shape mirrors
+    :func:`meho_backplane.memory.expiry.stop_memory_expiry_sweeper`
+    verbatim so future contributors find one disposal pattern across
+    the lifespan-owned tasks.
+    """
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -2588,6 +2588,32 @@ _AGENT_RUN_STATUSES: tuple[str, ...] = tuple(s.value for s in AgentRunStatus)
 #: discipline as :data:`_AGENT_RUN_STATUSES`.
 _AGENT_RUN_TRIGGERS: tuple[str, ...] = tuple(t.value for t in AgentRunTrigger)
 
+#: Closed enum of :attr:`AgentRun.in_flight_policy` -- the per-run
+#: snapshot of the firing trigger's :class:`ScheduledTriggerInFlightPolicy`
+#: copied at run-start so a mid-flight definition edit cannot flip
+#: behavior on a run that's already executing (T4 #825). Frozen literal
+#: tuple here (not derived from the enum class) because
+#: :class:`ScheduledTriggerInFlightPolicy` is defined further down in
+#: the module file -- reshuffling the file to import-order matters less
+#: than keeping the closed-vocab snapshot self-contained and the
+#: file-order grouping (agent-runtime models together, scheduler models
+#: together) intact. The drift guard
+#: :func:`tests.test_db_agent_run.test_in_flight_policy_check_matches_scheduled_trigger_enum`
+#: asserts this tuple matches :class:`ScheduledTriggerInFlightPolicy`
+#: at unit-test time so the two cannot silently drift.
+_AGENT_RUN_IN_FLIGHT_POLICIES: tuple[str, ...] = (
+    "resume",
+    "fail_into_audit",
+)
+
+#: Per-run default for :attr:`AgentRun.in_flight_policy`. Mirrors
+#: :class:`ScheduledTriggerInFlightPolicy.FAIL_INTO_AUDIT` -- the
+#: conservative outcome the consumer doc (``agent-runtime-for-ops-spec.md``
+#: §P2) explicitly accepts. Operators opt into ``resume`` per agent
+#: definition; the scheduler then copies the value into the run row
+#: at run-start.
+_AGENT_RUN_IN_FLIGHT_POLICY_DEFAULT: str = "fail_into_audit"
+
 
 class AgentRun(Base):
     """One row per LLM-agent invocation hosted in MEHO's process.
@@ -2706,6 +2732,37 @@ class AgentRun(Base):
       Both NULL until those transitions fire -- the lifecycle service
       stamps them.
 
+    * ``lease_owner`` -- Text nullable. Initiative #804 (G11.3
+      Scheduler), Task #825 (T4). The worker process / replica
+      identifier that holds the lease on this run while it executes.
+      NULL when no worker is executing the run (``pending`` /
+      ``awaiting_approval`` after a release / any terminal state). A
+      non-NULL value means "this worker is responsible for advancing
+      the run". The reaper consults it for diagnostics; the *expiry*
+      column drives reclaim.
+
+    * ``lease_expires_at`` -- ``timestamptz`` nullable. The wall-clock
+      after which the lease is considered abandoned (the worker died,
+      a pod was OOM-killed, the network partitioned). The reaper
+      (``meho_backplane.scheduler.reaper``) scans
+      ``status='running' AND lease_expires_at < now()`` and applies
+      :attr:`in_flight_policy`. The healthy worker bumps this
+      forward periodically via the lifecycle service's
+      ``heartbeat`` -- as long as heartbeats land, the reaper never
+      sees the run. NULL whenever ``lease_owner`` is NULL; the
+      lifecycle service keeps both columns in lock-step.
+
+    * ``in_flight_policy`` -- Text NOT NULL with a DB-layer ``CHECK
+      in_flight_policy IN (...)`` constraint enforcing the closed
+      :class:`ScheduledTriggerInFlightPolicy` vocabulary. Per-run
+      snapshot of the trigger's policy copied at run-start (T4 #825),
+      so a definition edit mid-flight cannot flip behavior on a run
+      that's already executing. Defaults to ``fail_into_audit`` --
+      the conservative outcome the consumer doc explicitly accepts.
+      ``direct`` and ``agent-invoked`` runs (no scheduler trigger)
+      take the default; they cannot resume regardless because nothing
+      will re-fire them.
+
     Indexes
     -------
 
@@ -2718,6 +2775,10 @@ class AgentRun(Base):
     * ``agent_run_parent_run_id_idx`` -- b-tree on ``parent_run_id``.
       Drives the composition-tree walk (children of a parent run,
       G11.1-T5).
+    * ``agent_run_lease_expires_at_idx`` -- partial b-tree on
+      ``lease_expires_at`` (PG ``WHERE status='running'``). Drives
+      the reaper's "what leases have expired" query without
+      scanning the table. T4 #825.
     """
 
     __tablename__ = "agent_run"
@@ -2793,6 +2854,28 @@ class AgentRun(Base):
         nullable=True,
         default=None,
     )
+    # Initiative #804 (G11.3 Scheduler), Task #825 (T4) -- lease /
+    # heartbeat / per-run in-flight-policy snapshot. ``lease_owner`` +
+    # ``lease_expires_at`` are kept in lock-step by the lifecycle
+    # service (both set together at claim, both cleared together at
+    # release). ``in_flight_policy`` is the per-run snapshot of the
+    # firing trigger's policy; defaults to ``fail_into_audit`` (the
+    # conservative outcome the consumer doc accepts).
+    lease_owner: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        default=None,
+    )
+    lease_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+    in_flight_policy: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default=_AGENT_RUN_IN_FLIGHT_POLICY_DEFAULT,
+    )
 
     __table_args__ = (
         Index(
@@ -2811,6 +2894,19 @@ class AgentRun(Base):
             "parent_run_id",
             postgresql_using="btree",
         ),
+        # T4 #825 -- the reaper's claim query is
+        # ``WHERE status='running' AND lease_expires_at < now()``.
+        # The full index drives the lookup on SQLite (which ignores
+        # the postgresql_where); the partial index on PG keeps the
+        # index narrow (terminal-state and ``pending`` rows are
+        # excluded since they have ``lease_expires_at IS NULL`` and
+        # the partial predicate filters them anyway).
+        Index(
+            "agent_run_lease_expires_at_idx",
+            "lease_expires_at",
+            postgresql_using="btree",
+            postgresql_where=sa.text("status = 'running'"),
+        ),
         sa.CheckConstraint(
             _ck_in("status", _AGENT_RUN_STATUSES),
             name="ck_agent_run_status",
@@ -2818,6 +2914,10 @@ class AgentRun(Base):
         sa.CheckConstraint(
             _ck_in("trigger", _AGENT_RUN_TRIGGERS),
             name="ck_agent_run_trigger",
+        ),
+        sa.CheckConstraint(
+            _ck_in("in_flight_policy", _AGENT_RUN_IN_FLIGHT_POLICIES),
+            name="ck_agent_run_in_flight_policy",
         ),
     )
 

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -50,6 +50,10 @@ from fastapi import FastAPI, Response
 from fastapi.staticfiles import StaticFiles
 
 from meho_backplane import __version__
+from meho_backplane.agent.reaper import (
+    start_agent_run_reaper,
+    stop_agent_run_reaper,
+)
 from meho_backplane.agents import (
     start_grant_expiry_sweeper,
     stop_grant_expiry_sweeper,
@@ -302,6 +306,7 @@ class _BackgroundTasks:
     memory_expiry: asyncio.Task[None] | None
     topology_history: asyncio.Task[None] | None
     grant_expiry: asyncio.Task[None] | None
+    agent_run_reaper: asyncio.Task[None] | None
 
 
 def _start_background_tasks() -> _BackgroundTasks:
@@ -335,11 +340,19 @@ def _start_background_tasks() -> _BackgroundTasks:
     grant_expiry: asyncio.Task[None] | None = None
     if settings.grant_expiry_enabled:
         grant_expiry = start_grant_expiry_sweeper()
+    # G11.3-T4 #825 — gated on AGENT_RUN_REAPER_ENABLED so operators
+    # running an external lease-reclaim mechanism (DBOS Transact, a
+    # workflow engine) can disable the in-tree reaper without
+    # patching code.
+    agent_run_reaper: asyncio.Task[None] | None = None
+    if settings.agent_run_reaper_enabled:
+        agent_run_reaper = start_agent_run_reaper()
     return _BackgroundTasks(
         topology_scheduler=topology_scheduler,
         memory_expiry=memory_expiry,
         topology_history=topology_history,
         grant_expiry=grant_expiry,
+        agent_run_reaper=agent_run_reaper,
     )
 
 
@@ -351,6 +364,8 @@ async def _stop_background_tasks(tasks: _BackgroundTasks) -> None:
     branches (``None`` task handles) are tolerated cleanly so a
     disable-and-shutdown sequence does not raise.
     """
+    if tasks.agent_run_reaper is not None:
+        await stop_agent_run_reaper(tasks.agent_run_reaper)
     if tasks.grant_expiry is not None:
         await stop_grant_expiry_sweeper(tasks.grant_expiry)
     if tasks.topology_history is not None:

--- a/backend/src/meho_backplane/operations/agent_run.py
+++ b/backend/src/meho_backplane/operations/agent_run.py
@@ -62,14 +62,21 @@ for the cancellation) inside one transaction.
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
-from typing import Final
+from typing import Any, Final, cast
 
+from sqlalchemy import update
+from sqlalchemy.engine.cursor import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.operator import Operator, TenantRole
-from meho_backplane.db.models import AgentRun, AgentRunStatus, AgentRunTrigger
+from meho_backplane.db.models import (
+    AgentRun,
+    AgentRunStatus,
+    AgentRunTrigger,
+    ScheduledTriggerInFlightPolicy,
+)
 
 __all__ = [
     "ALLOWED_TRANSITIONS",
@@ -77,12 +84,17 @@ __all__ = [
     "AgentRunError",
     "AgentRunNotFoundError",
     "IllegalTransitionError",
+    "LeaseLostError",
     "UnauthorizedCancellationError",
     "cancel_run",
+    "claim_lease",
     "create_run",
     "fail_run",
     "get_run",
+    "heartbeat",
     "increment_turns",
+    "release_lease",
+    "snapshot_in_flight_policy",
     "start_run",
     "succeed_run",
     "transition",
@@ -207,6 +219,33 @@ class UnauthorizedCancellationError(AgentRunError):
         super().__init__(
             f"operator {operator_sub!r} with role {role.value!r} may not cancel an agent run "
             f"(requires at least {_MIN_CANCEL_ROLE.value!r})"
+        )
+
+
+class LeaseLostError(AgentRunError):
+    """The lease this worker thought it held has been reassigned.
+
+    Initiative #804 (G11.3 Scheduler), Task #825 (T4). Raised by
+    :func:`heartbeat` when the conditional update touches zero rows --
+    the row's ``lease_owner`` no longer matches the heartbeating
+    worker (the reaper or another claimer has taken over) or the row
+    has reached a terminal status while the worker was off-CPU. The
+    worker must stop its work immediately on this signal: any further
+    side-effects would be at-least-twice (the reaper has handed the
+    work to someone else or recorded it as failed).
+
+    Distinct from :class:`IllegalTransitionError` (which is about
+    *state*) so the runtime can map this to a clean abort path rather
+    than a 409: a lost lease is a coordination event, not a caller
+    bug.
+    """
+
+    def __init__(self, *, run_id: uuid.UUID, owner: str) -> None:
+        self.run_id = run_id
+        self.owner = owner
+        super().__init__(
+            f"agent_run {run_id} lease no longer held by {owner!r} "
+            f"(reaper reclaimed or run terminated)"
         )
 
 
@@ -342,6 +381,14 @@ async def transition(
         row.started_at = now
     if to_status in TERMINAL_STATUSES:
         row.ended_at = now
+        # T4 #825 -- clear the lease on terminal transitions so the
+        # ``agent_run_lease_expires_at_idx`` does not retain stale
+        # metadata, and so a future reader sees "no worker holds
+        # this" rather than "the worker that ran this once held a
+        # lease here". The columns are nullable; clearing is
+        # idempotent.
+        row.lease_owner = None
+        row.lease_expires_at = None
 
     row.status = to_status.value
     await session.flush()
@@ -378,6 +425,198 @@ async def start_run(
     row.provider = provider
     row.model = model
     return await transition(session, row, AgentRunStatus.RUNNING)
+
+
+async def claim_lease(
+    session: AsyncSession,
+    row: AgentRun,
+    *,
+    owner: str,
+    ttl_seconds: int,
+) -> AgentRun:
+    """Stamp a lease on *row* and record the owning worker.
+
+    Initiative #804 (G11.3 Scheduler), Task #825 (T4). Called by the
+    trigger-firing path (T2 #823 / T3 #824) when a worker begins
+    executing a run; called by the reaper's ``resume`` policy when it
+    re-dispatches a run whose previous worker died. The lease + the
+    owner are written together so a reader that observes the lease
+    always sees who holds it.
+
+    Storage discipline
+    ------------------
+
+    The lease columns are pure side-effect: they do not change
+    ``status``. The caller threads :func:`claim_lease` and
+    :func:`start_run` (which transitions ``pending`` -> ``running``)
+    together inside the same transaction so a partial commit cannot
+    leave the row ``running`` without a lease (or with a lease but
+    still ``pending``).
+
+    Args:
+        session: Open :class:`AsyncSession`; flushed, not committed.
+        row: The :class:`AgentRun` to claim.
+        owner: A stable identifier for the worker (e.g. pod name +
+            pid). The reaper uses this for diagnostics; the *expiry*
+            column drives reclaim.
+        ttl_seconds: Wall-clock seconds the lease is valid for. The
+            worker must heartbeat within this window or the reaper
+            will reclaim the row. Typical values: 60-180s, with a
+            heartbeat at ~1/2 the TTL.
+
+    Returns:
+        The mutated, flushed row with ``lease_owner`` /
+        ``lease_expires_at`` populated.
+    """
+    row.lease_owner = owner
+    row.lease_expires_at = datetime.now(UTC) + timedelta(seconds=ttl_seconds)
+    await session.flush()
+    return row
+
+
+async def heartbeat(
+    session: AsyncSession,
+    *,
+    run_id: uuid.UUID,
+    owner: str,
+    ttl_seconds: int,
+) -> AgentRun:
+    """Extend the lease on *run_id* iff this worker still holds it.
+
+    Initiative #804 (G11.3 Scheduler), Task #825 (T4). The healthy
+    worker calls this on a periodic cadence (≈ ``ttl_seconds / 2``)
+    to keep the reaper from reclaiming the run. The update is
+    conditional on ``lease_owner = owner`` AND ``status = 'running'``
+    so a worker whose lease has been stolen by the reaper (or whose
+    run has been cancelled out from under it by an operator) gets a
+    :class:`LeaseLostError` and stops cleanly -- at-least-once
+    semantics depend on the worker honouring this signal.
+
+    Why a conditional ``UPDATE`` rather than a Python ``if`` + edit
+    -----------------------------------------------------------------
+
+    The Python-side check would race the reaper: between reading the
+    row and writing the new ``lease_expires_at`` the reaper could
+    reclaim, and the worker's later write would silently overwrite
+    the reaper's clear (or another claimer's owner). A single
+    conditional ``UPDATE`` is atomic at the DB layer -- the predicate
+    and the write commit together, so either the worker keeps the
+    lease (one row touched) or it has already lost it (zero rows
+    touched) and we raise.
+
+    Args:
+        session: Open :class:`AsyncSession`; flushed, not committed.
+        run_id: The run whose lease this worker is extending.
+        owner: The worker identifier (must match the row's current
+            ``lease_owner`` or the update touches zero rows).
+        ttl_seconds: The new lease window (same shape as
+            :func:`claim_lease`).
+
+    Returns:
+        The :class:`AgentRun` with its lease extended. Newly-loaded
+        from the DB after the update so the caller sees the latest
+        server-side values (the conditional update bypasses the ORM's
+        change tracking).
+
+    Raises:
+        LeaseLostError: The conditional update touched zero rows --
+            this worker no longer holds the lease.
+    """
+    new_expires_at = datetime.now(UTC) + timedelta(seconds=ttl_seconds)
+    # ``session.execute()`` on an ``UPDATE`` returns a
+    # :class:`~sqlalchemy.engine.cursor.CursorResult` (which carries
+    # the DBAPI ``rowcount``) at runtime; the static stub return type
+    # is the generic :class:`Result` so mypy needs the explicit cast
+    # to resolve ``rowcount``. ``synchronize_session=False`` is also
+    # correct semantically -- we are about to reload the row from the
+    # DB anyway, so synchronising the identity map before that reload
+    # would be wasted work.
+    raw_result = await session.execute(
+        update(AgentRun)
+        .where(
+            AgentRun.id == run_id,
+            AgentRun.lease_owner == owner,
+            AgentRun.status == AgentRunStatus.RUNNING.value,
+        )
+        .values(lease_expires_at=new_expires_at)
+        .execution_options(synchronize_session=False)
+    )
+    cursor_result = cast(CursorResult[Any], raw_result)
+    if cursor_result.rowcount == 0:
+        raise LeaseLostError(run_id=run_id, owner=owner)
+    await session.flush()
+    # Reload so the caller sees server-side state (the conditional
+    # UPDATE bypasses the ORM's identity map change tracking).
+    row = await session.get(AgentRun, run_id)
+    if row is None:
+        # Defensive: the rowcount>0 branch means the row existed at
+        # update time; deletion mid-flight would be a substrate-level
+        # event we do not currently model. Surface it as
+        # LeaseLostError so the worker stops.
+        raise LeaseLostError(run_id=run_id, owner=owner)
+    return row
+
+
+async def release_lease(session: AsyncSession, row: AgentRun) -> AgentRun:
+    """Clear the lease on *row* without changing its status.
+
+    Initiative #804 (G11.3 Scheduler), Task #825 (T4). Used by:
+
+    * The reaper's ``resume`` policy after marking a row eligible for
+      re-dispatch (the next worker claim populates the columns
+      fresh).
+    * The lifecycle service's terminal-transition helpers
+      (:func:`succeed_run`, :func:`fail_run`, :func:`cancel_run`)
+      after the row reaches a terminal state so the indexes do not
+      retain stale lease metadata.
+
+    Idempotent: clearing an already-cleared lease is a no-op (both
+    fields are set to ``None`` regardless of their prior value).
+
+    Args:
+        session: Open :class:`AsyncSession`; flushed, not committed.
+        row: The :class:`AgentRun` whose lease to clear.
+
+    Returns:
+        The mutated, flushed row.
+    """
+    row.lease_owner = None
+    row.lease_expires_at = None
+    await session.flush()
+    return row
+
+
+async def snapshot_in_flight_policy(
+    session: AsyncSession,
+    row: AgentRun,
+    policy: ScheduledTriggerInFlightPolicy,
+) -> AgentRun:
+    """Copy the firing trigger's :attr:`in_flight_policy` onto the run row.
+
+    Initiative #804 (G11.3 Scheduler), Task #825 (T4). T2 #823 / T3
+    #824 wire this call when they fire a run: the trigger's policy is
+    snapshotted onto the run row so a definition edit mid-flight
+    cannot flip behavior on a run that's already executing. The
+    runtime (G11.1) and the reaper (T4) both read the snapshot, not
+    the trigger.
+
+    The runtime helper here is a thin wrapper around the
+    column assignment because copying the policy is *part of* the
+    run-start handshake -- threading a separate caller path for the
+    snapshot risks the trigger / run rows committing in different
+    transactions and the run executing under the wrong policy.
+
+    Args:
+        session: Open :class:`AsyncSession`; flushed, not committed.
+        row: The :class:`AgentRun` being started.
+        policy: The trigger's current :class:`ScheduledTriggerInFlightPolicy`.
+
+    Returns:
+        The mutated, flushed row.
+    """
+    row.in_flight_policy = policy.value
+    await session.flush()
+    return row
 
 
 async def increment_turns(session: AsyncSession, row: AgentRun) -> AgentRun:

--- a/backend/src/meho_backplane/settings.py
+++ b/backend/src/meho_backplane/settings.py
@@ -640,6 +640,22 @@ class Settings(BaseModel):
     # elevation windows are typically hours, not days.
     grant_expiry_tick_interval_seconds: int = Field(default=300, ge=60, le=86400)
     grant_expiry_enabled: bool = True
+    # G11.3-T4 #825 -- agent_run reaper knobs. Same opt-out shape as
+    # GRANT_EXPIRY_ENABLED / MEMORY_EXPIRY_ENABLED so an operator
+    # running an external lease-reclaim mechanism (DBOS Transact, a
+    # workflow engine, etc.) can disable the in-tree reaper without
+    # patching code.
+    #
+    # The default tick (30s) + the default lease TTL (60s) give a
+    # worker two heartbeat windows of slack before reclaim -- a
+    # transient ~20s GC pause / network blip does not cost a run. The
+    # MAX_PER_TICK bound (50) keeps a post-outage backlog from
+    # monopolising one Postgres backend; a 500-row backlog drains
+    # across ~10 ticks.
+    agent_run_reaper_enabled: bool = True
+    agent_run_reaper_tick_interval_seconds: int = Field(default=30, ge=5, le=3600)
+    agent_run_reaper_max_per_tick: int = Field(default=50, ge=1, le=1000)
+    agent_run_lease_ttl_seconds: int = Field(default=60, ge=10, le=3600)
     ui_keycloak_client_id: str = ""
     ui_keycloak_client_secret: str = ""
     ui_session_encryption_key: str = ""
@@ -835,6 +851,18 @@ def get_settings() -> Settings:
         ),
         grant_expiry_enabled=parse_bool_env(
             os.environ.get("GRANT_EXPIRY_ENABLED", "true"),
+        ),
+        agent_run_reaper_enabled=parse_bool_env(
+            os.environ.get("AGENT_RUN_REAPER_ENABLED", "true"),
+        ),
+        agent_run_reaper_tick_interval_seconds=int(
+            os.environ.get("AGENT_RUN_REAPER_TICK_INTERVAL_SECONDS", "30"),
+        ),
+        agent_run_reaper_max_per_tick=int(
+            os.environ.get("AGENT_RUN_REAPER_MAX_PER_TICK", "50"),
+        ),
+        agent_run_lease_ttl_seconds=int(
+            os.environ.get("AGENT_RUN_LEASE_TTL_SECONDS", "60"),
         ),
         ui_keycloak_client_id=os.environ.get("UI_KEYCLOAK_CLIENT_ID", "").strip(),
         ui_keycloak_client_secret=os.environ.get("UI_KEYCLOAK_CLIENT_SECRET", "").strip(),

--- a/backend/tests/test_agent_run_lifecycle.py
+++ b/backend/tests/test_agent_run_lifecycle.py
@@ -39,18 +39,29 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import AgentRun, AgentRunStatus, AgentRunTrigger, Tenant
+from meho_backplane.db.models import (
+    AgentRun,
+    AgentRunStatus,
+    AgentRunTrigger,
+    ScheduledTriggerInFlightPolicy,
+    Tenant,
+)
 from meho_backplane.operations.agent_run import (
     ALLOWED_TRANSITIONS,
     TERMINAL_STATUSES,
     AgentRunNotFoundError,
     IllegalTransitionError,
+    LeaseLostError,
     UnauthorizedCancellationError,
     cancel_run,
+    claim_lease,
     create_run,
     fail_run,
     get_run,
+    heartbeat,
     increment_turns,
+    release_lease,
+    snapshot_in_flight_policy,
     start_run,
     succeed_run,
     transition,
@@ -449,3 +460,185 @@ async def test_cancel_run_raises_not_found_for_missing_id() -> None:
         with pytest.raises(AgentRunNotFoundError) as exc:
             await cancel_run(session, missing, operator=_operator(role=TenantRole.OPERATOR))
         assert exc.value.run_id == missing
+
+
+# ---------------------------------------------------------------------------
+# Lease / heartbeat / release / snapshot (T4 #825)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_claim_lease_stamps_owner_and_expiry() -> None:
+    """:func:`claim_lease` writes ``lease_owner`` + ``lease_expires_at``.
+
+    T4 #825 -- the worker's claim handshake. Status stays unchanged
+    (the caller composes claim_lease + start_run inside one
+    transaction).
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        run = await _make_run(session, status=AgentRunStatus.PENDING)
+        await claim_lease(session, run, owner="worker-a", ttl_seconds=60)
+        await session.commit()
+        run_id = run.id
+
+    async with sessionmaker() as session:
+        loaded = await get_run(session, run_id)
+        assert loaded is not None
+        assert loaded.lease_owner == "worker-a"
+        assert loaded.lease_expires_at is not None
+        # Status untouched -- claim_lease is a pure side-effect on lease columns.
+        assert loaded.status == AgentRunStatus.PENDING.value
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_extends_lease_for_holder() -> None:
+    """:func:`heartbeat` bumps ``lease_expires_at`` when the owner matches.
+
+    T4 #825. Conditional UPDATE -- atomic at the DB layer; the new
+    expiry value is what the caller sees after the helper returns.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        run = await _make_run(session, status=AgentRunStatus.PENDING)
+        await claim_lease(session, run, owner="worker-a", ttl_seconds=10)
+        # Walk to running so the heartbeat's status guard fires.
+        await transition(session, run, AgentRunStatus.RUNNING)
+        original_expiry = run.lease_expires_at
+        await session.commit()
+        run_id = run.id
+
+    assert original_expiry is not None
+
+    # New session -- production callers heartbeat from a fresh request.
+    async with sessionmaker() as session:
+        bumped = await heartbeat(session, run_id=run_id, owner="worker-a", ttl_seconds=60)
+        await session.commit()
+    assert bumped.lease_expires_at is not None
+    # SQLite drops tzinfo on read-back; compare wall-clock by
+    # normalising both sides to naive UTC. The production PG path
+    # preserves tz, so the production semantics are still
+    # "tz-aware > tz-aware".
+    assert bumped.lease_expires_at.replace(tzinfo=None) > original_expiry.replace(tzinfo=None)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_raises_lease_lost_when_owner_mismatches() -> None:
+    """A heartbeat from the wrong owner raises :class:`LeaseLostError`.
+
+    T4 #825 -- the worker's signal that its lease was stolen (by the
+    reaper or another claimer). Conditional UPDATE touches zero rows
+    -> raise.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        run = await _make_run(session, status=AgentRunStatus.PENDING)
+        await claim_lease(session, run, owner="worker-a", ttl_seconds=60)
+        await transition(session, run, AgentRunStatus.RUNNING)
+        await session.commit()
+        run_id = run.id
+
+    async with sessionmaker() as session:
+        with pytest.raises(LeaseLostError) as exc:
+            await heartbeat(session, run_id=run_id, owner="impostor", ttl_seconds=60)
+        assert exc.value.run_id == run_id
+        assert exc.value.owner == "impostor"
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_raises_lease_lost_when_run_already_terminal() -> None:
+    """A heartbeat against a non-running row raises :class:`LeaseLostError`.
+
+    T4 #825 -- the worker must stop on a status that's no longer
+    ``running``. Covers the operator-cancel-mid-flight race: the
+    cancel landed first, the worker tries to heartbeat, the UPDATE
+    predicate fails the status check, the worker gets the signal to
+    stop.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        run = await _make_run(session, status=AgentRunStatus.PENDING)
+        await claim_lease(session, run, owner="worker-a", ttl_seconds=60)
+        await transition(session, run, AgentRunStatus.RUNNING)
+        # The transition() to a terminal state clears the lease as a
+        # side effect -- but we want to exercise the "status guard
+        # caught it" branch specifically. Use the operator-cancel
+        # path which goes through the same transition guard.
+        await transition(session, run, AgentRunStatus.CANCELLED)
+        await session.commit()
+        run_id = run.id
+
+    async with sessionmaker() as session:
+        with pytest.raises(LeaseLostError):
+            await heartbeat(session, run_id=run_id, owner="worker-a", ttl_seconds=60)
+
+
+@pytest.mark.asyncio
+async def test_release_lease_clears_owner_and_expiry() -> None:
+    """:func:`release_lease` nulls both lease columns without touching status."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        run = await _make_run(session, status=AgentRunStatus.PENDING)
+        await claim_lease(session, run, owner="worker-a", ttl_seconds=60)
+        await release_lease(session, run)
+        await session.commit()
+        run_id = run.id
+
+    async with sessionmaker() as session:
+        loaded = await get_run(session, run_id)
+        assert loaded is not None
+        assert loaded.lease_owner is None
+        assert loaded.lease_expires_at is None
+        # Status untouched.
+        assert loaded.status == AgentRunStatus.PENDING.value
+
+
+@pytest.mark.asyncio
+async def test_terminal_transition_clears_lease_as_side_effect() -> None:
+    """``transition()`` clears the lease on any terminal status.
+
+    T4 #825 -- terminal-state side effect. A succeeded / failed /
+    cancelled run must not retain stale lease metadata (the partial
+    index would carry zombie entries; the reaper would skip them
+    because status != 'running', but the columns themselves should
+    reflect "no worker holds this").
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        run = await _make_run(session, status=AgentRunStatus.PENDING)
+        await claim_lease(session, run, owner="worker-a", ttl_seconds=60)
+        await transition(session, run, AgentRunStatus.RUNNING)
+        await transition(session, run, AgentRunStatus.SUCCEEDED)
+        await session.commit()
+        run_id = run.id
+
+    async with sessionmaker() as session:
+        loaded = await get_run(session, run_id)
+        assert loaded is not None
+        assert loaded.status == AgentRunStatus.SUCCEEDED.value
+        assert loaded.lease_owner is None
+        assert loaded.lease_expires_at is None
+        # ended_at still stamped -- the terminal-state side effects compose.
+        assert loaded.ended_at is not None
+
+
+@pytest.mark.asyncio
+async def test_snapshot_in_flight_policy_overwrites_column() -> None:
+    """:func:`snapshot_in_flight_policy` writes the trigger's policy onto the row.
+
+    T4 #825 -- the run-start handshake. A definition edit mid-flight
+    cannot flip behavior because the run carries its own copy.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        run = await _make_run(session, status=AgentRunStatus.PENDING)
+        # Default is FAIL_INTO_AUDIT.
+        assert run.in_flight_policy == ScheduledTriggerInFlightPolicy.FAIL_INTO_AUDIT.value
+        await snapshot_in_flight_policy(session, run, ScheduledTriggerInFlightPolicy.RESUME)
+        await session.commit()
+        run_id = run.id
+
+    async with sessionmaker() as session:
+        loaded = await get_run(session, run_id)
+        assert loaded is not None
+        assert loaded.in_flight_policy == ScheduledTriggerInFlightPolicy.RESUME.value

--- a/backend/tests/test_agent_run_reaper.py
+++ b/backend/tests/test_agent_run_reaper.py
@@ -1,0 +1,440 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the in-flight ``agent_run`` reaper.
+
+Initiative #804 (G11.3 Scheduler), Task #825 (T4). The reaper in
+:mod:`meho_backplane.agent.reaper` scans for ``status='running' AND
+lease_expires_at < now()`` on a fixed cadence and applies
+:attr:`AgentRun.in_flight_policy` (``fail_into_audit`` -> terminal
+``failed`` + audit row; ``resume`` -> clear lease + audit row,
+dispatcher re-claims).
+
+Acceptance criterion (T4 #825):
+
+> A run killed mid-flight ends in a terminal, audited state: either
+> resumed to completion or ``failed`` with an interruption reason --
+> never silently lost.
+
+These tests fixture a run directly into the DB (no dispatcher
+dependency on T2 #823 yet), back-date its ``lease_expires_at`` to
+simulate a dead worker, then run one reaper tick and assert the
+policy outcome + the audit row.
+
+Tests run synchronously against the ``sqlite+aiosqlite`` engine the
+autouse ``_default_database_url`` fixture pre-migrates to head.
+Advisory-lock single-flighting is a PG-only concern; the SQLite
+test path treats the lock as a no-op (the production guard is
+covered by the integration testcontainers suite a follow-up Task
+adds when DBOS-vs-roll-our-own is settled enterprise-wide).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.agent.reaper import (
+    AGENT_RUN_REAPER_INTERRUPTION_REASON,
+    _run_one_tick,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    AgentRun,
+    AgentRunStatus,
+    AgentRunTrigger,
+    AuditLog,
+    ScheduledTriggerInFlightPolicy,
+    Tenant,
+)
+from meho_backplane.operations.agent_run import (
+    claim_lease,
+    create_run,
+    transition,
+)
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module.
+
+    The autouse ``_default_database_url`` fixture only pins
+    ``DATABASE_URL``; Keycloak/Vault knobs come from each test file.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+async def _seed_tenant(session: AsyncSession, *, slug: str = "rdc-internal") -> uuid.UUID:
+    """Return the tenant row's id, inserting it on the first call.
+
+    Same shape as :func:`tests.test_agent_run_lifecycle._seed_tenant`
+    -- duplicated rather than imported because cross-module fixture
+    imports add maintenance cost without test-discovery benefit.
+    """
+    existing: uuid.UUID | None = await session.scalar(
+        select(Tenant.id).where(Tenant.slug == slug),
+    )
+    if existing is not None:
+        return existing
+    tenant_id = uuid.uuid4()
+    session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+    await session.commit()
+    return tenant_id
+
+
+async def _make_running_run_with_expired_lease(
+    session: AsyncSession,
+    *,
+    policy: ScheduledTriggerInFlightPolicy,
+    lease_age_seconds: int = 120,
+    owner: str = "worker-died",
+) -> uuid.UUID:
+    """Insert a running ``agent_run`` whose lease expired *lease_age_seconds* ago.
+
+    Returns the run's id. The expired lease + ``running`` status is
+    exactly what the reaper's claim query selects.
+
+    Each call uses a fresh tenant slug so xdist parallel runners do
+    not collide on the seeded ``rdc-internal`` row -- the per-run
+    tenant slug pattern mirrors :mod:`tests.test_agent_run_lifecycle`'s
+    ``_make_run``.
+    """
+    tenant_id = await _seed_tenant(session, slug=f"t-{uuid.uuid4().hex[:8]}")
+    run = await create_run(
+        session,
+        tenant_id=tenant_id,
+        identity_sub="user-killed",
+        trigger=AgentRunTrigger.SCHEDULED,
+        model_tier="deep",
+    )
+    # Snapshot the policy on the run (T2/T3's run-start handshake).
+    run.in_flight_policy = policy.value
+    # Claim + walk to running, then back-date the lease so the next
+    # reaper tick sees it.
+    await claim_lease(session, run, owner=owner, ttl_seconds=60)
+    await transition(session, run, AgentRunStatus.RUNNING)
+    run.lease_expires_at = datetime.now(UTC) - timedelta(seconds=lease_age_seconds)
+    await session.commit()
+    return run.id
+
+
+# ---------------------------------------------------------------------------
+# Acceptance criterion: no silently-lost run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kill_restart_run_with_fail_into_audit_ends_failed_and_audited() -> None:
+    """Acceptance: a killed run with ``fail_into_audit`` policy ends ``failed`` + audit row.
+
+    T4 #825 acceptance criterion. The run was alive (``status='running'``
+    with a lease), the worker died (lease expired in the past), one
+    reaper tick runs, the row ends in a terminal ``failed`` state with
+    a stable interruption error, and an audit row is written
+    pointing at the run.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        run_id = await _make_running_run_with_expired_lease(
+            session,
+            policy=ScheduledTriggerInFlightPolicy.FAIL_INTO_AUDIT,
+        )
+
+    await _run_one_tick()
+
+    async with sessionmaker() as session:
+        run = await session.get(AgentRun, run_id)
+        assert run is not None
+        assert run.status == AgentRunStatus.FAILED.value
+        assert run.error == AGENT_RUN_REAPER_INTERRUPTION_REASON
+        assert run.ended_at is not None
+        # Terminal-state side effect also clears the lease.
+        assert run.lease_owner is None
+        assert run.lease_expires_at is None
+
+        # Audit row landed with the run's id as the lineage key.
+        audit_rows = (
+            (await session.execute(select(AuditLog).where(AuditLog.agent_session_id == run_id)))
+            .scalars()
+            .all()
+        )
+        assert len(audit_rows) == 1
+        audit = audit_rows[0]
+        assert audit.method == "INTERNAL"
+        assert audit.path == "internal/agent-run/reaper/fail-into-audit"
+        assert audit.status_code == 200
+        assert audit.operator_sub == "system:agent-run-reaper"
+        assert audit.payload["policy"] == "fail_into_audit"
+        assert audit.payload["run_id"] == str(run_id)
+        assert audit.payload["prior_lease_owner"] == "worker-died"
+
+
+@pytest.mark.asyncio
+async def test_kill_restart_run_with_resume_clears_lease_and_audits() -> None:
+    """A killed run with ``resume`` policy stays ``running`` but loses its lease + audit row.
+
+    T4 #825. The reaper does NOT transition the row to a terminal
+    state -- it clears the lease so the next dispatcher sweep (T2 #823
+    / T3 #824) can re-claim and a fresh worker resumes. The audit
+    row records the interruption so the operator can see it happened.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        run_id = await _make_running_run_with_expired_lease(
+            session,
+            policy=ScheduledTriggerInFlightPolicy.RESUME,
+        )
+
+    await _run_one_tick()
+
+    async with sessionmaker() as session:
+        run = await session.get(AgentRun, run_id)
+        assert run is not None
+        # Status unchanged -- the run is *eligible for resume*, not
+        # terminal. The dispatcher (T2/T3) re-claims and a fresh
+        # worker continues from its recorded state.
+        assert run.status == AgentRunStatus.RUNNING.value
+        # Lease cleared -- ready for a fresh claim.
+        assert run.lease_owner is None
+        assert run.lease_expires_at is None
+
+        audit_rows = (
+            (await session.execute(select(AuditLog).where(AuditLog.agent_session_id == run_id)))
+            .scalars()
+            .all()
+        )
+        assert len(audit_rows) == 1
+        audit = audit_rows[0]
+        assert audit.path == "internal/agent-run/reaper/clear-for-resume"
+        assert audit.payload["policy"] == "resume"
+
+
+# ---------------------------------------------------------------------------
+# Filtering / claim-query correctness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reaper_ignores_running_run_with_fresh_lease() -> None:
+    """A healthy worker (lease in the future) is NOT reaped.
+
+    T4 #825 -- the *expired* in the claim predicate is load-bearing.
+    Any run with ``lease_expires_at >= now()`` is the healthy worker
+    holding its lease and must not be touched.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session, slug=f"t-{uuid.uuid4().hex[:8]}")
+        run = await create_run(
+            session,
+            tenant_id=tenant_id,
+            identity_sub="user-alive",
+            trigger=AgentRunTrigger.SCHEDULED,
+            model_tier="deep",
+        )
+        await claim_lease(session, run, owner="worker-alive", ttl_seconds=300)
+        await transition(session, run, AgentRunStatus.RUNNING)
+        await session.commit()
+        run_id = run.id
+
+    await _run_one_tick()
+
+    async with sessionmaker() as session:
+        run = await session.get(AgentRun, run_id)
+        assert run is not None
+        assert run.status == AgentRunStatus.RUNNING.value
+        assert run.lease_owner == "worker-alive"  # untouched
+        # No audit row written.
+        audit_rows = (
+            (await session.execute(select(AuditLog).where(AuditLog.agent_session_id == run_id)))
+            .scalars()
+            .all()
+        )
+        assert audit_rows == []
+
+
+@pytest.mark.asyncio
+async def test_reaper_ignores_terminal_runs_with_stale_lease() -> None:
+    """A ``failed`` / ``succeeded`` / ``cancelled`` run is not reaped.
+
+    T4 #825 -- the ``status='running'`` claim predicate excludes
+    terminal rows even if a stale lease somehow remained on them.
+    Defensive: the lifecycle service clears the lease on terminal
+    transitions, but the reaper's filter must still hold if a future
+    code path forgets to.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session, slug=f"t-{uuid.uuid4().hex[:8]}")
+        run = await create_run(
+            session,
+            tenant_id=tenant_id,
+            identity_sub="user-finished",
+            trigger=AgentRunTrigger.SCHEDULED,
+            model_tier="deep",
+        )
+        # Force the row to ``failed`` with a stale lease still present
+        # (bypassing the lifecycle service's terminal-state lease clear).
+        run.status = AgentRunStatus.FAILED.value
+        run.lease_owner = "worker-stale"
+        run.lease_expires_at = datetime.now(UTC) - timedelta(seconds=600)
+        run.ended_at = datetime.now(UTC)
+        await session.commit()
+        run_id = run.id
+
+    await _run_one_tick()
+
+    async with sessionmaker() as session:
+        run = await session.get(AgentRun, run_id)
+        assert run is not None
+        # Status untouched -- the reaper does not "re-reap" a row.
+        assert run.status == AgentRunStatus.FAILED.value
+        # No audit row written.
+        audit_rows = (
+            (await session.execute(select(AuditLog).where(AuditLog.agent_session_id == run_id)))
+            .scalars()
+            .all()
+        )
+        assert audit_rows == []
+
+
+@pytest.mark.asyncio
+async def test_reaper_handles_empty_table_cleanly() -> None:
+    """An empty agent_run table is the no-op fast path.
+
+    T4 #825 -- the most common state. The reaper's claim query
+    returns zero rows; the tick completes without an exception or
+    a stray audit row.
+    """
+    # Don't seed anything beyond what's already in the schema template.
+    await _run_one_tick()
+
+    # No assertion needed -- the test passes if no exception was
+    # raised. We add a sanity check that we have no orphan audit
+    # rows for nonexistent runs.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        reaper_audits = (
+            (
+                await session.execute(
+                    select(AuditLog).where(AuditLog.operator_sub == "system:agent-run-reaper")
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert reaper_audits == []
+
+
+@pytest.mark.asyncio
+async def test_reaper_processes_batch_under_per_tick_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A backlog of N expired runs is drained across ticks bounded by ``max_per_tick``.
+
+    T4 #825 -- per-tick bound. Lower the limit to 2, seed 5 expired
+    runs, run one tick -> exactly 2 are reaped. Run a second tick ->
+    2 more. Third tick -> the final 1.
+    """
+    monkeypatch.setenv("AGENT_RUN_REAPER_MAX_PER_TICK", "2")
+    get_settings.cache_clear()
+
+    sessionmaker = get_sessionmaker()
+    run_ids: list[uuid.UUID] = []
+    async with sessionmaker() as session:
+        for _ in range(5):
+            run_id = await _make_running_run_with_expired_lease(
+                session,
+                policy=ScheduledTriggerInFlightPolicy.FAIL_INTO_AUDIT,
+            )
+            run_ids.append(run_id)
+
+    async def count_failed() -> int:
+        async with sessionmaker() as s:
+            rows = (
+                (
+                    await s.execute(
+                        select(AgentRun).where(
+                            AgentRun.id.in_(run_ids),
+                            AgentRun.status == AgentRunStatus.FAILED.value,
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            return len(rows)
+
+    await _run_one_tick()
+    assert await count_failed() == 2
+
+    await _run_one_tick()
+    assert await count_failed() == 4
+
+    await _run_one_tick()
+    assert await count_failed() == 5
+
+    # No further work to do -- a fourth tick is a no-op.
+    await _run_one_tick()
+    assert await count_failed() == 5
+
+
+@pytest.mark.asyncio
+async def test_reaper_mixed_policies_apply_independently() -> None:
+    """One tick with both policies in the batch routes each correctly.
+
+    T4 #825 -- per-row policy dispatch. Seed two expired runs, one
+    ``fail_into_audit`` and one ``resume``. Run one tick. Assert
+    each landed in its policy's outcome state and the audit rows
+    have distinct paths.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        fail_id = await _make_running_run_with_expired_lease(
+            session,
+            policy=ScheduledTriggerInFlightPolicy.FAIL_INTO_AUDIT,
+        )
+        resume_id = await _make_running_run_with_expired_lease(
+            session,
+            policy=ScheduledTriggerInFlightPolicy.RESUME,
+        )
+
+    await _run_one_tick()
+
+    async with sessionmaker() as session:
+        fail_row = await session.get(AgentRun, fail_id)
+        resume_row = await session.get(AgentRun, resume_id)
+        assert fail_row is not None and resume_row is not None
+        assert fail_row.status == AgentRunStatus.FAILED.value
+        assert resume_row.status == AgentRunStatus.RUNNING.value
+        assert resume_row.lease_owner is None
+
+        # Two distinct audit rows, one per policy outcome.
+        all_audits = (
+            (
+                await session.execute(
+                    select(AuditLog)
+                    .where(AuditLog.agent_session_id.in_([fail_id, resume_id]))
+                    .order_by(AuditLog.path)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(all_audits) == 2
+        paths = {a.path for a in all_audits}
+        assert paths == {
+            "internal/agent-run/reaper/clear-for-resume",
+            "internal/agent-run/reaper/fail-into-audit",
+        }

--- a/backend/tests/test_connectors_registry.py
+++ b/backend/tests/test_connectors_registry.py
@@ -350,11 +350,17 @@ def test_lifespan_calls_eager_import_connectors() -> None:
             patch("meho_backplane.main.stop_grant_expiry_sweeper", new=AsyncMock()),
             # G11.3-T2 (#823) — scheduler patches; flag off in MagicMock so
             # start_scheduler is never reached, but the symbol must still
-            # exist as a patchable target.
-            patch("meho_backplane.main.start_scheduler"),
-            patch("meho_backplane.main.stop_scheduler", new=AsyncMock()),
-            patch("meho_backplane.main.start_agent_run_reaper"),
-            patch("meho_backplane.main.stop_agent_run_reaper", new=AsyncMock()),
+            # exist as a patchable target. Same for G11.3-T4 (#825)'s
+            # agent_run reaper patches -- combined into one ``patch.multiple``
+            # to stay under CPython's "too many statically nested blocks"
+            # limit (20) the parenthesised ``with`` form imposes.
+            patch.multiple(
+                "meho_backplane.main",
+                start_scheduler=MagicMock(),
+                stop_scheduler=AsyncMock(),
+                start_agent_run_reaper=MagicMock(),
+                stop_agent_run_reaper=AsyncMock(),
+            ),
         ):
             # Manually step through the lifespan async generator.
             gen = lifespan(None)  # type: ignore[arg-type]
@@ -422,13 +428,17 @@ def test_lifespan_runs_broadcast_dispose_even_when_engine_dispose_fails() -> Non
             ),
             patch("meho_backplane.main.start_grant_expiry_sweeper"),
             patch("meho_backplane.main.stop_grant_expiry_sweeper", new=AsyncMock()),
-            # G11.3-T2 (#823) — scheduler patches; flag off in MagicMock so
-            # start_scheduler is never reached, but the symbol must still
-            # exist as a patchable target.
-            patch("meho_backplane.main.start_scheduler"),
-            patch("meho_backplane.main.stop_scheduler", new=AsyncMock()),
-            patch("meho_backplane.main.start_agent_run_reaper"),
-            patch("meho_backplane.main.stop_agent_run_reaper", new=AsyncMock()),
+            # G11.3-T2 (#823) scheduler + G11.3-T4 (#825) agent_run-reaper
+            # patches combined via ``patch.multiple`` to stay under
+            # CPython's "too many statically nested blocks" limit (20) the
+            # parenthesised ``with`` form imposes.
+            patch.multiple(
+                "meho_backplane.main",
+                start_scheduler=MagicMock(),
+                stop_scheduler=AsyncMock(),
+                start_agent_run_reaper=MagicMock(),
+                stop_agent_run_reaper=AsyncMock(),
+            ),
         ):
             gen = lifespan(None)  # type: ignore[arg-type]
             await gen.__aenter__()

--- a/backend/tests/test_connectors_registry.py
+++ b/backend/tests/test_connectors_registry.py
@@ -324,16 +324,18 @@ def test_lifespan_calls_eager_import_connectors() -> None:
             # G5.2-T1 (#623) added a memory-expiry sweeper start to the
             # lifespan body; G9.3-T6 (#858) added a topology-history
             # retention sweeper; G11.2-T6 (#819) added a grant-expiry
-            # sweeper. All read ``get_settings`` to decide whether to
-            # start; patch all flags off so this test (which doesn't
-            # pin env vars) does not regress on the env-var lookup
-            # ``get_settings`` would otherwise hit.
+            # sweeper; G11.3-T4 (#825) added an agent_run reaper. All
+            # read ``get_settings`` to decide whether to start; patch
+            # all flags off so this test (which doesn't pin env vars)
+            # does not regress on the env-var lookup ``get_settings``
+            # would otherwise hit.
             patch(
                 "meho_backplane.main.get_settings",
                 return_value=MagicMock(
                     memory_expiry_enabled=False,
                     topology_history_prune_enabled=False,
                     grant_expiry_enabled=False,
+                    agent_run_reaper_enabled=False,
                 ),
             ),
             patch("meho_backplane.main.start_memory_expiry_sweeper"),
@@ -345,6 +347,8 @@ def test_lifespan_calls_eager_import_connectors() -> None:
             ),
             patch("meho_backplane.main.start_grant_expiry_sweeper"),
             patch("meho_backplane.main.stop_grant_expiry_sweeper", new=AsyncMock()),
+            patch("meho_backplane.main.start_agent_run_reaper"),
+            patch("meho_backplane.main.stop_agent_run_reaper", new=AsyncMock()),
         ):
             # Manually step through the lifespan async generator.
             gen = lifespan(None)  # type: ignore[arg-type]
@@ -388,17 +392,18 @@ def test_lifespan_runs_broadcast_dispose_even_when_engine_dispose_fails() -> Non
             patch("meho_backplane.main.eager_import_mcp_modules"),
             patch("meho_backplane.main._assert_mcp_resource_uri_configured"),
             patch("meho_backplane.main.get_embedding_service"),
-            # G5.2-T1 (#623) + G9.3-T6 (#858) + G11.2-T6 (#819) — same
-            # lifespan-task patches as the sibling test. All background-
-            # task flags are pinned off so this dispose-error test
-            # exercises only the disposer ordering, not the start-task
-            # race.
+            # G5.2-T1 (#623) + G9.3-T6 (#858) + G11.2-T6 (#819) +
+            # G11.3-T4 (#825) — same lifespan-task patches as the
+            # sibling test. All background-task flags are pinned off
+            # so this dispose-error test exercises only the disposer
+            # ordering, not the start-task race.
             patch(
                 "meho_backplane.main.get_settings",
                 return_value=MagicMock(
                     memory_expiry_enabled=False,
                     topology_history_prune_enabled=False,
                     grant_expiry_enabled=False,
+                    agent_run_reaper_enabled=False,
                 ),
             ),
             patch("meho_backplane.main.start_memory_expiry_sweeper"),
@@ -410,6 +415,8 @@ def test_lifespan_runs_broadcast_dispose_even_when_engine_dispose_fails() -> Non
             ),
             patch("meho_backplane.main.start_grant_expiry_sweeper"),
             patch("meho_backplane.main.stop_grant_expiry_sweeper", new=AsyncMock()),
+            patch("meho_backplane.main.start_agent_run_reaper"),
+            patch("meho_backplane.main.stop_agent_run_reaper", new=AsyncMock()),
         ):
             gen = lifespan(None)  # type: ignore[arg-type]
             await gen.__aenter__()

--- a/backend/tests/test_db_agent_run.py
+++ b/backend/tests/test_db_agent_run.py
@@ -49,11 +49,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import (
+    _AGENT_RUN_IN_FLIGHT_POLICIES,
     _AGENT_RUN_STATUSES,
     _AGENT_RUN_TRIGGERS,
     AgentRun,
     AgentRunStatus,
     AgentRunTrigger,
+    ScheduledTriggerInFlightPolicy,
     Tenant,
 )
 from meho_backplane.settings import get_settings
@@ -346,3 +348,157 @@ def test_migration_trigger_literals_match_model_enum() -> None:
     migration = _load_migration_0017()
 
     assert set(migration._AGENT_RUN_TRIGGERS) == {t.value for t in AgentRunTrigger}  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Lease / heartbeat / in_flight_policy columns (T4 #825)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_run_lease_columns_round_trip() -> None:
+    """Lease + in_flight_policy columns round-trip through the ORM.
+
+    T4 #825. ``lease_owner`` / ``lease_expires_at`` are nullable
+    side-effect columns the lifecycle service writes; ``in_flight_policy``
+    is NOT NULL with a server default. All three persist verbatim
+    through an insert + read cycle.
+    """
+    sessionmaker = get_sessionmaker()
+    run_id = uuid.uuid4()
+    lease_until = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        session.add(
+            AgentRun(
+                id=run_id,
+                tenant_id=tenant_id,
+                identity_sub="user-lease",
+                trigger=AgentRunTrigger.SCHEDULED.value,
+                model_tier="deep",
+                status=AgentRunStatus.RUNNING.value,
+                lease_owner="meho-backplane-pod-3:pid-42",
+                lease_expires_at=lease_until,
+                in_flight_policy=ScheduledTriggerInFlightPolicy.RESUME.value,
+            )
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        result = await session.execute(select(AgentRun).where(AgentRun.id == run_id))
+        row = result.scalar_one()
+
+    assert row.lease_owner == "meho-backplane-pod-3:pid-42"
+    assert row.lease_expires_at is not None
+    # SQLite drops tz; compare wall-clock.
+    assert row.lease_expires_at.replace(tzinfo=None) == lease_until.replace(tzinfo=None)
+    assert row.in_flight_policy == "resume"
+
+
+@pytest.mark.asyncio
+async def test_agent_run_in_flight_policy_default_is_fail_into_audit() -> None:
+    """The ORM default for ``in_flight_policy`` is ``'fail_into_audit'``.
+
+    T4 #825. The consumer doc accepts ``fail_into_audit`` as the
+    default outcome -- a run that does not opt into ``resume`` ends
+    up failed in the audit log. The server-side DEFAULT in the
+    migration fires for raw INSERTs; the ORM-side default fires for
+    SQLAlchemy ``add()`` calls. Both must produce the same value.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        run = AgentRun(
+            tenant_id=tenant_id,
+            identity_sub="user-default-policy",
+            trigger=AgentRunTrigger.DIRECT.value,
+            model_tier="cheap",
+        )
+        session.add(run)
+        await session.commit()
+        seen_policy = run.in_flight_policy
+        seen_lease_owner = run.lease_owner
+        seen_lease_expires_at = run.lease_expires_at
+
+    assert seen_policy == ScheduledTriggerInFlightPolicy.FAIL_INTO_AUDIT.value
+    # Lease columns default to None (no worker has claimed yet).
+    assert seen_lease_owner is None
+    assert seen_lease_expires_at is None
+
+
+@pytest.mark.asyncio
+async def test_agent_run_in_flight_policy_check_rejects_unknown() -> None:
+    """A policy outside the closed enum raises :class:`IntegrityError`.
+
+    T4 #825 -- the DB-layer closed-enum guard. Same pattern as the
+    ``status`` / ``trigger`` constraints.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        session.add(
+            AgentRun(
+                tenant_id=tenant_id,
+                identity_sub="user-bad-policy",
+                trigger=AgentRunTrigger.DIRECT.value,
+                model_tier="cheap",
+                in_flight_policy="retry_with_backoff",  # outside the closed enum
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Drift guards (T4 #825 -- in_flight_policy column)
+# ---------------------------------------------------------------------------
+
+
+def test_in_flight_policy_kinds_match_scheduled_trigger_enum() -> None:
+    """:data:`_AGENT_RUN_IN_FLIGHT_POLICIES` mirrors :class:`ScheduledTriggerInFlightPolicy`.
+
+    The per-run column's vocabulary is *the same* closed enum as the
+    trigger's policy column -- the run row carries a snapshot of the
+    trigger's value at run-start. The agent-run-side tuple is defined
+    independently (because :class:`ScheduledTriggerInFlightPolicy` lives
+    further down in the model file -- see the comment on
+    :data:`_AGENT_RUN_IN_FLIGHT_POLICIES`); this guard catches drift.
+    """
+    assert set(_AGENT_RUN_IN_FLIGHT_POLICIES) == {p.value for p in ScheduledTriggerInFlightPolicy}
+
+
+def _load_migration_0025() -> object:
+    """Load migration ``0025`` as a module via its file path.
+
+    Same shape as :func:`_load_migration_0017` -- digit-prefixed
+    filename, not importable as a dotted module.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "alembic"
+        / "versions"
+        / "0025_add_agent_run_lease_reaper.py"
+    )
+    spec = importlib.util.spec_from_file_location("_migration_0025", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_migration_0025_in_flight_policy_literals_match_scheduled_trigger_enum() -> None:
+    """Migration ``0025``'s frozen policy tuple matches :class:`ScheduledTriggerInFlightPolicy`.
+
+    T4 #825. The migration records the vocabulary as a literal tuple
+    (not an import) so its DDL is a frozen snapshot; equality with the
+    enum is the drift guard that keeps the CHECK constraint and the
+    enum in lock-step.
+    """
+    migration = _load_migration_0025()
+
+    assert set(migration._AGENT_RUN_IN_FLIGHT_POLICIES) == {  # type: ignore[attr-defined]
+        p.value for p in ScheduledTriggerInFlightPolicy
+    }

--- a/backend/tests/test_migration_0017_agent_run.py
+++ b/backend/tests/test_migration_0017_agent_run.py
@@ -169,13 +169,19 @@ _EXPECTED_INDEXES: frozenset[str] = frozenset(
 def test_upgrade_creates_agent_run_table_columns_indexes(
     alembic_cfg: tuple[Config, str],
 ) -> None:
-    """``upgrade head`` lands the ``agent_run`` table with all columns + indexes."""
-    cfg, sync_url = alembic_cfg
-    command.upgrade(cfg, "head")
+    """``upgrade "0017"`` lands the ``agent_run`` table with all columns + indexes.
 
-    assert "agent_run" in _table_names(sync_url), (
-        "migration 0017 must create the agent_run table on upgrade head"
-    )
+    The upgrade target is pinned to ``"0017"`` (not ``"head"``) so that
+    later migrations touching the ``agent_run`` table (e.g. T4 #825's
+    0025 lease/heartbeat columns) do not silently invalidate this
+    drift guard: ``_EXPECTED_COLUMNS`` documents the shape *0017
+    landed*, not whatever ``head`` happens to be today. Migrations
+    that add columns own their own drift assertions.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "0017")
+
+    assert "agent_run" in _table_names(sync_url), "migration 0017 must create the agent_run table"
 
     columns = _table_columns(sync_url, "agent_run")
     assert columns == _EXPECTED_COLUMNS, (
@@ -224,17 +230,17 @@ def test_column_nullability(alembic_cfg: tuple[Config, str]) -> None:
 def test_downgrade_then_upgrade_round_trips(
     alembic_cfg: tuple[Config, str],
 ) -> None:
-    """``downgrade "0016"`` drops the table; ``upgrade head`` restores it.
+    """``downgrade "0016"`` drops the table; ``upgrade "0017"`` restores it.
 
     The reversibility contract migration 0017 inherits from 0007 / 0012 /
-    0013. The downgrade target is the explicit revision ``"0016"``
-    (0017's ``down_revision``) rather than head-relative ``"-1"``, so the
-    moment a later migration (0018+) lands it would not silently stop
-    exercising 0017's reverse -- anchoring to ``"0016"`` keeps this test
-    pinned to 0017.
+    0013. Both upgrade targets are pinned to ``"0017"`` (not ``"head"``)
+    for the same reason as
+    :func:`test_upgrade_creates_agent_run_table_columns_indexes` --
+    the strict ``_EXPECTED_COLUMNS`` shape is 0017's, not whatever
+    later migrations layer on top.
     """
     cfg, sync_url = alembic_cfg
-    command.upgrade(cfg, "head")
+    command.upgrade(cfg, "0017")
 
     # Sanity -- the upgrade landed the table before we reverse it.
     assert "agent_run" in _table_names(sync_url)
@@ -243,7 +249,7 @@ def test_downgrade_then_upgrade_round_trips(
     assert "agent_run" not in _table_names(sync_url), "downgrade must drop the agent_run table"
 
     # Re-upgrade -- the table comes back, proving the round-trip.
-    command.upgrade(cfg, "head")
+    command.upgrade(cfg, "0017")
     assert "agent_run" in _table_names(sync_url)
     assert _table_columns(sync_url, "agent_run") == _EXPECTED_COLUMNS
 

--- a/backend/tests/test_migration_0025_agent_run_lease_reaper.py
+++ b/backend/tests/test_migration_0025_agent_run_lease_reaper.py
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0025_add_agent_run_lease_reaper``.
+
+Initiative #804 (G11.3 Scheduler), Task #825 (T4). The migration adds
+three columns (``lease_owner`` / ``lease_expires_at`` / ``in_flight_policy``),
+one partial index (``agent_run_lease_expires_at_idx``), and one
+``CHECK`` constraint (``ck_agent_run_in_flight_policy``) to the
+``agent_run`` table.
+
+Test matrix
+-----------
+
+* **Upgrade adds the three columns + the index.** ``upgrade head``
+  leaves ``agent_run`` with the new columns and the new index name
+  present.
+* **Reversibility round-trip.** ``downgrade "0024"`` drops the columns
+  and the index; a subsequent ``upgrade head`` re-creates them.
+* **Column nullability.** ``in_flight_policy`` is NOT NULL with a
+  ``'fail_into_audit'`` server default; ``lease_owner`` and
+  ``lease_expires_at`` are nullable.
+* **Server default backfills existing rows.** Inserting a pre-existing
+  row before upgrade, then upgrading, the post-upgrade row has
+  ``in_flight_policy = 'fail_into_audit'``. (The migration relies on
+  the column's server default to handle the NOT NULL flip without a
+  separate backfill UPDATE.)
+* **CHECK constraint rejects unknown.** Insert with
+  ``in_flight_policy='not_a_real_policy'`` -> IntegrityError after
+  upgrade.
+
+Same synchronous-pattern + tmp-path-DB shape as
+:mod:`tests.test_migration_0017_agent_run`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL.
+
+    Same shape as
+    :func:`tests.test_migration_0017_agent_run.alembic_cfg`. The DB
+    file lives under pytest's ``tmp_path`` so each test gets an
+    isolated SQLite database; engine + settings caches are reset
+    before and after so the alembic env reads *this* DATABASE_URL.
+    """
+    db_path = tmp_path / "migration_0025.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _table_columns(sync_url: str, table: str) -> set[str]:
+    """Return the set of column names on *table* via ``PRAGMA``."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def _column_is_nullable(sync_url: str, table: str, column: str) -> bool:
+    """Return True when *column* on *table* permits NULL."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    finally:
+        sync_eng.dispose()
+    for row in rows:
+        if str(row[1]) == column:
+            return int(row[3]) == 0
+    raise AssertionError(f"column {column!r} not present on {table}")
+
+
+def _table_indexes(sync_url: str, table: str) -> set[str]:
+    """Return the set of index names declared on *table*."""
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA index_list({table})")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def _seed_tenant(sync_url: str) -> str:
+    """Insert a tenant row directly; return its id as a hex string.
+
+    Independent of the lifecycle helpers because the migration tests
+    use a sync sqlalchemy engine (the alembic env's async loop is
+    closed by the time the test inspects the result).
+    """
+    tenant_id = uuid.uuid4()
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            existing = conn.execute(
+                text("SELECT id FROM tenant WHERE slug = 'rdc-internal'")
+            ).first()
+            if existing is not None:
+                return str(existing[0])
+            conn.execute(
+                text(
+                    "INSERT INTO tenant (id, slug, name) "
+                    "VALUES (:id, 'rdc-internal', 'Tenant rdc-internal')"
+                ),
+                {"id": tenant_id.hex},
+            )
+    finally:
+        sync_eng.dispose()
+    return tenant_id.hex
+
+
+def test_upgrade_adds_lease_columns_and_index(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``upgrade head`` adds the three columns and the partial index."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    columns = _table_columns(sync_url, "agent_run")
+    assert {"lease_owner", "lease_expires_at", "in_flight_policy"} <= columns
+
+    indexes = _table_indexes(sync_url, "agent_run")
+    assert "agent_run_lease_expires_at_idx" in indexes
+
+
+def test_column_nullability(alembic_cfg: tuple[Config, str]) -> None:
+    """``in_flight_policy`` is NOT NULL; the lease columns are nullable."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    assert _column_is_nullable(sync_url, "agent_run", "lease_owner")
+    assert _column_is_nullable(sync_url, "agent_run", "lease_expires_at")
+    assert not _column_is_nullable(sync_url, "agent_run", "in_flight_policy")
+
+
+def test_in_flight_policy_default_is_fail_into_audit(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """A row inserted post-upgrade picks up ``'fail_into_audit'`` from the server default.
+
+    Exercises the column's ``server_default=sa.text("'fail_into_audit'")``
+    which is what lets the migration flip the column to NOT NULL
+    against an existing table without a separate backfill UPDATE.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+    tenant_hex = _seed_tenant(sync_url)
+
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            run_id = uuid.uuid4().hex
+            # Insert without specifying in_flight_policy -- the server
+            # default must fire.
+            conn.execute(
+                text(
+                    "INSERT INTO agent_run (id, tenant_id, identity_sub, trigger, "
+                    "model_tier, status, turns, created_at) VALUES "
+                    "(:id, :tid, 'user-default', 'direct', 'cheap', 'pending', 0, "
+                    "datetime('now'))"
+                ),
+                {"id": run_id, "tid": tenant_hex},
+            )
+            row = conn.execute(
+                text("SELECT in_flight_policy FROM agent_run WHERE id = :id"),
+                {"id": run_id},
+            ).first()
+        assert row is not None
+        assert row[0] == "fail_into_audit"
+    finally:
+        sync_eng.dispose()
+
+
+def test_in_flight_policy_check_rejects_unknown(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """An ``in_flight_policy`` outside the closed enum raises :class:`IntegrityError`."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+    tenant_hex = _seed_tenant(sync_url)
+
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn, pytest.raises(IntegrityError):
+            conn.execute(
+                text(
+                    "INSERT INTO agent_run (id, tenant_id, identity_sub, trigger, "
+                    "model_tier, status, turns, in_flight_policy, created_at) VALUES "
+                    "(:id, :tid, 'user-bad', 'direct', 'cheap', 'pending', 0, "
+                    "'retry_with_backoff', datetime('now'))"
+                ),
+                {"id": uuid.uuid4().hex, "tid": tenant_hex},
+            )
+    finally:
+        sync_eng.dispose()
+
+
+def test_downgrade_then_upgrade_round_trips(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``downgrade "0024"`` drops the new columns / index; ``upgrade head`` restores them.
+
+    The reversibility contract -- migration 0025 inherits the explicit
+    drop-then-create symmetry every later migration in this chain follows.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+    assert {"lease_owner", "lease_expires_at", "in_flight_policy"} <= _table_columns(
+        sync_url, "agent_run"
+    )
+
+    command.downgrade(cfg, "0024")
+    columns_after_down = _table_columns(sync_url, "agent_run")
+    assert "lease_owner" not in columns_after_down
+    assert "lease_expires_at" not in columns_after_down
+    assert "in_flight_policy" not in columns_after_down
+    assert "agent_run_lease_expires_at_idx" not in _table_indexes(sync_url, "agent_run")
+
+    command.upgrade(cfg, "head")
+    assert {"lease_owner", "lease_expires_at", "in_flight_policy"} <= _table_columns(
+        sync_url, "agent_run"
+    )
+    assert "agent_run_lease_expires_at_idx" in _table_indexes(sync_url, "agent_run")

--- a/docs/codebase/agent-run.md
+++ b/docs/codebase/agent-run.md
@@ -1,4 +1,4 @@
-# agent-run — durable agent-invocation record + enforced lifecycle
+# agent-run — durable agent-invocation record + enforced lifecycle + in-flight reaper
 
 ## Overview
 
@@ -7,7 +7,10 @@ MEHO's process (Initiative #802, G11.1 Agent runtime; Task #813, T6).
 The runtime executes an agent's tool-use loop in-process (G11.1-T1);
 each invocation is one `agent_run` row that ties the session's tool
 calls together, makes a run inspectable + cancellable, and seeds the
-audit/replay lineage.
+audit/replay lineage. Initiative #804 (G11.3 Scheduler), Task #825 (T4)
+adds the **lease/heartbeat + reaper** that guarantees a run killed
+mid-flight (pod restart, OOM, network partition) ends in a terminal
+audited state — never silently lost.
 
 The row's `id` **is** the `agent_session_id` lineage key that G11.4/C2
 binds into every per-tool-call audit row (mirroring the
@@ -16,9 +19,9 @@ that creates a run threads `run.id` through the runtime so every audit
 row written during that run shares it; `meho audit replay <session-id>`
 then reconstructs the timeline.
 
-Two pieces ship in T6:
+Two pieces shipped in T6:
 
-- The **ORM model** `AgentRun` + migration `0015` — storage only, no
+- The **ORM model** `AgentRun` + migration `0017` — storage only, no
   helper logic on the class (the discipline `AuditLog` / `WebSession`
   follow).
 - The **lifecycle service**
@@ -26,12 +29,42 @@ Two pieces ship in T6:
   inspect / transition / cancel, with an explicit, enforced state
   machine.
 
-What is **not** in T6 (other G11.1 tasks own these):
+T4 (#825) extends both with the in-flight-reclaim contract:
+
+- **Three columns** added to `AgentRun` via migration `0025_add_agent_run_lease_reaper`:
+  `lease_owner` (nullable Text — the worker holding the run),
+  `lease_expires_at` (nullable `timestamptz` — the heartbeat deadline),
+  `in_flight_policy` (NOT NULL Text with a `CHECK` constraint backed
+  by `ScheduledTriggerInFlightPolicy` — the per-run snapshot of the
+  firing trigger's `resume | fail_into_audit` policy).
+- **Lease lifecycle helpers** in the service:
+  `claim_lease` / `heartbeat` / `release_lease` / `snapshot_in_flight_policy`,
+  plus a `LeaseLostError` the worker uses to abort on a stolen lease.
+  `transition()` clears the lease as a terminal-state side effect so
+  the partial index does not retain zombie entries.
+- **The reaper** at `backend/src/meho_backplane/agent/reaper.py` — an
+  `asyncio` lifespan-owned background task that scans for
+  `status='running' AND lease_expires_at < now()` on a fixed cadence
+  and applies the per-run policy: `fail_into_audit` transitions the
+  row to `failed` with a stable interruption reason; `resume` clears
+  the lease so the next dispatcher sweep re-claims and a fresh
+  worker continues. Both outcomes write an audit row in the same
+  transaction as the lifecycle change, so a crash between the two
+  cannot leave a reaped run without an audit row.
+
+What is **not** in T6 or T4 (other tasks own these):
 
 - The invocation surface (sync + async handle/poll/SSE on REST + MCP +
   CLI) — G11.1-T4 (#811). T4 calls this service.
 - The Pydantic-AI loop seam that actually runs the agent — G11.1-T1
-  (#808).
+  (#808). The agent loop must call `heartbeat()` at ≈ `ttl_seconds/2`
+  cadence so the reaper does not reclaim a healthy run; the loop must
+  also honour `LeaseLostError` by aborting immediately (any further
+  side effects would be at-least-twice).
+- The trigger-firing path that calls `claim_lease` +
+  `snapshot_in_flight_policy` at run-start — G11.3-T2 (#823, cron + one-off)
+  and G11.3-T3 (#824, event subscription). T4 ships the substrate;
+  T2/T3 wire the call site.
 - Per-tool-call raw+redacted audit rows + replay — G11.4/C2 (this is the
   run-level record those rows link to via `agent_session_id`).
 - Cost computation — G11.5/C3. The `cost` column is recorded here but
@@ -57,6 +90,16 @@ What is **not** in T6 (other G11.1 tasks own these):
   `awaiting_approval`, `succeeded`, `failed`, `cancelled`.
 - `AgentRunTrigger` — closed `StrEnum`: `direct`, `scheduled`, `event`,
   `agent-invoked`.
+- `lease_owner` / `lease_expires_at` (T4 #825) — the worker-identifier +
+  heartbeat-deadline pair the scheduler writes when a worker begins
+  executing a run. Both NULL when no worker holds it (`pending`,
+  `awaiting_approval` after release, or any terminal state). The
+  lifecycle service keeps the two columns in lock-step.
+- `in_flight_policy` (T4 #825) — NOT NULL Text, server-default
+  `'fail_into_audit'`, `CHECK` constraint binding to
+  `ScheduledTriggerInFlightPolicy`. Per-run snapshot of the firing
+  trigger's policy copied at run-start so a definition edit mid-flight
+  cannot flip behaviour on a run already executing.
 
 Both enums are backed by DB-layer `CHECK (col IN (...))` constraints
 that move in lock-step with the enum (`ck_agent_run_status`,
@@ -141,6 +184,86 @@ one transaction):
   observes the cancelled status at its next turn boundary and stops.
   Recording the intent durably first is what makes cancellation survive
   a process restart.
+- `claim_lease(session, row, *, owner, ttl_seconds)` — stamp
+  `lease_owner` + `lease_expires_at` on a run a worker is about to
+  execute (T4 #825). Status untouched — composed by the caller with
+  `start_run` inside one transaction so a partial commit cannot leave
+  the row `running` without a lease.
+- `heartbeat(session, *, run_id, owner, ttl_seconds) -> AgentRun` —
+  extend the lease iff the conditional `UPDATE … WHERE lease_owner =
+  owner AND status = 'running'` touches one row; zero rows raises
+  `LeaseLostError` so a worker whose lease was stolen by the reaper
+  (or whose run was cancelled out from under it) stops cleanly. The
+  conditional UPDATE is atomic at the DB layer — a Python-side check
+  would race the reaper.
+- `release_lease(session, row)` — clear both lease columns without
+  changing status. Used by the reaper's `resume` policy and by the
+  terminal-state side effect in `transition()`.
+- `snapshot_in_flight_policy(session, row, policy)` — copy the firing
+  trigger's `ScheduledTriggerInFlightPolicy` onto the run row at
+  run-start. T2/T3 call this inside the same transaction as the
+  initial `create_run` so the run never executes without a snapshotted
+  policy.
+
+## In-flight reaper (T4 #825)
+
+`backend/src/meho_backplane/agent/reaper.py` owns the *reclaim* half of
+the no-silently-lost contract. The trigger-firing path (T2 / T3) writes
+the lease at run-start; the healthy worker bumps it forward via
+`heartbeat`; the reaper scans for expired leases on a fixed cadence
+(`AGENT_RUN_REAPER_TICK_INTERVAL_SECONDS`, default 30s) and applies the
+per-run `in_flight_policy`:
+
+- **`fail_into_audit`** — the conservative default. Transition the run
+  to `failed` with the stable `AGENT_RUN_REAPER_INTERRUPTION_REASON`
+  string, plus an audit row at path
+  `internal/agent-run/reaper/fail-into-audit`. The next trigger tick
+  fires a fresh run.
+- **`resume`** — `release_lease` so the next dispatcher sweep
+  re-claims; status stays `running` (the row's current state IS the
+  resume point), plus an audit row at path
+  `internal/agent-run/reaper/clear-for-resume`. At-least-once
+  semantics; the agent's tool calls should be idempotent-friendly
+  (G11.1 design constraint).
+
+Shape mirrors the chassis's other lifespan-owned sweepers
+(`memory/expiry.py`, `topology/scheduler.py`):
+
+- `asyncio.create_task` started in `_BackgroundTasks` and cancelled on
+  lifespan shutdown. Strong-reference retention so the task isn't
+  garbage-collected mid-flight ("Task was destroyed but it is
+  pending!").
+- Sleep-then-sweep so the first tick does not race startup work
+  (eager engine init, embedding preload, typed-op registration).
+- Per-tick try/except + per-row try/except so one bad row never
+  stalls the batch and one transient DB blip never crashes the loop
+  (a crashed loop silently stops the reclaim contract — which is
+  exactly what we're protecting against).
+- Postgres advisory lock (`pg_try_advisory_lock`) for single-flighting
+  across replicas; SQLite (dev/test) treats it as no-op.
+- LIMIT bound (`AGENT_RUN_REAPER_MAX_PER_TICK`, default 50) so a
+  post-outage backlog drains across multiple ticks rather than
+  pinning one Postgres backend.
+
+The reaper writes its audit row via a private staging helper
+(`_stage_audit_row`) rather than the chassis's shared writers because
+the audit row + the lifecycle transition must commit in the **same
+transaction** — the chassis's shared writers each open their own
+session, which would split the reap across two commits and could
+leave a reaped run without an audit row if the second commit failed.
+
+Settings (all in `Settings`, all opt-out via env):
+
+- `AGENT_RUN_REAPER_ENABLED` (default `true`) — disable the in-tree
+  reaper when running an external lease-reclaim mechanism (DBOS
+  Transact, a workflow engine).
+- `AGENT_RUN_REAPER_TICK_INTERVAL_SECONDS` (default 30, range 5-3600).
+- `AGENT_RUN_REAPER_MAX_PER_TICK` (default 50, range 1-1000).
+- `AGENT_RUN_LEASE_TTL_SECONDS` (default 60, range 10-3600) — the
+  initial lease window callers pass to `claim_lease`. With the
+  default 30s tick + 60s TTL, a worker has two heartbeat windows of
+  slack before reclaim — a transient 20s GC pause or network blip
+  does not cost a run.
 
 ## Dependencies
 
@@ -152,6 +275,8 @@ one transaction):
   role-ranking tuple (`_ROLE_RANK`) rather than importing
   `auth.rbac._ROLE_ORDER` (a private HTTP-RBAC constant) so the service
   layer does not depend on the HTTP module's internals.
+- (Reaper only) `meho_backplane.db.models.AuditLog` — staged directly
+  in the same transaction as the lifecycle transition.
 
 ## Known issues / notes
 
@@ -166,16 +291,39 @@ one transaction):
   `timestamptz` columns; the chassis-wide "naive means UTC" convention
   applies. PG returns tz-aware values (covered by the testcontainers
   replay suite).
+- The reaper's `resume` policy is **at-least-once** by construction:
+  the original worker may still be alive (network-partitioned,
+  long GC pause) when the reaper clears its lease. The first defence
+  is `heartbeat`'s conditional `UPDATE` (raises `LeaseLostError` so a
+  partitioned worker stops on its next heartbeat). The second defence
+  is the agent runtime's idempotency-friendly tool calls (G11.1's
+  design constraint) — T4 does not enforce idempotency at the
+  substrate, it is the agent author's contract.
+- Migration `0025_add_agent_run_lease_reaper` collides numerically
+  with PR #1065 (G11.3-T2, cron + one-off triggers) which also numbers
+  its migration `0025`. Both PRs are in-flight in parallel; whichever
+  lands second rebases its migration to `0026`.
 
 ## References
 
 - Initiative #802 (G11.1 Agent runtime), Task #813 (T6). Parent Goal
   #800 (G11 agentic ops runtime).
-- Migration `0015_create_agent_run.py`; model `AgentRun` in
-  `backend/src/meho_backplane/db/models.py`; service
-  `backend/src/meho_backplane/operations/agent_run.py`.
+- Initiative #804 (G11.3 Scheduler), Task #825 (T4 — lease/heartbeat
+  + reaper).
+- Migration `0017_create_agent_run.py` (T6 — table) +
+  `0025_add_agent_run_lease_reaper.py` (T4 — lease columns); model
+  `AgentRun` in `backend/src/meho_backplane/db/models.py`; service
+  `backend/src/meho_backplane/operations/agent_run.py`; reaper
+  `backend/src/meho_backplane/agent/reaper.py`.
 - Lineage-key sibling: `audit_log.agent_session_id` (migration `0014`,
   G8.2-T1 #1009) — the column `agent_run.id` is consumed as.
+- Failure-isolation precedent: `memory/expiry.py` (per-tick try/except
+  + lifespan-owned sweeper) and `topology/scheduler.py` (advisory-lock
+  single-flighting).
+- Consumer doc: `agent-runtime-for-ops-spec.md` §P2 (the explicitly
+  accepted `fail_into_audit` default).
 - Tests: `tests/test_db_agent_run.py`,
-  `tests/test_migration_0015_agent_run.py`,
-  `tests/test_agent_run_lifecycle.py`.
+  `tests/test_migration_0017_agent_run.py`,
+  `tests/test_agent_run_lifecycle.py`,
+  `tests/test_migration_0025_agent_run_lease_reaper.py`,
+  `tests/test_agent_run_reaper.py`.


### PR DESCRIPTION
## Summary

- Add `lease_owner` / `lease_expires_at` / `in_flight_policy` columns to `agent_run` (migration 0025) and five lifecycle helpers (`claim_lease`, `heartbeat`, `release_lease`, `snapshot_in_flight_policy`, plus a `LeaseLostError` exception).
- Ship the in-flight `agent_run_reaper` background task at `backend/src/meho_backplane/agent/reaper.py` — `asyncio` lifespan-owned, single-flighted across replicas via `pg_try_advisory_lock`, per-tick LIMIT bounded, per-row failure isolation. Applies the per-run policy (`fail_into_audit` → terminal `failed` + audit row; `resume` → clear lease + audit row so dispatcher re-claims). Audit row staged in the same transaction as the lifecycle transition.
- Acceptance contract honoured: a run killed mid-flight ends in a terminal audited state — never silently lost.

## Test plan

- [x] `ruff check` (touched files) — clean
- [x] `ruff format --check` (backend/) — clean
- [x] `mypy src/meho_backplane/` — clean (316 files)
- [x] `pytest tests/test_agent_run_reaper.py tests/test_agent_run_lifecycle.py tests/test_db_agent_run.py tests/test_migration_0025_agent_run_lease_reaper.py tests/test_migration_0017_agent_run.py tests/test_connectors_registry.py` — **102 passed**
- [x] Full backend unit suite — **4803 passed, 49 skipped** (touched-file regression in `test_migration_0017_agent_run.py` fixed by pinning its upgrade target to `"0017"` instead of `"head"` — the strict `_EXPECTED_COLUMNS` assertion was invalidated whenever a later migration added columns to `agent_run`)
- [x] Acceptance criterion: kill-restart test — `test_kill_restart_run_with_fail_into_audit_ends_failed_and_audited` + `test_kill_restart_run_with_resume_clears_lease_and_audits` both green
- [x] Reaper ignores healthy runs (`test_reaper_ignores_running_run_with_fresh_lease`), ignores terminal-with-stale-lease (`test_reaper_ignores_terminal_runs_with_stale_lease`), respects per-tick LIMIT (`test_reaper_processes_batch_under_per_tick_limit`), mixed policies in one tick route correctly (`test_reaper_mixed_policies_apply_independently`)
- [x] Heartbeat CAS semantics: `test_heartbeat_extends_lease_for_holder`, `test_heartbeat_raises_lease_lost_when_owner_mismatches`, `test_heartbeat_raises_lease_lost_when_run_already_terminal`
- [x] Migration round-trip + CHECK constraint + server default: `test_migration_0025_agent_run_lease_reaper.py` — 5 passed

## Out of scope

- Trigger-firing path (T2 #823 cron+one-off, T3 #824 event subscription) and admin surface (T5 #826) — separate Tasks under the same Initiative. T4 ships the substrate (lease/heartbeat helpers + reaper); T2/T3 wire `claim_lease` + `snapshot_in_flight_policy` at run-start.
- Cross-replica work-stealing beyond claim-and-reap (out of scope per the Task body).
- Code paths in PR #1065 (T2 cron + one-off triggers, by @zdamir) — deliberately untouched per orchestrator brief.

## Adjacent findings (not edited)

- Migration `0025_add_agent_run_lease_reaper.py` collides numerically with PR #1065 (T2) which also uses `0025`. Whichever PR lands second rebases its migration to `0026`. Mechanical conflict, documented in the `Known issues` section of `docs/codebase/agent-run.md`.
- `tests/test_migration_0017_agent_run.py` used `command.upgrade(cfg, "head")` for two tests that strict-asserted against a fixed `_EXPECTED_COLUMNS` shape. The combination silently regresses on every later migration that adds columns to `agent_run`. Fixed in this PR by pinning both upgrades to `"0017"`; the same pattern in other `test_migration_*.py` files may have the same drift risk and is worth a follow-up sweep (out of scope here).
- Stale migration number references in `docs/codebase/agent-run.md` (the doc said `0015_create_agent_run.py` but the actual file is `0017_create_agent_run.py`) were corrected in passing.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #825


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic background process that detects and recovers agent runs stuck due to expired worker leases, enforcing configured policies to either transition to failed state with audit trail or resume and clear lease metadata.

* **Tests**
  * Added comprehensive test coverage for lease lifecycle operations, reaper behavior, database schema migrations, and recovery policy enforcement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->