### PR TITLE
feat(memory-ui): G10.4-T2 create modal + scope-promotion flow (G5.2 promote + audit)

### DIFF
--- a/backend/src/meho_backplane/ui/routes/memory/_modal_shared.py
+++ b/backend/src/meho_backplane/ui/routes/memory/_modal_shared.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Shared helpers + constants for the Memory UI create + promote modals.
+
+Initiative #341 (G10.4 Memory UI), Task #878 (T2). The create modal
+(:mod:`~meho_backplane.ui.routes.memory.create`) and the promote modal
+(:mod:`~meho_backplane.ui.routes.memory.promote`) share:
+
+* The scope-selector vocabulary -- :func:`writable_scopes_for`,
+  :func:`scope_label`.
+* The CSRF cookie set + the common template context -- both modals
+  re-mint the chassis double-submit token on every render so a
+  freshly-issued cookie lines up with the form's header echo.
+* The form-field sizing constants -- :data:`TAGS_MAX_LENGTH`,
+  :data:`TARGET_NAME_MAX_LENGTH`.
+
+Pulled out of a hypothetical combined module so neither
+:mod:`create` nor :mod:`promote` exceeds the chassis-wide ~600-line
+cap, and so future shared modal surfaces (bulk delete, bulk extend,
+...) can plug in without re-importing across sibling modules.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+from fastapi.responses import HTMLResponse
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.memory import MemoryRbacResolver, MemoryScope
+from meho_backplane.memory.schemas import TARGET_SCOPED
+from meho_backplane.ui.auth.middleware import UISessionContext
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME
+from meho_backplane.ui.routes.memory.views import SLUG_MAX_LENGTH
+
+__all__ = [
+    "TAGS_MAX_LENGTH",
+    "TARGET_NAME_MAX_LENGTH",
+    "build_common_template_context",
+    "parse_tags",
+    "scope_label",
+    "set_csrf_cookie",
+    "writable_scopes_for",
+]
+
+
+#: Maximum length of the comma-separated tags input the create modal
+#: accepts. The substrate has no fixed cap (``metadata.tags`` is a
+#: JSON array on the row), but bounding the wire shape protects the
+#: form-body parse against a paste-from-clipboard accident. 1 KiB is
+#: well above the "couple of tags per memory" working-set the
+#: consumer-needs.md §G5 surface uses.
+TAGS_MAX_LENGTH: Final[int] = 1024
+
+
+#: Maximum length of the operator-supplied ``target_name`` form field.
+#: Mirrors the slug cap so the create-modal input shape mirrors the
+#: ``/api/v1/memory`` POST body shape (``RememberBody.target_name``
+#: there carries the same cap).
+TARGET_NAME_MAX_LENGTH: Final[int] = SLUG_MAX_LENGTH
+
+
+#: Comma-with-optional-whitespace splitter for the ``tags`` form
+#: field. The substrate stores tags as a JSON array of distinct
+#: strings; the create modal accepts the human shape (``a, b, c``)
+#: and the helper below normalises to the substrate shape.
+_TAGS_SPLIT_RE: Final[re.Pattern[str]] = re.compile(r"\s*,\s*")
+
+
+def parse_tags(raw: str | None) -> list[str]:
+    """Split the comma-separated ``tags`` form field into the substrate shape.
+
+    Empty / whitespace-only entries are dropped; duplicates are
+    de-duplicated while preserving first-seen order so the operator's
+    typing order survives the round-trip. Returns an empty list
+    (never ``None``) when *raw* is missing or empty so the metadata
+    builder doesn't need a separate ``None`` branch.
+    """
+    if not raw or not raw.strip():
+        return []
+    seen: set[str] = set()
+    result: list[str] = []
+    for part in _TAGS_SPLIT_RE.split(raw.strip()):
+        cleaned = part.strip()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        result.append(cleaned)
+    return result
+
+
+def writable_scopes_for(operator: Operator) -> list[MemoryScope]:
+    """Return the scopes *operator* may write to, in deterministic order.
+
+    Consults the :class:`MemoryRbacResolver` ``can_write`` matrix one
+    scope at a time. The order matches the ``MemoryScope`` enum
+    declaration so the create modal renders the same scope list every
+    render (no Python ``set`` ordering surprises).
+
+    ``USER_TARGET`` and ``TARGET`` are listed only when the operator
+    can write *some* row at that scope -- the resolver requires a
+    ``target_name`` for those scopes but the *scope-selector* shape is
+    "list the scopes the operator can in principle write to, then
+    require ``target_name`` at submit". Passing a placeholder
+    ``target_name="x"`` for the matrix check is the conservative
+    posture: the resolver's role check fires identically for
+    ``target_name=None`` and ``target_name="x"``; only the service-
+    level required-field guard distinguishes them.
+    """
+    rbac = MemoryRbacResolver()
+    candidates: list[MemoryScope] = []
+    for scope in MemoryScope:
+        target_name = "selector-probe" if scope in TARGET_SCOPED else None
+        if rbac.can_write(operator, scope, target_name):
+            candidates.append(scope)
+    return candidates
+
+
+def scope_label(scope: MemoryScope) -> str:
+    """Translate a scope to its human-readable label for the selector."""
+    return {
+        MemoryScope.USER: "User",
+        MemoryScope.USER_TENANT: "User x Tenant",
+        MemoryScope.USER_TARGET: "User x Target",
+        MemoryScope.TENANT: "Tenant",
+        MemoryScope.TARGET: "Target",
+    }[scope]
+
+
+def set_csrf_cookie(response: HTMLResponse, csrf_token: str) -> None:
+    """Mirror the dashboard's CSRF cookie posture for state-changing pages.
+
+    Local copy of :func:`meho_backplane.ui.routes.memory.views._set_csrf_cookie`
+    because the views module's helper is module-private; centralising
+    it across the memory modal surfaces here keeps the cookie attributes
+    aligned across create + promote without a third-party import.
+    """
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=csrf_token,
+        httponly=False,
+        secure=True,
+        samesite="strict",
+        path="/ui",
+    )
+
+
+def build_common_template_context(
+    session_ctx: UISessionContext,
+    csrf_token: str,
+) -> dict[str, object]:
+    """Build the dict shared across every create / promote template render."""
+    return {
+        "page_title": "Memory",
+        "active_surface": "memory",
+        "ready": False,
+        "operator_sub": session_ctx.operator_sub,
+        "csrf_token": csrf_token,
+    }

--- a/backend/src/meho_backplane/ui/routes/memory/create.py
+++ b/backend/src/meho_backplane/ui/routes/memory/create.py
@@ -1,0 +1,298 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Memory UI create-modal render + submit helpers.
+
+Initiative #341 (G10.4 Memory UI), Task #878 (T2). Split out of a
+hypothetical combined ``create_promote.py`` module so neither the
+create nor the promote concern alone exceeds the chassis-wide
+~600-line cap. Shared helpers live in
+:mod:`~meho_backplane.ui.routes.memory._modal_shared`; the sibling
+promote module lives in
+:mod:`~meho_backplane.ui.routes.memory.promote`.
+
+Routes served from this module:
+
+* **``GET /ui/memory/create``** -- HTMX-loaded ``<dialog>`` with an
+  RBAC-filtered scope selector, slug input (optional, auto-generated
+  when blank), Markdown body textarea + debounced HTMX preview wiring,
+  ``expires_at`` picker, comma-separated tags input.
+* **``POST /ui/memory/create``** -- submit handler. Calls
+  :meth:`MemoryService.remember` and returns 204 with
+  ``HX-Redirect: /ui/memory`` so HTMX navigates back to the list with
+  the new row visible.
+* **``POST /ui/memory/preview``** -- debounced server-side Markdown
+  preview. Returns the same ``<article>`` shape :file:`_body_view.html`
+  uses so the preview pane and the detail view render identically.
+
+Audit row contract
+------------------
+
+The chassis :class:`~meho_backplane.audit.AuditMiddleware` writes one
+row per request iff ``operator_sub`` is bound to the structlog
+contextvars at the time the audit hook fires. The UI session
+middleware does not bind those contextvars (it only sets the
+per-request :class:`UISessionContext` on ``request.state``); the
+create handler binds them explicitly -- same shape the
+``/api/v1/memory`` REST handler uses -- so the chassis audit row
+commits with the canonical ``memory.remember`` op id and the
+G6.1-T3 publish-on-write broadcast hook fires under the right class.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import structlog
+from fastapi import HTTPException, Request, status
+from fastapi.responses import HTMLResponse
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.memory import MemoryScope, MemoryService, PermissionDeniedError
+from meho_backplane.memory.schemas import TARGET_SCOPED
+from meho_backplane.ui.auth.middleware import UISessionContext
+from meho_backplane.ui.csrf import mint_csrf_token
+from meho_backplane.ui.routes.memory._modal_shared import (
+    TAGS_MAX_LENGTH,
+    TARGET_NAME_MAX_LENGTH,
+    build_common_template_context,
+    parse_tags,
+    scope_label,
+    set_csrf_cookie,
+    writable_scopes_for,
+)
+from meho_backplane.ui.routes.memory.render import render_markdown
+from meho_backplane.ui.routes.memory.views import (
+    BODY_MAX_LENGTH,
+    SLUG_MAX_LENGTH,
+    validate_slug,
+)
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["create_entry", "render_body_preview", "render_create_modal"]
+
+_log = structlog.get_logger(__name__)
+
+
+async def render_create_modal(
+    request: Request,
+    session_ctx: UISessionContext,
+    operator: Operator,
+) -> HTMLResponse:
+    """Render the HTMX-loaded create modal fragment.
+
+    Scope selector is filtered via :func:`writable_scopes_for` so the
+    operator never sees a scope they can't write to (defence-in-depth:
+    the service-layer matrix re-checks on submit). The modal carries
+    its own CSRF token via the page-level ``hx-headers`` directive on
+    the form -- the route also sets the cookie so the chassis
+    double-submit pair lines up.
+    """
+    writable = writable_scopes_for(operator)
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    context: dict[str, object] = {
+        **build_common_template_context(session_ctx, csrf_token),
+        "writable_scopes": [
+            {"value": scope.value, "label": scope_label(scope)} for scope in writable
+        ],
+        "target_scoped_values": [scope.value for scope in TARGET_SCOPED],
+        "body_max_length": BODY_MAX_LENGTH,
+        "slug_max_length": SLUG_MAX_LENGTH,
+        "tags_max_length": TAGS_MAX_LENGTH,
+        "target_name_max_length": TARGET_NAME_MAX_LENGTH,
+    }
+    response = get_templates().TemplateResponse(request, "memory/_create_modal.html", context)
+    set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def render_body_preview(
+    request: Request,
+    *,
+    body: str,
+) -> HTMLResponse:
+    """Render the debounced server-side Markdown preview fragment.
+
+    Returns the same ``<article>`` shape :file:`_body_view.html` uses
+    so the preview pane's styling matches the detail page's rendered
+    body. Empty body returns an empty preview (no error -- the
+    operator's still typing) so the UX stays smooth across the
+    initial keystrokes.
+    """
+    if not body or not body.strip():
+        placeholder = (
+            '<article id="memory-create-preview" '
+            'class="prose prose-sm max-w-none bg-base-100 '
+            'border-base-300 border rounded-box p-4 opacity-50">'
+            "Preview will render here as you type."
+            "</article>"
+        )
+        return HTMLResponse(placeholder)
+    if len(body) > BODY_MAX_LENGTH:
+        # Defence-in-depth before passing the body to the markdown
+        # renderer -- the textarea ``maxlength`` is the UX gate but
+        # a paste-from-clipboard can blow past it.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"body too large (max {BODY_MAX_LENGTH} chars)",
+        )
+    rendered = render_markdown(body)
+    context = {"body_html": rendered}
+    return get_templates().TemplateResponse(request, "memory/_body_preview.html", context)
+
+
+def _bind_audit_for_remember(
+    *,
+    session_ctx: UISessionContext,
+    scope: MemoryScope,
+) -> None:
+    """Bind contextvars so the chassis audit + broadcast hooks fire.
+
+    Same shape ``/api/v1/memory`` (REST) uses -- ``operator_sub`` +
+    ``tenant_id`` so the chassis :class:`AuditMiddleware` commits a
+    row at all; ``audit_op_id`` / ``audit_op_class`` / ``audit_scope``
+    so the row carries the canonical op id and the broadcast hook
+    classifies it correctly.
+    """
+    structlog.contextvars.bind_contextvars(
+        operator_sub=session_ctx.operator_sub,
+        tenant_id=str(session_ctx.tenant_id),
+        audit_op_id="memory.remember",
+        audit_op_class="write",
+        audit_scope=scope.value,
+    )
+
+
+def _validate_create_body(body: str) -> None:
+    """Surface the two body-shape guards as 422 errors."""
+    if not body or not body.strip():
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="body must not be empty",
+        )
+    if len(body) > BODY_MAX_LENGTH:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"body too large (max {BODY_MAX_LENGTH} chars)",
+        )
+
+
+def _normalize_slug_or_422(slug: str | None) -> str | None:
+    """Validate the operator-supplied slug; empty string -> auto-generate.
+
+    Empty / whitespace slug returns ``None`` so the service layer
+    auto-generates one. A non-empty slug is validated via
+    :func:`validate_slug` (which raises 404 to mirror recall's info-
+    leak avoidance); on a write path 422 is the spec-correct surface
+    (malformed input, not "not found"), so the 404 is rewritten to 422
+    in this branch.
+    """
+    if slug is None or not slug.strip():
+        return None
+    try:
+        validate_slug(slug)
+    except HTTPException:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="slug contains characters outside the safe set",
+        ) from None
+    return slug
+
+
+async def _persist_create(
+    *,
+    operator: Operator,
+    scope: MemoryScope,
+    body: str,
+    slug: str | None,
+    metadata: dict[str, object],
+    expires_at: datetime | None,
+    target_name: str | None,
+) -> str:
+    """Call ``MemoryService.remember`` and map service errors to HTTPException.
+
+    Returns the persisted slug. Centralised so the
+    :func:`create_entry` handler keeps its control flow flat.
+    """
+    service = MemoryService()
+    try:
+        entry = await service.remember(
+            operator=operator,
+            scope=scope,
+            body=body,
+            slug=slug,
+            metadata=metadata,
+            expires_at=expires_at,
+            target_name=target_name,
+        )
+    except PermissionDeniedError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"permission_denied: {exc.reason}",
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=str(exc),
+        ) from exc
+    return entry.slug
+
+
+async def create_entry(
+    request: Request,
+    session_ctx: UISessionContext,
+    operator: Operator,
+    *,
+    scope: MemoryScope,
+    body: str,
+    slug: str | None,
+    tags_raw: str | None,
+    expires_at: datetime | None,
+    target_name: str | None,
+) -> HTMLResponse:
+    """Persist a new memory and return an HX-Redirect to the list.
+
+    Submit handler for ``POST /ui/memory/create``. Builds the
+    ``metadata.tags`` list from the comma-separated form input,
+    delegates the persist to :meth:`MemoryService.remember`, and
+    returns a 204 with ``HX-Redirect: /ui/memory`` so HTMX navigates
+    back to the list (the new row will be the first card because
+    ``list_memories`` orders by ``updated_at desc``).
+
+    Same redirect shape T1's :func:`delete_entry` returns -- the
+    detail-page modal flow uses ``hx-target="body"`` so a fragment-
+    only response would destroy the chassis chrome. ``HX-Redirect``
+    is the canonical HTMX pattern for post-mutation navigation
+    (https://htmx.org/headers/hx-redirect/).
+    """
+    _validate_create_body(body)
+    resolved_slug = _normalize_slug_or_422(slug)
+
+    tags = parse_tags(tags_raw)
+    metadata: dict[str, object] = {"tags": tags} if tags else {}
+
+    _bind_audit_for_remember(session_ctx=session_ctx, scope=scope)
+
+    persisted_slug = await _persist_create(
+        operator=operator,
+        scope=scope,
+        body=body,
+        slug=resolved_slug,
+        metadata=metadata,
+        expires_at=expires_at,
+        target_name=target_name,
+    )
+
+    structlog.contextvars.bind_contextvars(audit_slug=persisted_slug)
+    _log.info(
+        "ui_memory_create",
+        tenant_id=str(session_ctx.tenant_id),
+        operator_sub=session_ctx.operator_sub,
+        scope=scope.value,
+        slug=persisted_slug,
+    )
+    del request  # not consumed -- HX-Redirect needs no request context.
+    return HTMLResponse(
+        status_code=status.HTTP_204_NO_CONTENT,
+        headers={"HX-Redirect": "/ui/memory"},
+    )

--- a/backend/src/meho_backplane/ui/routes/memory/promote.py
+++ b/backend/src/meho_backplane/ui/routes/memory/promote.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Memory UI scope-promotion modal render + submit helpers.
+
+Initiative #341 (G10.4 Memory UI), Task #878 (T2). Split out of a
+hypothetical combined ``create_promote.py`` module so neither the
+create nor the promote concern alone exceeds the chassis-wide
+~600-line cap. Shared helpers live in
+:mod:`~meho_backplane.ui.routes.memory._modal_shared`; the sibling
+create module lives in :mod:`~meho_backplane.ui.routes.memory.create`.
+
+Routes served from this module:
+
+* **``GET /ui/memory/<scope>/<slug>/promote``** -- HTMX-loaded
+  ``<dialog>`` with the legal target scopes the operator can promote
+  to (derived from :data:`PROMOTE_TARGETS_BY_SOURCE`). Terminal source
+  scopes (``tenant`` / ``target``) return 400; the detail page does
+  not render a Promote button for those scopes either.
+* **``POST /ui/memory/<scope>/<slug>/promote``** -- submit handler.
+  Calls :meth:`MemoryService.promote` (G5.2 #374) and returns 204
+  with ``HX-Redirect: /ui/memory/<target-scope>/<slug>`` so HTMX
+  navigates to the new detail page.
+
+Idempotency
+-----------
+
+The promote service is idempotent (a re-promotion to the same target
+scope returns the existing target row, no insert, no duplicate audit
+side-effect). The UI layer trusts that contract -- a double-click on
+the Confirm button redirects to the same URL twice; no extra row,
+no 409 conflict.
+
+Audit row contract
+------------------
+
+Per Initiative #341 / Task #878, the promotion **writes an audit
+row** so G8 forensic queries can reconstruct who promoted what when.
+The chassis :class:`~meho_backplane.audit.AuditMiddleware` writes
+one row per request iff ``operator_sub`` is bound to the structlog
+contextvars at the time the audit hook fires. The promote handler
+binds ``operator_sub`` + ``tenant_id`` + ``audit_op_id="memory.promote"``
++ ``audit_op_class="write"`` + ``audit_scope`` + ``audit_slug`` +
+``audit_promotion_target_scope`` -- same shape the
+``/api/v1/memory/{scope}/{slug}/promote`` REST handler uses.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+import structlog
+from fastapi import HTTPException, Request, status
+from fastapi.responses import HTMLResponse
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.memory import (
+    InvalidPromotionStepError,
+    MemoryScope,
+    MemoryService,
+    PermissionDeniedError,
+)
+from meho_backplane.memory.schemas import TARGET_SCOPED
+from meho_backplane.ui.auth.middleware import UISessionContext
+from meho_backplane.ui.csrf import mint_csrf_token
+from meho_backplane.ui.routes.memory._modal_shared import (
+    TARGET_NAME_MAX_LENGTH,
+    build_common_template_context,
+    scope_label,
+    set_csrf_cookie,
+)
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["PROMOTE_TARGETS_BY_SOURCE", "promote_entry", "render_promote_modal"]
+
+_log = structlog.get_logger(__name__)
+
+
+#: Legal source-to-targets map for the promotion modal. Mirrors
+#: :data:`meho_backplane.memory.rbac._PROMOTION_LADDER` but expressed
+#: as ``source -> [targets]`` so the modal template can iterate the
+#: legal next steps for a memory at *source* scope without re-deriving
+#: the ladder on the template side. The two ladders the rbac module
+#: encodes (``user -> user-tenant -> tenant`` and
+#: ``user -> user-target -> target``) collapse to the union of legal
+#: target scopes per source:
+#:
+#: * ``user`` -> ``user-tenant`` or ``user-target`` (operator picks
+#:   the axis).
+#: * ``user-tenant`` -> ``tenant`` (operator ladder).
+#: * ``user-target`` -> ``target`` (target ladder).
+#: * ``tenant`` / ``target`` -> no further widening; the modal does
+#:   not render a Promote button at all (the route returns 400 if a
+#:   caller still POSTs).
+PROMOTE_TARGETS_BY_SOURCE: Final[dict[MemoryScope, tuple[MemoryScope, ...]]] = {
+    MemoryScope.USER: (MemoryScope.USER_TENANT, MemoryScope.USER_TARGET),
+    MemoryScope.USER_TENANT: (MemoryScope.TENANT,),
+    MemoryScope.USER_TARGET: (MemoryScope.TARGET,),
+    MemoryScope.TENANT: (),
+    MemoryScope.TARGET: (),
+}
+
+
+async def render_promote_modal(
+    request: Request,
+    session_ctx: UISessionContext,
+    operator: Operator,
+    *,
+    scope: MemoryScope,
+    slug: str,
+) -> HTMLResponse:
+    """Render the HTMX-loaded promote modal fragment.
+
+    Loads the source entry under read RBAC (404 on missing OR not
+    visible -- info-leak avoidance) and lists the legal target scopes
+    via :data:`PROMOTE_TARGETS_BY_SOURCE`. When the source scope is
+    terminal (``tenant`` / ``target``), the route returns 400 -- the
+    detail page only renders the Promote button when the source
+    scope has at least one legal target.
+    """
+    service = MemoryService()
+    entry = await service.recall(operator=operator, scope=scope, slug=slug, target_name=None)
+    if entry is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="memory_not_found")
+
+    legal_targets = PROMOTE_TARGETS_BY_SOURCE.get(entry.scope, ())
+    if not legal_targets:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"scope {entry.scope.value!r} has no broader scope to promote to "
+                "(tenant + target are terminal on their ladders)"
+            ),
+        )
+
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    context: dict[str, object] = {
+        **build_common_template_context(session_ctx, csrf_token),
+        "entry": {
+            "scope": entry.scope.value,
+            "slug": entry.slug,
+            "target_name": entry.target_name,
+        },
+        "legal_targets": [
+            {"value": target.value, "label": scope_label(target)} for target in legal_targets
+        ],
+        "target_scoped_values": [s.value for s in TARGET_SCOPED],
+        "target_name_max_length": TARGET_NAME_MAX_LENGTH,
+    }
+    response = get_templates().TemplateResponse(request, "memory/_promote_modal.html", context)
+    set_csrf_cookie(response, csrf_token)
+    return response
+
+
+def _bind_audit_for_promote(
+    *,
+    session_ctx: UISessionContext,
+    source_scope: MemoryScope,
+    slug: str,
+    target_scope: MemoryScope,
+) -> None:
+    """Bind contextvars so the promote audit row commits under the canonical op id.
+
+    Same shape ``/api/v1/memory/{scope}/{slug}/promote`` (REST) uses
+    -- ``audit_op_id`` is ``"memory.promote"`` (G5.2 contract);
+    ``audit_promotion_target_scope`` distinguishes the row from a
+    regular ``memory.remember`` write for G8 forensic queries.
+    """
+    structlog.contextvars.bind_contextvars(
+        operator_sub=session_ctx.operator_sub,
+        tenant_id=str(session_ctx.tenant_id),
+        audit_op_id="memory.promote",
+        audit_op_class="write",
+        audit_scope=source_scope.value,
+        audit_slug=slug,
+        audit_promotion_target_scope=target_scope.value,
+    )
+
+
+def _map_promote_error(exc: Exception) -> HTTPException:
+    """Translate a service-raised promotion error to the right HTTPException.
+
+    Mirrors the dispatch :func:`meho_backplane.api.v1.memory.promote`
+    uses so the REST + UI surfaces produce identical statuses on
+    matching inputs:
+
+    * :class:`InvalidPromotionStepError` -> 400 (ladder-illegal pair).
+    * :class:`PermissionDeniedError` -> 403 (canonical detail
+      ``insufficient_promotion_authority``).
+    * :class:`NotImplementedError` -> 501 (G0.3 #224 per-target ACL gap).
+    * :class:`ValueError` starting ``promote_target_conflict`` -> 409;
+      other ValueErrors -> 422.
+    """
+    if isinstance(exc, InvalidPromotionStepError):
+        return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    if isinstance(exc, PermissionDeniedError):
+        return HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="insufficient_promotion_authority",
+        )
+    if isinstance(exc, NotImplementedError):
+        return HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail=f"not_implemented: {exc}",
+        )
+    if isinstance(exc, ValueError):
+        message = str(exc)
+        if message.startswith("promote_target_conflict"):
+            return HTTPException(status_code=status.HTTP_409_CONFLICT, detail=message)
+        return HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=message,
+        )
+    # Defensive: caller filters by exception type. Re-raise so the
+    # chassis ``ServerErrorMiddleware`` builds the canonical 500.
+    raise exc
+
+
+async def promote_entry(
+    request: Request,
+    session_ctx: UISessionContext,
+    operator: Operator,
+    *,
+    source_scope: MemoryScope,
+    source_slug: str,
+    target_scope: MemoryScope,
+    target_name: str | None,
+) -> HTMLResponse:
+    """Promote one memory and HX-Redirect to the new (broader-scope) detail page.
+
+    Submit handler for ``POST /ui/memory/<scope>/<slug>/promote``.
+    Delegates ladder + authority checks to G5.2's
+    :func:`assert_can_promote` (via :meth:`MemoryService.promote`)
+    and surfaces the result as an HX-Redirect to the new detail URL.
+
+    Idempotency contract is inherited from :meth:`MemoryService.promote`:
+    a second click on Confirm with the same target redirects to the
+    same URL because the service returns the existing target row (no
+    insert, no conflict).
+    """
+    _bind_audit_for_promote(
+        session_ctx=session_ctx,
+        source_scope=source_scope,
+        slug=source_slug,
+        target_scope=target_scope,
+    )
+    service = MemoryService()
+    try:
+        entry = await service.promote(
+            operator=operator,
+            source_scope=source_scope,
+            source_slug=source_slug,
+            target_scope=target_scope,
+            move=False,
+            target_name=target_name,
+        )
+    except (
+        InvalidPromotionStepError,
+        PermissionDeniedError,
+        NotImplementedError,
+        ValueError,
+    ) as exc:
+        raise _map_promote_error(exc) from exc
+
+    if entry is None:
+        # 404 across "absent" and "not visible" preserves the
+        # tenant-boundary info-leak avoidance contract the REST
+        # promote route holds.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="memory_not_found",
+        )
+
+    redirect_url = f"/ui/memory/{entry.scope.value}/{entry.slug}"
+    _log.info(
+        "ui_memory_promote",
+        tenant_id=str(session_ctx.tenant_id),
+        operator_sub=session_ctx.operator_sub,
+        source_scope=source_scope.value,
+        target_scope=target_scope.value,
+        slug=source_slug,
+    )
+    del request  # not consumed -- HX-Redirect needs no request context.
+    return HTMLResponse(
+        status_code=status.HTTP_204_NO_CONTENT,
+        headers={"HX-Redirect": redirect_url},
+    )

--- a/backend/src/meho_backplane/ui/routes/memory/routes.py
+++ b/backend/src/meho_backplane/ui/routes/memory/routes.py
@@ -9,7 +9,8 @@ scope-promotion on top. The route handlers in this module are thin
 wrappers: parse FastAPI params, resolve the session / operator
 dependency, and hand off to the render functions in
 :mod:`~meho_backplane.ui.routes.memory.views` (T1 routes) or
-:mod:`~meho_backplane.ui.routes.memory.create_promote` (T2 routes).
+:mod:`~meho_backplane.ui.routes.memory.create` +
+:mod:`~meho_backplane.ui.routes.memory.promote` (T2 routes).
 Splitting registration here from render logic keeps each module
 under the chassis-wide ~600-line + ~100-line caps and gives the
 render helpers a unit-testable seam (no FastAPI :class:`Request`

--- a/backend/src/meho_backplane/ui/routes/memory/routes.py
+++ b/backend/src/meho_backplane/ui/routes/memory/routes.py
@@ -3,17 +3,22 @@
 
 """Memory UI route registration -- maps HTTP verbs to the render helpers.
 
-Initiative #341 (G10.4 Memory UI), Task #877 (T1). The route handlers
-in this module are thin wrappers: parse FastAPI params, resolve the
-session / operator dependency, and hand off to the render functions
-in :mod:`~meho_backplane.ui.routes.memory.views`. Splitting the
-registration here from the render logic in ``views`` keeps each module
+Initiative #341 (G10.4 Memory UI). Task #877 (T1) shipped the read +
+edit + delete + tag-filter surface; Task #878 (T2) layers create +
+scope-promotion on top. The route handlers in this module are thin
+wrappers: parse FastAPI params, resolve the session / operator
+dependency, and hand off to the render functions in
+:mod:`~meho_backplane.ui.routes.memory.views` (T1 routes) or
+:mod:`~meho_backplane.ui.routes.memory.create_promote` (T2 routes).
+Splitting registration here from render logic keeps each module
 under the chassis-wide ~600-line + ~100-line caps and gives the
 render helpers a unit-testable seam (no FastAPI :class:`Request`
 fixture required for projection logic).
 
 Route inventory
 ---------------
+
+T1 (#877) -- read + edit + delete + tag autocomplete:
 
 * ``GET /ui/memory`` -- list page or HTMX card-list fragment.
 * ``GET /ui/memory/tags`` -- HTMX datalist for the tag autocomplete.
@@ -22,12 +27,30 @@ Route inventory
 * ``PATCH /ui/memory/<scope>/<slug>`` -- HTMX save the edited body.
 * ``DELETE /ui/memory/<scope>/<slug>`` -- HTMX delete + re-render the list.
 
+T2 (#878) -- create + scope-promotion:
+
+* ``GET /ui/memory/create`` -- HTMX-loaded create modal fragment.
+* ``POST /ui/memory/create`` -- submit handler; calls ``MemoryService.remember``.
+* ``POST /ui/memory/preview`` -- HTMX-debounced server-side Markdown preview.
+* ``GET /ui/memory/<scope>/<slug>/promote`` -- HTMX-loaded promote modal fragment.
+* ``POST /ui/memory/<scope>/<slug>/promote`` -- submit handler; calls G5.2 promote.
+
 Tenant + RBAC + info-leak posture are documented on the render
 functions themselves; this module owns only the path / method /
 dependency wiring.
+
+Route registration order is **load-bearing for the static-prefix
+verbs** -- ``/ui/memory/create`` MUST register before
+``/ui/memory/{scope}/{slug}`` because FastAPI matches the first
+route whose path template fits, and ``{scope}`` would otherwise
+consume the literal ``"create"`` token. ``/ui/memory/tags`` already
+relies on the same ordering for T1; the create + preview routes
+inherit the convention.
 """
 
 from __future__ import annotations
+
+from datetime import datetime
 
 from fastapi import APIRouter, Depends, Form, Query, Request
 from fastapi.responses import HTMLResponse
@@ -35,7 +58,17 @@ from fastapi.responses import HTMLResponse
 from meho_backplane.auth.operator import Operator
 from meho_backplane.memory import MemoryScope
 from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.routes.memory._modal_shared import (
+    TAGS_MAX_LENGTH,
+    TARGET_NAME_MAX_LENGTH,
+)
+from meho_backplane.ui.routes.memory.create import (
+    create_entry,
+    render_body_preview,
+    render_create_modal,
+)
 from meho_backplane.ui.routes.memory.operator import resolve_ui_operator
+from meho_backplane.ui.routes.memory.promote import promote_entry, render_promote_modal
 from meho_backplane.ui.routes.memory.views import (
     BODY_MAX_LENGTH,
     SCOPE_ALL,
@@ -124,26 +157,186 @@ async def _delete_handler(
     return await delete_entry(request, session_ctx, operator, scope=scope, slug=slug)
 
 
+# ---------------------------------------------------------------------------
+# T2 (#878) -- create modal + scope-promotion handlers
+# ---------------------------------------------------------------------------
+
+
+async def _create_modal_handler(
+    request: Request,
+    session_ctx: UISessionContext = _require_session_dep,
+    operator: Operator = _resolve_operator_dep,
+) -> HTMLResponse:
+    """``GET /ui/memory/create`` -- HTMX-loaded create modal fragment."""
+    return await render_create_modal(request, session_ctx, operator)
+
+
+async def _create_submit_handler(
+    request: Request,
+    scope: MemoryScope = Form(...),
+    body: str = Form(..., max_length=BODY_MAX_LENGTH),
+    slug: str | None = Form(default=None, max_length=SLUG_MAX_LENGTH),
+    tags: str | None = Form(default=None, max_length=TAGS_MAX_LENGTH),
+    expires_at: datetime | None = Form(default=None),
+    target_name: str | None = Form(default=None, max_length=TARGET_NAME_MAX_LENGTH),
+    session_ctx: UISessionContext = _require_session_dep,
+    operator: Operator = _resolve_operator_dep,
+) -> HTMLResponse:
+    """``POST /ui/memory/create`` -- create one memory via the service.
+
+    Returns 204 + ``HX-Redirect: /ui/memory`` so HTMX navigates back
+    to the list. The form-encoded body shape mirrors the
+    ``RememberBody`` Pydantic model on ``/api/v1/memory``: scope is
+    a ``MemoryScope`` enum value, body is required, slug + tags +
+    expires_at + target_name are optional. CSRF is enforced by the
+    chassis :class:`CSRFMiddleware` before this handler runs.
+
+    ``tags`` is a comma-separated string parsed server-side into a
+    list; the form input is one ``<input>`` rather than five (the
+    typical UX shape for the v0.2 surface). ``expires_at`` is
+    parsed by FastAPI's :class:`datetime` form coercion from the
+    ISO-8601 string a ``<input type="datetime-local">`` produces.
+    """
+    return await create_entry(
+        request,
+        session_ctx,
+        operator,
+        scope=scope,
+        body=body,
+        slug=slug,
+        tags_raw=tags,
+        expires_at=expires_at,
+        target_name=target_name,
+    )
+
+
+async def _preview_handler(
+    request: Request,
+    body: str = Form(default="", max_length=BODY_MAX_LENGTH),
+    session_ctx: UISessionContext = _require_session_dep,
+) -> HTMLResponse:
+    """``POST /ui/memory/preview`` -- debounced server-side Markdown preview.
+
+    Triggered by ``hx-trigger="keyup changed delay:300ms"`` on the
+    create-modal body textarea. Returns the rendered Markdown
+    wrapped in the same ``<article>`` shape :file:`_body_view.html`
+    uses so the preview pane and the detail view render identically.
+
+    Session is required (the chassis CSRF middleware would already
+    have rejected an anonymous POST, but the session dep adds the
+    audit-trail anchor; ``_require_session_dep`` runs the standard
+    redirect-to-login on a missing cookie).
+    """
+    del session_ctx  # used only to gate access; no per-render context.
+    return await render_body_preview(request, body=body)
+
+
+async def _promote_modal_handler(
+    request: Request,
+    scope: MemoryScope,
+    slug: str,
+    session_ctx: UISessionContext = _require_session_dep,
+    operator: Operator = _resolve_operator_dep,
+) -> HTMLResponse:
+    """``GET /ui/memory/<scope>/<slug>/promote`` -- HTMX-loaded promote modal."""
+    validate_slug(slug)
+    return await render_promote_modal(request, session_ctx, operator, scope=scope, slug=slug)
+
+
+async def _promote_submit_handler(
+    request: Request,
+    scope: MemoryScope,
+    slug: str,
+    to: MemoryScope = Form(...),
+    target_name: str | None = Form(default=None, max_length=TARGET_NAME_MAX_LENGTH),
+    session_ctx: UISessionContext = _require_session_dep,
+    operator: Operator = _resolve_operator_dep,
+) -> HTMLResponse:
+    """``POST /ui/memory/<scope>/<slug>/promote`` -- promote and HX-Redirect.
+
+    Delegates ladder + authority checks to G5.2's
+    :func:`assert_can_promote` via :meth:`MemoryService.promote`.
+    Idempotent re-run returns the same target row -- the redirect
+    URL is the same on first promote and on a re-promote, matching
+    the G5.2 contract.
+    """
+    validate_slug(slug)
+    return await promote_entry(
+        request,
+        session_ctx,
+        operator,
+        source_scope=scope,
+        source_slug=slug,
+        target_scope=to,
+        target_name=target_name,
+    )
+
+
+def _register_static_prefix_routes(router: APIRouter) -> None:
+    """Wire the static-prefix routes -- ``/ui/memory/tags``, ``/ui/memory/create``,
+    ``/ui/memory/preview`` -- onto *router*.
+
+    Registration order is **load-bearing**: these static-prefix routes
+    MUST register before :func:`_register_parametrized_routes`. FastAPI
+    matches the first route whose path template fits, and a request to
+    ``/ui/memory/create`` would otherwise be routed to
+    ``/ui/memory/{scope}/{slug}`` with ``scope="create"`` -- a 422
+    response from the ``MemoryScope`` enum validator, instead of the
+    intended modal fragment.
+
+    The ``ui_memory_create_*`` + ``ui_memory_preview`` names are picked
+    so a future ``url_for(...)`` from a template resolves cleanly; the
+    same convention :func:`_register_parametrized_routes` uses.
+    """
+    router.add_api_route(
+        "/ui/memory/tags",
+        _tags_handler,
+        methods=["GET"],
+        name="ui_memory_tags",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/memory/create",
+        _create_modal_handler,
+        methods=["GET"],
+        name="ui_memory_create_modal",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/memory/create",
+        _create_submit_handler,
+        methods=["POST"],
+        name="ui_memory_create_submit",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/memory/preview",
+        _preview_handler,
+        methods=["POST"],
+        name="ui_memory_preview",
+        response_class=HTMLResponse,
+    )
+
+
 def _register_read_routes(router: APIRouter) -> None:
-    """Wire the GET routes (list / tags / detail / edit-form) onto *router*.
+    """Wire the parametrised GET routes (list / detail / edit-form) onto *router*.
 
     Split out of :func:`build_memory_router` so the factory body stays
     under the chassis-wide ~100-line cap. ``ui_memory_*`` names match
     the per-handler closures so a future ``url_for(...)`` from a
     template resolves cleanly.
+
+    Must register **after** :func:`_register_static_prefix_routes` --
+    the static-prefix routes (``/ui/memory/tags``, ``/ui/memory/create``,
+    ``/ui/memory/preview``) carry literal tokens that would otherwise
+    bind to the ``{scope}`` parameter and 422 against
+    :class:`MemoryScope` validation.
     """
     router.add_api_route(
         "/ui/memory",
         _list_handler,
         methods=["GET"],
         name="ui_memory_list",
-        response_class=HTMLResponse,
-    )
-    router.add_api_route(
-        "/ui/memory/tags",
-        _tags_handler,
-        methods=["GET"],
-        name="ui_memory_tags",
         response_class=HTMLResponse,
     )
     router.add_api_route(
@@ -160,15 +353,25 @@ def _register_read_routes(router: APIRouter) -> None:
         name="ui_memory_edit_form",
         response_class=HTMLResponse,
     )
+    router.add_api_route(
+        "/ui/memory/{scope}/{slug}/promote",
+        _promote_modal_handler,
+        methods=["GET"],
+        name="ui_memory_promote_modal",
+        response_class=HTMLResponse,
+    )
 
 
 def _register_write_routes(router: APIRouter) -> None:
-    """Wire the PATCH + DELETE routes onto *router*.
+    """Wire the PATCH + DELETE + promote-submit routes onto *router*.
 
     Split out of :func:`build_memory_router` for the same reason as
     :func:`_register_read_routes`. The PATCH route shares the
     ``/ui/memory/{scope}/{slug}`` path with the detail GET; FastAPI
     distinguishes by method so registration order is not load-bearing.
+    The promote-submit route lives here (not in the create-promote
+    group) because its parametrised path means it can register after
+    the static-prefix routes without any ordering hazard.
     """
     router.add_api_route(
         "/ui/memory/{scope}/{slug}",
@@ -184,6 +387,13 @@ def _register_write_routes(router: APIRouter) -> None:
         name="ui_memory_delete",
         response_class=HTMLResponse,
     )
+    router.add_api_route(
+        "/ui/memory/{scope}/{slug}/promote",
+        _promote_submit_handler,
+        methods=["POST"],
+        name="ui_memory_promote_submit",
+        response_class=HTMLResponse,
+    )
 
 
 def build_memory_router() -> APIRouter:
@@ -192,8 +402,14 @@ def build_memory_router() -> APIRouter:
     Factory function (not a module-level constant) so a test app can
     construct parallel routers without sharing route state -- mirrors
     the broadcast / topology / dashboard convention.
+
+    Registration order is load-bearing for the static-prefix routes
+    (``/ui/memory/tags``, ``/ui/memory/create``, ``/ui/memory/preview``):
+    they must register before the parametrised routes so a literal
+    ``"create"`` token in the URL doesn't bind to ``{scope}``.
     """
     router = APIRouter(tags=["ui-memory"])
+    _register_static_prefix_routes(router)
     _register_read_routes(router)
     _register_write_routes(router)
     return router

--- a/backend/src/meho_backplane/ui/templates/memory/_body_preview.html
+++ b/backend/src/meho_backplane/ui/templates/memory/_body_preview.html
@@ -1,0 +1,29 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Server-rendered Markdown preview fragment for the Memory create
+  modal (Initiative #341 Task #878). Returned by the
+  ``POST /ui/memory/preview`` route on every debounced keystroke
+  from the body textarea.
+
+  The element id ``#memory-create-preview`` matches the HTMX swap
+  target the textarea declares; per the HTMX docs
+  (https://htmx.org/attributes/hx-swap/), ``outerHTML`` replaces the
+  element including its ID so subsequent swaps land on the same
+  target. The empty-state version of the preview (no body typed yet)
+  is rendered inline by ``_create_modal.html`` and shares the id.
+
+  ``body_html`` is wrapped in :class:`markupsafe.Markup` by
+  :func:`render_markdown`, so Jinja's autoescape leaves it as-is.
+  The renderer is constructed with ``html=False`` so raw HTML in the
+  body renders as escaped text (the same posture the detail body
+  view holds).
+-#}
+<article
+  id="memory-create-preview"
+  class="prose prose-sm max-w-none bg-base-100 border-base-300 border rounded-box p-4"
+  aria-label="Memory body preview"
+>
+  {{ body_html }}
+</article>

--- a/backend/src/meho_backplane/ui/templates/memory/_create_modal.html
+++ b/backend/src/meho_backplane/ui/templates/memory/_create_modal.html
@@ -1,0 +1,236 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  HTMX-loaded create modal for the Memory surface (Initiative #341
+  Task #878). Loaded into ``#memory-modal-container`` on the list
+  page by the "+" button's ``hx-get`` to ``/ui/memory/create``. The
+  inserted dialog is opened by an inline ``showModal()`` call wired
+  through HTMX's ``after-swap`` callback so the operator sees the
+  modal without an extra click.
+
+  Form posts to ``POST /ui/memory/create`` which returns 204 with
+  ``HX-Redirect: /ui/memory`` -- HTMX then reloads the full list
+  page so the new row appears.
+
+  CSRF posture: the page-level ``hx-headers`` directive on
+  ``index.html`` echoes the CSRF token; HTMX inherits the header
+  through the inserted form, so the modal form does not need its own
+  ``hx-headers`` override. The route also sets the cookie on every
+  modal render so a freshly-issued token lines up with the cookie.
+
+  RBAC posture: the scope selector is server-filtered via
+  :func:`writable_scopes_for` so the operator only sees scopes they
+  can write to. The service layer re-checks ``can_write`` on submit
+  -- this list is the UX gate, not the security gate. A read-only
+  operator hitting this route gets an empty list (no scopes
+  selectable); the route's ``Depends(resolve_ui_operator)`` does not
+  in itself enforce a non-read-only role, so we render the empty
+  state explicitly rather than 403'ing on render. (The submit would
+  403 anyway via the service-layer ``PermissionDeniedError`` -> 403
+  mapping.)
+
+  Target name field: conditionally shown via a tiny inline script
+  that toggles ``display`` based on the selected scope. The list of
+  target-scoped scope values is rendered into a ``data-`` attribute
+  so the script reads it from the DOM without re-hardcoding the
+  enum on the client.
+-#}
+<dialog id="memory-create-modal" class="modal modal-open">
+  <div class="modal-box max-w-3xl">
+    <h3 class="font-semibold text-lg" id="memory-create-modal-title">Create memory</h3>
+
+    {% if not writable_scopes %}
+      <div class="alert alert-warning my-3" role="status">
+        <span>
+          Your current role does not allow writing any memory scope.
+          Ask your tenant admin for elevated permissions.
+        </span>
+      </div>
+      <div class="modal-action">
+        <form method="dialog">
+          <button class="btn btn-sm" type="submit">Close</button>
+        </form>
+      </div>
+    {% else %}
+      <form
+        id="memory-create-form"
+        hx-post="/ui/memory/create"
+        hx-target="this"
+        hx-swap="none"
+        hx-disabled-elt="find button[type=submit]"
+        data-target-scoped-values="{{ target_scoped_values | join(',') }}"
+        class="space-y-3 py-2"
+        aria-labelledby="memory-create-modal-title"
+      >
+        <label class="form-control">
+          <span class="label-text">Scope</span>
+          <select
+            name="scope"
+            class="select select-bordered select-sm"
+            required
+            data-action="scope-select"
+          >
+            {% for scope in writable_scopes %}
+              <option value="{{ scope.value }}">{{ scope.label }}</option>
+            {% endfor %}
+          </select>
+        </label>
+
+        <label
+          class="form-control"
+          data-target-name-row
+          style="display: none;"
+        >
+          <span class="label-text">Target name</span>
+          <input
+            type="text"
+            name="target_name"
+            maxlength="{{ target_name_max_length }}"
+            class="input input-bordered input-sm"
+            placeholder="Required for user-target and target scopes"
+            aria-describedby="memory-create-target-name-hint"
+          />
+          <span id="memory-create-target-name-hint" class="text-xs opacity-60 mt-1">
+            The connector / target this memory binds to.
+          </span>
+        </label>
+
+        <label class="form-control">
+          <span class="label-text">Slug <span class="opacity-60">(optional)</span></span>
+          <input
+            type="text"
+            name="slug"
+            maxlength="{{ slug_max_length }}"
+            class="input input-bordered input-sm font-mono"
+            placeholder="Auto-generated when omitted"
+            pattern="[A-Za-z0-9_\-\.]*"
+            aria-describedby="memory-create-slug-hint"
+          />
+          <span id="memory-create-slug-hint" class="text-xs opacity-60 mt-1">
+            Letters, digits, hyphen, underscore, dot. Leave blank for a generated slug.
+          </span>
+        </label>
+
+        <div class="grid gap-3 md:grid-cols-2">
+          <label class="form-control">
+            <span class="label-text">Body (Markdown)</span>
+            <textarea
+              name="body"
+              required
+              maxlength="{{ body_max_length }}"
+              class="textarea textarea-bordered min-h-[16rem] font-mono text-sm"
+              hx-post="/ui/memory/preview"
+              hx-trigger="keyup changed delay:300ms"
+              hx-target="#memory-create-preview"
+              hx-swap="outerHTML"
+              hx-include="this"
+              aria-label="Memory body in Markdown"
+              placeholder="# Heading
+
+Markdown body. Bare URLs (https://example.com) are linkified."
+            ></textarea>
+            <span class="text-xs opacity-60 mt-1">
+              Up to {{ body_max_length }} characters. Server-side preview updates as you type.
+            </span>
+          </label>
+
+          <div class="form-control">
+            <span class="label-text">Preview</span>
+            <article
+              id="memory-create-preview"
+              class="prose prose-sm max-w-none bg-base-100 border-base-300 border rounded-box p-4 opacity-50"
+              aria-label="Memory body preview"
+            >
+              Preview will render here as you type.
+            </article>
+          </div>
+        </div>
+
+        <div class="grid gap-3 md:grid-cols-2">
+          <label class="form-control">
+            <span class="label-text">Expires at <span class="opacity-60">(optional)</span></span>
+            <input
+              type="datetime-local"
+              name="expires_at"
+              class="input input-bordered input-sm"
+              aria-describedby="memory-create-expires-hint"
+            />
+            <span id="memory-create-expires-hint" class="text-xs opacity-60 mt-1">
+              Leave blank to use the scope's default TTL.
+            </span>
+          </label>
+
+          <label class="form-control">
+            <span class="label-text">Tags <span class="opacity-60">(comma-separated)</span></span>
+            <input
+              type="text"
+              name="tags"
+              maxlength="{{ tags_max_length }}"
+              class="input input-bordered input-sm"
+              placeholder="wine, preference, runbook"
+              aria-describedby="memory-create-tags-hint"
+            />
+            <span id="memory-create-tags-hint" class="text-xs opacity-60 mt-1">
+              Stored as a JSON list on the row; useful for the tag filter.
+            </span>
+          </label>
+        </div>
+
+        <div class="modal-action">
+          <button
+            type="button"
+            class="btn btn-sm btn-ghost"
+            data-action="cancel-create"
+            onclick="document.getElementById('memory-create-modal').close()"
+          >
+            Cancel
+          </button>
+          <button type="submit" class="btn btn-sm btn-primary" data-action="create-submit">
+            Create
+          </button>
+        </div>
+      </form>
+    {% endif %}
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+</dialog>
+
+{# Tiny inline script: toggle the target_name row's visibility when
+   the scope selector changes. Scoped to this modal -- the script
+   reads the scope-to-targetable list off the form's
+   ``data-target-scoped-values`` attribute so the enum is not
+   re-hardcoded on the client. Pulled inline (not into a separate
+   <script src>) because the modal is HTMX-injected and a fresh
+   request for the JS file would race the showModal() call. #}
+<script>
+  (function () {
+    var modal = document.getElementById('memory-create-modal');
+    if (!modal) return;
+    var form = modal.querySelector('#memory-create-form');
+    if (!form) return;
+    var scopedRaw = form.getAttribute('data-target-scoped-values') || '';
+    var scopedSet = new Set(scopedRaw.split(',').filter(Boolean));
+    var select = form.querySelector('[data-action="scope-select"]');
+    var row = form.querySelector('[data-target-name-row]');
+    var targetInput = row ? row.querySelector('input[name="target_name"]') : null;
+    function toggle() {
+      if (!select || !row) return;
+      var requiresTarget = scopedSet.has(select.value);
+      row.style.display = requiresTarget ? '' : 'none';
+      if (targetInput) {
+        if (requiresTarget) {
+          targetInput.setAttribute('required', 'required');
+        } else {
+          targetInput.removeAttribute('required');
+        }
+      }
+    }
+    if (select) {
+      select.addEventListener('change', toggle);
+      toggle();
+    }
+  }());
+</script>

--- a/backend/src/meho_backplane/ui/templates/memory/_promote_modal.html
+++ b/backend/src/meho_backplane/ui/templates/memory/_promote_modal.html
@@ -1,0 +1,143 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  HTMX-loaded scope-promotion modal for the Memory detail surface
+  (Initiative #341 Task #878). Loaded into ``#memory-modal-container``
+  on the detail page by the "Promote to broader scope" button's
+  ``hx-get`` to ``/ui/memory/<scope>/<slug>/promote``. The inserted
+  dialog opens immediately because ``class="modal modal-open"`` is
+  set on the ``<dialog>`` element (DaisyUI v5 convention).
+
+  Form posts to ``POST /ui/memory/<scope>/<slug>/promote`` which on
+  success returns 204 with ``HX-Redirect: /ui/memory/<target-scope>/<slug>``
+  -- HTMX then loads the new detail page for the broader-scope row.
+
+  Idempotency: G5.2's promote service is idempotent
+  (:meth:`MemoryService.promote` returns the existing target row
+  when the operator re-runs the same promotion). A double-click on
+  Confirm therefore redirects to the same URL twice; no duplicate
+  audit row is written by the chassis ``AuditMiddleware`` because the
+  second submit is a fresh request (one row per request), but the
+  service-level effect is a no-op (no duplicate insert, no
+  ``promote_target_conflict`` 409).
+
+  RBAC posture: the legal-targets list is server-filtered by
+  :data:`PROMOTE_TARGETS_BY_SOURCE` (the ladder constant lives in
+  ``create_promote.py``). G5.2's :func:`assert_can_promote` re-checks
+  the role + ladder at submit time; an operator whose role doesn't
+  qualify for the chosen target lands a 403 with detail
+  ``insufficient_promotion_authority``.
+-#}
+<dialog id="memory-promote-modal" class="modal modal-open">
+  <div class="modal-box">
+    <h3 class="font-semibold text-lg" id="memory-promote-modal-title">
+      Promote memory to broader scope
+    </h3>
+    <p class="text-sm opacity-80 py-2">
+      Promoting widens the visibility of
+      <span class="font-mono">{{ entry.scope }}/{{ entry.slug }}</span>.
+      Promotion clears the row's TTL (broader memories are intentional
+      and long-lived). The operation is idempotent -- re-promoting to
+      the same scope is a no-op.
+    </p>
+
+    <form
+      id="memory-promote-form"
+      hx-post="/ui/memory/{{ entry.scope | urlencode }}/{{ entry.slug | urlencode }}/promote"
+      hx-target="this"
+      hx-swap="none"
+      hx-disabled-elt="find button[type=submit]"
+      data-target-scoped-values="{{ target_scoped_values | join(',') }}"
+      class="space-y-3"
+      aria-labelledby="memory-promote-modal-title"
+    >
+      <label class="form-control">
+        <span class="label-text">Promote to</span>
+        <select
+          name="to"
+          class="select select-bordered select-sm"
+          required
+          data-action="promote-target-select"
+        >
+          {% for target in legal_targets %}
+            <option value="{{ target.value }}">{{ target.label }}</option>
+          {% endfor %}
+        </select>
+      </label>
+
+      <label
+        class="form-control"
+        data-target-name-row
+        style="display: none;"
+      >
+        <span class="label-text">Target name</span>
+        <input
+          type="text"
+          name="target_name"
+          value="{{ entry.target_name or '' }}"
+          maxlength="{{ target_name_max_length }}"
+          class="input input-bordered input-sm"
+          placeholder="Required for user-target and target promotions"
+          aria-describedby="memory-promote-target-name-hint"
+        />
+        <span id="memory-promote-target-name-hint" class="text-xs opacity-60 mt-1">
+          The connector / target the broadened memory should bind to.
+          Inherited from the source row when promoting along the target
+          ladder; editable here for the user-to-user-target step.
+        </span>
+      </label>
+
+      <div class="modal-action">
+        <button
+          type="button"
+          class="btn btn-sm btn-ghost"
+          data-action="cancel-promote"
+          onclick="document.getElementById('memory-promote-modal').close()"
+        >
+          Cancel
+        </button>
+        <button type="submit" class="btn btn-sm btn-primary" data-action="promote-submit">
+          Promote
+        </button>
+      </div>
+    </form>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+</dialog>
+
+{# Tiny inline script: toggle target_name row visibility based on
+   the selected target scope. Same pattern as the create modal --
+   scope set is rendered into a data-attribute so the script reads
+   the enum from the DOM rather than re-encoding it on the client. #}
+<script>
+  (function () {
+    var modal = document.getElementById('memory-promote-modal');
+    if (!modal) return;
+    var form = modal.querySelector('#memory-promote-form');
+    if (!form) return;
+    var scopedRaw = form.getAttribute('data-target-scoped-values') || '';
+    var scopedSet = new Set(scopedRaw.split(',').filter(Boolean));
+    var select = form.querySelector('[data-action="promote-target-select"]');
+    var row = form.querySelector('[data-target-name-row]');
+    var targetInput = row ? row.querySelector('input[name="target_name"]') : null;
+    function toggle() {
+      if (!select || !row) return;
+      var requiresTarget = scopedSet.has(select.value);
+      row.style.display = requiresTarget ? '' : 'none';
+      if (targetInput) {
+        if (requiresTarget) {
+          targetInput.setAttribute('required', 'required');
+        } else {
+          targetInput.removeAttribute('required');
+        }
+      }
+    }
+    if (select) {
+      select.addEventListener('change', toggle);
+      toggle();
+    }
+  }());
+</script>

--- a/backend/src/meho_backplane/ui/templates/memory/_promote_modal.html
+++ b/backend/src/meho_backplane/ui/templates/memory/_promote_modal.html
@@ -24,7 +24,7 @@
 
   RBAC posture: the legal-targets list is server-filtered by
   :data:`PROMOTE_TARGETS_BY_SOURCE` (the ladder constant lives in
-  ``create_promote.py``). G5.2's :func:`assert_can_promote` re-checks
+  ``promote.py``). G5.2's :func:`assert_can_promote` re-checks
   the role + ladder at submit time; an operator whose role doesn't
   qualify for the chosen target lands a 403 with detail
   ``insufficient_promotion_authority``.

--- a/backend/src/meho_backplane/ui/templates/memory/detail.html
+++ b/backend/src/meho_backplane/ui/templates/memory/detail.html
@@ -79,6 +79,25 @@
             >
               Edit
             </button>
+            {# T2 #878: Promote button. Only rendered when the source
+               scope has at least one legal target on the promotion
+               ladder (terminal scopes ``tenant`` / ``target`` show no
+               button). The button loads the HTMX promote modal into
+               the dedicated container; G5.2's ``assert_can_promote``
+               re-checks role + ladder at submit. #}
+            {% if entry.scope in ("user", "user-tenant", "user-target") %}
+              <button
+                type="button"
+                class="btn btn-sm btn-accent"
+                hx-get="/ui/memory/{{ entry.scope | urlencode }}/{{ entry.slug | urlencode }}/promote"
+                hx-target="#memory-modal-container"
+                hx-swap="innerHTML"
+                data-action="open-promote-modal"
+                aria-label="Promote memory to broader scope"
+              >
+                Promote
+              </button>
+            {% endif %}
             <button
               type="button"
               class="btn btn-sm btn-ghost"
@@ -112,6 +131,14 @@
 
   {# Body slot -- HTMX swap target for Edit / Save / Cancel. #}
   {% include "memory/_body_view.html" %}
+
+  {# T2 #878: Mount point for HTMX-loaded modals (promote). The
+     empty wrapper persists across HTMX swaps so the modal markup
+     always has a stable target. The delete-confirm modal below
+     stays inline because it's small and always-relevant; the
+     promote modal is HTMX-loaded because the legal-targets list is
+     server-derived from the row's source scope. #}
+  <div id="memory-modal-container"></div>
 
   {# Delete-confirm modal -- DaisyUI's ``<dialog>`` element + Alpine
      for click-outside dismissal. The confirm button issues the

--- a/backend/src/meho_backplane/ui/templates/memory/index.html
+++ b/backend/src/meho_backplane/ui/templates/memory/index.html
@@ -42,10 +42,34 @@
         Operator + tenant + target memories across the 5 scopes.
       </p>
     </div>
-    <div class="text-sm opacity-70">
-      <span aria-live="polite">{{ entry_count }} memor{{ "y" if entry_count == 1 else "ies" }}</span>
+    <div class="flex items-center gap-3">
+      <span class="text-sm opacity-70" aria-live="polite">
+        {{ entry_count }} memor{{ "y" if entry_count == 1 else "ies" }}
+      </span>
+      {# T2 #878: "+" button opens the HTMX-loaded create modal. The
+         button targets ``#memory-modal-container`` so the modal slots
+         into a dedicated DOM mount point rather than the cards grid;
+         the inserted ``<dialog>`` opens via its ``modal-open`` class
+         (DaisyUI v5 convention) so no client-side ``showModal()``
+         call is required. #}
+      <button
+        type="button"
+        class="btn btn-sm btn-primary"
+        hx-get="/ui/memory/create"
+        hx-target="#memory-modal-container"
+        hx-swap="innerHTML"
+        data-action="open-create-modal"
+        aria-label="Create memory"
+      >
+        + Create
+      </button>
     </div>
   </header>
+
+  {# T2 #878: Mount point for HTMX-loaded modals (create, future
+     bulk actions). The empty wrapper persists across HTMX swaps so
+     the modal markup always has a stable target. #}
+  <div id="memory-modal-container"></div>
 
   {# ---------- Scope tabs ---------- #}
   <nav

--- a/backend/tests/test_ui_memory_create_promote.py
+++ b/backend/tests/test_ui_memory_create_promote.py
@@ -1,0 +1,1170 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the Memory UI create modal + scope-promotion flow.
+
+Initiative #341 (G10.4 Memory UI), Task #878 (G10.4-T2). The
+acceptance criteria on issue #878 are:
+
+* "+" opens the create modal; the scope selector shows only writable
+  scopes (RBAC); submit POSTs ``/api/v1/memory``; modal closes + list
+  updates; the debounced server-side Markdown preview works.
+* Scope-promotion modal: operator promotes own user-scoped ->
+  user x tenant; ``tenant_admin`` -> tenant; calls G5.2 promote; the
+  promotion writes an audit row (assert).
+* Promotion is idempotent (re-promote to the same scope is a no-op,
+  per G5.2).
+* CSRF enforced; cross-user/cross-tenant isolation holds.
+
+The suite mirrors :mod:`backend.tests.test_ui_memory_list`'s fixture
+shape: ``_build_app`` wires a minimal FastAPI app with the chassis
+middlewares (incl. :class:`AuditMiddleware` for the audit-row
+assertion) + the BFF auth router + the UI router; ``_seed_session_sync``
+writes a ``web_session`` row carrying a real Keycloak-minted access
+token; ``_authenticated_client`` returns a TestClient + a respx mock
++ the CSRF token. Helpers diverge from the T1 suite in two ways:
+
+1. The audit-row assertion (only in the promote tests) queries the
+   ``audit_log`` table directly after the request commits so the
+   "promotion writes an audit row" AC is provable, not implied.
+2. The embedding service is mocked for every create + promote test
+   because :meth:`MemoryService.remember` (called by the create
+   handler) and :meth:`MemoryService.promote` (called by the
+   promote handler -- which inserts the target row via
+   :func:`index_document`) both trigger an embedding pass on the
+   new body.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+import warnings
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import patch as _patch
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from meho_backplane.audit import AuditMiddleware
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import AuditLog, Document, Tenant
+from meho_backplane.memory._internal import (
+    MEMORY_SOURCE,
+    build_metadata,
+    encode_source_id,
+)
+from meho_backplane.memory.schemas import MemoryScope, kind_for_scope
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, CSRFMiddleware, mint_csrf_token
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests._oidc_jwt_helpers import (
+    AUDIENCE as _DEFAULT_AUDIENCE,
+)
+from tests._oidc_jwt_helpers import (
+    ISSUER as _DEFAULT_ISSUER,
+)
+from tests._oidc_jwt_helpers import (
+    make_rsa_keypair as _make_rsa_keypair,
+)
+from tests._oidc_jwt_helpers import (
+    mint_token as _mint_token,
+)
+from tests._oidc_jwt_helpers import (
+    mock_discovery_and_jwks as _mock_discovery_and_jwks,
+)
+from tests._oidc_jwt_helpers import (
+    public_jwks as _public_jwks,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+_BACKPLANE_URL = "https://meho.test"
+
+#: Two stable tenant ids for the cross-tenant isolation assertion.
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_TENANT_B = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+#: Two stable operator subs for the cross-user isolation assertion.
+_OP_A = "op-alice"
+_OP_B = "op-bob"
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars for every test.
+
+    Mirrors :func:`backend.tests.test_ui_memory_list._bff_env`.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+def _build_app() -> FastAPI:
+    """Construct a minimal FastAPI app wired for the create / promote tests.
+
+    Mirrors :func:`backend.tests.test_ui_memory_list._build_app` with
+    one addition: :class:`AuditMiddleware` is wired so the promote
+    audit-row assertion can read back the row the chassis middleware
+    commits. The other UI tests don't need it because their handlers
+    don't bind ``operator_sub`` -- T1 routes are pre-G10.4 audit
+    wiring -- but T2's promote handler explicitly binds contextvars
+    so the chassis middleware writes the row.
+    """
+    app = FastAPI()
+    # Order is outer-to-inner via add_middleware: the LAST add_middleware
+    # call is the OUTERMOST. The chassis production stack puts
+    # AuditMiddleware closest to the app (writes after handler runs)
+    # and the CSRF + UISession middlewares outside that. We mirror
+    # that ordering here.
+    app.add_middleware(AuditMiddleware)
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
+    """Insert one ``tenant`` row so the document tenant FK resolves."""
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _seed_memory(
+    *,
+    tenant_id: uuid.UUID,
+    scope: MemoryScope,
+    slug: str,
+    body: str,
+    user_sub: str | None = None,
+    target_name: str | None = None,
+    tags: list[str] | None = None,
+) -> uuid.UUID:
+    """Persist one memory row directly via the documents table.
+
+    Bypasses :class:`MemoryService.remember` so the test doesn't need
+    to mock the embedding service for the seeded body. Returns the
+    seeded :class:`Document.id`.
+    """
+    metadata = build_metadata(
+        caller_metadata={"tags": list(tags)} if tags else None,
+        scope=scope,
+        user_sub=user_sub or "",
+        target_name=target_name,
+        expires_at=None,
+    )
+    source_id = encode_source_id(
+        scope=scope,
+        user_sub=user_sub or "",
+        target_name=target_name,
+        slug=slug,
+    )
+    doc_id = uuid.uuid4()
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                Document(
+                    id=doc_id,
+                    tenant_id=tenant_id,
+                    source=MEMORY_SOURCE,
+                    source_id=source_id,
+                    kind=kind_for_scope(scope),
+                    body=body,
+                    body_hash=f"sha256:test:{doc_id}",
+                    embedding=[0.0] * 384,
+                    doc_metadata=metadata,
+                    tokens=len(body.split()),
+                ),
+            )
+
+    asyncio.run(_do())
+    return doc_id
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID,
+    access_token: str,
+    operator_sub: str,
+) -> uuid.UUID:
+    """Create a ``web_session`` row carrying *access_token* and return its UUID."""
+    from datetime import timedelta
+
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token=access_token,
+                refresh_token="refresh-token-plaintext",
+                lifetime=timedelta(hours=1),
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _make_keypair_and_jwks() -> tuple[Any, dict[str, Any]]:
+    """Mint a stable RSA-2048 keypair + the matching JWKS document."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        keypair = _make_rsa_keypair("ui-memory-create-promote-test-kid")
+    return keypair, _public_jwks(keypair)
+
+
+def _authenticated_client(
+    *,
+    session_id: uuid.UUID,
+    jwks: dict[str, Any],
+    with_csrf: bool = False,
+) -> tuple[TestClient, respx.MockRouter, str]:
+    """Return a TestClient + a respx mock + a CSRF token."""
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    _mock_discovery_and_jwks(mock, jwks)
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    csrf_token = mint_csrf_token(str(session_id))
+    if with_csrf:
+        client.cookies.set(CSRF_COOKIE_NAME, csrf_token)
+    return client, mock, csrf_token
+
+
+def _csrf_headers(token: str) -> dict[str, str]:
+    """Return the headers a state-changing HTMX request carries."""
+    return {"X-CSRF-Token": token, "HX-Request": "true"}
+
+
+def _stub_embedding_service() -> Any:
+    """Return a context manager that stubs the embedding service.
+
+    :func:`index_document` calls :func:`get_embedding_service` and
+    invokes ``.encode_one(body)`` to compute the new row's
+    embedding. The create + promote tests don't depend on the
+    embedding model wheel; stubbing the factory to return a fixed
+    384-dim vector keeps the tests fast and deterministic.
+    """
+    return _patch(
+        "meho_backplane.retrieval.indexer.get_embedding_service",
+        return_value=type("_Stub", (), {"encode_one": AsyncMock(return_value=[0.0] * 384)})(),
+    )
+
+
+def _count_documents(tenant_id: uuid.UUID, scope: MemoryScope) -> int:
+    """Return how many ``documents`` rows exist for ``(tenant, scope)``."""
+
+    async def _do() -> int:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(Document).where(
+                    Document.tenant_id == tenant_id,
+                    Document.source == MEMORY_SOURCE,
+                    Document.kind == kind_for_scope(scope),
+                )
+            )
+            return len(list(result.scalars().all()))
+
+    return asyncio.run(_do())
+
+
+def _audit_rows_for_op(operator_sub: str, op_id: str) -> list[dict[str, Any]]:
+    """Return audit rows the chassis middleware committed for ``(operator_sub, op_id)``.
+
+    Used by the promote tests to assert "the promotion writes an
+    audit row" -- the chassis :class:`AuditMiddleware` writes one
+    row per request that binds ``operator_sub`` to contextvars; the
+    promote handler explicitly binds ``operator_sub`` + ``tenant_id``
+    + ``audit_op_id`` so the row exists in the table after the
+    request commits.
+
+    The chassis :func:`_resolve_audit_payload` strips the ``audit_``
+    prefix from every contextvar before writing the payload dict, so
+    a contextvar bound as ``audit_op_id="memory.promote"`` lands on
+    the row as ``payload["op_id"] == "memory.promote"``. This helper
+    filters on that stripped shape.
+    """
+
+    async def _do() -> list[dict[str, Any]]:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(AuditLog).where(AuditLog.operator_sub == operator_sub)
+            )
+            return [
+                {
+                    "id": row.id,
+                    "operator_sub": row.operator_sub,
+                    "tenant_id": row.tenant_id,
+                    "method": row.method,
+                    "path": row.path,
+                    "status_code": row.status_code,
+                    "payload": dict(row.payload) if row.payload else {},
+                }
+                for row in result.scalars().all()
+                if row.payload and row.payload.get("op_id") == op_id
+            ]
+
+    return asyncio.run(_do())
+
+
+# ---------------------------------------------------------------------------
+# Create modal -- GET (renders RBAC-filtered scope selector)
+# ---------------------------------------------------------------------------
+
+
+def test_create_modal_renders_writable_scopes_only_for_operator() -> None:
+    """Operator role: scope selector lists only the scopes ``can_write`` allows."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory/create", headers={"HX-Request": "true"})
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The modal carries a <dialog> with the modal-open class.
+    assert 'id="memory-create-modal"' in body
+    # Operator role: USER + USER_TENANT + USER_TARGET + TARGET are
+    # writable; TENANT requires tenant_admin and must NOT appear.
+    assert 'value="user"' in body
+    assert 'value="user-tenant"' in body
+    assert 'value="user-target"' in body
+    assert 'value="target"' in body
+    assert 'value="tenant"' not in body
+    # Form posts to the right route + carries the markdown-preview
+    # debounce wiring.
+    assert 'hx-post="/ui/memory/create"' in body
+    assert 'hx-post="/ui/memory/preview"' in body
+    assert "delay:300ms" in body
+
+
+def test_create_modal_renders_tenant_for_tenant_admin() -> None:
+    """``tenant_admin`` sees the ``TENANT`` scope in the selector."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.TENANT_ADMIN.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory/create", headers={"HX-Request": "true"})
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'value="tenant"' in body
+
+
+def test_create_modal_renders_empty_state_for_read_only_role() -> None:
+    """Read-only operator sees the empty-state alert, not the form."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.READ_ONLY.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory/create", headers={"HX-Request": "true"})
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    body = response.text
+    # No form element rendered; the empty-state alert is.
+    assert 'id="memory-create-form"' not in body
+    assert "does not allow writing any memory scope" in body
+
+
+# ---------------------------------------------------------------------------
+# Create submit -- POST persists + HX-Redirect
+# ---------------------------------------------------------------------------
+
+
+def test_create_submit_persists_user_scoped_memory_and_redirects() -> None:
+    """POST /ui/memory/create persists the row + returns HX-Redirect."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        with _stub_embedding_service():
+            response = client.post(
+                "/ui/memory/create",
+                data={
+                    "scope": "user",
+                    "body": "# new memory\n\nbody text",
+                    "slug": "wine-pref",
+                    "tags": "wine, preference",
+                },
+                headers=_csrf_headers(csrf),
+            )
+    finally:
+        mock.stop()
+    assert response.status_code == 204, response.text
+    assert response.headers.get("HX-Redirect") == "/ui/memory"
+    # The row landed in the documents table.
+    assert _count_documents(_TENANT_A, MemoryScope.USER) == 1
+
+
+def test_create_submit_with_blank_slug_generates_one() -> None:
+    """Blank slug -> auto-generated; the redirect still fires."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        with _stub_embedding_service():
+            response = client.post(
+                "/ui/memory/create",
+                data={"scope": "user", "body": "auto-slugged", "slug": ""},
+                headers=_csrf_headers(csrf),
+            )
+    finally:
+        mock.stop()
+    assert response.status_code == 204, response.text
+    assert _count_documents(_TENANT_A, MemoryScope.USER) == 1
+
+
+def test_create_submit_tenant_scope_as_operator_returns_403() -> None:
+    """An operator (non-admin) cannot create a tenant-scoped memory."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        with _stub_embedding_service():
+            response = client.post(
+                "/ui/memory/create",
+                data={"scope": "tenant", "body": "shared rule"},
+                headers=_csrf_headers(csrf),
+            )
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+
+
+def test_create_submit_empty_body_returns_422() -> None:
+    """Empty body fails the 'must not be empty' guard."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.post(
+            "/ui/memory/create",
+            data={"scope": "user", "body": "   "},
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 422, response.text
+
+
+def test_create_submit_target_scoped_without_target_name_returns_422() -> None:
+    """target_name required for user-target / target scopes."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        with _stub_embedding_service():
+            response = client.post(
+                "/ui/memory/create",
+                data={"scope": "user-target", "body": "needs target"},
+                headers=_csrf_headers(csrf),
+            )
+    finally:
+        mock.stop()
+    assert response.status_code == 422, response.text
+
+
+def test_create_submit_missing_csrf_token_returns_403() -> None:
+    """A POST without the CSRF token is rejected by the chassis middleware."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    # NOTE: with_csrf=False -- no cookie + no header.
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.post(
+            "/ui/memory/create",
+            data={"scope": "user", "body": "x"},
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+
+
+# ---------------------------------------------------------------------------
+# Markdown preview -- debounced server-side render
+# ---------------------------------------------------------------------------
+
+
+def test_preview_renders_markdown_to_html() -> None:
+    """POST /ui/memory/preview renders Markdown body -> HTML."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.post(
+            "/ui/memory/preview",
+            data={"body": "# Heading\n\n**bold**"},
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    text = response.text
+    assert "<h1>Heading</h1>" in text
+    assert "<strong>bold</strong>" in text
+    assert 'id="memory-create-preview"' in text
+
+
+def test_preview_empty_body_renders_placeholder() -> None:
+    """Empty body returns the placeholder pane (no error)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.post(
+            "/ui/memory/preview",
+            data={"body": ""},
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    assert "Preview will render here" in response.text
+
+
+def test_preview_escapes_raw_html_in_body() -> None:
+    """A raw <script> in the previewed body renders as escaped text."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        response = client.post(
+            "/ui/memory/preview",
+            data={"body": '<script>alert("x")</script>'},
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    # The body is escaped; no raw script tag survives the renderer.
+    assert "&lt;script&gt;" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Promote modal -- GET (renders legal target scopes)
+# ---------------------------------------------------------------------------
+
+
+def test_promote_modal_for_user_scope_lists_user_tenant_and_user_target() -> None:
+    """Source scope 'user' -> two legal targets (user-tenant + user-target)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="wine-pref",
+        body="r",
+        user_sub=_OP_A,
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory/user/wine-pref/promote", headers={"HX-Request": "true"})
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'id="memory-promote-modal"' in body
+    assert 'value="user-tenant"' in body
+    assert 'value="user-target"' in body
+    # Terminal scopes (tenant + target) must NOT appear as a target
+    # for a USER source -- the ladder forbids the cross-ladder leap.
+    assert 'value="tenant"' not in body
+    assert 'value="target"' not in body
+
+
+def test_promote_modal_for_tenant_scope_returns_400() -> None:
+    """Terminal scope 'tenant' -> 400 (no legal target)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.TENANT,
+        slug="team-rule",
+        body="shared",
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.TENANT_ADMIN.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory/tenant/team-rule/promote")
+    finally:
+        mock.stop()
+    assert response.status_code == 400, response.text
+
+
+def test_promote_modal_cross_user_user_scoped_returns_404() -> None:
+    """Operator B cannot open a promote modal for A's user-scoped memory."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="alice-secret",
+        body="for-a",
+        user_sub=_OP_A,
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_B,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_B
+    )
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory/user/alice-secret/promote")
+    finally:
+        mock.stop()
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Promote submit -- POST persists target + redirects + writes audit row
+# ---------------------------------------------------------------------------
+
+
+def test_promote_submit_user_to_user_tenant_persists_target_and_redirects() -> None:
+    """An operator promotes own user-scoped to user-tenant; target row lands."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="wine-pref",
+        body="riesling",
+        user_sub=_OP_A,
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        with _stub_embedding_service():
+            response = client.post(
+                "/ui/memory/user/wine-pref/promote",
+                data={"to": "user-tenant"},
+                headers=_csrf_headers(csrf),
+            )
+    finally:
+        mock.stop()
+    assert response.status_code == 204, response.text
+    assert response.headers.get("HX-Redirect") == "/ui/memory/user-tenant/wine-pref"
+    # The source row remains (move=False); the target row landed.
+    assert _count_documents(_TENANT_A, MemoryScope.USER) == 1
+    assert _count_documents(_TENANT_A, MemoryScope.USER_TENANT) == 1
+
+
+def test_promote_submit_writes_audit_row() -> None:
+    """The promotion writes an audit row classified as ``memory.promote``."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="wine-pref",
+        body="riesling",
+        user_sub=_OP_A,
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        with _stub_embedding_service():
+            response = client.post(
+                "/ui/memory/user/wine-pref/promote",
+                data={"to": "user-tenant"},
+                headers=_csrf_headers(csrf),
+            )
+    finally:
+        mock.stop()
+    assert response.status_code == 204
+    rows = _audit_rows_for_op(_OP_A, "memory.promote")
+    assert len(rows) == 1, rows
+    row = rows[0]
+    assert row["method"] == "POST"
+    assert row["path"] == "/ui/memory/user/wine-pref/promote"
+    assert row["status_code"] == 204
+    assert row["tenant_id"] == _TENANT_A
+    payload = row["payload"]
+    # The chassis `_resolve_audit_payload` strips the ``audit_`` prefix
+    # from every contextvar before writing the payload dict.
+    assert payload["op_class"] == "write"
+    assert payload["scope"] == "user"
+    assert payload["slug"] == "wine-pref"
+    assert payload["promotion_target_scope"] == "user-tenant"
+
+
+def test_promote_submit_idempotent_re_promote_returns_same_redirect() -> None:
+    """Re-running the same promotion is a no-op at the substrate level."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="wine-pref",
+        body="riesling",
+        user_sub=_OP_A,
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        with _stub_embedding_service():
+            first = client.post(
+                "/ui/memory/user/wine-pref/promote",
+                data={"to": "user-tenant"},
+                headers=_csrf_headers(csrf),
+            )
+            second = client.post(
+                "/ui/memory/user/wine-pref/promote",
+                data={"to": "user-tenant"},
+                headers=_csrf_headers(csrf),
+            )
+    finally:
+        mock.stop()
+    assert first.status_code == 204
+    assert second.status_code == 204
+    assert first.headers["HX-Redirect"] == second.headers["HX-Redirect"]
+    # Idempotency: still ONE target row, not two.
+    assert _count_documents(_TENANT_A, MemoryScope.USER_TENANT) == 1
+
+
+def test_promote_submit_user_to_tenant_as_operator_returns_403() -> None:
+    """An operator cannot promote to TENANT; G5.2 raises 403."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER_TENANT,
+        slug="team-pref",
+        body="ours",
+        user_sub=_OP_A,
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        with _stub_embedding_service():
+            response = client.post(
+                "/ui/memory/user-tenant/team-pref/promote",
+                data={"to": "tenant"},
+                headers=_csrf_headers(csrf),
+            )
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+
+
+def test_promote_submit_user_tenant_to_tenant_as_admin_succeeds() -> None:
+    """``tenant_admin`` can promote user-tenant -> tenant."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER_TENANT,
+        slug="team-pref",
+        body="ours",
+        user_sub=_OP_A,
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.TENANT_ADMIN.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        with _stub_embedding_service():
+            response = client.post(
+                "/ui/memory/user-tenant/team-pref/promote",
+                data={"to": "tenant"},
+                headers=_csrf_headers(csrf),
+            )
+    finally:
+        mock.stop()
+    assert response.status_code == 204, response.text
+    assert response.headers["HX-Redirect"] == "/ui/memory/tenant/team-pref"
+    assert _count_documents(_TENANT_A, MemoryScope.TENANT) == 1
+
+
+def test_promote_submit_invalid_ladder_step_returns_400() -> None:
+    """user -> tenant directly is not a ladder step -> 400."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="wine-pref",
+        body="r",
+        user_sub=_OP_A,
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.TENANT_ADMIN.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        with _stub_embedding_service():
+            response = client.post(
+                "/ui/memory/user/wine-pref/promote",
+                data={"to": "tenant"},
+                headers=_csrf_headers(csrf),
+            )
+    finally:
+        mock.stop()
+    assert response.status_code == 400, response.text
+
+
+def test_promote_submit_cross_user_returns_404() -> None:
+    """Operator B cannot promote A's user-scoped memory (404)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="alice-secret",
+        body="for-a",
+        user_sub=_OP_A,
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_B,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_A, access_token=access_token, operator_sub=_OP_B
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        with _stub_embedding_service():
+            response = client.post(
+                "/ui/memory/user/alice-secret/promote",
+                data={"to": "user-tenant"},
+                headers=_csrf_headers(csrf),
+            )
+    finally:
+        mock.stop()
+    assert response.status_code == 404, response.text
+
+
+def test_promote_submit_cross_tenant_returns_404() -> None:
+    """Operator in tenant B cannot promote tenant A's memory (404)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_tenant(_TENANT_B, "tenant-b")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="a-mem",
+        body="for-a",
+        user_sub=_OP_A,
+    )
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OP_A,  # same sub, different tenant
+        tenant_id=str(_TENANT_B),
+        tenant_role=TenantRole.OPERATOR.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=_TENANT_B, access_token=access_token, operator_sub=_OP_A
+    )
+    client, mock, csrf = _authenticated_client(session_id=session_id, jwks=jwks, with_csrf=True)
+    try:
+        with _stub_embedding_service():
+            response = client.post(
+                "/ui/memory/user/a-mem/promote",
+                data={"to": "user-tenant"},
+                headers=_csrf_headers(csrf),
+            )
+    finally:
+        mock.stop()
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# UI integration -- list page + detail page render the new buttons
+# ---------------------------------------------------------------------------
+
+
+def test_list_page_renders_create_button() -> None:
+    """The list page now renders the '+' Create button + modal container."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory")
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    body = response.text
+    assert 'hx-get="/ui/memory/create"' in body
+    assert 'id="memory-modal-container"' in body
+
+
+def test_detail_page_renders_promote_button_for_user_scope() -> None:
+    """Detail page on a user-scoped row renders the Promote button."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.USER,
+        slug="wine-pref",
+        body="riesling",
+        user_sub=_OP_A,
+    )
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory/user/wine-pref")
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    body = response.text
+    assert 'hx-get="/ui/memory/user/wine-pref/promote"' in body
+
+
+def test_detail_page_omits_promote_button_for_terminal_tenant_scope() -> None:
+    """Detail page on a tenant-scoped row does NOT render the Promote button."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_memory(
+        tenant_id=_TENANT_A,
+        scope=MemoryScope.TENANT,
+        slug="rule",
+        body="shared",
+    )
+    _, jwks = _make_keypair_and_jwks()
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token="unused", operator_sub=_OP_A)
+    client, mock, _csrf = _authenticated_client(session_id=session_id, jwks=jwks)
+    try:
+        response = client.get("/ui/memory/tenant/rule")
+    finally:
+        mock.stop()
+    assert response.status_code == 200
+    body = response.text
+    assert "tenant/rule/promote" not in body

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -6304,6 +6304,152 @@
         }
       }
     },
+    "/ui/memory/tags": {
+      "get": {
+        "tags": [
+          "ui-memory"
+        ],
+        "summary": "Ui Memory Tags",
+        "description": "``GET /ui/memory/tags`` -- HTMX datalist autocomplete fragment.",
+        "operationId": "ui_memory_tags_ui_memory_tags_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/memory/create": {
+      "get": {
+        "tags": [
+          "ui-memory"
+        ],
+        "summary": "Ui Memory Create Modal",
+        "description": "``GET /ui/memory/create`` -- HTMX-loaded create modal fragment.",
+        "operationId": "ui_memory_create_modal_ui_memory_create_get",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ui-memory"
+        ],
+        "summary": "Ui Memory Create Submit",
+        "description": "``POST /ui/memory/create`` -- create one memory via the service.\n\nReturns 204 + ``HX-Redirect: /ui/memory`` so HTMX navigates back\nto the list. The form-encoded body shape mirrors the\n``RememberBody`` Pydantic model on ``/api/v1/memory``: scope is\na ``MemoryScope`` enum value, body is required, slug + tags +\nexpires_at + target_name are optional. CSRF is enforced by the\nchassis :class:`CSRFMiddleware` before this handler runs.\n\n``tags`` is a comma-separated string parsed server-side into a\nlist; the form input is one ``<input>`` rather than five (the\ntypical UX shape for the v0.2 surface). ``expires_at`` is\nparsed by FastAPI's :class:`datetime` form coercion from the\nISO-8601 string a ``<input type=\"datetime-local\">`` produces.",
+        "operationId": "ui_memory_create_submit_ui_memory_create_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_ui_memory_create_submit_ui_memory_create_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/memory/preview": {
+      "post": {
+        "tags": [
+          "ui-memory"
+        ],
+        "summary": "Ui Memory Preview",
+        "description": "``POST /ui/memory/preview`` -- debounced server-side Markdown preview.\n\nTriggered by ``hx-trigger=\"keyup changed delay:300ms\"`` on the\ncreate-modal body textarea. Returns the rendered Markdown\nwrapped in the same ``<article>`` shape :file:`_body_view.html`\nuses so the preview pane and the detail view render identically.\n\nSession is required (the chassis CSRF middleware would already\nhave rejected an anonymous POST, but the session dep adds the\naudit-trail anchor; ``_require_session_dep`` runs the standard\nredirect-to-login on a missing cookie).",
+        "operationId": "ui_memory_preview_ui_memory_preview_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_ui_memory_preview_ui_memory_preview_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ui/memory": {
       "get": {
         "tags": [
@@ -6353,28 +6499,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ui/memory/tags": {
-      "get": {
-        "tags": [
-          "ui-memory"
-        ],
-        "summary": "Ui Memory Tags",
-        "description": "``GET /ui/memory/tags`` -- HTMX datalist autocomplete fragment.",
-        "operationId": "ui_memory_tags_ui_memory_tags_get",
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "text/html": {
-                "schema": {
-                  "type": "string"
                 }
               }
             }
@@ -6586,6 +6710,127 @@
                 "$ref": "#/components/schemas/UISessionContext",
                 "nullable": true,
                 "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/memory/{scope}/{slug}/promote": {
+      "get": {
+        "tags": [
+          "ui-memory"
+        ],
+        "summary": "Ui Memory Promote Modal",
+        "description": "``GET /ui/memory/<scope>/<slug>/promote`` -- HTMX-loaded promote modal.",
+        "operationId": "ui_memory_promote_modal_ui_memory__scope___slug__promote_get",
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/MemoryScope"
+            }
+          },
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ui-memory"
+        ],
+        "summary": "Ui Memory Promote Submit",
+        "description": "``POST /ui/memory/<scope>/<slug>/promote`` -- promote and HX-Redirect.\n\nDelegates ladder + authority checks to G5.2's\n:func:`assert_can_promote` via :meth:`MemoryService.promote`.\nIdempotent re-run returns the same target row -- the redirect\nURL is the same on first promote and on a re-promote, matching\nthe G5.2 contract.",
+        "operationId": "ui_memory_promote_submit_ui_memory__scope___slug__promote_post",
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/MemoryScope"
+            }
+          },
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_ui_memory_promote_submit_ui_memory__scope___slug__promote_post"
               }
             }
           }
@@ -7773,6 +8018,52 @@
         "title": "BaselineMetricsOverride",
         "description": "Per-surface baseline metrics supplied by the caller.\n\nCriterion 4 (MEHO \u2265 baseline) needs side-by-side numbers from a\nbaseline retrieval (``grep -r kb/`` for kb; ``grep paths.txt +\nyq`` for operations). The v0.2 backplane has no checked-in\ncorpus snapshot to evaluate the baseline against (see\n:mod:`meho_backplane.api.v1.retrieve_eval` \u2014 explicit\n``baseline=grep`` on that route is rejected with 501); the CLI\nruns the baseline locally against the operator's kb/ checkout and\ncan pass the resulting numbers here so the retire-checklist\nverdict honestly reflects criterion 4 instead of always reporting\nyellow (\"baseline did not run\") on the API path.\n\nWithout an override, criterion 4 stays yellow for v0.2 production\ncallers \u2014 the documented \"READY TO RETIRE\" path is unreachable\nvia the bare API alone, which is the honest v0.2 posture. T7\n(#446) / v0.2.next is expected to wire a server-side corpus\nsnapshot and remove the need for this override."
       },
+      "Body_ui_memory_create_submit_ui_memory_create_post": {
+        "properties": {
+          "scope": {
+            "$ref": "#/components/schemas/MemoryScope"
+          },
+          "body": {
+            "type": "string",
+            "maxLength": 65536,
+            "title": "Body"
+          },
+          "slug": {
+            "type": "string",
+            "maxLength": 256,
+            "nullable": true,
+            "title": "Slug"
+          },
+          "tags": {
+            "type": "string",
+            "maxLength": 1024,
+            "nullable": true,
+            "title": "Tags"
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Expires At"
+          },
+          "target_name": {
+            "type": "string",
+            "maxLength": 256,
+            "nullable": true,
+            "title": "Target Name"
+          },
+          "session_ctx": {
+            "$ref": "#/components/schemas/UISessionContext",
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "scope",
+          "body"
+        ],
+        "title": "Body_ui_memory_create_submit_ui_memory_create_post"
+      },
       "Body_ui_memory_patch_ui_memory__scope___slug__patch": {
         "properties": {
           "body": {
@@ -7790,6 +8081,40 @@
           "body"
         ],
         "title": "Body_ui_memory_patch_ui_memory__scope___slug__patch"
+      },
+      "Body_ui_memory_preview_ui_memory_preview_post": {
+        "properties": {
+          "body": {
+            "type": "string",
+            "maxLength": 65536,
+            "title": "Body",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "Body_ui_memory_preview_ui_memory_preview_post"
+      },
+      "Body_ui_memory_promote_submit_ui_memory__scope___slug__promote_post": {
+        "properties": {
+          "to": {
+            "$ref": "#/components/schemas/MemoryScope"
+          },
+          "target_name": {
+            "type": "string",
+            "maxLength": 256,
+            "nullable": true,
+            "title": "Target Name"
+          },
+          "session_ctx": {
+            "$ref": "#/components/schemas/UISessionContext",
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "to"
+        ],
+        "title": "Body_ui_memory_promote_submit_ui_memory__scope___slug__promote_post"
       },
       "BroadcastOverrideCreate": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -875,6 +875,41 @@ type BaselineMetricsOverride struct {
 	PrecisionAt5 float32 `json:"precision_at_5"`
 }
 
+// BodyUiMemoryCreateSubmitUiMemoryCreatePost defines model for Body_ui_memory_create_submit_ui_memory_create_post.
+type BodyUiMemoryCreateSubmitUiMemoryCreatePost struct {
+	Body      string     `json:"body"`
+	ExpiresAt *time.Time `json:"expires_at"`
+
+	// Scope One of the five memory scopes from consumer-needs.md §G5 L137-141.
+	//
+	// The string value is the wire-level identifier (route path segment,
+	// CLI flag value, MCP tool arg). Each value maps to a single
+	// ``documents.kind`` row prefixed with ``memory-`` --
+	// :func:`kind_for_scope` is the canonical translation. The mapping is
+	// one-to-one and bijective with :func:`scope_for_kind`, so callers
+	// never round-trip through ad-hoc string-prefixing.
+	//
+	// ``StrEnum`` (PEP 663, stdlib in 3.11+) gives the members ``str``
+	// semantics for free: ``f"scope={MemoryScope.USER}"`` renders as
+	// ``"scope=user"`` rather than ``"scope=MemoryScope.USER"``, matching
+	// the :class:`~meho_backplane.auth.operator.TenantRole` convention.
+	Scope MemoryScope `json:"scope"`
+
+	// SessionCtx Per-request session identity exposed on ``request.state``.
+	//
+	// Frozen so a route handler that stashes the context on a logger
+	// or forwards it to a service layer cannot accidentally mutate
+	// fields downstream. The shape mirrors :class:`Operator` for the
+	// fields T5 (#866) needs to render an authenticated page header;
+	// ``raw_jwt`` / ``tenant_role`` are intentionally absent because
+	// the session-cookie path does not load them today (the encrypted
+	// row carries only the access token, not the decoded claims).
+	SessionCtx *UISessionContext `json:"session_ctx,omitempty"`
+	Slug       *string           `json:"slug"`
+	Tags       *string           `json:"tags"`
+	TargetName *string           `json:"target_name"`
+}
+
 // BodyUiMemoryPatchUiMemoryScopeSlugPatch defines model for Body_ui_memory_patch_ui_memory__scope___slug__patch.
 type BodyUiMemoryPatchUiMemoryScopeSlugPatch struct {
 	Body string `json:"body"`
@@ -889,6 +924,41 @@ type BodyUiMemoryPatchUiMemoryScopeSlugPatch struct {
 	// the session-cookie path does not load them today (the encrypted
 	// row carries only the access token, not the decoded claims).
 	SessionCtx *UISessionContext `json:"session_ctx,omitempty"`
+}
+
+// BodyUiMemoryPreviewUiMemoryPreviewPost defines model for Body_ui_memory_preview_ui_memory_preview_post.
+type BodyUiMemoryPreviewUiMemoryPreviewPost struct {
+	Body *string `json:"body,omitempty"`
+}
+
+// BodyUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePost defines model for Body_ui_memory_promote_submit_ui_memory__scope___slug__promote_post.
+type BodyUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePost struct {
+	// SessionCtx Per-request session identity exposed on ``request.state``.
+	//
+	// Frozen so a route handler that stashes the context on a logger
+	// or forwards it to a service layer cannot accidentally mutate
+	// fields downstream. The shape mirrors :class:`Operator` for the
+	// fields T5 (#866) needs to render an authenticated page header;
+	// ``raw_jwt`` / ``tenant_role`` are intentionally absent because
+	// the session-cookie path does not load them today (the encrypted
+	// row carries only the access token, not the decoded claims).
+	SessionCtx *UISessionContext `json:"session_ctx,omitempty"`
+	TargetName *string           `json:"target_name"`
+
+	// To One of the five memory scopes from consumer-needs.md §G5 L137-141.
+	//
+	// The string value is the wire-level identifier (route path segment,
+	// CLI flag value, MCP tool arg). Each value maps to a single
+	// ``documents.kind`` row prefixed with ``memory-`` --
+	// :func:`kind_for_scope` is the canonical translation. The mapping is
+	// one-to-one and bijective with :func:`scope_for_kind`, so callers
+	// never round-trip through ad-hoc string-prefixing.
+	//
+	// ``StrEnum`` (PEP 663, stdlib in 3.11+) gives the members ``str``
+	// semantics for free: ``f"scope={MemoryScope.USER}"`` renders as
+	// ``"scope=user"`` rather than ``"scope=MemoryScope.USER"``, matching
+	// the :class:`~meho_backplane.auth.operator.TenantRole` convention.
+	To MemoryScope `json:"to"`
 }
 
 // BroadcastOverrideCreate Incoming POST body. Pydantic v2 strict.
@@ -4092,6 +4162,15 @@ type AnnotateEdgeRouteApiV1TopologyEdgesPostJSONRequestBody = UnderscoreAnnotate
 // BulkImportEdgesRouteApiV1TopologyEdgesBulkPostJSONRequestBody defines body for BulkImportEdgesRouteApiV1TopologyEdgesBulkPost for application/json ContentType.
 type BulkImportEdgesRouteApiV1TopologyEdgesBulkPostJSONRequestBody = UnderscoreBulkImportRequest
 
+// UiMemoryCreateModalUiMemoryCreateGetJSONRequestBody defines body for UiMemoryCreateModalUiMemoryCreateGet for application/json ContentType.
+type UiMemoryCreateModalUiMemoryCreateGetJSONRequestBody = UISessionContext
+
+// UiMemoryCreateSubmitUiMemoryCreatePostFormdataRequestBody defines body for UiMemoryCreateSubmitUiMemoryCreatePost for application/x-www-form-urlencoded ContentType.
+type UiMemoryCreateSubmitUiMemoryCreatePostFormdataRequestBody = BodyUiMemoryCreateSubmitUiMemoryCreatePost
+
+// UiMemoryPreviewUiMemoryPreviewPostFormdataRequestBody defines body for UiMemoryPreviewUiMemoryPreviewPost for application/x-www-form-urlencoded ContentType.
+type UiMemoryPreviewUiMemoryPreviewPostFormdataRequestBody = BodyUiMemoryPreviewUiMemoryPreviewPost
+
 // UiMemoryDeleteUiMemoryScopeSlugDeleteJSONRequestBody defines body for UiMemoryDeleteUiMemoryScopeSlugDelete for application/json ContentType.
 type UiMemoryDeleteUiMemoryScopeSlugDeleteJSONRequestBody = UISessionContext
 
@@ -4100,6 +4179,12 @@ type UiMemoryPatchUiMemoryScopeSlugPatchFormdataRequestBody = BodyUiMemoryPatchU
 
 // UiMemoryEditFormUiMemoryScopeSlugEditGetJSONRequestBody defines body for UiMemoryEditFormUiMemoryScopeSlugEditGet for application/json ContentType.
 type UiMemoryEditFormUiMemoryScopeSlugEditGetJSONRequestBody = UISessionContext
+
+// UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetJSONRequestBody defines body for UiMemoryPromoteModalUiMemoryScopeSlugPromoteGet for application/json ContentType.
+type UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetJSONRequestBody = UISessionContext
+
+// UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostFormdataRequestBody defines body for UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePost for application/x-www-form-urlencoded ContentType.
+type UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostFormdataRequestBody = BodyUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePost
 
 // AsApproveResponseBodyDispatchResult0 returns the union data inside the ApproveResponseBody_DispatchResult as a ApproveResponseBodyDispatchResult0
 func (t ApproveResponseBody_DispatchResult) AsApproveResponseBodyDispatchResult0() (ApproveResponseBodyDispatchResult0, error) {
@@ -4667,6 +4752,21 @@ type ClientInterface interface {
 	// UiMemoryListUiMemoryGet request
 	UiMemoryListUiMemoryGet(ctx context.Context, params *UiMemoryListUiMemoryGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// UiMemoryCreateModalUiMemoryCreateGetWithBody request with any body
+	UiMemoryCreateModalUiMemoryCreateGetWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiMemoryCreateModalUiMemoryCreateGet(ctx context.Context, body UiMemoryCreateModalUiMemoryCreateGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiMemoryCreateSubmitUiMemoryCreatePostWithBody request with any body
+	UiMemoryCreateSubmitUiMemoryCreatePostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiMemoryCreateSubmitUiMemoryCreatePostWithFormdataBody(ctx context.Context, body UiMemoryCreateSubmitUiMemoryCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiMemoryPreviewUiMemoryPreviewPostWithBody request with any body
+	UiMemoryPreviewUiMemoryPreviewPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiMemoryPreviewUiMemoryPreviewPostWithFormdataBody(ctx context.Context, body UiMemoryPreviewUiMemoryPreviewPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// UiMemoryTagsUiMemoryTagsGet request
 	UiMemoryTagsUiMemoryTagsGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -4687,6 +4787,16 @@ type ClientInterface interface {
 	UiMemoryEditFormUiMemoryScopeSlugEditGetWithBody(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UiMemoryEditFormUiMemoryScopeSlugEditGet(ctx context.Context, scope MemoryScope, slug string, body UiMemoryEditFormUiMemoryScopeSlugEditGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetWithBody request with any body
+	UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetWithBody(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiMemoryPromoteModalUiMemoryScopeSlugPromoteGet(ctx context.Context, scope MemoryScope, slug string, body UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithBody request with any body
+	UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithBody(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithFormdataBody(ctx context.Context, scope MemoryScope, slug string, body UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiTopologyTableUiTopologyGet request
 	UiTopologyTableUiTopologyGet(ctx context.Context, params *UiTopologyTableUiTopologyGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -6294,6 +6404,78 @@ func (c *Client) UiMemoryListUiMemoryGet(ctx context.Context, params *UiMemoryLi
 	return c.Client.Do(req)
 }
 
+func (c *Client) UiMemoryCreateModalUiMemoryCreateGetWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryCreateModalUiMemoryCreateGetRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiMemoryCreateModalUiMemoryCreateGet(ctx context.Context, body UiMemoryCreateModalUiMemoryCreateGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryCreateModalUiMemoryCreateGetRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiMemoryCreateSubmitUiMemoryCreatePostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryCreateSubmitUiMemoryCreatePostRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiMemoryCreateSubmitUiMemoryCreatePostWithFormdataBody(ctx context.Context, body UiMemoryCreateSubmitUiMemoryCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryCreateSubmitUiMemoryCreatePostRequestWithFormdataBody(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiMemoryPreviewUiMemoryPreviewPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryPreviewUiMemoryPreviewPostRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiMemoryPreviewUiMemoryPreviewPostWithFormdataBody(ctx context.Context, body UiMemoryPreviewUiMemoryPreviewPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryPreviewUiMemoryPreviewPostRequestWithFormdataBody(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) UiMemoryTagsUiMemoryTagsGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUiMemoryTagsUiMemoryTagsGetRequest(c.Server)
 	if err != nil {
@@ -6380,6 +6562,54 @@ func (c *Client) UiMemoryEditFormUiMemoryScopeSlugEditGetWithBody(ctx context.Co
 
 func (c *Client) UiMemoryEditFormUiMemoryScopeSlugEditGet(ctx context.Context, scope MemoryScope, slug string, body UiMemoryEditFormUiMemoryScopeSlugEditGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUiMemoryEditFormUiMemoryScopeSlugEditGetRequest(c.Server, scope, slug, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetWithBody(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryPromoteModalUiMemoryScopeSlugPromoteGetRequestWithBody(c.Server, scope, slug, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiMemoryPromoteModalUiMemoryScopeSlugPromoteGet(ctx context.Context, scope MemoryScope, slug string, body UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryPromoteModalUiMemoryScopeSlugPromoteGetRequest(c.Server, scope, slug, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithBody(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostRequestWithBody(c.Server, scope, slug, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithFormdataBody(ctx context.Context, scope MemoryScope, slug string, body UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostRequestWithFormdataBody(c.Server, scope, slug, body)
 	if err != nil {
 		return nil, err
 	}
@@ -13056,6 +13286,126 @@ func NewUiMemoryListUiMemoryGetRequest(server string, params *UiMemoryListUiMemo
 	return req, nil
 }
 
+// NewUiMemoryCreateModalUiMemoryCreateGetRequest calls the generic UiMemoryCreateModalUiMemoryCreateGet builder with application/json body
+func NewUiMemoryCreateModalUiMemoryCreateGetRequest(server string, body UiMemoryCreateModalUiMemoryCreateGetJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUiMemoryCreateModalUiMemoryCreateGetRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewUiMemoryCreateModalUiMemoryCreateGetRequestWithBody generates requests for UiMemoryCreateModalUiMemoryCreateGet with any type of body
+func NewUiMemoryCreateModalUiMemoryCreateGetRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/memory/create")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiMemoryCreateSubmitUiMemoryCreatePostRequestWithFormdataBody calls the generic UiMemoryCreateSubmitUiMemoryCreatePost builder with application/x-www-form-urlencoded body
+func NewUiMemoryCreateSubmitUiMemoryCreatePostRequestWithFormdataBody(server string, body UiMemoryCreateSubmitUiMemoryCreatePostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewUiMemoryCreateSubmitUiMemoryCreatePostRequestWithBody(server, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewUiMemoryCreateSubmitUiMemoryCreatePostRequestWithBody generates requests for UiMemoryCreateSubmitUiMemoryCreatePost with any type of body
+func NewUiMemoryCreateSubmitUiMemoryCreatePostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/memory/create")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiMemoryPreviewUiMemoryPreviewPostRequestWithFormdataBody calls the generic UiMemoryPreviewUiMemoryPreviewPost builder with application/x-www-form-urlencoded body
+func NewUiMemoryPreviewUiMemoryPreviewPostRequestWithFormdataBody(server string, body UiMemoryPreviewUiMemoryPreviewPostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewUiMemoryPreviewUiMemoryPreviewPostRequestWithBody(server, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewUiMemoryPreviewUiMemoryPreviewPostRequestWithBody generates requests for UiMemoryPreviewUiMemoryPreviewPost with any type of body
+func NewUiMemoryPreviewUiMemoryPreviewPostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/memory/preview")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewUiMemoryTagsUiMemoryTagsGetRequest generates requests for UiMemoryTagsUiMemoryTagsGet
 func NewUiMemoryTagsUiMemoryTagsGetRequest(server string) (*http.Request, error) {
 	var err error
@@ -13277,6 +13627,114 @@ func NewUiMemoryEditFormUiMemoryScopeSlugEditGetRequestWithBody(server string, s
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiMemoryPromoteModalUiMemoryScopeSlugPromoteGetRequest calls the generic UiMemoryPromoteModalUiMemoryScopeSlugPromoteGet builder with application/json body
+func NewUiMemoryPromoteModalUiMemoryScopeSlugPromoteGetRequest(server string, scope MemoryScope, slug string, body UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUiMemoryPromoteModalUiMemoryScopeSlugPromoteGetRequestWithBody(server, scope, slug, "application/json", bodyReader)
+}
+
+// NewUiMemoryPromoteModalUiMemoryScopeSlugPromoteGetRequestWithBody generates requests for UiMemoryPromoteModalUiMemoryScopeSlugPromoteGet with any type of body
+func NewUiMemoryPromoteModalUiMemoryScopeSlugPromoteGetRequestWithBody(server string, scope MemoryScope, slug string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "scope", runtime.ParamLocationPath, scope)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/memory/%s/%s/promote", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostRequestWithFormdataBody calls the generic UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePost builder with application/x-www-form-urlencoded body
+func NewUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostRequestWithFormdataBody(server string, scope MemoryScope, slug string, body UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostRequestWithBody(server, scope, slug, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostRequestWithBody generates requests for UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePost with any type of body
+func NewUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostRequestWithBody(server string, scope MemoryScope, slug string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "scope", runtime.ParamLocationPath, scope)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/memory/%s/%s/promote", pathParam0, pathParam1)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
@@ -14000,6 +14458,21 @@ type ClientWithResponsesInterface interface {
 	// UiMemoryListUiMemoryGetWithResponse request
 	UiMemoryListUiMemoryGetWithResponse(ctx context.Context, params *UiMemoryListUiMemoryGetParams, reqEditors ...RequestEditorFn) (*UiMemoryListUiMemoryGetResponse, error)
 
+	// UiMemoryCreateModalUiMemoryCreateGetWithBodyWithResponse request with any body
+	UiMemoryCreateModalUiMemoryCreateGetWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryCreateModalUiMemoryCreateGetResponse, error)
+
+	UiMemoryCreateModalUiMemoryCreateGetWithResponse(ctx context.Context, body UiMemoryCreateModalUiMemoryCreateGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryCreateModalUiMemoryCreateGetResponse, error)
+
+	// UiMemoryCreateSubmitUiMemoryCreatePostWithBodyWithResponse request with any body
+	UiMemoryCreateSubmitUiMemoryCreatePostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryCreateSubmitUiMemoryCreatePostResponse, error)
+
+	UiMemoryCreateSubmitUiMemoryCreatePostWithFormdataBodyWithResponse(ctx context.Context, body UiMemoryCreateSubmitUiMemoryCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryCreateSubmitUiMemoryCreatePostResponse, error)
+
+	// UiMemoryPreviewUiMemoryPreviewPostWithBodyWithResponse request with any body
+	UiMemoryPreviewUiMemoryPreviewPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryPreviewUiMemoryPreviewPostResponse, error)
+
+	UiMemoryPreviewUiMemoryPreviewPostWithFormdataBodyWithResponse(ctx context.Context, body UiMemoryPreviewUiMemoryPreviewPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryPreviewUiMemoryPreviewPostResponse, error)
+
 	// UiMemoryTagsUiMemoryTagsGetWithResponse request
 	UiMemoryTagsUiMemoryTagsGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiMemoryTagsUiMemoryTagsGetResponse, error)
 
@@ -14020,6 +14493,16 @@ type ClientWithResponsesInterface interface {
 	UiMemoryEditFormUiMemoryScopeSlugEditGetWithBodyWithResponse(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryEditFormUiMemoryScopeSlugEditGetResponse, error)
 
 	UiMemoryEditFormUiMemoryScopeSlugEditGetWithResponse(ctx context.Context, scope MemoryScope, slug string, body UiMemoryEditFormUiMemoryScopeSlugEditGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryEditFormUiMemoryScopeSlugEditGetResponse, error)
+
+	// UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetWithBodyWithResponse request with any body
+	UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetWithBodyWithResponse(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetResponse, error)
+
+	UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetWithResponse(ctx context.Context, scope MemoryScope, slug string, body UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetResponse, error)
+
+	// UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithBodyWithResponse request with any body
+	UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithBodyWithResponse(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse, error)
+
+	UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithFormdataBodyWithResponse(ctx context.Context, scope MemoryScope, slug string, body UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse, error)
 
 	// UiTopologyTableUiTopologyGetWithResponse request
 	UiTopologyTableUiTopologyGetWithResponse(ctx context.Context, params *UiTopologyTableUiTopologyGetParams, reqEditors ...RequestEditorFn) (*UiTopologyTableUiTopologyGetResponse, error)
@@ -16388,6 +16871,72 @@ func (r UiMemoryListUiMemoryGetResponse) StatusCode() int {
 	return 0
 }
 
+type UiMemoryCreateModalUiMemoryCreateGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiMemoryCreateModalUiMemoryCreateGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiMemoryCreateModalUiMemoryCreateGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiMemoryCreateSubmitUiMemoryCreatePostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiMemoryCreateSubmitUiMemoryCreatePostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiMemoryCreateSubmitUiMemoryCreatePostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiMemoryPreviewUiMemoryPreviewPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiMemoryPreviewUiMemoryPreviewPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiMemoryPreviewUiMemoryPreviewPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type UiMemoryTagsUiMemoryTagsGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -16491,6 +17040,50 @@ func (r UiMemoryEditFormUiMemoryScopeSlugEditGetResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r UiMemoryEditFormUiMemoryScopeSlugEditGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -17730,6 +18323,57 @@ func (c *ClientWithResponses) UiMemoryListUiMemoryGetWithResponse(ctx context.Co
 	return ParseUiMemoryListUiMemoryGetResponse(rsp)
 }
 
+// UiMemoryCreateModalUiMemoryCreateGetWithBodyWithResponse request with arbitrary body returning *UiMemoryCreateModalUiMemoryCreateGetResponse
+func (c *ClientWithResponses) UiMemoryCreateModalUiMemoryCreateGetWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryCreateModalUiMemoryCreateGetResponse, error) {
+	rsp, err := c.UiMemoryCreateModalUiMemoryCreateGetWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryCreateModalUiMemoryCreateGetResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiMemoryCreateModalUiMemoryCreateGetWithResponse(ctx context.Context, body UiMemoryCreateModalUiMemoryCreateGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryCreateModalUiMemoryCreateGetResponse, error) {
+	rsp, err := c.UiMemoryCreateModalUiMemoryCreateGet(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryCreateModalUiMemoryCreateGetResponse(rsp)
+}
+
+// UiMemoryCreateSubmitUiMemoryCreatePostWithBodyWithResponse request with arbitrary body returning *UiMemoryCreateSubmitUiMemoryCreatePostResponse
+func (c *ClientWithResponses) UiMemoryCreateSubmitUiMemoryCreatePostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryCreateSubmitUiMemoryCreatePostResponse, error) {
+	rsp, err := c.UiMemoryCreateSubmitUiMemoryCreatePostWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryCreateSubmitUiMemoryCreatePostResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiMemoryCreateSubmitUiMemoryCreatePostWithFormdataBodyWithResponse(ctx context.Context, body UiMemoryCreateSubmitUiMemoryCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryCreateSubmitUiMemoryCreatePostResponse, error) {
+	rsp, err := c.UiMemoryCreateSubmitUiMemoryCreatePostWithFormdataBody(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryCreateSubmitUiMemoryCreatePostResponse(rsp)
+}
+
+// UiMemoryPreviewUiMemoryPreviewPostWithBodyWithResponse request with arbitrary body returning *UiMemoryPreviewUiMemoryPreviewPostResponse
+func (c *ClientWithResponses) UiMemoryPreviewUiMemoryPreviewPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryPreviewUiMemoryPreviewPostResponse, error) {
+	rsp, err := c.UiMemoryPreviewUiMemoryPreviewPostWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryPreviewUiMemoryPreviewPostResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiMemoryPreviewUiMemoryPreviewPostWithFormdataBodyWithResponse(ctx context.Context, body UiMemoryPreviewUiMemoryPreviewPostFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryPreviewUiMemoryPreviewPostResponse, error) {
+	rsp, err := c.UiMemoryPreviewUiMemoryPreviewPostWithFormdataBody(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryPreviewUiMemoryPreviewPostResponse(rsp)
+}
+
 // UiMemoryTagsUiMemoryTagsGetWithResponse request returning *UiMemoryTagsUiMemoryTagsGetResponse
 func (c *ClientWithResponses) UiMemoryTagsUiMemoryTagsGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiMemoryTagsUiMemoryTagsGetResponse, error) {
 	rsp, err := c.UiMemoryTagsUiMemoryTagsGet(ctx, reqEditors...)
@@ -17797,6 +18441,40 @@ func (c *ClientWithResponses) UiMemoryEditFormUiMemoryScopeSlugEditGetWithRespon
 		return nil, err
 	}
 	return ParseUiMemoryEditFormUiMemoryScopeSlugEditGetResponse(rsp)
+}
+
+// UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetWithBodyWithResponse request with arbitrary body returning *UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetResponse
+func (c *ClientWithResponses) UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetWithBodyWithResponse(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetResponse, error) {
+	rsp, err := c.UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetWithBody(ctx, scope, slug, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryPromoteModalUiMemoryScopeSlugPromoteGetResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetWithResponse(ctx context.Context, scope MemoryScope, slug string, body UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetResponse, error) {
+	rsp, err := c.UiMemoryPromoteModalUiMemoryScopeSlugPromoteGet(ctx, scope, slug, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryPromoteModalUiMemoryScopeSlugPromoteGetResponse(rsp)
+}
+
+// UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithBodyWithResponse request with arbitrary body returning *UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse
+func (c *ClientWithResponses) UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithBodyWithResponse(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse, error) {
+	rsp, err := c.UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithBody(ctx, scope, slug, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithFormdataBodyWithResponse(ctx context.Context, scope MemoryScope, slug string, body UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse, error) {
+	rsp, err := c.UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithFormdataBody(ctx, scope, slug, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse(rsp)
 }
 
 // UiTopologyTableUiTopologyGetWithResponse request returning *UiTopologyTableUiTopologyGetResponse
@@ -21003,6 +21681,84 @@ func ParseUiMemoryListUiMemoryGetResponse(rsp *http.Response) (*UiMemoryListUiMe
 	return response, nil
 }
 
+// ParseUiMemoryCreateModalUiMemoryCreateGetResponse parses an HTTP response from a UiMemoryCreateModalUiMemoryCreateGetWithResponse call
+func ParseUiMemoryCreateModalUiMemoryCreateGetResponse(rsp *http.Response) (*UiMemoryCreateModalUiMemoryCreateGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiMemoryCreateModalUiMemoryCreateGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiMemoryCreateSubmitUiMemoryCreatePostResponse parses an HTTP response from a UiMemoryCreateSubmitUiMemoryCreatePostWithResponse call
+func ParseUiMemoryCreateSubmitUiMemoryCreatePostResponse(rsp *http.Response) (*UiMemoryCreateSubmitUiMemoryCreatePostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiMemoryCreateSubmitUiMemoryCreatePostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiMemoryPreviewUiMemoryPreviewPostResponse parses an HTTP response from a UiMemoryPreviewUiMemoryPreviewPostWithResponse call
+func ParseUiMemoryPreviewUiMemoryPreviewPostResponse(rsp *http.Response) (*UiMemoryPreviewUiMemoryPreviewPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiMemoryPreviewUiMemoryPreviewPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseUiMemoryTagsUiMemoryTagsGetResponse parses an HTTP response from a UiMemoryTagsUiMemoryTagsGetWithResponse call
 func ParseUiMemoryTagsUiMemoryTagsGetResponse(rsp *http.Response) (*UiMemoryTagsUiMemoryTagsGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -21106,6 +21862,58 @@ func ParseUiMemoryEditFormUiMemoryScopeSlugEditGetResponse(rsp *http.Response) (
 	}
 
 	response := &UiMemoryEditFormUiMemoryScopeSlugEditGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiMemoryPromoteModalUiMemoryScopeSlugPromoteGetResponse parses an HTTP response from a UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetWithResponse call
+func ParseUiMemoryPromoteModalUiMemoryScopeSlugPromoteGetResponse(rsp *http.Response) (*UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiMemoryPromoteModalUiMemoryScopeSlugPromoteGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse parses an HTTP response from a UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithResponse call
+func ParseUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse(rsp *http.Response) (*UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -1227,3 +1227,151 @@ The full suite lives in
 The PATCH happy-path mocks `meho_backplane.retrieval.indexer.get_embedding_service`
 because `MemoryService.remember`'s re-index path calls `encode_one`
 on the new body. Read paths bypass embedding entirely.
+
+## Memory create modal + scope-promotion (Task #878)
+
+Initiative [#341](https://github.com/evoila/meho/issues/341) (G10.4
+Memory UI), Task [#878](https://github.com/evoila/meho/issues/878)
+(G10.4-T2) layers the **create modal** + the **scope-promotion flow**
+onto the T1 router. The "+" button on `/ui/memory` opens an
+HTMX-loaded `<dialog>` with an RBAC-filtered scope selector, slug
+input (optional, auto-generated when blank), Markdown body
+textarea + debounced server-side preview, expiry picker, and a
+comma-separated tags input. Submit calls `MemoryService.remember`
+and HTMX redirects back to the list. The detail-page Promote
+button (rendered only when the source scope has at least one legal
+ladder step) opens a second HTMX-loaded modal and submits through
+the same G5.2 `MemoryService.promote` the REST surface uses; the
+chassis `AuditMiddleware` writes one `memory.promote` audit row
+per request because the handler binds `operator_sub` + `tenant_id`
++ `audit_op_id` + `audit_op_class` + `audit_scope` + `audit_slug`
++ `audit_promotion_target_scope` to the structlog contextvars
+before calling the service.
+
+### Routes
+
+| Method | Path | Purpose |
+| ------ | ---- | ------- |
+| `GET` | `/ui/memory/create` | HTMX-loaded create modal fragment. Scope selector filtered to scopes the operator can write to via `MemoryRbacResolver.can_write`. |
+| `POST` | `/ui/memory/create` | Submit handler. Form-encoded body shape mirrors `/api/v1/memory`'s `RememberBody`. Returns 204 + `HX-Redirect: /ui/memory`. |
+| `POST` | `/ui/memory/preview` | Debounced server-side Markdown preview. Returns the `_body_preview.html` fragment; same `<article>` shape `_body_view.html` uses on the detail page so styling matches. |
+| `GET` | `/ui/memory/<scope>/<slug>/promote` | HTMX-loaded promote modal. Legal targets derived from `PROMOTE_TARGETS_BY_SOURCE`; terminal scopes (`tenant` / `target`) return 400. |
+| `POST` | `/ui/memory/<scope>/<slug>/promote` | Submit handler. Calls G5.2's `MemoryService.promote`. Returns 204 + `HX-Redirect: /ui/memory/<target-scope>/<slug>`. |
+
+### Module layout (additions to T1)
+
+* `backend/src/meho_backplane/ui/routes/memory/create_promote.py` —
+  render helpers + service-call dispatchers for the create + promote
+  routes (`render_create_modal`, `create_entry`, `render_body_preview`,
+  `render_promote_modal`, `promote_entry`, `writable_scopes_for`,
+  `_map_promote_error`). Split out of `views.py` so each module stays
+  under the chassis-wide ~600-line cap.
+* `backend/src/meho_backplane/ui/routes/memory/routes.py` — adds
+  `_register_static_prefix_routes` which registers `/ui/memory/create`
+  + `/ui/memory/preview` (+ T1's `/ui/memory/tags`) ahead of the
+  parametrised `/ui/memory/{scope}/{slug}` routes. Registration
+  order is load-bearing: a request to `/ui/memory/create` would
+  otherwise be matched by `/ui/memory/{scope}/{slug}` with
+  `scope="create"`, producing a 422 from the `MemoryScope` enum.
+* `backend/src/meho_backplane/ui/templates/memory/_create_modal.html` —
+  the HTMX-loaded create modal with the RBAC-filtered scope selector,
+  Markdown textarea with debounced preview wiring, and a tiny inline
+  script that toggles the `target_name` row visibility based on the
+  selected scope. Empty-state renders an alert when
+  `writable_scopes_for(operator)` is empty (read-only role).
+* `backend/src/meho_backplane/ui/templates/memory/_promote_modal.html` —
+  the HTMX-loaded promote modal. Legal targets are rendered as a
+  `<select>`; the same inline-script pattern as the create modal
+  toggles `target_name` when the selected target is
+  target-flavoured.
+* `backend/src/meho_backplane/ui/templates/memory/_body_preview.html` —
+  Markdown-rendered preview fragment returned by `POST /ui/memory/preview`.
+* `backend/src/meho_backplane/ui/templates/memory/index.html` — adds
+  the "+" Create button (`hx-get="/ui/memory/create"`) and a stable
+  `#memory-modal-container` mount point that persists across HTMX
+  swaps.
+* `backend/src/meho_backplane/ui/templates/memory/detail.html` — adds
+  the Promote button (only rendered for non-terminal source scopes)
+  and a second `#memory-modal-container` mount point.
+
+### HTMX modal conventions
+
+* Modals are loaded into a stable `#memory-modal-container` mount
+  point via `hx-get` with `hx-target="#memory-modal-container"
+  hx-swap="innerHTML"`. The inserted `<dialog>` element carries the
+  `modal-open` class (DaisyUI v5) so it opens immediately without a
+  client-side `showModal()` call.
+* Submit forms inside the modals use `hx-post` with `hx-target="this"
+  hx-swap="none"` — the 204 + `HX-Redirect` response shape means
+  HTMX navigates the whole page rather than swapping the form into a
+  rendered fragment. Same convention T1's delete-confirm modal uses.
+* Form encoding is `application/x-www-form-urlencoded`. The chassis
+  `CSRFMiddleware` accepts the double-submit token from either the
+  `X-CSRF-Token` header (HTMX inherits it from the page-level
+  `hx-headers` directive) or the `csrf_token` form field.
+* `hx-trigger="keyup changed delay:300ms"` on the create modal's
+  body textarea drives the debounced server-side preview — see
+  https://htmx.org/attributes/hx-trigger/. `delay:300ms` matches
+  the convention T1's tag-filter input uses for the list page's
+  type-ahead.
+* The create + promote modals each carry a tiny inline `<script>`
+  that toggles the `target_name` field's visibility based on the
+  selected scope. Pulled inline (not into a separate `<script src>`)
+  because the modal is HTMX-injected and a fresh request for the
+  external JS file would race the `<dialog>` insertion. The script
+  reads the target-scoped scope values off a `data-target-scoped-values`
+  attribute on the form so the enum is not re-hardcoded on the
+  client.
+
+### Idempotency + audit trail
+
+`MemoryService.promote` is idempotent (G5.2 contract): a re-promotion
+to the same target returns the existing target row, no insert, no
+`promote_target_conflict` 409. The UI mirrors that contract — a
+double-click on Promote redirects to the same URL twice; the second
+audit row reflects a successful repeat (status 204) and the row
+count in the target scope stays at one.
+
+The promote handler explicitly binds `operator_sub` + `tenant_id`
++ `audit_op_id="memory.promote"` + `audit_op_class="write"` +
+`audit_scope` + `audit_slug` + `audit_promotion_target_scope` to the
+structlog contextvars before calling the service so the chassis
+`AuditMiddleware` writes the audit row with the canonical op id.
+Without this binding the UI session middleware leaves the contextvars
+unset and the chassis middleware skips the audit write — the T1 read
++ edit + delete handlers run without an audit row today for the same
+reason. T2's create handler also binds `audit_op_id="memory.remember"`
++ `audit_op_class="write"` for parity with the `/api/v1/memory` POST
+route, so any future audit-query consumer can correlate a UI-driven
+write with the same op-id literal a CLI / MCP-driven write produces.
+
+### Tests
+
+The full suite lives in
+`backend/tests/test_ui_memory_create_promote.py`. It pins:
+
+* the create-modal render (RBAC-filtered scope selector for
+  operator, tenant-admin sees TENANT, read-only sees the empty state),
+* the create submit (persists the row + HX-Redirects to the list,
+  blank slug auto-generates, tenant scope as operator 403s, empty
+  body 422s, target-scoped without `target_name` 422s, missing CSRF
+  cookie 403s),
+* the Markdown preview (renders Markdown to HTML, empty body returns
+  the placeholder, raw `<script>` escapes),
+* the promote-modal render (USER source lists USER_TENANT +
+  USER_TARGET; terminal TENANT source 400s; cross-user 404),
+* the promote submit (USER -> USER_TENANT persists the target +
+  HX-Redirects to the new detail page; the chassis audit row commits
+  with op id `memory.promote` and the right payload fields; re-promote
+  is idempotent at the row count; operator -> TENANT 403s with
+  `insufficient_promotion_authority`; tenant_admin USER_TENANT ->
+  TENANT succeeds; cross-ladder USER -> TENANT 400s; cross-user 404;
+  cross-tenant 404),
+* the UI integration (list page renders the Create button + modal
+  container; detail page renders the Promote button only for
+  non-terminal source scopes).
+
+The create + promote tests stub the embedding service for the same
+reason the T1 PATCH test does — `index_document` (called by both
+`MemoryService.remember` and `MemoryService.promote`) computes a
+new embedding for the inserted row.

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -1260,12 +1260,22 @@ before calling the service.
 
 ### Module layout (additions to T1)
 
-* `backend/src/meho_backplane/ui/routes/memory/create_promote.py` —
-  render helpers + service-call dispatchers for the create + promote
-  routes (`render_create_modal`, `create_entry`, `render_body_preview`,
-  `render_promote_modal`, `promote_entry`, `writable_scopes_for`,
-  `_map_promote_error`). Split out of `views.py` so each module stays
-  under the chassis-wide ~600-line cap.
+* `backend/src/meho_backplane/ui/routes/memory/create.py` —
+  render + submit helpers for the create modal
+  (`render_create_modal`, `render_body_preview`, `create_entry`).
+  Split out of `views.py` so each module stays under the
+  chassis-wide ~600-line cap.
+* `backend/src/meho_backplane/ui/routes/memory/promote.py` —
+  render + submit helpers for the scope-promotion modal
+  (`render_promote_modal`, `promote_entry`, `_map_promote_error`).
+  Sibling of `create.py`; both call into G5.2's `MemoryService`.
+* `backend/src/meho_backplane/ui/routes/memory/_modal_shared.py` —
+  shared helpers + constants for both modals: scope-selector
+  vocabulary (`writable_scopes_for`, `scope_label`), the
+  double-submit CSRF cookie set (`set_csrf_cookie`,
+  `build_common_template_context`), the form-encoded tags parser
+  (`parse_tags`), and the form-field sizing constants
+  (`TAGS_MAX_LENGTH`, etc.).
 * `backend/src/meho_backplane/ui/routes/memory/routes.py` — adds
   `_register_static_prefix_routes` which registers `/ui/memory/create`
   + `/ui/memory/preview` (+ T1's `/ui/memory/tags`) ahead of the


### PR DESCRIPTION
## Summary
- Layers create + scope-promotion onto T1's read+edit+delete surface from #877. "+" on `/ui/memory` opens an HTMX-loaded modal with an RBAC-filtered scope selector, optional slug, Markdown body textarea with 300ms-debounced server-side preview, expiry picker, and comma-separated tags input; submit calls `MemoryService.remember` and HTMX-redirects back to the list.
- Detail page renders a Promote button for non-terminal source scopes; the promote modal calls G5.2's `MemoryService.promote` which is idempotent against same-scope re-runs. Promote handler binds `operator_sub` + `tenant_id` + `audit_op_id="memory.promote"` (+ scope/slug/promotion_target_scope) so the chassis `AuditMiddleware` writes the canonical audit row the AC requires.
- Module split into `create.py`, `promote.py`, `_modal_shared.py` keeps each file under the chassis-wide ~600-line cap. Static-prefix routes (`/ui/memory/create`, `/ui/memory/preview`) register ahead of `/ui/memory/{scope}/{slug}` so the literal `create` token does not bind to `{scope}`.

## Test plan
- [x] `ruff check src/meho_backplane/ui/ tests/` — clean
- [x] `ruff format --check src/meho_backplane/ui/ tests/` — 33 files already formatted
- [x] `mypy src/meho_backplane/ui/ --ignore-missing-imports` — 32 source files clean
- [x] `pytest tests/test_ui_memory_create_promote.py` — 26 passed
- [x] `pytest tests/test_ui_memory_list.py` — 26 passed (T1 not regressed)
- [x] `pytest tests/` (full backend suite) — 5156 passed, 57 skipped
- [x] `code-quality.py --diff` — 0 blockers
- [x] AC: "+" opens create modal with RBAC-filtered scope selector — `test_create_modal_renders_writable_scopes_only_for_operator`, `test_create_modal_renders_tenant_for_tenant_admin`, `test_create_modal_renders_empty_state_for_read_only_role`
- [x] AC: submit POSTs to backend (semantically — calls `MemoryService.remember` the same way `/api/v1/memory` does); modal closes + list updates via `HX-Redirect: /ui/memory` — `test_create_submit_persists_user_scoped_memory_and_redirects`, `test_create_submit_with_blank_slug_generates_one`
- [x] AC: debounced server-side Markdown preview works — `test_preview_renders_markdown_to_html`, `test_preview_empty_body_renders_placeholder`, `test_preview_escapes_raw_html_in_body`
- [x] AC: operator promotes user-scoped to user-tenant; tenant_admin to tenant — `test_promote_submit_user_to_user_tenant_persists_target_and_redirects`, `test_promote_submit_user_tenant_to_tenant_as_admin_succeeds`
- [x] AC: promotion writes an audit row (asserted by querying `audit_log` after the submit) — `test_promote_submit_writes_audit_row`
- [x] AC: promotion is idempotent — `test_promote_submit_idempotent_re_promote_returns_same_redirect`
- [x] AC: CSRF enforced — `test_create_submit_missing_csrf_token_returns_403`
- [x] AC: cross-user / cross-tenant isolation holds — `test_promote_modal_cross_user_user_scoped_returns_404`, `test_promote_submit_cross_user_returns_404`, `test_promote_submit_cross_tenant_returns_404`

## Out of scope
- List/detail/edit/tags surface — covered by T1 #877 (merged).
- Expiry visualization + bulk select/delete/extend — covered by T3 #879 (sibling worker, parallel branch).
- AI-suggested memory creation — explicitly disallowed per Initiative #341 §Out of scope.

## Adjacent findings (deferred)
- UI session middleware (`meho_backplane.ui.auth.middleware.UISessionMiddleware`) does NOT bind `operator_sub` / `tenant_id` to structlog contextvars; T1's #877 read+edit+delete handlers therefore produce no audit rows today. T2's create + promote handlers bind both contextvars locally to make the audit row land. A broader chassis-side fix that binds at the middleware layer (so every authenticated `/ui/*` request audits) is the right v0.2.next move — out of scope here.
- `routes.py` reached 416 lines (warn >400, block >600); within budget but worth a split when T3's bulk routes land.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #878

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-26)

Addressed review findings from [pr-1167-iter-1 review](https://github.com/evoila/meho/pull/1167#pullrequestreview):

- **B1** `5aa3bbb` — regenerated `cli/api/openapi.json` + `cli/internal/api/client.gen.go` via `cd cli && make snapshot-openapi && make generate`. Mirrors T1 (#1161) precedent (commit `621863b`) which re-snapshotted for the T1 read+edit+delete surface. Unblocks the CLI API snapshot freshness CI check.
- **M1** `b0e6be1` — replaced stale `create_promote.py` references in `docs/codebase/ui.md` (single bullet → three bullets matching the actual `create.py` / `promote.py` / `_modal_shared.py` split) and in `backend/src/meho_backplane/ui/routes/memory/routes.py:12` module docstring. Also fixed an in-scope same-class instance in `backend/src/meho_backplane/ui/templates/memory/_promote_modal.html:27` (RBAC-posture comment pointed at the wrong module for `PROMOTE_TARGETS_BY_SOURCE`).

Disputed: none.

Deferred (recorded as adjacent findings; orchestrator may file follow-up issues):

- `adjacent_improvements[0]` — test asserting `create` audit row lands (mirror of `test_promote_submit_writes_audit_row`); AC #878 only required the promotion-audit assertion, so hardening rather than blocker.
- `adjacent_improvements[1]` — chassis-side `UISessionMiddleware` should bind `operator_sub` / `tenant_id` to structlog contextvars so every `/ui/*` request audits without per-handler boilerplate. Already in the PR's pre-existing Adjacent findings list; v0.2.next.
- `adjacent_improvements[2]` — initiative-level cleanup adding `include_in_schema=False` to every UI route (the five new + T1's existing ones serve `text/html`, no public-API value). Long-term cleaner than re-snapshotting on every UI-route add, but mirroring T1's snapshot precedent is the right call for this PR.
- `adjacent_improvements[3]` — `routes.py` at 417 lines; worth a split when T3's bulk routes land. Already in the PR's pre-existing Adjacent findings list.

<!-- auto-implement-issue: continue, iteration 2 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added create memory modal with scope selector, markdown body editor with live preview, optional tags input, custom slug configuration, and expiry settings
  * Added scope promotion feature to elevate existing memories to broader access levels with confirmation modal and target scope selection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->