### PR TITLE
feat(ui): G10.3-T3 bulk targets.yaml import — paste/upload → preview → in-process create/update CRUD

### DIFF
--- a/backend/src/meho_backplane/ui/routes/connectors/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/__init__.py
@@ -37,8 +37,16 @@ Module layout:
   into the REST ``POST``/``PATCH`` ``/api/v1/targets`` handlers
   in-process so the UI and REST surfaces share one validation +
   product-check + audit code path.
+* :mod:`~meho_backplane.ui.routes.connectors.import_router` -- the
+  T3 (#875) bulk-import routes (``GET``/``POST`` ``/ui/connectors/import``
+  + ``POST /ui/connectors/import/confirm``). Tenant_admin-gated
+  server-side; the operator pastes / uploads a ``targets.yaml`` which
+  is parsed (``yaml.safe_load``), classified CREATE-vs-UPDATE, and on
+  confirm applied **in-process** via ``create_target`` / ``update_target``
+  -- mirroring the client-orchestrated CRUD the ``meho targets import``
+  CLI (#257) performs (there is no ``/api/v1/targets/import`` endpoint).
 
-The umbrella :func:`build_router` aggregates all four. It is mounted
+The umbrella :func:`build_router` aggregates all five. It is mounted
 **before** :func:`~meho_backplane.ui.routes.stubs.build_stubs_router`
 in :func:`~meho_backplane.ui.routes.build_router` so the real
 ``/ui/connectors`` and ``/ui/connectors/{name}`` handlers win the
@@ -61,6 +69,7 @@ from fastapi import APIRouter
 
 from meho_backplane.ui.routes.connectors.detail import build_detail_router
 from meho_backplane.ui.routes.connectors.forms_router import build_forms_router
+from meho_backplane.ui.routes.connectors.import_router import build_import_router
 from meho_backplane.ui.routes.connectors.list_view import build_list_router
 from meho_backplane.ui.routes.connectors.probe import build_probe_router
 
@@ -83,6 +92,10 @@ def build_router() -> APIRouter:
     the detail router for the same reason -- its literal
     ``GET /ui/connectors/create`` route must win the first-match-wins
     lookup over ``GET /ui/connectors/{name}`` (otherwise ``"create"``
+    binds to ``name``). The T3 import router is included for the same
+    reason -- its literal ``/ui/connectors/import`` /
+    ``/ui/connectors/import/confirm`` routes must win the first-match
+    lookup over ``GET /ui/connectors/{name}`` (otherwise ``"import"``
     binds to ``name``). The probe route's path is fully literal
     (``/ui/connectors/{name}/probe``) so the ``POST`` verb plus the
     extra ``/probe`` segment makes it unambiguous regardless of order;
@@ -94,6 +107,7 @@ def build_router() -> APIRouter:
     router = APIRouter()
     router.include_router(build_list_router())
     router.include_router(build_forms_router())
+    router.include_router(build_import_router())
     router.include_router(build_detail_router())
     router.include_router(build_probe_router())
     return router

--- a/backend/src/meho_backplane/ui/routes/connectors/import_router.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/import_router.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Route registration for the bulk ``targets.yaml`` import UI (Task #875).
+
+Thin FastAPI wrappers that parse the multipart form (paste text + an
+optional uploaded file), resolve the tenant_admin-gated
+:class:`~meho_backplane.auth.operator.Operator`, and hand off to the
+render / submit helpers in
+:mod:`~meho_backplane.ui.routes.connectors.import_view`. Split from the
+parse / classify logic so neither module exceeds the chassis ~600-line
+cap and the mapping helpers stay unit-testable without a FastAPI
+:class:`Request` fixture.
+
+Route inventory (all tenant_admin-gated server-side via
+:func:`~meho_backplane.ui.routes.connectors.operator.resolve_operator_or_403`):
+
+* ``GET  /ui/connectors/import``         -- the full import page.
+* ``POST /ui/connectors/import``         -- parse + render the preview.
+* ``POST /ui/connectors/import/confirm`` -- apply the plan in-process.
+
+Registration order is **load-bearing**: every path here is a literal
+prefix (``/ui/connectors/import`` ...) that must register before the
+parametrised ``GET /ui/connectors/{name}`` detail route, otherwise the
+literal ``"import"`` token is captured as a target ``name`` by the
+detail handler. The umbrella
+:func:`~meho_backplane.ui.routes.connectors.build_router` includes this
+router before the detail router for that reason.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, File, Form, Request, UploadFile
+from fastapi.responses import HTMLResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.db.engine import get_session
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.routes.connectors.import_view import (
+    render_import_page,
+    render_preview,
+    submit_confirm,
+)
+from meho_backplane.ui.routes.connectors.operator import resolve_operator_or_403
+
+__all__ = ["build_import_router"]
+
+#: Module-level :class:`Depends` closures -- ruff B008 idiom matching
+#: the chassis list / detail / forms routers.
+_require_session_dep = Depends(require_ui_session)
+_require_admin_dep = Depends(resolve_operator_or_403)
+_get_session_dep = Depends(get_session)
+
+#: Upper bound on the YAML payload the parse path accepts. The chassis
+#: CSRF middleware already caps the buffered body at 256 KiB; this
+#: tighter cap rejects an oversized paste before the parse allocates,
+#: matching the form-field caps the T2 create / edit router sets.
+_YAML_MAX_BYTES = 256 * 1024
+
+
+async def _resolve_yaml_text(pasted: str | None, upload: UploadFile | None) -> str:
+    """Resolve the submitted YAML to a single string.
+
+    An uploaded file takes precedence over a non-empty paste (the file
+    is the more deliberate gesture). The bytes are decoded as UTF-8
+    with ``errors="replace"`` so a stray non-UTF-8 byte surfaces as a
+    YAML parse error in the preview rather than a 500; the parse path
+    owns the operator-facing error message.
+    """
+    if upload is not None and upload.filename:
+        raw = await upload.read()
+        return raw.decode("utf-8", errors="replace")
+    return pasted or ""
+
+
+async def _import_page_handler(
+    request: Request,
+    session_ctx: UISessionContext = _require_session_dep,
+    operator: Operator = _require_admin_dep,
+) -> HTMLResponse:
+    """``GET /ui/connectors/import`` -- the full import page."""
+    del operator  # gate only; the page render needs no operator context.
+    return await render_import_page(request, session_ctx)
+
+
+async def _import_preview_handler(
+    request: Request,
+    pasted: str | None = Form(default=None, max_length=_YAML_MAX_BYTES),
+    upload: UploadFile | None = File(default=None),
+    session_ctx: UISessionContext = _require_session_dep,
+    operator: Operator = _require_admin_dep,
+    db_session: AsyncSession = _get_session_dep,
+) -> HTMLResponse:
+    """``POST /ui/connectors/import`` -- parse + render the preview table.
+
+    ``operator`` is resolved purely as the tenant_admin gate; the
+    preview is read-only (it classifies but does not write), so the
+    existing-name lookup runs under ``session_ctx.tenant_id``.
+    """
+    del operator  # gate only; preview is read-only.
+    yaml_text = await _resolve_yaml_text(pasted, upload)
+    return await render_preview(request, session_ctx, db_session, yaml_text=yaml_text)
+
+
+async def _import_confirm_handler(
+    request: Request,
+    pasted: str | None = Form(default=None, max_length=_YAML_MAX_BYTES),
+    upload: UploadFile | None = File(default=None),
+    session_ctx: UISessionContext = _require_session_dep,
+    operator: Operator = _require_admin_dep,
+    db_session: AsyncSession = _get_session_dep,
+) -> HTMLResponse:
+    """``POST /ui/connectors/import/confirm`` -- apply the plan in-process."""
+    yaml_text = await _resolve_yaml_text(pasted, upload)
+    return await submit_confirm(request, session_ctx, operator, db_session, yaml_text=yaml_text)
+
+
+def build_import_router() -> APIRouter:
+    """Construct the bulk-import :class:`APIRouter`.
+
+    Factory function (not a module-level constant) so a test app can
+    construct parallel routers without sharing route state -- mirrors
+    the list / detail / probe / forms router convention. All paths are
+    literal prefixes that must register before the parametrised detail
+    route (handled by the include order in
+    :func:`~meho_backplane.ui.routes.connectors.build_router`).
+    """
+    router = APIRouter(tags=["ui-connectors"])
+    router.add_api_route(
+        "/ui/connectors/import",
+        _import_page_handler,
+        methods=["GET"],
+        name="ui_connectors_import_page",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/connectors/import",
+        _import_preview_handler,
+        methods=["POST"],
+        name="ui_connectors_import_preview",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/connectors/import/confirm",
+        _import_confirm_handler,
+        methods=["POST"],
+        name="ui_connectors_import_confirm",
+        response_class=HTMLResponse,
+    )
+    return router

--- a/backend/src/meho_backplane/ui/routes/connectors/import_router.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/import_router.py
@@ -52,10 +52,13 @@ _require_session_dep = Depends(require_ui_session)
 _require_admin_dep = Depends(resolve_operator_or_403)
 _get_session_dep = Depends(get_session)
 
-#: Upper bound on the YAML payload the parse path accepts. The chassis
-#: CSRF middleware already caps the buffered body at 256 KiB; this
-#: tighter cap rejects an oversized paste before the parse allocates,
-#: matching the form-field caps the T2 create / edit router sets.
+#: Upper bound on the YAML payload the parse path accepts. The CSRF
+#: middleware's 256 KiB body cap only runs for
+#: ``application/x-www-form-urlencoded`` requests; a multipart upload is
+#: instead bounded by Starlette's ``MultiPartParser.max_part_size``
+#: (1 MiB default, 422 on exceed). This tighter app-level cap rejects an
+#: oversized paste or upload before the parse allocates, matching the
+#: form-field caps the T2 create / edit router sets.
 _YAML_MAX_BYTES = 256 * 1024
 
 

--- a/backend/src/meho_backplane/ui/routes/connectors/import_view.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/import_view.py
@@ -1,0 +1,478 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Bulk ``targets.yaml`` import UI (paste / upload -> preview -> confirm).
+
+Initiative #340 (G10.3 Connectors + Targets UI), Task #875 (T3) work
+item #5. The operator pastes or uploads a ``targets.yaml`` file; the
+server parses it (:func:`yaml.safe_load`), classifies every entry as
+CREATE or UPDATE against the caller's tenant, and renders a preview
+table. On confirm the route applies the plan **in-process** via the
+existing target CRUD handlers
+(:func:`~meho_backplane.api.v1.targets.create_target` for new names,
+:func:`~meho_backplane.api.v1.targets.update_target` for existing
+ones) and renders a result summary.
+
+There is **no** ``/api/v1/targets/import`` server endpoint. This UI
+mirrors the client-orchestrated CRUD the ``meho targets import`` CLI
+tool (G0.3-T6 #257, ``cli/internal/cmd/targets/import.go``) performs:
+parse -> list existing names -> classify CREATE vs UPDATE -> POST new /
+PATCH existing. The key-mapping + classification logic here is a
+server-side port of that CLI's ``mapEntry`` / ``buildLivePlan``, so the
+web import and the CLI import produce byte-identical writes for the
+same YAML.
+
+Mapping rules (parity with ``import.go``)
+-----------------------------------------
+
+* **Known top-level keys** -- ``name``, ``aliases``, ``product``,
+  ``host``, ``port``, ``fqdn``, ``secret_ref``, ``auth_model``,
+  ``vpn_required``, ``notes``, ``preferred_impl_id``, ``extras`` -- map
+  1:1 to :class:`~meho_backplane.targets.schemas.TargetCreate` /
+  :class:`~meho_backplane.targets.schemas.TargetUpdate` fields.
+* **Unknown keys** spill into the ``extras`` JSONB column (merged with
+  an explicit ``extras:`` block when one is present in the YAML).
+* **``fingerprint``** is server-managed (the probe verb is the only
+  legitimate writer; both write schemas reject it via
+  ``extra='forbid'``) -> dropped from the import with a preview
+  warning.
+* **CREATE vs UPDATE** is decided by an existing-name lookup scoped to
+  the caller's tenant.
+* On **UPDATE** the body is **sparse** (only keys present in the YAML);
+  ``name`` and ``product`` are stripped because the PATCH route rejects
+  ``name`` and the CLI strips ``product`` on update (rename = delete +
+  create per the G0.3 contract).
+
+RBAC + isolation
+----------------
+
+Every route is **tenant_admin only**; the gate is server-side via
+:func:`~meho_backplane.ui.routes.connectors.operator.resolve_operator_or_403`
+(the same write-gate T1's re-probe and T2's create / edit use). CSRF is
+enforced by the chassis :class:`~meho_backplane.ui.csrf.CSRFMiddleware`
+on the ``POST`` routes. Cross-tenant isolation is enforced at two
+layers: the existing-name lookup filters on ``session_ctx.tenant_id``,
+and the in-process ``create_target`` / ``update_target`` handlers write
+/ resolve under ``operator.tenant_id`` (the caller's tenant), so an
+import can only ever land in the caller's own tenant.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import structlog
+import yaml
+from fastapi import Request, status
+from fastapi.responses import HTMLResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.api.v1.targets import create_target, update_target
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.targets.schemas import TargetCreate, TargetUpdate
+from meho_backplane.ui.auth.middleware import UISessionContext
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.templating import get_templates
+
+__all__ = [
+    "PlanEntry",
+    "build_plan",
+    "render_import_page",
+    "render_preview",
+    "submit_confirm",
+]
+
+_log = structlog.get_logger(__name__)
+
+#: YAML keys that map 1:1 to a top-level column on the write schemas.
+#: Verbatim parity with ``knownTopLevel`` in
+#: ``cli/internal/cmd/targets/import.go`` so the web import and the CLI
+#: import spill the same keys into ``extras``.
+_KNOWN_TOP_LEVEL: frozenset[str] = frozenset(
+    {
+        "aliases",
+        "auth_model",
+        "extras",
+        "fqdn",
+        "host",
+        "name",
+        "notes",
+        "port",
+        "preferred_impl_id",
+        "product",
+        "secret_ref",
+        "vpn_required",
+    }
+)
+
+#: YAML keys deliberately dropped with a warning rather than passed to
+#: the write schema. ``fingerprint`` is server-managed (probe verb is
+#: the only writer; the schemas reject it via ``extra='forbid'``).
+#: Parity with ``skipSilent`` in ``import.go``.
+_SKIP_SILENT: frozenset[str] = frozenset({"fingerprint"})
+
+
+@dataclass
+class PlanEntry:
+    """One classified import entry: what the confirm step would do.
+
+    ``action`` is ``"CREATE"`` or ``"UPDATE"``. ``body`` is the mapped
+    field dict already shaped for the chosen write path (full for
+    CREATE; sparse -- ``name`` / ``product`` stripped -- for UPDATE).
+    ``warnings`` collects per-entry advisories (e.g. a dropped
+    ``fingerprint`` key). The dataclass is the in-process equivalent of
+    the CLI's ``planEntry`` JSON shape; it is never serialised to the
+    wire here (the preview renders straight from it).
+    """
+
+    name: str
+    action: str
+    body: dict[str, Any]
+    warnings: list[str] = field(default_factory=list)
+
+
+def _map_entry(entry: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """Partition one YAML entry into a write body + per-entry warnings.
+
+    Port of ``mapEntry`` in ``import.go``: an explicit ``extras:`` block
+    is read first so unknown-key spills merge into it (rather than
+    overwriting the operator's intentional payload); ``fingerprint`` is
+    dropped with a warning; known keys pass through to the top level;
+    every other key spills into ``extras``.
+    """
+    body: dict[str, Any] = {}
+    extras: dict[str, Any] = {}
+    warnings: list[str] = []
+
+    raw_extras = entry.get("extras")
+    if isinstance(raw_extras, dict):
+        extras.update(raw_extras)
+
+    for key, value in entry.items():
+        if key == "extras":
+            # Handled in the pre-pass above; skip so it is not double-counted.
+            continue
+        if key in _SKIP_SILENT:
+            warnings.append(f"skipped field {key!r}: server-managed, set via probe verb")
+            continue
+        if key in _KNOWN_TOP_LEVEL:
+            body[key] = value
+            continue
+        extras[key] = value
+
+    if extras:
+        body["extras"] = extras
+    return body, warnings
+
+
+def _entry_to_update_body(entry: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """Map one YAML entry to a sparse PATCH body.
+
+    Only keys present in the YAML appear in the body so
+    ``update_target``'s ``model_dump(exclude_unset=True)`` touches only
+    the listed columns (the load-bearing sparse-PATCH contract PR #362's
+    review on #257 pinned). ``name`` and ``product`` are stripped --
+    the PATCH route rejects ``name`` and ``product`` is immutable on the
+    CLI update path.
+    """
+    body, warnings = _map_entry(entry)
+    body.pop("name", None)
+    body.pop("product", None)
+    return body, warnings
+
+
+class ImportParseError(Exception):
+    """Raised when the pasted / uploaded YAML cannot be turned into a plan.
+
+    Carries an operator-facing message rendered inline in the preview
+    fragment (no 500). Covers a YAML syntax error, a non-mapping root, a
+    missing / empty ``targets:`` list, and a per-entry required-field
+    violation (``name`` / ``product`` / ``host``) -- the same fail-fast
+    validation the CLI parser does before any write.
+    """
+
+
+def _parse_targets_yaml(raw: str) -> list[dict[str, Any]]:
+    """Parse the ``targets.yaml`` text into a list of per-entry maps.
+
+    Mirrors ``parseTargetsYAML`` in ``import.go``: ``yaml.safe_load`` so
+    no arbitrary Python objects can be constructed from operator input;
+    require a ``targets:`` list; validate ``name`` / ``product`` /
+    ``host`` per entry so a malformed file fails before any CRUD call.
+    """
+    try:
+        doc = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise ImportParseError(f"parse YAML: {exc}") from exc
+
+    if doc is None:
+        raise ImportParseError("parse YAML: file is empty")
+    if not isinstance(doc, dict):
+        raise ImportParseError("parse YAML: root must be a mapping with a `targets:` list")
+
+    targets = doc.get("targets")
+    if not isinstance(targets, list) or not targets:
+        raise ImportParseError("parse YAML: no `targets:` list found, or list is empty")
+
+    entries: list[dict[str, Any]] = []
+    for index, entry in enumerate(targets):
+        if not isinstance(entry, dict):
+            raise ImportParseError(f"entry {index}: each target must be a mapping")
+        name = entry.get("name")
+        if not isinstance(name, str) or not name:
+            raise ImportParseError(f"entry {index}: missing or empty `name` field")
+        if not isinstance(entry.get("product"), str):
+            raise ImportParseError(f"entry {name!r}: missing or non-string `product` field")
+        if not isinstance(entry.get("host"), str):
+            raise ImportParseError(f"entry {name!r}: missing or non-string `host` field")
+        entries.append(entry)
+    return entries
+
+
+async def _existing_names(db_session: AsyncSession, tenant_id: object) -> set[str]:
+    """Return the set of live target names in the caller's tenant.
+
+    The CREATE-vs-UPDATE classifier. Scoped to ``tenant_id`` and
+    excluding soft-deleted rows (``deleted_at IS NULL``) -- the same
+    filter the ``/api/v1/targets`` list route (which the CLI calls for
+    its classification) applies, so the web import and the CLI import
+    classify identically.
+    """
+    stmt = select(TargetORM.name).where(
+        TargetORM.tenant_id == tenant_id,
+        TargetORM.deleted_at.is_(None),
+    )
+    result = await db_session.execute(stmt)
+    return set(result.scalars().all())
+
+
+def build_plan(entries: list[dict[str, Any]], existing: set[str]) -> list[PlanEntry]:
+    """Classify every entry CREATE-vs-UPDATE and build its write body.
+
+    Existing names plan as UPDATE (sparse body); new names plan as
+    CREATE (full mapped body). Source order is preserved so the preview
+    table reads top-to-bottom in the same order as the YAML.
+    """
+    plan: list[PlanEntry] = []
+    for entry in entries:
+        name = str(entry["name"])
+        if name in existing:
+            body, warnings = _entry_to_update_body(entry)
+            plan.append(PlanEntry(name=name, action="UPDATE", body=body, warnings=warnings))
+        else:
+            body, warnings = _map_entry(entry)
+            plan.append(PlanEntry(name=name, action="CREATE", body=body, warnings=warnings))
+    return plan
+
+
+def _set_csrf_cookie(response: HTMLResponse, csrf_token: str) -> None:
+    """Mirror the chassis CSRF cookie posture for the import renders."""
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=csrf_token,
+        httponly=False,
+        secure=True,
+        samesite="strict",
+        path="/ui",
+    )
+
+
+def _plan_to_rows(plan: list[PlanEntry]) -> list[dict[str, Any]]:
+    """Project the plan into the template-friendly row shape.
+
+    Each row carries the name, the action, the JSON-present field keys
+    (so the preview can show *what* would be written without dumping the
+    full body), and any warnings.
+    """
+    return [
+        {
+            "name": entry.name,
+            "action": entry.action,
+            "fields": sorted(entry.body.keys()),
+            "warnings": entry.warnings,
+        }
+        for entry in plan
+    ]
+
+
+async def render_import_page(
+    request: Request,
+    session_ctx: UISessionContext,
+) -> HTMLResponse:
+    """Render the full bulk-import page (paste box + upload control)."""
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    response = get_templates().TemplateResponse(
+        request,
+        "connectors/import.html",
+        {
+            "page_title": "Connectors",
+            "active_surface": "connectors",
+            "ready": False,
+            "csrf_token": csrf_token,
+        },
+    )
+    _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def render_preview(
+    request: Request,
+    session_ctx: UISessionContext,
+    db_session: AsyncSession,
+    *,
+    yaml_text: str,
+) -> HTMLResponse:
+    """Parse the submitted YAML and render the CREATE / UPDATE preview.
+
+    A parse error renders the preview fragment with an inline error
+    message and HTTP 422 (never a 500). A clean parse renders the plan
+    table; the YAML is echoed back into a hidden field so the confirm
+    submit re-parses the same bytes (the preview is stateless -- the
+    server holds no plan between the two requests).
+    """
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    try:
+        entries = _parse_targets_yaml(yaml_text)
+    except ImportParseError as exc:
+        response = get_templates().TemplateResponse(
+            request,
+            "connectors/_import_preview.html",
+            {
+                "ready": False,
+                "csrf_token": csrf_token,
+                "error": str(exc),
+                "rows": [],
+                "yaml_text": yaml_text,
+            },
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        )
+        _set_csrf_cookie(response, csrf_token)
+        return response
+
+    existing = await _existing_names(db_session, session_ctx.tenant_id)
+    plan = build_plan(entries, existing)
+    rows = _plan_to_rows(plan)
+    response = get_templates().TemplateResponse(
+        request,
+        "connectors/_import_preview.html",
+        {
+            "ready": False,
+            "csrf_token": csrf_token,
+            "error": None,
+            "rows": rows,
+            "create_count": sum(1 for r in rows if r["action"] == "CREATE"),
+            "update_count": sum(1 for r in rows if r["action"] == "UPDATE"),
+            "yaml_text": yaml_text,
+        },
+    )
+    _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+def _build_create_body(body: dict[str, Any]) -> TargetCreate:
+    """Coerce a mapped CREATE body dict into a :class:`TargetCreate`.
+
+    ``auth_model`` arrives as a YAML string; coerce it through the enum
+    so an unknown value raises the same ``ValueError`` the schema would
+    on a bad enum member. All other fields flow straight to Pydantic,
+    which runs the identical validation the REST POST body runs.
+    """
+    coerced = dict(body)
+    if "auth_model" in coerced and coerced["auth_model"] is not None:
+        coerced["auth_model"] = AuthModel(coerced["auth_model"])
+    return TargetCreate.model_validate(coerced)
+
+
+def _build_update_body(body: dict[str, Any]) -> TargetUpdate:
+    """Coerce a sparse UPDATE body dict into a :class:`TargetUpdate`."""
+    coerced = dict(body)
+    if "auth_model" in coerced and coerced["auth_model"] is not None:
+        coerced["auth_model"] = AuthModel(coerced["auth_model"])
+    return TargetUpdate.model_validate(coerced)
+
+
+async def submit_confirm(
+    request: Request,
+    session_ctx: UISessionContext,
+    operator: Operator,
+    db_session: AsyncSession,
+    *,
+    yaml_text: str,
+) -> HTMLResponse:
+    """Re-parse, re-classify, and apply the plan in-process.
+
+    Re-parsing on confirm (rather than trusting a client-held plan)
+    keeps the server the source of truth for the classification: the
+    CREATE-vs-UPDATE decision is re-made against the tenant's *current*
+    target set, so a target created between preview and confirm is
+    correctly PATCHed rather than re-CREATEd into a 409. Each entry is
+    applied via the in-process REST handler -- ``create_target`` for new
+    names, ``update_target`` for existing -- so the product-registry
+    check, the audit binding, and the broadcast hook fire exactly as
+    they do on the REST and CLI surfaces. The result summary (N created,
+    M updated) renders into the same slot.
+    """
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    try:
+        entries = _parse_targets_yaml(yaml_text)
+    except ImportParseError as exc:
+        response = get_templates().TemplateResponse(
+            request,
+            "connectors/_import_preview.html",
+            {
+                "ready": False,
+                "csrf_token": csrf_token,
+                "error": str(exc),
+                "rows": [],
+                "yaml_text": yaml_text,
+            },
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        )
+        _set_csrf_cookie(response, csrf_token)
+        return response
+
+    existing = await _existing_names(db_session, session_ctx.tenant_id)
+    plan = build_plan(entries, existing)
+
+    created = 0
+    updated = 0
+    for entry in plan:
+        if entry.action == "CREATE":
+            await create_target(
+                body=_build_create_body(entry.body),
+                operator=operator,
+                session=db_session,
+            )
+            created += 1
+        else:
+            await update_target(
+                name=entry.name,
+                body=_build_update_body(entry.body),
+                operator=operator,
+                session=db_session,
+            )
+            updated += 1
+
+    _log.info(
+        "ui_target_import",
+        tenant_id=str(session_ctx.tenant_id),
+        operator_sub=session_ctx.operator_sub,
+        created=created,
+        updated=updated,
+    )
+    response = get_templates().TemplateResponse(
+        request,
+        "connectors/_import_result.html",
+        {
+            "ready": False,
+            "csrf_token": csrf_token,
+            "created": created,
+            "updated": updated,
+        },
+    )
+    _set_csrf_cookie(response, csrf_token)
+    return response

--- a/backend/src/meho_backplane/ui/routes/connectors/import_view.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/import_view.py
@@ -66,6 +66,7 @@ import structlog
 import yaml
 from fastapi import Request, status
 from fastapi.responses import HTMLResponse
+from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -120,18 +121,22 @@ _SKIP_SILENT: frozenset[str] = frozenset({"fingerprint"})
 class PlanEntry:
     """One classified import entry: what the confirm step would do.
 
-    ``action`` is ``"CREATE"`` or ``"UPDATE"``. ``body`` is the mapped
-    field dict already shaped for the chosen write path (full for
-    CREATE; sparse -- ``name`` / ``product`` stripped -- for UPDATE).
+    ``action`` is ``"CREATE"`` or ``"UPDATE"``. ``body`` is the
+    fully-validated write model (:class:`TargetCreate` for CREATE,
+    :class:`TargetUpdate` for UPDATE) -- it is built *and* schema-checked
+    by :func:`build_plan` before any write fires, so the confirm step
+    can never raise a schema error mid-loop. ``fields`` is the sorted
+    set of present field keys, retained for the preview projection.
     ``warnings`` collects per-entry advisories (e.g. a dropped
     ``fingerprint`` key). The dataclass is the in-process equivalent of
-    the CLI's ``planEntry`` JSON shape; it is never serialised to the
-    wire here (the preview renders straight from it).
+    the CLI's ``planEntry`` shape; it is never serialised to the wire
+    here (the preview renders straight from it).
     """
 
     name: str
     action: str
-    body: dict[str, Any]
+    body: TargetCreate | TargetUpdate
+    fields: list[str]
     warnings: list[str] = field(default_factory=list)
 
 
@@ -190,9 +195,12 @@ class ImportParseError(Exception):
 
     Carries an operator-facing message rendered inline in the preview
     fragment (no 500). Covers a YAML syntax error, a non-mapping root, a
-    missing / empty ``targets:`` list, and a per-entry required-field
-    violation (``name`` / ``product`` / ``host``) -- the same fail-fast
-    validation the CLI parser does before any write.
+    missing / empty ``targets:`` list, a per-entry required-field
+    violation (``name`` / ``product`` / ``host``), and a schema
+    validation failure when the mapped body is built into its Pydantic
+    write model (bad ``auth_model`` enum, out-of-range ``port``, etc.)
+    -- the same fail-fast validation the CLI parser + plan builder do
+    before any write.
     """
 
 
@@ -250,22 +258,91 @@ async def _existing_names(db_session: AsyncSession, tenant_id: object) -> set[st
     return set(result.scalars().all())
 
 
+def _build_create_body(body: dict[str, Any]) -> TargetCreate:
+    """Coerce a mapped CREATE body dict into a :class:`TargetCreate`.
+
+    ``auth_model`` arrives as a YAML string; coerce it through the enum
+    so an unknown value raises a ``ValueError`` the way the schema would
+    on a bad enum member. All other fields flow straight to Pydantic,
+    which runs the identical validation the REST POST body runs.
+    """
+    coerced = dict(body)
+    if "auth_model" in coerced and coerced["auth_model"] is not None:
+        coerced["auth_model"] = AuthModel(coerced["auth_model"])
+    return TargetCreate.model_validate(coerced)
+
+
+def _build_update_body(body: dict[str, Any]) -> TargetUpdate:
+    """Coerce a sparse UPDATE body dict into a :class:`TargetUpdate`."""
+    coerced = dict(body)
+    if "auth_model" in coerced and coerced["auth_model"] is not None:
+        coerced["auth_model"] = AuthModel(coerced["auth_model"])
+    return TargetUpdate.model_validate(coerced)
+
+
+def _format_schema_error(exc: Exception) -> str:
+    """Render a Pydantic ``ValidationError`` (or enum ``ValueError``) compactly.
+
+    The full Pydantic dump is noisy for an operator; surface just the
+    offending field and its message so the inline preview error is
+    readable (e.g. ``port: Input should be less than or equal to 65535``).
+    """
+    if isinstance(exc, ValidationError):
+        parts = []
+        for err in exc.errors():
+            loc = ".".join(str(p) for p in err["loc"]) or "(body)"
+            parts.append(f"{loc}: {err['msg']}")
+        return "; ".join(parts)
+    return str(exc)
+
+
 def build_plan(entries: list[dict[str, Any]], existing: set[str]) -> list[PlanEntry]:
-    """Classify every entry CREATE-vs-UPDATE and build its write body.
+    """Classify every entry CREATE-vs-UPDATE and build its **validated** body.
 
     Existing names plan as UPDATE (sparse body); new names plan as
-    CREATE (full mapped body). Source order is preserved so the preview
-    table reads top-to-bottom in the same order as the YAML.
+    CREATE (full mapped body). Every body is validated through its
+    Pydantic write model *here*, before the confirm step's write loop --
+    a schema-invalid entry (bad ``auth_model`` enum, out-of-range
+    ``port``, etc.) raises :class:`ImportParseError` now rather than a
+    500 mid-write. This mirrors the CLI's no-partial-write contract: the
+    full plan is built and validated before any write fires (see
+    ``cli/internal/cmd/targets/import.go`` -- "the plan is built before
+    any API call fires"). Source order is preserved so the preview table
+    reads top-to-bottom in the same order as the YAML.
     """
     plan: list[PlanEntry] = []
     for entry in entries:
         name = str(entry["name"])
         if name in existing:
-            body, warnings = _entry_to_update_body(entry)
-            plan.append(PlanEntry(name=name, action="UPDATE", body=body, warnings=warnings))
+            raw_body, warnings = _entry_to_update_body(entry)
+            try:
+                update_body = _build_update_body(raw_body)
+            except (ValidationError, ValueError) as exc:
+                raise ImportParseError(f"entry {name!r}: {_format_schema_error(exc)}") from exc
+            plan.append(
+                PlanEntry(
+                    name=name,
+                    action="UPDATE",
+                    body=update_body,
+                    fields=sorted(raw_body.keys()),
+                    warnings=warnings,
+                )
+            )
         else:
-            body, warnings = _map_entry(entry)
-            plan.append(PlanEntry(name=name, action="CREATE", body=body, warnings=warnings))
+            raw_body, warnings = _map_entry(entry)
+            try:
+                create_body = _build_create_body(raw_body)
+            except (ValidationError, ValueError) as exc:
+                raise ImportParseError(f"entry {name!r}: {_format_schema_error(exc)}") from exc
+            plan.append(
+                PlanEntry(
+                    name=name,
+                    action="CREATE",
+                    body=create_body,
+                    fields=sorted(raw_body.keys()),
+                    warnings=warnings,
+                )
+            )
     return plan
 
 
@@ -281,6 +358,35 @@ def _set_csrf_cookie(response: HTMLResponse, csrf_token: str) -> None:
     )
 
 
+def _render_inline_error(
+    request: Request,
+    *,
+    csrf_token: str,
+    message: str,
+    yaml_text: str,
+) -> HTMLResponse:
+    """Render the preview fragment with an inline error and HTTP 422.
+
+    The single fail-fast render path shared by the preview and confirm
+    routes: a YAML parse error, a missing required field, or a schema
+    validation failure all surface here (no 500, no partial write).
+    """
+    response = get_templates().TemplateResponse(
+        request,
+        "connectors/_import_preview.html",
+        {
+            "ready": False,
+            "csrf_token": csrf_token,
+            "error": message,
+            "rows": [],
+            "yaml_text": yaml_text,
+        },
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+    )
+    _set_csrf_cookie(response, csrf_token)
+    return response
+
+
 def _plan_to_rows(plan: list[PlanEntry]) -> list[dict[str, Any]]:
     """Project the plan into the template-friendly row shape.
 
@@ -292,7 +398,7 @@ def _plan_to_rows(plan: list[PlanEntry]) -> list[dict[str, Any]]:
         {
             "name": entry.name,
             "action": entry.action,
-            "fields": sorted(entry.body.keys()),
+            "fields": entry.fields,
             "warnings": entry.warnings,
         }
         for entry in plan
@@ -328,33 +434,25 @@ async def render_preview(
 ) -> HTMLResponse:
     """Parse the submitted YAML and render the CREATE / UPDATE preview.
 
-    A parse error renders the preview fragment with an inline error
-    message and HTTP 422 (never a 500). A clean parse renders the plan
-    table; the YAML is echoed back into a hidden field so the confirm
-    submit re-parses the same bytes (the preview is stateless -- the
-    server holds no plan between the two requests).
+    A parse error *or* a schema-validation error renders the preview
+    fragment with an inline error message and HTTP 422 (never a 500) --
+    building the plan here runs the same Pydantic validation the confirm
+    step relies on, so the preview never green-lights a plan that confirm
+    would reject. A clean parse renders the plan table; the YAML is echoed
+    back into a hidden field so the confirm submit re-parses the same
+    bytes (the preview is stateless -- the server holds no plan between
+    the two requests).
     """
     csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    existing = await _existing_names(db_session, session_ctx.tenant_id)
     try:
         entries = _parse_targets_yaml(yaml_text)
+        plan = build_plan(entries, existing)
     except ImportParseError as exc:
-        response = get_templates().TemplateResponse(
-            request,
-            "connectors/_import_preview.html",
-            {
-                "ready": False,
-                "csrf_token": csrf_token,
-                "error": str(exc),
-                "rows": [],
-                "yaml_text": yaml_text,
-            },
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        return _render_inline_error(
+            request, csrf_token=csrf_token, message=str(exc), yaml_text=yaml_text
         )
-        _set_csrf_cookie(response, csrf_token)
-        return response
 
-    existing = await _existing_names(db_session, session_ctx.tenant_id)
-    plan = build_plan(entries, existing)
     rows = _plan_to_rows(plan)
     response = get_templates().TemplateResponse(
         request,
@@ -373,28 +471,6 @@ async def render_preview(
     return response
 
 
-def _build_create_body(body: dict[str, Any]) -> TargetCreate:
-    """Coerce a mapped CREATE body dict into a :class:`TargetCreate`.
-
-    ``auth_model`` arrives as a YAML string; coerce it through the enum
-    so an unknown value raises the same ``ValueError`` the schema would
-    on a bad enum member. All other fields flow straight to Pydantic,
-    which runs the identical validation the REST POST body runs.
-    """
-    coerced = dict(body)
-    if "auth_model" in coerced and coerced["auth_model"] is not None:
-        coerced["auth_model"] = AuthModel(coerced["auth_model"])
-    return TargetCreate.model_validate(coerced)
-
-
-def _build_update_body(body: dict[str, Any]) -> TargetUpdate:
-    """Coerce a sparse UPDATE body dict into a :class:`TargetUpdate`."""
-    coerced = dict(body)
-    if "auth_model" in coerced and coerced["auth_model"] is not None:
-        coerced["auth_model"] = AuthModel(coerced["auth_model"])
-    return TargetUpdate.model_validate(coerced)
-
-
 async def submit_confirm(
     request: Request,
     session_ctx: UISessionContext,
@@ -409,41 +485,33 @@ async def submit_confirm(
     keeps the server the source of truth for the classification: the
     CREATE-vs-UPDATE decision is re-made against the tenant's *current*
     target set, so a target created between preview and confirm is
-    correctly PATCHed rather than re-CREATEd into a 409. Each entry is
-    applied via the in-process REST handler -- ``create_target`` for new
-    names, ``update_target`` for existing -- so the product-registry
-    check, the audit binding, and the broadcast hook fire exactly as
-    they do on the REST and CLI surfaces. The result summary (N created,
-    M updated) renders into the same slot.
+    correctly PATCHed rather than re-CREATEd into a 409. The whole plan
+    is built **and schema-validated** by :func:`build_plan` before the
+    write loop, so a structurally-valid-but-schema-invalid entry renders
+    the inline 422 fragment and writes nothing -- the same no-partial-
+    write contract the CLI honours. Each entry is then applied via the
+    in-process REST handler -- ``create_target`` for new names,
+    ``update_target`` for existing -- so the product-registry check, the
+    audit binding, and the broadcast hook fire exactly as they do on the
+    REST and CLI surfaces. The result summary (N created, M updated)
+    renders into the same slot.
     """
     csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    existing = await _existing_names(db_session, session_ctx.tenant_id)
     try:
         entries = _parse_targets_yaml(yaml_text)
+        plan = build_plan(entries, existing)
     except ImportParseError as exc:
-        response = get_templates().TemplateResponse(
-            request,
-            "connectors/_import_preview.html",
-            {
-                "ready": False,
-                "csrf_token": csrf_token,
-                "error": str(exc),
-                "rows": [],
-                "yaml_text": yaml_text,
-            },
-            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        return _render_inline_error(
+            request, csrf_token=csrf_token, message=str(exc), yaml_text=yaml_text
         )
-        _set_csrf_cookie(response, csrf_token)
-        return response
-
-    existing = await _existing_names(db_session, session_ctx.tenant_id)
-    plan = build_plan(entries, existing)
 
     created = 0
     updated = 0
     for entry in plan:
-        if entry.action == "CREATE":
+        if isinstance(entry.body, TargetCreate):
             await create_target(
-                body=_build_create_body(entry.body),
+                body=entry.body,
                 operator=operator,
                 session=db_session,
             )
@@ -451,7 +519,7 @@ async def submit_confirm(
         else:
             await update_target(
                 name=entry.name,
-                body=_build_update_body(entry.body),
+                body=entry.body,
                 operator=operator,
                 session=db_session,
             )

--- a/backend/src/meho_backplane/ui/templates/connectors/_import_preview.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/_import_preview.html
@@ -1,0 +1,87 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Bulk-import preview fragment (Initiative #340 Task #875 work item #5).
+  Swapped into ``#connectors-import-result`` by the import form's
+  ``hx-post`` to ``/ui/connectors/import``.
+
+  Two shapes:
+    * ``error`` set -> an inline DaisyUI alert with the parse error and
+      no confirm button (the response carries HTTP 422; HTMX still swaps
+      the fragment because the form has no ``hx-swap`` status filter).
+    * ``error`` unset -> the CREATE / UPDATE plan table plus a "Confirm
+      import" form that re-posts the same YAML (echoed into a hidden
+      field) to ``/ui/connectors/import/confirm``.
+
+  Context contract (set by
+  :func:`~meho_backplane.ui.routes.connectors.import_view.render_preview`):
+    * ``error``        -- str | None inline parse error.
+    * ``rows``         -- list of {name, action, fields, warnings}.
+    * ``create_count`` / ``update_count`` -- plan tallies.
+    * ``yaml_text``    -- the submitted YAML, echoed for the confirm re-post.
+    * ``csrf_token``   -- the freshly-minted double-submit token.
+-#}
+{% if error %}
+  <div class="alert alert-error" role="alert" data-import-error>
+    <span>{{ error }}</span>
+  </div>
+{% else %}
+  <div class="card bg-base-100 border-base-300 border shadow-sm" hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'>
+    <div class="card-body space-y-3">
+      <p class="text-sm" data-import-summary>
+        Plan: <span class="font-semibold">{{ create_count }}</span> to create,
+        <span class="font-semibold">{{ update_count }}</span> to update.
+      </p>
+
+      <div class="overflow-x-auto rounded-box border border-base-300">
+        <table class="table table-sm">
+          <thead>
+            <tr>
+              <th>Action</th>
+              <th>Name</th>
+              <th>Fields</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for row in rows %}
+              <tr data-import-row data-action="{{ row.action }}" data-name="{{ row.name }}">
+                <td>
+                  {% if row.action == "CREATE" %}
+                    <span class="badge badge-success badge-sm">CREATE</span>
+                  {% else %}
+                    <span class="badge badge-info badge-sm">UPDATE</span>
+                  {% endif %}
+                </td>
+                <td class="font-mono">{{ row.name }}</td>
+                <td class="text-xs opacity-80">
+                  {{ row.fields | join(", ") }}
+                  {% for warning in row.warnings %}
+                    <div class="text-warning mt-1" role="alert" data-import-warning>{{ warning }}</div>
+                  {% endfor %}
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+
+      <form
+        id="connectors-import-confirm-form"
+        hx-post="/ui/connectors/import/confirm"
+        hx-target="#connectors-import-result"
+        hx-swap="innerHTML"
+        hx-disabled-elt="find button[type=submit]"
+        class="flex justify-end"
+      >
+        {# Re-send the previewed YAML so confirm re-parses + re-classifies
+           against the tenant's current target set (server stays the source
+           of truth; no client-held plan). #}
+        <textarea name="pasted" class="hidden" aria-hidden="true">{{ yaml_text }}</textarea>
+        <button type="submit" class="btn btn-sm btn-primary" data-action="import-confirm">
+          Confirm import
+        </button>
+      </form>
+    </div>
+  </div>
+{% endif %}

--- a/backend/src/meho_backplane/ui/templates/connectors/_import_result.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/_import_result.html
@@ -1,0 +1,23 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Bulk-import result summary (Initiative #340 Task #875 work item #5).
+  Swapped into ``#connectors-import-result`` by the confirm form's
+  ``hx-post`` to ``/ui/connectors/import/confirm`` after the plan is
+  applied in-process.
+
+  Context contract (set by
+  :func:`~meho_backplane.ui.routes.connectors.import_view.submit_confirm`):
+    * ``created`` -- count of targets created (``create_target``).
+    * ``updated`` -- count of targets updated (``update_target``).
+-#}
+<div class="alert alert-success" role="status" data-import-result>
+  <span>
+    Import applied: <span class="font-semibold" data-created>{{ created }}</span> created,
+    <span class="font-semibold" data-updated>{{ updated }}</span> updated.
+  </span>
+  <a href="/ui/connectors" class="btn btn-sm" aria-label="View targets list">
+    View targets
+  </a>
+</div>

--- a/backend/src/meho_backplane/ui/templates/connectors/import.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/import.html
@@ -1,0 +1,92 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Full-page render of the bulk targets.yaml import surface (Initiative
+  #340 Task #875 work item #5). Extends ``base.html`` so the chrome
+  matches the rest of the console.
+
+  Flow:
+    * Operator pastes a ``targets.yaml`` into the textarea OR picks a
+      file with the upload control.
+    * The form ``hx-post``s to ``/ui/connectors/import`` (multipart) and
+      swaps the server-rendered preview table into
+      ``#connectors-import-result``.
+    * The preview fragment carries its own "Confirm import" button that
+      ``hx-post``s to ``/ui/connectors/import/confirm`` (re-sending the
+      same YAML via a hidden field) and swaps the result summary into
+      the same slot.
+
+  CSRF: the page-level ``hx-headers`` directive echoes ``X-CSRF-Token``;
+  HTMX inherits it on the form submit. The upload form sets
+  ``hx-encoding="multipart/form-data"`` so the file rides along as a
+  proper multipart part rather than url-encoded text.
+-#}
+{% extends "base.html" %}
+
+{% block page_title %}Bulk import &middot; Connectors &middot; MEHO Operator Console{% endblock %}
+
+{% block content %}
+<section
+  class="space-y-4"
+  hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
+>
+  <header class="flex flex-wrap items-center justify-between gap-4">
+    <div>
+      <h1 class="text-2xl font-semibold">Bulk import targets</h1>
+      <p class="text-sm opacity-70">
+        Paste or upload a <code class="font-mono">targets.yaml</code>. The
+        server previews which targets would be created vs updated before
+        anything is written. Mirrors <code class="font-mono">meho targets import</code>.
+      </p>
+    </div>
+    <a href="/ui/connectors" class="btn btn-ghost btn-sm" aria-label="Back to connectors list">
+      Back to list
+    </a>
+  </header>
+
+  <form
+    id="connectors-import-form"
+    hx-post="/ui/connectors/import"
+    hx-encoding="multipart/form-data"
+    hx-target="#connectors-import-result"
+    hx-swap="innerHTML"
+    hx-disabled-elt="find button[type=submit]"
+    class="card bg-base-100 border-base-300 border shadow-sm"
+    aria-label="Bulk import targets"
+  >
+    <div class="card-body space-y-3">
+      <label class="form-control">
+        <span class="label-text">Paste targets.yaml</span>
+        <textarea
+          name="pasted"
+          class="textarea textarea-bordered min-h-[14rem] font-mono text-sm"
+          aria-label="Paste targets.yaml"
+          placeholder="targets:&#10;  - name: example&#10;    product: kubernetes&#10;    host: cluster.example.internal"
+        ></textarea>
+      </label>
+
+      <label class="form-control">
+        <span class="label-text">…or upload a file <span class="opacity-60">(takes precedence over paste)</span></span>
+        <input
+          type="file"
+          name="upload"
+          accept=".yaml,.yml,text/yaml,application/x-yaml"
+          class="file-input file-input-bordered file-input-sm"
+          aria-label="Upload targets.yaml"
+        />
+      </label>
+
+      <div class="flex justify-end">
+        <button type="submit" class="btn btn-sm btn-primary" data-action="import-preview">
+          Preview import
+        </button>
+      </div>
+    </div>
+  </form>
+
+  {# Preview table + confirm button (or inline parse error) swap in here;
+     the confirm result summary then replaces the preview in the same slot. #}
+  <div id="connectors-import-result"></div>
+</section>
+{% endblock %}

--- a/backend/src/meho_backplane/ui/templates/connectors/list.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/list.html
@@ -49,16 +49,25 @@
        the role server-side via ``resolve_operator_or_403`` (403 for a
        non-admin); this hide is the UX affordance, not the gate. #}
     {% if is_tenant_admin %}
-      <button
-        type="button"
-        class="btn btn-primary btn-sm"
-        hx-get="/ui/connectors/create"
-        hx-target="#connectors-modal-container"
-        hx-swap="innerHTML"
-        aria-label="Create target"
-      >
-        Create target
-      </button>
+      <div class="flex items-center gap-2">
+        <a
+          href="/ui/connectors/import"
+          class="btn btn-outline btn-sm"
+          aria-label="Bulk import targets"
+        >
+          Bulk import
+        </a>
+        <button
+          type="button"
+          class="btn btn-primary btn-sm"
+          hx-get="/ui/connectors/create"
+          hx-target="#connectors-modal-container"
+          hx-swap="innerHTML"
+          aria-label="Create target"
+        >
+          Create target
+        </button>
+      </div>
     {% endif %}
   </header>
 

--- a/backend/tests/test_ui_connectors_import.py
+++ b/backend/tests/test_ui_connectors_import.py
@@ -1,0 +1,701 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the bulk targets.yaml import UI (Task #875).
+
+Initiative #340 (G10.3 Connectors + Targets UI), Task #875 (G10.3-T3).
+The acceptance criteria on issue #875 are:
+
+* Paste or upload of a ``targets.yaml`` renders a server-side preview
+  table marking each target CREATE-vs-UPDATE (HTMX); YAML parse errors
+  render inline (no 500).
+* Confirm applies the plan in-process via the REST ``create_target`` /
+  ``update_target`` handlers; a result summary (N created, M updated) is
+  shown.
+* Classification + key-mapping match ``meho targets import`` (#257):
+  known keys -> columns, unknown -> ``extras``, ``fingerprint`` dropped,
+  CREATE vs UPDATE decided by existing-name lookup.
+* ``tenant_admin`` only (server-side 403 for operators); CSRF enforced;
+  cross-tenant isolation (import only into the caller's tenant).
+
+Harness shape mirrors :mod:`backend.tests.test_ui_connectors_forms`: a
+minimal FastAPI app wired with the UI session + CSRF middlewares, a
+``web_session`` row carrying a real Keycloak-minted access token so the
+``resolve_operator_or_403`` dep can re-verify the role, and a fake
+connector registered so ``registered_product_tokens()`` advertises the
+product the imported entries POST.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+import warnings
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import FingerprintResult
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import Target as TargetORM
+from meho_backplane.db.models import Tenant
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, CSRFMiddleware, mint_csrf_token
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.routes.connectors.import_view import build_plan
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests._oidc_jwt_helpers import AUDIENCE as _DEFAULT_AUDIENCE
+from tests._oidc_jwt_helpers import ISSUER as _DEFAULT_ISSUER
+from tests._oidc_jwt_helpers import make_rsa_keypair as _make_rsa_keypair
+from tests._oidc_jwt_helpers import mint_token as _mint_token
+from tests._oidc_jwt_helpers import mock_discovery_and_jwks as _mock_discovery_and_jwks
+from tests._oidc_jwt_helpers import public_jwks as _public_jwks
+
+_BACKPLANE_URL = "https://meho.test"
+
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+_TENANT_B = uuid.UUID("22222222-2222-2222-2222-222222222222")
+
+_OP_OPERATOR = "op-operator"
+_OP_ADMIN = "op-admin"
+
+_PRODUCT = "fakeprod"
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars for every test (mirrors the forms suite)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+class _FakeConnector(Connector):
+    """Deterministic connector so ``registered_product_tokens()`` advertises
+    ``fakeprod`` -- the product the imported entries POST + validate against.
+    """
+
+    product = _PRODUCT
+    version = "1.0"
+    impl_id = _PRODUCT
+    supported_version_range = None
+
+    async def fingerprint(self, target: Any) -> FingerprintResult:  # pragma: no cover
+        return FingerprintResult(
+            vendor="FakeVendor",
+            product=_PRODUCT,
+            version="1.0",
+            build="fake-build",
+            reachable=True,
+            probed_at=datetime.now(UTC),
+            probe_method="test",
+        )
+
+    async def probe(self, target: Any) -> Any:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def execute(  # pragma: no cover - unused
+        self,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> Any:
+        raise NotImplementedError
+
+
+@pytest.fixture(autouse=True)
+def _registry_with_fakeprod() -> Iterator[None]:
+    """Register ``fakeprod`` so the imported entries' product validates."""
+    clear_registry()
+    register_connector_v2(product=_PRODUCT, version="1.0", impl_id=_PRODUCT, cls=_FakeConnector)
+    yield
+    clear_registry()
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _seed_target(
+    *,
+    tenant_id: uuid.UUID,
+    name: str,
+    product: str = _PRODUCT,
+    host: str = "host.example.test",
+    port: int | None = None,
+    aliases: list[str] | None = None,
+    notes: str | None = None,
+    extras: dict[str, Any] | None = None,
+) -> uuid.UUID:
+    target_id = uuid.uuid4()
+    now = datetime.now(UTC)
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                TargetORM(
+                    id=target_id,
+                    tenant_id=tenant_id,
+                    name=name,
+                    aliases=aliases or [],
+                    product=product,
+                    host=host,
+                    port=port,
+                    fqdn=None,
+                    secret_ref=None,
+                    auth_model="shared_service_account",
+                    vpn_required=False,
+                    extras=extras or {},
+                    notes=notes,
+                    fingerprint=None,
+                    preferred_impl_id=None,
+                    created_at=now,
+                    updated_at=now,
+                ),
+            )
+
+    asyncio.run(_do())
+    return target_id
+
+
+def _load_target(tenant_id: uuid.UUID, name: str) -> TargetORM | None:
+    from sqlalchemy import select
+
+    async def _do() -> TargetORM | None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            stmt = select(TargetORM).where(
+                TargetORM.tenant_id == tenant_id,
+                TargetORM.name == name,
+            )
+            return (await session.execute(stmt)).scalar_one_or_none()
+
+    return asyncio.run(_do())
+
+
+def _count_targets(tenant_id: uuid.UUID) -> int:
+    from sqlalchemy import func, select
+
+    async def _do() -> int:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            stmt = (
+                select(func.count())
+                .select_from(TargetORM)
+                .where(
+                    TargetORM.tenant_id == tenant_id,
+                )
+            )
+            return int((await session.execute(stmt)).scalar_one())
+
+    return asyncio.run(_do())
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID,
+    access_token: str = "unused",
+    operator_sub: str = _OP_OPERATOR,
+) -> uuid.UUID:
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token=access_token,
+                refresh_token="refresh-token-plaintext",
+                lifetime=timedelta(hours=1),
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _make_keypair_and_jwks() -> tuple[Any, dict[str, Any]]:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        keypair = _make_rsa_keypair("ui-connectors-import-test-kid")
+    return keypair, _public_jwks(keypair)
+
+
+def _client_with_role(
+    *,
+    tenant_id: uuid.UUID,
+    operator_sub: str,
+    role: TenantRole,
+) -> tuple[TestClient, respx.MockRouter, str]:
+    """Return a TestClient + respx mock + csrf token for the role-gated routes."""
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=operator_sub,
+        tenant_id=str(tenant_id),
+        tenant_role=role.value,
+    )
+    session_id = _seed_session_sync(
+        tenant_id=tenant_id,
+        access_token=access_token,
+        operator_sub=operator_sub,
+    )
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    _mock_discovery_and_jwks(mock, jwks)
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    csrf_token = mint_csrf_token(str(session_id))
+    client.cookies.set(CSRF_COOKIE_NAME, csrf_token)
+    return client, mock, csrf_token
+
+
+def _form_headers(token: str) -> dict[str, str]:
+    """Headers for an HTMX form submit -- CSRF + HX-Request."""
+    return {"X-CSRF-Token": token, "HX-Request": "true"}
+
+
+_TWO_ENTRY_YAML = """
+targets:
+  - name: alpha
+    product: fakeprod
+    host: alpha.example.test
+    port: 8443
+  - name: beta
+    product: fakeprod
+    host: beta.example.test
+    sso_realm: corp
+    fingerprint:
+      vendor: stale
+""".strip()
+
+
+# ---------------------------------------------------------------------------
+# build_plan -- mapping + classification parity (unit-level, no app)
+# ---------------------------------------------------------------------------
+
+
+def test_build_plan_classifies_create_and_update() -> None:
+    """Existing names plan UPDATE; new names plan CREATE; order preserved."""
+    entries = [
+        {"name": "alpha", "product": _PRODUCT, "host": "a.test"},
+        {"name": "beta", "product": _PRODUCT, "host": "b.test"},
+    ]
+    plan = build_plan(entries, existing={"alpha"})
+    assert [(p.name, p.action) for p in plan] == [("alpha", "UPDATE"), ("beta", "CREATE")]
+
+
+def test_build_plan_spills_unknown_keys_into_extras() -> None:
+    """Unknown YAML keys land in ``extras``; known keys stay top-level."""
+    entries = [{"name": "g", "product": _PRODUCT, "host": "h.test", "account": "acct-1"}]
+    plan = build_plan(entries, existing=set())
+    body = plan[0].body
+    assert body["host"] == "h.test"
+    assert body["extras"] == {"account": "acct-1"}
+    assert "account" not in body
+
+
+def test_build_plan_merges_explicit_extras_with_spilled() -> None:
+    """An explicit ``extras:`` block merges with the unknown-key spill."""
+    entries = [
+        {
+            "name": "g",
+            "product": _PRODUCT,
+            "host": "h.test",
+            "extras": {"region": "eu"},
+            "project_id": "proj-7",
+        }
+    ]
+    plan = build_plan(entries, existing=set())
+    assert plan[0].body["extras"] == {"region": "eu", "project_id": "proj-7"}
+
+
+def test_build_plan_drops_fingerprint_with_warning() -> None:
+    """``fingerprint`` is dropped from the body and a warning is recorded."""
+    entries = [{"name": "g", "product": _PRODUCT, "host": "h.test", "fingerprint": {"vendor": "x"}}]
+    plan = build_plan(entries, existing=set())
+    assert "fingerprint" not in plan[0].body
+    assert any("fingerprint" in w for w in plan[0].warnings)
+
+
+def test_build_plan_update_body_is_sparse_and_strips_name_product() -> None:
+    """The UPDATE body omits ``name`` / ``product`` and only carries YAML keys."""
+    entries = [{"name": "alpha", "product": _PRODUCT, "host": "a.test", "notes": "n"}]
+    plan = build_plan(entries, existing={"alpha"})
+    body = plan[0].body
+    assert "name" not in body
+    assert "product" not in body
+    assert body == {"host": "a.test", "notes": "n"}
+
+
+# ---------------------------------------------------------------------------
+# Authentication / RBAC boundary
+# ---------------------------------------------------------------------------
+
+
+def test_import_page_unauthenticated_redirects_to_login() -> None:
+    """``GET /ui/connectors/import`` without a session 302s to the BFF login."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/connectors/import")
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+
+
+def test_import_page_renders_for_tenant_admin() -> None:
+    """A tenant_admin GET renders the import page with paste + upload controls."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client, mock, _csrf = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_ADMIN, role=TenantRole.TENANT_ADMIN
+    )
+    try:
+        response = client.get("/ui/connectors/import")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'hx-post="/ui/connectors/import"' in body
+    assert 'name="pasted"' in body
+    assert 'name="upload"' in body
+    assert 'type="file"' in body
+
+
+def test_import_page_rejects_operator_role_with_403() -> None:
+    """An operator (non-admin) GET on the import page is 403'd server-side."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client, mock, _csrf = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    try:
+        response = client.get("/ui/connectors/import")
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+
+
+def test_import_preview_rejects_operator_role_with_403() -> None:
+    """A non-admin preview POST is 403'd before any parse."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_OPERATOR, role=TenantRole.OPERATOR
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/import",
+            headers=_form_headers(csrf),
+            data={"pasted": _TWO_ENTRY_YAML},
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+
+
+def test_import_preview_rejects_missing_csrf() -> None:
+    """A preview POST without the CSRF token is 403'd by the chassis middleware."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client, mock, _csrf = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_ADMIN, role=TenantRole.TENANT_ADMIN
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/import",
+            headers={"HX-Request": "true"},
+            data={"pasted": _TWO_ENTRY_YAML},
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+
+
+# ---------------------------------------------------------------------------
+# Preview -- paste, upload, parse error
+# ---------------------------------------------------------------------------
+
+
+def test_preview_paste_renders_create_and_update_table() -> None:
+    """A pasted YAML renders a preview classifying CREATE vs UPDATE."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    # ``alpha`` already exists -> UPDATE; ``beta`` is new -> CREATE.
+    _seed_target(tenant_id=_TENANT_A, name="alpha", host="old.example.test")
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_ADMIN, role=TenantRole.TENANT_ADMIN
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/import",
+            headers=_form_headers(csrf),
+            data={"pasted": _TWO_ENTRY_YAML},
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'data-name="alpha"' in body
+    assert 'data-name="beta"' in body
+    # alpha -> UPDATE, beta -> CREATE
+    assert 'data-action="UPDATE"' in body
+    assert 'data-action="CREATE"' in body
+    # fingerprint on beta surfaces as a preview warning, not a 500.
+    assert "fingerprint" in body
+    # No write happened on a preview.
+    row = _load_target(_TENANT_A, "beta")
+    assert row is None
+
+
+def test_preview_upload_file_renders_table() -> None:
+    """An uploaded targets.yaml is parsed and previewed (file path)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_ADMIN, role=TenantRole.TENANT_ADMIN
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/import",
+            headers=_form_headers(csrf),
+            files={"upload": ("targets.yaml", _TWO_ENTRY_YAML.encode(), "application/x-yaml")},
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    assert 'data-name="alpha"' in response.text
+    assert 'data-name="beta"' in response.text
+
+
+def test_preview_malformed_yaml_renders_inline_error_not_500() -> None:
+    """A YAML syntax error renders an inline error with 422 (never a 500)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_ADMIN, role=TenantRole.TENANT_ADMIN
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/import",
+            headers=_form_headers(csrf),
+            data={"pasted": "targets:\n  - name: a\n    product: [unclosed"},
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 422, response.text
+    assert "data-import-error" in response.text
+
+
+def test_preview_missing_required_field_renders_inline_error() -> None:
+    """An entry missing ``host`` fails fast with an inline error."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_ADMIN, role=TenantRole.TENANT_ADMIN
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/import",
+            headers=_form_headers(csrf),
+            data={"pasted": "targets:\n  - name: a\n    product: fakeprod"},
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 422, response.text
+    assert "data-import-error" in response.text
+    assert "host" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Confirm -- in-process create/update + result summary
+# ---------------------------------------------------------------------------
+
+
+def test_confirm_creates_and_updates_in_process() -> None:
+    """Confirm POSTs new targets + PATCHes existing ones, shows the summary."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="alpha", host="old.example.test", notes="orig")
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_ADMIN, role=TenantRole.TENANT_ADMIN
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/import/confirm",
+            headers=_form_headers(csrf),
+            data={"pasted": _TWO_ENTRY_YAML},
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "data-import-result" in body
+    # 1 created (beta), 1 updated (alpha).
+    assert "data-created>1" in body
+    assert "data-updated>1" in body
+
+    # beta created.
+    beta = _load_target(_TENANT_A, "beta")
+    assert beta is not None
+    assert beta.host == "beta.example.test"
+    # unknown key spilled into extras.
+    assert beta.extras == {"sso_realm": "corp"}
+    # fingerprint dropped (server-managed).
+    assert beta.fingerprint is None
+
+    # alpha updated -- host patched, product unchanged (sparse PATCH).
+    alpha = _load_target(_TENANT_A, "alpha")
+    assert alpha is not None
+    assert alpha.host == "alpha.example.test"
+    assert alpha.port == 8443
+    assert alpha.product == _PRODUCT
+
+
+def test_confirm_update_is_sparse_does_not_wipe_omitted_columns() -> None:
+    """A sparse YAML on UPDATE leaves columns it omits untouched."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(
+        tenant_id=_TENANT_A,
+        name="alpha",
+        host="old.example.test",
+        notes="keep-me",
+        aliases=["a1"],
+    )
+    yaml_text = "targets:\n  - name: alpha\n    product: fakeprod\n    host: new.example.test"
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_ADMIN, role=TenantRole.TENANT_ADMIN
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/import/confirm",
+            headers=_form_headers(csrf),
+            data={"pasted": yaml_text},
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    alpha = _load_target(_TENANT_A, "alpha")
+    assert alpha is not None
+    assert alpha.host == "new.example.test"
+    # notes + aliases were not in the YAML -> sparse PATCH leaves them.
+    assert alpha.notes == "keep-me"
+    assert list(alpha.aliases) == ["a1"]
+
+
+def test_confirm_malformed_yaml_renders_inline_error_no_write() -> None:
+    """A malformed YAML on confirm renders the inline error and writes nothing."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_ADMIN, role=TenantRole.TENANT_ADMIN
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/import/confirm",
+            headers=_form_headers(csrf),
+            data={"pasted": "targets:\n  - name: a\n    product: [unclosed"},
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 422, response.text
+    assert "data-import-error" in response.text
+    assert _count_targets(_TENANT_A) == 0
+
+
+# ---------------------------------------------------------------------------
+# Cross-tenant isolation
+# ---------------------------------------------------------------------------
+
+
+def test_confirm_imports_only_into_callers_tenant() -> None:
+    """A confirm by tenant A's admin lands the row in tenant A only."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_tenant(_TENANT_B, "tenant-b")
+    yaml_text = "targets:\n  - name: gamma\n    product: fakeprod\n    host: g.example.test"
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_ADMIN, role=TenantRole.TENANT_ADMIN
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/import/confirm",
+            headers=_form_headers(csrf),
+            data={"pasted": yaml_text},
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    assert _load_target(_TENANT_A, "gamma") is not None
+    assert _load_target(_TENANT_B, "gamma") is None
+
+
+def test_preview_classification_scoped_to_caller_tenant() -> None:
+    """A same-named target in another tenant does not flip CREATE to UPDATE."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_tenant(_TENANT_B, "tenant-b")
+    # ``delta`` exists in tenant B but NOT in tenant A.
+    _seed_target(tenant_id=_TENANT_B, name="delta", host="b.example.test")
+    yaml_text = "targets:\n  - name: delta\n    product: fakeprod\n    host: a.example.test"
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_ADMIN, role=TenantRole.TENANT_ADMIN
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/import",
+            headers=_form_headers(csrf),
+            data={"pasted": yaml_text},
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    # Tenant A has no ``delta`` -> the entry classifies as CREATE.
+    assert 'data-action="CREATE"' in response.text

--- a/backend/tests/test_ui_connectors_import.py
+++ b/backend/tests/test_ui_connectors_import.py
@@ -64,7 +64,7 @@ from meho_backplane.ui.auth.session_store import (
 from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, CSRFMiddleware, mint_csrf_token
 from meho_backplane.ui.paths import static_root_dir
 from meho_backplane.ui.routes import build_router as build_ui_router
-from meho_backplane.ui.routes.connectors.import_view import build_plan
+from meho_backplane.ui.routes.connectors.import_view import ImportParseError, build_plan
 from meho_backplane.ui.templating import reset_templating_for_testing
 from tests._oidc_jwt_helpers import AUDIENCE as _DEFAULT_AUDIENCE
 from tests._oidc_jwt_helpers import ISSUER as _DEFAULT_ISSUER
@@ -350,9 +350,9 @@ def test_build_plan_spills_unknown_keys_into_extras() -> None:
     entries = [{"name": "g", "product": _PRODUCT, "host": "h.test", "account": "acct-1"}]
     plan = build_plan(entries, existing=set())
     body = plan[0].body
-    assert body["host"] == "h.test"
-    assert body["extras"] == {"account": "acct-1"}
-    assert "account" not in body
+    assert body.host == "h.test"
+    assert body.extras == {"account": "acct-1"}
+    assert plan[0].fields == ["extras", "host", "name", "product"]
 
 
 def test_build_plan_merges_explicit_extras_with_spilled() -> None:
@@ -367,14 +367,14 @@ def test_build_plan_merges_explicit_extras_with_spilled() -> None:
         }
     ]
     plan = build_plan(entries, existing=set())
-    assert plan[0].body["extras"] == {"region": "eu", "project_id": "proj-7"}
+    assert plan[0].body.extras == {"region": "eu", "project_id": "proj-7"}
 
 
 def test_build_plan_drops_fingerprint_with_warning() -> None:
     """``fingerprint`` is dropped from the body and a warning is recorded."""
     entries = [{"name": "g", "product": _PRODUCT, "host": "h.test", "fingerprint": {"vendor": "x"}}]
     plan = build_plan(entries, existing=set())
-    assert "fingerprint" not in plan[0].body
+    assert "fingerprint" not in plan[0].fields
     assert any("fingerprint" in w for w in plan[0].warnings)
 
 
@@ -383,9 +383,28 @@ def test_build_plan_update_body_is_sparse_and_strips_name_product() -> None:
     entries = [{"name": "alpha", "product": _PRODUCT, "host": "a.test", "notes": "n"}]
     plan = build_plan(entries, existing={"alpha"})
     body = plan[0].body
-    assert "name" not in body
-    assert "product" not in body
-    assert body == {"host": "a.test", "notes": "n"}
+    # Sparse PATCH: only keys present in the YAML are set on the model.
+    assert body.model_dump(exclude_unset=True) == {"host": "a.test", "notes": "n"}
+    assert "name" not in plan[0].fields
+    assert "product" not in plan[0].fields
+
+
+def test_build_plan_raises_on_schema_invalid_auth_model() -> None:
+    """A structurally-valid entry with a bad ``auth_model`` enum fails the plan."""
+    entries = [
+        {"name": "g", "product": _PRODUCT, "host": "h.test", "auth_model": "NOT_A_VALID_ENUM"}
+    ]
+    with pytest.raises(ImportParseError) as excinfo:
+        build_plan(entries, existing=set())
+    assert "auth_model" in str(excinfo.value) or "NOT_A_VALID_ENUM" in str(excinfo.value)
+
+
+def test_build_plan_raises_on_out_of_range_port() -> None:
+    """An out-of-range ``port`` fails the plan before any write is attempted."""
+    entries = [{"name": "g", "product": _PRODUCT, "host": "h.test", "port": 70000}]
+    with pytest.raises(ImportParseError) as excinfo:
+        build_plan(entries, existing=set())
+    assert "port" in str(excinfo.value)
 
 
 # ---------------------------------------------------------------------------
@@ -558,6 +577,34 @@ def test_preview_missing_required_field_renders_inline_error() -> None:
     assert "host" in response.text
 
 
+def test_preview_schema_invalid_value_renders_inline_error() -> None:
+    """A structurally-valid entry with a schema-invalid value (bad ``auth_model``
+    enum) surfaces inline on preview -- the preview must not green-light a plan
+    that confirm would reject.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    yaml_text = (
+        "targets:\n"
+        "  - name: a\n"
+        "    product: fakeprod\n"
+        "    host: a.example.test\n"
+        "    auth_model: NOT_A_VALID_ENUM"
+    )
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_ADMIN, role=TenantRole.TENANT_ADMIN
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/import",
+            headers=_form_headers(csrf),
+            data={"pasted": yaml_text},
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 422, response.text
+    assert "data-import-error" in response.text
+
+
 # ---------------------------------------------------------------------------
 # Confirm -- in-process create/update + result summary
 # ---------------------------------------------------------------------------
@@ -650,6 +697,43 @@ def test_confirm_malformed_yaml_renders_inline_error_no_write() -> None:
     assert response.status_code == 422, response.text
     assert "data-import-error" in response.text
     assert _count_targets(_TENANT_A) == 0
+
+
+def test_confirm_schema_invalid_entry_422_writes_nothing() -> None:
+    """A schema-invalid entry mid-list aborts the whole import (no partial write).
+
+    The first entry is valid; the second carries an out-of-range ``port``.
+    Because the full plan is built and validated before the write loop, the
+    valid first entry must NOT be committed -- confirm renders the inline 422
+    and writes zero rows (parity with the CLI's no-partial-write contract).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    yaml_text = (
+        "targets:\n"
+        "  - name: valid-first\n"
+        "    product: fakeprod\n"
+        "    host: valid.example.test\n"
+        "  - name: bad-port\n"
+        "    product: fakeprod\n"
+        "    host: bad.example.test\n"
+        "    port: 70000"
+    )
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A, operator_sub=_OP_ADMIN, role=TenantRole.TENANT_ADMIN
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/import/confirm",
+            headers=_form_headers(csrf),
+            data={"pasted": yaml_text},
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 422, response.text
+    assert "data-import-error" in response.text
+    # No partial import: neither the valid first row nor the bad second row landed.
+    assert _count_targets(_TENANT_A) == 0
+    assert _load_target(_TENANT_A, "valid-first") is None
 
 
 # ---------------------------------------------------------------------------

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -7319,6 +7319,129 @@
         }
       }
     },
+    "/ui/connectors/import": {
+      "get": {
+        "tags": [
+          "ui-connectors"
+        ],
+        "summary": "Ui Connectors Import Page",
+        "description": "``GET /ui/connectors/import`` -- the full import page.",
+        "operationId": "ui_connectors_import_page_ui_connectors_import_get",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ui-connectors"
+        ],
+        "summary": "Ui Connectors Import Preview",
+        "description": "``POST /ui/connectors/import`` -- parse + render the preview table.\n\n``operator`` is resolved purely as the tenant_admin gate; the\npreview is read-only (it classifies but does not write), so the\nexisting-name lookup runs under ``session_ctx.tenant_id``.",
+        "operationId": "ui_connectors_import_preview_ui_connectors_import_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_ui_connectors_import_preview_ui_connectors_import_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/connectors/import/confirm": {
+      "post": {
+        "tags": [
+          "ui-connectors"
+        ],
+        "summary": "Ui Connectors Import Confirm",
+        "description": "``POST /ui/connectors/import/confirm`` -- apply the plan in-process.",
+        "operationId": "ui_connectors_import_confirm_ui_connectors_import_confirm_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_ui_connectors_import_confirm_ui_connectors_import_confirm_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ui/connectors/{name}/probe": {
       "post": {
         "tags": [
@@ -8652,6 +8775,50 @@
         },
         "type": "object",
         "title": "Body_ui_connectors_edit_submit_ui_connectors__name__patch"
+      },
+      "Body_ui_connectors_import_confirm_ui_connectors_import_confirm_post": {
+        "properties": {
+          "pasted": {
+            "type": "string",
+            "maxLength": 262144,
+            "nullable": true,
+            "title": "Pasted"
+          },
+          "upload": {
+            "type": "string",
+            "contentMediaType": "application/octet-stream",
+            "nullable": true,
+            "title": "Upload"
+          },
+          "session_ctx": {
+            "$ref": "#/components/schemas/UISessionContext",
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "title": "Body_ui_connectors_import_confirm_ui_connectors_import_confirm_post"
+      },
+      "Body_ui_connectors_import_preview_ui_connectors_import_post": {
+        "properties": {
+          "pasted": {
+            "type": "string",
+            "maxLength": 262144,
+            "nullable": true,
+            "title": "Pasted"
+          },
+          "upload": {
+            "type": "string",
+            "contentMediaType": "application/octet-stream",
+            "nullable": true,
+            "title": "Upload"
+          },
+          "session_ctx": {
+            "$ref": "#/components/schemas/UISessionContext",
+            "nullable": true
+          }
+        },
+        "type": "object",
+        "title": "Body_ui_connectors_import_preview_ui_connectors_import_post"
       },
       "Body_ui_memory_bulk_ui_memory_bulk_post": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -956,6 +956,40 @@ type BodyUiConnectorsEditSubmitUiConnectorsNamePatch struct {
 	VpnRequired *bool             `json:"vpn_required,omitempty"`
 }
 
+// BodyUiConnectorsImportConfirmUiConnectorsImportConfirmPost defines model for Body_ui_connectors_import_confirm_ui_connectors_import_confirm_post.
+type BodyUiConnectorsImportConfirmUiConnectorsImportConfirmPost struct {
+	Pasted *string `json:"pasted"`
+
+	// SessionCtx Per-request session identity exposed on ``request.state``.
+	//
+	// Frozen so a route handler that stashes the context on a logger
+	// or forwards it to a service layer cannot accidentally mutate
+	// fields downstream. The shape mirrors :class:`Operator` for the
+	// fields T5 (#866) needs to render an authenticated page header;
+	// ``raw_jwt`` / ``tenant_role`` are intentionally absent because
+	// the session-cookie path does not load them today (the encrypted
+	// row carries only the access token, not the decoded claims).
+	SessionCtx *UISessionContext `json:"session_ctx,omitempty"`
+	Upload     *string           `json:"upload"`
+}
+
+// BodyUiConnectorsImportPreviewUiConnectorsImportPost defines model for Body_ui_connectors_import_preview_ui_connectors_import_post.
+type BodyUiConnectorsImportPreviewUiConnectorsImportPost struct {
+	Pasted *string `json:"pasted"`
+
+	// SessionCtx Per-request session identity exposed on ``request.state``.
+	//
+	// Frozen so a route handler that stashes the context on a logger
+	// or forwards it to a service layer cannot accidentally mutate
+	// fields downstream. The shape mirrors :class:`Operator` for the
+	// fields T5 (#866) needs to render an authenticated page header;
+	// ``raw_jwt`` / ``tenant_role`` are intentionally absent because
+	// the session-cookie path does not load them today (the encrypted
+	// row carries only the access token, not the decoded claims).
+	SessionCtx *UISessionContext `json:"session_ctx,omitempty"`
+	Upload     *string           `json:"upload"`
+}
+
 // BodyUiMemoryBulkUiMemoryBulkPost defines model for Body_ui_memory_bulk_ui_memory_bulk_post.
 type BodyUiMemoryBulkUiMemoryBulkPost struct {
 	Action         string    `json:"action"`
@@ -4344,6 +4378,15 @@ type UiConnectorsCreateModalUiConnectorsCreateGetJSONRequestBody = UISessionCont
 // UiConnectorsCreateSubmitUiConnectorsCreatePostFormdataRequestBody defines body for UiConnectorsCreateSubmitUiConnectorsCreatePost for application/x-www-form-urlencoded ContentType.
 type UiConnectorsCreateSubmitUiConnectorsCreatePostFormdataRequestBody = BodyUiConnectorsCreateSubmitUiConnectorsCreatePost
 
+// UiConnectorsImportPageUiConnectorsImportGetJSONRequestBody defines body for UiConnectorsImportPageUiConnectorsImportGet for application/json ContentType.
+type UiConnectorsImportPageUiConnectorsImportGetJSONRequestBody = UISessionContext
+
+// UiConnectorsImportPreviewUiConnectorsImportPostMultipartRequestBody defines body for UiConnectorsImportPreviewUiConnectorsImportPost for multipart/form-data ContentType.
+type UiConnectorsImportPreviewUiConnectorsImportPostMultipartRequestBody = BodyUiConnectorsImportPreviewUiConnectorsImportPost
+
+// UiConnectorsImportConfirmUiConnectorsImportConfirmPostMultipartRequestBody defines body for UiConnectorsImportConfirmUiConnectorsImportConfirmPost for multipart/form-data ContentType.
+type UiConnectorsImportConfirmUiConnectorsImportConfirmPostMultipartRequestBody = BodyUiConnectorsImportConfirmUiConnectorsImportConfirmPost
+
 // UiConnectorsDetailUiConnectorsNameGetJSONRequestBody defines body for UiConnectorsDetailUiConnectorsNameGet for application/json ContentType.
 type UiConnectorsDetailUiConnectorsNameGetJSONRequestBody = UISessionContext
 
@@ -5019,6 +5062,17 @@ type ClientInterface interface {
 	UiConnectorsCreateSubmitUiConnectorsCreatePostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UiConnectorsCreateSubmitUiConnectorsCreatePostWithFormdataBody(ctx context.Context, body UiConnectorsCreateSubmitUiConnectorsCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiConnectorsImportPageUiConnectorsImportGetWithBody request with any body
+	UiConnectorsImportPageUiConnectorsImportGetWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiConnectorsImportPageUiConnectorsImportGet(ctx context.Context, body UiConnectorsImportPageUiConnectorsImportGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiConnectorsImportPreviewUiConnectorsImportPostWithBody request with any body
+	UiConnectorsImportPreviewUiConnectorsImportPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiConnectorsImportConfirmUiConnectorsImportConfirmPostWithBody request with any body
+	UiConnectorsImportConfirmUiConnectorsImportConfirmPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiConnectorsDetailUiConnectorsNameGetWithBody request with any body
 	UiConnectorsDetailUiConnectorsNameGetWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -6741,6 +6795,54 @@ func (c *Client) UiConnectorsCreateSubmitUiConnectorsCreatePostWithBody(ctx cont
 
 func (c *Client) UiConnectorsCreateSubmitUiConnectorsCreatePostWithFormdataBody(ctx context.Context, body UiConnectorsCreateSubmitUiConnectorsCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUiConnectorsCreateSubmitUiConnectorsCreatePostRequestWithFormdataBody(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsImportPageUiConnectorsImportGetWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsImportPageUiConnectorsImportGetRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsImportPageUiConnectorsImportGet(ctx context.Context, body UiConnectorsImportPageUiConnectorsImportGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsImportPageUiConnectorsImportGetRequest(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsImportPreviewUiConnectorsImportPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsImportPreviewUiConnectorsImportPostRequestWithBody(c.Server, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsImportConfirmUiConnectorsImportConfirmPostWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsImportConfirmUiConnectorsImportConfirmPostRequestWithBody(c.Server, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -13903,6 +14005,104 @@ func NewUiConnectorsCreateSubmitUiConnectorsCreatePostRequestWithBody(server str
 	return req, nil
 }
 
+// NewUiConnectorsImportPageUiConnectorsImportGetRequest calls the generic UiConnectorsImportPageUiConnectorsImportGet builder with application/json body
+func NewUiConnectorsImportPageUiConnectorsImportGetRequest(server string, body UiConnectorsImportPageUiConnectorsImportGetJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUiConnectorsImportPageUiConnectorsImportGetRequestWithBody(server, "application/json", bodyReader)
+}
+
+// NewUiConnectorsImportPageUiConnectorsImportGetRequestWithBody generates requests for UiConnectorsImportPageUiConnectorsImportGet with any type of body
+func NewUiConnectorsImportPageUiConnectorsImportGetRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/connectors/import")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiConnectorsImportPreviewUiConnectorsImportPostRequestWithBody generates requests for UiConnectorsImportPreviewUiConnectorsImportPost with any type of body
+func NewUiConnectorsImportPreviewUiConnectorsImportPostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/connectors/import")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiConnectorsImportConfirmUiConnectorsImportConfirmPostRequestWithBody generates requests for UiConnectorsImportConfirmUiConnectorsImportConfirmPost with any type of body
+func NewUiConnectorsImportConfirmUiConnectorsImportConfirmPostRequestWithBody(server string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/connectors/import/confirm")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewUiConnectorsDetailUiConnectorsNameGetRequest calls the generic UiConnectorsDetailUiConnectorsNameGet builder with application/json body
 func NewUiConnectorsDetailUiConnectorsNameGetRequest(server string, name string, body UiConnectorsDetailUiConnectorsNameGetJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -15403,6 +15603,17 @@ type ClientWithResponsesInterface interface {
 	UiConnectorsCreateSubmitUiConnectorsCreatePostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsCreateSubmitUiConnectorsCreatePostResponse, error)
 
 	UiConnectorsCreateSubmitUiConnectorsCreatePostWithFormdataBodyWithResponse(ctx context.Context, body UiConnectorsCreateSubmitUiConnectorsCreatePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsCreateSubmitUiConnectorsCreatePostResponse, error)
+
+	// UiConnectorsImportPageUiConnectorsImportGetWithBodyWithResponse request with any body
+	UiConnectorsImportPageUiConnectorsImportGetWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsImportPageUiConnectorsImportGetResponse, error)
+
+	UiConnectorsImportPageUiConnectorsImportGetWithResponse(ctx context.Context, body UiConnectorsImportPageUiConnectorsImportGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsImportPageUiConnectorsImportGetResponse, error)
+
+	// UiConnectorsImportPreviewUiConnectorsImportPostWithBodyWithResponse request with any body
+	UiConnectorsImportPreviewUiConnectorsImportPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsImportPreviewUiConnectorsImportPostResponse, error)
+
+	// UiConnectorsImportConfirmUiConnectorsImportConfirmPostWithBodyWithResponse request with any body
+	UiConnectorsImportConfirmUiConnectorsImportConfirmPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsImportConfirmUiConnectorsImportConfirmPostResponse, error)
 
 	// UiConnectorsDetailUiConnectorsNameGetWithBodyWithResponse request with any body
 	UiConnectorsDetailUiConnectorsNameGetWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsDetailUiConnectorsNameGetResponse, error)
@@ -17880,6 +18091,72 @@ func (r UiConnectorsCreateSubmitUiConnectorsCreatePostResponse) StatusCode() int
 	return 0
 }
 
+type UiConnectorsImportPageUiConnectorsImportGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiConnectorsImportPageUiConnectorsImportGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiConnectorsImportPageUiConnectorsImportGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiConnectorsImportPreviewUiConnectorsImportPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiConnectorsImportPreviewUiConnectorsImportPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiConnectorsImportPreviewUiConnectorsImportPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiConnectorsImportConfirmUiConnectorsImportConfirmPostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiConnectorsImportConfirmUiConnectorsImportConfirmPostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiConnectorsImportConfirmUiConnectorsImportConfirmPostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type UiConnectorsDetailUiConnectorsNameGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -19516,6 +19793,41 @@ func (c *ClientWithResponses) UiConnectorsCreateSubmitUiConnectorsCreatePostWith
 		return nil, err
 	}
 	return ParseUiConnectorsCreateSubmitUiConnectorsCreatePostResponse(rsp)
+}
+
+// UiConnectorsImportPageUiConnectorsImportGetWithBodyWithResponse request with arbitrary body returning *UiConnectorsImportPageUiConnectorsImportGetResponse
+func (c *ClientWithResponses) UiConnectorsImportPageUiConnectorsImportGetWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsImportPageUiConnectorsImportGetResponse, error) {
+	rsp, err := c.UiConnectorsImportPageUiConnectorsImportGetWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsImportPageUiConnectorsImportGetResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiConnectorsImportPageUiConnectorsImportGetWithResponse(ctx context.Context, body UiConnectorsImportPageUiConnectorsImportGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsImportPageUiConnectorsImportGetResponse, error) {
+	rsp, err := c.UiConnectorsImportPageUiConnectorsImportGet(ctx, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsImportPageUiConnectorsImportGetResponse(rsp)
+}
+
+// UiConnectorsImportPreviewUiConnectorsImportPostWithBodyWithResponse request with arbitrary body returning *UiConnectorsImportPreviewUiConnectorsImportPostResponse
+func (c *ClientWithResponses) UiConnectorsImportPreviewUiConnectorsImportPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsImportPreviewUiConnectorsImportPostResponse, error) {
+	rsp, err := c.UiConnectorsImportPreviewUiConnectorsImportPostWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsImportPreviewUiConnectorsImportPostResponse(rsp)
+}
+
+// UiConnectorsImportConfirmUiConnectorsImportConfirmPostWithBodyWithResponse request with arbitrary body returning *UiConnectorsImportConfirmUiConnectorsImportConfirmPostResponse
+func (c *ClientWithResponses) UiConnectorsImportConfirmUiConnectorsImportConfirmPostWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsImportConfirmUiConnectorsImportConfirmPostResponse, error) {
+	rsp, err := c.UiConnectorsImportConfirmUiConnectorsImportConfirmPostWithBody(ctx, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsImportConfirmUiConnectorsImportConfirmPostResponse(rsp)
 }
 
 // UiConnectorsDetailUiConnectorsNameGetWithBodyWithResponse request with arbitrary body returning *UiConnectorsDetailUiConnectorsNameGetResponse
@@ -23021,6 +23333,84 @@ func ParseUiConnectorsCreateSubmitUiConnectorsCreatePostResponse(rsp *http.Respo
 	}
 
 	response := &UiConnectorsCreateSubmitUiConnectorsCreatePostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiConnectorsImportPageUiConnectorsImportGetResponse parses an HTTP response from a UiConnectorsImportPageUiConnectorsImportGetWithResponse call
+func ParseUiConnectorsImportPageUiConnectorsImportGetResponse(rsp *http.Response) (*UiConnectorsImportPageUiConnectorsImportGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiConnectorsImportPageUiConnectorsImportGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiConnectorsImportPreviewUiConnectorsImportPostResponse parses an HTTP response from a UiConnectorsImportPreviewUiConnectorsImportPostWithResponse call
+func ParseUiConnectorsImportPreviewUiConnectorsImportPostResponse(rsp *http.Response) (*UiConnectorsImportPreviewUiConnectorsImportPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiConnectorsImportPreviewUiConnectorsImportPostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiConnectorsImportConfirmUiConnectorsImportConfirmPostResponse parses an HTTP response from a UiConnectorsImportConfirmUiConnectorsImportConfirmPostWithResponse call
+func ParseUiConnectorsImportConfirmUiConnectorsImportConfirmPostResponse(rsp *http.Response) (*UiConnectorsImportConfirmUiConnectorsImportConfirmPostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiConnectorsImportConfirmUiConnectorsImportConfirmPostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -1484,7 +1484,7 @@ the same way broadcast / topology / memory retired theirs.
 | `PATCH` | `/ui/connectors/{name}` | (T2 #874) Edit submit. Builds a `TargetUpdate` and delegates to the REST `update_target` handler in-process. Same success / failure shapes as create. |
 | `GET` | `/ui/connectors/import` | (T3 #875) Full bulk-import page: paste box + file upload. Tenant_admin gated. |
 | `POST` | `/ui/connectors/import` | (T3 #875) Parse the pasted / uploaded `targets.yaml` (`yaml.safe_load`) and render the CREATE-vs-UPDATE preview table; parse errors render inline (422, no 500). Read-only — no writes. |
-| `POST` | `/ui/connectors/import/confirm` | (T3 #875) Re-parse + re-classify against the tenant's current targets, then apply the plan in-process via `create_target` (new) + `update_target` (existing); renders the result summary (N created, M updated). |
+| `POST` | `/ui/connectors/import/confirm` | (T3 #875) Re-parse + re-classify against the tenant's current targets, validate the whole plan up front (schema-invalid entry → inline 422, no partial write), then apply it in-process via `create_target` (new) + `update_target` (existing); renders the result summary (N created, M updated). |
 
 ### Module layout
 
@@ -1650,16 +1650,29 @@ filters on `session_ctx.tenant_id`, and the in-process `create_target` /
 `update_target` handlers write / resolve under `operator.tenant_id`, so
 an import can only ever land in the caller's own tenant.
 
-**Parse errors render inline.** `yaml.safe_load` failures, a non-mapping
-root, a missing / empty `targets:` list, and per-entry required-field
-violations (`name` / `product` / `host`) all render an inline error in
-the preview fragment with HTTP 422 — never a 500.
+**Validate the whole plan before any write (no partial import).**
+`build_plan` constructs *and* schema-validates every `TargetCreate` /
+`TargetUpdate` body up front — before the confirm route's write loop
+runs. A structurally-valid YAML carrying a schema-invalid value (a bad
+`auth_model` enum, an out-of-range `port`, etc.) therefore fails the
+*whole* plan (`ImportParseError`, rendered as the inline 422 fragment)
+and writes nothing, rather than committing the rows ahead of the bad
+entry and then 500-ing mid-loop. This mirrors the CLI's no-partial-write
+contract (`import.go` builds the full plan before any API call fires).
+The same pre-validation runs in `render_preview`, so the preview never
+green-lights a plan the confirm step would reject.
+
+**Errors render inline.** `yaml.safe_load` failures, a non-mapping root,
+a missing / empty `targets:` list, per-entry required-field violations
+(`name` / `product` / `host`), and Pydantic schema-validation failures
+all render an inline error in the preview fragment with HTTP 422 — never
+a 500.
 
 #### Files (Task #875)
 
-* `backend/src/meho_backplane/ui/routes/connectors/import_view.py` — parse (`yaml.safe_load`) + key-mapping + CREATE/UPDATE classification (port of `import.go`'s `mapEntry` / `buildLivePlan`) + render helpers + in-process confirm.
+* `backend/src/meho_backplane/ui/routes/connectors/import_view.py` — parse (`yaml.safe_load`) + key-mapping + CREATE/UPDATE classification (port of `import.go`'s `mapEntry` / `buildLivePlan`) + up-front Pydantic body validation (whole plan validated before any write — no partial import) + render helpers + in-process confirm.
 * `backend/src/meho_backplane/ui/routes/connectors/import_router.py` — thin FastAPI route wrappers (multipart paste + upload parse; tenant_admin-gated deps); registered before the detail route so the literal `/ui/connectors/import` paths win the first-match lookup over `/ui/connectors/{name}`.
 * `backend/src/meho_backplane/ui/templates/connectors/import.html` — full-page paste-box + upload form.
 * `backend/src/meho_backplane/ui/templates/connectors/_import_preview.html` — preview table fragment (CREATE/UPDATE badges + per-entry warnings + confirm form, or an inline parse error).
 * `backend/src/meho_backplane/ui/templates/connectors/_import_result.html` — result summary fragment (N created, M updated).
-* `backend/tests/test_ui_connectors_import.py` — `build_plan` mapping / classification unit tests (extras spill, explicit-extras merge, fingerprint drop, sparse UPDATE) + behavioural tests: auth / RBAC (403 operator, 403 missing CSRF), preview (paste + upload + parse error + missing-field error), confirm (in-process create + update, sparse PATCH preserves omitted columns, malformed-YAML no-write), cross-tenant isolation (import lands in caller tenant only; same-name in another tenant does not flip CREATE→UPDATE).
+* `backend/tests/test_ui_connectors_import.py` — `build_plan` mapping / classification unit tests (extras spill, explicit-extras merge, fingerprint drop, sparse UPDATE) + behavioural tests: auth / RBAC (403 operator, 403 missing CSRF), preview (paste + upload + parse error + missing-field error + schema-invalid-value inline error), confirm (in-process create + update, sparse PATCH preserves omitted columns, malformed-YAML no-write, schema-invalid entry 422 + zero writes), cross-tenant isolation (import lands in caller tenant only; same-name in another tenant does not flip CREATE→UPDATE).

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -1482,6 +1482,9 @@ the same way broadcast / topology / memory retired theirs.
 | `POST` | `/ui/connectors/create` | (T2 #874) Create submit. Builds a `TargetCreate` and delegates to the REST `create_target` handler in-process. Success → 204 + `HX-Redirect: /ui/connectors`; validation failure → 422 + modal re-rendered with per-field errors. |
 | `GET` | `/ui/connectors/{name}/edit` | (T2 #874) HTMX-loaded edit-target modal, pre-populated server-side from the resolved target. Tenant_admin gated; alias-aware 404 on cross-tenant. |
 | `PATCH` | `/ui/connectors/{name}` | (T2 #874) Edit submit. Builds a `TargetUpdate` and delegates to the REST `update_target` handler in-process. Same success / failure shapes as create. |
+| `GET` | `/ui/connectors/import` | (T3 #875) Full bulk-import page: paste box + file upload. Tenant_admin gated. |
+| `POST` | `/ui/connectors/import` | (T3 #875) Parse the pasted / uploaded `targets.yaml` (`yaml.safe_load`) and render the CREATE-vs-UPDATE preview table; parse errors render inline (422, no 500). Read-only — no writes. |
+| `POST` | `/ui/connectors/import/confirm` | (T3 #875) Re-parse + re-classify against the tenant's current targets, then apply the plan in-process via `create_target` (new) + `update_target` (existing); renders the result summary (N created, M updated). |
 
 ### Module layout
 
@@ -1593,3 +1596,70 @@ modal form inherits the `X-CSRF-Token` header from the page-level
 * `backend/src/meho_backplane/ui/templates/connectors/_probe_alert.html` — failure alert fragment (no_connector / ambiguous).
 * `backend/src/meho_backplane/ui/static/src/app/connectors-feed.js` — `connectorsRecentOps` Alpine controller.
 * `backend/tests/test_ui_connectors_view.py` — auth boundary, list (full + fragment + sort + filter + cross-tenant), detail (properties + alias + 404 + cross-tenant + recent ops + ops matrix + ambiguous / no-connector branches), fingerprint card (present / never), re-probe button visibility (operator vs tenant_admin), SSE wiring + URL-encoding, re-probe (success + 403 operator + 501 no-connector + 404 unknown).
+
+### Bulk import (Task #875)
+
+T3 layers a **bulk `targets.yaml` import** surface on top of the T1 / T2
+surfaces. The operator pastes or uploads a `targets.yaml`; the server
+parses it, classifies every entry CREATE-vs-UPDATE against the caller's
+tenant, and renders a preview table; on confirm the route applies the
+plan **in-process** via the existing target CRUD handlers
+(`create_target` for new names, `update_target` for existing ones).
+
+**No `/api/v1/targets/import` endpoint exists.** This UI mirrors the
+client-orchestrated CRUD the `meho targets import` CLI tool (G0.3-T6
+#257, `cli/internal/cmd/targets/import.go`) performs: parse → list
+existing names → classify CREATE vs UPDATE → POST new / PATCH existing.
+The key-mapping + classification logic in `import_view.py` is a
+server-side port of that CLI's `mapEntry` / `buildLivePlan`, so the web
+import and the CLI import produce byte-identical writes for the same
+YAML.
+
+**Mapping rules (parity with `import.go`).**
+
+* **Known top-level keys** — `name`, `aliases`, `product`, `host`,
+  `port`, `fqdn`, `secret_ref`, `auth_model`, `vpn_required`, `notes`,
+  `preferred_impl_id`, `extras` — map 1:1 to `TargetCreate` /
+  `TargetUpdate` fields.
+* **Unknown keys** spill into the `extras` JSONB column (merged with an
+  explicit `extras:` block when one is present).
+* **`fingerprint`** is server-managed (probe verb is the only writer;
+  the write schemas reject it via `extra='forbid'`) → dropped with a
+  preview warning.
+* **CREATE vs UPDATE** is decided by an existing-name lookup scoped to
+  the caller's tenant (excluding soft-deleted rows — the same filter the
+  `/api/v1/targets` list route the CLI calls applies).
+* On **UPDATE** the body is **sparse** (only YAML-present keys); `name`
+  and `product` are stripped (the PATCH route rejects `name`; `product`
+  is not patched on the CLI update path). The sparse shape means
+  re-importing a YAML that omits some fields does not wipe those columns
+  — the same load-bearing contract PR #362's review on #257 pinned.
+
+**Stateless preview → confirm.** The server holds no plan between the
+two requests: the preview echoes the submitted YAML into a hidden field
+and the confirm route re-parses + re-classifies it. Re-classifying on
+confirm keeps the server the source of truth — a target created between
+preview and confirm is correctly PATCHed rather than re-CREATEd into a
+409.
+
+**RBAC + CSRF + isolation.** All three routes depend on
+`resolve_operator_or_403` (tenant_admin only; operators 403 server-side).
+CSRF is enforced by the chassis `CSRFMiddleware` on the two `POST`
+routes. Cross-tenant isolation is two-layer: the existing-name lookup
+filters on `session_ctx.tenant_id`, and the in-process `create_target` /
+`update_target` handlers write / resolve under `operator.tenant_id`, so
+an import can only ever land in the caller's own tenant.
+
+**Parse errors render inline.** `yaml.safe_load` failures, a non-mapping
+root, a missing / empty `targets:` list, and per-entry required-field
+violations (`name` / `product` / `host`) all render an inline error in
+the preview fragment with HTTP 422 — never a 500.
+
+#### Files (Task #875)
+
+* `backend/src/meho_backplane/ui/routes/connectors/import_view.py` — parse (`yaml.safe_load`) + key-mapping + CREATE/UPDATE classification (port of `import.go`'s `mapEntry` / `buildLivePlan`) + render helpers + in-process confirm.
+* `backend/src/meho_backplane/ui/routes/connectors/import_router.py` — thin FastAPI route wrappers (multipart paste + upload parse; tenant_admin-gated deps); registered before the detail route so the literal `/ui/connectors/import` paths win the first-match lookup over `/ui/connectors/{name}`.
+* `backend/src/meho_backplane/ui/templates/connectors/import.html` — full-page paste-box + upload form.
+* `backend/src/meho_backplane/ui/templates/connectors/_import_preview.html` — preview table fragment (CREATE/UPDATE badges + per-entry warnings + confirm form, or an inline parse error).
+* `backend/src/meho_backplane/ui/templates/connectors/_import_result.html` — result summary fragment (N created, M updated).
+* `backend/tests/test_ui_connectors_import.py` — `build_plan` mapping / classification unit tests (extras spill, explicit-extras merge, fingerprint drop, sparse UPDATE) + behavioural tests: auth / RBAC (403 operator, 403 missing CSRF), preview (paste + upload + parse error + missing-field error), confirm (in-process create + update, sparse PATCH preserves omitted columns, malformed-YAML no-write), cross-tenant isolation (import lands in caller tenant only; same-name in another tenant does not flip CREATE→UPDATE).


### PR DESCRIPTION
## Summary
- Adds the bulk `targets.yaml` import UI at `/ui/connectors/import` (work item #5 of Initiative #340 G10.3): paste OR upload a `targets.yaml` → server-side `yaml.safe_load` parse → HTMX preview table classifying each entry CREATE-vs-UPDATE → confirm → apply the plan **in-process** via the existing target CRUD (`create_target` for new names, `update_target` for existing).
- **No `/api/v1/targets/import` endpoint** — this mirrors the client-orchestrated CRUD the `meho targets import` CLI (#257) performs. `import_view`'s key-mapping + classification is a server-side port of `import.go`'s `mapEntry` / `buildLivePlan`, so the web import and CLI import produce byte-identical writes: known keys → columns, unknown → `extras` JSONB (merged with an explicit `extras:` block), `fingerprint` dropped with a warning, UPDATE emits a sparse body (`name`/`product` stripped) so re-imports don't wipe omitted columns.
- Preview→confirm is stateless: confirm re-parses + re-classifies against the tenant's current targets (a target created between preview and confirm is PATCHed, not re-CREATEd into a 409). `tenant_admin`-only via `resolve_operator_or_403`, CSRF-gated by the chassis middleware, cross-tenant-isolated at both the existing-name lookup and the in-process CRUD layer. Parse errors render inline (422, never a 500).
- Regenerated the CLI OpenAPI snapshot + `client.gen.go` for the new `/ui/connectors/import` routes; CLI builds clean.

## Test plan
- [x] `ruff check` / `ruff format --check` (connectors package + test) — clean
- [x] `mypy src/meho_backplane/ui/routes/connectors/` — clean (9 files)
- [x] `pytest -n auto backend/tests/test_ui_connectors_import.py` — 19 passed
- [x] `pytest tests/test_ui_connectors_{import,forms,view}.py` — 65 passed (no T1/T2 regression)
- [x] `code-quality.py --diff` — 0 blockers (2 sub-threshold warnings)
- [x] `cli && make snapshot-openapi && make generate && go build ./...` — new routes present, client compiles
- [x] Paste + upload preview classify CREATE/UPDATE; malformed YAML + missing required field render inline (no 500)
- [x] Confirm creates new + sparse-PATCHes existing; sparse PATCH preserves omitted columns; malformed YAML on confirm writes nothing
- [x] `tenant_admin` only (operator 403); missing CSRF 403; cross-tenant isolation (import lands in caller tenant only; same-name in another tenant does not flip CREATE→UPDATE)

## Out of scope
- List/detail (#873), create/edit forms (#874). A dedicated `/api/v1/targets/import` REST endpoint — deliberately not added; the CLI (#257) uses plain CRUD and this UI follows suit.
- `import_view.py` is 479 lines / `submit_confirm` 81 lines — both under the 600/100 block thresholds (sub-threshold code-quality warnings).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #875

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-26)

Addressed the REQUEST_CHANGES review findings from `/auto-review-pr` iteration 1:

- **B1** `42d9f17` — Validate the full import plan before any write. `build_plan` now constructs and schema-validates every `TargetCreate`/`TargetUpdate` body up front (catching Pydantic `ValidationError` + the `AuthModel` enum `ValueError`) and raises `ImportParseError` before the confirm write loop runs. A structurally-valid YAML with a schema-invalid value (bad `auth_model` enum, out-of-range `port`) now renders the inline 422 fragment and writes nothing — no more partial import + 500. The same validation runs in `render_preview`. Regression tests cover preview-inline + confirm-422-with-zero-writes (including the valid row ahead of the bad entry).

Adjacent (non-blocking, fixed while in `import_router.py`):

- Corrected the `_YAML_MAX_BYTES` comment — a multipart upload is bounded by Starlette `MultiPartParser.max_part_size` (1 MiB default), not the CSRF middleware's urlencoded-only body cap.

Disputed / not addressed (per the review's own disposition):

- CodeRabbit majors on `cli/api/openapi.json` declaring the 422 response as `text/html` — a generic FastAPI codegen artifact for any body-param route, not a PR defect; hand-editing the deterministic snapshot would fail the freshness check.
- CodeRabbit nitpick on markdown heading style in `docs/codebase/ui.md` — cosmetic.

<!-- auto-implement-issue: continue, iteration 1 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk import functionality for connector targets via YAML files or text paste.
  * Includes a preview step to review create/update actions before confirming.
  * Accessible to tenant admins via a new "Bulk import" link in the connectors page.

* **Documentation**
  * Updated codebase documentation with bulk import feature details and workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
