### PR TITLE
fix(redaction): G11.4-T6 restore wildcard register-as-global-override semantics

### DIFF
--- a/backend/src/meho_backplane/redaction/resolver.py
+++ b/backend/src/meho_backplane/redaction/resolver.py
@@ -13,15 +13,16 @@ are, in order of specificity:
 3. ``(connector_id, tenant)`` -- per-connector, per-tenant.
 4. ``connector_id`` -- per-connector default.
 5. ``tenant`` -- tenant-wide default across every connector.
-6. The conservative built-in default (:data:`DEFAULT_POLICY_NAME`).
+6. ``(None, None, None)`` -- the wildcard global override registered
+   via ``register_policy(policy)`` with no scope kwargs.
 
-The resolver is **default-safe**: a call that matches no registered
-override falls through to the conservative default policy packaged at
-:mod:`meho_backplane.redaction.policies`, which still applies the
-named-pattern library to credential shapes. **Pass-through is never
-the answer** -- the parent goal (#800) treats the API surface as the
-trust boundary, so an un-configured operator-facing connector still
-gets credentials stripped out of its responses.
+When no override at any of those levels matches, the resolver falls
+through to the conservative default-safe policy packaged at
+:mod:`meho_backplane.redaction.policies` (:data:`DEFAULT_POLICY_RESOURCE`).
+**Pass-through is never the answer** -- the parent goal (#800) treats
+the API surface as the trust boundary, so an un-configured
+operator-facing connector still gets credentials stripped out of its
+responses.
 
 Registration is process-global state, deliberately mutable so the
 middleware can be exercised in tests without monkeypatching:
@@ -210,13 +211,18 @@ def resolve_policy(
     # to one specificity level documented on the module docstring.
     # The wildcards are encoded as ``None`` so the resolver loop stays
     # a straight dict lookup; no per-call regex or per-call walk over
-    # the table is needed.
+    # the table is needed. The final ``(None, None, None)`` step is the
+    # wildcard-global override slot: ``register_policy(policy)`` with no
+    # scope kwargs stores under that key, and a hit there shadows the
+    # packaged default (#1189; the entry was missing pre-fix, so a
+    # wildcard registration was stored but never looked up).
     ladder: tuple[_OverrideKey, ...] = (
         (connector_id, tenant, op),
         (connector_id, None, op),
         (connector_id, tenant, None),
         (connector_id, None, None),
         (None, tenant, None),
+        (None, None, None),
     )
     with _overrides_lock:
         for key in ladder:

--- a/backend/tests/test_redaction_resolver.py
+++ b/backend/tests/test_redaction_resolver.py
@@ -162,3 +162,52 @@ def test_re_register_overwrites_previous_policy() -> None:
 
     resolved = resolve_policy(connector_id="github", tenant=None, op=None)
     assert resolved is second
+
+
+def test_wildcard_register_overrides_default_for_any_call() -> None:
+    """``register_policy(policy)`` with no scope kwargs shadows the
+    packaged default for every ``resolve_policy`` call (#1189).
+
+    The wildcard slot is the documented "tenant-wide, connector-wide,
+    op-wide" override (see ``register_policy`` docstring). Pre-fix,
+    the resolver ladder did not include ``(None, None, None)``, so the
+    registration was stored but never consulted -- ``resolve_policy``
+    silently fell through to ``get_default_policy()`` regardless. The
+    assertion targets every label shape (fully-labelled, partially-
+    labelled, fully-``None``) because the wildcard slot's value
+    proposition is "applies to every call when no more-specific
+    override hits."
+    """
+    custom = _policy("global-wildcard")
+    register_policy(custom)
+
+    for connector_id, tenant, op in (
+        ("github", "t1", "op.x"),
+        ("gitlab", None, "op.y"),
+        (None, "t2", None),
+        (None, None, None),
+    ):
+        resolved = resolve_policy(connector_id=connector_id, tenant=tenant, op=op)
+        assert resolved is custom, (
+            f"wildcard register should win for "
+            f"(connector_id={connector_id!r}, tenant={tenant!r}, op={op!r}); "
+            f"got {resolved.id!r}"
+        )
+
+
+def test_connector_specific_override_beats_wildcard_register() -> None:
+    """A more-specific override out-ranks the wildcard register (#1189).
+
+    Specificity is the resolver's whole contract; the wildcard slot is
+    the *lowest*-specificity override (one rung above the packaged
+    default). A connector-anchored registration must still win for
+    calls labelled with that connector. Calls without a matching
+    more-specific override fall through to the wildcard.
+    """
+    global_policy = _policy("global-wildcard")
+    github_policy = _policy("github-specific")
+    register_policy(global_policy)
+    register_policy(github_policy, connector_id="github")
+
+    assert resolve_policy(connector_id="github", tenant="t1", op="op.x") is github_policy
+    assert resolve_policy(connector_id="gitlab", tenant="t1", op="op.x") is global_policy

--- a/docs/codebase/redaction.md
+++ b/docs/codebase/redaction.md
@@ -170,8 +170,12 @@ specificity ladder, from most specific to least:
 3. `(connector_id, tenant)` — per-connector, per-tenant.
 4. `connector_id` — per-connector default.
 5. `tenant` — tenant-wide default across every connector.
-6. The packaged **default-safe** policy
-   (`policies/default.yaml`) — the conservative fallback.
+6. `(None, None, None)` — wildcard global override registered via
+   `register_policy(policy)` with no scope kwargs.
+
+When no override at any of those six levels matches, the resolver
+falls through to the packaged **default-safe** policy
+(`policies/default.yaml`) — the conservative unconditional fallback.
 
 The default-safe policy is the load-bearing guarantee: a connector
 landing without a registered override **still gets credentials
@@ -181,7 +185,10 @@ are deliberately not in the default — most connector responses are
 mostly identifiers, and a global default that redacts them would
 blank operator-facing summaries. Operators wanting them at the global
 level register a wider policy via `register_policy(policy)` (no
-connector/tenant/op filter = global override).
+connector/tenant/op filter = global override; step 6 above). The
+distinction matters: the registered wildcard policy fires *before*
+the packaged default, so it can extend or replace the default's rule
+set without touching `policies/default.yaml`.
 
 Policy registration is process-global mutable state. Tests call
 `clear_overrides()` in a fixture teardown to keep registrations from


### PR DESCRIPTION
## Summary

- Add `(None, None, None)` as the sixth and final override-lookup step in the redaction resolver ladder, restoring the wildcard register-as-global-override contract documented in both `register_policy()`'s docstring and `docs/codebase/redaction.md`.
- A wildcard `register_policy(policy)` call (no scope kwargs) now shadows the packaged default for every `resolve_policy(...)` call. More-specific overrides still win per the existing specificity hierarchy — adding the sixth step changes no other override path.
- Pre-existing from #1071 (the original wiring); flagged as adjacent findings during the PR #1180 and #1185 reviews and deferred to this single-Task follow-up.

## Test plan

- [x] `ruff check src/meho_backplane/redaction/resolver.py tests/test_redaction_resolver.py` — clean.
- [x] `ruff format --check ...` — clean.
- [x] `mypy src/meho_backplane/redaction/` — `Success: no issues found in 9 source files`.
- [x] `pytest tests/test_redaction_resolver.py` — **11 passed** (9 existing + 2 new regression tests).
- [x] `pytest tests/test_redaction_*.py` — **118 passed, 7 skipped, 0 failed** (full redaction-surface regression sweep — no impact on engine / policy / middleware / Tier-2 / shadow-mode / round-trip / Presidio test files).
- [x] `code-quality.py --files <changed>` — clean.
- [x] `test_wildcard_register_overrides_default_for_any_call` — proves the wildcard slot shadows the default for every label shape (fully-labelled, partially-labelled, fully-`None`).
- [x] `test_connector_specific_override_beats_wildcard_register` — proves a connector-anchored override still wins for matching calls; the wildcard catches calls to other connectors.

## Out of scope

- Refactoring the ladder generation into a function or table-driven form. The current explicit tuple is fine and the issue's AC explicitly forbids the rewrite.
- Lattice-completeness paths like `(None, None, op)` or `(None, tenant, op)`. The ladder's asymmetry (connector-anchored levels precede tenant-only) is deliberate; expand only when a real caller needs it.
- The per-tenant policy authoring path (UI / persistence / startup-time registration). This Task only unblocks the contract; the authoring surface is a separate follow-on Initiative.
- Touching `register_policy()` or `clear_overrides()`. The defect is in the lookup ladder only.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1189
