### PR TITLE
fix(connectors): G0.13-T5 /api/v1/connectors/{id}/review two-pass tenant lookup

### DIFF
--- a/backend/src/meho_backplane/operations/ingest/service.py
+++ b/backend/src/meho_backplane/operations/ingest/service.py
@@ -227,8 +227,54 @@ class ReviewService:
 
         No audit row is written; the surrounding HTTP / MCP request
         already audits the read at the chassis layer.
+
+        Visibility scope mirrors :func:`list_ingested_connectors`:
+        an operator sees rows under their own tenant **and** built-in
+        (``tenant_id IS NULL``) rows. When *tenant_id* equals the
+        operator's tenant and that probe misses, the lookup falls
+        back to ``tenant_id IS NULL`` so a ``GET
+        /api/v1/connectors/{id}/review`` against a global connector
+        returns 200 instead of 404 (G0.13-T5 #1135). When *tenant_id*
+        is passed explicitly as ``None`` (MCP admin path), the
+        existing admin-only gate stays; when it's any other UUID
+        (cross-tenant probe), the lookup stays single-pass and the
+        cross-tenant 404 conflation is preserved.
         """
         scope = self._resolve_scope(connector_id, tenant_id)
+        try:
+            return await self._render_payload(connector_id, scope)
+        except ConnectorNotFoundError:
+            if tenant_id is None or tenant_id != self._operator.tenant_id:
+                # Explicit built-in probe (MCP admin path) or genuine
+                # cross-tenant probe — no fall-through. The original
+                # 404 stays.
+                raise
+            # Operator's own-tenant probe missed; try the built-in
+            # scope. Build a fresh scope tuple with tenant_id=None;
+            # bypass _authorize_scope's admin-only gate intentionally
+            # because read access to built-ins is operator-level
+            # (matches the list endpoint).
+            fallback_scope = ConnectorScope(
+                product=scope.product,
+                version=scope.version,
+                impl_id=scope.impl_id,
+                tenant_id=None,
+            )
+            return await self._render_payload(connector_id, fallback_scope)
+
+    async def _render_payload(
+        self,
+        connector_id: str,
+        scope: ConnectorScope,
+    ) -> ConnectorReviewPayload:
+        """Load groups + ops for *scope* and pack them into the payload.
+
+        Raises :class:`ConnectorNotFoundError` when no group rows
+        exist under *scope*. Extracted from :meth:`get_review_payload`
+        so the two-pass tenant lookup there can reuse the same
+        rendering pipeline against a fallback scope without
+        duplicating the DB roundtrip + payload assembly.
+        """
         sessionmaker = self._sessionmaker()
         async with sessionmaker() as session:
             groups = await load_groups(session, scope, connector_id)

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -1095,6 +1095,41 @@ async def test_get_review_cross_tenant_returns_404(
     assert response.status_code == 404
 
 
+@pytest.mark.asyncio
+async def test_get_review_builtin_connector_visible_to_non_admin_operator(
+    client: TestClient,
+) -> None:
+    """G0.13-T5 (#1135): GET /{id}/review on a global (``tenant_id IS NULL``) row.
+
+    The listing endpoint promises "operator's-tenant rows +
+    built-ins" and surfaces them; the review endpoint must honour
+    the same scope rather than 404 on every global. Verifies the
+    full HTTP-to-service two-pass round-trip for a non-admin
+    operator role (the role that hit the bug on the daily-driver
+    path).
+    """
+    operator_tenant = uuid.uuid4()
+    await _seed_connector(
+        tenant_id=None,
+        product="vmware",
+        impl_id="vmware-rest",
+        group_count=2,
+        ops_per_group=3,
+    )
+    key, token = _operator_token(tenant_id=operator_tenant)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/connectors/vmware-rest-9.0/review",
+            headers=_authed(token),
+        )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["connector_id"] == "vmware-rest-9.0"
+    assert body["tenant_id"] is None
+    assert body["total_op_count"] == 6
+
+
 # ---------------------------------------------------------------------------
 # PATCH /{id}/groups/{key}
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_operations_ingest_review.py
+++ b/backend/tests/test_operations_ingest_review.py
@@ -326,6 +326,127 @@ async def test_get_review_payload_no_audit_row_written() -> None:
     assert await _count_audit_rows() == 0
 
 
+@pytest.mark.asyncio
+async def test_get_review_payload_falls_back_to_builtin_for_operator_tenant() -> None:
+    """G0.13-T5 (#1135): operator's-tenant probe falling through to built-in.
+
+    The listing endpoint already returns built-in (``tenant_id IS
+    NULL``) connectors to every operator. The review endpoint's
+    docstring promises the same scope but the route handler calls
+    ``get_review_payload(connector_id, operator.tenant_id)`` — a
+    single-pass lookup with ``WHERE tenant_id = X`` misses every
+    global row. The fix here makes the service do a two-pass lookup:
+    own-tenant first, then ``tenant_id IS NULL``. The non-admin
+    operator role is used deliberately — the bug only surfaced for
+    that role (admins could pass ``tenant_id=None`` directly).
+    """
+    operator_tenant = uuid.uuid4()
+    await _seed_connector(
+        tenant_id=None,  # built-in / global connector
+        group_count=2,
+        ops_per_group=3,
+        review_status="staged",
+    )
+    operator = _make_operator(
+        tenant_id=operator_tenant,
+        role=TenantRole.OPERATOR,
+    )
+    service = ReviewService(operator)
+
+    payload = await service.get_review_payload("vmware-rest-9.0", operator_tenant)
+
+    assert payload.connector_id == "vmware-rest-9.0"
+    assert payload.tenant_id is None  # rendered scope reflects the fallback
+    assert payload.total_op_count == 6
+    assert len(payload.groups) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_review_payload_does_not_fall_back_for_cross_tenant_probe() -> None:
+    """G0.13-T5 (#1135): cross-tenant probes stay 404, not 200.
+
+    The fallback only triggers when the caller passes the operator's
+    own tenant_id. A probe with a *different* tenant_id (operator A
+    asking after tenant B's connector) must keep the existing
+    cross-tenant 404 conflation — otherwise the fix would open a
+    cross-tenant info-leak surface.
+    """
+    tenant_a = uuid.uuid4()
+    tenant_b = uuid.uuid4()
+    # Built-in connector exists; tenant B has nothing.
+    await _seed_connector(
+        tenant_id=None,
+        group_count=1,
+        ops_per_group=1,
+        review_status="staged",
+    )
+    operator = _make_operator(
+        tenant_id=tenant_a,
+        role=TenantRole.OPERATOR,
+    )
+    service = ReviewService(operator)
+
+    with pytest.raises(ConnectorNotFoundError):
+        await service.get_review_payload("vmware-rest-9.0", tenant_b)
+
+
+@pytest.mark.asyncio
+async def test_get_review_payload_non_existent_connector_still_404() -> None:
+    """G0.13-T5 (#1135): genuinely missing connector_id still raises after both passes.
+
+    The two-pass fallback must not mask the "connector doesn't exist
+    anywhere" case: neither the operator's-tenant probe nor the
+    built-in probe finds a row, so the exception still propagates.
+    """
+    operator_tenant = uuid.uuid4()
+    operator = _make_operator(
+        tenant_id=operator_tenant,
+        role=TenantRole.OPERATOR,
+    )
+    service = ReviewService(operator)
+
+    with pytest.raises(ConnectorNotFoundError):
+        await service.get_review_payload("vmware-rest-9.0", operator_tenant)
+
+
+@pytest.mark.asyncio
+async def test_get_review_payload_prefers_tenant_row_over_builtin() -> None:
+    """G0.13-T5 (#1135): when both exist, the operator's-tenant row wins the first pass.
+
+    Defensive guard against the bait-and-switch failure mode: if an
+    operator's tenant has a curated row at ``(product, version,
+    impl_id)`` *and* a built-in row exists at the same key, the
+    fallback must not silently return the built-in. First-pass wins;
+    fallback is only consulted on miss.
+    """
+    operator_tenant = uuid.uuid4()
+    # Tenant-curated row (3 ops total).
+    await _seed_connector(
+        tenant_id=operator_tenant,
+        group_count=1,
+        ops_per_group=3,
+        review_status="staged",
+    )
+    # Built-in row at the same triple (5 ops total — distinct count
+    # so we can tell which payload we got).
+    await _seed_connector(
+        tenant_id=None,
+        group_count=1,
+        ops_per_group=5,
+        review_status="staged",
+    )
+    operator = _make_operator(
+        tenant_id=operator_tenant,
+        role=TenantRole.OPERATOR,
+    )
+    service = ReviewService(operator)
+
+    payload = await service.get_review_payload("vmware-rest-9.0", operator_tenant)
+
+    assert payload.tenant_id == operator_tenant
+    assert payload.total_op_count == 3
+
+
 # ---------------------------------------------------------------------------
 # edit_group
 # ---------------------------------------------------------------------------

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -477,9 +477,29 @@ to the operator-facing HTTP surface. RBAC: read paths (GET /, GET
 (`POST /ingest`, `PATCH /groups`, `PATCH /operations`, `POST
 /enable`, `POST /disable`) require `tenant_admin`. Tenant scoping
 derives from the JWT — there is no body / query parameter that can
-override the operator's tenant. Cross-tenant probes surface as 404
-`ConnectorNotFoundError`, not 403 — same conflation `ReviewService`
-uses to keep the operator-facing failure surface uniform.
+override the operator's tenant.
+
+Both read paths apply the same "operator's-tenant rows + built-ins
+(`tenant_id IS NULL`)" scope: the listing query does it via a
+single `WHERE tenant_id IS NULL OR tenant_id = X` clause, and
+`ReviewService.get_review_payload` mirrors it through a two-pass
+lookup (own-tenant probe first, then built-in fallback when the
+caller's tenant_id matches `operator.tenant_id`). G0.13-T5 (#1135)
+landed the review-route fallback after the v0.6.0 RDC dogfood
+flagged that every global connector in the catalog returned 404
+on review even though the listing surfaced them. Cross-tenant
+probes (`tenant_id` ≠ operator's own) still surface as 404
+`ConnectorNotFoundError` — same conflation `ReviewService` uses
+to keep the operator-facing failure surface uniform and stop
+status-code differential from enumerating other tenants.
+
+The PATCH editing routes (`/groups`, `/operations`) deliberately
+keep their single-pass lookup against the operator's `tenant_id`:
+"do tenant_admins get to edit built-ins?" is a policy choice
+distinct from the read-visibility bug, and the route gate is
+`tenant_admin`-only — built-in writes already have an explicit
+MCP / CLI affordance (`ReviewService` accepts `tenant_id=None`
+under the `TENANT_ADMIN` role).
 
 The `op_id` path segment uses the `:path` converter so operations
 whose natural key contains slashes (`"GET:/api/vcenter/cluster"`)


### PR DESCRIPTION
## Summary

- `GET /api/v1/connectors/{id}/review` now applies the same "operator's-tenant + built-ins" scope as `GET /api/v1/connectors` — global (`tenant_id IS NULL`) connectors stop returning 404 on the daily-driver path (RDC v0.6.0 closed-loop validate signal `connector-review-tenant-scope-404`).
- The fix is service-layer only: `ReviewService.get_review_payload` falls back to `tenant_id IS NULL` when the operator's own-tenant probe misses. The route handler stays untouched per the task scope; the PATCH edit routes also stay single-pass (the "do tenant_admins edit built-ins?" policy decision is intentionally distinct from this read-visibility bug).
- Cross-tenant probes still 404 — the fallback only triggers when the caller passes the operator's *own* `tenant_id`. The MCP explicit-built-in path (`tenant_id=None` argument) keeps its admin-only gate because that's a deliberate built-in probe, not a fall-through.
- `docs/codebase/spec-ingestion.md` updated to describe the two-pass scope and the PATCH-route divergence.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy` — no issues
- [x] `pytest backend/tests/test_operations_ingest_review.py` — 39 passed (4 new tests)
- [x] `pytest backend/tests/test_api_v1_connectors_ingest.py` — 39 passed (1 new test)
- [x] `pytest backend/tests/test_mcp_tools_connector_admin.py` — 16 passed (regression guard for the shared service)
- [x] AC #1 (global-row review returns 200): `test_get_review_builtin_connector_visible_to_non_admin_operator` (API) + `test_get_review_payload_falls_back_to_builtin_for_operator_tenant` (service)
- [x] AC #2 (cross-tenant still 404): `test_get_review_cross_tenant_returns_404` (pre-existing, still green) + `test_get_review_payload_does_not_fall_back_for_cross_tenant_probe` (new)
- [x] AC #3 (non-existent connector still 404): `test_get_review_payload_non_existent_connector_still_404` (new) + pre-existing `test_get_review_payload_raises_when_no_rows`
- [x] AC #4 (existing tenant-owned-row tests still pass): all 35 pre-existing service-layer tests + 38 pre-existing API tests green

## Out of scope

- PATCH `/groups` and `/operations` routes — task body explicitly leaves the "do tenant_admins edit built-ins?" policy choice for a separate scoping decision.
- The listing endpoint — already correct; it's the reference behavior we now match.
- The route handler at `api/v1/connectors_ingest.py:392-411` — its docstring already describes the right scope; the bug was the service-layer implementation diverging from it.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1135


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Non-admin operators can now view built-in connectors when reviewing their own tenant
  * Enhanced cross-tenant boundary handling for improved connector visibility

* **Bug Fixes**
  * Improved fallback logic for connector discovery in tenant-scoped operations

* **Documentation**
  * Clarified tenant-scoping behavior and access patterns for API routes
  * Documented connector visibility model across tenant boundaries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->