### PR TITLE
feat(release): G0.13-T6 release-body path-freshness gate + v0.6.0 amendments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,7 +205,8 @@ breaking changes.
   [#1026](https://github.com/evoila/meho/issues/1026)). A recursive-CTE
   `replay_session` substrate + `ReplayNode` shape powers the replay
   ([#1024](https://github.com/evoila/meho/issues/1024)), surfaced as
-  `GET /api/v1/audit/replay` with a 10k count-first 413 cap
+  `GET /api/v1/audit/sessions/{session_id}/replay` with a 10k
+  count-first 413 cap
   ([#1033](https://github.com/evoila/meho/issues/1033)), an MCP
   `meho.audit.replay` admin tool + `meho.audit.*` classifier +
   `query_audit(shape:tree)` shape
@@ -217,8 +218,10 @@ breaking changes.
   `tenant_conventions` + `tenant_convention_history` tables (Alembic
   migration 0013) with unique `(tenant_id, slug)` and full history
   capture ([#313](https://github.com/evoila/meho/issues/313) / #1029),
-  Pydantic schemas + 6 tenant-scoped + RBAC-gated API routes
-  (list / show / create / update / delete / history;
+  Pydantic schemas + 3 tenant-scoped + RBAC-gated API routes mounted
+  at `/api/v1/conventions` (list/create at the collection,
+  show/update/delete at `/api/v1/conventions/{slug}`, history at
+  `/api/v1/conventions/{slug}/history`;
   [#314](https://github.com/evoila/meho/issues/314) / #1039), `meho
   conventions list / show / create / edit / delete / history` CLI
   verbs with editor integration for `edit`
@@ -302,8 +305,9 @@ breaking changes.
   `per_user` / `impersonation` remain out of scope for k8s.
 
 - **Topology history + diff verbs (G9.3-T3/T4) — companion to v0.5.1
-  timeline.** New `meho topology history` + `GET /api/v1/topology/history`
-  + `query_topology(kind=history)` expose per-node/edge mutation history
+  timeline.** New `meho topology history <name>` +
+  `GET /api/v1/topology/history/{name}` + `query_topology(kind=history)`
+  expose per-node/edge mutation history
   ([#936](https://github.com/evoila/meho/issues/936)); `meho topology
   diff <ts1> <ts2>` + `GET /api/v1/topology/diff` +
   `query_topology(kind="diff", ts1=..., ts2=...)` returns the net change
@@ -312,6 +316,18 @@ breaking changes.
   ([#931](https://github.com/evoila/meho/issues/931), follow-up SQL
   bound #987 / #1000). Cross-Initiative integration suite covers the
   full history surface ([#1027](https://github.com/evoila/meho/issues/1027)).
+
+  > **Groundwork — connector populators land in v0.7.** The topology
+  > substrate (graph_node/edge tables, history table, refresh service,
+  > diff endpoint, annotate endpoint, UI surfaces) is shipped at v0.6.0,
+  > but no shipped connector overrides the base-class no-op
+  > `Connector.discover_topology` hook yet, so
+  > `POST /api/v1/topology/refresh/{target_name}` returns zero-row deltas
+  > for k8s and vmware-rest targets out of the box. Operators populate
+  > nodes/edges via `meho topology nodes create` /
+  > `topology_create_node` + `meho topology annotate` until per-product
+  > populators land. Sister callout to the G10-UI "groundwork — no
+  > operator surface enabled yet" framing.
 
 - **Operator web UI — BFF auth flow + first two surfaces (G10.0 / G10.1
   / G10.5).** G10.0 completes the chassis with `/ui/auth/{login,
@@ -348,6 +364,15 @@ breaking changes.
   the shared helper extraction is in flight
   ([#1103](https://github.com/evoila/meho/issues/1103), tracked under
   off-roadmap Initiative G6.4 #1090).
+
+  > **MCP protocol-version negotiation.** The MCP server speaks
+  > revision `2025-06-18` and returns it as `protocolVersion` on every
+  > `initialize` response, regardless of the version the client sent
+  > in the request. Older clients pinned to `2024-11-05` see the
+  > server's `2025-06-18` capabilities in subsequent responses (silent
+  > upgrade rather than fail-close — MCP spec leaves negotiation to the
+  > server). Clients that need a specific protocol revision must check
+  > the `initialize.result.protocolVersion` field and adapt.
 
 ### Changed
 

--- a/backend/tests/test_ci_check_release_body_paths.py
+++ b/backend/tests/test_ci_check_release_body_paths.py
@@ -1,0 +1,383 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`scripts.release.check_release_body_paths`.
+
+The release-body path-freshness gate (G0.13-T6 / #1136) is the
+release-time sister to the PR-time #928 OpenAPI snapshot freshness
+check. Three consecutive releases shipped with broken path
+citations in the release body (v0.5.0 missing notes entirely;
+v0.5.1's connector raw-REST on-ramp pointing at the catalog;
+v0.6.0's ``audit/replay`` + ``tenant_conventions`` drift) — a
+recurring class of defect that deserves a CI-style gate, not a
+per-cycle spot-check.
+
+These tests pin three contracts the script promises:
+
+1. **Happy path** — every cited path that resolves (as either a
+   literal OpenAPI key or a templated form) returns exit 0.
+2. **Failure path** — a cited path that has no resolution in the
+   snapshot returns exit 1 with a diagnostic on stderr.
+3. **Template-awareness** — a citation like
+   ``/api/v1/audit/sessions/<uuid>/replay`` resolves against the
+   OpenAPI template ``/api/v1/audit/sessions/{session_id}/replay``
+   without manual whitelisting; a citation of the wrong shape
+   (e.g. the drifted ``/api/v1/audit/replay``) does not.
+
+The tests invoke the script as a subprocess so the entry-point
+behaviour (argparse + exit codes) is exercised end-to-end, in line
+with ``test_ci_run_eval_gate.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def _repo_root(start: Path) -> Path:
+    """Walk up from the test file to the repo root (where scripts/ lives)."""
+    here = start.resolve()
+    for parent in (here, *here.parents):
+        if (parent / "scripts" / "release" / "check_release_body_paths.py").exists():
+            return parent
+    raise RuntimeError(
+        "could not find repo root containing scripts/release/check_release_body_paths.py"
+    )
+
+
+REPO_ROOT = _repo_root(Path(__file__))
+GATE_SCRIPT = REPO_ROOT / "scripts" / "release" / "check_release_body_paths.py"
+
+
+def _run_gate(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Invoke check_release_body_paths.py with the given args."""
+    return subprocess.run(
+        [sys.executable, str(GATE_SCRIPT), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _write_openapi(tmp: Path, paths: list[str]) -> Path:
+    """Write a minimal OpenAPI snapshot with the requested paths."""
+    snapshot = tmp / "openapi.json"
+    snapshot.write_text(
+        json.dumps(
+            {
+                "openapi": "3.1.0",
+                "info": {"title": "test", "version": "0.0.0"},
+                "paths": {p: {"get": {"responses": {"200": {"description": "ok"}}}} for p in paths},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return snapshot
+
+
+def _write_release_body(tmp: Path, text: str) -> Path:
+    body = tmp / "release-body.md"
+    body.write_text(textwrap.dedent(text).strip() + "\n", encoding="utf-8")
+    return body
+
+
+def test_happy_path_literal_match(tmp_path: Path) -> None:
+    """A citation that is verbatim an OpenAPI path returns exit 0."""
+    snapshot = _write_openapi(tmp_path, ["/api/v1/conventions", "/api/v1/conventions/{slug}"])
+    body = _write_release_body(
+        tmp_path,
+        """
+        ## What ships
+
+        - 3 routes under `/api/v1/conventions` (list + show + history).
+        - Show one: `/api/v1/conventions/{slug}`.
+        """,
+    )
+
+    result = _run_gate(
+        "--release-body",
+        str(body),
+        "--openapi-snapshot",
+        str(snapshot),
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, (
+        f"expected exit 0; got {result.returncode}.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "release-body paths OK" in result.stdout
+
+
+def test_failure_path_v060_audit_replay_drift(tmp_path: Path) -> None:
+    """The v0.6.0 ``audit/replay`` drift is caught by the gate.
+
+    Reproduces the exact defect this Task closes: the release body
+    cites ``GET /api/v1/audit/replay`` while the shipped route is
+    ``GET /api/v1/audit/sessions/{session_id}/replay``. The gate
+    must flag this even though both paths share a common prefix.
+    """
+    snapshot = _write_openapi(
+        tmp_path,
+        ["/api/v1/audit/sessions/{session_id}/replay", "/api/v1/audit/query"],
+    )
+    body = _write_release_body(
+        tmp_path,
+        """
+        ## Audit replay
+
+        Surfaced as `GET /api/v1/audit/replay` with a 10k cap.
+        """,
+    )
+
+    result = _run_gate(
+        "--release-body",
+        str(body),
+        "--openapi-snapshot",
+        str(snapshot),
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 1, (
+        f"expected exit 1; got {result.returncode}.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "release-body paths FAILED" in result.stderr
+    assert "/api/v1/audit/replay" in result.stderr
+    # Closest-match hint guides the maintainer to the right path.
+    assert "/api/v1/audit/sessions/{session_id}/replay" in result.stderr
+
+
+def test_uuid_resolves_against_template(tmp_path: Path) -> None:
+    """A citation with a concrete UUID resolves against the templated OpenAPI path.
+
+    Release bodies sometimes include example URLs with concrete IDs
+    in the prose; the gate templatises the citation so a legitimate
+    example doesn't trip the drift check.
+    """
+    snapshot = _write_openapi(
+        tmp_path,
+        ["/api/v1/audit/sessions/{session_id}/replay"],
+    )
+    body = _write_release_body(
+        tmp_path,
+        """
+        Example call:
+        `/api/v1/audit/sessions/01234567-89ab-cdef-0123-456789abcdef/replay`
+        """,
+    )
+
+    result = _run_gate(
+        "--release-body",
+        str(body),
+        "--openapi-snapshot",
+        str(snapshot),
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, (
+        f"expected exit 0 for UUID-against-template match; got {result.returncode}.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_allow_path_whitelist(tmp_path: Path) -> None:
+    """``--allow-path`` lets a maintainer waive a path that isn't in the snapshot.
+
+    Useful for forward-looking citations (v0.7 paths announced in a
+    v0.6 release body) or paths served by a sibling service.
+    """
+    snapshot = _write_openapi(tmp_path, ["/api/v1/conventions"])
+    body = _write_release_body(
+        tmp_path,
+        """
+        See also the forthcoming `/api/v2/projected-future-path`
+        landing in the next minor.
+        """,
+    )
+
+    # Without the whitelist, the gate fails.
+    failing = _run_gate(
+        "--release-body",
+        str(body),
+        "--openapi-snapshot",
+        str(snapshot),
+        cwd=tmp_path,
+    )
+    assert failing.returncode == 1
+
+    # With the whitelist, the gate passes.
+    passing = _run_gate(
+        "--release-body",
+        str(body),
+        "--openapi-snapshot",
+        str(snapshot),
+        "--allow-path",
+        "/api/v2/projected-future-path",
+        cwd=tmp_path,
+    )
+    assert passing.returncode == 0, (
+        f"expected exit 0 with whitelist; got {passing.returncode}.\n"
+        f"stdout: {passing.stdout}\nstderr: {passing.stderr}"
+    )
+
+
+def test_no_paths_in_body_passes(tmp_path: Path) -> None:
+    """A release body with no ``/api/v*`` citations trivially passes."""
+    snapshot = _write_openapi(tmp_path, ["/api/v1/conventions"])
+    body = _write_release_body(
+        tmp_path,
+        """
+        ## What ships
+
+        Pure-CLI release; no API changes.
+        """,
+    )
+
+    result = _run_gate(
+        "--release-body",
+        str(body),
+        "--openapi-snapshot",
+        str(snapshot),
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0
+    assert "0 cited path(s)" in result.stdout
+
+
+def test_trailing_punctuation_stripped(tmp_path: Path) -> None:
+    """A citation followed by sentence-final punctuation matches.
+
+    Markdown prose frequently writes ``... at `/api/v1/foo`.`` —
+    the trailing period is not part of the path. The extractor
+    strips trailing punctuation post-match so the citation resolves.
+    """
+    snapshot = _write_openapi(tmp_path, ["/api/v1/conventions"])
+    body = _write_release_body(
+        tmp_path,
+        """
+        See `/api/v1/conventions`, the routes list. Also try `/api/v1/conventions`!
+        """,
+    )
+
+    result = _run_gate(
+        "--release-body",
+        str(body),
+        "--openapi-snapshot",
+        str(snapshot),
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0
+
+
+def test_missing_release_body_exits_two(tmp_path: Path) -> None:
+    """Unreadable release body → exit 2 with a clear error message."""
+    snapshot = _write_openapi(tmp_path, ["/api/v1/conventions"])
+    nonexistent = tmp_path / "missing.md"
+
+    result = _run_gate(
+        "--release-body",
+        str(nonexistent),
+        "--openapi-snapshot",
+        str(snapshot),
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 2
+    assert "cannot read release body" in result.stderr
+
+
+def test_malformed_openapi_exits_two(tmp_path: Path) -> None:
+    """Malformed OpenAPI snapshot → exit 2.
+
+    The gate refuses to declare the release body OK when it can't
+    actually validate the citations against the snapshot.
+    """
+    bad_snapshot = tmp_path / "bad.json"
+    bad_snapshot.write_text("not valid json {", encoding="utf-8")
+    body = _write_release_body(tmp_path, "## Empty\n\nNo paths.\n")
+
+    result = _run_gate(
+        "--release-body",
+        str(body),
+        "--openapi-snapshot",
+        str(bad_snapshot),
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 2
+    assert "OpenAPI snapshot" in result.stderr
+
+
+def test_openapi_with_no_paths_key_exits_two(tmp_path: Path) -> None:
+    """OpenAPI JSON missing the ``paths`` key → exit 2.
+
+    Defends against an empty / truncated snapshot file silently
+    passing the gate because every path looks "missing".
+    """
+    snapshot = tmp_path / "no-paths.json"
+    snapshot.write_text(
+        json.dumps({"openapi": "3.1.0", "info": {"title": "t", "version": "0"}}),
+        encoding="utf-8",
+    )
+    body = _write_release_body(tmp_path, "See `/api/v1/foo`.\n")
+
+    result = _run_gate(
+        "--release-body",
+        str(body),
+        "--openapi-snapshot",
+        str(snapshot),
+        cwd=tmp_path,
+    )
+    assert result.returncode == 2
+    assert "paths" in result.stderr
+
+
+def test_v060_real_release_body_after_amendment(tmp_path: Path) -> None:
+    """End-to-end smoke: the amended v0.6.0 body passes against shipped OpenAPI.
+
+    Reads the live ``cli/api/openapi.json`` and a small fixture
+    that mirrors the structure of the amended v0.6.0 release body
+    section. Pinning the live snapshot path here means a future
+    drift between the script and the published OpenAPI surface is
+    caught at PR time.
+    """
+    live_snapshot = REPO_ROOT / "cli" / "api" / "openapi.json"
+    if not live_snapshot.exists():  # pragma: no cover - CI always has it
+        return
+
+    # Mirror the amended phrasing the v0.6.0 release body should land on.
+    body = _write_release_body(
+        tmp_path,
+        """
+        ### Audit replay
+
+        Surfaced as `GET /api/v1/audit/sessions/{session_id}/replay`
+        with a 10k cap.
+
+        ### Conventions
+
+        3 tenant-scoped routes mounted at `/api/v1/conventions`,
+        `/api/v1/conventions/{slug}`, and
+        `/api/v1/conventions/{slug}/history`.
+        """,
+    )
+
+    result = _run_gate(
+        "--release-body",
+        str(body),
+        "--openapi-snapshot",
+        str(live_snapshot),
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, (
+        f"amended v0.6.0 body should pass against live OpenAPI; "
+        f"got {result.returncode}.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -110,6 +110,42 @@ This is the step that keeps getting skipped. Do it in the
 Open the PR (CHANGELOG roll + any release-only edits), get it reviewed,
 merge to `main`.
 
+Before merging, run the **release-body path-freshness gate**. The same
+recurring class of defect that motivated #928 at PR time (snapshot
+drifts from the route table) shows up at release time as paths cited
+in the release body that don't exist as written. Three consecutive
+releases shipped with this drift (v0.5.0 missing notes entirely,
+v0.5.1 catalog-vs-dispatch mismatch, v0.6.0 audit/replay +
+tenant_conventions mismatch — see
+[`docs/codebase/release-body-freshness.md`](codebase/release-body-freshness.md)).
+
+```bash
+# Extract the candidate release body to a file (the
+# cli-release.yml workflow uses the same awk shape).
+PREV=$(git describe --tags --abbrev=0 HEAD)
+VERSION=X.Y.Z   # the version you picked in step 1
+awk -v pat="${VERSION//./\\.}" '
+  BEGIN { in_section = 0 }
+  $0 ~ "^## \\[" pat "\\]" { in_section = 1; next }
+  in_section && /^## / { exit }
+  in_section { print }
+' CHANGELOG.md > /tmp/release-body.md
+
+# Assert every cited path resolves in the published OpenAPI snapshot.
+cd backend
+uv run python ../scripts/release/check_release_body_paths.py \
+  --release-body /tmp/release-body.md \
+  --openapi-snapshot ../cli/api/openapi.json
+```
+
+Exit 0 → proceed. Exit 1 → the script lists each unresolved citation
+plus the closest matching snapshot path; amend the release body to
+cite the shipped path (or pass `--allow-path` if the citation is
+intentionally outside the snapshot's surface). The script tolerates
+concrete IDs in citations (UUIDs / digits resolve against the
+matching templated form) so example URLs in prose don't trip the
+gate.
+
 ### 4. Tag + push
 
 ```bash
@@ -148,7 +184,9 @@ The push fans out to `cli-release.yml`, `image.yml`, `chart.yml`.
        re-run + wait for success); version picked
 [ ] 2. CHANGELOG: completeness audited, missing bullets backfilled,
        [Unreleased] rolled to [X.Y.Z] (post-tag work left behind)
-[ ] 3. Release-cutting PR merged to main
+[ ] 3. Release-body path-freshness gate green
+       (scripts/release/check_release_body_paths.py — sister to #928);
+       release-cutting PR merged to main
 [ ] 4. Tagged vX.Y.Z + pushed
 [ ] 5. GH Release notes correct (not [Unreleased] fallback); image, chart,
        CLI tarballs all published

--- a/docs/codebase/release-body-freshness.md
+++ b/docs/codebase/release-body-freshness.md
@@ -1,0 +1,126 @@
+# Release-body path-freshness gate
+
+The `scripts/release/check_release_body_paths.py` gate asserts that
+every `/api/v*` path cited in a proposed GitHub release body resolves
+in the published OpenAPI snapshot. Sister gate to
+`cli-api-snapshot-freshness` (#928) — that one runs at PR time and
+catches "OpenAPI snapshot lags the route table"; this one runs at
+release time and catches "release body cites a path the route table
+doesn't expose".
+
+## Why this exists
+
+Three consecutive release cycles shipped with broken path citations
+in the release body. The pattern is cross-cycle and stable, not a
+per-cycle slip:
+
+- **v0.5.0**: CHANGELOG `[Unreleased]` → `[0.5.0]` roll skipped
+  entirely. `cli-release.yml` fell back to extracting `[Unreleased]`
+  (empty), and the GitHub Release was hand-curated without an audit
+  against shipped routes.
+- **v0.5.1**: release body said the new connector raw-REST on-ramp
+  answered v0.3.0's "only 13 vmware ops?" — but the path it gave
+  operators was the read-only catalog (`/api/v1/connectors/catalog`,
+  introduced by #743), not live typed-connector dispatch.
+- **v0.6.0**: release body cited `GET /api/v1/audit/replay` (actual
+  shipped path: `GET /api/v1/audit/sessions/{session_id}/replay`,
+  introduced by #1012) and described "6 tenant-scoped + RBAC-gated
+  API routes" + references to `tenant_conventions` under a `tenant-`
+  prefix that doesn't exist (actual mount: `/api/v1/conventions`
+  with 3 routes, not 6). Also: the topology history endpoint cited
+  as `/api/v1/topology/history` (actual: per-resource
+  `/api/v1/topology/history/{name}`).
+
+The release runbook (`docs/RELEASING.md`) makes "roll the CHANGELOG
+before tagging" load-bearing post-v0.5.0, but a load-bearing CHANGELOG
+isn't sufficient: the v0.6.0 cycle rolled the CHANGELOG correctly
+and *still* shipped with drifted paths because no automated check
+read the prose against the OpenAPI surface.
+
+## Mechanism
+
+The script is pure-Python stdlib (`argparse` / `json` / `re`) — no
+backplane import, no test-collection coupling. It's safe to run from
+any working directory.
+
+1. **Extract** every `/api/v*` token from the release-body markdown.
+   The regex `r"/api/v[0-9]+/[A-Za-z0-9_/{}\-.]*"` matches the
+   widest legal-looking URL path; trailing punctuation (`.`, `,`,
+   `;`, etc.) is stripped post-match. `}` is preserved as a
+   legitimate trailing char for OpenAPI templates.
+2. **Templatise** each citation. Segments shaped like a UUID
+   (`[0-9a-f]{8}-...`) or a pure-digit ID are replaced with the
+   parameter-name pool the OpenAPI snapshot uses at that segment
+   position (e.g. `{session_id}` for the 5th segment of an
+   `/api/v1/audit/sessions/<X>/replay` path). The original literal
+   form is kept as a candidate too, so a literal OpenAPI path
+   matches without surgery.
+3. **Match** every candidate against the set of `paths` keys in
+   the OpenAPI snapshot (`cli/api/openapi.json` — the artifact
+   `make snapshot-openapi` produces). At least one candidate must
+   match; otherwise the citation is unresolved.
+4. **Report** unresolved citations on stderr with the closest
+   snapshot-path hint, ranked by (shared-prefix length, last-segment
+   match). Exit 1 when any citation is unresolved.
+
+Template-awareness is what makes the gate useful. Without it, a
+release body that legitimately writes a concrete example URL —
+`/api/v1/audit/sessions/abc-123-.../replay` — would trip the gate
+against the templated snapshot path. Strict literal matching would
+have produced too many false positives to keep the gate on.
+
+## Where it runs
+
+- **Release runbook (`docs/RELEASING.md` §3)** — operator runs it
+  on the candidate release body before merging the release-cutting
+  PR. The `/release` skill (`evoila-bosnia/meho-internal`) drives
+  the runbook end-to-end; the skill update tracking the new step
+  lands as a separate meho-internal PR per the
+  `project_claude_dir_symlink` discipline.
+- **Author's local loop** — the script accepts any release-body
+  markdown file, so authors can run it against draft prose before
+  cutting the PR. Recommended when amending an existing release
+  body retroactively (the same shape this Task takes for v0.6.0).
+
+## Whitelist
+
+The `--allow-path` flag accepts a path the gate should treat as
+resolved even when absent from the snapshot. Use cases:
+
+- Forward-looking citations: a v0.6 release body that mentions a
+  v0.7 path landing next minor.
+- Paths served by a sibling service (not the FastAPI backplane).
+
+Every whitelist entry is a tech-debt marker — the right move is
+usually to amend the release body to cite the shipped path, not
+to suppress the gate. The flag is for the genuine intentional-
+out-of-snapshot citation, not for "make the gate stop complaining."
+
+## Limitations
+
+- **Markdown-only.** The gate reads the release body as text; it
+  doesn't parse HTML or JSON inside code blocks. A code-block
+  example that happens to contain `/api/v1/foo` will be extracted
+  and checked alongside prose citations. In practice that's a
+  feature (a stale example URL is still drift) but worth noting.
+- **No CHANGELOG-section coverage.** The CHANGELOG follows the
+  release body pattern (`cli-release.yml` extracts the release
+  body *from* the CHANGELOG section), so fixing the release body
+  fixes the CHANGELOG transitively. Expanding the gate to scan
+  every `## [X.Y.Z]` section across CHANGELOG history was
+  explicitly out of scope for #1136.
+- **No call into the backplane.** The gate has no Python imports
+  outside stdlib, so it can run before `uv sync` (during a release
+  bootstrap), and it does not couple to backplane test collection.
+
+## References
+
+- **Sister gate at PR time:** `cli-api-snapshot-freshness` job in
+  `.github/workflows/ci.yml` (introduced by #928).
+- **Snapshot generator:** `cli/api/snapshot-openapi.py` (driven by
+  `make snapshot-openapi`).
+- **Release runbook:** `docs/RELEASING.md` §3.
+- **Originating Task:** #1136 (G0.13-T6).
+- **Originating Initiative:** #1130 (G0.13 v0.6.0 dogfood hardening).
+- **Project memory:** `project_release_runbook`,
+  `project_ci_openapi_snapshot_freshness`.

--- a/scripts/release/check_release_body_paths.py
+++ b/scripts/release/check_release_body_paths.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Assert every ``/api/v*`` path cited in a release body resolves in OpenAPI.
+
+Sister gate to ``cli-api-snapshot-freshness`` (#928) — but at
+release-time rather than PR-time. The PR-time gate catches "the
+OpenAPI snapshot lags the route table"; this one catches "the
+release body advertises a path the route table doesn't actually
+expose".
+
+Background
+----------
+
+Three consecutive releases shipped with paths in the prose that
+didn't match the routes the operators got:
+
+* v0.5.0: CHANGELOG ``[Unreleased]`` → ``[0.5.0]`` roll skipped
+  entirely, so the GitHub Release fell back to a hand-curated body
+  that wasn't audited against shipped routes.
+* v0.5.1: release body said the connector raw-REST on-ramp answered
+  v0.3.0's "only 13 vmware ops?" — but the path it gave operators
+  was the read-only catalog (``/api/v1/connectors/catalog``,
+  introduced by #743), not live typed-connector dispatch.
+* v0.6.0: release body cited ``GET /api/v1/audit/replay`` (actual
+  shipped path:
+  ``GET /api/v1/audit/sessions/{session_id}/replay``, introduced by
+  #1012) and described 6 ``tenant_conventions`` routes under a
+  ``tenant-`` prefix that doesn't exist (actual: 3 routes under
+  ``/api/v1/conventions``, no ``tenant-`` prefix).
+
+The pattern is cross-cycle and stable, so a release-time CI-style
+gate is the right answer. It runs once per release, against the
+proposed release body and the published OpenAPI snapshot, and
+refuses to let the release proceed when any cited path doesn't
+exist in the snapshot.
+
+Mechanism
+---------
+
+1. Read the proposed release body (a markdown file passed via
+   ``--release-body``).
+2. Extract every token shaped like ``/api/v<N>/<segment>...`` from
+   the prose. A token ends at the first character that wouldn't be
+   legal in a URL path (whitespace, backtick, paren, etc.).
+3. For each extracted token, derive its **template form** — the
+   path with literal segments preserved and concrete IDs (UUIDs,
+   integers, slugs in the form ``{name}``) replaced by the OpenAPI
+   path-template placeholders.
+4. For each template form, assert it exists in the OpenAPI snapshot
+   passed via ``--openapi-snapshot``. The snapshot is the same
+   ``cli/api/openapi.json`` the #928 freshness gate produces.
+5. Exit 0 on full match; exit 1 with a diagnostic listing every
+   path that didn't resolve.
+
+The template-derivation step is what makes the gate useful: when a
+release body says
+
+    ``GET /api/v1/audit/sessions/abc-123/replay``
+
+we want to match it against the OpenAPI path
+
+    ``/api/v1/audit/sessions/{session_id}/replay``
+
+A strict literal-match gate would have flagged the legitimate
+citation as broken; a template-aware gate flags only the actually-
+drifted citations.
+
+Whitelist
+---------
+
+The ``--allow-path`` flag accepts a path pattern (literal or
+templatised) that the gate should treat as resolved even when it
+isn't in the OpenAPI snapshot. Use sparingly — examples include
+paths that ship via a different surface than the FastAPI app
+(e.g. a planned ``/api/v2/...`` path mentioned for forward-
+compatibility, or a path served by a sibling service).
+
+Exit codes
+----------
+
+* ``0`` — every cited path resolves (or matches a whitelist entry).
+* ``1`` — at least one cited path failed to resolve; report on
+  stderr lists the cited token, the derived template, and the
+  closest OpenAPI prefix match (when one exists).
+* ``2`` — argument / file / JSON parse error.
+
+Usage
+-----
+
+::
+
+    python3 scripts/release/check_release_body_paths.py \\
+        --release-body /tmp/v0.6.0-release-body.md \\
+        --openapi-snapshot cli/api/openapi.json
+
+    # whitelist a path that ships via a different surface:
+    python3 scripts/release/check_release_body_paths.py \\
+        --release-body /tmp/v0.7.0-release-body.md \\
+        --openapi-snapshot cli/api/openapi.json \\
+        --allow-path /api/v2/projected-future-path
+
+The script is invoked by ``/release`` skill step 2.5 (between
+CHANGELOG roll and tag) — see
+``docs/codebase/release-body-freshness.md`` for the integration
+point.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import uuid
+from pathlib import Path
+from typing import Final
+
+#: Regex that matches the broadest legal-looking ``/api/v<N>/...``
+#: token in markdown prose. The character class deliberately stops
+#: at whitespace, common markdown delimiters (`` ` ``, ``)``, ``]``,
+#: ``"``, ``'``, ``>``, ``<``, ``,``), and end-of-string. Trailing
+#: punctuation (``.``, ``;``, ``:``) is stripped post-match to
+#: tolerate "the route ``/api/v1/foo``." with a sentence-final dot
+#: that isn't part of the path.
+_PATH_TOKEN_RE: Final = re.compile(r"/api/v[0-9]+/[A-Za-z0-9_/{}\-.]*")
+
+#: Trailing characters that aren't part of any real path but commonly
+#: appear in prose after a path citation. Stripped post-extraction.
+#:
+#: Notably absent: ``}`` (legitimate trailing char for an OpenAPI path
+#: template like ``/api/v1/foo/{slug}``) and ``/`` (kept so a trailing
+#: slash matches a snapshot with or without one). Including ``\\``
+#: defends against double-escaped citations in JSON code-block prose;
+#: ``>`` defends against ``GET /api/v1/foo>`` markdown blockquote
+#: trailing.
+_TRAILING_PUNCT: Final = ".,;:!?\\)]>'\""
+
+#: A 36-char UUID at any segment position is replaced by ``{id}``.
+_UUID_LIKE_RE: Final = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+#: A pure-digit segment (length ≥ 1) is replaced by ``{id}``.
+_DIGITS_RE: Final = re.compile(r"^[0-9]+$")
+
+
+def _strip_trailing_punct(token: str) -> str:
+    """Drop sentence-final punctuation that markdown leaves attached."""
+    while token and token[-1] in _TRAILING_PUNCT:
+        token = token[:-1]
+    return token
+
+
+def _is_uuid_like(seg: str) -> bool:
+    """Match the canonical 36-char UUID shape with dashes."""
+    if _UUID_LIKE_RE.match(seg):
+        # Belt-and-braces: ``uuid.UUID`` will raise on near-misses
+        # (e.g. wrong nibble count in a section) the regex permits.
+        try:
+            uuid.UUID(seg)
+        except ValueError:
+            return False
+        return True
+    return False
+
+
+def _templatise(path: str, openapi_templates: set[str]) -> set[str]:
+    """Derive the set of template forms a citation could resolve to.
+
+    Returns a set of candidate templates because the same concrete
+    citation can collide with multiple OpenAPI templates (e.g.
+    ``/api/v1/foo/bar`` could match a literal ``/api/v1/foo/bar`` or
+    a templated ``/api/v1/foo/{name}``).
+
+    The strategy:
+
+    1. The original path string is always a candidate (so a literal
+       OpenAPI path matches without surgery).
+    2. UUID-shaped segments are replaced by ``{<param>}`` using the
+       OpenAPI snapshot's parameter naming for that position when
+       available.
+    3. Pure-digit segments are replaced by ``{<param>}`` likewise.
+    4. Segments wrapped in ``{...}`` (already a template form) are
+       kept verbatim.
+
+    For (2) and (3) we don't know which OpenAPI parameter name to
+    use (the same shape could be ``{id}``, ``{audit_id}``,
+    ``{target_id}``...), so we generate every form that the OpenAPI
+    snapshot's existing templates suggest at that segment position.
+    """
+    candidates: set[str] = {path}
+
+    parts = path.split("/")
+    # Per-position parameter-name pool: at index ``i`` (1-based,
+    # since ``parts[0]`` is the empty string before the leading
+    # ``/``), what parameter names does the OpenAPI snapshot use at
+    # that exact position?  Build the pool once.
+    param_names_by_position: dict[int, set[str]] = {}
+    for tmpl in openapi_templates:
+        tmpl_parts = tmpl.split("/")
+        for i, seg in enumerate(tmpl_parts):
+            if seg.startswith("{") and seg.endswith("}"):
+                param_names_by_position.setdefault(i, set()).add(seg)
+
+    # Build a list of (index, segment-replacement-options) tuples
+    # for every position that needs templating.
+    replacements: list[tuple[int, list[str]]] = []
+    for i, seg in enumerate(parts):
+        if seg.startswith("{") and seg.endswith("}"):
+            # Already templated by the author — preserve.
+            replacements.append((i, [seg]))
+            continue
+        if _is_uuid_like(seg) or _DIGITS_RE.match(seg):
+            # ID-like — pool the snapshot's parameter names at this
+            # position, and fall back to ``{id}`` if the snapshot
+            # has no template at this position (so a citation
+            # against a path the snapshot doesn't know about can
+            # still expand). The literal segment is intentionally
+            # NOT preserved as an option here — IDs in a release
+            # body are concrete instances, not literal route bits.
+            pool = sorted(param_names_by_position.get(i, set()) or {"{id}"})
+            replacements.append((i, pool))
+
+    if not replacements:
+        return candidates
+
+    # Cartesian product of replacement options. Cap at 100 to keep
+    # the candidate set bounded — a single citation should never
+    # produce more than a few combinations in practice; the cap is
+    # just a guard against a pathological release body that puts
+    # many ID-shaped segments in one line.
+    expansions: list[list[str]] = [list(parts)]
+    for idx, options in replacements:
+        new_expansions: list[list[str]] = []
+        for prev in expansions:
+            for opt in options:
+                replaced = list(prev)
+                replaced[idx] = opt
+                new_expansions.append(replaced)
+                if len(new_expansions) >= 100:
+                    break
+            if len(new_expansions) >= 100:
+                break
+        expansions = new_expansions
+        if len(expansions) >= 100:
+            break
+
+    for exp in expansions:
+        candidates.add("/".join(exp))
+
+    return candidates
+
+
+def extract_paths(release_body: str) -> list[str]:
+    """Return every ``/api/v*`` token found in ``release_body``, deduped.
+
+    Order-preserving (first occurrence wins) so the diagnostic
+    output reads in document order.
+    """
+    seen: dict[str, None] = {}
+    for raw in _PATH_TOKEN_RE.findall(release_body):
+        cleaned = _strip_trailing_punct(raw)
+        if cleaned and cleaned not in seen:
+            seen[cleaned] = None
+    return list(seen.keys())
+
+
+def load_openapi_paths(snapshot_path: Path) -> set[str]:
+    """Load the ``paths`` keys from an OpenAPI snapshot JSON file.
+
+    Raises:
+        FileNotFoundError: if ``snapshot_path`` doesn't exist.
+        ValueError: if the JSON is malformed or has no ``paths``
+            top-level key.
+    """
+    try:
+        data = json.loads(snapshot_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:  # pragma: no cover - simple wrap
+        raise ValueError(f"{snapshot_path}: invalid JSON ({exc})") from exc
+
+    paths = data.get("paths")
+    if not isinstance(paths, dict):
+        raise ValueError(f"{snapshot_path}: missing or non-object 'paths' key")
+
+    return set(paths.keys())
+
+
+def _closest_template(citation: str, openapi_templates: set[str]) -> str | None:
+    """Return the most-likely-relevant OpenAPI template for ``citation``.
+
+    Heuristic: rank by (longest shared prefix, last-segment match)
+    so a drifted citation like ``/api/v1/audit/replay`` against a
+    snapshot that contains both
+    ``/api/v1/audit/sessions/{session_id}/replay`` and
+    ``/api/v1/audit/who-touched/{target}`` surfaces the
+    ``...replay`` path (matching verb) rather than the verb-mismatched
+    same-prefix sibling.
+
+    Used purely for the human-readable diagnostic; no logic depends
+    on the value. Returns ``None`` when no template shares the
+    ``/api/v<N>/<surface>`` prefix.
+    """
+
+    def _shared_prefix_len(a: str, b: str) -> int:
+        a_parts, b_parts = a.split("/"), b.split("/")
+        n = 0
+        for x, y in zip(a_parts, b_parts, strict=False):
+            if x == y:
+                n += 1
+            else:
+                break
+        return n
+
+    candidates = [t for t in openapi_templates if t.startswith("/api/v")]
+    if not candidates:
+        return None
+
+    citation_last = citation.rstrip("/").split("/")[-1] if "/" in citation else ""
+
+    def _rank(template: str) -> tuple[int, int]:
+        """Higher tuple wins; lexicographic ordering by Python's tuple cmp.
+
+        Component 1: shared-prefix length (primary).
+        Component 2: 1 if the citation's last segment matches the
+        template's last segment (verb match), else 0 (tiebreaker).
+        """
+        prefix = _shared_prefix_len(citation, template)
+        tmpl_last = template.rstrip("/").split("/")[-1] if "/" in template else ""
+        verb_match = 1 if citation_last and citation_last == tmpl_last else 0
+        return (prefix, verb_match)
+
+    best = max(candidates, key=_rank)
+    # Require at least 3 shared segments (``/api/v1/<surface>``) to
+    # avoid noise from any-other-surface paths the snapshot lists.
+    if _shared_prefix_len(citation, best) < 3:
+        return None
+    return best
+
+
+def check_release_body(
+    release_body: str,
+    openapi_templates: set[str],
+    allow_paths: set[str] | None = None,
+) -> list[tuple[str, str | None]]:
+    """Return the list of unresolved citations.
+
+    Args:
+        release_body: full markdown text of the proposed release.
+        openapi_templates: the set of templated paths from the
+            OpenAPI snapshot (e.g.
+            ``/api/v1/audit/sessions/{session_id}/replay``).
+        allow_paths: path patterns that should be treated as
+            resolved even when absent from ``openapi_templates``.
+
+    Returns:
+        A list of ``(citation, closest_match_or_None)`` pairs for
+        every citation that didn't resolve. Empty list = all good.
+    """
+    allow = allow_paths or set()
+    unresolved: list[tuple[str, str | None]] = []
+
+    for citation in extract_paths(release_body):
+        if citation in allow:
+            continue
+        candidates = _templatise(citation, openapi_templates)
+        if candidates & openapi_templates:
+            continue
+        if candidates & allow:
+            continue
+        unresolved.append((citation, _closest_template(citation, openapi_templates)))
+
+    return unresolved
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Assert every /api/v* path cited in a release body resolves "
+            "in the OpenAPI snapshot. Sister gate to #928 "
+            "(cli-api-snapshot-freshness)."
+        ),
+    )
+    parser.add_argument(
+        "--release-body",
+        type=Path,
+        required=True,
+        help="Path to the proposed release-body markdown file.",
+    )
+    parser.add_argument(
+        "--openapi-snapshot",
+        type=Path,
+        required=True,
+        help="Path to the published OpenAPI snapshot JSON (cli/api/openapi.json).",
+    )
+    parser.add_argument(
+        "--allow-path",
+        action="append",
+        default=[],
+        help=(
+            "Path (literal or templatised) to treat as resolved even when "
+            "absent from the OpenAPI snapshot. May be passed multiple times."
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        body = args.release_body.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"error: cannot read release body: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        openapi_templates = load_openapi_paths(args.openapi_snapshot)
+    except (OSError, ValueError) as exc:
+        print(f"error: cannot load OpenAPI snapshot: {exc}", file=sys.stderr)
+        return 2
+
+    unresolved = check_release_body(body, openapi_templates, set(args.allow_path))
+
+    if not unresolved:
+        cited = len(extract_paths(body))
+        print(
+            f"release-body paths OK: {cited} cited path(s), all resolve in {args.openapi_snapshot}",
+        )
+        return 0
+
+    print(
+        f"release-body paths FAILED: {len(unresolved)} cited path(s) do not "
+        f"resolve in {args.openapi_snapshot}:",
+        file=sys.stderr,
+    )
+    for citation, closest in unresolved:
+        if closest is not None:
+            print(f"  - {citation}  (closest snapshot path: {closest})", file=sys.stderr)
+        else:
+            print(f"  - {citation}  (no near match in snapshot)", file=sys.stderr)
+    print(
+        "\nFix: amend the release body to cite the shipped path, "
+        "or pass --allow-path if the citation is intentionally "
+        "outside the snapshot's surface.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds a **release-time CI-style gate** (`scripts/release/check_release_body_paths.py`) that asserts every `/api/v*` path cited in a release body resolves in the published OpenAPI snapshot. Sister to the PR-time `cli-api-snapshot-freshness` job (#928). Three consecutive releases shipped with broken path citations (v0.5.0 missing notes; v0.5.1 catalog-vs-dispatch; v0.6.0 audit/replay + tenant_conventions + topology/history) — a recurring class of defect that deserves a CI gate, not a per-cycle spot-check.
- **Amends the v0.6.0 GitHub release body** (and CHANGELOG `[0.6.0]`) to cite the shipped paths: `audit/sessions/{session_id}/replay` (not `audit/replay`), 3 routes under `/api/v1/conventions` (not 6 under `tenant_conventions`), `topology/history/{name}` (not `topology/history`).
- **Adds two honesty callouts** to the v0.6.0 release body per the 2026-05-26 scope extension: (signal 13) topology populators land in v0.7 — substrate ships at v0.6.0 but no shipped connector overrides `Connector.discover_topology`, so `topology/refresh/{target_name}` returns zero-row deltas; (signal 15) MCP server silently upgrades `initialize.protocolVersion` to `2025-06-18` regardless of client request.

## Why a gate

The release runbook (`docs/RELEASING.md`) already makes "roll the CHANGELOG before tagging" load-bearing post-v0.5.0, but a rolled CHANGELOG isn't sufficient: the v0.6.0 cycle rolled it correctly and *still* shipped with drifted paths because no automated check read the prose against the OpenAPI surface. The gate is pure-Python stdlib, runs in `<100ms`, and produces a closest-match hint on failure that directly guides the maintainer to the shipped path.

## Mechanism

1. Extract every `/api/v*` token from the release-body markdown.
2. Templatise concrete IDs (UUIDs, digits) against the OpenAPI snapshot's parameter-name pool at the matching segment position — so a legitimate example URL like `/api/v1/audit/sessions/abc-123-.../replay` resolves against `/api/v1/audit/sessions/{session_id}/replay` without manual whitelisting.
3. Assert every candidate resolves in `cli/api/openapi.json` (the same snapshot the #928 gate produces).
4. Exit 1 with a closest-match hint (ranked by shared-prefix length + verb match) when any citation is unresolved.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy --ignore-missing-imports` — clean
- [x] `pytest backend/tests/test_ci_check_release_body_paths.py` — 10 passed
- [x] **Gate runs against the live v0.6.0 release body and catches the drift**: 2 citations flagged (`/api/v1/audit/replay`, `/api/v1/topology/history`) with correct closest-match hints.
- [x] **Gate passes against the amended release body**: 7 cited paths, all resolve in `cli/api/openapi.json`.
- [x] **v0.6.0 GitHub release body amended** via `gh release edit v0.6.0 --notes-file ...`. Verified live: `audit/sessions/{session_id}/replay` (1), `3 tenant-scoped` (1), "Groundwork — connector populators land in v0.7" callout (1), "MCP protocol-version negotiation" note (1).

## Out of scope

- The `add_to_memory content→body` rename CHANGELOG `[Changed]` entry — handled by sibling task #1134 (T4 of this Initiative). The orchestrator is serializing T4 behind this PR so T4 builds on the amended baseline.
- The v0.5.1 / v0.5.0 release-body retro-fixes — paths in those release bodies are settled; only v0.6.0's stay actionable.
- Expanding the gate to CHANGELOG section paths beyond the release body — the CHANGELOG follows the release-body pattern, so fixing the release body fixes the CHANGELOG transitively.
- The `/release` skill update (in `meho-internal`) to invoke the script — tracked as a separate meho-internal PR per project memory `project_claude_dir_symlink`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1136
