### PR TITLE
fix(backplane): G11.2 follow-up — swap include_router order so /agents/grants is reachable (#1168)

### DIFF
--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -609,6 +609,20 @@ app.include_router(api_v1_audit_router)
 # boundaries. Every mutation writes an audit row and broadcasts
 # under op_class=write.
 app.include_router(api_v1_broadcast_overrides_router)
+# G11.2-T6 (#819) -- agent permission grant management (grant / revoke /
+# list / elevate). All verbs gated to tenant_admin. Tenant-scoped via
+# the JWT; cross-tenant probes return 404. Every mutation writes an
+# audit row and broadcasts under op_class=write.
+#
+# Registered BEFORE ``api_v1_agents_router`` (G11.2 follow-up #1168):
+# FastAPI dispatches routes in include order, so the agents-router's
+# ``GET /{name}`` would otherwise shadow ``GET /api/v1/agents/grants``
+# (matching ``name="grants"``). Specific prefix first → grants-list
+# route resolves correctly; ``GET /api/v1/agents/incident-triage``
+# (and every other non-``grants`` name) still falls through to
+# ``show_agent`` because the grants router only matches paths under
+# its own ``/api/v1/agents/grants`` prefix.
+app.include_router(api_v1_agent_grants_router)
 # G11.1-T2 (#809) -- agent-definition CRUD verbs (list / show / create
 # / edit / delete) over the AgentDefinition ORM model. Reads gated to
 # operator-level, writes to tenant_admin. Tenant-scoped via the JWT's
@@ -616,11 +630,6 @@ app.include_router(api_v1_broadcast_overrides_router)
 # existence is not leaked across tenant boundaries. Every mutation
 # writes an audit row and broadcasts under op_class=write.
 app.include_router(api_v1_agents_router)
-# G11.2-T6 (#819) -- agent permission grant management (grant / revoke /
-# list / elevate). All verbs gated to tenant_admin. Tenant-scoped via
-# the JWT; cross-tenant probes return 404. Every mutation writes an
-# audit row and broadcasts under op_class=write.
-app.include_router(api_v1_agent_grants_router)
 # G11.2-T1 (#815) -- agent-principal lifecycle (register / list / revoke).
 # register creates a Keycloak client tagged kind=agent + inserts a DB row.
 # revoke disables the Keycloak client (kill switch) + marks the row revoked.

--- a/backend/tests/test_api_v1_agent_grants.py
+++ b/backend/tests/test_api_v1_agent_grants.py
@@ -110,25 +110,6 @@ def _token(key: Any, *, role: TenantRole, sub: str = "op-test") -> str:
 # be a dict (FastAPI doesn't validate it until the dependency chain
 # clears).
 #
-# Note on ``GET /api/v1/agents/grants`` (list)
-# --------------------------------------------
-# The agent-definitions router (``api/v1/agents.py``) is registered
-# BEFORE the grants router in :mod:`meho_backplane.main`, and its
-# ``GET /{name}`` route matches ``/api/v1/agents/grants`` first
-# (``name="grants"``). FastAPI route precedence is registration
-# order. The shadow is OPERATOR-gated rather than TENANT_ADMIN-gated:
-#
-# * A ``read_only`` request still surfaces as 403
-#   ``insufficient_role`` (from the agents-show gate, not the
-#   grants-list gate) — same observable behaviour from outside, so
-#   the route is covered for the ``read_only`` case at the bottom
-#   of this file via ``test_read_only_list_route_returns_403``.
-# * An ``operator`` request passes the agents-show gate and reaches
-#   the service, returning 404 ``agent_not_found`` rather than the
-#   grants-list 403. The route is excluded from the parametrised
-#   ``operator`` matrix below for that reason; the routing-shadow
-#   itself is an adjacent finding for the orchestrator to file
-#   separately.
 # Fixed UUID literals for path parameters. The role gate fires before
 # any DB lookup, so the value need only parse as a UUID; deterministic
 # literals keep ``pytest-xdist`` test-collection IDs stable across
@@ -138,6 +119,7 @@ _GRANT_ID_SHOW = uuid.UUID("11111111-1111-1111-1111-111111111111")
 _GRANT_ID_REVOKE = uuid.UUID("22222222-2222-2222-2222-222222222222")
 
 _GRANT_ENDPOINTS: tuple[tuple[str, str, dict[str, Any] | None], ...] = (
+    ("GET", "/api/v1/agents/grants", None),
     ("GET", f"/api/v1/agents/grants/{_GRANT_ID_SHOW}", None),
     (
         "POST",
@@ -195,43 +177,15 @@ def test_operator_role_is_rejected_with_insufficient_role(
     """``operator`` JWT → HTTP 403 ``insufficient_role`` on every grants route.
 
     One rank below ``tenant_admin``. This is the load-bearing assertion
-    for the surface: grants show / create / elevate / revoke expose
-    permission topology and must remain ``tenant_admin``-only. A
-    refactor that lowers the gate to ``operator`` (e.g. to align with
-    the approvals surface) trips this test. The list route is covered
-    separately below; see the matrix-level docstring for the routing
-    shadow that excludes it from this parametrised case.
+    for the surface: grants list / show / create / elevate / revoke
+    expose permission topology and must remain ``tenant_admin``-only.
+    A refactor that lowers the gate to ``operator`` (e.g. to align
+    with the approvals surface) trips this test.
     """
     key = make_rsa_keypair("kid-op")
     with respx.mock as r:
         mock_discovery_and_jwks(r, public_jwks(key))
         headers = {"Authorization": f"Bearer {_token(key, role=TenantRole.OPERATOR)}"}
         response = client.request(method, path, headers=headers, json=body)
-    assert response.status_code == 403, response.text
-    assert response.json() == {"detail": "insufficient_role"}
-
-
-def test_read_only_list_route_returns_403(client: TestClient) -> None:
-    """``read_only`` ``GET /api/v1/agents/grants`` returns 403 ``insufficient_role``.
-
-    The list route is shadowed by ``GET /api/v1/agents/{name}`` (see
-    the matrix-level note), but the shadow's ``_require_operator``
-    gate also rejects a ``read_only`` JWT with the same response
-    shape. The route is therefore covered for ``read_only`` from
-    outside — a refactor that drops the grants-list gate AND the
-    agents-show gate would be required to surface a non-403 here.
-
-    This test is the one in this file whose green status does NOT
-    prove the grants-list-specific gate is wired; it proves the
-    outer-observable behaviour. A separate fix that lands the
-    grants router before the agents router in
-    :mod:`meho_backplane.main` would let this case fold back into
-    the parametrised matrix above.
-    """
-    key = make_rsa_keypair("kid-ro")
-    with respx.mock as r:
-        mock_discovery_and_jwks(r, public_jwks(key))
-        headers = {"Authorization": f"Bearer {_token(key, role=TenantRole.READ_ONLY)}"}
-        response = client.get("/api/v1/agents/grants", headers=headers)
     assert response.status_code == 403, response.text
     assert response.json() == {"detail": "insufficient_role"}

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -3692,286 +3692,6 @@
         }
       }
     },
-    "/api/v1/agents": {
-      "get": {
-        "tags": [
-          "agents"
-        ],
-        "summary": "List Agents",
-        "description": "List agent definitions for the operator's tenant, name-sorted.\n\nTenant-scoped to ``operator.tenant_id`` -- no surface accepts a\ntenant id from the query string. ``operator`` and ``tenant_admin``\nboth pass; ``read_only`` is rejected by :func:`require_role`.",
-        "operationId": "list_agents_api_v1_agents_get",
-        "parameters": [
-          {
-            "name": "limit",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "maximum": 500,
-              "minimum": 1,
-              "default": 100,
-              "title": "Limit"
-            }
-          },
-          {
-            "name": "offset",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "integer",
-              "minimum": 0,
-              "default": 0,
-              "title": "Offset"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "nullable": true,
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentDefinitionListResponse"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": [
-          "agents"
-        ],
-        "summary": "Create Agent",
-        "description": "Create one agent definition under the operator's tenant.\n\n``tenant_admin`` only. A duplicate ``(tenant, name)`` returns 409\n``agent_already_exists`` (the per-tenant name natural-key contract\nthe ``agent_definition_tenant_name_idx`` unique index enforces).\nThe system prompt / toolset content is never bound to the audit row;\nonly the agent name is.",
-        "operationId": "create_agent_api_v1_agents_post",
-        "parameters": [
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "nullable": true,
-              "title": "Authorization"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AgentDefinitionCreate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentDefinitionRead"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/agents/{name}": {
-      "get": {
-        "tags": [
-          "agents"
-        ],
-        "summary": "Show Agent",
-        "description": "Return one agent definition by name.\n\nCross-tenant name probes surface as 404 ``agent_not_found`` (not\n403) -- the conflation prevents enumerating another tenant's agents\nvia a status-code differential.",
-        "operationId": "show_agent_api_v1_agents__name__get",
-        "parameters": [
-          {
-            "name": "name",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "maxLength": 128,
-              "title": "Name"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "nullable": true,
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentDefinitionRead"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "tags": [
-          "agents"
-        ],
-        "summary": "Edit Agent",
-        "description": "Apply a partial update to one agent definition by name.\n\n``tenant_admin`` only. Only the fields the caller set are applied\n(``exclude_unset``), so a PATCH can change a single field. ``name``\nis not updatable -- renaming is a delete + recreate. A cross-tenant\n/ absent name returns 404 ``agent_not_found``.",
-        "operationId": "edit_agent_api_v1_agents__name__patch",
-        "parameters": [
-          {
-            "name": "name",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "maxLength": 128,
-              "title": "Name"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "nullable": true,
-              "title": "Authorization"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AgentDefinitionUpdate"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentDefinitionRead"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": [
-          "agents"
-        ],
-        "summary": "Delete Agent",
-        "description": "Delete one agent definition by name.\n\n``tenant_admin`` only. A cross-tenant / absent name returns 404\n``agent_not_found`` -- never 403, so the existence of a definition\nis not leaked across the tenant boundary.",
-        "operationId": "delete_agent_api_v1_agents__name__delete",
-        "parameters": [
-          {
-            "name": "name",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "maxLength": 128,
-              "title": "Name"
-            }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string",
-              "nullable": true,
-              "title": "Authorization"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v1/agents/grants": {
       "get": {
         "tags": [
@@ -4250,6 +3970,286 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/agents": {
+      "get": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "List Agents",
+        "description": "List agent definitions for the operator's tenant, name-sorted.\n\nTenant-scoped to ``operator.tenant_id`` -- no surface accepts a\ntenant id from the query string. ``operator`` and ``tenant_admin``\nboth pass; ``read_only`` is rejected by :func:`require_role`.",
+        "operationId": "list_agents_api_v1_agents_get",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 500,
+              "minimum": 1,
+              "default": 100,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDefinitionListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "Create Agent",
+        "description": "Create one agent definition under the operator's tenant.\n\n``tenant_admin`` only. A duplicate ``(tenant, name)`` returns 409\n``agent_already_exists`` (the per-tenant name natural-key contract\nthe ``agent_definition_tenant_name_idx`` unique index enforces).\nThe system prompt / toolset content is never bound to the audit row;\nonly the agent name is.",
+        "operationId": "create_agent_api_v1_agents_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentDefinitionCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDefinitionRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/agents/{name}": {
+      "get": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "Show Agent",
+        "description": "Return one agent definition by name.\n\nCross-tenant name probes surface as 404 ``agent_not_found`` (not\n403) -- the conflation prevents enumerating another tenant's agents\nvia a status-code differential.",
+        "operationId": "show_agent_api_v1_agents__name__get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "title": "Name"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDefinitionRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "Edit Agent",
+        "description": "Apply a partial update to one agent definition by name.\n\n``tenant_admin`` only. Only the fields the caller set are applied\n(``exclude_unset``), so a PATCH can change a single field. ``name``\nis not updatable -- renaming is a delete + recreate. A cross-tenant\n/ absent name returns 404 ``agent_not_found``.",
+        "operationId": "edit_agent_api_v1_agents__name__patch",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "title": "Name"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentDefinitionUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentDefinitionRead"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "Delete Agent",
+        "description": "Delete one agent definition by name.\n\n``tenant_admin`` only. A cross-tenant / absent name returns 404\n``agent_not_found`` -- never 403, so the existence of a definition\nis not leaked across the tenant boundary.",
+        "operationId": "delete_agent_api_v1_agents__name__delete",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "title": "Name"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
           },
           "422": {
             "description": "Validation Error",


### PR DESCRIPTION
## Summary

- Fixes a FastAPI route-shadow regression where `GET /api/v1/agents/grants` was dispatched to `show_agent(name="grants")` instead of `list_grants()` because the agent-definitions router (with `GET /{name}`) was registered before the grants router. Solution: swap the `app.include_router(...)` order so `api_v1_agent_grants_router` runs first — FastAPI route precedence is registration order.
- Restores correct per-role behaviour on the list route: `read_only` and `operator` JWTs now both surface 403 `insufficient_role` from the grants-list `_require_admin` gate (the load-bearing assertion), and `tenant_admin` can actually reach `list_grants()`.
- Folds the carve-out `test_read_only_list_route_returns_403` back into the parametrised `_GRANT_ENDPOINTS` matrix and removes the matrix-level routing-shadow docstring — the workaround documented in #1124 is now obsolete.

## Test plan

- [x] `ruff check src/meho_backplane/main.py tests/test_api_v1_agent_grants.py` — clean
- [x] `ruff format --check` — 2 files already formatted
- [x] `mypy src/meho_backplane/main.py tests/test_api_v1_agent_grants.py` — no issues
- [x] `pytest backend/tests/test_api_v1_agent_grants.py -x -q` — 10 passed (was 9: 4×2 matrix + carve-out; now 5×2 matrix covers the list route through both `read_only` and `operator`)
- [x] `pytest backend/tests/test_api_v1_agents.py -x -q` — 14 passed (no regression in the agents-show suite; the parameterised `{name}` route still resolves correctly for non-`grants` names like `incident-triage` and `nope`)
- [x] Broader agent-API sweep (`test_api_v1_agents.py`, `test_api_v1_agent_grants.py`, `test_api_v1_agent_principals.py`, `test_api_v1_agent_runs.py`, `test_api_v1_approvals.py`, `test_agent_grants.py`) — 68 passed
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (2 pre-existing warnings unrelated to this change)
- [x] Acceptance criterion: `GET /api/v1/agents/grants` resolves to the grants-list route under all three roles — verified by the parametrised matrix (the matrix `read_only`/`operator` rows now exercise the grants-list-specific gate, not the shadow); empirical FastAPI repro in a scratch app confirms `tenant_admin` reaches `list_grants` while `incident-triage` still reaches `show_agent`

## Out of scope

- A general route-precedence lint / guard (per issue body).
- An exhaustive `prefix=` × `/{name}` shadow probe (per issue body).
- Restructuring grants under a non-overlapping prefix like `/api/v1/agent-grants/` (rejected in the issue body — current prefix is per the v0.2 surface design).
- Adjacent finding (audit per issue body): only one other `/api/v1/agents`-prefix router exists (`agent_runs.py`) and its routes are all multi-segment (`/{name}/run`, `/runs/{handle}`, `/{name}/run/events`), so it does not shadow against `agents.py`'s single-segment `GET /{name}`. No additional shadow patterns found.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1168

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-26)

Addressed review findings from [iter-1 review](https://github.com/evoila/meho/pull/1169#pullrequestreview):

- **B1** `247648b` — regenerated `cli/api/openapi.json` to reflect the new `include_router` order; `cli/internal/api/client.gen.go` confirmed not drifted (oapi-codegen sorts alphabetically). `make snapshot-openapi` is idempotent (second run produces no diff). Unblocks the `CLI API snapshot freshness` CI job.

<!-- auto-implement-issue: continue, iteration 1 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved routing issue where agent grants endpoints were being incorrectly handled. The `/api/v1/agents/grants` endpoint now properly routes to the grants management handlers.

* **Tests**
  * Strengthened role-based access control test coverage for grants endpoints, ensuring proper authorization responses across all user roles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
