### PR TITLE
feat(memory-ui): G10.4-T1 scope-aware list + detail/edit + delete + tag filter

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "tabulate>=0.9.0",
     "pydantic-ai-slim[anthropic]>=1.102.0",
     "croniter>=6.2.2",
-    "markdown-it-py>=3.0",
+    "markdown-it-py[linkify]>=3.0",
     "pygments>=2.18",
     "python-multipart>=0.0.12",
 ]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -35,6 +35,9 @@ dependencies = [
     "tabulate>=0.9.0",
     "pydantic-ai-slim[anthropic]>=1.102.0",
     "croniter>=6.2.2",
+    "markdown-it-py>=3.0",
+    "pygments>=2.18",
+    "python-multipart>=0.0.12",
 ]
 
 [dependency-groups]
@@ -246,6 +249,17 @@ ignore_missing_imports = true
 # upstream ships stubs.
 [[tool.mypy.overrides]]
 module = ["asyncssh.*"]
+ignore_missing_imports = true
+
+# pygments (G10.4-T1 #877) ships no ``py.typed`` marker as of 2.20.
+# Used by :mod:`meho_backplane.ui.routes.memory.render` for the
+# server-side Markdown code-block syntax highlighter; the call sites
+# are scoped to one module so the untyped surface stays narrow.
+# ``markdown-it-py`` itself ships ``py.typed``, no override needed.
+# Drop this override if upstream ships stubs (``types-Pygments`` is
+# available on PyPI but would add a build-time dep).
+[[tool.mypy.overrides]]
+module = ["pygments", "pygments.*"]
 ignore_missing_imports = true
 
 # defusedxml (G3.7-T2 #847) ships no ``py.typed`` marker as of 0.7.1.

--- a/backend/src/meho_backplane/ui/routes/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/__init__.py
@@ -9,9 +9,12 @@ ships the umbrella :func:`build_router` that aggregates:
 * :mod:`~meho_backplane.ui.routes.dashboard` -- ``GET /ui/`` --
   authenticated landing page with the 3x2 surface card grid, the
   HTMX SSE last-5-events snippet, and the version + readiness card.
-* :mod:`~meho_backplane.ui.routes.stubs` -- ``GET /ui/{broadcast,
-  knowledge,topology,connectors,memory}`` -- placeholder routes the
-  surface Initiatives G10.1-G10.5 replace.
+* :mod:`~meho_backplane.ui.routes.memory` -- the memory surface
+  (G10.4-T1 #877): ``/ui/memory`` list, ``/ui/memory/<scope>/<slug>``
+  detail + edit-in-place + delete, ``/ui/memory/tags`` autocomplete.
+* :mod:`~meho_backplane.ui.routes.stubs` -- ``GET /ui/{knowledge,
+  connectors}`` -- remaining placeholder routes the surface Initiatives
+  G10.2 (kb) + G10.3 (connectors) replace.
 
 Auth surfaces (``/ui/auth/login``, ``/ui/auth/callback``,
 ``/ui/auth/logout``) live under
@@ -33,12 +36,14 @@ from fastapi import APIRouter
 
 from meho_backplane.ui.routes.broadcast import build_router as build_broadcast_router
 from meho_backplane.ui.routes.dashboard import build_dashboard_router
+from meho_backplane.ui.routes.memory import build_memory_router
 from meho_backplane.ui.routes.stubs import build_stubs_router
 from meho_backplane.ui.routes.topology import build_router as build_topology_router
 
 __all__ = [
     "build_broadcast_router",
     "build_dashboard_router",
+    "build_memory_router",
     "build_router",
     "build_stubs_router",
     "build_topology_router",
@@ -46,19 +51,20 @@ __all__ = [
 
 
 def build_router() -> APIRouter:
-    """Aggregate the dashboard + broadcast + topology + stubs routers.
+    """Aggregate the dashboard + broadcast + topology + memory + stubs routers.
 
     Order matters: FastAPI matches by registration order, so a
     surface Initiative's real router is included **before** the
     stubs aggregate to win the first-match-wins path lookup. The
     dashboard ``/ui/`` route does not collide with any surface
-    sub-path; broadcast lands ``/ui/broadcast`` + ``/ui/broadcast/stream``
-    and topology lands ``/ui/topology`` + ``/ui/topology/node/{id}``,
+    sub-path; broadcast lands ``/ui/broadcast`` + ``/ui/broadcast/stream``,
+    topology lands ``/ui/topology`` + ``/ui/topology/node/{id}``, and
+    memory lands ``/ui/memory`` + ``/ui/memory/{scope}/{slug}`` --
     each of which would otherwise hit a ``/ui/{slug}`` stub. The
-    ``broadcast`` stub is also dropped from the stubs enumeration so the
-    real route is the only ``/ui/broadcast`` registration in the OpenAPI
-    schema. Once G10.2-G10.4 land their surface routers, each includes
-    itself ahead of the stubs the same way.
+    ``broadcast`` / ``memory`` stubs are dropped from the stubs
+    enumeration so the real routes are the only registrations in the
+    OpenAPI schema. Once G10.2-G10.3 land their surface routers, each
+    includes itself ahead of the stubs the same way.
     """
     router = APIRouter()
     router.include_router(build_dashboard_router())
@@ -66,5 +72,6 @@ def build_router() -> APIRouter:
     # the match against the stubs' placeholder ``/ui/{slug}``.
     router.include_router(build_broadcast_router())
     router.include_router(build_topology_router())
+    router.include_router(build_memory_router())
     router.include_router(build_stubs_router())
     return router

--- a/backend/src/meho_backplane/ui/routes/memory/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/memory/__init__.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Memory UI routes: scope-aware list + detail/edit + delete + tag filter.
+
+Initiative #341 (G10.4 Memory UI). Task #877 (G10.4-T1) ships the
+read + edit + delete + tag-filter surface at ``/ui/memory``; subsequent
+Tasks layer create+promote (T2 #878) and expiry-viz+bulk (T3 #879).
+
+Module layout:
+
+* :mod:`~meho_backplane.ui.routes.memory.routes` -- the request
+  handlers. ``GET /ui/memory`` (full page or HTMX card-list fragment),
+  ``GET /ui/memory/<scope>/<slug>`` (detail page or HTMX body fragment),
+  ``GET /ui/memory/<scope>/<slug>/edit`` (HTMX edit form fragment),
+  ``PATCH /ui/memory/<scope>/<slug>`` (HTMX save: replace the body
+  fragment), ``DELETE /ui/memory/<scope>/<slug>`` (HTMX delete: re-
+  render the list), ``GET /ui/memory/tags`` (HTMX datalist for the
+  tag autocomplete).
+* :mod:`~meho_backplane.ui.routes.memory.render` -- server-side
+  Markdown -> HTML rendering (markdown-it-py commonmark + pygments
+  syntax highlight). Mirrors the precedent the KB UI sets in
+  :mod:`~meho_backplane.ui.routes.kb.render` (G10.2-T1 #870); the two
+  modules will dedupe once both PRs land on ``main``.
+* :mod:`~meho_backplane.ui.routes.memory.operator` -- the
+  ``resolve_ui_operator`` FastAPI dependency that lifts the full
+  :class:`~meho_backplane.auth.operator.Operator` (carrying
+  :attr:`tenant_role`) from the BFF session by re-verifying the
+  stored access token. The chassis :class:`UISessionContext` only
+  carries ``operator_sub`` + ``tenant_id``; the memory RBAC matrix
+  needs the role to gate edit-in-place + tenant-scoped writes.
+
+The umbrella :func:`build_router` is mounted **before**
+:func:`meho_backplane.ui.routes.stubs.build_stubs_router` in
+:func:`meho_backplane.ui.routes.build_router` so the real
+``/ui/memory`` handler wins the first-match-wins path lookup. The
+``memory`` stub is retired by this task.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.ui.routes.memory.routes import build_memory_router
+
+__all__ = ["build_memory_router"]

--- a/backend/src/meho_backplane/ui/routes/memory/operator.py
+++ b/backend/src/meho_backplane/ui/routes/memory/operator.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``resolve_ui_operator`` -- lift a full :class:`Operator` from a BFF session.
+
+Initiative #341 (G10.4 Memory UI), Task #877 (T1). The chassis
+:class:`~meho_backplane.ui.auth.middleware.UISessionContext` carries
+``operator_sub`` + ``tenant_id`` only; the per-scope memory RBAC matrix
+(:mod:`~meho_backplane.memory.rbac`) also needs
+:attr:`~meho_backplane.auth.operator.Operator.tenant_role` to gate:
+
+* edit-in-place rendering on the detail view (operator vs tenant_admin),
+* the actual ``PATCH`` / ``DELETE`` handlers (re-checks the matrix
+  server-side; never trusts a client-supplied role hint),
+* the create / promote handlers T2 #878 will add on this same router.
+
+The dependency loads the encrypted session row (via the same
+:func:`~meho_backplane.ui.auth.session_store.load_session` the chassis
+middleware uses), decrypts the access token, and re-runs it through
+:func:`~meho_backplane.auth.jwt.verify_jwt_for_audience` to produce a
+fully-validated :class:`Operator`. The JWT chain caches the JWKS in
+process so the round-trip is local-only after the first hit.
+
+Why not store the role on the session row
+-----------------------------------------
+
+Two reasons:
+
+1. The role can change between login and now (a tenant admin demotes
+   the operator to ``read_only`` mid-session). Re-validating the
+   access token catches that the next time the operator's browser
+   issues a memory write. Storing a cached role on the session row
+   would extend the demotion's effective window to the session's
+   absolute TTL.
+
+2. The session row is encrypted with the BFF's Fernet key; widening
+   its schema means a migration plus a re-encrypt step on every
+   row. The current shape (encrypted tokens only) keeps the schema
+   minimal and lets the chassis carry the BFF concern without
+   memory-specific contamination.
+
+The cost is one in-process JWT decode per write request (~µs once the
+JWKS is cached). Read requests still build a synthesised
+:class:`Operator` with :attr:`TenantRole.OPERATOR` directly from the
+:class:`UISessionContext` because the RBAC matrix only blocks reads
+on the per-row ``user_sub`` check, which doesn't need the role. The
+:func:`build_read_operator` helper exposes that path for the list /
+recall handlers.
+"""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import HTTPException, Request, status
+
+from meho_backplane.auth.jwt import verify_jwt_for_audience
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.auth.session_store import load_session
+
+__all__ = ["build_read_operator", "resolve_ui_operator"]
+
+_log = structlog.get_logger(__name__)
+
+
+def build_read_operator(session_ctx: UISessionContext) -> Operator:
+    """Build a synthesised :class:`Operator` for read-only memory paths.
+
+    The memory RBAC matrix's read branch
+    (:meth:`~meho_backplane.memory.rbac.MemoryRbacResolver.can_read`)
+    gates user-flavoured rows on the stored ``user_sub`` match and
+    treats tenant / target rows as visible to every operator in the
+    tenant -- the role is not consulted. Synthesising an
+    :class:`Operator` with :attr:`TenantRole.OPERATOR` is therefore
+    sound for ``list_memories`` / ``recall``. The chassis session
+    middleware already enforced authentication; this helper avoids the
+    JWT round-trip on every list refresh.
+
+    The synthesised ``raw_jwt`` is a stable string (``"ui-session"``)
+    so any consumer that introspects it for chain-of-custody logging
+    can distinguish a UI-mediated read from an ``/api/*`` request
+    (which carries a real JWT).
+    """
+    return Operator(
+        sub=session_ctx.operator_sub,
+        raw_jwt="ui-session",
+        tenant_id=session_ctx.tenant_id,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _load_session_or_401(session_ctx: UISessionContext) -> str:
+    """Load the encrypted session row and return the decrypted access token.
+
+    The session middleware already validated the cookie before this
+    dependency runs; if the row vanished in the gap (revoked / expired
+    while the request was in-flight), raise 401 so the operator's
+    browser knows to re-authenticate. Centralised so the JWT-decode
+    branch of :func:`resolve_ui_operator` stays a one-liner.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as db_session, db_session.begin():
+        decrypted = await load_session(db_session, session_ctx.session_id)
+    if decrypted is None:
+        _log.info("ui_memory_session_gone", session_id=str(session_ctx.session_id))
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="ui_session_required",
+        )
+    return decrypted.access_token
+
+
+def _assert_token_matches_session(
+    operator: Operator,
+    session_ctx: UISessionContext,
+) -> None:
+    """Reject a token whose ``sub`` / ``tenant_id`` diverges from the session row.
+
+    A mismatch is a security anomaly (token swapped under the same
+    session row); it must surface as 401, not a silently-honoured
+    cross-identity read.
+    """
+    if operator.sub != session_ctx.operator_sub or operator.tenant_id != session_ctx.tenant_id:
+        _log.warning(
+            "ui_memory_session_identity_mismatch",
+            session_sub=session_ctx.operator_sub,
+            session_tenant_id=str(session_ctx.tenant_id),
+            token_sub=operator.sub,
+            token_tenant_id=str(operator.tenant_id),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="ui_session_identity_mismatch",
+        )
+
+
+async def resolve_ui_operator(
+    request: Request,
+    session_ctx: UISessionContext | None = None,
+) -> Operator:
+    """FastAPI dependency: lift the full :class:`Operator` from the BFF session.
+
+    Used by every memory write handler (``PATCH`` / ``DELETE``). Reads
+    the encrypted session row, decrypts the access token, and re-runs
+    it through the chassis JWT chain to produce a fully-validated
+    :class:`Operator` carrying :attr:`tenant_role`. Failure modes:
+
+    * The session middleware should have rejected the request before
+      this dependency runs; if the session row vanished between the
+      middleware check and now (revoked / expired in the gap), this
+      raises ``401`` with ``ui_session_required``.
+    * The decrypted access token failing JWT validation
+      (signature drift, expired, etc.) raises ``401`` with the chassis
+      JWT chain's own ``detail`` code -- propagated unchanged so the
+      operator can see the actual reason.
+
+    Parameters
+    ----------
+    request:
+        The FastAPI :class:`Request`. Used only to pull the chassis-
+        bound :class:`UISessionContext` off ``request.state`` when the
+        explicit ``session_ctx`` parameter isn't supplied.
+    session_ctx:
+        Optional pre-resolved session context. When ``None`` (the
+        normal FastAPI dependency path), the helper invokes
+        :func:`require_ui_session` to read it off ``request.state``.
+    """
+    if session_ctx is None:
+        session_ctx = require_ui_session(request)
+    access_token = await _load_session_or_401(session_ctx)
+    settings = get_settings()
+    operator = await verify_jwt_for_audience(
+        f"Bearer {access_token}",
+        expected_audience=settings.keycloak_audience,
+    )
+    _assert_token_matches_session(operator, session_ctx)
+    return operator

--- a/backend/src/meho_backplane/ui/routes/memory/render.py
+++ b/backend/src/meho_backplane/ui/routes/memory/render.py
@@ -74,6 +74,7 @@ References
 
 from __future__ import annotations
 
+import re
 import threading
 
 from markdown_it import MarkdownIt
@@ -86,6 +87,18 @@ from pygments.util import ClassNotFound
 __all__ = ["pygments_css", "render_markdown"]
 
 _lock = threading.Lock()
+
+#: Conservative allowlist for the fenced-code ``language-{lang}`` class
+#: attribute. Pygments lexer aliases use this character set
+#: (``python``, ``c++``, ``objective-c``, ``shell-session``), so the
+#: filter passes every well-formed lang token through while dropping
+#: anything that could break out of the ``class="..."`` attribute. A
+#: ``lang`` string that doesn't fullmatch falls back to ``text``.
+#: Defence against attribute-injection XSS:
+#:   ```a"onmouseover="alert(1)"x
+#: would otherwise interpolate verbatim into ``class="language-..."``
+#: and ship a working JS handler to the browser.
+_LANG_PATTERN_RE: re.Pattern[str] = re.compile(r"^[A-Za-z0-9_+\-.]+$")
 
 #: Shared :class:`HtmlFormatter` instance. ``nowrap=True`` emits bare
 #: ``<span>`` tokens so the wrapping ``<pre><code>`` block is
@@ -119,8 +132,13 @@ def _highlight_code(code: str, lang: str, attrs: str) -> str:
         lexer = TextLexer()
     highlighted = highlight(code, lexer, _FORMATTER)
     # Match the wrapping shape the KB renderer uses so a future
-    # consolidation can collapse the two modules into one.
-    lang_class = lang or "text"
+    # consolidation can collapse the two modules into one. The lang
+    # token is dropped to ``text`` unless it fullmatches the
+    # conservative allowlist -- markdown-it-py hands the fenced-code
+    # info string through verbatim, so a body like
+    # ```a"onmouseover="alert(1)"x  would otherwise inject a JS event
+    # handler into the rendered ``class="language-..."`` attribute.
+    lang_class = lang if lang and _LANG_PATTERN_RE.fullmatch(lang) else "text"
     return (
         f'<pre class="memory-code"><code class="language-{lang_class}">{highlighted}</code></pre>'
     )
@@ -136,7 +154,7 @@ def _highlight_code(code: str, lang: str, attrs: str) -> str:
 _MD = MarkdownIt(
     "commonmark",
     {"html": False, "linkify": True, "highlight": _highlight_code},
-).enable(["table", "strikethrough"])
+).enable(["table", "strikethrough", "linkify"])
 
 
 def render_markdown(body: str) -> Markup:

--- a/backend/src/meho_backplane/ui/routes/memory/render.py
+++ b/backend/src/meho_backplane/ui/routes/memory/render.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Server-side Markdown -> HTML renderer for the memory detail view.
+
+Initiative #341 (G10.4 Memory UI), Task #877 (T1). Mirrors the precedent
+:mod:`~meho_backplane.ui.routes.kb.render` sets for the KB read surface
+(G10.2-T1 #870): ``markdown-it-py`` (commonmark with ``table`` +
+``strikethrough`` enabled, ``html=False``) for the parse + render, and
+``pygments`` with :class:`HtmlFormatter` for code-block syntax
+highlighting. The two modules duplicate ~50 LOC by design while #870 /
+#877 are in flight on parallel branches; once both PRs land on ``main``
+a follow-up consolidation can promote one of them to a shared
+``ui.markdown`` module.
+
+Design decisions
+----------------
+
+* ``markdown-it-py`` ``commonmark`` preset is constructed with
+  ``html=False`` so a raw ``<script>`` (or ``<iframe`` / ``<object``)
+  in a memory body is rendered as escaped text, not parsed as HTML.
+  The ``commonmark`` preset's default for ``html`` is ``True``
+  (verified against markdown-it-py 4.2.0 installed locally on
+  2026-05-26), so the override is load-bearing -- a v0.2.next
+  upgrade that flips the default elsewhere will be caught by the
+  ``commonmark`` -> ``zero`` migration tests but not by this module's
+  unit tests.
+* ``table`` + ``strikethrough`` are enabled explicitly. The
+  ``gfm-like`` preset would enable those plus ``html=True``; the
+  explicit-enable shape keeps the raw-HTML surface closed while still
+  giving operators GFM-flavoured Markdown.
+* ``linkify`` (``https://example.com`` -> ``<a href="...">``) is
+  enabled so memory bodies that paste a runbook URL render as a
+  clickable link without forcing the operator to wrap it in
+  ``[text](url)`` syntax.
+* ``pygments`` :class:`HtmlFormatter` with ``nowrap=True`` emits bare
+  ``<span>`` tokens -- the wrapping ``<pre class="memory-code"><code
+  class="language-{lang}">`` block is controlled by the highlight
+  callback so the styling matches DaisyUI's ``mockup-code`` aesthetics
+  uniformly across the entry.
+* :class:`TextLexer` fallback: an unknown ``lang`` attribute falls
+  back to plain text (no decoration) rather than guessing. Pygments'
+  language-guesser frequently mis-classifies prose snippets as
+  another language and injects colourful noise; the memory surface
+  prefers boring + correct over clever + wrong.
+* ``Markup`` wrapping: the rendered HTML string is wrapped in
+  :class:`markupsafe.Markup` so Jinja2's autoescape does not
+  double-escape the already-sanitised HTML. The ``markdown-it-py``
+  renderer HTML-encodes user-supplied text (heading content,
+  paragraph text, link targets) before inserting it into the output;
+  with ``html=False`` raw HTML in the body is stripped to escaped
+  text. Both together mean the rendered output is safe to pass
+  through ``Markup``.
+
+Thread-safety
+-------------
+
+``MarkdownIt`` instances are not thread-safe for concurrent ``render()``
+calls against the same instance: ``render`` mutates internal parser
+state (the token stream is held on the instance for the duration of the
+call). The module-level singleton is therefore guarded by a lock; the
+lock is per-process (not per-request), so the overhead is negligible
+compared to the I/O cost of the surrounding DB read. An alternative
+would be constructing one ``MarkdownIt`` per request, but the per-
+request construction cost dominates the lock-contention cost at
+realistic QPS on an operator-facing surface.
+
+References
+----------
+
+* markdown-it-py API: https://markdown-it-py.readthedocs.io/en/latest/
+* pygments HtmlFormatter: https://pygments.org/docs/formatters/
+"""
+
+from __future__ import annotations
+
+import threading
+
+from markdown_it import MarkdownIt
+from markupsafe import Markup
+from pygments import highlight
+from pygments.formatters import HtmlFormatter
+from pygments.lexers import TextLexer, get_lexer_by_name
+from pygments.util import ClassNotFound
+
+__all__ = ["pygments_css", "render_markdown"]
+
+_lock = threading.Lock()
+
+#: Shared :class:`HtmlFormatter` instance. ``nowrap=True`` emits bare
+#: ``<span>`` tokens so the wrapping ``<pre><code>`` block is
+#: controlled by the highlight callback. ``cssclass`` is set to a
+#: memory-namespaced value so the generated style rules don't collide
+#: with DaisyUI's own ``.highlight`` utility class.
+_FORMATTER = HtmlFormatter(nowrap=True, cssclass="memory-code")
+
+#: Cached CSS for the current pygments style. Generated once at module
+#: load; safe to embed in a ``<style>`` block on the detail page.
+_PYGMENTS_CSS: str = _FORMATTER.get_style_defs(".memory-code")
+
+
+def _highlight_code(code: str, lang: str, attrs: str) -> str:
+    """Pygments callback for ``markdown-it-py``'s ``highlight`` option.
+
+    Returns a ``<pre class="memory-code"><code class="language-{lang}">``
+    block with pygments span annotations inside. Unknown ``lang``
+    values fall back to :class:`TextLexer` (no decoration) rather than
+    guessing. The ``attrs`` argument (fenced-code attributes) is
+    ignored in v0.2 -- the task body does not require attribute
+    parsing.
+    """
+    del attrs  # not consumed in v0.2; v0.2.next may use for ``hl_lines=...``
+    if lang:
+        try:
+            lexer = get_lexer_by_name(lang, stripall=True)
+        except ClassNotFound:
+            lexer = TextLexer()
+    else:
+        lexer = TextLexer()
+    highlighted = highlight(code, lexer, _FORMATTER)
+    # Match the wrapping shape the KB renderer uses so a future
+    # consolidation can collapse the two modules into one.
+    lang_class = lang or "text"
+    return (
+        f'<pre class="memory-code"><code class="language-{lang_class}">{highlighted}</code></pre>'
+    )
+
+
+#: Process-wide :class:`MarkdownIt` instance. Constructed once at
+#: module import so the parser + the bound highlight callback are
+#: hot-path-cheap. The ``commonmark`` preset's ``html`` default is
+#: ``True``; the explicit ``html=False`` override is the load-bearing
+#: defence against raw HTML smuggled inside memory bodies. ``linkify``
+#: turns bare ``https://...`` URLs into ``<a>`` tags so a pasted
+#: runbook URL is clickable without ``[text](url)`` wrapping.
+_MD = MarkdownIt(
+    "commonmark",
+    {"html": False, "linkify": True, "highlight": _highlight_code},
+).enable(["table", "strikethrough"])
+
+
+def render_markdown(body: str) -> Markup:
+    """Render *body* as Markdown -> HTML and return safe Jinja markup.
+
+    The :class:`markdown_it.MarkdownIt.render` call mutates internal
+    parser state, so the call is guarded by a process-level lock. The
+    returned :class:`Markup` flags the string as already-safe so
+    Jinja2's autoescape doesn't double-escape the output. The renderer
+    itself HTML-encodes every user-supplied text node and strips raw
+    HTML (``html=False``), so the ``Markup`` wrap is sound.
+    """
+    with _lock:
+        rendered = _MD.render(body)
+    return Markup(rendered)
+
+
+def pygments_css() -> str:
+    """Return the pre-generated pygments CSS for the ``.memory-code`` class.
+
+    Embedded as a ``<style>`` block on the entry-detail page so the
+    syntax-highlight span colours render without a separate stylesheet
+    round-trip. Cached at module load; safe to call on every request.
+    """
+    return _PYGMENTS_CSS

--- a/backend/src/meho_backplane/ui/routes/memory/routes.py
+++ b/backend/src/meho_backplane/ui/routes/memory/routes.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Memory UI route registration -- maps HTTP verbs to the render helpers.
+
+Initiative #341 (G10.4 Memory UI), Task #877 (T1). The route handlers
+in this module are thin wrappers: parse FastAPI params, resolve the
+session / operator dependency, and hand off to the render functions
+in :mod:`~meho_backplane.ui.routes.memory.views`. Splitting the
+registration here from the render logic in ``views`` keeps each module
+under the chassis-wide ~600-line + ~100-line caps and gives the
+render helpers a unit-testable seam (no FastAPI :class:`Request`
+fixture required for projection logic).
+
+Route inventory
+---------------
+
+* ``GET /ui/memory`` -- list page or HTMX card-list fragment.
+* ``GET /ui/memory/tags`` -- HTMX datalist for the tag autocomplete.
+* ``GET /ui/memory/<scope>/<slug>`` -- detail page or HTMX body fragment.
+* ``GET /ui/memory/<scope>/<slug>/edit`` -- HTMX edit-form fragment.
+* ``PATCH /ui/memory/<scope>/<slug>`` -- HTMX save the edited body.
+* ``DELETE /ui/memory/<scope>/<slug>`` -- HTMX delete + re-render the list.
+
+Tenant + RBAC + info-leak posture are documented on the render
+functions themselves; this module owns only the path / method /
+dependency wiring.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Form, Query, Request
+from fastapi.responses import HTMLResponse
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.memory import MemoryScope
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.routes.memory.operator import resolve_ui_operator
+from meho_backplane.ui.routes.memory.views import (
+    BODY_MAX_LENGTH,
+    SCOPE_ALL,
+    SLUG_MAX_LENGTH,
+    delete_entry,
+    patch_entry,
+    render_detail,
+    render_edit_form,
+    render_index,
+    render_tags,
+    validate_slug,
+)
+
+__all__ = ["build_memory_router"]
+
+#: Module-level :class:`Depends` closures -- ruff B008 idiom mirroring
+#: the chassis dashboard + topology routes (no calls in default
+#: argument positions).
+_require_session_dep = Depends(require_ui_session)
+_resolve_operator_dep = Depends(resolve_ui_operator)
+
+
+async def _list_handler(
+    request: Request,
+    scope: str = Query(default=SCOPE_ALL, max_length=64),
+    tag: str | None = Query(default=None, max_length=SLUG_MAX_LENGTH),
+    session_ctx: UISessionContext = _require_session_dep,
+) -> HTMLResponse:
+    """``GET /ui/memory`` -- list page or HTMX card-list fragment."""
+    return await render_index(request, session_ctx, scope=scope, tag=tag)
+
+
+async def _tags_handler(
+    request: Request,
+    session_ctx: UISessionContext = _require_session_dep,
+) -> HTMLResponse:
+    """``GET /ui/memory/tags`` -- HTMX datalist autocomplete fragment."""
+    return await render_tags(request, session_ctx)
+
+
+async def _detail_handler(
+    request: Request,
+    scope: MemoryScope,
+    slug: str,
+    session_ctx: UISessionContext = _require_session_dep,
+) -> HTMLResponse:
+    """``GET /ui/memory/<scope>/<slug>`` -- detail page or HTMX body fragment."""
+    validate_slug(slug)
+    return await render_detail(request, session_ctx, scope=scope, slug=slug)
+
+
+async def _edit_form_handler(
+    request: Request,
+    scope: MemoryScope,
+    slug: str,
+    session_ctx: UISessionContext = _require_session_dep,
+    operator: Operator = _resolve_operator_dep,
+) -> HTMLResponse:
+    """``GET /ui/memory/<scope>/<slug>/edit`` -- HTMX edit-form fragment."""
+    validate_slug(slug)
+    return await render_edit_form(request, session_ctx, operator, scope=scope, slug=slug)
+
+
+async def _patch_handler(
+    request: Request,
+    scope: MemoryScope,
+    slug: str,
+    body: str = Form(..., max_length=BODY_MAX_LENGTH),
+    session_ctx: UISessionContext = _require_session_dep,
+    operator: Operator = _resolve_operator_dep,
+) -> HTMLResponse:
+    """``PATCH /ui/memory/<scope>/<slug>`` -- save the edited body."""
+    validate_slug(slug)
+    return await patch_entry(request, session_ctx, operator, scope=scope, slug=slug, new_body=body)
+
+
+async def _delete_handler(
+    request: Request,
+    scope: MemoryScope,
+    slug: str,
+    session_ctx: UISessionContext = _require_session_dep,
+    operator: Operator = _resolve_operator_dep,
+) -> HTMLResponse:
+    """``DELETE /ui/memory/<scope>/<slug>`` -- delete + re-render the list."""
+    validate_slug(slug)
+    return await delete_entry(request, session_ctx, operator, scope=scope, slug=slug)
+
+
+def _register_read_routes(router: APIRouter) -> None:
+    """Wire the GET routes (list / tags / detail / edit-form) onto *router*.
+
+    Split out of :func:`build_memory_router` so the factory body stays
+    under the chassis-wide ~100-line cap. ``ui_memory_*`` names match
+    the per-handler closures so a future ``url_for(...)`` from a
+    template resolves cleanly.
+    """
+    router.add_api_route(
+        "/ui/memory",
+        _list_handler,
+        methods=["GET"],
+        name="ui_memory_list",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/memory/tags",
+        _tags_handler,
+        methods=["GET"],
+        name="ui_memory_tags",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/memory/{scope}/{slug}",
+        _detail_handler,
+        methods=["GET"],
+        name="ui_memory_detail",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/memory/{scope}/{slug}/edit",
+        _edit_form_handler,
+        methods=["GET"],
+        name="ui_memory_edit_form",
+        response_class=HTMLResponse,
+    )
+
+
+def _register_write_routes(router: APIRouter) -> None:
+    """Wire the PATCH + DELETE routes onto *router*.
+
+    Split out of :func:`build_memory_router` for the same reason as
+    :func:`_register_read_routes`. The PATCH route shares the
+    ``/ui/memory/{scope}/{slug}`` path with the detail GET; FastAPI
+    distinguishes by method so registration order is not load-bearing.
+    """
+    router.add_api_route(
+        "/ui/memory/{scope}/{slug}",
+        _patch_handler,
+        methods=["PATCH"],
+        name="ui_memory_patch",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/memory/{scope}/{slug}",
+        _delete_handler,
+        methods=["DELETE"],
+        name="ui_memory_delete",
+        response_class=HTMLResponse,
+    )
+
+
+def build_memory_router() -> APIRouter:
+    """Construct the memory UI :class:`APIRouter`.
+
+    Factory function (not a module-level constant) so a test app can
+    construct parallel routers without sharing route state -- mirrors
+    the broadcast / topology / dashboard convention.
+    """
+    router = APIRouter(tags=["ui-memory"])
+    _register_read_routes(router)
+    _register_write_routes(router)
+    return router

--- a/backend/src/meho_backplane/ui/routes/memory/views.py
+++ b/backend/src/meho_backplane/ui/routes/memory/views.py
@@ -1,0 +1,527 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Render helpers + projections for the memory UI surface.
+
+Initiative #341 (G10.4 Memory UI), Task #877 (T1). Pulled out of
+:mod:`~meho_backplane.ui.routes.memory.routes` so the route handlers
+stay thin signature wrappers and the render logic + projection
+helpers can be unit-tested without an HTTP layer.
+
+The split is by responsibility:
+
+* **Constants + parsing helpers** -- :data:`_SCOPE_ALL`,
+  :data:`_SCOPE_TABS`, :func:`resolve_scope_filter`, :func:`is_htmx_request`,
+  :func:`validate_slug`. Pure functions; no FastAPI / service deps.
+* **Projection helpers** -- :func:`preview`, :func:`entry_tags`,
+  :func:`collect_visible_tags`, :func:`entries_with_preview`,
+  :func:`detail_context`. Transform :class:`MemoryEntry` into the
+  dict shape Jinja consumes; no DB / network IO.
+* **Render functions** -- :func:`render_index`, :func:`render_detail`,
+  :func:`render_edit_form`, :func:`render_tags`, :func:`patch_entry`,
+  :func:`delete_entry`. The route handlers in
+  :mod:`~meho_backplane.ui.routes.memory.routes` are thin wrappers
+  around these.
+
+The render functions take the FastAPI :class:`Request` so they can
+return :class:`HTMLResponse` via :class:`Jinja2Templates`; they do
+not declare FastAPI :class:`Depends` parameters themselves (the
+route layer is responsible for resolving deps and passing them
+through).
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from typing import Final
+
+import structlog
+from fastapi import HTTPException, Request
+from fastapi.responses import HTMLResponse
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.memory import (
+    MemoryEntry,
+    MemoryRbacResolver,
+    MemoryScope,
+    MemoryService,
+    PermissionDeniedError,
+)
+from meho_backplane.ui.auth.middleware import UISessionContext
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.routes.memory.operator import build_read_operator
+from meho_backplane.ui.routes.memory.render import pygments_css, render_markdown
+from meho_backplane.ui.templating import get_templates
+
+__all__ = [
+    "BODY_MAX_LENGTH",
+    "LIST_LIMIT",
+    "SCOPE_ALL",
+    "SCOPE_TABS",
+    "SLUG_MAX_LENGTH",
+    "TAG_AUTOCOMPLETE_LIMIT",
+    "delete_entry",
+    "is_htmx_request",
+    "patch_entry",
+    "render_detail",
+    "render_edit_form",
+    "render_index",
+    "render_tags",
+    "resolve_scope_filter",
+    "validate_slug",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Maximum length of any path slug accepted by the detail / edit /
+#: patch / delete routes. Mirrors
+#: :data:`meho_backplane.api.v1.memory._SLUG_MAX_LENGTH` so a slug
+#: that passes the API surface also passes here.
+SLUG_MAX_LENGTH: Final[int] = 256
+
+#: Maximum length of the body field accepted by the edit-in-place
+#: save. The substrate has no fixed cap (``Document.body`` is
+#: ``TEXT``); 64 KiB is well above the consumer-needs-named ~15
+#: file memory corpus while bounding the worst-case allocation
+#: against a paste-from-clipboard accident.
+BODY_MAX_LENGTH: Final[int] = 64 * 1024
+
+#: Maximum number of memories pulled per list fetch. Aligned with
+#: the ``/api/v1/memory`` ``list`` route cap so the UI never sees a
+#: row the API would have suppressed.
+LIST_LIMIT: Final[int] = 500
+
+#: Maximum count of distinct tags rendered into the autocomplete
+#: datalist. The operator picks from a finite vocabulary; surfacing
+#: more than a couple hundred kills the input lag and isn't useful.
+TAG_AUTOCOMPLETE_LIMIT: Final[int] = 200
+
+#: Sentinel for the "show every visible scope" tab. Distinct from
+#: the :class:`MemoryScope` enum values so the route's scope param is
+#: a closed union of (one-of-five-scopes, ``"all"``); a typo on the
+#: query string surfaces as 422.
+SCOPE_ALL: Final[str] = "all"
+
+#: Ordered (label, value) for the scope tabs in the template.
+SCOPE_TABS: Final[tuple[tuple[str, str], ...]] = (
+    ("User", MemoryScope.USER.value),
+    ("User x Tenant", MemoryScope.USER_TENANT.value),
+    ("User x Target", MemoryScope.USER_TARGET.value),
+    ("Tenant", MemoryScope.TENANT.value),
+    ("Target", MemoryScope.TARGET.value),
+    ("All visible", SCOPE_ALL),
+)
+
+#: Length of the body preview rendered on each card. The issue body
+#: names "200-char preview"; pinned as a constant so the template
+#: doesn't hard-code the slice and the test can pin the cap without
+#: scraping HTML.
+_PREVIEW_CHARS: Final[int] = 200
+
+#: Slug pattern is constrained by :data:`SLUG_PATTERN` at the schema
+#: layer; the route surface re-validates so a malformed slug arrives
+#: as 404 (info-leak avoidance) rather than reaching the service's
+#: regex check.
+_SLUG_PATTERN_RE: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9_\-\.]+$")
+
+
+# ---------------------------------------------------------------------------
+# Parsing + small pure helpers
+# ---------------------------------------------------------------------------
+
+
+def is_htmx_request(request: Request) -> bool:
+    """Return ``True`` when the request was issued by HTMX.
+
+    HTMX 2 sets ``HX-Request: true`` on every fetch its directives
+    drive (see https://htmx.org/reference/#request_headers).
+    """
+    return request.headers.get("hx-request", "").lower() == "true"
+
+
+def resolve_scope_filter(scope: str) -> MemoryScope | None:
+    """Parse the tab's ``scope`` query value.
+
+    ``"all"`` -> ``None`` (every visible scope). A valid
+    :class:`MemoryScope` -> that scope. Anything else -> 422 via
+    :class:`HTTPException` so a typo on the URL doesn't silently
+    collapse to "all".
+    """
+    if scope == SCOPE_ALL:
+        return None
+    try:
+        return MemoryScope(scope)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"scope must be one of {[s.value for s in MemoryScope]} or 'all'; got {scope!r}"
+            ),
+        ) from exc
+
+
+def validate_slug(slug: str) -> None:
+    """Translate a malformed slug into 404 at the path-parameter stage.
+
+    Defence-in-depth before the service-layer regex check. Mirrors
+    :mod:`meho_backplane.api.v1.memory`'s posture: malformed slugs
+    surface as 404 (info-leak avoidance), not 422.
+    """
+    if len(slug) > SLUG_MAX_LENGTH or not _SLUG_PATTERN_RE.fullmatch(slug):
+        raise HTTPException(status_code=404, detail="memory_not_found")
+
+
+def _preview(body: str) -> str:
+    """Truncate *body* to the card-preview length without splitting words."""
+    stripped = body.strip()
+    if len(stripped) <= _PREVIEW_CHARS:
+        return stripped
+    head = stripped[:_PREVIEW_CHARS]
+    last_space = head.rfind(" ")
+    if last_space > 0:
+        head = head[:last_space]
+    return head + "..."
+
+
+def _entry_tags(entry: MemoryEntry) -> list[str]:
+    """Extract the ``tags`` list from metadata defensively."""
+    raw = entry.metadata.get("tags")
+    if not isinstance(raw, list):
+        return []
+    return [t for t in raw if isinstance(t, str)]
+
+
+def _collect_visible_tags(entries: Iterable[MemoryEntry], limit: int) -> list[str]:
+    """Build a sorted unique list of tags seen across *entries*."""
+    seen: set[str] = set()
+    for entry in entries:
+        for tag in _entry_tags(entry):
+            if not tag:
+                continue
+            seen.add(tag)
+            if len(seen) >= limit:
+                break
+        if len(seen) >= limit:
+            break
+    return sorted(seen)
+
+
+def _entries_with_preview(entries: list[MemoryEntry]) -> list[dict[str, object]]:
+    """Project ``MemoryEntry`` rows into the dict shape the template renders."""
+    return [
+        {
+            "id": str(entry.id),
+            "scope": entry.scope.value,
+            "slug": entry.slug,
+            "preview": _preview(entry.body),
+            "user_sub": entry.user_sub,
+            "target_name": entry.target_name,
+            "expires_at": entry.expires_at,
+            "tags": _entry_tags(entry),
+            "updated_at": entry.updated_at,
+        }
+        for entry in entries
+    ]
+
+
+def _can_write(operator: Operator, entry: MemoryEntry) -> bool:
+    """Return ``True`` when the operator can edit / delete *entry*."""
+    return MemoryRbacResolver().can_write(operator, entry.scope, entry.target_name)
+
+
+def _set_csrf_cookie(response: HTMLResponse, csrf_token: str) -> None:
+    """Mirror the dashboard's CSRF cookie posture for state-changing pages."""
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=csrf_token,
+        httponly=False,
+        secure=True,
+        samesite="strict",
+        path="/ui",
+    )
+
+
+def _common_template_context(
+    session_ctx: UISessionContext,
+    csrf_token: str,
+) -> dict[str, object]:
+    """Build the dict shared across every memory template render."""
+    return {
+        "page_title": "Memory",
+        "active_surface": "memory",
+        "ready": False,
+        "operator_sub": session_ctx.operator_sub,
+        "csrf_token": csrf_token,
+    }
+
+
+def _detail_context(entry: MemoryEntry, *, can_write: bool) -> dict[str, object]:
+    """Project a :class:`MemoryEntry` into the detail-template shape."""
+    return {
+        "id": str(entry.id),
+        "scope": entry.scope.value,
+        "slug": entry.slug,
+        "body_raw": entry.body,
+        "body_html": render_markdown(entry.body),
+        "user_sub": entry.user_sub,
+        "target_name": entry.target_name,
+        "expires_at": entry.expires_at,
+        "tags": _entry_tags(entry),
+        "created_at": entry.created_at,
+        "updated_at": entry.updated_at,
+        "can_write": can_write,
+    }
+
+
+async def _list_for_render(
+    operator: Operator,
+    scope_filter: MemoryScope | None,
+    tag_filter: str | None,
+) -> list[MemoryEntry]:
+    """Pull the list-view rows for *operator* under the active filters."""
+    service = MemoryService()
+    return await service.list_memories(
+        operator=operator,
+        scope=scope_filter,
+        tag=tag_filter or None,
+        include_expired=False,
+        limit=LIST_LIMIT,
+    )
+
+
+async def _fetch_entry_or_404(
+    operator: Operator,
+    scope: MemoryScope,
+    slug: str,
+) -> MemoryEntry:
+    """Pull one memory by natural key. 404 on missing OR RBAC-deny.
+
+    The 404-vs-403 collapse is the info-leak avoidance the
+    ``/api/v1/memory`` route holds: a caller cannot distinguish
+    "no such memory" from "you can't read it" by the response status.
+    """
+    service = MemoryService()
+    entry = await service.recall(operator=operator, scope=scope, slug=slug, target_name=None)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="memory_not_found")
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Render entry points (consumed by the route handlers)
+# ---------------------------------------------------------------------------
+
+
+async def render_index(
+    request: Request,
+    session_ctx: UISessionContext,
+    *,
+    scope: str = SCOPE_ALL,
+    tag: str | None = None,
+    flash: str | None = None,
+) -> HTMLResponse:
+    """Render the list page or the HTMX card-list fragment."""
+    scope_filter = resolve_scope_filter(scope)
+    operator = build_read_operator(session_ctx)
+    entries = await _list_for_render(operator, scope_filter, tag)
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    context: dict[str, object] = {
+        **_common_template_context(session_ctx, csrf_token),
+        "scope_tabs": SCOPE_TABS,
+        "active_scope": scope,
+        "active_tag": tag or "",
+        "entries": _entries_with_preview(entries),
+        "entry_count": len(entries),
+        "flash": flash or "",
+    }
+    template_name = "memory/_cards.html" if is_htmx_request(request) else "memory/index.html"
+    response = get_templates().TemplateResponse(request, template_name, context)
+    _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def render_detail(
+    request: Request,
+    session_ctx: UISessionContext,
+    *,
+    scope: MemoryScope,
+    slug: str,
+) -> HTMLResponse:
+    """Render the detail page or the HTMX body fragment."""
+    operator = build_read_operator(session_ctx)
+    entry = await _fetch_entry_or_404(operator, scope, slug)
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    context: dict[str, object] = {
+        **_common_template_context(session_ctx, csrf_token),
+        "entry": _detail_context(entry, can_write=_can_write(operator, entry)),
+        "pygments_css": pygments_css(),
+    }
+    template_name = "memory/_body_view.html" if is_htmx_request(request) else "memory/detail.html"
+    response = get_templates().TemplateResponse(request, template_name, context)
+    _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def render_edit_form(
+    request: Request,
+    session_ctx: UISessionContext,
+    operator: Operator,
+    *,
+    scope: MemoryScope,
+    slug: str,
+) -> HTMLResponse:
+    """Render the HTMX edit-form fragment.
+
+    403 when the operator cannot write the scope -- the template gate
+    is UX, this is the server-side gate. The fragment carries the
+    existing body as the textarea's default value so a cancel-then-
+    edit roundtrip doesn't lose work.
+    """
+    entry = await _fetch_entry_or_404(operator, scope, slug)
+    if not _can_write(operator, entry):
+        raise HTTPException(status_code=403, detail="permission_denied")
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    context: dict[str, object] = {
+        **_common_template_context(session_ctx, csrf_token),
+        "entry": _detail_context(entry, can_write=True),
+        "max_body_length": BODY_MAX_LENGTH,
+    }
+    response = get_templates().TemplateResponse(request, "memory/_body_edit.html", context)
+    _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def render_tags(
+    request: Request,
+    session_ctx: UISessionContext,
+) -> HTMLResponse:
+    """Return the tag-autocomplete datalist fragment."""
+    operator = build_read_operator(session_ctx)
+    entries = await _list_for_render(operator, scope_filter=None, tag_filter=None)
+    tags = _collect_visible_tags(entries, TAG_AUTOCOMPLETE_LIMIT)
+    context = {"tags": tags}
+    return get_templates().TemplateResponse(request, "memory/_tags_options.html", context)
+
+
+def _validate_body_or_422(new_body: str) -> None:
+    """Surface the two body-shape guards as 422 errors."""
+    if len(new_body) > BODY_MAX_LENGTH:
+        raise HTTPException(
+            status_code=422,
+            detail=f"body too large (max {BODY_MAX_LENGTH} chars)",
+        )
+    if not new_body.strip():
+        raise HTTPException(status_code=422, detail="body must not be empty")
+
+
+def _strip_service_bookkeeping(metadata: dict[str, object]) -> dict[str, object]:
+    """Drop the service-owned bookkeeping keys before re-passing metadata."""
+    return {
+        k: v
+        for k, v in metadata.items()
+        if k not in {"scope", "user_sub", "target_name", "expires_at"}
+    }
+
+
+async def patch_entry(
+    request: Request,
+    session_ctx: UISessionContext,
+    operator: Operator,
+    *,
+    scope: MemoryScope,
+    slug: str,
+    new_body: str,
+) -> HTMLResponse:
+    """Persist the edit and return the updated body fragment.
+
+    Two-step: ``recall`` (preserves metadata + RBAC re-check) then
+    ``remember`` with the same natural key (the service-layer
+    ``index_document`` upserts on ``(tenant_id, source, source_id)``,
+    so the row body + ``updated_at`` change while ``created_at`` /
+    ``id`` stay put). Tags + caller metadata ride through the save
+    unchanged; ``expires_at`` is preserved so an operator's edit
+    doesn't accidentally clear the row's TTL.
+    """
+    _validate_body_or_422(new_body)
+
+    service = MemoryService()
+    existing = await service.recall(operator=operator, scope=scope, slug=slug, target_name=None)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="memory_not_found")
+    if not _can_write(operator, existing):
+        raise HTTPException(status_code=403, detail="permission_denied")
+
+    try:
+        await service.remember(
+            operator=operator,
+            scope=scope,
+            body=new_body,
+            slug=slug,
+            metadata=_strip_service_bookkeeping(existing.metadata),
+            expires_at=existing.expires_at,
+            target_name=existing.target_name,
+        )
+    except PermissionDeniedError as exc:
+        raise HTTPException(status_code=403, detail=f"permission_denied: {exc.reason}") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    updated = await _fetch_entry_or_404(operator, scope, slug)
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    context: dict[str, object] = {
+        **_common_template_context(session_ctx, csrf_token),
+        "entry": _detail_context(updated, can_write=True),
+        "pygments_css": pygments_css(),
+    }
+    response = get_templates().TemplateResponse(request, "memory/_body_view.html", context)
+    _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def delete_entry(
+    request: Request,
+    session_ctx: UISessionContext,
+    operator: Operator,
+    *,
+    scope: MemoryScope,
+    slug: str,
+) -> HTMLResponse:
+    """Delete the memory and re-render the list with a flash banner.
+
+    Re-fetches under read RBAC so we can surface a true 404 when the
+    row doesn't exist for this operator -- :meth:`MemoryService.forget`
+    is idempotent and would otherwise return ``False`` silently, which
+    misleads the UX (the modal said "delete" and the row didn't
+    disappear because it was never there).
+    """
+    service = MemoryService()
+    existing = await service.recall(operator=operator, scope=scope, slug=slug, target_name=None)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="memory_not_found")
+    try:
+        await service.forget(
+            operator=operator,
+            scope=scope,
+            slug=slug,
+            target_name=existing.target_name,
+        )
+    except PermissionDeniedError as exc:
+        raise HTTPException(status_code=403, detail=f"permission_denied: {exc.reason}") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    _log.info(
+        "ui_memory_delete",
+        tenant_id=str(session_ctx.tenant_id),
+        operator_sub=session_ctx.operator_sub,
+        scope=scope.value,
+        slug=slug,
+    )
+    return await render_index(
+        request,
+        session_ctx,
+        scope=SCOPE_ALL,
+        tag=None,
+        flash=f"Deleted memory {scope.value}/{slug}",
+    )

--- a/backend/src/meho_backplane/ui/routes/memory/views.py
+++ b/backend/src/meho_backplane/ui/routes/memory/views.py
@@ -487,13 +487,23 @@ async def delete_entry(
     scope: MemoryScope,
     slug: str,
 ) -> HTMLResponse:
-    """Delete the memory and re-render the list with a flash banner.
+    """Delete the memory and redirect the client back to the list page.
 
     Re-fetches under read RBAC so we can surface a true 404 when the
     row doesn't exist for this operator -- :meth:`MemoryService.forget`
     is idempotent and would otherwise return ``False`` silently, which
     misleads the UX (the modal said "delete" and the row didn't
     disappear because it was never there).
+
+    Response shape: an empty ``204`` carrying the ``HX-Redirect`` header
+    so HTMX issues a full client-side GET to ``/ui/memory``. The detail
+    page's confirm-delete button targets ``hx-target="body"`` so a
+    fragment-only re-render would destroy the chassis chrome
+    (``<html>``/``<head>``/``<body>``); ``HX-Redirect`` is the canonical
+    HTMX pattern for post-delete navigation -- see
+    https://htmx.org/headers/hx-redirect/. The list GET that follows
+    re-derives the empty-or-trimmed state, so no flash plumbing is
+    needed: the user lands on the list with the deleted row absent.
     """
     service = MemoryService()
     existing = await service.recall(operator=operator, scope=scope, slug=slug, target_name=None)
@@ -518,10 +528,8 @@ async def delete_entry(
         scope=scope.value,
         slug=slug,
     )
-    return await render_index(
-        request,
-        session_ctx,
-        scope=SCOPE_ALL,
-        tag=None,
-        flash=f"Deleted memory {scope.value}/{slug}",
+    del request  # not consumed -- HX-Redirect needs no request context.
+    return HTMLResponse(
+        status_code=204,
+        headers={"HX-Redirect": "/ui/memory"},
     )

--- a/backend/src/meho_backplane/ui/routes/stubs.py
+++ b/backend/src/meho_backplane/ui/routes/stubs.py
@@ -18,12 +18,13 @@ shell renders end-to-end before the per-surface Initiatives
   has the double-submit chain in place from request one.
 
 The remaining stub paths are kept consistent with the chassis
-``base.html`` sidebar -- ``/ui/knowledge``, ``/ui/connectors``,
-``/ui/memory``. ``/ui/topology`` and ``/ui/broadcast`` are intentionally
-NOT stubbed here: topology's real table view ships in G10.5-T1 (#880)
-and broadcast's real live-feed view ships in G10.1-T1 (#867), each
-owning its path; registering a stub for either would shadow the real
-route in the generated OpenAPI schema. The Goal #336 done-when and
+``base.html`` sidebar -- ``/ui/knowledge`` and ``/ui/connectors``.
+``/ui/topology``, ``/ui/broadcast``, and ``/ui/memory`` are
+intentionally NOT stubbed here: topology's real table view ships in
+G10.5-T1 (#880), broadcast's real live-feed view ships in G10.1-T1
+(#867), and memory's real list / detail / edit surface ships in
+G10.4-T1 (#877), each owning its path; registering a stub for any
+would shadow the real route in the generated OpenAPI schema. The Goal #336 done-when and
 Initiative #337 work-item #5 reference these exact URLs.
 
 Why one shared template
@@ -85,12 +86,6 @@ _SURFACE_STUBS: Final[tuple[_SurfaceStub, ...]] = (
         title="Connectors",
         initiative_number=340,
         summary="Per-tenant target CRUD + per-target detail (fingerprint, last probe, ops).",
-    ),
-    _SurfaceStub(
-        slug="memory",
-        title="Memory",
-        initiative_number=341,
-        summary="Browse + edit memories across the 5 scopes; scope-promotion UI.",
     ),
 )
 

--- a/backend/src/meho_backplane/ui/templates/memory/_body_edit.html
+++ b/backend/src/meho_backplane/ui/templates/memory/_body_edit.html
@@ -1,0 +1,57 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Edit-in-place form for the Memory detail page (Initiative #341 Task
+  #877). Replaces the body view (``#memory-body``) on Edit click;
+  Save submits ``hx-patch`` and replaces the form with the rendered
+  body view; Cancel reloads the body view via ``hx-get`` against the
+  same detail route.
+
+  CSRF posture: the page-level ``hx-headers`` directive on
+  ``memory/detail.html`` echoes the token; HTMX inherits the header
+  through the swapped fragment, so the textarea form does not need
+  its own ``hx-headers`` override.
+
+  Form encoding: ``hx-encoding="multipart/form-data"`` is **not**
+  used because the body field is text-only and the chassis CSRF
+  middleware accepts the token from either header or form field.
+  The default ``application/x-www-form-urlencoded`` is the cheapest
+  shape for the wire.
+-#}
+<form
+  id="memory-body"
+  class="bg-base-100 border-base-300 border rounded-box p-4 space-y-3"
+  hx-patch="/ui/memory/{{ entry.scope | urlencode }}/{{ entry.slug | urlencode }}"
+  hx-target="this"
+  hx-swap="outerHTML"
+  hx-disabled-elt="find button[type=submit]"
+  aria-label="Edit memory body"
+>
+  <label class="form-control">
+    <span class="label-text">Body (Markdown)</span>
+    <textarea
+      name="body"
+      class="textarea textarea-bordered min-h-[16rem] font-mono text-sm"
+      required
+      maxlength="{{ max_body_length }}"
+      aria-label="Memory body in Markdown"
+    >{{ entry.body_raw }}</textarea>
+    <div class="text-xs opacity-60 mt-1">
+      Up to {{ max_body_length }} characters. Tags + expiry are preserved across save.
+    </div>
+  </label>
+  <div class="flex justify-end gap-2">
+    <button
+      type="button"
+      class="btn btn-sm btn-ghost"
+      hx-get="/ui/memory/{{ entry.scope | urlencode }}/{{ entry.slug | urlencode }}"
+      hx-target="#memory-body"
+      hx-swap="outerHTML"
+      data-action="cancel-edit"
+    >
+      Cancel
+    </button>
+    <button type="submit" class="btn btn-sm btn-primary" data-action="save">Save</button>
+  </div>
+</form>

--- a/backend/src/meho_backplane/ui/templates/memory/_body_view.html
+++ b/backend/src/meho_backplane/ui/templates/memory/_body_view.html
@@ -1,0 +1,34 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  HTMX-swappable body view partial for the Memory detail page
+  (Initiative #341 Task #877). Rendered:
+
+    * Inline by ``memory/detail.html`` on first page load.
+    * As the response to the Cancel-edit button (HTMX returns this
+      partial after a ``GET /ui/memory/<scope>/<slug>`` with the
+      ``HX-Request: true`` header so the body slot swaps back).
+    * As the response to the Save button on the edit form (HTMX
+      ``PATCH /ui/memory/<scope>/<slug>`` returns this partial with
+      the freshly-rendered Markdown body).
+
+  The outer element id ``#memory-body`` is the HTMX swap target.
+  Per the HTMX docs (https://htmx.org/attributes/hx-swap/), an
+  ``outerHTML`` swap replaces the element including its ID so the
+  edit form (with the same id) can swap back into this partial after
+  Save.
+
+  ``entry.body_html`` is wrapped in :class:`markupsafe.Markup` by
+  :func:`render_markdown` so Jinja's autoescape leaves it as-is. The
+  ``commonmark`` preset is constructed with ``html=False`` so raw
+  HTML smuggled inside a memory body renders as escaped text, not
+  parsed markup.
+-#}
+<article
+  id="memory-body"
+  class="prose prose-sm max-w-none bg-base-100 border-base-300 border rounded-box p-4"
+  aria-label="Memory body"
+>
+  {{ entry.body_html }}
+</article>

--- a/backend/src/meho_backplane/ui/templates/memory/_cards.html
+++ b/backend/src/meho_backplane/ui/templates/memory/_cards.html
@@ -1,0 +1,93 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  HTMX-swappable card grid for the Memory list (Initiative #341 Task
+  #877). Rendered both inline by ``memory/index.html`` (full page) and
+  by the route handler as a partial response (HTMX swap target on
+  scope-tab + tag-filter changes).
+
+  Each card shows:
+    * Slug + scope badge.
+    * Expiry timestamp (when set) with a ``data-expires-at`` attribute
+      so a future client-side countdown (T3 #879) can render the
+      "expires in 3d 4h" cue without a server change.
+    * Tag chips (DaisyUI badges).
+    * 200-char body preview (truncated server-side).
+    * "View" link to the detail page.
+
+  The element ID ``#memory-cards`` is the HTMX swap target. Per the
+  HTMX docs (https://htmx.org/attributes/hx-swap/), an ``outerHTML``
+  swap replaces the element including its ID, which we want so the
+  empty / non-empty states can swap interchangeably.
+-#}
+<section
+  id="memory-cards"
+  aria-label="Memory card grid"
+  class="space-y-3"
+>
+  {% if flash %}
+    <div class="alert alert-info" role="status">
+      <span>{{ flash }}</span>
+    </div>
+  {% endif %}
+
+  {% if not entries %}
+    <div class="card bg-base-100 border-base-300 border">
+      <div class="card-body text-sm opacity-70">
+        No memories match the current scope / tag filter.
+      </div>
+    </div>
+  {% else %}
+    <ul class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+      {% for entry in entries %}
+        <li
+          class="card bg-base-100 border-base-300 border shadow-sm"
+          data-memory-id="{{ entry.id }}"
+          data-memory-scope="{{ entry.scope }}"
+        >
+          <div class="card-body p-4">
+            <div class="flex items-start justify-between gap-2">
+              <h2 class="card-title text-base font-mono break-all">
+                <a
+                  href="/ui/memory/{{ entry.scope | urlencode }}/{{ entry.slug | urlencode }}"
+                  class="link link-hover"
+                >{{ entry.slug }}</a>
+              </h2>
+              <span class="badge badge-outline badge-sm shrink-0">{{ entry.scope }}</span>
+            </div>
+            {% if entry.expires_at %}
+              <div
+                class="text-xs opacity-70"
+                data-expires-at="{{ entry.expires_at.isoformat() }}"
+              >
+                Expires {{ entry.expires_at.isoformat() }}
+              </div>
+            {% endif %}
+            {% if entry.tags %}
+              <ul class="flex flex-wrap gap-1" aria-label="Memory tags">
+                {% for tag in entry.tags %}
+                  <li>
+                    <span class="badge badge-sm badge-ghost">{{ tag }}</span>
+                  </li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+            <p class="text-sm opacity-80 whitespace-pre-wrap break-words">
+              {{ entry.preview }}
+            </p>
+            <div class="card-actions justify-end">
+              <a
+                class="btn btn-xs btn-ghost"
+                href="/ui/memory/{{ entry.scope | urlencode }}/{{ entry.slug | urlencode }}"
+                aria-label="View memory {{ entry.scope }}/{{ entry.slug }}"
+              >
+                View
+              </a>
+            </div>
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+  {% endif %}
+</section>

--- a/backend/src/meho_backplane/ui/templates/memory/_tags_options.html
+++ b/backend/src/meho_backplane/ui/templates/memory/_tags_options.html
@@ -1,0 +1,13 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Datalist <option> partial for the tag autocomplete (Initiative #341
+  Task #877). Loaded via HTMX on the index page's ``<datalist>``
+  ``hx-trigger="load"``; the datalist renders type-ahead suggestions
+  for the tag-filter <input>.
+
+  Browsers wire ``<datalist>``-bound ``<input list>`` autocomplete
+  natively, so no JS is required -- HTMX just injects the option list.
+-#}
+{% for tag in tags %}<option value="{{ tag }}"></option>{% endfor %}

--- a/backend/src/meho_backplane/ui/templates/memory/detail.html
+++ b/backend/src/meho_backplane/ui/templates/memory/detail.html
@@ -1,0 +1,152 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Full-page render of the Memory detail view (Initiative #341 Task
+  #877). Extends ``base.html``. Renders:
+
+    * Slug + scope + expiry + tag chips header.
+    * Body rendered server-side as Markdown (via markdown-it-py + pygments).
+    * Edit / Delete action buttons (visible only when ``entry.can_write``).
+
+  HTMX wiring:
+    * The body slot ``#memory-body`` is the swap target for the
+      ``Edit`` button: ``hx-get /ui/memory/<scope>/<slug>/edit`` returns
+      the edit-form partial which replaces the body slot.
+    * The edit form's Save submits ``hx-patch /ui/memory/<scope>/<slug>``
+      which returns ``_body_view.html`` replacing the slot back with the
+      rendered Markdown view.
+    * The Delete button opens a confirmation modal; the modal's
+      Confirm-Delete button issues ``hx-delete /ui/memory/<scope>/<slug>``
+      which returns the re-rendered card list at the ``/ui/memory``
+      surface (we navigate via ``hx-push-url="true"`` so the operator
+      ends up on the list).
+
+  The pygments CSS for syntax-highlighted code blocks is embedded as
+  a per-page ``<style>`` block. The block lives inside ``{% block
+  content %}`` (rather than ``{% block head %}``) because the chassis
+  ``base.html`` does not expose a per-page head slot; an in-body style
+  block is valid HTML5 and the browser applies the styles to every
+  descendant element identically.
+-#}
+{% extends "base.html" %}
+
+{% block page_title %}Memory: {{ entry.slug }} &middot; MEHO Operator Console{% endblock %}
+
+{% block content %}
+<style>
+{{ pygments_css }}
+</style>
+<section
+  class="space-y-4"
+  hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+>
+  <nav class="text-sm" aria-label="Breadcrumb">
+    <a href="/ui/memory" class="link link-hover">Memory</a>
+    <span aria-hidden="true">/</span>
+    <span class="font-mono">{{ entry.scope }}/{{ entry.slug }}</span>
+  </nav>
+
+  <header
+    class="card bg-base-100 border-base-300 border shadow-sm"
+    data-memory-id="{{ entry.id }}"
+    data-memory-scope="{{ entry.scope }}"
+    data-memory-slug="{{ entry.slug }}"
+  >
+    <div class="card-body p-4 space-y-2">
+      <div class="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h1 class="text-xl font-semibold font-mono break-all">{{ entry.slug }}</h1>
+          <div class="text-xs opacity-70">
+            <span class="badge badge-outline badge-sm mr-2">{{ entry.scope }}</span>
+            {% if entry.user_sub %}
+              <span>owner: {{ entry.user_sub }}</span>
+            {% endif %}
+            {% if entry.target_name %}
+              <span class="ml-2">target: {{ entry.target_name }}</span>
+            {% endif %}
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          {% if entry.can_write %}
+            <button
+              type="button"
+              class="btn btn-sm btn-primary"
+              hx-get="/ui/memory/{{ entry.scope | urlencode }}/{{ entry.slug | urlencode }}/edit"
+              hx-target="#memory-body"
+              hx-swap="outerHTML"
+              data-action="edit"
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              class="btn btn-sm btn-ghost"
+              data-action="delete"
+              onclick="document.getElementById('memory-delete-modal').showModal()"
+            >
+              Delete
+            </button>
+          {% endif %}
+        </div>
+      </div>
+      {% if entry.expires_at %}
+        <div
+          class="text-xs opacity-70"
+          data-expires-at="{{ entry.expires_at.isoformat() }}"
+        >
+          Expires {{ entry.expires_at.isoformat() }}
+        </div>
+      {% endif %}
+      {% if entry.tags %}
+        <ul class="flex flex-wrap gap-1" aria-label="Memory tags">
+          {% for tag in entry.tags %}
+            <li>
+              <span class="badge badge-sm badge-ghost">{{ tag }}</span>
+            </li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    </div>
+  </header>
+
+  {# Body slot -- HTMX swap target for Edit / Save / Cancel. #}
+  {% include "memory/_body_view.html" %}
+
+  {# Delete-confirm modal -- DaisyUI's ``<dialog>`` element + Alpine
+     for click-outside dismissal. The confirm button issues the
+     HTMX delete which redirects to the list. #}
+  {% if entry.can_write %}
+    <dialog id="memory-delete-modal" class="modal">
+      <div class="modal-box">
+        <h3 class="font-semibold text-lg">Delete this memory?</h3>
+        <p class="text-sm py-2 opacity-80">
+          This action permanently removes
+          <span class="font-mono">{{ entry.scope }}/{{ entry.slug }}</span>.
+          The delete is idempotent: re-clicking on a deleted memory is a no-op.
+        </p>
+        <div class="modal-action">
+          <form method="dialog">
+            <button class="btn btn-sm btn-ghost" type="submit">Cancel</button>
+          </form>
+          <button
+            type="button"
+            class="btn btn-sm btn-error"
+            hx-delete="/ui/memory/{{ entry.scope | urlencode }}/{{ entry.slug | urlencode }}"
+            hx-target="body"
+            hx-swap="outerHTML"
+            hx-push-url="/ui/memory"
+            data-action="confirm-delete"
+            onclick="document.getElementById('memory-delete-modal').close()"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+      <form method="dialog" class="modal-backdrop">
+        <button>close</button>
+      </form>
+    </dialog>
+  {% endif %}
+</section>
+{% endblock %}

--- a/backend/src/meho_backplane/ui/templates/memory/index.html
+++ b/backend/src/meho_backplane/ui/templates/memory/index.html
@@ -1,0 +1,113 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Full-page render of the Memory list surface (Initiative #341 Task
+  #877). Extends ``base.html`` so the chrome (navbar, sidebar, footer)
+  matches the rest of the operator console.
+
+  Layout (top-down):
+    * Scope tabs -- one tab per memory scope plus an "All visible" tab.
+      Each tab is an HTMX-bound link that re-renders the card-list
+      partial in place (``#memory-cards``).
+    * Tag filter -- free-text input bound to a datalist sourced from
+      ``/ui/memory/tags``. HTMX-debounced; keystrokes that don't change
+      the value don't fire a request.
+    * Card grid (``#memory-cards``) -- one DaisyUI card per memory:
+      slug, scope badge, expiry timestamp, tag chips, 200-char preview.
+      Click on the card heading navigates to the detail page.
+
+  HTMX wiring:
+    * Scope tabs: ``hx-get`` with ``hx-target="#memory-cards"``,
+      ``hx-swap="outerHTML"``, ``hx-push-url="true"`` so the browser
+      URL stays in sync with the active scope (copy/paste reproduces).
+    * Tag filter: same target, debounced 300ms.
+    * The page-level ``hx-headers`` directive echoes the CSRF token
+      for any state-changing request triggered from this page
+      (delete-from-detail, for example).
+-#}
+{% extends "base.html" %}
+
+{% block page_title %}Memory &middot; MEHO Operator Console{% endblock %}
+
+{% block content %}
+<section
+  class="space-y-4"
+  hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+>
+  <header class="flex flex-wrap items-center justify-between gap-4">
+    <div>
+      <h1 class="text-2xl font-semibold">Memory</h1>
+      <p class="text-sm opacity-70">
+        Operator + tenant + target memories across the 5 scopes.
+      </p>
+    </div>
+    <div class="text-sm opacity-70">
+      <span aria-live="polite">{{ entry_count }} memor{{ "y" if entry_count == 1 else "ies" }}</span>
+    </div>
+  </header>
+
+  {# ---------- Scope tabs ---------- #}
+  <nav
+    class="tabs tabs-boxed"
+    role="tablist"
+    aria-label="Memory scope filter"
+  >
+    {% for tab_label, tab_value in scope_tabs %}
+      <a
+        role="tab"
+        class="tab{% if tab_value == active_scope %} tab-active{% endif %}"
+        href="/ui/memory?scope={{ tab_value | urlencode }}{% if active_tag %}&tag={{ active_tag | urlencode }}{% endif %}"
+        hx-get="/ui/memory?scope={{ tab_value | urlencode }}{% if active_tag %}&tag={{ active_tag | urlencode }}{% endif %}"
+        hx-target="#memory-cards"
+        hx-swap="outerHTML"
+        hx-push-url="true"
+        {% if tab_value == active_scope %}aria-selected="true"{% else %}aria-selected="false"{% endif %}
+      >
+        {{ tab_label }}
+      </a>
+    {% endfor %}
+  </nav>
+
+  {# ---------- Tag filter ---------- #}
+  <form
+    class="card bg-base-100 border-base-300 border shadow-sm"
+    hx-get="/ui/memory"
+    hx-target="#memory-cards"
+    hx-swap="outerHTML"
+    hx-trigger="input changed delay:300ms from:find input"
+    hx-include="closest form"
+    hx-push-url="true"
+    role="search"
+    aria-label="Filter memories by tag"
+    onsubmit="return false;"
+  >
+    <div class="card-body grid gap-3 md:grid-cols-3">
+      <label class="form-control md:col-span-2">
+        <span class="label-text">Filter by tag</span>
+        <input
+          type="search"
+          name="tag"
+          value="{{ active_tag }}"
+          list="memory-tag-options"
+          placeholder="Equal-match against the row's tags list"
+          class="input input-bordered input-sm"
+          aria-label="Filter memories by tag"
+        />
+        <datalist
+          id="memory-tag-options"
+          hx-get="/ui/memory/tags"
+          hx-trigger="load"
+          hx-swap="innerHTML"
+        ></datalist>
+      </label>
+      {# Hidden input echoes the active scope so a tag-filter change
+         doesn't drop the scope tab on the next HTMX swap. #}
+      <input type="hidden" name="scope" value="{{ active_scope }}" />
+    </div>
+  </form>
+
+  {# ---------- Card grid ---------- #}
+  {% include "memory/_cards.html" %}
+</section>
+{% endblock %}

--- a/backend/tests/test_ui_chassis_smoke.py
+++ b/backend/tests/test_ui_chassis_smoke.py
@@ -109,12 +109,14 @@ _SURFACE_ROUTES = ("/ui/broadcast", "/ui/knowledge", "/ui/topology", "/ui/connec
 #: "Coming soon" stub. ``/ui/topology`` is omitted because Initiative
 #: #342 Task #880 (G10.5-T1) replaced the stub with the real table
 #: view; ``/ui/broadcast`` is omitted because Initiative #338 Task #867
-#: (G10.1-T1) replaced the stub with the real live-feed view. G10.2-G10.4
-#: will trim this tuple further as their surface Initiatives land. The
-#: chassis smoke test still pins the sidebar links via
-#: :data:`_SURFACE_ROUTES` so a sidebar-vs-route divergence surfaces
-#: explicitly.
-_STUB_SURFACE_ROUTES = ("/ui/knowledge", "/ui/connectors", "/ui/memory")
+#: (G10.1-T1) replaced the stub with the real live-feed view; and
+#: ``/ui/memory`` is omitted because Initiative #341 Task #877
+#: (G10.4-T1) replaced the stub with the real list / detail / edit
+#: surface. G10.2 (kb) + G10.3 (connectors) will trim this tuple
+#: further as their surface Initiatives land. The chassis smoke test
+#: still pins the sidebar links via :data:`_SURFACE_ROUTES` so a
+#: sidebar-vs-route divergence surfaces explicitly.
+_STUB_SURFACE_ROUTES = ("/ui/knowledge", "/ui/connectors")
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_ui_memory_list.py
+++ b/backend/tests/test_ui_memory_list.py
@@ -554,6 +554,39 @@ def test_detail_full_page_renders_markdown_body() -> None:
     assert "<code>code</code>" in text
 
 
+def test_detail_strips_attribute_injection_from_fenced_code_lang() -> None:
+    """A crafted fenced-code lang token cannot escape the ``class="..."`` attribute.
+
+    Before the allowlist landed, the fenced-code info string was
+    interpolated verbatim into ``<code class="language-{lang}">``: a
+    body of ```` ```a"onmouseover="alert(1)"x ```` rendered as an HTML
+    fragment carrying a live ``onmouseover`` handler. The fix
+    restricts the rendered ``lang`` to ``[A-Za-z0-9_+-.]+`` and falls
+    back to ``text`` otherwise.
+    """
+    from meho_backplane.ui.routes.memory.render import render_markdown
+
+    payload = '```a"onmouseover="alert(1)"x\nfoo\n```'
+    out = str(render_markdown(payload))
+    assert "onmouseover" not in out
+    assert 'class="language-text"' in out
+
+
+def test_render_markdown_linkifies_bare_urls() -> None:
+    """``render_markdown`` converts a bare HTTPS URL into an ``<a>`` tag.
+
+    ``linkify=True`` on the ``markdown-it-py`` constructor silently
+    no-ops when ``linkify-it-py`` isn't installed. Pinning the test
+    here makes the dependency contract failable: a future
+    ``pyproject.toml`` edit that drops the ``[linkify]`` extra fails
+    this assertion before CI gets to the integration smoke.
+    """
+    from meho_backplane.ui.routes.memory.render import render_markdown
+
+    out = str(render_markdown("Visit https://example.com"))
+    assert '<a href="https://example.com"' in out
+
+
 def test_detail_strips_inline_html_from_body() -> None:
     """Raw ``<script>`` in a memory body renders as escaped text, not script."""
     _seed_tenant(_TENANT_A, "tenant-a")

--- a/backend/tests/test_ui_memory_list.py
+++ b/backend/tests/test_ui_memory_list.py
@@ -894,8 +894,15 @@ def test_patch_save_empty_body_returns_422() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_delete_removes_row_and_re_renders_list() -> None:
-    """DELETE returns the re-rendered card list with a flash banner."""
+def test_delete_removes_row_and_redirects_to_list() -> None:
+    """DELETE returns 204 + HX-Redirect so HTMX navigates to the list.
+
+    The detail page's confirm-delete button uses ``hx-target="body"
+    hx-swap="outerHTML"`` -- a fragment-only re-render would destroy
+    the chassis chrome. ``HX-Redirect`` makes HTMX issue a full client
+    GET against ``/ui/memory`` instead, which rebuilds the page from
+    the base template.
+    """
     _seed_tenant(_TENANT_A, "tenant-a")
     _seed_memory(
         tenant_id=_TENANT_A,
@@ -923,11 +930,17 @@ def test_delete_removes_row_and_re_renders_list() -> None:
         )
     finally:
         mock.stop()
-    assert response.status_code == 200, response.text
-    body = response.text
-    assert "Deleted memory user/ephemeral" in body
-    # The card list re-renders with the empty state.
-    assert 'id="memory-cards"' in body
+    assert response.status_code == 204, response.text
+    assert response.headers.get("HX-Redirect") == "/ui/memory"
+    assert response.text == ""
+    # Follow the redirect and confirm the chassis chrome is intact
+    # and the deleted row is absent from the rendered list.
+    follow = client.get("/ui/memory")
+    assert follow.status_code == 200, follow.text
+    follow_body = follow.text
+    assert "<html" in follow_body and "</html>" in follow_body
+    assert 'id="memory-cards"' in follow_body
+    assert "ephemeral" not in follow_body
 
 
 def test_delete_tenant_scoped_as_operator_returns_403() -> None:

--- a/backend/tests/test_ui_memory_list.py
+++ b/backend/tests/test_ui_memory_list.py
@@ -1,0 +1,974 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the Memory UI surface.
+
+Initiative #341 (G10.4 Memory UI), Task #877 (G10.4-T1). The
+acceptance criteria on issue #877 are:
+
+* ``/ui/memory`` lists memories filtered by scope; switching scope
+  tabs re-renders the list via HTMX; cards show slug / preview /
+  scope-badge / expiry / tags.
+* ``/ui/memory/<scope>/<slug>`` renders the body as server-side
+  Markdown; edit-in-place saves via PATCH; delete via confirm modal
+  + DELETE, list re-renders.
+* RBAC: operator can edit own user-scoped; cannot edit tenant-scoped
+  without ``tenant_admin`` (assert 403).
+* Tag filter + autocomplete (``/ui/memory/tags``) narrows the list.
+* Cross-user isolation (A's user-scoped invisible to B) + cross-tenant
+  isolation.
+
+Suite shape:
+
+* :func:`_build_app` wires a minimal FastAPI app with the chassis
+  middlewares + the BFF auth router + the UI router; mirrors
+  :mod:`backend.tests.test_ui_chassis_smoke._build_app` and the
+  topology suite's pattern.
+* :func:`_seed_session_sync` writes a ``web_session`` row with a
+  real Keycloak-minted access token (signed by the test JWKS) so
+  the ``resolve_ui_operator`` write dep can re-verify the token and
+  pick up the right :class:`TenantRole`.
+* Tests cover list (empty + populated + scope-filter + tag-filter),
+  detail (200 + Markdown + 404), edit-form (operator vs read-only
+  RBAC + cross-user 404), PATCH save (happy + tenant-admin gate +
+  body too large), DELETE (happy + re-render), tag autocomplete,
+  cross-user isolation, and cross-tenant isolation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+import warnings
+from collections.abc import Iterator
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import Document, Tenant
+from meho_backplane.memory._internal import (
+    MEMORY_SOURCE,
+    build_metadata,
+    encode_source_id,
+)
+from meho_backplane.memory.schemas import MemoryScope, kind_for_scope
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, CSRFMiddleware, mint_csrf_token
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests._oidc_jwt_helpers import (
+    AUDIENCE as _DEFAULT_AUDIENCE,
+)
+from tests._oidc_jwt_helpers import (
+    ISSUER as _DEFAULT_ISSUER,
+)
+from tests._oidc_jwt_helpers import (
+    make_rsa_keypair as _make_rsa_keypair,
+)
+from tests._oidc_jwt_helpers import (
+    mint_token as _mint_token,
+)
+from tests._oidc_jwt_helpers import (
+    mock_discovery_and_jwks as _mock_discovery_and_jwks,
+)
+from tests._oidc_jwt_helpers import (
+    public_jwks as _public_jwks,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_BACKPLANE_URL = "https://meho.test"
+
+#: Two stable tenant ids for the cross-tenant isolation assertion.
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_TENANT_B = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+#: Two stable operator subs for the cross-user isolation assertion.
+_OP_A = "op-alice"
+_OP_B = "op-bob"
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars for every test.
+
+    Mirrors :func:`backend.tests.test_ui_topology_table._bff_env`
+    + the chassis smoke + auth flow suites so the baseline (issuer,
+    audience, vault url, encryption key, BFF client) is identical
+    across the UI test surface.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+def _build_app() -> FastAPI:
+    """Construct a minimal FastAPI app wired for the memory UI tests.
+
+    Mirrors the production wiring + the topology suite: StaticFiles
+    at ``/ui/static``, BFF auth router + UI surface router (which
+    includes the memory routes ahead of the stubs), ``UISessionMiddleware``
+    outermost + ``CSRFMiddleware`` next.
+    """
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
+    """Insert one ``tenant`` row so the document tenant FK resolves."""
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _seed_memory(
+    *,
+    tenant_id: uuid.UUID,
+    scope: MemoryScope,
+    slug: str,
+    body: str,
+    user_sub: str | None = None,
+    target_name: str | None = None,
+    tags: list[str] | None = None,
+    expires_at: datetime | None = None,
+) -> uuid.UUID:
+    """Persist one memory row directly via the documents table.
+
+    Bypasses :class:`MemoryService.remember` so the test doesn't need
+    to mock the embedding service for the seeded body. The natural
+    key encoding mirrors the service layer's
+    :func:`encode_source_id` so a subsequent ``recall`` finds the row.
+
+    Returns the seeded :class:`Document.id`.
+    """
+    metadata = build_metadata(
+        caller_metadata={"tags": list(tags)} if tags else None,
+        scope=scope,
+        user_sub=user_sub or "",
+        target_name=target_name,
+        expires_at=expires_at,
+    )
+    source_id = encode_source_id(
+        scope=scope,
+        user_sub=user_sub or "",
+        target_name=target_name,
+        slug=slug,
+    )
+    doc_id = uuid.uuid4()
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                Document(
+                    id=doc_id,
+                    tenant_id=tenant_id,
+                    source=MEMORY_SOURCE,
+                    source_id=source_id,
+                    kind=kind_for_scope(scope),
+                    body=body,
+                    body_hash=f"sha256:test:{doc_id}",
+                    embedding=[0.0] * 384,
+                    doc_metadata=metadata,
+                    tokens=len(body.split()),
+                ),
+            )
+
+    asyncio.run(_do())
+    return doc_id
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID,
+    access_token: str,
+    operator_sub: str,
+    lifetime: timedelta = timedelta(hours=1),
+) -> uuid.UUID:
+    """Create a ``web_session`` row carrying *access_token* and return its UUID."""
+
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token=access_token,
+                refresh_token="refresh-token-plaintext",
+                lifetime=lifetime,
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _make_keypair_and_jwks() -> tuple[Any, dict[str, Any]]:
+    """Mint a stable RSA-2048 keypair + the matching JWKS document.
+
+    Wraps :func:`tests._oidc_jwt_helpers.make_rsa_keypair` with a
+    deterministic kid so a respx replay across multiple JWT decodes
+    in one test resolves through the same cache entry.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        keypair = _make_rsa_keypair("ui-memory-test-kid")
+    return keypair, _public_jwks(keypair)
+
+
+def _authenticated_client(
+    *,
+    session_id: uuid.UUID,
+    jwks: dict[str, Any],
+    with_csrf: bool = False,
+) -> tuple[TestClient, respx.MockRouter, str]:
+    """Return a TestClient + a respx mock + a CSRF token.
+
+    The mock router stays open across the test scope so the
+    ``resolve_ui_operator`` dependency can call into the JWKS endpoint
+    on each PATCH / DELETE / edit-form request. The caller is
+    responsible for entering the mock as a context manager
+    (``with mock: ...``).
+
+    ``with_csrf=True`` pre-seeds the CSRF cookie so PATCH / DELETE
+    requests can include the matching token without a GET round-trip
+    -- the chassis cookie ships with ``secure=True``, which the
+    TestClient's default ``http://testserver`` origin drops, so a
+    GET-then-PATCH test would otherwise see a missing cookie. The
+    third tuple element is the token value the caller passes back
+    via the ``X-CSRF-Token`` header (the double-submit pair).
+    """
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    _mock_discovery_and_jwks(mock, jwks)
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    csrf_token = mint_csrf_token(str(session_id))
+    if with_csrf:
+        client.cookies.set(CSRF_COOKIE_NAME, csrf_token)
+    return client, mock, csrf_token
+
+
+def _csrf_headers(token: str) -> dict[str, str]:
+    """Return the headers a state-changing HTMX request carries.
+
+    Mirrors the page-level ``hx-headers`` directive that ships the
+    CSRF token on every HTMX request from the memory surface.
+    """
+    return {"X-CSRF-Token": token, "HX-Request": "true"}
+
+
+# ---------------------------------------------------------------------------
+# Authentication boundary
+# ---------------------------------------------------------------------------
+
+
+def test_list_unauthenticated_redirects_to_login() -> None:
+    """``GET /ui/memory`` without a session 302s to the BFF login."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/memory")
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+
+
+def test_detail_unauthenticated_redirects_to_login() -> None:
+    """``GET /ui/memory/user/x`` without a session 302s to login."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/memory/user/some-slug")
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+
+
+# ---------------------------------------------------------------------------
+# List view -- full page + HTMX fragment + scope tabs + cards
+# ---------------------------------------------------------------------------
+
+
+def test_list_full_page_renders_with_empty_inventory() -> None:
+    """``GET /ui/memory`` with no memories renders the empty state."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A,
+        access_token="unused",
+        operator_sub=_OP_A,
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "<title>Memory" in body
+    assert 'id="memory-cards"' in body
+    assert "No memories match the current scope" in body
+    # Scope tabs are rendered for every scope plus All.
+    for label in ("User", "Tenant", "Target", "All visible"):
+        assert label in body
+    # CSRF cookie set by the route.
+    assert CSRF_COOKIE_NAME in response.cookies
+
+
+def test_list_renders_cards_with_preview_and_scope_badge() -> None:
+    """Seeded memories render as cards with the slug + scope badge + preview."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="wine-pref",
+        body="Damir prefers Riesling. " * 20,  # > 200 chars
+        user_sub=_OP_A,
+        tags=["preference", "wine"],
+    )
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.TENANT,
+        slug="team-runbook",
+        body="On-call rotation lives in the kb.",
+    )
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory")
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    body = response.text
+    assert "wine-pref" in body
+    assert "team-runbook" in body
+    # Scope badges + preview text both rendered.
+    assert ">user<" in body
+    assert ">tenant<" in body
+    assert "Damir prefers Riesling." in body
+    # Tag chips.
+    assert "preference" in body
+    assert "wine" in body
+    # 200-char preview truncated -- the body is >400 chars but the
+    # preview slice is bounded; verifying the ellipsis suffix is enough.
+    assert "..." in body
+
+
+def test_list_htmx_fragment_returns_cards_partial_only() -> None:
+    """HTMX request to ``/ui/memory`` returns the ``_cards.html`` fragment."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(tenant_id=_TENANT_A, scope=MemoryScope.USER, slug="x", body="x", user_sub=_OP_A)
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory", headers={"HX-Request": "true"})
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    body = response.text
+    # Fragment includes ``#memory-cards`` but no full ``<title>`` chrome.
+    assert 'id="memory-cards"' in body
+    assert "<title>" not in body
+
+
+def test_list_scope_filter_narrows_to_one_scope() -> None:
+    """``?scope=tenant`` returns only tenant-scoped memories."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A, scope=MemoryScope.USER, slug="user-1", body="u", user_sub=_OP_A
+    )
+    _seed_memory(tenant_id=_TENANT_A, scope=MemoryScope.TENANT, slug="tenant-1", body="t")
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory?scope=tenant")
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    body = response.text
+    assert "tenant-1" in body
+    assert "user-1" not in body
+
+
+def test_list_invalid_scope_returns_422() -> None:
+    """A typoed scope query value 422s rather than collapsing to 'all'."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory?scope=bogus")
+    finally:
+        mock.stop()
+    assert response.status_code == 422
+
+
+def test_list_tag_filter_narrows_results() -> None:
+    """``?tag=wine`` returns only rows whose metadata.tags includes 'wine'."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="wine-pref",
+        body="riesling",
+        user_sub=_OP_A,
+        tags=["wine"],
+    )
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="food-pref",
+        body="pasta",
+        user_sub=_OP_A,
+        tags=["food"],
+    )
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory?tag=wine")
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    body = response.text
+    assert "wine-pref" in body
+    assert "food-pref" not in body
+
+
+def test_tags_endpoint_returns_distinct_sorted_tag_options() -> None:
+    """``/ui/memory/tags`` returns the union of tags in distinct sorted order."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="a",
+        body="a",
+        user_sub=_OP_A,
+        tags=["wine", "food"],
+    )
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.TENANT,
+        slug="b",
+        body="b",
+        tags=["food", "ops"],
+    )
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory/tags")
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    body = response.text
+    # Three distinct tags, sorted; rendered as <option> elements.
+    assert body.index("food") < body.index("ops") < body.index("wine")
+    assert body.count("<option ") == 3
+
+
+# ---------------------------------------------------------------------------
+# Detail view -- 200 + Markdown render + 404 + cross-user
+# ---------------------------------------------------------------------------
+
+
+def test_detail_full_page_renders_markdown_body() -> None:
+    """Detail page renders body as HTML (Markdown -> tags + escaped HTML)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    body_md = "# Title\n\n*italic* and **bold** and a `code` snippet."
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="readme",
+        body=body_md,
+        user_sub=_OP_A,
+    )
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory/user/readme")
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    text = response.text
+    # Markdown rendered to HTML -- not raw Markdown.
+    assert "<h1>Title</h1>" in text
+    assert "<em>italic</em>" in text
+    assert "<strong>bold</strong>" in text
+    assert "<code>code</code>" in text
+
+
+def test_detail_strips_inline_html_from_body() -> None:
+    """Raw ``<script>`` in a memory body renders as escaped text, not script."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="xss-probe",
+        body='<script>alert("x")</script>',
+        user_sub=_OP_A,
+    )
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory/user/xss-probe")
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    text = response.text
+    # The body is escaped; no raw script tag survives inside the
+    # body article. The DOM detail-page rendering can still embed
+    # ``<script>`` tags elsewhere (HTMX, Alpine), so we narrow the
+    # assertion to the escaped form.
+    assert "&lt;script&gt;" in text
+
+
+def test_detail_missing_slug_returns_404() -> None:
+    """A non-existent slug returns 404 (info-leak-avoidance: no 403)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory/user/not-there")
+    finally:
+        mock.stop()
+    assert response.status_code == 404
+
+
+def test_detail_cross_user_user_scoped_returns_404() -> None:
+    """Operator B cannot see Operator A's user-scoped memory (404, not 403)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="alice-secret",
+        body="for-alice-only",
+        user_sub=_OP_A,
+    )
+    _, jwks = _make_keypair_and_jwks()
+    session_id_b = _seed_session_sync(
+        tenant_id=_TENANT_A,  # same tenant
+        access_token="unused",
+        operator_sub=_OP_B,  # different operator
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id_b, jwks=jwks)
+    try:
+        response = client.get("/ui/memory/user/alice-secret")
+    finally:
+        mock.stop()
+    assert response.status_code == 404
+
+
+def test_detail_cross_tenant_returns_404() -> None:
+    """Operator in tenant B cannot see tenant A's tenant-scoped memory."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_tenant(_TENANT_B, "tenant-b")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.TENANT,
+        slug="a-runbook",
+        body="for-a",
+    )
+    _, jwks = _make_keypair_and_jwks()
+    session_id_b = _seed_session_sync(
+        tenant_id=_TENANT_B,
+        access_token="unused",
+        operator_sub=_OP_A,  # same sub, different tenant
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id_b, jwks=jwks)
+    try:
+        response = client.get("/ui/memory/tenant/a-runbook")
+    finally:
+        mock.stop()
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Edit-in-place -- RBAC gate on render + save
+# ---------------------------------------------------------------------------
+
+
+def test_edit_form_for_own_user_scoped_renders_textarea() -> None:
+    """``GET /ui/memory/user/<slug>/edit`` renders a textarea for own user-scoped."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="wine-pref",
+        body="riesling",
+        user_sub=_OP_A,
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A,
+        access_token=access_token,
+        operator_sub=_OP_A,
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get(
+            "/ui/memory/user/wine-pref/edit",
+            headers={"HX-Request": "true"},
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    body = response.text
+    assert "<textarea" in body
+    assert 'name="body"' in body
+    assert "riesling" in body
+    # The form is the swap target (id=memory-body) so the cancel/save
+    # roundtrip swaps in place.
+    assert 'id="memory-body"' in body
+
+
+def test_edit_form_tenant_scoped_as_operator_returns_403() -> None:
+    """Operator cannot edit tenant-scoped without tenant_admin (RBAC=403)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.TENANT,
+        slug="team-rule",
+        body="shared",
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory/tenant/team-rule/edit")
+    finally:
+        mock.stop()
+    assert response.status_code == 403
+
+
+def test_edit_form_tenant_scoped_as_admin_renders_textarea() -> None:
+    """``tenant_admin`` role unlocks the edit form on tenant-scoped memories."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.TENANT,
+        slug="team-rule",
+        body="shared",
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.TENANT_ADMIN.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory/tenant/team-rule/edit")
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    assert "<textarea" in response.text
+
+
+def test_patch_save_persists_new_body_and_returns_rendered_view() -> None:
+    """PATCH save updates the body in place and re-renders the body view fragment."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="wine-pref",
+        body="original",
+        user_sub=_OP_A,
+        tags=["wine"],
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    # Stub the embedding service: ``index_document``'s re-embed
+    # branch will call ``encode_one`` because the body hash
+    # changed; we mock it to return a fixed-dim vector so the test
+    # doesn't depend on the embedding-model wheel.
+    from unittest.mock import AsyncMock
+    from unittest.mock import patch as _patch
+
+    try:
+        with _patch("meho_backplane.retrieval.indexer.get_embedding_service") as mock_embed_factory:
+            mock_embed_factory.return_value = type(
+                "_Stub", (), {"encode_one": AsyncMock(return_value=[0.0] * 384)}
+            )()
+            response = client.request(
+                "PATCH",
+                "/ui/memory/user/wine-pref",
+                data={"body": "edited via UI"},
+                headers=_csrf_headers(_csrf),
+            )
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The response is the body-view fragment with the new content
+    # rendered through Markdown.
+    assert "edited via UI" in body
+    assert 'id="memory-body"' in body
+
+
+def test_patch_save_tenant_scoped_as_operator_returns_403() -> None:
+    """Operator role cannot PATCH a tenant-scoped memory (RBAC=403)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.TENANT,
+        slug="team-rule",
+        body="shared",
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.request(
+            "PATCH",
+            "/ui/memory/tenant/team-rule",
+            data={"body": "edited"},
+            headers=_csrf_headers(_csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+
+
+def test_patch_save_empty_body_returns_422() -> None:
+    """An empty body fails the 'must not be empty' guard."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="wine-pref",
+        body="original",
+        user_sub=_OP_A,
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.request(
+            "PATCH",
+            "/ui/memory/user/wine-pref",
+            data={"body": "   "},
+            headers=_csrf_headers(_csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Delete -- happy path + idempotent + RBAC
+# ---------------------------------------------------------------------------
+
+
+def test_delete_removes_row_and_re_renders_list() -> None:
+    """DELETE returns the re-rendered card list with a flash banner."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="ephemeral",
+        body="goodbye",
+        user_sub=_OP_A,
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.request(
+            "DELETE",
+            "/ui/memory/user/ephemeral",
+            headers=_csrf_headers(_csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "Deleted memory user/ephemeral" in body
+    # The card list re-renders with the empty state.
+    assert 'id="memory-cards"' in body
+
+
+def test_delete_tenant_scoped_as_operator_returns_403() -> None:
+    """Operator role cannot DELETE a tenant-scoped memory."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.TENANT,
+        slug="team-rule",
+        body="shared",
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.request(
+            "DELETE",
+            "/ui/memory/tenant/team-rule",
+            headers=_csrf_headers(_csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 403
+
+
+def test_delete_missing_slug_returns_404() -> None:
+    """DELETE on a non-existent slug returns 404 (info-leak-avoidance)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.request(
+            "DELETE",
+            "/ui/memory/user/never-existed",
+            headers=_csrf_headers(_csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Stub retirement -- ensure ``/ui/memory`` is no longer a stub
+# ---------------------------------------------------------------------------
+
+
+def test_ui_memory_is_not_a_chassis_stub() -> None:
+    """The real memory router replaces the stub."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory")
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    # The chassis stub renders "Coming soon" -- the real surface
+    # never does.
+    assert "Coming soon" not in response.text

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1294,6 +1294,18 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
 name = "logfire-api"
 version = "4.33.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1337,6 +1349,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
 ]
 
 [[package]]
@@ -1431,7 +1448,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "jsonschema" },
     { name = "kubernetes-asyncio" },
-    { name = "markdown-it-py" },
+    { name = "markdown-it-py", extra = ["linkify"] },
     { name = "msgspec" },
     { name = "packaging" },
     { name = "pgvector" },
@@ -1482,7 +1499,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "kubernetes-asyncio", specifier = ">=35.0.1,<36" },
-    { name = "markdown-it-py", specifier = ">=3.0" },
+    { name = "markdown-it-py", extras = ["linkify"], specifier = ">=3.0" },
     { name = "msgspec", specifier = ">=0.20.0" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "pgvector", specifier = ">=0.3,<1.0" },
@@ -2907,6 +2924,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1431,6 +1431,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "jsonschema" },
     { name = "kubernetes-asyncio" },
+    { name = "markdown-it-py" },
     { name = "msgspec" },
     { name = "packaging" },
     { name = "pgvector" },
@@ -1438,7 +1439,9 @@ dependencies = [
     { name = "pyarrow" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-ai-slim", extra = ["anthropic"] },
+    { name = "pygments" },
     { name = "python-frontmatter" },
+    { name = "python-multipart" },
     { name = "redis" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "structlog" },
@@ -1479,6 +1482,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "kubernetes-asyncio", specifier = ">=35.0.1,<36" },
+    { name = "markdown-it-py", specifier = ">=3.0" },
     { name = "msgspec", specifier = ">=0.20.0" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "pgvector", specifier = ">=0.3,<1.0" },
@@ -1486,7 +1490,9 @@ requires-dist = [
     { name = "pyarrow", specifier = ">=21.0.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.13.4" },
     { name = "pydantic-ai-slim", extras = ["anthropic"], specifier = ">=1.102.0" },
+    { name = "pygments", specifier = ">=2.18" },
     { name = "python-frontmatter", specifier = ">=1.3.0" },
+    { name = "python-multipart", specifier = ">=0.0.12" },
     { name = "redis", specifier = ">=5,<8" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.50" },
     { name = "structlog", specifier = ">=24.1" },
@@ -2445,6 +2451,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9d/e8/79cbe69864d44f3b48e70ebee0a872a7d5a4e7150c9f8577ed7a5beefff0/python_frontmatter-1.3.0.tar.gz", hash = "sha256:acc73e477a568dc2a25c9e130c6c68ae8daa8c204c8f7e813db47d6a7280dcf2", size = 8322, upload-time = "2026-05-20T19:21:44.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/a3/17c284b4f4d8ad50f0f9ba70ad8fcc35c777aeafcdbbffdd91bbdc5ab379/python_frontmatter-1.3.0-py3-none-any.whl", hash = "sha256:9f7dd9260bec99044219159a329f64f039087f9d1a2124c9442556f2fe6f82ec", size = 10562, upload-time = "2026-05-20T19:21:43.323Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.29"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
 ]
 
 [[package]]

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -6304,6 +6304,316 @@
         }
       }
     },
+    "/ui/memory": {
+      "get": {
+        "tags": [
+          "ui-memory"
+        ],
+        "summary": "Ui Memory List",
+        "description": "``GET /ui/memory`` -- list page or HTMX card-list fragment.",
+        "operationId": "ui_memory_list_ui_memory_get",
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 64,
+              "default": "all",
+              "title": "Scope"
+            }
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 256,
+              "nullable": true,
+              "title": "Tag"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/memory/tags": {
+      "get": {
+        "tags": [
+          "ui-memory"
+        ],
+        "summary": "Ui Memory Tags",
+        "description": "``GET /ui/memory/tags`` -- HTMX datalist autocomplete fragment.",
+        "operationId": "ui_memory_tags_ui_memory_tags_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/memory/{scope}/{slug}": {
+      "get": {
+        "tags": [
+          "ui-memory"
+        ],
+        "summary": "Ui Memory Detail",
+        "description": "``GET /ui/memory/<scope>/<slug>`` -- detail page or HTMX body fragment.",
+        "operationId": "ui_memory_detail_ui_memory__scope___slug__get",
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/MemoryScope"
+            }
+          },
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "ui-memory"
+        ],
+        "summary": "Ui Memory Patch",
+        "description": "``PATCH /ui/memory/<scope>/<slug>`` -- save the edited body.",
+        "operationId": "ui_memory_patch_ui_memory__scope___slug__patch",
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/MemoryScope"
+            }
+          },
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_ui_memory_patch_ui_memory__scope___slug__patch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ui-memory"
+        ],
+        "summary": "Ui Memory Delete",
+        "description": "``DELETE /ui/memory/<scope>/<slug>`` -- delete + re-render the list.",
+        "operationId": "ui_memory_delete_ui_memory__scope___slug__delete",
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/MemoryScope"
+            }
+          },
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/memory/{scope}/{slug}/edit": {
+      "get": {
+        "tags": [
+          "ui-memory"
+        ],
+        "summary": "Ui Memory Edit Form",
+        "description": "``GET /ui/memory/<scope>/<slug>/edit`` -- HTMX edit-form fragment.",
+        "operationId": "ui_memory_edit_form_ui_memory__scope___slug__edit_get",
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/MemoryScope"
+            }
+          },
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ui/knowledge": {
       "get": {
         "tags": [
@@ -6332,27 +6642,6 @@
         ],
         "summary": "Ui Stub Connectors",
         "operationId": "ui_stub_connectors_ui_connectors_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "text/html": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ui/memory": {
-      "get": {
-        "tags": [
-          "ui-stubs"
-        ],
-        "summary": "Ui Stub Memory",
-        "operationId": "ui_stub_memory_ui_memory_get",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -7483,6 +7772,24 @@
         ],
         "title": "BaselineMetricsOverride",
         "description": "Per-surface baseline metrics supplied by the caller.\n\nCriterion 4 (MEHO \u2265 baseline) needs side-by-side numbers from a\nbaseline retrieval (``grep -r kb/`` for kb; ``grep paths.txt +\nyq`` for operations). The v0.2 backplane has no checked-in\ncorpus snapshot to evaluate the baseline against (see\n:mod:`meho_backplane.api.v1.retrieve_eval` \u2014 explicit\n``baseline=grep`` on that route is rejected with 501); the CLI\nruns the baseline locally against the operator's kb/ checkout and\ncan pass the resulting numbers here so the retire-checklist\nverdict honestly reflects criterion 4 instead of always reporting\nyellow (\"baseline did not run\") on the API path.\n\nWithout an override, criterion 4 stays yellow for v0.2 production\ncallers \u2014 the documented \"READY TO RETIRE\" path is unreachable\nvia the bare API alone, which is the honest v0.2 posture. T7\n(#446) / v0.2.next is expected to wire a server-side corpus\nsnapshot and remove the need for this override."
+      },
+      "Body_ui_memory_patch_ui_memory__scope___slug__patch": {
+        "properties": {
+          "body": {
+            "type": "string",
+            "maxLength": 65536,
+            "title": "Body"
+          },
+          "session_ctx": {
+            "$ref": "#/components/schemas/UISessionContext",
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "body"
+        ],
+        "title": "Body_ui_memory_patch_ui_memory__scope___slug__patch"
       },
       "BroadcastOverrideCreate": {
         "properties": {
@@ -10905,6 +11212,32 @@
         ],
         "title": "TopologyTimelineResult",
         "description": "Page of timeline rows plus the forward-only continuation cursor.\n\n``next_cursor`` is :data:`None` when fewer than ``limit`` rows\nwere available (the query reached the end of the matching set).\nConsumers iterate by re-issuing the same filter with\n``cursor = next_cursor`` until ``next_cursor`` is None.\n\nThe cursor is opaque (base64-encoded JSON over ``(valid_from,\nhistory_id, source)``) -- consumers treat it as a token. Stability\nunder concurrent inserts: a new history row landing in the window\nbetween page N and page N+1 is naturally placed by the keyset\ncompare (``(valid_from, history_id) < (cursor.ts, cursor.id)``)\nand either appears on a later page (if it falls below the cursor)\nor never (if it lands above the cursor). No row is duplicated or\nskipped by the act of paging."
+      },
+      "UISessionContext": {
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Session Id"
+          },
+          "operator_sub": {
+            "type": "string",
+            "title": "Operator Sub"
+          },
+          "tenant_id": {
+            "type": "string",
+            "format": "uuid",
+            "title": "Tenant Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "session_id",
+          "operator_sub",
+          "tenant_id"
+        ],
+        "title": "UISessionContext",
+        "description": "Per-request session identity exposed on ``request.state``.\n\nFrozen so a route handler that stashes the context on a logger\nor forwards it to a service layer cannot accidentally mutate\nfields downstream. The shape mirrors :class:`Operator` for the\nfields T5 (#866) needs to render an authenticated page header;\n``raw_jwt`` / ``tenant_role`` are intentionally absent because\nthe session-cookie path does not load them today (the encrypted\nrow carries only the access token, not the decoded claims)."
       },
       "UsageReport": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -875,6 +875,22 @@ type BaselineMetricsOverride struct {
 	PrecisionAt5 float32 `json:"precision_at_5"`
 }
 
+// BodyUiMemoryPatchUiMemoryScopeSlugPatch defines model for Body_ui_memory_patch_ui_memory__scope___slug__patch.
+type BodyUiMemoryPatchUiMemoryScopeSlugPatch struct {
+	Body string `json:"body"`
+
+	// SessionCtx Per-request session identity exposed on ``request.state``.
+	//
+	// Frozen so a route handler that stashes the context on a logger
+	// or forwards it to a service layer cannot accidentally mutate
+	// fields downstream. The shape mirrors :class:`Operator` for the
+	// fields T5 (#866) needs to render an authenticated page header;
+	// ``raw_jwt`` / ``tenant_role`` are intentionally absent because
+	// the session-cookie path does not load them today (the encrypted
+	// row carries only the access token, not the decoded claims).
+	SessionCtx *UISessionContext `json:"session_ctx,omitempty"`
+}
+
 // BroadcastOverrideCreate Incoming POST body. Pydantic v2 strict.
 //
 // “extra="forbid"“ rejects unknown fields with 422 -- catches a
@@ -3051,6 +3067,21 @@ type TopologyTimelineResult struct {
 	Rows       []TopologyTimelineEntry `json:"rows"`
 }
 
+// UISessionContext Per-request session identity exposed on “request.state“.
+//
+// Frozen so a route handler that stashes the context on a logger
+// or forwards it to a service layer cannot accidentally mutate
+// fields downstream. The shape mirrors :class:`Operator` for the
+// fields T5 (#866) needs to render an authenticated page header;
+// “raw_jwt“ / “tenant_role“ are intentionally absent because
+// the session-cookie path does not load them today (the encrypted
+// row carries only the access token, not the decoded claims).
+type UISessionContext struct {
+	OperatorSub string             `json:"operator_sub"`
+	SessionId   openapi_types.UUID `json:"session_id"`
+	TenantId    openapi_types.UUID `json:"tenant_id"`
+}
+
 // UsageReport Top-level shape returned by :func:`compute_usage` + the API route.
 //
 // “buckets“ is sorted by “(date, surface)“ ascending — the text
@@ -3946,6 +3977,12 @@ type UiBroadcastStreamUiBroadcastStreamGetParams struct {
 	Since *string `form:"since,omitempty" json:"since,omitempty"`
 }
 
+// UiMemoryListUiMemoryGetParams defines parameters for UiMemoryListUiMemoryGet.
+type UiMemoryListUiMemoryGetParams struct {
+	Scope *string `form:"scope,omitempty" json:"scope,omitempty"`
+	Tag   *string `form:"tag,omitempty" json:"tag,omitempty"`
+}
+
 // UiTopologyTableUiTopologyGetParams defines parameters for UiTopologyTableUiTopologyGet.
 type UiTopologyTableUiTopologyGetParams struct {
 	Sort *UnderscoreSortColumn `form:"sort,omitempty" json:"sort,omitempty"`
@@ -4054,6 +4091,15 @@ type AnnotateEdgeRouteApiV1TopologyEdgesPostJSONRequestBody = UnderscoreAnnotate
 
 // BulkImportEdgesRouteApiV1TopologyEdgesBulkPostJSONRequestBody defines body for BulkImportEdgesRouteApiV1TopologyEdgesBulkPost for application/json ContentType.
 type BulkImportEdgesRouteApiV1TopologyEdgesBulkPostJSONRequestBody = UnderscoreBulkImportRequest
+
+// UiMemoryDeleteUiMemoryScopeSlugDeleteJSONRequestBody defines body for UiMemoryDeleteUiMemoryScopeSlugDelete for application/json ContentType.
+type UiMemoryDeleteUiMemoryScopeSlugDeleteJSONRequestBody = UISessionContext
+
+// UiMemoryPatchUiMemoryScopeSlugPatchFormdataRequestBody defines body for UiMemoryPatchUiMemoryScopeSlugPatch for application/x-www-form-urlencoded ContentType.
+type UiMemoryPatchUiMemoryScopeSlugPatchFormdataRequestBody = BodyUiMemoryPatchUiMemoryScopeSlugPatch
+
+// UiMemoryEditFormUiMemoryScopeSlugEditGetJSONRequestBody defines body for UiMemoryEditFormUiMemoryScopeSlugEditGet for application/json ContentType.
+type UiMemoryEditFormUiMemoryScopeSlugEditGetJSONRequestBody = UISessionContext
 
 // AsApproveResponseBodyDispatchResult0 returns the union data inside the ApproveResponseBody_DispatchResult as a ApproveResponseBodyDispatchResult0
 func (t ApproveResponseBody_DispatchResult) AsApproveResponseBodyDispatchResult0() (ApproveResponseBodyDispatchResult0, error) {
@@ -4618,8 +4664,29 @@ type ClientInterface interface {
 	// UiStubKnowledgeUiKnowledgeGet request
 	UiStubKnowledgeUiKnowledgeGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// UiStubMemoryUiMemoryGet request
-	UiStubMemoryUiMemoryGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// UiMemoryListUiMemoryGet request
+	UiMemoryListUiMemoryGet(ctx context.Context, params *UiMemoryListUiMemoryGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiMemoryTagsUiMemoryTagsGet request
+	UiMemoryTagsUiMemoryTagsGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiMemoryDeleteUiMemoryScopeSlugDeleteWithBody request with any body
+	UiMemoryDeleteUiMemoryScopeSlugDeleteWithBody(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiMemoryDeleteUiMemoryScopeSlugDelete(ctx context.Context, scope MemoryScope, slug string, body UiMemoryDeleteUiMemoryScopeSlugDeleteJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiMemoryDetailUiMemoryScopeSlugGet request
+	UiMemoryDetailUiMemoryScopeSlugGet(ctx context.Context, scope MemoryScope, slug string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiMemoryPatchUiMemoryScopeSlugPatchWithBody request with any body
+	UiMemoryPatchUiMemoryScopeSlugPatchWithBody(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiMemoryPatchUiMemoryScopeSlugPatchWithFormdataBody(ctx context.Context, scope MemoryScope, slug string, body UiMemoryPatchUiMemoryScopeSlugPatchFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiMemoryEditFormUiMemoryScopeSlugEditGetWithBody request with any body
+	UiMemoryEditFormUiMemoryScopeSlugEditGetWithBody(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiMemoryEditFormUiMemoryScopeSlugEditGet(ctx context.Context, scope MemoryScope, slug string, body UiMemoryEditFormUiMemoryScopeSlugEditGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiTopologyTableUiTopologyGet request
 	UiTopologyTableUiTopologyGet(ctx context.Context, params *UiTopologyTableUiTopologyGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -6215,8 +6282,104 @@ func (c *Client) UiStubKnowledgeUiKnowledgeGet(ctx context.Context, reqEditors .
 	return c.Client.Do(req)
 }
 
-func (c *Client) UiStubMemoryUiMemoryGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUiStubMemoryUiMemoryGetRequest(c.Server)
+func (c *Client) UiMemoryListUiMemoryGet(ctx context.Context, params *UiMemoryListUiMemoryGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryListUiMemoryGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiMemoryTagsUiMemoryTagsGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryTagsUiMemoryTagsGetRequest(c.Server)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiMemoryDeleteUiMemoryScopeSlugDeleteWithBody(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryDeleteUiMemoryScopeSlugDeleteRequestWithBody(c.Server, scope, slug, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiMemoryDeleteUiMemoryScopeSlugDelete(ctx context.Context, scope MemoryScope, slug string, body UiMemoryDeleteUiMemoryScopeSlugDeleteJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryDeleteUiMemoryScopeSlugDeleteRequest(c.Server, scope, slug, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiMemoryDetailUiMemoryScopeSlugGet(ctx context.Context, scope MemoryScope, slug string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryDetailUiMemoryScopeSlugGetRequest(c.Server, scope, slug)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiMemoryPatchUiMemoryScopeSlugPatchWithBody(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryPatchUiMemoryScopeSlugPatchRequestWithBody(c.Server, scope, slug, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiMemoryPatchUiMemoryScopeSlugPatchWithFormdataBody(ctx context.Context, scope MemoryScope, slug string, body UiMemoryPatchUiMemoryScopeSlugPatchFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryPatchUiMemoryScopeSlugPatchRequestWithFormdataBody(c.Server, scope, slug, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiMemoryEditFormUiMemoryScopeSlugEditGetWithBody(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryEditFormUiMemoryScopeSlugEditGetRequestWithBody(c.Server, scope, slug, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiMemoryEditFormUiMemoryScopeSlugEditGet(ctx context.Context, scope MemoryScope, slug string, body UiMemoryEditFormUiMemoryScopeSlugEditGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryEditFormUiMemoryScopeSlugEditGetRequest(c.Server, scope, slug, body)
 	if err != nil {
 		return nil, err
 	}
@@ -12828,8 +12991,8 @@ func NewUiStubKnowledgeUiKnowledgeGetRequest(server string) (*http.Request, erro
 	return req, nil
 }
 
-// NewUiStubMemoryUiMemoryGetRequest generates requests for UiStubMemoryUiMemoryGet
-func NewUiStubMemoryUiMemoryGetRequest(server string) (*http.Request, error) {
+// NewUiMemoryListUiMemoryGetRequest generates requests for UiMemoryListUiMemoryGet
+func NewUiMemoryListUiMemoryGetRequest(server string, params *UiMemoryListUiMemoryGetParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -12847,10 +13010,278 @@ func NewUiStubMemoryUiMemoryGetRequest(server string) (*http.Request, error) {
 		return nil, err
 	}
 
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Scope != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "scope", runtime.ParamLocationQuery, *params.Scope); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Tag != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "tag", runtime.ParamLocationQuery, *params.Tag); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewUiMemoryTagsUiMemoryTagsGetRequest generates requests for UiMemoryTagsUiMemoryTagsGet
+func NewUiMemoryTagsUiMemoryTagsGetRequest(server string) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/memory/tags")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUiMemoryDeleteUiMemoryScopeSlugDeleteRequest calls the generic UiMemoryDeleteUiMemoryScopeSlugDelete builder with application/json body
+func NewUiMemoryDeleteUiMemoryScopeSlugDeleteRequest(server string, scope MemoryScope, slug string, body UiMemoryDeleteUiMemoryScopeSlugDeleteJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUiMemoryDeleteUiMemoryScopeSlugDeleteRequestWithBody(server, scope, slug, "application/json", bodyReader)
+}
+
+// NewUiMemoryDeleteUiMemoryScopeSlugDeleteRequestWithBody generates requests for UiMemoryDeleteUiMemoryScopeSlugDelete with any type of body
+func NewUiMemoryDeleteUiMemoryScopeSlugDeleteRequestWithBody(server string, scope MemoryScope, slug string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "scope", runtime.ParamLocationPath, scope)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/memory/%s/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiMemoryDetailUiMemoryScopeSlugGetRequest generates requests for UiMemoryDetailUiMemoryScopeSlugGet
+func NewUiMemoryDetailUiMemoryScopeSlugGetRequest(server string, scope MemoryScope, slug string) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "scope", runtime.ParamLocationPath, scope)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/memory/%s/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewUiMemoryPatchUiMemoryScopeSlugPatchRequestWithFormdataBody calls the generic UiMemoryPatchUiMemoryScopeSlugPatch builder with application/x-www-form-urlencoded body
+func NewUiMemoryPatchUiMemoryScopeSlugPatchRequestWithFormdataBody(server string, scope MemoryScope, slug string, body UiMemoryPatchUiMemoryScopeSlugPatchFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewUiMemoryPatchUiMemoryScopeSlugPatchRequestWithBody(server, scope, slug, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewUiMemoryPatchUiMemoryScopeSlugPatchRequestWithBody generates requests for UiMemoryPatchUiMemoryScopeSlugPatch with any type of body
+func NewUiMemoryPatchUiMemoryScopeSlugPatchRequestWithBody(server string, scope MemoryScope, slug string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "scope", runtime.ParamLocationPath, scope)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/memory/%s/%s", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiMemoryEditFormUiMemoryScopeSlugEditGetRequest calls the generic UiMemoryEditFormUiMemoryScopeSlugEditGet builder with application/json body
+func NewUiMemoryEditFormUiMemoryScopeSlugEditGetRequest(server string, scope MemoryScope, slug string, body UiMemoryEditFormUiMemoryScopeSlugEditGetJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUiMemoryEditFormUiMemoryScopeSlugEditGetRequestWithBody(server, scope, slug, "application/json", bodyReader)
+}
+
+// NewUiMemoryEditFormUiMemoryScopeSlugEditGetRequestWithBody generates requests for UiMemoryEditFormUiMemoryScopeSlugEditGet with any type of body
+func NewUiMemoryEditFormUiMemoryScopeSlugEditGetRequestWithBody(server string, scope MemoryScope, slug string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "scope", runtime.ParamLocationPath, scope)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/memory/%s/%s/edit", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -13566,8 +13997,29 @@ type ClientWithResponsesInterface interface {
 	// UiStubKnowledgeUiKnowledgeGetWithResponse request
 	UiStubKnowledgeUiKnowledgeGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiStubKnowledgeUiKnowledgeGetResponse, error)
 
-	// UiStubMemoryUiMemoryGetWithResponse request
-	UiStubMemoryUiMemoryGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiStubMemoryUiMemoryGetResponse, error)
+	// UiMemoryListUiMemoryGetWithResponse request
+	UiMemoryListUiMemoryGetWithResponse(ctx context.Context, params *UiMemoryListUiMemoryGetParams, reqEditors ...RequestEditorFn) (*UiMemoryListUiMemoryGetResponse, error)
+
+	// UiMemoryTagsUiMemoryTagsGetWithResponse request
+	UiMemoryTagsUiMemoryTagsGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiMemoryTagsUiMemoryTagsGetResponse, error)
+
+	// UiMemoryDeleteUiMemoryScopeSlugDeleteWithBodyWithResponse request with any body
+	UiMemoryDeleteUiMemoryScopeSlugDeleteWithBodyWithResponse(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryDeleteUiMemoryScopeSlugDeleteResponse, error)
+
+	UiMemoryDeleteUiMemoryScopeSlugDeleteWithResponse(ctx context.Context, scope MemoryScope, slug string, body UiMemoryDeleteUiMemoryScopeSlugDeleteJSONRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryDeleteUiMemoryScopeSlugDeleteResponse, error)
+
+	// UiMemoryDetailUiMemoryScopeSlugGetWithResponse request
+	UiMemoryDetailUiMemoryScopeSlugGetWithResponse(ctx context.Context, scope MemoryScope, slug string, reqEditors ...RequestEditorFn) (*UiMemoryDetailUiMemoryScopeSlugGetResponse, error)
+
+	// UiMemoryPatchUiMemoryScopeSlugPatchWithBodyWithResponse request with any body
+	UiMemoryPatchUiMemoryScopeSlugPatchWithBodyWithResponse(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryPatchUiMemoryScopeSlugPatchResponse, error)
+
+	UiMemoryPatchUiMemoryScopeSlugPatchWithFormdataBodyWithResponse(ctx context.Context, scope MemoryScope, slug string, body UiMemoryPatchUiMemoryScopeSlugPatchFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryPatchUiMemoryScopeSlugPatchResponse, error)
+
+	// UiMemoryEditFormUiMemoryScopeSlugEditGetWithBodyWithResponse request with any body
+	UiMemoryEditFormUiMemoryScopeSlugEditGetWithBodyWithResponse(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryEditFormUiMemoryScopeSlugEditGetResponse, error)
+
+	UiMemoryEditFormUiMemoryScopeSlugEditGetWithResponse(ctx context.Context, scope MemoryScope, slug string, body UiMemoryEditFormUiMemoryScopeSlugEditGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryEditFormUiMemoryScopeSlugEditGetResponse, error)
 
 	// UiTopologyTableUiTopologyGetWithResponse request
 	UiTopologyTableUiTopologyGetWithResponse(ctx context.Context, params *UiTopologyTableUiTopologyGetParams, reqEditors ...RequestEditorFn) (*UiTopologyTableUiTopologyGetResponse, error)
@@ -15914,13 +16366,14 @@ func (r UiStubKnowledgeUiKnowledgeGetResponse) StatusCode() int {
 	return 0
 }
 
-type UiStubMemoryUiMemoryGetResponse struct {
+type UiMemoryListUiMemoryGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
 }
 
 // Status returns HTTPResponse.Status
-func (r UiStubMemoryUiMemoryGetResponse) Status() string {
+func (r UiMemoryListUiMemoryGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -15928,7 +16381,116 @@ func (r UiStubMemoryUiMemoryGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r UiStubMemoryUiMemoryGetResponse) StatusCode() int {
+func (r UiMemoryListUiMemoryGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiMemoryTagsUiMemoryTagsGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+}
+
+// Status returns HTTPResponse.Status
+func (r UiMemoryTagsUiMemoryTagsGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiMemoryTagsUiMemoryTagsGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiMemoryDeleteUiMemoryScopeSlugDeleteResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiMemoryDeleteUiMemoryScopeSlugDeleteResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiMemoryDeleteUiMemoryScopeSlugDeleteResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiMemoryDetailUiMemoryScopeSlugGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiMemoryDetailUiMemoryScopeSlugGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiMemoryDetailUiMemoryScopeSlugGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiMemoryPatchUiMemoryScopeSlugPatchResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiMemoryPatchUiMemoryScopeSlugPatchResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiMemoryPatchUiMemoryScopeSlugPatchResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiMemoryEditFormUiMemoryScopeSlugEditGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiMemoryEditFormUiMemoryScopeSlugEditGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiMemoryEditFormUiMemoryScopeSlugEditGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -17159,13 +17721,82 @@ func (c *ClientWithResponses) UiStubKnowledgeUiKnowledgeGetWithResponse(ctx cont
 	return ParseUiStubKnowledgeUiKnowledgeGetResponse(rsp)
 }
 
-// UiStubMemoryUiMemoryGetWithResponse request returning *UiStubMemoryUiMemoryGetResponse
-func (c *ClientWithResponses) UiStubMemoryUiMemoryGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiStubMemoryUiMemoryGetResponse, error) {
-	rsp, err := c.UiStubMemoryUiMemoryGet(ctx, reqEditors...)
+// UiMemoryListUiMemoryGetWithResponse request returning *UiMemoryListUiMemoryGetResponse
+func (c *ClientWithResponses) UiMemoryListUiMemoryGetWithResponse(ctx context.Context, params *UiMemoryListUiMemoryGetParams, reqEditors ...RequestEditorFn) (*UiMemoryListUiMemoryGetResponse, error) {
+	rsp, err := c.UiMemoryListUiMemoryGet(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseUiStubMemoryUiMemoryGetResponse(rsp)
+	return ParseUiMemoryListUiMemoryGetResponse(rsp)
+}
+
+// UiMemoryTagsUiMemoryTagsGetWithResponse request returning *UiMemoryTagsUiMemoryTagsGetResponse
+func (c *ClientWithResponses) UiMemoryTagsUiMemoryTagsGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiMemoryTagsUiMemoryTagsGetResponse, error) {
+	rsp, err := c.UiMemoryTagsUiMemoryTagsGet(ctx, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryTagsUiMemoryTagsGetResponse(rsp)
+}
+
+// UiMemoryDeleteUiMemoryScopeSlugDeleteWithBodyWithResponse request with arbitrary body returning *UiMemoryDeleteUiMemoryScopeSlugDeleteResponse
+func (c *ClientWithResponses) UiMemoryDeleteUiMemoryScopeSlugDeleteWithBodyWithResponse(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryDeleteUiMemoryScopeSlugDeleteResponse, error) {
+	rsp, err := c.UiMemoryDeleteUiMemoryScopeSlugDeleteWithBody(ctx, scope, slug, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryDeleteUiMemoryScopeSlugDeleteResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiMemoryDeleteUiMemoryScopeSlugDeleteWithResponse(ctx context.Context, scope MemoryScope, slug string, body UiMemoryDeleteUiMemoryScopeSlugDeleteJSONRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryDeleteUiMemoryScopeSlugDeleteResponse, error) {
+	rsp, err := c.UiMemoryDeleteUiMemoryScopeSlugDelete(ctx, scope, slug, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryDeleteUiMemoryScopeSlugDeleteResponse(rsp)
+}
+
+// UiMemoryDetailUiMemoryScopeSlugGetWithResponse request returning *UiMemoryDetailUiMemoryScopeSlugGetResponse
+func (c *ClientWithResponses) UiMemoryDetailUiMemoryScopeSlugGetWithResponse(ctx context.Context, scope MemoryScope, slug string, reqEditors ...RequestEditorFn) (*UiMemoryDetailUiMemoryScopeSlugGetResponse, error) {
+	rsp, err := c.UiMemoryDetailUiMemoryScopeSlugGet(ctx, scope, slug, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryDetailUiMemoryScopeSlugGetResponse(rsp)
+}
+
+// UiMemoryPatchUiMemoryScopeSlugPatchWithBodyWithResponse request with arbitrary body returning *UiMemoryPatchUiMemoryScopeSlugPatchResponse
+func (c *ClientWithResponses) UiMemoryPatchUiMemoryScopeSlugPatchWithBodyWithResponse(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryPatchUiMemoryScopeSlugPatchResponse, error) {
+	rsp, err := c.UiMemoryPatchUiMemoryScopeSlugPatchWithBody(ctx, scope, slug, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryPatchUiMemoryScopeSlugPatchResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiMemoryPatchUiMemoryScopeSlugPatchWithFormdataBodyWithResponse(ctx context.Context, scope MemoryScope, slug string, body UiMemoryPatchUiMemoryScopeSlugPatchFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryPatchUiMemoryScopeSlugPatchResponse, error) {
+	rsp, err := c.UiMemoryPatchUiMemoryScopeSlugPatchWithFormdataBody(ctx, scope, slug, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryPatchUiMemoryScopeSlugPatchResponse(rsp)
+}
+
+// UiMemoryEditFormUiMemoryScopeSlugEditGetWithBodyWithResponse request with arbitrary body returning *UiMemoryEditFormUiMemoryScopeSlugEditGetResponse
+func (c *ClientWithResponses) UiMemoryEditFormUiMemoryScopeSlugEditGetWithBodyWithResponse(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryEditFormUiMemoryScopeSlugEditGetResponse, error) {
+	rsp, err := c.UiMemoryEditFormUiMemoryScopeSlugEditGetWithBody(ctx, scope, slug, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryEditFormUiMemoryScopeSlugEditGetResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiMemoryEditFormUiMemoryScopeSlugEditGetWithResponse(ctx context.Context, scope MemoryScope, slug string, body UiMemoryEditFormUiMemoryScopeSlugEditGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryEditFormUiMemoryScopeSlugEditGetResponse, error) {
+	rsp, err := c.UiMemoryEditFormUiMemoryScopeSlugEditGet(ctx, scope, slug, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryEditFormUiMemoryScopeSlugEditGetResponse(rsp)
 }
 
 // UiTopologyTableUiTopologyGetWithResponse request returning *UiTopologyTableUiTopologyGetResponse
@@ -20346,17 +20977,147 @@ func ParseUiStubKnowledgeUiKnowledgeGetResponse(rsp *http.Response) (*UiStubKnow
 	return response, nil
 }
 
-// ParseUiStubMemoryUiMemoryGetResponse parses an HTTP response from a UiStubMemoryUiMemoryGetWithResponse call
-func ParseUiStubMemoryUiMemoryGetResponse(rsp *http.Response) (*UiStubMemoryUiMemoryGetResponse, error) {
+// ParseUiMemoryListUiMemoryGetResponse parses an HTTP response from a UiMemoryListUiMemoryGetWithResponse call
+func ParseUiMemoryListUiMemoryGetResponse(rsp *http.Response) (*UiMemoryListUiMemoryGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &UiStubMemoryUiMemoryGetResponse{
+	response := &UiMemoryListUiMemoryGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiMemoryTagsUiMemoryTagsGetResponse parses an HTTP response from a UiMemoryTagsUiMemoryTagsGetWithResponse call
+func ParseUiMemoryTagsUiMemoryTagsGetResponse(rsp *http.Response) (*UiMemoryTagsUiMemoryTagsGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiMemoryTagsUiMemoryTagsGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	return response, nil
+}
+
+// ParseUiMemoryDeleteUiMemoryScopeSlugDeleteResponse parses an HTTP response from a UiMemoryDeleteUiMemoryScopeSlugDeleteWithResponse call
+func ParseUiMemoryDeleteUiMemoryScopeSlugDeleteResponse(rsp *http.Response) (*UiMemoryDeleteUiMemoryScopeSlugDeleteResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiMemoryDeleteUiMemoryScopeSlugDeleteResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiMemoryDetailUiMemoryScopeSlugGetResponse parses an HTTP response from a UiMemoryDetailUiMemoryScopeSlugGetWithResponse call
+func ParseUiMemoryDetailUiMemoryScopeSlugGetResponse(rsp *http.Response) (*UiMemoryDetailUiMemoryScopeSlugGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiMemoryDetailUiMemoryScopeSlugGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiMemoryPatchUiMemoryScopeSlugPatchResponse parses an HTTP response from a UiMemoryPatchUiMemoryScopeSlugPatchWithResponse call
+func ParseUiMemoryPatchUiMemoryScopeSlugPatchResponse(rsp *http.Response) (*UiMemoryPatchUiMemoryScopeSlugPatchResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiMemoryPatchUiMemoryScopeSlugPatchResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiMemoryEditFormUiMemoryScopeSlugEditGetResponse parses an HTTP response from a UiMemoryEditFormUiMemoryScopeSlugEditGetWithResponse call
+func ParseUiMemoryEditFormUiMemoryScopeSlugEditGetResponse(rsp *http.Response) (*UiMemoryEditFormUiMemoryScopeSlugEditGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiMemoryEditFormUiMemoryScopeSlugEditGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	}
 
 	return response, nil

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -1082,3 +1082,146 @@ against the SQLite fixture.
 - Cytoscape `cy.pan` / `cy.zoom` — https://js.cytoscape.org/#cy.pan
 - Cytoscape selector classes — https://js.cytoscape.org/#selectors/class
 - FastAPI `StaticFiles` (consumed by T5) — https://fastapi.tiangolo.com/tutorial/static-files/
+- markdown-it-py — https://markdown-it-py.readthedocs.io/en/latest/
+- pygments `HtmlFormatter` — https://pygments.org/docs/formatters/
+
+## Memory surface (Task #877)
+
+Initiative [#341](https://github.com/evoila/meho/issues/341) (G10.4
+Memory UI), Task [#877](https://github.com/evoila/meho/issues/877)
+(G10.4-T1) replaces the chassis stub at `/ui/memory` with the real
+**scope-aware list** + **per-memory detail/edit view** + **delete with
+confirm modal** + **tag autocomplete**. Sibling Tasks T2
+([#878](https://github.com/evoila/meho/issues/878)) and T3
+([#879](https://github.com/evoila/meho/issues/879)) layer create+promote
+and expiry-viz+bulk on top of the same router.
+
+### Routes
+
+| Method | Path | Purpose |
+| ------ | ---- | ------- |
+| `GET` | `/ui/memory` | List page or HTMX card-list fragment. Accepts `?scope=` (one of the five `MemoryScope` values or `"all"`) and `?tag=` (equal-match against `metadata.tags`). HTMX fragment when `HX-Request: true`. |
+| `GET` | `/ui/memory/tags` | Tag-autocomplete datalist fragment. Returns `<option>` rows for the union of tags the operator can see, sorted, capped at 200. |
+| `GET` | `/ui/memory/<scope>/<slug>` | Detail page (server-rendered Markdown body) or HTMX body fragment. |
+| `GET` | `/ui/memory/<scope>/<slug>/edit` | HTMX edit-form fragment. 403 when RBAC denies the write. |
+| `PATCH` | `/ui/memory/<scope>/<slug>` | Save the edited body (HTMX form post). Returns the re-rendered body view. CSRF-enforced. |
+| `DELETE` | `/ui/memory/<scope>/<slug>` | Delete + re-render the card list with a flash banner. CSRF-enforced. |
+
+### Module layout
+
+* `backend/src/meho_backplane/ui/routes/memory/__init__.py` — exports
+  `build_memory_router`.
+* `backend/src/meho_backplane/ui/routes/memory/routes.py` — thin
+  FastAPI handlers that resolve session + operator deps and delegate
+  to the render helpers in `views`.
+* `backend/src/meho_backplane/ui/routes/memory/views.py` — render
+  functions + projection helpers (`render_index`, `render_detail`,
+  `render_edit_form`, `patch_entry`, `delete_entry`, `render_tags`).
+  Pulled out of `routes` so the render logic is unit-testable
+  without an HTTP fixture and so each module fits the chassis-wide
+  ~600-line cap.
+* `backend/src/meho_backplane/ui/routes/memory/render.py` — Markdown
+  → HTML renderer (`markdown-it-py` commonmark + `pygments`). Mirrors
+  the precedent the KB UI sets in `kb/render.py`
+  (G10.2-T1 #870); the two modules will dedupe once both PRs land on
+  `main`.
+* `backend/src/meho_backplane/ui/routes/memory/operator.py` —
+  `resolve_ui_operator` FastAPI dependency that lifts a full
+  `Operator` (carrying `tenant_role`) from the BFF session by
+  re-verifying the stored access token. Used by every write handler.
+  Read handlers use `build_read_operator` which synthesises an
+  `OPERATOR`-role operator without a JWT round-trip (the read RBAC
+  matrix only consults the per-row `user_sub`, never the role).
+* `backend/src/meho_backplane/ui/templates/memory/` — Jinja2
+  templates: `index.html` (full list page), `_cards.html` (HTMX list
+  fragment), `detail.html` (full detail page), `_body_view.html` /
+  `_body_edit.html` (HTMX swap targets on Edit / Save / Cancel),
+  `_tags_options.html` (autocomplete datalist).
+
+### Markdown rendering
+
+`render_markdown` constructs a process-wide `MarkdownIt("commonmark",
+{"html": False, "linkify": True, "highlight": _highlight_code})` and
+enables `table` + `strikethrough`. The `html=False` override is
+load-bearing — `markdown-it-py` 4.2.0's `commonmark` preset has
+`html` defaulted to `True`, which would render raw `<script>` /
+`<iframe>` in a memory body as live HTML. With `html=False`, raw HTML
+is rendered as escaped text and Markdown structure (headings, links,
+code blocks) still parses.
+
+Code blocks pass through `pygments`'s `HtmlFormatter(nowrap=True,
+cssclass="memory-code")` so each token is a bare `<span>` annotated
+with a class; the highlight callback wraps the spans in
+`<pre class="memory-code"><code class="language-{lang}">`. Unknown
+languages fall back to `TextLexer` (no decoration) rather than
+guessing.
+
+`MarkdownIt.render` mutates internal parser state, so the singleton
+is guarded by a `threading.Lock`. The lock-contention cost is
+negligible compared to the surrounding DB read at realistic UI QPS.
+
+### RBAC posture
+
+Read paths (list / detail / edit-form GET / tags) build a synthesised
+`Operator` with `TenantRole.OPERATOR` and rely on
+`MemoryRbacResolver.can_read`'s per-row `user_sub` gate for cross-user
+isolation. Write paths (edit-form, PATCH, DELETE) re-verify the BFF
+session's access token through the chassis JWT chain
+(`verify_jwt_for_audience`) to produce a fully-validated `Operator`
+carrying the live `tenant_role`. The matrix is re-checked at the
+service layer (`MemoryService.remember` / `forget` call
+`can_write`); the route-side check is for the UX "show / hide Edit
+button" decision and a quick 403 on the edit-form GET so the
+operator doesn't load the textarea for an action the save would
+reject anyway.
+
+The 404-vs-403 collapse on detail / edit-form / PATCH / DELETE for
+non-existent slugs is the info-leak avoidance the `/api/v1/memory`
+surface holds: a caller cannot distinguish "no such memory" from
+"you can't read it" by the response status. PATCH / DELETE on a
+tenant-scoped row by an `operator` role do surface as 403 (the
+matrix mismatch is honest feedback — the alternative would be a
+silent no-op that audits worse).
+
+### HTMX conventions
+
+* `hx-get` for scope tabs + tag filter (idempotent reads).
+* `hx-patch` for the edit-in-place save; the form's
+  `id="memory-body"` is the swap target so Save replaces the form
+  with the rendered body view in place.
+* `hx-delete` for the delete-with-confirm-modal; the modal's
+  Confirm button swaps the full `<body>` with the re-rendered list
+  page (`hx-target="body" hx-push-url="/ui/memory"`) so the
+  operator lands on the list with the deleted row absent.
+* The page-level `hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'`
+  directive on `detail.html` echoes the chassis double-submit token
+  on every HTMX request from that page; the index page sets the
+  same directive so future state-changing actions on the list (T3's
+  bulk delete) inherit the token without per-element wiring.
+
+### Tests
+
+The full suite lives in
+`backend/tests/test_ui_memory_list.py`. It pins:
+
+* the auth boundary (unauthenticated requests 302 to the BFF login),
+* the list view (empty inventory + populated cards with scope badge
+  + 200-char preview + tag chips + scope tab + tag filter +
+  `/ui/memory/tags` autocomplete),
+* the detail view (Markdown → HTML rendering, raw `<script>` stripped
+  to escaped text, 404 on missing slug, cross-user 404 on another
+  operator's user-scoped slug, cross-tenant 404 on another tenant's
+  tenant-scoped slug),
+* the edit-in-place flow (textarea fragment renders for own
+  user-scoped, 403 for tenant-scoped under `operator` role, textarea
+  for tenant-scoped under `tenant_admin`, PATCH save persists +
+  returns the rendered body view, empty body 422),
+* the delete flow (DELETE removes the row + re-renders the empty
+  list with a flash banner, 403 on tenant-scoped under `operator`,
+  404 on missing slug),
+* the stub-retirement (the chassis "Coming soon" stub no longer
+  renders for `/ui/memory`).
+
+The PATCH happy-path mocks `meho_backplane.retrieval.indexer.get_embedding_service`
+because `MemoryService.remember`'s re-index path calls `encode_one`
+on the new body. Read paths bypass embedding entirely.

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -1162,18 +1162,20 @@ negligible compared to the surrounding DB read at realistic UI QPS.
 
 ### RBAC posture
 
-Read paths (list / detail / edit-form GET / tags) build a synthesised
-`Operator` with `TenantRole.OPERATOR` and rely on
-`MemoryRbacResolver.can_read`'s per-row `user_sub` gate for cross-user
-isolation. Write paths (edit-form, PATCH, DELETE) re-verify the BFF
-session's access token through the chassis JWT chain
-(`verify_jwt_for_audience`) to produce a fully-validated `Operator`
-carrying the live `tenant_role`. The matrix is re-checked at the
-service layer (`MemoryService.remember` / `forget` call
-`can_write`); the route-side check is for the UX "show / hide Edit
-button" decision and a quick 403 on the edit-form GET so the
-operator doesn't load the textarea for an action the save would
-reject anyway.
+Read paths (list / detail / tags) build a synthesised `Operator` with
+`TenantRole.OPERATOR` and rely on `MemoryRbacResolver.can_read`'s
+per-row `user_sub` gate for cross-user isolation. Write paths
+(edit-form GET, PATCH, DELETE) re-verify the BFF session's access
+token through the chassis JWT chain (`verify_jwt_for_audience`) to
+produce a fully-validated `Operator` carrying the live `tenant_role`.
+The matrix is re-checked at the service layer
+(`MemoryService.remember` / `forget` call `can_write`); the
+route-side check is for the UX "show / hide Edit button" decision
+and a quick 403 on the edit-form GET so the operator doesn't load
+the textarea for an action the save would reject anyway. The
+edit-form GET surfaces RBAC denial as **403** (not 404, the read
+posture) — mirroring `/api/v1/memory`'s write-side posture and
+pinned by `test_edit_form_tenant_scoped_as_operator_returns_403`.
 
 The 404-vs-403 collapse on detail / edit-form / PATCH / DELETE for
 non-existent slugs is the info-leak avoidance the `/api/v1/memory`


### PR DESCRIPTION
## Summary

- Replace the `/ui/memory` chassis stub (#866) with the real read + edit + delete + tag-filter surface across the five memory scopes (user / user-tenant / user-target / tenant / target).
- Server-side Markdown rendering of memory bodies via `markdown-it-py` (commonmark with `html=False` for XSS defence) + pygments syntax highlighting on code blocks; mirrors the KB UI render precedent (#870).
- Edit-in-place is gated on `MemoryRbacResolver.can_write`: operator edits own user-scoped; tenant-scoped requires `tenant_admin`. Cross-user / cross-tenant isolation holds (returns 404, never 403, matching the `/api/v1/memory` info-leak avoidance).
- New `resolve_ui_operator` FastAPI dependency lifts a full `Operator` with `tenant_role` from the BFF session by re-verifying the stored access token through the chassis JWT chain; read paths skip the round-trip via `build_read_operator`.

## Test plan

- [x] `ruff check src/ tests/` — clean.
- [x] `ruff format --check src/ tests/` — clean.
- [x] `mypy src/` — clean (1 new override added for `pygments`, which ships no `py.typed`).
- [x] `pytest backend/tests/test_ui_memory_list.py -n auto` — 24 passed.
- [x] `pytest backend/tests/test_ui_chassis_smoke.py -n auto` — 16 passed (the `_STUB_SURFACE_ROUTES` tuple dropped `/ui/memory`).
- [x] Regression: `pytest backend/tests/test_ui_topology_table.py backend/tests/test_ui_broadcast_feed.py backend/tests/test_ui_templates.py backend/tests/test_memory_service.py backend/tests/test_memory_rbac.py backend/tests/test_api_v1_memory.py` — 190 passed.
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (1 warning on `views.py` at 528 lines, below the 600-line block threshold).
- [x] Each acceptance criterion on #877 pinned by a behavioural test:
  - `/ui/memory` lists by scope; HTMX tab swap; cards show slug/preview/scope-badge/expiry/tags — `test_list_*`.
  - `/ui/memory/<scope>/<slug>` server-rendered Markdown; PATCH save; DELETE via confirm modal + re-render — `test_detail_*`, `test_patch_save_*`, `test_delete_*`.
  - RBAC: operator edits own user-scoped; tenant-scoped without `tenant_admin` returns 403 — `test_edit_form_tenant_scoped_as_operator_returns_403`, `test_patch_save_tenant_scoped_as_operator_returns_403`, `test_delete_tenant_scoped_as_operator_returns_403`.
  - Tag filter + `/ui/memory/tags` autocomplete — `test_list_tag_filter_narrows_results`, `test_tags_endpoint_returns_distinct_sorted_tag_options`.
  - Cross-user + cross-tenant isolation — `test_detail_cross_user_user_scoped_returns_404`, `test_detail_cross_tenant_returns_404`.

## Out of scope

- Create modal + scope-promotion flow — sibling Task #878 (T2).
- Expiry-countdown visualisation + bulk select/delete/extend — sibling Task #879 (T3).
- AI-suggested memory creation — explicitly disallowed per consumer-needs.md §G5 OOS.

## Adjacent findings (recorded, not fixed)

- The Markdown renderer in `memory/render.py` duplicates ~50 LOC against `kb/render.py` (#870 PR still open at filing time). Once both land on `main`, a follow-up consolidation can promote one to a shared `ui.markdown` module. Filed in the result file's `adjacent_findings`.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #877


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Memory UI surface with list, detail, edit, and delete functionality
  * Memory bodies render with Markdown formatting and syntax-highlighted code blocks
  * Tag filtering and autocomplete support for organizing memories
  * Dynamic in-place editing with real-time updates
  * Responsive card-based memory grid displaying scope, expiration, and tags

* **Documentation**
  * Added comprehensive Memory surface documentation with usage guidelines

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-26)

Addressed review findings from [`pr-1161-iter-1.json`](.claude/auto/review-results/pr-1161-iter-1.json):

- **B1** `1bdf8ff` — XSS via fenced-code lang attribute closed by a strict allowlist (`^[A-Za-z0-9_+\-.]+$`) with `text` fallback; regression test pins the invariant.
- **B2** `1bdf8ff` — `markdown-it-py[linkify]` extra added (so `linkify-it-py` lands in `uv.lock`); `linkify` rule explicitly `.enable()`'d alongside `table`+`strikethrough`; regression test asserts bare URL becomes `<a>`.
- **B3** `719738e` — `cd cli && make snapshot-openapi && make generate` regenerated `cli/api/openapi.json` + `cli/internal/api/client.gen.go` for the new `/ui/memory/*` routes; the `CLI API snapshot freshness` job should now go green.
- **B4** `d2bf95f` — `delete_entry` now returns `HTMLResponse(204, headers={"HX-Redirect": "/ui/memory"})`; detail page's `hx-target="body"` no longer destroys the chassis chrome. Test rewritten to assert 204 + header + empty body + follow-redirect chrome integrity.
- **M1** `c513a5d` — `docs/codebase/ui.md` RBAC posture section: edit-form GET moved out of read paths into write paths; added a sentence pinning the 403-on-deny invariant against the test that backs it.
- **B5** `01e2c74` — Empty `--allow-empty -s` follow-up signoff per orchestrator directive. Note: Probot DCO validates each commit individually, so this is **best-effort** -- the failing check on `29d8987` may still need admin override or a maintainer-driven rebase-with-signoff.

Disputed: none.

Deferred (recorded as adjacent improvements; orchestrator may file follow-ups):

- CodeRabbit nitpick: parametrise `test_list_scope_filter_narrows_to_one_scope` over the full `MemoryScope` matrix.
- CodeRabbit nitpick: follow-up GET in `test_patch_save_persists_new_body_and_returns_rendered_view` to prove the PATCH commits to the DB.
- Promote `resolve_ui_operator` to a UI-wide `ui/auth/operator.py` module after T2 #878 / T3 #879 land.
- Re-evaluate the `MarkdownIt` singleton + `threading.Lock` once #870 KB renderer lands and the consolidation happens.

<!-- auto-implement-issue: continue, iteration 1 -->
