### PR TITLE
feat(redaction): G11.4-T1 declarative policy schema + Tier-1 regex engine

### DIFF
--- a/backend/src/meho_backplane/redaction/__init__.py
+++ b/backend/src/meho_backplane/redaction/__init__.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``meho_backplane.redaction`` -- Tier-1 connector-boundary redaction.
+
+Initiative #805 (G11.4 Safety, C1), Task #1070 (T1). This package
+ships the **schema + engine + named-pattern library** half of the
+sanitization deliverable; the middleware that wires the engine into
+``dispatcher._reduce_or_error`` lives in #1071 (C1-b), and the Tier-2
+Microsoft Presidio adapter for free-text NER lives in #1072 (C1-c).
+
+Public surface:
+
+* :class:`RedactionPolicy` / :class:`RedactionRule` / :class:`RedactionScope`
+  -- declarative policy schema (Pydantic, frozen, ``extra='forbid'``).
+* :class:`RedactionAction` -- ``Literal["redact", "mask", "hash"]``.
+* :func:`parse_policy` / :func:`load_policy_yaml` -- YAML loaders.
+* :func:`redact` -- the engine entry point; returns ``(redacted, manifest)``.
+* :class:`RedactionResult` / :class:`RedactionManifestEntry` -- result shapes.
+* :data:`PATTERN_NAMES` -- the named-pattern catalogue.
+
+The package is import-safe and side-effect-free; no global state, no
+I/O at import time, no clocks. Callers may import it from anywhere
+without lifecycle concerns.
+"""
+
+from meho_backplane.redaction.engine import (
+    RedactionManifestEntry,
+    RedactionResult,
+    redact,
+)
+from meho_backplane.redaction.patterns import NAMED_PATTERNS, PATTERN_NAMES, get_pattern
+from meho_backplane.redaction.policy import (
+    RedactionAction,
+    RedactionPolicy,
+    RedactionPolicyError,
+    RedactionRule,
+    RedactionScope,
+    load_policy_yaml,
+    parse_policy,
+)
+
+__all__ = [
+    "NAMED_PATTERNS",
+    "PATTERN_NAMES",
+    "RedactionAction",
+    "RedactionManifestEntry",
+    "RedactionPolicy",
+    "RedactionPolicyError",
+    "RedactionResult",
+    "RedactionRule",
+    "RedactionScope",
+    "get_pattern",
+    "load_policy_yaml",
+    "parse_policy",
+    "redact",
+]

--- a/backend/src/meho_backplane/redaction/engine.py
+++ b/backend/src/meho_backplane/redaction/engine.py
@@ -34,9 +34,14 @@ JSONFlux boundary.
 * ``count`` -- number of matches in this leaf. Multiple matches in one
   leaf collapse into one manifest entry (count tracks them); the audit
   row stays compact even on a paste-heavy payload.
-* ``span`` -- ``(start, end)`` of the *first* match in the original
-  string, byte-indexed against the pre-redaction value. For
-  diagnostic display only; the count is the load-bearing quantity.
+* ``span`` -- ``(start, end)`` of the *first* match in the leaf as
+  the firing rule saw it (i.e. the input to *this* rule, after any
+  earlier rule already rewrote the leaf). For a single-rule policy
+  this equals the offset in the true original; for a multi-rule
+  policy where an earlier rule fired on the same leaf, replay
+  consumers must re-apply earlier rules first to reconstruct the
+  string ``span`` indexes against. For diagnostic display only; the
+  count is the load-bearing quantity.
 * ``reason`` -- the rule's ``reason`` string, propagated verbatim.
 * ``path`` -- dotted path to the leaf within the payload tree
   (``"items.3.password"``). Consumers correlate this with the raw row.
@@ -97,11 +102,15 @@ class RedactionManifestEntry(BaseModel):
 class RedactionResult(BaseModel):
     """Engine return value: ``(redacted, manifest)``.
 
-    The redacted payload is structurally identical to the input (same
-    nesting; only string leaves change) so callers can hand it to the
-    JSONFlux reducer without further shape-fixing. The manifest is
-    ordered by traversal: stable for a given input, which lets the
-    C1-d round-trip CI gate diff manifest-to-manifest.
+    The redacted payload has the same *nesting* as the input but is
+    always normalised to JSON-shaped containers: ``Mapping`` subtypes
+    flatten to ``dict``, ``Sequence`` subtypes (excluding ``str`` /
+    ``bytes`` / ``bytearray``) flatten to ``list``, and only string
+    leaves change. This matches the JSONFlux reduce boundary the
+    payload is being prepared for; callers can hand the result to the
+    reducer without further shape-fixing. The manifest is ordered by
+    traversal: stable for a given input, which lets the C1-d
+    round-trip CI gate diff manifest-to-manifest.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
@@ -161,12 +170,15 @@ def _walk_and_apply(
 ) -> object:
     """Recurse through *node*, applying *rule* at every string leaf.
 
-    The walk is shape-preserving: mappings stay mappings, sequences
-    stay (the same) sequence type by way of ``type(node)(...)`` where
-    safe, falling back to ``list`` for unrecognized sequence subtypes.
-    The Pydantic schema validates payloads only at the connector
-    boundary, not here -- the engine is duck-typed against ``Mapping``
-    and ``Sequence`` (excluding ``str`` / ``bytes``).
+    The walk is *nesting*-preserving but **not subtype-preserving**:
+    every ``Mapping`` (including ``OrderedDict``, ``defaultdict``, and
+    user subclasses) is materialised as a plain ``dict``, and every
+    ``Sequence`` other than ``str`` / ``bytes`` / ``bytearray`` is
+    materialised as a plain ``list``. The output is therefore always
+    JSON-serialisable, which is the contract the JSONFlux reduce
+    boundary downstream relies on. The Pydantic schema validates
+    payloads only at the connector boundary, not here -- the engine
+    is duck-typed against ``Mapping`` and ``Sequence``.
     """
     if isinstance(node, str):
         return _apply_to_str(node, rule, manifest, path=path)

--- a/backend/src/meho_backplane/redaction/engine.py
+++ b/backend/src/meho_backplane/redaction/engine.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tier-1 redaction engine -- Initiative #805, Task #1070.
+
+The deterministic, sub-ms half of the C1 sanitization middleware:
+walks a nested dict/list/str payload and applies a
+:class:`~meho_backplane.redaction.policy.RedactionPolicy`'s rules,
+returning ``(redacted_value, manifest)``. The middleware (#1071,
+C1-b) calls :func:`redact` once per connector response between
+"capture raw" and "JSONFlux reduce"; the audit row carries the
+manifest verbatim.
+
+**Pure and side-effect-free.** No I/O, no logging, no clocks --
+deterministic for identical inputs. The engine is therefore safely
+callable from CI fixtures (C1-d round-trip gate), unit tests, and the
+production hot path without any setup. Callers that need timing or
+logging wrap the call, not patch the engine.
+
+**Walking strategy.** Strings are matched directly. Mappings are walked
+key-by-key; the key itself is not redacted (operator-facing keys are
+schema, not secrets), but its value is. Sequences are walked
+positionally. Anything that is not a str / Mapping / Sequence (numbers,
+booleans, None, bytes) is passed through verbatim -- regex redaction
+on numerics is nonsensical and bytes are not expected at the
+JSONFlux boundary.
+
+**Manifest contract.** :class:`RedactionManifestEntry` per match:
+
+* ``rule`` -- the firing rule's name (the operator-facing handle).
+* ``pattern`` -- the named pattern that matched (``bearer_token``,
+  ``uuid``, ...). Audit consumers can bin by pattern across rules.
+* ``action`` -- which action ran (``redact`` / ``mask`` / ``hash``).
+* ``count`` -- number of matches in this leaf. Multiple matches in one
+  leaf collapse into one manifest entry (count tracks them); the audit
+  row stays compact even on a paste-heavy payload.
+* ``span`` -- ``(start, end)`` of the *first* match in the original
+  string, byte-indexed against the pre-redaction value. For
+  diagnostic display only; the count is the load-bearing quantity.
+* ``reason`` -- the rule's ``reason`` string, propagated verbatim.
+* ``path`` -- dotted path to the leaf within the payload tree
+  (``"items.3.password"``). Consumers correlate this with the raw row.
+
+Multiple rules firing on the same leaf emit one manifest entry per
+firing rule, in policy order. A subsequent rule sees the
+already-redacted leaf produced by the previous rule, so wide rules
+(``fqdn``) should come **after** narrow ones (``api_key``) -- the
+policy is responsible for ordering.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping, Sequence
+from typing import Final
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from meho_backplane.redaction.patterns import get_pattern
+from meho_backplane.redaction.policy import RedactionPolicy, RedactionRule
+
+__all__ = [
+    "RedactionManifestEntry",
+    "RedactionResult",
+    "redact",
+]
+
+
+#: Length of the hex suffix the ``hash`` action exposes. 12 hex
+#: characters = 48 bits -- enough that two distinct secrets cannot
+#: practically collide in one audit row, short enough that the
+#: hashed-view string stays compact.
+_HASH_SUFFIX_LEN: Final[int] = 12
+
+#: Length of the value suffix the ``mask`` action preserves to aid
+#: correlation. 4 chars matches the credit-card convention; for hex
+#: tokens it carries enough to disambiguate without leaking more than
+#: log2(16^4) = 16 bits.
+_MASK_SUFFIX_LEN: Final[int] = 4
+
+
+class RedactionManifestEntry(BaseModel):
+    """One firing of one rule on one leaf. See module docstring."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    rule: str
+    pattern: str
+    action: str
+    count: int = Field(ge=1)
+    span: tuple[int, int]
+    reason: str
+    path: str
+
+
+class RedactionResult(BaseModel):
+    """Engine return value: ``(redacted, manifest)``.
+
+    The redacted payload is structurally identical to the input (same
+    nesting; only string leaves change) so callers can hand it to the
+    JSONFlux reducer without further shape-fixing. The manifest is
+    ordered by traversal: stable for a given input, which lets the
+    C1-d round-trip CI gate diff manifest-to-manifest.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    redacted: object
+    manifest: tuple[RedactionManifestEntry, ...]
+
+
+def redact(
+    payload: object,
+    policy: RedactionPolicy,
+    *,
+    connector_id: str | None = None,
+    tenant: str | None = None,
+    op: str | None = None,
+) -> RedactionResult:
+    """Apply *policy* to *payload*; return ``(redacted, manifest)``.
+
+    *connector_id*, *tenant*, *op* are the call-site labels the
+    middleware passes through; rules with a non-empty
+    :class:`~meho_backplane.redaction.policy.RedactionScope` use them
+    to short-circuit non-matching calls. All three default to ``None``
+    for test convenience -- a scope-less rule fires regardless.
+
+    Rule ordering: rules apply in policy order. Each rule walks the
+    full payload before the next rule runs; later rules see the
+    already-redacted output of earlier ones (see module docstring).
+    """
+    # Pre-filter rules by scope so the inner walk does not re-evaluate
+    # the predicate per leaf. The remaining rules ``apply`` unconditionally
+    # at every string leaf.
+    applicable_rules = tuple(
+        rule
+        for rule in policy.rules
+        if rule.scope.matches(connector_id=connector_id, tenant=tenant, op=op)
+    )
+
+    manifest: list[RedactionManifestEntry] = []
+    current = payload
+    for rule in applicable_rules:
+        current = _walk_and_apply(current, rule, manifest, path="")
+
+    return RedactionResult(redacted=current, manifest=tuple(manifest))
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _walk_and_apply(
+    node: object,
+    rule: RedactionRule,
+    manifest: list[RedactionManifestEntry],
+    *,
+    path: str,
+) -> object:
+    """Recurse through *node*, applying *rule* at every string leaf.
+
+    The walk is shape-preserving: mappings stay mappings, sequences
+    stay (the same) sequence type by way of ``type(node)(...)`` where
+    safe, falling back to ``list`` for unrecognized sequence subtypes.
+    The Pydantic schema validates payloads only at the connector
+    boundary, not here -- the engine is duck-typed against ``Mapping``
+    and ``Sequence`` (excluding ``str`` / ``bytes``).
+    """
+    if isinstance(node, str):
+        return _apply_to_str(node, rule, manifest, path=path)
+    if isinstance(node, Mapping):
+        return {
+            key: _walk_and_apply(
+                value,
+                rule,
+                manifest,
+                path=_join_path(path, str(key)),
+            )
+            for key, value in node.items()
+        }
+    if isinstance(node, Sequence) and not isinstance(node, (str, bytes, bytearray)):
+        return [
+            _walk_and_apply(
+                item,
+                rule,
+                manifest,
+                path=_join_path(path, str(index)),
+            )
+            for index, item in enumerate(node)
+        ]
+    # Numbers, booleans, None, bytes, custom scalars: pass through.
+    # Regex redaction on these is nonsensical; the C1-b middleware is
+    # the boundary that asserts what shapes the engine ever sees.
+    return node
+
+
+def _apply_to_str(
+    leaf: str,
+    rule: RedactionRule,
+    manifest: list[RedactionManifestEntry],
+    *,
+    path: str,
+) -> str:
+    """Match *rule* against *leaf*; emit manifest + return new string.
+
+    The named-pattern lookup raises :class:`KeyError` on an unknown
+    name, but the policy schema rejects unknown names at parse time
+    so that branch is unreachable in production. Defensively, an
+    unknown name here would crash policy load before any traffic, not
+    a request mid-flight.
+    """
+    pattern = get_pattern(rule.pattern)
+    matches = list(pattern.finditer(leaf))
+    if not matches:
+        return leaf
+
+    redacted = pattern.sub(
+        lambda m: _replacement_for(rule, m),
+        leaf,
+    )
+    first = matches[0]
+    manifest.append(
+        RedactionManifestEntry(
+            rule=rule.name,
+            pattern=rule.pattern,
+            action=rule.action,
+            count=len(matches),
+            span=(first.start(), first.end()),
+            reason=rule.reason,
+            path=path,
+        ),
+    )
+    return redacted
+
+
+def _replacement_for(rule: RedactionRule, match: re.Match[str]) -> str:
+    """Return the per-match replacement string for *rule*'s action.
+
+    Centralised so the three actions stay alignable; adding a new
+    action (e.g. ``tokenize`` for the secret-broker integration #581)
+    is one literal here plus one entry in the
+    :data:`~meho_backplane.redaction.policy.RedactionAction` union.
+    """
+    matched = match.group(0)
+    if rule.action == "redact":
+        return f"[REDACTED:{rule.pattern}]"
+    if rule.action == "mask":
+        # Length-preserving asterisk run + last-N suffix. When the
+        # match is shorter than the suffix we want to preserve, fall
+        # back to a pure asterisk run -- exposing the whole value as
+        # "suffix" defeats the masking.
+        if len(matched) <= _MASK_SUFFIX_LEN:
+            return "*" * len(matched)
+        return "*" * (len(matched) - _MASK_SUFFIX_LEN) + matched[-_MASK_SUFFIX_LEN:]
+    if rule.action == "hash":
+        # SHA-256 is overkill cryptographically for what is really a
+        # stable correlator, but it costs ~microseconds on the leaf
+        # sizes the connector boundary sees and keeps the audit
+        # column type-stable across rule revisions. UTF-8 encoding is
+        # explicit so the hashed value is stable across platforms.
+        digest = hashlib.sha256(matched.encode("utf-8")).hexdigest()
+        return f"sha256:{digest[:_HASH_SUFFIX_LEN]}"
+    # The Literal union on RedactionAction excludes any other value
+    # at the schema layer; the catch-all is defensive against future
+    # action additions that forget to extend this match.
+    raise RuntimeError(f"unsupported redaction action {rule.action!r}")
+
+
+def _join_path(parent: str, child: str) -> str:
+    """Build dotted JSON-ish paths for manifest entries.
+
+    Root leaves get the empty path ``""`` so a top-level string
+    payload (uncommon but legal) emits ``path=""`` rather than a
+    leading dot.
+    """
+    if not parent:
+        return child
+    return f"{parent}.{child}"

--- a/backend/src/meho_backplane/redaction/patterns.py
+++ b/backend/src/meho_backplane/redaction/patterns.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tier-1 named-pattern library for the connector-boundary redactor.
+
+Initiative #805 (G11.4 Safety, C1), Task #1070 (T1). This module ships
+the **deterministic, hot-path** half of the tiered redaction design
+sketched in #805 §Approach: a small, fixed set of regexes targeting
+infra-leak shapes (authorization headers, bearer/JWT/API tokens,
+kubeconfig, network identifiers). Free-text NER is out of scope here --
+that is Tier-2 Microsoft Presidio in C1-c (#1072).
+
+Why named (vs raw inline regex)? Three reasons:
+
+1. **Policy YAML stays readable.** A policy author references
+   ``bearer_token`` by name; the regex itself is owned, version-pinned,
+   and unit-tested in this module.
+2. **Audit manifests carry semantic types**, not opaque match indices.
+   Downstream consumers (C1-b audit row, C1-d round-trip CI gate) bin
+   by ``pattern.name`` -- which would be brittle if the name were the
+   regex source.
+3. **Calibration without a YAML rev.** A false-positive against e.g.
+   ``fqdn`` is fixed by editing :data:`NAMED_PATTERNS` in this file
+   plus a regression test; every policy that references the name picks
+   up the fix on the next process boot.
+
+**Pattern contract.** Every entry in :data:`NAMED_PATTERNS` is a
+pre-compiled :class:`re.Pattern` with the ``re.IGNORECASE`` flag where
+casing varies in the wild (HTTP header names; hex tokens). Patterns are
+**anchored to a boundary** (word boundary or punctuation) wherever
+possible so they do not over-match in the middle of unrelated text;
+the engine then redacts the full match span (group 0). Patterns capture
+the *value* shape, not the surrounding context, except for
+``authorization_header`` where the redacted span is the whole
+``Authorization: ...`` line because the header name itself is the
+operator-facing signal.
+
+**False-positive posture.** Tier-1 is the cheap layer. It will
+*occasionally* over-redact a benign UUID-shaped or FQDN-shaped string,
+and an operator who needs to surface those can scope the rule with
+``connector_id`` / ``op`` (see :mod:`.policy`). The opposite mistake
+(under-redaction of a real secret) is the one we cannot afford -- the
+trust boundary is the API surface, per the parent goal (#800).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+__all__ = [
+    "NAMED_PATTERNS",
+    "PATTERN_NAMES",
+    "get_pattern",
+]
+
+
+# -- Authorization-style headers --------------------------------------------
+#
+# ``Authorization: Bearer <jwt>`` and ``Authorization: Basic
+# <base64>`` are the two RFC 7235 shapes operators paste into ticket
+# bodies and log lines. We match the whole header line so the audit
+# manifest carries the type label ``authorization_header`` rather than
+# the inner-token type -- the operator-facing signal is the header
+# itself. ``re.IGNORECASE`` covers ``authorization`` / ``Authorization``
+# / ``AUTHORIZATION`` (HTTP header names are case-insensitive per
+# RFC 7230).
+_AUTHORIZATION_HEADER = re.compile(
+    r"Authorization\s*:\s*[A-Za-z]+\s+[A-Za-z0-9._\-+/=]+",
+    re.IGNORECASE,
+)
+
+# Bare bearer tokens: ``Bearer <opaque>``. Separate from
+# authorization_header because operators paste ``Bearer eyJ...`` into
+# Slack snippets without the surrounding header name (curl ``-H "Bearer
+# ..."`` is wrong but common). The token body matches base64url + hex +
+# the JWT three-segment shape; the leading ``\b`` anchor prevents
+# matching ``foobarBearer ...`` mid-word.
+_BEARER_TOKEN = re.compile(
+    r"\bBearer\s+[A-Za-z0-9._\-+/=]{8,}",
+    re.IGNORECASE,
+)
+
+# JWTs: three base64url segments separated by dots, header starts with
+# ``ey`` (the base64 of ``{"``). The 16-char minimum on header/payload
+# segments avoids matching arbitrary ``a.b.c`` strings while still
+# catching the smallest real JWTs (which run ~80+ chars total).
+_JWT = re.compile(
+    r"\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}",
+)
+
+# Generic API keys / secret tokens. This is intentionally narrow: we
+# only match labelled secrets (``api[_-]?key``, ``token``, ``secret``,
+# ``password``) followed by ``=`` / ``:`` / `` `` and a non-trivial
+# value. A naked 40-char base64 string in a paragraph is **not** matched
+# here because the false-positive rate against opaque IDs (Git SHAs,
+# build hashes, CSP nonces) would be intolerable; downstream Tier-2 NER
+# can take a second pass on free text.
+_API_KEY = re.compile(
+    r"\b(?:api[_-]?key|access[_-]?token|secret(?:[_-]?key)?|password|passwd|pwd|client[_-]?secret)"
+    r"\s*[=:]\s*['\"]?[A-Za-z0-9._\-+/=]{8,}['\"]?",
+    re.IGNORECASE,
+)
+
+# Kubeconfig: the giveaway is ``apiVersion: v1`` + ``kind: Config``
+# nearby in the same blob. We match the whole document by locking onto
+# the YAML preamble and then sweeping until the next blank line OR end
+# of string (whichever comes first). Operators paste these into ticket
+# bodies wholesale; redacting the file shell + leaving the structure is
+# pointless, so we redact the full match.
+_KUBECONFIG = re.compile(
+    r"apiVersion\s*:\s*v1\s*\n(?:.*\n){0,80}?kind\s*:\s*Config(?:\n(?:.*\n){0,200}?(?:\n|$))?",
+    re.IGNORECASE,
+)
+
+# UUIDs (RFC 4122 canonical 8-4-4-4-12 hex). UUIDs in operator-facing
+# payloads are often resource identifiers (tenant id, agent run id) --
+# arguably non-sensitive -- but they are stable per-tenant correlators
+# that an LLM context window does not need. Tier-1 redacts; per-op
+# scopes (see :mod:`.policy`) opt back in where needed.
+_UUID = re.compile(
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b",
+    re.IGNORECASE,
+)
+
+# IPv4 dotted-quad. The 0-255 per-octet constraint avoids matching
+# arbitrary 4-tuples like build version numbers (``1.2.3.4`` parses as a
+# valid IP but is also the canonical 4-segment marketing version, so a
+# policy that needs to surface it scopes the rule out).
+_IPV4 = re.compile(
+    r"\b(?:25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])"
+    r"(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])){3}\b",
+)
+
+# IPv6: full + compressed forms. Built from the union of the canonical
+# RFC 5952 patterns; intentionally rejects the dual-IPv6/IPv4 embedded
+# form (e.g. ``::ffff:192.0.2.1``) to keep the regex tractable -- the
+# embedded-IPv4 half is caught by :data:`_IPV4` anyway.
+_IPV6 = re.compile(
+    r"(?<![:.A-Za-z0-9])"
+    r"(?:"
+    # 8-group full form (1762:0:0:0:0:B03:1:AF18)
+    r"(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}"
+    r"|"
+    # Compressed forms with one ``::``
+    r"(?:[0-9A-Fa-f]{1,4}:){1,7}:"
+    r"|"
+    r":(?::[0-9A-Fa-f]{1,4}){1,7}"
+    r"|"
+    r"(?:[0-9A-Fa-f]{1,4}:){1,6}(?::[0-9A-Fa-f]{1,4}){1,6}"
+    r")"
+    r"(?![:.A-Za-z0-9])",
+)
+
+# Fully-qualified domain names. We require at least two labels and a
+# 2-24 char TLD with no leading digit (the leading-digit clause kills
+# version triples like ``1.2.3``). Single-label hostnames (``localhost``,
+# ``vcenter``) are out of scope -- they are not "fully qualified" by
+# definition. The trailing-dot canonical FQDN form is allowed but
+# optional. Labels follow RFC 1035 syntax (LDH; no leading/trailing
+# hyphen; 1-63 chars), so we use the standard ``[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?``
+# label production rather than free-form ``[A-Za-z0-9\-]+``.
+_FQDN = re.compile(
+    r"\b(?:[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?\.)+"
+    r"[A-Za-z][A-Za-z0-9\-]{1,23}\b",
+)
+
+
+#: Frozen mapping from pattern name to compiled regex. Insertion order is
+#: the canonical evaluation order (engine iterates rules, not patterns,
+#: so this is documentation rather than a contract -- the engine applies
+#: rules in policy order). Names match the catalogue called out in the
+#: task body (#1070).
+NAMED_PATTERNS: Final[dict[str, re.Pattern[str]]] = {
+    "authorization_header": _AUTHORIZATION_HEADER,
+    "bearer_token": _BEARER_TOKEN,
+    "jwt": _JWT,
+    "api_key": _API_KEY,
+    "kubeconfig": _KUBECONFIG,
+    "uuid": _UUID,
+    "ipv4": _IPV4,
+    "ipv6": _IPV6,
+    "fqdn": _FQDN,
+}
+
+#: Stable, sorted tuple of pattern names; what the Pydantic policy
+#: schema validates rule.pattern against. Sorted for deterministic
+#: error messages.
+PATTERN_NAMES: Final[tuple[str, ...]] = tuple(sorted(NAMED_PATTERNS))
+
+
+def get_pattern(name: str) -> re.Pattern[str]:
+    """Return the compiled regex for *name*.
+
+    Raises :class:`KeyError` with the known-names list when *name* is
+    unknown -- the policy schema rejects unknown names at parse time
+    via a field validator, so reaching this branch indicates a
+    programmer error (engine wired up against a stale name).
+    """
+    try:
+        return NAMED_PATTERNS[name]
+    except KeyError as exc:
+        raise KeyError(
+            f"unknown named pattern {name!r}; known patterns: {', '.join(PATTERN_NAMES)}",
+        ) from exc

--- a/backend/src/meho_backplane/redaction/policies/__init__.py
+++ b/backend/src/meho_backplane/redaction/policies/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Packaged Tier-1 redaction policies -- accessed via ``importlib.resources``.
+
+This subpackage ships YAML policy fixtures as package data alongside
+the loader so the packaged wheel can resolve them without a
+bind-mount. See :mod:`meho_backplane.redaction.policy` for the loader
+(:func:`~meho_backplane.redaction.policy.load_policy_yaml`).
+"""

--- a/backend/src/meho_backplane/redaction/policies/example.yaml
+++ b/backend/src/meho_backplane/redaction/policies/example.yaml
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# Example Tier-1 redaction policy -- Initiative #805 (G11.4 Safety, C1),
+# Task #1070 (T1). Ships as package data alongside the loader so the
+# packaged backend wheel can resolve it via importlib.resources without
+# a bind-mount; tests round-trip raw YAML strings through parse_policy
+# directly, so this file is reference + an integration-shape proof, not
+# the canonical authority on which rules production runs.
+#
+# Sibling task #1071 (C1-b) wires policies into the middleware; the
+# operator-facing policy authoring path (per-tenant, per-op) is part
+# of that ticket, not this one.
+
+id: default-tier1
+version: 1
+description: |
+  Tier-1 default policy for the connector-boundary redactor. Hot-path
+  regex over named patterns -- targets credentials, tokens, network
+  identifiers, and kubeconfig blobs. Free-text NER (descriptions,
+  error strings) is handled by the Tier-2 Presidio adapter (#1072).
+
+rules:
+  - name: strip-authorization-header
+    pattern: authorization_header
+    action: redact
+    reason: "RFC 7235 secret on the header line"
+
+  - name: strip-bearer-token
+    pattern: bearer_token
+    action: redact
+    reason: "bare bearer token outside an Authorization header"
+
+  - name: strip-jwt
+    pattern: jwt
+    action: redact
+    reason: "JWT in payload body"
+
+  - name: strip-api-key
+    pattern: api_key
+    action: redact
+    reason: "labelled credential pair (api_key/token/secret/password)"
+
+  - name: strip-kubeconfig
+    pattern: kubeconfig
+    action: redact
+    reason: "kubeconfig blob in payload"
+
+  - name: mask-uuids
+    pattern: uuid
+    action: mask
+    reason: "UUIDs are tenant-stable correlators; mask preserves shape"
+
+  - name: hash-fqdn
+    pattern: fqdn
+    action: hash
+    reason: "FQDN reveals tenant infra topology; hashed correlator suffices"
+
+  - name: redact-ipv4
+    pattern: ipv4
+    action: redact
+    reason: "IPv4 reveals tenant infra topology"
+
+  - name: redact-ipv6
+    pattern: ipv6
+    action: redact
+    reason: "IPv6 reveals tenant infra topology"

--- a/backend/src/meho_backplane/redaction/policy.py
+++ b/backend/src/meho_backplane/redaction/policy.py
@@ -1,0 +1,311 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Declarative redaction policy schema -- Initiative #805, Task #1070.
+
+Pydantic models that parse a YAML policy file into a validated,
+immutable :class:`RedactionPolicy`. The schema is one half of the
+C1 deliverable; the engine in :mod:`.engine` consumes it.
+
+Shape (mirrors the YAML):
+
+.. code-block:: yaml
+
+    id: default-connector-redaction
+    version: 1
+    description: |
+      Tier-1 hot-path redaction for every connector response.
+    rules:
+      - name: strip-authorization-headers
+        pattern: authorization_header
+        action: redact
+        reason: "RFC 7235 secret in header"
+      - name: mask-uuids-in-github
+        pattern: uuid
+        action: mask
+        scope:
+          connector_id: github
+        reason: "GitHub correlator UUIDs are tenant-stable"
+
+**Action semantics** (consumed by :func:`engine.redact`):
+
+* ``redact`` -- replace the matched span with a fixed marker
+  (``"[REDACTED:<pattern>]"``). The default; appropriate for raw
+  secrets where partial reveal is itself a leak.
+* ``mask`` -- replace the matched span with a length-preserving
+  asterisk run plus a short suffix (``"********a1b2"``). Useful when
+  downstream consumers correlate by identifier shape but cannot see
+  the value.
+* ``hash`` -- replace the matched span with the prefix
+  ``"sha256:<12-hex>"`` of the SHA-256 of the match. Stable across
+  identical inputs so audit replay can compare hashed views without
+  reissuing the secret.
+
+**Why version-controlled and testable.** The parent initiative (#805
+DoD) treats redaction policies as code: every rule has a unit-test
+fixture, every policy round-trips raw -> redacted in CI (C1-d).
+Pydantic's ``extra='forbid'`` + the field validators below catch the
+typos and stale pattern names that would otherwise silently neuter a
+rule.
+
+**Boundary purity.** The model is frozen and side-effect-free.
+:func:`load_policy_yaml` is the only I/O entry point. Callers that
+need to compose policies in tests (or generate one from a tenant
+record at runtime) use :meth:`RedactionPolicy.model_validate` against
+a plain dict.
+"""
+
+from __future__ import annotations
+
+from importlib import resources
+from typing import Annotated, Final, Literal
+
+import yaml
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+)
+
+from meho_backplane.redaction.patterns import PATTERN_NAMES
+
+__all__ = [
+    "RedactionAction",
+    "RedactionPolicy",
+    "RedactionPolicyError",
+    "RedactionRule",
+    "RedactionScope",
+    "load_policy_yaml",
+    "parse_policy",
+]
+
+
+#: Marker for the supported pattern actions; :class:`RedactionRule`
+#: pins the literal so an unsupported value surfaces as a typed
+#: ValidationError, and downstream pattern-matches over the union
+#: stay exhaustive under ``mypy --strict``.
+RedactionAction = Literal["redact", "mask", "hash"]
+
+#: Max length of a rule / policy identifier. Long enough for
+#: human-readable slugs (``strip-authorization-headers``) plus a
+#: tenant suffix; short enough that the audit-manifest entries the
+#: engine emits stay compact.
+_NAME_MAX_LENGTH: Final[int] = 96
+
+#: Max length of a free-text ``reason`` field. The audit manifest
+#: carries this verbatim into the C1-b audit row; capping prevents an
+#: adversarial / pasted-novel policy from bloating audit storage.
+_REASON_MAX_LENGTH: Final[int] = 512
+
+
+class RedactionPolicyError(RuntimeError):
+    """Raised when a redaction policy is malformed or incoherent.
+
+    Mirrors the :class:`~meho_backplane.operations.ingest.catalog.CatalogError`
+    posture: callers get one remediation-bearing exception type rather
+    than handling :class:`yaml.YAMLError` and
+    :class:`pydantic.ValidationError` separately.
+    """
+
+
+class RedactionScope(BaseModel):
+    """Optional rule scope -- limits which calls a rule applies to.
+
+    All three fields are optional and combined with **AND** semantics
+    when present: a rule with ``connector_id='github'`` and
+    ``op='issues.create'`` fires only when both labels match. Empty
+    scope (the default) means "apply on every call".
+
+    The engine receives the (connector_id, tenant, op) labels from the
+    middleware (C1-b, #1071); this module just stores the predicate.
+    Tenant is the OIDC ``sub`` / tenant id string, matching the type
+    used in :mod:`meho_backplane.tenancy`.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    connector_id: Annotated[str | None, Field(max_length=_NAME_MAX_LENGTH)] = None
+    tenant: Annotated[str | None, Field(max_length=_NAME_MAX_LENGTH)] = None
+    op: Annotated[str | None, Field(max_length=_NAME_MAX_LENGTH)] = None
+
+    def matches(
+        self,
+        *,
+        connector_id: str | None,
+        tenant: str | None,
+        op: str | None,
+    ) -> bool:
+        """Return ``True`` when the scope predicate fires for these labels.
+
+        Unset scope fields are wildcards. The engine calls this once per
+        rule per payload; it is pure and allocation-free in the common
+        case (all scope fields ``None`` -> short-circuit to ``True``).
+        """
+        if self.connector_id is not None and self.connector_id != connector_id:
+            return False
+        if self.tenant is not None and self.tenant != tenant:
+            return False
+        if self.op is not None and self.op != op:  # noqa: SIM103 -- explicit reads clearer than `not (... and ...)`
+            return False
+        return True
+
+
+class RedactionRule(BaseModel):
+    """One ``named pattern -> action`` binding inside a policy.
+
+    The rule's ``name`` is the operator-facing handle (shows up in
+    audit manifests; what a sibling task / runtime config flag toggles).
+    The ``pattern`` MUST be one of :data:`patterns.PATTERN_NAMES`; the
+    field validator rejects unknown names at parse time so a misspelled
+    pattern fails policy load, not silently at first match.
+
+    ``reason`` is a one-line operator-facing rationale, emitted verbatim
+    into the audit manifest by the engine and consumed by C1-b for the
+    audit row (#1071). Required because every redaction the auditor sees
+    has to answer "why did this fire" without crawling git blame.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: Annotated[str, Field(min_length=1, max_length=_NAME_MAX_LENGTH)]
+    pattern: Annotated[str, Field(min_length=1, max_length=_NAME_MAX_LENGTH)]
+    action: RedactionAction = "redact"
+    scope: RedactionScope = Field(default_factory=RedactionScope)
+    reason: Annotated[str, Field(min_length=1, max_length=_REASON_MAX_LENGTH)]
+
+    @field_validator("name")
+    @classmethod
+    def _name_is_slug(cls, value: str) -> str:
+        """Strip + assert non-empty after strip.
+
+        We do not enforce a strict slug shape (``[a-z0-9-]+``) here --
+        the audit-manifest consumer surfaces names verbatim and an
+        operator who wants ``StripAuth/2025`` should be able to keep
+        it. The cap on length protects the audit row.
+        """
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("rule name must not be blank or whitespace-only")
+        return normalized
+
+    @field_validator("pattern")
+    @classmethod
+    def _pattern_is_known(cls, value: str) -> str:
+        """Reject unknown pattern names with the known-set in the error.
+
+        :data:`PATTERN_NAMES` is the source of truth; a stale rule
+        referencing a removed/renamed pattern fails policy load with a
+        list of valid replacements. Tier-2 (#1072) Presidio recognizers
+        will register their names here too when that lands.
+        """
+        normalized = value.strip()
+        if normalized not in PATTERN_NAMES:
+            raise ValueError(
+                f"unknown pattern {normalized!r}; known patterns: {', '.join(PATTERN_NAMES)}",
+            )
+        return normalized
+
+    @field_validator("reason")
+    @classmethod
+    def _reason_non_blank(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("rule reason must not be blank or whitespace-only")
+        return normalized
+
+
+class RedactionPolicy(BaseModel):
+    """A named, versioned bundle of redaction rules.
+
+    ``id`` is the policy slug (per-tenant or system-wide); ``version``
+    is a monotonically-increasing integer the C1-d round-trip CI gate
+    pins to. A policy with no rules is rejected -- an empty policy is
+    almost certainly a mistake and would silently let raw payloads
+    through; the explicit error forces the author to either delete the
+    file or write at least one rule.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    id: Annotated[str, Field(min_length=1, max_length=_NAME_MAX_LENGTH)]
+    version: Annotated[int, Field(ge=1)]
+    description: Annotated[str, Field(default="", max_length=2048)]
+    rules: Annotated[tuple[RedactionRule, ...], Field(min_length=1)]
+
+    @field_validator("id")
+    @classmethod
+    def _id_non_blank(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("policy id must not be blank or whitespace-only")
+        return normalized
+
+    @field_validator("rules")
+    @classmethod
+    def _rule_names_unique(cls, rules: tuple[RedactionRule, ...]) -> tuple[RedactionRule, ...]:
+        """Reject duplicate ``rule.name`` within one policy.
+
+        Duplicate names would make audit-manifest entries ambiguous
+        (which rule fired?) and would let an operator silently shadow
+        an earlier rule by re-defining the same name later in the
+        file. Enforced here so the YAML diff is self-explanatory.
+        """
+        seen: set[str] = set()
+        for rule in rules:
+            if rule.name in seen:
+                raise ValueError(f"duplicate rule name {rule.name!r} within policy")
+            seen.add(rule.name)
+        return rules
+
+
+def parse_policy(raw: str) -> RedactionPolicy:
+    """Parse + schema-validate a YAML policy string.
+
+    Raises :class:`RedactionPolicyError` (never a bare ``yaml`` /
+    ``pydantic`` error) so callers get one remediation-bearing exception
+    type. The error message embeds the underlying validator output --
+    pydantic's tree-form error already lists every offending field --
+    so an operator pasting a malformed policy sees the path
+    (``rules.2.pattern``) and the reason in one place.
+    """
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise RedactionPolicyError(f"redaction policy is not valid YAML: {exc}") from exc
+    if not isinstance(data, dict):
+        raise RedactionPolicyError(
+            "redaction policy must be a YAML mapping at the top level",
+        )
+    try:
+        return RedactionPolicy.model_validate(data)
+    except ValidationError as exc:
+        raise RedactionPolicyError(
+            f"redaction policy failed schema validation: {exc}",
+        ) from exc
+
+
+def load_policy_yaml(package: str, resource: str) -> RedactionPolicy:
+    """Load + validate a packaged YAML policy via ``importlib.resources``.
+
+    Mirrors the connector-spec catalog precedent
+    (:func:`~meho_backplane.operations.ingest.catalog.load_catalog`):
+    policies ship as package data colocated with their loader so a
+    deployed wheel resolves them through
+    :func:`importlib.resources.files` regardless of cwd.
+
+    Parameters
+    ----------
+    package
+        Dotted package name where the policy lives (e.g.
+        ``"meho_backplane.redaction.policies"``).
+    resource
+        File name within *package* (e.g. ``"example.yaml"``).
+
+    This is the only I/O entry point in the module; tests round-trip
+    raw YAML strings through :func:`parse_policy` directly and never
+    touch the filesystem.
+    """
+    raw = resources.files(package).joinpath(resource).read_text(encoding="utf-8")
+    return parse_policy(raw)

--- a/backend/tests/test_redaction_engine.py
+++ b/backend/tests/test_redaction_engine.py
@@ -1,0 +1,355 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Redaction engine integration tests (Task #1070).
+
+Acceptance criteria covered:
+
+* "The engine returns ``(redacted, manifest)`` for a nested dict/list
+  payload; manifest entries carry type/count/span/reason."
+* The engine is pure: identical inputs produce identical outputs;
+  no I/O; no globals mutated.
+
+Each test names exactly which acceptance bit it pins; the file is
+the load-bearing proof of the C1-a deliverable's behavioural contract.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from meho_backplane.redaction import (
+    RedactionManifestEntry,
+    RedactionPolicy,
+    RedactionResult,
+    parse_policy,
+    redact,
+)
+
+
+def _policy_with_rules(*rules_yaml: str) -> RedactionPolicy:
+    """Build a one-off policy from a list of rule YAML fragments.
+
+    Keeps test bodies focused on the assertion rather than
+    boilerplate. The YAML preamble is fixed; rules are spliced in,
+    each indented two spaces so they nest under the ``rules:`` key.
+    """
+    # textwrap.dedent unindents the f-string's leading whitespace; we
+    # build the YAML with no leading indent, then attach rules already
+    # indented two spaces for the list-under-mapping nesting.
+    rules_block = "\n".join(
+        textwrap.indent(textwrap.dedent(rule).strip("\n"), "  ") for rule in rules_yaml
+    )
+    raw = f"id: test\nversion: 1\nrules:\n{rules_block}\n"
+    return parse_policy(raw)
+
+
+# ---------------------------------------------------------------------------
+# Return shape + manifest contract
+# ---------------------------------------------------------------------------
+
+
+def test_redact_returns_redaction_result_tuple_shape() -> None:
+    """Engine yields a RedactionResult; the docstring's tuple framing
+    is realised by the (redacted, manifest) field pair."""
+    policy = _policy_with_rules(
+        textwrap.dedent(
+            """
+            - name: r
+              pattern: bearer_token
+              action: redact
+              reason: "test"
+            """,
+        ),
+    )
+    result = redact("Bearer abcdef0123456789", policy)
+    assert isinstance(result, RedactionResult)
+    # Field access mirroring the ``(redacted, manifest)`` framing.
+    assert "[REDACTED:bearer_token]" in str(result.redacted)
+    assert len(result.manifest) == 1
+
+
+def test_no_matches_emits_empty_manifest_unchanged_payload() -> None:
+    policy = _policy_with_rules(
+        textwrap.dedent(
+            """
+            - name: r
+              pattern: bearer_token
+              action: redact
+              reason: "test"
+            """,
+        ),
+    )
+    payload = {"status": "ok", "items": [1, 2, 3]}
+    result = redact(payload, policy)
+    assert result.redacted == payload
+    assert result.manifest == ()
+
+
+def test_manifest_entry_shape_per_match() -> None:
+    """Each manifest entry carries type / count / span / reason."""
+    policy = _policy_with_rules(
+        textwrap.dedent(
+            """
+            - name: strip-uuid
+              pattern: uuid
+              action: redact
+              reason: "tenant correlator"
+            """,
+        ),
+    )
+    result = redact(
+        "tenant=12345678-1234-1234-1234-123456789abc",
+        policy,
+    )
+    assert len(result.manifest) == 1
+    entry = result.manifest[0]
+    assert isinstance(entry, RedactionManifestEntry)
+    assert entry.rule == "strip-uuid"
+    assert entry.pattern == "uuid"
+    assert entry.action == "redact"
+    assert entry.count == 1
+    assert entry.reason == "tenant correlator"
+    # Span is byte-indexed against the *pre-redaction* leaf; the UUID
+    # starts after ``tenant=`` (7 chars) and is 36 chars long.
+    start, end = entry.span
+    assert start == len("tenant=")
+    assert end == start + 36
+
+
+def test_multiple_matches_collapse_to_one_manifest_entry_with_count() -> None:
+    """Two UUIDs in one string => one manifest row, count=2."""
+    policy = _policy_with_rules(
+        textwrap.dedent(
+            """
+            - name: strip-uuid
+              pattern: uuid
+              action: redact
+              reason: "tenant correlator"
+            """,
+        ),
+    )
+    leaf = (
+        "primary=12345678-1234-1234-1234-123456789abc "
+        "secondary=abcdef00-aaaa-bbbb-cccc-aabbccddeeff"
+    )
+    result = redact(leaf, policy)
+    assert len(result.manifest) == 1
+    assert result.manifest[0].count == 2
+
+
+# ---------------------------------------------------------------------------
+# Nested payload walk + path tracking
+# ---------------------------------------------------------------------------
+
+
+def test_nested_dict_and_list_payload_walked() -> None:
+    """The walker visits both Mapping and Sequence children."""
+    policy = _policy_with_rules(
+        textwrap.dedent(
+            """
+            - name: strip-bearer
+              pattern: bearer_token
+              action: redact
+              reason: "embedded token"
+            """,
+        ),
+    )
+    payload = {
+        "request": {
+            "headers": "Bearer eyJhbGciOiJIUzI1NiJ9",
+            "method": "GET",
+        },
+        "items": [
+            "Bearer abc123def456GHIJKL",
+            {"deep": "no secret here"},
+        ],
+    }
+    result = redact(payload, policy)
+    # Structural identity preserved; mappings stay dicts, lists stay
+    # lists, scalars untouched where no pattern fires.
+    assert isinstance(result.redacted, dict)
+    assert isinstance(result.redacted["items"], list)
+    assert result.redacted["request"]["method"] == "GET"
+
+    # Two leaves matched; manifest carries two entries with their paths.
+    paths = sorted(entry.path for entry in result.manifest)
+    assert paths == ["items.0", "request.headers"]
+
+
+def test_non_string_scalars_passed_through() -> None:
+    """Numbers / booleans / None survive the walk verbatim."""
+    policy = _policy_with_rules(
+        textwrap.dedent(
+            """
+            - name: strip-uuid
+              pattern: uuid
+              action: redact
+              reason: "should not affect ints"
+            """,
+        ),
+    )
+    payload = {"count": 42, "active": True, "missing": None, "ratio": 0.5}
+    result = redact(payload, policy)
+    assert result.redacted == payload
+    assert result.manifest == ()
+
+
+# ---------------------------------------------------------------------------
+# Action semantics
+# ---------------------------------------------------------------------------
+
+
+def test_redact_action_substitutes_pattern_marker() -> None:
+    policy = _policy_with_rules(
+        textwrap.dedent(
+            """
+            - name: r
+              pattern: bearer_token
+              action: redact
+              reason: "redact action"
+            """,
+        ),
+    )
+    result = redact("Bearer abcdefghij1234567890", policy)
+    assert result.redacted == "[REDACTED:bearer_token]"
+
+
+def test_mask_action_preserves_suffix() -> None:
+    policy = _policy_with_rules(
+        textwrap.dedent(
+            """
+            - name: r
+              pattern: uuid
+              action: mask
+              reason: "mask action"
+            """,
+        ),
+    )
+    leaf = "tenant=12345678-1234-1234-1234-123456789abc"
+    result = redact(leaf, policy)
+    # Last four characters of the matched UUID are preserved; the
+    # rest become asterisks. Total length unchanged.
+    uuid_str = "12345678-1234-1234-1234-123456789abc"
+    expected_mask = "*" * (len(uuid_str) - 4) + uuid_str[-4:]
+    assert result.redacted == f"tenant={expected_mask}"
+
+
+def test_hash_action_returns_stable_sha_prefix() -> None:
+    policy = _policy_with_rules(
+        textwrap.dedent(
+            """
+            - name: r
+              pattern: fqdn
+              action: hash
+              reason: "hash action"
+            """,
+        ),
+    )
+    leaf = "endpoint=vcenter.lab.example.com"
+    first = redact(leaf, policy)
+    second = redact(leaf, policy)
+    # Same input => same hashed string. The redacted suffix is
+    # ``sha256:<12-hex>``; the prefix proves the format.
+    assert first.redacted == second.redacted
+    redacted_str = str(first.redacted)
+    assert "sha256:" in redacted_str
+    # The hex suffix is 12 lowercase hex characters.
+    after_marker = redacted_str.split("sha256:", 1)[1][:12]
+    assert all(c in "0123456789abcdef" for c in after_marker)
+
+
+# ---------------------------------------------------------------------------
+# Scope predicate
+# ---------------------------------------------------------------------------
+
+
+def test_rule_with_scope_skipped_when_labels_mismatch() -> None:
+    """A scoped rule does nothing when the call labels don't match."""
+    policy = _policy_with_rules(
+        textwrap.dedent(
+            """
+            - name: github-only
+              pattern: bearer_token
+              action: redact
+              reason: "github only"
+              scope:
+                connector_id: github
+            """,
+        ),
+    )
+    payload = "Bearer abcdef1234567890"
+    no_match = redact(payload, policy, connector_id="kubernetes")
+    assert no_match.redacted == payload
+    assert no_match.manifest == ()
+
+    match = redact(payload, policy, connector_id="github")
+    assert "[REDACTED:bearer_token]" in str(match.redacted)
+    assert len(match.manifest) == 1
+
+
+# ---------------------------------------------------------------------------
+# Determinism (no I/O / no clocks)
+# ---------------------------------------------------------------------------
+
+
+def test_redact_is_deterministic_for_identical_inputs() -> None:
+    """Two back-to-back calls on the same input produce identical
+    outputs and manifests (pure-function contract; required for
+    C1-d's round-trip CI gate)."""
+    policy = _policy_with_rules(
+        textwrap.dedent(
+            """
+            - name: r1
+              pattern: bearer_token
+              action: redact
+              reason: "first rule"
+            - name: r2
+              pattern: uuid
+              action: mask
+              reason: "second rule"
+            """,
+        ),
+    )
+    payload = {
+        "auth": "Bearer abc123def456GHIJKL",
+        "items": [
+            "id=12345678-1234-1234-1234-123456789abc",
+            "id=abcdef00-aaaa-bbbb-cccc-aabbccddeeff",
+        ],
+    }
+    first = redact(payload, policy)
+    second = redact(payload, policy)
+    assert first.redacted == second.redacted
+    assert first.manifest == second.manifest
+
+
+# ---------------------------------------------------------------------------
+# Defensive: get_pattern KeyError surfacing for an unknown name
+# ---------------------------------------------------------------------------
+
+
+def test_engine_raises_on_unknown_pattern_name_in_rule() -> None:
+    """The schema rejects unknown names, but an engine-internal lookup
+    must still raise cleanly if a rule is constructed via
+    ``RedactionRule.model_construct`` (test-only path that skips
+    validators)."""
+    from meho_backplane.redaction.policy import RedactionRule, RedactionScope
+
+    bogus = RedactionRule.model_construct(
+        name="bogus",
+        pattern="not_in_catalogue",
+        action="redact",
+        scope=RedactionScope(),
+        reason="forced via model_construct",
+    )
+    policy = RedactionPolicy.model_construct(
+        id="bogus",
+        version=1,
+        description="",
+        rules=(bogus,),
+    )
+    with pytest.raises(KeyError):
+        redact("anything", policy)

--- a/backend/tests/test_redaction_patterns.py
+++ b/backend/tests/test_redaction_patterns.py
@@ -258,6 +258,8 @@ _PATTERN_TEST_ROWS: list[tuple[str, str, bool]] = [
     ("jwt", "a.b.c is not a JWT, neither is foo.bar.baz", False),
     ("api_key", "api_key=AKIAIOSFODNN7EXAMPLE", True),
     ("api_key", "the resource id is 12345-abcdef", False),
+    ("api_key", "password: 's3cr3tValue!'", True),
+    ("api_key", _CLIENT_SECRET_FIXTURE_POS, True),
     ("kubeconfig", "apiVersion: v1\nkind: Config\n", True),
     ("kubeconfig", "apiVersion: v1\nkind: Pod\n", False),
     ("uuid", "tenant_id=12345678-1234-1234-1234-123456789abc", True),

--- a/backend/tests/test_redaction_patterns.py
+++ b/backend/tests/test_redaction_patterns.py
@@ -47,13 +47,7 @@ _EXPECTED_NAMES = {
 # source -- the regex still gets the same effective input shape, but
 # the literal high-entropy form never appears in the file. Same
 # posture as ``test_connectors_holodeck_auth.py``'s _FAKE_KEY_HEADER.
-_JWT_FIXTURE_POS = (
-    "eyJhbGciOiJIUzI1NiJ9"
-    + "."
-    + "eyJzdWIiOiIxMjM0NTY3ODkwIn0"
-    + "."
-    + "abcdefghij"
-)
+_JWT_FIXTURE_POS = "eyJhbGciOiJIUzI1NiJ9" + "." + "eyJzdWIiOiIxMjM0NTY3ODkwIn0" + "." + "abcdefghij"
 _AUTH_HEADER_FIXTURE = "Authorization: Bearer " + _JWT_FIXTURE_POS
 _CLIENT_SECRET_FIXTURE_POS = "client_secret" + " = " + "ABCDEFGHIJKL" + "12345"
 

--- a/backend/tests/test_redaction_patterns.py
+++ b/backend/tests/test_redaction_patterns.py
@@ -1,0 +1,277 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tier-1 named-pattern unit tests (Task #1070).
+
+Coverage per named pattern: one positive case (matches the secret
+shape) + one negative case (does not match benign text). Patterns
+that need extra calibration carry a second positive / negative case.
+
+Acceptance criterion: "Each named pattern has a unit test (positive
++ negative) proving it matches the intended secret shape and not
+benign text." Each ``parametrize`` row is one (pattern, sample,
+expect_match) triple; the matrix lists out every pattern explicitly
+so a pattern added in a future task fails CI until a row is added.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from meho_backplane.redaction.patterns import (
+    NAMED_PATTERNS,
+    PATTERN_NAMES,
+    get_pattern,
+)
+
+# The full named-pattern catalogue called out in the task body. The
+# test below uses this list as the source of truth -- if a pattern is
+# added without a matching test row, the parametrize matrix loses a
+# branch and CI surfaces it via the "every pattern covered" assertion.
+_EXPECTED_NAMES = {
+    "authorization_header",
+    "bearer_token",
+    "jwt",
+    "api_key",
+    "kubeconfig",
+    "uuid",
+    "ipv4",
+    "ipv6",
+    "fqdn",
+}
+
+
+# Fixture strings the regex sees at runtime. Assembled from
+# non-secret-shaped fragments at runtime so gitleaks' built-in rules
+# (``jwt``, ``generic-api-key``) do not false-positive on the test
+# source -- the regex still gets the same effective input shape, but
+# the literal high-entropy form never appears in the file. Same
+# posture as ``test_connectors_holodeck_auth.py``'s _FAKE_KEY_HEADER.
+_JWT_FIXTURE_POS = (
+    "eyJhbGciOiJIUzI1NiJ9"
+    + "."
+    + "eyJzdWIiOiIxMjM0NTY3ODkwIn0"
+    + "."
+    + "abcdefghij"
+)
+_AUTH_HEADER_FIXTURE = "Authorization: Bearer " + _JWT_FIXTURE_POS
+_CLIENT_SECRET_FIXTURE_POS = "client_secret" + " = " + "ABCDEFGHIJKL" + "12345"
+
+
+def test_catalog_lists_expected_patterns() -> None:
+    """Both module exports must agree with the task-body catalogue."""
+    assert set(NAMED_PATTERNS) == _EXPECTED_NAMES
+    assert set(PATTERN_NAMES) == _EXPECTED_NAMES
+    # PATTERN_NAMES is sorted; downstream policy error messages rely
+    # on the deterministic order.
+    assert list(PATTERN_NAMES) == sorted(_EXPECTED_NAMES)
+
+
+def test_get_pattern_returns_compiled_regex() -> None:
+    """get_pattern is the runtime accessor the engine uses."""
+    pat = get_pattern("uuid")
+    # ``re.Pattern`` exposes ``.pattern`` (source) and ``.flags``;
+    # confirming type by attribute access rather than ``isinstance``
+    # keeps the test resilient to the typing of compiled regexes.
+    assert hasattr(pat, "search")
+    assert hasattr(pat, "finditer")
+
+
+def test_get_pattern_unknown_raises() -> None:
+    """Unknown name yields KeyError with the known-set listed."""
+    with pytest.raises(KeyError) as excinfo:
+        get_pattern("not_a_pattern")
+    msg = str(excinfo.value)
+    # Error message lists every known pattern -- helps the operator
+    # debug a typo in their policy without grepping source.
+    for name in _EXPECTED_NAMES:
+        assert name in msg
+
+
+# ---------------------------------------------------------------------------
+# Per-pattern positive + negative cases
+# ---------------------------------------------------------------------------
+
+
+# (pattern, sample, expect_match)
+# ``expect_match`` is True when the pattern must fire on the sample
+# (positive case) and False when it must not (negative case).
+@pytest.mark.parametrize(
+    ("pattern", "sample", "expect_match"),
+    [
+        # authorization_header
+        (
+            "authorization_header",
+            _AUTH_HEADER_FIXTURE,
+            True,
+        ),
+        (
+            "authorization_header",
+            "Author: jdoe; the auth flow failed",
+            False,
+        ),
+        # bearer_token: bare ``Bearer <token>`` outside an Authorization line
+        (
+            "bearer_token",
+            "curl -H 'Bearer abc123def456GHIJKL'",
+            True,
+        ),
+        (
+            "bearer_token",
+            "The bear came over the mountain",
+            False,
+        ),
+        # jwt: three base64url segments separated by dots, header
+        # starts with ``ey``
+        (
+            "jwt",
+            _JWT_FIXTURE_POS,
+            True,
+        ),
+        (
+            "jwt",
+            "a.b.c is not a JWT, neither is foo.bar.baz",
+            False,
+        ),
+        # api_key: labelled credential pair
+        (
+            "api_key",
+            "api_key=AKIAIOSFODNN7EXAMPLE",
+            True,
+        ),
+        (
+            "api_key",
+            "the resource id is 12345-abcdef",
+            False,
+        ),
+        # api_key: alternative label + spacing forms
+        (
+            "api_key",
+            "password: 's3cr3tValue!'",
+            True,
+        ),
+        (
+            "api_key",
+            _CLIENT_SECRET_FIXTURE_POS,
+            True,
+        ),
+        # kubeconfig: requires the apiVersion + kind preamble
+        (
+            "kubeconfig",
+            ("apiVersion: v1\nclusters:\n  - name: prod\nkind: Config\nusers:\n  - name: admin\n"),
+            True,
+        ),
+        (
+            "kubeconfig",
+            ("apiVersion: v1\nkind: Pod\nmetadata:\n  name: nginx\n"),
+            False,
+        ),
+        # uuid: RFC 4122 canonical hex form
+        (
+            "uuid",
+            "tenant_id=12345678-1234-1234-1234-123456789abc",
+            True,
+        ),
+        (
+            "uuid",
+            "build_hash=abcdef0123456789 (16 hex, not uuid-shaped)",
+            False,
+        ),
+        # ipv4: dotted quad with valid 0-255 octets
+        (
+            "ipv4",
+            "the cluster node is at 192.168.1.42 (private subnet)",
+            True,
+        ),
+        (
+            "ipv4",
+            "version 999.999.999.999 has invalid octets",
+            False,
+        ),
+        # ipv6: full + compressed forms
+        (
+            "ipv6",
+            "router cfg loopback 2001:db8::8a2e:370:7334",
+            True,
+        ),
+        (
+            "ipv6",
+            "git commit 1234deadbeef is not an ipv6 address",
+            False,
+        ),
+        # fqdn: ≥2 labels, non-numeric TLD start
+        (
+            "fqdn",
+            "the api endpoint is vcenter.lab.example.com",
+            True,
+        ),
+        (
+            "fqdn",
+            "the build is at version 1.2.3 (no fqdn here)",
+            False,
+        ),
+    ],
+)
+def test_pattern_matches_or_not(
+    pattern: str,
+    sample: str,
+    expect_match: bool,
+) -> None:
+    """Each pattern fires (or doesn't) on its representative sample."""
+    pat = get_pattern(pattern)
+    matched = pat.search(sample)
+    if expect_match:
+        assert matched is not None, (
+            f"{pattern!r} did not match {sample!r} -- "
+            f"either the regex is too narrow or the sample is wrong"
+        )
+    else:
+        assert matched is None, (
+            f"{pattern!r} unexpectedly matched {sample!r} -- "
+            f"over-match risks false redaction in production"
+        )
+
+
+def test_every_pattern_has_both_polarities() -> None:
+    """Defensive: every catalogued pattern has at least one positive
+    AND at least one negative test row above.
+
+    A pattern added without test coverage silently passes CI -- this
+    assertion makes the gap surface as a test failure instead.
+    """
+    # Re-derive the matrix by importing the parametrize source from
+    # this module via inspection of the function -- but simpler: hard
+    # check that every entry in ``_EXPECTED_NAMES`` has appeared in
+    # the matrix above as both polarities.
+    rows = _PATTERN_TEST_ROWS
+    positives = {p for p, _, expect in rows if expect}
+    negatives = {p for p, _, expect in rows if not expect}
+    missing_pos = _EXPECTED_NAMES - positives
+    missing_neg = _EXPECTED_NAMES - negatives
+    assert not missing_pos, f"patterns missing a positive test row: {sorted(missing_pos)}"
+    assert not missing_neg, f"patterns missing a negative test row: {sorted(missing_neg)}"
+
+
+# Static catalogue mirroring the parametrize matrix; kept in sync by
+# the assertion above. Centralised so the coverage check does not
+# depend on pytest internals.
+_PATTERN_TEST_ROWS: list[tuple[str, str, bool]] = [
+    ("authorization_header", _AUTH_HEADER_FIXTURE, True),
+    ("authorization_header", "Author: jdoe; the auth flow failed", False),
+    ("bearer_token", "curl -H 'Bearer abc123def456GHIJKL'", True),
+    ("bearer_token", "The bear came over the mountain", False),
+    ("jwt", _JWT_FIXTURE_POS, True),
+    ("jwt", "a.b.c is not a JWT, neither is foo.bar.baz", False),
+    ("api_key", "api_key=AKIAIOSFODNN7EXAMPLE", True),
+    ("api_key", "the resource id is 12345-abcdef", False),
+    ("kubeconfig", "apiVersion: v1\nkind: Config\n", True),
+    ("kubeconfig", "apiVersion: v1\nkind: Pod\n", False),
+    ("uuid", "tenant_id=12345678-1234-1234-1234-123456789abc", True),
+    ("uuid", "build_hash=abcdef0123456789", False),
+    ("ipv4", "192.168.1.42", True),
+    ("ipv4", "999.999.999.999", False),
+    ("ipv6", "2001:db8::8a2e:370:7334", True),
+    ("ipv6", "1234deadbeef", False),
+    ("fqdn", "vcenter.lab.example.com", True),
+    ("fqdn", "version 1.2.3", False),
+]

--- a/backend/tests/test_redaction_policy.py
+++ b/backend/tests/test_redaction_policy.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Redaction policy schema tests (Task #1070).
+
+Acceptance criterion: "The Pydantic policy model parses a YAML
+fixture with named-pattern rules + scope; an invalid policy raises a
+typed error." This file covers:
+
+* the shipped example.yaml round-trips through
+  :func:`load_policy_yaml`;
+* :func:`parse_policy` accepts a multi-rule policy with scope;
+* invalid policies (unknown pattern, duplicate rule names, malformed
+  YAML, missing fields, extra keys) raise :class:`RedactionPolicyError`
+  with the offending field in the message.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+from pydantic import ValidationError
+
+from meho_backplane.redaction import (
+    PATTERN_NAMES,
+    RedactionPolicy,
+    RedactionPolicyError,
+    RedactionRule,
+    RedactionScope,
+    load_policy_yaml,
+    parse_policy,
+)
+
+# ---------------------------------------------------------------------------
+# Loading + parsing happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_shipped_example_policy_loads() -> None:
+    """The packaged example.yaml parses cleanly and looks well-formed."""
+    policy = load_policy_yaml("meho_backplane.redaction.policies", "example.yaml")
+    assert isinstance(policy, RedactionPolicy)
+    assert policy.id == "default-tier1"
+    assert policy.version == 1
+    # The example covers every Tier-1 named pattern in the catalogue
+    # at least once -- if a pattern is added without a rule, the
+    # mismatch surfaces here.
+    used_patterns = {rule.pattern for rule in policy.rules}
+    assert used_patterns == set(PATTERN_NAMES), (
+        f"example.yaml pattern coverage drifted; missing={set(PATTERN_NAMES) - used_patterns} "
+        f"extra={used_patterns - set(PATTERN_NAMES)}"
+    )
+
+
+def test_parse_policy_accepts_minimal_policy() -> None:
+    """A one-rule policy with no scope and no description is valid."""
+    raw = textwrap.dedent(
+        """
+        id: minimal
+        version: 1
+        rules:
+          - name: strip-bearer
+            pattern: bearer_token
+            action: redact
+            reason: "smallest valid policy"
+        """,
+    )
+    policy = parse_policy(raw)
+    assert policy.id == "minimal"
+    assert policy.version == 1
+    assert len(policy.rules) == 1
+    rule = policy.rules[0]
+    assert isinstance(rule, RedactionRule)
+    assert rule.scope == RedactionScope()
+
+
+def test_parse_policy_accepts_scope_fields() -> None:
+    """Scope fields parse into the typed model."""
+    raw = textwrap.dedent(
+        """
+        id: scoped
+        version: 1
+        rules:
+          - name: github-only-uuids
+            pattern: uuid
+            action: mask
+            reason: "GitHub correlator UUIDs only"
+            scope:
+              connector_id: github
+              op: issues.list
+        """,
+    )
+    policy = parse_policy(raw)
+    rule = policy.rules[0]
+    assert rule.scope.connector_id == "github"
+    assert rule.scope.op == "issues.list"
+    assert rule.scope.tenant is None
+
+
+# ---------------------------------------------------------------------------
+# Scope.matches predicate
+# ---------------------------------------------------------------------------
+
+
+def test_empty_scope_matches_anything() -> None:
+    scope = RedactionScope()
+    assert scope.matches(connector_id="github", tenant="t1", op="any")
+    assert scope.matches(connector_id=None, tenant=None, op=None)
+
+
+def test_scope_with_connector_id_filters() -> None:
+    scope = RedactionScope(connector_id="github")
+    assert scope.matches(connector_id="github", tenant=None, op=None)
+    assert not scope.matches(connector_id="kubernetes", tenant=None, op=None)
+    assert not scope.matches(connector_id=None, tenant=None, op=None)
+
+
+def test_scope_with_all_fields_is_and() -> None:
+    scope = RedactionScope(connector_id="github", tenant="t1", op="issues.list")
+    assert scope.matches(connector_id="github", tenant="t1", op="issues.list")
+    assert not scope.matches(connector_id="github", tenant="t2", op="issues.list")
+    assert not scope.matches(connector_id="github", tenant="t1", op="issues.create")
+
+
+# ---------------------------------------------------------------------------
+# Validation failure modes (all raise RedactionPolicyError)
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_pattern_rejected_with_known_set() -> None:
+    raw = textwrap.dedent(
+        """
+        id: bad
+        version: 1
+        rules:
+          - name: nope
+            pattern: not_a_pattern
+            action: redact
+            reason: "should fail at parse"
+        """,
+    )
+    with pytest.raises(RedactionPolicyError) as excinfo:
+        parse_policy(raw)
+    msg = str(excinfo.value)
+    assert "unknown pattern" in msg or "not_a_pattern" in msg
+    # The known-set hint is in the validator output -- confirm at
+    # least one canonical pattern name surfaces in the error string.
+    assert "bearer_token" in msg
+
+
+def test_duplicate_rule_names_rejected() -> None:
+    raw = textwrap.dedent(
+        """
+        id: dup
+        version: 1
+        rules:
+          - name: same-name
+            pattern: bearer_token
+            action: redact
+            reason: "first"
+          - name: same-name
+            pattern: jwt
+            action: redact
+            reason: "second"
+        """,
+    )
+    with pytest.raises(RedactionPolicyError) as excinfo:
+        parse_policy(raw)
+    assert "duplicate rule name" in str(excinfo.value)
+
+
+def test_empty_rules_rejected() -> None:
+    raw = textwrap.dedent(
+        """
+        id: empty
+        version: 1
+        rules: []
+        """,
+    )
+    with pytest.raises(RedactionPolicyError):
+        parse_policy(raw)
+
+
+def test_extra_top_level_key_rejected() -> None:
+    """``extra='forbid'`` catches typo'd top-level keys."""
+    raw = textwrap.dedent(
+        """
+        id: x
+        version: 1
+        descriptionn: "typo'd description key"
+        rules:
+          - name: only
+            pattern: bearer_token
+            action: redact
+            reason: "typo target"
+        """,
+    )
+    with pytest.raises(RedactionPolicyError):
+        parse_policy(raw)
+
+
+def test_extra_rule_field_rejected() -> None:
+    """``extra='forbid'`` applies inside rules too."""
+    raw = textwrap.dedent(
+        """
+        id: x
+        version: 1
+        rules:
+          - name: only
+            pattern: bearer_token
+            action: redact
+            reason: "ok"
+            severity: high
+        """,
+    )
+    with pytest.raises(RedactionPolicyError):
+        parse_policy(raw)
+
+
+def test_invalid_action_rejected() -> None:
+    raw = textwrap.dedent(
+        """
+        id: x
+        version: 1
+        rules:
+          - name: only
+            pattern: bearer_token
+            action: encrypt
+            reason: "encrypt is not a Tier-1 action"
+        """,
+    )
+    with pytest.raises(RedactionPolicyError):
+        parse_policy(raw)
+
+
+def test_blank_reason_rejected() -> None:
+    raw = textwrap.dedent(
+        """
+        id: x
+        version: 1
+        rules:
+          - name: only
+            pattern: bearer_token
+            action: redact
+            reason: "   "
+        """,
+    )
+    with pytest.raises(RedactionPolicyError):
+        parse_policy(raw)
+
+
+def test_malformed_yaml_rejected() -> None:
+    """Broken YAML surfaces as RedactionPolicyError, not yaml.YAMLError."""
+    raw = "id: [\n unclosed:"
+    with pytest.raises(RedactionPolicyError) as excinfo:
+        parse_policy(raw)
+    assert "not valid YAML" in str(excinfo.value)
+
+
+def test_non_mapping_top_level_rejected() -> None:
+    """A YAML list at the top level is not a policy."""
+    raw = "- not a mapping"
+    with pytest.raises(RedactionPolicyError) as excinfo:
+        parse_policy(raw)
+    assert "mapping" in str(excinfo.value)
+
+
+def test_policy_is_frozen() -> None:
+    """Policies are immutable; accidental mutation raises a typed error."""
+    raw = textwrap.dedent(
+        """
+        id: frozen
+        version: 1
+        rules:
+          - name: only
+            pattern: bearer_token
+            action: redact
+            reason: "ok"
+        """,
+    )
+    policy = parse_policy(raw)
+    # Frozen Pydantic models raise ValidationError (v2 surfaces it for
+    # assignment to a frozen field; the wider Exception catch would mask
+    # an accidental regression to a mutable model).
+    with pytest.raises(ValidationError):
+        policy.rules[0].name = "rebound"  # type: ignore[misc]

--- a/docs/codebase/redaction.md
+++ b/docs/codebase/redaction.md
@@ -22,11 +22,17 @@ known to the engine, e.g. `bearer_token`, `kubeconfig`, `uuid`) to an
 The **engine** walks a nested dict / list / str payload, applies the
 rules in policy order, and returns:
 
-- `redacted` — the same payload shape with string leaves rewritten per
-  the matching rule's action.
+- `redacted` — same *nesting* as the input, but normalised to
+  JSON-shaped containers: `Mapping` subtypes (e.g. `OrderedDict`,
+  `defaultdict`) flatten to `dict` and `Sequence` subtypes (other
+  than `str` / `bytes` / `bytearray`) flatten to `list`. Only string
+  leaves change content; everything else is structure. The result is
+  always JSON-serialisable so the downstream JSONFlux reducer can
+  consume it without further shape-fixing.
 - `manifest` — a tuple of `RedactionManifestEntry` records, one per
-  rule firing per leaf, carrying `type`, `count`, `span`, `reason`,
-  and `path`. C1-b will persist this verbatim into the audit row.
+  rule firing per leaf, carrying `rule`, `pattern`, `action`,
+  `count`, `span`, `reason`, and `path`. C1-b will persist this
+  verbatim into the audit row.
 
 The engine is **pure and side-effect-free**: no I/O, no logging, no
 clocks. Identical inputs produce identical outputs (load-bearing for
@@ -142,6 +148,16 @@ No new runtime dependencies were added by Task #1070.
   manifest tracks `count` and the span of the *first* match; if an
   audit consumer needs per-match spans, that is a Tier-1 extension
   worth filing after C1-b lands and we see real consumption patterns.
+- **Manifest `span` is indexed against the per-rule input, not the
+  true original leaf.** When two rules fire on the same leaf in one
+  policy, the second rule sees the already-redacted output of the
+  first; the span it records is an offset into *that* rewritten
+  string, not the original. For a single-rule policy the span equals
+  the offset in the true original. Replay consumers that need to
+  reconstruct the substring `span` indexes into must re-apply earlier
+  rules in policy order first. The diagnostic value of `span` is
+  consequently bounded; `count`, `rule`, and `path` remain the
+  load-bearing manifest fields.
 - **No per-tenant policy resolution yet.** This task ships the schema
   and engine only. The middleware (#1071) is responsible for
   resolving "which policy applies to this call" from settings / DB;

--- a/docs/codebase/redaction.md
+++ b/docs/codebase/redaction.md
@@ -1,0 +1,169 @@
+# Redaction (connector-boundary, Tier-1)
+
+Initiative [#805](https://github.com/evoila/meho/issues/805) (G11.4 Safety,
+C1) ships a sanitization middleware that redacts every connector response
+before it reaches a caller or LLM. This document covers the foundation
+slice landed by Task [#1070](https://github.com/evoila/meho/issues/1070):
+the **declarative policy schema** + the **Tier-1 named-pattern regex
+engine** + the **named-pattern library**. The middleware that wires the
+engine into `dispatcher._reduce_or_error` (C1-b, #1071), the Tier-2
+Microsoft Presidio NER adapter (C1-c, #1072), the round-trip CI gate
+(C1-d, #1073), and the agent-invocation audit row (C2-b, #1074) are
+sibling tickets and land on top of this surface.
+
+## Overview
+
+A redaction **policy** is a YAML document declaring one or more
+**rules**. Each rule binds a **named pattern** (a pre-compiled regex
+known to the engine, e.g. `bearer_token`, `kubeconfig`, `uuid`) to an
+**action** (`redact` / `mask` / `hash`) and optionally a **scope**
+(connector_id, tenant, op) limiting which calls the rule fires on.
+
+The **engine** walks a nested dict / list / str payload, applies the
+rules in policy order, and returns:
+
+- `redacted` — the same payload shape with string leaves rewritten per
+  the matching rule's action.
+- `manifest` — a tuple of `RedactionManifestEntry` records, one per
+  rule firing per leaf, carrying `type`, `count`, `span`, `reason`,
+  and `path`. C1-b will persist this verbatim into the audit row.
+
+The engine is **pure and side-effect-free**: no I/O, no logging, no
+clocks. Identical inputs produce identical outputs (load-bearing for
+the C1-d round-trip CI gate).
+
+## Key types
+
+All types are Pydantic v2 frozen models, defined in
+`backend/src/meho_backplane/redaction/`.
+
+| Type | Module | Role |
+| --- | --- | --- |
+| `RedactionAction` | `policy.py` | `Literal["redact", "mask", "hash"]` |
+| `RedactionScope` | `policy.py` | Optional connector_id/tenant/op predicate |
+| `RedactionRule` | `policy.py` | One named-pattern → action binding |
+| `RedactionPolicy` | `policy.py` | Versioned bundle of rules |
+| `RedactionPolicyError` | `policy.py` | One typed exception for any parse / validation failure |
+| `RedactionManifestEntry` | `engine.py` | One manifest row (rule, pattern, action, count, span, reason, path) |
+| `RedactionResult` | `engine.py` | Engine return value: `redacted` + `manifest` |
+
+`PATTERN_NAMES` (`patterns.py`) is the source of truth for the named
+catalogue; the policy schema validates `rule.pattern` against it at
+parse time.
+
+## Control flow
+
+```
+                          parse_policy(yaml_str)
+                          load_policy_yaml(pkg, file)
+                                    |
+                                    v
+                          +-------------------+
+                          | RedactionPolicy   |   immutable, frozen
+                          | (rules in order)  |
+                          +-------------------+
+                                    |
+       connector response  ─┐       |
+       (dict / list / str)  │       v
+                            └─►  redact(payload, policy,
+                                        connector_id, tenant, op)
+                                          |
+                                          v
+                              for each rule, in policy order:
+                                   1. scope.matches(...) — skip if no
+                                   2. walk dict/list/str leaves
+                                   3. at each str leaf:
+                                         pat.finditer(leaf)
+                                         pat.sub(replacement, leaf)
+                                         append RedactionManifestEntry
+                                          |
+                                          v
+                              RedactionResult(redacted, manifest)
+```
+
+The engine **never raises** for an input shape it can't redact
+(numbers, booleans, `None`, bytes pass through). The single failure
+mode is `KeyError` from `get_pattern(...)` when a `RedactionRule` was
+constructed via `model_construct` against an unknown name; the policy
+schema's `field_validator` rejects unknown names at load time, so
+production traffic cannot reach that branch.
+
+## Named-pattern catalogue
+
+| Name | Targets |
+| --- | --- |
+| `authorization_header` | `Authorization: Bearer ...` / `Basic ...` header lines |
+| `bearer_token` | Bare `Bearer <opaque>` outside an Authorization header |
+| `jwt` | `ey<base64url>.<base64url>.<base64url>` three-segment tokens |
+| `api_key` | Labelled credential pairs (`api_key=`, `password:`, `client_secret=`...) |
+| `kubeconfig` | YAML kubeconfig blobs (`apiVersion: v1` + `kind: Config`) |
+| `uuid` | RFC 4122 canonical 8-4-4-4-12 hex |
+| `ipv4` | Dotted-quad with 0-255 per-octet bounds |
+| `ipv6` | Full + compressed RFC 5952 forms |
+| `fqdn` | ≥2 labels with non-numeric TLD start |
+
+Calibration notes (over-match vs under-match) are inline in
+`patterns.py`. The Tier-1 posture deliberately leans toward
+**over-redaction**: a false positive on a benign UUID is recoverable
+via a scoped rule, but a missed secret is the failure the parent goal
+(#800) cannot accept.
+
+## Action semantics
+
+| Action | Replacement |
+| --- | --- |
+| `redact` | `[REDACTED:<pattern>]` (fixed marker; default) |
+| `mask` | `*…*<last-4-chars>` (length-preserving; shape-correlatable) |
+| `hash` | `sha256:<first-12-hex-of-SHA-256(match)>` (stable; replay-correlatable) |
+
+Choose `redact` for raw secrets, `mask` when downstream consumers
+need to spot duplicates without seeing the value, and `hash` when an
+audit replay needs to confirm the same identifier appears across
+calls.
+
+## Dependencies
+
+- **PyYAML** (`yaml.safe_load`) — already a transitive dep; matches
+  the precedent set by `operations/ingest/catalog.py`.
+- **Pydantic v2** — already pinned in `backend/pyproject.toml`.
+- **Python stdlib** — `re`, `hashlib`, `importlib.resources`,
+  `collections.abc`. No third-party regex / NER libraries here;
+  Tier-2 (#1072) adds Microsoft Presidio.
+
+No new runtime dependencies were added by Task #1070.
+
+## Known issues / future work
+
+- **Wide patterns benefit from policy ordering.** The engine applies
+  rules in policy order; a later rule sees the already-redacted
+  output of earlier rules. Place narrow patterns (`api_key`,
+  `bearer_token`) before wide ones (`fqdn`, `uuid`) in the YAML.
+- **Multiple matches collapse into one manifest entry per leaf.** The
+  manifest tracks `count` and the span of the *first* match; if an
+  audit consumer needs per-match spans, that is a Tier-1 extension
+  worth filing after C1-b lands and we see real consumption patterns.
+- **No per-tenant policy resolution yet.** This task ships the schema
+  and engine only. The middleware (#1071) is responsible for
+  resolving "which policy applies to this call" from settings / DB;
+  the engine accepts the policy as a parameter and applies it
+  verbatim.
+- **Bytes payloads are passed through.** The JSONFlux reduce boundary
+  produces JSON-shaped values, so the engine's contract excludes
+  bytes; if a future connector emits binary payloads at the
+  redaction boundary, this surface needs revisiting.
+
+## References
+
+- Parent goal: [#800](https://github.com/evoila/meho/issues/800)
+  (G11 Agentic ops runtime) §"trust boundary has to be the API".
+- Parent initiative: [#805](https://github.com/evoila/meho/issues/805)
+  (G11.4 Safety) §Approach for the tiered design.
+- Task: [#1070](https://github.com/evoila/meho/issues/1070).
+- Seam: `dispatcher._reduce_or_error`
+  (`backend/src/meho_backplane/operations/dispatcher.py`) — the
+  C1-b middleware (#1071) sits here.
+- YAML-as-package-data precedent:
+  `backend/src/meho_backplane/operations/ingest/catalog.py` +
+  `catalog.yaml`.
+- Microsoft Presidio (Tier-2; #1072):
+  <https://github.com/microsoft/presidio>.


### PR DESCRIPTION
## Summary

- First task of Initiative #805 (G11.4 Safety, C1). Ships the **foundation** of the sanitization middleware: declarative YAML policy schema, Tier-1 deterministic regex engine, and the named-pattern library.
- Middleware wiring (C1-b, #1071), Tier-2 Microsoft Presidio NER (C1-c, #1072), and the round-trip CI gate (C1-d, #1073) are deliberately out of scope and land on top of this surface.
- The engine is pure and side-effect-free (no I/O, no clocks, no logging) so the C1-d round-trip CI gate can pin determinism; YAML loading uses `importlib.resources` mirroring the `operations/ingest/catalog.py` precedent.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/` — clean (`--strict`, 344 files)
- [x] `pytest tests/test_redaction_*.py` — 52 passed
- [x] `code-quality.py --diff` — exit 0
- [x] AC1 — Pydantic policy model parses YAML with named-pattern rules + scope; invalid policies raise `RedactionPolicyError` (covered by `test_redaction_policy.py`)
- [x] AC2 — Each named pattern has a positive + negative unit test (`test_redaction_patterns.py::test_pattern_matches_or_not` parametrized over all 9 patterns)
- [x] AC3 — Engine returns `(redacted, manifest)` for a nested dict/list payload with type/count/span/reason per entry (`test_redaction_engine.py::test_nested_dict_and_list_payload_walked` + `::test_manifest_entry_shape_per_match`)
- [x] AC4 — `ruff + mypy + pytest` green; engine is import-safe and side-effect-free (`test_redaction_engine.py::test_redact_is_deterministic_for_identical_inputs`)

## Out of scope

- Middleware wiring at `dispatcher._reduce_or_error` (#1071, C1-b)
- Tier-2 Presidio NER for free-text fields (#1072, C1-c)
- Round-trip fixture testing + CI gate (#1073, C1-d)
- Per-op policy authoring UI

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1070


---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-26)

Addressed review findings from review #4366644100:

- **B1** `5864756` — `ruff format` reformats `_JWT_FIXTURE_POS` to a single-line concat; CI gate now green.
- **m1** `9c7d1bd` — Add the two missing `api_key` alt-positive rows to `_PATTERN_TEST_ROWS` so the static catalogue mirrors the parametrize matrix.
- **m2** `85f6fae` — Tighten `_walk_and_apply` + `RedactionResult` docstrings + `docs/codebase/redaction.md` to say the engine normalises `Mapping` -> `dict` and non-string `Sequence` -> `list` (it does not preserve subtypes via `type(node)(...)`).
- **m3** `85f6fae` — Document that manifest `span` is indexed against the leaf as the firing rule saw it (post earlier-rule rewrites), in the engine module docstring and `docs/codebase/redaction.md` "Known issues".

<!-- auto-implement-issue: continue, iteration 2 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redaction system with policy-based configuration supporting multiple transformation actions (`redact`, `mask`, `hash`).
  * Processes nested data structures and outputs redacted results with detailed audit trail (rule, pattern, action, match count, span, and path).
  * Pre-configured policy and pattern catalogue included.

* **Documentation**
  * Added comprehensive redaction system documentation with policy schema and behavior reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->