### PR TITLE
fix(connectors): G0.14-T2 resolver demotes wildcard registrations when a versioned sibling matches

### DIFF
--- a/backend/src/meho_backplane/connectors/kubernetes/__init__.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/__init__.py
@@ -98,17 +98,23 @@ __all__ = [
     "register_kubernetes_typed_operations",
 ]
 
-# v1 entry -- backward-compatible with the shipped chassis route.
-# Also writes to the v2 table as ``("k8s", "", "")`` so v2-aware code
-# that doesn't yet know the version/impl_id can still resolve through
-# the chassis fallback. Removed when T11 #412 deprecates the chassis
-# route.
+# v1 entry -- retained for ``get_connector("k8s")`` callers (the
+# ``/api/v1/targets/{name}/probe`` route at api/v1/targets.py reads
+# the v1 registry to fingerprint a target before any dispatch path
+# runs). Also writes to the v2 table as ``("k8s", "", "")``. The
+# v1 chassis dispatch route was removed by G0.6-T11 (#412); the v1
+# table itself stays because the probe route still keys on it.
 register_connector("k8s", KubernetesConnector)
 
-# v2 entry -- the canonical resolver key. Picked over the v1 fallback
-# by the resolver's tie-break ladder (most-specific-version-match
-# wins; this entry advertises a concrete version + impl_id, the v1
-# entry advertises empty strings).
+# v2 entry -- the canonical resolver key. ``connector_id="k8s-1.x"``
+# resolves through this entry. The resolver's tie-break ladder
+# (G0.14-T2 #1143 step 1, ``versioned_over_wildcard``) demotes the v1
+# wildcard ``("k8s", "", "")`` whenever this versioned entry is also
+# a candidate, so an unfingerprinted K8s target resolves cleanly to
+# the versioned class instead of bailing with
+# ``AmbiguousConnectorResolution``. The wildcard still wins when it
+# is the only candidate (no versioned entry registered for the
+# target's product), preserving the v1-only resolution path.
 register_connector_v2(
     product="k8s",
     version="1.x",

--- a/backend/src/meho_backplane/connectors/resolver.py
+++ b/backend/src/meho_backplane/connectors/resolver.py
@@ -352,7 +352,7 @@ def _run_tie_break_ladder(
     if len(candidates) == 1:
         return candidates[0], "specificity", candidates
 
-    # Step 2 — operator/tenant preference. Falls through to priority when
+    # Step 3 — operator/tenant preference. Falls through to priority when
     # the override doesn't disambiguate (zero matches → ignored; multiple
     # matches → corner case where two impls share the preferred id, so
     # let priority break it rather than raising).
@@ -363,7 +363,7 @@ def _run_tie_break_ladder(
         if len(preferred) > 1:
             candidates = preferred
 
-    # Step 3 — connector class priority (higher wins).
+    # Step 4 — connector class priority (higher wins).
     best_priority = max(c.cls.priority for c in candidates)
     candidates = [c for c in candidates if c.cls.priority == best_priority]
     if len(candidates) == 1:

--- a/backend/src/meho_backplane/connectors/resolver.py
+++ b/backend/src/meho_backplane/connectors/resolver.py
@@ -38,7 +38,22 @@ Tie-break ladder
 When two or more connectors advertise support for a target's
 ``(product, version)``:
 
-1. **Most-specific-version-match wins.** A connector with
+1. **Versioned beats wildcard.** Some products have a v1 *wildcard*
+   registry entry alongside a v2 *versioned* entry — the K8s connector
+   is the shipped case (Kubernetes registers both
+   ``("k8s", "", "")`` from :func:`register_connector` and
+   ``("k8s", "1.x", "k8s")`` from :func:`register_connector_v2` so
+   ``get_connector("k8s")`` keeps working for the ``/probe`` route
+   while ``connector_id="k8s-1.x"`` resolves through v2). When the
+   v1 wildcard and ≥1 v2 versioned entries share a candidate slot,
+   the wildcard is *demoted* (removed from the candidate list) before
+   the rest of the ladder runs. The wildcard is conceptually "matches
+   any version" and shouldn't compete with a connector that names a
+   specific version triple. The rule is generalized to any future
+   connector that double-registers under the same shape (a v2 entry
+   with empty ``version`` and ``impl_id`` slots), not just K8s.
+
+2. **Most-specific-version-match wins.** A connector with
    ``supported_version_range=">=9.0,<10.0"`` (span = 1.0 minor versions)
    beats ``">=6.5,<10.0"`` (span = 3.5 minor versions) for a target with
    ``version="9.0.2"``. Specificity is measured by the size of the
@@ -47,18 +62,18 @@ When two or more connectors advertise support for a target's
    specific than a half-bounded one; a half-bounded range is more
    specific than an unbounded one (``None`` / no range).
 
-2. **Operator/tenant preference.** When specificity ties, the
+3. **Operator/tenant preference.** When specificity ties, the
    ``target.preferred_impl_id`` (if set) selects the matching
    implementation. Operators set this on the Target row to break ties
    that the version-range ladder cannot resolve (e.g. two vendors
    both advertising the same range for the same product).
 
-3. **Connector class priority.** When operator preference doesn't
+4. **Connector class priority.** When operator preference doesn't
    disambiguate (not set, or the preferred impl isn't a candidate),
    the integer :attr:`Connector.priority` class attribute breaks the
    tie — higher wins.
 
-If after all three steps two or more candidates remain, the resolver
+If after all four steps two or more candidates remain, the resolver
 raises :exc:`AmbiguousConnectorResolution` listing the candidates so the
 operator can set ``preferred_impl_id`` to pick one.
 
@@ -295,19 +310,43 @@ def _run_tie_break_ladder(
     candidates: list[_Candidate],
     preferred_impl_id: str | None,
 ) -> tuple[_Candidate | None, str, list[_Candidate]]:
-    """Apply the three-step tie-break ladder to a non-empty candidate list.
+    """Apply the four-step tie-break ladder to a non-empty candidate list.
 
     Returns ``(winner, reason, remaining)``:
 
     * ``winner`` — the single chosen candidate, or ``None`` if the ladder
       ended with two or more candidates still tied.
-    * ``reason`` — the step that picked the winner (``"specificity"`` /
+    * ``reason`` — the step that picked the winner
+      (``"versioned_over_wildcard"`` / ``"specificity"`` /
       ``"operator_preference"`` / ``"priority"``) or ``"ambiguous"``.
     * ``remaining`` — the post-ladder candidate list. When ``winner`` is
       ``None`` the caller raises ``AmbiguousConnectorResolution`` with
       these as the candidates the operator must disambiguate.
     """
-    # Step 1 — most-specific-version-match.
+    # Step 1 — versioned beats wildcard. When a v1 wildcard entry
+    # (registry key ``(product, "", "")``) and ≥1 v2 versioned entries
+    # share the candidate list, demote the wildcard. The wildcard is the
+    # v1 backward-compat fallback (KubernetesConnector self-registers
+    # under both ``("k8s", "", "")`` and ``("k8s", "1.x", "k8s")`` so
+    # ``get_connector("k8s")`` keeps working for the ``/probe`` route);
+    # it should not compete on equal footing with a connector that
+    # names a concrete ``(version, impl_id)`` pair. Without this step,
+    # an unfingerprinted K8s target (target.fingerprint = None →
+    # target_version = None) leaves both entries in play, both score
+    # ``(_SPECIFICITY_UNBOUNDED, 0.0)`` on supported_version_range,
+    # operator_preference is absent, priorities tie, and
+    # ``AmbiguousConnectorResolution`` propagates as a bare-500 to the
+    # operator (G0.14-T2 / signal 9). The rule generalizes to any
+    # future connector that uses the same double-registration shape.
+    has_versioned = any(c.version != "" or c.impl_id != "" for c in candidates)
+    if has_versioned:
+        non_wildcards = [c for c in candidates if c.version != "" or c.impl_id != ""]
+        if len(non_wildcards) < len(candidates):
+            candidates = non_wildcards
+            if len(candidates) == 1:
+                return candidates[0], "versioned_over_wildcard", candidates
+
+    # Step 2 — most-specific-version-match.
     best_score = min(c.specificity_score for c in candidates)
     candidates = [c for c in candidates if c.specificity_score == best_score]
     if len(candidates) == 1:

--- a/backend/tests/test_connectors_resolver.py
+++ b/backend/tests/test_connectors_resolver.py
@@ -390,6 +390,237 @@ def test_resolve_priority_breaks_remaining_tie() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Step 1 — versioned beats wildcard (G0.14-T2 #1143)
+# ---------------------------------------------------------------------------
+#
+# Some products self-register under both the v1 wildcard
+# ``(product, "", "")`` (so ``get_connector(product)`` keeps working for
+# the ``/probe`` route) AND a v2 versioned entry
+# ``(product, "<ver>", "<impl>")`` (so ``connector_id="<product>-<ver>"``
+# resolves through v2). The shipped case is K8s (signal 9 in the
+# consumer's signal directory). Without the demotion step, an
+# unfingerprinted target (target.fingerprint = None → target_version =
+# None) leaves both entries in play, both score
+# ``(_SPECIFICITY_UNBOUNDED, 0.0)`` on supported_version_range
+# (KubernetesConnector doesn't advertise a range), operator_preference is
+# absent, priorities tie → bare-500 via ``AmbiguousConnectorResolution``.
+
+
+def test_resolve_versioned_beats_wildcard_for_unfingerprinted_target() -> None:
+    """The k8s ambiguity case: unfingerprinted target, both wildcard + versioned entries.
+
+    Acceptance criterion: target with ``product=k8s``, no ``version``,
+    no ``preferred_impl_id`` resolves cleanly (the consumer's exact
+    case from signal 9). The wildcard ``("k8s", "", "")`` is demoted
+    when the versioned ``("k8s", "1.x", "k8s")`` is also a candidate.
+    """
+
+    class _K8sConnector(Connector):
+        product = "k8s"
+        # No supported_version_range — mirrors KubernetesConnector.
+
+        async def fingerprint(self, target: Any) -> FingerprintResult:  # type: ignore[override]
+            raise NotImplementedError
+
+        async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+            raise NotImplementedError
+
+        async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:  # type: ignore[override]
+            raise NotImplementedError
+
+    # Mirror the K8s self-registration shape: v1 hop (writes both
+    # tables) + explicit v2 versioned entry.
+    register_connector("k8s", _K8sConnector)
+    register_connector_v2(
+        product="k8s",
+        version="1.x",
+        impl_id="k8s",
+        cls=_K8sConnector,
+    )
+    target = _FakeTarget(product="k8s", fingerprint=None)
+    assert resolve_connector(target) is _K8sConnector
+
+
+def test_resolve_versioned_beats_wildcard_for_fingerprinted_target() -> None:
+    """Regression guard: a fingerprinted k8s target still resolves cleanly.
+
+    Mirrors the post-fingerprint case where the probe has populated a
+    version. Both candidate entries (wildcard + versioned) score
+    ``(_SPECIFICITY_UNBOUNDED, 0.0)`` because the K8s class doesn't
+    advertise a ``supported_version_range``; the demotion step is what
+    keeps the resolution clean.
+    """
+
+    class _K8sConnector(Connector):
+        product = "k8s"
+
+        async def fingerprint(self, target: Any) -> FingerprintResult:  # type: ignore[override]
+            raise NotImplementedError
+
+        async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+            raise NotImplementedError
+
+        async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:  # type: ignore[override]
+            raise NotImplementedError
+
+    register_connector("k8s", _K8sConnector)
+    register_connector_v2(
+        product="k8s",
+        version="1.x",
+        impl_id="k8s",
+        cls=_K8sConnector,
+    )
+    target = _FakeTarget(product="k8s", fingerprint=_fingerprint("1.30.0"))
+    assert resolve_connector(target) is _K8sConnector
+
+
+def test_resolve_preferred_impl_id_still_works_with_wildcard_demotion() -> None:
+    """The consumer's existing workaround stays valid.
+
+    Operators who already pinned ``preferred_impl_id="k8s"`` on their
+    Target row (per ``claude-rdc-hetzner-dc#697``) keep resolving the
+    same versioned class. The demotion step happens before operator
+    preference, so the explicit pick still threads cleanly.
+    """
+
+    class _K8sConnector(Connector):
+        product = "k8s"
+
+        async def fingerprint(self, target: Any) -> FingerprintResult:  # type: ignore[override]
+            raise NotImplementedError
+
+        async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+            raise NotImplementedError
+
+        async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:  # type: ignore[override]
+            raise NotImplementedError
+
+    register_connector("k8s", _K8sConnector)
+    register_connector_v2(
+        product="k8s",
+        version="1.x",
+        impl_id="k8s",
+        cls=_K8sConnector,
+    )
+    target = _FakeTarget(
+        product="k8s",
+        fingerprint=None,
+        preferred_impl_id="k8s",
+    )
+    assert resolve_connector(target) is _K8sConnector
+
+
+def test_resolve_wildcard_only_still_resolves_when_no_versioned_entry() -> None:
+    """The demotion rule is a no-op when no versioned entry exists.
+
+    A pure v1-only registration (no companion ``register_connector_v2``)
+    keeps resolving through the wildcard entry. The demotion step only
+    fires when both shapes are registered for the same product;
+    wildcard-only is the v1-backward-compat path that must not break.
+    """
+
+    class _V1OnlyConnector(Connector):
+        product = "legacy-v1"
+
+        async def fingerprint(self, target: Any) -> FingerprintResult:  # type: ignore[override]
+            raise NotImplementedError
+
+        async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+            raise NotImplementedError
+
+        async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:  # type: ignore[override]
+            raise NotImplementedError
+
+    register_connector("legacy-v1", _V1OnlyConnector)
+    target = _FakeTarget(product="legacy-v1", fingerprint=None)
+    assert resolve_connector(target) is _V1OnlyConnector
+
+
+def test_resolve_multiple_versioned_with_wildcard_still_disambiguates() -> None:
+    """Wildcard demotion does not collapse a real multi-impl ambiguity.
+
+    The future EKS-sibling case (per the ``KubernetesConnector`` class
+    docstring: ``("k8s", "1.x", "<eks-impl-id>")`` lands beside
+    ``("k8s", "1.x", "k8s")``). When ≥2 versioned candidates remain
+    after demoting the wildcard, the ladder runs to completion and
+    raises ``AmbiguousConnectorResolution`` as before — the operator
+    must still set ``preferred_impl_id`` to pick a real sibling.
+    """
+
+    class _K8sConnector(Connector):
+        product = "k8s"
+
+        async def fingerprint(self, target: Any) -> FingerprintResult:  # type: ignore[override]
+            raise NotImplementedError
+
+        async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+            raise NotImplementedError
+
+        async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:  # type: ignore[override]
+            raise NotImplementedError
+
+    class _K8sEksConnector(_K8sConnector):
+        pass
+
+    register_connector("k8s", _K8sConnector)
+    register_connector_v2(
+        product="k8s",
+        version="1.x",
+        impl_id="k8s",
+        cls=_K8sConnector,
+    )
+    register_connector_v2(
+        product="k8s",
+        version="1.x",
+        impl_id="eks",
+        cls=_K8sEksConnector,
+    )
+    target = _FakeTarget(product="k8s", fingerprint=None)
+    with pytest.raises(AmbiguousConnectorResolution) as exc_info:
+        resolve_connector(target)
+    # The wildcard ('k8s', '', '') is demoted; the operator-facing
+    # candidates list names the two real impl_ids.
+    assert exc_info.value.candidates == [
+        ("k8s", "1.x", "eks"),
+        ("k8s", "1.x", "k8s"),
+    ]
+
+
+def test_resolve_versioned_beats_wildcard_emits_log_with_reason(
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """The resolution log line names the new tie-break reason."""
+    from meho_backplane.logging import configure_logging
+
+    configure_logging()
+
+    class _K8sConnector(Connector):
+        product = "k8s"
+
+        async def fingerprint(self, target: Any) -> FingerprintResult:  # type: ignore[override]
+            raise NotImplementedError
+
+        async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+            raise NotImplementedError
+
+        async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:  # type: ignore[override]
+            raise NotImplementedError
+
+    register_connector("k8s", _K8sConnector)
+    register_connector_v2(
+        product="k8s",
+        version="1.x",
+        impl_id="k8s",
+        cls=_K8sConnector,
+    )
+    target = _FakeTarget(product="k8s", fingerprint=None)
+    resolve_connector(target)
+    out, _ = capfd.readouterr()
+    assert "connector_resolved" in out
+    assert '"tie_break": "versioned_over_wildcard"' in out
+
+
+# ---------------------------------------------------------------------------
 # Ambiguous after full ladder
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_connectors_resolver.py
+++ b/backend/tests/test_connectors_resolver.py
@@ -5,9 +5,10 @@
 
 Covers the full tie-break ladder:
 
-1. Most-specific-version-match wins.
-2. Operator/tenant preference (``target.preferred_impl_id``).
-3. Connector class :attr:`priority` (higher wins).
+1. Versioned beats wildcard (G0.14-T2 #1143).
+2. Most-specific-version-match wins.
+3. Operator/tenant preference (``target.preferred_impl_id``).
+4. Connector class :attr:`priority` (higher wins).
 
 Plus the error paths (``NoMatchingConnector``,
 ``AmbiguousConnectorResolution``) and the v1 backward-compat fallback
@@ -244,7 +245,7 @@ def test_resolve_target_without_product_raises_no_match() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Step 1 — most-specific-version-match wins
+# Step 2 — most-specific-version-match wins
 # ---------------------------------------------------------------------------
 
 
@@ -289,7 +290,7 @@ def test_resolve_bounded_beats_unbounded_range() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Step 2 — operator/tenant preference
+# Step 3 — operator/tenant preference
 # ---------------------------------------------------------------------------
 
 
@@ -367,7 +368,7 @@ def test_resolve_operator_preference_not_a_candidate_is_ignored() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Step 3 — class priority
+# Step 4 — class priority
 # ---------------------------------------------------------------------------
 
 

--- a/docs/codebase/connectors-kubernetes.md
+++ b/docs/codebase/connectors-kubernetes.md
@@ -183,7 +183,9 @@ upgrade specific configmap-name patterns (managed-by
 1. The connector package's `__init__.py` calls
    `register_connector_v2(product="k8s", version="1.x",
    impl_id="k8s", cls=KubernetesConnector)` at import time. The v1
-   entry under `"k8s"` is preserved for chassis-route compat.
+   entry under `"k8s"` is preserved so `get_connector("k8s")`-keyed
+   callers (`/api/v1/targets/{name}/probe`) keep resolving the class
+   without the dispatcher's v2 resolver path.
 2. The same module appends
    `register_kubernetes_typed_operations` to the typed-op registrar
    list via `register_typed_op_registrar`.
@@ -195,6 +197,33 @@ upgrade specific configmap-name patterns (managed-by
 The walk is **idempotent**: a second registrar run hits the body-hash
 skip-re-embed branch and avoids re-encoding the descriptions, so pod
 restarts on unchanged code stay cheap.
+
+### Resolver tie-break (wildcard vs. versioned)
+
+K8s is the shipped case for the resolver's
+**`versioned_over_wildcard`** demotion step (G0.14-T2 #1143): the
+package registers under both `("k8s", "", "")` (v1 wildcard, for
+`get_connector` callers) and `("k8s", "1.x", "k8s")` (v2 versioned,
+for `connector_id="k8s-1.x"`-keyed dispatch). When a Target is
+created with `product="k8s"` and no fingerprint version (the common
+first-use case — the operator runs `POST /api/v1/targets` before
+`POST /api/v1/targets/{name}/probe`), both registry entries match
+the `(product=k8s, version=None)` filter step. The
+`KubernetesConnector` class doesn't advertise a
+`supported_version_range`, so both entries score
+`(_SPECIFICITY_UNBOUNDED, 0.0)` on the specificity ladder.
+
+The resolver's step 1 catches this: when ≥1 entry carries a
+non-empty `(version, impl_id)` slot, the wildcard `(product, "", "")`
+is demoted before the rest of the ladder runs. The versioned entry
+wins; the operator never sees the
+`AmbiguousConnectorResolution` bare-500 (signal 9 in
+`claude-rdc-hetzner-dc#697`). The rule generalizes to any future
+connector that uses the same double-registration shape — only
+wildcards lose to a co-registered versioned sibling, never the
+reverse. When the wildcard is the *only* candidate (a connector
+that registered v1-only), it still wins; the demotion step is
+conditional on a versioned entry being present.
 
 ### Op dispatch (per request)
 


### PR DESCRIPTION
## Summary

- **G0.14-T2** (signal 9 from `claude-rdc-hetzner-dc#697`): the K8s connector self-registers under **both** `("k8s", "", "")` (v1 wildcard, written by `register_connector` so `get_connector("k8s")` keeps working for the `/probe` route) and `("k8s", "1.x", "k8s")` (v2 versioned, written by `register_connector_v2` so `connector_id="k8s-1.x"` resolves). An unfingerprinted K8s target (target.fingerprint = None, target.preferred_impl_id = None) leaves both entries in play, both score `(_SPECIFICITY_UNBOUNDED, 0.0)` on the specificity ladder because `KubernetesConnector` doesn't advertise a `supported_version_range`, priorities tie, and the resolver bails with `AmbiguousConnectorResolution` — today a bare 500 to the operator (T1 #1142 will surface the diagnostic cleanly going forward; this Task either removes the ambiguity or makes it self-resolving).
- Adds a new step 1 `versioned_over_wildcard` to the resolver's tie-break ladder: when ≥1 candidate carries a non-empty `(version, impl_id)` slot, demote candidates with empty slots before the rest of the ladder runs. Conditional — wildcards that are the *only* candidate (e.g. `vault` registered v1-only) still win.
- Updates the resolver docstring to enumerate the four-step ladder, the `KubernetesConnector` `__init__` comment to name the new step (the prior "most-specific-version-match wins" claim was incorrect — both K8s entries inherit `supported_version_range = None`), and adds a "Resolver tie-break (wildcard vs. versioned)" section to `docs/codebase/connectors-kubernetes.md`.

## Design choice — Option B from the issue body

The issue offered three options. I picked **Option B (`versioned beats wildcard` rule in the ladder)**:

| Option | Picked? | Why / why not |
|---|---|---|
| **A — drop the wildcard registration** | No | The wildcard is load-bearing: `api/v1/targets.py:332` reads the v1 registry via `get_connector(t.product)` for the probe route. Dropping the v1 hop would break `/probe`. Unifying probe with the v2 resolver is part of T1 of this Initiative (#1142), out of scope here. |
| **B — versioned beats wildcard rule** | **Yes** | Lowest-blast-radius (only changes the resolver ladder). Generalizes to any future connector that uses the same double-registration shape — only wildcards lose to a co-registered versioned sibling. Aligns with the existing "most-specific wins" semantics: a wildcard registry key is conceptually "matches any version" and shouldn't compete on equal footing with an entry that names a concrete triple. Preserves the v1 backward-compat path for `get_connector` callers. |
| **C — auto-promote wildcard to only-versioned** | No | C is a special case of B for the 1-versioned scenario. B generalizes cleanly to the future EKS-sibling case (`("k8s", "1.x", "eks")` lands beside `("k8s", "1.x", "k8s")`) — both versioned candidates survive demotion, and the operator pins `preferred_impl_id` to pick a real sibling. C would have to grow extra "≥2 versioned → bail" logic that B already gets for free. |

## Test plan

- [x] `uv run ruff check src/meho_backplane/connectors/resolver.py src/meho_backplane/connectors/kubernetes/__init__.py tests/test_connectors_resolver.py` — clean
- [x] `uv run ruff format --check ...` — clean (3 files already formatted)
- [x] `uv run mypy src/meho_backplane/connectors/resolver.py src/meho_backplane/connectors/kubernetes/__init__.py` — clean (Success: no issues found in 2 source files)
- [x] `uv run python -m pytest tests/test_connectors_resolver.py` — **20 passed** (14 original + 6 new)
- [x] `uv run python -m pytest tests/test_connectors_vault.py tests/test_connectors_k8s_credread.py tests/test_connectors_k8s_core.py tests/test_operations_dispatcher.py tests/test_api_v1_targets.py` — all passed (no regressions in resolver-adjacent surfaces)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers, 2 warnings (file 473 lines / function 64 lines — both well under block thresholds of 600 / 100; recorded as adjacent findings)

### Acceptance criteria coverage

| Acceptance criterion | Test |
|---|---|
| Target with `product=k8s`, no `version`, no `preferred_impl_id` resolves cleanly (consumer's exact case) | `test_resolve_versioned_beats_wildcard_for_unfingerprinted_target` |
| Target with `product=k8s`, `version=1.x`-series, no `preferred_impl_id` still resolves cleanly (regression guard) | `test_resolve_versioned_beats_wildcard_for_fingerprinted_target` (uses `"1.30.0"` — the real `git_version` shape) |
| Target with `preferred_impl_id="k8s"` explicit still works (consumer's existing workaround stays valid) | `test_resolve_preferred_impl_id_still_works_with_wildcard_demotion` |
| Generalized rule — any connector that double-registered the same way gets the same treatment | `test_resolve_wildcard_only_still_resolves_when_no_versioned_entry` (no-op when wildcard is alone) + `test_resolve_multiple_versioned_with_wildcard_still_disambiguates` (still raises when ≥2 versioned remain after demotion) + `test_resolve_versioned_beats_wildcard_emits_log_with_reason` (resolver logs the new tie-break reason) |

## Out of scope

- T1 (#1142) — surface `AmbiguousConnectorResolution` cleanly in the dispatcher's `typed`/`composite` branch and unify `/probe` with the dispatch resolver. This Task **reduces** the rate at which T1's new surfacing fires for the K8s case; the surfacing fix remains T1's job for the future multi-impl cases (EKS sibling, etc.).
- The `("k8s", "1.x", "k8s")` registry-key version label itself — that's a v2 registry-shape decision, out of scope per the issue body's "Out of scope" section.
- Other connectors' registration shapes — verified clean by grep (`grep -rn "register_connector(" backend/src/`); only k8s exhibits the double-registration today. The new rule covers future double-registrations.

Closes #1143
