### PR TITLE
feat(targets): G0.14-T3 TargetCreate.product enum at boot + discoverable 422

### DIFF
--- a/backend/src/meho_backplane/api/v1/targets.py
+++ b/backend/src/meho_backplane/api/v1/targets.py
@@ -98,7 +98,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
 from meho_backplane.connectors.base import Connector
-from meho_backplane.connectors.registry import all_connectors_v2
+from meho_backplane.connectors.registry import all_connectors_v2, registered_product_tokens
 from meho_backplane.connectors.resolver import resolve_connector_or_label
 from meho_backplane.connectors.schemas import AuthModel, CandidateHint, FingerprintResult
 from meho_backplane.db.engine import get_session
@@ -172,6 +172,40 @@ def _to_summary(t: TargetORM) -> TargetSummary:
         product=t.product,
         host=t.host,
     )
+
+
+def _build_unknown_product_detail(
+    product: str,
+    valid_products: list[str],
+) -> dict[str, object]:
+    """Build the T11-compliant ``unknown_product`` 422 detail.
+
+    G0.14-T3 (#1144). Mirrors the ``/probe`` 501's diagnostic shape
+    but moves it forward to the POST / PATCH validation boundary so
+    the operator sees the actionable error at create time instead of
+    after committing a permanent broken row. The detail follows the
+    convention codified in ``docs/codebase/error-message-shape.md``
+    (T11 #1141): a stable ``kind`` code, a ``message`` naming the
+    offending value + remediation + a doc reference, and a machine-
+    actionable ``valid_products`` list the client can branch on.
+
+    Pure builder — no I/O, no logging. Called from both
+    :func:`create_target` (POST) and (after T4 #1145 consolidation)
+    :func:`update_target` (PATCH); the shared shape is what lets a
+    CLI / agent handle the two surfaces identically.
+    """
+    return {
+        "kind": "unknown_product",
+        "product": product,
+        "valid_products": valid_products,
+        "message": (
+            f"product={product!r} is not registered; "
+            f"pick one of {valid_products!r} or register a "
+            f"connector for it before retrying. "
+            f"See docs/codebase/error-message-shape.md for "
+            f"the convention."
+        ),
+    }
 
 
 def _to_full(t: TargetORM) -> Target:
@@ -424,7 +458,29 @@ async def create_target(
     the tenant. The ``id`` and timestamps are generated server-side.
     ``tenant_id`` is always taken from the JWT — the body cannot override
     it.
+
+    G0.14-T3 (#1144). The ``product`` field is validated at request time
+    against :func:`~meho_backplane.connectors.registry.registered_product_tokens`.
+    An unknown product yields a structured 422 (see
+    :func:`_build_unknown_product_detail`); the OpenAPI schema also
+    exposes the enum (see :func:`meho_backplane.main.build_openapi_schema`)
+    so Swagger / generator tooling surfaces the valid set before the
+    request leaves the editor. Both layers share the same source-of-
+    truth helper so they cannot drift.
+
+    Validation is skipped when the registry is empty — that state means
+    "no connectors imported" (test isolation, or a deploy booted before
+    :func:`_eager_import_connectors` ran). In production the lifespan
+    populates the registry before the first request arrives, so the
+    skip branch never fires; a misregistered deploy that *did* hit it
+    is recoverable via T4 #1145's PATCH-product or DELETE path.
     """
+    valid_products = sorted(registered_product_tokens())
+    if valid_products and body.product not in valid_products:
+        raise HTTPException(
+            status_code=422,
+            detail=_build_unknown_product_detail(body.product, valid_products),
+        )
     now = datetime.now(UTC)
     t = TargetORM(
         id=uuid.uuid4(),

--- a/backend/src/meho_backplane/connectors/registry.py
+++ b/backend/src/meho_backplane/connectors/registry.py
@@ -48,6 +48,7 @@ __all__ = [
     "list_connector_impls",
     "register_connector",
     "register_connector_v2",
+    "registered_product_tokens",
 ]
 
 _log = structlog.get_logger(__name__)
@@ -177,6 +178,39 @@ def list_connector_impls() -> list[tuple[str, str, str]]:
     debug endpoints render deterministically across hosts.
     """
     return sorted(_REGISTRY_V2.keys())
+
+
+def registered_product_tokens() -> set[str]:
+    """Return the set of product tokens advertised by registered connectors.
+
+    G0.14-T3 (#1144). The set is the union of the v2 registry's ``product``
+    keys, drained of the empty-string placeholder. The padding placeholders
+    appear on the ``version`` / ``impl_id`` axes when a v1
+    :func:`register_connector` call writes a ``(product, "", "")`` entry;
+    the bare product token is what callers see. An empty ``product`` value
+    has no addressable meaning (the resolver could never tie-break it
+    against a real registration) and is filtered defensively.
+
+    This is the canonical source of "what product slugs the operator may
+    POST" — every operator-facing validation path (POST
+    :func:`~meho_backplane.api.v1.targets.create_target`, PATCH
+    :func:`~meho_backplane.api.v1.targets.update_target`, the OpenAPI
+    ``TargetCreate.product`` enum hook in
+    :mod:`meho_backplane.main`) reads from here so they never disagree
+    about which tokens are valid. The set tracks the resolver's notion
+    of "valid product" at probe / dispatch time, so a request that
+    passes here does not surprise the operator with a 501 on the next
+    probe.
+
+    Returned as a fresh ``set`` so callers can mutate / sort without
+    affecting the underlying registry.
+
+    Sibling Task T4 #1145 inlines an equivalent ``_registered_products()``
+    in :mod:`meho_backplane.api.v1.targets`; once both PRs land the
+    inline helper consolidates against this function (note in #1164's
+    PR description).
+    """
+    return {product for (product, _version, _impl_id) in _REGISTRY_V2 if product}
 
 
 def _eager_import_connectors() -> None:

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -47,6 +47,7 @@ from typing import Final
 
 import structlog
 from fastapi import FastAPI, Response
+from fastapi.openapi.utils import get_openapi
 from fastapi.staticfiles import StaticFiles
 
 from meho_backplane import __version__
@@ -98,7 +99,7 @@ from meho_backplane.broadcast import (
     dispose_broadcast_client,
     get_broadcast_client,
 )
-from meho_backplane.connectors.registry import _eager_import_connectors
+from meho_backplane.connectors.registry import _eager_import_connectors, registered_product_tokens
 from meho_backplane.db.engine import dispose_engine, get_engine
 from meho_backplane.db.migrations import db_migration_probe
 from meho_backplane.events import start_event_drain, stop_event_drain
@@ -731,6 +732,97 @@ if parse_bool_env(os.environ.get("MEHO_ENABLE_RBAC_TEST_ROUTE")):
     )
 
     app.include_router(api_v1_rbac_test_router)
+
+
+def _inject_target_product_enum(schema: dict[str, object]) -> None:
+    """Mutate ``TargetCreate.product`` in ``schema`` with the live product enum.
+
+    G0.14-T3 (#1144). Reads :func:`registered_product_tokens` and sets
+    the ``enum`` + ``description`` on the ``TargetCreate.product``
+    JSON Schema property in place. Defensive ``isinstance`` walks let
+    the override survive future schema-shape rearrangements without
+    raising on a missing key (the worst case becomes "the enum is not
+    injected" rather than "the OpenAPI doc fails to serve").
+    """
+    valid_products = sorted(registered_product_tokens())
+    if not valid_products:
+        return
+    components = schema.get("components")
+    if not isinstance(components, dict):
+        return
+    schemas = components.get("schemas")
+    if not isinstance(schemas, dict):
+        return
+    target_create = schemas.get("TargetCreate")
+    if not isinstance(target_create, dict):
+        return
+    properties = target_create.get("properties")
+    if not isinstance(properties, dict):
+        return
+    product_field = properties.get("product")
+    if not isinstance(product_field, dict):
+        return
+    product_field["enum"] = list(valid_products)
+    product_field["description"] = (
+        "Connector product slug. Must match the ``product`` "
+        "field of a registered connector class; see "
+        "``GET /api/v1/connectors`` for the live list and "
+        "``docs/codebase/error-message-shape.md`` for the "
+        "422 shape returned on miss."
+    )
+
+
+def build_openapi_schema() -> dict[str, object]:
+    """Generate the OpenAPI schema with the ``TargetCreate.product`` enum injected.
+
+    G0.14-T3 (#1144). Overrides the default :meth:`FastAPI.openapi` so
+    the ``product`` property on the ``TargetCreate`` request schema
+    renders as a JSON Schema enum populated from the live connector
+    registry. Without this hook the schema would surface ``product`` as
+    a free-form string — the dogfood signal 5 UX miss in
+    ``claude-rdc-hetzner-dc#697`` (operator typed ``'kubernetes'``,
+    resolver matched on ``'k8s'``, no early signal). Paired with the
+    runtime 422 in :func:`~meho_backplane.api.v1.targets.create_target`
+    (Options A + C from the task body, sharing one source-of-truth
+    helper so they cannot drift).
+
+    Calls :func:`_eager_import_connectors` when the registry is empty
+    so the schema is correct even when the override fires before the
+    FastAPI lifespan (the OpenAPI snapshot script under
+    ``cli/api/snapshot-openapi.py`` calls :meth:`app.openapi` directly
+    without running the lifespan). Idempotent — modules already in
+    ``sys.modules`` are a no-op on the second call.
+
+    Caches the result on ``app.openapi_schema`` to match FastAPI's
+    own caching behaviour.
+    """
+    if app.openapi_schema is not None:
+        return app.openapi_schema
+
+    if not registered_product_tokens():
+        _eager_import_connectors()
+
+    schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        openapi_version=app.openapi_version,
+        summary=app.summary,
+        description=app.description,
+        routes=app.routes,
+        webhooks=app.webhooks.routes,
+        tags=app.openapi_tags,
+        servers=app.servers,
+        terms_of_service=app.terms_of_service,
+        contact=app.contact,
+        license_info=app.license_info,
+        separate_input_output_schemas=app.separate_input_output_schemas,
+    )
+    _inject_target_product_enum(schema)
+    app.openapi_schema = schema
+    return schema
+
+
+app.openapi = build_openapi_schema  # type: ignore[method-assign]
 
 
 @app.get("/")

--- a/backend/tests/test_api_v1_targets.py
+++ b/backend/tests/test_api_v1_targets.py
@@ -566,6 +566,216 @@ def test_create_target_with_all_fields(client: TestClient) -> None:
 
 
 # ---------------------------------------------------------------------------
+# POST /api/v1/targets — product-enum validation (G0.14-T3 #1144)
+# ---------------------------------------------------------------------------
+
+
+def _register_fake_k8s_connector() -> None:
+    """Register a no-op connector under ``product='k8s'`` for enum tests.
+
+    The autouse :func:`_empty_connector_registry` fixture clears the
+    registry between tests, so each enum-validation test that needs a
+    known set of valid products registers its own minimal stand-in
+    here. ``product='k8s'`` mirrors the real dogfood case
+    (``claude-rdc-hetzner-dc#697`` signal 5 — operator typed
+    ``'kubernetes'``, real registration is ``'k8s'``).
+    """
+    from meho_backplane.connectors.base import Connector
+    from meho_backplane.connectors.registry import register_connector_v2
+    from meho_backplane.connectors.schemas import FingerprintResult, OperationResult
+
+    class _FakeK8sConnector(Connector):
+        product = "k8s"
+
+        async def probe(self, target: Any) -> ProbeResult:
+            raise NotImplementedError
+
+        async def fingerprint(self, target: Any) -> FingerprintResult:  # type: ignore[override]
+            raise NotImplementedError
+
+        async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:  # type: ignore[override]
+            raise NotImplementedError
+
+    register_connector_v2(product="k8s", version="1.x", impl_id="k8s", cls=_FakeK8sConnector)
+
+
+def test_create_target_unknown_product_returns_422(client: TestClient) -> None:
+    """POST with a product no connector advertises returns a structured 422.
+
+    G0.14-T3 (#1144) acceptance criterion. Replays the real-world
+    typo from ``claude-rdc-hetzner-dc#697`` signal 5: the operator
+    posts ``product='kubernetes'`` (the friendly common name) when the
+    registered connector advertises ``'k8s'``. Before this PR the
+    POST succeeded and the broken row was unrecoverable (no DELETE,
+    no PATCH on ``product``). After this PR the POST is rejected at
+    the validation boundary with a structured detail naming the
+    typo'd value + the valid set + the convention doc.
+    """
+    _register_fake_k8s_connector()
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/targets",
+            json={
+                "name": "rdc-rke2-infra",
+                "product": "kubernetes",
+                "host": "10.10.0.1",
+            },
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    # T11 convention compliance — a stable ``kind`` code, the offending
+    # product value, the valid set, and a human-readable message naming
+    # the doc reference. Each assertion pins one clause of the
+    # convention.
+    assert detail["kind"] == "unknown_product"
+    assert detail["product"] == "kubernetes"
+    assert detail["valid_products"] == ["k8s"]
+    assert "kubernetes" in detail["message"]
+    assert "k8s" in detail["message"]
+    assert "docs/codebase/error-message-shape.md" in detail["message"]
+
+
+def test_create_target_unknown_product_does_not_create_row(client: TestClient) -> None:
+    """A 422 from the product-enum guard does not commit the row.
+
+    Pinning that the validator runs BEFORE ``session.add(t)`` so a
+    rejected POST does not leave a tombstone the operator would
+    have to recover from. Re-POSTing the same name with a valid
+    product must succeed (it would 409 if the previous insert had
+    landed).
+    """
+    _register_fake_k8s_connector()
+    key = make_rsa_keypair("kid-A")
+    headers = {"Authorization": f"Bearer {_admin_token(key)}"}
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        r_typo = client.post(
+            "/api/v1/targets",
+            json={
+                "name": "rdc-rke2-infra",
+                "product": "kubernetes",
+                "host": "10.10.0.1",
+            },
+            headers=headers,
+        )
+        # Retry with the right product; if the typo POST had committed
+        # the row, this second POST would 409.
+        r_retry = client.post(
+            "/api/v1/targets",
+            json={
+                "name": "rdc-rke2-infra",
+                "product": "k8s",
+                "host": "10.10.0.1",
+            },
+            headers=headers,
+        )
+    assert r_typo.status_code == 422
+    assert r_retry.status_code == 201
+
+
+def test_create_target_valid_product_succeeds(client: TestClient) -> None:
+    """POST with a registered product token still returns 201.
+
+    Sanity-check that the new validator does not break the happy
+    path: a request whose product matches the registered set
+    proceeds to the existing insert + 201 flow unchanged.
+    """
+    _register_fake_k8s_connector()
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/targets",
+            json={
+                "name": "rdc-rke2-infra",
+                "product": "k8s",
+                "host": "10.10.0.1",
+            },
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 201
+    assert response.json()["product"] == "k8s"
+
+
+def test_create_target_empty_registry_skips_validation(client: TestClient) -> None:
+    """An empty connector registry does not block POST.
+
+    The validator skips when ``registered_product_tokens()`` is
+    empty -- that state means "no connectors imported" (test
+    isolation, deploy booted before eager import ran), and
+    rejecting every product in that state would be the wrong
+    default. This pins that the existing test suite's
+    create-target paths (which use ``product='ssh'`` /
+    ``product='vsphere'`` without registering anything) continue
+    to work. The lifespan calls ``_eager_import_connectors`` in
+    production, so the empty-registry branch is a
+    test-environment-only path.
+    """
+    # No connector registered — autouse fixture cleared the registry.
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/targets",
+            json={"name": "no-registry-target", "product": "ssh", "host": "10.0.0.1"},
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 201
+
+
+def test_create_target_unknown_product_lists_all_valid(client: TestClient) -> None:
+    """The 422 ``valid_products`` lists every registered product, sorted.
+
+    Multiple connectors registered → the rejected POST surfaces the
+    full set so the operator does not need a second round-trip to
+    ``GET /api/v1/connectors`` to find the right token. Sorted
+    order is the stability contract — generators that diff the
+    response body across releases stay deterministic.
+    """
+    from meho_backplane.connectors.base import Connector
+    from meho_backplane.connectors.registry import register_connector_v2
+    from meho_backplane.connectors.schemas import FingerprintResult, OperationResult
+
+    class _NoopConnector(Connector):
+        product = "placeholder"
+
+        async def probe(self, target: Any) -> ProbeResult:
+            raise NotImplementedError
+
+        async def fingerprint(self, target: Any) -> FingerprintResult:  # type: ignore[override]
+            raise NotImplementedError
+
+        async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:  # type: ignore[override]
+            raise NotImplementedError
+
+    register_connector_v2(
+        product="vmware", version="9.0", impl_id="vmware-rest", cls=_NoopConnector
+    )
+    register_connector_v2(product="k8s", version="1.x", impl_id="k8s", cls=_NoopConnector)
+    register_connector_v2(product="vault", version="1.x", impl_id="vault", cls=_NoopConnector)
+
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/targets",
+            json={
+                "name": "bad-product",
+                "product": "kubernetes",  # not registered
+                "host": "10.0.0.1",
+            },
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 422
+    detail = response.json()["detail"]
+    # Sorted, complete, no duplicates from v1-compat empty padding.
+    assert detail["valid_products"] == ["k8s", "vault", "vmware"]
+
+
+# ---------------------------------------------------------------------------
 # PATCH /api/v1/targets/{name} — update
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_connectors_registry_v2.py
+++ b/backend/tests/test_connectors_registry_v2.py
@@ -27,7 +27,7 @@ from meho_backplane.connectors import (
     register_connector,
     register_connector_v2,
 )
-from meho_backplane.connectors.registry import clear_registry
+from meho_backplane.connectors.registry import clear_registry, registered_product_tokens
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -443,3 +443,101 @@ def test_holodeck_connector_registered_under_v2_triple() -> None:
     key = ("holodeck", "9.0", "holodeck-ssh")
     assert key in snapshot
     assert snapshot[key] is HolodeckConnector
+
+
+# ---------------------------------------------------------------------------
+# registered_product_tokens — G0.14-T3 #1144
+# ---------------------------------------------------------------------------
+
+
+def test_registered_product_tokens_returns_empty_set_for_empty_registry() -> None:
+    """An empty registry → an empty product-tokens set.
+
+    Pins the source-of-truth invariant: callers (the
+    :func:`create_target` validator, the OpenAPI enum hook) can
+    distinguish "registry is empty" from "registry is populated but
+    no products advertised" via the empty set return. The empty
+    state is what tests with isolated registries see; production
+    sees a full set after the lifespan's eager-import call.
+    """
+    assert registered_product_tokens() == set()
+
+
+def test_registered_product_tokens_returns_product_axis_of_v2_registry() -> None:
+    """The token set is the union of v2 ``product`` fields.
+
+    Registering connectors under distinct ``(product, version, impl_id)``
+    triples produces one entry per *product* (the version and impl_id
+    axes are collapsed). Mirrors the resolver's "valid product"
+    judgement at probe / dispatch time.
+    """
+    register_connector_v2(
+        product="vmware",
+        version="9.0",
+        impl_id="vmware-rest",
+        cls=_FakeConnector,
+    )
+    register_connector_v2(
+        product="vmware",
+        version="7.0",
+        impl_id="vmware-pyvmomi",
+        cls=_AnotherFakeConnector,
+    )
+    register_connector_v2(
+        product="k8s",
+        version="1.x",
+        impl_id="k8s",
+        cls=_FakeConnector,
+    )
+    # Two ``vmware`` triples collapse to one entry; ``k8s`` adds a
+    # second.
+    assert registered_product_tokens() == {"vmware", "k8s"}
+
+
+def test_registered_product_tokens_includes_v1_compat_entries() -> None:
+    """v1 ``register_connector`` registrations show up under their product token.
+
+    The v1 entry point writes a ``(product, "", "")`` row into the v2
+    registry; the helper must surface the product token from that
+    padded triple just like any v2-native entry. Without this
+    contract a deploy that mixes v1- and v2-registered connectors
+    would only see the v2 set, and the v1 products would silently
+    miss the discoverability enum.
+    """
+    register_connector(product="vault", cls=_FakeConnector)
+    assert registered_product_tokens() == {"vault"}
+
+
+def test_registered_product_tokens_filters_empty_product_defensively() -> None:
+    """An empty ``product`` slug is filtered (defensive).
+
+    Direct ``_REGISTRY_V2`` mutation simulates a hypothetical bug-
+    state (the public registrars don't reject empty ``product``
+    today but no real connector ships with one). The helper drops
+    the empty entry rather than surfacing a meaningless token to
+    the operator's discoverability layer.
+    """
+    from meho_backplane.connectors.registry import _REGISTRY_V2
+
+    _REGISTRY_V2[("", "1.x", "ghost")] = _FakeConnector
+    _REGISTRY_V2[("k8s", "1.x", "k8s")] = _FakeConnector
+    assert registered_product_tokens() == {"k8s"}
+
+
+def test_registered_product_tokens_returns_fresh_set_each_call() -> None:
+    """Callers can mutate the returned set without affecting the registry.
+
+    The helper returns a fresh ``set`` so a caller that sorts /
+    extends / filters the result cannot accidentally corrupt the
+    canonical registry. Defensive return-by-value invariant for any
+    snapshot accessor over a mutable internal collection.
+    """
+    register_connector_v2(
+        product="k8s",
+        version="1.x",
+        impl_id="k8s",
+        cls=_FakeConnector,
+    )
+    snapshot = registered_product_tokens()
+    snapshot.add("phantom")
+    assert "phantom" not in registered_product_tokens()

--- a/backend/tests/test_openapi_target_product_enum.py
+++ b/backend/tests/test_openapi_target_product_enum.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural test for the ``TargetCreate.product`` OpenAPI enum hook.
+
+G0.14-T3 (#1144). The ``build_openapi_schema`` override in
+:mod:`meho_backplane.main` injects a JSON Schema ``enum`` populated from
+the live connector registry into the ``TargetCreate.product`` property
+of the generated OpenAPI document. Operators using Swagger UI or
+OpenAPI-driven generator tooling see the valid product tokens before
+they submit a typo — the *discoverability* path the task body calls
+**Option A**. The runtime 422 in
+:func:`~meho_backplane.api.v1.targets.create_target` (covered in
+``tests/test_api_v1_targets.py``) is the *recovery* path (**Option C**);
+both share the same source of truth.
+
+This test pins the three properties of the hook that matter for the
+committed contract:
+
+* The injected ``enum`` matches :func:`registered_product_tokens`
+  exactly — the source-of-truth invariant. If the two ever drifted,
+  Swagger UI would advertise a product the runtime 422 then rejected.
+* The injected ``description`` points at the discoverability route
+  and the convention doc, in line with the T11 message-shape
+  convention.
+* The override's cache invariant (re-using FastAPI's
+  ``app.openapi_schema``) — subsequent calls are O(1) identity hits.
+
+Module-level eager-import note
+------------------------------
+
+The conftest autouse fixture :func:`_isolate_global_registries`
+snapshots ``_REGISTRY_V2`` at test setup and restores it at teardown,
+so the registry state a test sees is whatever was registered *before*
+the test's autouse fixtures ran. If the eager-import call lived inside
+the test body (or its fixture), the populated state would not survive
+into subsequent tests in the same module — each test would have to
+re-import, but :func:`_eager_import_connectors` is idempotent
+(``sys.modules``-guarded), so the second test would see an empty
+registry and the assertion would fail.
+
+The pattern this file uses: call :func:`_eager_import_connectors` at
+**module import time** (before any conftest fixture runs), so by the
+time pytest collects the first test the registry is populated and the
+isolate fixture's snapshot captures the full set. Subsequent tests
+restore to that populated snapshot too. This is the same pattern
+``test_alembic_*`` and several connector tests use.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.openapi.utils import get_openapi
+
+from meho_backplane.connectors.registry import (
+    _eager_import_connectors,
+    registered_product_tokens,
+)
+from meho_backplane.main import app
+
+# Module-level eager-import so the conftest isolate fixture's snapshot
+# captures the populated registry — see the module docstring above for
+# why this lives at import time and not in a fixture body.
+_eager_import_connectors()
+
+
+@pytest.fixture
+def fresh_schema() -> dict[str, object]:
+    """Drop the cached schema and return a freshly-generated one.
+
+    The override caches on ``app.openapi_schema`` (FastAPI's own
+    contract); test setup busts the cache so each test runs against a
+    schema generated against the *current* registry.
+    """
+    app.openapi_schema = None
+    return app.openapi()
+
+
+def _product_field(schema: dict[str, object]) -> dict[str, object]:
+    components = schema["components"]
+    assert isinstance(components, dict)
+    schemas = components["schemas"]
+    assert isinstance(schemas, dict)
+    target_create = schemas["TargetCreate"]
+    assert isinstance(target_create, dict)
+    properties = target_create["properties"]
+    assert isinstance(properties, dict)
+    field = properties["product"]
+    assert isinstance(field, dict)
+    return field
+
+
+def test_openapi_product_enum_matches_registered_tokens(
+    fresh_schema: dict[str, object],
+) -> None:
+    """The generated enum matches the live registry's product set, sorted.
+
+    Pins the source-of-truth invariant: the OpenAPI enum and the
+    runtime ``unknown_product`` 422 (in
+    :func:`~meho_backplane.api.v1.targets.create_target`) read from
+    the same :func:`registered_product_tokens` helper, so they cannot
+    advertise a product the runtime then rejects.
+    """
+    field = _product_field(fresh_schema)
+    expected = sorted(registered_product_tokens())
+    assert field["enum"] == expected
+    # Sanity: the live set is non-empty (otherwise the enum hook is a
+    # no-op and the test would pass vacuously).
+    assert expected
+    # A well-known token from the real registry — guards against a
+    # future change that empties the enum while keeping it non-empty
+    # via stub entries.
+    assert "k8s" in expected
+
+
+def test_openapi_product_field_carries_discoverability_description(
+    fresh_schema: dict[str, object],
+) -> None:
+    """The injected description names the discovery route + the convention doc.
+
+    Both clauses come from the T11 message-shape convention
+    (``docs/codebase/error-message-shape.md``): the operator gets a
+    GET endpoint to enumerate the live set and a doc to read the
+    422 contract. Pin them both as substring matches so a future
+    rewording does not silently drop either reference.
+    """
+    field = _product_field(fresh_schema)
+    description = field["description"]
+    assert isinstance(description, str)
+    assert "GET /api/v1/connectors" in description
+    assert "docs/codebase/error-message-shape.md" in description
+
+
+def test_openapi_hook_caches_result() -> None:
+    """``app.openapi()`` returns the same dict object across calls.
+
+    FastAPI's default caches on ``app.openapi_schema``; the override
+    preserves the same caching contract so subsequent ``/openapi.json``
+    requests don't re-run ``get_openapi`` + the enum injection on
+    every hit. The same identity invariant is what the FastAPI docs
+    recommend (https://fastapi.tiangolo.com/how-to/extending-openapi/).
+    """
+    app.openapi_schema = None
+    first = app.openapi()
+    second = app.openapi()
+    assert first is second
+
+
+def test_openapi_default_schema_lacks_enum_without_hook() -> None:
+    """Sanity baseline: the raw ``get_openapi`` output has no enum.
+
+    Pins that the enum is exclusively the responsibility of the
+    ``build_openapi_schema`` override — if a future ``TargetCreate``
+    Pydantic model added a static ``Literal[...]`` for ``product``
+    the hook would become redundant and this test would catch it
+    so the override could be removed cleanly (rather than silently
+    doing duplicate work).
+    """
+    schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        openapi_version=app.openapi_version,
+        summary=app.summary,
+        description=app.description,
+        routes=app.routes,
+        webhooks=app.webhooks.routes,
+        tags=app.openapi_tags,
+        servers=app.servers,
+        terms_of_service=app.terms_of_service,
+        contact=app.contact,
+        license_info=app.license_info,
+        separate_input_output_schemas=app.separate_input_output_schemas,
+    )
+    field = _product_field(schema)
+    assert "enum" not in field

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -487,7 +487,7 @@
           "targets"
         ],
         "summary": "Create Target",
-        "description": "Create a new target in the requesting tenant.\n\nReturns 409 when a target with the same ``name`` already exists in\nthe tenant. The ``id`` and timestamps are generated server-side.\n``tenant_id`` is always taken from the JWT \u2014 the body cannot override\nit.",
+        "description": "Create a new target in the requesting tenant.\n\nReturns 409 when a target with the same ``name`` already exists in\nthe tenant. The ``id`` and timestamps are generated server-side.\n``tenant_id`` is always taken from the JWT \u2014 the body cannot override\nit.\n\nG0.14-T3 (#1144). The ``product`` field is validated at request time\nagainst :func:`~meho_backplane.connectors.registry.registered_product_tokens`.\nAn unknown product yields a structured 422 (see\n:func:`_build_unknown_product_detail`); the OpenAPI schema also\nexposes the enum (see :func:`meho_backplane.main.build_openapi_schema`)\nso Swagger / generator tooling surfaces the valid set before the\nrequest leaves the editor. Both layers share the same source-of-\ntruth helper so they cannot drift.\n\nValidation is skipped when the registry is empty \u2014 that state means\n\"no connectors imported\" (test isolation, or a deploy booted before\n:func:`_eager_import_connectors` ran). In production the lifespan\npopulates the registry before the first request arrives, so the\nskip branch never fires; a misregistered deploy that *did* hit it\nis recoverable via T4 #1145's PATCH-product or DELETE path.",
         "operationId": "create_target_api_v1_targets_post",
         "parameters": [
           {
@@ -10324,7 +10324,25 @@
             "type": "string",
             "maxLength": 100,
             "minLength": 1,
-            "title": "Product"
+            "title": "Product",
+            "enum": [
+              "bind9",
+              "gcloud",
+              "harbor",
+              "hetzner-robot",
+              "holodeck",
+              "k8s",
+              "nsx",
+              "pfsense",
+              "sddc-manager",
+              "vault",
+              "vcf-automation",
+              "vcf-fleet",
+              "vcf-logs",
+              "vcf-operations",
+              "vmware"
+            ],
+            "description": "Connector product slug. Must match the ``product`` field of a registered connector class; see ``GET /api/v1/connectors`` for the live list and ``docs/codebase/error-message-shape.md`` for the 422 shape returned on miss."
           },
           "host": {
             "type": "string",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -222,6 +222,25 @@ const (
 	SurfaceResultVerdictYellow SurfaceResultVerdict = "yellow"
 )
 
+// Defines values for TargetCreateProduct.
+const (
+	Bind9         TargetCreateProduct = "bind9"
+	Gcloud        TargetCreateProduct = "gcloud"
+	Harbor        TargetCreateProduct = "harbor"
+	HetznerRobot  TargetCreateProduct = "hetzner-robot"
+	Holodeck      TargetCreateProduct = "holodeck"
+	K8s           TargetCreateProduct = "k8s"
+	Nsx           TargetCreateProduct = "nsx"
+	Pfsense       TargetCreateProduct = "pfsense"
+	SddcManager   TargetCreateProduct = "sddc-manager"
+	Vault         TargetCreateProduct = "vault"
+	VcfAutomation TargetCreateProduct = "vcf-automation"
+	VcfFleet      TargetCreateProduct = "vcf-fleet"
+	VcfLogs       TargetCreateProduct = "vcf-logs"
+	VcfOperations TargetCreateProduct = "vcf-operations"
+	Vmware        TargetCreateProduct = "vmware"
+)
+
 // Defines values for TopologyDiffEntryChangeKind.
 const (
 	Created TopologyDiffEntryChangeKind = "created"
@@ -2671,10 +2690,15 @@ type TargetCreate struct {
 	Notes           *string                 `json:"notes"`
 	Port            *int                    `json:"port"`
 	PreferredImplId *string                 `json:"preferred_impl_id"`
-	Product         string                  `json:"product"`
-	SecretRef       *string                 `json:"secret_ref"`
-	VpnRequired     *bool                   `json:"vpn_required,omitempty"`
+
+	// Product Connector product slug. Must match the ``product`` field of a registered connector class; see ``GET /api/v1/connectors`` for the live list and ``docs/codebase/error-message-shape.md`` for the 422 shape returned on miss.
+	Product     TargetCreateProduct `json:"product"`
+	SecretRef   *string             `json:"secret_ref"`
+	VpnRequired *bool               `json:"vpn_required,omitempty"`
 }
+
+// TargetCreateProduct Connector product slug. Must match the “product“ field of a registered connector class; see “GET /api/v1/connectors“ for the live list and “docs/codebase/error-message-shape.md“ for the 422 shape returned on miss.
+type TargetCreateProduct string
 
 // TargetSummary Short shape for list endpoints.
 //

--- a/docs/codebase/error-message-shape.md
+++ b/docs/codebase/error-message-shape.md
@@ -242,6 +242,7 @@ specifically referenced).
 | `POST /api/v1/agent-principals` 503 (Keycloak admin not configured) | `{"detail":"keycloak_admin_not_configured"}` | partial — names the domain but not the env vars or the doc | T7 #1148 (symmetrize with the `/ui/auth/login` shape) |
 | `POST /api/v1/agent-principals` 502 (Keycloak admin runtime error) | `{"detail":"keycloak_admin_error"}` | intentionally bare (upstream failure; remediation is identical regardless of upstream code; structured log carries detail) | — |
 | `/api/v1/auth-config` features visibility (whether agent-runtime is configured) | implicit — the agent-runtime configuration state is not surfaced anywhere on `/ready` or `/api/v1/auth-config` (signal 17) | non-compliant *as a discoverability gap* — when the surface emits `keycloak_admin_not_configured` the operator has no way to discover the feature was supposed to be configured | T7 #1148 (`/ready` features block with `configured: bool` + `missing_env`) |
+| `POST /api/v1/targets` 422 (`unknown_product` — typo at create time) | structured `detail` with `kind="unknown_product"`, `product`, `valid_products[]`, `message` (`_build_unknown_product_detail` in `api/v1/targets.py`); also exposed proactively as a JSON Schema enum on `TargetCreate.product` via `build_openapi_schema` in `main.py` | compliant (structured + discoverable) — sibling **Option A** (enum in OpenAPI) and **Option C** (recovery-time 422) from the task body; T4 #1145 ships the same shape at PATCH time | T3 #1144 (this PR) |
 
 The table is the audit artefact's deliverable, not a separate
 spreadsheet. Adding new error surfaces against the convention
@@ -304,7 +305,15 @@ set).
   `/ui/auth/login`) + `backend/src/meho_backplane/ui/auth/flow.py`
   (`MISSING_CLIENT_SECRET_DETAIL` constant).
 - `backend/src/meho_backplane/api/v1/targets.py` (`/probe` 501
-  message).
+  message; `POST /api/v1/targets` `unknown_product` 422 via
+  `_build_unknown_product_detail`, T3 #1144).
+- `backend/src/meho_backplane/connectors/registry.py` —
+  `registered_product_tokens()`, the canonical source-of-truth for
+  the `TargetCreate.product` enum and the validators in
+  `create_target` (POST) + `update_target` (PATCH, T4 #1145).
+- `backend/src/meho_backplane/main.py` — `build_openapi_schema`
+  hook that injects the live product enum into the OpenAPI
+  document so generator tooling surfaces it (T3 #1144 Option A).
 - `backend/src/meho_backplane/api/v1/connectors_ingest.py` (REST
   ingest 422 + 4xx error shape via shared builders).
 - `backend/src/meho_backplane/operations/ingest/error_envelopes.py`
@@ -350,6 +359,16 @@ set).
   the operator cannot discover *what* needs to be configured to
   satisfy a `*_not_configured` error. T7 #1148 adds the features
   block.
+- **Signal 5** — `POST /api/v1/targets` accepts any `product`
+  string but the resolver matches on exact connector-class tokens,
+  so a single typo (`'kubernetes'` instead of `'k8s'`) silently
+  creates a permanent broken row. T3 #1144 ships boot-time enum
+  generation (Option A: JSON Schema enum on `TargetCreate.product`
+  populated from the live registry, surfaces in Swagger /
+  OpenAPI-driven tooling) plus a structured 422 with
+  `valid_products: [...]` on miss (Option C: recovery-time net).
+  Both layers share `registered_product_tokens()` as the
+  source-of-truth so they cannot disagree.
 
 ## References
 


### PR DESCRIPTION
## Summary

- Closes the "single typo at target creation silently creates a permanent
  broken row" hole from signal 5 of `claude-rdc-hetzner-dc#697`. An
  operator who POSTed `product='kubernetes'` (the friendly common name)
  when the registered connector advertises `product='k8s'` previously
  got 201, then `501 no_connector` on probe and no recovery path
  (signal 6, fixed by sibling T4 #1145).
- Ships **both** gold-standard layers from the issue body:
  - **Option A** (discoverability): a JSON Schema enum on
    `TargetCreate.product` populated from the live connector registry,
    injected by a `build_openapi_schema` override on `main.app.openapi`.
    Swagger UI / OpenAPI-driven generator tooling surfaces the valid
    set before the request leaves the editor.
  - **Option C** (recovery): a structured 422 with `kind`, `product`,
    `valid_products`, and a `message` naming the remediation step +
    the convention doc. Shape complies with the T11 #1141
    `docs/codebase/error-message-shape.md` convention.
- Both layers read from the same `registered_product_tokens()` helper
  in `connectors/registry.py` so they cannot drift. The OpenAPI
  override calls `_eager_import_connectors()` defensively so the
  snapshot script under `cli/api/snapshot-openapi.py` (which doesn't
  run the FastAPI lifespan) renders the correct enum -- the
  committed `cli/api/openapi.json` snapshot is updated accordingly.

## Design choices

**Source-of-truth helper.** A new `registered_product_tokens() -> set[str]`
in `connectors/registry.py` returns the union of v2 registry product
keys, drained of the empty-string placeholder. T4 #1145 currently has
an inline `_registered_products()` in `api/v1/targets.py`; once both PRs
land it will consolidate against this helper (note in T4's PR
description; minor follow-up since T4 ships first per the wave order).

**Empty-registry skip in the runtime validator.** The validator skips
when `registered_product_tokens()` is empty -- that state means "no
connectors imported" (test isolation, or a deploy booted before
`_eager_import_connectors` ran). In production the lifespan populates
the registry before the first request arrives, so the skip branch never
fires; a misregistered deploy that *did* hit it is recoverable via T4
#1145's PATCH-product or DELETE path.

**OpenAPI override eager-import.** The snapshot script under
`cli/api/snapshot-openapi.py` imports `app` and calls `app.openapi()`
directly without running the ASGI lifespan, so without the defensive
`_eager_import_connectors()` call in the override the committed
snapshot would render an empty enum. The eager import is idempotent
(modules already in `sys.modules` are a no-op) so calling it from the
override does not double-register.

**Error shape compliance.** The new 422 complies with the T11 #1141
convention codified in `docs/codebase/error-message-shape.md`:
structured `detail` with `kind="unknown_product"`, machine-actionable
`product` + `valid_products` fields, and a `message` naming the
offending value + remediation + a doc reference. The convention's
audit table is extended with one new row marking the new compliant
surface (T4's PATCH-time 422 is added in #1164's PR; the doc note in
this PR mentions T4 ships the same shape).

## Test plan

- [x] `uv run ruff check src/ tests/` -- clean
- [x] `uv run ruff format --check src/ tests/` -- 672 formatted
- [x] `uv run mypy src/` -- Success: no issues found in 330 source files
- [x] `pytest tests/test_api_v1_targets.py tests/test_connectors_registry_v2.py
  tests/test_openapi_target_product_enum.py tests/test_app_starts.py` --
  **66 passed**
- [x] Targeted sweep: `pytest tests/test_api_v1_targets.py
  tests/test_api_v1_targets_discover.py tests/test_api_v1_targets_import.py
  tests/test_targets_audit_integration.py tests/test_targets_fingerprint.py
  tests/test_connectors_registry.py tests/test_connectors_registry_v2.py
  tests/test_openapi_target_product_enum.py tests/test_app_starts.py
  tests/test_alembic_probe.py tests/test_operations_dispatcher.py` --
  **164 passed**
- [x] Cross-area sweep: `pytest tests/test_api_v1_targets.py
  tests/test_api_v1_health.py tests/test_api_v1_operations.py
  tests/test_api_v1_topology.py tests/test_api_audit_routes.py
  tests/test_app_starts.py tests/test_audit_middleware.py
  tests/test_audit_actor_sub.py tests/test_mcp_tools_topology.py` --
  **166 passed**
- [x] OpenAPI snapshot regenerated (`make snapshot-openapi`); diff shows
  the `TargetCreate.product.enum` array + description added
- [x] `code-quality.py --diff`: **0 blockers**, 5 warnings (all
  pre-existing -- file size + function size on neighbouring
  pre-existing code)

### Acceptance-criteria mapping

| Criterion | Evidence |
|---|---|
| Either Option A or Option C is implemented; ideally both | **Both shipped.** Option A: `build_openapi_schema` override in `main.py` injects the enum into `TargetCreate.product`. Option C: `create_target` raises 422 with structured `_build_unknown_product_detail` |
| If Option A: enum regenerated when new connectors register; OpenAPI snapshot reflects it | The override reads `registered_product_tokens()` on every uncached call; the snapshot script regenerates the snapshot via the same hook. Snapshot diff in `cli/api/openapi.json` shows the 15 currently-registered products |
| POST with `product="kubernetes"` returns 422 with `valid_products` listing `[k8s, ...]` AND does not create the row | `test_create_target_unknown_product_returns_422` + `test_create_target_unknown_product_does_not_create_row` -- both passed |
| POST with `product="k8s"` still works | `test_create_target_valid_product_succeeds` -- passed |
| If Option C: response shape complies with T11's convention | The detail carries `kind="unknown_product"`, structured `product` + `valid_products`, and a human-readable `message` naming the value + remediation + doc reference; `test_create_target_unknown_product_returns_422` asserts each clause |
| Python (ruff + mypy + pytest) green | All three gates clean (see test plan) |

## Out of scope

- The DELETE / PATCH lifecycle gap for already-created bad-product
  rows -- T4 #1145 (open as PR #1164, lands in same wave).
- Consolidating T4's inline `_registered_products()` against this PR's
  `registered_product_tokens()` helper -- follow-up after both land
  (Wave 5 cleanup; note in T4's PR description).
- Renaming connector `product` tokens to match common names
  (`"kubernetes"` instead of `"k8s"`) -- settled architecture, not in
  scope.
- Mechanizing the error-message-shape audit table -- stretch goal per
  T11 #1141; per-surface compliance is the discipline today.

## Adjacent findings

- The `create_target` function is now 64 lines (within the 60-line warn
  threshold by 4 lines, well under the 100-line block threshold) --
  acceptable; the validator is two lines, the rest is pre-existing.
- `main.py` has been over the 600-line block limit for a while; my
  change adds 51 lines (including the new helper). Pre-existing; not
  this PR's scope.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1144

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-26)

Addressed review findings from
`.claude/auto/review-results/pr-1166-iter-1.json`:

- **B1** `0502d94` -- regenerated `cli/internal/api/client.gen.go`
  via `cd cli && make snapshot-openapi && make generate`. Adds the
  `TargetCreateProduct` typedef, 15 named constants, and retypes
  `TargetCreate.Product` from `string` to `TargetCreateProduct` to
  match the new `enum` block in `cli/api/openapi.json`. Unblocks the
  `CLI API snapshot freshness` CI lane. No behavior change in the Go
  client beyond stronger typing at the struct field; verified
  diff-clean via re-running `make snapshot-openapi && make generate`
  in the worktree, plus `go build ./...`, `go vet ./...`, and
  `go test ./internal/api/...` all green.

<!-- auto-implement-issue: continue, iteration 2 -->
