### PR TITLE
feat(memory-ui): G10.4-T3 expiry countdown + recently-expired + bulk select/delete/extend

### DIFF
--- a/backend/src/meho_backplane/ui/routes/memory/bulk.py
+++ b/backend/src/meho_backplane/ui/routes/memory/bulk.py
@@ -1,0 +1,467 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Expiry visualisation + bulk select/delete/extend for the memory UI.
+
+Initiative #341 (G10.4 Memory UI), Task #879 (T3). Pulled out of
+:mod:`~meho_backplane.ui.routes.memory.views` so the T1 render module
+stays at its existing size and the T3 additions live in one cohesive
+unit:
+
+* **Countdown formatting** -- :func:`format_countdown` renders a
+  human-readable "expires in 3d 4h" string from a future ``expires_at``
+  datetime, mirroring the ``meho status``-style cadence the rest of the
+  console uses.
+* **Expiry partition** -- :func:`partition_expired` splits a flat list
+  of :class:`MemoryEntry` into ``(active, recently_expired)`` so the
+  list template can render the two sections separately. The "recently
+  expired" bucket is naturally bounded by the G5.2 sweeper window
+  (#623) -- between expiry and the next sweeper tick, expired rows are
+  still in the documents table and visible to the read path.
+* **Bulk action dispatch** -- :func:`apply_bulk_action` looks up
+  memories by their ``Document.id`` (tenant-scoped + ``source='memory'``
+  filtered), gates each candidate against
+  :class:`MemoryRbacResolver.can_write`, and routes to
+  :meth:`MemoryService.forget` (delete) or
+  :meth:`MemoryService.remember` (extend, body unchanged with a fresh
+  ``expires_at``).
+
+The bulk handler accepts memory ``Document.id`` UUIDs (the same value
+the list template renders as ``data-memory-id`` on each card) rather
+than the natural ``(scope, slug, target_name)`` triple. Reasons:
+
+* IDs are the value the issue body specifies ("collects checked IDs").
+* IDs are opaque -- a non-writable selection is rejected the same way
+  whether the operator typed a UUID by hand or checked a box. Sending
+  a triple leaks the existence of a scope/slug the operator can read
+  but not write.
+* The natural-key triple needs target_name on the wire for
+  target-scoped rows; passing only UUIDs keeps the form body simple
+  and avoids encoding/decoding edge cases.
+
+The cost is one extra DB read per bulk action to resolve IDs to
+natural keys; this is acceptable at UI rates (bulk actions are
+operator-driven, not background traffic) and the same query that
+re-renders the list runs after.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Final, Literal
+
+import structlog
+from fastapi import HTTPException
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Document
+from meho_backplane.memory import (
+    MemoryEntry,
+    MemoryRbacResolver,
+    MemoryService,
+    PermissionDeniedError,
+)
+from meho_backplane.memory._internal import MEMORY_SOURCE, document_to_entry
+
+__all__ = [
+    "BULK_ACTIONS",
+    "BULK_EXTEND_DURATIONS",
+    "BULK_MAX_IDS",
+    "BulkActionResult",
+    "apply_bulk_action",
+    "format_countdown",
+    "parse_bulk_ids",
+    "parse_extend_duration",
+    "partition_expired",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: Allowed values for the ``action`` form field on ``POST /ui/memory/bulk``.
+#: Centralised here so the route handler, the template's button set, and
+#: the service-layer dispatch agree on the literal strings.
+BulkAction = Literal["delete", "extend"]
+BULK_ACTIONS: Final[tuple[str, ...]] = ("delete", "extend")
+
+#: Allowed values for the ``extend_duration`` form field. Pre-canned
+#: options keep the UI honest -- an operator either bumps by a day or
+#: by a week; arbitrary durations would invite "extend by 10 years"
+#: footguns that defeat the TTL contract. The string maps to a
+#: :class:`timedelta` in :data:`_EXTEND_DURATION_MAP`.
+ExtendDuration = Literal["1d", "7d", "30d"]
+BULK_EXTEND_DURATIONS: Final[tuple[str, ...]] = ("1d", "7d", "30d")
+
+#: Upper bound on the number of memory IDs accepted in a single bulk
+#: form post. Matches the list-view's :data:`LIST_LIMIT` cap so the
+#: operator cannot select more rows than the list ever rendered.
+#: Sending more than this on the wire is treated as malformed input
+#: (likely a script abusing the route).
+BULK_MAX_IDS: Final[int] = 500
+
+_EXTEND_DURATION_MAP: Final[dict[str, timedelta]] = {
+    "1d": timedelta(days=1),
+    "7d": timedelta(days=7),
+    "30d": timedelta(days=30),
+}
+
+
+@dataclass(frozen=True)
+class BulkActionResult:
+    """Outcome of one bulk action invocation.
+
+    Returned by :func:`apply_bulk_action` and surfaced as a flash banner
+    on the re-rendered list. Distinguishes between "the operator asked
+    to act on 5 rows, 3 went through, 2 were RBAC-denied" and the
+    all-or-nothing failure shape so the UX banner can be honest.
+    """
+
+    action: BulkAction
+    requested: int
+    succeeded: int
+    denied: int
+    missing: int
+
+    @property
+    def flash_message(self) -> str:
+        """Build the flash banner the list template renders post-bulk."""
+        verb = "deleted" if self.action == "delete" else "extended"
+        parts = [f"{self.succeeded} {verb}"]
+        if self.denied:
+            parts.append(f"{self.denied} denied (RBAC)")
+        if self.missing:
+            parts.append(f"{self.missing} not found")
+        return f"Bulk: {', '.join(parts)}."
+
+
+# ---------------------------------------------------------------------------
+# Countdown rendering
+# ---------------------------------------------------------------------------
+
+
+def format_countdown(expires_at: datetime, *, now: datetime | None = None) -> str:
+    """Render a coarse human-readable countdown string.
+
+    The operator wants "expires in 3d 4h" not "expires in 3 days,
+    4 hours, 17 minutes, 22 seconds". Truncation rules:
+
+    * ``>= 1 day`` -> ``"expires in {d}d {h}h"`` (drops minutes/seconds).
+    * ``>= 1 hour`` -> ``"expires in {h}h {m}m"`` (drops seconds).
+    * ``> 0`` -> ``"expires in {m}m"`` (drops seconds; clamped to 1m).
+    * ``<= 0`` -> ``"expired"``. Callers should partition before
+      calling so this branch only fires on rare timing skew at the
+      partition boundary.
+
+    The ``now`` parameter is exposed for unit tests so the truncation
+    behaviour is pin-able without freezing the clock at module scope.
+    """
+    anchor = now if now is not None else datetime.now(UTC)
+    delta = expires_at - anchor
+    seconds = int(delta.total_seconds())
+    if seconds <= 0:
+        return "expired"
+    days, remainder = divmod(seconds, 86400)
+    hours, remainder = divmod(remainder, 3600)
+    minutes = remainder // 60
+    if days > 0:
+        return f"expires in {days}d {hours}h"
+    if hours > 0:
+        return f"expires in {hours}h {minutes}m"
+    # ``minutes`` can be 0 when the delta is < 60s; show "1m" rather
+    # than "0m" so the cue stays meaningful at the edge.
+    return f"expires in {max(minutes, 1)}m"
+
+
+# ---------------------------------------------------------------------------
+# Partition (active vs recently expired)
+# ---------------------------------------------------------------------------
+
+
+def partition_expired(
+    entries: Iterable[MemoryEntry],
+    *,
+    now: datetime | None = None,
+) -> tuple[list[MemoryEntry], list[MemoryEntry]]:
+    """Split *entries* into ``(active, recently_expired)``.
+
+    "Recently expired" means ``expires_at <= now`` -- the row is past
+    its TTL but still in the documents table because the G5.2 sweeper
+    (#623) hasn't reaped it yet. The natural window is ``<=
+    memory_expiry_tick_interval_seconds`` (24 h by default); callers
+    don't need to apply a separate lower bound because the sweeper's
+    next tick removes rows older than that.
+
+    Entries with ``expires_at is None`` are always "active" (persistent
+    memories, no TTL). The ``now`` parameter is exposed for tests.
+    """
+    anchor = now if now is not None else datetime.now(UTC)
+    active: list[MemoryEntry] = []
+    expired: list[MemoryEntry] = []
+    for entry in entries:
+        if entry.expires_at is not None and _is_expired_at(entry.expires_at, now=anchor):
+            expired.append(entry)
+        else:
+            active.append(entry)
+    return active, expired
+
+
+def _is_expired_at(expires_at: datetime, *, now: datetime) -> bool:
+    """Local mirror of :func:`~meho_backplane.memory._internal.is_expired`
+    that accepts an explicit anchor.
+
+    The shared :func:`~meho_backplane.memory._internal.is_expired` pins
+    ``datetime.now(UTC)`` internally, which is correct for service
+    callers but defeats unit-test pinning at the partition boundary.
+    This helper preserves the ``<=`` semantics (a row landing at
+    exactly ``now`` is treated as expired) so both anchors agree.
+    """
+    return expires_at <= now
+
+
+# ---------------------------------------------------------------------------
+# Bulk action parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_bulk_ids(raw_ids: list[str]) -> list[uuid.UUID]:
+    """Validate + parse the form's ``ids`` field into typed UUIDs.
+
+    The form field arrives as ``list[str]`` (FastAPI's
+    :class:`Form` with a list type for multi-value form fields).
+    Validation:
+
+    * Empty list -> :class:`HTTPException` 422. A bulk submit with no
+      selection is operator error worth surfacing rather than a
+      no-op.
+    * Length above :data:`BULK_MAX_IDS` -> 422. Caps the worst-case
+      DB round-trip per request.
+    * Any non-UUID value -> 422 with the offending value in the
+      detail (the operator's form was tampered with or HTMX
+      mis-serialised the input).
+    * Duplicates are de-duplicated silently -- the worst case is the
+      operator clicked the same row twice; preserving the
+      multiplicity would just cause two failed natural-key lookups
+      on the second hit.
+    """
+    if not raw_ids:
+        raise HTTPException(status_code=422, detail="bulk_no_ids_selected")
+    if len(raw_ids) > BULK_MAX_IDS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"bulk_too_many_ids (max {BULK_MAX_IDS})",
+        )
+    parsed: list[uuid.UUID] = []
+    seen: set[uuid.UUID] = set()
+    for raw in raw_ids:
+        try:
+            parsed_id = uuid.UUID(raw)
+        except (ValueError, AttributeError) as exc:
+            raise HTTPException(
+                status_code=422,
+                detail=f"bulk_invalid_id: {raw!r}",
+            ) from exc
+        if parsed_id in seen:
+            continue
+        seen.add(parsed_id)
+        parsed.append(parsed_id)
+    return parsed
+
+
+def parse_extend_duration(raw: str | None) -> timedelta:
+    """Resolve the ``extend_duration`` form value to a timedelta.
+
+    ``None`` -> 422. The form's hidden default is ``"7d"`` so a missing
+    value indicates form tampering; the route surfaces this as 422
+    rather than picking a default the operator didn't ask for.
+    """
+    if raw is None:
+        raise HTTPException(status_code=422, detail="bulk_missing_extend_duration")
+    if raw not in _EXTEND_DURATION_MAP:
+        raise HTTPException(
+            status_code=422,
+            detail=f"bulk_invalid_extend_duration: {raw!r} (allowed: {BULK_EXTEND_DURATIONS})",
+        )
+    return _EXTEND_DURATION_MAP[raw]
+
+
+# ---------------------------------------------------------------------------
+# Bulk action dispatch
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_entries_by_ids(
+    operator: Operator,
+    ids: list[uuid.UUID],
+) -> dict[uuid.UUID, MemoryEntry]:
+    """Resolve *ids* to :class:`MemoryEntry` rows in *operator*'s tenant.
+
+    Tenant-scoped + ``source='memory'`` filtered so an operator cannot
+    smuggle a non-memory document ID (a knowledge-base row, an audit
+    row) into the bulk form and have the route mutate it. Returns a
+    dict keyed by ID so callers can report per-ID outcomes without a
+    second lookup; IDs absent from the dict are the "missing" bucket.
+    """
+    if not ids:
+        return {}
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(
+            select(Document).where(
+                Document.tenant_id == operator.tenant_id,
+                Document.source == MEMORY_SOURCE,
+                Document.id.in_(ids),
+            )
+        )
+        docs = list(result.scalars().all())
+    return {doc.id: document_to_entry(doc) for doc in docs}
+
+
+async def _bulk_delete_one(
+    service: MemoryService,
+    operator: Operator,
+    entry: MemoryEntry,
+) -> bool:
+    """Delete one entry. Returns ``True`` on success.
+
+    Returns ``False`` on :class:`PermissionDeniedError` so the outer
+    loop can tally a denied count without halting the batch. Any other
+    exception (:class:`ValueError` from a malformed target row, a DB
+    failure) propagates -- a bulk action that hits an unexpected
+    failure is louder if surfaced than swallowed.
+    """
+    try:
+        await service.forget(
+            operator=operator,
+            scope=entry.scope,
+            slug=entry.slug,
+            target_name=entry.target_name,
+        )
+    except PermissionDeniedError:
+        return False
+    return True
+
+
+async def _bulk_extend_one(
+    service: MemoryService,
+    operator: Operator,
+    entry: MemoryEntry,
+    new_expires_at: datetime,
+) -> bool:
+    """Re-write *entry* with a fresh ``expires_at``.
+
+    Uses :meth:`MemoryService.remember` with the same body + metadata
+    so the natural key is preserved and only ``metadata.expires_at``
+    changes. The service strips the bookkeeping keys before merging
+    so we don't double-write them.
+    """
+    metadata = {
+        k: v
+        for k, v in entry.metadata.items()
+        if k not in {"scope", "user_sub", "target_name", "expires_at"}
+    }
+    try:
+        await service.remember(
+            operator=operator,
+            scope=entry.scope,
+            body=entry.body,
+            slug=entry.slug,
+            metadata=metadata,
+            expires_at=new_expires_at,
+            target_name=entry.target_name,
+        )
+    except PermissionDeniedError:
+        return False
+    return True
+
+
+async def apply_bulk_action(
+    operator: Operator,
+    *,
+    action: BulkAction,
+    ids: list[uuid.UUID],
+    extend_duration: timedelta | None = None,
+    now: datetime | None = None,
+) -> BulkActionResult:
+    """Dispatch one bulk action across *ids*.
+
+    Resolution + RBAC posture:
+
+    1. **Tenant filter** -- ``_fetch_entries_by_ids`` only returns rows
+       whose ``tenant_id == operator.tenant_id`` AND
+       ``source='memory'``. Rows the operator's tenant cannot see (or
+       isn't a memory row) are silently missing -- counted under
+       ``missing`` so the flash banner reports them, but never acted
+       on.
+    2. **Per-row RBAC re-check** -- :class:`MemoryRbacResolver` is
+       consulted on each row. The service's ``forget`` / ``remember``
+       call also re-checks; the route-side check filters the bulk into
+       a writable subset *before* the service mutates so the count is
+       honest and a denied row doesn't half-act (the service is
+       idempotent on denial, but the count would be wrong without
+       this pass).
+    3. **Per-row dispatch** -- ``delete`` -> ``forget``; ``extend`` ->
+       ``remember`` with the existing body + a fresh ``expires_at``.
+
+    The ``now`` parameter is exposed for tests so the extend anchor is
+    pin-able.
+    """
+    if action not in BULK_ACTIONS:
+        # Defensive -- the route's Literal-typed Form should reject
+        # this before we get here, but a direct caller could pass an
+        # arbitrary string.
+        raise HTTPException(status_code=422, detail=f"bulk_invalid_action: {action!r}")
+    if action == "extend" and extend_duration is None:
+        raise HTTPException(status_code=422, detail="bulk_extend_requires_duration")
+
+    entries_by_id = await _fetch_entries_by_ids(operator, ids)
+    missing = len(ids) - len(entries_by_id)
+
+    rbac = MemoryRbacResolver()
+    service = MemoryService(rbac=rbac)
+    anchor = now if now is not None else datetime.now(UTC)
+    new_expires_at = anchor + extend_duration if extend_duration else None
+
+    succeeded = 0
+    denied = 0
+    for entry in entries_by_id.values():
+        if not rbac.can_write(operator, entry.scope, entry.target_name):
+            denied += 1
+            continue
+        if action == "delete":
+            ok = await _bulk_delete_one(service, operator, entry)
+        else:
+            # ``new_expires_at`` is non-None on the extend branch
+            # (validated above); the assertion silences mypy.
+            assert new_expires_at is not None
+            ok = await _bulk_extend_one(service, operator, entry, new_expires_at)
+        if ok:
+            succeeded += 1
+        else:
+            # Service-layer permission denial -- the route-side check
+            # already passed, so this is the rare "RBAC changed between
+            # check and act" race. Count under denied so the banner
+            # reports it; the row stayed intact.
+            denied += 1
+
+    result = BulkActionResult(
+        action=action,
+        requested=len(ids),
+        succeeded=succeeded,
+        denied=denied,
+        missing=missing,
+    )
+    _log.info(
+        "ui_memory_bulk",
+        tenant_id=str(operator.tenant_id),
+        operator_sub=operator.sub,
+        action=action,
+        requested=result.requested,
+        succeeded=result.succeeded,
+        denied=result.denied,
+        missing=result.missing,
+    )
+    return result

--- a/backend/src/meho_backplane/ui/routes/memory/routes.py
+++ b/backend/src/meho_backplane/ui/routes/memory/routes.py
@@ -36,6 +36,10 @@ T2 (#878) -- create + scope-promotion:
 * ``GET /ui/memory/<scope>/<slug>/promote`` -- HTMX-loaded promote modal fragment.
 * ``POST /ui/memory/<scope>/<slug>/promote`` -- submit handler; calls G5.2 promote.
 
+T3 (#879) -- expiry visualization + bulk:
+
+* ``POST /ui/memory/bulk`` -- HTMX bulk delete / bulk extend-expiry.
+
 Tenant + RBAC + info-leak posture are documented on the render
 functions themselves; this module owns only the path / method /
 dependency wiring.
@@ -76,6 +80,7 @@ from meho_backplane.ui.routes.memory.views import (
     SLUG_MAX_LENGTH,
     delete_entry,
     patch_entry,
+    render_bulk_action,
     render_detail,
     render_edit_form,
     render_index,
@@ -273,6 +278,39 @@ async def _promote_submit_handler(
     )
 
 
+# ---------------------------------------------------------------------------
+# T3 (#879) -- bulk delete / bulk extend-expiry handler
+# ---------------------------------------------------------------------------
+
+
+async def _bulk_handler(
+    request: Request,
+    action: str = Form(..., max_length=16),
+    # The HTMX form posts ``ids`` as a multi-value field (one per
+    # checked checkbox). FastAPI's ``Form(...)`` with a ``list[str]``
+    # annotation collects every same-named entry into the list.
+    ids: list[str] = Form(default_factory=list),
+    extend_duration: str | None = Form(default=None, max_length=8),
+    # Active scope + tag are echoed back as hidden fields so the
+    # post-bulk render preserves the operator's filter state.
+    scope: str = Form(default=SCOPE_ALL, max_length=64),
+    tag: str | None = Form(default=None, max_length=SLUG_MAX_LENGTH),
+    session_ctx: UISessionContext = _require_session_dep,
+    operator: Operator = _resolve_operator_dep,
+) -> HTMLResponse:
+    """``POST /ui/memory/bulk`` -- T3 (#879) bulk delete / bulk extend-expiry."""
+    return await render_bulk_action(
+        request,
+        session_ctx,
+        operator,
+        action=action,
+        raw_ids=ids,
+        extend_duration=extend_duration,
+        scope=scope,
+        tag=tag,
+    )
+
+
 def _register_static_prefix_routes(router: APIRouter) -> None:
     """Wire the static-prefix routes -- ``/ui/memory/tags``, ``/ui/memory/create``,
     ``/ui/memory/preview`` -- onto *router*.
@@ -364,7 +402,7 @@ def _register_read_routes(router: APIRouter) -> None:
 
 
 def _register_write_routes(router: APIRouter) -> None:
-    """Wire the PATCH + DELETE + promote-submit routes onto *router*.
+    """Wire the PATCH + DELETE + promote-submit + bulk POST routes onto *router*.
 
     Split out of :func:`build_memory_router` for the same reason as
     :func:`_register_read_routes`. The PATCH route shares the
@@ -373,7 +411,21 @@ def _register_write_routes(router: APIRouter) -> None:
     The promote-submit route lives here (not in the create-promote
     group) because its parametrised path means it can register after
     the static-prefix routes without any ordering hazard.
+
+    ``POST /ui/memory/bulk`` (T3 #879) is registered ahead of the
+    parameterised PATCH/DELETE so the literal ``/bulk`` path segment
+    is never mistaken for a scope value (the scope path param is
+    typed as :class:`MemoryScope` so a stray ``bulk`` would 422 from
+    FastAPI's converter, but registering the literal first keeps the
+    OpenAPI surface clean).
     """
+    router.add_api_route(
+        "/ui/memory/bulk",
+        _bulk_handler,
+        methods=["POST"],
+        name="ui_memory_bulk",
+        response_class=HTMLResponse,
+    )
     router.add_api_route(
         "/ui/memory/{scope}/{slug}",
         _patch_handler,

--- a/backend/src/meho_backplane/ui/routes/memory/views.py
+++ b/backend/src/meho_backplane/ui/routes/memory/views.py
@@ -50,6 +50,11 @@ from meho_backplane.memory import (
 )
 from meho_backplane.ui.auth.middleware import UISessionContext
 from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.routes.memory.bulk import (
+    BULK_EXTEND_DURATIONS,
+    format_countdown,
+    partition_expired,
+)
 from meho_backplane.ui.routes.memory.operator import build_read_operator
 from meho_backplane.ui.routes.memory.render import pygments_css, render_markdown
 from meho_backplane.ui.templating import get_templates
@@ -207,8 +212,18 @@ def _collect_visible_tags(entries: Iterable[MemoryEntry], limit: int) -> list[st
     return sorted(seen)
 
 
-def _entries_with_preview(entries: list[MemoryEntry]) -> list[dict[str, object]]:
-    """Project ``MemoryEntry`` rows into the dict shape the template renders."""
+def _entries_with_preview(
+    entries: list[MemoryEntry],
+    operator: Operator,
+) -> list[dict[str, object]]:
+    """Project ``MemoryEntry`` rows into the dict shape the template renders.
+
+    ``operator`` is consulted to project a per-row ``can_write`` flag
+    used by T3's bulk-select UX: the checkbox renders only when the
+    operator can write the row. The flag is for UX only -- the bulk
+    handler re-checks RBAC server-side per row.
+    """
+    rbac = MemoryRbacResolver()
     return [
         {
             "id": str(entry.id),
@@ -218,8 +233,12 @@ def _entries_with_preview(entries: list[MemoryEntry]) -> list[dict[str, object]]
             "user_sub": entry.user_sub,
             "target_name": entry.target_name,
             "expires_at": entry.expires_at,
+            "countdown": (
+                format_countdown(entry.expires_at) if entry.expires_at is not None else None
+            ),
             "tags": _entry_tags(entry),
             "updated_at": entry.updated_at,
+            "can_write": rbac.can_write(operator, entry.scope, entry.target_name),
         }
         for entry in entries
     ]
@@ -279,13 +298,20 @@ async def _list_for_render(
     scope_filter: MemoryScope | None,
     tag_filter: str | None,
 ) -> list[MemoryEntry]:
-    """Pull the list-view rows for *operator* under the active filters."""
+    """Pull the list-view rows for *operator* under the active filters.
+
+    Includes expired-but-unswept rows so T3's "Recently expired
+    (cleanup pending)" section can render them; the partition split
+    happens at :func:`render_index`. The G5.2 sweeper (#623) bounds
+    the size of the expired bucket -- between expiry and the next
+    sweeper tick, expired rows are still in the documents table.
+    """
     service = MemoryService()
     return await service.list_memories(
         operator=operator,
         scope=scope_filter,
         tag=tag_filter or None,
-        include_expired=False,
+        include_expired=True,
         limit=LIST_LIMIT,
     )
 
@@ -321,24 +347,58 @@ async def render_index(
     tag: str | None = None,
     flash: str | None = None,
 ) -> HTMLResponse:
-    """Render the list page or the HTMX card-list fragment."""
+    """Render the list page or the HTMX card-list fragment.
+
+    T3 (#879) partitions the entries into ``active`` and
+    ``recently_expired`` buckets so the template can render the
+    expired-pending-cleanup section as a greyed sibling list. The
+    ``hx-trigger="every 60s"`` on the cards fragment is what refreshes
+    the countdown badges; the same handler responds to both the full
+    page render and the HTMX poll.
+    """
     scope_filter = resolve_scope_filter(scope)
     operator = build_read_operator(session_ctx)
     entries = await _list_for_render(operator, scope_filter, tag)
+    active, recently_expired = partition_expired(entries)
     csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    # The refresh URL preserves the active scope + tag so the HTMX
+    # poll re-renders with the same filter state. T1's tabs already
+    # encode the query string into the request URL; the fragment
+    # carries the same shape so a poll mid-page-stay stays aligned.
+    refresh_url = _build_refresh_url(scope, tag)
     context: dict[str, object] = {
         **_common_template_context(session_ctx, csrf_token),
         "scope_tabs": SCOPE_TABS,
         "active_scope": scope,
         "active_tag": tag or "",
-        "entries": _entries_with_preview(entries),
-        "entry_count": len(entries),
+        "entries": _entries_with_preview(active, operator),
+        "expired_entries": _entries_with_preview(recently_expired, operator),
+        "entry_count": len(active),
+        "expired_count": len(recently_expired),
         "flash": flash or "",
+        "bulk_extend_durations": BULK_EXTEND_DURATIONS,
+        "refresh_url": refresh_url,
     }
     template_name = "memory/_cards.html" if is_htmx_request(request) else "memory/index.html"
     response = get_templates().TemplateResponse(request, template_name, context)
     _set_csrf_cookie(response, csrf_token)
     return response
+
+
+def _build_refresh_url(scope: str, tag: str | None) -> str:
+    """Compose the URL the HTMX cards fragment polls every 60 seconds.
+
+    Preserves the active scope + tag so a refresh while the operator
+    is staring at a filtered list doesn't snap back to "all visible".
+    Pure string composition; no Request dependency so unit tests can
+    pin the output without an HTTP fixture.
+    """
+    from urllib.parse import urlencode
+
+    params: list[tuple[str, str]] = [("scope", scope)]
+    if tag:
+        params.append(("tag", tag))
+    return f"/ui/memory?{urlencode(params)}"
 
 
 async def render_detail(
@@ -532,4 +592,69 @@ async def delete_entry(
     return HTMLResponse(
         status_code=204,
         headers={"HX-Redirect": "/ui/memory"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# T3 (#879) bulk actions
+# ---------------------------------------------------------------------------
+
+
+async def render_bulk_action(
+    request: Request,
+    session_ctx: UISessionContext,
+    operator: Operator,
+    *,
+    action: str,
+    raw_ids: list[str],
+    extend_duration: str | None,
+    scope: str = SCOPE_ALL,
+    tag: str | None = None,
+) -> HTMLResponse:
+    """Apply a bulk action and re-render the cards fragment with a flash banner.
+
+    T3 (#879). The flow:
+
+    1. Validate the form via :func:`parse_bulk_ids` /
+       :func:`parse_extend_duration` (422 on malformed input).
+    2. Dispatch via :func:`apply_bulk_action` -- tenant + RBAC filtered.
+    3. Re-render the list under the active scope/tag so the operator
+       sees the post-bulk state in the same swap target. The flash
+       banner reports the (succeeded / denied / missing) counts.
+
+    Response shape: the ``_cards.html`` partial -- the form's
+    ``hx-target="#memory-cards"`` swaps the cards in place without a
+    full-page nav. This mirrors the scope-tab / tag-filter HTMX swap
+    target so the operator's mental model is consistent.
+    """
+    # Local import keeps the bulk module's dependencies (uuid / datetime
+    # / SQLAlchemy session helpers) from leaking into the read paths.
+    from meho_backplane.ui.routes.memory.bulk import (
+        BULK_ACTIONS,
+        BulkAction,
+        apply_bulk_action,
+        parse_bulk_ids,
+        parse_extend_duration,
+    )
+
+    if action not in BULK_ACTIONS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"bulk_invalid_action: {action!r} (allowed: {list(BULK_ACTIONS)})",
+        )
+    typed_action: BulkAction = "delete" if action == "delete" else "extend"
+    ids = parse_bulk_ids(raw_ids)
+    duration = parse_extend_duration(extend_duration) if typed_action == "extend" else None
+    result = await apply_bulk_action(
+        operator,
+        action=typed_action,
+        ids=ids,
+        extend_duration=duration,
+    )
+    return await render_index(
+        request,
+        session_ctx,
+        scope=scope,
+        tag=tag,
+        flash=result.flash_message,
     )

--- a/backend/src/meho_backplane/ui/templates/memory/_cards.html
+++ b/backend/src/meho_backplane/ui/templates/memory/_cards.html
@@ -2,29 +2,51 @@
   SPDX-License-Identifier: Apache-2.0
   Copyright (c) 2026 evoila Group
 
-  HTMX-swappable card grid for the Memory list (Initiative #341 Task
-  #877). Rendered both inline by ``memory/index.html`` (full page) and
-  by the route handler as a partial response (HTMX swap target on
-  scope-tab + tag-filter changes).
+  HTMX-swappable card grid for the Memory list (Initiative #341).
 
-  Each card shows:
-    * Slug + scope badge.
-    * Expiry timestamp (when set) with a ``data-expires-at`` attribute
-      so a future client-side countdown (T3 #879) can render the
-      "expires in 3d 4h" cue without a server change.
-    * Tag chips (DaisyUI badges).
-    * 200-char body preview (truncated server-side).
-    * "View" link to the detail page.
+  T1 (#877) shipped the read surface: scope-filtered DaisyUI cards with
+  slug, scope badge, expiry timestamp, tag chips, 200-char preview.
 
-  The element ID ``#memory-cards`` is the HTMX swap target. Per the
-  HTMX docs (https://htmx.org/attributes/hx-swap/), an ``outerHTML``
-  swap replaces the element including its ID, which we want so the
-  empty / non-empty states can swap interchangeably.
+  T3 (#879) layers:
+
+  * **Countdown badges** -- the ``entry.countdown`` projection renders
+    "expires in 3d 4h" server-side; the cards block re-renders every 60
+    seconds via ``hx-trigger="every 60s"`` so the cue stays fresh
+    without a client-side timer.
+  * **Recently expired section** -- ``expired_entries`` are rendered in
+    a separate greyed list below the active cards. The bucket is
+    naturally bounded by the G5.2 sweeper window (#623) -- between
+    expiry and the next sweeper tick, expired rows are still in the
+    documents table and visible to the read path.
+  * **Bulk select + actions** -- writable cards carry a checkbox;
+    Active + Recently-expired cards both participate in the same form.
+    The bulk-action toolbar (delete / extend-by-Xd) posts the selected
+    IDs to ``/ui/memory/bulk`` via HTMX; the response replaces this
+    fragment in place. RBAC is re-checked server-side per row -- the
+    checkbox visibility is a UX hint, not a security boundary.
+
+  HTMX wiring:
+
+    * ``hx-trigger="every 60s"`` on the wrapper fires a GET against
+      ``refresh_url`` (the active scope+tag preserved) and swaps the
+      ``outerHTML`` so the wrapper's ``hx-trigger`` re-installs on the
+      new element. This is the same shape as the topology graph's
+      30-second poll (G10.5-T3 #882).
+    * The bulk form's ``hx-post`` targets the same wrapper so the
+      post-bulk render swaps in place.
+    * The ``form="memory-bulk-form"`` attribute on each checkbox
+      means the checkbox participates in the bulk form regardless of
+      DOM nesting -- HTML5 standard form-association
+      (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#form).
 -#}
 <section
   id="memory-cards"
   aria-label="Memory card grid"
   class="space-y-3"
+  hx-get="{{ refresh_url | default('/ui/memory') }}"
+  hx-trigger="every 60s"
+  hx-swap="outerHTML"
+  hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
 >
   {% if flash %}
     <div class="alert alert-info" role="status">
@@ -32,6 +54,65 @@
     </div>
   {% endif %}
 
+  {# ----------- Bulk-action toolbar (form posts to /ui/memory/bulk) ----------- #}
+  {#
+    The form lives outside the cards <ul> so the cards can keep their
+    semantic <li> shape. Checkboxes inside the cards use the ``form=``
+    attribute to participate in this form.
+  #}
+  <form
+    id="memory-bulk-form"
+    class="card bg-base-100 border-base-300 border shadow-sm"
+    hx-post="/ui/memory/bulk"
+    hx-target="#memory-cards"
+    hx-swap="outerHTML"
+    hx-include="this"
+    aria-label="Bulk actions on selected memories"
+  >
+    <div class="card-body p-3 flex flex-wrap items-center gap-3">
+      <input type="hidden" name="scope" value="{{ active_scope }}" />
+      {% if active_tag %}
+        <input type="hidden" name="tag" value="{{ active_tag }}" />
+      {% endif %}
+      <span class="text-xs opacity-70" data-bulk-summary>
+        Select rows below, then choose an action.
+      </span>
+      <div class="ml-auto flex flex-wrap items-center gap-2">
+        <label class="form-control">
+          <span class="sr-only">Extend duration</span>
+          <select
+            name="extend_duration"
+            class="select select-bordered select-sm"
+            aria-label="Extend duration"
+          >
+            {% for d in bulk_extend_durations %}
+              <option value="{{ d }}"{% if d == '7d' %} selected{% endif %}>+{{ d }}</option>
+            {% endfor %}
+          </select>
+        </label>
+        <button
+          type="submit"
+          name="action"
+          value="extend"
+          class="btn btn-sm btn-primary"
+          data-action="bulk-extend"
+        >
+          Extend selected
+        </button>
+        <button
+          type="submit"
+          name="action"
+          value="delete"
+          class="btn btn-sm btn-error"
+          data-action="bulk-delete"
+        >
+          Delete selected
+        </button>
+      </div>
+    </div>
+  </form>
+
+  {# ----------- Active cards ----------- #}
   {% if not entries %}
     <div class="card bg-base-100 border-base-300 border">
       <div class="card-body text-sm opacity-70">
@@ -39,7 +120,7 @@
       </div>
     </div>
   {% else %}
-    <ul class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+    <ul class="grid gap-3 md:grid-cols-2 xl:grid-cols-3" aria-label="Active memories">
       {% for entry in entries %}
         <li
           class="card bg-base-100 border-base-300 border shadow-sm"
@@ -48,15 +129,35 @@
         >
           <div class="card-body p-4">
             <div class="flex items-start justify-between gap-2">
-              <h2 class="card-title text-base font-mono break-all">
-                <a
-                  href="/ui/memory/{{ entry.scope | urlencode }}/{{ entry.slug | urlencode }}"
-                  class="link link-hover"
-                >{{ entry.slug }}</a>
-              </h2>
+              <div class="flex items-start gap-2">
+                {% if entry.can_write %}
+                  <input
+                    type="checkbox"
+                    class="checkbox checkbox-sm"
+                    name="ids"
+                    value="{{ entry.id }}"
+                    form="memory-bulk-form"
+                    aria-label="Select memory {{ entry.scope }}/{{ entry.slug }}"
+                  />
+                {% endif %}
+                <h2 class="card-title text-base font-mono break-all">
+                  <a
+                    href="/ui/memory/{{ entry.scope | urlencode }}/{{ entry.slug | urlencode }}"
+                    class="link link-hover"
+                  >{{ entry.slug }}</a>
+                </h2>
+              </div>
               <span class="badge badge-outline badge-sm shrink-0">{{ entry.scope }}</span>
             </div>
-            {% if entry.expires_at %}
+            {% if entry.countdown %}
+              <div
+                class="text-xs opacity-70"
+                data-expires-at="{{ entry.expires_at.isoformat() }}"
+                data-countdown="{{ entry.countdown }}"
+              >
+                {{ entry.countdown }}
+              </div>
+            {% elif entry.expires_at %}
               <div
                 class="text-xs opacity-70"
                 data-expires-at="{{ entry.expires_at.isoformat() }}"
@@ -89,5 +190,78 @@
         </li>
       {% endfor %}
     </ul>
+  {% endif %}
+
+  {# ----------- Recently expired section (cleanup pending) ----------- #}
+  {% if expired_entries %}
+    <section
+      id="memory-recently-expired"
+      class="space-y-2 mt-6"
+      aria-label="Recently expired memories (cleanup pending)"
+    >
+      <header class="flex items-baseline justify-between gap-2">
+        <h2 class="text-sm font-semibold opacity-70">
+          Recently expired (cleanup pending)
+        </h2>
+        <span class="text-xs opacity-60">
+          {{ expired_count }} expired, awaiting the next sweeper tick
+        </span>
+      </header>
+      <ul
+        class="grid gap-3 md:grid-cols-2 xl:grid-cols-3 opacity-60"
+        aria-label="Recently expired memories"
+      >
+        {% for entry in expired_entries %}
+          <li
+            class="card bg-base-200 border-base-300 border"
+            data-memory-id="{{ entry.id }}"
+            data-memory-scope="{{ entry.scope }}"
+            data-expired="true"
+          >
+            <div class="card-body p-4">
+              <div class="flex items-start justify-between gap-2">
+                <div class="flex items-start gap-2">
+                  {% if entry.can_write %}
+                    <input
+                      type="checkbox"
+                      class="checkbox checkbox-sm"
+                      name="ids"
+                      value="{{ entry.id }}"
+                      form="memory-bulk-form"
+                      aria-label="Select expired memory {{ entry.scope }}/{{ entry.slug }}"
+                    />
+                  {% endif %}
+                  <h3 class="card-title text-sm font-mono break-all">
+                    <a
+                      href="/ui/memory/{{ entry.scope | urlencode }}/{{ entry.slug | urlencode }}"
+                      class="link link-hover"
+                    >{{ entry.slug }}</a>
+                  </h3>
+                </div>
+                <span class="badge badge-outline badge-sm shrink-0">{{ entry.scope }}</span>
+              </div>
+              <div
+                class="text-xs"
+                data-expires-at="{{ entry.expires_at.isoformat() }}"
+              >
+                Expired {{ entry.expires_at.isoformat() }}
+              </div>
+              {% if entry.tags %}
+                <ul class="flex flex-wrap gap-1" aria-label="Memory tags">
+                  {% for tag in entry.tags %}
+                    <li>
+                      <span class="badge badge-sm badge-ghost">{{ tag }}</span>
+                    </li>
+                  {% endfor %}
+                </ul>
+              {% endif %}
+              <p class="text-xs whitespace-pre-wrap break-words">
+                {{ entry.preview }}
+              </p>
+            </div>
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
   {% endif %}
 </section>

--- a/backend/tests/test_ui_memory_expiry_bulk.py
+++ b/backend/tests/test_ui_memory_expiry_bulk.py
@@ -1,0 +1,874 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the Memory UI expiry visualisation + bulk actions.
+
+Initiative #341 (G10.4 Memory UI), Task #879 (G10.4-T3). The acceptance
+criteria on issue #879 are:
+
+* memories with ``expires_at`` show a server-rendered countdown badge
+  ("expires in 3d 4h"); the HTMX 60s refresh updates it,
+* expired-but-not-yet-swept memories appear greyed in a separate
+  "Recently expired (cleanup pending)" section (consistent with the
+  G5.2 sweeper window #623),
+* bulk select -> bulk delete / bulk extend-expiry acts only on writable
+  memories (RBAC); non-writable selections rejected server-side,
+* CSRF enforced; cross-user/cross-tenant isolation holds.
+
+Suite shape mirrors :mod:`backend.tests.test_ui_memory_list` (T1) so
+the fixtures, app-build, and seed helpers stay coherent across the
+memory UI test surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+import warnings
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import Document, Tenant
+from meho_backplane.memory._internal import (
+    MEMORY_SOURCE,
+    build_metadata,
+    encode_source_id,
+)
+from meho_backplane.memory.schemas import MemoryScope, kind_for_scope
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, CSRFMiddleware, mint_csrf_token
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.routes.memory.bulk import (
+    BULK_MAX_IDS,
+    apply_bulk_action,
+    format_countdown,
+    parse_bulk_ids,
+    parse_extend_duration,
+    partition_expired,
+)
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests._oidc_jwt_helpers import (
+    AUDIENCE as _DEFAULT_AUDIENCE,
+)
+from tests._oidc_jwt_helpers import (
+    ISSUER as _DEFAULT_ISSUER,
+)
+from tests._oidc_jwt_helpers import (
+    make_rsa_keypair as _make_rsa_keypair,
+)
+from tests._oidc_jwt_helpers import (
+    mint_token as _mint_token,
+)
+from tests._oidc_jwt_helpers import (
+    mock_discovery_and_jwks as _mock_discovery_and_jwks,
+)
+from tests._oidc_jwt_helpers import (
+    public_jwks as _public_jwks,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirror test_ui_memory_list.py)
+# ---------------------------------------------------------------------------
+
+_BACKPLANE_URL = "https://meho.test"
+
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_TENANT_B = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+_OP_A = "op-alice"
+_OP_B = "op-bob"
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars (mirrors :mod:`test_ui_memory_list`)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _seed_memory(
+    *,
+    tenant_id: uuid.UUID,
+    scope: MemoryScope,
+    slug: str,
+    body: str,
+    user_sub: str | None = None,
+    target_name: str | None = None,
+    tags: list[str] | None = None,
+    expires_at: datetime | None = None,
+) -> uuid.UUID:
+    """Persist one memory row directly via the documents table.
+
+    Mirrors :func:`test_ui_memory_list._seed_memory` -- bypasses the
+    service so the test doesn't pull in the embedding model wheel.
+    """
+    metadata = build_metadata(
+        caller_metadata={"tags": list(tags)} if tags else None,
+        scope=scope,
+        user_sub=user_sub or "",
+        target_name=target_name,
+        expires_at=expires_at,
+    )
+    source_id = encode_source_id(
+        scope=scope,
+        user_sub=user_sub or "",
+        target_name=target_name,
+        slug=slug,
+    )
+    doc_id = uuid.uuid4()
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                Document(
+                    id=doc_id,
+                    tenant_id=tenant_id,
+                    source=MEMORY_SOURCE,
+                    source_id=source_id,
+                    kind=kind_for_scope(scope),
+                    body=body,
+                    body_hash=f"sha256:test:{doc_id}",
+                    embedding=[0.0] * 384,
+                    doc_metadata=metadata,
+                    tokens=len(body.split()),
+                ),
+            )
+
+    asyncio.run(_do())
+    return doc_id
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID,
+    access_token: str,
+    operator_sub: str,
+    lifetime: timedelta = timedelta(hours=1),
+) -> uuid.UUID:
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token=access_token,
+                refresh_token="refresh-token-plaintext",
+                lifetime=lifetime,
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _make_keypair_and_jwks() -> tuple[Any, dict[str, Any]]:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        keypair = _make_rsa_keypair("ui-memory-expiry-test-kid")
+    return keypair, _public_jwks(keypair)
+
+
+def _authenticated_client(
+    *,
+    session_id: uuid.UUID,
+    jwks: dict[str, Any],
+    with_csrf: bool = False,
+) -> tuple[TestClient, respx.MockRouter, str]:
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    _mock_discovery_and_jwks(mock, jwks)
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    csrf_token = mint_csrf_token(str(session_id))
+    if with_csrf:
+        client.cookies.set(CSRF_COOKIE_NAME, csrf_token)
+    return client, mock, csrf_token
+
+
+def _csrf_headers(token: str) -> dict[str, str]:
+    return {"X-CSRF-Token": token, "HX-Request": "true"}
+
+
+def _read_doc(doc_id: uuid.UUID) -> Document | None:
+    async def _do() -> Document | None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            return await session.get(Document, doc_id)
+
+    return asyncio.run(_do())
+
+
+# ---------------------------------------------------------------------------
+# Unit tests -- countdown formatting
+# ---------------------------------------------------------------------------
+
+
+def test_format_countdown_days_and_hours() -> None:
+    now = datetime(2026, 5, 26, 12, 0, 0, tzinfo=UTC)
+    expires_at = now + timedelta(days=3, hours=4, minutes=30)
+    assert format_countdown(expires_at, now=now) == "expires in 3d 4h"
+
+
+def test_format_countdown_hours_and_minutes() -> None:
+    now = datetime(2026, 5, 26, 12, 0, 0, tzinfo=UTC)
+    expires_at = now + timedelta(hours=5, minutes=42)
+    assert format_countdown(expires_at, now=now) == "expires in 5h 42m"
+
+
+def test_format_countdown_minutes_only() -> None:
+    now = datetime(2026, 5, 26, 12, 0, 0, tzinfo=UTC)
+    expires_at = now + timedelta(minutes=18)
+    assert format_countdown(expires_at, now=now) == "expires in 18m"
+
+
+def test_format_countdown_clamps_to_one_minute_on_sub_minute_delta() -> None:
+    now = datetime(2026, 5, 26, 12, 0, 0, tzinfo=UTC)
+    expires_at = now + timedelta(seconds=42)
+    assert format_countdown(expires_at, now=now) == "expires in 1m"
+
+
+def test_format_countdown_returns_expired_on_past_value() -> None:
+    now = datetime(2026, 5, 26, 12, 0, 0, tzinfo=UTC)
+    expires_at = now - timedelta(seconds=1)
+    assert format_countdown(expires_at, now=now) == "expired"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests -- partition_expired
+# ---------------------------------------------------------------------------
+
+
+def test_partition_expired_splits_by_now_boundary() -> None:
+    now = datetime(2026, 5, 26, 12, 0, 0, tzinfo=UTC)
+    # Build minimal MemoryEntry-shaped objects via the constructor;
+    # exercising the partition function does not require a service.
+    from meho_backplane.memory.schemas import MemoryEntry
+
+    def _make(expires_at: datetime | None, slug: str) -> MemoryEntry:
+        return MemoryEntry(
+            id=uuid.uuid4(),
+            tenant_id=_TENANT_A,
+            scope=MemoryScope.USER,
+            slug=slug,
+            body="x",
+            metadata={},
+            expires_at=expires_at,
+            user_sub=_OP_A,
+            target_name=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+    persistent = _make(None, "persistent")
+    future = _make(now + timedelta(hours=1), "future")
+    just_now = _make(now, "just-now")
+    past = _make(now - timedelta(hours=1), "past")
+    active, recently_expired = partition_expired([persistent, future, just_now, past], now=now)
+    active_slugs = {e.slug for e in active}
+    expired_slugs = {e.slug for e in recently_expired}
+    assert active_slugs == {"persistent", "future"}
+    assert expired_slugs == {"just-now", "past"}
+
+
+# ---------------------------------------------------------------------------
+# Unit tests -- bulk-form parsers
+# ---------------------------------------------------------------------------
+
+
+def test_parse_bulk_ids_rejects_empty_selection() -> None:
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        parse_bulk_ids([])
+    assert exc.value.status_code == 422
+    assert "bulk_no_ids_selected" in str(exc.value.detail)
+
+
+def test_parse_bulk_ids_rejects_overflow() -> None:
+    from fastapi import HTTPException
+
+    raw = [str(uuid.uuid4()) for _ in range(BULK_MAX_IDS + 1)]
+    with pytest.raises(HTTPException) as exc:
+        parse_bulk_ids(raw)
+    assert exc.value.status_code == 422
+    assert "bulk_too_many_ids" in str(exc.value.detail)
+
+
+def test_parse_bulk_ids_rejects_non_uuid() -> None:
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        parse_bulk_ids(["not-a-uuid"])
+    assert exc.value.status_code == 422
+    assert "bulk_invalid_id" in str(exc.value.detail)
+
+
+def test_parse_bulk_ids_deduplicates_silently() -> None:
+    same = str(uuid.uuid4())
+    parsed = parse_bulk_ids([same, same, same])
+    assert len(parsed) == 1
+
+
+def test_parse_extend_duration_rejects_missing() -> None:
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        parse_extend_duration(None)
+    assert exc.value.status_code == 422
+
+
+def test_parse_extend_duration_rejects_unknown_value() -> None:
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        parse_extend_duration("100y")
+    assert exc.value.status_code == 422
+    assert "bulk_invalid_extend_duration" in str(exc.value.detail)
+
+
+def test_parse_extend_duration_maps_known_values() -> None:
+    assert parse_extend_duration("1d") == timedelta(days=1)
+    assert parse_extend_duration("7d") == timedelta(days=7)
+    assert parse_extend_duration("30d") == timedelta(days=30)
+
+
+# ---------------------------------------------------------------------------
+# Integration -- countdown badge in the list HTML
+# ---------------------------------------------------------------------------
+
+
+def test_list_renders_countdown_badge_for_active_memory() -> None:
+    """An ``expires_at`` future-dated memory shows a countdown badge."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    future_expiry = datetime.now(UTC) + timedelta(days=3, hours=4)
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="will-expire",
+        body="hot tip",
+        user_sub=_OP_A,
+        expires_at=future_expiry,
+    )
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "expires in" in body
+    # The badge carries a ``data-countdown`` attribute so external
+    # observers (selenium tests, browser devtools) can read the cue
+    # without scraping inner text.
+    assert "data-countdown=" in body
+    assert "will-expire" in body
+
+
+def test_list_renders_recently_expired_section_for_past_expires_at() -> None:
+    """Memory with ``expires_at`` in the past lands in the recently-expired bucket."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    past = datetime.now(UTC) - timedelta(hours=1)
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="stale-note",
+        body="should be greyed",
+        user_sub=_OP_A,
+        expires_at=past,
+    )
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "Recently expired" in body
+    assert 'id="memory-recently-expired"' in body
+    assert "stale-note" in body
+    # The expired card carries ``data-expired="true"`` so observers
+    # can target the greyed bucket without inferring from siblings.
+    assert 'data-expired="true"' in body
+
+
+def test_list_60s_refresh_attribute_present() -> None:
+    """The cards wrapper carries ``hx-trigger="every 60s"`` per the AC."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'hx-trigger="every 60s"' in body
+    assert 'id="memory-cards"' in body
+
+
+def test_list_htmx_60s_refresh_returns_partial() -> None:
+    """An HTMX poll against ``/ui/memory`` returns just the cards partial."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="alive",
+        body="b",
+        user_sub=_OP_A,
+        expires_at=datetime.now(UTC) + timedelta(days=2),
+    )
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory", headers={"HX-Request": "true"})
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    body = response.text
+    assert "<title>" not in body
+    # The wrapper retains the refresh trigger so subsequent polls fire.
+    assert 'hx-trigger="every 60s"' in body
+    assert "expires in" in body
+
+
+# ---------------------------------------------------------------------------
+# Integration -- bulk delete / bulk extend via POST /ui/memory/bulk
+# ---------------------------------------------------------------------------
+
+
+def test_bulk_delete_removes_writable_rows_and_returns_partial() -> None:
+    """POST /ui/memory/bulk action=delete deletes the writable rows."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keep_id = _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="keep",
+        body="k",
+        user_sub=_OP_A,
+    )
+    drop_id = _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="drop",
+        body="d",
+        user_sub=_OP_A,
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.post(
+            "/ui/memory/bulk",
+            data={"action": "delete", "ids": [str(drop_id)], "scope": "all"},
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Flash banner reports the outcome.
+    assert "Bulk: 1 deleted" in body
+    # The kept row is still in the rendered list; the dropped row is not.
+    assert "keep" in body
+    assert "drop" not in body
+    # Row physically gone from the DB.
+    assert _read_doc(drop_id) is None
+    assert _read_doc(keep_id) is not None
+
+
+def test_bulk_extend_pushes_expires_at_into_the_future() -> None:
+    """POST /ui/memory/bulk action=extend updates expires_at to now + duration."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    soon = datetime.now(UTC) + timedelta(hours=2)
+    doc_id = _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="bump-me",
+        body="b",
+        user_sub=_OP_A,
+        expires_at=soon,
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    # ``MemoryService.remember`` re-runs the indexer's re-embed branch
+    # when the body hash matches; stub the embedding service so the
+    # test doesn't pull the wheel.
+    from unittest.mock import AsyncMock, patch
+
+    try:
+        with patch("meho_backplane.retrieval.indexer.get_embedding_service") as mock_embed_factory:
+            mock_embed_factory.return_value = type(
+                "_Stub", (), {"encode_one": AsyncMock(return_value=[0.0] * 384)}
+            )()
+            response = client.post(
+                "/ui/memory/bulk",
+                data={
+                    "action": "extend",
+                    "ids": [str(doc_id)],
+                    "extend_duration": "7d",
+                    "scope": "all",
+                },
+                headers=_csrf_headers(csrf),
+            )
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "Bulk: 1 extended" in body
+    # The row's expires_at is now ~7 days out (well beyond the original 2h).
+    doc = _read_doc(doc_id)
+    assert doc is not None
+    new_iso = doc.doc_metadata["expires_at"]
+    new_expires = datetime.fromisoformat(new_iso)
+    assert new_expires > soon + timedelta(days=6)
+
+
+def test_bulk_delete_denies_tenant_scoped_for_non_admin_operator() -> None:
+    """An operator (not tenant_admin) cannot bulk-delete a tenant-scoped memory."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    doc_id = _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.TENANT,
+        slug="shared-rule",
+        body="shared",
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.post(
+            "/ui/memory/bulk",
+            data={"action": "delete", "ids": [str(doc_id)], "scope": "all"},
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    # The handler accepts the request and reports the RBAC denial in
+    # the flash banner; the row remains untouched.
+    assert response.status_code == 200, response.text
+    assert "denied" in response.text
+    assert _read_doc(doc_id) is not None
+
+
+def test_bulk_delete_cross_tenant_id_falls_into_missing_bucket() -> None:
+    """A doc id from another tenant is silently missing, never acted on."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_tenant(_TENANT_B, "tenant-b")
+    # Owned by tenant B; operator authenticates against tenant A.
+    other_tenant_doc = _seed_memory(
+        tenant_id=_TENANT_B,
+        scope=MemoryScope.USER,
+        slug="not-yours",
+        body="z",
+        user_sub=_OP_A,
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.post(
+            "/ui/memory/bulk",
+            data={"action": "delete", "ids": [str(other_tenant_doc)], "scope": "all"},
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    assert "not found" in response.text
+    # Tenant B's row is untouched.
+    assert _read_doc(other_tenant_doc) is not None
+
+
+def test_bulk_post_without_csrf_token_rejected() -> None:
+    """POST /ui/memory/bulk without the CSRF header is 403."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    doc_id = _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="x",
+        body="x",
+        user_sub=_OP_A,
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    # ``with_csrf=False`` means the cookie isn't seeded; the middleware
+    # rejects on the missing token half.
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=False)
+    try:
+        response = client.post(
+            "/ui/memory/bulk",
+            data={"action": "delete", "ids": [str(doc_id)], "scope": "all"},
+            headers={"HX-Request": "true"},
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+
+
+def test_bulk_post_with_empty_ids_returns_422() -> None:
+    """Submitting the form with no selection returns 422."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.post(
+            "/ui/memory/bulk",
+            data={"action": "delete", "scope": "all"},
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 422
+
+
+def test_bulk_post_with_invalid_action_returns_422() -> None:
+    """Submitting an unknown action value returns 422."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    doc_id = _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="x",
+        body="x",
+        user_sub=_OP_A,
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.post(
+            "/ui/memory/bulk",
+            data={"action": "incinerate", "ids": [str(doc_id)], "scope": "all"},
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 422
+
+
+def test_bulk_delete_unauthenticated_redirects_to_login() -> None:
+    """POST /ui/memory/bulk without a session 302s to the BFF login."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.post(
+            "/ui/memory/bulk",
+            data={"action": "delete", "ids": [str(uuid.uuid4())]},
+        )
+    # The session middleware short-circuits on the unauthenticated
+    # request before the CSRF check sees it.
+    assert response.status_code in {302, 403}
+
+
+def test_bulk_post_renders_checkboxes_only_for_writable_rows() -> None:
+    """Tenant-scoped memory shows no checkbox for an ``operator`` role."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="own-row",
+        body="x",
+        user_sub=_OP_A,
+    )
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.TENANT,
+        slug="tenant-row",
+        body="y",
+    )
+    # Sign in as a plain operator so tenant-scoped rows are read-only.
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory")
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    body = response.text
+    # Both cards rendered.
+    assert "own-row" in body
+    assert "tenant-row" in body
+    # Only the own (user-scoped) row carries the checkbox label.
+    assert 'aria-label="Select memory user/own-row"' in body
+    assert "Select memory tenant/tenant-row" not in body
+
+
+# ---------------------------------------------------------------------------
+# Service-level -- apply_bulk_action via direct unit call
+# ---------------------------------------------------------------------------
+
+
+def test_apply_bulk_action_unit_delete_counts_succeeded_denied_missing() -> None:
+    """Unit test: the result tally is honest across the three buckets."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    own = _seed_memory(
+        tenant_id=_TENANT_A, scope=MemoryScope.USER, slug="own", body="o", user_sub=_OP_A
+    )
+    tenant_row = _seed_memory(
+        tenant_id=_TENANT_A, scope=MemoryScope.TENANT, slug="tenant", body="t"
+    )
+    missing_id = uuid.uuid4()
+    from meho_backplane.auth.operator import Operator
+
+    operator = Operator(
+        sub=_OP_A,
+        raw_jwt="test",
+        tenant_id=_TENANT_A,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+    async def _run() -> Any:
+        return await apply_bulk_action(
+            operator,
+            action="delete",
+            ids=[own, tenant_row, missing_id],
+        )
+
+    result = asyncio.run(_run())
+    assert result.requested == 3
+    assert result.succeeded == 1  # own
+    assert result.denied == 1  # tenant_row (operator role can't write tenant scope)
+    assert result.missing == 1  # missing_id
+    assert "1 deleted" in result.flash_message
+    assert "1 denied" in result.flash_message
+    assert "1 not found" in result.flash_message
+    # Physical state: own gone, tenant_row intact, missing never existed.
+    assert _read_doc(own) is None
+    assert _read_doc(tenant_row) is not None

--- a/backend/tests/test_ui_memory_expiry_bulk.py
+++ b/backend/tests/test_ui_memory_expiry_bulk.py
@@ -783,9 +783,16 @@ def test_bulk_delete_unauthenticated_redirects_to_login() -> None:
             "/ui/memory/bulk",
             data={"action": "delete", "ids": [str(uuid.uuid4())]},
         )
-    # The session middleware short-circuits on the unauthenticated
-    # request before the CSRF check sees it.
-    assert response.status_code in {302, 403}
+    # The session middleware short-circuits on the unauthenticated request
+    # before the CSRF check sees it -- main.py installs UISessionMiddleware
+    # outermost and CSRFMiddleware inside, so the response is deterministically
+    # a 302 to /ui/auth/login?return_to=... (not a 403 from the CSRF layer).
+    # Asserting the exact status + Location shape pins this ordering so a
+    # future middleware swap would surface as a loud regression instead of
+    # silently flipping the auth boundary.
+    assert response.status_code == 302, response.text
+    assert response.headers["Location"].startswith("/ui/auth/login"), response.headers["Location"]
+    assert "return_to=" in response.headers["Location"], response.headers["Location"]
 
 
 def test_bulk_post_renders_checkboxes_only_for_writable_rows() -> None:

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -6859,6 +6859,48 @@
         }
       }
     },
+    "/ui/memory/bulk": {
+      "post": {
+        "tags": [
+          "ui-memory"
+        ],
+        "summary": "Ui Memory Bulk",
+        "description": "``POST /ui/memory/bulk`` -- T3 (#879) bulk delete / bulk extend-expiry.",
+        "operationId": "ui_memory_bulk_ui_memory_bulk_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_ui_memory_bulk_ui_memory_bulk_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ui/knowledge": {
       "get": {
         "tags": [
@@ -8017,6 +8059,49 @@
         ],
         "title": "BaselineMetricsOverride",
         "description": "Per-surface baseline metrics supplied by the caller.\n\nCriterion 4 (MEHO \u2265 baseline) needs side-by-side numbers from a\nbaseline retrieval (``grep -r kb/`` for kb; ``grep paths.txt +\nyq`` for operations). The v0.2 backplane has no checked-in\ncorpus snapshot to evaluate the baseline against (see\n:mod:`meho_backplane.api.v1.retrieve_eval` \u2014 explicit\n``baseline=grep`` on that route is rejected with 501); the CLI\nruns the baseline locally against the operator's kb/ checkout and\ncan pass the resulting numbers here so the retire-checklist\nverdict honestly reflects criterion 4 instead of always reporting\nyellow (\"baseline did not run\") on the API path.\n\nWithout an override, criterion 4 stays yellow for v0.2 production\ncallers \u2014 the documented \"READY TO RETIRE\" path is unreachable\nvia the bare API alone, which is the honest v0.2 posture. T7\n(#446) / v0.2.next is expected to wire a server-side corpus\nsnapshot and remove the need for this override."
+      },
+      "Body_ui_memory_bulk_ui_memory_bulk_post": {
+        "properties": {
+          "action": {
+            "type": "string",
+            "maxLength": 16,
+            "title": "Action"
+          },
+          "ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Ids"
+          },
+          "extend_duration": {
+            "type": "string",
+            "maxLength": 8,
+            "nullable": true,
+            "title": "Extend Duration"
+          },
+          "scope": {
+            "type": "string",
+            "maxLength": 64,
+            "title": "Scope",
+            "default": "all"
+          },
+          "tag": {
+            "type": "string",
+            "maxLength": 256,
+            "nullable": true,
+            "title": "Tag"
+          },
+          "session_ctx": {
+            "$ref": "#/components/schemas/UISessionContext",
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "action"
+        ],
+        "title": "Body_ui_memory_bulk_ui_memory_bulk_post"
       },
       "Body_ui_memory_create_submit_ui_memory_create_post": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -875,6 +875,26 @@ type BaselineMetricsOverride struct {
 	PrecisionAt5 float32 `json:"precision_at_5"`
 }
 
+// BodyUiMemoryBulkUiMemoryBulkPost defines model for Body_ui_memory_bulk_ui_memory_bulk_post.
+type BodyUiMemoryBulkUiMemoryBulkPost struct {
+	Action         string    `json:"action"`
+	ExtendDuration *string   `json:"extend_duration"`
+	Ids            *[]string `json:"ids,omitempty"`
+	Scope          *string   `json:"scope,omitempty"`
+
+	// SessionCtx Per-request session identity exposed on ``request.state``.
+	//
+	// Frozen so a route handler that stashes the context on a logger
+	// or forwards it to a service layer cannot accidentally mutate
+	// fields downstream. The shape mirrors :class:`Operator` for the
+	// fields T5 (#866) needs to render an authenticated page header;
+	// ``raw_jwt`` / ``tenant_role`` are intentionally absent because
+	// the session-cookie path does not load them today (the encrypted
+	// row carries only the access token, not the decoded claims).
+	SessionCtx *UISessionContext `json:"session_ctx,omitempty"`
+	Tag        *string           `json:"tag"`
+}
+
 // BodyUiMemoryCreateSubmitUiMemoryCreatePost defines model for Body_ui_memory_create_submit_ui_memory_create_post.
 type BodyUiMemoryCreateSubmitUiMemoryCreatePost struct {
 	Body      string     `json:"body"`
@@ -4187,6 +4207,9 @@ type AnnotateEdgeRouteApiV1TopologyEdgesPostJSONRequestBody = UnderscoreAnnotate
 // BulkImportEdgesRouteApiV1TopologyEdgesBulkPostJSONRequestBody defines body for BulkImportEdgesRouteApiV1TopologyEdgesBulkPost for application/json ContentType.
 type BulkImportEdgesRouteApiV1TopologyEdgesBulkPostJSONRequestBody = UnderscoreBulkImportRequest
 
+// UiMemoryBulkUiMemoryBulkPostFormdataRequestBody defines body for UiMemoryBulkUiMemoryBulkPost for application/x-www-form-urlencoded ContentType.
+type UiMemoryBulkUiMemoryBulkPostFormdataRequestBody = BodyUiMemoryBulkUiMemoryBulkPost
+
 // UiMemoryCreateModalUiMemoryCreateGetJSONRequestBody defines body for UiMemoryCreateModalUiMemoryCreateGet for application/json ContentType.
 type UiMemoryCreateModalUiMemoryCreateGetJSONRequestBody = UISessionContext
 
@@ -4838,6 +4861,11 @@ type ClientInterface interface {
 
 	// UiMemoryListUiMemoryGet request
 	UiMemoryListUiMemoryGet(ctx context.Context, params *UiMemoryListUiMemoryGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiMemoryBulkUiMemoryBulkPostWithBody request with any body
+	UiMemoryBulkUiMemoryBulkPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiMemoryBulkUiMemoryBulkPostWithFormdataBody(ctx context.Context, body UiMemoryBulkUiMemoryBulkPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiMemoryCreateModalUiMemoryCreateGetWithBody request with any body
 	UiMemoryCreateModalUiMemoryCreateGetWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -6481,6 +6509,30 @@ func (c *Client) UiStubKnowledgeUiKnowledgeGet(ctx context.Context, reqEditors .
 
 func (c *Client) UiMemoryListUiMemoryGet(ctx context.Context, params *UiMemoryListUiMemoryGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUiMemoryListUiMemoryGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiMemoryBulkUiMemoryBulkPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryBulkUiMemoryBulkPostRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiMemoryBulkUiMemoryBulkPostWithFormdataBody(ctx context.Context, body UiMemoryBulkUiMemoryBulkPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryBulkUiMemoryBulkPostRequestWithFormdataBody(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -13373,6 +13425,46 @@ func NewUiMemoryListUiMemoryGetRequest(server string, params *UiMemoryListUiMemo
 	return req, nil
 }
 
+// NewUiMemoryBulkUiMemoryBulkPostRequestWithFormdataBody calls the generic UiMemoryBulkUiMemoryBulkPost builder with application/x-www-form-urlencoded body
+func NewUiMemoryBulkUiMemoryBulkPostRequestWithFormdataBody(server string, body UiMemoryBulkUiMemoryBulkPostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewUiMemoryBulkUiMemoryBulkPostRequestWithBody(server, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewUiMemoryBulkUiMemoryBulkPostRequestWithBody generates requests for UiMemoryBulkUiMemoryBulkPost with any type of body
+func NewUiMemoryBulkUiMemoryBulkPostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/memory/bulk")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewUiMemoryCreateModalUiMemoryCreateGetRequest calls the generic UiMemoryCreateModalUiMemoryCreateGet builder with application/json body
 func NewUiMemoryCreateModalUiMemoryCreateGetRequest(server string, body UiMemoryCreateModalUiMemoryCreateGetJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -14544,6 +14636,11 @@ type ClientWithResponsesInterface interface {
 
 	// UiMemoryListUiMemoryGetWithResponse request
 	UiMemoryListUiMemoryGetWithResponse(ctx context.Context, params *UiMemoryListUiMemoryGetParams, reqEditors ...RequestEditorFn) (*UiMemoryListUiMemoryGetResponse, error)
+
+	// UiMemoryBulkUiMemoryBulkPostWithBodyWithResponse request with any body
+	UiMemoryBulkUiMemoryBulkPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryBulkUiMemoryBulkPostResponse, error)
+
+	UiMemoryBulkUiMemoryBulkPostWithFormdataBodyWithResponse(ctx context.Context, body UiMemoryBulkUiMemoryBulkPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryBulkUiMemoryBulkPostResponse, error)
 
 	// UiMemoryCreateModalUiMemoryCreateGetWithBodyWithResponse request with any body
 	UiMemoryCreateModalUiMemoryCreateGetWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryCreateModalUiMemoryCreateGetResponse, error)
@@ -16958,6 +17055,28 @@ func (r UiMemoryListUiMemoryGetResponse) StatusCode() int {
 	return 0
 }
 
+type UiMemoryBulkUiMemoryBulkPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiMemoryBulkUiMemoryBulkPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiMemoryBulkUiMemoryBulkPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type UiMemoryCreateModalUiMemoryCreateGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -18408,6 +18527,23 @@ func (c *ClientWithResponses) UiMemoryListUiMemoryGetWithResponse(ctx context.Co
 		return nil, err
 	}
 	return ParseUiMemoryListUiMemoryGetResponse(rsp)
+}
+
+// UiMemoryBulkUiMemoryBulkPostWithBodyWithResponse request with arbitrary body returning *UiMemoryBulkUiMemoryBulkPostResponse
+func (c *ClientWithResponses) UiMemoryBulkUiMemoryBulkPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryBulkUiMemoryBulkPostResponse, error) {
+	rsp, err := c.UiMemoryBulkUiMemoryBulkPostWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryBulkUiMemoryBulkPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiMemoryBulkUiMemoryBulkPostWithFormdataBodyWithResponse(ctx context.Context, body UiMemoryBulkUiMemoryBulkPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryBulkUiMemoryBulkPostResponse, error) {
+	rsp, err := c.UiMemoryBulkUiMemoryBulkPostWithFormdataBody(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryBulkUiMemoryBulkPostResponse(rsp)
 }
 
 // UiMemoryCreateModalUiMemoryCreateGetWithBodyWithResponse request with arbitrary body returning *UiMemoryCreateModalUiMemoryCreateGetResponse
@@ -21751,6 +21887,32 @@ func ParseUiMemoryListUiMemoryGetResponse(rsp *http.Response) (*UiMemoryListUiMe
 	}
 
 	response := &UiMemoryListUiMemoryGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiMemoryBulkUiMemoryBulkPostResponse parses an HTTP response from a UiMemoryBulkUiMemoryBulkPostWithResponse call
+func ParseUiMemoryBulkUiMemoryBulkPostResponse(rsp *http.Response) (*UiMemoryBulkUiMemoryBulkPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiMemoryBulkUiMemoryBulkPostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -1385,3 +1385,79 @@ The create + promote tests stub the embedding service for the same
 reason the T1 PATCH test does — `index_document` (called by both
 `MemoryService.remember` and `MemoryService.promote`) computes a
 new embedding for the inserted row.
+
+### Expiry visualisation + bulk actions (Task #879)
+
+Initiative [#341](https://github.com/evoila/meho/issues/341) (G10.4
+Memory UI), Task [#879](https://github.com/evoila/meho/issues/879)
+(G10.4-T3) layers two surfaces on top of T1's list:
+
+* **Server-rendered countdown badges** — every memory with
+  `expires_at` shows an `"expires in 3d 4h"` cue, formatted by
+  `bulk.format_countdown`. The cards block wrapper carries
+  `hx-trigger="every 60s"` (mirrors topology graph's poll at #882's
+  30-second cadence) so the badge re-renders without a client-side
+  timer. The refresh URL preserves the active scope + tag so a poll
+  mid-page-stay stays aligned with the operator's filter state.
+* **Recently expired section** — expired-but-unswept rows render in a
+  greyed `<ul>` below the active cards. The bucket is naturally
+  bounded by the G5.2 sweeper window
+  ([#623](https://github.com/evoila/meho/issues/623)) — between
+  expiry and the next sweeper tick (default 24 h via
+  `memory_expiry_tick_interval_seconds`), expired rows are still in
+  the documents table. `MemoryService.list_memories` is called with
+  `include_expired=True` and the partition runs in
+  `bulk.partition_expired`.
+* **Bulk select + actions** — writable cards carry a checkbox (form
+  association via the HTML5 `form="memory-bulk-form"` attribute so
+  the checkbox participates in the bulk form regardless of DOM
+  nesting); the toolbar posts the selected `Document.id` UUIDs to
+  `POST /ui/memory/bulk` via HTMX. Two actions: `delete` (calls
+  `MemoryService.forget` per row) and `extend` (calls
+  `MemoryService.remember` with the existing body + a fresh
+  `expires_at = now + duration`; durations are pre-canned at 1d /
+  7d / 30d to prevent "extend by 10 years" footguns).
+
+#### Bulk RBAC posture
+
+The route resolves IDs to entries via a tenant-scoped + `source='memory'`
+filter so an operator can't smuggle a knowledge-base or audit-row UUID
+through the form. Per row, `MemoryRbacResolver.can_write` is re-checked
+before dispatch; the service's own `can_write` re-check still runs
+inside `forget` / `remember`. The route-side check exists so the
+result counts (`succeeded` / `denied` / `missing`) are honest in the
+flash banner.
+
+The flash message follows the shape `"Bulk: N deleted, M denied
+(RBAC), K not found."` with the denied / not-found terms suppressed
+when their count is zero. Cross-tenant IDs fall silently into the
+`missing` bucket — the row is real in another tenant, but invisible
+to this operator.
+
+#### Routes (T3 additions)
+
+| Method | Path | Purpose |
+| ------ | ---- | ------- |
+| `POST` | `/ui/memory/bulk` | Bulk delete or bulk extend-expiry. Form fields: `action` (`delete` \| `extend`), `ids` (multi-value `Document.id`), `extend_duration` (one of `1d` / `7d` / `30d`, required when `action=extend`), `scope` + `tag` (echoed back so the post-bulk render preserves the operator's filter state). CSRF-enforced. Returns the re-rendered `_cards.html` partial with a flash banner. |
+
+#### Files
+
+* `backend/src/meho_backplane/ui/routes/memory/bulk.py` — countdown
+  formatter, partition helper, form parsers, and `apply_bulk_action`.
+  Pulled out of `views.py` so the T3 code lands in one cohesive
+  module without growing the T1 render file past its cap.
+* `backend/src/meho_backplane/ui/routes/memory/views.py` (extended) —
+  `render_index` partitions the entries and passes the active +
+  recently-expired buckets to the template; `render_bulk_action`
+  dispatches the bulk handler.
+* `backend/src/meho_backplane/ui/routes/memory/routes.py` (extended) —
+  registers `POST /ui/memory/bulk` ahead of the parameterised
+  PATCH/DELETE so the literal path segment is unambiguous.
+* `backend/src/meho_backplane/ui/templates/memory/_cards.html`
+  (extended) — countdown badge, checkbox column on writable rows,
+  bulk-action toolbar, recently-expired section, and the
+  `hx-trigger="every 60s"` poll attribute on the wrapper.
+* `backend/tests/test_ui_memory_expiry_bulk.py` — countdown
+  formatting, partition split, parser guards, badge + recently-
+  expired rendering, bulk delete + extend, RBAC denial path,
+  cross-tenant safety, CSRF gate.


### PR DESCRIPTION
## Summary

- Adds **server-rendered countdown badges** ("expires in 3d 4h") on each memory card, with an `hx-trigger="every 60s"` poll on the cards fragment so the cue stays fresh without a client-side timer. The refresh URL preserves the active scope + tag.
- Adds the **"Recently expired (cleanup pending)" greyed section** below the active cards — the bucket is naturally bounded by the G5.2 sweeper window (#623), so the operator sees what just rotated out before the next 24 h sweeper tick reaps it.
- Adds **bulk select via checkboxes on writable rows** and `POST /ui/memory/bulk` for bulk delete / bulk extend-expiry (pre-canned at 1d / 7d / 30d). HTML5 `form=` attribute associates the checkboxes with the toolbar form regardless of DOM nesting. Tenant + RBAC re-checked server-side per row; cross-tenant IDs silently fall into the "not found" bucket. CSRF inherited from the chassis double-submit cookie.

Builds on T1's #877 router shape; T2 (#878, in flight in parallel) lands create + promote on distinct files / routes so the two PRs don't collide.

This is the closing task of Initiative #341 (G10.4 Memory UI) — when this PR merges and #341 closes, Goal **#336 G10.4** checklist line ticks.

## Test plan

- [x] `ruff check src/meho_backplane/ui/routes/memory/ tests/test_ui_memory_expiry_bulk.py` — clean
- [x] `ruff format --check ...` — clean
- [x] `mypy src/meho_backplane/ui/routes/memory/` — clean (6 files, no issues)
- [x] `mypy src/meho_backplane/ --ignore-missing-imports` — broad-scope clean (336 files, no issues)
- [x] `pytest tests/test_ui_memory_expiry_bulk.py -x -q` — **27 passed**
- [x] `pytest tests/test_ui_memory_list.py -x -q` (T1 regression check) — **26 passed**
- [x] `pytest tests/test_memory_service.py tests/test_memory_rbac.py tests/test_memory_expiry.py tests/test_api_v1_memory.py -x -q` — **163 passed**
- [x] `pytest tests/test_ui_chassis_smoke.py tests/test_ui_topology_table.py -q` — **38 passed**
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers, 3 warnings (function-size + file-size on legacy/expanded files; no agent-introduced violations)

### Acceptance criteria mapping (#879)

- [x] **`expires_at` memories show a countdown badge; the HTMX 60s refresh updates it** — `test_list_renders_countdown_badge_for_active_memory`, `test_list_60s_refresh_attribute_present`, `test_list_htmx_60s_refresh_returns_partial`; unit tests cover the day/hour/minute/clamp/expired branches of `format_countdown`.
- [x] **Recently expired section** — `test_list_renders_recently_expired_section_for_past_expires_at` (greyed section with `id="memory-recently-expired"` + `data-expired="true"`); `test_partition_expired_splits_by_now_boundary` (partition boundary).
- [x] **Bulk acts only on writable memories (RBAC)** — `test_bulk_delete_denies_tenant_scoped_for_non_admin_operator`, `test_apply_bulk_action_unit_delete_counts_succeeded_denied_missing`, `test_bulk_post_renders_checkboxes_only_for_writable_rows`; cross-tenant safety in `test_bulk_delete_cross_tenant_id_falls_into_missing_bucket`.
- [x] **CSRF enforced; cross-user/cross-tenant isolation** — `test_bulk_post_without_csrf_token_rejected` (403 on missing token), `test_bulk_delete_unauthenticated_redirects_to_login`, plus the cross-tenant "not found" path.
- [x] **`ruff` + `mypy` clean; new test file passes** — see Test plan.

## Out of scope

- Create modal + scope-promotion (T2 #878, sibling in flight).
- Memory analytics — explicitly OOS per #341 body.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #879


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bulk delete and extend actions for multiple memory entries
  * Expiry countdown display and recently-expired section
  * Automatic card refresh every 60 seconds
  * Selection checkboxes for bulk operations

* **Documentation**
  * Memory UI expiry visualization and bulk actions guide added

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-26)

Addressed review findings from `/auto-review-pr` iter-1
(`.claude/auto/review-results/pr-1165-iter-1.json`):

- **B1** `7af05cf` — `chore(cli): regenerate OpenAPI snapshot + Go client for /ui/memory/bulk`. CLI API snapshot freshness CI was red because the new `POST /ui/memory/bulk` route was not in `cli/api/openapi.json` / `cli/internal/api/client.gen.go`. Ran `cd cli && make snapshot-openapi && make generate`; +247 LoC mechanical regen, no other routes drift. Mirrors T1 PR #1161's precedent (commit 621863b).
- **M1** `c03b016` — `test(memory-ui): tighten unauthenticated bulk-delete assertion to 302 + Location`. Replaced the loose `assert response.status_code in {302, 403}` with an exact `302` check plus `Location` starts-with `/ui/auth/login` and contains a `return_to=` query param. Pins the `UISessionMiddleware`-outermost / `CSRFMiddleware`-inside ordering so an auth-boundary regression surfaces loudly. Matches CodeRabbit's inline thread on the same line.

Disputed: none.

Deferred (recorded as `adjacent_findings` in the result file — CodeRabbit's two extra nits are behavior-correct + implicitly tested; orchestrator may file a follow-up issue if explicit coverage is desired):

- explicit `test_list_htmx_refresh_url_preserves_scope_and_tag` (behavior covered via `_build_refresh_url`).
- explicit `test_bulk_delete_cross_user_same_tenant_isolation` (behavior covered via RBAC matrix).

<!-- auto-implement-issue: continue, iteration 1 -->
