### PR TITLE
feat(ui): G10.3-T2 target create/edit forms (DaisyUI modal, HTMX) + Pydantic validation + tenant_admin RBAC + CSRF

### DIFF
--- a/backend/src/meho_backplane/ui/routes/connectors/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/__init__.py
@@ -29,8 +29,16 @@ Module layout:
   Uses the same :func:`~meho_backplane.connectors.resolver
   .resolve_connector_or_label` helper the ``/api/v1/targets/{name}/probe``
   REST route does so the two surfaces stay byte-compatible.
+* :mod:`~meho_backplane.ui.routes.connectors.forms_router` -- the
+  T2 (#874) create / edit form routes
+  (``GET``/``POST`` ``/ui/connectors/create`` +
+  ``GET /ui/connectors/{name}/edit`` + ``PATCH /ui/connectors/{name}``).
+  Tenant_admin-gated server-side; the DaisyUI modal forms HTMX-submit
+  into the REST ``POST``/``PATCH`` ``/api/v1/targets`` handlers
+  in-process so the UI and REST surfaces share one validation +
+  product-check + audit code path.
 
-The umbrella :func:`build_router` aggregates all three. It is mounted
+The umbrella :func:`build_router` aggregates all four. It is mounted
 **before** :func:`~meho_backplane.ui.routes.stubs.build_stubs_router`
 in :func:`~meho_backplane.ui.routes.build_router` so the real
 ``/ui/connectors`` and ``/ui/connectors/{name}`` handlers win the
@@ -52,6 +60,7 @@ from __future__ import annotations
 from fastapi import APIRouter
 
 from meho_backplane.ui.routes.connectors.detail import build_detail_router
+from meho_backplane.ui.routes.connectors.forms_router import build_forms_router
 from meho_backplane.ui.routes.connectors.list_view import build_list_router
 from meho_backplane.ui.routes.connectors.probe import build_probe_router
 
@@ -70,14 +79,21 @@ def build_router() -> APIRouter:
     Registration order is **load-bearing**: the literal ``GET /ui/connectors``
     list route registers before the parametrised ``GET /ui/connectors/{name}``
     detail route so the empty-tail URL is matched as the list rather than
-    captured with ``name=""``. The probe route's path is fully literal
+    captured with ``name=""``. The T2 forms router is included **before**
+    the detail router for the same reason -- its literal
+    ``GET /ui/connectors/create`` route must win the first-match-wins
+    lookup over ``GET /ui/connectors/{name}`` (otherwise ``"create"``
+    binds to ``name``). The probe route's path is fully literal
     (``/ui/connectors/{name}/probe``) so the ``POST`` verb plus the
     extra ``/probe`` segment makes it unambiguous regardless of order;
     we still include it last for the same readability convention the
-    memory router uses.
+    memory router uses. The forms router's ``PATCH /ui/connectors/{name}``
+    shares the detail route's path but is distinguished by HTTP method,
+    so its ordering relative to the detail ``GET`` is not load-bearing.
     """
     router = APIRouter()
     router.include_router(build_list_router())
+    router.include_router(build_forms_router())
     router.include_router(build_detail_router())
     router.include_router(build_probe_router())
     return router

--- a/backend/src/meho_backplane/ui/routes/connectors/forms.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/forms.py
@@ -1,0 +1,477 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Target create / edit forms (DaisyUI modal, HTMX) for the connectors UI.
+
+Initiative #340 (G10.3 Connectors + Targets UI), Task #874 (T2) work
+items #3 / #4. T1 (#873) shipped the read surface (list + detail +
+re-probe); this module layers the **write** surface on top:
+
+* **``GET /ui/connectors/create``** -- HTMX-loaded create modal. The
+  product ``<select>`` is server-rendered from
+  :func:`~meho_backplane.connectors.registry.registered_product_tokens`
+  -- the same set the ``POST /api/v1/targets`` handler validates
+  ``product`` against, so a product an operator can pick is always a
+  product the create call will accept (no dropdown / validator drift).
+* **``POST /ui/connectors/create``** -- submit handler. Builds a
+  :class:`~meho_backplane.targets.schemas.TargetCreate` from the form
+  fields and delegates to the REST handler
+  :func:`~meho_backplane.api.v1.targets.create_target` in-process so
+  the UI and the REST surface share one validation + product-check +
+  audit-binding code path (the same posture T1's re-probe handler uses
+  by sharing ``resolve_connector_or_label`` with the REST probe route).
+  Success -> 204 + ``HX-Redirect: /ui/connectors`` (re-renders the
+  list with the new row); a Pydantic ``ValidationError`` (port out of
+  1-65535, empty name, ...) re-renders the modal with per-field error
+  messages and HTTP 422.
+* **``GET /ui/connectors/{name}/edit``** -- HTMX-loaded edit modal,
+  fields pre-populated server-side from the resolved target.
+* **``PATCH /ui/connectors/{name}``** -- submit handler. Builds a
+  :class:`~meho_backplane.targets.schemas.TargetUpdate` and delegates
+  to :func:`~meho_backplane.api.v1.targets.update_target`.
+
+RBAC posture
+------------
+
+Create / edit are **tenant_admin only** and the gate is server-side:
+every route here depends on
+:func:`~meho_backplane.ui.routes.connectors.operator.resolve_operator_or_403`,
+which lifts the full :class:`~meho_backplane.auth.operator.Operator`
+from the BFF session, re-validates the access token through the
+chassis JWT chain, and raises 403 for a non-admin caller. The list /
+detail templates additionally hide the create / edit affordances from
+non-admins (UX), but a crafted POST / PATCH still hits the 403 -- the
+template hiding is not the security boundary.
+
+The lifted ``Operator`` is passed into the in-process REST handler so
+the create / update logic runs under the caller's tenant scope; the
+handler's own ``Depends(require_role(TENANT_ADMIN))`` is not re-run on
+the in-process call, which is why the 403 gate lives on *this*
+module's route deps.
+
+CSRF posture
+------------
+
+``POST`` / ``PATCH`` under ``/ui/`` are gated by the chassis
+:class:`~meho_backplane.ui.csrf.CSRFMiddleware` (signed double-submit)
+before the handler runs. The modal form inherits the ``X-CSRF-Token``
+header from the page-level ``hx-headers`` directive; each modal render
+also re-mints + re-sets the ``meho_csrf`` cookie so a freshly-issued
+token lines up with the cookie.
+"""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import Request, status
+from fastapi.responses import HTMLResponse
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.api.v1.targets import create_target, update_target
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.registry import registered_product_tokens
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.targets.resolver import resolve_target
+from meho_backplane.targets.schemas import TargetCreate, TargetUpdate
+from meho_backplane.ui.auth.middleware import UISessionContext
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.templating import get_templates
+
+__all__ = [
+    "parse_aliases",
+    "render_create_modal",
+    "render_edit_modal",
+    "submit_create",
+    "submit_edit",
+]
+
+_log = structlog.get_logger(__name__)
+
+
+def _set_csrf_cookie(response: HTMLResponse, csrf_token: str) -> None:
+    """Mirror the chassis CSRF cookie posture for the modal renders.
+
+    Same attributes T1's list / detail / probe renders set so the
+    freshly-minted double-submit token lines up with the cookie the
+    browser sends back on the form submit.
+    """
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=csrf_token,
+        httponly=False,
+        secure=True,
+        samesite="strict",
+        path="/ui",
+    )
+
+
+def _product_options() -> list[str]:
+    """Return the sorted product tokens the create dropdown offers.
+
+    Sourced from
+    :func:`~meho_backplane.connectors.registry.registered_product_tokens`
+    -- the canonical set ``POST /api/v1/targets`` validates ``product``
+    against. ``GET /api/v1/connectors`` surfaces the operator's
+    *ingested* connectors, but the create-time validator keys on the
+    registered-connector products; sourcing the dropdown from the same
+    set the validator uses means a selectable product is always an
+    acceptable product (the alternative -- driving the dropdown from
+    the ingest list -- would let an operator pick a product the POST
+    then rejects with a 422). Sorted for a stable render order.
+    """
+    return sorted(registered_product_tokens())
+
+
+def parse_aliases(raw: str | None) -> list[str]:
+    """Split the comma-separated ``aliases`` form field into a list.
+
+    Empty / whitespace entries are dropped and duplicates de-duplicated
+    while preserving first-seen order. Returns ``[]`` (never ``None``)
+    when *raw* is missing so the :class:`TargetCreate` /
+    :class:`TargetUpdate` builders never need a separate ``None``
+    branch. Mirrors the comma-list shape the memory create modal uses
+    for tags (:func:`~meho_backplane.ui.routes.memory._modal_shared.parse_tags`).
+    """
+    if not raw or not raw.strip():
+        return []
+    seen: set[str] = set()
+    result: list[str] = []
+    for part in raw.split(","):
+        cleaned = part.strip()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        result.append(cleaned)
+    return result
+
+
+def _validation_errors_by_field(exc: ValidationError) -> dict[str, str]:
+    """Project a Pydantic :class:`ValidationError` into a field->message map.
+
+    Keys are the first ``loc`` element (the field name); the value is
+    the human-readable ``msg`` Pydantic produced (e.g. "Input should be
+    less than or equal to 65535" for a port out of range, "String
+    should have at least 1 character" for an empty name). The template
+    renders the message under the matching field. A field with multiple
+    errors keeps the first -- the form surfaces one message per field,
+    which is the convention DaisyUI's ``input-error`` + label pattern
+    expects.
+    """
+    errors: dict[str, str] = {}
+    for err in exc.errors():
+        loc = err.get("loc") or ()
+        field = str(loc[0]) if loc else "__root__"
+        errors.setdefault(field, str(err.get("msg", "invalid value")))
+    return errors
+
+
+async def render_create_modal(
+    request: Request,
+    session_ctx: UISessionContext,
+) -> HTMLResponse:
+    """Render the HTMX-loaded create modal fragment.
+
+    Called by ``GET /ui/connectors/create`` (tenant_admin-gated on the
+    route dep). The product dropdown is server-rendered from the
+    registered-connector product set; the auth_model dropdown from the
+    :class:`~meho_backplane.connectors.schemas.AuthModel` enum.
+    """
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    response = get_templates().TemplateResponse(
+        request,
+        "connectors/_create_modal.html",
+        _build_form_context(csrf_token, mode="create"),
+    )
+    _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def render_edit_modal(
+    request: Request,
+    session_ctx: UISessionContext,
+    db_session: AsyncSession,
+    *,
+    target_name: str,
+) -> HTMLResponse:
+    """Render the edit modal pre-populated from the resolved target.
+
+    Called by ``GET /ui/connectors/{name}/edit`` (tenant_admin-gated).
+    Resolves the target tenant-scoped via
+    :func:`~meho_backplane.targets.resolver.resolve_target` (404 on a
+    cross-tenant or unknown name, so an admin in tenant B can never
+    load tenant A's edit form). ``name`` and ``product`` render as
+    read-only context for the operator (``name`` is immutable per the
+    G0.3 contract; ``product`` is patchable but edited through the same
+    dropdown the create form uses).
+    """
+    target = await resolve_target(db_session, session_ctx.tenant_id, target_name)
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    context = _build_form_context(csrf_token, mode="edit")
+    context["target"] = {
+        "name": target.name,
+        # The aliases input is a comma-separated free-text field (parsed
+        # back to a list by ``parse_aliases`` on submit), so pre-populate
+        # it as the joined string rather than the list repr.
+        "aliases": ", ".join(target.aliases),
+        "product": target.product,
+        "host": target.host,
+        # ``port`` is rendered into a numeric ``value=""`` attribute;
+        # ``None`` must render as empty (not the literal "None"), so the
+        # ``field_value`` macro's ``not in (None, "")`` guard already
+        # drops it -- but stringify a present port so the macro's
+        # value-echo path renders the digits.
+        "port": str(target.port) if target.port is not None else None,
+        "fqdn": target.fqdn,
+        "secret_ref": target.secret_ref,
+        "auth_model": target.auth_model,
+        "vpn_required": target.vpn_required,
+        "notes": target.notes,
+    }
+    response = get_templates().TemplateResponse(
+        request,
+        "connectors/_edit_modal.html",
+        context,
+    )
+    _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+def _build_form_context(csrf_token: str, *, mode: str) -> dict[str, object]:
+    """Build the template context shared by the create + edit modals."""
+    return {
+        "page_title": "Connectors",
+        "active_surface": "connectors",
+        "ready": False,
+        "csrf_token": csrf_token,
+        "mode": mode,
+        "product_options": _product_options(),
+        "auth_models": [m.value for m in AuthModel],
+        # Bare-form re-render carries no errors / submitted values.
+        "errors": {},
+        "values": {},
+    }
+
+
+def _redirect_to_list() -> HTMLResponse:
+    """Return a 204 + ``HX-Redirect`` so HTMX reloads the targets list.
+
+    The canonical HTMX post-mutation navigation pattern
+    (https://htmx.org/headers/hx-redirect/). The list re-renders with
+    the freshly created / edited row -- satisfying the #874 acceptance
+    criterion "success -> updated list". Mirrors the memory create
+    handler's success shape.
+    """
+    return HTMLResponse(
+        status_code=status.HTTP_204_NO_CONTENT,
+        headers={"HX-Redirect": "/ui/connectors"},
+    )
+
+
+async def submit_create(
+    request: Request,
+    session_ctx: UISessionContext,
+    operator: Operator,
+    db_session: AsyncSession,
+    *,
+    name: str,
+    product: str,
+    host: str,
+    port: str | None,
+    auth_model: str,
+    secret_ref: str | None,
+    vpn_required: bool,
+    aliases_raw: str | None,
+    notes: str | None,
+) -> HTMLResponse:
+    """Build a :class:`TargetCreate` and delegate to the REST create handler.
+
+    Form fields arrive as strings (``port`` is a free-text input so an
+    empty submit is ``None`` rather than 0); we hand the raw shapes to
+    :class:`TargetCreate` so Pydantic runs the *same* coercion +
+    validation the REST POST body runs (port 1-65535, name min_length=1,
+    auth_model enum membership). A :class:`ValidationError` re-renders
+    the modal with per-field messages + HTTP 422; a valid model is
+    passed straight to :func:`~meho_backplane.api.v1.targets.create_target`
+    so the product-registry check, the duplicate-name 409, the audit
+    binding, and the broadcast hook all fire exactly as they do on the
+    REST surface.
+    """
+    raw_values = {
+        "name": name,
+        "product": product,
+        "host": host,
+        "port": port or "",
+        "auth_model": auth_model,
+        "secret_ref": secret_ref or "",
+        "vpn_required": vpn_required,
+        "aliases": aliases_raw or "",
+        "notes": notes or "",
+    }
+    try:
+        body = TargetCreate(
+            name=name,
+            product=product,
+            host=host,
+            port=_coerce_port(port),
+            auth_model=AuthModel(auth_model),
+            secret_ref=secret_ref or None,
+            vpn_required=vpn_required,
+            aliases=parse_aliases(aliases_raw),
+            notes=notes or None,
+        )
+    except (ValidationError, ValueError) as exc:
+        return _render_form_with_errors(
+            request,
+            csrf_session_id=str(session_ctx.session_id),
+            mode="create",
+            exc=exc,
+            values=raw_values,
+        )
+
+    await create_target(body=body, operator=operator, session=db_session)
+    _log.info(
+        "ui_target_create",
+        tenant_id=str(session_ctx.tenant_id),
+        operator_sub=session_ctx.operator_sub,
+        name=body.name,
+    )
+    del request  # HX-Redirect needs no request context.
+    return _redirect_to_list()
+
+
+async def submit_edit(
+    request: Request,
+    session_ctx: UISessionContext,
+    operator: Operator,
+    db_session: AsyncSession,
+    *,
+    target_name: str,
+    product: str,
+    host: str,
+    port: str | None,
+    auth_model: str,
+    secret_ref: str | None,
+    vpn_required: bool,
+    aliases_raw: str | None,
+    notes: str | None,
+) -> HTMLResponse:
+    """Build a :class:`TargetUpdate` and delegate to the REST update handler.
+
+    The edit form posts every field every time (it's pre-populated, so
+    the operator's view of "the target" is the full set), so the PATCH
+    body carries the full editable surface rather than a sparse diff.
+    ``name`` is not patchable (G0.3 contract: rename = delete + create)
+    so it only addresses the row -- it is never in the
+    :class:`TargetUpdate` body. A :class:`ValidationError` re-renders
+    the edit modal with per-field messages; a valid model goes to
+    :func:`~meho_backplane.api.v1.targets.update_target`, which runs the
+    product-registry validation and the 404-on-cross-tenant resolve.
+    """
+    raw_values = {
+        "name": target_name,
+        "product": product,
+        "host": host,
+        "port": port or "",
+        "auth_model": auth_model,
+        "secret_ref": secret_ref or "",
+        "vpn_required": vpn_required,
+        "aliases": aliases_raw or "",
+        "notes": notes or "",
+    }
+    try:
+        body = TargetUpdate(
+            product=product,
+            host=host,
+            port=_coerce_port(port),
+            auth_model=AuthModel(auth_model),
+            secret_ref=secret_ref or None,
+            vpn_required=vpn_required,
+            aliases=parse_aliases(aliases_raw),
+            notes=notes or None,
+        )
+    except (ValidationError, ValueError) as exc:
+        return _render_form_with_errors(
+            request,
+            csrf_session_id=str(session_ctx.session_id),
+            mode="edit",
+            exc=exc,
+            values=raw_values,
+        )
+
+    await update_target(
+        name=target_name,
+        body=body,
+        operator=operator,
+        session=db_session,
+    )
+    _log.info(
+        "ui_target_edit",
+        tenant_id=str(session_ctx.tenant_id),
+        operator_sub=session_ctx.operator_sub,
+        name=target_name,
+    )
+    del request
+    return _redirect_to_list()
+
+
+def _coerce_port(raw: str | None) -> int | None:
+    """Coerce the free-text ``port`` field to ``int | None``.
+
+    An empty / whitespace input is ``None`` (port is optional). A
+    non-empty value is parsed to ``int``; a non-numeric value raises
+    :class:`ValueError`, which the submit handlers catch alongside
+    :class:`ValidationError` so a typo'd port ("80a") surfaces as a
+    field error rather than a 500. The 1-65535 range check is left to
+    :class:`TargetCreate` / :class:`TargetUpdate` so the bound lives in
+    one place (the schema) rather than being duplicated here.
+    """
+    if raw is None or not raw.strip():
+        return None
+    return int(raw.strip())
+
+
+def _render_form_with_errors(
+    request: Request,
+    *,
+    csrf_session_id: str,
+    mode: str,
+    exc: ValidationError | ValueError,
+    values: dict[str, object],
+) -> HTMLResponse:
+    """Re-render the modal form fragment carrying per-field errors + 422.
+
+    The HTMX form targets itself with ``hx-swap="outerHTML"`` so the
+    422 response body (the re-rendered form) replaces the form in
+    place; the operator keeps their typed values (echoed back via
+    ``values``) and sees the field-level messages. 422 is the
+    spec-correct status for "the submitted form failed validation" and
+    matches the status the REST ``POST /api/v1/targets`` returns for the
+    same Pydantic failure.
+    """
+    if isinstance(exc, ValidationError):
+        errors = _validation_errors_by_field(exc)
+    else:
+        # A bare ValueError comes only from the port coercion; attribute
+        # it to the port field so the message lands under the right input.
+        errors = {"port": "port must be a whole number between 1 and 65535"}
+    csrf_token = mint_csrf_token(csrf_session_id)
+    context = _build_form_context(csrf_token, mode=mode)
+    context["errors"] = errors
+    context["values"] = values
+    if mode == "edit":
+        # The edit modal reads ``target.name`` for the form action URL;
+        # echo it back from the submitted values so the re-render posts
+        # to the same target.
+        context["target"] = {"name": values.get("name", "")}
+    template = (
+        "connectors/_create_modal.html" if mode == "create" else "connectors/_edit_modal.html"
+    )
+    response = get_templates().TemplateResponse(
+        request,
+        template,
+        context,
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+    )
+    _set_csrf_cookie(response, csrf_token)
+    return response

--- a/backend/src/meho_backplane/ui/routes/connectors/forms_router.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/forms_router.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Route registration for the target create / edit forms (Task #874).
+
+Thin wrappers that parse FastAPI params + resolve the
+tenant_admin-gated :class:`~meho_backplane.auth.operator.Operator`
+dependency, then hand off to the render / submit helpers in
+:mod:`~meho_backplane.ui.routes.connectors.forms`. Split from the
+render logic so neither module exceeds the chassis-wide ~600-line
+cap and the helpers stay unit-testable without a FastAPI
+:class:`Request` fixture for the projection paths.
+
+Route inventory (all tenant_admin-gated server-side via
+:func:`~meho_backplane.ui.routes.connectors.operator.resolve_operator_or_403`):
+
+* ``GET   /ui/connectors/create``        -- HTMX-loaded create modal.
+* ``POST  /ui/connectors/create``        -- create submit handler.
+* ``GET   /ui/connectors/{name}/edit``   -- HTMX-loaded edit modal.
+* ``PATCH /ui/connectors/{name}``        -- edit submit handler.
+
+Registration order is **load-bearing**: the literal-prefix routes
+(``/ui/connectors/create``, ``/ui/connectors/{name}/edit``) are
+mounted on their own router and the umbrella
+:func:`~meho_backplane.ui.routes.connectors.build_router` includes
+this router **before** the parametrised ``GET /ui/connectors/{name}``
+detail route so the literal ``"create"`` token is never captured as a
+target ``name`` by the detail handler.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Form, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.db.engine import get_session
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.routes.connectors.forms import (
+    render_create_modal,
+    render_edit_modal,
+    submit_create,
+    submit_edit,
+)
+from meho_backplane.ui.routes.connectors.operator import resolve_operator_or_403
+
+__all__ = ["build_forms_router"]
+
+#: Module-level :class:`Depends` closures -- ruff B008 idiom matching
+#: the chassis dashboard / topology / memory routes.
+_require_session_dep = Depends(require_ui_session)
+_require_admin_dep = Depends(resolve_operator_or_403)
+_get_session_dep = Depends(get_session)
+
+#: Form-field length caps mirroring the
+#: :class:`~meho_backplane.targets.schemas.TargetCreate` field bounds.
+#: The server-side Pydantic validation is authoritative; these caps
+#: bound the form-body parse against a paste-from-clipboard accident
+#: before the bytes reach the schema.
+_NAME_MAX = 200
+_PRODUCT_MAX = 100
+_HOST_MAX = 512
+_SECRET_REF_MAX = 1024
+_ALIASES_MAX = 2048
+_NOTES_MAX = 8192
+_PORT_MAX = 16
+
+
+async def _create_modal_handler(
+    request: Request,
+    session_ctx: UISessionContext = _require_session_dep,
+    operator: Operator = _require_admin_dep,
+) -> HTMLResponse:
+    """``GET /ui/connectors/create`` -- HTMX-loaded create modal fragment."""
+    del operator  # gate only; render needs no operator-specific context.
+    return await render_create_modal(request, session_ctx)
+
+
+async def _create_submit_handler(
+    request: Request,
+    # ``Form(default="")`` (not ``Form(...)``) on the text fields so an
+    # empty / omitted submit flows to the ``TargetCreate`` Pydantic
+    # validation rather than tripping FastAPI's own raw-JSON 422 -- the
+    # #874 contract is "invalid input re-renders the *form* with field
+    # errors", which means the modal-rendering handler must own the
+    # validation, not the framework boundary.
+    name: str = Form(default="", max_length=_NAME_MAX),
+    product: str = Form(default="", max_length=_PRODUCT_MAX),
+    host: str = Form(default="", max_length=_HOST_MAX),
+    port: str | None = Form(default=None, max_length=_PORT_MAX),
+    auth_model: str = Form(default="shared_service_account"),
+    secret_ref: str | None = Form(default=None, max_length=_SECRET_REF_MAX),
+    vpn_required: bool = Form(default=False),
+    aliases: str | None = Form(default=None, max_length=_ALIASES_MAX),
+    notes: str | None = Form(default=None, max_length=_NOTES_MAX),
+    session_ctx: UISessionContext = _require_session_dep,
+    operator: Operator = _require_admin_dep,
+    db_session: AsyncSession = _get_session_dep,
+) -> HTMLResponse:
+    """``POST /ui/connectors/create`` -- create one target via the REST handler.
+
+    An unchecked ``vpn_required`` checkbox is omitted from the form
+    body entirely (HTML checkbox semantics), so FastAPI's
+    ``Form(default=False)`` lands the correct ``False``; a checked box
+    posts the literal value the template sets and coerces to ``True``.
+    """
+    return await submit_create(
+        request,
+        session_ctx,
+        operator,
+        db_session,
+        name=name,
+        product=product,
+        host=host,
+        port=port,
+        auth_model=auth_model,
+        secret_ref=secret_ref,
+        vpn_required=vpn_required,
+        aliases_raw=aliases,
+        notes=notes,
+    )
+
+
+async def _edit_modal_handler(
+    request: Request,
+    name: str,
+    session_ctx: UISessionContext = _require_session_dep,
+    operator: Operator = _require_admin_dep,
+    db_session: AsyncSession = _get_session_dep,
+) -> HTMLResponse:
+    """``GET /ui/connectors/{name}/edit`` -- pre-populated edit modal fragment."""
+    del operator  # gate only.
+    return await render_edit_modal(request, session_ctx, db_session, target_name=name)
+
+
+async def _edit_submit_handler(
+    request: Request,
+    name: str,
+    # ``Form(default=...)`` for the same reason as the create handler:
+    # invalid input must re-render the modal with field errors, so the
+    # ``TargetUpdate`` Pydantic pass owns validation rather than the
+    # framework boundary.
+    product: str = Form(default="", max_length=_PRODUCT_MAX),
+    host: str = Form(default="", max_length=_HOST_MAX),
+    port: str | None = Form(default=None, max_length=_PORT_MAX),
+    auth_model: str = Form(default="shared_service_account"),
+    secret_ref: str | None = Form(default=None, max_length=_SECRET_REF_MAX),
+    vpn_required: bool = Form(default=False),
+    aliases: str | None = Form(default=None, max_length=_ALIASES_MAX),
+    notes: str | None = Form(default=None, max_length=_NOTES_MAX),
+    session_ctx: UISessionContext = _require_session_dep,
+    operator: Operator = _require_admin_dep,
+    db_session: AsyncSession = _get_session_dep,
+) -> HTMLResponse:
+    """``PATCH /ui/connectors/{name}`` -- update one target via the REST handler."""
+    return await submit_edit(
+        request,
+        session_ctx,
+        operator,
+        db_session,
+        target_name=name,
+        product=product,
+        host=host,
+        port=port,
+        auth_model=auth_model,
+        secret_ref=secret_ref,
+        vpn_required=vpn_required,
+        aliases_raw=aliases,
+        notes=notes,
+    )
+
+
+def build_forms_router() -> APIRouter:
+    """Construct the target create / edit forms :class:`APIRouter`.
+
+    Factory function (not a module-level constant) so a test app can
+    construct parallel routers without sharing route state -- mirrors
+    the list / detail / probe router convention. The literal-prefix
+    ``/ui/connectors/create`` and ``/ui/connectors/{name}/edit`` routes
+    must register before the parametrised ``GET /ui/connectors/{name}``
+    detail route (handled by the include order in
+    :func:`~meho_backplane.ui.routes.connectors.build_router`).
+    """
+    router = APIRouter(tags=["ui-connectors"])
+    router.add_api_route(
+        "/ui/connectors/create",
+        _create_modal_handler,
+        methods=["GET"],
+        name="ui_connectors_create_modal",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/connectors/create",
+        _create_submit_handler,
+        methods=["POST"],
+        name="ui_connectors_create_submit",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/connectors/{name}/edit",
+        _edit_modal_handler,
+        methods=["GET"],
+        name="ui_connectors_edit_modal",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/connectors/{name}",
+        _edit_submit_handler,
+        methods=["PATCH"],
+        name="ui_connectors_edit_submit",
+        response_class=HTMLResponse,
+    )
+    return router

--- a/backend/src/meho_backplane/ui/routes/connectors/list_view.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/list_view.py
@@ -72,6 +72,10 @@ from meho_backplane.db.engine import get_raw_session
 from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
 from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.routes.connectors.operator import (
+    OperatorRoleProbe,
+    resolve_role_probe,
+)
 from meho_backplane.ui.templating import get_templates
 
 __all__ = ["build_list_router"]
@@ -234,6 +238,7 @@ def _next_direction_factory(
 #: function calls in default argument positions).
 _require_ui_session_dep = Depends(require_ui_session)
 _get_raw_session_dep = Depends(get_raw_session)
+_role_probe_dep = Depends(resolve_role_probe)
 
 
 async def _list_targets(
@@ -337,6 +342,7 @@ async def _render(
     product_filter: str | None,
     session_ctx: UISessionContext,
     db_session: AsyncSession,
+    is_tenant_admin: bool,
 ) -> HTMLResponse:
     """Render the list page or the table-rows fragment.
 
@@ -373,6 +379,14 @@ async def _render(
         "direction": direction,
         "next_direction_for": _next_direction_factory(sort, direction),
         "csrf_token": csrf_token,
+        # tenant_admin gate for the "Create target" button (T2 #874).
+        # The create / edit routes re-check the role server-side via
+        # ``resolve_operator_or_403``; the template hides the affordance
+        # from operators who can't use it so the button only surfaces to
+        # tenant_admins. Fails soft to ``False`` (button hidden) on a
+        # transient JWT-validation hiccup -- the write routes remain the
+        # security authority.
+        "is_tenant_admin": is_tenant_admin,
         # The footer in ``base.html`` reads ``ready`` to colour the
         # readiness pill; the connectors surface doesn't poll readiness
         # (the dashboard owns that), so ship ``False`` here so Jinja's
@@ -412,6 +426,7 @@ def build_list_router() -> APIRouter:
         product: str | None = Query(default=None, max_length=100),
         session_ctx: UISessionContext = _require_ui_session_dep,
         db_session: AsyncSession = _get_raw_session_dep,
+        role_probe: OperatorRoleProbe = _role_probe_dep,
     ) -> HTMLResponse:
         """Serve ``GET /ui/connectors``. See module docstring for the
         URL contract.
@@ -428,6 +443,7 @@ def build_list_router() -> APIRouter:
             product_filter=product,
             session_ctx=session_ctx,
             db_session=db_session,
+            is_tenant_admin=role_probe.is_tenant_admin,
         )
 
     router.add_api_route(

--- a/backend/src/meho_backplane/ui/templates/connectors/_create_modal.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/_create_modal.html
@@ -1,0 +1,59 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  HTMX-loaded create-target modal for the Connectors surface
+  (Initiative #340 Task #874 work item #3). Loaded into
+  ``#connectors-modal-container`` on the list page by the "Create
+  target" button's ``hx-get`` to ``/ui/connectors/create``. The
+  inserted ``<dialog>`` carries ``modal-open`` so it shows without an
+  extra click.
+
+  Submit contract: the form ``hx-post``s to ``/ui/connectors/create``
+  targeting itself (``hx-target="this"``, ``hx-swap="outerHTML"``).
+    * Success -> the handler returns 204 + ``HX-Redirect: /ui/connectors``
+      so HTMX reloads the list page with the new row.
+    * Validation failure -> the handler returns 422 + this same modal
+      re-rendered with ``errors`` populated and the operator's typed
+      values echoed back; HTMX swaps it in place so the operator fixes
+      the field without losing their input.
+
+  CSRF: the page-level ``hx-headers`` directive on ``list.html`` echoes
+  ``X-CSRF-Token``; HTMX inherits it through the inserted form. The
+  route also re-mints + re-sets the ``meho_csrf`` cookie on every modal
+  render so the double-submit pair lines up.
+-#}
+<dialog id="connectors-create-modal" class="modal modal-open">
+  <div class="modal-box max-w-2xl">
+    <h3 class="font-semibold text-lg" id="connectors-create-modal-title">Create target</h3>
+
+    <form
+      id="connectors-create-form"
+      hx-post="/ui/connectors/create"
+      hx-target="this"
+      hx-swap="outerHTML"
+      hx-disabled-elt="find button[type=submit]"
+      class="space-y-3 py-2"
+      aria-labelledby="connectors-create-modal-title"
+    >
+      {% include "connectors/_target_form_fields.html" %}
+
+      <div class="modal-action">
+        <button
+          type="button"
+          class="btn btn-sm btn-ghost"
+          data-action="cancel-create"
+          onclick="document.getElementById('connectors-create-modal').close()"
+        >
+          Cancel
+        </button>
+        <button type="submit" class="btn btn-sm btn-primary" data-action="create-submit">
+          Create
+        </button>
+      </div>
+    </form>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+</dialog>

--- a/backend/src/meho_backplane/ui/templates/connectors/_edit_modal.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/_edit_modal.html
@@ -1,0 +1,58 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  HTMX-loaded edit-target modal for the Connectors surface
+  (Initiative #340 Task #874 work item #4). Loaded into
+  ``#connectors-modal-container`` on the detail page by the "Edit"
+  button's ``hx-get`` to ``/ui/connectors/<name>/edit``. Fields are
+  pre-populated server-side from the resolved target.
+
+  Submit contract: the form ``hx-patch``es to ``/ui/connectors/<name>``
+  targeting itself.
+    * Success -> 204 + ``HX-Redirect: /ui/connectors`` (back to the
+      list with the edited row).
+    * Validation failure -> 422 + this modal re-rendered with
+      ``errors`` + echoed ``values``.
+
+  The ``name`` field renders read-only -- ``name`` is immutable per the
+  G0.3 contract (rename = delete + create), and the PATCH route
+  addresses the target by the path segment, not the form body. CSRF
+  posture matches the create modal.
+-#}
+<dialog id="connectors-edit-modal" class="modal modal-open">
+  <div class="modal-box max-w-2xl">
+    <h3 class="font-semibold text-lg" id="connectors-edit-modal-title">
+      Edit target <span class="font-mono">{{ target.name }}</span>
+    </h3>
+
+    <form
+      id="connectors-edit-form"
+      hx-patch="/ui/connectors/{{ target.name | urlencode }}"
+      hx-target="this"
+      hx-swap="outerHTML"
+      hx-disabled-elt="find button[type=submit]"
+      class="space-y-3 py-2"
+      aria-labelledby="connectors-edit-modal-title"
+    >
+      {% include "connectors/_target_form_fields.html" %}
+
+      <div class="modal-action">
+        <button
+          type="button"
+          class="btn btn-sm btn-ghost"
+          data-action="cancel-edit"
+          onclick="document.getElementById('connectors-edit-modal').close()"
+        >
+          Cancel
+        </button>
+        <button type="submit" class="btn btn-sm btn-primary" data-action="edit-submit">
+          Save changes
+        </button>
+      </div>
+    </form>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+</dialog>

--- a/backend/src/meho_backplane/ui/templates/connectors/_target_form_fields.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/_target_form_fields.html
@@ -1,0 +1,203 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Shared target form fields for the create + edit modals (Task #874).
+  Included by ``_create_modal.html`` and ``_edit_modal.html`` so both
+  modals render the same field set + the same per-field error +
+  echoed-value wiring.
+
+  Context contract (set by
+  :func:`~meho_backplane.ui.routes.connectors.forms._build_form_context`):
+    * ``product_options`` -- list[str] of registered product tokens.
+    * ``auth_models``     -- list[str] of AuthModel enum values.
+    * ``errors``          -- dict[field -> message]; empty on a fresh
+                             render, populated on a 422 re-render.
+    * ``values``          -- dict[field -> submitted value]; echoed back
+                             on a 422 re-render so the operator keeps
+                             their typed input.
+    * ``mode``            -- "create" | "edit". In edit mode the ``name``
+                             input is read-only (rename = delete +
+                             create per the G0.3 contract).
+    * ``target``          -- (edit mode) the pre-populated target dict.
+
+  Client-side validation: HTML5 ``required`` + ``minlength`` + numeric
+  ``min``/``max`` on the port input give immediate DaisyUI feedback;
+  the server-side Pydantic validation (port 1-65535, name min_length=1,
+  auth_model enum) is the authoritative gate and re-renders this
+  fragment with ``errors`` on failure.
+
+  ``field_value(field, fallback)`` macro centralises the
+  "echoed submitted value > pre-populated target value > empty" lookup
+  so each input doesn't re-implement the precedence.
+-#}
+{%- macro field_value(field) -%}
+  {%- if values and field in values and values[field] not in (None, "") -%}
+    {{- values[field] -}}
+  {%- elif mode == "edit" and target is defined and target.get(field) not in (None, "") -%}
+    {{- target[field] -}}
+  {%- endif -%}
+{%- endmacro -%}
+
+{%- macro error_for(field) -%}
+  {%- if errors and field in errors -%}
+    <span class="label-text-alt text-error" role="alert" data-error-for="{{ field }}">
+      {{ errors[field] }}
+    </span>
+  {%- endif -%}
+{%- endmacro -%}
+
+{%- macro error_class(field, base) -%}
+  {%- if errors and field in errors -%}{{ base }}{%- endif -%}
+{%- endmacro -%}
+
+<label class="form-control">
+  <span class="label-text">Name</span>
+  <input
+    type="text"
+    name="name"
+    required
+    minlength="1"
+    maxlength="200"
+    value="{{ field_value('name') }}"
+    {% if mode == "edit" %}readonly{% endif %}
+    class="input input-bordered input-sm font-mono {{ error_class('name', 'input-error') }}"
+    aria-label="Target name"
+    {% if mode == "edit" %}aria-describedby="target-name-immutable-hint"{% endif %}
+  />
+  {% if mode == "edit" %}
+    <span id="target-name-immutable-hint" class="text-xs opacity-60 mt-1">
+      Name is immutable. To rename, delete and re-create the target.
+    </span>
+  {% endif %}
+  {{ error_for('name') }}
+</label>
+
+<div class="grid gap-3 md:grid-cols-2">
+  <label class="form-control">
+    <span class="label-text">Product</span>
+    <select
+      name="product"
+      required
+      class="select select-bordered select-sm {{ error_class('product', 'select-error') }}"
+      aria-label="Connector product"
+    >
+      <option value="" disabled {% if not field_value('product') %}selected{% endif %}>
+        Select a product
+      </option>
+      {% for option in product_options %}
+        <option value="{{ option }}" {% if option == field_value('product') %}selected{% endif %}>
+          {{ option }}
+        </option>
+      {% endfor %}
+    </select>
+    {{ error_for('product') }}
+  </label>
+
+  <label class="form-control">
+    <span class="label-text">Auth model</span>
+    <select
+      name="auth_model"
+      required
+      class="select select-bordered select-sm {{ error_class('auth_model', 'select-error') }}"
+      aria-label="Auth model"
+    >
+      {%- set selected_auth = field_value('auth_model') or 'shared_service_account' -%}
+      {% for option in auth_models %}
+        <option value="{{ option }}" {% if option == selected_auth %}selected{% endif %}>
+          {{ option }}
+        </option>
+      {% endfor %}
+    </select>
+    {{ error_for('auth_model') }}
+  </label>
+</div>
+
+<div class="grid gap-3 md:grid-cols-2">
+  <label class="form-control">
+    <span class="label-text">Host</span>
+    <input
+      type="text"
+      name="host"
+      required
+      minlength="1"
+      maxlength="512"
+      value="{{ field_value('host') }}"
+      class="input input-bordered input-sm font-mono {{ error_class('host', 'input-error') }}"
+      aria-label="Host"
+      placeholder="host.example.internal"
+    />
+    {{ error_for('host') }}
+  </label>
+
+  <label class="form-control">
+    <span class="label-text">Port <span class="opacity-60">(optional)</span></span>
+    <input
+      type="number"
+      name="port"
+      min="1"
+      max="65535"
+      value="{{ field_value('port') }}"
+      class="input input-bordered input-sm {{ error_class('port', 'input-error') }}"
+      aria-label="Port"
+      placeholder="1-65535"
+    />
+    {{ error_for('port') }}
+  </label>
+</div>
+
+<label class="form-control">
+  <span class="label-text">Secret ref <span class="opacity-60">(optional)</span></span>
+  <input
+    type="text"
+    name="secret_ref"
+    maxlength="1024"
+    value="{{ field_value('secret_ref') }}"
+    class="input input-bordered input-sm font-mono {{ error_class('secret_ref', 'input-error') }}"
+    aria-label="Secret reference"
+    placeholder="secret/data/targets/&lt;name&gt;"
+    aria-describedby="target-secret-ref-hint"
+  />
+  <span id="target-secret-ref-hint" class="text-xs opacity-60 mt-1">
+    Vault path the connector reads credentials from.
+  </span>
+  {{ error_for('secret_ref') }}
+</label>
+
+<label class="form-control">
+  <span class="label-text">Aliases <span class="opacity-60">(comma-separated, optional)</span></span>
+  <input
+    type="text"
+    name="aliases"
+    maxlength="2048"
+    value="{{ field_value('aliases') }}"
+    class="input input-bordered input-sm {{ error_class('aliases', 'input-error') }}"
+    aria-label="Aliases"
+    placeholder="prod-cluster, primary"
+  />
+  {{ error_for('aliases') }}
+</label>
+
+<label class="form-control">
+  <span class="label-text">Notes <span class="opacity-60">(optional)</span></span>
+  <textarea
+    name="notes"
+    maxlength="8192"
+    class="textarea textarea-bordered min-h-[6rem] text-sm {{ error_class('notes', 'textarea-error') }}"
+    aria-label="Notes"
+    placeholder="Free-form operator notes."
+  >{{ field_value('notes') }}</textarea>
+  {{ error_for('notes') }}
+</label>
+
+<label class="label cursor-pointer justify-start gap-3">
+  <input
+    type="checkbox"
+    name="vpn_required"
+    value="true"
+    {% if field_value('vpn_required') in ('true', 'True', True) %}checked{% endif %}
+    class="checkbox checkbox-sm"
+    aria-label="VPN required"
+  />
+  <span class="label-text">VPN required</span>
+</label>

--- a/backend/src/meho_backplane/ui/templates/connectors/detail.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/detail.html
@@ -42,7 +42,25 @@
         {% if target.vpn_required %}<span aria-label="VPN required" title="VPN required">&#x1F512;</span>{% endif %}
       </p>
     </div>
+    {# "Edit" button -- tenant_admin only (T2 #874). Same server-side
+       gate as the re-probe button (``resolve_operator_or_403`` on the
+       PATCH route); the hide is the UX affordance. #}
+    {% if is_tenant_admin %}
+      <button
+        type="button"
+        class="btn btn-outline btn-sm"
+        hx-get="/ui/connectors/{{ target.name | urlencode }}/edit"
+        hx-target="#connectors-modal-container"
+        hx-swap="innerHTML"
+        aria-label="Edit {{ target.name }}"
+      >
+        Edit
+      </button>
+    {% endif %}
   </header>
+
+  {# HTMX modal mount point for the edit modal fragment. #}
+  <div id="connectors-modal-container"></div>
 
   <div class="grid gap-4 lg:grid-cols-2">
     {# ---------- Column 1 -- Properties + Fingerprint + Recent ops ---------- #}

--- a/backend/src/meho_backplane/ui/templates/connectors/list.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/list.html
@@ -45,7 +45,26 @@
         fingerprint, recent operations, and available verbs.
       </p>
     </div>
+    {# "Create target" button -- tenant_admin only. The route re-checks
+       the role server-side via ``resolve_operator_or_403`` (403 for a
+       non-admin); this hide is the UX affordance, not the gate. #}
+    {% if is_tenant_admin %}
+      <button
+        type="button"
+        class="btn btn-primary btn-sm"
+        hx-get="/ui/connectors/create"
+        hx-target="#connectors-modal-container"
+        hx-swap="innerHTML"
+        aria-label="Create target"
+      >
+        Create target
+      </button>
+    {% endif %}
   </header>
+
+  {# HTMX modal mount point -- the create modal fragment is swapped in
+     here; the inserted ``<dialog class="modal-open">`` shows itself. #}
+  <div id="connectors-modal-container"></div>
 
   {# ---------- Filter bar ---------- #}
   <form

--- a/backend/tests/test_ui_connectors_forms.py
+++ b/backend/tests/test_ui_connectors_forms.py
@@ -1,0 +1,741 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the target create / edit forms (Task #874).
+
+Initiative #340 (G10.3 Connectors + Targets UI), Task #874 (G10.3-T2).
+The acceptance criteria on issue #874 are:
+
+* Create form fields match G0.3 ``TargetCreate``; product dropdown
+  from the registered-connector set; submit POSTs ``/api/v1/targets``;
+  success -> updated list; invalid input (port outside 1-65535, empty
+  name) -> form re-renders with field errors.
+* Edit form pre-populates server-side; PATCHes ``/api/v1/targets/{name}``.
+* Only ``tenant_admin`` sees create / edit; ``operator`` -> 403
+  (server-side gate).
+* CSRF enforced on create / edit (chassis double-submit).
+* Cross-tenant isolation: cannot edit another tenant's target.
+* ``ruff`` + ``mypy`` clean; ``pytest -n auto
+  backend/tests/test_ui_connectors_forms.py`` passes.
+
+Harness shape mirrors :mod:`backend.tests.test_ui_connectors_view`: a
+minimal FastAPI app wired with the UI session + CSRF middlewares, a
+``web_session`` row carrying a real Keycloak-minted access token so
+the ``resolve_operator_or_403`` dep can re-verify the role, and a fake
+connector registered so ``registered_product_tokens()`` advertises the
+product the create / edit forms POST.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+import warnings
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import FingerprintResult
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.db.models import Tenant
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, CSRFMiddleware, mint_csrf_token
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests._oidc_jwt_helpers import AUDIENCE as _DEFAULT_AUDIENCE
+from tests._oidc_jwt_helpers import ISSUER as _DEFAULT_ISSUER
+from tests._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
+from tests._oidc_jwt_helpers import mint_token as _mint_token
+from tests._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
+from tests._oidc_jwt_helpers import public_jwks as _public_jwks
+
+_BACKPLANE_URL = "https://meho.test"
+
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_TENANT_B = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+_OP_OPERATOR = "op-operator"
+_OP_ADMIN = "op-admin"
+
+_PRODUCT = "fakeprod"
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars for every test (mirrors the view suite)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+class _FakeConnector(Connector):
+    """Deterministic connector so ``registered_product_tokens()`` advertises
+    ``fakeprod`` -- the product the create / edit forms POST + validate against.
+    """
+
+    product = _PRODUCT
+    version = "1.0"
+    impl_id = _PRODUCT
+    supported_version_range = None
+
+    async def fingerprint(self, target: Any) -> FingerprintResult:  # pragma: no cover
+        return FingerprintResult(
+            vendor="FakeVendor",
+            product=_PRODUCT,
+            version="1.0",
+            build="fake-build",
+            reachable=True,
+            probed_at=datetime.now(UTC),
+            probe_method="test",
+        )
+
+    async def probe(self, target: Any) -> Any:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def execute(  # pragma: no cover - unused
+        self,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> Any:
+        raise NotImplementedError
+
+
+@pytest.fixture(autouse=True)
+def _registry_with_fakeprod() -> Iterator[None]:
+    """Register ``fakeprod`` so the product dropdown + POST validator accept it.
+
+    The create / edit POST validate ``product`` against
+    ``registered_product_tokens()``; without a registration the create
+    handler would 422 on every product. Clear + re-register per test so
+    no registration leaks across cases.
+    """
+    clear_registry()
+    register_connector_v2(product=_PRODUCT, version="1.0", impl_id=_PRODUCT, cls=_FakeConnector)
+    yield
+    clear_registry()
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _seed_target(
+    *,
+    tenant_id: uuid.UUID,
+    name: str,
+    product: str = _PRODUCT,
+    host: str = "host.example.test",
+    port: int | None = None,
+    aliases: list[str] | None = None,
+    notes: str | None = None,
+) -> uuid.UUID:
+    target_id = uuid.uuid4()
+    now = datetime.now(UTC)
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                TargetORM(
+                    id=target_id,
+                    tenant_id=tenant_id,
+                    name=name,
+                    aliases=aliases or [],
+                    product=product,
+                    host=host,
+                    port=port,
+                    fqdn=None,
+                    secret_ref=None,
+                    auth_model="shared_service_account",
+                    vpn_required=False,
+                    extras={},
+                    notes=notes,
+                    fingerprint=None,
+                    preferred_impl_id=None,
+                    created_at=now,
+                    updated_at=now,
+                ),
+            )
+
+    asyncio.run(_do())
+    return target_id
+
+
+def _load_target(tenant_id: uuid.UUID, name: str) -> TargetORM | None:
+    """Read a target row back for post-mutation assertions."""
+    from sqlalchemy import select
+
+    async def _do() -> TargetORM | None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            stmt = select(TargetORM).where(
+                TargetORM.tenant_id == tenant_id,
+                TargetORM.name == name,
+            )
+            return (await session.execute(stmt)).scalar_one_or_none()
+
+    return asyncio.run(_do())
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID,
+    access_token: str = "unused",
+    operator_sub: str = _OP_OPERATOR,
+) -> uuid.UUID:
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token=access_token,
+                refresh_token="refresh-token-plaintext",
+                lifetime=timedelta(hours=1),
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _make_keypair_and_jwks() -> tuple[Any, dict[str, Any]]:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        keypair = _make_rsa_keypair("ui-connectors-forms-test-kid")
+    return keypair, _public_jwks(keypair)
+
+
+def _client_with_role(
+    *,
+    tenant_id: uuid.UUID,
+    operator_sub: str,
+    role: TenantRole,
+) -> tuple[TestClient, respx.MockRouter, str]:
+    """Return a TestClient + respx mock + csrf token for the role-gated routes."""
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=operator_sub,
+        tenant_id=str(tenant_id),
+        tenant_role=role.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=tenant_id,
+        access_token=access_token,
+        operator_sub=operator_sub,
+    )
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    _mock_discovery_and_jwks(mock, jwks)
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    csrf_token = mint_csrf_token(str(session_id))
+    client.cookies.set(CSRF_COOKIE_NAME, csrf_token)
+    return client, mock, csrf_token
+
+
+def _form_headers(token: str) -> dict[str, str]:
+    """Headers for an HTMX form submit -- CSRF + HX-Request."""
+    return {"X-CSRF-Token": token, "HX-Request": "true"}
+
+
+# ---------------------------------------------------------------------------
+# Authentication boundary
+# ---------------------------------------------------------------------------
+
+
+def test_create_modal_unauthenticated_redirects_to_login() -> None:
+    """``GET /ui/connectors/create`` without a session 302s to the BFF login."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/connectors/create")
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+
+
+# ---------------------------------------------------------------------------
+# Create modal render -- RBAC gate
+# ---------------------------------------------------------------------------
+
+
+def test_create_modal_renders_for_tenant_admin() -> None:
+    """A tenant_admin GET renders the create modal with product + auth options."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client, mock, _csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.get("/ui/connectors/create")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'id="connectors-create-modal"' in body
+    assert 'hx-post="/ui/connectors/create"' in body
+    # Product dropdown driven by the registered-connector set.
+    assert f'value="{_PRODUCT}"' in body
+    # Auth model dropdown carries the AuthModel enum values.
+    assert "shared_service_account" in body
+    # Required fields present.
+    assert 'name="name"' in body
+    assert 'name="host"' in body
+    assert 'name="port"' in body
+
+
+def test_create_modal_rejects_operator_role_with_403() -> None:
+    """An operator (non-admin) GET on the create modal is 403'd server-side."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client, mock, _csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_OPERATOR,
+        role=TenantRole.OPERATOR,
+    )
+    try:
+        response = client.get("/ui/connectors/create")
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+
+
+def test_list_shows_create_button_for_tenant_admin_only() -> None:
+    """The list page renders the "Create target" button only for tenant_admin."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    admin_client, admin_mock, _ = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        admin_response = admin_client.get("/ui/connectors")
+    finally:
+        admin_mock.stop()
+    assert admin_response.status_code == 200, admin_response.text
+    assert 'hx-get="/ui/connectors/create"' in admin_response.text
+
+    op_client, op_mock, _ = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_OPERATOR,
+        role=TenantRole.OPERATOR,
+    )
+    try:
+        op_response = op_client.get("/ui/connectors")
+    finally:
+        op_mock.stop()
+    assert op_response.status_code == 200, op_response.text
+    assert 'hx-get="/ui/connectors/create"' not in op_response.text
+
+
+# ---------------------------------------------------------------------------
+# Create submit -- success + validation failure
+# ---------------------------------------------------------------------------
+
+
+def test_create_submit_persists_target_and_redirects_to_list() -> None:
+    """A valid create POST persists the row + returns HX-Redirect to the list."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/create",
+            headers=_form_headers(csrf),
+            data={
+                "name": "new-target",
+                "product": _PRODUCT,
+                "host": "new.example.test",
+                "port": "8443",
+                "auth_model": "shared_service_account",
+                "aliases": "alpha, beta, alpha",
+                "notes": "created via UI",
+            },
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 204, response.text
+    assert response.headers["HX-Redirect"] == "/ui/connectors"
+
+    row = _load_target(_TENANT_A, "new-target")
+    assert row is not None
+    assert row.product == _PRODUCT
+    assert row.host == "new.example.test"
+    assert row.port == 8443
+    # Aliases parsed + de-duplicated, first-seen order preserved.
+    assert list(row.aliases) == ["alpha", "beta"]
+    assert row.notes == "created via UI"
+
+
+def test_create_submit_rejects_port_out_of_range_with_field_error() -> None:
+    """A port outside 1-65535 re-renders the form with a 422 + field error."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/create",
+            headers=_form_headers(csrf),
+            data={
+                "name": "bad-port",
+                "product": _PRODUCT,
+                "host": "host.example.test",
+                "port": "99999",
+                "auth_model": "shared_service_account",
+            },
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 422, response.text
+    body = response.text
+    # Form re-rendered (not a redirect) with the port field error.
+    assert 'id="connectors-create-modal"' in body
+    assert 'data-error-for="port"' in body
+    # The operator's typed values are echoed back.
+    assert 'value="bad-port"' in body
+    # Nothing persisted.
+    assert _load_target(_TENANT_A, "bad-port") is None
+
+
+def test_create_submit_rejects_empty_name_with_field_error() -> None:
+    """An empty name re-renders the form with a 422 + name field error."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/create",
+            headers=_form_headers(csrf),
+            data={
+                "name": "",
+                "product": _PRODUCT,
+                "host": "host.example.test",
+                "auth_model": "shared_service_account",
+            },
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 422, response.text
+    assert 'data-error-for="name"' in response.text
+
+
+def test_create_submit_rejects_operator_role_with_403() -> None:
+    """An operator (non-admin) create POST is rejected with 403."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_OPERATOR,
+        role=TenantRole.OPERATOR,
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/create",
+            headers=_form_headers(csrf),
+            data={
+                "name": "op-cant-create",
+                "product": _PRODUCT,
+                "host": "host.example.test",
+                "auth_model": "shared_service_account",
+            },
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+    assert _load_target(_TENANT_A, "op-cant-create") is None
+
+
+def test_create_submit_without_csrf_is_rejected() -> None:
+    """A create POST missing the CSRF header is rejected by the chassis middleware."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client, mock, _csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/create",
+            headers={"HX-Request": "true"},  # no X-CSRF-Token
+            data={
+                "name": "no-csrf",
+                "product": _PRODUCT,
+                "host": "host.example.test",
+                "auth_model": "shared_service_account",
+            },
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+    assert _load_target(_TENANT_A, "no-csrf") is None
+
+
+# ---------------------------------------------------------------------------
+# Edit modal render -- pre-population + RBAC + cross-tenant
+# ---------------------------------------------------------------------------
+
+
+def test_edit_modal_prepopulates_target_fields() -> None:
+    """The edit modal pre-populates the fields from the resolved target."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(
+        tenant_id=_TENANT_A,
+        name="edit-me",
+        host="orig.example.test",
+        port=9000,
+        aliases=["primary"],
+        notes="original notes",
+    )
+    client, mock, _csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.get("/ui/connectors/edit-me/edit")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'id="connectors-edit-modal"' in body
+    assert 'hx-patch="/ui/connectors/edit-me"' in body
+    assert 'value="edit-me"' in body
+    assert 'value="orig.example.test"' in body
+    assert 'value="9000"' in body
+    assert 'value="primary"' in body
+    assert "original notes" in body
+    # Name input is read-only (rename = delete + create).
+    assert "readonly" in body
+
+
+def test_edit_modal_rejects_operator_role_with_403() -> None:
+    """An operator (non-admin) GET on the edit modal is 403'd server-side."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="op-cant-edit")
+    client, mock, _csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_OPERATOR,
+        role=TenantRole.OPERATOR,
+    )
+    try:
+        response = client.get("/ui/connectors/op-cant-edit/edit")
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+
+
+def test_edit_modal_isolates_other_tenants_target() -> None:
+    """An admin in tenant B cannot load tenant A's edit form (404)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_tenant(_TENANT_B, "tenant-b")
+    _seed_target(tenant_id=_TENANT_A, name="a-target")
+    # Admin authenticated in tenant B.
+    client, mock, _csrf = _client_with_role(
+        tenant_id=_TENANT_B,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.get("/ui/connectors/a-target/edit")
+    finally:
+        mock.stop()
+    assert response.status_code == 404, response.text
+
+
+# ---------------------------------------------------------------------------
+# Edit submit -- success + validation + cross-tenant
+# ---------------------------------------------------------------------------
+
+
+def test_edit_submit_patches_target_and_redirects_to_list() -> None:
+    """A valid edit PATCH updates the row + returns HX-Redirect to the list."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="patch-me", host="old.example.test", port=80)
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.patch(
+            "/ui/connectors/patch-me",
+            headers=_form_headers(csrf),
+            data={
+                "product": _PRODUCT,
+                "host": "new.example.test",
+                "port": "443",
+                "auth_model": "per_user",
+                "aliases": "renamed",
+                "notes": "patched",
+            },
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 204, response.text
+    assert response.headers["HX-Redirect"] == "/ui/connectors"
+
+    row = _load_target(_TENANT_A, "patch-me")
+    assert row is not None
+    assert row.host == "new.example.test"
+    assert row.port == 443
+    assert row.auth_model == "per_user"
+    assert list(row.aliases) == ["renamed"]
+    assert row.notes == "patched"
+
+
+def test_edit_submit_rejects_port_out_of_range_with_field_error() -> None:
+    """An out-of-range port on edit re-renders the edit modal with a 422 + error."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="patch-bad-port", port=80)
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.patch(
+            "/ui/connectors/patch-bad-port",
+            headers=_form_headers(csrf),
+            data={
+                "product": _PRODUCT,
+                "host": "host.example.test",
+                "port": "70000",
+                "auth_model": "shared_service_account",
+            },
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 422, response.text
+    body = response.text
+    assert 'id="connectors-edit-modal"' in body
+    assert 'data-error-for="port"' in body
+    # Unchanged in the DB.
+    row = _load_target(_TENANT_A, "patch-bad-port")
+    assert row is not None
+    assert row.port == 80
+
+
+def test_edit_submit_isolates_other_tenants_target() -> None:
+    """An admin in tenant B cannot PATCH tenant A's target (404)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_tenant(_TENANT_B, "tenant-b")
+    _seed_target(tenant_id=_TENANT_A, name="a-only", host="orig.example.test")
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_B,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.patch(
+            "/ui/connectors/a-only",
+            headers=_form_headers(csrf),
+            data={
+                "product": _PRODUCT,
+                "host": "hijacked.example.test",
+                "auth_model": "shared_service_account",
+            },
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 404, response.text
+    # Tenant A's row is untouched.
+    row = _load_target(_TENANT_A, "a-only")
+    assert row is not None
+    assert row.host == "orig.example.test"
+
+
+def test_edit_submit_rejects_operator_role_with_403() -> None:
+    """An operator (non-admin) edit PATCH is rejected with 403."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="op-patch", host="orig.example.test")
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_OPERATOR,
+        role=TenantRole.OPERATOR,
+    )
+    try:
+        response = client.patch(
+            "/ui/connectors/op-patch",
+            headers=_form_headers(csrf),
+            data={
+                "product": _PRODUCT,
+                "host": "changed.example.test",
+                "auth_model": "shared_service_account",
+            },
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+    row = _load_target(_TENANT_A, "op-patch")
+    assert row is not None
+    assert row.host == "orig.example.test"

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -7032,6 +7032,153 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/connectors/create": {
+      "get": {
+        "tags": [
+          "ui-connectors"
+        ],
+        "summary": "Ui Connectors Create Modal",
+        "description": "``GET /ui/connectors/create`` -- HTMX-loaded create modal fragment.",
+        "operationId": "ui_connectors_create_modal_ui_connectors_create_get",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ui-connectors"
+        ],
+        "summary": "Ui Connectors Create Submit",
+        "description": "``POST /ui/connectors/create`` -- create one target via the REST handler.\n\nAn unchecked ``vpn_required`` checkbox is omitted from the form\nbody entirely (HTML checkbox semantics), so FastAPI's\n``Form(default=False)`` lands the correct ``False``; a checked box\nposts the literal value the template sets and coerces to ``True``.",
+        "operationId": "ui_connectors_create_submit_ui_connectors_create_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_ui_connectors_create_submit_ui_connectors_create_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/connectors/{name}/edit": {
+      "get": {
+        "tags": [
+          "ui-connectors"
+        ],
+        "summary": "Ui Connectors Edit Modal",
+        "description": "``GET /ui/connectors/{name}/edit`` -- pre-populated edit modal fragment.",
+        "operationId": "ui_connectors_edit_modal_ui_connectors__name__edit_get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -7057,6 +7204,56 @@
       }
     },
     "/ui/connectors/{name}": {
+      "patch": {
+        "tags": [
+          "ui-connectors"
+        ],
+        "summary": "Ui Connectors Edit Submit",
+        "description": "``PATCH /ui/connectors/{name}`` -- update one target via the REST handler.",
+        "operationId": "ui_connectors_edit_submit_ui_connectors__name__patch",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_ui_connectors_edit_submit_ui_connectors__name__patch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
       "get": {
         "tags": [
           "ui-connectors"
@@ -8337,6 +8534,124 @@
         ],
         "title": "BaselineMetricsOverride",
         "description": "Per-surface baseline metrics supplied by the caller.\n\nCriterion 4 (MEHO \u2265 baseline) needs side-by-side numbers from a\nbaseline retrieval (``grep -r kb/`` for kb; ``grep paths.txt +\nyq`` for operations). The v0.2 backplane has no checked-in\ncorpus snapshot to evaluate the baseline against (see\n:mod:`meho_backplane.api.v1.retrieve_eval` \u2014 explicit\n``baseline=grep`` on that route is rejected with 501); the CLI\nruns the baseline locally against the operator's kb/ checkout and\ncan pass the resulting numbers here so the retire-checklist\nverdict honestly reflects criterion 4 instead of always reporting\nyellow (\"baseline did not run\") on the API path.\n\nWithout an override, criterion 4 stays yellow for v0.2 production\ncallers \u2014 the documented \"READY TO RETIRE\" path is unreachable\nvia the bare API alone, which is the honest v0.2 posture. T7\n(#446) / v0.2.next is expected to wire a server-side corpus\nsnapshot and remove the need for this override."
+      },
+      "Body_ui_connectors_create_submit_ui_connectors_create_post": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 200,
+            "title": "Name",
+            "default": ""
+          },
+          "product": {
+            "type": "string",
+            "maxLength": 100,
+            "title": "Product",
+            "default": ""
+          },
+          "host": {
+            "type": "string",
+            "maxLength": 512,
+            "title": "Host",
+            "default": ""
+          },
+          "port": {
+            "type": "string",
+            "maxLength": 16,
+            "nullable": true,
+            "title": "Port"
+          },
+          "auth_model": {
+            "type": "string",
+            "title": "Auth Model",
+            "default": "shared_service_account"
+          },
+          "secret_ref": {
+            "type": "string",
+            "maxLength": 1024,
+            "nullable": true,
+            "title": "Secret Ref"
+          },
+          "vpn_required": {
+            "type": "boolean",
+            "title": "Vpn Required",
+            "default": false
+          },
+          "aliases": {
+            "type": "string",
+            "maxLength": 2048,
+            "nullable": true,
+            "title": "Aliases"
+          },
+          "notes": {
+            "type": "string",
+            "maxLength": 8192,
+            "nullable": true,
+            "title": "Notes"
+          },
+          "session_ctx": {
+            "$ref": "#/components/schemas/UISessionContext",
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "title": "Body_ui_connectors_create_submit_ui_connectors_create_post"
+      },
+      "Body_ui_connectors_edit_submit_ui_connectors__name__patch": {
+        "properties": {
+          "product": {
+            "type": "string",
+            "maxLength": 100,
+            "title": "Product",
+            "default": ""
+          },
+          "host": {
+            "type": "string",
+            "maxLength": 512,
+            "title": "Host",
+            "default": ""
+          },
+          "port": {
+            "type": "string",
+            "maxLength": 16,
+            "nullable": true,
+            "title": "Port"
+          },
+          "auth_model": {
+            "type": "string",
+            "title": "Auth Model",
+            "default": "shared_service_account"
+          },
+          "secret_ref": {
+            "type": "string",
+            "maxLength": 1024,
+            "nullable": true,
+            "title": "Secret Ref"
+          },
+          "vpn_required": {
+            "type": "boolean",
+            "title": "Vpn Required",
+            "default": false
+          },
+          "aliases": {
+            "type": "string",
+            "maxLength": 2048,
+            "nullable": true,
+            "title": "Aliases"
+          },
+          "notes": {
+            "type": "string",
+            "maxLength": 8192,
+            "nullable": true,
+            "title": "Notes"
+          },
+          "session_ctx": {
+            "$ref": "#/components/schemas/UISessionContext",
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "title": "Body_ui_connectors_edit_submit_ui_connectors__name__patch"
       },
       "Body_ui_memory_bulk_ui_memory_bulk_post": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -909,6 +909,53 @@ type BaselineMetricsOverride struct {
 	PrecisionAt5 float32 `json:"precision_at_5"`
 }
 
+// BodyUiConnectorsCreateSubmitUiConnectorsCreatePost defines model for Body_ui_connectors_create_submit_ui_connectors_create_post.
+type BodyUiConnectorsCreateSubmitUiConnectorsCreatePost struct {
+	Aliases   *string `json:"aliases"`
+	AuthModel *string `json:"auth_model,omitempty"`
+	Host      *string `json:"host,omitempty"`
+	Name      *string `json:"name,omitempty"`
+	Notes     *string `json:"notes"`
+	Port      *string `json:"port"`
+	Product   *string `json:"product,omitempty"`
+	SecretRef *string `json:"secret_ref"`
+
+	// SessionCtx Per-request session identity exposed on ``request.state``.
+	//
+	// Frozen so a route handler that stashes the context on a logger
+	// or forwards it to a service layer cannot accidentally mutate
+	// fields downstream. The shape mirrors :class:`Operator` for the
+	// fields T5 (#866) needs to render an authenticated page header;
+	// ``raw_jwt`` / ``tenant_role`` are intentionally absent because
+	// the session-cookie path does not load them today (the encrypted
+	// row carries only the access token, not the decoded claims).
+	SessionCtx  *UISessionContext `json:"session_ctx,omitempty"`
+	VpnRequired *bool             `json:"vpn_required,omitempty"`
+}
+
+// BodyUiConnectorsEditSubmitUiConnectorsNamePatch defines model for Body_ui_connectors_edit_submit_ui_connectors__name__patch.
+type BodyUiConnectorsEditSubmitUiConnectorsNamePatch struct {
+	Aliases   *string `json:"aliases"`
+	AuthModel *string `json:"auth_model,omitempty"`
+	Host      *string `json:"host,omitempty"`
+	Notes     *string `json:"notes"`
+	Port      *string `json:"port"`
+	Product   *string `json:"product,omitempty"`
+	SecretRef *string `json:"secret_ref"`
+
+	// SessionCtx Per-request session identity exposed on ``request.state``.
+	//
+	// Frozen so a route handler that stashes the context on a logger
+	// or forwards it to a service layer cannot accidentally mutate
+	// fields downstream. The shape mirrors :class:`Operator` for the
+	// fields T5 (#866) needs to render an authenticated page header;
+	// ``raw_jwt`` / ``tenant_role`` are intentionally absent because
+	// the session-cookie path does not load them today (the encrypted
+	// row carries only the access token, not the decoded claims).
+	SessionCtx  *UISessionContext `json:"session_ctx,omitempty"`
+	VpnRequired *bool             `json:"vpn_required,omitempty"`
+}
+
 // BodyUiMemoryBulkUiMemoryBulkPost defines model for Body_ui_memory_bulk_ui_memory_bulk_post.
 type BodyUiMemoryBulkUiMemoryBulkPost struct {
 	Action         string    `json:"action"`
@@ -4288,8 +4335,23 @@ type AnnotateEdgeRouteApiV1TopologyEdgesPostJSONRequestBody = UnderscoreAnnotate
 // BulkImportEdgesRouteApiV1TopologyEdgesBulkPostJSONRequestBody defines body for BulkImportEdgesRouteApiV1TopologyEdgesBulkPost for application/json ContentType.
 type BulkImportEdgesRouteApiV1TopologyEdgesBulkPostJSONRequestBody = UnderscoreBulkImportRequest
 
+// UiConnectorsListUiConnectorsGetJSONRequestBody defines body for UiConnectorsListUiConnectorsGet for application/json ContentType.
+type UiConnectorsListUiConnectorsGetJSONRequestBody = UISessionContext
+
+// UiConnectorsCreateModalUiConnectorsCreateGetJSONRequestBody defines body for UiConnectorsCreateModalUiConnectorsCreateGet for application/json ContentType.
+type UiConnectorsCreateModalUiConnectorsCreateGetJSONRequestBody = UISessionContext
+
+// UiConnectorsCreateSubmitUiConnectorsCreatePostFormdataRequestBody defines body for UiConnectorsCreateSubmitUiConnectorsCreatePost for application/x-www-form-urlencoded ContentType.
+type UiConnectorsCreateSubmitUiConnectorsCreatePostFormdataRequestBody = BodyUiConnectorsCreateSubmitUiConnectorsCreatePost
+
 // UiConnectorsDetailUiConnectorsNameGetJSONRequestBody defines body for UiConnectorsDetailUiConnectorsNameGet for application/json ContentType.
 type UiConnectorsDetailUiConnectorsNameGetJSONRequestBody = UISessionContext
+
+// UiConnectorsEditSubmitUiConnectorsNamePatchFormdataRequestBody defines body for UiConnectorsEditSubmitUiConnectorsNamePatch for application/x-www-form-urlencoded ContentType.
+type UiConnectorsEditSubmitUiConnectorsNamePatchFormdataRequestBody = BodyUiConnectorsEditSubmitUiConnectorsNamePatch
+
+// UiConnectorsEditModalUiConnectorsNameEditGetJSONRequestBody defines body for UiConnectorsEditModalUiConnectorsNameEditGet for application/json ContentType.
+type UiConnectorsEditModalUiConnectorsNameEditGetJSONRequestBody = UISessionContext
 
 // UiConnectorsReprobeUiConnectorsNameProbePostJSONRequestBody defines body for UiConnectorsReprobeUiConnectorsNameProbePost for application/json ContentType.
 type UiConnectorsReprobeUiConnectorsNameProbePostJSONRequestBody = UISessionContext
@@ -4943,13 +5005,35 @@ type ClientInterface interface {
 	// UiBroadcastStreamUiBroadcastStreamGet request
 	UiBroadcastStreamUiBroadcastStreamGet(ctx context.Context, params *UiBroadcastStreamUiBroadcastStreamGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// UiConnectorsListUiConnectorsGet request
-	UiConnectorsListUiConnectorsGet(ctx context.Context, params *UiConnectorsListUiConnectorsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// UiConnectorsListUiConnectorsGetWithBody request with any body
+	UiConnectorsListUiConnectorsGetWithBody(ctx context.Context, params *UiConnectorsListUiConnectorsGetParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiConnectorsListUiConnectorsGet(ctx context.Context, params *UiConnectorsListUiConnectorsGetParams, body UiConnectorsListUiConnectorsGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiConnectorsCreateModalUiConnectorsCreateGetWithBody request with any body
+	UiConnectorsCreateModalUiConnectorsCreateGetWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiConnectorsCreateModalUiConnectorsCreateGet(ctx context.Context, body UiConnectorsCreateModalUiConnectorsCreateGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiConnectorsCreateSubmitUiConnectorsCreatePostWithBody request with any body
+	UiConnectorsCreateSubmitUiConnectorsCreatePostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiConnectorsCreateSubmitUiConnectorsCreatePostWithFormdataBody(ctx context.Context, body UiConnectorsCreateSubmitUiConnectorsCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiConnectorsDetailUiConnectorsNameGetWithBody request with any body
 	UiConnectorsDetailUiConnectorsNameGetWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UiConnectorsDetailUiConnectorsNameGet(ctx context.Context, name string, body UiConnectorsDetailUiConnectorsNameGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiConnectorsEditSubmitUiConnectorsNamePatchWithBody request with any body
+	UiConnectorsEditSubmitUiConnectorsNamePatchWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiConnectorsEditSubmitUiConnectorsNamePatchWithFormdataBody(ctx context.Context, name string, body UiConnectorsEditSubmitUiConnectorsNamePatchFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiConnectorsEditModalUiConnectorsNameEditGetWithBody request with any body
+	UiConnectorsEditModalUiConnectorsNameEditGetWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiConnectorsEditModalUiConnectorsNameEditGet(ctx context.Context, name string, body UiConnectorsEditModalUiConnectorsNameEditGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiConnectorsReprobeUiConnectorsNameProbePostWithBody request with any body
 	UiConnectorsReprobeUiConnectorsNameProbePostWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -6595,8 +6679,68 @@ func (c *Client) UiBroadcastStreamUiBroadcastStreamGet(ctx context.Context, para
 	return c.Client.Do(req)
 }
 
-func (c *Client) UiConnectorsListUiConnectorsGet(ctx context.Context, params *UiConnectorsListUiConnectorsGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUiConnectorsListUiConnectorsGetRequest(c.Server, params)
+func (c *Client) UiConnectorsListUiConnectorsGetWithBody(ctx context.Context, params *UiConnectorsListUiConnectorsGetParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsListUiConnectorsGetRequestWithBody(c.Server, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsListUiConnectorsGet(ctx context.Context, params *UiConnectorsListUiConnectorsGetParams, body UiConnectorsListUiConnectorsGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsListUiConnectorsGetRequest(c.Server, params, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsCreateModalUiConnectorsCreateGetWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsCreateModalUiConnectorsCreateGetRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsCreateModalUiConnectorsCreateGet(ctx context.Context, body UiConnectorsCreateModalUiConnectorsCreateGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsCreateModalUiConnectorsCreateGetRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsCreateSubmitUiConnectorsCreatePostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsCreateSubmitUiConnectorsCreatePostRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsCreateSubmitUiConnectorsCreatePostWithFormdataBody(ctx context.Context, body UiConnectorsCreateSubmitUiConnectorsCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsCreateSubmitUiConnectorsCreatePostRequestWithFormdataBody(c.Server, body)
 	if err != nil {
 		return nil, err
 	}
@@ -6621,6 +6765,54 @@ func (c *Client) UiConnectorsDetailUiConnectorsNameGetWithBody(ctx context.Conte
 
 func (c *Client) UiConnectorsDetailUiConnectorsNameGet(ctx context.Context, name string, body UiConnectorsDetailUiConnectorsNameGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUiConnectorsDetailUiConnectorsNameGetRequest(c.Server, name, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsEditSubmitUiConnectorsNamePatchWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsEditSubmitUiConnectorsNamePatchRequestWithBody(c.Server, name, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsEditSubmitUiConnectorsNamePatchWithFormdataBody(ctx context.Context, name string, body UiConnectorsEditSubmitUiConnectorsNamePatchFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsEditSubmitUiConnectorsNamePatchRequestWithFormdataBody(c.Server, name, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsEditModalUiConnectorsNameEditGetWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsEditModalUiConnectorsNameEditGetRequestWithBody(c.Server, name, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsEditModalUiConnectorsNameEditGet(ctx context.Context, name string, body UiConnectorsEditModalUiConnectorsNameEditGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsEditModalUiConnectorsNameEditGetRequest(c.Server, name, body)
 	if err != nil {
 		return nil, err
 	}
@@ -13537,8 +13729,19 @@ func NewUiBroadcastStreamUiBroadcastStreamGetRequest(server string, params *UiBr
 	return req, nil
 }
 
-// NewUiConnectorsListUiConnectorsGetRequest generates requests for UiConnectorsListUiConnectorsGet
-func NewUiConnectorsListUiConnectorsGetRequest(server string, params *UiConnectorsListUiConnectorsGetParams) (*http.Request, error) {
+// NewUiConnectorsListUiConnectorsGetRequest calls the generic UiConnectorsListUiConnectorsGet builder with application/json body
+func NewUiConnectorsListUiConnectorsGetRequest(server string, params *UiConnectorsListUiConnectorsGetParams, body UiConnectorsListUiConnectorsGetJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUiConnectorsListUiConnectorsGetRequestWithBody(server, params, "application/json", bodyReader)
+}
+
+// NewUiConnectorsListUiConnectorsGetRequestWithBody generates requests for UiConnectorsListUiConnectorsGet with any type of body
+func NewUiConnectorsListUiConnectorsGetRequestWithBody(server string, params *UiConnectorsListUiConnectorsGetParams, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	serverURL, err := url.Parse(server)
@@ -13610,10 +13813,92 @@ func NewUiConnectorsListUiConnectorsGetRequest(server string, params *UiConnecto
 		queryURL.RawQuery = queryValues.Encode()
 	}
 
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	req, err := http.NewRequest("GET", queryURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiConnectorsCreateModalUiConnectorsCreateGetRequest calls the generic UiConnectorsCreateModalUiConnectorsCreateGet builder with application/json body
+func NewUiConnectorsCreateModalUiConnectorsCreateGetRequest(server string, body UiConnectorsCreateModalUiConnectorsCreateGetJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUiConnectorsCreateModalUiConnectorsCreateGetRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewUiConnectorsCreateModalUiConnectorsCreateGetRequestWithBody generates requests for UiConnectorsCreateModalUiConnectorsCreateGet with any type of body
+func NewUiConnectorsCreateModalUiConnectorsCreateGetRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/connectors/create")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiConnectorsCreateSubmitUiConnectorsCreatePostRequestWithFormdataBody calls the generic UiConnectorsCreateSubmitUiConnectorsCreatePost builder with application/x-www-form-urlencoded body
+func NewUiConnectorsCreateSubmitUiConnectorsCreatePostRequestWithFormdataBody(server string, body UiConnectorsCreateSubmitUiConnectorsCreatePostFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewUiConnectorsCreateSubmitUiConnectorsCreatePostRequestWithBody(server, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewUiConnectorsCreateSubmitUiConnectorsCreatePostRequestWithBody generates requests for UiConnectorsCreateSubmitUiConnectorsCreatePost with any type of body
+func NewUiConnectorsCreateSubmitUiConnectorsCreatePostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/connectors/create")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
 
 	return req, nil
 }
@@ -13646,6 +13931,100 @@ func NewUiConnectorsDetailUiConnectorsNameGetRequestWithBody(server string, name
 	}
 
 	operationPath := fmt.Sprintf("/ui/connectors/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiConnectorsEditSubmitUiConnectorsNamePatchRequestWithFormdataBody calls the generic UiConnectorsEditSubmitUiConnectorsNamePatch builder with application/x-www-form-urlencoded body
+func NewUiConnectorsEditSubmitUiConnectorsNamePatchRequestWithFormdataBody(server string, name string, body UiConnectorsEditSubmitUiConnectorsNamePatchFormdataRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	bodyStr, err := runtime.MarshalForm(body, nil)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = strings.NewReader(bodyStr.Encode())
+	return NewUiConnectorsEditSubmitUiConnectorsNamePatchRequestWithBody(server, name, "application/x-www-form-urlencoded", bodyReader)
+}
+
+// NewUiConnectorsEditSubmitUiConnectorsNamePatchRequestWithBody generates requests for UiConnectorsEditSubmitUiConnectorsNamePatch with any type of body
+func NewUiConnectorsEditSubmitUiConnectorsNamePatchRequestWithBody(server string, name string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/connectors/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PATCH", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiConnectorsEditModalUiConnectorsNameEditGetRequest calls the generic UiConnectorsEditModalUiConnectorsNameEditGet builder with application/json body
+func NewUiConnectorsEditModalUiConnectorsNameEditGetRequest(server string, name string, body UiConnectorsEditModalUiConnectorsNameEditGetJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUiConnectorsEditModalUiConnectorsNameEditGetRequestWithBody(server, name, "application/json", bodyReader)
+}
+
+// NewUiConnectorsEditModalUiConnectorsNameEditGetRequestWithBody generates requests for UiConnectorsEditModalUiConnectorsNameEditGet with any type of body
+func NewUiConnectorsEditModalUiConnectorsNameEditGetRequestWithBody(server string, name string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/connectors/%s/edit", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -15010,13 +15389,35 @@ type ClientWithResponsesInterface interface {
 	// UiBroadcastStreamUiBroadcastStreamGetWithResponse request
 	UiBroadcastStreamUiBroadcastStreamGetWithResponse(ctx context.Context, params *UiBroadcastStreamUiBroadcastStreamGetParams, reqEditors ...RequestEditorFn) (*UiBroadcastStreamUiBroadcastStreamGetResponse, error)
 
-	// UiConnectorsListUiConnectorsGetWithResponse request
-	UiConnectorsListUiConnectorsGetWithResponse(ctx context.Context, params *UiConnectorsListUiConnectorsGetParams, reqEditors ...RequestEditorFn) (*UiConnectorsListUiConnectorsGetResponse, error)
+	// UiConnectorsListUiConnectorsGetWithBodyWithResponse request with any body
+	UiConnectorsListUiConnectorsGetWithBodyWithResponse(ctx context.Context, params *UiConnectorsListUiConnectorsGetParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsListUiConnectorsGetResponse, error)
+
+	UiConnectorsListUiConnectorsGetWithResponse(ctx context.Context, params *UiConnectorsListUiConnectorsGetParams, body UiConnectorsListUiConnectorsGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsListUiConnectorsGetResponse, error)
+
+	// UiConnectorsCreateModalUiConnectorsCreateGetWithBodyWithResponse request with any body
+	UiConnectorsCreateModalUiConnectorsCreateGetWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsCreateModalUiConnectorsCreateGetResponse, error)
+
+	UiConnectorsCreateModalUiConnectorsCreateGetWithResponse(ctx context.Context, body UiConnectorsCreateModalUiConnectorsCreateGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsCreateModalUiConnectorsCreateGetResponse, error)
+
+	// UiConnectorsCreateSubmitUiConnectorsCreatePostWithBodyWithResponse request with any body
+	UiConnectorsCreateSubmitUiConnectorsCreatePostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsCreateSubmitUiConnectorsCreatePostResponse, error)
+
+	UiConnectorsCreateSubmitUiConnectorsCreatePostWithFormdataBodyWithResponse(ctx context.Context, body UiConnectorsCreateSubmitUiConnectorsCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsCreateSubmitUiConnectorsCreatePostResponse, error)
 
 	// UiConnectorsDetailUiConnectorsNameGetWithBodyWithResponse request with any body
 	UiConnectorsDetailUiConnectorsNameGetWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsDetailUiConnectorsNameGetResponse, error)
 
 	UiConnectorsDetailUiConnectorsNameGetWithResponse(ctx context.Context, name string, body UiConnectorsDetailUiConnectorsNameGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsDetailUiConnectorsNameGetResponse, error)
+
+	// UiConnectorsEditSubmitUiConnectorsNamePatchWithBodyWithResponse request with any body
+	UiConnectorsEditSubmitUiConnectorsNamePatchWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsEditSubmitUiConnectorsNamePatchResponse, error)
+
+	UiConnectorsEditSubmitUiConnectorsNamePatchWithFormdataBodyWithResponse(ctx context.Context, name string, body UiConnectorsEditSubmitUiConnectorsNamePatchFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsEditSubmitUiConnectorsNamePatchResponse, error)
+
+	// UiConnectorsEditModalUiConnectorsNameEditGetWithBodyWithResponse request with any body
+	UiConnectorsEditModalUiConnectorsNameEditGetWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsEditModalUiConnectorsNameEditGetResponse, error)
+
+	UiConnectorsEditModalUiConnectorsNameEditGetWithResponse(ctx context.Context, name string, body UiConnectorsEditModalUiConnectorsNameEditGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsEditModalUiConnectorsNameEditGetResponse, error)
 
 	// UiConnectorsReprobeUiConnectorsNameProbePostWithBodyWithResponse request with any body
 	UiConnectorsReprobeUiConnectorsNameProbePostWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsReprobeUiConnectorsNameProbePostResponse, error)
@@ -17435,6 +17836,50 @@ func (r UiConnectorsListUiConnectorsGetResponse) StatusCode() int {
 	return 0
 }
 
+type UiConnectorsCreateModalUiConnectorsCreateGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiConnectorsCreateModalUiConnectorsCreateGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiConnectorsCreateModalUiConnectorsCreateGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiConnectorsCreateSubmitUiConnectorsCreatePostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiConnectorsCreateSubmitUiConnectorsCreatePostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiConnectorsCreateSubmitUiConnectorsCreatePostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type UiConnectorsDetailUiConnectorsNameGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -17451,6 +17896,50 @@ func (r UiConnectorsDetailUiConnectorsNameGetResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r UiConnectorsDetailUiConnectorsNameGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiConnectorsEditSubmitUiConnectorsNamePatchResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiConnectorsEditSubmitUiConnectorsNamePatchResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiConnectorsEditSubmitUiConnectorsNamePatchResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiConnectorsEditModalUiConnectorsNameEditGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiConnectorsEditModalUiConnectorsNameEditGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiConnectorsEditModalUiConnectorsNameEditGetResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -18978,13 +19467,55 @@ func (c *ClientWithResponses) UiBroadcastStreamUiBroadcastStreamGetWithResponse(
 	return ParseUiBroadcastStreamUiBroadcastStreamGetResponse(rsp)
 }
 
-// UiConnectorsListUiConnectorsGetWithResponse request returning *UiConnectorsListUiConnectorsGetResponse
-func (c *ClientWithResponses) UiConnectorsListUiConnectorsGetWithResponse(ctx context.Context, params *UiConnectorsListUiConnectorsGetParams, reqEditors ...RequestEditorFn) (*UiConnectorsListUiConnectorsGetResponse, error) {
-	rsp, err := c.UiConnectorsListUiConnectorsGet(ctx, params, reqEditors...)
+// UiConnectorsListUiConnectorsGetWithBodyWithResponse request with arbitrary body returning *UiConnectorsListUiConnectorsGetResponse
+func (c *ClientWithResponses) UiConnectorsListUiConnectorsGetWithBodyWithResponse(ctx context.Context, params *UiConnectorsListUiConnectorsGetParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsListUiConnectorsGetResponse, error) {
+	rsp, err := c.UiConnectorsListUiConnectorsGetWithBody(ctx, params, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
 	return ParseUiConnectorsListUiConnectorsGetResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiConnectorsListUiConnectorsGetWithResponse(ctx context.Context, params *UiConnectorsListUiConnectorsGetParams, body UiConnectorsListUiConnectorsGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsListUiConnectorsGetResponse, error) {
+	rsp, err := c.UiConnectorsListUiConnectorsGet(ctx, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsListUiConnectorsGetResponse(rsp)
+}
+
+// UiConnectorsCreateModalUiConnectorsCreateGetWithBodyWithResponse request with arbitrary body returning *UiConnectorsCreateModalUiConnectorsCreateGetResponse
+func (c *ClientWithResponses) UiConnectorsCreateModalUiConnectorsCreateGetWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsCreateModalUiConnectorsCreateGetResponse, error) {
+	rsp, err := c.UiConnectorsCreateModalUiConnectorsCreateGetWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsCreateModalUiConnectorsCreateGetResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiConnectorsCreateModalUiConnectorsCreateGetWithResponse(ctx context.Context, body UiConnectorsCreateModalUiConnectorsCreateGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsCreateModalUiConnectorsCreateGetResponse, error) {
+	rsp, err := c.UiConnectorsCreateModalUiConnectorsCreateGet(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsCreateModalUiConnectorsCreateGetResponse(rsp)
+}
+
+// UiConnectorsCreateSubmitUiConnectorsCreatePostWithBodyWithResponse request with arbitrary body returning *UiConnectorsCreateSubmitUiConnectorsCreatePostResponse
+func (c *ClientWithResponses) UiConnectorsCreateSubmitUiConnectorsCreatePostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsCreateSubmitUiConnectorsCreatePostResponse, error) {
+	rsp, err := c.UiConnectorsCreateSubmitUiConnectorsCreatePostWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsCreateSubmitUiConnectorsCreatePostResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiConnectorsCreateSubmitUiConnectorsCreatePostWithFormdataBodyWithResponse(ctx context.Context, body UiConnectorsCreateSubmitUiConnectorsCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsCreateSubmitUiConnectorsCreatePostResponse, error) {
+	rsp, err := c.UiConnectorsCreateSubmitUiConnectorsCreatePostWithFormdataBody(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsCreateSubmitUiConnectorsCreatePostResponse(rsp)
 }
 
 // UiConnectorsDetailUiConnectorsNameGetWithBodyWithResponse request with arbitrary body returning *UiConnectorsDetailUiConnectorsNameGetResponse
@@ -19002,6 +19533,40 @@ func (c *ClientWithResponses) UiConnectorsDetailUiConnectorsNameGetWithResponse(
 		return nil, err
 	}
 	return ParseUiConnectorsDetailUiConnectorsNameGetResponse(rsp)
+}
+
+// UiConnectorsEditSubmitUiConnectorsNamePatchWithBodyWithResponse request with arbitrary body returning *UiConnectorsEditSubmitUiConnectorsNamePatchResponse
+func (c *ClientWithResponses) UiConnectorsEditSubmitUiConnectorsNamePatchWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsEditSubmitUiConnectorsNamePatchResponse, error) {
+	rsp, err := c.UiConnectorsEditSubmitUiConnectorsNamePatchWithBody(ctx, name, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsEditSubmitUiConnectorsNamePatchResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiConnectorsEditSubmitUiConnectorsNamePatchWithFormdataBodyWithResponse(ctx context.Context, name string, body UiConnectorsEditSubmitUiConnectorsNamePatchFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsEditSubmitUiConnectorsNamePatchResponse, error) {
+	rsp, err := c.UiConnectorsEditSubmitUiConnectorsNamePatchWithFormdataBody(ctx, name, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsEditSubmitUiConnectorsNamePatchResponse(rsp)
+}
+
+// UiConnectorsEditModalUiConnectorsNameEditGetWithBodyWithResponse request with arbitrary body returning *UiConnectorsEditModalUiConnectorsNameEditGetResponse
+func (c *ClientWithResponses) UiConnectorsEditModalUiConnectorsNameEditGetWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsEditModalUiConnectorsNameEditGetResponse, error) {
+	rsp, err := c.UiConnectorsEditModalUiConnectorsNameEditGetWithBody(ctx, name, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsEditModalUiConnectorsNameEditGetResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiConnectorsEditModalUiConnectorsNameEditGetWithResponse(ctx context.Context, name string, body UiConnectorsEditModalUiConnectorsNameEditGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsEditModalUiConnectorsNameEditGetResponse, error) {
+	rsp, err := c.UiConnectorsEditModalUiConnectorsNameEditGet(ctx, name, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsEditModalUiConnectorsNameEditGetResponse(rsp)
 }
 
 // UiConnectorsReprobeUiConnectorsNameProbePostWithBodyWithResponse request with arbitrary body returning *UiConnectorsReprobeUiConnectorsNameProbePostResponse
@@ -22421,6 +22986,58 @@ func ParseUiConnectorsListUiConnectorsGetResponse(rsp *http.Response) (*UiConnec
 	return response, nil
 }
 
+// ParseUiConnectorsCreateModalUiConnectorsCreateGetResponse parses an HTTP response from a UiConnectorsCreateModalUiConnectorsCreateGetWithResponse call
+func ParseUiConnectorsCreateModalUiConnectorsCreateGetResponse(rsp *http.Response) (*UiConnectorsCreateModalUiConnectorsCreateGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiConnectorsCreateModalUiConnectorsCreateGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiConnectorsCreateSubmitUiConnectorsCreatePostResponse parses an HTTP response from a UiConnectorsCreateSubmitUiConnectorsCreatePostWithResponse call
+func ParseUiConnectorsCreateSubmitUiConnectorsCreatePostResponse(rsp *http.Response) (*UiConnectorsCreateSubmitUiConnectorsCreatePostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiConnectorsCreateSubmitUiConnectorsCreatePostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseUiConnectorsDetailUiConnectorsNameGetResponse parses an HTTP response from a UiConnectorsDetailUiConnectorsNameGetWithResponse call
 func ParseUiConnectorsDetailUiConnectorsNameGetResponse(rsp *http.Response) (*UiConnectorsDetailUiConnectorsNameGetResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -22430,6 +23047,58 @@ func ParseUiConnectorsDetailUiConnectorsNameGetResponse(rsp *http.Response) (*Ui
 	}
 
 	response := &UiConnectorsDetailUiConnectorsNameGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiConnectorsEditSubmitUiConnectorsNamePatchResponse parses an HTTP response from a UiConnectorsEditSubmitUiConnectorsNamePatchWithResponse call
+func ParseUiConnectorsEditSubmitUiConnectorsNamePatchResponse(rsp *http.Response) (*UiConnectorsEditSubmitUiConnectorsNamePatchResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiConnectorsEditSubmitUiConnectorsNamePatchResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiConnectorsEditModalUiConnectorsNameEditGetResponse parses an HTTP response from a UiConnectorsEditModalUiConnectorsNameEditGetWithResponse call
+func ParseUiConnectorsEditModalUiConnectorsNameEditGetResponse(rsp *http.Response) (*UiConnectorsEditModalUiConnectorsNameEditGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiConnectorsEditModalUiConnectorsNameEditGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -1478,6 +1478,10 @@ the same way broadcast / topology / memory retired theirs.
 | `GET` | `/ui/connectors` | Sortable + filterable targets list. URL: `?sort=name|product|host|last_probed_at|status&dir=asc|desc&product=<slug>`. Full-page render or `_table_rows.html` fragment (HX-Request branch). |
 | `GET` | `/ui/connectors/{name}` | Per-target detail. Renders properties + fingerprint card + recent-ops card (SSE-live) + available-operations matrix. Alias-aware target resolution via `resolve_target`. |
 | `POST` | `/ui/connectors/{name}/probe` | Re-probe action. Tenant_admin RBAC gated server-side (the template hides the button optimistically; the handler is the authority). Persists the new fingerprint and swaps the refreshed `_fingerprint_card.html` fragment. |
+| `GET` | `/ui/connectors/create` | (T2 #874) HTMX-loaded create-target modal. Tenant_admin gated. Product `<select>` server-rendered from `registered_product_tokens()`; auth_model `<select>` from the `AuthModel` enum. |
+| `POST` | `/ui/connectors/create` | (T2 #874) Create submit. Builds a `TargetCreate` and delegates to the REST `create_target` handler in-process. Success → 204 + `HX-Redirect: /ui/connectors`; validation failure → 422 + modal re-rendered with per-field errors. |
+| `GET` | `/ui/connectors/{name}/edit` | (T2 #874) HTMX-loaded edit-target modal, pre-populated server-side from the resolved target. Tenant_admin gated; alias-aware 404 on cross-tenant. |
+| `PATCH` | `/ui/connectors/{name}` | (T2 #874) Edit submit. Builds a `TargetUpdate` and delegates to the REST `update_target` handler in-process. Same success / failure shapes as create. |
 
 ### Module layout
 
@@ -1510,13 +1514,76 @@ Every list / detail / probe path filters on `session_ctx.tenant_id`:
 * Ops matrix: `(operation_group.tenant_id IS NULL OR operation_group.tenant_id = :tenant_id)` — same shape `list_operation_groups` uses for the agent surface.
 * Recent-ops SSE: the underlying `/ui/broadcast/stream` bridge takes the tenant from the session row, never from a query parameter, so the per-target filter cannot leak across tenants.
 
+### Create / edit forms (Task #874)
+
+T2 layers the **write** surface on the T1 read surface. The DaisyUI
+modal forms HTMX-submit into the REST `POST` / `PATCH`
+`/api/v1/targets` *handlers* in-process (`create_target` /
+`update_target` imported directly), so the UI and REST surfaces share
+one validation + product-registry-check + audit-binding code path —
+the same posture T1's re-probe handler uses by sharing
+`resolve_connector_or_label` with the REST probe route. The
+form-field strings are fed into `TargetCreate` / `TargetUpdate`, so
+Pydantic runs the identical coercion + validation the REST body runs
+(port 1-65535, name `min_length=1`, `auth_model` enum membership).
+
+* **Success** → the handler returns 204 + `HX-Redirect: /ui/connectors`
+  (the canonical HTMX post-mutation navigation); the list re-renders
+  with the new / edited row.
+* **Validation failure** → the handler catches the `ValidationError`,
+  projects it to a `{field → message}` map, and re-renders the modal
+  fragment (422) with the messages under each field and the operator's
+  typed values echoed back. The form targets itself
+  (`hx-target="this"`, `hx-swap="outerHTML"`) so HTMX swaps the
+  errored form in place without losing input.
+
+Client-side validation (HTML5 `required` / `minlength` / numeric
+`min`/`max` with DaisyUI `input-error` styling) gives immediate
+feedback; the server-side Pydantic pass is authoritative.
+
+**Product dropdown source.** The create dropdown is rendered from
+`registered_product_tokens()` — the canonical set `create_target`
+validates `product` against — rather than from the raw
+`GET /api/v1/connectors` ingest list, so a selectable product is
+always an acceptable product (no dropdown / validator drift, no
+surprise 422 on a product the operator could pick).
+
+**RBAC posture.** All four routes depend on `resolve_operator_or_403`
+(the same rigorous tenant_admin write-gate T1's probe uses): a
+non-admin GET (modal) or POST/PATCH (submit) hits 403 server-side. The
+list / detail templates additionally hide the "Create target" / "Edit"
+buttons from non-admins (UX); the hide is not the security boundary.
+Because the in-process REST handler's own `Depends(require_role(...))`
+is not re-run on a direct function call, the 403 gate lives on the UI
+route deps and the lifted `Operator` is passed into the handler so it
+runs under the caller's tenant scope.
+
+**Cross-tenant isolation.** The edit modal + PATCH resolve the target
+via `resolve_target(db_session, session_ctx.tenant_id, name)` → 404 on
+a cross-tenant or unknown name, so a tenant_admin in tenant B can
+neither load nor PATCH tenant A's target. Create writes
+`tenant_id = operator.tenant_id` (the REST handler never trusts a
+body-supplied tenant).
+
+**CSRF.** `POST` / `PATCH` under `/ui/` are gated by the chassis
+`CSRFMiddleware` (signed double-submit) before the handler runs. The
+modal form inherits the `X-CSRF-Token` header from the page-level
+`hx-headers` directive; each modal render re-mints + re-sets the
+`meho_csrf` cookie so the double-submit pair lines up.
+
 ### Files
 
 * `backend/src/meho_backplane/ui/routes/connectors/__init__.py` — umbrella router factory.
-* `backend/src/meho_backplane/ui/routes/connectors/list_view.py` — list view handler + freshness classifier.
+* `backend/src/meho_backplane/ui/routes/connectors/list_view.py` — list view handler + freshness classifier (T2 adds the `is_tenant_admin` role probe for the create button).
 * `backend/src/meho_backplane/ui/routes/connectors/detail.py` — detail handler + connector_id resolution + ops matrix query + recent-ops query.
 * `backend/src/meho_backplane/ui/routes/connectors/operator.py` — role-probe (read) + operator-403 (write).
 * `backend/src/meho_backplane/ui/routes/connectors/probe.py` — re-probe POST handler.
+* `backend/src/meho_backplane/ui/routes/connectors/forms.py` — (T2 #874) create / edit render + submit helpers; builds `TargetCreate` / `TargetUpdate`, delegates to the REST handlers, maps `ValidationError` to per-field form errors.
+* `backend/src/meho_backplane/ui/routes/connectors/forms_router.py` — (T2 #874) create / edit route registration (thin FastAPI wrappers; tenant_admin-gated deps).
+* `backend/src/meho_backplane/ui/templates/connectors/_target_form_fields.html` — (T2 #874) shared form fields for both modals.
+* `backend/src/meho_backplane/ui/templates/connectors/_create_modal.html` — (T2 #874) create modal.
+* `backend/src/meho_backplane/ui/templates/connectors/_edit_modal.html` — (T2 #874) edit modal.
+* `backend/tests/test_ui_connectors_forms.py` — (T2 #874) create / edit form tests: modal render (admin) + 403 (operator), create success + Pydantic validation errors (port out of range, empty name), edit pre-population + PATCH, cross-tenant isolation, CSRF enforcement.
 * `backend/src/meho_backplane/ui/templates/connectors/list.html` — full-page list template.
 * `backend/src/meho_backplane/ui/templates/connectors/_table_rows.html` — list rows fragment (HTMX swap target).
 * `backend/src/meho_backplane/ui/templates/connectors/detail.html` — full-page detail template.


### PR DESCRIPTION
## Summary

- G10.3-T2: target **create/edit forms** layered on the T1 (#873) read surface. Two DaisyUI modals (HTMX-loaded) replace the YAML-edit workflow for the common cases — `GET`/`POST /ui/connectors/create` and `GET /ui/connectors/{name}/edit` + `PATCH /ui/connectors/{name}`.
- The submit handlers build `TargetCreate` / `TargetUpdate` from the form fields and delegate to the REST `create_target` / `update_target` handlers **in-process**, so the UI and REST surfaces share one validation + product-registry-check + audit code path (the posture T1's re-probe handler uses by sharing `resolve_connector_or_label`). Success → 204 + `HX-Redirect: /ui/connectors`; a Pydantic `ValidationError` (port outside 1–65535, empty name) re-renders the modal in place (422) with per-field messages + echoed values.
- `tenant_admin`-only, gated server-side via `resolve_operator_or_403` (403 for a non-admin GET modal or POST/PATCH submit); templates hide the affordances from non-admins as UX only. Cross-tenant isolation rides `resolve_target` (404). CSRF enforced by the chassis double-submit middleware; client-side HTML5 validation gives immediate DaisyUI feedback ahead of the authoritative Pydantic pass.
- The product dropdown is sourced from `registered_product_tokens()` — the same set `create_target` validates against — so a selectable product is always an acceptable product (no dropdown/validator drift).
- Regenerates the CLI OpenAPI snapshot + Go client for the two new `/ui/connectors` form routes.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy src/meho_backplane/ui/routes/connectors/` — clean (7 files)
- [x] `pytest tests/test_ui_connectors_forms.py` — 16 passed
- [x] `pytest tests/test_ui_connectors_view.py tests/test_api_v1_targets.py` — no regression (90 passed incl. forms)
- [x] `.claude/hooks/code-quality.py --diff` — 0 blockers (warnings only, all under hard caps)
- [x] `cd cli && make snapshot-openapi && make generate` + `go build ./...` — client regenerated, CLI builds
- [x] **Create form fields match `TargetCreate`; product dropdown from registered set; submit POSTs `/api/v1/targets`; success → list; invalid (port out of range / empty name) → form re-renders with field errors** — `test_create_modal_renders_for_tenant_admin`, `test_create_submit_persists_target_and_redirects_to_list`, `test_create_submit_rejects_port_out_of_range_with_field_error`, `test_create_submit_rejects_empty_name_with_field_error`
- [x] **Edit form pre-populates server-side; PATCHes `/api/v1/targets/{name}`** — `test_edit_modal_prepopulates_target_fields`, `test_edit_submit_patches_target_and_redirects_to_list`
- [x] **Only `tenant_admin` sees create/edit; `operator` → 403 server-side** — `test_create_modal_rejects_operator_role_with_403`, `test_create_submit_rejects_operator_role_with_403`, `test_edit_modal_rejects_operator_role_with_403`, `test_edit_submit_rejects_operator_role_with_403`, `test_list_shows_create_button_for_tenant_admin_only`
- [x] **CSRF enforced (chassis double-submit)** — `test_create_submit_without_csrf_is_rejected`
- [x] **Cross-tenant isolation: cannot edit another tenant's target** — `test_edit_modal_isolates_other_tenants_target`, `test_edit_submit_isolates_other_tenants_target`

## Out of scope

- List / detail / matrix — #873 (T1, merged). Bulk `targets.yaml` import — #875 (T3, parallel sibling). Target cloning — per #340 OOS.
- Adjacent findings (recorded, not edited): `forms.py` is 478 lines and `list_view.py` 457 lines (both under the 600 hard cap); `submit_create`/`submit_edit`/`_render` are 70–73 lines (under the 100 hard cap). All within thresholds — flagged for future splitting if they grow.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #874
