### PR TITLE
feat(conventions): G0.14-T8 surface preamble_status on POST/PATCH (signal 18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,27 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added
+
+- **Per-write preamble-inclusion feedback on the conventions write
+  surface (G0.14-T8 #1149).** `POST /api/v1/conventions` and
+  `PATCH /api/v1/conventions/{slug}` now attach a `preamble_status`
+  sub-document to the response when the convention is
+  `kind='operational'`. Fields: `included` (whether the slug landed
+  in the assembled preamble), `position` (1-based index in the
+  packed order, `null` when dropped), `token_count` (the convention
+  body's own estimated token cost), and `would_drop_slugs` (the
+  full dropped-slug list from this pack — names other slugs the
+  write displaced, or includes the just-written slug when it was
+  itself dropped). Closes the `claude-rdc-hetzner-dc#697` signal 18
+  failure mode: previously an operator who wrote a convention got a
+  `201` with no indication whether the row would ever reach an
+  agent session; with `preamble_status` the answer arrives in the
+  same round-trip. `preamble_status` is `null` on `GET /{slug}`
+  (the aggregate budget signal lives on the list response's
+  `budget_status`) and `null` for writes against `workflow` /
+  `reference` kinds. (#1149)
+
 ### Changed
 
 - **`call_operation` accepts bare-string `target` alongside dict —

--- a/backend/src/meho_backplane/api/v1/conventions.py
+++ b/backend/src/meho_backplane/api/v1/conventions.py
@@ -60,7 +60,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from meho_backplane.audit import bind_preallocated_audit_id
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
-from meho_backplane.conventions.preamble import assemble_preamble
+from meho_backplane.conventions.preamble import (
+    assemble_preamble,
+    assemble_preamble_detailed,
+)
 from meho_backplane.conventions.schemas import (
     DEFAULT_MAX_PREAMBLE_TOKENS,
     BudgetStatus,
@@ -71,6 +74,7 @@ from meho_backplane.conventions.schemas import (
     ConventionListResponse,
     ConventionSummary,
     ConventionUpdate,
+    PreambleInclusion,
     estimate_tokens,
 )
 from meho_backplane.db.engine import get_session
@@ -251,6 +255,74 @@ def _enforce_patch_budget(
     except ValueError:
         existing_kind = ConventionKind.REFERENCE
     _enforce_budget(new_body, existing_kind)
+
+
+async def _compute_preamble_status(
+    *,
+    session: AsyncSession,
+    tenant_id: uuid.UUID,
+    slug: str,
+    kind: ConventionKind,
+) -> PreambleInclusion | None:
+    """Resolve preamble inclusion for the just-written *(tenant, slug)* pair.
+
+    G0.14-T8 (#1149, signal 18). Returns ``None`` for kinds that
+    don't enter the preamble (``workflow`` / ``reference``); a
+    populated :class:`PreambleInclusion` for ``operational`` rows.
+
+    The function runs
+    :func:`~meho_backplane.conventions.preamble.assemble_preamble_detailed`
+    through the route handler's *session* so the pack reflects the
+    in-progress write. SQLAlchemy 2.x reads within the same
+    transaction see flushed-but-not-committed rows, so the caller
+    must :meth:`session.flush` the convention INSERT/UPDATE before
+    calling; the read here will then include it. Threading the
+    route's session through (over opening a new one) means the
+    feedback reflects the same state the post-commit MCP
+    ``initialize`` handler will see -- no risk of an in-flight
+    concurrent write from another request changing the answer
+    mid-response.
+
+    Three reads from the detailed assembly drive the four output
+    fields:
+
+    * ``kept_slugs.index(slug) + 1`` -> ``position`` (1-based, or
+      ``None`` when this slug was dropped).
+    * ``slug in kept_slugs`` -> ``included``.
+    * ``token_counts[slug]`` -> ``token_count`` (own body weight).
+    * ``dropped_slugs`` -> ``would_drop_slugs`` (verbatim).
+
+    The ``slug`` argument is the slug as written (POST: ``body.slug``;
+    PATCH: the path parameter — PATCH cannot rename, so the slug
+    is stable across the update). ``kind`` is the convention's
+    current kind: POST uses the request body's kind; PATCH uses the
+    existing row's kind (PATCH cannot change kind per the
+    :class:`ConventionUpdate` schema).
+    """
+    if kind is not ConventionKind.OPERATIONAL:
+        # ``workflow`` / ``reference`` are not preamble-bound -- a
+        # write against them does not affect the assembled preamble,
+        # so the operator's "did this land in the preamble?" question
+        # doesn't apply. Returning ``None`` (over a stub
+        # ``PreambleInclusion(included=False, ...)``) keeps the
+        # response shape honest: ``preamble_status`` present iff the
+        # write was a preamble-bound one.
+        return None
+    assembly = await assemble_preamble_detailed(tenant_id, session=session)
+    included = slug in assembly.kept_slugs
+    position = assembly.kept_slugs.index(slug) + 1 if included else None
+    # ``token_counts`` carries every considered slug (kept + dropped);
+    # the just-written slug must appear there because the assembler
+    # ran after the write flushed. The ``get`` fallback is paranoia
+    # against an unforeseen race (e.g. a concurrent DELETE) and
+    # short-circuits to 0 so the response shape still validates.
+    token_count = assembly.token_counts.get(slug, 0)
+    return PreambleInclusion(
+        included=included,
+        position=position,
+        token_count=token_count,
+        would_drop_slugs=assembly.dropped_slugs,
+    )
 
 
 async def _load_convention(
@@ -461,11 +533,25 @@ async def create_convention(
     # Refresh so any DB-side defaults are visible on the returned
     # row (mirrors the broadcast_overrides + memory surfaces).
     await session.refresh(convention)
+    # G0.14-T8 (#1149, signal 18) preamble-status feedback.
+    # The convention has flushed inside the route's session (above
+    # at ``session.flush()``); reads through the same session see it,
+    # so the preamble assembler resolves the just-written slug's
+    # position against the post-write state. ``None`` for
+    # workflow/reference (preamble-unbound kinds).
+    preamble_status = await _compute_preamble_status(
+        session=session,
+        tenant_id=operator.tenant_id,
+        slug=body.slug,
+        kind=body.kind,
+    )
     # Conditional MCP resources/updated notification (T4 #316).
     # No-op while ``resources.subscribe`` is False; structured emit
     # call site is in place for the v0.2.next subscribe flip.
     _maybe_emit_resource_updated(tenant_id=operator.tenant_id, slug=body.slug)
-    return Convention.model_validate(convention)
+    return Convention.model_validate(convention).model_copy(
+        update={"preamble_status": preamble_status},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -534,11 +620,31 @@ async def update_convention(
     session.add(history)
     await session.flush()
     await session.refresh(existing)
+    # G0.14-T8 (#1149, signal 18) preamble-status feedback. PATCH
+    # cannot change kind per :class:`ConventionUpdate`, so the
+    # post-PATCH kind is the existing row's kind; resolve back to
+    # the enum for the helper. An existing row carrying a kind
+    # outside the closed :class:`ConventionKind` vocabulary
+    # (possible per T1's Out of scope on DB-level enum) falls back
+    # to ``REFERENCE`` -- the safe direction; reference-kind
+    # short-circuits to ``preamble_status=None`` (preamble-unbound).
+    try:
+        existing_kind = ConventionKind(existing.kind)
+    except ValueError:
+        existing_kind = ConventionKind.REFERENCE
+    preamble_status = await _compute_preamble_status(
+        session=session,
+        tenant_id=operator.tenant_id,
+        slug=slug,
+        kind=existing_kind,
+    )
     # Conditional MCP resources/updated notification (T4 #316).
     # No-op while ``resources.subscribe`` is False; structured emit
     # call site is in place for the v0.2.next subscribe flip.
     _maybe_emit_resource_updated(tenant_id=operator.tenant_id, slug=slug)
-    return Convention.model_validate(existing)
+    return Convention.model_validate(existing).model_copy(
+        update={"preamble_status": preamble_status},
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/meho_backplane/conventions/__init__.py
+++ b/backend/src/meho_backplane/conventions/__init__.py
@@ -37,8 +37,10 @@ from meho_backplane.conventions.preamble import (
     BLOCK_END,
     BLOCK_START,
     GUARD_PREFIX,
+    PreambleAssembly,
     PreambleResult,
     assemble_preamble,
+    assemble_preamble_detailed,
 )
 from meho_backplane.conventions.schemas import (
     DEFAULT_MAX_PREAMBLE_TOKENS,
@@ -50,6 +52,7 @@ from meho_backplane.conventions.schemas import (
     ConventionListResponse,
     ConventionSummary,
     ConventionUpdate,
+    PreambleInclusion,
     estimate_tokens,
 )
 
@@ -66,7 +69,10 @@ __all__ = [
     "ConventionListResponse",
     "ConventionSummary",
     "ConventionUpdate",
+    "PreambleAssembly",
+    "PreambleInclusion",
     "PreambleResult",
     "assemble_preamble",
+    "assemble_preamble_detailed",
     "estimate_tokens",
 ]

--- a/backend/src/meho_backplane/conventions/preamble.py
+++ b/backend/src/meho_backplane/conventions/preamble.py
@@ -78,6 +78,7 @@ from typing import Final, NamedTuple
 from uuid import UUID
 
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from meho_backplane.conventions.schemas import (
     DEFAULT_MAX_PREAMBLE_TOKENS,
@@ -91,8 +92,10 @@ __all__ = [
     "BLOCK_END",
     "BLOCK_START",
     "GUARD_PREFIX",
+    "PreambleAssembly",
     "PreambleResult",
     "assemble_preamble",
+    "assemble_preamble_detailed",
 ]
 
 
@@ -150,6 +153,76 @@ class PreambleResult(NamedTuple):
     dropped_slugs: list[str]
 
 
+class PreambleAssembly(NamedTuple):
+    """Verbose assembly return shape -- :class:`PreambleResult` plus the kept ordering.
+
+    G0.14-T8 (#1149, signal 18) added the
+    :func:`assemble_preamble_detailed` variant so the
+    ``POST/PATCH /api/v1/conventions`` handlers can resolve a
+    just-written slug's preamble position from the same pack the MCP
+    ``initialize`` consumer sees. Fields:
+
+    * ``text`` / ``dropped_slugs`` -- identical to
+      :class:`PreambleResult` so callers needing the wire-format
+      preamble can keep using the same access pattern.
+    * ``kept_slugs`` -- slugs that landed in the preamble, in pack
+      order (``priority DESC, created_at ASC`` then greedy add to
+      budget). ``len(kept_slugs)`` equals the number of operational
+      blocks the agent session receives; ``kept_slugs.index(slug) + 1``
+      is the 1-based preamble position for a slug the operator just
+      wrote.
+    * ``token_counts`` -- ``{slug: estimate_tokens(block)}`` for every
+      operational row considered (kept and dropped). Caller uses it
+      to surface the just-written slug's own budget weight on
+      ``preamble_status.token_count`` without re-running
+      :func:`~meho_backplane.conventions.schemas.estimate_tokens`.
+
+    The MCP read path stays on :func:`assemble_preamble` (returns a
+    :class:`PreambleResult`); the inclusion-feedback write path uses
+    :func:`assemble_preamble_detailed` so the post-write resolution
+    sees the same pack the read path produces. A divergence between
+    "the preamble I told the operator they were in" and "the
+    preamble the agent session actually received" is the failure
+    mode signal 18 names; using one packer for both reads eliminates
+    it by construction.
+    """
+
+    text: str
+    dropped_slugs: list[str]
+    kept_slugs: list[str]
+    token_counts: dict[str, int]
+
+
+async def _fetch_operational_conventions(
+    session: AsyncSession,
+    tenant_id: UUID,
+) -> list[TenantConvention]:
+    """Read all ``kind='operational'`` rows for *tenant_id* in pack order.
+
+    Extracted helper shared by :func:`assemble_preamble_detailed`'s
+    two code paths -- when it owns a session vs. when the caller
+    passes one in. Centralises the ORDER BY contract (``priority
+    DESC, created_at ASC``) so the two paths cannot drift.
+    """
+    result = await session.execute(
+        select(TenantConvention)
+        .where(
+            TenantConvention.tenant_id == tenant_id,
+            # ``kind`` is stored as free-form text per T1's
+            # schema-deferred decision; the API layer (T2) binds
+            # writes to :class:`ConventionKind`. Reading the enum's
+            # ``.value`` here keeps the comparison exact-match
+            # against the same string T2 wrote.
+            TenantConvention.kind == ConventionKind.OPERATIONAL.value,
+        )
+        .order_by(
+            TenantConvention.priority.desc(),
+            TenantConvention.created_at.asc(),
+        ),
+    )
+    return list(result.scalars().all())
+
+
 async def assemble_preamble(
     tenant_id: UUID,
     max_tokens: int = DEFAULT_MAX_PREAMBLE_TOKENS,
@@ -167,71 +240,55 @@ async def assemble_preamble(
     how to surface "no preamble" (the MCP ``_initialize`` wrapper
     maps it to ``instructions: None`` on the wire).
 
-    Token-budget math
-    -----------------
-
-    Each entry's cost is computed via
-    :func:`~meho_backplane.conventions.schemas.estimate_tokens`
-    (chars-per-token heuristic; 3.3 chars/token, conservative
-    direction for ASCII English -- see the schemas docstring for
-    the full rationale). The header + delimiter + guard cost is
-    computed through the same helper so the budget contract stays
-    end-to-end aligned with T2's write-time 422 check; a body the
-    write gate admits always fits this packer's budget under the
-    same arithmetic.
-
-    The function opens its own DB session via
-    :func:`~meho_backplane.db.engine.get_sessionmaker` rather than
-    accepting one from the caller -- the MCP ``initialize`` handler
-    is not a FastAPI request handler and has no
-    :func:`~meho_backplane.db.engine.get_session` dependency-injected
-    session; the assembler is the natural owner of the read
-    transaction. Same shape :mod:`~meho_backplane.mcp.resources.tenant_info`
-    uses for its DB probe.
+    Delegates to :func:`assemble_preamble_detailed` and discards the
+    verbose fields -- the MCP read path only needs ``text`` and
+    ``dropped_slugs``. The G0.14-T8 (#1149) post-write inclusion
+    feedback uses the verbose form so a single pack drives both
+    consumers (no risk of "the position I told the operator" drifting
+    from "the preamble the agent session received").
     """
-    sessionmaker = get_sessionmaker()
-    async with sessionmaker() as session:
-        result = await session.execute(
-            select(TenantConvention)
-            .where(
-                TenantConvention.tenant_id == tenant_id,
-                # ``kind`` is stored as free-form text per T1's
-                # schema-deferred decision; the API layer (T2)
-                # binds writes to :class:`ConventionKind`. Reading
-                # the enum's ``.value`` here keeps the comparison
-                # exact-match against the same string T2 wrote.
-                TenantConvention.kind == ConventionKind.OPERATIONAL.value,
-            )
-            .order_by(
-                TenantConvention.priority.desc(),
-                TenantConvention.created_at.asc(),
-            ),
-        )
-        conventions = result.scalars().all()
+    detailed = await assemble_preamble_detailed(tenant_id, max_tokens=max_tokens)
+    return PreambleResult(detailed.text, detailed.dropped_slugs)
 
-    if not conventions:
-        return PreambleResult("", [])
 
-    # Header is fixed-overhead per the issue body's example: a section
-    # heading + the guard prefix + a blank-line separator. The header
-    # cost is counted against the budget so a tenant with one
-    # over-budget convention can't trick the packer into letting it
-    # through (the header has to fit too).
-    header_lines: list[str] = [
+#: Fixed-overhead header that precedes the packed blocks in the
+#: assembled preamble. A section heading + the guard prefix + a
+#: blank-line separator. The header cost is counted against the
+#: budget so a tenant with one over-budget convention can't trick
+#: the packer into letting it through (the header has to fit too).
+_HEADER_TEXT: Final[str] = "\n".join(
+    [
         "## Operational conventions for this tenant",
         "",
         GUARD_PREFIX,
         "",
-    ]
-    header_text = "\n".join(header_lines)
+    ],
+)
 
+
+def _pack_conventions(
+    conventions: list[TenantConvention],
+    max_tokens: int,
+) -> tuple[list[str], list[str], list[str], dict[str, int]]:
+    """Greedy-pack ordered ``conventions`` against the ``max_tokens`` budget.
+
+    Returns ``(kept_blocks, kept_slugs, dropped_slugs, token_counts)``.
+    The first entry that would push the cumulative token count past
+    *max_tokens* (and every entry after it) is dropped whole and
+    recorded in ``dropped_slugs``. The issue body is explicit:
+    "Silent truncation of an operational rule is a safety bug, not a
+    UX nit." Lowest-priority entries are the last considered (caller
+    sorts ``priority DESC, created_at ASC``), so they're naturally
+    the first dropped under the iteration order.
+    """
     # ``estimate_tokens`` is the same heuristic T2's POST/PATCH 422
     # gate uses, so the two sites cannot drift: a body that T2 admits
     # fits this packer's budget under the same arithmetic.
-    used_tokens = estimate_tokens(header_text)
-
+    used_tokens = estimate_tokens(_HEADER_TEXT)
     kept_blocks: list[str] = []
+    kept_slugs: list[str] = []
     dropped: list[str] = []
+    token_counts: dict[str, int] = {}
     for conv in conventions:
         # Block shape: a level-3 heading per convention so the
         # rendered Markdown is grep-friendly in the assembled
@@ -239,27 +296,92 @@ async def assemble_preamble(
         # as separate sections.
         block = f"### {conv.title}\n{conv.body.strip()}\n"
         block_tokens = estimate_tokens(block)
+        # Record every considered slug's cost -- G0.14-T8 callers
+        # need to surface the just-written slug's weight whether it
+        # landed in the preamble or got dropped.
+        token_counts[conv.slug] = block_tokens
         if used_tokens + block_tokens > max_tokens:
-            # Drop the whole entry rather than truncate -- the issue
-            # body is explicit: "Silent truncation of an operational
-            # rule is a safety bug, not a UX nit." Lowest-priority
-            # entries are the last considered, so they're naturally
-            # the first dropped under the iteration order; the test
-            # suite asserts this contract.
             dropped.append(conv.slug)
             continue
         kept_blocks.append(block)
+        kept_slugs.append(conv.slug)
         used_tokens += block_tokens
+    return kept_blocks, kept_slugs, dropped, token_counts
 
-    # Body assembly: header followed by blank-line-separated blocks.
-    # The blocks already carry their own trailing newline so a
-    # single "\n" separator between them produces one blank line
-    # (rendered as: block-content + "\n" + "\n" + next-block-content).
-    body_text = header_text + "\n".join(kept_blocks)
 
-    # Positional wrapper: the BLOCK_START / BLOCK_END strings are
-    # never derived from user content, so a body containing
-    # "END_TENANT_CONVENTIONS>>" cannot escape the block. The
-    # f-string interpolation is a one-shot, no recursive expansion.
-    text = f"{BLOCK_START}\n{body_text}\n{BLOCK_END}"
-    return PreambleResult(text, dropped)
+def _wrap_preamble(kept_blocks: list[str]) -> str:
+    """Render the packed blocks into the wire-format preamble string.
+
+    Body assembly: header followed by blank-line-separated blocks.
+    The blocks already carry their own trailing newline so a single
+    ``\\n`` separator between them produces one blank line (rendered
+    as: block-content + ``\\n`` + ``\\n`` + next-block-content).
+
+    Then the positional wrapper: the :data:`BLOCK_START` /
+    :data:`BLOCK_END` strings are never derived from user content,
+    so a body containing ``END_TENANT_CONVENTIONS>>`` cannot escape
+    the block. The f-string interpolation is a one-shot, no
+    recursive expansion.
+    """
+    body_text = _HEADER_TEXT + "\n".join(kept_blocks)
+    return f"{BLOCK_START}\n{body_text}\n{BLOCK_END}"
+
+
+async def assemble_preamble_detailed(
+    tenant_id: UUID,
+    max_tokens: int = DEFAULT_MAX_PREAMBLE_TOKENS,
+    *,
+    session: AsyncSession | None = None,
+) -> PreambleAssembly:
+    """Assemble the preamble and return the verbose pack record.
+
+    G0.14-T8 (#1149, signal 18) addition. Same packer logic as
+    :func:`assemble_preamble` -- ``priority DESC, created_at ASC``,
+    greedy fill against the ``max_tokens`` budget, lowest-priority
+    overflow drops whole -- but the return shape also carries
+    ``kept_slugs`` (pack order of slugs that landed in the preamble)
+    and ``token_counts`` (the estimated token cost per row).
+
+    The two are what the POST/PATCH preamble-status feedback needs:
+
+    * ``kept_slugs`` lets the route handler resolve the just-written
+      slug's 1-based preamble position without re-running the pack
+      (``kept_slugs.index(slug) + 1``).
+    * ``token_counts`` lets the handler surface the just-written
+      slug's own token weight via ``preamble_status.token_count``
+      without a second :func:`~meho_backplane.conventions.schemas.estimate_tokens`
+      call on the body text.
+
+    When *session* is ``None`` the function opens its own DB session
+    via :func:`~meho_backplane.db.engine.get_sessionmaker` -- the
+    MCP ``initialize`` handler is not a FastAPI request handler and
+    has no :func:`~meho_backplane.db.engine.get_session`
+    dependency-injected session; the assembler is the natural owner
+    of the read transaction.
+
+    When *session* is supplied, the assembler reads through it
+    rather than opening its own. G0.14-T8's POST/PATCH preamble-
+    status feedback uses this so the pack reflects the in-progress
+    write (the convention's INSERT/UPDATE has flushed but not
+    committed; a separately-opened session would not see it).
+    SQLAlchemy 2.x reads within the same transaction see
+    flushed-but-not-committed rows, so the just-written convention
+    appears in the assembler's query as long as the caller has
+    flushed before calling.
+    """
+    if session is None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as owned_session:
+            conventions = await _fetch_operational_conventions(owned_session, tenant_id)
+    else:
+        conventions = await _fetch_operational_conventions(session, tenant_id)
+
+    if not conventions:
+        return PreambleAssembly("", [], [], {})
+
+    kept_blocks, kept_slugs, dropped, token_counts = _pack_conventions(
+        conventions,
+        max_tokens,
+    )
+    text = _wrap_preamble(kept_blocks)
+    return PreambleAssembly(text, dropped, kept_slugs, token_counts)

--- a/backend/src/meho_backplane/conventions/schemas.py
+++ b/backend/src/meho_backplane/conventions/schemas.py
@@ -69,6 +69,7 @@ __all__ = [
     "ConventionListResponse",
     "ConventionSummary",
     "ConventionUpdate",
+    "PreambleInclusion",
     "estimate_tokens",
 ]
 
@@ -251,6 +252,58 @@ class ConventionSummary(BaseModel):
     updated_at: datetime
 
 
+class PreambleInclusion(BaseModel):
+    """Whether a just-written convention reaches the session preamble.
+
+    G0.14-T8 (#1149, signal 18) -- the post-write feedback shape
+    ``POST /api/v1/conventions`` and ``PATCH /api/v1/conventions/{slug}``
+    attach to the response when the convention is ``kind='operational'``.
+    Without it, the operator gets a ``201`` (or ``200`` on PATCH), assumes
+    the rule is in effect, and the agent silently never sees it because
+    the preamble packer dropped it on budget overflow.
+
+    Fields:
+
+    * ``included`` -- ``True`` when the slug landed in the assembled
+      preamble (after the priority-ranked pack against
+      :data:`DEFAULT_MAX_PREAMBLE_TOKENS`). ``False`` when the packer
+      dropped it whole on overflow.
+    * ``position`` -- 1-based index of the convention in the assembled
+      preamble's packed order (the packer iterates ``priority DESC,
+      created_at ASC``; ``position=1`` means highest-priority slot in
+      the operator's tenant). ``None`` when ``included=False``.
+    * ``token_count`` -- the convention body's own estimated token
+      cost via :func:`estimate_tokens`. Useful for the operator to
+      see why a near-budget body got dropped (it weighed more than
+      the remaining headroom).
+    * ``would_drop_slugs`` -- the full ``dropped_slugs`` list the
+      packer produced on this assembly. When ``included=True`` this
+      names *other* slugs that fell out of the preamble (the just-
+      written convention may have pushed a lower-priority neighbour
+      out); when ``included=False`` the list contains *this* slug
+      plus any others dropped under the same pack. The shape lets
+      a single ``meho conventions create ...`` round-trip surface
+      both the personal outcome (did mine land?) and the collateral
+      damage (did mine push someone else out?).
+
+    Why a separate model instead of inlining fields on
+    :class:`Convention`: the response shape ``Convention`` is used
+    by ``GET /{slug}`` too, where ``preamble_status`` would be
+    redundant (operators inspecting a row already have the
+    ``GET /api/v1/conventions``'s ``budget_status`` envelope for
+    aggregate budget signal). Keeping the inclusion shape on a
+    sub-model means GET-single can drop the field cleanly while
+    POST/PATCH attach it.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    included: bool
+    position: int | None = Field(default=None, ge=1)
+    token_count: int = Field(ge=0)
+    would_drop_slugs: list[str]
+
+
 class Convention(BaseModel):
     """Full-row representation returned by GET-single / POST / PATCH.
 
@@ -262,6 +315,13 @@ class Convention(BaseModel):
     bound writes to the enum but read paths surface whatever the
     DB stored (a future ``kind`` value introduced by a migration
     would otherwise blow up the JSON encoder on every read).
+
+    ``preamble_status`` (G0.14-T8 #1149) is the post-write inclusion
+    signal POST/PATCH attach: ``None`` on ``GET /{slug}`` (the
+    aggregate budget signal lives on the list response's
+    ``budget_status``) and on writes against ``workflow`` /
+    ``reference`` kinds (those are not preamble-bound). Populated
+    only when the write touched an ``operational`` row.
     """
 
     model_config = ConfigDict(frozen=True, from_attributes=True)
@@ -276,6 +336,7 @@ class Convention(BaseModel):
     created_by_sub: str | None
     created_at: datetime
     updated_at: datetime
+    preamble_status: PreambleInclusion | None = None
 
 
 class BudgetStatus(BaseModel):

--- a/backend/tests/test_api_v1_conventions.py
+++ b/backend/tests/test_api_v1_conventions.py
@@ -1223,3 +1223,237 @@ async def test_list_budget_status_kind_filter_does_not_narrow_budget(
     bs = body["budget_status"]
     assert bs["over_budget"] is True
     assert "op-c" in bs["dropped_slugs"]
+
+
+# ---------------------------------------------------------------------------
+# G0.14-T8 #1149 -- preamble_status on POST/PATCH responses (signal 18)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_operational_returns_preamble_status_included(
+    client: TestClient,
+) -> None:
+    """POST an operational convention that fits → ``preamble_status.included=True``."""
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-preamble-included")
+    token = _token(key)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _post_convention(
+            client,
+            token,
+            slug="fits-easily",
+            body="Short body that fits.",
+            kind="operational",
+            priority=10,
+        )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert "preamble_status" in body, "POST operational must surface inclusion"
+    ps = body["preamble_status"]
+    assert ps["included"] is True
+    assert ps["position"] == 1  # only convention in the tenant; takes first slot
+    assert ps["token_count"] > 0
+    assert ps["would_drop_slugs"] == []
+
+
+def _sized_body(char_count: int) -> str:
+    """Build an ASCII body of exactly *char_count* characters.
+
+    Pairs with the ``ceil(len / 3.3)`` heuristic so callers can
+    target a precise estimated-token cost without leaning on
+    :func:`_near_budget_body`'s ``max(target*4, 1400)`` floor (which
+    over-shoots for small targets).
+    """
+    return "x" * char_count
+
+
+@pytest.mark.asyncio
+async def test_post_operational_dropped_when_over_budget(
+    client: TestClient,
+) -> None:
+    """POST a convention that doesn't fit → ``included=False`` + slug in ``would_drop_slugs``."""
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-preamble-dropped")
+    token = _token(key)
+    # ~250-token bodies (825 chars → ceil(825/3.3)=250). Two fit
+    # comfortably under the 600-token budget; a third pushes the
+    # cumulative pack over and the lowest-priority row drops.
+    body_mid = _sized_body(825)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        # Two priority-10 mid-sized rows fill most of the budget...
+        _post_convention(client, token, slug="winner-a", body=body_mid, priority=10)
+        _post_convention(client, token, slug="winner-b", body=body_mid, priority=10)
+        # ...the third lands at priority 1 -- packer drops it on overflow.
+        resp = _post_convention(
+            client,
+            token,
+            slug="loser-c",
+            body=body_mid,
+            priority=1,
+        )
+    assert resp.status_code == 201, resp.text
+    ps = resp.json()["preamble_status"]
+    assert ps["included"] is False
+    assert ps["position"] is None
+    assert ps["token_count"] > 0
+    # The just-written slug appears in would_drop_slugs (it was the
+    # one the packer dropped); the other two priority-10 rows fit
+    # and must not appear.
+    assert "loser-c" in ps["would_drop_slugs"]
+    assert "winner-a" not in ps["would_drop_slugs"]
+    assert "winner-b" not in ps["would_drop_slugs"]
+
+
+@pytest.mark.asyncio
+async def test_post_operational_high_priority_displaces_existing_slugs(
+    client: TestClient,
+) -> None:
+    """A high-prio POST that pushes a lower-prio neighbour out lists it in ``would_drop_slugs``."""
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-preamble-displace")
+    token = _token(key)
+    # Two ~250-token rows fit; a third pushes overflow. The new top-
+    # priority row goes in at position 1 and the lowest-priority
+    # existing row drops.
+    body_mid = _sized_body(825)  # ~250 tokens
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        _post_convention(client, token, slug="existing-mid", body=body_mid, priority=5)
+        _post_convention(client, token, slug="existing-low", body=body_mid, priority=1)
+        # New row at priority 100 -- highest -- takes position 1; the
+        # cumulative pack now overflows and the lowest-priority
+        # neighbour drops.
+        resp = _post_convention(
+            client,
+            token,
+            slug="new-top",
+            body=body_mid,
+            priority=100,
+        )
+    assert resp.status_code == 201, resp.text
+    ps = resp.json()["preamble_status"]
+    assert ps["included"] is True
+    assert ps["position"] == 1  # priority=100 wins the top slot
+    # ``existing-low`` had priority 1 -- the lowest -- so it's the
+    # natural drop on overflow. ``new-top`` itself is NOT in the
+    # drop list (it's the included one).
+    assert "existing-low" in ps["would_drop_slugs"]
+    assert "new-top" not in ps["would_drop_slugs"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["workflow", "reference"])
+async def test_post_workflow_reference_omits_preamble_status(
+    client: TestClient,
+    kind: str,
+) -> None:
+    """Non-operational kinds don't enter the preamble → ``preamble_status`` is ``None``."""
+    await _seed_tenants()
+    key = make_rsa_keypair(f"kid-preamble-{kind}")
+    token = _token(key)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        resp = _post_convention(
+            client,
+            token,
+            slug=f"non-op-{kind}",
+            body="Workflow / reference text.",
+            kind=kind,
+        )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    # The field is present on the schema (``Convention.preamble_status``)
+    # but null for preamble-unbound kinds. JSON consumers branching
+    # on ``preamble_status is None`` get the right "this write does
+    # not affect the preamble" signal.
+    assert body["preamble_status"] is None
+
+
+@pytest.mark.asyncio
+async def test_patch_operational_returns_preamble_status(client: TestClient) -> None:
+    """PATCH an operational convention's body → response carries fresh ``preamble_status``."""
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-preamble-patch")
+    token = _token(key)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        _post_convention(
+            client,
+            token,
+            slug="patch-target",
+            body="Original short.",
+            priority=5,
+        )
+        resp = client.patch(
+            "/api/v1/conventions/patch-target",
+            json={"body": "Updated body text."},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200, resp.text
+    ps = resp.json()["preamble_status"]
+    assert ps is not None
+    assert ps["included"] is True
+    assert ps["position"] == 1
+    assert ps["would_drop_slugs"] == []
+
+
+@pytest.mark.asyncio
+async def test_patch_priority_only_returns_preamble_status(client: TestClient) -> None:
+    """Priority-only PATCH that re-ranks the convention still surfaces ``preamble_status``."""
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-preamble-patch-prio")
+    token = _token(key)
+    body_near = _near_budget_body(target_tokens=400)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        # Three rows; only two fit. Start the to-be-patched row at
+        # priority 1 (definitely dropped) and bump it to 100 via
+        # PATCH (should now be included at position 1).
+        _post_convention(client, token, slug="patch-prio", body=body_near, priority=1)
+        _post_convention(client, token, slug="other-a", body=body_near, priority=5)
+        _post_convention(client, token, slug="other-b", body=body_near, priority=5)
+        # Pre-PATCH state: patch-prio is dropped.
+        resp_pre = client.get(
+            "/api/v1/conventions/patch-prio",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp_pre.status_code == 200
+        # GET-single does NOT carry preamble_status (the aggregate
+        # signal lives on the list response's budget_status); the
+        # write-time feedback is the only post-mutation signal.
+        assert resp_pre.json().get("preamble_status") is None
+        # Bump priority to 100 -- now patch-prio takes the top slot.
+        resp = client.patch(
+            "/api/v1/conventions/patch-prio",
+            json={"priority": 100},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200, resp.text
+    ps = resp.json()["preamble_status"]
+    assert ps is not None
+    assert ps["included"] is True
+    assert ps["position"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_single_does_not_carry_preamble_status(client: TestClient) -> None:
+    """``GET /{slug}`` returns ``preamble_status=None`` -- inclusion signal is write-time only."""
+    await _seed_tenants()
+    key = make_rsa_keypair("kid-preamble-get")
+    token = _token(key)
+    with respx.mock as r:
+        mock_discovery_and_jwks(r, public_jwks(key))
+        _post_convention(client, token, slug="get-only")
+        resp = client.get(
+            "/api/v1/conventions/get-only",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    # GET-single is the natural read shape; ``budget_status`` on the
+    # list response is the aggregate-budget signal, so the per-row
+    # GET deliberately omits preamble_status (returns None) to keep
+    # the read paths' responsibilities clean.
+    assert resp.json()["preamble_status"] is None

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -8781,6 +8781,10 @@
             "type": "string",
             "format": "date-time",
             "title": "Updated At"
+          },
+          "preamble_status": {
+            "$ref": "#/components/schemas/PreambleInclusion",
+            "nullable": true
           }
         },
         "type": "object",
@@ -8797,7 +8801,7 @@
           "updated_at"
         ],
         "title": "Convention",
-        "description": "Full-row representation returned by GET-single / POST / PATCH.\n\nCarries the entire ``body`` text -- the natural shape for\n``GET /{slug}`` and the return value of POST/PATCH where the\ncaller wants to confirm what they wrote landed verbatim.\n``kind`` is exposed as the raw string from the DB rather than\nas :class:`ConventionKind`; the API layer's pydantic models\nbound writes to the enum but read paths surface whatever the\nDB stored (a future ``kind`` value introduced by a migration\nwould otherwise blow up the JSON encoder on every read)."
+        "description": "Full-row representation returned by GET-single / POST / PATCH.\n\nCarries the entire ``body`` text -- the natural shape for\n``GET /{slug}`` and the return value of POST/PATCH where the\ncaller wants to confirm what they wrote landed verbatim.\n``kind`` is exposed as the raw string from the DB rather than\nas :class:`ConventionKind`; the API layer's pydantic models\nbound writes to the enum but read paths surface whatever the\nDB stored (a future ``kind`` value introduced by a migration\nwould otherwise blow up the JSON encoder on every read).\n\n``preamble_status`` (G0.14-T8 #1149) is the post-write inclusion\nsignal POST/PATCH attach: ``None`` on ``GET /{slug}`` (the\naggregate budget signal lives on the list response's\n``budget_status``) and on writes against ``workflow`` /\n``reference`` kinds (those are not preamble-bound). Populated\nonly when the write touched an ``operational`` row."
       },
       "ConventionCreate": {
         "properties": {
@@ -10009,6 +10013,40 @@
         ],
         "title": "PermissionVerdict",
         "description": "Three-state verdict returned by the permission resolver.\n\n:attr:`AUTO_EXECUTE` \u2014 the op proceeds without human review.\n:attr:`NEEDS_APPROVAL` \u2014 the op is parked pending an operator\ndecision; the approval queue (G11.2-T4) handles the resume path.\n:attr:`DENY` \u2014 the op is refused immediately with a structured,\nagent-reasonable error.\n\nThe vocabulary is intentionally closed: a fourth verdict would\nrequire a code + migration change, which is the cheapest way to\nprevent drift between the DB layer and the policy engine."
+      },
+      "PreambleInclusion": {
+        "properties": {
+          "included": {
+            "type": "boolean",
+            "title": "Included"
+          },
+          "position": {
+            "type": "integer",
+            "minimum": 1.0,
+            "nullable": true,
+            "title": "Position"
+          },
+          "token_count": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Token Count"
+          },
+          "would_drop_slugs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Would Drop Slugs"
+          }
+        },
+        "type": "object",
+        "required": [
+          "included",
+          "token_count",
+          "would_drop_slugs"
+        ],
+        "title": "PreambleInclusion",
+        "description": "Whether a just-written convention reaches the session preamble.\n\nG0.14-T8 (#1149, signal 18) -- the post-write feedback shape\n``POST /api/v1/conventions`` and ``PATCH /api/v1/conventions/{slug}``\nattach to the response when the convention is ``kind='operational'``.\nWithout it, the operator gets a ``201`` (or ``200`` on PATCH), assumes\nthe rule is in effect, and the agent silently never sees it because\nthe preamble packer dropped it on budget overflow.\n\nFields:\n\n* ``included`` -- ``True`` when the slug landed in the assembled\n  preamble (after the priority-ranked pack against\n  :data:`DEFAULT_MAX_PREAMBLE_TOKENS`). ``False`` when the packer\n  dropped it whole on overflow.\n* ``position`` -- 1-based index of the convention in the assembled\n  preamble's packed order (the packer iterates ``priority DESC,\n  created_at ASC``; ``position=1`` means highest-priority slot in\n  the operator's tenant). ``None`` when ``included=False``.\n* ``token_count`` -- the convention body's own estimated token\n  cost via :func:`estimate_tokens`. Useful for the operator to\n  see why a near-budget body got dropped (it weighed more than\n  the remaining headroom).\n* ``would_drop_slugs`` -- the full ``dropped_slugs`` list the\n  packer produced on this assembly. When ``included=True`` this\n  names *other* slugs that fell out of the preamble (the just-\n  written convention may have pushed a lower-priority neighbour\n  out); when ``included=False`` the list contains *this* slug\n  plus any others dropped under the same pack. The shape lets\n  a single ``meho conventions create ...`` round-trip surface\n  both the personal outcome (did mine land?) and the collateral\n  damage (did mine push someone else out?).\n\nWhy a separate model instead of inlining fields on\n:class:`Convention`: the response shape ``Convention`` is used\nby ``GET /{slug}`` too, where ``preamble_status`` would be\nredundant (operators inspecting a row already have the\n``GET /api/v1/conventions``'s ``budget_status`` envelope for\naggregate budget signal). Keeping the inclusion shape on a\nsub-model means GET-single can drop the field cleanly while\nPOST/PATCH attach it."
       },
       "PromoteBody": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -1279,17 +1279,67 @@ type ConnectorSpecEntry struct {
 // bound writes to the enum but read paths surface whatever the
 // DB stored (a future “kind“ value introduced by a migration
 // would otherwise blow up the JSON encoder on every read).
+//
+// “preamble_status“ (G0.14-T8 #1149) is the post-write inclusion
+// signal POST/PATCH attach: “None“ on “GET /{slug}“ (the
+// aggregate budget signal lives on the list response's
+// “budget_status“) and on writes against “workflow“ /
+// “reference“ kinds (those are not preamble-bound). Populated
+// only when the write touched an “operational“ row.
 type Convention struct {
 	Body         string             `json:"body"`
 	CreatedAt    time.Time          `json:"created_at"`
 	CreatedBySub *string            `json:"created_by_sub"`
 	Id           openapi_types.UUID `json:"id"`
 	Kind         string             `json:"kind"`
-	Priority     int                `json:"priority"`
-	Slug         string             `json:"slug"`
-	TenantId     openapi_types.UUID `json:"tenant_id"`
-	Title        string             `json:"title"`
-	UpdatedAt    time.Time          `json:"updated_at"`
+
+	// PreambleStatus Whether a just-written convention reaches the session preamble.
+	//
+	// G0.14-T8 (#1149, signal 18) -- the post-write feedback shape
+	// ``POST /api/v1/conventions`` and ``PATCH /api/v1/conventions/{slug}``
+	// attach to the response when the convention is ``kind='operational'``.
+	// Without it, the operator gets a ``201`` (or ``200`` on PATCH), assumes
+	// the rule is in effect, and the agent silently never sees it because
+	// the preamble packer dropped it on budget overflow.
+	//
+	// Fields:
+	//
+	// * ``included`` -- ``True`` when the slug landed in the assembled
+	//   preamble (after the priority-ranked pack against
+	//   :data:`DEFAULT_MAX_PREAMBLE_TOKENS`). ``False`` when the packer
+	//   dropped it whole on overflow.
+	// * ``position`` -- 1-based index of the convention in the assembled
+	//   preamble's packed order (the packer iterates ``priority DESC,
+	//   created_at ASC``; ``position=1`` means highest-priority slot in
+	//   the operator's tenant). ``None`` when ``included=False``.
+	// * ``token_count`` -- the convention body's own estimated token
+	//   cost via :func:`estimate_tokens`. Useful for the operator to
+	//   see why a near-budget body got dropped (it weighed more than
+	//   the remaining headroom).
+	// * ``would_drop_slugs`` -- the full ``dropped_slugs`` list the
+	//   packer produced on this assembly. When ``included=True`` this
+	//   names *other* slugs that fell out of the preamble (the just-
+	//   written convention may have pushed a lower-priority neighbour
+	//   out); when ``included=False`` the list contains *this* slug
+	//   plus any others dropped under the same pack. The shape lets
+	//   a single ``meho conventions create ...`` round-trip surface
+	//   both the personal outcome (did mine land?) and the collateral
+	//   damage (did mine push someone else out?).
+	//
+	// Why a separate model instead of inlining fields on
+	// :class:`Convention`: the response shape ``Convention`` is used
+	// by ``GET /{slug}`` too, where ``preamble_status`` would be
+	// redundant (operators inspecting a row already have the
+	// ``GET /api/v1/conventions``'s ``budget_status`` envelope for
+	// aggregate budget signal). Keeping the inclusion shape on a
+	// sub-model means GET-single can drop the field cleanly while
+	// POST/PATCH attach it.
+	PreambleStatus *PreambleInclusion `json:"preamble_status,omitempty"`
+	Priority       int                `json:"priority"`
+	Slug           string             `json:"slug"`
+	TenantId       openapi_types.UUID `json:"tenant_id"`
+	Title          string             `json:"title"`
+	UpdatedAt      time.Time          `json:"updated_at"`
 }
 
 // ConventionCreate POST body for “/api/v1/conventions“.
@@ -2103,6 +2153,54 @@ type OperatorIdentity struct {
 // require a code + migration change, which is the cheapest way to
 // prevent drift between the DB layer and the policy engine.
 type PermissionVerdict string
+
+// PreambleInclusion Whether a just-written convention reaches the session preamble.
+//
+// G0.14-T8 (#1149, signal 18) -- the post-write feedback shape
+// “POST /api/v1/conventions“ and “PATCH /api/v1/conventions/{slug}“
+// attach to the response when the convention is “kind='operational'“.
+// Without it, the operator gets a “201“ (or “200“ on PATCH), assumes
+// the rule is in effect, and the agent silently never sees it because
+// the preamble packer dropped it on budget overflow.
+//
+// Fields:
+//
+//   - “included“ -- “True“ when the slug landed in the assembled
+//     preamble (after the priority-ranked pack against
+//     :data:`DEFAULT_MAX_PREAMBLE_TOKENS`). “False“ when the packer
+//     dropped it whole on overflow.
+//   - “position“ -- 1-based index of the convention in the assembled
+//     preamble's packed order (the packer iterates “priority DESC,
+//     created_at ASC“; “position=1“ means highest-priority slot in
+//     the operator's tenant). “None“ when “included=False“.
+//   - “token_count“ -- the convention body's own estimated token
+//     cost via :func:`estimate_tokens`. Useful for the operator to
+//     see why a near-budget body got dropped (it weighed more than
+//     the remaining headroom).
+//   - “would_drop_slugs“ -- the full “dropped_slugs“ list the
+//     packer produced on this assembly. When “included=True“ this
+//     names *other* slugs that fell out of the preamble (the just-
+//     written convention may have pushed a lower-priority neighbour
+//     out); when “included=False“ the list contains *this* slug
+//     plus any others dropped under the same pack. The shape lets
+//     a single “meho conventions create ...“ round-trip surface
+//     both the personal outcome (did mine land?) and the collateral
+//     damage (did mine push someone else out?).
+//
+// Why a separate model instead of inlining fields on
+// :class:`Convention`: the response shape “Convention“ is used
+// by “GET /{slug}“ too, where “preamble_status“ would be
+// redundant (operators inspecting a row already have the
+// “GET /api/v1/conventions“'s “budget_status“ envelope for
+// aggregate budget signal). Keeping the inclusion shape on a
+// sub-model means GET-single can drop the field cleanly while
+// POST/PATCH attach it.
+type PreambleInclusion struct {
+	Included       bool     `json:"included"`
+	Position       *int     `json:"position"`
+	TokenCount     int      `json:"token_count"`
+	WouldDropSlugs []string `json:"would_drop_slugs"`
+}
 
 // PromoteBody POST body for “/api/v1/memory/{scope}/{slug}/promote“.
 //

--- a/docs/codebase/tenant_conventions.md
+++ b/docs/codebase/tenant_conventions.md
@@ -409,6 +409,46 @@ honours the over-budget warning AC. The
 sub-document (`max_tokens`, `estimated_tokens`, `over_budget`,
 `dropped_slugs`) computed by a call to
 `assemble_preamble(operator.tenant_id)` on every list call.
+
+**Per-write inclusion feedback (G0.14-T8 #1149).** A complementary
+post-write signal: `POST /api/v1/conventions` and
+`PATCH /api/v1/conventions/{slug}` attach a `preamble_status`
+sub-document to the response when the convention is
+`kind='operational'`. The shape:
+
+```json
+{
+  "preamble_status": {
+    "included": true,
+    "position": 4,
+    "token_count": 142,
+    "would_drop_slugs": []
+  }
+}
+```
+
+* `included` — `True` when the just-written slug landed in the
+  preamble after the priority-ranked pack against
+  `DEFAULT_MAX_PREAMBLE_TOKENS`; `False` when it was dropped.
+* `position` — 1-based index of the slug in the assembled
+  preamble's packed order (`priority DESC, created_at ASC`).
+  `None` when `included=False`.
+* `token_count` — the convention body's own estimated token cost.
+* `would_drop_slugs` — every slug dropped on this pack. When
+  `included=True` this names *other* slugs the write displaced;
+  when `included=False` the just-written slug appears here.
+
+`preamble_status` is `null` on `GET /{slug}` (the aggregate budget
+signal lives on the list response's `budget_status`) and `null` for
+writes against `workflow` / `reference` kinds (those don't enter
+the preamble). The route handler resolves inclusion via
+`assemble_preamble_detailed(tenant_id, session=session)` -- the
+same session the write committed through, so the pack reflects
+the post-write state without an extra commit round-trip. Signal 18
+in `claude-rdc-hetzner-dc#697` motivated the addition: an operator
+who writes a convention previously got a `201` with no indication
+the row would ever reach an agent session; with `preamble_status`
+the answer arrives in the same round-trip.
 When the tenant is over budget:
 
 - **Table mode** (default): the table still prints to stdout (the
@@ -448,7 +488,11 @@ Downstream consumers:
   (`docs/examples/consumer-onboarding/CLAUDE.md`). **Landed.**
 - **T7 (#1094)** -- `BudgetStatus` surfacing on
   `GET /api/v1/conventions` + `meho conventions list` exit-code-5
-  warning. **Landed** (this task).
+  warning. **Landed**.
+- **G0.14-T8 (#1149)** -- `preamble_status` per-write inclusion
+  feedback on `POST` / `PATCH /api/v1/conventions[/{slug}]`. Surfaces
+  whether the just-written operational convention landed in the
+  preamble (signal 18 from `claude-rdc-hetzner-dc#697`). **Landed**.
 
 ## Migration
 


### PR DESCRIPTION
## Summary

- Surfaces `preamble_status` on `POST /api/v1/conventions` and `PATCH /api/v1/conventions/{slug}` responses for `kind='operational'` writes, naming whether the convention landed in the assembled preamble, its 1-based position, its own token weight, and the full dropped-slug list from the same pack.
- Closes `claude-rdc-hetzner-dc#697` signal 18: previously, an operator who POSTed a convention got a `201` with no signal whether the row would ever reach an MCP `initialize.instructions` preamble (token-budget drop). The answer now arrives in the same round-trip.
- Threads the route handler's session into a new `assemble_preamble_detailed` so the pack reflects the in-progress write (post-flush, pre-commit) without an extra round-trip — same session, same transaction, identical to what the post-commit MCP `initialize` handler will assemble.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy --ignore-missing-imports` — clean
- [x] `pytest tests/test_api_v1_conventions.py tests/test_conventions_preamble.py tests/test_db_conventions.py tests/test_mcp_resource_tenant_conventions.py tests/test_alembic_seed_rdc_conventions.py tests/test_mcp_initialize_instructions.py` — 82 passed (51 pre-existing + 8 new + 23 across siblings)
- [x] Full backend test suite — 4988 passed, 362 skipped (no regressions)
- [x] `code-quality.py --diff` — 0 blockers, 7 pre-existing/style warnings
- [x] AC1: `POST /api/v1/conventions` response includes `preamble_status` with `included` / `position` / `would_drop_slugs` — covered by `test_post_operational_returns_preamble_status_included`, `test_post_operational_dropped_when_over_budget`, `test_post_operational_high_priority_displaces_existing_slugs`.
- [x] AC2: `PATCH /api/v1/conventions/{slug}` similarly returns `preamble_status` — covered by `test_patch_operational_returns_preamble_status` and `test_patch_priority_only_returns_preamble_status`.
- [x] AC3 (Option B `GET /preamble` route): NOT shipped — Option A is the actionable shape; the GET `/api/v1/conventions` list response already carries `budget_status` (T7 #1094) covering the aggregate read need.
- [x] AC4: a fitting convention yields `included=true`; an oversized one (over budget) yields `included=false` with `would_drop_slugs` populated.
- [x] AC5: documentation update in `docs/codebase/tenant_conventions.md` adds a "Per-write inclusion feedback" section under the budget surfacing area.
- [x] AC6: `ruff` + `mypy` + `pytest` green.

## Implementation notes

- The new `PreambleInclusion` model lives next to `BudgetStatus` in `conventions/schemas.py`; the `Convention` response model gains a `preamble_status: PreambleInclusion | None = None` field. GET-single returns `None` (the aggregate signal lives on the list response's `budget_status`).
- `preamble.py` ships a new `PreambleAssembly` NamedTuple (text + dropped_slugs + kept_slugs + token_counts) and `assemble_preamble_detailed()` that returns it. The original `assemble_preamble()` delegates to `assemble_preamble_detailed()` and discards the verbose fields, so a single packer drives both consumers. No risk of "the position I told the operator" drifting from "the preamble the agent session received".
- `assemble_preamble_detailed` accepts an optional `session=` so the POST/PATCH handlers can use the same in-flight transaction. Refactored the body of the function into `_pack_conventions` + `_wrap_preamble` helpers to stay under the code-quality function-size threshold.

## Out of scope

- Option B (`GET /api/v1/conventions/preamble`) — the existing `budget_status` envelope on `GET /api/v1/conventions` already covers the aggregate read need; adding a third surface would be redundant for v0.6.x.
- Reshuffling the priority-drop behavior — the algorithm is fine; this Task only surfaces the result.
- Real-time preamble subscriptions (SSE / watch surface) — premature; the polling shape works for now.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1149
