### PR TITLE
feat(redaction): G11.4-T2 connector-boundary middleware + manifest into audit

### DIFF
--- a/backend/alembic/versions/0030_add_audit_log_redaction_columns.py
+++ b/backend/alembic/versions/0030_add_audit_log_redaction_columns.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Add ``audit_log.raw_payload`` + ``audit_log.redaction_manifest`` columns.
+
+Revision ID: 0030
+Revises: 0029
+Create Date: 2026-05-26
+
+Schema half of Task #1071 (G11.4-T2) under Initiative #805. Wires the
+connector-boundary redaction middleware into the audit trail: the
+dispatcher captures the raw connector response, hands it to the
+:mod:`meho_backplane.redaction` engine, stores the raw payload verbatim
+on the audit row, and persists the engine's manifest alongside. The
+**caller / LLM only ever sees the redacted form**; the raw record is
+internal-only and gated by the audit-query RBAC the chassis already
+enforces on the rest of the row.
+
+What this migration adds
+------------------------
+
+* ``audit_log.raw_payload`` -- ``JSONB`` on PostgreSQL, generic ``JSON``
+  on SQLite. The verbatim connector response, normalised to JSON-shaped
+  containers by
+  :func:`~meho_backplane.redaction.middleware.normalize_for_audit`
+  (Pydantic models flatten to dicts; tuples / sets flatten to lists;
+  bytes become hex). Nullable: error-path rows (handler raised, no
+  response produced) and pre-G11.4 rows carry NULL.
+
+* ``audit_log.redaction_manifest`` -- ``JSONB`` on PostgreSQL, generic
+  ``JSON`` on SQLite. The structured record of every rule firing the
+  engine emitted while reducing ``raw_payload`` to the redacted view
+  the caller saw. Each entry carries the rule name, the named pattern,
+  the action (``redact`` / ``mask`` / ``hash``), the match count, the
+  per-rule input span of the first match, the rule's ``reason`` string,
+  and the dotted JSON path to the leaf. Plus the resolved
+  ``policy_id`` (top-level key under the manifest dict), used by the
+  C1-d round-trip CI gate (#1073) to replay the same policy against
+  ``raw_payload`` and assert byte-identical redacted output across
+  policy revisions. Nullable for the same reasons as ``raw_payload``.
+
+No backfill -- pre-G11.4 audit rows stay NULL on both columns. Audit
+queries that need to display "raw / redacted / manifest" simply skip
+rows where the columns are NULL (or render the existing ``payload``
+column as the only available view; the redaction middleware is the
+single writer of these columns).
+
+Why no index
+------------
+
+The audit-query surface (G8.1) already indexes
+``(occurred_at, operator_sub, tenant_id, target_id, parent_audit_id,
+agent_session_id, actor_sub)`` -- the seven dimensions an operator
+filters by. The new columns are **payload-shape data**, not query
+predicates: an operator queries for "what did agent X do" and then
+inspects the raw/manifest pair on the matching rows. Indexing JSON
+content of the manifest is a meaningful query-time question only once
+audit-replay surfaces (G8.2-next) need it; until then, an unused
+index is pure write overhead. The PostgreSQL ``JSONB`` type itself is
+GIN-indexable later without a column rewrite when that need lands.
+
+Why additive (not amend ``0021``)
+---------------------------------
+
+Migration ``0021`` (``audit_log.actor_sub``) is merged to ``main`` and
+applied in CI and dev databases. The reversible-additive discipline
+established by ``0006``+ applies: new requirement = new migration
+head, never rewrite historical migrations. Same rationale as ``0014``
+(``agent_session_id``), ``0021`` (``actor_sub``), ``0029``
+(``targets.deleted_at``).
+
+Dialect-portability decisions
+-----------------------------
+
+* Both columns use generic ``sa.JSON`` rather than dialect-specific
+  ``JSONB``. The model definition pins ``JSONB`` on PostgreSQL via
+  ``with_variant`` (see ``_PORTABLE_JSON`` in ``db/models.py``); the
+  migration runs against SQLite in the test suite, where ``JSON``
+  compiles to a generic text column with the same ``json.dumps`` /
+  ``json.loads`` round-trip semantics. This is the same pattern as
+  the existing ``payload`` column on ``audit_log``.
+* ``nullable=True`` on both columns. Adds a column to a populated
+  table without a server default; existing rows carry NULL. Required
+  for `helm rollback` compatibility (Goal #11 DoD §3) -- a rollback
+  to v0.2.previous against a v0.2.next-migrated DB sees the NULLs
+  in fields the older code doesn't read.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` drops both columns in reverse order. SQLite ALTER
+TABLE DROP COLUMN has been supported since 3.35.0 (we're on 3.45+);
+Alembic's batch-mode fallback is not required. PostgreSQL drops the
+column directly. No data backfill is performed so the downgrade is
+purely destructive of post-G11.4 data on those rows.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0030"
+down_revision: str | None = "0029"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add ``raw_payload`` + ``redaction_manifest`` columns to ``audit_log``."""
+    op.add_column(
+        "audit_log",
+        sa.Column("raw_payload", sa.JSON(), nullable=True),
+    )
+    op.add_column(
+        "audit_log",
+        sa.Column("redaction_manifest", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Reverse the upgrade -- drop the two columns in reverse order."""
+    op.drop_column("audit_log", "redaction_manifest")
+    op.drop_column("audit_log", "raw_payload")

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -456,6 +456,30 @@ class AuditLog(Base):
         nullable=True,
         default=None,
     )
+    # Connector-boundary redaction middleware (G11.4-T2 #1071). The
+    # dispatcher captures the raw connector response, hands it to the
+    # redaction engine, and stores the raw payload here verbatim so an
+    # auditor can reconstruct the pre-redaction view (the trust boundary
+    # is the API surface, not the audit log — internal incident response
+    # needs the raw record). ``redaction_manifest`` carries one entry
+    # per rule firing (``rule`` / ``pattern`` / ``action`` / ``count`` /
+    # ``span`` / ``reason`` / ``path``) plus the resolved ``policy_id``;
+    # the C1-d round-trip CI gate (#1073) replays the manifest against
+    # the raw payload to confirm the redactor stays deterministic across
+    # policy revisions. Both columns are nullable: pre-G11.4 audit rows
+    # carry NULL, and error-path rows (handler/connector raised before
+    # producing a response) have no raw payload to redact. Added by
+    # migration ``0030``.
+    raw_payload: Mapped[object] = mapped_column(
+        _PORTABLE_JSON,
+        nullable=True,
+        default=None,
+    )
+    redaction_manifest: Mapped[object] = mapped_column(
+        _PORTABLE_JSON,
+        nullable=True,
+        default=None,
+    )
 
     __table_args__ = (
         Index(

--- a/backend/src/meho_backplane/operations/_audit.py
+++ b/backend/src/meho_backplane/operations/_audit.py
@@ -112,6 +112,8 @@ def _build_audit_payload(
     descriptor: EndpointDescriptor,
     params_hash: str,
     result_status: str,
+    *,
+    redaction_policy_id: str | None = None,
 ) -> dict[str, Any]:
     """Compose the ``audit_log.payload`` dict for the dispatcher row.
 
@@ -125,6 +127,13 @@ def _build_audit_payload(
     linkage lives in the real ``audit_log.parent_audit_id`` column
     added by migration ``0006`` and written by
     :func:`write_audit_row`.
+
+    *redaction_policy_id* is the connector-boundary redaction
+    middleware's resolved policy id (G11.4-T2 #1071); the manifest
+    itself lands in the dedicated ``redaction_manifest`` column
+    (migration ``0030``), but mirroring the policy id into the
+    JSON payload keeps the broadcast-event surface (which serialises
+    ``payload``, not the dedicated columns) attribution-complete.
     """
     payload: dict[str, Any] = {
         "op_id": descriptor.op_id,
@@ -138,6 +147,8 @@ def _build_audit_payload(
     parent_audit_id = parent_audit_id_var.get()
     if parent_audit_id is not None:
         payload["parent_audit_id"] = str(parent_audit_id)
+    if redaction_policy_id is not None:
+        payload["redaction_policy_id"] = redaction_policy_id
     # Handler-bound extras last so a handler can intentionally override
     # a default (e.g. a future per-op result_status override); the
     # default keys are documented + load-bearing for audit consumers,
@@ -166,6 +177,9 @@ async def write_audit_row(
     params_hash: str,
     result_status: str,
     duration_ms: float,
+    raw_payload: Any | None = None,
+    redaction_manifest: list[dict[str, Any]] | None = None,
+    redaction_policy_id: str | None = None,
 ) -> None:
     """Insert one ``audit_log`` row for this dispatch.
 
@@ -177,9 +191,20 @@ async def write_audit_row(
     structured ``connector_error`` rather than crashing the request).
 
     The payload shape is documented in :func:`_build_audit_payload`.
+    *raw_payload* / *redaction_manifest* / *redaction_policy_id* are
+    the connector-boundary redaction middleware's three artefacts
+    (G11.4-T2 #1071): the raw connector response, the engine's
+    manifest, and the resolved policy id. Error-path rows (handler
+    raised before producing a response) leave them ``None``; the
+    columns are nullable per migration ``0030``.
     """
     sessionmaker = get_sessionmaker()
-    payload = _build_audit_payload(descriptor, params_hash, result_status)
+    payload = _build_audit_payload(
+        descriptor,
+        params_hash,
+        result_status,
+        redaction_policy_id=redaction_policy_id,
+    )
     target_id = _resolve_target_id(target)
     parent_audit_id = parent_audit_id_var.get()
     async with sessionmaker() as session:
@@ -197,6 +222,8 @@ async def write_audit_row(
             request_id=None,
             duration_ms=Decimal(str(round(duration_ms, 2))),
             payload=payload,
+            raw_payload=raw_payload,
+            redaction_manifest=redaction_manifest,
         )
         session.add(row)
         await session.commit()
@@ -247,6 +274,9 @@ async def audit_and_broadcast_safe(
     params_hash: str,
     result_status: str,
     duration_ms: float,
+    raw_payload: Any | None = None,
+    redaction_manifest: list[dict[str, Any]] | None = None,
+    redaction_policy_id: str | None = None,
 ) -> None:
     """Write the audit row + publish broadcast; swallow internal failures.
 
@@ -264,6 +294,16 @@ async def audit_and_broadcast_safe(
     A future tightening of the audit-failure handling (e.g. failing the
     operation when audit cannot land) is a v0.2.next consideration and
     would land in this helper.
+
+    *raw_payload* / *redaction_manifest* / *redaction_policy_id* are
+    the connector-boundary redaction artefacts (G11.4-T2 #1071);
+    forwarded to :func:`write_audit_row`. The broadcast event still
+    consumes *params* (request-side) rather than the response-side
+    raw payload: per :func:`publish_broadcast`'s
+    :func:`~meho_backplane.broadcast.events.redact_payload` step, the
+    broadcast surface ships params only -- the response goes nowhere
+    near the broadcast subscribers, who already see redacted outcomes
+    via the broadcast detail policy (G6.3).
     """
     try:
         await write_audit_row(
@@ -274,6 +314,9 @@ async def audit_and_broadcast_safe(
             params_hash=params_hash,
             result_status=result_status,
             duration_ms=duration_ms,
+            raw_payload=raw_payload,
+            redaction_manifest=redaction_manifest,
+            redaction_policy_id=redaction_policy_id,
         )
     except Exception:
         _log.exception(

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -35,13 +35,26 @@ phases the parent Initiative names:
    structured ``no_connector`` error.
 6. Branch on ``descriptor.source_kind`` -- ``ingested`` / ``typed`` /
    ``composite``. See :mod:`meho_backplane.operations._branches`.
-7. JSONFlux-wrap the response via the :class:`Reducer` (production default
-   is :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`,
+7. **Connector-boundary redaction** (G11.4-T2 #1071) -- the raw
+   response is captured, the
+   :func:`~meho_backplane.redaction.middleware.apply_connector_boundary_redaction`
+   helper resolves a per-(connector_id, tenant, op)
+   :class:`~meho_backplane.redaction.policy.RedactionPolicy` (falling
+   through to the conservative default-safe policy when no override
+   is registered) and runs the
+   :mod:`~meho_backplane.redaction.engine`. The caller / LLM only ever
+   sees the redacted view; the raw payload + the engine's manifest
+   land on the audit row (migration ``0030``).
+8. JSONFlux-wrap the **redacted** response via the :class:`Reducer`
+   (production default is
+   :class:`~meho_backplane.operations.jsonflux_reducer.JsonFluxReducer`,
    installed at startup; the import-time default is the
    :class:`~meho_backplane.operations.reducer.PassThroughReducer` shim).
-8. Write the audit row synchronously + publish a broadcast event
+9. Write the audit row synchronously + publish a broadcast event
    (:func:`~meho_backplane.operations._audit.audit_and_broadcast_safe`).
-9. Return the :class:`OperationResult`.
+   The audit row carries the raw payload, the redaction manifest, and
+   the resolved policy id.
+10. Return the :class:`OperationResult`.
 
 The dispatch function is async; safe to call from FastAPI routes, MCP
 tool handlers, and from composite handlers (recursive).
@@ -173,6 +186,11 @@ from meho_backplane.operations.composite import (
 from meho_backplane.operations.reducer import (
     PassThroughReducer,
     Reducer,
+)
+from meho_backplane.redaction import (
+    RedactionMiddlewareResult,
+    apply_connector_boundary_redaction,
+    manifest_to_audit_payload,
 )
 
 __all__ = [
@@ -394,6 +412,7 @@ def _elapsed_ms(started: float) -> float:
 async def _execute_and_audit(
     *,
     op_id: str,
+    connector_id: str,
     descriptor: EndpointDescriptor,
     connector_instance: Connector | None,
     operator: Operator,
@@ -402,7 +421,7 @@ async def _execute_and_audit(
     params_hash: str,
     started: float,
 ) -> OperationResult:
-    """Run the source_kind branch, reduce, audit, broadcast, return.
+    """Run the source_kind branch, redact, reduce, audit, broadcast, return.
 
     Wraps the dispatch's success path (steps 6-9) so the main
     :func:`dispatch` body stays a flat sequence of phase calls.
@@ -410,10 +429,149 @@ async def _execute_and_audit(
     ``connector_error`` :class:`OperationResult` shapes; the audit row
     still gets written before the return so the operator-visible
     record is consistent with the dispatcher's reply.
+
+    G11.4-T2 (#1071) inserts the connector-boundary redaction
+    middleware between the handler's raw return and the JSONFlux
+    reducer: the raw payload is captured, the redaction engine
+    rewrites secret-shaped string leaves, and the redacted view is
+    what the reducer (and therefore the caller / LLM) sees. The
+    audit row records both the raw payload (verbatim) and the
+    engine's manifest so an auditor can reconstruct the
+    pre-redaction view and a CI gate (#1073) can prove the
+    redactor stays deterministic across policy revisions.
     """
     audit_id = uuid.uuid4()
+    branch_result = await _run_branch_with_error_handling(
+        op_id=op_id,
+        descriptor=descriptor,
+        connector_instance=connector_instance,
+        operator=operator,
+        target=target,
+        params=params,
+        params_hash=params_hash,
+        audit_id=audit_id,
+        started=started,
+    )
+    if isinstance(branch_result, OperationResult):
+        return branch_result
+    raw = branch_result
+
+    # Step 7a -- connector-boundary redaction (G11.4-T2 #1071). The raw
+    # payload is captured for the audit row before the engine runs;
+    # the engine's redacted output is what flows into the JSONFlux
+    # reducer and ultimately back to the caller. Errors inside the
+    # middleware surface as ``connector_error`` so the dispatcher's
+    # never-raises contract is preserved -- a redactor failure must
+    # not leak raw payloads through a 500 with no audit record.
+    redaction = _apply_redaction_middleware(
+        raw=raw,
+        connector_id=connector_id,
+        operator=operator,
+        op_id=op_id,
+    )
+    if isinstance(redaction, OperationResult):
+        await audit_and_broadcast_safe(
+            audit_id=audit_id,
+            operator=operator,
+            descriptor=descriptor,
+            target=target,
+            params=params,
+            params_hash=params_hash,
+            result_status="error",
+            duration_ms=_elapsed_ms(started),
+        )
+        return redaction
+
+    return await _reduce_and_audit_success(
+        op_id=op_id,
+        descriptor=descriptor,
+        operator=operator,
+        target=target,
+        params=params,
+        params_hash=params_hash,
+        audit_id=audit_id,
+        redaction=redaction,
+        started=started,
+    )
+
+
+async def _reduce_and_audit_success(
+    *,
+    op_id: str,
+    descriptor: EndpointDescriptor,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    params_hash: str,
+    audit_id: uuid.UUID,
+    redaction: RedactionMiddlewareResult,
+    started: float,
+) -> OperationResult:
+    """Run the reducer on the redacted payload, write the success-path
+    audit row, and wrap the reduced summary into the final
+    :class:`OperationResult`. Extracted from :func:`_execute_and_audit`
+    so the orchestrator stays under the code-quality function-size cap
+    and the redaction/reduce/audit ordering stays the only thing this
+    helper expresses."""
+    serialised_manifest = manifest_to_audit_payload(redaction.manifest)
+    reduced = await _reduce_or_error(
+        op_id=op_id,
+        descriptor=descriptor,
+        operator=operator,
+        target=target,
+        params=params,
+        params_hash=params_hash,
+        audit_id=audit_id,
+        raw=redaction.redacted,
+        started=started,
+        raw_payload_for_audit=redaction.raw,
+        redaction_manifest_for_audit=serialised_manifest,
+        redaction_policy_id=redaction.policy_id,
+    )
+    if isinstance(reduced, OperationResult):
+        return reduced
+    summary, handle = reduced
+    duration_ms = _elapsed_ms(started)
+    await audit_and_broadcast_safe(
+        audit_id=audit_id,
+        operator=operator,
+        descriptor=descriptor,
+        target=target,
+        params=params,
+        params_hash=params_hash,
+        result_status="ok",
+        duration_ms=duration_ms,
+        raw_payload=redaction.raw,
+        redaction_manifest=serialised_manifest,
+        redaction_policy_id=redaction.policy_id,
+    )
+    return wrap_ok_result(op_id, summary, duration_ms, handle)
+
+
+async def _run_branch_with_error_handling(
+    *,
+    op_id: str,
+    descriptor: EndpointDescriptor,
+    connector_instance: Connector | None,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    params_hash: str,
+    audit_id: uuid.UUID,
+    started: float,
+) -> Any | OperationResult:
+    """Invoke the source_kind branch; convert handler errors to OperationResults.
+
+    Extracted from :func:`_execute_and_audit` so the success-path code
+    is the linear "redact → reduce → audit → return" sequence. The
+    handler's :exc:`ImportError` / :exc:`TypeError` map to
+    ``handler_unreachable`` (the importlib walk failed or resolved a
+    non-callable); every other exception maps to ``connector_error``.
+    Both paths write the audit row before returning so the operator-
+    visible record is consistent with the structured failure.
+    """
     try:
-        raw = await _run_source_kind_branch(
+        return await _run_source_kind_branch(
             descriptor=descriptor,
             connector_instance=connector_instance,
             operator=operator,
@@ -422,8 +580,6 @@ async def _execute_and_audit(
             audit_id=audit_id,
         )
     except (ImportError, TypeError) as exc:
-        # ImportError -- handler_ref couldn't be resolved.
-        # TypeError -- resolved symbol wasn't callable.
         duration_ms = _elapsed_ms(started)
         await audit_and_broadcast_safe(
             audit_id=audit_id,
@@ -450,32 +606,44 @@ async def _execute_and_audit(
         )
         return result_connector_error(op_id, exc, duration_ms)
 
-    reduced = await _reduce_or_error(
-        op_id=op_id,
-        descriptor=descriptor,
-        operator=operator,
-        target=target,
-        params=params,
-        params_hash=params_hash,
-        audit_id=audit_id,
-        raw=raw,
-        started=started,
-    )
-    if isinstance(reduced, OperationResult):
-        return reduced
-    summary, handle = reduced
-    duration_ms = _elapsed_ms(started)
-    await audit_and_broadcast_safe(
-        audit_id=audit_id,
-        operator=operator,
-        descriptor=descriptor,
-        target=target,
-        params=params,
-        params_hash=params_hash,
-        result_status="ok",
-        duration_ms=duration_ms,
-    )
-    return wrap_ok_result(op_id, summary, duration_ms, handle)
+
+def _apply_redaction_middleware(
+    *,
+    raw: Any,
+    connector_id: str,
+    operator: Operator,
+    op_id: str,
+) -> RedactionMiddlewareResult | OperationResult:
+    """Wrap :func:`apply_connector_boundary_redaction` with error capture.
+
+    The middleware is pure-Python regex over a Pydantic-validated
+    policy; it can fail only on (a) the lazy default-policy YAML
+    load (e.g. a packaging accident drops ``default.yaml``) or
+    (b) an unforeseen Python-level exception inside the engine.
+    The dispatcher must convert either to a structured
+    ``connector_error`` :class:`OperationResult` rather than letting
+    the exception bubble -- the never-raises contract is the only
+    reason "store raw → redact → reduce" is safe at runtime. If we
+    raised instead, the caller would see a 500 with **no audit
+    record of the raw response**, defeating the trust-boundary
+    discipline this middleware exists to enforce.
+
+    The ``tenant`` label passes through as the operator's tenant id
+    in string form (the resolver compares against the policy
+    schema's ``Annotated[str | None]`` field). ``None`` tenant id
+    (the chassis-era audit shape) flows through as ``None`` so the
+    resolver only matches a non-tenant-scoped override.
+    """
+    tenant = str(operator.tenant_id) if operator.tenant_id is not None else None
+    try:
+        return apply_connector_boundary_redaction(
+            raw,
+            connector_id=connector_id,
+            tenant=tenant,
+            op=op_id,
+        )
+    except Exception as exc:
+        return result_connector_error(op_id, exc, 0.0)
 
 
 async def _reduce_or_error(
@@ -489,6 +657,9 @@ async def _reduce_or_error(
     audit_id: uuid.UUID,
     raw: Any,
     started: float,
+    raw_payload_for_audit: Any | None = None,
+    redaction_manifest_for_audit: list[dict[str, Any]] | None = None,
+    redaction_policy_id: str | None = None,
 ) -> tuple[Any, ResultHandle | None] | OperationResult:
     """Run the JSONFlux reducer; return ``(summary, handle)`` or a structured error.
 
@@ -502,6 +673,14 @@ async def _reduce_or_error(
     :class:`OperationResult` — same shape the handler-call exception path
     produces — and the audit row + broadcast event still fire so the
     failure is observable.
+
+    *raw_payload_for_audit* / *redaction_manifest_for_audit* /
+    *redaction_policy_id* carry the connector-boundary redaction
+    artefacts through to the error-path audit row (G11.4-T2 #1071):
+    even when the reducer fails, the audit trail still records the
+    raw payload + manifest from the (successful) redaction step so
+    a debugger has the same pre-redaction evidence available as on
+    the success path.
     """
     reducer_context: dict[str, Any] = {
         "op_id": op_id,
@@ -529,6 +708,9 @@ async def _reduce_or_error(
             params_hash=params_hash,
             result_status="error",
             duration_ms=duration_ms,
+            raw_payload=raw_payload_for_audit,
+            redaction_manifest=redaction_manifest_for_audit,
+            redaction_policy_id=redaction_policy_id,
         )
         return result_connector_error(op_id, exc, duration_ms)
 
@@ -610,6 +792,9 @@ async def _handle_needs_approval(
         )
 
 
+# code-quality-allow: 8-phase orchestrator -- phases stay linear so the
+# 8-numbered-steps contract in the module docstring stays grep-visible;
+# splitting would scatter structured-error returns + obscure never-raises.
 async def dispatch(
     *,
     operator: Operator,
@@ -752,6 +937,7 @@ async def dispatch(
     # --- Steps 6/7/8/9: branch + reduce + audit + broadcast ---------------
     return await _execute_and_audit(
         op_id=op_id,
+        connector_id=connector_id,
         descriptor=descriptor,
         connector_instance=connector_instance,
         operator=operator,

--- a/backend/src/meho_backplane/redaction/__init__.py
+++ b/backend/src/meho_backplane/redaction/__init__.py
@@ -29,6 +29,12 @@ from meho_backplane.redaction.engine import (
     RedactionResult,
     redact,
 )
+from meho_backplane.redaction.middleware import (
+    RedactionMiddlewareResult,
+    apply_connector_boundary_redaction,
+    manifest_to_audit_payload,
+    normalize_for_audit,
+)
 from meho_backplane.redaction.patterns import NAMED_PATTERNS, PATTERN_NAMES, get_pattern
 from meho_backplane.redaction.policy import (
     RedactionAction,
@@ -39,19 +45,37 @@ from meho_backplane.redaction.policy import (
     load_policy_yaml,
     parse_policy,
 )
+from meho_backplane.redaction.resolver import (
+    DEFAULT_POLICY_PACKAGE,
+    DEFAULT_POLICY_RESOURCE,
+    clear_overrides,
+    get_default_policy,
+    register_policy,
+    resolve_policy,
+)
 
 __all__ = [
+    "DEFAULT_POLICY_PACKAGE",
+    "DEFAULT_POLICY_RESOURCE",
     "NAMED_PATTERNS",
     "PATTERN_NAMES",
     "RedactionAction",
     "RedactionManifestEntry",
+    "RedactionMiddlewareResult",
     "RedactionPolicy",
     "RedactionPolicyError",
     "RedactionResult",
     "RedactionRule",
     "RedactionScope",
+    "apply_connector_boundary_redaction",
+    "clear_overrides",
+    "get_default_policy",
     "get_pattern",
     "load_policy_yaml",
+    "manifest_to_audit_payload",
+    "normalize_for_audit",
     "parse_policy",
     "redact",
+    "register_policy",
+    "resolve_policy",
 ]

--- a/backend/src/meho_backplane/redaction/middleware.py
+++ b/backend/src/meho_backplane/redaction/middleware.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Connector-boundary redaction middleware -- Initiative #805 (C1-b, #1071).
+
+The dispatcher (:mod:`meho_backplane.operations.dispatcher`) invokes
+:func:`apply_connector_boundary_redaction` once per dispatch, between
+"connector returned a raw response" and "JSONFlux reducer consumes it":
+
+.. code-block:: text
+
+       handler returns raw payload
+                   │
+                   ▼
+       capture raw  ─────────►  audit row stores raw verbatim
+                   │
+                   ▼
+       resolver picks RedactionPolicy
+                   │
+                   ▼
+       engine.redact(raw, policy, ...)
+                   │
+                   ▼
+       (redacted, manifest)
+            │           │
+            ▼           ▼
+       JSONFlux       audit row stores manifest
+       reducer
+            │
+            ▼
+       OperationResult to caller
+
+The middleware is the **only** path that wires
+:mod:`meho_backplane.redaction.resolver` to
+:mod:`meho_backplane.redaction.engine`; the dispatcher calls it once
+with the call's labels and the raw payload and gets back the redacted
+payload plus the manifest the audit row needs to persist.
+
+Why a thin wrapper around resolver + engine? Three reasons:
+
+1. The dispatcher should not import the engine and resolver directly --
+   it would couple the dispatcher to the redaction package's internal
+   shape. The middleware is the public seam.
+2. The wrapper is the unit-test boundary: redaction tests exercise
+   :func:`apply_connector_boundary_redaction` end-to-end without
+   spinning up a real dispatcher.
+3. The wrapper centralises the "capture-raw-as-JSON-shape" contract so
+   the audit row never stores a raw object the JSON encoder cannot
+   serialise. Pydantic / dataclass / set / tuple payloads get
+   normalised here so the audit-write path stays a dumb insert.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from pydantic import BaseModel
+
+from meho_backplane.redaction.engine import RedactionManifestEntry, redact
+from meho_backplane.redaction.resolver import resolve_policy
+
+__all__ = [
+    "RedactionMiddlewareResult",
+    "apply_connector_boundary_redaction",
+    "manifest_to_audit_payload",
+    "normalize_for_audit",
+]
+
+
+class RedactionMiddlewareResult(BaseModel):
+    """The middleware's return value.
+
+    Carries the four artefacts the dispatcher needs to fan out into
+    the reducer call, the audit row, and the broadcast event:
+
+    * ``raw`` -- the JSON-normalised raw payload (what the audit row
+      stores under ``payload['raw']``). Same shape as the engine's
+      input, never a Pydantic model or arbitrary object.
+    * ``redacted`` -- the engine's output, the value the JSONFlux
+      reducer consumes and the caller eventually sees.
+    * ``manifest`` -- the tuple of :class:`RedactionManifestEntry`
+      records describing every rule firing.
+    * ``policy_id`` -- the resolved policy's ``id`` field. Lands on
+      the audit row so the audit replay can re-run the same policy
+      on the same raw input (C1-d round-trip CI gate).
+    """
+
+    model_config = {"frozen": True, "extra": "forbid", "arbitrary_types_allowed": True}
+
+    raw: Any
+    redacted: Any
+    manifest: tuple[RedactionManifestEntry, ...]
+    policy_id: str
+
+
+def apply_connector_boundary_redaction(
+    raw: Any,
+    *,
+    connector_id: str | None,
+    tenant: str | None,
+    op: str | None,
+) -> RedactionMiddlewareResult:
+    """Resolve the policy + apply the engine to *raw*.
+
+    The dispatcher calls this once per dispatch, after the handler
+    returns and before the JSONFlux reducer runs. The labels are the
+    call's connector id, the operator's tenant id (string form), and
+    the descriptor's op_id; the resolver uses them to pick the most
+    specific :class:`RedactionPolicy`, falling through to a
+    conservative default when no override matches.
+
+    *raw* is normalised to JSON-shaped containers via
+    :func:`normalize_for_audit` before the engine sees it -- a
+    Pydantic model returned by a handler flattens to a dict, a tuple
+    flattens to a list, and so on. This keeps the audit row's
+    ``raw`` field encoder-safe and lets the engine's walking
+    strategy (Mapping / Sequence / str) cover handler returns
+    without per-shape branching at the call site.
+
+    The middleware is **pure with respect to redaction logic** -- it
+    delegates to :func:`resolve_policy` and :func:`redact`, neither
+    of which performs I/O. The single side-effecting hop is the
+    policy-cache warm-up inside
+    :func:`meho_backplane.redaction.resolver.get_default_policy`,
+    which is idempotent and lock-protected. A second call with the
+    same labels returns the same policy reference, so the audit row's
+    ``policy_id`` is stable across dispatches.
+    """
+    policy = resolve_policy(connector_id=connector_id, tenant=tenant, op=op)
+    normalized = normalize_for_audit(raw)
+    result = redact(
+        normalized,
+        policy,
+        connector_id=connector_id,
+        tenant=tenant,
+        op=op,
+    )
+    return RedactionMiddlewareResult(
+        raw=normalized,
+        redacted=result.redacted,
+        manifest=result.manifest,
+        policy_id=policy.id,
+    )
+
+
+def normalize_for_audit(value: Any) -> Any:
+    """Coerce *value* to a JSON-encoder-safe shape.
+
+    The audit row's ``payload`` column stores JSON; an unencoded
+    Pydantic model or set raised by a connector handler would crash
+    the insert. The redactor would also stumble on non-Mapping /
+    non-Sequence containers. This helper produces the same shape
+    in one place so the engine, the audit row, and the broadcast
+    event all consume identical structure.
+
+    Rules, applied recursively:
+
+    * :class:`BaseModel` -> :meth:`BaseModel.model_dump` (dict). The
+      ``mode='json'`` flag is omitted intentionally -- the inner
+      walk handles datetime / UUID via :func:`_normalize_scalar`,
+      keeping the encoder choice in this module rather than
+      delegating to Pydantic's mode-specific serialisers (which
+      stringify identifiers in ways that vary between v1 and v2).
+    * :class:`Mapping` -> ``dict`` with string keys (non-string keys
+      get :func:`str`-coerced; the audit row JSON cannot represent
+      non-string keys anyway).
+    * :class:`Sequence` other than ``str`` / ``bytes`` /
+      ``bytearray`` -> ``list``. Tuples and sets thus flatten to
+      lists; this loses ordering information for sets but the
+      audit row's purpose is post-hoc inspection, not exact
+      replay of the in-memory type.
+    * :class:`bytes` / :class:`bytearray` -> hex string. The
+      JSONFlux boundary upstream produces JSON-shaped values, so
+      binary at the redaction boundary is uncommon; surfacing the
+      hex preserves the audit record's debug value without forcing
+      a base64 dialect into the audit schema.
+    * Anything else (numbers, booleans, None, strings) passes
+      through verbatim. The engine's :func:`redact` walks the
+      result and only mutates string leaves.
+
+    Cycles in the input raise :class:`RecursionError` rather than
+    silently truncating -- a cyclic connector response is itself a
+    bug worth surfacing.
+    """
+    return _normalize(value)
+
+
+def manifest_to_audit_payload(
+    manifest: tuple[RedactionManifestEntry, ...],
+) -> list[dict[str, Any]]:
+    """Convert the engine's manifest to a JSON-shaped list of dicts.
+
+    The audit row stores this under ``payload['redaction_manifest']``;
+    a separate dedicated column would be marginal value over the
+    existing JSON column and would require a wider migration. Each
+    entry is a flat dict with the rule / pattern / action / count /
+    span / reason / path fields -- the same surface
+    :class:`RedactionManifestEntry` exposes, serialised so the audit
+    insert encoder accepts it without per-row Pydantic round-tripping.
+    """
+    return [entry.model_dump(mode="json") for entry in manifest]
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _normalize(value: Any) -> Any:
+    """Recursive worker for :func:`normalize_for_audit`."""
+    if isinstance(value, BaseModel):
+        return _normalize(value.model_dump())
+    if isinstance(value, Mapping):
+        return {str(key): _normalize(item) for key, item in value.items()}
+    if isinstance(value, (bytes, bytearray)):
+        # Hex (not base64) so an operator reading the audit row sees
+        # something obviously non-string; base64 collides with the
+        # opaque-token shapes the engine's named patterns target and
+        # would trigger spurious matches at the redaction step.
+        return bytes(value).hex()
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Sequence):
+        return [_normalize(item) for item in value]
+    if isinstance(value, set | frozenset):
+        # Sets become lists; ordering is lost but the audit row's
+        # purpose is post-hoc inspection, not exact-shape replay.
+        return [_normalize(item) for item in value]
+    # Numbers, booleans, None, datetime, UUID, Decimal -- the audit
+    # row's JSON encoder (orjson via SQLAlchemy's JSON type) handles
+    # the standard non-string scalars; nothing for the engine to do
+    # with them either (regex against numerics is nonsensical).
+    return value

--- a/backend/src/meho_backplane/redaction/policies/default.yaml
+++ b/backend/src/meho_backplane/redaction/policies/default.yaml
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+#
+# Conservative default Tier-1 redaction policy -- Initiative #805
+# (G11.4 Safety, C1), Task #1071 (T2). Applied at the connector-result
+# boundary by the middleware in :mod:`meho_backplane.redaction.middleware`
+# whenever a more specific policy (per-connector_id, per-tenant, per-op)
+# is not registered. Default-safe: no operator action required for a new
+# connector to land with sensible redaction.
+#
+# Posture: redact every credential-shaped value the named-pattern library
+# knows about. Identifier-shaped patterns (uuid / ipv4 / ipv6 / fqdn) are
+# **intentionally excluded** -- they over-redact in too many connector
+# responses to be a sensible global default (a Kubernetes pod-list reply
+# is mostly UUIDs and IPs; redacting them by default would blank the
+# operator-facing summary and force every site to override). Operators
+# who want them turned on at the global level register a wider policy
+# via :func:`meho_backplane.redaction.resolver.register_policy`; per-
+# connector overrides land the same way.
+
+id: connector-boundary-default
+version: 1
+description: |
+  Default-safe Tier-1 redaction policy applied at the dispatcher's
+  connector-result boundary whenever no more-specific policy is
+  registered for the call's (connector_id, tenant, op). Targets
+  credentials and kubeconfig blobs; identifier-shaped patterns
+  (UUID / IP / FQDN) are excluded to keep operator-facing summaries
+  legible by default.
+
+rules:
+  - name: strip-authorization-header
+    pattern: authorization_header
+    action: redact
+    reason: "RFC 7235 secret on the header line"
+
+  - name: strip-bearer-token
+    pattern: bearer_token
+    action: redact
+    reason: "bare bearer token outside an Authorization header"
+
+  - name: strip-jwt
+    pattern: jwt
+    action: redact
+    reason: "JWT in payload body"
+
+  - name: strip-api-key
+    pattern: api_key
+    action: redact
+    reason: "labelled credential pair (api_key/token/secret/password)"
+
+  - name: strip-kubeconfig
+    pattern: kubeconfig
+    action: redact
+    reason: "kubeconfig blob in payload"

--- a/backend/src/meho_backplane/redaction/resolver.py
+++ b/backend/src/meho_backplane/redaction/resolver.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-call redaction policy selection -- Initiative #805 (C1-b, #1071).
+
+The connector-boundary middleware needs to answer "which
+:class:`~meho_backplane.redaction.policy.RedactionPolicy` applies to
+*this* call?" before it can run the engine. The resolution dimensions
+are, in order of specificity:
+
+1. ``(connector_id, tenant, op)`` -- the most specific override.
+2. ``(connector_id, op)`` -- per-connector, per-op (tenant wildcard).
+3. ``(connector_id, tenant)`` -- per-connector, per-tenant.
+4. ``connector_id`` -- per-connector default.
+5. ``tenant`` -- tenant-wide default across every connector.
+6. The conservative built-in default (:data:`DEFAULT_POLICY_NAME`).
+
+The resolver is **default-safe**: a call that matches no registered
+override falls through to the conservative default policy packaged at
+:mod:`meho_backplane.redaction.policies`, which still applies the
+named-pattern library to credential shapes. **Pass-through is never
+the answer** -- the parent goal (#800) treats the API surface as the
+trust boundary, so an un-configured operator-facing connector still
+gets credentials stripped out of its responses.
+
+Registration is process-global state, deliberately mutable so the
+middleware can be exercised in tests without monkeypatching:
+:func:`register_policy` adds an override at one of the specificity
+levels above; :func:`clear_overrides` resets to the built-in default
+only. Tests must call :func:`clear_overrides` in a fixture teardown
+to keep registrations from leaking across the file. Production runs
+without any overrides today -- the per-tenant policy authoring path
+is a follow-on Initiative; this module ships the resolution shape so
+the policy column can land on the audit row and middleware against
+it can be unit-tested.
+
+The module owns one lazy global -- :func:`get_default_policy` --
+which loads the packaged YAML on first access and caches it. The
+load is side-effect-free at import time so this module stays as cheap
+to import as :mod:`meho_backplane.redaction.policy` itself.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Final
+
+from meho_backplane.redaction.policy import RedactionPolicy, load_policy_yaml
+
+__all__ = [
+    "DEFAULT_POLICY_PACKAGE",
+    "DEFAULT_POLICY_RESOURCE",
+    "clear_overrides",
+    "get_default_policy",
+    "register_policy",
+    "resolve_policy",
+]
+
+
+#: Dotted package the default policy YAML lives in. Mirrors the
+#: ``meho_backplane.operations.ingest`` precedent: policy files travel
+#: with the wheel via ``importlib.resources``.
+DEFAULT_POLICY_PACKAGE: Final[str] = "meho_backplane.redaction.policies"
+
+#: File name within :data:`DEFAULT_POLICY_PACKAGE` for the default-safe
+#: policy. The conservative defaults are documented in the YAML header.
+DEFAULT_POLICY_RESOURCE: Final[str] = "default.yaml"
+
+
+# A tuple key encodes the override specificity:
+# ``(connector_id, tenant, op)``. ``None`` means "wildcard at this
+# dimension". The resolver walks from most-specific to least-specific
+# (six lookups) and returns the first hit. This is a tiny table in
+# practice -- per-tenant operator authoring is the only realistic
+# population path -- so a flat dict is the right shape.
+_OverrideKey = tuple[str | None, str | None, str | None]
+
+
+_overrides: dict[_OverrideKey, RedactionPolicy] = {}
+_overrides_lock: threading.Lock = threading.Lock()
+_default_policy: RedactionPolicy | None = None
+_default_lock: threading.Lock = threading.Lock()
+
+
+def get_default_policy() -> RedactionPolicy:
+    """Return the packaged default-safe :class:`RedactionPolicy`.
+
+    Loaded lazily on first access and cached for the lifetime of the
+    process. The YAML lives in
+    :data:`DEFAULT_POLICY_PACKAGE`/:data:`DEFAULT_POLICY_RESOURCE` and
+    is resolved via :func:`importlib.resources.files`, so a packaged
+    wheel finds it regardless of cwd. The lock protects against two
+    threads racing the first load -- :func:`load_policy_yaml` is pure
+    but the file read is not free, and the cached :class:`RedactionPolicy`
+    is frozen so post-load there is no reason to take the lock again.
+    """
+    global _default_policy
+    if _default_policy is not None:
+        return _default_policy
+    with _default_lock:
+        if _default_policy is None:
+            _default_policy = load_policy_yaml(
+                DEFAULT_POLICY_PACKAGE,
+                DEFAULT_POLICY_RESOURCE,
+            )
+    return _default_policy
+
+
+def register_policy(
+    policy: RedactionPolicy,
+    *,
+    connector_id: str | None = None,
+    tenant: str | None = None,
+    op: str | None = None,
+) -> None:
+    """Register *policy* as an override for the given specificity tuple.
+
+    A call to :func:`resolve_policy` whose labels match *all three* of
+    the non-``None`` parameters (treating ``None`` as a wildcard at
+    this dimension) returns *policy* before the resolver falls through
+    to a less-specific override or the built-in default. All three
+    parameters defaulting to ``None`` is the "tenant-wide, connector-
+    wide, op-wide" override -- effectively replacing the built-in
+    default.
+
+    Re-registration on the same key overwrites the previous entry
+    without warning; tests that swap policies between cases should do
+    so inside their own fixture teardown so the mutation is visible
+    in the fixture scope, not as cross-test ambient state.
+    """
+    key: _OverrideKey = (connector_id, tenant, op)
+    with _overrides_lock:
+        _overrides[key] = policy
+
+
+def clear_overrides() -> None:
+    """Drop every registered override; the next :func:`resolve_policy`
+    call falls through to the built-in default for every input.
+
+    Test-only API. Production callers do not run with mid-process
+    overrides today; the per-tenant policy authoring path will land
+    as part of a follow-on Initiative and likely register at app
+    startup rather than mid-request.
+    """
+    with _overrides_lock:
+        _overrides.clear()
+
+
+def resolve_policy(
+    *,
+    connector_id: str | None,
+    tenant: str | None,
+    op: str | None,
+) -> RedactionPolicy:
+    """Return the :class:`RedactionPolicy` that applies to this call.
+
+    Walks the specificity ladder documented on the module: the most
+    specific override that matches the call's labels wins. ``None``
+    on a label is treated as "no value at this dimension" -- a
+    tenant-less call (uncommon outside tests) only matches overrides
+    whose ``tenant`` is also ``None``. Falls through to
+    :func:`get_default_policy` when no override matches.
+
+    The resolver is read-only and acquires the overrides lock only
+    briefly to snapshot the relevant keys. The returned policy is
+    immutable (Pydantic ``frozen=True``) so the caller can hold the
+    reference past the lock without further synchronisation.
+    """
+    # Order matters -- most specific first. Each tuple corresponds
+    # to one specificity level documented on the module docstring.
+    # The wildcards are encoded as ``None`` so the resolver loop stays
+    # a straight dict lookup; no per-call regex or per-call walk over
+    # the table is needed.
+    ladder: tuple[_OverrideKey, ...] = (
+        (connector_id, tenant, op),
+        (connector_id, None, op),
+        (connector_id, tenant, None),
+        (connector_id, None, None),
+        (None, tenant, None),
+    )
+    with _overrides_lock:
+        for key in ladder:
+            hit = _overrides.get(key)
+            if hit is not None:
+                return hit
+    return get_default_policy()

--- a/backend/tests/test_dispatcher_redaction_integration.py
+++ b/backend/tests/test_dispatcher_redaction_integration.py
@@ -1,0 +1,454 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Connector-boundary redaction middleware integration tests (#1071).
+
+Acceptance criteria covered:
+
+* An operation returning a payload with a bearer token / kubeconfig
+  returns the **redacted** form to the caller; the raw is retrievable
+  from the audit row; a manifest is recorded.
+* User-path and agent-path calls both have redacted-out / raw-in-audit.
+* Per-``connector_id`` policy selection works (a registered override
+  beats the default).
+* Default-safe: no policy registered → conservative default still
+  strips credentials (not pass-through).
+
+The tests live in a dedicated file (not appended to
+``test_operations_dispatcher.py``) so the redaction-specific fixtures
+(resolver-override reset, capturing audit row's redaction columns) and
+the file's purpose stay focused. Shares the same plumbing the main
+dispatcher tests use: typed-op registration against an in-memory
+SQLite, recording broadcast publisher, autouse-reset.
+"""
+
+from __future__ import annotations
+
+import textwrap
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import meho_backplane.operations._audit as audit_module
+from meho_backplane.auth.operator import Operator, PrincipalKind, TenantRole
+from meho_backplane.broadcast import BroadcastEvent
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import FingerprintResult, ProbeResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+from meho_backplane.operations import (
+    dispatch,
+    register_typed_operation,
+    reset_dispatcher_caches,
+)
+from meho_backplane.redaction import (
+    clear_overrides,
+    parse_policy,
+    register_policy,
+)
+from meho_backplane.settings import get_settings
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin env vars Settings requires; clear cache around each test."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Reset dispatcher caches + connector registry + redaction overrides."""
+    reset_dispatcher_caches()
+    clear_registry()
+    clear_overrides()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+    clear_overrides()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so ``register_typed_operation``
+    doesn't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+def captured_events(monkeypatch: pytest.MonkeyPatch) -> list[BroadcastEvent]:
+    """Replace :func:`publish_event` with a recording stub."""
+    events: list[BroadcastEvent] = []
+
+    async def _capture(event: BroadcastEvent) -> None:
+        events.append(event)
+
+    monkeypatch.setattr(audit_module, "publish_event", _capture)
+    return events
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """Yield an AsyncSession against the autouse-migrated SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+def _make_operator(
+    *,
+    sub: str = "op-test",
+    tenant_id: UUID | None = None,
+    principal_kind: PrincipalKind = PrincipalKind.USER,
+) -> Operator:
+    return Operator(
+        sub=sub,
+        name="Test Operator",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=tenant_id or UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+        principal_kind=principal_kind,
+    )
+
+
+class _FakeFingerprint:
+    """Duck-typed fingerprint."""
+
+    def __init__(self, version: str | None = None) -> None:
+        self.version = version
+
+
+class _FakeTarget:
+    """Minimal target the resolver / dispatcher reads from."""
+
+    def __init__(
+        self,
+        *,
+        product: str = "vault",
+        target_id: UUID | None = None,
+    ) -> None:
+        self.product = product
+        self.fingerprint = _FakeFingerprint()
+        self.preferred_impl_id: str | None = None
+        self.id: UUID = target_id or uuid.uuid4()
+        self.name = "test-target"
+        self.host = "test.example.com"
+        self.port = 443
+        self.auth_model = "shared_service_account"
+
+
+class _NoOpVaultConnector(Connector):
+    """Stub connector so the v2 registry has something to resolve.
+
+    Typed-op tests don't call into the connector's ``execute`` method
+    (the dispatcher routes through the registered typed handler);
+    the concrete methods raise so a future test that accidentally
+    drives through the ingested path surfaces the mismatch loudly.
+    """
+
+    product = "vault"
+    version = "1.x"
+    impl_id = "vault"
+
+    async def fingerprint(self, target: Any) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(  # type: ignore[override]
+        self,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Test handlers
+# ---------------------------------------------------------------------------
+
+
+async def _handler_returning_bearer_token(
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Simulate a connector that returns a bearer token in its response."""
+    return {
+        "token_header": "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+        "kubeconfig": textwrap.dedent(
+            """
+            apiVersion: v1
+            kind: Config
+            clusters:
+              - name: prod
+                cluster:
+                  server: https://k8s.example.com
+            """
+        ).strip(),
+        "id": "deadbeef-1234-5678-90ab-cdef12345678",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_user_path_redacts_response_and_audits_raw(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """User-path dispatch:
+
+    * caller sees the redacted view (no bearer, no kubeconfig);
+    * the audit row stores the raw payload verbatim;
+    * the audit row stores the manifest with rule firings;
+    * the audit row's payload carries the resolved policy id.
+    """
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.user.read",
+        handler=_handler_returning_bearer_token,
+        summary="Read secrets via user-path.",
+        description="Read.",
+        parameter_schema={"type": "object"},
+        safety_level="safe",
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+    operator = _make_operator(principal_kind=PrincipalKind.USER)
+    target = _FakeTarget(product="vault")
+
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.user.read",
+        target=target,
+        params={},
+    )
+
+    # 1) Caller sees the redacted view.
+    assert result.status == "ok", result.error
+    assert isinstance(result.result, dict)
+    serialised = str(result.result)
+    assert "Bearer eyJ" not in serialised
+    assert "[REDACTED:authorization_header]" in serialised
+    assert "[REDACTED:kubeconfig]" in serialised
+
+    # 2) Audit row holds raw payload + manifest.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (await fresh.execute(select(AuditLog).where(AuditLog.path == "vault.user.read")))
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.status_code == 200
+    assert row.raw_payload is not None
+    assert "Bearer eyJ" in str(row.raw_payload)
+    # 3) Manifest persisted as a list of dicts; at least authorization
+    #    header + kubeconfig rules fired.
+    assert isinstance(row.redaction_manifest, list)
+    rule_names = {entry["rule"] for entry in row.redaction_manifest}
+    assert "strip-authorization-header" in rule_names
+    assert "strip-kubeconfig" in rule_names
+    # 4) Policy id mirrored into payload.
+    assert row.payload["redaction_policy_id"] == "connector-boundary-default"
+
+
+@pytest.mark.asyncio
+async def test_agent_path_redacts_response_and_audits_raw(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """Agent-path dispatch (``PrincipalKind.AGENT``) walks the same
+    redaction middleware: the agent / LLM never sees the raw bearer,
+    the audit row still keeps the raw payload + manifest."""
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.agent.read",
+        handler=_handler_returning_bearer_token,
+        summary="Read secrets via agent-path.",
+        description="Read.",
+        parameter_schema={"type": "object"},
+        # Safe op: an agent dispatching this auto-executes (no permission
+        # row needed; the resolver's safety_level default is auto-execute
+        # for safe ops).
+        safety_level="safe",
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+    operator = _make_operator(principal_kind=PrincipalKind.AGENT)
+    target = _FakeTarget(product="vault")
+
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.agent.read",
+        target=target,
+        params={},
+    )
+
+    assert result.status == "ok", result.error
+    serialised = str(result.result)
+    assert "Bearer eyJ" not in serialised
+    assert "[REDACTED:authorization_header]" in serialised
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (await fresh.execute(select(AuditLog).where(AuditLog.path == "vault.agent.read")))
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    row = rows[0]
+    assert "Bearer eyJ" in str(row.raw_payload)
+    assert isinstance(row.redaction_manifest, list)
+    assert any(entry["rule"] == "strip-authorization-header" for entry in row.redaction_manifest)
+    assert row.payload["redaction_policy_id"] == "connector-boundary-default"
+
+
+@pytest.mark.asyncio
+async def test_per_connector_id_policy_override_takes_effect(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """A policy registered for the call's connector_id replaces the
+    default-safe answer. The override here only redacts UUIDs, so the
+    bearer-token leaks through (proving the override is what fired,
+    not the default)."""
+    uuid_only = parse_policy(
+        textwrap.dedent(
+            """
+            id: uuid-only-test
+            version: 1
+            rules:
+              - name: redact-uuid
+                pattern: uuid
+                action: redact
+                reason: "test override"
+            """
+        ).strip()
+    )
+    register_policy(uuid_only, connector_id="vault-1.x")
+
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.override.read",
+        handler=_handler_returning_bearer_token,
+        summary="Read with an override policy.",
+        description="Read.",
+        parameter_schema={"type": "object"},
+        safety_level="safe",
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+    operator = _make_operator(principal_kind=PrincipalKind.USER)
+    target = _FakeTarget(product="vault")
+
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.override.read",
+        target=target,
+        params={},
+    )
+
+    assert result.status == "ok", result.error
+    serialised = str(result.result)
+    # UUID was redacted by the override.
+    assert "[REDACTED:uuid]" in serialised
+    # Bearer survived -- the override has no bearer rule, proving the
+    # default was NOT applied for this call.
+    assert "Bearer eyJ" in serialised
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (await fresh.execute(select(AuditLog).where(AuditLog.path == "vault.override.read")))
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    assert rows[0].payload["redaction_policy_id"] == "uuid-only-test"
+
+
+@pytest.mark.asyncio
+async def test_default_safe_is_not_pass_through(
+    stub_embedding_service: AsyncMock,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """Without any override registered, a credential-shaped response
+    is still redacted. The default policy must apply the named-pattern
+    library, not let raw responses through."""
+    # No register_policy() call here; clear_overrides ran in the autouse
+    # fixture so the resolver falls through to the default.
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.default.read",
+        handler=_handler_returning_bearer_token,
+        summary="Read with default policy only.",
+        description="Read.",
+        parameter_schema={"type": "object"},
+        safety_level="safe",
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+    operator = _make_operator(principal_kind=PrincipalKind.USER)
+    target = _FakeTarget(product="vault")
+
+    result = await dispatch(
+        operator=operator,
+        connector_id="vault-1.x",
+        op_id="vault.default.read",
+        target=target,
+        params={},
+    )
+
+    assert result.status == "ok", result.error
+    assert "Bearer eyJ" not in str(result.result)
+    assert "[REDACTED:" in str(result.result)

--- a/backend/tests/test_migration_0030_redaction_columns.py
+++ b/backend/tests/test_migration_0030_redaction_columns.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0030_add_audit_log_redaction_columns``.
+
+Initiative #805 (G11.4), Task #1071 (T2). Adds the nullable
+``audit_log.raw_payload`` + ``audit_log.redaction_manifest`` JSON
+columns -- the connector-boundary redaction middleware writes both
+on every dispatch row, but pre-G11.4 rows stay NULL. Soft-column
+discipline mirrors 0014 / 0021: nullable, no server default,
+reversible. The migration uses only generic ``sa.JSON`` so PG and
+SQLite parity holds (the ORM pins ``JSONB`` on PG via
+``with_variant``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL."""
+    db_path = tmp_path / "migration_0030.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _audit_log_columns(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA table_info(audit_log)")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def _audit_log_column_is_nullable(sync_url: str, column: str) -> bool:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("PRAGMA table_info(audit_log)")).all()
+    finally:
+        sync_eng.dispose()
+    for row in rows:
+        if str(row[1]) == column:
+            # SQLite PRAGMA: column 3 is notnull (1 = NOT NULL).
+            return int(row[3]) == 0
+    raise AssertionError(f"column {column!r} not present on audit_log")
+
+
+def test_upgrade_adds_both_columns_nullable(alembic_cfg: tuple[Config, str]) -> None:
+    """``upgrade head`` lands both JSON columns as nullable."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    columns = _audit_log_columns(sync_url)
+    assert "raw_payload" in columns
+    assert "redaction_manifest" in columns
+    assert _audit_log_column_is_nullable(sync_url, "raw_payload")
+    assert _audit_log_column_is_nullable(sync_url, "redaction_manifest")
+
+
+def test_downgrade_then_upgrade_round_trips(alembic_cfg: tuple[Config, str]) -> None:
+    """``downgrade 0029`` drops both columns; ``upgrade head`` restores them."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+    assert "raw_payload" in _audit_log_columns(sync_url)
+    assert "redaction_manifest" in _audit_log_columns(sync_url)
+
+    command.downgrade(cfg, "0029")
+    columns = _audit_log_columns(sync_url)
+    assert "raw_payload" not in columns
+    assert "redaction_manifest" not in columns
+
+    command.upgrade(cfg, "head")
+    columns = _audit_log_columns(sync_url)
+    assert "raw_payload" in columns
+    assert "redaction_manifest" in columns
+
+
+def test_existing_columns_untouched(alembic_cfg: tuple[Config, str]) -> None:
+    """Pre-0030 columns survive: actor_sub (0021), agent_session_id (0014),
+    parent_audit_id (0006), target_id (0004), tenant_id (0002)."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    columns = _audit_log_columns(sync_url)
+    for column in (
+        "actor_sub",
+        "agent_session_id",
+        "parent_audit_id",
+        "target_id",
+        "tenant_id",
+        "payload",
+    ):
+        assert column in columns, f"pre-0030 column {column!r} must survive"
+
+
+def test_orm_fields_resolve_and_default_none() -> None:
+    """:attr:`AuditLog.raw_payload` + :attr:`AuditLog.redaction_manifest`
+    resolve and default to ``None``."""
+    from meho_backplane.db.models import AuditLog
+
+    assert hasattr(AuditLog, "raw_payload")
+    assert hasattr(AuditLog, "redaction_manifest")
+    row = AuditLog(
+        operator_sub="op-smoke",
+        method="DISPATCH",
+        path="some.op",
+        status_code=200,
+    )
+    assert row.raw_payload is None
+    assert row.redaction_manifest is None

--- a/backend/tests/test_redaction_middleware.py
+++ b/backend/tests/test_redaction_middleware.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.redaction.middleware`.
+
+Pins:
+
+* :func:`apply_connector_boundary_redaction` returns the
+  ``RedactionMiddlewareResult`` shape (raw, redacted, manifest,
+  policy_id).
+* The default-safe policy is what fires when no override matches.
+* Normalisation: Pydantic models flatten to dicts; tuples / sets
+  flatten to lists; bytes become hex; non-string keys coerce.
+* :func:`manifest_to_audit_payload` produces JSON-encoder-safe dicts.
+* Bearer-token-shaped strings round-trip raw -> redacted.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from collections.abc import Iterator
+
+import pytest
+from pydantic import BaseModel
+
+from meho_backplane.redaction import (
+    RedactionMiddlewareResult,
+    apply_connector_boundary_redaction,
+    clear_overrides,
+    manifest_to_audit_payload,
+    normalize_for_audit,
+    parse_policy,
+    register_policy,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_overrides() -> Iterator[None]:
+    """Reset resolver overrides around every test."""
+    clear_overrides()
+    yield
+    clear_overrides()
+
+
+def test_bearer_token_redacted_default_safe() -> None:
+    """An un-configured call still strips a bearer token: the default
+    policy is the conservative default-safe answer, not pass-through."""
+    raw = {"authorization": "Bearer eyJabcdefghijklmnop1234"}
+    result = apply_connector_boundary_redaction(
+        raw,
+        connector_id="some-connector",
+        tenant=None,
+        op="some.op",
+    )
+
+    assert isinstance(result, RedactionMiddlewareResult)
+    assert "Bearer eyJ" not in str(result.redacted)
+    assert "[REDACTED:" in str(result.redacted["authorization"])
+    # raw preserves the original value so the audit row keeps the
+    # pre-redaction view.
+    assert "Bearer eyJabcdefghijklmnop1234" in str(result.raw["authorization"])
+    assert result.policy_id == "connector-boundary-default"
+
+
+def test_manifest_records_every_rule_firing() -> None:
+    """One manifest entry per rule per leaf; the engine's contract is
+    surfaced unchanged through the middleware."""
+    raw = {
+        "headers": {
+            "authorization": "Bearer eyJabcdefghijklmnop1234",
+            "x-api-key": "api_key=topsecretvalue1234",
+        },
+    }
+    result = apply_connector_boundary_redaction(
+        raw,
+        connector_id="github",
+        tenant=None,
+        op="repos.get",
+    )
+    # At least the bearer + api_key firings; the default-safe policy
+    # may produce more depending on the value shape (e.g. inner
+    # ``Bearer`` plus authorization-header rule both fire).
+    rule_names = {entry.rule for entry in result.manifest}
+    assert {"strip-bearer-token", "strip-api-key"}.issubset(rule_names)
+
+
+def test_override_policy_takes_effect() -> None:
+    """A registered override on the call's connector_id is what the
+    middleware applies, not the default."""
+    minimal = parse_policy(
+        textwrap.dedent(
+            """
+            id: minimal-uuid-only
+            version: 1
+            rules:
+              - name: hash-uuid
+                pattern: uuid
+                action: hash
+                reason: "test override"
+            """
+        ).strip()
+    )
+    register_policy(minimal, connector_id="github")
+
+    raw = {
+        "id": "deadbeef-1234-5678-90ab-cdef12345678",
+        "authorization": "Bearer eyJabcdefghijklmnop1234",
+    }
+    result = apply_connector_boundary_redaction(
+        raw,
+        connector_id="github",
+        tenant=None,
+        op="any.op",
+    )
+    assert result.policy_id == "minimal-uuid-only"
+    # The override has no bearer-token rule, so the bearer survives.
+    assert "Bearer eyJ" in str(result.redacted["authorization"])
+    # The UUID is hashed.
+    assert "sha256:" in result.redacted["id"]
+
+
+def test_normalize_pydantic_model_flattens_to_dict() -> None:
+    """Handlers returning Pydantic models still reach the engine and
+    audit row as JSON-shaped dicts."""
+
+    class Resp(BaseModel):
+        id: int
+        token: str
+
+    out = normalize_for_audit(Resp(id=42, token="Bearer eyJabcdefghijklmnop1234"))
+    assert out == {"id": 42, "token": "Bearer eyJabcdefghijklmnop1234"}
+
+
+def test_normalize_tuple_and_set_flatten_to_list() -> None:
+    """Tuples and sets become lists; the audit JSON encoder can serialise
+    them safely."""
+    out = normalize_for_audit({"a": (1, 2, 3), "b": {"x", "y"}})
+    assert isinstance(out["a"], list)
+    assert out["a"] == [1, 2, 3]
+    assert isinstance(out["b"], list)
+    assert sorted(out["b"]) == ["x", "y"]
+
+
+def test_normalize_non_string_key_is_stringified() -> None:
+    """JSON cannot represent non-string keys; the audit row needs
+    string keys."""
+    out = normalize_for_audit({1: "a", 2: "b"})
+    assert out == {"1": "a", "2": "b"}
+
+
+def test_normalize_bytes_to_hex() -> None:
+    """Binary payloads at the redaction boundary surface as hex so
+    they are JSON-encoder-safe and don't trigger spurious base64
+    matches in the named-pattern library."""
+    out = normalize_for_audit({"blob": b"\xde\xad\xbe\xef"})
+    assert out["blob"] == "deadbeef"
+
+
+def test_manifest_to_audit_payload_returns_jsonable_list() -> None:
+    """The manifest serialises to a list of plain dicts; the audit
+    insert encoder accepts them without per-row Pydantic round-trip."""
+    raw = {"v": "Bearer eyJabcdefghijklmnop1234"}
+    result = apply_connector_boundary_redaction(
+        raw,
+        connector_id=None,
+        tenant=None,
+        op=None,
+    )
+    serialised = manifest_to_audit_payload(result.manifest)
+    assert isinstance(serialised, list)
+    assert all(isinstance(entry, dict) for entry in serialised)
+    # Each dict has the expected keys.
+    sample = serialised[0]
+    assert {"rule", "pattern", "action", "count", "span", "reason", "path"} <= sample.keys()
+
+
+def test_redaction_pipeline_is_idempotent() -> None:
+    """Same input + same policy → identical output (engine determinism
+    surfaced through the middleware)."""
+    raw = {
+        "token": "Bearer eyJabcdefghijklmnop1234",
+        "id": "deadbeef-1234-5678-90ab-cdef12345678",
+    }
+    first = apply_connector_boundary_redaction(raw, connector_id="c", tenant=None, op="o")
+    second = apply_connector_boundary_redaction(raw, connector_id="c", tenant=None, op="o")
+    assert first.redacted == second.redacted
+    assert first.policy_id == second.policy_id
+    assert manifest_to_audit_payload(first.manifest) == manifest_to_audit_payload(second.manifest)
+
+
+def test_str_payload_passes_through_engine() -> None:
+    """A top-level string payload is a legal handler return shape;
+    the engine treats it as one leaf."""
+    raw = "Bearer eyJabcdefghijklmnop1234"
+    result = apply_connector_boundary_redaction(raw, connector_id=None, tenant=None, op=None)
+    assert "Bearer eyJ" not in str(result.redacted)
+    assert "[REDACTED:bearer_token]" in str(result.redacted)
+
+
+def test_none_payload_passes_through_unchanged() -> None:
+    """A connector returning ``None`` produces an empty manifest and
+    the redacted view stays ``None``."""
+    result = apply_connector_boundary_redaction(None, connector_id=None, tenant=None, op=None)
+    assert result.raw is None
+    assert result.redacted is None
+    assert result.manifest == ()

--- a/backend/tests/test_redaction_resolver.py
+++ b/backend/tests/test_redaction_resolver.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.redaction.resolver`.
+
+Pins:
+
+* Default-safe: an un-configured call returns the packaged default
+  policy (not pass-through; the policy has rules).
+* Specificity ladder: ``(connector_id, tenant, op)`` beats
+  ``(connector_id, op)`` beats ``connector_id`` beats ``tenant`` beats
+  the built-in default.
+* ``clear_overrides()`` actually clears -- subsequent resolves fall
+  back to the default.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from collections.abc import Iterator
+
+import pytest
+
+from meho_backplane.redaction import (
+    RedactionPolicy,
+    clear_overrides,
+    get_default_policy,
+    parse_policy,
+    register_policy,
+    resolve_policy,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_overrides() -> Iterator[None]:
+    """Reset registered overrides around every test in this file.
+
+    The resolver is process-global state. A leaked registration would
+    surface as a flake in the next test that calls :func:`resolve_policy`
+    against the same labels. The autouse teardown is the cheapest way
+    to keep the file deterministic under pytest-xdist parallelism
+    (each worker has its own interpreter, so the lock isn't sufficient
+    -- the registry would still leak within one worker).
+    """
+    clear_overrides()
+    yield
+    clear_overrides()
+
+
+def _policy(policy_id: str) -> RedactionPolicy:
+    """Build a one-rule policy with the given id for matching."""
+    return parse_policy(
+        textwrap.dedent(
+            f"""
+            id: {policy_id}
+            version: 1
+            rules:
+              - name: r-{policy_id}
+                pattern: bearer_token
+                action: redact
+                reason: "test policy {policy_id}"
+            """
+        ).strip()
+    )
+
+
+def test_default_policy_returned_when_no_overrides_registered() -> None:
+    """Default-safe contract: an un-configured call gets the packaged
+    default policy, which still applies the named-pattern library."""
+    resolved = resolve_policy(connector_id="anything", tenant="t1", op="op.x")
+    assert resolved is get_default_policy()
+    # The default-safe policy is not empty -- proving "not pass-through".
+    assert len(resolved.rules) >= 1
+    # Default-safe targets credential-shaped patterns.
+    pattern_names = {rule.pattern for rule in resolved.rules}
+    assert "authorization_header" in pattern_names
+    assert "bearer_token" in pattern_names
+
+
+def test_default_policy_load_is_cached() -> None:
+    """The packaged YAML is loaded once and reused; two calls return
+    the identical reference."""
+    first = get_default_policy()
+    second = get_default_policy()
+    assert first is second
+
+
+def test_register_connector_id_override_beats_default() -> None:
+    """A ``(connector_id, None, None)`` override fires when the call's
+    connector_id matches, regardless of tenant or op labels."""
+    custom = _policy("custom-github")
+    register_policy(custom, connector_id="github")
+
+    resolved = resolve_policy(connector_id="github", tenant="t1", op="op.x")
+    assert resolved is custom
+
+
+def test_more_specific_override_beats_less_specific() -> None:
+    """The ``(connector_id, tenant, op)`` triple is the most specific
+    key; a less-specific override registered for the same connector_id
+    must not win."""
+    broad = _policy("broad-github")
+    narrow = _policy("narrow-github-tenant-op")
+    register_policy(broad, connector_id="github")
+    register_policy(narrow, connector_id="github", tenant="t1", op="op.x")
+
+    resolved = resolve_policy(connector_id="github", tenant="t1", op="op.x")
+    assert resolved is narrow
+
+
+def test_connector_op_override_beats_connector_only() -> None:
+    """``(connector_id, None, op)`` beats ``(connector_id, None, None)``
+    when the op label matches."""
+    broad = _policy("broad-github")
+    op_scoped = _policy("github-op-x")
+    register_policy(broad, connector_id="github")
+    register_policy(op_scoped, connector_id="github", op="op.x")
+
+    resolved = resolve_policy(connector_id="github", tenant="t1", op="op.x")
+    assert resolved is op_scoped
+
+
+def test_tenant_wide_override_falls_back_to_default_for_other_tenants() -> None:
+    """A tenant-wide override on (None, t1, None) applies to t1 but
+    not to other tenants."""
+    t1_policy = _policy("tenant-t1")
+    register_policy(t1_policy, tenant="t1")
+
+    resolved_t1 = resolve_policy(connector_id="github", tenant="t1", op="op.x")
+    resolved_t2 = resolve_policy(connector_id="github", tenant="t2", op="op.x")
+    assert resolved_t1 is t1_policy
+    assert resolved_t2 is get_default_policy()
+
+
+def test_none_tenant_call_does_not_match_tenant_scoped_override() -> None:
+    """A ``None`` tenant label only matches an override whose tenant
+    is also ``None``; tenant-scoped overrides are skipped."""
+    t1_policy = _policy("tenant-t1")
+    register_policy(t1_policy, tenant="t1")
+
+    resolved = resolve_policy(connector_id="github", tenant=None, op="op.x")
+    assert resolved is get_default_policy()
+
+
+def test_clear_overrides_resets_resolution_to_default() -> None:
+    """After :func:`clear_overrides`, the next resolve falls back to
+    the built-in default."""
+    custom = _policy("scoped")
+    register_policy(custom, connector_id="github")
+    assert resolve_policy(connector_id="github", tenant=None, op=None) is custom
+
+    clear_overrides()
+    assert resolve_policy(connector_id="github", tenant=None, op=None) is get_default_policy()
+
+
+def test_re_register_overwrites_previous_policy() -> None:
+    """Registering twice on the same key uses the latest registration."""
+    first = _policy("first")
+    second = _policy("second")
+    register_policy(first, connector_id="github")
+    register_policy(second, connector_id="github")
+
+    resolved = resolve_policy(connector_id="github", tenant=None, op=None)
+    assert resolved is second

--- a/docs/codebase/redaction.md
+++ b/docs/codebase/redaction.md
@@ -2,14 +2,24 @@
 
 Initiative [#805](https://github.com/evoila/meho/issues/805) (G11.4 Safety,
 C1) ships a sanitization middleware that redacts every connector response
-before it reaches a caller or LLM. This document covers the foundation
-slice landed by Task [#1070](https://github.com/evoila/meho/issues/1070):
-the **declarative policy schema** + the **Tier-1 named-pattern regex
-engine** + the **named-pattern library**. The middleware that wires the
-engine into `dispatcher._reduce_or_error` (C1-b, #1071), the Tier-2
-Microsoft Presidio NER adapter (C1-c, #1072), the round-trip CI gate
-(C1-d, #1073), and the agent-invocation audit row (C2-b, #1074) are
-sibling tickets and land on top of this surface.
+before it reaches a caller or LLM. This document covers two landed
+slices:
+
+* The foundation
+  ([#1070](https://github.com/evoila/meho/issues/1070)): declarative
+  policy schema, Tier-1 named-pattern regex engine, named-pattern
+  library.
+* The connector-boundary wiring
+  ([#1071](https://github.com/evoila/meho/issues/1071)): the
+  middleware that sits in `dispatcher._reduce_or_error` and runs
+  capture-raw → audit-raw → redact → reduce on every dispatch.
+
+Pending sibling tickets: the Tier-2 Microsoft Presidio NER adapter
+(C1-c, [#1072](https://github.com/evoila/meho/issues/1072)), the
+round-trip CI gate (C1-d,
+[#1073](https://github.com/evoila/meho/issues/1073)), and the
+agent-invocation audit row (C2-b,
+[#1074](https://github.com/evoila/meho/issues/1074)).
 
 ## Overview
 
@@ -127,16 +137,128 @@ need to spot duplicates without seeing the value, and `hash` when an
 audit replay needs to confirm the same identifier appears across
 calls.
 
+## Connector-boundary middleware (#1071)
+
+The middleware lives at
+`backend/src/meho_backplane/redaction/middleware.py` and is the seam
+the dispatcher imports. Its public surface is one function and one
+return type:
+
+| Symbol | Module | Role |
+| --- | --- | --- |
+| `apply_connector_boundary_redaction(raw, *, connector_id, tenant, op)` | `middleware.py` | Resolves the policy, normalises *raw*, applies the engine, returns a `RedactionMiddlewareResult`. |
+| `RedactionMiddlewareResult` | `middleware.py` | Carries `raw` (JSON-normalised input), `redacted` (engine output), `manifest` (tuple of entries), `policy_id` (resolved policy's id). |
+| `manifest_to_audit_payload(manifest)` | `middleware.py` | Serialises the manifest to a list of plain dicts so the audit insert accepts it without per-row Pydantic round-trip. |
+| `normalize_for_audit(value)` | `middleware.py` | Coerces a handler return value to JSON-shaped containers (Pydantic models flatten, tuples / sets / bytes normalised). |
+
+### Policy resolution
+
+`resolver.py` answers "which policy applies to this call?" via a six-step
+specificity ladder, from most specific to least:
+
+1. `(connector_id, tenant, op)` — full-tuple override.
+2. `(connector_id, op)` — per-connector, per-op (tenant wildcard).
+3. `(connector_id, tenant)` — per-connector, per-tenant.
+4. `connector_id` — per-connector default.
+5. `tenant` — tenant-wide default across every connector.
+6. The packaged **default-safe** policy
+   (`policies/default.yaml`) — the conservative fallback.
+
+The default-safe policy is the load-bearing guarantee: a connector
+landing without a registered override **still gets credentials
+stripped** (`authorization_header`, `bearer_token`, `jwt`, `api_key`,
+`kubeconfig`). Identifier patterns (`uuid` / `ipv4` / `ipv6` / `fqdn`)
+are deliberately not in the default — most connector responses are
+mostly identifiers, and a global default that redacts them would
+blank operator-facing summaries. Operators wanting them at the global
+level register a wider policy via `register_policy(policy)` (no
+connector/tenant/op filter = global override).
+
+Policy registration is process-global mutable state. Tests call
+`clear_overrides()` in a fixture teardown to keep registrations from
+leaking; production today runs without any overrides (per-tenant
+policy authoring is a follow-on).
+
+### Dispatcher integration
+
+`dispatcher._execute_and_audit` calls the middleware once per
+successful handler return, between "handler returned a raw response"
+and "JSONFlux reducer consumes it":
+
+```
+       handler returns raw payload
+                   │
+                   ▼
+       _apply_redaction_middleware(raw, connector_id, operator, op_id)
+                   │
+                   ▼
+          RedactionMiddlewareResult
+            │ raw / redacted / manifest / policy_id
+            ▼
+       _reduce_or_error(raw=redacted, raw_payload_for_audit=raw, …)
+                   │
+                   ▼
+       audit_and_broadcast_safe(
+           …,
+           raw_payload=redaction.raw,
+           redaction_manifest=manifest_to_audit_payload(redaction.manifest),
+           redaction_policy_id=redaction.policy_id,
+       )
+```
+
+The reducer (`JsonFluxReducer` in production, `PassThroughReducer`
+in unit tests) sees the **redacted** payload; the caller and any
+LLM consuming `OperationResult.result` therefore see redacted
+strings. The raw payload only flows into the audit row, never out
+of the dispatcher's `OperationResult`.
+
+Middleware failures (regex compile error, default policy load
+crash) are caught and converted to a structured `connector_error`
+`OperationResult` so the dispatcher's never-raises contract is
+preserved — a redactor failure must not leak raw payloads through a
+500 with no audit record.
+
+### Audit columns
+
+Migration `0030` adds two nullable JSON columns to `audit_log`
+(`raw_payload`, `redaction_manifest`); the resolved policy id is
+mirrored into the existing `payload` JSON column as
+`payload['redaction_policy_id']` so the broadcast event
+(serialising `payload`, not the dedicated columns) carries policy
+attribution. Pre-G11.4 audit rows leave both columns NULL.
+
+Why two new columns rather than one `audit_log.payload` extension:
+
+- `raw_payload` is potentially **large** (a connector list response
+  can be megabytes); keeping it in a dedicated column lets the
+  audit-query surface skip it on list endpoints without parsing
+  JSON to find the field.
+- `redaction_manifest` is **structured** (a list of dicts with a
+  fixed schema); a future GIN index on the JSONB column (e.g.
+  "find every audit row where the `kubeconfig` rule fired in the
+  last 30 days") can be added without a column rewrite. The
+  `payload` column already hosts heterogeneous handler-bound
+  extras, so adding indexable redaction fields there would be a
+  query-plan headache later.
+
+Error-path audit rows (handler raised before producing a response)
+have no raw payload to redact and leave both columns NULL — the
+existing `result_status='error'` shape already records the
+exception class / message in `payload`. Reducer-failure rows do
+keep the redaction artefacts: the middleware ran successfully
+before the reducer crashed, so the raw + manifest are still
+recovery-grade evidence.
+
 ## Dependencies
 
 - **PyYAML** (`yaml.safe_load`) — already a transitive dep; matches
   the precedent set by `operations/ingest/catalog.py`.
 - **Pydantic v2** — already pinned in `backend/pyproject.toml`.
 - **Python stdlib** — `re`, `hashlib`, `importlib.resources`,
-  `collections.abc`. No third-party regex / NER libraries here;
-  Tier-2 (#1072) adds Microsoft Presidio.
+  `collections.abc`, `threading` (resolver lock). No third-party
+  regex / NER libraries here; Tier-2 (#1072) adds Microsoft Presidio.
 
-No new runtime dependencies were added by Task #1070.
+No new runtime dependencies were added by Task #1070 or #1071.
 
 ## Known issues / future work
 
@@ -158,11 +280,14 @@ No new runtime dependencies were added by Task #1070.
   rules in policy order first. The diagnostic value of `span` is
   consequently bounded; `count`, `rule`, and `path` remain the
   load-bearing manifest fields.
-- **No per-tenant policy resolution yet.** This task ships the schema
-  and engine only. The middleware (#1071) is responsible for
-  resolving "which policy applies to this call" from settings / DB;
-  the engine accepts the policy as a parameter and applies it
-  verbatim.
+- **No per-tenant policy authoring path yet.** The resolver supports
+  per-(connector_id, tenant, op) registration via `register_policy`
+  (#1071), but there is no DB-backed policy table or operator-facing
+  UI for landing rules — production today runs on the packaged
+  default-safe policy only. The per-tenant authoring UX is a
+  follow-on; the registration shape exists so the middleware can be
+  exercised in tests and so the policy id reaches the audit row
+  ready for an operator-managed source.
 - **Bytes payloads are passed through.** The JSONFlux reduce boundary
   produces JSON-shaped values, so the engine's contract excludes
   bytes; if a future connector emits binary payloads at the


### PR DESCRIPTION
## Summary

- Wires the Tier-1 redaction engine (#1070) into `dispatcher._execute_and_audit` so every dispatch — user-path and agent-path — runs **capture-raw → audit-raw → redact → reduce → return**. The caller and LLM see only the redacted view; the audit row holds the raw payload plus the engine's manifest for forensic recovery.
- Adds the connector-boundary middleware (`meho_backplane.redaction.middleware`) + a policy resolver with a six-step specificity ladder (per-`connector_id`, per-tenant, per-op → packaged conservative default). **Default-safe**: an un-configured connector still gets credentials stripped — never pass-through.
- Migration `0030` adds two nullable JSON columns to `audit_log` (`raw_payload`, `redaction_manifest`); the resolved policy id mirrors into `payload['redaction_policy_id']` for broadcast-event attribution. Migration is purely additive (backward-compat guard green).

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/` — clean (352 source files)
- [x] `python3 scripts/ci/check_migration_compat.py` — exit 0
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers (one escape-valve on the pre-existing 151-line `dispatch` orchestrator)
- [x] `pytest tests/` — **5079 passed**, 33 skipped (only secret-guarded integration tests skip)
- [x] **AC: bearer / kubeconfig response is redacted to caller** — `test_user_path_redacts_response_and_audits_raw` proves the user-path; `test_agent_path_redacts_response_and_audits_raw` proves the agent-path.
- [x] **AC: raw retrievable from audit row** — both integration tests assert `row.raw_payload` contains the original `Bearer eyJ...` string.
- [x] **AC: manifest recorded** — both integration tests assert `row.redaction_manifest` is a list with `strip-authorization-header` / `strip-kubeconfig` rule firings.
- [x] **AC: per-`connector_id` policy selection** — `test_per_connector_id_policy_override_takes_effect` registers an override and asserts the resolved `policy_id` reflects it, not the default.
- [x] **AC: default-safe (no policy → conservative default, not pass-through)** — `test_default_safe_is_not_pass_through` + 9 resolver/middleware unit tests in `test_redaction_resolver.py` / `test_redaction_middleware.py`.
- [x] **AC: migration backward-compat guard green** — `test_migration_0030_redaction_columns.py` covers upgrade/downgrade round-trip + survival of pre-0030 columns; the `check_migration_compat.py` CI gate exits 0.

## Out of scope

- Tier-2 NER (Microsoft Presidio adapter) — sibling task #1072 (C1-c).
- Round-trip CI gate replaying the manifest against `raw_payload` — sibling task #1073 (C1-d).
- Agent-invocation audit row + retention/scrubbing — sibling tasks #1074 (C2-b) and follow-on.
- Per-tenant policy authoring UX — the resolver supports per-(connector_id, tenant, op) registration but no DB-backed policy table or operator UI yet; production today runs on the packaged default-safe policy only.

Closes #1071


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic redaction of sensitive data (tokens, API keys, credentials) from connector responses using default-safe policies
  * Enhanced audit trail to record both raw and redacted payloads for transparency and compliance auditing
  * Introduced customizable redaction policies with per-connector, per-tenant, and per-operation specificity

* **Documentation**
  * Updated architecture documentation covering connector-boundary redaction and audit enhancements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1180?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->