### PR TITLE
feat(connectors): G0.13-T3 surface next_step hint on state=registered connectors

### DIFF
--- a/backend/src/meho_backplane/operations/ingest/api_schemas.py
+++ b/backend/src/meho_backplane/operations/ingest/api_schemas.py
@@ -71,6 +71,7 @@ __all__ = [
     "IngestRequest",
     "IngestResponse",
     "IngestionResultModel",
+    "NextStep",
     "SpecSource",
 ]
 
@@ -232,6 +233,38 @@ class IngestResponse(BaseModel):
 ConnectorState = Literal["ingested", "registered"]
 
 
+class NextStep(BaseModel):
+    """Self-describing in-product hint pointing at the verb that closes the workflow.
+
+    Surfaced on :class:`ConnectorListItem` rows whose :attr:`~ConnectorListItem.state`
+    is ``"registered"`` (G0.13-T3 / #1133). An ``"ingested"`` row sets
+    :attr:`ConnectorListItem.next_step` to ``None`` because the dispatcher
+    already resolves operations against it -- there is nothing left for the
+    operator to do.
+
+    Two ``verb`` shapes ship:
+
+    * ``meho connector ingest --catalog <product>/<version>`` -- when the
+      connector-spec catalog (G0.7-T8 / #743) carries an entry for the
+      registry's ``(product, version)``. The operator copies the verb,
+      ``meho connector ingest`` looks up the upstream spec URL, and
+      dispatchability follows after operator review.
+    * ``meho connector ingest --product <p> --version <v> --impl <i> --spec <uri>``
+      -- when the catalog has no entry. The ``rationale`` makes the
+      missing-catalog branch explicit so the operator knows they need
+      to source the OpenAPI spec themselves.
+
+    Frozen for the same reason every wire shape in this module is frozen:
+    responses are read-only and any in-place mutation should surface as a
+    Pydantic error rather than a silently-modified payload.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    verb: str = Field(min_length=1, max_length=512)
+    rationale: str = Field(min_length=1, max_length=512)
+
+
 class ConnectorListItem(BaseModel):
     """One row in the ``GET /api/v1/connectors`` response.
 
@@ -262,6 +295,20 @@ class ConnectorListItem(BaseModel):
     not-yet-dispatchable when ``state == "registered"``. Defaults to
     ``"ingested"`` so existing call sites (tests, MCP fakes)
     construct rows without breakage.
+
+    ``next_step`` (G0.13-T3 / #1133) is the self-describing hint that
+    closes the workflow gap the v0.6.0 RDC dogfood surfaced (signal 11:
+    half-registered connectors fail lookup with no in-product hint
+    about what verb closes the workflow). It is a :class:`NextStep`
+    object on ``state="registered"`` rows and ``None`` on
+    ``state="ingested"`` rows (no operator action remains for an
+    ingested connector). The hint is computed against the curated
+    connector-spec catalog (#743): when the catalog carries an entry
+    for the registry's ``(product, version)`` the verb points at
+    ``meho connector ingest --catalog ...``; otherwise it points at
+    the manual-mode flags. Defaults to ``None`` so existing
+    construction call sites (tests, MCP fakes) continue to compile
+    without explicit assignment.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -277,6 +324,7 @@ class ConnectorListItem(BaseModel):
     disabled_group_count: int
     operation_count: int
     state: ConnectorState = "ingested"
+    next_step: NextStep | None = None
 
 
 class ConnectorListResponse(BaseModel):

--- a/backend/src/meho_backplane/operations/ingest/list_connectors.py
+++ b/backend/src/meho_backplane/operations/ingest/list_connectors.py
@@ -49,6 +49,20 @@ Dialect portability
 The conditional aggregation uses portable ``CASE WHEN ... THEN 1
 ELSE 0 END`` SUM expressions rather than dialect-specific ``FILTER``
 clauses (PG-only) so the same query runs against SQLite in tests.
+
+next_step hint (G0.13-T3 / #1133)
+---------------------------------
+
+``state="registered"`` rows carry a :class:`NextStep` object pointing
+at the verb that closes the workflow gap surfaced by the v0.6.0 RDC
+dogfood (consumer's signal 11: half-registered connectors fail
+lookup with no in-product hint). ``state="ingested"`` rows omit it
+(``next_step=None``) because the dispatcher already resolves them.
+
+The catalog lookup uses the v2-registry's ``(product, version)``,
+not the parser-derived shortening, because the catalog stores SDDC
+under ``product="sddc-manager"`` while the listing emits
+``product="sddc"``. See :func:`_next_step_for_registered`.
 """
 
 from __future__ import annotations
@@ -69,11 +83,72 @@ from meho_backplane.operations.ingest._llm_grouping_internals import build_conne
 from meho_backplane.operations.ingest.api_schemas import (
     ConnectorListItem,
     ConnectorStatusFilter,
+    NextStep,
+)
+from meho_backplane.operations.ingest.catalog import (
+    CatalogError,
+    ConnectorSpecCatalog,
+    load_catalog,
 )
 
 __all__ = ["list_ingested_connectors"]
 
 _log = structlog.get_logger(__name__)
+
+
+def _next_step_for_registered(
+    *,
+    catalog: ConnectorSpecCatalog | None,
+    registry_product: str,
+    registry_version: str,
+    registry_impl_id: str,
+) -> NextStep:
+    """Build the ``next_step`` hint for a ``state="registered"`` row.
+
+    Looks up the registry's ``(product, version)`` in the connector-spec
+    catalog (#743). The registry product is the right lookup key (not the
+    parser-derived one): the catalog stores ``product="sddc-manager"`` but
+    the listing emits ``product="sddc"`` per
+    :func:`parse_connector_id`'s deterministic shortening, and looking up
+    ``("sddc", "9.0")`` would always miss for SDDC.
+
+    Two branches:
+
+    * **Catalog hit** — verb points at ``meho connector ingest --catalog
+      <product>/<version>``; rationale says the spec is available in the
+      catalog. The CLI form is the same one the curated-on-ramp ships
+      (#915 / G0.7-T5); copying the verb verbatim closes the workflow.
+    * **Catalog miss** — verb points at the manual-mode ``meho connector
+      ingest --product <p> --version <v> --impl <i> --spec <uri>``;
+      rationale calls out the missing catalog entry so the operator
+      knows they need to source the OpenAPI spec themselves. Manual
+      mode is the same path G0.7-T5 already supports for one-off /
+      not-yet-curated specs (see ``ingest.go``'s mode dispatch).
+
+    *catalog* is ``None`` when the package-data load failed (a malformed
+    catalog at startup would have crashed the lifespan, so this branch
+    only fires in tests where the loader was monkeypatched or the
+    process is mid-catalog-reload); the helper degrades to the
+    manual-mode rationale rather than raising, because the operator's
+    workflow doesn't depend on the catalog being live.
+    """
+    entry = catalog.get(registry_product, registry_version) if catalog is not None else None
+    if entry is not None:
+        return NextStep(
+            verb=f"meho connector ingest --catalog {entry.product}/{entry.version}",
+            rationale="spec available in catalog; run ingest to populate operations",
+        )
+    return NextStep(
+        verb=(
+            f"meho connector ingest --product {registry_product} "
+            f"--version {registry_version} --impl {registry_impl_id} "
+            f"--spec <upstream-openapi-uri>"
+        ),
+        rationale=(
+            "not in catalog; run manual ingest with --spec pointing at the "
+            "vendor OpenAPI spec (file:// / https:// / docs:<...>)"
+        ),
+    )
 
 
 def _matches_status_filter(
@@ -284,6 +359,44 @@ async def list_ingested_connectors(
             operator_tenant_id=operator.tenant_id,
         )
 
+    items = await _emit_db_backed_rows(
+        operator=operator,
+        groups_by_connector=groups_by_connector,
+        op_counts_by_connector=op_counts_by_connector,
+        status=status,
+    )
+    items.extend(
+        _class_side_only_items(
+            groups_by_connector.keys(),
+            status=status,
+            catalog=_load_catalog_or_none(),
+        ),
+    )
+    return items
+
+
+async def _emit_db_backed_rows(
+    *,
+    operator: Operator,
+    groups_by_connector: dict[tuple[UUID | None, str, str, str], dict[str, int]],
+    op_counts_by_connector: dict[tuple[UUID | None, str, str, str], int],
+    status: ConnectorStatusFilter | None,
+) -> list[ConnectorListItem]:
+    """Emit one ``state="ingested"`` :class:`ConnectorListItem` per DB-backed connector.
+
+    Walks the aggregated ``operation_group`` rows in stable sort order,
+    applies the :attr:`~ConnectorListItem.status` filter, drops rows
+    whose ``connector_id`` would not round-trip through the
+    dispatcher's resolve path (per the G0.9.1-T1 / #773 listing-
+    integrity contract — see :func:`_resolves_through_dispatcher`), and
+    projects each survivor into the wire shape with ``state="ingested"``
+    and ``next_step=None`` (the catalog-completion hint only applies
+    to the class-side-only path; ingested rows already dispatch).
+
+    Extracted from :func:`list_ingested_connectors` so the DB-side
+    emission and the class-side-only emission stay each below the
+    code-quality function-size limit.
+    """
     items: list[ConnectorListItem] = []
     for key, row in sorted(groups_by_connector.items(), key=_connector_sort_key):
         tenant_uuid, product, version, impl_id = key
@@ -315,14 +428,40 @@ async def list_ingested_connectors(
                 state="ingested",
             ),
         )
-    items.extend(_class_side_only_items(groups_by_connector.keys(), status=status))
     return items
+
+
+def _load_catalog_or_none() -> ConnectorSpecCatalog | None:
+    """Return the cached catalog, or ``None`` if the load failed.
+
+    Startup parses the catalog inside the lifespan -- a malformed catalog
+    would already have crashed the app before any request reached this
+    code. The defensive ``except`` here covers two edge cases that
+    appear only in test contexts:
+
+    * a unit test that monkeypatches the resource loader to inject a
+      malformed YAML and then asserts the listing degrades gracefully;
+    * a process mid-reload where :func:`load_catalog`'s lru_cache was
+      explicitly cleared.
+
+    Both cases prefer a degraded ``next_step`` hint (manual-mode rationale)
+    over a 500 from a route the operator depends on for diagnosability.
+    """
+    try:
+        return load_catalog()
+    except CatalogError:
+        _log.warning(
+            "next_step_catalog_load_failed",
+            reason="catalog_error_at_listing_time_fallback_to_manual_hint",
+        )
+        return None
 
 
 def _class_side_only_items(
     db_keys: Iterable[tuple[UUID | None, str, str, str]],
     *,
     status: ConnectorStatusFilter | None,
+    catalog: ConnectorSpecCatalog | None,
 ) -> list[ConnectorListItem]:
     """Return rows for v2-registered connectors with no DB-side state.
 
@@ -370,67 +509,143 @@ def _class_side_only_items(
     db_triples = {(product, version, impl_id) for (_, product, version, impl_id) in db_keys}
     rows: list[ConnectorListItem] = []
     for product, version, impl_id in sorted(all_connectors_v2().keys()):
-        if not version or not impl_id:
-            # v1-compat shim — see docstring.
-            continue
-        connector_id = build_connector_id(product, version, impl_id)
-        try:
-            parsed_product, parsed_version, parsed_impl_id = parse_connector_id(connector_id)
-        except ValueError:
-            _log.warning(
-                "dropped_unresolvable_connector_id",
-                source="v2_registry",
-                connector_id=connector_id,
-                registry_product=product,
-                registry_version=version,
-                registry_impl_id=impl_id,
-                reason="parse_connector_id_raised",
-            )
-            continue
-        if (parsed_version, parsed_impl_id) != (version, impl_id):
-            # The parser cannot recover the (version, impl_id) the
-            # registry advertises; even if a DB row eventually lands
-            # under the registry's natural key, the dispatcher will
-            # parse this connector_id to a different triple and fail
-            # to resolve. Drop and log — there is no clean
-            # remediation from inside the listing.
-            _log.warning(
-                "dropped_unresolvable_connector_id",
-                source="v2_registry",
-                connector_id=connector_id,
-                registry_product=product,
-                registry_version=version,
-                registry_impl_id=impl_id,
-                parsed_product=parsed_product,
-                parsed_version=parsed_version,
-                parsed_impl_id=parsed_impl_id,
-                reason="impl_id_or_version_not_recoverable_from_connector_id",
-            )
-            continue
-        if (parsed_product, parsed_version, parsed_impl_id) in db_triples:
-            # DB rows already represent this connector under the
-            # parser-derived natural key; the DB-loop emitted the
-            # ingested row, so skip the class-only ``registered`` row
-            # to avoid duplication. Covers both the trivial case
-            # (registry product == parsed product) and the SDDC case
-            # (registry product "sddc-manager" vs parsed "sddc").
-            continue
-        rows.append(
-            ConnectorListItem(
-                connector_id=connector_id,
-                product=parsed_product,
-                version=parsed_version,
-                impl_id=parsed_impl_id,
-                tenant_id=None,
-                group_count=0,
-                staged_group_count=0,
-                enabled_group_count=0,
-                disabled_group_count=0,
-                operation_count=0,
-                state="registered",
-            ),
+        item = _maybe_build_class_only_item(
+            registry_product=product,
+            registry_version=version,
+            registry_impl_id=impl_id,
+            db_triples=db_triples,
+            catalog=catalog,
         )
+        if item is not None:
+            rows.append(item)
     return rows
+
+
+def _maybe_build_class_only_item(
+    *,
+    registry_product: str,
+    registry_version: str,
+    registry_impl_id: str,
+    db_triples: set[tuple[str, str, str]],
+    catalog: ConnectorSpecCatalog | None,
+) -> ConnectorListItem | None:
+    """Project one v2-registry entry into a ``state="registered"`` row or skip it.
+
+    Returns ``None`` for any of four drop conditions (v1-compat shim,
+    parser failure, lossy parse, DB-dedupe); each drop emits a
+    structured ``dropped_unresolvable_connector_id`` log via
+    :func:`_resolve_class_only_natural_key`. Otherwise builds the
+    :class:`ConnectorListItem` with ``state="registered"`` and the
+    catalog-driven ``next_step`` hint.
+
+    Extracted from :func:`_class_side_only_items` so the per-entry
+    branching stays under the code-quality function-size limit.
+    Keyword-only to avoid positional-arg confusion (``product`` and
+    ``impl_id`` can both look like an identifier at the call site).
+    """
+    parsed = _resolve_class_only_natural_key(
+        registry_product=registry_product,
+        registry_version=registry_version,
+        registry_impl_id=registry_impl_id,
+    )
+    if parsed is None:
+        return None
+    connector_id, parsed_product, parsed_version, parsed_impl_id = parsed
+    if (parsed_product, parsed_version, parsed_impl_id) in db_triples:
+        # DB rows already represent this connector under the parser-
+        # derived natural key; the DB-loop emitted the ingested row,
+        # so skip the class-only ``registered`` row to avoid
+        # duplication. Covers both the trivial case (registry product
+        # == parsed product) and the SDDC case (registry product
+        # "sddc-manager" vs parsed "sddc").
+        return None
+    return ConnectorListItem(
+        connector_id=connector_id,
+        product=parsed_product,
+        version=parsed_version,
+        impl_id=parsed_impl_id,
+        tenant_id=None,
+        group_count=0,
+        staged_group_count=0,
+        enabled_group_count=0,
+        disabled_group_count=0,
+        operation_count=0,
+        state="registered",
+        next_step=_next_step_for_registered(
+            catalog=catalog,
+            # Lookup against the registry triple (the catalog's native
+            # key) rather than the parsed one — for SDDC the registry
+            # holds ``product="sddc-manager"`` while the listing emits
+            # ``product="sddc"``. The catalog is keyed on the registry
+            # side; this is the lookup the operator-facing verb
+            # resolves against.
+            registry_product=registry_product,
+            registry_version=registry_version,
+            registry_impl_id=registry_impl_id,
+        ),
+    )
+
+
+def _resolve_class_only_natural_key(
+    *,
+    registry_product: str,
+    registry_version: str,
+    registry_impl_id: str,
+) -> tuple[str, str, str, str] | None:
+    """Validate + parse a v2-registry entry's natural key.
+
+    Returns ``(connector_id, parsed_product, parsed_version,
+    parsed_impl_id)`` for a survivor, or ``None`` for any of three
+    drop reasons (with a structured log per drop):
+
+    * **v1-compat shim** — ``version`` or ``impl_id`` empty
+      (``(product, "", "")``); registry-internal shim, not a
+      separately registered connector.
+    * **Parser failure** — :func:`parse_connector_id` raises on the
+      emitted ``connector_id`` (impossible-to-parse ``impl_id`` shape).
+    * **Lossy parse** — the parser recovers a different
+      ``(version, impl_id)`` than the registry advertised; the
+      dispatcher would fail to resolve any DB row eventually written
+      under the registry's natural key.
+
+    The SDDC case (registry ``product="sddc-manager"``, parsed
+    ``product="sddc"``) survives because the ``(version, impl_id)``
+    pair round-trips losslessly even though ``product`` doesn't —
+    that's the documented exception the dispatcher's parsed product
+    matches what ``SDDC_PRODUCT="sddc"`` already writes into
+    ``endpoint_descriptor`` rows.
+    """
+    if not registry_version or not registry_impl_id:
+        return None
+    connector_id = build_connector_id(registry_product, registry_version, registry_impl_id)
+    try:
+        parsed_product, parsed_version, parsed_impl_id = parse_connector_id(connector_id)
+    except ValueError:
+        _log.warning(
+            "dropped_unresolvable_connector_id",
+            source="v2_registry",
+            connector_id=connector_id,
+            registry_product=registry_product,
+            registry_version=registry_version,
+            registry_impl_id=registry_impl_id,
+            reason="parse_connector_id_raised",
+        )
+        return None
+    if (parsed_version, parsed_impl_id) != (registry_version, registry_impl_id):
+        _log.warning(
+            "dropped_unresolvable_connector_id",
+            source="v2_registry",
+            connector_id=connector_id,
+            registry_product=registry_product,
+            registry_version=registry_version,
+            registry_impl_id=registry_impl_id,
+            parsed_product=parsed_product,
+            parsed_version=parsed_version,
+            parsed_impl_id=parsed_impl_id,
+            reason="impl_id_or_version_not_recoverable_from_connector_id",
+        )
+        return None
+    return connector_id, parsed_product, parsed_version, parsed_impl_id
 
 
 async def _resolves_through_dispatcher(

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -746,6 +746,166 @@ async def test_list_class_only_entries_excluded_under_status_narrowing(
 
 
 # ---------------------------------------------------------------------------
+# G0.13-T3 (#1133) next_step hint contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _registered_class_only_with_uncatalogued_entry() -> Iterator[None]:
+    """Register one v2 connector whose ``(product, version)`` is NOT in the catalog.
+
+    Drives the not-in-catalog branch of :func:`_next_step_for_registered`.
+    Uses a deliberately synthetic ``("custom-vendor", "1.0")`` triple — no
+    catalog entry exists under that pair (the catalog ships seven curated
+    products and ``custom-vendor`` is not one of them), so the hint must
+    fall through to the manual-mode rationale.
+
+    Re-uses :class:`HarborConnector` as the placeholder class because it
+    has a no-arg construct path and the test only exercises the listing —
+    the class is never instantiated.
+    """
+    from meho_backplane.connectors.harbor.connector import HarborConnector
+    from meho_backplane.connectors.registry import (
+        all_connectors_v2,
+        register_connector_v2,
+    )
+
+    existing = all_connectors_v2()
+    if ("custom-vendor", "1.0", "custom-rest") not in existing:
+        register_connector_v2(
+            product="custom-vendor",
+            version="1.0",
+            impl_id="custom-rest",
+            cls=HarborConnector,
+        )
+    yield
+
+
+@pytest.mark.asyncio
+async def test_list_registered_row_carries_catalog_next_step_hint(
+    client: TestClient,
+    _registered_class_only_connectors: None,
+) -> None:
+    """Catalog-hit branch: ``state="registered"`` rows carry the ``--catalog`` verb.
+
+    G0.13-T3 (#1133) AC #1 + #3 (catalog-hit half):
+    rows with ``state="registered"`` include a ``next_step`` field with
+    ``verb`` + ``rationale``, and the hint correctly distinguishes "catalog
+    has it" — the verb points at ``meho connector ingest --catalog
+    <product>/<version>``.
+
+    SDDC is the load-bearing case: the listing emits ``product="sddc"``
+    (parser-derived), but the catalog stores ``product="sddc-manager"``
+    (registry-side). The hint must use the catalog's native key, i.e.
+    ``--catalog sddc-manager/9.0`` not ``--catalog sddc/9.0``. Harbor
+    exercises the trivial case where registry and parsed product agree.
+    """
+    tenant_a = uuid.uuid4()
+    key, token = _operator_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get("/api/v1/connectors", headers=_authed(token))
+    assert response.status_code == 200
+    by_id = {c["connector_id"]: c for c in response.json()["connectors"]}
+
+    harbor = by_id["harbor-rest-2.x"]
+    assert harbor["state"] == "registered"
+    assert harbor["next_step"] is not None
+    assert harbor["next_step"]["verb"] == "meho connector ingest --catalog harbor/2.x"
+    assert "catalog" in harbor["next_step"]["rationale"]
+    assert "ingest" in harbor["next_step"]["rationale"]
+
+    sddc = by_id["sddc-rest-9.0"]
+    assert sddc["state"] == "registered"
+    assert sddc["next_step"] is not None
+    # Catalog lookup must use the *registry's* product ("sddc-manager"),
+    # not the parsed product ("sddc") — see _next_step_for_registered.
+    assert sddc["next_step"]["verb"] == "meho connector ingest --catalog sddc-manager/9.0"
+    assert "catalog" in sddc["next_step"]["rationale"]
+
+
+@pytest.mark.asyncio
+async def test_list_registered_row_without_catalog_entry_points_at_manual_mode(
+    client: TestClient,
+    _registered_class_only_with_uncatalogued_entry: None,
+) -> None:
+    """Catalog-miss branch: not-in-catalog rows point at manual-mode ingest.
+
+    G0.13-T3 (#1133) AC #2 + #3 (catalog-miss half): when the catalog
+    doesn't carry the registered connector, the rationale says so and
+    points at manual-mode ``meho connector ingest`` with ``--spec``.
+
+    Uses a synthetic ``("custom-vendor", "1.0")`` v2 registration with
+    no catalog entry. The hint must:
+
+    * point at ``meho connector ingest --product custom-vendor --version
+      1.0 --impl custom-rest --spec <upstream-openapi-uri>`` (the
+      manual-mode invocation), echoing the registry's natural key so
+      the operator copies the right values verbatim;
+    * carry a rationale that says the catalog has no entry so the
+      operator knows they need to source the OpenAPI spec themselves.
+    """
+    tenant_a = uuid.uuid4()
+    key, token = _operator_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get("/api/v1/connectors", headers=_authed(token))
+    assert response.status_code == 200
+    by_id = {c["connector_id"]: c for c in response.json()["connectors"]}
+
+    custom = by_id["custom-rest-1.0"]
+    assert custom["state"] == "registered"
+    assert custom["next_step"] is not None
+    verb = custom["next_step"]["verb"]
+    assert "--catalog" not in verb
+    assert "--product custom-vendor" in verb
+    assert "--version 1.0" in verb
+    assert "--impl custom-rest" in verb
+    assert "--spec" in verb
+    rationale = custom["next_step"]["rationale"]
+    assert "not in catalog" in rationale
+    assert "--spec" in rationale
+
+
+@pytest.mark.asyncio
+async def test_list_ingested_row_omits_next_step_hint(
+    client: TestClient,
+) -> None:
+    """``state="ingested"`` rows set ``next_step=None`` (no operator action remains).
+
+    G0.13-T3 (#1133) AC #1 (ingested-rows half): an ingested connector's
+    dispatcher resolves operations against it, so there is no workflow-
+    completion verb to surface. The contract is ``next_step=null`` (we
+    chose the null shape, documented in the schema, rather than the
+    field-omission alternative — both were called out as
+    implementer's-call in the task body).
+    """
+    tenant_a = uuid.uuid4()
+    await _seed_connector(
+        tenant_id=tenant_a,
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        group_count=1,
+        ops_per_group=2,
+    )
+    key, token = _operator_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get("/api/v1/connectors", headers=_authed(token))
+    assert response.status_code == 200
+    by_id = {c["connector_id"]: c for c in response.json()["connectors"]}
+
+    vmware = by_id["vmware-rest-9.0"]
+    assert vmware["state"] == "ingested"
+    # Field is present in the wire shape (Pydantic emits the default) and
+    # explicitly null — the catalog-completion verb only applies to the
+    # registered-but-not-yet-ingested branch.
+    assert "next_step" in vmware
+    assert vmware["next_step"] is None
+
+
+# ---------------------------------------------------------------------------
 # G0.9.1-T1 (#773) listing-integrity contract
 # ---------------------------------------------------------------------------
 

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -445,6 +445,51 @@ Regression test:
 asserts the contract over a seeded DB that includes a stale-rename
 row and a class-side-only opless connector.
 
+#### `next_step` workflow-completion hint (G0.13-T3 / #1133)
+
+`state="registered"` rows carry a `next_step: NextStep` object that
+points at the verb that closes the workflow gap surfaced by the
+v0.6.0 RDC dogfood (signal 11: half-registered connectors fail
+lookup with no in-product hint about what verb closes the workflow).
+`state="ingested"` rows set `next_step` to `null` because the
+dispatcher already resolves operations against them — there is no
+operator action remaining.
+
+The hint comes from `_next_step_for_registered` in `list_connectors.py`.
+It consults the connector-spec catalog (`ingest/catalog.py`, #743) and
+emits one of two verb shapes:
+
+* **Catalog hit** — verb points at `meho connector ingest --catalog
+  <product>/<version>`. Rationale says the spec is available in the
+  catalog. The CLI's `meho connector ingest --catalog ...` form
+  (G0.7-T5 / #405) drives the rest of the workflow.
+* **Catalog miss** — verb points at `meho connector ingest --product
+  <p> --version <v> --impl <i> --spec <upstream-openapi-uri>`.
+  Rationale calls out the missing catalog entry so the operator
+  knows they need to source the OpenAPI spec themselves.
+
+The catalog lookup uses the **registry's** `(product, version)`, not
+the parser-derived shortening. The SDDC case is canonical: the
+catalog stores `product="sddc-manager"`, the listing emits
+`product="sddc"`, but the hint says `--catalog sddc-manager/9.0`
+because that is what `meho connector ingest --catalog ...` resolves
+against. Looking up the parsed product would always miss for SDDC.
+
+If `load_catalog()` raises `CatalogError` at listing time (only
+possible mid-test-monkeypatch or mid-reload — startup parse failures
+crash the lifespan), the helper degrades to the manual-mode
+rationale rather than 500ing the route. A `next_step_catalog_load_failed`
+log line is emitted so the observability trail flags the degraded
+path.
+
+Regression tests:
+`tests/test_api_v1_connectors_ingest.py::test_list_registered_row_carries_catalog_next_step_hint`
+(catalog-hit branch incl. SDDC's registry-vs-parsed asymmetry),
+`::test_list_registered_row_without_catalog_entry_points_at_manual_mode`
+(catalog-miss branch), and
+`::test_list_ingested_row_omits_next_step_hint`
+(ingested-row contract: field present, value `null`).
+
 ### API request / response models (`ingest/api_schemas.py`)
 
 The shared Pydantic-v2 surface T5 (CLI), T6 (REST), and T7 (MCP) all
@@ -461,6 +506,15 @@ consume so the wire contract is defined once:
   for DB-backed rows the dispatcher can resolve and `"registered"`
   for class-side-only rows the dispatcher cannot resolve yet — see
   the listing-integrity contract section above.
+  `ConnectorListItem.next_step` (G0.13-T3 / #1133) is the workflow-
+  completion hint: a `NextStep` object (verb + rationale) on
+  `state="registered"` rows, `null` on `state="ingested"` rows — see
+  the next-step hint section above.
+* `NextStep` (G0.13-T3 / #1133) — `{verb, rationale}` pair surfaced
+  on `state="registered"` rows. `verb` is a copy/pasteable
+  `meho connector ingest ...` invocation; `rationale` is one
+  sentence explaining why that verb is the right next step
+  (catalog-hit vs catalog-miss).
 * `EditGroupBody` / `EditOpBody` — PATCH bodies for the per-group
   and per-op edit verbs. Pydantic enforces the bounded enum for
   `safety_level` and the empty-body rejection lands as a service-


### PR DESCRIPTION
## Summary

- `GET /api/v1/connectors` now ships a `next_step: NextStep | null` field on every row. `state="registered"` rows carry a copy/pasteable `meho connector ingest --catalog <product>/<version>` verb (when the connector-spec catalog #743 has the entry) or a manual-mode `meho connector ingest --product ... --version ... --impl ... --spec <upstream-openapi-uri>` verb (when it doesn't). `state="ingested"` rows set `next_step` to `null` — the dispatcher already resolves them.
- Closes the v0.6.0 RDC dogfood signal 11 framing: half-registered connectors fail lookup with no in-product hint about what closes the workflow. Surfaces the right verb as structured response data instead of relying on tribal knowledge of `meho connector ingest --catalog ...`.
- Catalog lookup uses the v2-registry's `(product, version)`, not the parser-derived shortening, so SDDC (`registry="sddc-manager"` / `parsed="sddc"`) resolves to `--catalog sddc-manager/9.0` not `--catalog sddc/9.0`.

## Phase 4 pushback — Part B dropped

The task body proposed a `meho connector enable <connector_id>` convenience verb that does the catalog lookup + ingest in one shot. Phase 4 critical review found that **`meho connector enable <connector_id>` already exists** in the CLI tree (`cli/internal/cmd/connector/enable.go`) with distinct state-machine semantics: it POSTs to `/api/v1/connectors/<id>/enable` to transition a staged connector to `enabled` (operations become dispatchable).

Adding a second meaning to the same verb name would:

1. Break the staged→enabled review gate (a connector with `state=registered` would skip the operator-review step entirely).
2. Make verb behaviour depend on connector state in a confusing way (lookup-then-ingest for `registered`, transition for `staged|disabled`).

The task body's explicit carve-out applies: "If Part B is contentious (it's a thin wrapper), Part A alone closes the signal." So this PR ships Part A only. If a catalog-lookup-then-ingest convenience verb is still wanted, file a follow-up under a different name (e.g. `meho connector quick-ingest <connector_id>`).

## Test plan

- [x] `ruff check` / `ruff format --check` / `mypy` — all clean against `src/meho_backplane/` + touched tests.
- [x] `pytest tests/test_api_v1_connectors_ingest.py` — 41 passed (incl. 3 new `next_step` assertions: catalog-hit incl. SDDC asymmetry, catalog-miss manual-mode, ingested-row null contract).
- [x] `pytest tests/test_mcp_tools_connector_admin.py` — 16 passed (MCP path picks up the new field through the shared `list_ingested_connectors` + `model_dump(mode="json")`).
- [x] Broader `pytest tests/ --ignore=acceptance --ignore=integration -n auto` — 4720 passed, 13 skipped, 0 failed.
- [x] `code-quality.py --diff` — 0 blockers (function-size refactors: extracted `_emit_db_backed_rows`, `_maybe_build_class_only_item`, `_resolve_class_only_natural_key`).
- [x] `make snapshot-openapi` — no diff (list endpoint is untyped at the route layer, so adding fields to `ConnectorListItem` doesn't move the snapshot).

## Acceptance criteria

- [x] Listing rows with `state="registered"` include a `next_step` field with `verb` + `rationale`; ingested rows set it to `null` (contract documented in `ConnectorListItem` + `NextStep` docstrings + `docs/codebase/spec-ingestion.md`).
- [x] The hint correctly distinguishes "catalog has it" from "catalog doesn't have it"; the latter points at manual-mode `--spec`.
- [x] Test asserts the hint shape for both branches against a fixtured catalog (catalog-hit covers Harbor + SDDC's registry-vs-parsed asymmetry; catalog-miss uses a synthetic `custom-vendor/1.0` v2 registration).
- [x] `Python (ruff + mypy + pytest)` green.
- [ ] (Part B, optional) `meho connector enable <connector_id>` convenience verb — **dropped per Phase 4 pushback**; verb name already taken by the staged→enabled transition.

## Out of scope

- Part B convenience verb (see Phase 4 pushback above).
- CLI `meho connector list` decoder changes — Go's `encoding/json` ignores unknown fields by default, so the existing `Summary` struct keeps working without `NextStep`. Surfacing the hint in the human `list` table is a separate UX choice (could ship in a follow-up if wanted).
- Underlying state-machine changes — `state=registered → state=ingested` transitions already work via `meho connector ingest`; only discoverability changes here.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1133
