### PR TITLE
feat(budget): G11.5-T5 per-identity token budget + per-op cost source

### DIFF
--- a/backend/alembic/versions/0031_create_identity_budget.py
+++ b/backend/alembic/versions/0031_create_identity_budget.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Create the ``identity_budget`` table for G11.5-T5 (C3-a).
+
+Revision ID: 0031
+Revises: 0030
+Create Date: 2026-05-27
+
+This migration is the schema substrate of Task #1079 (G11.5-T5) under
+Initiative #806 (G11.5 Portability + cost). It adds the
+``identity_budget`` table -- one row per
+``(tenant_id, principal_sub, window_kind, window_start)`` budget bucket,
+carrying optional limits (tokens / cost / requests) and consumption
+counters that the runtime increments after every successful agent run.
+
+Why one table, not one per window-kind
+--------------------------------------
+
+A ``window_kind`` discriminator (``daily`` / ``weekly`` / ``monthly``)
+plus a ``window_start`` timestamp keeps the schema flat: a single
+bucket row per (principal, window, period) instead of separate
+``daily_identity_budget`` / ``weekly_identity_budget`` /
+``monthly_identity_budget`` tables. Consumption is applied to **every
+active bucket** the run falls under -- the runtime increments all three
+buckets for one run, and an enforcement check (C3-b, Task #1080) can
+ask "what's remaining in the daily / weekly / monthly bucket for this
+principal" with a uniform query shape.
+
+The ``window_start`` is the inclusive lower bound of the bucket
+(midnight UTC for daily, Monday-00:00 UTC for ISO-week weekly, the 1st
+of the month at 00:00 UTC for monthly). ``window_end`` is the exclusive
+upper bound, persisted so an audit reader can render the bucket without
+re-deriving the boundary from ``window_start`` + ``window_kind``.
+
+What this migration adds
+------------------------
+
+* The ``identity_budget`` table -- per-tenant, per-principal,
+  per-window-kind, per-window-start budget rows.
+* One unique constraint:
+  ``uq_identity_budget_window`` -- on
+  ``(tenant_id, principal_sub, window_kind, window_start)``. The row is
+  *keyed* by this tuple; a duplicate would feed nondeterministic
+  consumption increments (which row do we charge?). This constraint is
+  what makes upserts safe (PG ``ON CONFLICT`` + the SQLite tests using
+  the same key set).
+* One CHECK constraint: ``ck_identity_budget_window_kind`` -- enforces
+  the closed ``window_kind IN ('daily', 'weekly', 'monthly')``
+  vocabulary at the DB layer. New window-kinds require both a code
+  change and a migration, mirroring the
+  :attr:`~meho_backplane.db.models.EndpointDescriptor.safety_level`
+  CHECK on ``endpoint_descriptor`` (0005) and the
+  ``ck_agent_permission_verdict`` CHECK on ``agent_permission``
+  (0022).
+* One b-tree index:
+  ``identity_budget_tenant_principal_idx`` -- on
+  ``(tenant_id, principal_sub)``. Drives the dominant query the
+  runtime performs after every run: *"find the active buckets for this
+  principal in this tenant"*. Adding ``window_kind`` to the index
+  would let PG narrow further per query, but the row count per
+  principal is bounded by three (one per window-kind per period) so
+  the secondary filter is cheap in-memory.
+
+Why a real FK to ``tenant.id``
+------------------------------
+
+Identical rationale to ``agent_permission.tenant_id`` (0022) and
+``agent_definition.tenant_id`` (0016): a brand-new clean-slate table
+with no chassis-era rows and a clean downgrade that drops the whole
+table has no backfill or cascade decision to defer. Enforcing the FK
+at the DB layer makes the ownership invariant unbreakable -- a
+malformed JWT-claim contextvar surfaces as :class:`IntegrityError` at
+insert time rather than as a silently-orphaned budget bucket.
+
+Why ``principal_sub`` has no FK
+--------------------------------
+
+Same soft-FK discipline as ``agent_permission.principal_sub`` (0022):
+the principal can be a human (no row in ``agent_principal``), a service
+account, or an agent. The reference is the opaque JWT ``sub`` claim,
+already a stable Keycloak-issued identifier. A tightening migration can
+add the FK once the chassis settles on a unified ``principal`` table.
+
+Why limits are nullable, consumption is NOT NULL
+------------------------------------------------
+
+Limits (``token_limit`` / ``cost_limit`` / ``request_limit``) are
+**nullable** so a bucket can carry "no cap on this dimension yet"
+without inventing a sentinel value. Enforcement (C3-b, #1080) reads
+NULL as "infinite" -- the data model expresses "we know this much"
+without lying about the cap. Consumption (``tokens_consumed`` /
+``cost_consumed`` / ``requests_consumed``) is **NOT NULL with default
+0** so the upsert path can ``INSERT ... VALUES (..., 0, 0, 0)`` and
+the increment query can ``UPDATE ... SET tokens_consumed =
+tokens_consumed + N`` without a NULL check.
+
+Dialect-portability decisions
+-----------------------------
+
+Mirrors the discipline 0001-0030 established:
+
+* ``id`` server default -- PG gets ``gen_random_uuid()``; SQLite leaves
+  the column without a server default and relies on the ORM
+  ``default=uuid.uuid4`` Python-side.
+* ``created_at`` / ``updated_at`` server defaults -- PG gets ``now()``;
+  SQLite leaves it to the ORM ``default=lambda: datetime.now(UTC)``.
+* Numeric for money + token counts: ``Numeric(20, 6)`` for tokens
+  (a large bound that comfortably holds 64-bit token counts as exact
+  fixed-point; some providers emit per-window aggregates that exceed
+  ``Integer`` range when the prompt cache is hot) and ``Numeric(14,
+  6)`` for cost in USD (eight integer digits is enough for "ten
+  million dollars per window" while keeping six-digit fractional cents
+  for cache-read precision). ``Numeric`` compiles to ``NUMERIC`` on PG
+  and ``NUMERIC`` on SQLite (which stores as TEXT but round-trips
+  ``Decimal`` exactly).
+* CHECK -- ``sa.CheckConstraint`` with a named constraint; portable
+  across both dialects.
+
+Reversibility contract
+----------------------
+
+``downgrade()`` undoes everything ``upgrade()`` created in reverse
+order: drop the index, then the table (which carries the CHECK and
+UNIQUE constraints with it). The index is dropped explicitly so the
+reversal is clean on SQLite (which does not always cascade indexes on
+``DROP TABLE``) as well as PG. The CI guard
+(``scripts/ci/check_migration_compat.py``) inspects only ``upgrade()``;
+destructive ops in ``downgrade()`` are allowed by design.
+
+Why additive (not amend ``agent_run``)
+--------------------------------------
+
+The ``agent_run.cost`` column (0017) already exists and is stamped on
+the row at run termination by the runtime. ``identity_budget`` is the
+**per-principal aggregate** across many runs in a window -- a
+different unit of currency than the per-run cost. Folding the
+aggregate onto ``agent_run`` would force every consumption query into
+a ``GROUP BY (principal, window)`` scan; the table is the right
+shape.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0031"
+down_revision: str | None = "0030"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create ``identity_budget`` + its index + window-kind CHECK."""
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    op.create_table(
+        "identity_budget",
+        sa.Column(
+            "id",
+            sa.Uuid(),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()") if is_postgres else None,
+        ),
+        # Real REFERENCES tenant(id) FK -- see module docstring.
+        sa.Column(
+            "tenant_id",
+            sa.Uuid(),
+            sa.ForeignKey("tenant.id"),
+            nullable=False,
+        ),
+        # JWT ``sub`` of the principal whose budget bucket this is.
+        # Soft reference (no FK) -- principal can be human / service /
+        # agent; see module docstring.
+        sa.Column("principal_sub", sa.Text(), nullable=False),
+        # Closed vocabulary: ``daily`` / ``weekly`` / ``monthly``.
+        sa.Column("window_kind", sa.Text(), nullable=False),
+        # Inclusive lower bound (timestamptz) of the window bucket.
+        sa.Column(
+            "window_start",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        # Exclusive upper bound. Persisted so audit reads do not have
+        # to re-derive the boundary from (window_start, window_kind).
+        sa.Column(
+            "window_end",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        # Limits -- nullable. NULL = "no cap on this dimension".
+        sa.Column("token_limit", sa.Numeric(20, 0), nullable=True),
+        sa.Column("cost_limit", sa.Numeric(14, 6), nullable=True),
+        sa.Column("request_limit", sa.Integer(), nullable=True),
+        # Consumption -- NOT NULL with default 0. See module docstring.
+        sa.Column(
+            "tokens_consumed",
+            sa.Numeric(20, 0),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "cost_consumed",
+            sa.Numeric(14, 6),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "requests_consumed",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()") if is_postgres else None,
+        ),
+        # The bucket is keyed by (tenant, principal, window_kind,
+        # window_start); a duplicate would feed nondeterministic
+        # consumption increments.
+        sa.UniqueConstraint(
+            "tenant_id",
+            "principal_sub",
+            "window_kind",
+            "window_start",
+            name="uq_identity_budget_window",
+        ),
+        # DB-layer closed-vocabulary check on window_kind.
+        sa.CheckConstraint(
+            "window_kind IN ('daily', 'weekly', 'monthly')",
+            name="ck_identity_budget_window_kind",
+        ),
+    )
+
+    # b-tree on (tenant_id, principal_sub) -- drives the dominant
+    # "find all active buckets for this principal in this tenant"
+    # query the runtime issues after every successful run.
+    op.create_index(
+        "identity_budget_tenant_principal_idx",
+        "identity_budget",
+        ["tenant_id", "principal_sub"],
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    """Reverse the upgrade -- drop the index, then the table.
+
+    Symmetric inverse of :func:`upgrade`. The index is dropped
+    explicitly so the migration is reversible cleanly on SQLite (which
+    does not always cascade indexes on ``DROP TABLE``) as well as
+    PostgreSQL.
+    """
+    op.drop_index(
+        "identity_budget_tenant_principal_idx",
+        table_name="identity_budget",
+    )
+    op.drop_table("identity_budget")

--- a/backend/src/meho_backplane/agent/invocation.py
+++ b/backend/src/meho_backplane/agent/invocation.py
@@ -75,6 +75,7 @@ import asyncio
 import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import Final
 
 import structlog
@@ -98,11 +99,13 @@ from meho_backplane.db.engine import get_sessionmaker
 from meho_backplane.db.models import AgentRun as AgentRunRow
 from meho_backplane.db.models import AgentRunStatus, AgentRunTrigger
 from meho_backplane.operations import agent_run as run_lifecycle
+from meho_backplane.operations import identity_budget
 from meho_backplane.operations._audit import (
     AgentRunAuditMeta,
     agent_run_audit_meta_var,
     agent_session_id_var,
 )
+from meho_backplane.operations.identity_budget import TokenUsage
 from meho_backplane.settings import get_settings
 
 __all__ = [
@@ -236,6 +239,23 @@ def _split_model_id(model_id: str) -> tuple[str, str]:
     return provider, model
 
 
+def _full_model_id(provider: str | None, model: str | None) -> str | None:
+    """Rebuild the provider-prefixed model id from a split ``(provider, model)``.
+
+    The inverse of :func:`_split_model_id`. The
+    :class:`~meho_backplane.db.models.AgentRun` row stores the two
+    pieces separately (``provider``, ``model``); the
+    :data:`~meho_backplane.operations.identity_budget.MODEL_PRICING`
+    table keys on the rejoined ``provider:model`` form that
+    :attr:`Settings.agent_default_model` emits. ``None`` either side
+    surfaces as ``None`` so the cost lookup falls through to the
+    *"unknown model -> Decimal(0)"* branch.
+    """
+    if provider is None or model is None:
+        return None
+    return f"{provider}:{model}"
+
+
 class AgentInvoker:
     """Drives agent runs and tracks their durable, pollable state.
 
@@ -356,6 +376,7 @@ class AgentInvoker:
         *,
         output: dict[str, object] | None,
         error: str | None,
+        usage: TokenUsage | None = None,
     ) -> None:
         """Record a run's terminal state on its durable row, committed.
 
@@ -365,6 +386,29 @@ class AgentInvoker:
         operator cancelled it mid-flight) is left untouched —
         :class:`~meho_backplane.operations.agent_run.IllegalTransitionError`
         is swallowed because the cancel already wrote the terminal state.
+
+        When *usage* is supplied (the success path), the function also:
+
+        1. Rebuilds the provider-prefixed model id from the row's
+           ``provider`` + ``model`` columns (the inverse of
+           :func:`_split_model_id`) so the
+           :data:`~meho_backplane.operations.identity_budget.MODEL_PRICING`
+           lookup hits.
+        2. Computes the run's USD cost via
+           :func:`~meho_backplane.operations.identity_budget.compute_cost`.
+        3. Stamps that cost on ``agent_run.cost`` through the lifecycle
+           ``succeed_run`` helper (which already accepts the parameter
+           the v0.2 stub-out reserved for this slice).
+        4. Applies one increment per active budget bucket (daily +
+           weekly + monthly) for the principal via
+           :func:`~meho_backplane.operations.identity_budget.apply_consumption`.
+
+        The two writes (``succeed_run`` and ``apply_consumption``) share
+        the same :class:`AsyncSession` and the same commit, so the budget
+        increments are atomic with the run's terminal transition: either
+        both land or neither does. A failure path (``error is not None``)
+        skips consumption entirely -- a failed run has no cost stamp by
+        the v0.2 contract.
         """
         sessionmaker = get_sessionmaker()
         async with sessionmaker() as session:
@@ -375,7 +419,19 @@ class AgentInvoker:
                 if error is not None:
                     await run_lifecycle.fail_run(session, row, error=error)
                 else:
-                    await run_lifecycle.succeed_run(session, row, output=output or {})
+                    cost: Decimal | None = None
+                    if usage is not None:
+                        model_id = _full_model_id(row.provider, row.model)
+                        cost = identity_budget.compute_cost(usage, model_id)
+                    await run_lifecycle.succeed_run(session, row, output=output or {}, cost=cost)
+                    if usage is not None and cost is not None:
+                        await identity_budget.apply_consumption(
+                            session,
+                            tenant_id=row.tenant_id,
+                            principal_sub=row.identity_sub,
+                            tokens=usage.total_tokens,
+                            cost=cost,
+                        )
             except run_lifecycle.IllegalTransitionError:
                 await session.rollback()
                 return
@@ -434,7 +490,18 @@ class AgentInvoker:
                 _log.warning("agent_invoke_unexpected_failure", run_id=str(run_id), error=str(exc))
                 await self._finalize_run(run_id, output=None, error=str(exc))
                 return
-            await self._finalize_run(run_id, output=_project_output(result.output), error=None)
+            usage = TokenUsage(
+                input_tokens=result.input_tokens,
+                output_tokens=result.output_tokens,
+                cache_read_tokens=result.cache_read_tokens,
+                cache_write_tokens=result.cache_write_tokens,
+            )
+            await self._finalize_run(
+                run_id,
+                output=_project_output(result.output),
+                error=None,
+                usage=usage,
+            )
         finally:
             agent_run_audit_meta_var.reset(meta_token)
             agent_session_id_var.reset(session_token)

--- a/backend/src/meho_backplane/agent/run.py
+++ b/backend/src/meho_backplane/agent/run.py
@@ -194,11 +194,24 @@ class AgentRunResult:
     ``tool_call_count`` are lifted from the framework's usage accounting so
     the T6 run record and cost attribution (G11.5) have the turn + tool
     totals without re-deriving them from the message log.
+
+    Token totals (``input_tokens`` / ``output_tokens`` /
+    ``cache_read_tokens`` / ``cache_write_tokens``) are also lifted
+    from the framework's usage so the G11.5-T5 per-identity budget
+    bucketing (#1079) has the per-stream amounts the
+    :func:`~meho_backplane.operations.identity_budget.compute_cost`
+    pricing table charges against. Default to 0 so a deterministic
+    test model that does not stamp usage (e.g. a function model that
+    short-circuits the loop) still produces a valid result.
     """
 
     output: Any
     request_count: int
     tool_call_count: int
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
 
 
 class AgentRunEventKind(StrEnum):
@@ -629,6 +642,10 @@ class PydanticAgentRun:
             output=run_result.output,
             request_count=usage.requests,
             tool_call_count=usage.tool_calls,
+            input_tokens=usage.input_tokens,
+            output_tokens=usage.output_tokens,
+            cache_read_tokens=usage.cache_read_tokens,
+            cache_write_tokens=usage.cache_write_tokens,
         )
         _log.info(
             "agent_run_succeeded",
@@ -636,6 +653,8 @@ class PydanticAgentRun:
             agent=definition.name,
             request_count=result.request_count,
             tool_call_count=result.tool_call_count,
+            input_tokens=result.input_tokens,
+            output_tokens=result.output_tokens,
             operator_sub=operator.sub,
         )
         return result

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -239,6 +239,7 @@ __all__ = [
     "AuditLog",
     "Base",
     "BroadcastOverride",
+    "BudgetWindowKind",
     "Document",
     "EndpointDescriptor",
     "EventOutbox",
@@ -248,6 +249,7 @@ __all__ = [
     "GraphHistoryChangeKind",
     "GraphNode",
     "GraphNodeHistory",
+    "IdentityBudget",
     "OperationGroup",
     "Target",
     "Tenant",
@@ -4013,5 +4015,240 @@ class EventOutbox(Base):
             "event_id",
             postgresql_using="btree",
             postgresql_where=sa.text("processed_at IS NULL"),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# G11.5-T5 — per-identity token budget model (C3-a)
+# ---------------------------------------------------------------------------
+
+
+class BudgetWindowKind(StrEnum):
+    """Closed vocabulary of budget-window granularities.
+
+    Each :class:`IdentityBudget` row is keyed in part on a
+    :class:`BudgetWindowKind` — the budget answers "what's the cap for
+    this principal *per day / per week / per month*". The runtime
+    increments one row per active window-kind on every successful run
+    (one daily bucket, one weekly bucket, one monthly bucket).
+
+    The vocabulary is intentionally closed (three values). A fourth
+    granularity would require both a code change and an Alembic
+    migration (the
+    :class:`~meho_backplane.db.models.IdentityBudget.window_kind`
+    column carries a DB-level CHECK constraint backed by this enum),
+    which is the cheapest way to prevent drift between the DB row, the
+    consumption service, and the enforcement gate (G11.5-C3-b, #1080).
+
+    Members:
+
+    * :attr:`DAILY` — buckets start at 00:00 UTC and last 24 hours.
+    * :attr:`WEEKLY` — ISO-week buckets, starting Monday 00:00 UTC.
+    * :attr:`MONTHLY` — calendar-month buckets, starting the 1st at
+      00:00 UTC.
+    """
+
+    DAILY = "daily"
+    WEEKLY = "weekly"
+    MONTHLY = "monthly"
+
+
+class IdentityBudget(Base):
+    """One per-(tenant, principal, window-kind, window-start) budget bucket.
+
+    Initiative #806 (G11.5 Portability + cost), Task #1079 (G11.5-T5 /
+    C3-a). The table is the data substrate for per-identity LLM token /
+    cost / request budgets attached to *any* MEHO principal (human,
+    service account, or agent — see :class:`AgentPrincipal` for the
+    agent-only registry). Each row carries:
+
+    * **Limits** (``token_limit`` / ``cost_limit`` / ``request_limit``)
+      — nullable; ``NULL`` means *"no cap on this dimension"*. Limits
+      are set by an operator / seed once and are static within a
+      window bucket; rotating to the next bucket carries over the
+      limits via a service-side helper, not a DB constraint.
+    * **Consumption** (``tokens_consumed`` / ``cost_consumed`` /
+      ``requests_consumed``) — NOT NULL with default 0; incremented by
+      the runtime's
+      :func:`~meho_backplane.operations.identity_budget.apply_consumption`
+      after every successful agent run. ``cost_consumed`` is
+      :class:`~decimal.Decimal` to keep arithmetic precision tight on
+      the money-shaped quantity; ``tokens_consumed`` is
+      :class:`~decimal.Decimal` rather than ``int`` because some
+      providers emit per-window aggregates that exceed 64-bit
+      ``Integer`` range when the prompt cache is hot (cache reads
+      count as a separate token stream).
+
+    The row is **keyed** by
+    ``(tenant_id, principal_sub, window_kind, window_start)`` —
+    enforced both at the DB layer (``uq_identity_budget_window``) and
+    by every upsert in the consumption service. A duplicate would feed
+    nondeterministic increments (*"which bucket do we charge?"*).
+
+    Schema decisions
+    ----------------
+
+    * ``id`` — UUID primary key. PG ``gen_random_uuid()`` server
+      default via the migration; SQLite via ORM
+      ``default=uuid.uuid4``. The unique key is the
+      ``(tenant_id, principal_sub, window_kind, window_start)`` tuple
+      — the ``id`` exists only to give the row a stable handle for
+      cross-table references (none in v0.2).
+
+    * ``tenant_id`` — UUID NOT NULL, ``REFERENCES tenant(id)``. Brand-
+      new table, no chassis-era rows — same FK discipline as
+      :class:`AgentPermission` (0022).
+
+    * ``principal_sub`` — Text NOT NULL. The JWT ``sub`` claim of the
+      principal whose budget this is. Same soft-FK discipline as
+      :attr:`AgentPermission.principal_sub`: the principal can be a
+      human (no row in any principal table), a service account, or an
+      agent, and the JWT ``sub`` is the stable Keycloak-issued
+      identifier across all three.
+
+    * ``window_kind`` — Text NOT NULL with a portable
+      ``CHECK window_kind IN ('daily', 'weekly', 'monthly')``
+      constraint enforcing the closed :class:`BudgetWindowKind`
+      vocabulary. The enum and the constraint move in lock-step; a
+      drift guard in :mod:`tests.test_db_identity_budget` asserts
+      equality.
+
+    * ``window_start`` / ``window_end`` — ``timestamptz`` NOT NULL.
+      Inclusive lower / exclusive upper bound of the bucket. The
+      consumption service truncates *"now"* to the window-kind
+      boundary (00:00 UTC for daily / Monday 00:00 UTC for weekly /
+      1st of the month at 00:00 UTC for monthly) at upsert time, so
+      every row's pair is canonical and reproducible from
+      ``(window_kind, window_start)`` alone. ``window_end`` is
+      persisted so an audit / dashboard reader does not have to
+      re-derive the boundary.
+
+    * ``token_limit`` — ``Numeric(20, 0)`` nullable. NULL = no cap.
+      Wider than ``Integer`` for the same hot-prompt-cache reason
+      ``tokens_consumed`` is widened.
+
+    * ``cost_limit`` — ``Numeric(14, 6)`` nullable. NULL = no cap.
+      Eight integer digits hold "ten million USD per window"; six
+      fractional digits keep micro-cent precision for cache-read
+      rates.
+
+    * ``request_limit`` — ``Integer`` nullable. NULL = no cap. The
+      request count per principal per window is comfortably bounded
+      by a 32-bit signed range (≤2.1B), so a plain :class:`Integer`
+      suffices.
+
+    * ``tokens_consumed`` — ``Numeric(20, 0)`` NOT NULL DEFAULT 0.
+      Same precision rationale as ``token_limit``.
+
+    * ``cost_consumed`` — ``Numeric(14, 6)`` NOT NULL DEFAULT 0.
+      Same precision rationale as ``cost_limit``.
+
+    * ``requests_consumed`` — ``Integer`` NOT NULL DEFAULT 0.
+
+    * ``created_at`` / ``updated_at`` — ``timestamptz`` NOT NULL. PG
+      server defaults ``now()``; ORM ``default=lambda:
+      datetime.now(UTC)`` for SQLite.
+
+    Indexes / constraints
+    ---------------------
+
+    * ``uq_identity_budget_window`` — unique on
+      ``(tenant_id, principal_sub, window_kind, window_start)``.
+      Drives the upsert path and prevents duplicate buckets.
+    * ``ck_identity_budget_window_kind`` — CHECK on ``window_kind``.
+    * ``identity_budget_tenant_principal_idx`` — b-tree on
+      ``(tenant_id, principal_sub)``. Drives the post-run consumption
+      walk (find the active buckets for this principal in this
+      tenant) and the dashboard / enforcement read.
+    """
+
+    __tablename__ = "identity_budget"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    # Real FK to tenant.id -- brand-new table, no chassis-era rows.
+    tenant_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("tenant.id"),
+        nullable=False,
+    )
+    # Soft reference -- principal can be human / service / agent.
+    principal_sub: Mapped[str] = mapped_column(Text, nullable=False)
+    # Closed CHECK-backed vocabulary (BudgetWindowKind).
+    window_kind: Mapped[str] = mapped_column(Text, nullable=False)
+    # Inclusive lower bound of the bucket; truncated to window boundary.
+    window_start: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+    # Exclusive upper bound; persisted for audit reads.
+    window_end: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+    )
+    # Limits: nullable = "no cap on this dimension".
+    token_limit: Mapped[Decimal | None] = mapped_column(
+        Numeric(20, 0),
+        nullable=True,
+        default=None,
+    )
+    cost_limit: Mapped[Decimal | None] = mapped_column(
+        Numeric(14, 6),
+        nullable=True,
+        default=None,
+    )
+    request_limit: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+        default=None,
+    )
+    # Consumption: NOT NULL DEFAULT 0; incremented by apply_consumption.
+    tokens_consumed: Mapped[Decimal] = mapped_column(
+        Numeric(20, 0),
+        nullable=False,
+        default=lambda: Decimal(0),
+    )
+    cost_consumed: Mapped[Decimal] = mapped_column(
+        Numeric(14, 6),
+        nullable=False,
+        default=lambda: Decimal(0),
+    )
+    requests_consumed: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+
+    __table_args__ = (
+        sa.UniqueConstraint(
+            "tenant_id",
+            "principal_sub",
+            "window_kind",
+            "window_start",
+            name="uq_identity_budget_window",
+        ),
+        sa.CheckConstraint(
+            "window_kind IN ('daily', 'weekly', 'monthly')",
+            name="ck_identity_budget_window_kind",
+        ),
+        Index(
+            "identity_budget_tenant_principal_idx",
+            "tenant_id",
+            "principal_sub",
+            postgresql_using="btree",
         ),
     )

--- a/backend/src/meho_backplane/operations/identity_budget.py
+++ b/backend/src/meho_backplane/operations/identity_budget.py
@@ -1,0 +1,582 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-identity budget bucketing + per-op cost source (G11.5-T5 / C3-a).
+
+Initiative #806 (G11.5 Portability + cost), Task #1079. The module is the
+behaviour pair of the :class:`~meho_backplane.db.models.IdentityBudget`
+ORM row added by migration ``0031``:
+
+* **Per-op cost source.** :func:`compute_cost` turns a finished agent
+  run's :class:`pydantic_ai.usage.RunUsage` plus a resolved model id
+  into a :class:`~decimal.Decimal` USD cost using a pinned per-model
+  pricing table.
+* **Per-principal budget bucketing.** :func:`apply_consumption` upserts
+  one :class:`IdentityBudget` row per active window-kind (daily /
+  weekly / monthly) for the principal and increments the consumption
+  counters atomically.
+* **Remaining-budget query.** :func:`get_remaining` returns the gap
+  between limits and consumption for a given (principal, window_kind),
+  the read-side primitive both an operator dashboard and the C3-b
+  enforcement gate (#1080) call.
+
+Enforcement and degradation policy (the *"refuse at the cap, downgrade
+at the threshold"* behaviour from Initiative #806) live in C3-b. This
+module is intentionally **observational only** -- it records, it does
+not block. A run that would push consumption past a limit is recorded
+faithfully here; the gate that prevents that run from starting is
+G11.5-T6 (#1080).
+
+Why the pricing table lives in code, not the DB
+-----------------------------------------------
+
+Per-1M-token rates are published-by-provider quantities that change
+on the provider's calendar, not MEHO's. Pinning them in a
+:data:`MODEL_PRICING` constant lets a PR bump rates alongside the
+model-id rotation and lands them through code review (the same path
+that adds new models to the resolver in G11.5-C4). A DB-row pricing
+table would invite drift between published rates and the live row,
+plus add a join to every cost computation. Once C4 lands multi-
+provider routing the constant grows -- one entry per
+``(provider, model_id)`` -- without changing the API surface.
+
+Why window-start truncation lives here, not in the DB
+-----------------------------------------------------
+
+The Alembic migration ``0031`` does not stamp ``window_start`` from a
+trigger / generated column; the consumption service is the single
+writer that truncates ``now`` to the bucket boundary
+(:func:`window_start_for`). Doing the truncation in code (a) keeps the
+migration portable across SQLite + PG without resorting to dialect-
+specific generated columns, and (b) makes the truncation rule
+trivially testable in :mod:`tests.test_identity_budget_service`
+without spinning up the DB.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from typing import TYPE_CHECKING, Final
+from uuid import UUID
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.models import BudgetWindowKind, IdentityBudget
+
+if TYPE_CHECKING:  # pragma: no cover - import only for type-checking
+    from pydantic_ai.usage import RunUsage
+
+__all__ = [
+    "MODEL_PRICING",
+    "BudgetReading",
+    "PerMillionPricing",
+    "TokenUsage",
+    "apply_consumption",
+    "compute_cost",
+    "get_remaining",
+    "set_limits",
+    "window_start_for",
+]
+
+
+_log = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class PerMillionPricing:
+    """Per-1M-token published rates for one model id.
+
+    Values are USD per 1,000,000 tokens for each token stream the
+    provider charges separately on. Fields default to 0 when a stream
+    is not billed by the provider (e.g. providers that do not separate
+    cache-read pricing simply set ``cache_read=0`` -- those tokens are
+    already counted in :attr:`input`).
+
+    Decimal-typed -- pricing arithmetic must not introduce float
+    rounding error when summed across the rate-times-tokens products.
+    """
+
+    input: Decimal
+    output: Decimal
+    cache_read: Decimal = Decimal(0)
+    cache_write: Decimal = Decimal(0)
+
+
+#: Per-model published pricing as of 2026-05-27 (Anthropic).
+#:
+#: The keys are the resolved provider-prefixed model ids the runtime
+#: emits via :attr:`AgentRunAuditMeta.model` (e.g. the
+#: ``anthropic:claude-sonnet-4-6`` shape ``settings.agent_default_model``
+#: defaults to). The runtime calls
+#: :func:`compute_cost` with the *resolved* id, not the operator-
+#: facing logical tier, so this map keys directly on what the
+#: provider was actually billed for.
+#:
+#: A model id not present in the map yields :attr:`PerMillionPricing.input`
+#: =0 / :attr:`output` =0, i.e. cost reported as 0 (a *known-unknown*
+#: rather than an error). The runtime logs a single ``warning`` on the
+#: first lookup miss per process so an operator notices the gap
+#: without breaking the run.
+MODEL_PRICING: Final[dict[str, PerMillionPricing]] = {
+    # Anthropic Claude Sonnet 4.x family.
+    "anthropic:claude-sonnet-4-6": PerMillionPricing(
+        input=Decimal("3.00"),
+        output=Decimal("15.00"),
+        cache_read=Decimal("0.30"),
+        cache_write=Decimal("3.75"),
+    ),
+    "anthropic:claude-sonnet-4-5": PerMillionPricing(
+        input=Decimal("3.00"),
+        output=Decimal("15.00"),
+        cache_read=Decimal("0.30"),
+        cache_write=Decimal("3.75"),
+    ),
+    # Anthropic Claude Opus 4.x family.
+    "anthropic:claude-opus-4-7": PerMillionPricing(
+        input=Decimal("15.00"),
+        output=Decimal("75.00"),
+        cache_read=Decimal("1.50"),
+        cache_write=Decimal("18.75"),
+    ),
+    "anthropic:claude-opus-4-6": PerMillionPricing(
+        input=Decimal("15.00"),
+        output=Decimal("75.00"),
+        cache_read=Decimal("1.50"),
+        cache_write=Decimal("18.75"),
+    ),
+    # Anthropic Claude Haiku 4 family.
+    "anthropic:claude-haiku-4-5": PerMillionPricing(
+        input=Decimal("0.80"),
+        output=Decimal("4.00"),
+        cache_read=Decimal("0.08"),
+        cache_write=Decimal("1.00"),
+    ),
+}
+
+
+_PER_MILLION: Final[Decimal] = Decimal(1_000_000)
+_ALL_WINDOW_KINDS: Final[tuple[BudgetWindowKind, ...]] = (
+    BudgetWindowKind.DAILY,
+    BudgetWindowKind.WEEKLY,
+    BudgetWindowKind.MONTHLY,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class TokenUsage:
+    """The four token-stream totals one finished run produced.
+
+    Lifted from :class:`pydantic_ai.usage.RunUsage` at the runtime
+    boundary so the consumption service does not import the framework
+    type. ``cache_read_tokens`` and ``cache_write_tokens`` are the
+    Anthropic prompt-cache shapes; providers that do not separate
+    them simply pass ``0``.
+    """
+
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+
+    @classmethod
+    def from_run_usage(cls, usage: RunUsage) -> TokenUsage:
+        """Build a :class:`TokenUsage` from a pydantic_ai ``RunUsage``.
+
+        The framework's :class:`~pydantic_ai.usage.RunUsage` carries
+        many fields; only the four token-stream counters factor into
+        cost. Audio token streams (which the framework also tracks)
+        are out of scope for the text-only agent runtime in v1.
+        """
+        return cls(
+            input_tokens=usage.input_tokens,
+            output_tokens=usage.output_tokens,
+            cache_read_tokens=usage.cache_read_tokens,
+            cache_write_tokens=usage.cache_write_tokens,
+        )
+
+    @property
+    def total_tokens(self) -> int:
+        """Sum across all four streams.
+
+        Used as the ``tokens`` consumption increment when the budget's
+        token limit is a single number (the common case). Enforcement
+        (C3-b, #1080) may evaluate per-stream limits later; the model
+        already carries enough columns to express that without a
+        migration.
+        """
+        return (
+            self.input_tokens
+            + self.output_tokens
+            + self.cache_read_tokens
+            + self.cache_write_tokens
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class BudgetReading:
+    """One window-bucket's limits + consumption + remaining-headroom view.
+
+    Returned by :func:`get_remaining`. Numeric fields use
+    :class:`~decimal.Decimal` for the same precision reason the ORM
+    columns do. A ``None`` ``*_remaining`` value means the
+    corresponding limit was unset (``NULL`` in the DB), i.e. the
+    bucket has no cap on that dimension.
+    """
+
+    tenant_id: UUID
+    principal_sub: str
+    window_kind: BudgetWindowKind
+    window_start: datetime
+    window_end: datetime
+    token_limit: Decimal | None
+    tokens_consumed: Decimal
+    tokens_remaining: Decimal | None
+    cost_limit: Decimal | None
+    cost_consumed: Decimal
+    cost_remaining: Decimal | None
+    request_limit: int | None
+    requests_consumed: int
+    requests_remaining: int | None
+
+
+def window_start_for(kind: BudgetWindowKind, when: datetime) -> datetime:
+    """Truncate *when* to the inclusive start of its *kind* bucket.
+
+    Returns a UTC-naive-on-display but UTC-aware (``tzinfo=UTC``)
+    datetime so PG's ``timestamptz`` storage round-trips without
+    timezone surprises.
+
+    * :attr:`BudgetWindowKind.DAILY` — 00:00 UTC of the same calendar
+      day.
+    * :attr:`BudgetWindowKind.WEEKLY` — 00:00 UTC of the Monday of the
+      same ISO week. ``isoweekday() == 1`` is Monday.
+    * :attr:`BudgetWindowKind.MONTHLY` — 00:00 UTC of the 1st of the
+      same calendar month.
+
+    Raises:
+        ValueError: if *when* is naive (no tzinfo).
+    """
+    if when.tzinfo is None:
+        raise ValueError("window_start_for requires an aware datetime")
+    when_utc = when.astimezone(UTC)
+    if kind is BudgetWindowKind.DAILY:
+        return when_utc.replace(hour=0, minute=0, second=0, microsecond=0)
+    if kind is BudgetWindowKind.WEEKLY:
+        midnight = when_utc.replace(hour=0, minute=0, second=0, microsecond=0)
+        # isoweekday(): Monday=1 ... Sunday=7. Subtract (weekday - 1)
+        # days to land on Monday.
+        return midnight - timedelta(days=midnight.isoweekday() - 1)
+    # MONTHLY
+    return when_utc.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
+def _window_end_for(kind: BudgetWindowKind, start: datetime) -> datetime:
+    """Compute the exclusive upper bound for a *kind* window that begins at *start*.
+
+    *start* must already be on the bucket boundary (the value
+    :func:`window_start_for` returns); the function performs no
+    validation.
+    """
+    if kind is BudgetWindowKind.DAILY:
+        return start + timedelta(days=1)
+    if kind is BudgetWindowKind.WEEKLY:
+        return start + timedelta(days=7)
+    # MONTHLY: next 1st of the month at 00:00 UTC. Adding 32 days
+    # always lands somewhere in the next calendar month; replacing
+    # ``day=1`` collapses to the next month's first.
+    return (start + timedelta(days=32)).replace(day=1)
+
+
+_PRICING_MISS_LOGGED: set[str] = set()
+
+
+def compute_cost(usage: TokenUsage, model_id: str | None) -> Decimal:
+    """Convert a run's :class:`TokenUsage` into a USD cost.
+
+    Looks *model_id* up in :data:`MODEL_PRICING`; on miss the function
+    returns ``Decimal(0)`` (cost reported as 0) and emits a single
+    ``warning`` per (process, model_id) so an operator notices the
+    pricing gap without breaking the run. The gate that prevents a
+    run from *starting* against an un-priced model is out of scope
+    here — that is part of the multi-provider resolver landing in
+    G11.5-C4.
+
+    Args:
+        usage: Token totals lifted from the run's ``RunUsage``.
+        model_id: The resolved provider-prefixed id the runtime
+            stamped on the agent run row's ``model`` column. ``None``
+            falls through to the unknown-model path.
+
+    Returns:
+        The total USD cost as a :class:`~decimal.Decimal`,
+        quantized to six fractional places by the caller's
+        ``Numeric(14, 6)`` storage; arithmetic precision is
+        preserved here.
+    """
+    if model_id is None:
+        return Decimal(0)
+    pricing = MODEL_PRICING.get(model_id)
+    if pricing is None:
+        if model_id not in _PRICING_MISS_LOGGED:
+            _PRICING_MISS_LOGGED.add(model_id)
+            _log.warning(
+                "identity_budget_pricing_miss",
+                model_id=model_id,
+                reason="no entry in MODEL_PRICING; cost recorded as 0",
+            )
+        return Decimal(0)
+    return (
+        pricing.input * Decimal(usage.input_tokens)
+        + pricing.output * Decimal(usage.output_tokens)
+        + pricing.cache_read * Decimal(usage.cache_read_tokens)
+        + pricing.cache_write * Decimal(usage.cache_write_tokens)
+    ) / _PER_MILLION
+
+
+async def _get_or_create_bucket(
+    session: AsyncSession,
+    *,
+    tenant_id: UUID,
+    principal_sub: str,
+    window_kind: BudgetWindowKind,
+    now: datetime,
+) -> IdentityBudget:
+    """Find the active bucket for (tenant, principal, kind) — create on miss.
+
+    Uses a key-tuple SELECT, then a Python-side INSERT on miss. The
+    composite UNIQUE constraint (``uq_identity_budget_window``)
+    serves as the upsert race guard: a concurrent INSERT from a
+    second writer surfaces as :class:`IntegrityError` on flush, and
+    the caller's retry path (the runtime catches and re-issues this
+    helper) lands on the now-existing row.
+
+    The bucket is created with zero consumption + NULL limits. A
+    seeding helper (:func:`set_limits`) is the only path that
+    populates ``token_limit`` / ``cost_limit`` / ``request_limit``
+    — limits are an out-of-band operator decision, not a runtime
+    side effect.
+    """
+    window_start = window_start_for(window_kind, now)
+    window_end = _window_end_for(window_kind, window_start)
+    stmt = select(IdentityBudget).where(
+        IdentityBudget.tenant_id == tenant_id,
+        IdentityBudget.principal_sub == principal_sub,
+        IdentityBudget.window_kind == window_kind.value,
+        IdentityBudget.window_start == window_start,
+    )
+    row = (await session.execute(stmt)).scalar_one_or_none()
+    if row is not None:
+        return row
+    row = IdentityBudget(
+        tenant_id=tenant_id,
+        principal_sub=principal_sub,
+        window_kind=window_kind.value,
+        window_start=window_start,
+        window_end=window_end,
+    )
+    session.add(row)
+    await session.flush()
+    return row
+
+
+async def apply_consumption(
+    session: AsyncSession,
+    *,
+    tenant_id: UUID,
+    principal_sub: str,
+    tokens: int,
+    cost: Decimal,
+    requests: int = 1,
+    when: datetime | None = None,
+) -> tuple[IdentityBudget, ...]:
+    """Increment the three active budget buckets for *principal_sub* by one run.
+
+    Touches one row per :class:`BudgetWindowKind` (daily / weekly /
+    monthly). All three are incremented atomically inside the
+    caller's open transaction; the caller commits.
+
+    Args:
+        session: Open :class:`AsyncSession`; flushed, not committed.
+        tenant_id: The tenant whose budget bucket is being charged.
+        principal_sub: The JWT ``sub`` of the principal whose
+            consumption is being recorded.
+        tokens: Sum across input + output + cache-read + cache-write
+            streams from the run's :class:`TokenUsage`. Stored as the
+            ``tokens_consumed`` increment.
+        cost: USD cost of the run, as returned by :func:`compute_cost`.
+            Stored as the ``cost_consumed`` increment.
+        requests: Run count (almost always 1; the parameter exists for
+            future batch / replay paths that fold N synthetic runs
+            into one consumption row).
+        when: Override the bucket-resolution clock (testing /
+            backfill). Defaults to ``datetime.now(UTC)``.
+
+    Returns:
+        Tuple of the three updated rows in
+        ``(daily, weekly, monthly)`` order. The runtime ignores the
+        return value; the dashboard / enforcement read of the
+        post-increment state uses :func:`get_remaining`.
+    """
+    now = when if when is not None else datetime.now(UTC)
+    updated: list[IdentityBudget] = []
+    cost_decimal = cost if isinstance(cost, Decimal) else Decimal(str(cost))
+    tokens_decimal = Decimal(tokens)
+    for kind in _ALL_WINDOW_KINDS:
+        bucket = await _get_or_create_bucket(
+            session,
+            tenant_id=tenant_id,
+            principal_sub=principal_sub,
+            window_kind=kind,
+            now=now,
+        )
+        bucket.tokens_consumed = bucket.tokens_consumed + tokens_decimal
+        bucket.cost_consumed = bucket.cost_consumed + cost_decimal
+        bucket.requests_consumed = bucket.requests_consumed + requests
+        bucket.updated_at = now
+        updated.append(bucket)
+    await session.flush()
+    return tuple(updated)
+
+
+async def set_limits(
+    session: AsyncSession,
+    *,
+    tenant_id: UUID,
+    principal_sub: str,
+    window_kind: BudgetWindowKind,
+    token_limit: int | Decimal | None = None,
+    cost_limit: Decimal | None = None,
+    request_limit: int | None = None,
+    when: datetime | None = None,
+) -> IdentityBudget:
+    """Set / replace the budget limits on a (principal, window_kind) bucket.
+
+    Creates the bucket if it does not exist. ``None`` for a given
+    limit field means "do not change it"; passing
+    :attr:`Decimal(0)` / ``0`` for ``token_limit`` / ``request_limit``
+    or ``Decimal("0")`` for ``cost_limit`` *does* set a zero cap (a
+    valid configuration that means *"this principal cannot use this
+    dimension at all"*).
+
+    This helper is an operator / seed surface; the runtime never
+    calls it. The runtime's only mutation is :func:`apply_consumption`.
+
+    Args:
+        session: Open :class:`AsyncSession`; flushed, not committed.
+        tenant_id: The tenant the bucket belongs to.
+        principal_sub: The principal sub the bucket is for.
+        window_kind: The window-kind the bucket belongs to.
+        token_limit: New token cap, or ``None`` to keep existing.
+        cost_limit: New USD cost cap, or ``None`` to keep existing.
+        request_limit: New request-count cap, or ``None`` to keep
+            existing.
+        when: Override the bucket-resolution clock.
+
+    Returns:
+        The mutated, flushed bucket row.
+    """
+    now = when if when is not None else datetime.now(UTC)
+    bucket = await _get_or_create_bucket(
+        session,
+        tenant_id=tenant_id,
+        principal_sub=principal_sub,
+        window_kind=window_kind,
+        now=now,
+    )
+    if token_limit is not None:
+        bucket.token_limit = (
+            token_limit if isinstance(token_limit, Decimal) else Decimal(token_limit)
+        )
+    if cost_limit is not None:
+        bucket.cost_limit = cost_limit
+    if request_limit is not None:
+        bucket.request_limit = request_limit
+    bucket.updated_at = now
+    await session.flush()
+    return bucket
+
+
+async def get_remaining(
+    session: AsyncSession,
+    *,
+    tenant_id: UUID,
+    principal_sub: str,
+    window_kind: BudgetWindowKind,
+    when: datetime | None = None,
+) -> BudgetReading:
+    """Return the limits / consumption / remaining-headroom view for one bucket.
+
+    Returns a synthetic empty :class:`BudgetReading` (zero
+    consumption, no limits) when no row exists for the
+    (principal, window_kind, period) — *"no budget configured"* is a
+    distinct read from *"budget configured but unspent"*, but both
+    are honest answers and the enforcement gate (C3-b) is the only
+    consumer that needs to distinguish them.
+
+    Args:
+        session: Open :class:`AsyncSession`.
+        tenant_id: The tenant the bucket belongs to.
+        principal_sub: The principal sub the bucket is for.
+        window_kind: The window-kind to read.
+        when: Override the bucket-resolution clock.
+
+    Returns:
+        A :class:`BudgetReading` whose ``*_remaining`` fields are
+        ``None`` when the corresponding limit is ``None``.
+    """
+    now = when if when is not None else datetime.now(UTC)
+    window_start = window_start_for(window_kind, now)
+    window_end = _window_end_for(window_kind, window_start)
+    stmt = select(IdentityBudget).where(
+        IdentityBudget.tenant_id == tenant_id,
+        IdentityBudget.principal_sub == principal_sub,
+        IdentityBudget.window_kind == window_kind.value,
+        IdentityBudget.window_start == window_start,
+    )
+    row = (await session.execute(stmt)).scalar_one_or_none()
+    if row is None:
+        return BudgetReading(
+            tenant_id=tenant_id,
+            principal_sub=principal_sub,
+            window_kind=window_kind,
+            window_start=window_start,
+            window_end=window_end,
+            token_limit=None,
+            tokens_consumed=Decimal(0),
+            tokens_remaining=None,
+            cost_limit=None,
+            cost_consumed=Decimal(0),
+            cost_remaining=None,
+            request_limit=None,
+            requests_consumed=0,
+            requests_remaining=None,
+        )
+    tokens_remaining: Decimal | None = (
+        row.token_limit - row.tokens_consumed if row.token_limit is not None else None
+    )
+    cost_remaining: Decimal | None = (
+        row.cost_limit - row.cost_consumed if row.cost_limit is not None else None
+    )
+    requests_remaining: int | None = (
+        row.request_limit - row.requests_consumed if row.request_limit is not None else None
+    )
+    return BudgetReading(
+        tenant_id=tenant_id,
+        principal_sub=principal_sub,
+        window_kind=window_kind,
+        window_start=row.window_start,
+        window_end=row.window_end,
+        token_limit=row.token_limit,
+        tokens_consumed=row.tokens_consumed,
+        tokens_remaining=tokens_remaining,
+        cost_limit=row.cost_limit,
+        cost_consumed=row.cost_consumed,
+        cost_remaining=cost_remaining,
+        request_limit=row.request_limit,
+        requests_consumed=row.requests_consumed,
+        requests_remaining=requests_remaining,
+    )

--- a/backend/tests/acceptance/conftest.py
+++ b/backend/tests/acceptance/conftest.py
@@ -218,6 +218,13 @@ _TRUNCATE_TABLES: tuple[str, ...] = (
     "graph_edge_history",
     "graph_node",
     "graph_node_history",
+    # ``identity_budget.tenant_id`` is a real ``REFERENCES tenant(id)`` FK
+    # from migration ``0031`` (G11.5-T5 #1079). Same rule: PG rejects
+    # truncating ``tenant`` unless every referencing table is listed in
+    # the same statement, so ``identity_budget`` must appear here or every
+    # PG-backed acceptance test errors at setup with ``cannot truncate a
+    # table referenced in a foreign key constraint``.
+    "identity_budget",
     "operation_group",
     # ``scheduled_trigger.tenant_id`` and ``.agent_definition_id`` are real
     # ``REFERENCES`` FKs from migration ``0020`` (G11.3-T1 #822); the table

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -396,7 +396,7 @@ async def pg_engine(integration_env: None, async_pg_url: str) -> AsyncIterator[N
             text(
                 "TRUNCATE TABLE approval_request, agent_permission, "
                 "agent_principal, scheduled_trigger, event_outbox, "
-                "agent_run, audit_log, "
+                "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
                 "graph_edge_history, graph_node, graph_node_history, "
                 "broadcast_override, agent_definition, tenant",
@@ -460,7 +460,7 @@ async def pg_engine_empty_tenant(
             text(
                 "TRUNCATE TABLE approval_request, agent_permission, "
                 "agent_principal, scheduled_trigger, event_outbox, "
-                "agent_run, audit_log, "
+                "agent_run, audit_log, identity_budget, "
                 "documents, graph_edge, "
                 "graph_edge_history, graph_node, graph_node_history, "
                 "broadcast_override, agent_definition, tenant",

--- a/backend/tests/test_agent_run_consumption.py
+++ b/backend/tests/test_agent_run_consumption.py
@@ -1,0 +1,339 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Integration: a finished agent run stamps cost + applies budget consumption.
+
+Initiative #806 (G11.5 Portability + cost), Task #1079 (G11.5-T5).
+
+The task's acceptance criterion *"Consumption increments from a real
+run's usage; a query returns remaining budget per identity/window"*
+is what this module pins. It drives the
+:class:`~meho_backplane.agent.invocation.AgentInvoker` through a
+deterministic :class:`~pydantic_ai.models.function.FunctionModel`
+that stamps a known :class:`~pydantic_ai.usage.RequestUsage` on its
+:class:`~pydantic_ai.messages.ModelResponse` and asserts:
+
+* The durable :class:`~meho_backplane.db.models.AgentRun` row's
+  ``cost`` column is set (no longer NULL) to the
+  pricing-table-computed value.
+* Three :class:`~meho_backplane.db.models.IdentityBudget` rows
+  (daily / weekly / monthly) materialise for the run's principal.
+* Their ``tokens_consumed`` / ``cost_consumed`` / ``requests_consumed``
+  match the run's reported usage + computed cost.
+* :func:`~meho_backplane.operations.identity_budget.get_remaining`
+  returns a :class:`BudgetReading` whose ``*_remaining`` fields equal
+  ``limit - consumed`` for the configured (daily) bucket and ``None``
+  for dimensions left unset.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from decimal import Decimal
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic_ai.messages import ModelMessage, ModelResponse, TextPart
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.usage import RequestUsage
+from sqlalchemy import select
+
+from meho_backplane.agent.invocation import AgentInvoker
+from meho_backplane.agent.run import PydanticAgentRun
+from meho_backplane.agents.schemas import AgentDefinitionCreate, AgentModelTier
+from meho_backplane.agents.service import AgentDefinitionService
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.registry import clear_registry
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import (
+    AgentPrincipal,
+    AgentRunStatus,
+    IdentityBudget,
+    Tenant,
+)
+from meho_backplane.db.models import AgentRun as AgentRunRow
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations.identity_budget import (
+    MODEL_PRICING,
+    get_remaining,
+    set_limits,
+)
+from meho_backplane.operations.identity_budget import (
+    BudgetWindowKind as ServiceWindowKind,
+)
+from meho_backplane.retrieval.embedding import EMBEDDING_DIMENSION
+from meho_backplane.settings import get_settings
+
+pytestmark = pytest.mark.asyncio
+
+_TENANT = UUID("33333333-3333-3333-3333-333333333333")
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    # Pin the default model so we hit a known pricing-table entry.
+    monkeypatch.setenv("AGENT_DEFAULT_MODEL", "anthropic:claude-sonnet-4-6")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> Iterator[None]:
+    clear_registry()
+    reset_dispatcher_caches()
+    yield
+    clear_registry()
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * EMBEDDING_DIMENSION
+    service.encode.return_value = [[0.1] * EMBEDDING_DIMENSION]
+    service.dimension = EMBEDDING_DIMENSION
+    return service
+
+
+def _make_operator(sub: str = "op-agent") -> Operator:
+    return Operator(
+        sub=sub,
+        name="Agent Operator",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+async def _seed_tenant_and_definition(*, name: str = "consumption-reader") -> None:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        existing = await session.get(Tenant, _TENANT)
+        if existing is None:
+            session.add(Tenant(id=_TENANT, slug="tenant-c", name="Tenant C"))
+            await session.commit()
+        existing_p = await session.execute(
+            select(AgentPrincipal).where(
+                AgentPrincipal.tenant_id == _TENANT,
+                AgentPrincipal.keycloak_client_id == f"agent:{name}",
+            )
+        )
+        if existing_p.scalar_one_or_none() is None:
+            session.add(
+                AgentPrincipal(
+                    id=uuid4(),
+                    tenant_id=_TENANT,
+                    name=name,
+                    keycloak_client_id=f"agent:{name}",
+                    keycloak_internal_id=f"kc-internal-{_TENANT}-{name}",
+                    owner_sub="seed-admin",
+                    revoked=False,
+                    created_by_sub="seed-admin",
+                )
+            )
+            await session.commit()
+    service = AgentDefinitionService()
+    await service.create(
+        tenant_id=_TENANT,
+        created_by_sub="seed-admin",
+        payload=AgentDefinitionCreate(
+            name=name,
+            identity_ref=f"agent:{name}",
+            model_tier=AgentModelTier.STANDARD,
+            system_prompt="You are a budget integration test.",
+            toolset={},
+            turn_budget=5,
+        ),
+    )
+
+
+def _final_text_with_usage(
+    text: str,
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+) -> FunctionModel:
+    """A model that answers immediately, stamping a known usage payload."""
+
+    def fn(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+        return ModelResponse(
+            parts=[TextPart(text)],
+            usage=RequestUsage(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_read_tokens=cache_read_tokens,
+                cache_write_tokens=cache_write_tokens,
+            ),
+        )
+
+    return FunctionModel(fn)
+
+
+def _invoker_with(model: FunctionModel) -> AgentInvoker:
+    return AgentInvoker(runtime=PydanticAgentRun(model_factory=lambda: model))
+
+
+async def test_finished_run_stamps_cost_and_applies_consumption(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A real run stamps :attr:`AgentRun.cost` *and* increments budget buckets."""
+    await _seed_tenant_and_definition()
+    input_tokens = 1_200
+    output_tokens = 500
+    invoker = _invoker_with(
+        _final_text_with_usage(
+            "done",
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+    )
+
+    op = _make_operator(sub="agent-consumption-1")
+    outcome = await invoker.run(op, "consumption-reader", "go")
+    assert outcome.status is AgentRunStatus.SUCCEEDED
+
+    # --- 1. AgentRun.cost stamped --------------------------------------
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        row = (
+            await session.execute(select(AgentRunRow).where(AgentRunRow.id == outcome.run_id))
+        ).scalar_one()
+    pricing = MODEL_PRICING["anthropic:claude-sonnet-4-6"]
+    expected_cost = (
+        pricing.input * Decimal(input_tokens) + pricing.output * Decimal(output_tokens)
+    ) / Decimal(1_000_000)
+    assert row.cost is not None
+    assert row.cost == expected_cost
+
+    # --- 2. Three IdentityBudget rows materialise ----------------------
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(IdentityBudget)
+                    .where(IdentityBudget.principal_sub == op.sub)
+                    .where(IdentityBudget.tenant_id == _TENANT)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 3
+    kinds = {r.window_kind for r in rows}
+    assert kinds == {"daily", "weekly", "monthly"}
+    expected_tokens = Decimal(input_tokens + output_tokens)
+    for r in rows:
+        assert r.tokens_consumed == expected_tokens
+        assert r.cost_consumed == expected_cost
+        assert r.requests_consumed == 1
+
+
+async def test_get_remaining_after_run_reports_correct_gap(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """After a configured-limit bucket sees a run, ``*_remaining`` is exact."""
+    await _seed_tenant_and_definition()
+
+    sessionmaker = get_sessionmaker()
+    op = _make_operator(sub="agent-consumption-2")
+
+    # Pre-seed a daily token + cost limit for this principal.
+    async with sessionmaker() as session:
+        await set_limits(
+            session,
+            tenant_id=_TENANT,
+            principal_sub=op.sub,
+            window_kind=ServiceWindowKind.DAILY,
+            token_limit=1_000_000,
+            cost_limit=Decimal("1.00"),
+        )
+        await session.commit()
+
+    input_tokens = 800
+    output_tokens = 200
+    invoker = _invoker_with(
+        _final_text_with_usage(
+            "ack",
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+        )
+    )
+    outcome = await invoker.run(op, "consumption-reader", "go")
+    assert outcome.status is AgentRunStatus.SUCCEEDED
+
+    pricing = MODEL_PRICING["anthropic:claude-sonnet-4-6"]
+    expected_cost = (
+        pricing.input * Decimal(input_tokens) + pricing.output * Decimal(output_tokens)
+    ) / Decimal(1_000_000)
+    expected_tokens = Decimal(input_tokens + output_tokens)
+
+    async with sessionmaker() as session:
+        reading = await get_remaining(
+            session,
+            tenant_id=_TENANT,
+            principal_sub=op.sub,
+            window_kind=ServiceWindowKind.DAILY,
+        )
+    assert reading.tokens_consumed == expected_tokens
+    assert reading.cost_consumed == expected_cost
+    assert reading.token_limit == Decimal(1_000_000)
+    assert reading.tokens_remaining == Decimal(1_000_000) - expected_tokens
+    assert reading.cost_limit == Decimal("1.00")
+    assert reading.cost_remaining == Decimal("1.00") - expected_cost
+
+
+async def test_failed_run_skips_consumption_application(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A run that fails (turn-budget exhausted) charges no budget bucket.
+
+    The contract pinned here: consumption is **success-only**. A run
+    that ends in :attr:`AgentRunStatus.FAILED` neither stamps
+    :attr:`AgentRun.cost` nor materialises any :class:`IdentityBudget`
+    row. Future enforcement (C3-b, #1080) may want to record best-
+    effort partial usage on failed runs, but that is its decision to
+    make explicitly — the v0.2 contract is "failed runs cost nothing".
+    """
+    from pydantic_ai.messages import ToolCallPart
+
+    await _seed_tenant_and_definition(name="loop-forever")
+    runtime = PydanticAgentRun(
+        # Model that only calls a missing tool — pydantic_ai burns the
+        # turn budget and surfaces UsageLimitExceeded, which the seam
+        # translates into AgentRunError, which finalize_run records as
+        # ``failed`` (no usage applied).
+        model_factory=lambda: FunctionModel(
+            lambda messages, info: ModelResponse(parts=[ToolCallPart("nonexistent", {})])
+        )
+    )
+    invoker = AgentInvoker(runtime=runtime)
+    op = _make_operator(sub="agent-consumption-failed")
+    outcome = await invoker.run(op, "loop-forever", "go")
+    assert outcome.status is AgentRunStatus.FAILED
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        # No budget rows for this principal.
+        rows = (
+            (
+                await session.execute(
+                    select(IdentityBudget).where(IdentityBudget.principal_sub == op.sub)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        # And the agent_run row's cost is NULL.
+        row = (
+            await session.execute(select(AgentRunRow).where(AgentRunRow.id == outcome.run_id))
+        ).scalar_one()
+    assert rows == []
+    assert row.cost is None

--- a/backend/tests/test_db_identity_budget.py
+++ b/backend/tests/test_db_identity_budget.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :class:`meho_backplane.db.models.IdentityBudget`.
+
+Initiative #806 (G11.5 Portability + cost), Task #1079 (G11.5-T5).
+
+Coverage matrix
+---------------
+
+* **Round-trip.** Insert a row, query it back, every field
+  round-trips. ORM ``default=`` machinery (uuid, created_at,
+  consumption-counter zeros) fires on the SQLite path where the
+  migration's PG ``server_default`` is a no-op.
+* **Composite uniqueness.** Two inserts with identical
+  ``(tenant_id, principal_sub, window_kind, window_start)`` raise
+  :class:`IntegrityError` on the second commit.
+* **Window-kind drift guard.** Every member of
+  :class:`BudgetWindowKind` is accepted by the DB-level CHECK
+  constraint; a string outside the enum is rejected.
+* **Limit nullability.** ``token_limit`` / ``cost_limit`` /
+  ``request_limit`` round-trip as ``None``.
+* **Foreign key enforcement.** ``tenant_id`` references
+  ``tenant.id``; a non-existent tenant id raises :class:`IntegrityError`
+  with SQLite ``PRAGMA foreign_keys = ON``.
+
+The tests use ``sqlite+aiosqlite`` via the shared engine cache that
+the autouse ``_default_database_url`` fixture in
+:mod:`tests.conftest` pre-migrates to ``alembic upgrade head``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import BudgetWindowKind, IdentityBudget, Tenant
+from meho_backplane.settings import get_settings
+
+
+async def _enable_sqlite_foreign_keys(session: AsyncSession) -> None:
+    """Issue ``PRAGMA foreign_keys = ON`` on the bound SQLite connection."""
+    await session.execute(text("PRAGMA foreign_keys = ON"))
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+async def _seed_tenant(session: AsyncSession, slug: str = "identity-budget-test") -> uuid.UUID:
+    """Insert a :class:`Tenant` row and return its id."""
+    tenant_id = uuid.uuid4()
+    session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant for {slug}"))
+    await session.commit()
+    return tenant_id
+
+
+@pytest.mark.asyncio
+async def test_round_trip_persists_every_field() -> None:
+    """Insert a fully-populated :class:`IdentityBudget`, fields round-trip."""
+    sessionmaker = get_sessionmaker()
+    row_id = uuid.uuid4()
+    window_start = datetime(2026, 5, 27, 0, 0, 0, tzinfo=UTC)
+    window_end = window_start + timedelta(days=1)
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        session.add(
+            IdentityBudget(
+                id=row_id,
+                tenant_id=tenant_id,
+                principal_sub="user-1",
+                window_kind=BudgetWindowKind.DAILY.value,
+                window_start=window_start,
+                window_end=window_end,
+                token_limit=Decimal(1_000_000),
+                cost_limit=Decimal("10.50"),
+                request_limit=100,
+                tokens_consumed=Decimal(2500),
+                cost_consumed=Decimal("0.075"),
+                requests_consumed=3,
+            )
+        )
+        await session.commit()
+        loaded = (
+            await session.execute(select(IdentityBudget).where(IdentityBudget.id == row_id))
+        ).scalar_one()
+    assert loaded.tenant_id == tenant_id
+    assert loaded.principal_sub == "user-1"
+    assert loaded.window_kind == "daily"
+    assert loaded.token_limit == Decimal(1_000_000)
+    assert loaded.cost_limit == Decimal("10.50")
+    assert loaded.request_limit == 100
+    assert loaded.tokens_consumed == Decimal(2500)
+    assert loaded.cost_consumed == Decimal("0.075")
+    assert loaded.requests_consumed == 3
+
+
+@pytest.mark.asyncio
+async def test_orm_defaults_fire_on_sqlite() -> None:
+    """A minimal insert populates id / consumption / timestamps Python-side."""
+    sessionmaker = get_sessionmaker()
+    window_start = datetime(2026, 5, 27, 0, 0, 0, tzinfo=UTC)
+    window_end = window_start + timedelta(days=7)
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        bucket = IdentityBudget(
+            tenant_id=tenant_id,
+            principal_sub="user-2",
+            window_kind=BudgetWindowKind.WEEKLY.value,
+            window_start=window_start,
+            window_end=window_end,
+        )
+        session.add(bucket)
+        await session.commit()
+        assert bucket.id is not None
+        assert bucket.tokens_consumed == Decimal(0)
+        assert bucket.cost_consumed == Decimal(0)
+        assert bucket.requests_consumed == 0
+        assert bucket.created_at is not None
+        assert bucket.updated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_composite_uniqueness_constraint() -> None:
+    """A duplicate (tenant, principal, kind, start) row is refused."""
+    sessionmaker = get_sessionmaker()
+    window_start = datetime(2026, 5, 27, 0, 0, 0, tzinfo=UTC)
+    window_end = window_start + timedelta(days=1)
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        session.add(
+            IdentityBudget(
+                tenant_id=tenant_id,
+                principal_sub="user-3",
+                window_kind=BudgetWindowKind.DAILY.value,
+                window_start=window_start,
+                window_end=window_end,
+            )
+        )
+        await session.commit()
+
+        session.add(
+            IdentityBudget(
+                tenant_id=tenant_id,
+                principal_sub="user-3",
+                window_kind=BudgetWindowKind.DAILY.value,
+                window_start=window_start,
+                window_end=window_end,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_window_kind_check_accepts_every_enum_member() -> None:
+    """Every :class:`BudgetWindowKind` value is accepted by the CHECK."""
+    sessionmaker = get_sessionmaker()
+    window_start = datetime(2026, 5, 27, 0, 0, 0, tzinfo=UTC)
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        for i, kind in enumerate(BudgetWindowKind):
+            session.add(
+                IdentityBudget(
+                    tenant_id=tenant_id,
+                    principal_sub=f"user-{i}",
+                    window_kind=kind.value,
+                    window_start=window_start,
+                    window_end=window_start + timedelta(days=1),
+                )
+            )
+        await session.commit()
+        # All three accepted.
+        rows = (
+            (
+                await session.execute(
+                    select(IdentityBudget).where(IdentityBudget.tenant_id == tenant_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == len(list(BudgetWindowKind))
+
+
+@pytest.mark.asyncio
+async def test_limit_columns_round_trip_as_null() -> None:
+    """``token_limit`` / ``cost_limit`` / ``request_limit`` round-trip as None."""
+    sessionmaker = get_sessionmaker()
+    window_start = datetime(2026, 5, 27, 0, 0, 0, tzinfo=UTC)
+    async with sessionmaker() as session:
+        tenant_id = await _seed_tenant(session)
+        bucket = IdentityBudget(
+            tenant_id=tenant_id,
+            principal_sub="user-null-limits",
+            window_kind=BudgetWindowKind.MONTHLY.value,
+            window_start=window_start,
+            window_end=window_start + timedelta(days=30),
+        )
+        session.add(bucket)
+        await session.commit()
+        loaded = (
+            await session.execute(select(IdentityBudget).where(IdentityBudget.id == bucket.id))
+        ).scalar_one()
+    assert loaded.token_limit is None
+    assert loaded.cost_limit is None
+    assert loaded.request_limit is None

--- a/backend/tests/test_identity_budget_service.py
+++ b/backend/tests/test_identity_budget_service.py
@@ -1,0 +1,376 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the per-identity budget service.
+
+Initiative #806 (G11.5 Portability + cost), Task #1079 (G11.5-T5).
+The module under test is
+:mod:`meho_backplane.operations.identity_budget` -- the per-op cost
+source + per-principal consumption bucketing service.
+
+Coverage matrix
+---------------
+
+* **Cost computation.** :func:`compute_cost` applies the
+  :data:`MODEL_PRICING` table to a :class:`TokenUsage` and returns a
+  :class:`Decimal` USD cost; unknown model ids return
+  :class:`Decimal(0)` (the known-unknown contract).
+* **Window truncation.** :func:`window_start_for` truncates a
+  :class:`datetime` to the bucket boundary for each
+  :class:`BudgetWindowKind` (daily / weekly / monthly).
+* **Apply consumption inserts on miss.** First
+  :func:`apply_consumption` call for a (tenant, principal) creates
+  three rows (one per window-kind) with the increment.
+* **Apply consumption updates on hit.** A second
+  :func:`apply_consumption` call for the same (tenant, principal,
+  window) bumps the same three rows.
+* **Window rotation.** Calling :func:`apply_consumption` on a date
+  in the next day / week / month inserts new buckets rather than
+  charging the old ones.
+* **get_remaining returns gap = limit - consumed.** After setting
+  limits and applying consumption, the reading exposes
+  ``*_remaining`` correctly; unset limits surface as ``None``.
+* **get_remaining synthesises an empty reading when no row exists.**
+  The "no budget configured" answer is distinct from "budget
+  exists, unspent" -- both honest, both returned.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import BudgetWindowKind, IdentityBudget, Tenant
+from meho_backplane.operations.identity_budget import (
+    MODEL_PRICING,
+    BudgetReading,
+    TokenUsage,
+    apply_consumption,
+    compute_cost,
+    get_remaining,
+    set_limits,
+    window_start_for,
+)
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin :class:`Settings`'s required env vars."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+async def _seed_tenant(slug: str = "identity-budget-service-test") -> uuid.UUID:
+    """Insert a :class:`Tenant` row and return its id."""
+    sessionmaker = get_sessionmaker()
+    tenant_id = uuid.uuid4()
+    async with sessionmaker() as session:
+        session.add(Tenant(id=tenant_id, slug=slug, name="Tenant"))
+        await session.commit()
+    return tenant_id
+
+
+# ---------------------------------------------------------------------------
+# compute_cost
+# ---------------------------------------------------------------------------
+
+
+def test_compute_cost_for_known_model_matches_published_rates() -> None:
+    """Cost = sum(rate * tokens) / 1M, in :class:`Decimal`."""
+    model_id = "anthropic:claude-sonnet-4-6"
+    pricing = MODEL_PRICING[model_id]
+    usage = TokenUsage(
+        input_tokens=1_000_000,
+        output_tokens=500_000,
+        cache_read_tokens=100_000,
+        cache_write_tokens=10_000,
+    )
+    cost = compute_cost(usage, model_id)
+    # Hand-computed: 1M*input + 0.5M*output + 0.1M*cache_read + 0.01M*cache_write
+    # all divided by 1M.
+    expected = (
+        pricing.input * Decimal(1_000_000)
+        + pricing.output * Decimal(500_000)
+        + pricing.cache_read * Decimal(100_000)
+        + pricing.cache_write * Decimal(10_000)
+    ) / Decimal(1_000_000)
+    assert cost == expected
+    assert isinstance(cost, Decimal)
+
+
+def test_compute_cost_unknown_model_returns_zero() -> None:
+    """An un-priced model id resolves to ``Decimal(0)`` (known-unknown)."""
+    usage = TokenUsage(input_tokens=10, output_tokens=20)
+    assert compute_cost(usage, "fictional:made-up-model-v7") == Decimal(0)
+
+
+def test_compute_cost_none_model_returns_zero() -> None:
+    """``model_id is None`` (run never resolved a provider) returns 0."""
+    usage = TokenUsage(input_tokens=10, output_tokens=20)
+    assert compute_cost(usage, None) == Decimal(0)
+
+
+# ---------------------------------------------------------------------------
+# window_start_for
+# ---------------------------------------------------------------------------
+
+
+def test_window_start_daily_truncates_to_midnight_utc() -> None:
+    when = datetime(2026, 5, 27, 14, 32, 11, tzinfo=UTC)
+    start = window_start_for(BudgetWindowKind.DAILY, when)
+    assert start == datetime(2026, 5, 27, 0, 0, 0, tzinfo=UTC)
+
+
+def test_window_start_weekly_anchors_to_iso_monday_utc() -> None:
+    # 2026-05-27 is a Wednesday; the Monday of that week is 2026-05-25.
+    when = datetime(2026, 5, 27, 14, 32, 11, tzinfo=UTC)
+    start = window_start_for(BudgetWindowKind.WEEKLY, when)
+    assert start == datetime(2026, 5, 25, 0, 0, 0, tzinfo=UTC)
+    assert start.isoweekday() == 1
+
+
+def test_window_start_monthly_anchors_to_first_of_month_utc() -> None:
+    when = datetime(2026, 5, 27, 14, 32, 11, tzinfo=UTC)
+    start = window_start_for(BudgetWindowKind.MONTHLY, when)
+    assert start == datetime(2026, 5, 1, 0, 0, 0, tzinfo=UTC)
+
+
+def test_window_start_rejects_naive_datetime() -> None:
+    """A naive datetime is a programming error (silent UTC assumption would be a bug)."""
+    naive = datetime(2026, 5, 27, 14, 32, 11)
+    with pytest.raises(ValueError, match="aware"):
+        window_start_for(BudgetWindowKind.DAILY, naive)
+
+
+# ---------------------------------------------------------------------------
+# apply_consumption
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_consumption_creates_three_buckets_on_miss() -> None:
+    """First charge for a (tenant, principal) inserts daily + weekly + monthly."""
+    tenant_id = await _seed_tenant()
+    when = datetime(2026, 5, 27, 14, 0, 0, tzinfo=UTC)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        buckets = await apply_consumption(
+            session,
+            tenant_id=tenant_id,
+            principal_sub="agent-1",
+            tokens=12_000,
+            cost=Decimal("0.075"),
+            when=when,
+        )
+        await session.commit()
+
+    assert len(buckets) == 3
+    kinds = {b.window_kind for b in buckets}
+    assert kinds == {"daily", "weekly", "monthly"}
+    for bucket in buckets:
+        assert bucket.tokens_consumed == Decimal(12_000)
+        assert bucket.cost_consumed == Decimal("0.075")
+        assert bucket.requests_consumed == 1
+
+
+@pytest.mark.asyncio
+async def test_apply_consumption_increments_existing_buckets_on_hit() -> None:
+    """A second charge in the same window updates rather than inserts."""
+    tenant_id = await _seed_tenant()
+    when = datetime(2026, 5, 27, 14, 0, 0, tzinfo=UTC)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await apply_consumption(
+            session,
+            tenant_id=tenant_id,
+            principal_sub="agent-2",
+            tokens=10_000,
+            cost=Decimal("0.05"),
+            when=when,
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        await apply_consumption(
+            session,
+            tenant_id=tenant_id,
+            principal_sub="agent-2",
+            tokens=5_000,
+            cost=Decimal("0.025"),
+            when=when + timedelta(minutes=5),  # same windows
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(IdentityBudget)
+                    .where(IdentityBudget.principal_sub == "agent-2")
+                    .where(IdentityBudget.tenant_id == tenant_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 3  # still three buckets, not six
+    for row in rows:
+        assert row.tokens_consumed == Decimal(15_000)
+        assert row.cost_consumed == Decimal("0.075")
+        assert row.requests_consumed == 2
+
+
+@pytest.mark.asyncio
+async def test_apply_consumption_rotates_daily_bucket_on_new_day() -> None:
+    """A charge on day N+1 creates a new daily bucket, not a hit on day N."""
+    tenant_id = await _seed_tenant()
+    day_one = datetime(2026, 5, 27, 14, 0, 0, tzinfo=UTC)
+    day_two = datetime(2026, 5, 28, 14, 0, 0, tzinfo=UTC)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await apply_consumption(
+            session,
+            tenant_id=tenant_id,
+            principal_sub="agent-3",
+            tokens=1000,
+            cost=Decimal("0.01"),
+            when=day_one,
+        )
+        await apply_consumption(
+            session,
+            tenant_id=tenant_id,
+            principal_sub="agent-3",
+            tokens=2000,
+            cost=Decimal("0.02"),
+            when=day_two,
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(IdentityBudget)
+                    .where(IdentityBudget.principal_sub == "agent-3")
+                    .where(IdentityBudget.window_kind == "daily")
+                )
+            )
+            .scalars()
+            .all()
+        )
+    # Two daily buckets, distinct window_start.
+    assert len(rows) == 2
+    starts = sorted(r.window_start for r in rows)
+    assert starts[0].day == 27
+    assert starts[1].day == 28
+
+
+# ---------------------------------------------------------------------------
+# set_limits + get_remaining
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_limits_creates_bucket_with_caps() -> None:
+    """Seed limits on a brand-new bucket; consumption stays zero."""
+    tenant_id = await _seed_tenant()
+    when = datetime(2026, 5, 27, 14, 0, 0, tzinfo=UTC)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        bucket = await set_limits(
+            session,
+            tenant_id=tenant_id,
+            principal_sub="agent-4",
+            window_kind=BudgetWindowKind.DAILY,
+            token_limit=1_000_000,
+            cost_limit=Decimal("5.00"),
+            request_limit=100,
+            when=when,
+        )
+        await session.commit()
+    assert bucket.token_limit == Decimal(1_000_000)
+    assert bucket.cost_limit == Decimal("5.00")
+    assert bucket.request_limit == 100
+    assert bucket.tokens_consumed == Decimal(0)
+
+
+@pytest.mark.asyncio
+async def test_get_remaining_returns_gap_after_consumption() -> None:
+    """remaining = limit - consumed; unset limit dimensions surface as None."""
+    tenant_id = await _seed_tenant()
+    when = datetime(2026, 5, 27, 14, 0, 0, tzinfo=UTC)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        await set_limits(
+            session,
+            tenant_id=tenant_id,
+            principal_sub="agent-5",
+            window_kind=BudgetWindowKind.DAILY,
+            token_limit=100_000,
+            cost_limit=Decimal("1.00"),
+            # request_limit intentionally not set -- stays NULL.
+            when=when,
+        )
+        await apply_consumption(
+            session,
+            tenant_id=tenant_id,
+            principal_sub="agent-5",
+            tokens=12_000,
+            cost=Decimal("0.30"),
+            when=when,
+        )
+        await session.commit()
+
+    async with sessionmaker() as session:
+        reading = await get_remaining(
+            session,
+            tenant_id=tenant_id,
+            principal_sub="agent-5",
+            window_kind=BudgetWindowKind.DAILY,
+            when=when,
+        )
+    assert isinstance(reading, BudgetReading)
+    assert reading.token_limit == Decimal(100_000)
+    assert reading.tokens_consumed == Decimal(12_000)
+    assert reading.tokens_remaining == Decimal(88_000)
+    assert reading.cost_limit == Decimal("1.00")
+    assert reading.cost_consumed == Decimal("0.30")
+    assert reading.cost_remaining == Decimal("0.70")
+    assert reading.request_limit is None
+    assert reading.requests_remaining is None
+
+
+@pytest.mark.asyncio
+async def test_get_remaining_returns_empty_reading_when_no_bucket() -> None:
+    """A principal with no budget configured returns zero / None remaining."""
+    tenant_id = await _seed_tenant()
+    when = datetime(2026, 5, 27, 14, 0, 0, tzinfo=UTC)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        reading = await get_remaining(
+            session,
+            tenant_id=tenant_id,
+            principal_sub="unknown-principal",
+            window_kind=BudgetWindowKind.DAILY,
+            when=when,
+        )
+    assert reading.tokens_consumed == Decimal(0)
+    assert reading.cost_consumed == Decimal(0)
+    assert reading.requests_consumed == 0
+    assert reading.token_limit is None
+    assert reading.cost_limit is None
+    assert reading.request_limit is None
+    assert reading.tokens_remaining is None
+    assert reading.cost_remaining is None
+    assert reading.requests_remaining is None

--- a/backend/tests/test_migration_0031_identity_budget.py
+++ b/backend/tests/test_migration_0031_identity_budget.py
@@ -1,0 +1,342 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0031_create_identity_budget``.
+
+Initiative #806 (G11.5 Portability + cost), Task #1079 (G11.5-T5). The
+migration adds the ``identity_budget`` table -- one row per
+(tenant, principal, window-kind, window-start) budget bucket, carrying
+optional limits + consumption counters.
+
+Test matrix
+-----------
+
+* **Upgrade creates the table + columns + indexes.** ``upgrade head``
+  from a clean DB leaves ``identity_budget`` present with every
+  documented column and its named index.
+* **Reversibility round-trip.** ``downgrade "0030"`` (0031's
+  ``down_revision``) drops the table; a subsequent ``upgrade head``
+  re-creates it.
+* **audit_log / agent_run untouched.** The migration must not disturb
+  pre-existing tables.
+* **Column nullability.** The nullable columns (``token_limit`` /
+  ``cost_limit`` / ``request_limit``) permit NULL; the NOT NULL columns
+  reject it.
+* **Window-kind CHECK + uniqueness constraint** behave correctly at
+  the DB layer.
+
+Follows the synchronous pattern of
+:mod:`tests.test_migration_0023_approval_request`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL."""
+    db_path = tmp_path / "migration_0031.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _table_names(sync_url: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text("SELECT name FROM sqlite_master WHERE type = 'table'")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[0]) for row in rows}
+
+
+def _table_columns(sync_url: str, table: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def _column_is_nullable(sync_url: str, table: str, column: str) -> bool:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    finally:
+        sync_eng.dispose()
+    for row in rows:
+        if str(row[1]) == column:
+            return int(row[3]) == 0
+    raise AssertionError(f"column {column!r} not present on {table}")
+
+
+def _table_indexes(sync_url: str, table: str) -> set[str]:
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA index_list({table})")).all()
+    finally:
+        sync_eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_creates_identity_budget_table(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``upgrade head`` creates the ``identity_budget`` table."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+    assert "identity_budget" in _table_names(sync_url)
+
+
+def test_upgrade_creates_expected_columns(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``identity_budget`` has every documented column after upgrade."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+    cols = _table_columns(sync_url, "identity_budget")
+    expected = {
+        "id",
+        "tenant_id",
+        "principal_sub",
+        "window_kind",
+        "window_start",
+        "window_end",
+        "token_limit",
+        "cost_limit",
+        "request_limit",
+        "tokens_consumed",
+        "cost_consumed",
+        "requests_consumed",
+        "created_at",
+        "updated_at",
+    }
+    assert expected <= cols
+
+
+def test_upgrade_creates_named_index(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """The documented index exists after upgrade."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+    idx = _table_indexes(sync_url, "identity_budget")
+    assert "identity_budget_tenant_principal_idx" in idx
+
+
+def test_limits_columns_are_nullable(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """Optional-limit columns permit NULL (NULL = no cap)."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+    for col in ("token_limit", "cost_limit", "request_limit"):
+        assert _column_is_nullable(sync_url, "identity_budget", col), (
+            f"{col} must be nullable (NULL means no cap)"
+        )
+
+
+def test_consumption_columns_are_not_nullable(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """Consumption columns reject NULL (default 0)."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+    for col in ("tokens_consumed", "cost_consumed", "requests_consumed"):
+        assert not _column_is_nullable(sync_url, "identity_budget", col), (
+            f"{col} must be NOT NULL with default 0"
+        )
+
+
+def test_keying_columns_are_not_nullable(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """tenant_id / principal_sub / window_kind / window_start / window_end are NOT NULL."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+    for col in (
+        "tenant_id",
+        "principal_sub",
+        "window_kind",
+        "window_start",
+        "window_end",
+    ):
+        assert not _column_is_nullable(sync_url, "identity_budget", col), (
+            f"{col} must be NOT NULL (keying / boundary column)"
+        )
+
+
+def test_window_kind_check_constraint_rejects_unknown(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """The window_kind CHECK refuses values outside the closed enum."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    # Bootstrap a tenant row so the FK insert can succeed.
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO tenant (id, slug, name, created_at) "
+                    "VALUES (:id, :slug, :name, '2026-05-27 00:00:00')"
+                ),
+                {
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "slug": "t1",
+                    "name": "Tenant One",
+                },
+            )
+
+        # A row with a bogus window_kind must be rejected by the CHECK.
+        with pytest.raises(IntegrityError), sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO identity_budget ("
+                    "id, tenant_id, principal_sub, window_kind, "
+                    "window_start, window_end, tokens_consumed, "
+                    "cost_consumed, requests_consumed, created_at, updated_at"
+                    ") VALUES ("
+                    ":id, :tid, 'sub-1', 'fortnightly', "
+                    "'2026-05-27 00:00:00', '2026-05-28 00:00:00', "
+                    "0, 0, 0, '2026-05-27 00:00:00', '2026-05-27 00:00:00')"
+                ),
+                {
+                    "id": "22222222-2222-2222-2222-222222222222",
+                    "tid": "11111111-1111-1111-1111-111111111111",
+                },
+            )
+    finally:
+        sync_eng.dispose()
+
+
+def test_unique_constraint_rejects_duplicate_bucket(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """A duplicate (tenant, principal, kind, start) row is refused."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    sync_eng = sa_create_engine(sync_url)
+    try:
+        with sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO tenant (id, slug, name, created_at) "
+                    "VALUES (:id, :slug, :name, '2026-05-27 00:00:00')"
+                ),
+                {
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "slug": "t1",
+                    "name": "Tenant One",
+                },
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO identity_budget ("
+                    "id, tenant_id, principal_sub, window_kind, "
+                    "window_start, window_end, tokens_consumed, "
+                    "cost_consumed, requests_consumed, created_at, updated_at"
+                    ") VALUES ("
+                    ":id, :tid, 'sub-1', 'daily', "
+                    "'2026-05-27 00:00:00', '2026-05-28 00:00:00', "
+                    "0, 0, 0, '2026-05-27 00:00:00', '2026-05-27 00:00:00')"
+                ),
+                {
+                    "id": "33333333-3333-3333-3333-333333333333",
+                    "tid": "11111111-1111-1111-1111-111111111111",
+                },
+            )
+
+        with pytest.raises(IntegrityError), sync_eng.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO identity_budget ("
+                    "id, tenant_id, principal_sub, window_kind, "
+                    "window_start, window_end, tokens_consumed, "
+                    "cost_consumed, requests_consumed, created_at, updated_at"
+                    ") VALUES ("
+                    ":id, :tid, 'sub-1', 'daily', "
+                    "'2026-05-27 00:00:00', '2026-05-28 00:00:00', "
+                    "0, 0, 0, '2026-05-27 00:00:00', '2026-05-27 00:00:00')"
+                ),
+                {
+                    "id": "44444444-4444-4444-4444-444444444444",
+                    "tid": "11111111-1111-1111-1111-111111111111",
+                },
+            )
+    finally:
+        sync_eng.dispose()
+
+
+def test_pre_existing_tables_undisturbed(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """The migration touches no other table.
+
+    A sanity check that ``identity_budget`` lands additively without
+    column changes on ``audit_log`` / ``agent_run`` / ``agent_permission``.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+    # Spot-check three pre-existing tables.
+    for table in ("audit_log", "agent_run", "agent_permission"):
+        assert table in _table_names(sync_url), (
+            f"{table} must still be present after migration 0031"
+        )
+
+
+def test_reversibility_round_trip(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """downgrade to 0030 drops the table; upgrade recreates it."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+    assert "identity_budget" in _table_names(sync_url)
+
+    command.downgrade(cfg, "0030")
+    assert "identity_budget" not in _table_names(sync_url)
+
+    command.upgrade(cfg, "head")
+    assert "identity_budget" in _table_names(sync_url)

--- a/docs/codebase/identity-budget.md
+++ b/docs/codebase/identity-budget.md
@@ -1,0 +1,219 @@
+# identity-budget — per-identity token / cost / request budgets, per-window
+
+## Overview
+
+`identity_budget` is the data substrate for per-principal LLM consumption
+caps. Initiative #806 (G11.5 Portability + cost) attaches budgets to
+**any** MEHO principal — human user, service account, or agent — keyed
+on a `(tenant, principal, window-kind, window-start)` tuple. Task #1079
+(G11.5-T5 / C3-a) ships:
+
+- The **table** (`identity_budget`, migration `0031`) and its ORM model
+  (`IdentityBudget`) with optional limits + NOT-NULL consumption.
+- A **per-op cost source**: a pricing table keyed on resolved
+  `provider:model_id` (`MODEL_PRICING`) and a `compute_cost(usage,
+  model_id) -> Decimal` function over a finished run's `RunUsage`.
+- A **consumption service** (`meho_backplane.operations.identity_budget`)
+  exposing `apply_consumption`, `set_limits`, `get_remaining`, plus the
+  window-truncation helper `window_start_for`.
+- **Runtime wiring**: `_finalize_run` in `agent/invocation.py` computes
+  cost on every successful run, stamps it on `agent_run.cost`, and
+  increments the three active budget buckets (daily + weekly + monthly)
+  atomically in the same transaction as the `succeed_run` transition.
+
+Enforcement (the *"refuse at the cap, downgrade at the threshold"*
+half) lands in Task #1080 (G11.5-T6 / C3-b). This task is intentionally
+**observational only** — it records, it does not block.
+
+## Key types
+
+| Type | Where | Role |
+|---|---|---|
+| `IdentityBudget` (ORM) | `db/models.py` | The durable bucket row |
+| `BudgetWindowKind` | `db/models.py` | Closed enum (`daily` / `weekly` / `monthly`) backed by a DB-level CHECK |
+| `PerMillionPricing` | `operations/identity_budget.py` | Per-1M-token published rates for one model |
+| `MODEL_PRICING` | `operations/identity_budget.py` | The pinned `provider:model -> PerMillionPricing` map |
+| `TokenUsage` | `operations/identity_budget.py` | Framework-free token-stream record (input / output / cache-read / cache-write) |
+| `BudgetReading` | `operations/identity_budget.py` | Read-side view: limits + consumption + remaining-headroom |
+
+## Control flow
+
+```
+                 ┌─────────────────────────────┐
+agent_run loop ─►│ AgentRun.start / .result    │
+                 │  (PydanticAgentRun)         │
+                 └──────────────┬──────────────┘
+                                │ RunUsage(input, output,
+                                │   cache_read, cache_write,
+                                │   requests, tool_calls)
+                                ▼
+                  ┌──────────────────────────────┐
+                  │ AgentRunResult (extended)    │
+                  │  • request_count             │
+                  │  • tool_call_count           │
+                  │  • input_tokens              │
+                  │  • output_tokens             │
+                  │  • cache_read_tokens         │
+                  │  • cache_write_tokens        │
+                  └──────────────┬───────────────┘
+                                 │ TokenUsage
+                                 ▼
+            ┌─────────────────────────────────────────┐
+            │ AgentInvoker._finalize_run              │
+            │  (success path)                         │
+            │                                         │
+            │  1. provider:model = _full_model_id(.)  │
+            │  2. cost = compute_cost(usage, full_id) │
+            │  3. succeed_run(session, row, cost=...) │
+            │  4. apply_consumption(session, ...)     │
+            │  5. commit                              │
+            └─────────────────────────────────────────┘
+                                 │
+                                 ▼
+               ┌─────────────────────────────────────┐
+               │ identity_budget rows (per window)    │
+               │  • daily  (00:00 UTC of today)       │
+               │  • weekly (Monday 00:00 UTC of week) │
+               │  • monthly (1st 00:00 UTC of month)  │
+               └─────────────────────────────────────┘
+```
+
+A **failed** run skips steps 1-4 entirely; `agent_run.cost` stays NULL
+and no budget rows materialise. Future enforcement may opt to charge
+best-effort partial usage on failure, but the v0.2 contract is
+"failed runs cost nothing".
+
+## The pricing table
+
+`MODEL_PRICING` is a `Final[dict[str, PerMillionPricing]]` pinned at
+import time. The keys are the **resolved** provider-prefixed ids the
+runtime emits via `AgentRunAuditMeta.model` (e.g.
+`anthropic:claude-sonnet-4-6`). The runtime calls `compute_cost(usage,
+model_id)` with the *resolved* id, not the operator-facing logical
+tier, so the table keys directly on what the provider was actually
+billed for.
+
+Why in code and not the DB:
+
+- Per-1M-token rates are published-by-provider quantities. The cadence
+  is the provider's calendar, not MEHO's.
+- A code-resident table lands rate bumps through code review, the same
+  path that adds new models to the resolver in G11.5-C4.
+- A DB-row pricing table invites drift between published rates and
+  the live row, plus adds a join to every cost computation.
+
+An unknown model id (lookup miss) yields `Decimal(0)` and logs a
+single `warning` per process — the "known unknown" contract. The gate
+that prevents a run from *starting* against an un-priced model lives
+in the multi-provider resolver (G11.5-C4).
+
+## Window truncation
+
+`window_start_for(kind, when)` truncates a UTC-aware datetime to the
+inclusive lower bound of its bucket:
+
+- **Daily** — 00:00 UTC of the same calendar day.
+- **Weekly** — 00:00 UTC of the Monday of the same ISO week
+  (`isoweekday() == 1`).
+- **Monthly** — 00:00 UTC of the 1st of the same calendar month.
+
+The window end is computed by `_window_end_for` (`+1 day` / `+7 days`
+/ next-month-1st) and persisted on the row so audit reads do not have
+to re-derive the boundary.
+
+Truncation lives **in code, not in the DB**, so:
+
+- The Alembic migration stays portable across SQLite + PG without
+  dialect-specific generated columns.
+- The truncation rule is unit-testable without spinning up the DB
+  (`test_identity_budget_service.py::test_window_start_*`).
+
+## Upserts and the unique-key contract
+
+Each bucket is uniquely identified by
+`(tenant_id, principal_sub, window_kind, window_start)` — enforced
+both at the DB layer (`uq_identity_budget_window` UNIQUE constraint)
+and by the consumption service's
+`_get_or_create_bucket`. The composite UNIQUE serves as the upsert
+race guard: a concurrent INSERT from a second writer surfaces as
+`IntegrityError` on flush, and the caller's retry path lands on the
+now-existing row.
+
+## Schema column rationale
+
+| Column | Type | Nullable | Why |
+|---|---|---|---|
+| `id` | UUID | NO | Stable handle (no cross-table refs in v0.2) |
+| `tenant_id` | UUID FK → `tenant(id)` | NO | Real FK, brand-new clean-slate table |
+| `principal_sub` | Text | NO | JWT `sub`; soft-FK (could be human / service / agent) |
+| `window_kind` | Text + CHECK | NO | Closed `BudgetWindowKind` vocabulary |
+| `window_start` | timestamptz | NO | Inclusive lower bound; truncated to boundary |
+| `window_end` | timestamptz | NO | Exclusive upper bound (computed) |
+| `token_limit` | Numeric(20,0) | YES | NULL = no token cap |
+| `cost_limit` | Numeric(14,6) | YES | NULL = no cost cap; money-shape precision |
+| `request_limit` | Integer | YES | NULL = no request cap |
+| `tokens_consumed` | Numeric(20,0) | NO | Default 0; wider than Integer for hot-cache cases |
+| `cost_consumed` | Numeric(14,6) | NO | Default 0; money-shape precision |
+| `requests_consumed` | Integer | NO | Default 0 |
+| `created_at` | timestamptz | NO | PG `now()`; ORM fallback for SQLite |
+| `updated_at` | timestamptz | NO | Bumped by service on every consumption / set_limits call |
+
+## Indexes
+
+- `uq_identity_budget_window` (UNIQUE) — drives upsert + serves as race guard.
+- `ck_identity_budget_window_kind` (CHECK) — closes the window-kind vocabulary at the DB layer.
+- `identity_budget_tenant_principal_idx` (b-tree) — drives the dominant query: *"find the active buckets for this principal in this tenant"*.
+
+The `(window_kind)` filter on top of the b-tree is cheap in-memory because the row count per principal is bounded by **three buckets per period** (one each for daily / weekly / monthly).
+
+## Dependencies
+
+- **Upstream:** `agent_run` table (#813), `agent_principal` table (#815),
+  `tenant` table (G0.1). All present on `main`.
+- **Downstream consumer (sibling):** G11.5-T6 / C3-b (#1080) — the
+  pre-execution enforcement gate + degradation policy. Reads
+  `BudgetReading` from `get_remaining` and decides
+  `auto-execute | downgrade-tier | refuse`.
+
+## Known issues
+
+- **Single token-stream limit.** The DB has one `token_limit` field;
+  enforcement that wants to cap *output tokens specifically* (vs.
+  total tokens) cannot do that with `IdentityBudget` alone. The
+  consumption service tracks all four streams on the row's
+  `tokens_consumed` aggregate, so the enforcement gate can read the
+  per-stream amounts off `agent_run.cost` × pricing if needed in
+  v1.next; a per-stream limit column would be additive.
+- **No retention policy.** Old buckets accumulate indefinitely; a
+  cleanup job (G11.5-T-followup or G11.3 scheduler trigger) is the
+  natural home but is not scoped in v1.
+- **Child runs do not separately charge consumption.** Pydantic AI
+  shares the parent run's `RunUsage` across `invoke_agent` cascades
+  (`usage=usage` in `run_child`), so the parent's terminal usage
+  reflects the whole cascade. Applying consumption again on each
+  child's `_finalize_child_run` would double-charge. The
+  `_finalize_child_run` path calls `_finalize_run` without
+  `usage=`, which the `if usage is not None` guard turns into a
+  no-op for consumption. This is the right answer in the shared-
+  usage world; a hypothetical per-child cost attribution would need
+  RFC 8693 act-claim chain attribution (out of scope for this
+  initiative).
+
+## References
+
+- Migration: `backend/alembic/versions/0031_create_identity_budget.py`
+- ORM: `IdentityBudget` + `BudgetWindowKind` in
+  `backend/src/meho_backplane/db/models.py`
+- Service: `backend/src/meho_backplane/operations/identity_budget.py`
+- Runtime wiring: `_finalize_run` + `_full_model_id` in
+  `backend/src/meho_backplane/agent/invocation.py`
+- Result-shape extension: `AgentRunResult` token fields in
+  `backend/src/meho_backplane/agent/run.py`
+- Tests:
+  - `backend/tests/test_migration_0031_identity_budget.py`
+  - `backend/tests/test_db_identity_budget.py`
+  - `backend/tests/test_identity_budget_service.py`
+  - `backend/tests/test_agent_run_consumption.py`
+- Initiative #806 §C3; Task #1079; sibling Task #1080 (C3-b
+  enforcement gate).
+- Anthropic published pricing (as of 2026-05-27).


### PR DESCRIPTION
## Summary
- Adds the data substrate for per-identity LLM budget caps (Initiative #806 / G11.5 Portability + cost): each MEHO principal (human / service / agent) now gets per-(daily, weekly, monthly) buckets carrying optional limits + NOT-NULL consumption counters, keyed on `(tenant_id, principal_sub, window_kind, window_start)`.
- Adds the per-op cost source: a pinned `MODEL_PRICING` table for current Anthropic models + `compute_cost(usage, model_id) -> Decimal` keyed on the resolved `provider:model` id the runtime stamps on `agent_run.model`.
- Wires the agent runtime: `_finalize_run` in `agent/invocation.py` now computes cost on every successful run, stamps `agent_run.cost`, and increments the three active budget buckets atomically with the `succeed_run` transition. Failed runs charge nothing (v0.2 contract).

## Test plan
- [x] `ruff check` — clean (modified src + tests + alembic 0031)
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/` — `Success: no issues found in 366 source files`
- [x] `scripts/ci/check_migration_compat.py` — exit 0 (additive migration; the "Backward-compat migration guard" the AC requires)
- [x] `pytest tests/test_migration_0031_identity_budget.py` — 10 passed (upgrade / reversibility / CHECK + UNIQUE behaviour / column nullability / pre-existing tables untouched)
- [x] `pytest tests/test_db_identity_budget.py` — 5 passed (ORM round-trip / composite uniqueness / enum drift guard / NULL limits)
- [x] `pytest tests/test_identity_budget_service.py` — 13 passed (compute_cost / window_start_for / apply_consumption upsert+rotation / set_limits / get_remaining)
- [x] `pytest tests/test_agent_run_consumption.py` — 3 passed (the AC: a real `AgentInvoker.run` against a FunctionModel stamping known usage → `agent_run.cost` set + three IdentityBudget rows materialise + get_remaining = limit - consumed; failure path skips consumption)
- [x] `pytest tests/ -q --ignore=tests/acceptance` — **5303 passed, 217 skipped, 0 failed** (full unit + integration; confirms no regressions, including the `test_truncate_list_drift` guard which gated on `identity_budget` being added to both conftests)

## Acceptance criteria
- [x] A migration adds the budget table (principal + window + limits + consumed); the `Backward-compat migration guard` is green — migration `0031_create_identity_budget` is additive, covered by `check_migration_compat.py`.
- [x] Consumption increments from a real run's usage; a query returns remaining budget per identity/window — `test_finished_run_stamps_cost_and_applies_consumption` + `test_get_remaining_after_run_reports_correct_gap` in `tests/test_agent_run_consumption.py`.
- [x] `Python (ruff + mypy + pytest)` green.

## Out of scope (per task body)
- Enforcement / degradation policy / kill switch — that is sibling task #1080 (C3-b). This task is **observational only**: it records, it does not block.
- Per-call-source chain attribution (the `act` claim + `parent_audit_id` follow-up) — out of scope per Initiative #806.

## Adjacent findings (recorded; no edits)
- None. The scope was the touched seam (`_finalize_run` in `agent/invocation.py`) plus the new module + table; pricing for additional providers + a UI / dashboard route for `get_remaining` will land naturally with C4 and the operator surface.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1079
