### PR TITLE
feat(mcp): G0.13-T4 add_to_memory content alias shim + v0.6.0 breaking-change callout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,8 +139,29 @@ vcf-automation), the **G10.0** OAuth2.1 + PKCE BFF auth flow, the first
 two **G10 operator-UI surfaces** (broadcast live feed + topology graph),
 the **G3.8 Holodeck** typed connector, the **G6.4 broadcast meta-tools**
 that make the G7.1 consumer-onboarding CLAUDE.md broadcast-discipline
-contract executable, and the **G0.6.1** JsonFluxReducer wiring. No
-breaking changes.
+contract executable, and the **G0.6.1** JsonFluxReducer wiring.
+**Breaking changes: 1 — see Changed (breaking) section.**
+
+### Changed (breaking)
+
+- **MCP `add_to_memory` body field renamed `content` -> `body`
+  (deferred-callout from G0.9.1-T7, #779).** The rename actually
+  landed in this release window (the original task targeted v0.3.2 in
+  its CHANGELOG AC, but the release tagged as v0.6.0 due to the v0.3.2
+  slip; the breaking-change callout evaporated in the transition).
+  Live consumers pinned to the v0.3.1 wire field received a 422
+  `missing required field: body` with no migration breadcrumb. v0.6.x
+  ships a **one-cycle compatibility shim**: the MCP `add_to_memory`
+  tool accepts both `body` (canonical) and `content` (deprecated
+  alias). When `content` is supplied, a structured
+  `add_to_memory_field_deprecated` warning log line fires with
+  `replacement="body"`, `removal_version="0.7"`, and
+  `body_supplied=<bool>`. When both fields are supplied, `body` wins.
+  **The shim is removed in v0.7** -- agents and SDKs pinned to
+  `content` must migrate to `body` before the v0.7 release.
+  Acceptance criteria from #779 (v0.3.2 callout) are satisfied
+  retroactively here against the actual release window.
+  ([#1134](https://github.com/evoila/meho/issues/1134))
 
 ### Added
 

--- a/backend/src/meho_backplane/mcp/tools/memory.py
+++ b/backend/src/meho_backplane/mcp/tools/memory.py
@@ -108,6 +108,8 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 from typing import Any, Final
 
+import structlog
+
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
 from meho_backplane.mcp.server import McpInvalidParamsError
@@ -117,6 +119,18 @@ from meho_backplane.memory.service import MemoryService
 from meho_backplane.memory.ttl import resolve_default_expires_at
 
 __all__: list[str] = []
+
+# NOTE: structlog logger is resolved per-call inside ``_add_to_memory_handler``
+# rather than held as a module-level proxy. Production sets
+# ``cache_logger_on_first_use=True`` in
+# ``meho_backplane.logging.configure_logging``; a cached BoundLogger
+# pins a reference to the processor chain it was built with, and later
+# ``structlog.configure(...)`` calls *replace* (not mutate) that
+# reference -- so test fixtures using ``structlog.testing.capture_logs``
+# cannot observe events written through the orphaned cached proxy.
+# Same precedent + rationale as :mod:`meho_backplane.auth.jwt` (see
+# ``docs/codebase/backend.md``). Per-call cost is microseconds;
+# acceptable on the ``add_to_memory`` path which is not latency-critical.
 
 
 #: Op-class strings keep parity with :mod:`meho_backplane.broadcast.classify`'s
@@ -264,14 +278,56 @@ async def _search_memory_handler(
     }
 
 
+def _resolve_body_with_content_shim(arguments: dict[str, Any]) -> str:
+    """Resolve the body string from ``body`` (canonical) or ``content`` (deprecated).
+
+    v0.6.x ships a one-cycle deprecation shim for the v0.3.2 ``content`` ->
+    v0.6.0 ``body`` rename. ``body`` wins when both are supplied; ``content``
+    is accepted as an alias and emits a structured
+    ``add_to_memory_field_deprecated`` warning log line with
+    ``replacement="body"`` so an operator scanning logs sees the migration
+    breadcrumb directly (the ai-engineering anchor for agent-facing schema
+    changes). The shim is dropped in v0.7 -- see ``docs/RELEASING.md``
+    v0.7 follow-ups.
+
+    The dispatcher's JSON-Schema gate ensures at least one of the two
+    is supplied via the schema's ``anyOf`` clause; the ``else`` branch
+    below is the fail-closed answer to a schema regression rather than a
+    real run-time path.
+    """
+    body_arg: str | None = arguments.get("body")
+    content_arg: str | None = arguments.get("content")
+    if content_arg is not None:
+        structlog.get_logger(__name__).warning(
+            "add_to_memory_field_deprecated",
+            replacement="body",
+            removal_version="0.7",
+            body_supplied=body_arg is not None,
+        )
+    if body_arg is not None:
+        return body_arg
+    if content_arg is not None:
+        return content_arg
+    # Unreachable in practice -- the schema's ``anyOf`` gate makes
+    # this branch impossible without a schema regression. Surface the
+    # contract violation as INVALID_PARAMS rather than the opaque
+    # ``KeyError`` of the pre-shim code path.
+    raise McpInvalidParamsError(
+        "add_to_memory: one of 'body' or 'content' must be supplied",
+    )
+
+
 async def _add_to_memory_handler(
     operator: Operator,
     arguments: dict[str, Any],
 ) -> dict[str, Any]:
     """Create one memory entry under the operator's tenant.
 
-    Three things this handler is responsible for:
+    Four things this handler is responsible for:
 
+    * Resolving the body string from one of two accepted fields via
+      :func:`_resolve_body_with_content_shim` (v0.6.x one-cycle
+      ``content`` -> ``body`` deprecation shim; G0.13-T4 #1134).
     * Translating the ``scope`` argument from its wire string into the
       typed :class:`MemoryScope` before reaching the service. The
       tool's ``inputSchema`` enum gates the values, so a bad scope
@@ -298,7 +354,7 @@ async def _add_to_memory_handler(
     verify the write landed without a follow-up
     ``resources/read meho://memory/{scope}/{slug}`` round-trip.
     """
-    body: str = arguments["body"]
+    body = _resolve_body_with_content_shim(arguments)
     scope = MemoryScope(arguments["scope"])
     slug = arguments.get("slug")
     target_name = arguments.get("target_name")
@@ -460,6 +516,10 @@ register_mcp_tool(
             "MEMORY_USER_DEFAULT_TTL_DAYS); pass explicit null to "
             "persist forever; tenant- and target-scope writes default "
             "to no expiry. "
+            "Compatibility shim (v0.6.x only): the body field is also "
+            "accepted under its pre-v0.6 name `content`. Prefer `body`; "
+            "`content` emits a deprecation log line and is removed in "
+            "v0.7. If both are supplied, `body` wins. "
             "Do NOT use this for durable, generalizable team knowledge — "
             "that belongs in `add_to_knowledge`. Memory is for shorter-"
             "lived, operator/tenant/target-scoped state."
@@ -477,6 +537,19 @@ register_mcp_tool(
                         "for cosine). Field name aligned with "
                         "`add_to_knowledge` and the REST `POST /api/v1/memory` "
                         "body schema (G0.9.1-T7, #779)."
+                    ),
+                },
+                "content": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "DEPRECATED v0.6.x alias for `body`; removed in "
+                        "v0.7. Provided so v0.3.x clients pinned to the "
+                        "pre-rename field continue to work for one cycle. "
+                        "Prefer `body`; `body` wins if both are supplied. "
+                        "Supplying `content` emits a structured "
+                        "`add_to_memory_field_deprecated` warning log "
+                        'with `replacement="body"`.'
                     ),
                 },
                 "scope": {
@@ -532,7 +605,24 @@ register_mcp_tool(
                     ),
                 },
             },
-            "required": ["body", "scope"],
+            "required": ["scope"],
+            # The body field is required, but for the v0.6.x deprecation
+            # window it is accepted under either of two names -- ``body``
+            # (canonical) or ``content`` (pre-v0.6 alias, dropped v0.7).
+            # ``anyOf`` is stripped from the wire ``inputSchema`` by
+            # :func:`_wire_safe_input_schema` (Anthropic Messages API
+            # rejects top-level combinators), so the wire ``required``
+            # only lists ``scope``; the description prose carries the
+            # body-or-content contract to agents. Server-side
+            # ``jsonschema.validate`` in
+            # :mod:`~meho_backplane.mcp.handlers` still enforces the
+            # combinator before the handler runs, so a call supplying
+            # neither field fails ``-32602`` rather than hitting
+            # ``KeyError`` in the handler.
+            "anyOf": [
+                {"required": ["body"]},
+                {"required": ["content"]},
+            ],
             "additionalProperties": False,
         },
         required_role=TenantRole.OPERATOR,

--- a/backend/tests/test_mcp_tools_memory.py
+++ b/backend/tests/test_mcp_tools_memory.py
@@ -11,9 +11,12 @@ tool surface:
   (``additionalProperties: false``) and the MEHO-internal RBAC fields
   stripped from the wire shape.
 * ``inputSchema`` ``required`` lists match the spec: ``[query]`` for
-  ``search_memory``; ``[body, scope]`` for ``add_to_memory`` (renamed
-  from ``content`` to align with ``add_to_knowledge`` + the REST
-  ``POST /api/v1/memory`` body schema per G0.9.1-T7 (#779)).
+  ``search_memory``; ``[scope]`` for ``add_to_memory`` -- with the
+  ``body`` field required server-side via the ``anyOf`` combinator
+  (G0.13-T4 #1134 one-cycle ``content`` -> ``body`` alias shim;
+  G0.9.1-T7 (#779) did the original rename to align with
+  ``add_to_knowledge`` + the REST ``POST /api/v1/memory`` body
+  schema).
 * Tool descriptions name what + when + which scope + cross-reference
   G5.2's TTL default (load-bearing per the AI-engineering anchor).
 * ``tools/call search_memory`` against a seeded corpus returns ranked
@@ -49,6 +52,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+from structlog.testing import capture_logs
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.mcp.schemas import INVALID_PARAMS
@@ -125,13 +129,25 @@ def test_tools_list_exposes_memory_tools_with_strict_input_schema(
 
     assert "add_to_memory" in tools_by_name
     add = tools_by_name["add_to_memory"]
-    assert add["inputSchema"]["required"] == ["body", "scope"]
+    # G0.13-T4 (#1134): the wire ``required`` lists only ``scope``;
+    # ``body`` is required server-side via the ``anyOf`` combinator
+    # which is stripped from the wire copy (the Anthropic Messages API
+    # rejects top-level combinators). The body-or-content contract is
+    # carried by the description prose.
+    assert add["inputSchema"]["required"] == ["scope"]
     assert add["inputSchema"]["additionalProperties"] is False
+    # ``anyOf`` is wire-safe-stripped on tools/list (top-level
+    # combinator).
+    assert "anyOf" not in add["inputSchema"]
     assert "body" in add["inputSchema"]["properties"]
-    # G0.9.1-T7 (#779): the old ``content`` name is gone; ``extra="forbid"``
-    # via additionalProperties:false means a v0.3.1 client posting
-    # ``content`` will fail loud at the JSON-Schema gate.
-    assert "content" not in add["inputSchema"]["properties"]
+    # G0.13-T4 (#1134): one-cycle deprecation shim re-adds ``content``
+    # as a wire-visible alias for ``body``. The schema gates "at least
+    # one of body/content" via ``anyOf`` on the server side; the wire
+    # description marks ``content`` as deprecated. v0.7 drops the shim
+    # and ``content`` goes back to being rejected by
+    # ``additionalProperties: false``.
+    assert "content" in add["inputSchema"]["properties"]
+    assert "DEPRECATED" in add["inputSchema"]["properties"]["content"]["description"]
     assert "scope" in add["inputSchema"]["properties"]
     assert "ttl" in add["inputSchema"]["properties"]
     assert "target_name" in add["inputSchema"]["properties"]
@@ -478,6 +494,256 @@ async def test_tools_call_add_to_memory_creates_entry_and_is_recallable(
     assert fetched is not None
     assert fetched.body == "Operator prefers concise CLI output."
     assert fetched.metadata["tags"] == ["preference"]
+
+
+# ---------------------------------------------------------------------------
+# G0.13-T4 (#1134): one-cycle deprecation shim for ``content`` field
+# ---------------------------------------------------------------------------
+#
+# The shim accepts ``content`` (the pre-v0.6 field name, renamed to
+# ``body`` by G0.9.1-T7 #779) for v0.6.x. Calls supplying ``content``
+# round-trip to the same stored row as ``body`` and emit a structured
+# ``add_to_memory_field_deprecated`` warning log line. When both fields
+# are supplied, ``body`` wins. The shim is dropped in v0.7 (see
+# ``docs/RELEASING.md`` v0.7 follow-ups).
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_tools_call_add_to_memory_accepts_content_alias(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    stub_embedding: AsyncMock,
+) -> None:
+    """AC: ``content`` field rounds-trip to the same stored row as ``body``.
+
+    A v0.3.x client pinned to ``content`` succeeds and the body is
+    stored under the canonical ``body`` field; the substrate doesn't
+    care which wire field carried it. ``service.recall`` (REST shape)
+    returns the body just like a ``body``-shaped call would.
+    """
+    client, op = client_with_operator
+
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "add_to_memory",
+                "arguments": {
+                    "content": "Pinned-to-content client write.",
+                    "scope": "user",
+                    "slug": "shim-content-only",
+                },
+            },
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["result"]["isError"] is False
+    created = json.loads(payload["result"]["content"][0]["text"])
+    assert created["scope"] == "user"
+    assert created["slug"] == "shim-content-only"
+    assert created["body"] == "Pinned-to-content client write."
+
+    service = MemoryService()
+    fetched = await service.recall(op, scope=MemoryScope.USER, slug="shim-content-only")
+    assert fetched is not None
+    assert fetched.body == "Pinned-to-content client write."
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_tools_call_add_to_memory_content_emits_deprecation_log(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    stub_embedding: AsyncMock,
+) -> None:
+    """AC: supplying ``content`` emits ``add_to_memory_field_deprecated``.
+
+    The structured warning carries ``replacement="body"`` so an
+    operator scanning logs sees the migration breadcrumb directly,
+    matching ai-engineering-best-practices guidance (agent-facing
+    schema changes need a migration breadcrumb in the response or
+    logs).
+    """
+    client, _op = client_with_operator
+
+    with capture_logs() as captured:
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "add_to_memory",
+                    "arguments": {
+                        "content": "Deprecation-log canary write.",
+                        "scope": "user",
+                        "slug": "shim-content-deprecation-log",
+                    },
+                },
+            },
+        )
+    assert response.status_code == 200
+    assert response.json()["result"]["isError"] is False
+
+    deprecation_events = [
+        ev for ev in captured if ev.get("event") == "add_to_memory_field_deprecated"
+    ]
+    assert len(deprecation_events) == 1, (
+        f"expected exactly one add_to_memory_field_deprecated event; got captured={captured}"
+    )
+    event = deprecation_events[0]
+    assert event["replacement"] == "body"
+    assert event["log_level"] == "warning"
+    assert event["removal_version"] == "0.7"
+    assert event["body_supplied"] is False
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_tools_call_add_to_memory_body_wins_when_both_supplied(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    stub_embedding: AsyncMock,
+) -> None:
+    """AC: when both ``body`` and ``content`` are supplied, ``body`` wins.
+
+    A client mid-migration (sending both fields) gets a deterministic
+    outcome: the canonical ``body`` is persisted. The deprecation log
+    still fires because ``content`` was supplied; the event carries
+    ``body_supplied=True`` so an operator can tell apart "pure pinned
+    client" from "mid-migration client" in the log stream.
+    """
+    client, op = client_with_operator
+
+    with capture_logs() as captured:
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "add_to_memory",
+                    "arguments": {
+                        "body": "Canonical body wins.",
+                        "content": "Legacy content loses.",
+                        "scope": "user",
+                        "slug": "shim-both-fields",
+                    },
+                },
+            },
+        )
+    assert response.status_code == 200
+    created = json.loads(response.json()["result"]["content"][0]["text"])
+    assert created["body"] == "Canonical body wins."
+
+    # Persisted row matches the body field, not content.
+    service = MemoryService()
+    fetched = await service.recall(op, scope=MemoryScope.USER, slug="shim-both-fields")
+    assert fetched is not None
+    assert fetched.body == "Canonical body wins."
+
+    # The deprecation log fires (content was supplied) and records that
+    # body was also supplied so the operator can identify mid-migration
+    # clients distinctly from pure pinned clients.
+    deprecation_events = [
+        ev for ev in captured if ev.get("event") == "add_to_memory_field_deprecated"
+    ]
+    assert len(deprecation_events) == 1
+    assert deprecation_events[0]["body_supplied"] is True
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+def test_tools_call_add_to_memory_rejects_neither_body_nor_content(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: server-side ``anyOf`` rejects a call supplying neither field.
+
+    The wire ``required`` lists only ``scope``, but the server-side
+    schema (with the wire-stripped ``anyOf``) still enforces "at least
+    one of body/content". A call missing both surfaces as INVALID_PARAMS
+    via :mod:`jsonschema` validation in
+    :mod:`~meho_backplane.mcp.handlers`, not as a handler-level
+    ``KeyError``.
+    """
+    client, _op = client_with_operator
+    response = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "add_to_memory",
+                "arguments": {"scope": "user"},
+            },
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert "error" in body, f"expected JSON-RPC error; got {body}"
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize(
+    "client_with_operator",
+    [TenantRole.OPERATOR],
+    indirect=True,
+)
+@pytest.mark.asyncio
+async def test_tools_call_add_to_memory_body_only_no_deprecation_log(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    stub_embedding: AsyncMock,
+) -> None:
+    """The canonical ``body``-only path does not emit the deprecation log.
+
+    Negative control for the shim: a modern client should not see the
+    warning in its log stream.
+    """
+    client, _op = client_with_operator
+
+    with capture_logs() as captured:
+        response = post_mcp(
+            client,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "add_to_memory",
+                    "arguments": {
+                        "body": "Modern client write.",
+                        "scope": "user",
+                        "slug": "shim-body-only-control",
+                    },
+                },
+            },
+        )
+    assert response.status_code == 200
+    assert response.json()["result"]["isError"] is False
+    deprecation_events = [
+        ev for ev in captured if ev.get("event") == "add_to_memory_field_deprecated"
+    ]
+    assert deprecation_events == []
 
 
 @pytest.mark.parametrize(
@@ -891,69 +1157,20 @@ def test_tools_call_add_to_memory_requires_target_name_for_target_scope(
     assert "target_name" in body["error"]["message"]
 
 
-@pytest.mark.parametrize(
-    "client_with_operator",
-    [TenantRole.OPERATOR],
-    indirect=True,
-)
-def test_tools_call_add_to_memory_rejects_missing_required(
-    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
-) -> None:
-    """Schema validation fires before the handler — missing ``body`` → -32602."""
-    client, _op = client_with_operator
-    response = post_mcp(
-        client,
-        {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "tools/call",
-            "params": {
-                "name": "add_to_memory",
-                "arguments": {"scope": "user"},
-            },
-        },
-    )
-    assert response.status_code == 200
-    body = response.json()
-    assert body["error"]["code"] == INVALID_PARAMS
-
-
-@pytest.mark.parametrize(
-    "client_with_operator",
-    [TenantRole.OPERATOR],
-    indirect=True,
-)
-def test_tools_call_add_to_memory_rejects_legacy_content_field(
-    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
-) -> None:
-    """G0.9.1-T7 (#779): the old ``content`` field is now rejected.
-
-    The MCP `add_to_memory` tool renamed `content` -> `body` to align
-    with `add_to_knowledge` and the REST `POST /api/v1/memory` body
-    schema. ``additionalProperties: false`` on the inputSchema means a
-    v0.3.1 client posting ``content`` (without ``body``) fails the
-    JSON-Schema gate with INVALID_PARAMS -- not a silent drop. This is
-    the breaking-change contract documented in CHANGELOG [0.3.2].
-    """
-    client, _op = client_with_operator
-    response = post_mcp(
-        client,
-        {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "tools/call",
-            "params": {
-                "name": "add_to_memory",
-                "arguments": {
-                    "content": "legacy v0.3.1 wire shape",
-                    "scope": "user",
-                },
-            },
-        },
-    )
-    assert response.status_code == 200
-    err = response.json()["error"]
-    assert err["code"] == INVALID_PARAMS
+# G0.13-T4 (#1134) removed two tests that no longer match the contract:
+#
+# * ``test_tools_call_add_to_memory_rejects_missing_required`` -- the
+#   missing-body-and-content case is now covered by
+#   ``test_tools_call_add_to_memory_rejects_neither_body_nor_content``
+#   above (same INVALID_PARAMS assertion against the server-side
+#   ``anyOf`` gate).
+# * ``test_tools_call_add_to_memory_rejects_legacy_content_field`` --
+#   the legacy ``content`` field is intentionally re-accepted under
+#   the one-cycle deprecation shim and covered by
+#   ``test_tools_call_add_to_memory_accepts_content_alias`` +
+#   ``test_tools_call_add_to_memory_content_emits_deprecation_log``
+#   above. The shim is dropped in v0.7; restore a rejection assertion
+#   when that lands (see ``docs/RELEASING.md`` v0.7 follow-ups).
 
 
 # ---------------------------------------------------------------------------

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -210,3 +210,20 @@ The push fans out to `cli-release.yml`, `image.yml`, `chart.yml`.
   inconclusive, not a pass. Step 1 now makes both gates explicit:
   confirm the tagged commit's `main` run is a real `success`, and
   re-run any `cancelled` run before trusting it.
+
+## v0.7 follow-ups (deprecation removals)
+
+When cutting v0.7, drop these v0.6.x compatibility shims:
+
+- **MCP `add_to_memory.content` -> `body` alias shim** (G0.13-T4,
+  #1134). Remove the `content` field from
+  `backend/src/meho_backplane/mcp/tools/memory.py`'s `inputSchema`
+  `properties`; drop the `anyOf` clause; restore
+  `required: ["body", "scope"]`. Drop the body/content resolution
+  branch + the `add_to_memory_field_deprecated` log emission from
+  `_add_to_memory_handler`. Update
+  `backend/tests/test_mcp_tools_memory.py` to assert `content` is
+  rejected by the JSON-Schema gate (re-introduce a variant of the
+  deleted `test_tools_call_add_to_memory_rejects_legacy_content_field`
+  test). CHANGELOG `[0.7.0]` entry under **Removed** naming the shim
+  and pointing at this paragraph.

--- a/docs/codebase/memory.md
+++ b/docs/codebase/memory.md
@@ -247,9 +247,16 @@ marker.
   exercises PG-only operators (`@@`, `<=>`); the unit tests mock
   the retrieve helper and the PG-real contract lives in
   `tests/acceptance/test_g51_memory_canary.py`.
-* The MCP `add_to_memory` schema names the body field `content` while
-  the REST + KB schemas use `body` — sibling task #779 (G0.9.1-T7)
-  closes that asymmetry separately. Out of scope here.
+* The MCP `add_to_memory` body field underwent a rename
+  `content` -> `body` to align with `add_to_knowledge` and the REST
+  `POST /api/v1/memory` body schema. G0.9.1-T7 (#779) shipped the
+  rename; G0.13-T4 (#1134) retro-fitted the missing CHANGELOG and
+  release-body callout against the actual release window (v0.6.0, not
+  v0.3.2 as the original task's AC targeted) and added a one-cycle
+  compatibility shim. v0.6.x accepts both fields: `body` is canonical
+  and wins when both are supplied; `content` is a deprecated alias
+  that fires a structured `add_to_memory_field_deprecated` warning
+  log line with `replacement="body"`. The shim is dropped in v0.7.
 * Non-`user` scopes have no default-TTL gate by design (per #624's
   narrow scope). A future Task widening it should change the
   `scope is not MemoryScope.USER` branch in `memory/ttl.py` and add


### PR DESCRIPTION
## Summary

- **One-cycle deprecation shim** for the `add_to_memory` MCP tool's body field. v0.6.x now accepts both `body` (canonical) and `content` (deprecated alias from v0.3.x); `body` wins when both are supplied; `content` fires a structured `add_to_memory_field_deprecated` warning log line with `replacement="body"`, `removal_version="0.7"`, and `body_supplied=<bool>` so an operator can distinguish pure pinned clients from mid-migration clients. Closes the silent-breaking-rename gap RDC reported (consumer signal `add-to-memory-content-to-body-silent-rename`; pinned v0.3.x clients hit 422 with no migration breadcrumb at v0.6.0).
- **v0.6.0 CHANGELOG amendment.** The `[0.6.0]` opening now reads "Breaking changes: 1 — see Changed (breaking) section." and carries a new `### Changed (breaking)` entry naming the rename, the v0.6.x shim grace period, the structured log shape, and the v0.7 removal plan. Retroactively satisfies the closed-#779 (G0.9.1-T7) CHANGELOG-callout AC against the actual release window.
- **v0.6.0 GitHub release body amended live** via `gh release edit v0.6.0` (layered on top of sibling T6 PR #1159's amendments — confirmed live at impl time). The "No breaking changes." line is replaced with "Breaking changes: 1" + the same `### Changed (breaking)` entry.
- **v0.7 follow-up** logged as a `## v0.7 follow-ups (deprecation removals)` section in `docs/RELEASING.md` with the explicit removal recipe (drop `content` from `properties`, drop `anyOf`, restore `required: ["body", "scope"]`, drop the shim handler branch + log line, re-introduce a `rejects_legacy_content_field` test, add a CHANGELOG `[0.7.0] ### Removed` entry).

## Design notes

- **Schema gate uses server-side `anyOf`** stripped from the wire copy by `_wire_safe_input_schema` (the Anthropic Messages API rejects top-level combinators on a tool's `input_schema`). The wire `required` lists only `["scope"]` and the body-or-content contract is carried by the description prose; server-side `jsonschema.validate` in `mcp/handlers.py` still enforces the combinator so a call supplying neither field fails INVALID_PARAMS at the schema layer, not as a handler `KeyError`.
- **Logger is resolved per-call** inside the handler rather than as a module-level proxy. Production sets `cache_logger_on_first_use=True`; a cached `BoundLogger` pins the processor chain it was built with, so `structlog.testing.capture_logs` in tests can't observe events written through the orphaned proxy. Same precedent as `meho_backplane.auth.jwt` (memory `ref_structlog_cached_proxy`).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (647 files)
- [x] `mypy src/ --ignore-missing-imports` — clean (315 source files)
- [x] `pytest tests/test_mcp_tools_memory.py -x -q` — 24 passed
- [x] `pytest tests/test_mcp_audit.py tests/test_mcp_resources_memory.py tests/test_memory_service.py -x -q` — 59 passed (sibling/downstream)
- [x] **Full backend unit suite** — 4662 passed, 13 skipped
- [x] `code-quality.py --diff` — 0 blockers (file-size + handler-size warnings on pre-existing growth; helper extracted to keep handler <100 lines)
- [x] **AC: `add_to_memory` MCP tool accepts both `content` and `body`** — `test_tools_call_add_to_memory_accepts_content_alias`
- [x] **AC: deprecation log fires with `replacement="body"`** — `test_tools_call_add_to_memory_content_emits_deprecation_log`
- [x] **AC: `body` wins when both are supplied** — `test_tools_call_add_to_memory_body_wins_when_both_supplied`
- [x] **AC: server-side `anyOf` rejects neither-supplied** — `test_tools_call_add_to_memory_rejects_neither_body_nor_content`
- [x] **AC: body-only path does NOT emit the deprecation log** — `test_tools_call_add_to_memory_body_only_no_deprecation_log`
- [x] **AC: CHANGELOG `[0.6.0]` `### Changed (breaking)` entry added** — see diff
- [x] **AC: v0.6.0 GitHub release body amended** — verified live via `gh release view v0.6.0 --json body --jq '.body'`
- [x] **AC: v0.7 follow-up logged** — `docs/RELEASING.md` `## v0.7 follow-ups (deprecation removals)` section

## Out of scope

- Re-opening #779 (closed; this is the follow-up that handles its missed CHANGELOG-callout AC retroactively).
- Other MCP write-surface field renames — none pending; this is the one missed callout.
- Release-body path-citation freshness — sibling T6 (#1136 / PR #1159) lands that gate + the audit-replay/conventions/topology-history path corrections. This PR layers its `### Changed (breaking)` entry on top of T6's amended release body (verified live at impl time).
- Doc updates beyond `docs/codebase/memory.md` (Known issues bullet flipped from "out of scope here" to record the rename + the shim) and `docs/RELEASING.md` v0.7 follow-up.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1134
