### PR TITLE
feat(ui): G10.3-T1 Targets list + detail view + re-probe + recent-ops SSE

### DIFF
--- a/backend/src/meho_backplane/ui/routes/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/__init__.py
@@ -12,9 +12,15 @@ ships the umbrella :func:`build_router` that aggregates:
 * :mod:`~meho_backplane.ui.routes.memory` -- the memory surface
   (G10.4-T1 #877): ``/ui/memory`` list, ``/ui/memory/<scope>/<slug>``
   detail + edit-in-place + delete, ``/ui/memory/tags`` autocomplete.
-* :mod:`~meho_backplane.ui.routes.stubs` -- ``GET /ui/{knowledge,
-  connectors}`` -- remaining placeholder routes the surface Initiatives
-  G10.2 (kb) + G10.3 (connectors) replace.
+* :mod:`~meho_backplane.ui.routes.connectors` -- the connectors
+  surface (G10.3-T1 #873): ``/ui/connectors`` targets list
+  (sortable / filterable), ``/ui/connectors/<name>`` per-target
+  detail (full row + fingerprint card + recent-ops SSE-live +
+  available-operations matrix), ``POST /ui/connectors/<name>/probe``
+  tenant_admin re-probe.
+* :mod:`~meho_backplane.ui.routes.stubs` -- ``GET /ui/knowledge`` --
+  the remaining placeholder route the kb surface Initiative G10.2
+  replaces.
 
 Auth surfaces (``/ui/auth/login``, ``/ui/auth/callback``,
 ``/ui/auth/logout``) live under
@@ -35,6 +41,7 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from meho_backplane.ui.routes.broadcast import build_router as build_broadcast_router
+from meho_backplane.ui.routes.connectors import build_router as build_connectors_router
 from meho_backplane.ui.routes.dashboard import build_dashboard_router
 from meho_backplane.ui.routes.memory import build_memory_router
 from meho_backplane.ui.routes.stubs import build_stubs_router
@@ -42,6 +49,7 @@ from meho_backplane.ui.routes.topology import build_router as build_topology_rou
 
 __all__ = [
     "build_broadcast_router",
+    "build_connectors_router",
     "build_dashboard_router",
     "build_memory_router",
     "build_router",
@@ -51,20 +59,22 @@ __all__ = [
 
 
 def build_router() -> APIRouter:
-    """Aggregate the dashboard + broadcast + topology + memory + stubs routers.
+    """Aggregate the dashboard + broadcast + topology + memory + connectors + stubs routers.
 
     Order matters: FastAPI matches by registration order, so a
     surface Initiative's real router is included **before** the
     stubs aggregate to win the first-match-wins path lookup. The
     dashboard ``/ui/`` route does not collide with any surface
     sub-path; broadcast lands ``/ui/broadcast`` + ``/ui/broadcast/stream``,
-    topology lands ``/ui/topology`` + ``/ui/topology/node/{id}``, and
-    memory lands ``/ui/memory`` + ``/ui/memory/{scope}/{slug}`` --
-    each of which would otherwise hit a ``/ui/{slug}`` stub. The
-    ``broadcast`` / ``memory`` stubs are dropped from the stubs
-    enumeration so the real routes are the only registrations in the
-    OpenAPI schema. Once G10.2-G10.3 land their surface routers, each
-    includes itself ahead of the stubs the same way.
+    topology lands ``/ui/topology`` + ``/ui/topology/node/{id}``,
+    memory lands ``/ui/memory`` + ``/ui/memory/{scope}/{slug}``, and
+    connectors lands ``/ui/connectors`` + ``/ui/connectors/{name}`` +
+    ``POST /ui/connectors/{name}/probe`` -- each of which would
+    otherwise hit a ``/ui/{slug}`` stub. The ``broadcast`` / ``memory``
+    / ``connectors`` stubs are dropped from the stubs enumeration so
+    the real routes are the only registrations in the OpenAPI schema.
+    Once G10.2 lands its kb surface router, the ``knowledge`` stub
+    follows the same retirement pattern.
     """
     router = APIRouter()
     router.include_router(build_dashboard_router())
@@ -73,5 +83,6 @@ def build_router() -> APIRouter:
     router.include_router(build_broadcast_router())
     router.include_router(build_topology_router())
     router.include_router(build_memory_router())
+    router.include_router(build_connectors_router())
     router.include_router(build_stubs_router())
     return router

--- a/backend/src/meho_backplane/ui/routes/connectors/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/__init__.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Connectors UI routes: targets list + per-target detail + re-probe.
+
+Initiative #340 (G10.3 Connectors + Targets UI). Task #873 (T1) ships
+the **read** surface: sortable / filterable targets table, the
+per-target detail page (full row + fingerprint card + recent-ops
+SSE-live + available-operations matrix), and a tenant_admin-gated
+re-probe action. T2 (#874) layers create / edit forms, T3 (#875)
+layers bulk import.
+
+Module layout:
+
+* :mod:`~meho_backplane.ui.routes.connectors.list_view` -- the
+  ``GET /ui/connectors`` route. One handler serves both shapes:
+  the full page (browser nav) and the table-rows fragment (HTMX
+  sort / filter swap, branch on ``HX-Request``).
+* :mod:`~meho_backplane.ui.routes.connectors.detail` -- the
+  ``GET /ui/connectors/{name}`` route. Renders the detail page: the
+  full target row, the fingerprint card, the recent-ops card
+  (last 10 audit rows, SSE-live filtered to ``target=<name>``),
+  and the available-operations matrix grouped by ``operation_group``.
+* :mod:`~meho_backplane.ui.routes.connectors.probe` -- the
+  ``POST /ui/connectors/{name}/probe`` route. Tenant_admin-gated
+  re-probe verb that re-runs the connector ``fingerprint`` step,
+  persists the result to ``targets.fingerprint``, and returns the
+  refreshed ``_fingerprint_card.html`` fragment for an HTMX swap.
+  Uses the same :func:`~meho_backplane.connectors.resolver
+  .resolve_connector_or_label` helper the ``/api/v1/targets/{name}/probe``
+  REST route does so the two surfaces stay byte-compatible.
+
+The umbrella :func:`build_router` aggregates all three. It is mounted
+**before** :func:`~meho_backplane.ui.routes.stubs.build_stubs_router`
+in :func:`~meho_backplane.ui.routes.build_router` so the real
+``/ui/connectors`` and ``/ui/connectors/{name}`` handlers win the
+first-match-wins path lookup. The ``connectors`` stub is retired by
+this task.
+
+Tenant scoping is non-overrideable. Every target query passes
+``session_ctx.tenant_id`` from the chassis-validated
+:class:`UISessionContext`; no query parameter or path segment carries
+a tenant id. The recent-ops SSE feed flows through the existing
+``/ui/broadcast/stream`` bridge (G10.1) which is itself session-gated
+on the same boundary -- a target name typed into the URL bar that
+belongs to another tenant returns 404 from the detail handler before
+the SSE wiring even renders.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from meho_backplane.ui.routes.connectors.detail import build_detail_router
+from meho_backplane.ui.routes.connectors.list_view import build_list_router
+from meho_backplane.ui.routes.connectors.probe import build_probe_router
+
+__all__ = ["build_router"]
+
+
+def build_router() -> APIRouter:
+    """Aggregate the connectors UI routes into one ``/ui/connectors*`` router.
+
+    Factory function (not a module-level constant) so a test app can
+    construct multiple parallel routers without sharing route state --
+    mirrors the chassis convention in
+    :mod:`meho_backplane.ui.routes.topology` /
+    :mod:`meho_backplane.ui.routes.memory`.
+
+    Registration order is **load-bearing**: the literal ``GET /ui/connectors``
+    list route registers before the parametrised ``GET /ui/connectors/{name}``
+    detail route so the empty-tail URL is matched as the list rather than
+    captured with ``name=""``. The probe route's path is fully literal
+    (``/ui/connectors/{name}/probe``) so the ``POST`` verb plus the
+    extra ``/probe`` segment makes it unambiguous regardless of order;
+    we still include it last for the same readability convention the
+    memory router uses.
+    """
+    router = APIRouter()
+    router.include_router(build_list_router())
+    router.include_router(build_detail_router())
+    router.include_router(build_probe_router())
+    return router

--- a/backend/src/meho_backplane/ui/routes/connectors/detail.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/detail.py
@@ -1,0 +1,564 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``GET /ui/connectors/{name}`` -- the per-target detail surface.
+
+Initiative #340 (G10.3 Connectors + Targets UI), Task #873 (T1) work
+items #2 / #6 / #7. The detail page renders four cards under the
+target's identity header:
+
+1. **Properties** -- the full :class:`~meho_backplane.db.models.Target`
+   row (id, aliases, host, port, fqdn, auth_model, vpn_required,
+   extras, notes, preferred_impl_id, timestamps) as a description
+   list. This is the "full row" surface mentioned in the issue body.
+
+2. **Fingerprint card** (``_fingerprint_card.html``) -- the cached
+   :class:`~meho_backplane.connectors.schemas.FingerprintResult` from
+   the most recent successful probe. Rendered as a structured
+   summary (product/version/build/extras) plus a re-probe button.
+   The button (``hx-post`` to ``/ui/connectors/{name}/probe``) is
+   tenant_admin-gated -- the gate runs server-side in the
+   :mod:`~meho_backplane.ui.routes.connectors.probe` handler; the
+   template hides the button when the operator's session is not a
+   tenant_admin so the affordance only appears to operators who can
+   actually use it.
+
+3. **Recent operations** (``_recent_ops.html``) -- the last 10
+   ``audit_log`` rows scoped to this target plus the operator's
+   tenant. Initially seeded by the server-rendered list, then live-
+   appended via the existing ``/ui/broadcast/stream`` SSE bridge
+   filtered to ``target=<name>`` (G6.1 + G10.1). The HTMX 2 ``sse``
+   extension's ``sse-swap="broadcast"`` directive deserialises the
+   ``event: broadcast`` frames; an Alpine.js controller prepends
+   matching events to the list (cap at 50 rendered rows so a busy
+   target doesn't grow the DOM unboundedly).
+
+4. **Available operations matrix** (``_ops_matrix.html``) -- the
+   ``endpoint_descriptor`` rows for the resolved connector, grouped
+   by ``operation_group`` and rendered as a collapsed accordion
+   (each group's ``when_to_use`` is the subtitle; clicking expands
+   to the per-op rows carrying ``safety_level`` and
+   ``requires_approval`` flags). The connector_id is resolved from
+   the target's ``(product, fingerprint.version)`` via the same
+   :func:`~meho_backplane.connectors.resolver.resolve_connector_or_label`
+   helper the ``/api/v1/targets/{name}/probe`` REST route uses, so
+   the matrix surfaces the dispatcher's actual choice rather than
+   re-implementing connector selection. An ambiguous or missing
+   connector is rendered as an explanation panel pointing the
+   operator at the remediation step (set ``preferred_impl_id`` or
+   register a connector); the operator can still re-probe to refresh
+   the fingerprint.
+
+Tenant scoping is non-overrideable. The target resolver
+:func:`~meho_backplane.targets.resolver.resolve_target` raises 404
+on a name belonging to another tenant (alias-aware match). The audit-
+log read joins on ``audit_log.target_id == targets.id`` AND
+``audit_log.tenant_id == session_ctx.tenant_id`` so a stale
+``target_id`` from another tenant could never surface even if it
+existed in this tenant's audit_log (which the soft-FK on
+``audit_log.target_id`` makes structurally impossible but the join
+defends against anyway). The operations-matrix query filters on
+``(tenant_id IS NULL OR tenant_id == session_ctx.tenant_id)`` --
+the same shape :func:`~meho_backplane.operations.meta_tools
+.list_operation_groups` uses for the agent surface.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any, Final
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.connectors.registry import all_connectors_v2
+from meho_backplane.connectors.resolver import resolve_connector_or_label
+from meho_backplane.db.engine import get_raw_session
+from meho_backplane.db.models import (
+    AuditLog,
+    EndpointDescriptor,
+    OperationGroup,
+)
+from meho_backplane.db.models import (
+    Target as TargetORM,
+)
+from meho_backplane.targets.resolver import resolve_target
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.routes.connectors.operator import (
+    OperatorRoleProbe,
+    resolve_role_probe,
+)
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["build_detail_router"]
+
+_log = structlog.get_logger(__name__)
+
+#: Number of recent ``audit_log`` rows seeded into the recent-ops card.
+#: Acceptance criterion on #873 pins this at "last 10 audit rows"; the
+#: SSE-live extension adds rows as they stream in, capped client-side
+#: to keep the DOM bounded.
+_RECENT_OPS_LIMIT: Final[int] = 10
+
+#: Client-side DOM row cap for the recent-ops card. The seeded server
+#: list is 10; SSE-live additions prepend until the cap is hit, then
+#: older rows trim. Mirrors the broadcast feed's bounded-list discipline.
+_RECENT_OPS_DOM_CAP: Final[int] = 50
+
+
+@dataclass(frozen=True)
+class _ConnectorResolution:
+    """Outcome of resolving the target to a registered connector.
+
+    Three shapes:
+
+    * **resolved** -- ``connector_id`` carries the canonical
+      ``"<impl_id>-<version>"`` id the operations matrix queries
+      against. ``message`` is ``None``.
+    * **no_connector** -- the resolver reported ``no_connector``;
+      ``connector_id`` is ``None``, ``message`` is the diagnostic
+      text. The ops matrix renders an explanation panel instead of
+      group rows.
+    * **ambiguous_connector** -- the resolver reported
+      ``ambiguous_connector``; same shape as no_connector. The
+      explanation includes the candidate set and the remediation
+      step (set ``preferred_impl_id``).
+    """
+
+    connector_id: str | None
+    label: str  # "resolved" | "no_connector" | "ambiguous_connector"
+    message: str | None
+
+
+def _build_connector_id(target: TargetORM) -> _ConnectorResolution:
+    """Resolve the target to its dispatcher-chosen ``connector_id``.
+
+    Routes through
+    :func:`~meho_backplane.connectors.resolver.resolve_connector_or_label`
+    -- the same helper :func:`~meho_backplane.api.v1.targets.probe_target`
+    uses -- so the UI matrix and the REST probe surface agree on which
+    connector the dispatcher would pick. The returned class's
+    ``(product, version, impl_id)`` registry entry yields the
+    canonical ``"<impl_id>-<version>"`` id the operations meta-tools
+    query against.
+
+    When the registry has the connector class under multiple keys
+    (e.g. KubernetesConnector under both the v1 wildcard and a v2
+    versioned entry), prefer the versioned entry -- that's the one the
+    G0.6 dispatcher's lookup queries against. If the chosen class only
+    appears under a wildcard entry (v1-only registration), fall back
+    to the bare product as the connector_id; ``parse_connector_id``
+    handles that shape symmetrically.
+    """
+    cls, label, message = resolve_connector_or_label(target)
+    if cls is None or label is not None:
+        return _ConnectorResolution(
+            connector_id=None,
+            label=label or "no_connector",
+            message=message,
+        )
+
+    # Find the registry entry the class is registered under and build
+    # the connector_id. Prefer the most-specific entry (versioned over
+    # wildcard) so the operations-matrix query hits the actual
+    # descriptor rows the dispatcher would dispatch to.
+    versioned: tuple[str, str, str] | None = None
+    wildcard: tuple[str, str, str] | None = None
+    for key, registered_cls in all_connectors_v2().items():
+        if registered_cls is not cls:
+            continue
+        product, version, impl_id = key
+        if version != "" or impl_id != "":
+            # Pick the lexicographically-first versioned key when the
+            # class is registered under multiple. Stable so the surface
+            # never flips choices between two equivalent registrations.
+            if versioned is None or key < versioned:
+                versioned = key
+        else:
+            wildcard = key
+
+    if versioned is not None:
+        _product, version, impl_id = versioned
+        return _ConnectorResolution(
+            connector_id=f"{impl_id}-{version}",
+            label="resolved",
+            message=None,
+        )
+    if wildcard is not None:
+        product, _version, _impl_id = wildcard
+        return _ConnectorResolution(connector_id=product, label="resolved", message=None)
+    # No registry entry matched -- defensive; the resolver returned a
+    # class that isn't in the registry. Treat as no_connector.
+    return _ConnectorResolution(
+        connector_id=None,
+        label="no_connector",
+        message="resolved connector class has no v2 registry entry",
+    )
+
+
+@dataclass(frozen=True)
+class _OpsMatrixOp:
+    """One operation row in the matrix (per-group leaf)."""
+
+    op_id: str
+    summary: str | None
+    safety_level: str
+    requires_approval: bool
+
+
+@dataclass(frozen=True)
+class _OpsMatrixGroup:
+    """One operation_group's rendered shape in the matrix."""
+
+    group_key: str
+    name: str
+    when_to_use: str
+    operations: tuple[_OpsMatrixOp, ...]
+
+
+async def _load_ops_matrix(
+    db_session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    product: str,
+    version: str,
+    impl_id: str,
+) -> tuple[_OpsMatrixGroup, ...]:
+    """Load the available-operations matrix for the resolved connector.
+
+    The query mirrors the shape
+    :func:`~meho_backplane.operations.meta_tools.list_operation_groups`
+    uses for the agent surface:
+
+    * Tenant scoping: tenant rows (``tenant_id == operator.tenant_id``)
+      and built-in / global rows (``tenant_id IS NULL``) are both
+      visible.
+    * Only ``review_status='enabled'`` groups are included -- staged /
+      disabled groups stay hidden from the operator the same way they
+      stay hidden from the agent.
+    * Within each group, only ``is_enabled=True`` descriptors are
+      surfaced -- a descriptor whose ingestion review left it disabled
+      should not appear in the operations matrix.
+
+    Returns groups sorted by ``group_key``; operations within a group
+    sorted by ``op_id``. Both orders are stable across page renders
+    so an operator's "click the same row twice" never reshuffles
+    rendering.
+    """
+    group_stmt = (
+        select(OperationGroup)
+        .where(
+            OperationGroup.product == product,
+            OperationGroup.version == version,
+            OperationGroup.impl_id == impl_id,
+            OperationGroup.review_status == "enabled",
+            (OperationGroup.tenant_id.is_(None)) | (OperationGroup.tenant_id == tenant_id),
+        )
+        .order_by(OperationGroup.group_key)
+    )
+    groups = (await db_session.execute(group_stmt)).scalars().all()
+    if not groups:
+        return ()
+
+    group_ids = [g.id for g in groups]
+    descriptor_stmt = (
+        select(EndpointDescriptor)
+        .where(
+            EndpointDescriptor.group_id.in_(group_ids),
+            EndpointDescriptor.is_enabled.is_(True),
+            (EndpointDescriptor.tenant_id.is_(None)) | (EndpointDescriptor.tenant_id == tenant_id),
+        )
+        .order_by(EndpointDescriptor.group_id, EndpointDescriptor.op_id)
+    )
+    descriptors = (await db_session.execute(descriptor_stmt)).scalars().all()
+
+    by_group: dict[uuid.UUID, list[_OpsMatrixOp]] = {gid: [] for gid in group_ids}
+    for descriptor in descriptors:
+        if descriptor.group_id is None:
+            continue
+        by_group.setdefault(descriptor.group_id, []).append(
+            _OpsMatrixOp(
+                op_id=descriptor.op_id,
+                summary=descriptor.summary,
+                safety_level=descriptor.safety_level,
+                requires_approval=descriptor.requires_approval,
+            ),
+        )
+
+    return tuple(
+        _OpsMatrixGroup(
+            group_key=g.group_key,
+            name=g.name,
+            when_to_use=g.when_to_use,
+            operations=tuple(by_group.get(g.id, [])),
+        )
+        for g in groups
+    )
+
+
+async def _load_recent_ops(
+    db_session: AsyncSession,
+    *,
+    tenant_id: uuid.UUID,
+    target_id: uuid.UUID,
+    limit: int = _RECENT_OPS_LIMIT,
+) -> list[AuditLog]:
+    """Return the most recent ``audit_log`` rows on this target.
+
+    Filters on ``(tenant_id, target_id)`` so a soft-FK violation
+    (audit row carrying another tenant's target_id) could never leak
+    into this surface. Ordered ``occurred_at DESC, id DESC`` for a
+    deterministic page-load order; ties on ``occurred_at`` are
+    extremely rare (microsecond resolution on PG timestamps) but the
+    explicit tie-break on ``id`` keeps two-rows-in-the-same-tick
+    rendering stable across reloads.
+    """
+    stmt = (
+        select(AuditLog)
+        .where(
+            AuditLog.tenant_id == tenant_id,
+            AuditLog.target_id == target_id,
+        )
+        .order_by(AuditLog.occurred_at.desc(), AuditLog.id.desc())
+        .limit(limit)
+    )
+    result = await db_session.execute(stmt)
+    return list(result.scalars().all())
+
+
+def _project_target(target: TargetORM) -> dict[str, Any]:
+    """Project the ORM row into a template-friendly dict.
+
+    Centralised so the detail page render path and the re-probe HTMX
+    response (which also re-renders the fingerprint card) carry the
+    same shape; a template helper accidentally widening the shape on
+    one path can't break the other.
+    """
+    return {
+        "id": str(target.id),
+        "name": target.name,
+        "aliases": list(target.aliases),
+        "product": target.product,
+        "host": target.host,
+        "port": target.port,
+        "fqdn": target.fqdn,
+        "secret_ref": target.secret_ref,
+        "auth_model": target.auth_model,
+        "vpn_required": target.vpn_required,
+        "extras": dict(target.extras),
+        "notes": target.notes,
+        "fingerprint": target.fingerprint,
+        "preferred_impl_id": target.preferred_impl_id,
+        "created_at": target.created_at,
+        "updated_at": target.updated_at,
+    }
+
+
+def _project_audit_rows(rows: Iterable[AuditLog]) -> list[dict[str, Any]]:
+    """Project audit rows into the template-friendly shape.
+
+    Keeps the recent-ops template free of ORM imports + tolerant of
+    the ``payload`` JSON's flexible shape; the template renders the
+    method + path + status_code + occurred_at, plus ``op_id`` /
+    ``op_class`` from the payload bag when present (these are the
+    same fields the broadcast publisher reads in
+    :func:`~meho_backplane.audit._resolve_op_id_and_class_override`).
+
+    ``occurred_at`` is serialised to an ISO-8601 string here (not left
+    as a :class:`datetime`) because the template emits the rows
+    through Jinja ``| tojson`` into the Alpine ``x-data`` seed array:
+    ``tojson`` rejects datetimes by default (``TypeError: Object of
+    type datetime is not JSON serializable``). Pre-stringifying at
+    the projection boundary keeps the template free of datetime
+    handling and matches the SSE bridge's wire format (events on
+    ``/ui/broadcast/stream`` already carry ISO strings).
+    """
+    projected: list[dict[str, Any]] = []
+    for row in rows:
+        payload = row.payload if isinstance(row.payload, dict) else {}
+        op_id = payload.get("op_id")
+        op_class = payload.get("op_class")
+        projected.append(
+            {
+                "audit_id": str(row.id),
+                "occurred_at": row.occurred_at.isoformat(),
+                "method": row.method,
+                "path": row.path,
+                "status_code": row.status_code,
+                "op_id": op_id if isinstance(op_id, str) else None,
+                "op_class": op_class if isinstance(op_class, str) else None,
+            }
+        )
+    return projected
+
+
+#: Module-level :class:`fastapi.Depends` closures -- ruff B008 idiom.
+_require_ui_session_dep = Depends(require_ui_session)
+_get_raw_session_dep = Depends(get_raw_session)
+_role_probe_dep = Depends(resolve_role_probe)
+
+
+def _resolve_target_or_404(
+    *,
+    target_name: str,
+) -> None:
+    """Validate the path parameter before the substrate hits the DB.
+
+    Names longer than 200 characters cannot exist in the ``targets``
+    table (the schema caps ``name`` at 200), so a longer path segment
+    is a guaranteed 404. Reject explicitly with the same 404 the
+    resolver would raise after the round-trip; this saves the DB
+    query in the spam-vector case (a fuzzer hammering long names).
+    """
+    if not target_name or len(target_name) > 200:
+        raise HTTPException(status_code=404, detail=f"target {target_name!r} not found")
+
+
+async def _render_detail(
+    request: Request,
+    *,
+    target_name: str,
+    session_ctx: UISessionContext,
+    db_session: AsyncSession,
+    role_probe: OperatorRoleProbe,
+) -> HTMLResponse:
+    """Render the detail page for *target_name* in the operator's tenant."""
+    _resolve_target_or_404(target_name=target_name)
+    target = await resolve_target(db_session, session_ctx.tenant_id, target_name)
+    resolution = _build_connector_id(target)
+    ops_matrix: tuple[_OpsMatrixGroup, ...] = ()
+    if resolution.connector_id is not None:
+        from meho_backplane.operations._lookup import parse_connector_id
+
+        product, version, impl_id = parse_connector_id(resolution.connector_id)
+        ops_matrix = await _load_ops_matrix(
+            db_session,
+            tenant_id=session_ctx.tenant_id,
+            product=product,
+            version=version,
+            impl_id=impl_id,
+        )
+    recent_ops = await _load_recent_ops(
+        db_session,
+        tenant_id=session_ctx.tenant_id,
+        target_id=target.id,
+    )
+
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    context = {
+        "page_title": f"Connector · {target.name}",
+        "active_surface": "connectors",
+        "target": _project_target(target),
+        "connector_id": resolution.connector_id,
+        "connector_label": resolution.label,
+        "connector_message": resolution.message,
+        "ops_matrix": ops_matrix,
+        "recent_ops": _project_audit_rows(recent_ops),
+        "recent_ops_dom_cap": _RECENT_OPS_DOM_CAP,
+        # SSE bridge URL -- the existing G10.1 stream supports a
+        # ``target=<name>`` filter so we ride it straight rather than
+        # duplicating the bridge. URL-encoded so a name carrying
+        # ``&`` or ``?`` does not split the query string.
+        "stream_endpoint": _build_stream_endpoint(target.name),
+        # tenant_admin gate for the re-probe button. The handler in
+        # :mod:`probe` re-checks the role server-side; the template
+        # hides the button when the operator can't use it so the
+        # affordance only surfaces to operators with the privilege.
+        "is_tenant_admin": role_probe.is_tenant_admin,
+        "csrf_token": csrf_token,
+        # The footer in ``base.html`` reads ``ready`` to colour the
+        # readiness pill; the connectors surface doesn't poll readiness
+        # itself, so ship ``False`` here so Jinja's ``StrictUndefined``
+        # env does not raise on the read.
+        "ready": False,
+    }
+    response = get_templates().TemplateResponse(request, "connectors/detail.html", context)
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=csrf_token,
+        httponly=False,
+        secure=True,
+        samesite="strict",
+        path="/ui",
+    )
+    return response
+
+
+def _build_stream_endpoint(target_name: str) -> str:
+    """Build the URL-encoded SSE bridge endpoint for *target_name*.
+
+    The G10.1 broadcast SSE bridge (``/ui/broadcast/stream``) takes a
+    ``target=<name>`` query parameter and filters the stream to events
+    whose ``BroadcastEvent.target_name`` matches. We piggy-back on it
+    (instead of standing up a parallel connectors-only stream) so the
+    SSE plumbing -- session gate, cursor resolver, heartbeat, replay
+    -- stays single-sourced. The target name is percent-encoded so a
+    name containing ``&`` / ``?`` / ``#`` does not split the query
+    string.
+    """
+    from urllib.parse import quote
+
+    return f"/ui/broadcast/stream?target={quote(target_name, safe='')}"
+
+
+def build_detail_router() -> APIRouter:
+    """Construct the targets-detail :class:`APIRouter`.
+
+    Registers the single ``GET /ui/connectors/{name}`` route. The
+    route name (``ui_connectors_detail``) is referenced by the list
+    template's row "View" links and by the probe handler's
+    HX-Redirect on the fingerprint-card refresh -- a rename here must
+    update both in lockstep.
+    """
+    router = APIRouter(tags=["ui-connectors"])
+
+    async def _handler(
+        request: Request,
+        name: str,
+        session_ctx: UISessionContext = _require_ui_session_dep,
+        db_session: AsyncSession = _get_raw_session_dep,
+        role_probe: OperatorRoleProbe = _role_probe_dep,
+    ) -> HTMLResponse:
+        """``GET /ui/connectors/{name}``."""
+        return await _render_detail(
+            request,
+            target_name=name,
+            session_ctx=session_ctx,
+            db_session=db_session,
+            role_probe=role_probe,
+        )
+
+    router.add_api_route(
+        "/ui/connectors/{name}",
+        _handler,
+        methods=["GET"],
+        name="ui_connectors_detail",
+        response_class=HTMLResponse,
+        responses={
+            404: {
+                "description": (
+                    "Target name does not resolve in the caller's tenant. "
+                    "Returns the 404 from the shared "
+                    ":func:`~meho_backplane.targets.resolver.resolve_target` "
+                    "helper -- alias-aware, with near-miss suggestions when "
+                    "the substring search lands hits."
+                ),
+                "content": {"text/html": {}},
+            },
+            409: {
+                "description": (
+                    "Target name resolves to multiple targets in the caller's "
+                    "tenant (ambiguous alias match). Returns the 409 from "
+                    ":func:`resolve_target`."
+                ),
+                "content": {"text/html": {}},
+            },
+        },
+    )
+    return router

--- a/backend/src/meho_backplane/ui/routes/connectors/list_view.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/list_view.py
@@ -1,0 +1,440 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``GET /ui/connectors`` -- the per-tenant targets list (table view).
+
+Initiative #340 (G10.3 Connectors + Targets UI), Task #873 (T1) work
+item #1. The route serves two response shapes from one handler:
+
+* **Full page** (normal browser navigation) -- returns the
+  ``connectors/list.html`` page extending ``base.html``. The chrome
+  (navbar, sidebar, footer) matches the rest of the operator console.
+
+* **HTMX fragment** (``HX-Request: true`` header set, sent by the
+  HTMX 2 ``sse`` / ``hx-get`` directives) -- returns the
+  ``connectors/_table_rows.html`` partial so a sort header click or
+  product-filter change only re-renders the table body without a
+  full-page reload.
+
+Tenant scoping is non-overrideable. The substrate query passes
+``session_ctx.tenant_id`` from the chassis-validated
+:class:`~meho_backplane.ui.auth.middleware.UISessionContext`; no
+query parameter, header, or path segment carries a tenant id, so a
+cross-tenant target row never enters the rendered set (per the
+acceptance criterion on #873).
+
+URL contract::
+
+    GET /ui/connectors
+        [?sort=name|product|host|last_probed_at|status
+         &dir=asc|desc
+         &product=<exact-match slug>]
+
+Out-of-range ``sort`` / ``dir`` -> 422 (Pydantic enum validator at the
+HTTP boundary). The handler defaults to ``sort=name`` / ``dir=asc`` --
+a stable, human-meaningful order matching the `/api/v1/targets` list
+route's ``ORDER BY name`` (G0.3-T3 / #254).
+
+last_probed_at + status
+-----------------------
+
+The ``last_probed_at`` column surfaces the timestamp of the target's
+most recent successful probe. It is sourced from
+``targets.updated_at`` -- the
+:func:`~meho_backplane.api.v1.targets.probe_target` handler refreshes
+``updated_at`` on every successful probe persist (and is the only
+mutator that also writes the ``fingerprint`` column), so on a target
+that has been probed at least once the column is the probe timestamp;
+on a target that has never been probed the column is the row's
+``created_at``. ``status`` is the rendered classification ``ok`` /
+``stale`` / ``never``: ``never`` when ``fingerprint IS NULL``,
+``stale`` when the probe is older than the freshness window
+(:data:`_STALE_THRESHOLD` -- 24 h), ``ok`` otherwise. Both columns are
+computed in the handler so the substrate ``Target`` model stays a
+plain CRUD shape; the substrate would have to teach itself the
+freshness window otherwise and the freshness contract is a UI-side
+concern (operators tune the window; agents read the raw timestamp via
+``/api/v1/targets``).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from typing import Final, Literal
+
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.engine import get_raw_session
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["build_list_router"]
+
+
+class _SortColumn(StrEnum):
+    """Closed enum of sort columns exposed in the URL.
+
+    Mirrors the human-meaningful columns in the rendered table. An
+    out-of-enum value fails Pydantic validation at the HTTP boundary
+    with a 422 carrying the candidate list in the error context. The
+    enum's ``str`` mixin keeps the template's ``{{ sort }}`` rendering
+    + ``href`` building stable -- ``str(_SortColumn.NAME)`` is
+    ``"name"`` (not ``"_SortColumn.NAME"``).
+    """
+
+    NAME = "name"
+    PRODUCT = "product"
+    HOST = "host"
+    LAST_PROBED_AT = "last_probed_at"
+    STATUS = "status"
+
+
+class _SortDirection(StrEnum):
+    """Sort direction -- ``asc`` (default) or ``desc``."""
+
+    ASC = "asc"
+    DESC = "desc"
+
+
+#: Threshold for the ``stale`` status classification. A target whose
+#: most recent successful probe is older than this is rendered with a
+#: warning pill so the operator notices the staleness before relying
+#: on the cached fingerprint. 24 h matches the freshness signal the
+#: G0.6 dispatcher's connector-resolution log line uses to flag a
+#: cold fingerprint (the resolver does not refuse to dispatch on
+#: stale fingerprint -- it logs and proceeds; the UI flag is the
+#: operator-facing complement).
+_STALE_THRESHOLD: Final[timedelta] = timedelta(hours=24)
+
+
+def _coerce_utc_aware(ts: datetime) -> datetime:
+    """Normalise *ts* to a tz-aware UTC :class:`datetime`.
+
+    The ``DateTime(timezone=True)`` ORM column round-trips tz-aware
+    on PostgreSQL but the SQLite ``aiosqlite`` driver hands back
+    naive datetimes (the chassis test fixture leaves the connection's
+    ``detect_types`` flag unset; the column is stored as an ISO
+    string and reconstructed without the offset). The handler does
+    timedelta arithmetic between the live "now" (tz-aware) and the
+    row's ``updated_at``, so a naive value raises ``TypeError: can't
+    subtract offset-naive and offset-aware datetimes`` mid-render.
+    Coercing here keeps the substrate dialect-portable without
+    teaching the column shape about the dialect mismatch.
+    """
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=UTC)
+    return ts
+
+
+def _target_status(target: TargetORM, *, now: datetime) -> Literal["ok", "stale", "never"]:
+    """Classify a target's freshness for the table's status column.
+
+    ``never`` when ``fingerprint IS NULL`` -- the target has never
+    been probed. ``stale`` when the row's ``updated_at`` is older
+    than :data:`_STALE_THRESHOLD` (the probe path is the only writer
+    that bumps ``updated_at`` alongside the ``fingerprint`` column,
+    so a stale ``updated_at`` is a stale probe). ``ok`` otherwise.
+
+    ``now`` is injected so the test suite can pin a deterministic
+    "now" without monkeypatching :func:`datetime.now`.
+    """
+    if target.fingerprint is None:
+        return "never"
+    # ORM stores ``updated_at`` tz-aware on PG; on the SQLite test
+    # dialect the round-trip drops tzinfo so we coerce here before
+    # the comparison.
+    if now - _coerce_utc_aware(target.updated_at) >= _STALE_THRESHOLD:
+        return "stale"
+    return "ok"
+
+
+def _apply_sort(
+    stmt: Select[tuple[TargetORM]],
+    *,
+    sort: _SortColumn,
+    direction: _SortDirection,
+) -> Select[tuple[TargetORM]]:
+    """Apply the requested column + direction to *stmt*.
+
+    The ``status`` and ``last_probed_at`` columns are computed in the
+    handler (not stored), so the SQL-level ``ORDER BY`` covers the
+    other three columns directly; status / last_probed_at fall back
+    to ``updated_at`` (the underlying timestamp the status derives
+    from) for stable database-level ordering, with a Python-side
+    re-sort layered on top so the rendered order still honours the
+    semantic status classification. The semantics:
+
+    * ``name`` / ``product`` / ``host`` -- direct column sort, the SQL
+      ``ORDER BY`` is the rendered order.
+    * ``last_probed_at`` -- ``ORDER BY updated_at`` (same column).
+    * ``status`` -- ``ORDER BY updated_at`` (a proxy); the handler then
+      re-sorts the page's rows by the classified status string after
+      :func:`_target_status` runs so ``never`` < ``stale`` < ``ok``
+      ordering reflects the freshness ladder.
+    """
+    column_map = {
+        _SortColumn.NAME: TargetORM.name,
+        _SortColumn.PRODUCT: TargetORM.product,
+        _SortColumn.HOST: TargetORM.host,
+        _SortColumn.LAST_PROBED_AT: TargetORM.updated_at,
+        _SortColumn.STATUS: TargetORM.updated_at,
+    }
+    column = column_map[sort]
+    if direction == _SortDirection.DESC:
+        return stmt.order_by(column.desc(), TargetORM.name)
+    return stmt.order_by(column.asc(), TargetORM.name)
+
+
+def _is_htmx_request(request: Request) -> bool:
+    """Return ``True`` when HTMX issued the request.
+
+    HTMX 2 sets ``HX-Request: true`` on every fetch its directives
+    drive (https://htmx.org/reference/#request_headers). The handler
+    branches on this header to decide between rendering the full page
+    (a normal navigation) and the table-rows fragment (a sort or
+    filter swap). The check is case-insensitive because HTTP header
+    names are case-insensitive by spec.
+    """
+    return request.headers.get("hx-request", "").lower() == "true"
+
+
+def _next_direction_factory(
+    current_sort: _SortColumn,
+    current_direction: _SortDirection,
+) -> object:
+    """Return a Jinja-callable closure computing the next sort direction.
+
+    Clicking the currently-active sort column toggles asc/desc; clicking
+    a different column resets to asc. The returned object is a small
+    one-arg callable the template invokes as
+    ``next_direction_for(col_value)``; the template never has to learn
+    about ``_SortColumn`` / ``_SortDirection`` enums.
+    """
+
+    def _call(target: str) -> str:
+        if current_sort.value == target:
+            return (
+                _SortDirection.DESC.value
+                if current_direction == _SortDirection.ASC
+                else _SortDirection.ASC.value
+            )
+        return _SortDirection.ASC.value
+
+    return _call
+
+
+#: Module-level :class:`fastapi.Depends` closures -- ruff B008 idiom
+#: matching the chassis dashboard + topology + memory routes (no
+#: function calls in default argument positions).
+_require_ui_session_dep = Depends(require_ui_session)
+_get_raw_session_dep = Depends(get_raw_session)
+
+
+async def _list_targets(
+    db_session: AsyncSession,
+    *,
+    tenant_id: object,
+    product_filter: str | None,
+    sort: _SortColumn,
+    direction: _SortDirection,
+) -> list[TargetORM]:
+    """Pull the tenant's targets honouring the active filter + sort.
+
+    Tenant scoping is the first ``WHERE`` clause -- the
+    cross-tenant-isolation acceptance criterion is enforced at the
+    substrate layer, never at the template. ``product_filter`` is
+    exact-match (matching the ``/api/v1/targets`` list route's
+    ``?product=`` shape from #254) so the dropdown's
+    selected-or-cleared state maps 1:1 to the active query.
+    """
+    stmt = select(TargetORM).where(TargetORM.tenant_id == tenant_id)
+    if product_filter:
+        stmt = stmt.where(TargetORM.product == product_filter)
+    stmt = _apply_sort(stmt, sort=sort, direction=direction)
+    result = await db_session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def _distinct_products(
+    db_session: AsyncSession,
+    *,
+    tenant_id: object,
+) -> list[str]:
+    """Return the distinct ``product`` values present in this tenant.
+
+    Drives the product-filter dropdown's option list. Sourced from
+    the live data (not a closed enum) because the connector registry
+    grows as new connectors land -- ingested / typed / composite
+    connectors all create their own product slugs, and an operator's
+    catalogue may carry mature products plus an experimental one in
+    the same tenant. A ``SELECT DISTINCT`` round trip on the
+    targets table costs one extra query per page render; the table
+    is already paged so the cost is bounded.
+    """
+    stmt = (
+        select(TargetORM.product)
+        .where(TargetORM.tenant_id == tenant_id)
+        .distinct()
+        .order_by(TargetORM.product)
+    )
+    result = await db_session.execute(stmt)
+    return [row for row in result.scalars().all() if row]
+
+
+_STATUS_ORDER: Final[dict[str, int]] = {"never": 0, "stale": 1, "ok": 2}
+
+
+def _render_rows(
+    targets: list[TargetORM],
+    *,
+    now: datetime,
+    sort: _SortColumn,
+    direction: _SortDirection,
+) -> list[dict[str, object]]:
+    """Project rows into the template-friendly dict shape.
+
+    Each dict carries the column values plus the computed status
+    string and a flag for the VPN icon. When sorting by ``status``
+    we apply the rendered-order re-sort here (the SQL-level sort
+    falls back to ``updated_at``); for the other columns the SQL
+    order is the rendered order.
+    """
+    rows = [
+        {
+            "name": t.name,
+            "aliases": list(t.aliases),
+            "product": t.product,
+            "host": t.host,
+            "auth_model": t.auth_model,
+            "vpn_required": t.vpn_required,
+            "last_probed_at": _coerce_utc_aware(t.updated_at),
+            "status": _target_status(t, now=now),
+        }
+        for t in targets
+    ]
+    if sort == _SortColumn.STATUS:
+        rows.sort(
+            key=lambda r: (
+                _STATUS_ORDER[str(r["status"])],
+                str(r["name"]),
+            ),
+            reverse=direction == _SortDirection.DESC,
+        )
+    return rows
+
+
+async def _render(
+    request: Request,
+    *,
+    sort: _SortColumn,
+    direction: _SortDirection,
+    product_filter: str | None,
+    session_ctx: UISessionContext,
+    db_session: AsyncSession,
+) -> HTMLResponse:
+    """Render the list page or the table-rows fragment.
+
+    Branches on ``HX-Request``. Both branches receive the same context
+    shape so the fragment template and the full-page template remain
+    interchangeable -- swapping ``connectors/list.html`` for
+    ``connectors/_table_rows.html`` and back never requires a context
+    rewrite.
+    """
+    targets = await _list_targets(
+        db_session,
+        tenant_id=session_ctx.tenant_id,
+        product_filter=product_filter,
+        sort=sort,
+        direction=direction,
+    )
+    products = await _distinct_products(db_session, tenant_id=session_ctx.tenant_id)
+    now = datetime.now(UTC)
+    rows = _render_rows(targets, now=now, sort=sort, direction=direction)
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    context = {
+        "page_title": "Connectors",
+        "active_surface": "connectors",
+        "rows": rows,
+        # Template macro ``_relative_time`` reads ``now_utc`` to render
+        # the "X ago" column. Sharing one "now" across every row keeps
+        # the relative timestamps consistent within a single page
+        # render (otherwise per-row calls to ``datetime.now`` would
+        # drift across millisecond boundaries).
+        "now_utc": now,
+        "product_options": products,
+        "product_filter": product_filter or "",
+        "sort": sort,
+        "direction": direction,
+        "next_direction_for": _next_direction_factory(sort, direction),
+        "csrf_token": csrf_token,
+        # The footer in ``base.html`` reads ``ready`` to colour the
+        # readiness pill; the connectors surface doesn't poll readiness
+        # (the dashboard owns that), so ship ``False`` here so Jinja's
+        # ``StrictUndefined`` env does not raise on the read.
+        "ready": False,
+    }
+    template_name = (
+        "connectors/_table_rows.html" if _is_htmx_request(request) else "connectors/list.html"
+    )
+    response = get_templates().TemplateResponse(request, template_name, context)
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=csrf_token,
+        httponly=False,
+        secure=True,
+        samesite="strict",
+        path="/ui",
+    )
+    return response
+
+
+def build_list_router() -> APIRouter:
+    """Construct the targets-list :class:`APIRouter`.
+
+    Registers the single ``GET /ui/connectors`` route serving both
+    the full page and the HTMX fragment from one handler. The route
+    name (``ui_connectors_list``) is referenced by ``url_for`` in the
+    list template's sort header links and the chassis sidebar -- a
+    rename here must update both in lockstep.
+    """
+    router = APIRouter(tags=["ui-connectors"])
+
+    async def _handler(
+        request: Request,
+        sort: _SortColumn = Query(default=_SortColumn.NAME),
+        direction: _SortDirection = Query(default=_SortDirection.ASC, alias="dir"),
+        product: str | None = Query(default=None, max_length=100),
+        session_ctx: UISessionContext = _require_ui_session_dep,
+        db_session: AsyncSession = _get_raw_session_dep,
+    ) -> HTMLResponse:
+        """Serve ``GET /ui/connectors``. See module docstring for the
+        URL contract.
+
+        ``dir`` (not ``direction``) is the spelling on the URL the
+        issue body pinned -- the alias above keeps the Python kwarg
+        readable (``direction``) without breaking the URL contract
+        the operator sees in the address bar.
+        """
+        return await _render(
+            request,
+            sort=sort,
+            direction=direction,
+            product_filter=product,
+            session_ctx=session_ctx,
+            db_session=db_session,
+        )
+
+    router.add_api_route(
+        "/ui/connectors",
+        _handler,
+        methods=["GET"],
+        name="ui_connectors_list",
+        response_class=HTMLResponse,
+    )
+    return router

--- a/backend/src/meho_backplane/ui/routes/connectors/operator.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/operator.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Operator-role lift for the connectors detail + probe routes.
+
+Initiative #340 (G10.3 Connectors + Targets UI), Task #873 (T1). The
+chassis :class:`~meho_backplane.ui.auth.middleware.UISessionContext`
+carries ``operator_sub`` + ``tenant_id`` only; the connectors detail
+template needs to know whether to render the re-probe button
+(tenant_admin-only) and the probe handler needs to gate the write.
+
+The lift mirrors the pattern
+:mod:`~meho_backplane.ui.routes.memory.operator` ships for the
+memory surface: read the encrypted session row, decrypt the access
+token, re-validate it through the chassis JWT chain to produce a
+full :class:`~meho_backplane.auth.operator.Operator` carrying
+``tenant_role``. The JWT round-trip catches a same-session role
+demotion the next time the operator browses the detail page; storing
+a cached role on the session row would extend the demotion's
+effective window to the session's absolute TTL.
+
+Two surfaces:
+
+* :class:`OperatorRoleProbe` -- a tiny shape carrying the booleans
+  the detail template reads (``is_tenant_admin``). The full
+  :class:`Operator` is heavier than the template needs and the
+  detail route is read-only, so passing the probe shape (rather than
+  the operator itself) keeps the template helper-free of auth
+  internals.
+
+* :func:`resolve_role_probe` -- the FastAPI dependency the detail
+  handler uses. Used only for read paths (the probe handler uses
+  :func:`resolve_operator_or_403` to get the full Operator + 403
+  on a non-admin call).
+
+* :func:`resolve_operator_or_403` -- the FastAPI dependency the
+  probe handler uses. Returns the full :class:`Operator` after
+  asserting :class:`~meho_backplane.auth.operator.TenantRole.TENANT_ADMIN`;
+  a non-admin caller raises 403 with a structured detail so the
+  HTMX response carries the gate-failure semantics the template's
+  ``hx-on::after-request`` handler can branch on.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import structlog
+from fastapi import HTTPException, Request, status
+
+from meho_backplane.auth.jwt import verify_jwt_for_audience
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.auth.session_store import load_session
+
+__all__ = [
+    "OperatorRoleProbe",
+    "resolve_operator_or_403",
+    "resolve_role_probe",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class OperatorRoleProbe:
+    """Tiny shape carrying the role booleans the detail template reads.
+
+    The connectors detail page only needs to know whether to render the
+    re-probe button (tenant_admin-only). The probe RBAC gate is the
+    server-side authority -- this shape is a UX hint that hides the
+    affordance from operators who can't use it. The two role classes
+    we surface today are ``tenant_admin`` (re-probe surface) and the
+    catch-all ``operator`` (read surfaces); the dataclass leaves
+    room for future role flags without rewriting the call sites.
+    """
+
+    is_tenant_admin: bool
+    is_operator: bool
+
+
+def _probe_from_operator(operator: Operator) -> OperatorRoleProbe:
+    """Project a full :class:`Operator` into the booleans the template reads."""
+    return OperatorRoleProbe(
+        is_tenant_admin=operator.tenant_role == TenantRole.TENANT_ADMIN,
+        is_operator=operator.tenant_role in (TenantRole.OPERATOR, TenantRole.TENANT_ADMIN),
+    )
+
+
+async def _load_access_token_or_401(session_ctx: UISessionContext) -> str:
+    """Load the encrypted session row, return the decrypted access token.
+
+    The session middleware already validated the cookie before this
+    helper runs; if the row vanished in the gap (revoked / expired
+    while the request was in-flight), raise 401 so the operator's
+    browser knows to re-authenticate. Mirrors the same shape
+    :func:`~meho_backplane.ui.routes.memory.operator._load_session_or_401`
+    uses.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as db_session, db_session.begin():
+        decrypted = await load_session(db_session, session_ctx.session_id)
+    if decrypted is None:
+        _log.info("ui_connectors_session_gone", session_id=str(session_ctx.session_id))
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="ui_session_required",
+        )
+    return decrypted.access_token
+
+
+def _assert_identity_matches(operator: Operator, session_ctx: UISessionContext) -> None:
+    """Reject a token whose sub / tenant_id diverges from the session row.
+
+    A mismatch is a security anomaly (token swapped under the same
+    session row); it must surface as 401, not a silently-honoured
+    cross-identity read.
+    """
+    if operator.sub != session_ctx.operator_sub or operator.tenant_id != session_ctx.tenant_id:
+        _log.warning(
+            "ui_connectors_session_identity_mismatch",
+            session_sub=session_ctx.operator_sub,
+            session_tenant_id=str(session_ctx.tenant_id),
+            token_sub=operator.sub,
+            token_tenant_id=str(operator.tenant_id),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="ui_session_identity_mismatch",
+        )
+
+
+async def _lift_operator(session_ctx: UISessionContext) -> Operator:
+    """Lift the full :class:`Operator` from the BFF session row.
+
+    Common helper for the read-only role probe and the write-gating
+    403 dependency. The JWT chain caches the JWKS in process so the
+    round-trip is local-only after the first hit.
+    """
+    access_token = await _load_access_token_or_401(session_ctx)
+    settings = get_settings()
+    operator = await verify_jwt_for_audience(
+        f"Bearer {access_token}",
+        expected_audience=settings.keycloak_audience,
+    )
+    _assert_identity_matches(operator, session_ctx)
+    return operator
+
+
+async def resolve_role_probe(
+    request: Request,
+    session_ctx: UISessionContext | None = None,
+) -> OperatorRoleProbe:
+    """FastAPI dependency: project the BFF session's operator role into
+    the booleans the detail template reads.
+
+    Used by the read-only ``GET /ui/connectors/{name}`` handler. Fails
+    **soft**: any JWT-validation hiccup (session row gone, JWKS endpoint
+    unreachable from this deploy, token swapped) projects to a
+    "no privileges" probe rather than 5xx-ing the page. The probe
+    handler (``POST /ui/connectors/{name}/probe``) remains the
+    server-side authority -- a soft "no privileges" hint just hides
+    the re-probe button optimistically; an attacker who crafts the
+    POST with a forged form still hits the 403 gate on the write
+    surface. The read surface must keep rendering even when the
+    JWT round-trip can't complete (transient JWKS outage, etc.).
+    """
+    if session_ctx is None:
+        session_ctx = require_ui_session(request)
+    try:
+        operator = await _lift_operator(session_ctx)
+    except Exception as exc:
+        _log.info(
+            "ui_connectors_role_probe_unavailable",
+            session_id=str(session_ctx.session_id),
+            reason=type(exc).__name__,
+        )
+        return OperatorRoleProbe(is_tenant_admin=False, is_operator=False)
+    return _probe_from_operator(operator)
+
+
+async def resolve_operator_or_403(
+    request: Request,
+    session_ctx: UISessionContext | None = None,
+) -> Operator:
+    """FastAPI dependency: lift the operator + gate to tenant_admin.
+
+    Used by ``POST /ui/connectors/{name}/probe``. A non-admin call
+    raises 403 with the structured detail the HTMX response carries
+    back to the template's ``hx-on::after-request`` so the surface
+    can render the "insufficient privilege" alert without losing the
+    rest of the page state.
+    """
+    if session_ctx is None:
+        session_ctx = require_ui_session(request)
+    operator = await _lift_operator(session_ctx)
+    if operator.tenant_role != TenantRole.TENANT_ADMIN:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="re-probe requires tenant_admin",
+        )
+    return operator

--- a/backend/src/meho_backplane/ui/routes/connectors/probe.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/probe.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``POST /ui/connectors/{name}/probe`` -- tenant_admin re-probe action.
+
+Initiative #340 (G10.3 Connectors + Targets UI), Task #873 (T1) work
+item #6. The re-probe button on the detail page (fingerprint card)
+posts here via HTMX (``hx-post`` + ``hx-target="#fingerprint-card"``
++ ``hx-swap="outerHTML"``). The handler:
+
+1. Lifts the full operator via
+   :func:`~meho_backplane.ui.routes.connectors.operator.resolve_operator_or_403`,
+   which re-validates the access token through the chassis JWT chain
+   and gates on :class:`~meho_backplane.auth.operator.TenantRole.TENANT_ADMIN`
+   server-side. A non-admin call raises 403 -- the template's
+   ``hx-on::after-request`` handler renders the alert.
+
+2. Resolves the target tenant-scoped via
+   :func:`~meho_backplane.targets.resolver.resolve_target`. 404 on
+   a cross-tenant or near-miss name (alias-aware match).
+
+3. Re-runs the connector probe through the same shared helper
+   :func:`~meho_backplane.connectors.resolver.resolve_connector_or_label`
+   the ``/api/v1/targets/{name}/probe`` REST route uses, so the two
+   surfaces stay byte-compatible -- a future change to the
+   resolver's tie-break ladder takes effect on both at once. The
+   resolver's two error labels are surfaced as alert HTML fragments
+   so HTMX can swap them into the fingerprint card slot without a
+   full-page reload:
+
+   * ``no_connector`` -> 501 + alert fragment naming the missing
+     ``(product, version)`` pair. The cached fingerprint (if any)
+     survives unchanged on the DB row.
+   * ``ambiguous_connector`` -> 409 + alert fragment naming the
+     candidate set and the remediation step (set
+     ``target.preferred_impl_id`` to one of them). Same survival
+     semantics.
+
+4. Persists the new :class:`FingerprintResult` to
+   ``targets.fingerprint`` and bumps ``updated_at`` -- the same
+   write the REST route does, in the same shape, so a re-render of
+   the detail page after a UI re-probe is indistinguishable from a
+   re-render after a CLI re-probe.
+
+5. Returns the freshly-rendered ``_fingerprint_card.html`` fragment.
+   The HTMX swap replaces the previous card in place.
+
+The handler is **server-side authoritative** on the RBAC gate; the
+template hides the button when the operator isn't admin, but a
+crafted POST hitting this endpoint with a stolen / forged form still
+fails on the 403 from
+:func:`~meho_backplane.ui.routes.connectors.operator.resolve_operator_or_403`.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.resolver import resolve_connector_or_label
+from meho_backplane.db.engine import get_session
+from meho_backplane.targets.resolver import resolve_target
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.routes.connectors.detail import _project_target
+from meho_backplane.ui.routes.connectors.operator import resolve_operator_or_403
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["build_probe_router"]
+
+_log = structlog.get_logger(__name__)
+
+
+def _render_alert(
+    request: Request,
+    *,
+    title: str,
+    message: str,
+    status_code: int,
+) -> HTMLResponse:
+    """Render the alert HTML fragment for a probe failure.
+
+    Returned in place of the fingerprint card so the HTMX swap drops
+    the alert into the slot without disturbing the rest of the
+    detail page. The ``status_code`` is propagated so the template's
+    ``hx-on::after-request`` handler can branch on the response code
+    (e.g. open the alert toast at the top of the page in addition to
+    swapping the slot).
+    """
+    return get_templates().TemplateResponse(
+        request,
+        "connectors/_probe_alert.html",
+        {"title": title, "message": message},
+        status_code=status_code,
+    )
+
+
+#: Module-level :class:`fastapi.Depends` closures -- ruff B008 idiom.
+_require_ui_session_dep = Depends(require_ui_session)
+_get_session_dep = Depends(get_session)
+_require_admin_operator_dep = Depends(resolve_operator_or_403)
+
+
+async def _do_probe(
+    request: Request,
+    *,
+    target_name: str,
+    session_ctx: UISessionContext,
+    db_session: AsyncSession,
+    operator: Operator,
+) -> HTMLResponse:
+    """Re-run the connector probe and return the refreshed card or alert."""
+    target = await resolve_target(db_session, session_ctx.tenant_id, target_name)
+    cls, label, message = resolve_connector_or_label(target)
+    if label == "no_connector":
+        return _render_alert(
+            request,
+            title="No matching connector",
+            message=message or f"no connector registered for product={target.product!r}",
+            status_code=501,
+        )
+    if label == "ambiguous_connector":
+        return _render_alert(
+            request,
+            title="Connector resolution ambiguous",
+            message=message
+            or (
+                f"connector resolution ambiguous for product={target.product!r}; "
+                "set target.preferred_impl_id to disambiguate."
+            ),
+            status_code=409,
+        )
+    assert cls is not None  # narrow for mypy; resolver contract guarantees this
+    fp = await cls().fingerprint(target)
+    # ``model_dump(mode='json')`` produces a JSONB-safe dict; plain
+    # ``model_dump()`` would leak Python-native types into the JSON
+    # column. Mirror the REST route's write shape exactly.
+    target.fingerprint = fp.model_dump(mode="json")
+    target.updated_at = datetime.now(UTC)
+    await db_session.flush()
+    _log.info(
+        "ui_target_reprobe_success",
+        target_id=str(target.id),
+        target_name=target.name,
+        tenant_id=str(session_ctx.tenant_id),
+        operator_sub=operator.sub,
+    )
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    context = {
+        "target": _project_target(target),
+        "is_tenant_admin": True,
+        "csrf_token": csrf_token,
+    }
+    response = get_templates().TemplateResponse(
+        request,
+        "connectors/_fingerprint_card.html",
+        context,
+    )
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=csrf_token,
+        httponly=False,
+        secure=True,
+        samesite="strict",
+        path="/ui",
+    )
+    return response
+
+
+def build_probe_router() -> APIRouter:
+    """Construct the re-probe :class:`APIRouter`.
+
+    Registers the single ``POST /ui/connectors/{name}/probe`` route.
+    The chassis :class:`~meho_backplane.ui.csrf.CSRFMiddleware`
+    enforces the double-submit cookie chain on every state-changing
+    UI verb; the template's ``hx-headers`` directive (set on the
+    page wrapper) echoes ``X-CSRF-Token`` into the outbound request
+    so the gate passes by construction.
+    """
+    router = APIRouter(tags=["ui-connectors"])
+
+    async def _handler(
+        request: Request,
+        name: str,
+        session_ctx: UISessionContext = _require_ui_session_dep,
+        db_session: AsyncSession = _get_session_dep,
+        operator: Operator = _require_admin_operator_dep,
+    ) -> HTMLResponse:
+        """``POST /ui/connectors/{name}/probe``."""
+        if not name or len(name) > 200:
+            raise HTTPException(status_code=404, detail=f"target {name!r} not found")
+        return await _do_probe(
+            request,
+            target_name=name,
+            session_ctx=session_ctx,
+            db_session=db_session,
+            operator=operator,
+        )
+
+    router.add_api_route(
+        "/ui/connectors/{name}/probe",
+        _handler,
+        methods=["POST"],
+        name="ui_connectors_reprobe",
+        response_class=HTMLResponse,
+        responses={
+            403: {
+                "description": (
+                    "Operator is not a tenant_admin. The re-probe verb is "
+                    "tenant_admin-only, mirroring the ``/api/v1/targets/"
+                    "{name}/probe`` REST route's posture."
+                ),
+                "content": {"text/html": {}},
+            },
+            404: {
+                "description": ("Target name does not resolve in the caller's tenant."),
+                "content": {"text/html": {}},
+            },
+            409: {
+                "description": (
+                    "Resolver reported ambiguous connector resolution. The "
+                    "alert fragment names the candidate set."
+                ),
+                "content": {"text/html": {}},
+            },
+            501: {
+                "description": (
+                    "Resolver found no matching connector for the target's "
+                    "(product, fingerprint.version) pair."
+                ),
+                "content": {"text/html": {}},
+            },
+        },
+    )
+    return router

--- a/backend/src/meho_backplane/ui/routes/stubs.py
+++ b/backend/src/meho_backplane/ui/routes/stubs.py
@@ -17,15 +17,16 @@ shell renders end-to-end before the per-surface Initiatives
   state-changing form rendered before the surface Initiative lands
   has the double-submit chain in place from request one.
 
-The remaining stub paths are kept consistent with the chassis
-``base.html`` sidebar -- ``/ui/knowledge`` and ``/ui/connectors``.
-``/ui/topology``, ``/ui/broadcast``, and ``/ui/memory`` are
+The remaining stub path is ``/ui/knowledge`` -- the only surface
+that has not yet shipped its real Initiative. ``/ui/topology``,
+``/ui/broadcast``, ``/ui/memory``, and ``/ui/connectors`` are
 intentionally NOT stubbed here: topology's real table view ships in
 G10.5-T1 (#880), broadcast's real live-feed view ships in G10.1-T1
-(#867), and memory's real list / detail / edit surface ships in
-G10.4-T1 (#877), each owning its path; registering a stub for any
-would shadow the real route in the generated OpenAPI schema. The Goal #336 done-when and
-Initiative #337 work-item #5 reference these exact URLs.
+(#867), memory's real list / detail / edit surface ships in G10.4-T1
+(#877), and the connectors targets list + detail ships in G10.3-T1
+(#873) -- each owning its path; registering a stub for any would
+shadow the real route in the generated OpenAPI schema. The Goal #336
+done-when and Initiative #337 work-item #5 reference these exact URLs.
 
 Why one shared template
 -----------------------
@@ -80,12 +81,6 @@ _SURFACE_STUBS: Final[tuple[_SurfaceStub, ...]] = (
         title="Knowledge",
         initiative_number=339,
         summary="Search + view + drag-and-drop upload + Markdown editor over the team kb.",
-    ),
-    _SurfaceStub(
-        slug="connectors",
-        title="Connectors",
-        initiative_number=340,
-        summary="Per-tenant target CRUD + per-target detail (fingerprint, last probe, ops).",
     ),
 )
 

--- a/backend/src/meho_backplane/ui/static/src/app/connectors-feed.js
+++ b/backend/src/meho_backplane/ui/static/src/app/connectors-feed.js
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+//
+// Connectors recent-ops Alpine controller (Initiative #340; Task #873
+// G10.3-T1). Registers on ``alpine:init`` so the
+// ``x-data="connectorsRecentOps(...)"`` wrapper in
+// ``connectors/_recent_ops.html`` resolves to this component. Kept
+// in a static file (loaded via ``<script src=... defer>``) rather
+// than an inline ``<script>`` block so a future nonce-based CSP
+// needs no inline-script exception -- matching the chassis
+// ``base.html`` "zero inline script" posture.
+//
+// Responsibilities:
+//   * Seed ``events`` from the server-rendered payload passed in
+//     through ``opts.seed`` (the last 10 audit_log rows on this
+//     target). The seed payload arrives pre-serialised by the
+//     Python route's ``_project_audit_rows`` helper -- datetimes
+//     are ISO strings, ids are stringified UUIDs.
+//   * Subscribe (indirectly) to the SSE feed: the HTMX ``sse``
+//     extension owns the EventSource pointed at
+//     ``/ui/broadcast/stream?target=<name>``; this controller hooks
+//     ``htmx:sseBeforeMessage`` to parse each ``event: broadcast``
+//     frame and route it into the ``events`` array instead of
+//     letting the extension swap the raw JSON text into the DOM.
+//   * Prepend newest-first and trim to the in-DOM cap (default 50)
+//     so a busy target doesn't grow the DOM unboundedly.
+//
+// Wire-shape note
+//   The SSE bridge emits ``BroadcastEvent`` JSON (G6.1) which carries:
+//     { event_id, ts, principal_sub, op_id, op_class, result_status,
+//       audit_id, payload: { method, path, status_code, ... } }
+//   We project that into the per-row shape the template renders
+//   (``{ audit_id, occurred_at, method, path, status_code, op_id,
+//   op_class }``) so streamed rows visually match the server-seeded
+//   rows. ``payload.method`` / ``payload.path`` / ``payload.status_code``
+//   are the same fields the audit middleware writes into the audit_log
+//   row's ``payload`` JSONB column on the server side -- see
+//   ``backend/src/meho_backplane/audit.py``'s
+//   ``_resolve_audit_payload``.
+
+document.addEventListener("alpine:init", () => {
+  Alpine.data("connectorsRecentOps", (opts) => ({
+    // Seed array materialises the server-rendered rows; the SSE
+    // stream prepends new events on top. ``slice()`` defensive-copies
+    // so a future re-init re-reading ``opts.seed`` doesn't see the
+    // controller's mutations.
+    events: Array.isArray(opts.seed) ? opts.seed.slice() : [],
+    connected: false,
+    cap: typeof opts.cap === "number" && opts.cap > 0 ? opts.cap : 50,
+
+    // Parse the SSE frame and prepend to ``events``. Mirrors the
+    // shape ``broadcast-feed.js`` uses for the live feed, narrowed
+    // to the fields the recent-ops template renders. Bad JSON (a
+    // mid-stream truncation, an upstream serialisation glitch) is
+    // dropped silently rather than throwing into the user-visible
+    // surface -- a single bad frame must not break the live row.
+    onSseMessage($event) {
+      // The HTMX 2 sse extension exposes the raw frame data on
+      // ``$event.detail.data``. Falsy => malformed; bail and let
+      // the extension's default no-op handle the rest. ``preventDefault``
+      // cancels the extension's raw-text swap so the JSON does not
+      // land in the hidden sink as literal text.
+      const raw = $event && $event.detail && $event.detail.data;
+      if (!raw) {
+        return;
+      }
+      $event.preventDefault();
+      let frame;
+      try {
+        frame = JSON.parse(raw);
+      } catch {
+        return;
+      }
+      // Project the BroadcastEvent wire shape into the row shape the
+      // template renders. Missing fields render as empty -- never
+      // throw.
+      const payload = frame.payload && typeof frame.payload === "object"
+        ? frame.payload
+        : {};
+      const row = {
+        audit_id: frame.audit_id || frame.event_id || "",
+        occurred_at: frame.ts || "",
+        method: payload.method || "",
+        path: payload.path || "",
+        status_code: payload.status_code || "",
+        op_id: frame.op_id || "",
+        op_class: frame.op_class || "",
+      };
+      this.events.unshift(row);
+      if (this.events.length > this.cap) {
+        this.events.length = this.cap;
+      }
+    },
+  }));
+});

--- a/backend/src/meho_backplane/ui/templates/connectors/_fingerprint_card.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/_fingerprint_card.html
@@ -1,0 +1,84 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Fingerprint card fragment (Task #873 work item #2 / #6).
+
+  Rendered in two contexts:
+    * Included by ``detail.html`` on the initial full-page render.
+    * Returned standalone by ``POST /ui/connectors/{name}/probe`` so
+      a re-probe action swaps this fragment into ``#fingerprint-card``
+      without a full-page reload.
+
+  Surfaces the cached fingerprint (product, version, build, raw
+  extras JSON for forensic shape) plus the re-probe action. The
+  re-probe button is rendered only when ``is_tenant_admin`` is true;
+  the server-side gate in the probe handler is the authority, but
+  the template hides the affordance from operators who can't use it.
+
+  When the target has no fingerprint yet (``fingerprint IS NULL``)
+  the card renders an explanatory "never probed" state plus the
+  re-probe button (so a tenant_admin can seed the fingerprint with
+  one click).
+-#}
+<article
+  id="fingerprint-card"
+  class="card bg-base-100 border-base-300 border shadow-sm"
+  aria-label="Target fingerprint"
+>
+  <div class="card-body space-y-2">
+    <header class="flex items-center justify-between">
+      <h2 class="card-title text-base">Fingerprint</h2>
+      {% if is_tenant_admin %}
+        <button
+          type="button"
+          class="btn btn-primary btn-xs"
+          hx-post="/ui/connectors/{{ target.name | urlencode }}/probe"
+          hx-target="#fingerprint-card"
+          hx-swap="outerHTML"
+          hx-disabled-elt="this"
+          aria-label="Re-probe {{ target.name }}"
+        >
+          Re-probe
+        </button>
+      {% endif %}
+    </header>
+
+    {% if target.fingerprint %}
+      <dl class="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-sm">
+        {% if target.fingerprint.get("product") %}
+          <dt class="opacity-60">product</dt>
+          <dd>{{ target.fingerprint.product }}</dd>
+        {% endif %}
+        {% if target.fingerprint.get("version") %}
+          <dt class="opacity-60">version</dt>
+          <dd class="font-mono">{{ target.fingerprint.version }}</dd>
+        {% endif %}
+        {% if target.fingerprint.get("build") %}
+          <dt class="opacity-60">build</dt>
+          <dd class="font-mono text-xs">{{ target.fingerprint.build }}</dd>
+        {% endif %}
+        {% if target.fingerprint.get("captured_at") %}
+          <dt class="opacity-60">captured_at</dt>
+          <dd class="text-xs">{{ target.fingerprint.captured_at }}</dd>
+        {% endif %}
+        <dt class="opacity-60">last_probed_at</dt>
+        <dd class="text-xs">{{ target.updated_at.isoformat() }}</dd>
+      </dl>
+      <details class="mt-2">
+        <summary class="cursor-pointer text-xs opacity-70">Raw fingerprint JSON</summary>
+        <pre class="mt-2 max-h-48 overflow-auto rounded bg-base-200 p-2 text-xs">{{ target.fingerprint | tojson(indent=2) }}</pre>
+      </details>
+    {% else %}
+      <p class="text-sm opacity-70">
+        No fingerprint captured yet.
+        {% if is_tenant_admin %}
+          Click <strong>Re-probe</strong> to invoke the connector probe and
+          cache the fingerprint.
+        {% else %}
+          A tenant_admin can capture one via the re-probe action.
+        {% endif %}
+      </p>
+    {% endif %}
+  </div>
+</article>

--- a/backend/src/meho_backplane/ui/templates/connectors/_ops_matrix.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/_ops_matrix.html
@@ -1,0 +1,145 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Available-operations matrix (Task #873 work item #7).
+
+  Renders the resolved connector's enabled operation_groups as a
+  collapsed-by-default accordion. Each group's <details> carries:
+    * The group name + operation count (collapsed summary).
+    * The ``when_to_use`` agent-facing copy as a subtitle (the same
+      string the ``list_operation_groups`` meta-tool returns to the
+      agent; surfacing it here gives the operator the same context
+      the agent uses to pick a group).
+    * Per-op rows with op_id + summary + safety_level badge +
+      requires_approval flag.
+
+  Three branches on the resolver's verdict:
+    * ``resolved`` -- normal matrix render.
+    * ``no_connector`` -- explanatory panel naming the missing
+      ``(product, version)`` pair. The operator can re-probe to
+      refresh the fingerprint.
+    * ``ambiguous_connector`` -- explanatory panel naming the
+      candidate set + the remediation step (set
+      ``target.preferred_impl_id``).
+-#}
+<article
+  id="ops-matrix-card"
+  class="card bg-base-100 border-base-300 border shadow-sm"
+  aria-label="Available operations matrix"
+>
+  <div class="card-body space-y-2">
+    <header class="flex items-baseline justify-between">
+      <h2 class="card-title text-base">Available operations</h2>
+      {% if connector_id %}
+        <code class="badge badge-outline badge-sm">{{ connector_id }}</code>
+      {% endif %}
+    </header>
+
+    {% if connector_label == "resolved" %}
+      {% if ops_matrix %}
+        <div class="space-y-2">
+          {% for group in ops_matrix %}
+            <details
+              class="rounded-box border border-base-300 bg-base-50"
+              data-group-key="{{ group.group_key }}"
+            >
+              <summary class="cursor-pointer px-3 py-2 text-sm font-semibold">
+                {{ group.name }}
+                <span class="ml-2 text-xs opacity-60">
+                  ({{ group.operations | length }} ops)
+                </span>
+              </summary>
+              <div class="border-t border-base-300 px-3 py-2 text-xs">
+                {% if group.when_to_use %}
+                  <p class="opacity-70 italic mb-2">{{ group.when_to_use }}</p>
+                {% endif %}
+                {% if group.operations %}
+                  <ul class="divide-y divide-base-300" role="list">
+                    {% for op in group.operations %}
+                      <li class="flex items-start gap-2 py-1.5">
+                        <span class="font-mono shrink-0">{{ op.op_id }}</span>
+                        {% if op.summary %}
+                          <span class="opacity-70 truncate">{{ op.summary }}</span>
+                        {% endif %}
+                        <span class="ml-auto flex items-center gap-1 shrink-0">
+                          {#- ``safety_level`` is the closed enum the DB-layer
+                              CHECK constraint pins: ``safe`` / ``caution`` /
+                              ``dangerous`` (see ``EndpointDescriptor`` model
+                              docstring). The badge palette colours by level
+                              so an operator scanning the matrix sees the
+                              policy gate visually before reading the label.
+                          -#}
+                          {%- set safety = op.safety_level -%}
+                          {% if safety == "dangerous" %}
+                            <span
+                              class="badge badge-error badge-xs"
+                              title="Dangerous — irreversible or high-impact"
+                            >{{ safety }}</span>
+                          {% elif safety == "caution" %}
+                            <span
+                              class="badge badge-warning badge-xs"
+                              title="Caution — state-changing"
+                            >{{ safety }}</span>
+                          {% else %}
+                            <span
+                              class="badge badge-ghost badge-xs"
+                              title="Safe — read or non-impacting"
+                            >{{ safety }}</span>
+                          {% endif %}
+                          {% if op.requires_approval %}
+                            <span
+                              class="badge badge-outline badge-xs"
+                              title="Requires approval"
+                            >approval</span>
+                          {% endif %}
+                        </span>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                {% else %}
+                  <p class="opacity-60 italic">No enabled operations in this group.</p>
+                {% endif %}
+              </div>
+            </details>
+          {% endfor %}
+        </div>
+      {% else %}
+        <p class="text-sm opacity-60">
+          No enabled operation groups for connector
+          <code>{{ connector_id }}</code>.
+        </p>
+      {% endif %}
+    {% elif connector_label == "no_connector" %}
+      <div role="alert" class="alert alert-warning">
+        <div>
+          <h3 class="font-semibold text-sm">No matching connector</h3>
+          <p class="text-xs">
+            {{ connector_message or "no connector matches the target's (product, version)" }}
+          </p>
+          {% if is_tenant_admin %}
+            <p class="text-xs mt-1 opacity-80">
+              Re-probe the target to refresh its fingerprint, or register a
+              connector for this product/version.
+            </p>
+          {% endif %}
+        </div>
+      </div>
+    {% elif connector_label == "ambiguous_connector" %}
+      <div role="alert" class="alert alert-warning">
+        <div>
+          <h3 class="font-semibold text-sm">Ambiguous connector resolution</h3>
+          <p class="text-xs">
+            {{ connector_message or "multiple connector candidates remain" }}
+          </p>
+          {% if is_tenant_admin %}
+            <p class="text-xs mt-1 opacity-80">
+              Set the target's <code>preferred_impl_id</code> to one of the
+              candidate impls.
+            </p>
+          {% endif %}
+        </div>
+      </div>
+    {% endif %}
+  </div>
+</article>

--- a/backend/src/meho_backplane/ui/templates/connectors/_probe_alert.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/_probe_alert.html
@@ -1,0 +1,27 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Re-probe failure alert fragment (Task #873 work item #6). Returned
+  in place of the fingerprint card when the resolver reports
+  ``no_connector`` (501) or ``ambiguous_connector`` (409). The HTMX
+  swap drops this fragment into ``#fingerprint-card`` so the rest of
+  the detail page stays intact.
+
+  The wrapper keeps the same ``id="fingerprint-card"`` so a follow-up
+  successful re-probe (after the operator fixes the underlying state)
+  can swap the real card back into the same slot via the same
+  ``hx-target="#fingerprint-card"`` selector.
+-#}
+<article
+  id="fingerprint-card"
+  class="card border-warning border bg-warning/10 shadow-sm"
+  aria-label="Re-probe failure"
+>
+  <div class="card-body space-y-1">
+    <div role="alert" class="space-y-1">
+      <h2 class="card-title text-sm text-warning">{{ title }}</h2>
+      <p class="text-xs whitespace-pre-line">{{ message }}</p>
+    </div>
+  </div>
+</article>

--- a/backend/src/meho_backplane/ui/templates/connectors/_recent_ops.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/_recent_ops.html
@@ -1,0 +1,107 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Recent operations card (Task #873 work item #6). Lists the most
+  recent audit_log rows scoped to this target (server-rendered: the
+  last 10) and live-appends new events via the HTMX 2 ``sse``
+  extension subscribing to the broadcast bridge filtered to
+  ``target=<name>``.
+
+  Live-streaming model
+  --------------------
+  The HTMX ``sse`` extension opens an ``EventSource`` to the feed
+  fragment's ``sse-connect`` -- ``stream_endpoint`` carries the
+  pre-encoded ``/ui/broadcast/stream?target=<name>`` URL. A hidden
+  sink carries ``sse-swap="broadcast"``; an Alpine controller hooks
+  ``htmx:sse-before-message``, parses the JSON, ``preventDefault()``s
+  the raw swap, and prepends the event to its bounded ``events``
+  array. New rows render through the same row markup the
+  server-seeded rows use so a streamed row is visually identical to
+  a refresh-loaded row.
+
+  XSS hardening (review precedent: PR #1044 broadcast filter regex)
+  ----------------------------------------------------------------
+  ``target.name`` (which the SSE URL embeds) is operator-supplied
+  text. Jinja's ``urlencode`` filter is applied in the Python helper
+  (:func:`_build_stream_endpoint` -> ``urllib.parse.quote(safe='')``)
+  before the URL lands in the context, so by the time the template
+  renders ``stream_endpoint`` the bytes are already percent-encoded
+  and ride harmlessly into the attribute. The Alpine ``x-data``
+  attribute uses single-quoted delimiters so ``tojson`` output
+  (which never emits a raw ``'``) cannot break out of it -- mirrors
+  the precedent the broadcast feed sets in
+  ``broadcast/_feed.html``.
+-#}
+<article
+  id="recent-ops-card"
+  class="card bg-base-100 border-base-300 border shadow-sm"
+  aria-label="Recent operations on this target"
+  x-data='connectorsRecentOps({
+    cap: {{ recent_ops_dom_cap }},
+    seed: {{ recent_ops | tojson }}
+  })'
+  x-on:htmx:sse-before-message="onSseMessage($event)"
+  x-on:htmx:sse-open="connected = true"
+  x-on:htmx:sse-error="connected = false"
+>
+  <div class="card-body space-y-2">
+    <header class="flex items-center justify-between">
+      <h2 class="card-title text-base">
+        Recent operations
+        <span
+          class="ml-2 inline-flex items-center gap-1 text-xs font-normal opacity-70"
+          aria-live="polite"
+        >
+          <span
+            class="inline-block h-2 w-2 rounded-full"
+            :class="connected ? 'bg-success' : 'bg-warning'"
+            aria-hidden="true"
+          ></span>
+          <span x-text="connected ? 'live' : 'connecting…'"></span>
+        </span>
+      </h2>
+      <span class="text-xs opacity-70">
+        <span x-text="events.length"></span>
+        / {{ recent_ops_dom_cap }} rows
+      </span>
+    </header>
+
+    {# ---------- SSE sink ---------- #}
+    <div
+      hx-ext="sse"
+      sse-connect="{{ stream_endpoint }}"
+      sse-swap="broadcast"
+      class="hidden"
+      aria-hidden="true"
+    ></div>
+
+    {# ---------- Empty state ---------- #}
+    <div
+      x-show="events.length === 0"
+      class="text-sm opacity-60 py-4 text-center"
+    >
+      No operations recorded for this target yet.
+    </div>
+
+    {# ---------- Rows ---------- #}
+    <ul
+      x-show="events.length > 0"
+      class="divide-y divide-base-300 text-sm"
+      role="list"
+    >
+      <template x-for="ev in events" :key="ev.audit_id">
+        <li class="flex items-center gap-2 py-1.5">
+          <time
+            class="text-xs opacity-70 w-44 shrink-0"
+            x-bind:datetime="ev.occurred_at"
+            x-text="ev.occurred_at"
+          ></time>
+          <span class="badge badge-outline badge-xs" x-text="ev.method"></span>
+          <span class="font-mono text-xs truncate" x-text="ev.path"></span>
+          <span class="text-xs opacity-50 ml-auto" x-text="ev.status_code"></span>
+        </li>
+      </template>
+    </ul>
+  </div>
+</article>

--- a/backend/src/meho_backplane/ui/templates/connectors/_table_rows.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/_table_rows.html
@@ -1,0 +1,107 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Connectors table-rows fragment (Task #873 work item #1).
+
+  Rendered in two contexts:
+    * As a partial ``{% include %}``d by ``list.html`` on the initial
+      full-page render.
+    * As a standalone fragment ``GET /ui/connectors`` returns when the
+      ``HX-Request`` header is set (sort header click, product filter
+      change). HTMX outerHTML-swaps it into the existing
+      ``#connectors-table-body`` element.
+
+  The ``Last probed`` column renders the timestamp as a relative
+  string ("3h ago", "yesterday") + a tooltip with the full ISO
+  timestamp for forensic clarity. Pure server-side via a small
+  ``_relative_time`` macro further down; no JS needed.
+-#}
+{% macro _relative_time(ts) -%}
+  {#- A tiny self-contained renderer for "X ago" copy. Server-side so
+      the surface stays HTMX-pure (no client-side date library). The
+      computation is approximate (one-minute resolution); the tooltip
+      carries the exact ISO timestamp for operators needing precision.
+      Inputs are tz-aware UTC datetimes (the ORM column is
+      ``DateTime(timezone=True)``). -#}
+  {%- set delta = (now_utc - ts).total_seconds() | int -%}
+  {%- if delta < 60 -%}
+    just now
+  {%- elif delta < 3600 -%}
+    {{ (delta // 60) }} min ago
+  {%- elif delta < 86400 -%}
+    {{ (delta // 3600) }} h ago
+  {%- elif delta < 604800 -%}
+    {{ (delta // 86400) }} d ago
+  {%- else -%}
+    {{ ts.strftime("%Y-%m-%d") }}
+  {%- endif -%}
+{%- endmacro %}
+<tbody id="connectors-table-body">
+  {% if rows %}
+    {% for row in rows %}
+      <tr data-target-name="{{ row.name }}">
+        <td>
+          <a
+            href="/ui/connectors/{{ row.name | urlencode }}"
+            class="link link-hover font-mono"
+            aria-label="View detail for {{ row.name }}"
+          >
+            {{ row.name }}
+          </a>
+        </td>
+        <td>{{ row.product }}</td>
+        <td class="font-mono text-xs">{{ row.host }}</td>
+        <td>
+          <span
+            class="text-xs"
+            title="{{ row.last_probed_at.isoformat() }}"
+          >
+            {{ _relative_time(row.last_probed_at) }}
+          </span>
+        </td>
+        <td>
+          {% if row.status == "ok" %}
+            <span class="badge badge-success badge-sm">ok</span>
+          {% elif row.status == "stale" %}
+            <span class="badge badge-warning badge-sm">stale</span>
+          {% else %}
+            <span class="badge badge-ghost badge-sm">never</span>
+          {% endif %}
+        </td>
+        <td class="text-xs opacity-70">
+          {% if row.aliases %}
+            {{ row.aliases | join(", ") }}
+          {% else %}
+            <span class="opacity-50">—</span>
+          {% endif %}
+        </td>
+        <td>
+          <span class="badge badge-ghost badge-xs">{{ row.auth_model }}</span>
+        </td>
+        <td>
+          {% if row.vpn_required %}
+            <span aria-label="VPN required" title="VPN required">&#x1F512;</span>
+          {% else %}
+            <span class="opacity-30" aria-label="Direct access">—</span>
+          {% endif %}
+        </td>
+        <td>
+          <a
+            href="/ui/connectors/{{ row.name | urlencode }}"
+            class="btn btn-ghost btn-xs"
+            aria-label="View {{ row.name }}"
+          >
+            View
+          </a>
+        </td>
+      </tr>
+    {% endfor %}
+  {% else %}
+    <tr>
+      <td colspan="9" class="text-center text-sm opacity-60 py-6">
+        No targets match the current filter.
+      </td>
+    </tr>
+  {% endif %}
+</tbody>

--- a/backend/src/meho_backplane/ui/templates/connectors/detail.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/detail.html
@@ -1,0 +1,124 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Per-target detail page (Task #873 work items #2/#6/#7). Extends
+  ``base.html`` so the chrome (navbar, sidebar, footer) matches the
+  rest of the console.
+
+  Layout (top-down):
+    * Header -- breadcrumb back to ``/ui/connectors`` + target name +
+      product/host summary line.
+    * Two-column grid (stacks on mobile):
+        Column 1: Properties card + Fingerprint card + Recent ops card.
+        Column 2: Available operations matrix.
+    * The fingerprint card hosts the re-probe button (tenant_admin
+      gated). The recent-ops card hosts the SSE-live wiring via the
+      HTMX 2 ``sse`` extension; the broadcast bridge (G10.1) carries
+      the ``target=<name>`` filter.
+-#}
+{% extends "base.html" %}
+
+{% block page_title %}{{ target.name }} &middot; Connectors &middot; MEHO Operator Console{% endblock %}
+
+{% block content %}
+<section
+  class="space-y-4"
+  hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+>
+  {# ---------- Breadcrumb + header ---------- #}
+  <nav aria-label="Breadcrumb" class="text-xs opacity-70">
+    <a href="/ui/connectors" class="link link-hover">Connectors</a>
+    <span aria-hidden="true">/</span>
+    <span class="font-mono">{{ target.name }}</span>
+  </nav>
+
+  <header class="flex flex-wrap items-baseline justify-between gap-4">
+    <div>
+      <h1 class="text-2xl font-semibold font-mono">{{ target.name }}</h1>
+      <p class="text-sm opacity-70">
+        <span class="badge badge-outline badge-sm">{{ target.product }}</span>
+        <span class="font-mono">{{ target.host }}</span>
+        {% if target.vpn_required %}<span aria-label="VPN required" title="VPN required">&#x1F512;</span>{% endif %}
+      </p>
+    </div>
+  </header>
+
+  <div class="grid gap-4 lg:grid-cols-2">
+    {# ---------- Column 1 -- Properties + Fingerprint + Recent ops ---------- #}
+    <div class="space-y-4">
+      {# ---------- Properties card ---------- #}
+      <article
+        id="properties-card"
+        class="card bg-base-100 border-base-300 border shadow-sm"
+        aria-label="Target properties"
+      >
+        <div class="card-body space-y-2">
+          <h2 class="card-title text-base">Properties</h2>
+          <dl class="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-sm">
+            <dt class="opacity-60">id</dt>
+            <dd class="font-mono text-xs">{{ target.id }}</dd>
+            <dt class="opacity-60">name</dt>
+            <dd class="font-mono">{{ target.name }}</dd>
+            <dt class="opacity-60">aliases</dt>
+            <dd>
+              {% if target.aliases %}
+                {{ target.aliases | join(", ") }}
+              {% else %}
+                <span class="opacity-50">—</span>
+              {% endif %}
+            </dd>
+            <dt class="opacity-60">product</dt>
+            <dd>{{ target.product }}</dd>
+            <dt class="opacity-60">host</dt>
+            <dd class="font-mono">{{ target.host }}</dd>
+            <dt class="opacity-60">port</dt>
+            <dd>{{ target.port if target.port is not none else "—" }}</dd>
+            <dt class="opacity-60">fqdn</dt>
+            <dd>{{ target.fqdn or "—" }}</dd>
+            <dt class="opacity-60">auth_model</dt>
+            <dd><span class="badge badge-ghost badge-xs">{{ target.auth_model }}</span></dd>
+            <dt class="opacity-60">vpn_required</dt>
+            <dd>{{ "yes" if target.vpn_required else "no" }}</dd>
+            <dt class="opacity-60">secret_ref</dt>
+            <dd class="font-mono text-xs">{{ target.secret_ref or "—" }}</dd>
+            <dt class="opacity-60">preferred_impl_id</dt>
+            <dd class="font-mono text-xs">{{ target.preferred_impl_id or "—" }}</dd>
+            <dt class="opacity-60">created_at</dt>
+            <dd class="text-xs">{{ target.created_at.isoformat() }}</dd>
+            <dt class="opacity-60">updated_at</dt>
+            <dd class="text-xs">{{ target.updated_at.isoformat() }}</dd>
+          </dl>
+          {% if target.extras %}
+            <details class="mt-2">
+              <summary class="cursor-pointer text-xs opacity-70">Raw extras JSON</summary>
+              <pre class="mt-2 max-h-48 overflow-auto rounded bg-base-200 p-2 text-xs">{{ target.extras | tojson(indent=2) }}</pre>
+            </details>
+          {% endif %}
+          {% if target.notes %}
+            <div class="mt-2">
+              <h3 class="text-xs font-semibold uppercase opacity-60">Notes</h3>
+              <p class="text-sm whitespace-pre-line">{{ target.notes }}</p>
+            </div>
+          {% endif %}
+        </div>
+      </article>
+
+      {# ---------- Fingerprint card ---------- #}
+      {% include "connectors/_fingerprint_card.html" %}
+
+      {# ---------- Recent ops card ---------- #}
+      {% include "connectors/_recent_ops.html" %}
+    </div>
+
+    {# ---------- Column 2 -- Available operations matrix ---------- #}
+    <div>
+      {% include "connectors/_ops_matrix.html" %}
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+{% block scripts %}
+  <script src="/ui/static/src/app/connectors-feed.js" defer></script>
+{% endblock %}

--- a/backend/src/meho_backplane/ui/templates/connectors/list.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/list.html
@@ -1,0 +1,131 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Full-page render of the Connectors targets list (Initiative #340
+  Task #873 work item #1). Extends ``base.html`` so the chrome
+  (navbar, sidebar, footer) matches the rest of the console.
+
+  Layout (top-down):
+    * Filter bar -- product <select> HTMX-bound to ``/ui/connectors``
+      with ``hx-target`` swapping the <tbody> (id="connectors-table-body")
+      so re-renders skip the surrounding chrome.
+    * Sortable column headers -- each header is an <a> whose href
+      flips the sort direction (asc<->desc) via the
+      ``next_direction_for`` Jinja closure the route handler binds
+      into the context.
+    * Table body (``_table_rows.html`` partial) -- one row per target,
+      "View" button drives the detail navigation.
+
+  HTMX wiring:
+    * Filter <select>: ``hx-get`` to ``/ui/connectors`` with
+      ``hx-include="closest form"`` so every filter+sort value rides
+      along on each change, ``hx-target="#connectors-table-body"``
+      to swap only the table body, ``hx-push-url`` so the browser URL
+      reflects the active filter and a copy/paste reproduces it.
+    * Row "View" buttons: plain ``<a href>`` to
+      ``/ui/connectors/{name}`` -- the detail page is a full
+      navigation (not a drawer) because the detail surface carries
+      its own SSE subscription and multiple per-card hx-targets.
+-#}
+{% extends "base.html" %}
+
+{% block page_title %}Connectors &middot; MEHO Operator Console{% endblock %}
+
+{% block content %}
+<section
+  class="space-y-4"
+  hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+>
+  <header class="flex flex-wrap items-center justify-between gap-4">
+    <div>
+      <h1 class="text-2xl font-semibold">Connectors</h1>
+      <p class="text-sm opacity-70">
+        Per-tenant targets registry. Click a row to inspect the target's
+        fingerprint, recent operations, and available verbs.
+      </p>
+    </div>
+  </header>
+
+  {# ---------- Filter bar ---------- #}
+  <form
+    class="card bg-base-100 border-base-300 border shadow-sm"
+    hx-get="/ui/connectors"
+    hx-target="#connectors-table-body"
+    hx-swap="outerHTML"
+    hx-trigger="change from:find select"
+    hx-include="closest form"
+    hx-push-url="true"
+    role="search"
+    aria-label="Filter connectors"
+    onsubmit="return false;"
+  >
+    <div class="card-body grid gap-3 md:grid-cols-3">
+      <label class="form-control">
+        <span class="label-text">Product</span>
+        <select
+          name="product"
+          class="select select-bordered select-sm"
+          aria-label="Filter by product"
+        >
+          <option value="">All products</option>
+          {% for option in product_options %}
+            <option value="{{ option }}" {% if option == product_filter %}selected{% endif %}>
+              {{ option }}
+            </option>
+          {% endfor %}
+        </select>
+      </label>
+      {# Hidden inputs carry the active sort + direction across filter
+         submits so the next HTMX swap preserves them on top of the
+         filter change. Without them ``hx-include="closest form"`` +
+         ``hx-push-url="true"`` would drop ``?sort=`` / ``?dir=``
+         from the URL on the first filter change, snapping the sort
+         back to the default. #}
+      <input type="hidden" name="sort" value="{{ sort.value }}" />
+      <input type="hidden" name="dir" value="{{ direction.value }}" />
+    </div>
+  </form>
+
+  {# ---------- Table ---------- #}
+  <div class="overflow-x-auto rounded-box border border-base-300 bg-base-100">
+    <table class="table table-sm">
+      <thead>
+        <tr>
+          {%- set columns = [
+            ("name", "Name"),
+            ("product", "Product"),
+            ("host", "Host"),
+            ("last_probed_at", "Last probed"),
+            ("status", "Status"),
+          ] -%}
+          {% for col_value, col_label in columns %}
+            {%- set next_dir = next_direction_for(col_value) -%}
+            <th>
+              <a
+                href="/ui/connectors?sort={{ col_value }}&dir={{ next_dir }}{% if product_filter %}&product={{ product_filter | urlencode }}{% endif %}"
+                hx-get="/ui/connectors?sort={{ col_value }}&dir={{ next_dir }}{% if product_filter %}&product={{ product_filter | urlencode }}{% endif %}"
+                hx-target="#connectors-table-body"
+                hx-swap="outerHTML"
+                hx-push-url="true"
+                class="link link-hover"
+                aria-label="Sort by {{ col_label }} {{ next_dir }}ending"
+              >
+                {{ col_label }}
+                {% if sort.value == col_value %}
+                  <span aria-hidden="true">{% if direction.value == "asc" %}&uarr;{% else %}&darr;{% endif %}</span>
+                {% endif %}
+              </a>
+            </th>
+          {% endfor %}
+          <th>Aliases</th>
+          <th>Auth</th>
+          <th>VPN</th>
+          <th class="w-12"></th>
+        </tr>
+      </thead>
+      {% include "connectors/_table_rows.html" %}
+    </table>
+  </div>
+</section>
+{% endblock %}

--- a/backend/tests/test_ui_chassis_smoke.py
+++ b/backend/tests/test_ui_chassis_smoke.py
@@ -109,14 +109,16 @@ _SURFACE_ROUTES = ("/ui/broadcast", "/ui/knowledge", "/ui/topology", "/ui/connec
 #: "Coming soon" stub. ``/ui/topology`` is omitted because Initiative
 #: #342 Task #880 (G10.5-T1) replaced the stub with the real table
 #: view; ``/ui/broadcast`` is omitted because Initiative #338 Task #867
-#: (G10.1-T1) replaced the stub with the real live-feed view; and
+#: (G10.1-T1) replaced the stub with the real live-feed view;
 #: ``/ui/memory`` is omitted because Initiative #341 Task #877
 #: (G10.4-T1) replaced the stub with the real list / detail / edit
-#: surface. G10.2 (kb) + G10.3 (connectors) will trim this tuple
-#: further as their surface Initiatives land. The chassis smoke test
-#: still pins the sidebar links via :data:`_SURFACE_ROUTES` so a
+#: surface; and ``/ui/connectors`` is omitted because Initiative #340
+#: Task #873 (G10.3-T1) replaced the stub with the real targets list
+#: + per-target detail + re-probe surface. G10.2 (kb) will trim this
+#: tuple further once its surface Initiative lands. The chassis smoke
+#: test still pins the sidebar links via :data:`_SURFACE_ROUTES` so a
 #: sidebar-vs-route divergence surfaces explicitly.
-_STUB_SURFACE_ROUTES = ("/ui/knowledge", "/ui/connectors")
+_STUB_SURFACE_ROUTES = ("/ui/knowledge",)
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_ui_connectors_view.py
+++ b/backend/tests/test_ui_connectors_view.py
@@ -1,0 +1,1121 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the Connectors UI surface.
+
+Initiative #340 (G10.3 Connectors + Targets UI), Task #873 (G10.3-T1).
+The acceptance criteria on issue #873 are:
+
+* ``/ui/connectors`` lists tenant targets (name, aliases, product,
+  host, auth_model, vpn icon, last_probed_at relative, status); HTMX
+  column-sort + product filter re-render the table.
+* ``/ui/connectors/<name>`` shows the full row + fingerprint card +
+  recent-ops + the available-operations matrix grouped by
+  ``operation_group`` (collapsed; expandable) with ``when_to_use``
+  subtitles + per-op ``safety_level`` + ``requires_approval``.
+* Re-probe (tenant_admin) POSTs ``/api/v1/targets/{name}/probe`` and
+  swaps the updated fingerprint card in place; failure shows the
+  probe ``reason`` in an alert.
+* Recent-ops card live-updates via the SSE feed filtered to
+  ``target=<name>``.
+* Cross-tenant isolation: a target/op from another tenant never
+  renders.
+* ``ruff`` + ``mypy`` clean; ``pytest -n auto
+  backend/tests/test_ui_connectors_view.py`` passes.
+
+Suite shape:
+
+* :func:`_build_app` constructs a minimal FastAPI app wired the
+  same way :mod:`backend.tests.test_ui_topology_table._build_app`
+  does (UI session + CSRF middlewares, BFF auth router, UI router).
+* :func:`_seed_session_sync` writes a ``web_session`` row with a
+  real Keycloak-minted access token (signed by the test JWKS) so
+  the role-probe / re-probe deps can re-verify the token and pick
+  up the right :class:`TenantRole`.
+* :func:`_FakeConnector` is a minimal :class:`Connector` subclass
+  registered via :func:`register_connector_v2` so the re-probe
+  path resolves a known impl and returns a deterministic
+  :class:`FingerprintResult`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+import warnings
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import Any
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import (
+    clear_registry,
+    register_connector_v2,
+)
+from meho_backplane.connectors.schemas import FingerprintResult
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import (
+    AuditLog,
+    EndpointDescriptor,
+    OperationGroup,
+    Tenant,
+)
+from meho_backplane.db.models import (
+    Target as TargetORM,
+)
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, CSRFMiddleware, mint_csrf_token
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests._oidc_jwt_helpers import (
+    AUDIENCE as _DEFAULT_AUDIENCE,
+)
+from tests._oidc_jwt_helpers import (
+    ISSUER as _DEFAULT_ISSUER,
+)
+from tests._oidc_jwt_helpers import (
+    make_rsa_keypair as _make_rsa_keypair,
+)
+from tests._oidc_jwt_helpers import (
+    mint_token as _mint_token,
+)
+from tests._oidc_jwt_helpers import (
+    mock_discovery_and_jwks as _mock_discovery_and_jwks,
+)
+from tests._oidc_jwt_helpers import (
+    public_jwks as _public_jwks,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+_BACKPLANE_URL = "https://meho.test"
+
+# Two stable tenant ids -- shape matches the topology suite so the
+# cross-tenant isolation assertion has concrete state to lean on.
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_TENANT_B = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+# Stable operator subs.
+_OP_OPERATOR = "op-operator"
+_OP_ADMIN = "op-admin"
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars for every test.
+
+    Mirrors :func:`backend.tests.test_ui_memory_list._bff_env` /
+    :func:`backend.tests.test_ui_topology_table._bff_env` so the
+    chassis Keycloak / Vault / DB / encryption-key baseline is
+    identical across the UI test surface. Cache + global-state
+    resets on both setup + teardown so a failing test cannot leak
+    ``_TEMPLATES`` / session-engine state into the next case.
+    """
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+@pytest.fixture(autouse=True)
+def _empty_connector_registry() -> Iterator[None]:
+    """Reset the v2 connector registry between tests.
+
+    The detail + probe paths consult the v2 registry to pick a
+    connector class. A test that registers a fake connector must not
+    leak that registration into the next test.
+    """
+    clear_registry()
+    yield
+    clear_registry()
+
+
+def _build_app() -> FastAPI:
+    """Construct a minimal FastAPI app wired for the connectors UI tests."""
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
+    """Insert one ``tenant`` row so the target FK resolves."""
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _seed_target(
+    *,
+    tenant_id: uuid.UUID,
+    name: str,
+    product: str = "vmware",
+    host: str = "host.example.test",
+    aliases: list[str] | None = None,
+    fingerprint: dict[str, Any] | None = None,
+    vpn_required: bool = False,
+    updated_at: datetime | None = None,
+) -> uuid.UUID:
+    """Insert one ``targets`` row and return its id."""
+    target_id = uuid.uuid4()
+    now = updated_at if updated_at is not None else datetime.now(UTC)
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                TargetORM(
+                    id=target_id,
+                    tenant_id=tenant_id,
+                    name=name,
+                    aliases=aliases or [],
+                    product=product,
+                    host=host,
+                    port=None,
+                    fqdn=None,
+                    secret_ref=None,
+                    auth_model="shared_service_account",
+                    vpn_required=vpn_required,
+                    extras={},
+                    notes=None,
+                    fingerprint=fingerprint,
+                    preferred_impl_id=None,
+                    created_at=now,
+                    updated_at=now,
+                ),
+            )
+
+    asyncio.run(_do())
+    return target_id
+
+
+def _seed_audit_row(
+    *,
+    tenant_id: uuid.UUID,
+    target_id: uuid.UUID,
+    method: str = "GET",
+    path: str = "/api/v1/example",
+    status_code: int = 200,
+    occurred_at: datetime | None = None,
+) -> None:
+    """Insert one ``audit_log`` row associated with *target_id*."""
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                AuditLog(
+                    id=uuid.uuid4(),
+                    occurred_at=occurred_at or datetime.now(UTC),
+                    operator_sub="op-1",
+                    method=method,
+                    path=path,
+                    status_code=status_code,
+                    request_id=uuid.uuid4(),
+                    duration_ms=Decimal("12.50"),
+                    payload={},
+                    tenant_id=tenant_id,
+                    target_id=target_id,
+                ),
+            )
+
+    asyncio.run(_do())
+
+
+def _seed_group_and_op(
+    *,
+    tenant_id: uuid.UUID | None,
+    product: str,
+    version: str,
+    impl_id: str,
+    group_key: str,
+    group_name: str,
+    when_to_use: str,
+    op_id: str,
+    summary: str = "test op",
+    safety_level: str = "safe",
+    requires_approval: bool = False,
+    review_status: str = "enabled",
+    is_enabled: bool = True,
+) -> tuple[uuid.UUID, uuid.UUID]:
+    """Seed one ``operation_group`` row + one ``endpoint_descriptor`` row."""
+    group_id = uuid.uuid4()
+    desc_id = uuid.uuid4()
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                OperationGroup(
+                    id=group_id,
+                    tenant_id=tenant_id,
+                    product=product,
+                    version=version,
+                    impl_id=impl_id,
+                    group_key=group_key,
+                    name=group_name,
+                    when_to_use=when_to_use,
+                    review_status=review_status,
+                ),
+            )
+            session.add(
+                EndpointDescriptor(
+                    id=desc_id,
+                    tenant_id=tenant_id,
+                    product=product,
+                    version=version,
+                    impl_id=impl_id,
+                    op_id=op_id,
+                    source_kind="typed",
+                    summary=summary,
+                    group_id=group_id,
+                    safety_level=safety_level,
+                    requires_approval=requires_approval,
+                    is_enabled=is_enabled,
+                ),
+            )
+
+    asyncio.run(_do())
+    return group_id, desc_id
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID,
+    access_token: str = "unused",
+    operator_sub: str = _OP_OPERATOR,
+    lifetime: timedelta = timedelta(hours=1),
+) -> uuid.UUID:
+    """Create a ``web_session`` row carrying *access_token* and return its UUID."""
+
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token=access_token,
+                refresh_token="refresh-token-plaintext",
+                lifetime=lifetime,
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _make_keypair_and_jwks() -> tuple[Any, dict[str, Any]]:
+    """Mint a stable RSA-2048 keypair + the matching JWKS document."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        keypair = _make_rsa_keypair("ui-connectors-test-kid")
+    return keypair, _public_jwks(keypair)
+
+
+def _authenticated_client(session_id: uuid.UUID) -> TestClient:
+    """Return a TestClient with the session cookie pre-set (no JWKS mock)."""
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client
+
+
+def _authenticated_client_with_role_jwks(
+    *,
+    tenant_id: uuid.UUID,
+    operator_sub: str,
+    role: TenantRole,
+) -> tuple[TestClient, respx.MockRouter, str]:
+    """Return a TestClient + respx mock + csrf token for the role-gated routes.
+
+    The role probe + ``resolve_operator_or_403`` deps re-validate the
+    BFF session's access token through the JWT chain; the chain needs
+    the JWKS endpoint mocked for the test to resolve cleanly. The
+    caller enters ``mock`` as a context manager.
+    """
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=operator_sub,
+        tenant_id=str(tenant_id),
+        tenant_role=role.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=tenant_id,
+        access_token=access_token,
+        operator_sub=operator_sub,
+    )
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    _mock_discovery_and_jwks(mock, jwks)
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    csrf_token = mint_csrf_token(str(session_id))
+    client.cookies.set(CSRF_COOKIE_NAME, csrf_token)
+    return client, mock, csrf_token
+
+
+def _csrf_headers(token: str) -> dict[str, str]:
+    """Headers for an HTMX state-changing request -- CSRF + HX-Request."""
+    return {"X-CSRF-Token": token, "HX-Request": "true"}
+
+
+# ---------------------------------------------------------------------------
+# Fake connector for re-probe path resolution
+# ---------------------------------------------------------------------------
+
+
+class _FakeConnector(Connector):
+    """Deterministic :class:`Connector` subclass for the re-probe tests.
+
+    Returns a stable :class:`FingerprintResult` so assertions can check
+    that the re-probe persisted the expected shape. Registered via
+    :func:`register_connector_v2` in the tests that exercise the probe
+    path; the autouse ``_empty_connector_registry`` fixture clears
+    every registration between tests.
+
+    ``supported_version_range = None`` makes the connector advertise
+    "any version" so the resolver's specificity ladder picks it for
+    every target carrying ``product == 'fakeprod'`` regardless of the
+    target's cached fingerprint shape -- crucial for the re-probe
+    happy-path test that exercises the never-probed branch (the
+    target has no fingerprint yet; the resolver must still match).
+    """
+
+    product = "fakeprod"
+    version = "1.0"
+    impl_id = "fakeprod"
+    supported_version_range = None
+
+    async def fingerprint(self, target: Any) -> FingerprintResult:
+        return FingerprintResult(
+            vendor="FakeVendor",
+            product="fakeprod",
+            version="1.0",
+            build="fake-build-42",
+            reachable=True,
+            probed_at=datetime.now(UTC),
+            probe_method="test",
+        )
+
+    async def probe(self, target: Any) -> Any:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def execute(  # pragma: no cover - unused
+        self,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> Any:
+        raise NotImplementedError
+
+
+class _NoConnectorMatchTarget:  # pragma: no cover - never instantiated
+    """Sentinel for the no_connector branch -- we register no class."""
+
+
+# ---------------------------------------------------------------------------
+# Authentication boundary
+# ---------------------------------------------------------------------------
+
+
+def test_list_unauthenticated_redirects_to_login() -> None:
+    """``GET /ui/connectors`` without a session 302s to the BFF login."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/connectors")
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+
+
+def test_detail_unauthenticated_redirects_to_login() -> None:
+    """``GET /ui/connectors/<name>`` without a session 302s to login."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/connectors/some-target")
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+
+
+# ---------------------------------------------------------------------------
+# List view -- full page + HTMX fragment + empty state
+# ---------------------------------------------------------------------------
+
+
+def test_list_full_page_renders_seeded_targets() -> None:
+    """``GET /ui/connectors`` with a session renders the full page + rows."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="vmware-prod", product="vmware")
+    _seed_target(tenant_id=_TENANT_A, name="vmware-dev", product="vmware")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors")
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "<title>Connectors" in body
+    assert "vmware-prod" in body
+    assert "vmware-dev" in body
+    # Sidebar link to /ui/connectors carries the active highlight.
+    assert 'href="/ui/connectors"' in body
+    # Product filter dropdown contains the seeded product.
+    assert "All products" in body
+    assert ">vmware<" in body
+    # CSRF cookie set by the route.
+    assert CSRF_COOKIE_NAME in response.cookies
+
+
+def test_list_handles_empty_inventory() -> None:
+    """An empty tenant renders the "no targets" empty-state row."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors")
+    assert response.status_code == 200, response.text
+    assert "No targets match the current filter." in response.text
+
+
+def test_list_htmx_request_returns_fragment_only() -> None:
+    """``HX-Request: true`` returns the ``_table_rows.html`` partial only."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="fragment-target", product="ssh")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors", headers={"HX-Request": "true"})
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Fragment starts with <tbody> and has no <html>/<body> chrome.
+    assert "<tbody" in body
+    assert "<html" not in body.lower()
+    assert "<title>" not in body.lower()
+    assert "fragment-target" in body
+
+
+# ---------------------------------------------------------------------------
+# List view -- sort
+# ---------------------------------------------------------------------------
+
+
+def test_list_sort_by_name_ascending_is_default() -> None:
+    """Default sort is name ascending -- ``apple`` before ``banana``."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="banana", product="p")
+    _seed_target(tenant_id=_TENANT_A, name="apple", product="p")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors")
+    body = response.text
+    assert body.index("apple") < body.index("banana"), (
+        "expected ascending name sort to place 'apple' before 'banana'"
+    )
+
+
+def test_list_sort_by_name_descending_inverts_order() -> None:
+    """``dir=desc`` flips the order -- ``banana`` before ``apple``."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="apple", product="p")
+    _seed_target(tenant_id=_TENANT_A, name="banana", product="p")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors?sort=name&dir=desc")
+    body = response.text
+    assert body.index("banana") < body.index("apple")
+
+
+def test_list_sort_by_unknown_column_returns_422() -> None:
+    """An out-of-enum ``sort`` value 422s at the HTTP boundary."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors?sort=bogus")
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# List view -- product filter
+# ---------------------------------------------------------------------------
+
+
+def test_list_filter_by_product_narrows_results() -> None:
+    """``?product=ssh`` returns only ``ssh`` rows."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="ssh-keep", product="ssh")
+    _seed_target(tenant_id=_TENANT_A, name="vmware-hide", product="vmware")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors?product=ssh")
+    body = response.text
+    assert "ssh-keep" in body
+    assert "vmware-hide" not in body
+
+
+# ---------------------------------------------------------------------------
+# List view -- cross-tenant isolation
+# ---------------------------------------------------------------------------
+
+
+def test_list_isolates_other_tenants_targets() -> None:
+    """Tenant A's session never sees tenant B's targets in the table."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_tenant(_TENANT_B, "tenant-b")
+    _seed_target(tenant_id=_TENANT_A, name="tenant-a-only", product="ssh")
+    _seed_target(tenant_id=_TENANT_B, name="tenant-b-secret", product="ssh")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors")
+    body = response.text
+    assert "tenant-a-only" in body
+    assert "tenant-b-secret" not in body
+
+
+# ---------------------------------------------------------------------------
+# Detail view -- properties + recent ops + ops matrix
+# ---------------------------------------------------------------------------
+
+
+def test_detail_renders_target_properties_and_aliases() -> None:
+    """The detail page surfaces the full target row."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(
+        tenant_id=_TENANT_A,
+        name="vmware-prod",
+        product="vmware",
+        host="vcenter.example.test",
+        aliases=["vc-prod", "vsphere-prod"],
+        vpn_required=True,
+    )
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors/vmware-prod")
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "vmware-prod" in body
+    assert "vcenter.example.test" in body
+    assert "vc-prod" in body
+    assert "vsphere-prod" in body
+    # VPN icon (lock) renders.
+    assert "&#x1F512;" in body or "\U0001f512" in body
+    # Breadcrumb back to the list.
+    assert 'href="/ui/connectors"' in body
+
+
+def test_detail_resolves_target_by_alias() -> None:
+    """Looking up the target by an alias resolves the same row."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(
+        tenant_id=_TENANT_A,
+        name="canonical-name",
+        product="ssh",
+        aliases=["alias-1"],
+    )
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors/alias-1")
+    assert response.status_code == 200, response.text
+    assert "canonical-name" in response.text
+
+
+def test_detail_returns_404_for_unknown_target() -> None:
+    """An unknown target name returns 404."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors/nonexistent")
+    assert response.status_code == 404
+
+
+def test_detail_isolates_other_tenants_target() -> None:
+    """A target belonging to tenant B is invisible to tenant A's session."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_tenant(_TENANT_B, "tenant-b")
+    _seed_target(tenant_id=_TENANT_B, name="tenant-b-target", product="ssh")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors/tenant-b-target")
+    # Cross-tenant target name surfaces as 404 with the resolver's
+    # ``no_target`` shape, never as a successful 200 rendering the
+    # other tenant's row contents (host, fingerprint, ops, ...).
+    assert response.status_code == 404
+    # Negative: the rendered body must NOT contain the target's host
+    # or product specifics from tenant B -- the only echo of the
+    # name is the resolver's diagnostic detail (``"query": "tenant-b-target"``),
+    # which is acceptable (the operator typed the name; the resolver
+    # is allowed to echo it back).
+    assert "host.example.test" not in response.text
+
+
+def test_detail_renders_recent_ops_for_target() -> None:
+    """The detail page surfaces the last 10 audit_log rows for the target."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    target_id = _seed_target(tenant_id=_TENANT_A, name="audited-target", product="ssh")
+    _seed_audit_row(
+        tenant_id=_TENANT_A,
+        target_id=target_id,
+        method="POST",
+        path="/api/v1/operations/call",
+        status_code=200,
+    )
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors/audited-target")
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "Recent operations" in body
+    # The recent-ops card seeds its Alpine state via a JSON island; the
+    # audit row's method/path land in the seed payload.
+    assert "POST" in body
+    assert "/api/v1/operations/call" in body
+
+
+def test_detail_isolates_recent_ops_from_other_tenants() -> None:
+    """Audit rows under another tenant's target id never seed into the card."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_tenant(_TENANT_B, "tenant-b")
+    target_id = _seed_target(tenant_id=_TENANT_A, name="shared-name", product="ssh")
+    # An audit row carrying a target_id from tenant B but bound to
+    # tenant_id=tenant_B should never surface on tenant A's detail page
+    # even though tenant A has its own target with the same name.
+    _seed_audit_row(
+        tenant_id=_TENANT_B,
+        target_id=target_id,  # same id, wrong tenant on the audit row
+        method="DELETE",
+        path="/api/v1/secret-action",
+    )
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors/shared-name")
+    assert response.status_code == 200, response.text
+    assert "/api/v1/secret-action" not in response.text
+
+
+def test_detail_renders_ops_matrix_when_connector_resolves() -> None:
+    """A target whose fingerprint resolves to a connector shows the ops matrix."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    register_connector_v2(
+        product="fakeprod",
+        version="1.0",
+        impl_id="fakeprod",
+        cls=_FakeConnector,
+    )
+    _seed_target(
+        tenant_id=_TENANT_A,
+        name="fp-target",
+        product="fakeprod",
+        fingerprint={"version": "1.0"},
+    )
+    _seed_group_and_op(
+        tenant_id=None,  # global / built-in
+        product="fakeprod",
+        version="1.0",
+        impl_id="fakeprod",
+        group_key="vm-lifecycle",
+        group_name="VM lifecycle",
+        when_to_use="When you need to start, stop, or query VM state.",
+        op_id="fakeprod.vm.start",
+        summary="Start a VM",
+        safety_level="dangerous",
+        requires_approval=True,
+    )
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors/fp-target")
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Group name surfaces.
+    assert "VM lifecycle" in body
+    # when_to_use subtitle surfaces.
+    assert "When you need to start" in body
+    # The per-op row surfaces op_id + safety_level badge + approval flag.
+    assert "fakeprod.vm.start" in body
+    assert "dangerous" in body
+    assert "approval" in body
+    # Resolved connector_id rendered.
+    assert "fakeprod-1.0" in body
+
+
+def test_detail_renders_ambiguous_connector_alert_when_resolver_returns_ambiguous() -> None:
+    """The matrix slot shows an alert when two impls tie on tie-break."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+
+    # Two connectors registered for the same (product, version) with no
+    # tie-breaker -- the resolver returns ambiguous_connector.
+    class _FakeAlt(Connector):
+        product = "fakeprod"
+        version = "1.0"
+        impl_id = "fakeprod-alt"
+        supported_version_range = None
+
+        async def fingerprint(self, target: Any) -> FingerprintResult:  # pragma: no cover
+            raise NotImplementedError
+
+        async def probe(self, target: Any) -> Any:  # pragma: no cover
+            raise NotImplementedError
+
+        async def execute(  # pragma: no cover
+            self, target: Any, op_id: str, params: dict[str, Any]
+        ) -> Any:
+            raise NotImplementedError
+
+    register_connector_v2(product="fakeprod", version="1.0", impl_id="fakeprod", cls=_FakeConnector)
+    register_connector_v2(product="fakeprod", version="1.0", impl_id="fakeprod-alt", cls=_FakeAlt)
+    _seed_target(
+        tenant_id=_TENANT_A,
+        name="ambig",
+        product="fakeprod",
+        fingerprint={"version": "1.0"},
+    )
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors/ambig")
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "Ambiguous connector resolution" in body
+
+
+def test_detail_renders_no_connector_alert_when_no_match() -> None:
+    """The matrix slot shows the no-connector alert when registry is empty."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(
+        tenant_id=_TENANT_A,
+        name="no-fp",
+        product="unknown-product",
+        fingerprint={"version": "1.0"},
+    )
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors/no-fp")
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "No matching connector" in body
+
+
+# ---------------------------------------------------------------------------
+# Detail view -- fingerprint card + status + re-probe button visibility
+# ---------------------------------------------------------------------------
+
+
+def test_detail_fingerprint_card_renders_when_fingerprint_present() -> None:
+    """The fingerprint card surfaces the cached fingerprint fields."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(
+        tenant_id=_TENANT_A,
+        name="fp-present",
+        product="fakeprod",
+        fingerprint={
+            "version": "1.2.3",
+            "build": "build-001",
+            "vendor": "FakeVendor",
+            "product": "fakeprod",
+            "reachable": True,
+            "probed_at": "2026-05-25T10:00:00+00:00",
+            "probe_method": "test",
+            "extras": {},
+        },
+    )
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors/fp-present")
+    body = response.text
+    assert "Fingerprint" in body
+    assert "1.2.3" in body
+    assert "build-001" in body
+
+
+def test_detail_fingerprint_card_shows_never_state_when_no_fingerprint() -> None:
+    """A target with no fingerprint yet shows the explanatory empty state."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="no-fp-yet", product="ssh")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors/no-fp-yet")
+    body = response.text
+    assert "No fingerprint captured yet" in body
+
+
+def test_detail_hides_reprobe_button_for_operator_role() -> None:
+    """An operator (not tenant_admin) does NOT see the re-probe button."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="op-view", product="ssh")
+    client, mock, _csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_OPERATOR,
+        role=TenantRole.OPERATOR,
+    )
+    try:
+        response = client.get("/ui/connectors/op-view")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    # The button carries an aria-label naming the target -- present on
+    # tenant_admin renders, absent on operator renders. Assert on the
+    # specific aria-label so the assertion fails if the gate breaks
+    # silently.
+    assert "Re-probe op-view" not in response.text
+
+
+def test_detail_shows_reprobe_button_for_tenant_admin_role() -> None:
+    """A tenant_admin sees the re-probe button."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="admin-view", product="ssh")
+    client, mock, _csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.get("/ui/connectors/admin-view")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "Re-probe admin-view" in body
+    # The button uses ``hx-post`` to the probe endpoint.
+    assert 'hx-post="/ui/connectors/admin-view/probe"' in body
+
+
+# ---------------------------------------------------------------------------
+# Detail view -- SSE wiring to broadcast bridge with target filter
+# ---------------------------------------------------------------------------
+
+
+def test_detail_wires_sse_to_broadcast_stream_with_target_filter() -> None:
+    """The recent-ops card carries an ``sse-connect`` URL filtered to the target."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="sse-target", product="ssh")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors/sse-target")
+    body = response.text
+    assert 'sse-connect="/ui/broadcast/stream?target=sse-target"' in body
+    assert 'sse-swap="broadcast"' in body
+
+
+def test_detail_sse_url_percent_encodes_target_name() -> None:
+    """A target name carrying reserved URL characters round-trips encoded."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="tricky name & co", product="ssh")
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors/tricky%20name%20%26%20co")
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The bare "&" inside the name would break the SSE URL's query
+    # parsing if interpolated verbatim. The percent-encoded form
+    # survives. ``quote(safe='')`` encodes spaces as ``%20``.
+    assert "target=tricky%20name%20%26%20co" in body
+
+
+# ---------------------------------------------------------------------------
+# Re-probe -- tenant_admin gate + happy path
+# ---------------------------------------------------------------------------
+
+
+def test_reprobe_succeeds_for_tenant_admin_and_swaps_fingerprint_card() -> None:
+    """A tenant_admin re-probe persists the fingerprint and returns the card."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    register_connector_v2(
+        product="fakeprod",
+        version="1.0",
+        impl_id="fakeprod",
+        cls=_FakeConnector,
+    )
+    _seed_target(
+        tenant_id=_TENANT_A,
+        name="reprobe-me",
+        product="fakeprod",
+        # No prior fingerprint so the resolver doesn't filter on a
+        # stale version that the connector doesn't advertise. The
+        # re-probe path's resolver consults
+        # ``target.fingerprint.version`` to filter candidates; a stale
+        # 0.5 against ``supported_version_range=">=1.0,<2.0"`` would
+        # legitimately resolve to ``no_connector``. ``None`` lets the
+        # specificity ladder pick the only registered class.
+        fingerprint=None,
+    )
+    client, mock, csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/reprobe-me/probe",
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The refreshed fingerprint card swaps in -- the fake connector
+    # returned version 1.0.
+    assert 'id="fingerprint-card"' in body
+    assert "FakeVendor" in body
+    assert "1.0" in body
+    assert "fake-build-42" in body
+
+
+def test_reprobe_rejects_operator_role_with_403() -> None:
+    """An operator (non-admin) re-probe POST is rejected with 403."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    register_connector_v2(product="fakeprod", version="1.0", impl_id="fakeprod", cls=_FakeConnector)
+    _seed_target(tenant_id=_TENANT_A, name="op-cant-probe", product="fakeprod")
+    client, mock, csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_OPERATOR,
+        role=TenantRole.OPERATOR,
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/op-cant-probe/probe",
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+
+
+def test_reprobe_returns_alert_when_no_matching_connector() -> None:
+    """The no_connector branch returns a 501 + alert fragment."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    # No connectors registered for this product.
+    _seed_target(tenant_id=_TENANT_A, name="no-impl", product="unknown")
+    client, mock, csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/no-impl/probe",
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 501, response.text
+    body = response.text
+    assert "No matching connector" in body
+
+
+def test_reprobe_returns_404_for_unknown_target() -> None:
+    """A re-probe POST against an unknown target returns 404."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client, mock, csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/nonexistent/probe",
+            headers=_csrf_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# URL contract -- sort hrefs preserve product filter
+# ---------------------------------------------------------------------------
+
+
+def test_list_sort_hrefs_preserve_active_product_filter() -> None:
+    """Sort-column hrefs carry ``?product=`` back into the next URL."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="t1", product="vmware")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors?product=vmware")
+    body = response.text
+    # The header link to swap the sort direction must carry the filter
+    # so a sort click doesn't drop ``?product=``.
+    assert "product=vmware" in body

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -6077,7 +6077,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "$ref": "#/components/schemas/_SortColumn",
+              "$ref": "#/components/schemas/meho_backplane__ui__routes__topology__table___SortColumn",
               "default": "name"
             }
           },
@@ -6901,13 +6901,45 @@
         }
       }
     },
-    "/ui/knowledge": {
+    "/ui/connectors": {
       "get": {
         "tags": [
-          "ui-stubs"
+          "ui-connectors"
         ],
-        "summary": "Ui Stub Knowledge",
-        "operationId": "ui_stub_knowledge_ui_knowledge_get",
+        "summary": "Ui Connectors List",
+        "description": "Serve ``GET /ui/connectors``. See module docstring for the\nURL contract.\n\n``dir`` (not ``direction``) is the spelling on the URL the\nissue body pinned -- the alias above keeps the Python kwarg\nreadable (``direction``) without breaking the URL contract\nthe operator sees in the address bar.",
+        "operationId": "ui_connectors_list_ui_connectors_get",
+        "parameters": [
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/meho_backplane__ui__routes__connectors__list_view___SortColumn",
+              "default": "name"
+            }
+          },
+          {
+            "name": "dir",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/_SortDirection",
+              "default": "asc"
+            }
+          },
+          {
+            "name": "product",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 100,
+              "nullable": true,
+              "title": "Product"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -6918,17 +6950,171 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
           }
         }
       }
     },
-    "/ui/connectors": {
+    "/ui/connectors/{name}": {
+      "get": {
+        "tags": [
+          "ui-connectors"
+        ],
+        "summary": "Ui Connectors Detail",
+        "description": "``GET /ui/connectors/{name}``.",
+        "operationId": "ui_connectors_detail_ui_connectors__name__get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Target name does not resolve in the caller's tenant. Returns the 404 from the shared :func:`~meho_backplane.targets.resolver.resolve_target` helper -- alias-aware, with near-miss suggestions when the substring search lands hits.",
+            "content": {
+              "text/html": {}
+            }
+          },
+          "409": {
+            "description": "Target name resolves to multiple targets in the caller's tenant (ambiguous alias match). Returns the 409 from :func:`resolve_target`.",
+            "content": {
+              "text/html": {}
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/connectors/{name}/probe": {
+      "post": {
+        "tags": [
+          "ui-connectors"
+        ],
+        "summary": "Ui Connectors Reprobe",
+        "description": "``POST /ui/connectors/{name}/probe``.",
+        "operationId": "ui_connectors_reprobe_ui_connectors__name__probe_post",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Operator is not a tenant_admin. The re-probe verb is tenant_admin-only, mirroring the ``/api/v1/targets/{name}/probe`` REST route's posture.",
+            "content": {
+              "text/html": {}
+            }
+          },
+          "404": {
+            "description": "Target name does not resolve in the caller's tenant.",
+            "content": {
+              "text/html": {}
+            }
+          },
+          "409": {
+            "description": "Resolver reported ambiguous connector resolution. The alert fragment names the candidate set.",
+            "content": {
+              "text/html": {}
+            }
+          },
+          "501": {
+            "description": "Resolver found no matching connector for the target's (product, fingerprint.version) pair.",
+            "content": {
+              "text/html": {}
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/knowledge": {
       "get": {
         "tags": [
           "ui-stubs"
         ],
-        "summary": "Ui Stub Connectors",
-        "operationId": "ui_stub_connectors_ui_connectors_get",
+        "summary": "Ui Stub Knowledge",
+        "operationId": "ui_stub_knowledge_ui_knowledge_get",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -12001,16 +12187,14 @@
         "title": "_EdgeEndpoint",
         "description": "Inbound JSON shape for one annotation endpoint.\n\nMirrors :class:`meho_backplane.topology.annotate.NodeRef` on the wire:\n``name`` is required, ``kind`` is the optional disambiguator for a\nbare name that resolves to multiple :class:`GraphNode` rows in the\ntenant. Frozen so the route handler cannot accidentally rebind the\nfield; ``extra=\"forbid\"`` rejects typo'd keys at the boundary\n(``{from: {nme: ...}}`` is a 422, not a silently-ignored body)."
       },
-      "_SortColumn": {
+      "_SortDirection": {
         "type": "string",
         "enum": [
-          "name",
-          "kind",
-          "last_seen",
-          "first_seen"
+          "asc",
+          "desc"
         ],
-        "title": "_SortColumn",
-        "description": "Closed enum of sort columns exposed in the URL.\n\nMirrors :data:`meho_backplane.topology.query._NODE_SORT_COLUMNS`\n-- redeclared at the route boundary so an out-of-range value\nfails Pydantic validation (422 with the candidate list in the\nerror context) before the substrate's defensive\n:class:`ValueError` guard runs. The enum's ``str`` mixin keeps\nthe template's ``{{ sort }}`` rendering / ``href`` building\nstable -- ``str(SortColumn.NAME)`` is ``\"name\"`` (not\n``\"_SortColumn.NAME\"``)."
+        "title": "_SortDirection",
+        "description": "Sort direction -- ``asc`` (default) or ``desc``."
       },
       "_ViewMode": {
         "type": "string",
@@ -12020,6 +12204,29 @@
         ],
         "title": "_ViewMode",
         "description": "Closed enum of view modes exposed on ``GET /ui/topology``.\n\n``table`` is the default (T1 / #880); ``graph`` switches to the\nCytoscape.js surface (T2 / #881). The enum's ``str`` mixin keeps\ntemplate URL building stable -- ``str(_ViewMode.GRAPH)`` is\n``\"graph\"`` (not ``\"_ViewMode.GRAPH\"``). An out-of-range value\nfails Pydantic validation (422) at the HTTP boundary so the route\nbody never sees an unknown mode."
+      },
+      "meho_backplane__ui__routes__connectors__list_view___SortColumn": {
+        "type": "string",
+        "enum": [
+          "name",
+          "product",
+          "host",
+          "last_probed_at",
+          "status"
+        ],
+        "title": "_SortColumn",
+        "description": "Closed enum of sort columns exposed in the URL.\n\nMirrors the human-meaningful columns in the rendered table. An\nout-of-enum value fails Pydantic validation at the HTTP boundary\nwith a 422 carrying the candidate list in the error context. The\nenum's ``str`` mixin keeps the template's ``{{ sort }}`` rendering\n+ ``href`` building stable -- ``str(_SortColumn.NAME)`` is\n``\"name\"`` (not ``\"_SortColumn.NAME\"``)."
+      },
+      "meho_backplane__ui__routes__topology__table___SortColumn": {
+        "type": "string",
+        "enum": [
+          "name",
+          "kind",
+          "last_seen",
+          "first_seen"
+        ],
+        "title": "_SortColumn",
+        "description": "Closed enum of sort columns exposed in the URL.\n\nMirrors :data:`meho_backplane.topology.query._NODE_SORT_COLUMNS`\n-- redeclared at the route boundary so an out-of-range value\nfails Pydantic validation (422 with the candidate list in the\nerror context) before the substrate's defensive\n:class:`ValueError` guard runs. The enum's ``str`` mixin keeps\nthe template's ``{{ sort }}`` rendering / ``href`` building\nstable -- ``str(SortColumn.NAME)`` is ``\"name\"`` (not\n``\"_SortColumn.NAME\"``)."
       }
     }
   }

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -235,18 +235,33 @@ const (
 	Node TopologyDiffEntrySource = "node"
 )
 
-// Defines values for UnderscoreSortColumn.
+// Defines values for UnderscoreSortDirection.
 const (
-	FirstSeen UnderscoreSortColumn = "first_seen"
-	Kind      UnderscoreSortColumn = "kind"
-	LastSeen  UnderscoreSortColumn = "last_seen"
-	Name      UnderscoreSortColumn = "name"
+	Asc  UnderscoreSortDirection = "asc"
+	Desc UnderscoreSortDirection = "desc"
 )
 
 // Defines values for UnderscoreViewMode.
 const (
 	Graph UnderscoreViewMode = "graph"
 	Table UnderscoreViewMode = "table"
+)
+
+// Defines values for MehoBackplaneUiRoutesConnectorsListViewSortColumn.
+const (
+	MehoBackplaneUiRoutesConnectorsListViewSortColumnHost         MehoBackplaneUiRoutesConnectorsListViewSortColumn = "host"
+	MehoBackplaneUiRoutesConnectorsListViewSortColumnLastProbedAt MehoBackplaneUiRoutesConnectorsListViewSortColumn = "last_probed_at"
+	MehoBackplaneUiRoutesConnectorsListViewSortColumnName         MehoBackplaneUiRoutesConnectorsListViewSortColumn = "name"
+	MehoBackplaneUiRoutesConnectorsListViewSortColumnProduct      MehoBackplaneUiRoutesConnectorsListViewSortColumn = "product"
+	MehoBackplaneUiRoutesConnectorsListViewSortColumnStatus       MehoBackplaneUiRoutesConnectorsListViewSortColumn = "status"
+)
+
+// Defines values for MehoBackplaneUiRoutesTopologyTableSortColumn.
+const (
+	MehoBackplaneUiRoutesTopologyTableSortColumnFirstSeen MehoBackplaneUiRoutesTopologyTableSortColumn = "first_seen"
+	MehoBackplaneUiRoutesTopologyTableSortColumnKind      MehoBackplaneUiRoutesTopologyTableSortColumn = "kind"
+	MehoBackplaneUiRoutesTopologyTableSortColumnLastSeen  MehoBackplaneUiRoutesTopologyTableSortColumn = "last_seen"
+	MehoBackplaneUiRoutesTopologyTableSortColumnName      MehoBackplaneUiRoutesTopologyTableSortColumn = "name"
 )
 
 // Defines values for ListEndpointApiV1ConnectorsGetParamsStatus.
@@ -3487,17 +3502,8 @@ type UnderscoreEdgeEndpoint struct {
 	Name string  `json:"name"`
 }
 
-// UnderscoreSortColumn Closed enum of sort columns exposed in the URL.
-//
-// Mirrors :data:`meho_backplane.topology.query._NODE_SORT_COLUMNS`
-// -- redeclared at the route boundary so an out-of-range value
-// fails Pydantic validation (422 with the candidate list in the
-// error context) before the substrate's defensive
-// :class:`ValueError` guard runs. The enum's “str“ mixin keeps
-// the template's “{{ sort }}“ rendering / “href“ building
-// stable -- “str(SortColumn.NAME)“ is “"name"“ (not
-// “"_SortColumn.NAME"“).
-type UnderscoreSortColumn string
+// UnderscoreSortDirection Sort direction -- “asc“ (default) or “desc“.
+type UnderscoreSortDirection string
 
 // UnderscoreViewMode Closed enum of view modes exposed on “GET /ui/topology“.
 //
@@ -3508,6 +3514,28 @@ type UnderscoreSortColumn string
 // fails Pydantic validation (422) at the HTTP boundary so the route
 // body never sees an unknown mode.
 type UnderscoreViewMode string
+
+// MehoBackplaneUiRoutesConnectorsListViewSortColumn Closed enum of sort columns exposed in the URL.
+//
+// Mirrors the human-meaningful columns in the rendered table. An
+// out-of-enum value fails Pydantic validation at the HTTP boundary
+// with a 422 carrying the candidate list in the error context. The
+// enum's “str“ mixin keeps the template's “{{ sort }}“ rendering
+// + “href“ building stable -- “str(_SortColumn.NAME)“ is
+// “"name"“ (not “"_SortColumn.NAME"“).
+type MehoBackplaneUiRoutesConnectorsListViewSortColumn string
+
+// MehoBackplaneUiRoutesTopologyTableSortColumn Closed enum of sort columns exposed in the URL.
+//
+// Mirrors :data:`meho_backplane.topology.query._NODE_SORT_COLUMNS`
+// -- redeclared at the route boundary so an out-of-range value
+// fails Pydantic validation (422 with the candidate list in the
+// error context) before the substrate's defensive
+// :class:`ValueError` guard runs. The enum's “str“ mixin keeps
+// the template's “{{ sort }}“ rendering / “href“ building
+// stable -- “str(SortColumn.NAME)“ is “"name"“ (not
+// “"_SortColumn.NAME"“).
+type MehoBackplaneUiRoutesTopologyTableSortColumn string
 
 // ListAgentPrincipalsApiV1AgentPrincipalsGetParams defines parameters for ListAgentPrincipalsApiV1AgentPrincipalsGet.
 type ListAgentPrincipalsApiV1AgentPrincipalsGetParams struct {
@@ -4092,6 +4120,13 @@ type UiBroadcastStreamUiBroadcastStreamGetParams struct {
 	Since *string `form:"since,omitempty" json:"since,omitempty"`
 }
 
+// UiConnectorsListUiConnectorsGetParams defines parameters for UiConnectorsListUiConnectorsGet.
+type UiConnectorsListUiConnectorsGetParams struct {
+	Sort    *MehoBackplaneUiRoutesConnectorsListViewSortColumn `form:"sort,omitempty" json:"sort,omitempty"`
+	Dir     *UnderscoreSortDirection                           `form:"dir,omitempty" json:"dir,omitempty"`
+	Product *string                                            `form:"product,omitempty" json:"product,omitempty"`
+}
+
 // UiMemoryListUiMemoryGetParams defines parameters for UiMemoryListUiMemoryGet.
 type UiMemoryListUiMemoryGetParams struct {
 	Scope *string `form:"scope,omitempty" json:"scope,omitempty"`
@@ -4100,7 +4135,7 @@ type UiMemoryListUiMemoryGetParams struct {
 
 // UiTopologyTableUiTopologyGetParams defines parameters for UiTopologyTableUiTopologyGet.
 type UiTopologyTableUiTopologyGetParams struct {
-	Sort *UnderscoreSortColumn `form:"sort,omitempty" json:"sort,omitempty"`
+	Sort *MehoBackplaneUiRoutesTopologyTableSortColumn `form:"sort,omitempty" json:"sort,omitempty"`
 
 	// Direction Dual-purpose: ``asc`` / ``desc`` on the table branch (``view=table``), ``dependents`` / ``dependencies`` on the graph overlay branch (``view=graph&from=<name>``).
 	Direction *string             `form:"direction,omitempty" json:"direction,omitempty"`
@@ -4206,6 +4241,12 @@ type AnnotateEdgeRouteApiV1TopologyEdgesPostJSONRequestBody = UnderscoreAnnotate
 
 // BulkImportEdgesRouteApiV1TopologyEdgesBulkPostJSONRequestBody defines body for BulkImportEdgesRouteApiV1TopologyEdgesBulkPost for application/json ContentType.
 type BulkImportEdgesRouteApiV1TopologyEdgesBulkPostJSONRequestBody = UnderscoreBulkImportRequest
+
+// UiConnectorsDetailUiConnectorsNameGetJSONRequestBody defines body for UiConnectorsDetailUiConnectorsNameGet for application/json ContentType.
+type UiConnectorsDetailUiConnectorsNameGetJSONRequestBody = UISessionContext
+
+// UiConnectorsReprobeUiConnectorsNameProbePostJSONRequestBody defines body for UiConnectorsReprobeUiConnectorsNameProbePost for application/json ContentType.
+type UiConnectorsReprobeUiConnectorsNameProbePostJSONRequestBody = UISessionContext
 
 // UiMemoryBulkUiMemoryBulkPostFormdataRequestBody defines body for UiMemoryBulkUiMemoryBulkPost for application/x-www-form-urlencoded ContentType.
 type UiMemoryBulkUiMemoryBulkPostFormdataRequestBody = BodyUiMemoryBulkUiMemoryBulkPost
@@ -4853,8 +4894,18 @@ type ClientInterface interface {
 	// UiBroadcastStreamUiBroadcastStreamGet request
 	UiBroadcastStreamUiBroadcastStreamGet(ctx context.Context, params *UiBroadcastStreamUiBroadcastStreamGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// UiStubConnectorsUiConnectorsGet request
-	UiStubConnectorsUiConnectorsGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// UiConnectorsListUiConnectorsGet request
+	UiConnectorsListUiConnectorsGet(ctx context.Context, params *UiConnectorsListUiConnectorsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiConnectorsDetailUiConnectorsNameGetWithBody request with any body
+	UiConnectorsDetailUiConnectorsNameGetWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiConnectorsDetailUiConnectorsNameGet(ctx context.Context, name string, body UiConnectorsDetailUiConnectorsNameGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiConnectorsReprobeUiConnectorsNameProbePostWithBody request with any body
+	UiConnectorsReprobeUiConnectorsNameProbePostWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiConnectorsReprobeUiConnectorsNameProbePost(ctx context.Context, name string, body UiConnectorsReprobeUiConnectorsNameProbePostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiStubKnowledgeUiKnowledgeGet request
 	UiStubKnowledgeUiKnowledgeGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -6483,8 +6534,56 @@ func (c *Client) UiBroadcastStreamUiBroadcastStreamGet(ctx context.Context, para
 	return c.Client.Do(req)
 }
 
-func (c *Client) UiStubConnectorsUiConnectorsGet(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUiStubConnectorsUiConnectorsGetRequest(c.Server)
+func (c *Client) UiConnectorsListUiConnectorsGet(ctx context.Context, params *UiConnectorsListUiConnectorsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsListUiConnectorsGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsDetailUiConnectorsNameGetWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsDetailUiConnectorsNameGetRequestWithBody(c.Server, name, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsDetailUiConnectorsNameGet(ctx context.Context, name string, body UiConnectorsDetailUiConnectorsNameGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsDetailUiConnectorsNameGetRequest(c.Server, name, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsReprobeUiConnectorsNameProbePostWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsReprobeUiConnectorsNameProbePostRequestWithBody(c.Server, name, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsReprobeUiConnectorsNameProbePost(ctx context.Context, name string, body UiConnectorsReprobeUiConnectorsNameProbePostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsReprobeUiConnectorsNameProbePostRequest(c.Server, name, body)
 	if err != nil {
 		return nil, err
 	}
@@ -13306,8 +13405,8 @@ func NewUiBroadcastStreamUiBroadcastStreamGetRequest(server string, params *UiBr
 	return req, nil
 }
 
-// NewUiStubConnectorsUiConnectorsGetRequest generates requests for UiStubConnectorsUiConnectorsGet
-func NewUiStubConnectorsUiConnectorsGetRequest(server string) (*http.Request, error) {
+// NewUiConnectorsListUiConnectorsGetRequest generates requests for UiConnectorsListUiConnectorsGet
+func NewUiConnectorsListUiConnectorsGetRequest(server string, params *UiConnectorsListUiConnectorsGetParams) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -13325,10 +13424,158 @@ func NewUiStubConnectorsUiConnectorsGetRequest(server string) (*http.Request, er
 		return nil, err
 	}
 
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Sort != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "sort", runtime.ParamLocationQuery, *params.Sort); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Dir != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "dir", runtime.ParamLocationQuery, *params.Dir); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Product != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "product", runtime.ParamLocationQuery, *params.Product); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
 		return nil, err
 	}
+
+	return req, nil
+}
+
+// NewUiConnectorsDetailUiConnectorsNameGetRequest calls the generic UiConnectorsDetailUiConnectorsNameGet builder with application/json body
+func NewUiConnectorsDetailUiConnectorsNameGetRequest(server string, name string, body UiConnectorsDetailUiConnectorsNameGetJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUiConnectorsDetailUiConnectorsNameGetRequestWithBody(server, name, "application/json", bodyReader)
+}
+
+// NewUiConnectorsDetailUiConnectorsNameGetRequestWithBody generates requests for UiConnectorsDetailUiConnectorsNameGet with any type of body
+func NewUiConnectorsDetailUiConnectorsNameGetRequestWithBody(server string, name string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/connectors/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiConnectorsReprobeUiConnectorsNameProbePostRequest calls the generic UiConnectorsReprobeUiConnectorsNameProbePost builder with application/json body
+func NewUiConnectorsReprobeUiConnectorsNameProbePostRequest(server string, name string, body UiConnectorsReprobeUiConnectorsNameProbePostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUiConnectorsReprobeUiConnectorsNameProbePostRequestWithBody(server, name, "application/json", bodyReader)
+}
+
+// NewUiConnectorsReprobeUiConnectorsNameProbePostRequestWithBody generates requests for UiConnectorsReprobeUiConnectorsNameProbePost with any type of body
+func NewUiConnectorsReprobeUiConnectorsNameProbePostRequestWithBody(server string, name string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/connectors/%s/probe", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -14628,8 +14875,18 @@ type ClientWithResponsesInterface interface {
 	// UiBroadcastStreamUiBroadcastStreamGetWithResponse request
 	UiBroadcastStreamUiBroadcastStreamGetWithResponse(ctx context.Context, params *UiBroadcastStreamUiBroadcastStreamGetParams, reqEditors ...RequestEditorFn) (*UiBroadcastStreamUiBroadcastStreamGetResponse, error)
 
-	// UiStubConnectorsUiConnectorsGetWithResponse request
-	UiStubConnectorsUiConnectorsGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiStubConnectorsUiConnectorsGetResponse, error)
+	// UiConnectorsListUiConnectorsGetWithResponse request
+	UiConnectorsListUiConnectorsGetWithResponse(ctx context.Context, params *UiConnectorsListUiConnectorsGetParams, reqEditors ...RequestEditorFn) (*UiConnectorsListUiConnectorsGetResponse, error)
+
+	// UiConnectorsDetailUiConnectorsNameGetWithBodyWithResponse request with any body
+	UiConnectorsDetailUiConnectorsNameGetWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsDetailUiConnectorsNameGetResponse, error)
+
+	UiConnectorsDetailUiConnectorsNameGetWithResponse(ctx context.Context, name string, body UiConnectorsDetailUiConnectorsNameGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsDetailUiConnectorsNameGetResponse, error)
+
+	// UiConnectorsReprobeUiConnectorsNameProbePostWithBodyWithResponse request with any body
+	UiConnectorsReprobeUiConnectorsNameProbePostWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsReprobeUiConnectorsNameProbePostResponse, error)
+
+	UiConnectorsReprobeUiConnectorsNameProbePostWithResponse(ctx context.Context, name string, body UiConnectorsReprobeUiConnectorsNameProbePostJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsReprobeUiConnectorsNameProbePostResponse, error)
 
 	// UiStubKnowledgeUiKnowledgeGetWithResponse request
 	UiStubKnowledgeUiKnowledgeGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiStubKnowledgeUiKnowledgeGetResponse, error)
@@ -16991,13 +17248,14 @@ func (r UiBroadcastStreamUiBroadcastStreamGetResponse) StatusCode() int {
 	return 0
 }
 
-type UiStubConnectorsUiConnectorsGetResponse struct {
+type UiConnectorsListUiConnectorsGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
 }
 
 // Status returns HTTPResponse.Status
-func (r UiStubConnectorsUiConnectorsGetResponse) Status() string {
+func (r UiConnectorsListUiConnectorsGetResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -17005,7 +17263,51 @@ func (r UiStubConnectorsUiConnectorsGetResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r UiStubConnectorsUiConnectorsGetResponse) StatusCode() int {
+func (r UiConnectorsListUiConnectorsGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiConnectorsDetailUiConnectorsNameGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiConnectorsDetailUiConnectorsNameGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiConnectorsDetailUiConnectorsNameGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiConnectorsReprobeUiConnectorsNameProbePostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiConnectorsReprobeUiConnectorsNameProbePostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiConnectorsReprobeUiConnectorsNameProbePostResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -18502,13 +18804,47 @@ func (c *ClientWithResponses) UiBroadcastStreamUiBroadcastStreamGetWithResponse(
 	return ParseUiBroadcastStreamUiBroadcastStreamGetResponse(rsp)
 }
 
-// UiStubConnectorsUiConnectorsGetWithResponse request returning *UiStubConnectorsUiConnectorsGetResponse
-func (c *ClientWithResponses) UiStubConnectorsUiConnectorsGetWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*UiStubConnectorsUiConnectorsGetResponse, error) {
-	rsp, err := c.UiStubConnectorsUiConnectorsGet(ctx, reqEditors...)
+// UiConnectorsListUiConnectorsGetWithResponse request returning *UiConnectorsListUiConnectorsGetResponse
+func (c *ClientWithResponses) UiConnectorsListUiConnectorsGetWithResponse(ctx context.Context, params *UiConnectorsListUiConnectorsGetParams, reqEditors ...RequestEditorFn) (*UiConnectorsListUiConnectorsGetResponse, error) {
+	rsp, err := c.UiConnectorsListUiConnectorsGet(ctx, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseUiStubConnectorsUiConnectorsGetResponse(rsp)
+	return ParseUiConnectorsListUiConnectorsGetResponse(rsp)
+}
+
+// UiConnectorsDetailUiConnectorsNameGetWithBodyWithResponse request with arbitrary body returning *UiConnectorsDetailUiConnectorsNameGetResponse
+func (c *ClientWithResponses) UiConnectorsDetailUiConnectorsNameGetWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsDetailUiConnectorsNameGetResponse, error) {
+	rsp, err := c.UiConnectorsDetailUiConnectorsNameGetWithBody(ctx, name, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsDetailUiConnectorsNameGetResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiConnectorsDetailUiConnectorsNameGetWithResponse(ctx context.Context, name string, body UiConnectorsDetailUiConnectorsNameGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsDetailUiConnectorsNameGetResponse, error) {
+	rsp, err := c.UiConnectorsDetailUiConnectorsNameGet(ctx, name, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsDetailUiConnectorsNameGetResponse(rsp)
+}
+
+// UiConnectorsReprobeUiConnectorsNameProbePostWithBodyWithResponse request with arbitrary body returning *UiConnectorsReprobeUiConnectorsNameProbePostResponse
+func (c *ClientWithResponses) UiConnectorsReprobeUiConnectorsNameProbePostWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsReprobeUiConnectorsNameProbePostResponse, error) {
+	rsp, err := c.UiConnectorsReprobeUiConnectorsNameProbePostWithBody(ctx, name, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsReprobeUiConnectorsNameProbePostResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiConnectorsReprobeUiConnectorsNameProbePostWithResponse(ctx context.Context, name string, body UiConnectorsReprobeUiConnectorsNameProbePostJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsReprobeUiConnectorsNameProbePostResponse, error) {
+	rsp, err := c.UiConnectorsReprobeUiConnectorsNameProbePost(ctx, name, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsReprobeUiConnectorsNameProbePostResponse(rsp)
 }
 
 // UiStubKnowledgeUiKnowledgeGetWithResponse request returning *UiStubKnowledgeUiKnowledgeGetResponse
@@ -21846,17 +22182,79 @@ func ParseUiBroadcastStreamUiBroadcastStreamGetResponse(rsp *http.Response) (*Ui
 	return response, nil
 }
 
-// ParseUiStubConnectorsUiConnectorsGetResponse parses an HTTP response from a UiStubConnectorsUiConnectorsGetWithResponse call
-func ParseUiStubConnectorsUiConnectorsGetResponse(rsp *http.Response) (*UiStubConnectorsUiConnectorsGetResponse, error) {
+// ParseUiConnectorsListUiConnectorsGetResponse parses an HTTP response from a UiConnectorsListUiConnectorsGetWithResponse call
+func ParseUiConnectorsListUiConnectorsGetResponse(rsp *http.Response) (*UiConnectorsListUiConnectorsGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &UiStubConnectorsUiConnectorsGetResponse{
+	response := &UiConnectorsListUiConnectorsGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiConnectorsDetailUiConnectorsNameGetResponse parses an HTTP response from a UiConnectorsDetailUiConnectorsNameGetWithResponse call
+func ParseUiConnectorsDetailUiConnectorsNameGetResponse(rsp *http.Response) (*UiConnectorsDetailUiConnectorsNameGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiConnectorsDetailUiConnectorsNameGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiConnectorsReprobeUiConnectorsNameProbePostResponse parses an HTTP response from a UiConnectorsReprobeUiConnectorsNameProbePostWithResponse call
+func ParseUiConnectorsReprobeUiConnectorsNameProbePostResponse(rsp *http.Response) (*UiConnectorsReprobeUiConnectorsNameProbePostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiConnectorsReprobeUiConnectorsNameProbePostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
 	}
 
 	return response, nil

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -1461,3 +1461,68 @@ to this operator.
   formatting, partition split, parser guards, badge + recently-
   expired rendering, bulk delete + extend, RBAC denial path,
   cross-tenant safety, CSRF gate.
+
+## Connectors surface (Task #873)
+
+Initiative #340 (G10.3 Connectors + Targets UI). Task #873 (T1)
+ships the **read** surface — the targets list + per-target detail
+page. T2 (#874) layers create / edit forms; T3 (#875) layers bulk
+import. The connectors stub registered in T5 #866 is retired by
+this task — the real router is included ahead of the chassis stubs
+the same way broadcast / topology / memory retired theirs.
+
+### Routes
+
+| Method | Path | Purpose |
+| ------ | ---- | ------- |
+| `GET` | `/ui/connectors` | Sortable + filterable targets list. URL: `?sort=name|product|host|last_probed_at|status&dir=asc|desc&product=<slug>`. Full-page render or `_table_rows.html` fragment (HX-Request branch). |
+| `GET` | `/ui/connectors/{name}` | Per-target detail. Renders properties + fingerprint card + recent-ops card (SSE-live) + available-operations matrix. Alias-aware target resolution via `resolve_target`. |
+| `POST` | `/ui/connectors/{name}/probe` | Re-probe action. Tenant_admin RBAC gated server-side (the template hides the button optimistically; the handler is the authority). Persists the new fingerprint and swaps the refreshed `_fingerprint_card.html` fragment. |
+
+### Module layout
+
+* `backend/src/meho_backplane/ui/routes/connectors/__init__.py` — the umbrella `build_router()` aggregating the list / detail / probe routers in registration order.
+* `backend/src/meho_backplane/ui/routes/connectors/list_view.py` — the list handler. Sort enum, direction enum, status freshness classifier (24 h threshold), distinct-products query for the filter dropdown, Python-side re-sort layered on top of the SQL `ORDER BY` so status sorts honour the `never < stale < ok` ladder.
+* `backend/src/meho_backplane/ui/routes/connectors/detail.py` — the detail handler. Resolves the target via `targets.resolver.resolve_target`, projects it via `_project_target` (shared with probe), resolves the connector via `resolve_connector_or_label` (the same helper `/api/v1/targets/{name}/probe` uses), loads the operations matrix grouped by `operation_group` with the same tenant scoping shape `list_operation_groups` uses, loads the last 10 audit rows for the target. SSE bridge URL is the existing `/ui/broadcast/stream?target=<name>` (G10.1 already supports the `target` filter; piggy-backing keeps the SSE plumbing single-sourced).
+* `backend/src/meho_backplane/ui/routes/connectors/operator.py` — `resolve_role_probe` (fails soft to `is_tenant_admin=False` on any JWT hiccup so a transient JWKS outage doesn't 5xx the read surface) + `resolve_operator_or_403` (the rigorous write-gate dep used by the probe handler).
+* `backend/src/meho_backplane/ui/routes/connectors/probe.py` — the re-probe POST handler. Uses the same `resolve_connector_or_label` path the REST `/api/v1/targets/{name}/probe` route uses so the two surfaces stay byte-compatible. Maps `no_connector` → 501 + alert fragment, `ambiguous_connector` → 409 + alert fragment.
+
+### Connector resolution
+
+The detail page's available-operations matrix and the re-probe action both consume `resolve_connector_or_label(target)` — the same helper the `/api/v1/targets/{name}/probe` REST route uses (G0.14-T1 #1142). The detail page then resolves the matching v2-registry entry to produce the canonical `"<impl_id>-<version>"` `connector_id` the operations meta-tool query reads (`list_operation_groups`'s shape). When the registry has the chosen class under multiple keys (the K8s pattern, both a v1 wildcard and a v2 versioned key), the detail page picks the versioned key — same precedence the G0.6 dispatcher's lookup uses.
+
+### SSE wiring for recent ops
+
+The recent-ops card on the detail page is live-driven by the existing G10.1 broadcast SSE bridge: the card embeds `sse-connect="/ui/broadcast/stream?target=<urlencoded-name>"` plus `sse-swap="broadcast"`. An Alpine controller (`connectorsRecentOps`, `backend/src/meho_backplane/ui/static/src/app/connectors-feed.js`) hooks `htmx:sse-before-message`, parses each `event: broadcast` frame's JSON, and prepends a row to its bounded `events` array (cap 50; older rows trim). The card is initially seeded by the server-rendered last-10 audit rows so the page is useful even before any new event streams in.
+
+### RBAC posture for re-probe
+
+The re-probe button is rendered only when the page-load role probe returned `is_tenant_admin=True`. The button hides for operators who can't use it. The server-side authority is `resolve_operator_or_403` on the POST handler — a crafted POST hitting the endpoint with a stolen / forged form still hits the 403 gate. The probe handler also re-validates the target tenant-scoped via `resolve_target` so a cross-tenant target name never resolves on the write surface.
+
+### Cross-tenant isolation
+
+Every list / detail / probe path filters on `session_ctx.tenant_id`:
+
+* List: `WHERE targets.tenant_id = :tenant_id` is the first clause in the substrate query.
+* Detail: `resolve_target` raises 404 on a cross-tenant name.
+* Probe: same `resolve_target` gate before the write.
+* Recent ops: `WHERE audit_log.tenant_id = :tenant_id AND audit_log.target_id = :target_id` — defense in depth even though the soft-FK on `audit_log.target_id` makes a cross-tenant target_id structurally impossible.
+* Ops matrix: `(operation_group.tenant_id IS NULL OR operation_group.tenant_id = :tenant_id)` — same shape `list_operation_groups` uses for the agent surface.
+* Recent-ops SSE: the underlying `/ui/broadcast/stream` bridge takes the tenant from the session row, never from a query parameter, so the per-target filter cannot leak across tenants.
+
+### Files
+
+* `backend/src/meho_backplane/ui/routes/connectors/__init__.py` — umbrella router factory.
+* `backend/src/meho_backplane/ui/routes/connectors/list_view.py` — list view handler + freshness classifier.
+* `backend/src/meho_backplane/ui/routes/connectors/detail.py` — detail handler + connector_id resolution + ops matrix query + recent-ops query.
+* `backend/src/meho_backplane/ui/routes/connectors/operator.py` — role-probe (read) + operator-403 (write).
+* `backend/src/meho_backplane/ui/routes/connectors/probe.py` — re-probe POST handler.
+* `backend/src/meho_backplane/ui/templates/connectors/list.html` — full-page list template.
+* `backend/src/meho_backplane/ui/templates/connectors/_table_rows.html` — list rows fragment (HTMX swap target).
+* `backend/src/meho_backplane/ui/templates/connectors/detail.html` — full-page detail template.
+* `backend/src/meho_backplane/ui/templates/connectors/_fingerprint_card.html` — fingerprint card (also returned by the re-probe POST).
+* `backend/src/meho_backplane/ui/templates/connectors/_recent_ops.html` — SSE-live recent-ops card.
+* `backend/src/meho_backplane/ui/templates/connectors/_ops_matrix.html` — grouped operations matrix.
+* `backend/src/meho_backplane/ui/templates/connectors/_probe_alert.html` — failure alert fragment (no_connector / ambiguous).
+* `backend/src/meho_backplane/ui/static/src/app/connectors-feed.js` — `connectorsRecentOps` Alpine controller.
+* `backend/tests/test_ui_connectors_view.py` — auth boundary, list (full + fragment + sort + filter + cross-tenant), detail (properties + alias + 404 + cross-tenant + recent ops + ops matrix + ambiguous / no-connector branches), fingerprint card (present / never), re-probe button visibility (operator vs tenant_admin), SSE wiring + URL-encoding, re-probe (success + 403 operator + 501 no-connector + 404 unknown).


### PR DESCRIPTION
## Summary

- Replaces the chassis `/ui/connectors` stub with the real read surface for G10.3-T1: sortable + filterable targets list, per-target detail page with fingerprint card + SSE-live recent-ops + grouped operations matrix, and a tenant_admin-gated re-probe action that delegates to the same `resolve_connector_or_label` helper the REST `/api/v1/targets/<name>/probe` route uses.
- Recent-ops streaming piggy-backs on the existing G10.1 broadcast SSE bridge (`/ui/broadcast/stream?target=<name>`) — single-sourced SSE plumbing, identical tenant gate.
- Operations matrix consumes the same `(tenant_id IS NULL OR tenant_id = :tenant)` scoping `list_operation_groups` uses for the agent surface, so the UI's view of available verbs matches what the agent sees.

## Scope (T1 only — read surface)

- T2 (#874, create/edit forms) and T3 (#875, bulk import) are sibling tasks landing as parallel Wave 2 once this merges; the umbrella router factory in `connectors/__init__.py` is set up to accept their additions without reshaping.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/` — clean (344 files)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers, 8 warnings (file/function size; all under the 600/100 block thresholds, recorded as adjacent findings)
- [x] `pytest backend/tests/test_ui_connectors_view.py` — 30 passed
- [x] `pytest backend/tests/test_ui_*.py` — 299 passed (no regressions on chassis / topology / memory / broadcast / auth)
- [x] Cross-tenant isolation: list query filters on `session_ctx.tenant_id`; detail `resolve_target` 404s on a cross-tenant name; recent-ops query joins on `(tenant_id, target_id)`; ops-matrix filters on `(tenant_id IS NULL OR = :tenant)`; SSE bridge takes tenant from session row, never URL.
- [x] Re-probe RBAC: server-side `resolve_operator_or_403` gates the write; template hides the button optimistically for non-admin operators.
- [x] URL encoding: target names containing `&` / spaces percent-encode through the SSE URL builder (`urllib.parse.quote(safe='')`).

## Acceptance criteria mapping

- [x] `/ui/connectors` lists tenant targets with name / aliases / product / host / auth_model / vpn icon / last_probed_at relative / status; HTMX column-sort + product filter re-render the table.
- [x] `/ui/connectors/<name>` shows the full row + fingerprint card + recent-ops + the available-operations matrix grouped by `operation_group` (collapsed; expandable) with `when_to_use` subtitles + per-op `safety_level` + `requires_approval`.
- [x] Re-probe (tenant_admin) POSTs the re-probe verb and swaps the updated fingerprint card in place; failure renders the resolver's message in an alert (501 no-connector, 409 ambiguous).
- [x] Recent-ops card live-updates via the SSE feed filtered to `target=<name>`.
- [x] Cross-tenant isolation: a target/op from another tenant never renders.
- [x] `ruff` + `mypy` clean; `pytest -n auto backend/tests/test_ui_connectors_view.py` passes.

## Out of scope (adjacent findings)

- File-size + function-size soft warnings on `detail.py` (565 lines), `list_view.py` (441 lines), and several helpers (60-78 lines). Under the 600/100 block thresholds; refactor opportunistic for T2/T3.

Closes #873

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Connectors UI surface with sortable, filterable target inventory listing
  * Added per-target detail pages displaying properties, recent operations, and available operations matrix
  * Enabled tenant administrators to refresh connector fingerprints via re-probe action
  * Integrated live operation feed on detail pages via server-sent events

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-26)

Addressed review findings from `/auto-review-pr` iteration 1 (result file `.claude/auto/review-results/pr-1172-iter-1.json`):

- **B1** `31ad1f2` — Regenerated `cli/api/openapi.json` + `cli/internal/api/client.gen.go` via `cd cli && make snapshot-openapi && make generate`. CI's `CLI API snapshot freshness` check should now go green.

Deferred (recorded as adjacent findings; orchestrator may file follow-up issues if warranted):

- `docs/codebase/ui.md` line 1478 — cosmetic markdown pipe escape inside backtick code span; GitHub renders fine, only Sphinx/MkDocs/pandoc affected.
- `detail.py` line 281-292 — `by_group.setdefault(group_id, [])` is redundant; pre-populated map. Cosmetic.
- `list_view.py` — `tenant_id: object` could tighten to `uuid.UUID`. Low-value typing nit.
- `connectors-feed.js` `onSseMessage` — defensive `audit_id` dedup on SSE reconnect replay. Parity with `broadcast-feed.js` (which also doesn't dedup) is acceptable.

Disputed (no code change):

- `_table_rows.html` line 61 — CodeRabbit suggested `row.last_probed_at` null-check; `Target.updated_at` is `nullable=False` in the model and `_render_rows` always sets it, so the field is non-null by construction. Reviewer concurred.

<!-- auto-implement-issue: continue, iteration 1 -->
