### PR TITLE
feat(ingest): G0.14-T9 catalog-driven REST ingest — accept {catalog_entry} server-side

### DIFF
--- a/backend/src/meho_backplane/api/v1/connectors_ingest.py
+++ b/backend/src/meho_backplane/api/v1/connectors_ingest.py
@@ -125,6 +125,7 @@ from meho_backplane.operations.ingest import (
     CatalogListResponse,
     ConnectorNotFoundError,
     ConnectorReviewPayload,
+    ConnectorSpecEntry,
     EditGroupBody,
     EditOpBody,
     IngestionPipelineResult,
@@ -139,9 +140,13 @@ from meho_backplane.operations.ingest import (
     LlmOutputInvalid,
     OpIdCollision,
     ReviewService,
+    SpecSource,
     UncoveredVersionLabel,
     UnsupportedSpecError,
     VersionMismatchError,
+    build_catalog_entry_malformed_detail,
+    build_catalog_entry_not_found_detail,
+    build_catalog_entry_typed_connector_detail,
     build_version_mismatch_detail,
     default_llm_client_factory,
     list_ingested_connectors,
@@ -222,6 +227,19 @@ async def ingest_endpoint(
     ingested → run_llm_grouping pipeline serially and returns the
     aggregated counts + grouping result.
 
+    The body accepts two mutually-exclusive request shapes (see
+    :class:`IngestRequest`):
+
+    * **Catalog-driven shape** (G0.14-T9 / #1150) — ``catalog_entry``
+      is a ``"<product>/<version>"`` reference; this handler resolves
+      it against the packaged catalog (:func:`load_catalog`) and
+      dispatches through the same ingest path as if the caller had
+      supplied the resolved quadruple.
+    * **Explicit-quadruple shape** — ``product`` + ``version`` +
+      ``impl_id`` + ``specs[]`` carry the resolved triple plus the
+      spec sources. The MCP admin tool and historical clients use
+      this shape.
+
     Tenant scoping: the operator's tenant_id from the JWT is used
     as the write scope unless the operator is ``tenant_admin``
     (built-in ingest, ``tenant_id=NULL``). For v0.2 the route always
@@ -232,13 +250,146 @@ async def ingest_endpoint(
     by hitting :class:`IngestionPipelineService` directly with
     ``tenant_id=None``.
     """
+    resolved = _resolve_catalog_entry_if_set(body)
     service = IngestionPipelineService(
         operator=operator,
         llm_client_factory=llm_client_factory,
     )
-    result = await _run_ingest_with_http_mapping(service=service, body=body, operator=operator)
+    result = await _run_ingest_with_http_mapping(service=service, body=resolved, operator=operator)
     ingestion_model, grouping_model = result.to_api_models()
     return IngestResponse(ingestion=ingestion_model, grouping=grouping_model)
+
+
+def _resolve_catalog_entry_if_set(body: IngestRequest) -> IngestRequest:
+    """Resolve ``body.catalog_entry`` against the packaged catalog.
+
+    Returns a new :class:`IngestRequest` in the explicit-quadruple
+    shape so the rest of the ingest pipeline doesn't need to branch
+    on which shape the caller used. The catalog-driven shape is
+    G0.14-T9 (#1150): REST-native clients ship
+    ``{"catalog_entry": "vmware/9.0"}`` and the server resolves the
+    triple + spec sources from the package-data catalog.
+
+    Raises :class:`HTTPException` (422) with structured detail bodies
+    per the T11 error-shape convention
+    (:doc:`docs/codebase/error-message-shape.md`) for the four
+    catalog-side validation outcomes:
+
+    * Malformed reference (no slash, blank halves) →
+      ``catalog_entry_malformed``.
+    * Reference well-formed but not in catalog →
+      ``catalog_entry_not_found`` carrying ``available_entries[]``.
+    * Reference resolves to a typed connector (``upstream is None``)
+      with no ingestable spec → ``catalog_entry_typed_connector``.
+    * Reference resolves to a fqdn-templated upstream
+      (placeholder ``<...>`` in the URL — appliance-served NSX) →
+      ``catalog_entry_templated_upstream``. The operator must supply
+      the concrete spec via the explicit-quadruple shape.
+
+    A body with ``catalog_entry=None`` is returned verbatim — the
+    explicit-quadruple shape doesn't need resolution.
+    """
+    if body.catalog_entry is None:
+        return body
+    catalog_entry = body.catalog_entry
+    product, version = _parse_catalog_entry(catalog_entry)
+    catalog = load_catalog()
+    entry = catalog.get(product, version)
+    if entry is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=build_catalog_entry_not_found_detail(
+                catalog_entry=catalog_entry,
+                available_entries=[f"{e.product}/{e.version}" for e in catalog.entries],
+            ),
+        )
+    _reject_unusable_entry(catalog_entry=catalog_entry, entry=entry)
+    # The catalog entry is good — round-trip through the explicit
+    # shape so the downstream pipeline can stay unchanged. The
+    # validator on IngestRequest still passes because catalog_entry
+    # is unset in the round-tripped object.
+    return body.model_copy(
+        update={
+            "catalog_entry": None,
+            "product": entry.product,
+            "version": entry.version,
+            "impl_id": entry.impl_id,
+            "specs": [SpecSource(uri=uri) for uri in (entry.upstream or ())],
+        },
+    )
+
+
+def _parse_catalog_entry(catalog_entry: str) -> tuple[str, str]:
+    """Split a ``"<product>/<version>"`` reference; raise 422 on a
+    malformed shape.
+
+    Mirrors the CLI's ``parseCatalogRef`` validation contract but
+    runs server-side so REST-native clients get the same diagnostic
+    without round-tripping through the CLI. Per T11 convention.
+    """
+    if "/" not in catalog_entry:
+        raise HTTPException(
+            status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=build_catalog_entry_malformed_detail(catalog_entry=catalog_entry),
+        )
+    product_raw, _, version_raw = catalog_entry.partition("/")
+    product = product_raw.strip()
+    version = version_raw.strip()
+    if not product or not version or "/" in version:
+        raise HTTPException(
+            status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=build_catalog_entry_malformed_detail(catalog_entry=catalog_entry),
+        )
+    return product, version
+
+
+def _reject_unusable_entry(
+    *,
+    catalog_entry: str,
+    entry: ConnectorSpecEntry,
+) -> None:
+    """Reject typed-connector and fqdn-templated entries with
+    structured 422s per T11 convention.
+
+    A typed connector (``upstream is None``) has no ingestable spec;
+    a fqdn-templated upstream (placeholder ``<...>`` characters) is
+    appliance-served (NSX manager URL, vCenter FQDN) and the catalog
+    can't dereference it server-side. Both surfaces refuse the catalog-
+    driven shape and point the operator at the explicit-quadruple
+    fallback documented in ``docs/cross-repo/connector-catalog.md``.
+    """
+    if entry.upstream is None:
+        raise HTTPException(
+            status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=build_catalog_entry_typed_connector_detail(
+                catalog_entry=catalog_entry,
+                product=entry.product,
+                version=entry.version,
+                impl_id=entry.impl_id,
+            ),
+        )
+    templated = [url for url in entry.upstream if "<" in url or ">" in url]
+    if templated:
+        raise HTTPException(
+            status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={
+                "detail": "catalog_entry_templated_upstream",
+                "catalog_entry": catalog_entry,
+                "product": entry.product,
+                "version": entry.version,
+                "impl_id": entry.impl_id,
+                "templated_upstream": templated,
+                "message": (
+                    f"catalog_entry_templated_upstream: {catalog_entry!r} "
+                    f"upstream {templated!r} is fqdn-templated and cannot "
+                    "be resolved server-side. Supply the concrete spec via "
+                    "the explicit-quadruple shape "
+                    "(product/version/impl_id/specs). "
+                    "See docs/cross-repo/connector-catalog.md. "
+                    "See docs/codebase/error-message-shape.md."
+                ),
+            },
+        )
 
 
 async def _run_ingest_with_http_mapping(
@@ -253,7 +404,18 @@ async def _run_ingest_with_http_mapping(
     under the code-quality function-size threshold; the mapping
     table itself is the load-bearing contract documented at the top
     of the module.
+
+    Pre-condition: ``body`` is in the explicit-quadruple shape
+    (``product`` / ``version`` / ``impl_id`` / ``specs`` populated).
+    The catalog-driven shape is resolved upstream by
+    :func:`_resolve_catalog_entry_if_set`; the asserts below pin the
+    invariant so a future refactor that bypasses that helper trips
+    at the boundary rather than landing a half-populated ingest
+    against ``product=None`` / ``version=None`` / ``impl_id=None``.
     """
+    assert body.product is not None, "post-resolution invariant: product must be set"
+    assert body.version is not None, "post-resolution invariant: version must be set"
+    assert body.impl_id is not None, "post-resolution invariant: impl_id must be set"
     try:
         return await service.ingest(
             product=body.product,

--- a/backend/src/meho_backplane/mcp/tools/connector_admin.py
+++ b/backend/src/meho_backplane/mcp/tools/connector_admin.py
@@ -198,6 +198,16 @@ async def _ingest_handler(
         base_url=arguments.get("base_url"),
         dry_run=bool(arguments.get("dry_run", False)),
     )
+    # Post-validator invariant: the MCP path always constructs the
+    # explicit-quadruple shape (the JSON-Schema layer doesn't expose
+    # ``catalog_entry`` — that lives only on the REST surface today),
+    # so product/version/impl_id are guaranteed non-None. The asserts
+    # pin the invariant for mypy after the schema's optional typing
+    # widened to support the REST ``catalog_entry`` shape
+    # (G0.14-T9 / #1150).
+    assert request.product is not None
+    assert request.version is not None
+    assert request.impl_id is not None
     tenant_id = _coerce_tenant_id(arguments.get("tenant_id"))
     service = IngestionPipelineService(
         operator,

--- a/backend/src/meho_backplane/operations/ingest/__init__.py
+++ b/backend/src/meho_backplane/operations/ingest/__init__.py
@@ -43,6 +43,9 @@ from meho_backplane.operations.ingest.connector_registration import (
     ensure_connector_class_registered,
 )
 from meho_backplane.operations.ingest.error_envelopes import (
+    build_catalog_entry_malformed_detail,
+    build_catalog_entry_not_found_detail,
+    build_catalog_entry_typed_connector_detail,
     build_uncovered_version_label_detail,
     build_version_mismatch_detail,
 )
@@ -135,6 +138,9 @@ __all__ = [
     "UncoveredVersionLabel",
     "UnsupportedSpecError",
     "VersionMismatchError",
+    "build_catalog_entry_malformed_detail",
+    "build_catalog_entry_not_found_detail",
+    "build_catalog_entry_typed_connector_detail",
     "build_uncovered_version_label_detail",
     "build_version_mismatch_detail",
     "check_version_covered_by_registered_class",

--- a/backend/src/meho_backplane/operations/ingest/api_schemas.py
+++ b/backend/src/meho_backplane/operations/ingest/api_schemas.py
@@ -58,7 +58,7 @@ from __future__ import annotations
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 __all__ = [
     "ConnectorListItem",
@@ -120,6 +120,30 @@ class IngestRequest(BaseModel):
     ingestion (vCenter's ``vcenter.yaml`` + ``vi-json.yaml``) lands as
     multiple ``SpecSource`` entries in one request.
 
+    Two mutually-exclusive request shapes:
+
+    * **Explicit-quadruple shape** — ``product`` + ``version`` +
+      ``impl_id`` + ``specs[]`` carry the resolved triple plus the
+      spec sources the caller already knows. The MCP admin tool and
+      the historical CLI manual mode use this shape.
+    * **Catalog-driven shape** (G0.14-T9 / #1150) — ``catalog_entry``
+      carries a ``"<product>/<version>"`` reference; the route
+      handler resolves the entry against the packaged catalog (see
+      :mod:`meho_backplane.operations.ingest.catalog`) and fills in
+      ``product`` / ``version`` / ``impl_id`` / ``specs[]`` from the
+      catalog entry before dispatching through the existing ingest
+      path. REST-native agent runtimes that can't shell out to the
+      CLI use this shape; the CLI's ``--catalog`` flag has been
+      refactored to POST this shape rather than resolving the entry
+      client-side.
+
+    The two shapes are mutually exclusive: a body that sets
+    ``catalog_entry`` alongside any of ``product`` / ``version`` /
+    ``impl_id`` / ``specs[]`` fails 422 ``catalog_entry_conflict`` at
+    the validator below. A body that sets neither fails 422
+    ``ingest_request_underspecified``. ``base_url`` and ``dry_run``
+    are accepted in both shapes.
+
     ``dry_run=True`` skips both the DB writes and the grouping pass:
     only :func:`parse_openapi` runs, and the response carries
     :class:`IngestionResultModel` counts derived from the parse output
@@ -139,12 +163,79 @@ class IngestRequest(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    product: str = Field(min_length=1, max_length=64)
-    version: str = Field(min_length=1, max_length=64)
-    impl_id: str = Field(min_length=1, max_length=128)
-    specs: list[SpecSource] = Field(min_length=1, max_length=16)
+    product: str | None = Field(default=None, min_length=1, max_length=64)
+    version: str | None = Field(default=None, min_length=1, max_length=64)
+    impl_id: str | None = Field(default=None, min_length=1, max_length=128)
+    specs: list[SpecSource] = Field(default_factory=list, max_length=16)
+    catalog_entry: str | None = Field(default=None, min_length=1, max_length=128)
     base_url: str | None = Field(default=None, max_length=2048)
     dry_run: bool = False
+
+    @model_validator(mode="after")
+    def _exactly_one_request_shape(self) -> IngestRequest:
+        """Reject bodies that mix or omit both request shapes.
+
+        Catalog-driven shape: ``catalog_entry`` set, every quadruple
+        field unset / empty. Explicit-quadruple shape: every quadruple
+        field set, ``catalog_entry`` unset. Anything else is a
+        caller-side bug worth a 422 rather than a half-resolved
+        downstream failure (the route handler can't tell which shape
+        the caller intended, and silently picking one would land an
+        ingest under either the wrong triple or a half-populated
+        catalog entry).
+
+        The error messages carry the convention's diagnostic shape
+        (see :doc:`docs/codebase/error-message-shape.md`): a stable
+        ``snake_case`` classifier prefix (``catalog_entry_conflict``
+        / ``ingest_request_underspecified``) so REST callers and the
+        MCP-driving agent can branch without re-parsing the prose.
+        """
+        catalog_set = self.catalog_entry is not None
+        quadruple_set = (
+            self.product is not None
+            or self.version is not None
+            or self.impl_id is not None
+            or len(self.specs) > 0
+        )
+        if catalog_set and quadruple_set:
+            raise ValueError(
+                "catalog_entry_conflict: 'catalog_entry' is mutually exclusive "
+                "with 'product' / 'version' / 'impl_id' / 'specs[]'; "
+                "supply only one request shape. "
+                "See docs/codebase/error-message-shape.md.",
+            )
+        if not catalog_set and not quadruple_set:
+            raise ValueError(
+                "ingest_request_underspecified: supply either "
+                "'catalog_entry' (catalog-driven shape) or "
+                "'product' + 'version' + 'impl_id' + 'specs[]' "
+                "(explicit-quadruple shape). "
+                "See docs/codebase/error-message-shape.md.",
+            )
+        if not catalog_set:
+            # Explicit-quadruple shape — every quadruple field must
+            # be set. Partial-quadruple bodies (e.g. impl_id missing)
+            # would otherwise silently default to None and surface
+            # downstream as a confusing register_ingested error.
+            missing = [
+                name
+                for name, value in (
+                    ("product", self.product),
+                    ("version", self.version),
+                    ("impl_id", self.impl_id),
+                )
+                if value is None
+            ]
+            if not self.specs:
+                missing.append("specs")
+            if missing:
+                raise ValueError(
+                    "ingest_request_underspecified: explicit-quadruple shape "
+                    f"requires {missing}. Supply the missing field(s), or use "
+                    "the catalog-driven shape via 'catalog_entry'. "
+                    "See docs/codebase/error-message-shape.md.",
+                )
+        return self
 
 
 class IngestionResultModel(BaseModel):

--- a/backend/src/meho_backplane/operations/ingest/error_envelopes.py
+++ b/backend/src/meho_backplane/operations/ingest/error_envelopes.py
@@ -38,6 +38,9 @@ from meho_backplane.operations.ingest.exceptions import (
 )
 
 __all__ = [
+    "build_catalog_entry_malformed_detail",
+    "build_catalog_entry_not_found_detail",
+    "build_catalog_entry_typed_connector_detail",
     "build_uncovered_version_label_detail",
     "build_version_mismatch_detail",
 ]
@@ -72,6 +75,101 @@ def build_version_mismatch_detail(exc: VersionMismatchError) -> dict[str, Any]:
             {"spec_uri": uri, "info_version": version} for uri, version in exc.spec_info_versions
         ],
         "message": str(exc),
+    }
+
+
+def build_catalog_entry_not_found_detail(
+    *,
+    catalog_entry: str,
+    available_entries: list[str],
+) -> dict[str, Any]:
+    """Structured 422 detail for ``POST /api/v1/connectors/ingest``
+    when the operator-supplied ``catalog_entry`` is well-formed but
+    not present in the packaged catalog (G0.14-T9 / #1150).
+
+    Body shape (T11 convention, see
+    :doc:`docs/codebase/error-message-shape.md`):
+
+    * ``detail`` — stable ``snake_case`` classifier
+      ``"catalog_entry_not_found"`` so callers can branch without
+      re-parsing the message.
+    * ``catalog_entry`` — the operator-supplied
+      ``"<product>/<version>"`` reference, echoed back so an agent
+      doesn't need to re-thread it from its own prompt.
+    * ``available_entries`` — sorted list of ``"<product>/<version>"``
+      strings the catalog actually contains. An agent picks one and
+      retries; an interactive operator gets the same enumeration the
+      ``meho connector catalog list`` verb prints.
+    * ``message`` — the rendered human-readable detail for clients
+      that ignore the structured fields.
+    """
+    sorted_available = sorted(set(available_entries))
+    return {
+        "detail": "catalog_entry_not_found",
+        "catalog_entry": catalog_entry,
+        "available_entries": sorted_available,
+        "message": (
+            f"catalog_entry_not_found: no catalog entry for {catalog_entry!r}; "
+            f"available: {', '.join(sorted_available) if sorted_available else '<empty catalog>'}. "
+            "Pick one of the available entries or use the explicit-quadruple shape. "
+            "See docs/codebase/error-message-shape.md."
+        ),
+    }
+
+
+def build_catalog_entry_malformed_detail(
+    *,
+    catalog_entry: str,
+) -> dict[str, Any]:
+    """Structured 422 detail when the operator's ``catalog_entry`` does
+    not match the ``"<product>/<version>"`` shape (G0.14-T9 / #1150).
+
+    Distinct from ``catalog_entry_not_found`` so an agent can branch on
+    "the reference itself is malformed" (fix the slash) vs "the
+    reference is well-formed but no entry exists" (fix the value). Per
+    T11 convention.
+    """
+    return {
+        "detail": "catalog_entry_malformed",
+        "catalog_entry": catalog_entry,
+        "message": (
+            f"catalog_entry_malformed: {catalog_entry!r} is not "
+            f"'<product>/<version>' (e.g. 'vmware/9.0'). "
+            "See docs/codebase/error-message-shape.md."
+        ),
+    }
+
+
+def build_catalog_entry_typed_connector_detail(
+    *,
+    catalog_entry: str,
+    product: str,
+    version: str,
+    impl_id: str,
+) -> dict[str, Any]:
+    """Structured 422 detail when the operator's ``catalog_entry``
+    resolves to a typed connector with no ingestable spec
+    (``upstream is None``) — there is nothing to ingest
+    (G0.14-T9 / #1150).
+
+    The detail names the resolved triple so an interactive operator
+    sees that the entry exists in the catalog but is intentionally
+    typed (e.g. ``vault/1.x``, ``k8s/1.x``, ``bind9/9.x``). Per T11
+    convention; the doc reference belongs at the operator's checked-
+    out clone.
+    """
+    return {
+        "detail": "catalog_entry_typed_connector",
+        "catalog_entry": catalog_entry,
+        "product": product,
+        "version": version,
+        "impl_id": impl_id,
+        "message": (
+            f"catalog_entry_typed_connector: {catalog_entry!r} is a typed "
+            f"connector ({product}/{version}/{impl_id}) with no ingestable "
+            "spec; nothing to ingest. See docs/cross-repo/connector-catalog.md. "
+            "See docs/codebase/error-message-shape.md."
+        ),
     }
 
 

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -1999,5 +1999,358 @@ paths:
     assert "version='7.0'" in response.json()["detail"]
 
 
+# ---------------------------------------------------------------------------
+# G0.14-T9 (#1150) — catalog-driven REST ingest shape
+# ---------------------------------------------------------------------------
+
+
+def _patch_catalog(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    entries: list[dict[str, Any]],
+) -> None:
+    """Install a fake packaged catalog for the route's resolver.
+
+    The route handler calls :func:`load_catalog`, which is cached with
+    ``functools.lru_cache``. The cleanest swap is to drop the cache and
+    monkey-patch the module-level callable on the symbol the route
+    actually imports — without that, an earlier test in the file may
+    have warmed the cache against the on-disk catalog and the patched
+    entries never reach the resolver.
+    """
+    from meho_backplane.operations.ingest import catalog as _catalog_mod
+    from meho_backplane.operations.ingest.catalog import (
+        ConnectorSpecCatalog,
+        ConnectorSpecEntry,
+    )
+
+    fake = ConnectorSpecCatalog(entries=tuple(ConnectorSpecEntry(**e) for e in entries))
+    _catalog_mod.load_catalog.cache_clear()
+    # The route imports ``load_catalog`` via the
+    # ``meho_backplane.operations.ingest`` package; patching the
+    # package attribute is what the handler resolves at call time.
+    import meho_backplane.api.v1.connectors_ingest as _route_mod
+
+    monkeypatch.setattr(_route_mod, "load_catalog", lambda: fake)
+
+
+def test_ingest_catalog_entry_resolves_and_ingests_successfully(
+    client: TestClient,
+    tmp_path: Any,
+    stub_embedding_service: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """G0.14-T9: ``{catalog_entry: "vmware/9.0"}`` resolves server-side and ingests.
+
+    The packaged catalog is patched to a single entry pointing at a
+    local-file spec so the request body can stay minimal. The
+    response carries the same shape an explicit-quadruple request
+    against the resolved triple would produce — the catalog-driven
+    shape is sugar over the existing ingest path.
+    """
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(
+        """openapi: 3.0.3
+info:
+  title: catalog
+  version: '9.0'
+paths:
+  /items:
+    get:
+      summary: list items
+      responses:
+        '200':
+          description: ok
+""",
+    )
+    _patch_catalog(
+        monkeypatch,
+        entries=[
+            {
+                "product": "vmware-t9",
+                "version": "9.0",
+                "impl_id": "vmware-rest-t9",
+                "requires_connector_class": "VmwareRestConnector",
+                "upstream": (str(spec_path),),
+            },
+        ],
+    )
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={"catalog_entry": "vmware-t9/9.0", "dry_run": True},
+            headers=_authed(token),
+        )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ingestion"]["inserted_count"] == 1
+    # The resolved triple round-trips into the connector_id the response
+    # echoes (`<impl_id>-<version>`) so a REST client sees the resolved
+    # identity without needing to re-derive it.
+    assert body["ingestion"]["connector_id"] == "vmware-rest-t9-9.0"
+
+
+def test_ingest_catalog_entry_unknown_returns_structured_422(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """G0.14-T9: unknown ``catalog_entry`` → structured 422 per T11 convention.
+
+    The detail body carries ``detail="catalog_entry_not_found"`` plus
+    the offending value and the list of valid alternatives so an agent
+    can branch + retry without re-fetching the catalog.
+    """
+    _patch_catalog(
+        monkeypatch,
+        entries=[
+            {
+                "product": "vmware-t9",
+                "version": "9.0",
+                "impl_id": "vmware-rest-t9",
+                "requires_connector_class": "VmwareRestConnector",
+                "upstream": ("https://example.lab/spec.yaml",),
+            },
+        ],
+    )
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={"catalog_entry": "nope/1.0"},
+            headers=_authed(token),
+        )
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert detail["detail"] == "catalog_entry_not_found"
+    assert detail["catalog_entry"] == "nope/1.0"
+    assert detail["available_entries"] == ["vmware-t9/9.0"]
+    assert "error-message-shape" in detail["message"]
+
+
+def test_ingest_catalog_entry_and_quadruple_supplied_returns_422_conflict(
+    client: TestClient,
+) -> None:
+    """G0.14-T9: both request shapes supplied → 422 ``catalog_entry_conflict``.
+
+    The validator on :class:`IngestRequest` rejects the mixed body at
+    the framework boundary (FastAPI surfaces validator failures as 422
+    with the message in ``detail[0]["msg"]``); per T11 convention the
+    stable classifier is embedded in the message so clients can branch.
+    """
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={
+                "catalog_entry": "vmware/9.0",
+                "product": "vmware",
+                "version": "9.0",
+                "impl_id": "vmware-rest",
+                "specs": [{"uri": "/abs/spec.yaml"}],
+            },
+            headers=_authed(token),
+        )
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    # FastAPI renders validator failures as a list of error objects;
+    # the message carries the convention's snake_case classifier so a
+    # client can branch on ``catalog_entry_conflict`` without parsing
+    # prose.
+    messages = [e["msg"] for e in detail]
+    assert any("catalog_entry_conflict" in m for m in messages), messages
+
+
+def test_ingest_empty_body_returns_422_underspecified(
+    client: TestClient,
+) -> None:
+    """G0.14-T9: neither request shape supplied → 422
+    ``ingest_request_underspecified``.
+
+    The empty-body shape used to fail "Field required" four times
+    (one per quadruple field). The new validator collapses that into
+    one classifier-bearing message so the operator's error is
+    actionable: pick a shape.
+    """
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={},
+            headers=_authed(token),
+        )
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    messages = [e["msg"] for e in detail]
+    assert any("ingest_request_underspecified" in m for m in messages), messages
+
+
+def test_ingest_catalog_entry_malformed_ref_returns_422(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """G0.14-T9: ``catalog_entry`` without a ``/`` separator → structured 422.
+
+    A reference shape miss is distinct from "valid shape, not in
+    catalog" so an agent can branch differently — the first means
+    "fix the slash"; the second means "pick a different entry".
+    """
+    _patch_catalog(
+        monkeypatch,
+        entries=[
+            {
+                "product": "vmware-t9",
+                "version": "9.0",
+                "impl_id": "vmware-rest-t9",
+                "requires_connector_class": "VmwareRestConnector",
+                "upstream": ("https://example.lab/spec.yaml",),
+            },
+        ],
+    )
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={"catalog_entry": "vmware9.0"},
+            headers=_authed(token),
+        )
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert detail["detail"] == "catalog_entry_malformed"
+    assert detail["catalog_entry"] == "vmware9.0"
+    assert "error-message-shape" in detail["message"]
+
+
+def test_ingest_catalog_entry_typed_connector_returns_422(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """G0.14-T9: a typed-connector entry (``upstream=null``) → structured 422.
+
+    The catalog ships typed connectors (vault, k8s, bind9) with
+    ``upstream=null`` — there is no spec to ingest, but the entry
+    exists in the catalog. The detail names the resolved triple so an
+    interactive operator sees the entry exists but is intentionally
+    typed.
+    """
+    _patch_catalog(
+        monkeypatch,
+        entries=[
+            {
+                "product": "vault-t9",
+                "version": "1.x",
+                "impl_id": "vault-t9",
+                "requires_connector_class": "VaultConnector",
+                "upstream": None,
+            },
+        ],
+    )
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={"catalog_entry": "vault-t9/1.x"},
+            headers=_authed(token),
+        )
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert detail["detail"] == "catalog_entry_typed_connector"
+    assert detail["catalog_entry"] == "vault-t9/1.x"
+    assert detail["product"] == "vault-t9"
+    assert detail["impl_id"] == "vault-t9"
+
+
+def test_ingest_catalog_entry_templated_upstream_returns_422(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """G0.14-T9: an fqdn-templated upstream URL → structured 422.
+
+    Appliance-served catalog entries (NSX manager's
+    ``https://<nsx-mgr-fqdn>/...``) cannot be dereferenced server-side
+    — the placeholder needs an operator-supplied FQDN. The detail
+    names the templated URL so the operator sees what to fill in and
+    points at the explicit-quadruple fallback.
+    """
+    _patch_catalog(
+        monkeypatch,
+        entries=[
+            {
+                "product": "nsx-t9",
+                "version": "4.2",
+                "impl_id": "nsx-rest-t9",
+                "requires_connector_class": "NsxConnector",
+                "upstream": ("https://<nsx-mgr-fqdn>/api/v1/spec/openapi/nsx_api.yaml",),
+            },
+        ],
+    )
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={"catalog_entry": "nsx-t9/4.2"},
+            headers=_authed(token),
+        )
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert detail["detail"] == "catalog_entry_templated_upstream"
+    assert detail["catalog_entry"] == "nsx-t9/4.2"
+    assert detail["templated_upstream"] == [
+        "https://<nsx-mgr-fqdn>/api/v1/spec/openapi/nsx_api.yaml",
+    ]
+
+
+def test_ingest_explicit_quadruple_still_works_regression(
+    client: TestClient,
+    tmp_path: Any,
+) -> None:
+    """G0.14-T9 regression guard: the historical explicit-quadruple shape
+    still parses + validates after the schema gained ``catalog_entry``.
+
+    The MCP admin tool and any pre-G0.14-T9 REST client send this
+    shape; a regression here would break both. The smoke is just the
+    dry-run happy path; the rest of the test file covers the deep
+    ingest mechanics.
+    """
+    spec_path = tmp_path / "spec.yaml"
+    spec_path.write_text(
+        """openapi: 3.0.3
+info:
+  title: t
+  version: '1'
+paths:
+  /items:
+    get:
+      summary: list items
+      responses:
+        '200':
+          description: ok
+""",
+    )
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={
+                "product": "test-quadruple",
+                "version": "1.0",
+                "impl_id": "test-impl",
+                "specs": [{"uri": str(spec_path)}],
+                "dry_run": True,
+            },
+            headers=_authed(token),
+        )
+    assert response.status_code == 200, response.text
+    assert response.json()["ingestion"]["inserted_count"] == 1
+
+
 # Silence unused-import lints on test seams reserved for sibling tasks.
 _ = (AsyncMock, patch, GroupingResult, IngestionResult)

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -2247,7 +2247,7 @@
           "connectors"
         ],
         "summary": "Ingest Endpoint",
-        "description": "Run the full ingestion pipeline (T1 \u2192 T2 \u2192 T3) for one connector.\n\n``dry_run=true`` parses every spec but writes nothing; the\nresponse carries the parser's ``inserted_count`` projection and\n``grouping=None``. The real path runs the parse \u2192 register_\ningested \u2192 run_llm_grouping pipeline serially and returns the\naggregated counts + grouping result.\n\nTenant scoping: the operator's tenant_id from the JWT is used\nas the write scope unless the operator is ``tenant_admin``\n(built-in ingest, ``tenant_id=NULL``). For v0.2 the route always\nwrites under the operator's tenant_id; built-in ingest is the\nsame call shape from a tenant_admin operator whose tenant_id\nhappens to be the \"built-in\" admin tenant. The CLI / MCP\nsiblings can target the built-in scope explicitly when needed\nby hitting :class:`IngestionPipelineService` directly with\n``tenant_id=None``.",
+        "description": "Run the full ingestion pipeline (T1 \u2192 T2 \u2192 T3) for one connector.\n\n``dry_run=true`` parses every spec but writes nothing; the\nresponse carries the parser's ``inserted_count`` projection and\n``grouping=None``. The real path runs the parse \u2192 register_\ningested \u2192 run_llm_grouping pipeline serially and returns the\naggregated counts + grouping result.\n\nThe body accepts two mutually-exclusive request shapes (see\n:class:`IngestRequest`):\n\n* **Catalog-driven shape** (G0.14-T9 / #1150) \u2014 ``catalog_entry``\n  is a ``\"<product>/<version>\"`` reference; this handler resolves\n  it against the packaged catalog (:func:`load_catalog`) and\n  dispatches through the same ingest path as if the caller had\n  supplied the resolved quadruple.\n* **Explicit-quadruple shape** \u2014 ``product`` + ``version`` +\n  ``impl_id`` + ``specs[]`` carry the resolved triple plus the\n  spec sources. The MCP admin tool and historical clients use\n  this shape.\n\nTenant scoping: the operator's tenant_id from the JWT is used\nas the write scope unless the operator is ``tenant_admin``\n(built-in ingest, ``tenant_id=NULL``). For v0.2 the route always\nwrites under the operator's tenant_id; built-in ingest is the\nsame call shape from a tenant_admin operator whose tenant_id\nhappens to be the \"built-in\" admin tenant. The CLI / MCP\nsiblings can target the built-in scope explicitly when needed\nby hitting :class:`IngestionPipelineService` directly with\n``tenant_id=None``.",
         "operationId": "ingest_endpoint_api_v1_connectors_ingest_post",
         "parameters": [
           {
@@ -9965,18 +9965,21 @@
             "type": "string",
             "maxLength": 64,
             "minLength": 1,
+            "nullable": true,
             "title": "Product"
           },
           "version": {
             "type": "string",
             "maxLength": 64,
             "minLength": 1,
+            "nullable": true,
             "title": "Version"
           },
           "impl_id": {
             "type": "string",
             "maxLength": 128,
             "minLength": 1,
+            "nullable": true,
             "title": "Impl Id"
           },
           "specs": {
@@ -9985,8 +9988,14 @@
             },
             "type": "array",
             "maxItems": 16,
-            "minItems": 1,
             "title": "Specs"
+          },
+          "catalog_entry": {
+            "type": "string",
+            "maxLength": 128,
+            "minLength": 1,
+            "nullable": true,
+            "title": "Catalog Entry"
           },
           "base_url": {
             "type": "string",
@@ -10002,14 +10011,8 @@
         },
         "additionalProperties": false,
         "type": "object",
-        "required": [
-          "product",
-          "version",
-          "impl_id",
-          "specs"
-        ],
         "title": "IngestRequest",
-        "description": "POST body for ``/api/v1/connectors/ingest``.\n\nDrives a full pipeline run: parse every spec in *specs*, call\n:func:`register_ingested_operations` once per spec under the same\n``(product, version, impl_id)`` connector triple, then run\n:func:`run_llm_grouping` once for the whole connector. Multi-spec\ningestion (vCenter's ``vcenter.yaml`` + ``vi-json.yaml``) lands as\nmultiple ``SpecSource`` entries in one request.\n\n``dry_run=True`` skips both the DB writes and the grouping pass:\nonly :func:`parse_openapi` runs, and the response carries\n:class:`IngestionResultModel` counts derived from the parse output\nplus ``grouping=None``. Operators use the dry-run path to validate\na spec before committing.\n\n``base_url`` is the optional default base URL for the auto-\nregistered :class:`GenericRestConnector` shim; ``None`` leaves\nthe shim unconfigured (the connector's eventual hand-coded\nsubclass at G3.x will set its own base URL).\n\n``extra=\"forbid\"`` rejects unknown body fields with 422\n``extra_forbidden`` (G0.9-T2 / #729) \u2014 silent-drop on a typo\nwould otherwise mean the pipeline runs with the wrong impl_id\nand the operator only finds out at review-time."
+        "description": "POST body for ``/api/v1/connectors/ingest``.\n\nDrives a full pipeline run: parse every spec in *specs*, call\n:func:`register_ingested_operations` once per spec under the same\n``(product, version, impl_id)`` connector triple, then run\n:func:`run_llm_grouping` once for the whole connector. Multi-spec\ningestion (vCenter's ``vcenter.yaml`` + ``vi-json.yaml``) lands as\nmultiple ``SpecSource`` entries in one request.\n\nTwo mutually-exclusive request shapes:\n\n* **Explicit-quadruple shape** \u2014 ``product`` + ``version`` +\n  ``impl_id`` + ``specs[]`` carry the resolved triple plus the\n  spec sources the caller already knows. The MCP admin tool and\n  the historical CLI manual mode use this shape.\n* **Catalog-driven shape** (G0.14-T9 / #1150) \u2014 ``catalog_entry``\n  carries a ``\"<product>/<version>\"`` reference; the route\n  handler resolves the entry against the packaged catalog (see\n  :mod:`meho_backplane.operations.ingest.catalog`) and fills in\n  ``product`` / ``version`` / ``impl_id`` / ``specs[]`` from the\n  catalog entry before dispatching through the existing ingest\n  path. REST-native agent runtimes that can't shell out to the\n  CLI use this shape; the CLI's ``--catalog`` flag has been\n  refactored to POST this shape rather than resolving the entry\n  client-side.\n\nThe two shapes are mutually exclusive: a body that sets\n``catalog_entry`` alongside any of ``product`` / ``version`` /\n``impl_id`` / ``specs[]`` fails 422 ``catalog_entry_conflict`` at\nthe validator below. A body that sets neither fails 422\n``ingest_request_underspecified``. ``base_url`` and ``dry_run``\nare accepted in both shapes.\n\n``dry_run=True`` skips both the DB writes and the grouping pass:\nonly :func:`parse_openapi` runs, and the response carries\n:class:`IngestionResultModel` counts derived from the parse output\nplus ``grouping=None``. Operators use the dry-run path to validate\na spec before committing.\n\n``base_url`` is the optional default base URL for the auto-\nregistered :class:`GenericRestConnector` shim; ``None`` leaves\nthe shim unconfigured (the connector's eventual hand-coded\nsubclass at G3.x will set its own base URL).\n\n``extra=\"forbid\"`` rejects unknown body fields with 422\n``extra_forbidden`` (G0.9-T2 / #729) \u2014 silent-drop on a typo\nwould otherwise mean the pipeline runs with the wrong impl_id\nand the operator only finds out at review-time."
       },
       "IngestResponse": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -1940,6 +1940,30 @@ type IngestKbRequest struct {
 // ingestion (vCenter's “vcenter.yaml“ + “vi-json.yaml“) lands as
 // multiple “SpecSource“ entries in one request.
 //
+// Two mutually-exclusive request shapes:
+//
+//   - **Explicit-quadruple shape** — “product“ + “version“ +
+//     “impl_id“ + “specs[]“ carry the resolved triple plus the
+//     spec sources the caller already knows. The MCP admin tool and
+//     the historical CLI manual mode use this shape.
+//   - **Catalog-driven shape** (G0.14-T9 / #1150) — “catalog_entry“
+//     carries a “"<product>/<version>"“ reference; the route
+//     handler resolves the entry against the packaged catalog (see
+//     :mod:`meho_backplane.operations.ingest.catalog`) and fills in
+//     “product“ / “version“ / “impl_id“ / “specs[]“ from the
+//     catalog entry before dispatching through the existing ingest
+//     path. REST-native agent runtimes that can't shell out to the
+//     CLI use this shape; the CLI's “--catalog“ flag has been
+//     refactored to POST this shape rather than resolving the entry
+//     client-side.
+//
+// The two shapes are mutually exclusive: a body that sets
+// “catalog_entry“ alongside any of “product“ / “version“ /
+// “impl_id“ / “specs[]“ fails 422 “catalog_entry_conflict“ at
+// the validator below. A body that sets neither fails 422
+// “ingest_request_underspecified“. “base_url“ and “dry_run“
+// are accepted in both shapes.
+//
 // “dry_run=True“ skips both the DB writes and the grouping pass:
 // only :func:`parse_openapi` runs, and the response carries
 // :class:`IngestionResultModel` counts derived from the parse output
@@ -1956,12 +1980,13 @@ type IngestKbRequest struct {
 // would otherwise mean the pipeline runs with the wrong impl_id
 // and the operator only finds out at review-time.
 type IngestRequest struct {
-	BaseUrl *string      `json:"base_url"`
-	DryRun  *bool        `json:"dry_run,omitempty"`
-	ImplId  string       `json:"impl_id"`
-	Product string       `json:"product"`
-	Specs   []SpecSource `json:"specs"`
-	Version string       `json:"version"`
+	BaseUrl      *string       `json:"base_url"`
+	CatalogEntry *string       `json:"catalog_entry"`
+	DryRun       *bool         `json:"dry_run,omitempty"`
+	ImplId       *string       `json:"impl_id"`
+	Product      *string       `json:"product"`
+	Specs        *[]SpecSource `json:"specs,omitempty"`
+	Version      *string       `json:"version"`
 }
 
 // IngestResponse Response shape for “POST /api/v1/connectors/ingest“.

--- a/cli/internal/cmd/connector/catalog.go
+++ b/cli/internal/cmd/connector/catalog.go
@@ -5,10 +5,8 @@ package connector
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -40,13 +38,6 @@ type CatalogEntry struct {
 type CatalogResponse struct {
 	Catalog []CatalogEntry `json:"catalog"`
 }
-
-// errCatalogResolve tags the local (non-transport) failures of
-// resolveCatalogEntry — entry-not-found, typed-connector, templated
-// upstream — so the ingest verb renders them as `unexpected` (a clear
-// operator message) rather than routing them through the transport
-// error classifier.
-var errCatalogResolve = errors.New("catalog resolve")
 
 // newCatalogCmd returns the `meho connector catalog` parent command.
 // The catalog is the curated map of (product, version) -> recommended
@@ -217,84 +208,12 @@ func pluralY(n int) string {
 	return "ies"
 }
 
-// resolveCatalogEntry fetches the catalog and resolves a
-// "<product>/<version>" reference to its entry, validating that the
-// entry is generic-ingestable. Local (non-transport) failures are
-// wrapped in errCatalogResolve so the caller can render them as
-// `unexpected`; transport/auth errors from the GET propagate
-// unwrapped for renderRequestError.
-func resolveCatalogEntry(ctx context.Context, backplaneURL, ref string) (*CatalogEntry, error) {
-	product, version, err := parseCatalogRef(ref)
-	if err != nil {
-		return nil, err
-	}
-	catalog, err := getCatalog(ctx, backplaneURL)
-	if err != nil {
-		return nil, err // transport/auth — caller routes via renderRequestError
-	}
-	var entry *CatalogEntry
-	available := make([]string, 0, len(catalog.Catalog))
-	for i := range catalog.Catalog {
-		e := catalog.Catalog[i]
-		available = append(available, e.Product+"/"+e.Version)
-		if e.Product == product && e.Version == version {
-			// The backend model enforces (product, version) uniqueness,
-			// but don't trust the response blindly — a second match means
-			// duplicated catalog data, and silently taking the last would
-			// ingest an ambiguous impl_id.
-			if entry != nil {
-				return nil, fmt.Errorf(
-					"%w: catalog has multiple entries for %q; disambiguate catalog data before ingest",
-					errCatalogResolve, ref)
-			}
-			entry = &catalog.Catalog[i]
-		}
-	}
-	if entry == nil {
-		return nil, fmt.Errorf("%w: no catalog entry for %q; available: %s",
-			errCatalogResolve, ref, strings.Join(available, ", "))
-	}
-	if len(entry.Upstream) == 0 {
-		return nil, fmt.Errorf(
-			"%w: %q is a typed connector with no ingestable spec; nothing to ingest",
-			errCatalogResolve, ref)
-	}
-	for i, u := range entry.Upstream {
-		u = strings.TrimSpace(u)
-		if u == "" {
-			return nil, fmt.Errorf("%w: %q has an empty upstream URL entry",
-				errCatalogResolve, ref)
-		}
-		entry.Upstream[i] = u
-		if strings.ContainsAny(u, "<>") {
-			return nil, fmt.Errorf(
-				"%w: %q upstream URL %q is fqdn-templated; supply the concrete spec via "+
-					"`meho connector ingest --product %s --version %s --impl %s --spec <url>`",
-				errCatalogResolve, ref, u, entry.Product, entry.Version, entry.ImplID)
-		}
-	}
-	return entry, nil
-}
-
-// parseCatalogRef splits a "<product>/<version>" reference. Both
-// halves must be non-empty; the version may itself contain no slash.
-func parseCatalogRef(ref string) (product, version string, err error) {
-	parts := strings.SplitN(ref, "/", 2)
-	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
-		return "", "", fmt.Errorf(
-			"%w: --catalog value %q must be <product>/<version> (e.g. vmware/9.0)",
-			errCatalogResolve, ref)
-	}
-	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), nil
-}
-
-// upstreamSpecs turns a catalog entry's upstream URLs into the
-// SpecSource list the backplane's IngestRequest expects. The backend
-// parser fetches each URL; the CLI does not download.
-func upstreamSpecs(upstream []string) []SpecSource {
-	specs := make([]SpecSource, 0, len(upstream))
-	for _, u := range upstream {
-		specs = append(specs, SpecSource{URI: u})
-	}
-	return specs
-}
+// Catalog resolution moved to the backplane in G0.14-T9 (#1150).
+// The CLI's `--catalog <product>/<version>` flag is now a thin shell
+// that POSTs `{"catalog_entry": "<product>/<version>"}` directly; the
+// backplane validates the reference, resolves the entry against the
+// packaged catalog, and surfaces structured 422 envelopes per the
+// T11 error-shape convention for the four failure modes
+// (`catalog_entry_malformed`, `catalog_entry_not_found`,
+// `catalog_entry_typed_connector`, `catalog_entry_templated_upstream`).
+// See docs/cross-repo/connector-catalog.md.

--- a/cli/internal/cmd/connector/catalog_test.go
+++ b/cli/internal/cmd/connector/catalog_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -17,51 +16,6 @@ import (
 )
 
 func strptr(s string) *string { return &s }
-
-// --- parseCatalogRef -------------------------------------------------------
-
-func TestParseCatalogRefTable(t *testing.T) {
-	cases := []struct {
-		in               string
-		product, version string
-		wantErr          bool
-	}{
-		{"vmware/9.0", "vmware", "9.0", false},
-		{"sddc-manager/9.0", "sddc-manager", "9.0", false},
-		{"  vmware / 9.0  ", "vmware", "9.0", false},
-		{"vmware", "", "", true},
-		{"", "", "", true},
-		{"vmware/", "", "", true},
-		{"/9.0", "", "", true},
-	}
-	for _, c := range cases {
-		p, v, err := parseCatalogRef(c.in)
-		if c.wantErr {
-			if err == nil {
-				t.Errorf("parseCatalogRef(%q): want error, got (%q,%q)", c.in, p, v)
-			} else if !errors.Is(err, errCatalogResolve) {
-				t.Errorf("parseCatalogRef(%q): error should wrap errCatalogResolve, got %v", c.in, err)
-			}
-			continue
-		}
-		if err != nil || p != c.product || v != c.version {
-			t.Errorf("parseCatalogRef(%q) = (%q,%q,%v); want (%q,%q,nil)",
-				c.in, p, v, err, c.product, c.version)
-		}
-	}
-}
-
-// --- upstreamSpecs ---------------------------------------------------------
-
-func TestUpstreamSpecs(t *testing.T) {
-	got := upstreamSpecs([]string{"https://a/x.yaml", "https://b/y.yaml"})
-	if len(got) != 2 || got[0].URI != "https://a/x.yaml" || got[1].URI != "https://b/y.yaml" {
-		t.Fatalf("upstreamSpecs mapping wrong: %+v", got)
-	}
-	if len(upstreamSpecs(nil)) != 0 {
-		t.Fatalf("upstreamSpecs(nil) should be empty")
-	}
-}
 
 // --- validateIngestMode ----------------------------------------------------
 
@@ -140,109 +94,6 @@ func TestGetCatalogDecodesEntries(t *testing.T) {
 	}
 }
 
-// --- resolveCatalogEntry ---------------------------------------------------
-
-func catalogServer(t *testing.T, entries []CatalogEntry) string {
-	t.Helper()
-	srv := mockBackplane(t, map[string]mockHandler{
-		"GET /api/v1/connectors/catalog": func(w http.ResponseWriter, _ *http.Request) {
-			writeJSON(t, w, 200, CatalogResponse{Catalog: entries})
-		},
-	})
-	t.Cleanup(srv.Close)
-	primeToken(t, srv.URL)
-	return srv.URL
-}
-
-func TestResolveCatalogEntryHappyPath(t *testing.T) {
-	url := catalogServer(t, []CatalogEntry{{
-		Product: "vmware", Version: "9.0", ImplID: "vmware-rest",
-		RequiresConnectorClass: "VmwareRestConnector",
-		Upstream:               []string{"https://example.test/vcenter.yaml"},
-	}})
-	entry, err := resolveCatalogEntry(context.Background(), url, "vmware/9.0")
-	if err != nil {
-		t.Fatalf("resolveCatalogEntry: %v", err)
-	}
-	if entry.ImplID != "vmware-rest" || len(entry.Upstream) != 1 {
-		t.Fatalf("unexpected entry: %+v", entry)
-	}
-}
-
-func TestResolveCatalogEntryNotFound(t *testing.T) {
-	url := catalogServer(t, []CatalogEntry{{
-		Product: "vmware", Version: "9.0", ImplID: "vmware-rest",
-		Upstream: []string{"https://example.test/x.yaml"},
-	}})
-	_, err := resolveCatalogEntry(context.Background(), url, "nsx/4.2")
-	if err == nil || !errors.Is(err, errCatalogResolve) {
-		t.Fatalf("want errCatalogResolve, got %v", err)
-	}
-	if !strings.Contains(err.Error(), "vmware/9.0") {
-		t.Errorf("not-found error should list available entries; got %v", err)
-	}
-}
-
-func TestResolveCatalogEntryTypedRefused(t *testing.T) {
-	url := catalogServer(t, []CatalogEntry{{
-		Product: "vault", Version: "1.x", ImplID: "vault",
-		RequiresConnectorClass: "VaultConnector",
-		Upstream:               nil,
-	}})
-	_, err := resolveCatalogEntry(context.Background(), url, "vault/1.x")
-	if err == nil || !errors.Is(err, errCatalogResolve) {
-		t.Fatalf("want errCatalogResolve, got %v", err)
-	}
-	if !strings.Contains(err.Error(), "typed connector") {
-		t.Errorf("typed refusal message wrong: %v", err)
-	}
-}
-
-func TestResolveCatalogEntryTemplatedRefused(t *testing.T) {
-	url := catalogServer(t, []CatalogEntry{{
-		Product: "nsx", Version: "4.2", ImplID: "nsx-rest",
-		RequiresConnectorClass: "NsxConnector",
-		Upstream:               []string{"https://<nsx-mgr-fqdn>/api/v1/spec/openapi/nsx_api.yaml"},
-	}})
-	_, err := resolveCatalogEntry(context.Background(), url, "nsx/4.2")
-	if err == nil || !errors.Is(err, errCatalogResolve) {
-		t.Fatalf("want errCatalogResolve, got %v", err)
-	}
-	if !strings.Contains(err.Error(), "templated") {
-		t.Errorf("templated refusal message wrong: %v", err)
-	}
-}
-
-func TestResolveCatalogEntryDuplicateRejected(t *testing.T) {
-	url := catalogServer(t, []CatalogEntry{
-		{Product: "vmware", Version: "9.0", ImplID: "vmware-rest",
-			Upstream: []string{"https://example.test/a.yaml"}},
-		{Product: "vmware", Version: "9.0", ImplID: "vmware-rest-2",
-			Upstream: []string{"https://example.test/b.yaml"}},
-	})
-	_, err := resolveCatalogEntry(context.Background(), url, "vmware/9.0")
-	if err == nil || !errors.Is(err, errCatalogResolve) {
-		t.Fatalf("want errCatalogResolve, got %v", err)
-	}
-	if !strings.Contains(err.Error(), "multiple entries") {
-		t.Errorf("duplicate message wrong: %v", err)
-	}
-}
-
-func TestResolveCatalogEntryEmptyUpstreamRejected(t *testing.T) {
-	url := catalogServer(t, []CatalogEntry{{
-		Product: "vmware", Version: "9.0", ImplID: "vmware-rest",
-		Upstream: []string{"   "},
-	}})
-	_, err := resolveCatalogEntry(context.Background(), url, "vmware/9.0")
-	if err == nil || !errors.Is(err, errCatalogResolve) {
-		t.Fatalf("want errCatalogResolve, got %v", err)
-	}
-	if !strings.Contains(err.Error(), "empty upstream") {
-		t.Errorf("empty-upstream message wrong: %v", err)
-	}
-}
-
 // --- printCatalogTable -----------------------------------------------------
 
 func TestPrintCatalogTableHappyPath(t *testing.T) {
@@ -307,26 +158,17 @@ func TestRegisteredTriplesFromMockServer(t *testing.T) {
 	}
 }
 
-// --- runIngest catalog mode (end-to-end through the verb) -------------------
+// --- runIngest catalog mode (G0.14-T9 / #1150) -----------------------------
 
-func TestRunIngestCatalogModeRoundTrip(t *testing.T) {
-	var posted IngestRequest
+// TestRunIngestCatalogModePostsCatalogEntry pins the post-#1150
+// contract: catalog mode POSTs `{"catalog_entry": "..."}` directly.
+// The backplane now resolves the entry server-side, so the CLI no
+// longer pre-fetches the catalog and posts the resolved quadruple.
+func TestRunIngestCatalogModePostsCatalogEntry(t *testing.T) {
+	var rawBody []byte
 	srv := mockBackplane(t, map[string]mockHandler{
-		"GET /api/v1/connectors/catalog": func(w http.ResponseWriter, _ *http.Request) {
-			writeJSON(t, w, 200, CatalogResponse{Catalog: []CatalogEntry{{
-				Product: "vmware", Version: "9.0", ImplID: "vmware-rest",
-				RequiresConnectorClass: "VmwareRestConnector",
-				Upstream: []string{
-					"https://example.test/vcenter.yaml",
-					"https://example.test/vi-json.yaml",
-				},
-			}}})
-		},
 		"POST /api/v1/connectors/ingest": func(w http.ResponseWriter, r *http.Request) {
-			body, _ := io.ReadAll(r.Body)
-			if err := json.Unmarshal(body, &posted); err != nil {
-				t.Errorf("decode ingest body: %v", err)
-			}
+			rawBody, _ = io.ReadAll(r.Body)
 			writeJSON(t, w, 200, IngestResponse{
 				Ingestion: IngestionResult{ConnectorID: "vmware-rest-9.0", InsertedCount: 961},
 			})
@@ -340,13 +182,70 @@ func TestRunIngestCatalogModeRoundTrip(t *testing.T) {
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 
-	if err := runIngest(cmd, ingestOptions{Catalog: "vmware/9.0", BackplaneOverride: srv.URL}); err != nil {
+	if err := runIngest(cmd, ingestOptions{
+		Catalog:           "vmware/9.0",
+		BackplaneOverride: srv.URL,
+	}); err != nil {
 		t.Fatalf("runIngest catalog mode: %v", err)
 	}
-	if posted.Product != "vmware" || posted.Version != "9.0" || posted.ImplID != "vmware-rest" {
-		t.Fatalf("posted triple wrong: %+v", posted)
+
+	// Decode into a generic map to inspect the exact wire shape. The
+	// CLI must NOT post product/version/impl_id/specs in catalog mode
+	// — the backend's mutual-exclusivity validator would reject the
+	// body. The omitempty tags on IngestRequest's pointer fields are
+	// the load-bearing mechanism.
+	var posted map[string]any
+	if err := json.Unmarshal(rawBody, &posted); err != nil {
+		t.Fatalf("decode posted body: %v", err)
 	}
-	if len(posted.Specs) != 2 || posted.Specs[0].URI != "https://example.test/vcenter.yaml" {
-		t.Fatalf("posted specs wrong: %+v", posted.Specs)
+	if posted["catalog_entry"] != "vmware/9.0" {
+		t.Errorf("catalog_entry not posted: %+v", posted)
+	}
+	for _, banned := range []string{"product", "version", "impl_id", "specs"} {
+		if _, present := posted[banned]; present {
+			t.Errorf("catalog mode must not post %q (would conflict): %+v", banned, posted)
+		}
+	}
+}
+
+// TestRunIngestManualModePostsQuadruple pins the parallel contract:
+// manual mode POSTs the explicit quadruple, NOT a catalog_entry.
+// This is the regression guard for the historical
+// --product/--version/--impl/--spec form.
+func TestRunIngestManualModePostsQuadruple(t *testing.T) {
+	var rawBody []byte
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/connectors/ingest": func(w http.ResponseWriter, r *http.Request) {
+			rawBody, _ = io.ReadAll(r.Body)
+			writeJSON(t, w, 200, IngestResponse{
+				Ingestion: IngestionResult{ConnectorID: "test-1.0", InsertedCount: 2},
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := runIngest(cmd, ingestOptions{
+		Product: "test", Version: "1.0", ImplID: "test-impl",
+		Specs:             []string{"https://example.test/spec.yaml"},
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runIngest manual mode: %v", err)
+	}
+
+	var posted map[string]any
+	if err := json.Unmarshal(rawBody, &posted); err != nil {
+		t.Fatalf("decode posted body: %v", err)
+	}
+	if _, present := posted["catalog_entry"]; present {
+		t.Errorf("manual mode must not post catalog_entry: %+v", posted)
+	}
+	if posted["product"] != "test" || posted["version"] != "1.0" || posted["impl_id"] != "test-impl" {
+		t.Errorf("manual mode posted quadruple wrong: %+v", posted)
 	}
 }

--- a/cli/internal/cmd/connector/catalog_test.go
+++ b/cli/internal/cmd/connector/catalog_test.go
@@ -208,6 +208,64 @@ func TestRunIngestCatalogModePostsCatalogEntry(t *testing.T) {
 	}
 }
 
+// TestRunIngestCatalogModeRendersResolvedTriple pins the operator-
+// visible summary heading in catalog mode (G0.14-T9 / #1150). The
+// CLI posts `{"catalog_entry": "vmware/9.0"}` without the explicit
+// quadruple; the backplane resolves the entry and returns a
+// connector_id (`vmware-rest-9.0`) that round-trips through
+// parse_connector_id to the resolved triple. The CLI derives the
+// `<product>/<version>/<impl_id>` heading from that response value,
+// so the operator sees `ingest vmware/9.0/vmware-rest — ...` even
+// though opts.Product/Version/ImplID stay empty in catalog mode.
+// Regression guard against the B1 finding on PR #1182 where the
+// post-#1150 CLI rendered `ingest // — ...` (bare slashes) because
+// the heading was sourced from the empty request opts.
+func TestRunIngestCatalogModeRendersResolvedTriple(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/connectors/ingest": func(w http.ResponseWriter, _ *http.Request) {
+			// Mock the backplane's resolved-quadruple response shape:
+			// catalog_entry "vmware/9.0" resolves to connector_id
+			// "vmware-rest-9.0" via parse_connector_id's convention
+			// (impl_id "vmware-rest", version "9.0", product "vmware").
+			writeJSON(t, w, 200, IngestResponse{
+				Ingestion: IngestionResult{
+					ConnectorID:   "vmware-rest-9.0",
+					InsertedCount: 961,
+				},
+			})
+		},
+	})
+	defer srv.Close()
+	primeToken(t, srv.URL)
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := runIngest(cmd, ingestOptions{
+		Catalog:           "vmware/9.0",
+		DryRun:            true,
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runIngest catalog mode: %v", err)
+	}
+
+	out := stdout.String()
+	// The resolved triple must appear in the heading (derived from
+	// the response's connector_id, NOT from opts.Product/Version/ImplID
+	// which are empty in catalog mode).
+	if !strings.Contains(out, "ingest vmware/9.0/vmware-rest") {
+		t.Errorf("catalog-mode summary missing resolved triple `vmware/9.0/vmware-rest` in:\n%s", out)
+	}
+	// Bare `//` is the regression: it appears only when the heading
+	// renders product/version/impl_id all empty.
+	if strings.Contains(out, "ingest // —") {
+		t.Errorf("catalog-mode summary contains bare `//` heading (B1 regression); got:\n%s", out)
+	}
+}
+
 // TestRunIngestManualModePostsQuadruple pins the parallel contract:
 // manual mode POSTs the explicit quadruple, NOT a catalog_entry.
 // This is the regression guard for the historical

--- a/cli/internal/cmd/connector/connector_test.go
+++ b/cli/internal/cmd/connector/connector_test.go
@@ -378,6 +378,110 @@ func TestPrintIngestSummaryDryRun(t *testing.T) {
 	}
 }
 
+// TestPrintIngestSummaryCatalogMode — catalog-mode regression (G0.14-T9
+// / #1150). The pre-#1150 CLI resolved the catalog entry client-side
+// and populated opts.Product/Version/ImplID before printing; post-#1150
+// the backplane resolves the entry and opts stays empty in catalog
+// mode. The heading must still carry the resolved triple — derived
+// from the response's connector_id via parseConnectorID — so the
+// operator-visible output (`ingest vmware/9.0/vmware-rest — ...`)
+// matches v0.6.0 verbatim. The B1 review on PR #1182 caught the
+// regression where opts.Product/Version/ImplID being empty rendered
+// `ingest // — ...` (bare slashes); this test pins the fix.
+func TestPrintIngestSummaryCatalogMode(t *testing.T) {
+	cases := []struct {
+		name   string
+		dryRun bool
+		// The bits the operator reads to identify what was ingested.
+		// Bare `//` would mean the heading was rendered from empty
+		// opts.Product/Version/ImplID — the regression we're guarding.
+		wantStrings  []string
+		bannedString string
+	}{
+		{
+			name:        "dry-run",
+			dryRun:      true,
+			wantStrings: []string{"ingest vmware/9.0/vmware-rest", "DRY RUN"},
+			// `//` appears bare only when product/version/impl are all
+			// empty; the post-fix render carries `vmware/9.0/vmware-rest`.
+			bannedString: "ingest // —",
+		},
+		{
+			name:   "non-dry-run",
+			dryRun: false,
+			wantStrings: []string{
+				"ingest vmware/9.0/vmware-rest",
+				"connector_id=vmware-rest-9.0",
+			},
+			bannedString: "ingest // —",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &IngestResponse{
+				Ingestion: IngestionResult{
+					ConnectorID:         "vmware-rest-9.0",
+					InsertedCount:       961,
+					ConnectorRegistered: true,
+					OperationsGrouped:   !tc.dryRun,
+				},
+			}
+			// Catalog mode: opts.Product/Version/ImplID are unset; the
+			// CLI's runIngest leaves them empty because the request
+			// shape is `{"catalog_entry": "..."}` (no client-side
+			// resolution).
+			opts := ingestOptions{Catalog: "vmware/9.0", DryRun: tc.dryRun}
+			var buf bytes.Buffer
+			printIngestSummary(&buf, opts, r)
+			out := buf.String()
+			for _, want := range tc.wantStrings {
+				if !strings.Contains(out, want) {
+					t.Errorf("catalog-mode render missing %q in:\n%s", want, out)
+				}
+			}
+			if strings.Contains(out, tc.bannedString) {
+				t.Errorf("catalog-mode render contains %q (bare-slash regression); got:\n%s",
+					tc.bannedString, out)
+			}
+		})
+	}
+}
+
+// TestIngestSummaryHeadingFromConnectorID — table-pins the parser's
+// shape against the backend's parse_connector_id convention
+// (backend/src/meho_backplane/operations/ingest/parser.py). The
+// heading derives the (product, version, impl_id) triple from the
+// response's connector_id so catalog mode (G0.14-T9 / #1150) renders
+// the resolved triple instead of empty placeholders.
+func TestIngestSummaryHeadingFromConnectorID(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// Worked examples from parse_connector_id's docstring — the
+		// CLI parser must agree on every one or the heading drifts
+		// from `meho connector list` / review output.
+		{"vmware-rest-9.0", "vmware/9.0/vmware-rest"},
+		{"nsx-4.2", "nsx/4.2/nsx"},
+		{"harbor-2.x", "harbor/2.x/harbor"},
+		{"hetzner-robot-2026-04", "hetzner/2026-04/hetzner-robot"},
+		{"vault-1.x", "vault/1.x/vault"},
+		{"k8s-1.x", "k8s/1.x/k8s"},
+		// Non-conforming connector_id (no dash-before-digit) falls
+		// back to echoing verbatim — operators still see something
+		// useful instead of bare slashes if the backend ever drifts.
+		{"weird", "weird"},
+		// Empty impl_id segment (`-9.0`) is non-conforming; fall back
+		// to the verbatim form rather than render `/9.0/`.
+		{"-9.0", "-9.0"},
+	}
+	for _, tc := range cases {
+		if got := ingestSummaryHeading(tc.in); got != tc.want {
+			t.Errorf("ingestSummaryHeading(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 // TestPrintIngestSummaryNonDryRun — happy-path render includes
 // connector_id + next-steps hint + canonical IngestionResult fields
 // (connector_registered, operations_grouped) and the canonical

--- a/cli/internal/cmd/connector/connector_test.go
+++ b/cli/internal/cmd/connector/connector_test.go
@@ -857,7 +857,12 @@ func TestPostIngestRoundTripWithMockServer(t *testing.T) {
 				w.WriteHeader(400)
 				return
 			}
-			if req.Product != "vmware" || req.Version != "9.0" || req.ImplID != "vmware-rest" {
+			// G0.14-T9 (#1150): IngestRequest.Product/Version/ImplID are
+			// now *string so the JSON serializer can omit them on the
+			// catalog-driven shape. Deref for the equality check; nil
+			// here means the test request was misconstructed.
+			if req.Product == nil || req.Version == nil || req.ImplID == nil ||
+				*req.Product != "vmware" || *req.Version != "9.0" || *req.ImplID != "vmware-rest" {
 				t.Errorf("unexpected triple: %+v", req)
 			}
 			if len(req.Specs) != 1 || req.Specs[0].URI != "file:///abs/vcenter.yaml" {
@@ -882,8 +887,11 @@ func TestPostIngestRoundTripWithMockServer(t *testing.T) {
 	defer srv.Close()
 
 	primeToken(t, srv.URL)
+	product := "vmware"
+	version := "9.0"
+	implID := "vmware-rest"
 	got, err := postIngest(context.Background(), srv.URL, IngestRequest{
-		Product: "vmware", Version: "9.0", ImplID: "vmware-rest",
+		Product: &product, Version: &version, ImplID: &implID,
 		Specs: []SpecSource{{URI: "file:///abs/vcenter.yaml"}},
 	})
 	if err != nil {
@@ -1142,8 +1150,11 @@ func TestHTTPErrorClassification403(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
+	product := "x"
+	version := "y"
+	implID := "z"
 	_, err := postIngest(context.Background(), srv.URL, IngestRequest{
-		Product: "x", Version: "y", ImplID: "z",
+		Product: &product, Version: &version, ImplID: &implID,
 		Specs: []SpecSource{{URI: "file:///a.yaml"}},
 	})
 	if err == nil {

--- a/cli/internal/cmd/connector/ingest.go
+++ b/cli/internal/cmd/connector/ingest.go
@@ -332,15 +332,22 @@ func postIngest(ctx context.Context, backplaneURL string, body IngestRequest) (*
 // breakdown and the embeddings split that the original PR-body
 // contract carried are not in the wire shape — operators see the
 // aggregate via this rollup and the per-spec story via the audit log.
+//
+// The `<product>/<version>/<impl_id>` heading is derived from the
+// response's `connector_id` rather than `opts.Product/Version/ImplID`
+// because catalog mode (G0.14-T9 / #1150) leaves those opts empty —
+// the backplane resolves the catalog entry server-side and returns
+// the resolved triple via `connector_id`. Deriving from the response
+// keeps the heading correct in both modes and matches the pre-#1150
+// operator-visible output.
 func printIngestSummary(w io.Writer, opts ingestOptions, r *IngestResponse) {
 	totalOps := r.Ingestion.InsertedCount + r.Ingestion.UpdatedCount + r.Ingestion.SkippedCount
+	heading := ingestSummaryHeading(r.Ingestion.ConnectorID)
 	if opts.DryRun {
-		fmt.Fprintf(w, "ingest %s/%s/%s — DRY RUN (no DB writes)\n",
-			opts.Product, opts.Version, opts.ImplID,
-		)
+		fmt.Fprintf(w, "ingest %s — DRY RUN (no DB writes)\n", heading)
 	} else {
-		fmt.Fprintf(w, "ingest %s/%s/%s — connector_id=%s\n",
-			opts.Product, opts.Version, opts.ImplID, r.Ingestion.ConnectorID,
+		fmt.Fprintf(w, "ingest %s — connector_id=%s\n",
+			heading, r.Ingestion.ConnectorID,
 		)
 	}
 	fmt.Fprintf(w, "  operations: %d total (%d inserted / %d updated / %d skipped)\n",
@@ -378,4 +385,45 @@ func printIngestSummary(w io.Writer, opts ingestOptions, r *IngestResponse) {
 			r.Ingestion.ConnectorID, r.Ingestion.ConnectorID,
 		)
 	}
+}
+
+// ingestSummaryHeading derives the `<product>/<version>/<impl_id>`
+// heading from a response connector_id. Both ingest modes route
+// through this helper so the operator-visible output is identical
+// to v0.6.0 regardless of which request shape (catalog or explicit
+// quadruple) the CLI used. The backend resolves the catalog entry
+// server-side, so deriving from the response is what makes the
+// catalog-mode heading carry the resolved triple instead of empty
+// `//` placeholders.
+//
+// Mirrors `parse_connector_id` in
+// `backend/src/meho_backplane/operations/ingest/parser.py` — the
+// operator-facing identifier is `<impl_id>-<version>` where
+// `version` starts with a digit; `product` is the first
+// dash-segment of `impl_id`. If the response carries a
+// non-conforming connector_id (shouldn't happen in practice — the
+// backend builds it from a validated triple) we fall back to
+// echoing the connector_id verbatim so the operator still sees
+// something useful instead of bare slashes.
+func ingestSummaryHeading(connectorID string) string {
+	for i, ch := range connectorID {
+		if ch != '-' || i+1 >= len(connectorID) {
+			continue
+		}
+		next := connectorID[i+1]
+		if next < '0' || next > '9' {
+			continue
+		}
+		implID := connectorID[:i]
+		version := connectorID[i+1:]
+		if implID == "" {
+			return connectorID
+		}
+		product := implID
+		if first := strings.IndexByte(implID, '-'); first != -1 {
+			product = implID[:first]
+		}
+		return fmt.Sprintf("%s/%s/%s", product, version, implID)
+	}
+	return connectorID
 }

--- a/cli/internal/cmd/connector/ingest.go
+++ b/cli/internal/cmd/connector/ingest.go
@@ -26,20 +26,32 @@ type SpecSource struct {
 }
 
 // IngestRequest mirrors the backend IngestRequest Pydantic model.
-// product / version / impl_id are the connector_id triple stored on
-// the endpoint_descriptor row; specs is the list of (method, path)
-// providers that merge under that one connector_id (vSphere is the
-// canonical multi-spec case — vcenter.yaml + vi-json.yaml).
+// Two mutually-exclusive request shapes:
+//
+//   - Explicit-quadruple shape: product / version / impl_id / specs
+//     carry the resolved triple plus the spec sources. The historical
+//     manual-mode --product/--version/--impl/--spec form uses this.
+//   - Catalog-driven shape (G0.14-T9 / #1150): catalog_entry carries a
+//     "<product>/<version>" reference; the backplane resolves the
+//     entry against the packaged catalog and fills in the quadruple
+//     server-side. The --catalog flag uses this shape so REST-native
+//     agent runtimes and the CLI share a single ingest path.
+//
+// Quadruple fields are pointers so the JSON serializer omits them on
+// the catalog-driven shape: an empty string would fail the backend
+// validator's mutual-exclusivity check (the empty quadruple is read
+// as "explicit-quadruple supplied but blank").
 //
 // DryRun=true makes the backplane parse + plan without writing to
 // the DB; the response carries the same IngestionResult shape but
 // the GroupingResult field is null (no LLM call on dry-run).
 type IngestRequest struct {
-	Product string       `json:"product"`
-	Version string       `json:"version"`
-	ImplID  string       `json:"impl_id"`
-	Specs   []SpecSource `json:"specs"`
-	DryRun  bool         `json:"dry_run"`
+	Product      *string      `json:"product,omitempty"`
+	Version      *string      `json:"version,omitempty"`
+	ImplID       *string      `json:"impl_id,omitempty"`
+	Specs        []SpecSource `json:"specs,omitempty"`
+	CatalogEntry *string      `json:"catalog_entry,omitempty"`
+	DryRun       bool         `json:"dry_run"`
 }
 
 // IngestionResult mirrors the canonical backend IngestionResultModel
@@ -201,43 +213,12 @@ func runIngest(cmd *cobra.Command, opts ingestOptions) error {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
 	}
 
-	var specs []SpecSource
-	if opts.Catalog != "" {
-		entry, rerr := resolveCatalogEntry(cmd.Context(), backplaneURL, opts.Catalog)
-		if rerr != nil {
-			// Local resolution failures (bad ref, no entry, typed
-			// connector, templated upstream) carry errCatalogResolve and
-			// render as `unexpected`; transport/auth errors from the GET
-			// route through renderRequestError.
-			if errors.Is(rerr, errCatalogResolve) {
-				return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(rerr.Error()), opts.JSONOut)
-			}
-			return renderRequestError(cmd, backplaneURL, rerr, opts.JSONOut)
-		}
-		// Adopt the catalog's recommended triple so the summary + the
-		// posted body carry it (the catalog flag supplies no triple).
-		opts.Product, opts.Version, opts.ImplID = entry.Product, entry.Version, entry.ImplID
-		specs = upstreamSpecs(entry.Upstream)
-	} else {
-		// Manual mode: resolve each --spec URI locally so the operator
-		// gets a fast hint on a typo'd scheme rather than a backplane 422.
-		specs = make([]SpecSource, 0, len(opts.Specs))
-		for _, raw := range opts.Specs {
-			uri, uerr := resolveSpecURI(raw)
-			if uerr != nil {
-				return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(uerr.Error()), opts.JSONOut)
-			}
-			specs = append(specs, SpecSource{URI: uri})
-		}
+	body, err := buildIngestRequest(opts)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), opts.JSONOut)
 	}
 
-	result, err := postIngest(cmd.Context(), backplaneURL, IngestRequest{
-		Product: opts.Product,
-		Version: opts.Version,
-		ImplID:  opts.ImplID,
-		Specs:   specs,
-		DryRun:  opts.DryRun,
-	})
+	result, err := postIngest(cmd.Context(), backplaneURL, body)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
@@ -246,6 +227,41 @@ func runIngest(cmd *cobra.Command, opts ingestOptions) error {
 	}
 	printIngestSummary(cmd.OutOrStdout(), opts, result)
 	return nil
+}
+
+// buildIngestRequest assembles the POST body for either of the two
+// mutually-exclusive request shapes (catalog-driven or explicit
+// quadruple). Catalog mode (G0.14-T9 / #1150) ships the
+// "<product>/<version>" reference verbatim — the backplane resolves
+// the entry against the packaged catalog so REST-native clients and
+// the CLI share the resolution path. Manual mode resolves each spec
+// URI locally to give the operator a fast hint on a typo'd scheme.
+func buildIngestRequest(opts ingestOptions) (IngestRequest, error) {
+	if opts.Catalog != "" {
+		catalog := opts.Catalog
+		return IngestRequest{
+			CatalogEntry: &catalog,
+			DryRun:       opts.DryRun,
+		}, nil
+	}
+	specs := make([]SpecSource, 0, len(opts.Specs))
+	for _, raw := range opts.Specs {
+		uri, uerr := resolveSpecURI(raw)
+		if uerr != nil {
+			return IngestRequest{}, uerr
+		}
+		specs = append(specs, SpecSource{URI: uri})
+	}
+	product := opts.Product
+	version := opts.Version
+	implID := opts.ImplID
+	return IngestRequest{
+		Product: &product,
+		Version: &version,
+		ImplID:  &implID,
+		Specs:   specs,
+		DryRun:  opts.DryRun,
+	}, nil
 }
 
 // validateIngestMode enforces the catalog/manual split: exactly one

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -90,6 +90,37 @@ All T1–T8 substrate work merged to `main` before T9 (#409); the
 pipeline is shipped and ready for per-G3.x consumer Initiatives
 to drive ingestion against their target vendor surfaces.
 
+### Catalog-driven REST ingest (G0.14-T9 / #1150)
+
+`POST /api/v1/connectors/ingest` accepts a second request shape
+beyond the explicit-quadruple `(product, version, impl_id, specs[])`:
+a body of `{"catalog_entry": "<product>/<version>"}` resolves the
+catalog entry server-side (`load_catalog().get(product, version)`)
+and routes through the same `_run_ingest_with_http_mapping` path as
+if the caller had supplied the resolved quadruple. The two shapes
+are mutually exclusive — a `@model_validator(mode="after")` on
+`IngestRequest` rejects mixed bodies with `catalog_entry_conflict`
+(422) and empty bodies with `ingest_request_underspecified` (422)
+per the T11 [error-message-shape](error-message-shape.md) convention.
+
+Why server-side: a REST-native agent runtime (no shell-out to the
+CLI) needs an actionable REST surface that mirrors the discoverable
+`GET /api/v1/connectors/catalog` shape. Before #1150, only the CLI
+could resolve a catalog entry; the REST endpoint required the
+already-resolved quadruple. Moving the resolver server-side means
+the CLI's `--catalog` flag is now a thin shell that POSTs the
+catalog-driven body shape directly — one canonical resolution
+path, no client-side catalog cache to drift against the server's
+package data.
+
+The four catalog-side validation outcomes (`catalog_entry_malformed`,
+`catalog_entry_not_found`, `catalog_entry_typed_connector`,
+`catalog_entry_templated_upstream`) ship through
+`build_catalog_entry_*_detail` helpers in `error_envelopes.py` so
+the REST 422 envelope can't drift from any future MCP equivalent
+(same shared-builder pattern G0.9.1-T5 / #777 used for
+`VersionMismatchError`).
+
 T1 produces the proto shape every other stage consumes; T2 is the
 single write path into `endpoint_descriptor` for ingested rows; T3
 groups them; T4 gates dispatchability behind operator review; T6

--- a/docs/cross-repo/connector-catalog.md
+++ b/docs/cross-repo/connector-catalog.md
@@ -85,21 +85,71 @@ of each connector's first verified `--catalog` ingest.
    covers it, whether that class is registered on this backplane (`reg`
    column), the observed `spec_info_version`, and notes. Read-only;
    operator role suffices.
-2. `meho connector ingest --catalog <product>/<version>` — resolve the
-   entry and ingest its recommended triple + upstream spec URL(s) (the
-   backplane fetches each URL). Typed-connector entries (`upstream:
-   null`) and fqdn-templated upstream URLs are refused with a hint to
-   use the explicit `--spec` form instead. `--catalog` is mutually
-   exclusive with the manual `--product`/`--version`/`--impl`/`--spec`
-   flags. Add `--dry-run` to validate before committing.
+2. `meho connector ingest --catalog <product>/<version>` — POST
+   `{"catalog_entry": "<product>/<version>"}` to
+   `/api/v1/connectors/ingest`; the backplane resolves the entry,
+   fills in `product` + `version` + `impl_id` + `specs[]`, and runs
+   the standard ingest pipeline. Typed-connector entries (`upstream:
+   null`) and fqdn-templated upstream URLs are refused with a
+   structured 422 hint pointing at the explicit-quadruple shape.
+   `--catalog` is mutually exclusive with the manual
+   `--product`/`--version`/`--impl`/`--spec` flags. Add `--dry-run`
+   to validate before committing.
 3. `meho connector review <connector_id>` → `meho connector enable <id>` —
    vet the LLM-summarised groups and turn the operations on.
+
+REST-native clients (agent runtimes that can't shell out to the
+CLI) hit the same path by POSTing the catalog-driven body shape
+directly. See the *REST shape* section below.
 
 For an entry the catalog can't ingest directly (typed, or fqdn-templated
 upstream such as `nsx`), fall back to the explicit `meho connector ingest
 --product … --version … --impl … --spec <url>` form documented in
 [`connector-ingestion.md`](connector-ingestion.md), reading the `upstream`
 URL(s) from `catalog list`.
+
+## REST shape (G0.14-T9 / #1150)
+
+`POST /api/v1/connectors/ingest` accepts two mutually-exclusive
+request shapes. The catalog-driven shape moved server-side in
+G0.14-T9 so REST-native agent runtimes (which can't shell out to
+the CLI) reach the same ingest path the CLI's `--catalog` flag
+hits.
+
+**Catalog-driven shape** — pass `catalog_entry`; the server resolves
+the entry against the packaged catalog:
+
+```json
+{ "catalog_entry": "vmware/9.0", "dry_run": false }
+```
+
+**Explicit-quadruple shape** — pass the resolved triple plus the
+spec sources (MCP admin tool and historical clients):
+
+```json
+{
+  "product": "vmware",
+  "version": "9.0",
+  "impl_id": "vmware-rest",
+  "specs": [{ "uri": "https://example.lab/vcenter.yaml" }]
+}
+```
+
+A body that sets both shapes fails 422 `catalog_entry_conflict`. A
+body that sets neither fails 422 `ingest_request_underspecified`. A
+body that sets `catalog_entry` but the entry is unknown / malformed
+/ typed-only / fqdn-templated fails 422 with one of the four
+classifier codes below — every shape follows the T11
+[error-message-shape](../codebase/error-message-shape.md) convention:
+
+| Failure | Code | When |
+|---|---|---|
+| Reference missing `/` separator | `catalog_entry_malformed` | `"vmware9.0"` |
+| Reference well-formed, not in catalog | `catalog_entry_not_found` | `"foo/1.0"` |
+| Resolved entry has `upstream: null` | `catalog_entry_typed_connector` | `"vault/1.x"` |
+| Resolved entry's upstream has `<...>` placeholders | `catalog_entry_templated_upstream` | `"nsx/4.2"` |
+| Both shapes supplied | `catalog_entry_conflict` | shape conflict |
+| Neither shape supplied | `ingest_request_underspecified` | empty body |
 
 ## Adding or updating an entry
 


### PR DESCRIPTION
## Summary

- **Catalog-driven REST ingest, G0.14-T9 / #1150 / signal 14.**
  `POST /api/v1/connectors/ingest` now accepts
  `{"catalog_entry": "vmware/9.0"}` as an alternative to the
  resolved-quadruple shape. The route resolves the entry against the
  packaged catalog server-side and dispatches through the existing
  ingest path. REST-native agent runtimes (and the CLI, refactored)
  hit one canonical resolution path; the discoverability-vs-
  actionability asymmetry that consumer feedback flagged is closed.
- **Mutual exclusivity + structured 422s per T11.** A
  `@model_validator(mode="after")` on `IngestRequest` rejects mixed
  bodies (`catalog_entry_conflict`) and empty bodies
  (`ingest_request_underspecified`). Catalog-side failures
  (`catalog_entry_malformed` / `_not_found` / `_typed_connector` /
  `_templated_upstream`) ship structured 422 envelopes via
  `build_catalog_entry_*_detail` helpers in `error_envelopes.py`,
  citing `docs/codebase/error-message-shape.md` (T11 convention) in
  every message.
- **CLI refactor.** `meho connector ingest --catalog <p>/<v>` posts
  `{"catalog_entry": "..."}` directly — no client-side catalog
  fetch + resolve. Removed the now-dead `resolveCatalogEntry` /
  `parseCatalogRef` / `upstreamSpecs` helpers + their tests; pinned
  the new body shape with two new round-trip tests
  (`TestRunIngestCatalogModePostsCatalogEntry` +
  `TestRunIngestManualModePostsQuadruple`).
- **OpenAPI snapshot + client regen.** Refreshed
  `cli/api/openapi.json` + `cli/internal/api/client.gen.go` so the
  Go SDK carries the new `catalog_entry` field on `IngestRequest`.

## Test plan

- [x] `cd backend && uv run ruff check src/ tests/` — clean
- [x] `cd backend && uv run ruff format --check` — clean (711 files
  formatted)
- [x] `cd backend && uv run mypy src/meho_backplane/` — clean (353
  files)
- [x] `cd backend && uv run pytest tests/test_api_v1_connectors_ingest.py` —
  50 passed (7 new tests for the catalog-driven shape: happy path,
  unknown entry → 422, mixed shapes → 422 conflict, empty body →
  422 underspecified, malformed ref → 422, typed-connector → 422,
  templated-upstream → 422, plus the explicit-quadruple regression
  guard)
- [x] `cd backend && uv run pytest tests/test_api_v1_schema_extras.py
  tests/test_operations_ingest_catalog.py
  tests/test_mcp_tools_connector_admin.py` — 52 passed (MCP path
  still constructs the explicit-quadruple shape; no regressions)
- [x] `cd cli && go vet ./... && go build ./...` — clean
- [x] `cd cli && go test ./...` — every package green; CLI catalog
  tests rewritten to pin the new posted body shape
- [x] `cd cli && make snapshot-openapi && make generate` — refreshed

## Acceptance criteria

- [x] `POST /api/v1/connectors/ingest` accepts
  `{catalog_entry, dry_run?}` as an alternative to the
  explicit-quadruple shape; both shapes are mutually exclusive.
- [x] Server-side resolution loads the catalog (per #743's loader),
  validates the entry exists, dispatches through the existing
  ingest path.
- [x] Unknown `catalog_entry` returns structured 422 per T11
  convention (`{"detail":"catalog_entry_not_found", ...,
  "available_entries": [...]}`).
- [x] CLI verb `meho connector ingest --catalog <p>/<v>`
  refactored to use the new REST shape (thin wrapper); operator-
  visible v0.6.0 behavior preserved.
- [x] Tests cover: catalog_entry resolves and ingest succeeds;
  catalog_entry not found returns structured 422; both shapes
  supplied returns the conflict 422; explicit-quadruple shape
  still works (regression guard).
- [x] Python (ruff + mypy + pytest) green; Go (gofmt + go vet + go
  test) green for the CLI refactor.

## Out of scope

- T10 #1151 (vmware composite L2 dependency strategy) — independent.
  T9 lands the prerequisite REST shape; T10's implementer is free to
  pick Option A (auto-ingest L2 at registration), B (lazy first-call
  validation), or C (ship-L1+L2-as-unit). Options A/C call the new
  catalog-driven shape from server code; Option B doesn't need T9.
- Adding new catalog entries (settled per #743; only consumption
  shape changes here).
- Renaming the catalog file structure or its on-disk location.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1150

---

## Follow-up (auto-implement-issue, iteration 1, 2026-05-26)

Addressed review finding from
[`pr-1182-iter-1`](https://github.com/evoila/meho/pull/1182#discussion_r3307021507):

- **B1** `54d9297` — Derive CLI summary heading from response
  `connector_id` via the new `ingestSummaryHeading` helper (mirrors
  backend `parse_connector_id`). Catalog mode now renders
  `ingest vmware/9.0/vmware-rest — ...` instead of bare `ingest // — ...`
  because the heading is sourced from the resolved response value
  rather than the (empty in catalog mode) request opts. v0.6.0
  user-visible CLI output is preserved verbatim in both modes.
  Coverage: `TestPrintIngestSummaryCatalogMode` (pure-function,
  dry-run + non-dry-run), `TestIngestSummaryHeadingFromConnectorID`
  (table-pinned against `parse_connector_id`'s worked examples),
  `TestRunIngestCatalogModeRendersResolvedTriple` (end-to-end mock
  REST server, asserts the printed summary carries the resolved
  triple and no bare-slash regression).

Disputed: none.

Deferred (recorded as adjacent findings; orchestrator may file
follow-up issues):

- The `_templated_upstream` 422 envelope is built inline in
  `_reject_unusable_entry` rather than via a shared builder in
  `error_envelopes.py`. The reviewer noted the asymmetry is
  intentional (REST-only surface for now); deferring as not-blocking.
- Generated SDK `IngestRequest` (cli/internal/api/client.gen.go)
  lacks `omitempty` on pointer quadruple fields. Reviewer verified
  inline that Pydantic accepts explicit null equivalently to
  omission, so SDK callers writing `{CatalogEntry: ptr(...)}` post
  a working catalog-mode body — deferring as not-blocking.

<!-- auto-implement-issue: continue, iteration 1 -->
