### PR TITLE
feat(connectors): G0.14-T12 KubernetesConnector.discover_topology populator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,38 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Added
+
+- **`KubernetesConnector.discover_topology` populator — closes v0.6.0
+  signal-13 amendment promise (G0.14-T12 #1201).** First shipped
+  override of `Connector.discover_topology` against the K8s connector
+  the typed-connector dispatch exercise proved live in v0.6.0. Emits
+  one `target`-kinded `NodeHint` for the cluster (properties: server
+  `git_version` / `major` / `minor` / `platform` — same payload
+  `k8s.about` returns, no extra round-trip), one `namespace` `NodeHint`
+  per namespace (properties from `namespace_row` — `status` /
+  `age_seconds` / `labels`), one `node` `NodeHint` per cluster node
+  (properties from `node_row` — `roles` / kubelet `version` / `kernel`
+  / …), plus `belongs-to` `EdgeHint`s from every namespace and every
+  cluster node to the target. Pods / services / ingresses /
+  deployments / volumes are **explicitly out of scope** at v0.7 — each
+  would multiply the per-refresh API-call cost in proportion to
+  namespace count, and the v0.7.x deploy hasn't surfaced refresh-cost
+  data yet; sibling Tasks land them when justified. The
+  [refresh service](backend/src/meho_backplane/topology/refresh.py)
+  forwards the per-tenant system operator the scheduler already
+  synthesises (`_system_operator` in `topology/scheduler.py`) via
+  `inspect.signature`-based detection on the bound `discover_topology`
+  method — `Connector` ABC stays unchanged, connectors whose override
+  doesn't declare `operator` run verbatim. The deleted regression at
+  `backend/tests/test_connectors_topology.py:231` (which asserted
+  `KubernetesConnector.discover_topology is Connector.discover_topology`)
+  is itself the test that this Task ran. Closes
+  `claude-rdc-hetzner-dc#697` signal 13
+  (`topology-refresh-no-populator-for-k8s`) and the v0.6.0 GitHub
+  release body's "topology populators land in v0.7" honesty callout.
+  (#1201)
+
 ## [0.7.0] - 2026-05-27
 
 **MVP6 — agent runtime floor (P1 + P2 + P3) + safety (C1 sanitization)

--- a/backend/src/meho_backplane/connectors/kubernetes/_topology.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/_topology.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Topology-populator helpers for :class:`KubernetesConnector`.
+
+G0.14-T12 (#1201) lands the first
+:meth:`~meho_backplane.connectors.base.Connector.discover_topology`
+override against a shipped connector, closing the v0.6.0 release-body
+amendment promise (`claude-rdc-hetzner-dc#697` signal 13).
+
+The populator scope at v0.7 is deliberately minimal:
+
+* one ``target`` :class:`NodeHint` per cluster, properties carrying the
+  cluster's Kubernetes server version (same ``VersionApi.get_code``
+  payload :meth:`KubernetesConnector.fingerprint` and
+  :meth:`KubernetesConnector.about` already issue);
+* one ``namespace`` :class:`NodeHint` per namespace, properties built
+  from the existing
+  :func:`~meho_backplane.connectors.kubernetes.ops_core.namespace_row`
+  projection (``status`` / ``age_seconds`` / ``labels``);
+* one ``node`` :class:`NodeHint` per cluster node, properties built
+  from the existing
+  :func:`~meho_backplane.connectors.kubernetes.ops_core.node_row`
+  projection (``roles`` / ``version`` (kubelet) / ``kernel``);
+* one ``belongs-to`` :class:`EdgeHint` from each namespace to the
+  target node;
+* one ``belongs-to`` :class:`EdgeHint` from each cluster node to the
+  target node.
+
+Pods / services / ingresses / deployments / volumes are explicitly out
+of scope for v0.7 — each would multiply the per-refresh API-call cost
+(a 100-namespace cluster would mean 100 list calls per refresh tick)
+and the v0.7.x deploy hasn't surfaced refresh-cost data yet. Sibling
+Tasks under #1139 (or a future G9.4) will land them when the cost
+picture justifies it.
+
+The helpers live in this dedicated module (rather than inline on
+``connector.py``) for the same reason
+:mod:`~meho_backplane.connectors.kubernetes.ops_core` separates its
+row-shape helpers from the connector: the tests can pin the wire
+shape against synthetic :class:`V1Namespace` / :class:`V1Node` model
+instances without booting an event loop.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from meho_backplane.connectors.kubernetes.ops_core import namespace_row, node_row
+from meho_backplane.connectors.schemas import EdgeHint, NodeHint, TopologyHints
+
+if TYPE_CHECKING:
+    from kubernetes_asyncio.client.models import V1Namespace, V1Node, VersionInfo
+
+__all__ = [
+    "build_target_node_hint",
+    "build_topology_hints",
+    "namespace_node_hint",
+    "namespace_to_target_edge",
+    "node_node_hint",
+    "node_to_target_edge",
+]
+
+
+def build_target_node_hint(
+    target_name: str,
+    version: VersionInfo | None,
+) -> NodeHint:
+    """Build the cluster's ``target`` :class:`NodeHint`.
+
+    ``cluster`` is not in the v0.2 :data:`NodeKind` enum (the enum is
+    closed per ``connectors/schemas.py``); represent the cluster as a
+    ``target``-kinded node so the refresh service can wire the
+    namespace and node ``belongs-to`` edges back to it.
+
+    Properties carry the cluster's Kubernetes server version data —
+    the same ``VersionApi.get_code()`` payload :meth:`fingerprint` and
+    :meth:`about` already pull, so the populator pays no extra
+    round-trip to expose it. ``version`` may be ``None`` (testing /
+    network failure tolerance); in that case ``properties`` is an
+    empty dict.
+    """
+    properties: dict[str, Any] = {}
+    if version is not None:
+        # Mirror the ``about`` op's flat-dict projection so the row's
+        # shape is operator-recognisable across both surfaces.
+        properties = {
+            "git_version": version.git_version,
+            "major": version.major,
+            "minor": version.minor,
+            "platform": version.platform,
+        }
+    return NodeHint(kind="target", name=target_name, properties=properties)
+
+
+def namespace_node_hint(ns: V1Namespace, *, now: datetime | None = None) -> NodeHint:
+    """Project a :class:`V1Namespace` into a ``namespace`` :class:`NodeHint`.
+
+    Re-uses :func:`namespace_row` so the populator and the
+    ``k8s.namespace.list`` op share their wire shape — operators
+    inspecting the graph row see the same ``status`` / ``age_seconds``
+    / ``labels`` fields they see in the inventory listing.
+
+    The row's ``name`` field is dropped from ``properties`` (it
+    becomes :attr:`NodeHint.name`); the rest survives verbatim. A
+    namespace whose ``metadata.name`` is ``None`` (a corrupt fixture,
+    in practice never seen in the wild — the API server requires it)
+    is **not** filtered here; the caller is responsible for skipping
+    it before the row would land in the snapshot.
+    """
+    row = namespace_row(ns, now=now)
+    name = row["name"] or ""
+    properties = {k: v for k, v in row.items() if k != "name"}
+    return NodeHint(kind="namespace", name=name, properties=properties)
+
+
+def node_node_hint(node: V1Node, *, now: datetime | None = None) -> NodeHint:
+    """Project a :class:`V1Node` into a ``node`` :class:`NodeHint`.
+
+    Re-uses :func:`node_row` so the populator and the ``k8s.node.list``
+    op share their wire shape. ``roles`` / ``version`` (kubelet) /
+    ``kernel`` are the load-bearing fields per the issue body's
+    desired-state spec; the rest of the projection rides along.
+    """
+    row = node_row(node, now=now)
+    name = row["name"] or ""
+    properties = {k: v for k, v in row.items() if k != "name"}
+    return NodeHint(kind="node", name=name, properties=properties)
+
+
+def namespace_to_target_edge(namespace_name: str, target_name: str) -> EdgeHint:
+    """Build the ``namespace --belongs-to--> target`` :class:`EdgeHint`."""
+    return EdgeHint(
+        from_kind="namespace",
+        from_name=namespace_name,
+        to_kind="target",
+        to_name=target_name,
+        kind="belongs-to",
+    )
+
+
+def node_to_target_edge(node_name: str, target_name: str) -> EdgeHint:
+    """Build the ``node --belongs-to--> target`` :class:`EdgeHint`."""
+    return EdgeHint(
+        from_kind="node",
+        from_name=node_name,
+        to_kind="target",
+        to_name=target_name,
+        kind="belongs-to",
+    )
+
+
+def build_topology_hints(
+    target_name: str,
+    version: VersionInfo | None,
+    namespaces: list[V1Namespace],
+    nodes: list[V1Node],
+    *,
+    now: datetime | None = None,
+) -> TopologyHints:
+    """Assemble the full :class:`TopologyHints` for a Kubernetes cluster.
+
+    Pure function over already-fetched API responses so the unit suite
+    can drive it with synthetic :class:`V1Namespace` / :class:`V1Node`
+    fixtures. The connector's
+    :meth:`~KubernetesConnector.discover_topology` issues the three
+    round-trips (``VersionApi.get_code()`` /
+    ``CoreV1Api.list_namespace()`` / ``CoreV1Api.list_node()``) and
+    hands the results in here.
+
+    Namespaces or nodes with a missing ``metadata.name`` are skipped —
+    we cannot emit a ``belongs-to`` edge for an object we can't
+    identify, and the refresh service's natural key is
+    ``(kind, name)``. The API server enforces ``metadata.name`` on
+    every persisted object so this is defensive-only.
+
+    ``now`` is parameterised for test-determinism (the
+    :func:`age_seconds` derivation inside the row helpers); production
+    callers leave it ``None`` and the helpers resolve
+    :func:`datetime.now` at call time.
+    """
+    discovered_at = datetime.now(UTC) if now is None else now
+
+    node_hints: list[NodeHint] = [build_target_node_hint(target_name, version)]
+    edge_hints: list[EdgeHint] = []
+
+    for ns in namespaces:
+        if ns.metadata is None or not ns.metadata.name:
+            continue
+        node_hints.append(namespace_node_hint(ns, now=now))
+        edge_hints.append(namespace_to_target_edge(ns.metadata.name, target_name))
+
+    for n in nodes:
+        if n.metadata is None or not n.metadata.name:
+            continue
+        node_hints.append(node_node_hint(n, now=now))
+        edge_hints.append(node_to_target_edge(n.metadata.name, target_name))
+
+    return TopologyHints(
+        nodes=tuple(node_hints),
+        edges=tuple(edge_hints),
+        discovered_at=discovered_at,
+    )

--- a/backend/src/meho_backplane/connectors/kubernetes/connector.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/connector.py
@@ -79,6 +79,7 @@ from meho_backplane.connectors.schemas import (
     FingerprintResult,
     OperationResult,
     ProbeResult,
+    TopologyHints,
 )
 
 __all__ = ["KubernetesConnector", "product_from_git_version"]
@@ -397,6 +398,72 @@ class KubernetesConnector(Connector):
             "git_commit": version.git_commit,
             "git_tree_state": version.git_tree_state,
         }
+
+    async def discover_topology(
+        self,
+        target: KubernetesTargetLike,
+        *,
+        operator: Operator | None = None,
+    ) -> TopologyHints:
+        """Return cluster + namespaces + nodes as a :class:`TopologyHints`.
+
+        Op-side: this is the G0.14-T12 (#1201) populator the refresh
+        service (:func:`meho_backplane.topology.refresh.refresh_target_topology`)
+        calls on demand and on the per-tenant scheduled tick. The
+        returned snapshot is diffed against the existing ``graph_node`` +
+        ``graph_edge`` rows for ``(operator.tenant_id, target.id)`` and
+        applied as inserts / updates / soft-deletes.
+
+        Scope (deliberately minimal for v0.7):
+
+        * one ``target`` :class:`NodeHint` for the cluster — properties
+          carry the K8s server version, the same ``VersionApi.get_code()``
+          payload :meth:`about` already issues. ``cluster`` is not in the
+          v0.2 :data:`NodeKind` enum (the enum is closed per
+          ``connectors/schemas.py``) so the cluster manifests as
+          ``kind="target"``.
+        * one ``namespace`` :class:`NodeHint` per namespace — properties
+          from :func:`namespace_row` (``status`` / ``age_seconds`` /
+          ``labels``).
+        * one ``node`` :class:`NodeHint` per cluster node — properties
+          from :func:`node_row` (``roles`` / ``version`` /
+          ``kernel``…).
+        * one ``belongs-to`` :class:`EdgeHint` from each namespace and
+          each cluster node to the target node.
+
+        Pods / services / ingresses / deployments / volumes are
+        **explicitly out of scope** — each would multiply the
+        per-refresh API-call cost in proportion to the namespace count.
+        Sibling Tasks land them when refresh-cost data justifies the
+        spend.
+
+        ``operator`` is keyword-only with a ``None`` default to keep the
+        :class:`Connector` ABC signature unchanged while letting the
+        refresh service forward the per-tenant system operator the
+        scheduler synthesises
+        (:func:`~meho_backplane.topology.scheduler._system_operator`).
+        The forwarded operator flows through :meth:`_get_api_client` so
+        the operator-context Vault → kubeconfig chain reads under the
+        scheduler's synthetic tenant identity. The ``None`` fall-back
+        synthesises the system operator the fingerprint/probe paths
+        already use, so a direct caller (test, future on-demand surface
+        that doesn't yet thread the operator) still works closed-loop.
+        """
+        from meho_backplane.connectors.kubernetes._topology import build_topology_hints
+
+        eff_operator = operator if operator is not None else synthesise_system_operator()
+        api_client = await self._get_api_client(target, eff_operator)
+        version_api = client.VersionApi(api_client)
+        core_v1 = client.CoreV1Api(api_client)
+        version = await version_api.get_code()
+        namespaces_resp = await core_v1.list_namespace()
+        nodes_resp = await core_v1.list_node()
+        return build_topology_hints(
+            target_name=target.name,
+            version=version,
+            namespaces=list(namespaces_resp.items or []),
+            nodes=list(nodes_resp.items or []),
+        )
 
     async def k8s_namespace_list(
         self,

--- a/backend/src/meho_backplane/topology/refresh.py
+++ b/backend/src/meho_backplane/topology/refresh.py
@@ -37,6 +37,7 @@ defaults hold without a redactor pass (Initiative #363 item 11).
 
 from __future__ import annotations
 
+import inspect
 import time
 import uuid
 from datetime import UTC, datetime
@@ -931,6 +932,46 @@ async def _apply_reconcile(
     return result
 
 
+async def _invoke_discover_topology(
+    connector: Connector,
+    target: Any,
+    operator: Operator,
+) -> TopologyHints:
+    """Call ``connector.discover_topology(target)``, forwarding the operator when accepted.
+
+    G0.14-T12 (#1201) lands the first
+    :class:`~meho_backplane.connectors.base.Connector` override that needs
+    the acting operator in scope — the populator on
+    :class:`~meho_backplane.connectors.kubernetes.connector.KubernetesConnector`
+    re-uses the per-target ``_get_api_client(target, operator)`` chain to
+    read the cluster's namespaces + nodes under the per-tenant system
+    operator the scheduler already synthesises. Out of scope for that
+    Task: changing the :class:`Connector` ABC signature (refresh-service
+    internal, not a connector-level contract change).
+
+    The refresh service therefore forwards ``operator`` as a
+    **refresh-private bound keyword argument** when the override
+    declares it. Connectors that inherit the base no-op default (every
+    shipped connector except K8s as of v0.7.x) keep their
+    ``(self, target)`` signature and are invoked unchanged. Signature
+    introspection on the bound method is the same shape the K8s
+    dispatcher shim already uses in
+    :meth:`~meho_backplane.connectors.kubernetes.connector.KubernetesConnector.execute`
+    to detect operator-aware typed handlers.
+    """
+    method = connector.discover_topology
+    params = inspect.signature(method).parameters
+    if "operator" in params:
+        # Forwarded as a refresh-private bound keyword argument; the
+        # Connector ABC declares ``discover_topology(self, target)`` so
+        # mypy sees the base signature here. Overrides that opt into
+        # the keyword (currently KubernetesConnector — G0.14-T12 #1201)
+        # declare ``operator`` keyword-only so this call lands on the
+        # override unambiguously.
+        return await method(target, operator=operator)  # type: ignore[call-arg]
+    return await method(target)
+
+
 async def refresh_target_topology(
     target: Any,
     operator: Operator,
@@ -970,7 +1011,7 @@ async def refresh_target_topology(
 
     connector_cls = resolve_connector(target)
     connector: Connector = get_or_create_connector_instance(connector_cls)
-    hints: TopologyHints = await connector.discover_topology(target)
+    hints: TopologyHints = await _invoke_discover_topology(connector, target, operator)
 
     audit_id = uuid.uuid4()
     result = await _apply_reconcile(

--- a/backend/tests/integration/test_connectors_k8s_k3d.py
+++ b/backend/tests/integration/test_connectors_k8s_k3d.py
@@ -644,3 +644,86 @@ async def test_event_list_against_k3s_field_selector_filters(
     assert isinstance(result["rows"], list)
     for row in result["rows"]:
         assert row["type"] == "Warning"
+
+
+# ---------------------------------------------------------------------------
+# G0.14-T12 (#1201) discover_topology populator -- live k3s exercise.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_discover_topology_against_k3s_returns_cluster_namespaces_and_nodes(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """``discover_topology`` over live k3s emits target + namespace + node hints.
+
+    The populator scope is deliberately minimal: 1 ``target`` NodeHint
+    for the cluster (with the server version on properties), N
+    ``namespace`` NodeHints, M ``node`` NodeHints, and ``belongs-to``
+    edges from every namespace and every cluster node to the target.
+    Pods / services / ingresses / deployments / volumes are out of
+    scope at v0.7 — sibling Tasks under Initiative #1139 land them
+    when refresh-cost data justifies the spend.
+    """
+    from meho_backplane.connectors.schemas import TopologyHints
+
+    connector, target = k3s_connector
+    hints = await connector.discover_topology(target, operator=_make_k3d_operator())
+
+    assert isinstance(hints, TopologyHints)
+
+    target_hints = [n for n in hints.nodes if n.kind == "target"]
+    namespace_hints = [n for n in hints.nodes if n.kind == "namespace"]
+    node_hints = [n for n in hints.nodes if n.kind == "node"]
+
+    # Exactly one cluster anchor.
+    assert len(target_hints) == 1
+    assert target_hints[0].name == target.name
+    # Server version surfaces verbatim on the target node's properties
+    # so an operator inspecting the graph can identify the cluster.
+    assert target_hints[0].properties["git_version"].startswith("v")
+
+    # k3s ships ``default`` / ``kube-system`` / ``kube-public`` /
+    # ``kube-node-lease`` from boot.
+    namespace_names = {n.name for n in namespace_hints}
+    assert "default" in namespace_names
+    assert "kube-system" in namespace_names
+    assert len(namespace_hints) >= 4
+
+    # Single-node default k3s cluster.
+    assert len(node_hints) >= 1
+
+    # Every namespace and every cluster node carries a belongs-to edge
+    # to the target.
+    namespace_edges = [
+        e for e in hints.edges if e.from_kind == "namespace" and e.to_kind == "target"
+    ]
+    node_edges = [e for e in hints.edges if e.from_kind == "node" and e.to_kind == "target"]
+    assert {e.from_name for e in namespace_edges} == namespace_names
+    assert {e.from_name for e in node_edges} == {n.name for n in node_hints}
+    assert all(e.kind == "belongs-to" for e in hints.edges)
+    assert all(e.to_name == target.name for e in hints.edges)
+
+
+@pytest.mark.asyncio
+async def test_discover_topology_against_k3s_is_idempotent_when_recalled(
+    k3s_connector: tuple[KubernetesConnector, _K3sTarget],
+) -> None:
+    """Two back-to-back populator calls return the same node/edge keys.
+
+    The refresh service's diff/apply sweep depends on stable
+    ``(kind, name)`` natural keys across snapshots; this test pins
+    that against the live API server (creation_timestamp-derived
+    ``age_seconds`` properties drift but the key tuples don't).
+    """
+    connector, target = k3s_connector
+    snap1 = await connector.discover_topology(target, operator=_make_k3d_operator())
+    snap2 = await connector.discover_topology(target, operator=_make_k3d_operator())
+
+    keys1 = {(n.kind, n.name) for n in snap1.nodes}
+    keys2 = {(n.kind, n.name) for n in snap2.nodes}
+    assert keys1 == keys2
+
+    edge_keys1 = {(e.from_kind, e.from_name, e.to_kind, e.to_name, e.kind) for e in snap1.edges}
+    edge_keys2 = {(e.from_kind, e.from_name, e.to_kind, e.to_name, e.kind) for e in snap2.edges}
+    assert edge_keys1 == edge_keys2

--- a/backend/tests/test_connectors_k8s_topology.py
+++ b/backend/tests/test_connectors_k8s_topology.py
@@ -1,0 +1,432 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the G0.14-T12 (#1201) K8s topology populator.
+
+Coverage matrix (per Issue #1201 acceptance criteria, unit slice):
+
+* :func:`build_target_node_hint` projects a :class:`VersionInfo` into
+  the ``target``-kinded :class:`NodeHint` with the cluster's server
+  version on ``properties`` (no extra round-trip vs. ``k8s.about``).
+* :func:`namespace_node_hint` re-uses
+  :func:`~meho_backplane.connectors.kubernetes.ops_core.namespace_row`
+  so the populator and ``k8s.namespace.list`` share their wire shape.
+* :func:`node_node_hint` re-uses
+  :func:`~meho_backplane.connectors.kubernetes.ops_core.node_row` for
+  the same reason.
+* :func:`namespace_to_target_edge` / :func:`node_to_target_edge` emit
+  ``belongs-to`` edges with the namespace / cluster-node as ``from``
+  and the target as ``to``.
+* :func:`build_topology_hints` assembles the full snapshot: 1 target
+  + N namespaces + M nodes + (N + M) ``belongs-to`` edges. Objects
+  with a missing ``metadata.name`` are skipped (defensive — the API
+  server requires the field in practice).
+* :meth:`KubernetesConnector.discover_topology` end-to-end against a
+  mocked ApiClient: returns the cluster + namespaces + nodes
+  :class:`TopologyHints` and accepts the refresh-private
+  ``operator`` keyword argument (re-uses the per-target
+  ``_get_api_client(target, operator)`` chain).
+
+The k3s testcontainer slice lives in
+``tests/integration/test_connectors_k8s_k3d.py`` — these unit tests
+drive synthetic ``V1Namespace`` / ``V1Node`` / ``VersionInfo``
+fixtures so the suite runs without Docker.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from kubernetes_asyncio.client.models import (
+    V1Namespace,
+    V1NamespaceList,
+    V1NamespaceStatus,
+    V1Node,
+    V1NodeCondition,
+    V1NodeList,
+    V1NodeSpec,
+    V1NodeStatus,
+    V1NodeSystemInfo,
+    V1ObjectMeta,
+    VersionInfo,
+)
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.kubernetes import (
+    KubernetesConnector,
+    KubernetesTargetLike,
+)
+from meho_backplane.connectors.kubernetes._topology import (
+    build_target_node_hint,
+    build_topology_hints,
+    namespace_node_hint,
+    namespace_to_target_edge,
+    node_node_hint,
+    node_to_target_edge,
+)
+from meho_backplane.connectors.schemas import TopologyHints
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for the DB-touching path."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Synthetic K8s model fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_version() -> VersionInfo:
+    return VersionInfo(
+        build_date="2026-01-01T00:00:00Z",
+        compiler="gc",
+        git_commit="abcdef0",
+        git_tree_state="clean",
+        git_version="v1.32.5+rke2r1",
+        go_version="go1.22.0",
+        major="1",
+        minor="32",
+        platform="linux/amd64",
+    )
+
+
+def _make_namespace(name: str, *, phase: str = "Active") -> V1Namespace:
+    return V1Namespace(
+        metadata=V1ObjectMeta(
+            name=name,
+            creation_timestamp=datetime(2026, 5, 1, tzinfo=UTC),
+            labels={"k8s.io/managed-by": "rke2"},
+        ),
+        status=V1NamespaceStatus(phase=phase),
+    )
+
+
+def _make_node(name: str, *, roles: tuple[str, ...] = ("control-plane",)) -> V1Node:
+    role_labels = {f"node-role.kubernetes.io/{role}": "" for role in roles}
+    return V1Node(
+        metadata=V1ObjectMeta(
+            name=name,
+            creation_timestamp=datetime(2026, 5, 1, tzinfo=UTC),
+            labels=role_labels,
+        ),
+        status=V1NodeStatus(
+            conditions=[V1NodeCondition(type="Ready", status="True")],
+            node_info=V1NodeSystemInfo(
+                architecture="amd64",
+                boot_id="b",
+                container_runtime_version="containerd://1.7",
+                kernel_version="6.1.0-test",
+                kube_proxy_version="v1.32.5+rke2r1",
+                kubelet_version="v1.32.5+rke2r1",
+                machine_id="m",
+                operating_system="Linux",
+                os_image="SLES Micro",
+                system_uuid="u",
+            ),
+            addresses=[],
+        ),
+        spec=V1NodeSpec(taints=[]),
+    )
+
+
+@dataclass
+class _StubTarget:
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str
+
+
+_TARGET = _StubTarget(
+    name="rke2-meho",
+    host="rke2-meho.test.invalid",
+    port=6443,
+    secret_ref="k8s/rke2-meho",
+)
+
+
+def _stub_kubeconfig() -> dict[str, Any]:
+    return {
+        "apiVersion": "v1",
+        "kind": "Config",
+        "current-context": "default",
+        "contexts": [{"name": "default", "context": {"cluster": "c1", "user": "u1"}}],
+        "clusters": [{"name": "c1", "cluster": {"server": "https://k8s.test:6443"}}],
+        "users": [{"name": "u1", "user": {"token": "stub-token"}}],
+    }
+
+
+def _make_connector() -> KubernetesConnector:
+    async def _loader(_target: KubernetesTargetLike, _operator: Operator) -> dict[str, Any]:
+        return _stub_kubeconfig()
+
+    return KubernetesConnector(kubeconfig_loader=_loader)
+
+
+def _make_operator() -> Operator:
+    return Operator(
+        sub="op-topo-test",
+        name="Topo Test Operator",
+        email=None,
+        raw_jwt="op.topo.jwt",
+        tenant_id=uuid.UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_target_node_hint
+# ---------------------------------------------------------------------------
+
+
+def test_target_node_hint_carries_version_properties() -> None:
+    version = _make_version()
+    hint = build_target_node_hint("rke2-meho", version)
+    assert hint.kind == "target"
+    assert hint.name == "rke2-meho"
+    assert hint.properties["git_version"] == "v1.32.5+rke2r1"
+    assert hint.properties["major"] == "1"
+    assert hint.properties["minor"] == "32"
+    assert hint.properties["platform"] == "linux/amd64"
+
+
+def test_target_node_hint_with_no_version_has_empty_properties() -> None:
+    hint = build_target_node_hint("offline-cluster", None)
+    assert hint.kind == "target"
+    assert hint.name == "offline-cluster"
+    assert dict(hint.properties) == {}
+
+
+# ---------------------------------------------------------------------------
+# namespace_node_hint
+# ---------------------------------------------------------------------------
+
+
+def test_namespace_node_hint_shares_namespace_row_shape() -> None:
+    ns = _make_namespace("argocd")
+    hint = namespace_node_hint(ns)
+    assert hint.kind == "namespace"
+    assert hint.name == "argocd"
+    # Same fields as ``namespace_row`` minus ``name`` (which is the
+    # NodeHint's own field). The wire shape stays uniform across the
+    # populator and the ``k8s.namespace.list`` op.
+    assert "status" in hint.properties
+    assert "age_seconds" in hint.properties
+    assert "labels" in hint.properties
+    assert hint.properties["status"] == "Active"
+
+
+def test_namespace_node_hint_name_is_string_even_when_metadata_is_partial() -> None:
+    # Build a corrupt fixture where metadata.name is None — defensive
+    # path. ``NodeHint.name`` is typed ``str`` so the helper coerces
+    # ``None`` to ``""``; the caller filters these in
+    # ``build_topology_hints`` so the empty-name path never lands in a
+    # snapshot.
+    ns = V1Namespace(metadata=V1ObjectMeta(name=None), status=V1NamespaceStatus(phase="Active"))
+    hint = namespace_node_hint(ns)
+    assert hint.name == ""
+
+
+# ---------------------------------------------------------------------------
+# node_node_hint
+# ---------------------------------------------------------------------------
+
+
+def test_node_node_hint_shares_node_row_shape() -> None:
+    node = _make_node("ctrl-plane-1", roles=("control-plane", "etcd"))
+    hint = node_node_hint(node)
+    assert hint.kind == "node"
+    assert hint.name == "ctrl-plane-1"
+    assert hint.properties["roles"] == ["control-plane", "etcd"]
+    assert hint.properties["version"] == "v1.32.5+rke2r1"
+    assert hint.properties["kernel"] == "6.1.0-test"
+    assert hint.properties["status"] == "Ready"
+
+
+# ---------------------------------------------------------------------------
+# Edge helpers
+# ---------------------------------------------------------------------------
+
+
+def test_namespace_to_target_edge_is_belongs_to() -> None:
+    edge = namespace_to_target_edge("argocd", "rke2-meho")
+    assert edge.kind == "belongs-to"
+    assert edge.from_kind == "namespace"
+    assert edge.from_name == "argocd"
+    assert edge.to_kind == "target"
+    assert edge.to_name == "rke2-meho"
+
+
+def test_node_to_target_edge_is_belongs_to() -> None:
+    edge = node_to_target_edge("ctrl-plane-1", "rke2-meho")
+    assert edge.kind == "belongs-to"
+    assert edge.from_kind == "node"
+    assert edge.from_name == "ctrl-plane-1"
+    assert edge.to_kind == "target"
+    assert edge.to_name == "rke2-meho"
+
+
+# ---------------------------------------------------------------------------
+# build_topology_hints
+# ---------------------------------------------------------------------------
+
+
+def test_build_topology_hints_emits_target_namespaces_nodes_and_edges() -> None:
+    namespaces = [_make_namespace("default"), _make_namespace("argocd")]
+    nodes = [_make_node("ctrl-plane-1"), _make_node("worker-1", roles=("worker",))]
+
+    hints = build_topology_hints(
+        target_name="rke2-meho",
+        version=_make_version(),
+        namespaces=namespaces,
+        nodes=nodes,
+    )
+
+    assert isinstance(hints, TopologyHints)
+    # 1 target + 2 namespaces + 2 nodes.
+    assert len(hints.nodes) == 5
+    kinds = [n.kind for n in hints.nodes]
+    assert kinds.count("target") == 1
+    assert kinds.count("namespace") == 2
+    assert kinds.count("node") == 2
+
+    # 2 namespace-->target + 2 node-->target belongs-to edges.
+    assert len(hints.edges) == 4
+    assert all(e.kind == "belongs-to" for e in hints.edges)
+    assert all(e.to_kind == "target" and e.to_name == "rke2-meho" for e in hints.edges)
+    edge_endpoints = {(e.from_kind, e.from_name) for e in hints.edges}
+    assert ("namespace", "default") in edge_endpoints
+    assert ("namespace", "argocd") in edge_endpoints
+    assert ("node", "ctrl-plane-1") in edge_endpoints
+    assert ("node", "worker-1") in edge_endpoints
+
+
+def test_build_topology_hints_skips_objects_with_no_metadata_name() -> None:
+    # API server requires ``metadata.name`` so this is defensive only;
+    # but the test pins the shape so a future bug in fixture-building
+    # surfaces here rather than as an opaque "kind/name unique key
+    # violated" error downstream in the refresh service.
+    bogus_ns = V1Namespace(metadata=V1ObjectMeta(name=None), status=V1NamespaceStatus(phase="x"))
+    good_ns = _make_namespace("default")
+    hints = build_topology_hints(
+        target_name="rke2-meho",
+        version=_make_version(),
+        namespaces=[bogus_ns, good_ns],
+        nodes=[],
+    )
+    namespace_hints = [n for n in hints.nodes if n.kind == "namespace"]
+    assert [h.name for h in namespace_hints] == ["default"]
+    # No belongs-to edge for the skipped namespace.
+    namespace_edges = [e for e in hints.edges if e.from_kind == "namespace"]
+    assert [e.from_name for e in namespace_edges] == ["default"]
+
+
+def test_build_topology_hints_stamps_discovered_at_at_call_time() -> None:
+    before = datetime.now(UTC)
+    hints = build_topology_hints(
+        target_name="rke2-meho",
+        version=None,
+        namespaces=[],
+        nodes=[],
+    )
+    after = datetime.now(UTC)
+    assert before <= hints.discovered_at <= after
+    # Even with zero namespaces and zero nodes, the cluster target node
+    # is always emitted so the refresh service's diff/apply has an
+    # anchor for the ``belongs-to`` edges future Tasks may add.
+    assert len(hints.nodes) == 1
+    assert hints.nodes[0].kind == "target"
+
+
+# ---------------------------------------------------------------------------
+# KubernetesConnector.discover_topology -- integration of the helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kubernetes_connector_discover_topology_returns_hints_with_operator() -> None:
+    """``discover_topology`` issues 3 API calls and shapes the snapshot."""
+    connector = _make_connector()
+
+    version_resp = _make_version()
+    namespaces_resp = V1NamespaceList(
+        items=[_make_namespace("default"), _make_namespace("kube-system")]
+    )
+    nodes_resp = V1NodeList(items=[_make_node("ctrl-plane-1")])
+
+    with (
+        patch("meho_backplane.connectors.kubernetes.connector.client.VersionApi") as mock_version,
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as mock_core,
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new=AsyncMock(return_value=MagicMock()),
+        ),
+    ):
+        mock_version.return_value.get_code = AsyncMock(return_value=version_resp)
+        mock_core.return_value.list_namespace = AsyncMock(return_value=namespaces_resp)
+        mock_core.return_value.list_node = AsyncMock(return_value=nodes_resp)
+
+        hints = await connector.discover_topology(_TARGET, operator=_make_operator())
+
+    assert isinstance(hints, TopologyHints)
+    kinds = {(n.kind, n.name) for n in hints.nodes}
+    assert ("target", "rke2-meho") in kinds
+    assert ("namespace", "default") in kinds
+    assert ("namespace", "kube-system") in kinds
+    assert ("node", "ctrl-plane-1") in kinds
+    # 2 namespaces + 1 node = 3 belongs-to edges.
+    assert len(hints.edges) == 3
+    assert all(e.kind == "belongs-to" and e.to_name == "rke2-meho" for e in hints.edges)
+
+
+@pytest.mark.asyncio
+async def test_kubernetes_connector_discover_topology_default_operator_is_system() -> None:
+    """Omitting ``operator`` falls back to the synthesised system operator.
+
+    The same fail-closed posture the fingerprint/probe paths use — a
+    direct caller (test, future on-demand surface that doesn't yet
+    thread the operator) still works closed-loop and the kubeconfig
+    loader receives the system-operator placeholder JWT.
+    """
+    captured_operators: list[Operator] = []
+
+    async def _loader(_target: KubernetesTargetLike, operator: Operator) -> dict[str, Any]:
+        captured_operators.append(operator)
+        return _stub_kubeconfig()
+
+    connector = KubernetesConnector(kubeconfig_loader=_loader)
+
+    with (
+        patch("meho_backplane.connectors.kubernetes.connector.client.VersionApi") as mock_version,
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as mock_core,
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new=AsyncMock(return_value=MagicMock()),
+        ),
+    ):
+        mock_version.return_value.get_code = AsyncMock(return_value=_make_version())
+        mock_core.return_value.list_namespace = AsyncMock(return_value=V1NamespaceList(items=[]))
+        mock_core.return_value.list_node = AsyncMock(return_value=V1NodeList(items=[]))
+
+        hints = await connector.discover_topology(_TARGET)
+
+    assert isinstance(hints, TopologyHints)
+    # System operator's identifier surfaces in the kubeconfig loader so
+    # the system-call carve-out (operator-context Vault read rejects
+    # the placeholder JWT) keeps holding.
+    assert len(captured_operators) == 1
+    assert captured_operators[0].sub == "system:connector-probe"

--- a/backend/tests/test_connectors_topology.py
+++ b/backend/tests/test_connectors_topology.py
@@ -215,11 +215,17 @@ def test_overridden_list_candidates_dispatches_via_abc() -> None:
 
 
 def test_shipped_v1_subclasses_inherit_topology_defaults() -> None:
-    # Backward-compat guard: VaultConnector (#244) and KubernetesConnector
-    # skeleton (#321) only set ``product`` and override fingerprint/probe/
-    # execute. They must remain importable AND inherit the new
-    # ``discover_topology`` + ``list_candidates`` defaults without code
-    # change.
+    # Backward-compat guard: VaultConnector (#244) inherits the no-op
+    # default for both ``discover_topology`` and ``list_candidates``;
+    # ``KubernetesConnector`` (#321) inherits the ``list_candidates``
+    # default. The K8s ``discover_topology`` override landed in
+    # G0.14-T12 (#1201), so the "no override yet" invariant moved from
+    # tested-fact to deleted line — see the populator at
+    # :meth:`meho_backplane.connectors.kubernetes.connector.KubernetesConnector.discover_topology`
+    # and the live coverage in ``test_connectors_k8s_topology.py``
+    # (unit, synthetic V1Namespace/V1Node fixtures) +
+    # ``tests/integration/test_connectors_k8s_k3d.py`` (k3s
+    # testcontainer round-trip).
     from meho_backplane.connectors.kubernetes.connector import KubernetesConnector
     from meho_backplane.connectors.vault.connector import VaultConnector
 
@@ -228,7 +234,6 @@ def test_shipped_v1_subclasses_inherit_topology_defaults() -> None:
     # touch settings + Vault).
     assert VaultConnector.discover_topology is Connector.discover_topology
     assert VaultConnector.list_candidates is Connector.list_candidates
-    assert KubernetesConnector.discover_topology is Connector.discover_topology
     assert KubernetesConnector.list_candidates is Connector.list_candidates
 
 

--- a/backend/tests/test_topology_refresh.py
+++ b/backend/tests/test_topology_refresh.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import uuid
 from collections.abc import Iterator
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, ClassVar
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -610,3 +610,171 @@ async def test_refresh_does_not_soft_delete_other_targets_nodes() -> None:
         ).scalar_one()
     assert a_vm_a.target_id == target_a.id
     assert a_vm_a.last_seen is not None, "target B's refresh must not soft-delete target A's node"
+
+
+# ---------------------------------------------------------------------------
+# G0.14-T12 (#1201) -- refresh service forwards the operator to
+# operator-aware ``discover_topology`` overrides (K8s populator).
+# ---------------------------------------------------------------------------
+
+
+class _OperatorAwareConnector(Connector):
+    """Connector whose ``discover_topology`` declares ``operator`` keyword.
+
+    Mirrors the
+    :meth:`~meho_backplane.connectors.kubernetes.connector.KubernetesConnector.discover_topology`
+    signature shape (``(self, target, *, operator: Operator | None = None)``)
+    so the refresh service's signature-introspection forwarder is
+    exercised against the same contract the K8s populator declares,
+    without booting a k3s testcontainer in the unit suite.
+    """
+
+    product = "k8s-test-populator"
+
+    captured_operators: ClassVar[list[Operator]] = []
+
+    async def fingerprint(self, target: Any) -> Any:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> Any:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def execute(
+        self, target: Any, op_id: str, params: dict[str, Any]
+    ) -> Any:  # pragma: no cover - unused
+        raise NotImplementedError
+
+    async def discover_topology(  # type: ignore[override]
+        self,
+        target: Any,
+        *,
+        operator: Operator | None = None,
+    ) -> TopologyHints:
+        if operator is not None:
+            type(self).captured_operators.append(operator)
+        return TopologyHints(
+            discovered_at=datetime.now(UTC),
+            nodes=(
+                NodeHint(kind="target", name=target.name, properties={"git_version": "v1.32.5"}),
+                NodeHint(kind="namespace", name="default"),
+                NodeHint(kind="node", name="ctrl-plane-1"),
+            ),
+            edges=(
+                EdgeHint(
+                    from_kind="namespace",
+                    from_name="default",
+                    to_kind="target",
+                    to_name=target.name,
+                    kind="belongs-to",
+                ),
+                EdgeHint(
+                    from_kind="node",
+                    from_name="ctrl-plane-1",
+                    to_kind="target",
+                    to_name=target.name,
+                    kind="belongs-to",
+                ),
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_refresh_forwards_operator_to_k8s_style_discover_topology() -> None:
+    """The refresh service introspects the override and forwards ``operator`` when accepted.
+
+    Pins the G0.14-T12 (#1201) decision: refresh service is the
+    authority on threading the per-tenant system operator into a
+    populator that needs it (e.g. K8s' kubeconfig-from-Vault chain
+    reads under the operator's identity). Connectors whose override
+    didn't declare ``operator`` keep their ``(self, target)`` signature
+    and run unchanged.
+    """
+    register_connector_v2(
+        product="k8s-test-populator",
+        version="",
+        impl_id="",
+        cls=_OperatorAwareConnector,
+    )
+    tenant_id, target = await _seed_tenant_and_target("rdc-internal")
+    target.product = "k8s-test-populator"
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(target)
+        await session.commit()
+
+    op = _operator(tenant_id)
+    _OperatorAwareConnector.captured_operators = []
+
+    with patch(_PUBLISH, new=AsyncMock()):
+        result = await refresh_target_topology(target, op)
+
+    assert _OperatorAwareConnector.captured_operators == [op], (
+        "refresh service must forward the operator to a populator whose "
+        "``discover_topology`` override declares the keyword parameter"
+    )
+    # 1 target anchor + 1 namespace + 1 cluster node = 3 nodes; 2 belongs-to edges.
+    assert result.added_nodes == 3
+    assert result.added_edges == 2
+
+
+@pytest.mark.asyncio
+async def test_refresh_with_k8s_style_populator_is_idempotent_on_recall() -> None:
+    """Acceptance criterion: ``RefreshResult`` second-call counts must be all zero.
+
+    Mirrors the issue body's "first call ``added_nodes >= 2``;
+    immediate second call ``added_nodes == 0, updated_nodes == 0``"
+    contract under the refresh service's diff/apply sweep — the same
+    sweep that runs against the live rke2-infra cluster in the v0.7.x
+    deploy.
+    """
+    register_connector_v2(
+        product="k8s-test-populator",
+        version="",
+        impl_id="",
+        cls=_OperatorAwareConnector,
+    )
+    tenant_id, target = await _seed_tenant_and_target("rdc-internal")
+    target.product = "k8s-test-populator"
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(target)
+        await session.commit()
+
+    op = _operator(tenant_id)
+
+    with patch(_PUBLISH, new=AsyncMock()):
+        first = await refresh_target_topology(target, op)
+        second = await refresh_target_topology(target, op)
+
+    assert first.added_nodes >= 2  # ≥2 per the issue body's acceptance criterion.
+    assert second.added_nodes == 0
+    assert second.added_edges == 0
+    assert second.updated_nodes == 0
+    assert second.updated_edges == 0
+    assert second.removed_nodes == 0
+    assert second.removed_edges == 0
+
+    # Acceptance criterion: graph_node rows are visible to subsequent
+    # queries scoped to this (tenant, target). Existing ``query_topology``
+    # and MCP tools (``topology/dependents/{name}`` /
+    # ``topology/path/{from}/{to}``) read against this same
+    # (tenant_id, kind, name) natural key, so visibility here implies
+    # visibility there without further wiring.
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(GraphNode).where(
+                        GraphNode.tenant_id == tenant_id,
+                        GraphNode.target_id == target.id,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert {(r.kind, r.name) for r in rows} == {
+        ("target", target.name),
+        ("namespace", "default"),
+        ("node", "ctrl-plane-1"),
+    }

--- a/docs/codebase/connectors-kubernetes.md
+++ b/docs/codebase/connectors-kubernetes.md
@@ -245,6 +245,86 @@ conditional on a versioned entry being present.
    ones pass through — writes the audit row, fires the broadcast event,
    and wraps the result in `OperationResult.status="ok"`.
 
+### Topology discovery (`discover_topology`)
+
+G0.14-T12 (#1201) lands the first
+[`Connector.discover_topology`](../../backend/src/meho_backplane/connectors/base.py)
+override against a shipped connector. The populator emits the minimum
+the v0.6.0 release-body amendment promised: cluster + namespaces +
+nodes, with `belongs-to` edges from each namespace and each cluster
+node to the target. The
+[refresh service](../../backend/src/meho_backplane/topology/refresh.py)
+calls the override on demand
+(`POST /api/v1/topology/refresh/{target_name}`) and on the per-tenant
+scheduled cadence, diffs the snapshot against `graph_node` +
+`graph_edge` rows for `(tenant_id, target_id)`, and applies inserts /
+updates / soft-deletes in one transaction.
+
+**What lands on the graph (v0.7-shape)**
+
+| `NodeHint.kind` | Count             | Properties carried                              |
+| --------------- | ----------------- | ----------------------------------------------- |
+| `target`        | exactly 1         | `git_version` / `major` / `minor` / `platform` from `VersionApi.get_code()` (same payload `k8s.about` returns) |
+| `namespace`     | N (≥ 4 on k3s)    | Mirrors [`namespace_row`](../../backend/src/meho_backplane/connectors/kubernetes/ops_core.py): `status` / `age_seconds` / `labels` |
+| `node`          | M (≥ 1)           | Mirrors [`node_row`](../../backend/src/meho_backplane/connectors/kubernetes/ops_core.py): `status` / `roles` / `version` (kubelet) / `kernel` / `os` / `internal_ip` / `taints` / `age_seconds` / `labels` |
+
+`EdgeHint` rows: one `belongs-to` from every namespace to the target,
+one `belongs-to` from every cluster node to the target. `cluster` is
+**not** in the v0.2 [`NodeKind` enum](../../backend/src/meho_backplane/connectors/schemas.py)
+(the enum is closed per the module docstring); the cluster manifests
+as a `target`-kinded node so the refresh service's natural-key
+contract holds without enum changes (which are a G9.2 concern).
+
+**Explicit out-of-scope (sibling Tasks)**
+
+- **Pods** — `CoreV1Api.list_pod_for_all_namespaces()` or N
+  `list_namespaced_pod(namespace)` calls. A 100-namespace cluster
+  would mean 100 list calls per refresh tick; the v0.7.x deploy
+  hasn't surfaced refresh-cost data yet.
+- **Services** — same scaling concern as pods.
+- **Ingresses** — same.
+- **Deployments** — same.
+- **Volumes** (`PersistentVolume` cluster-scope + `PersistentVolumeClaim`
+  namespaced) — same.
+
+When the cost picture and operator demand justify them, file sibling
+Tasks against [Initiative #1139](https://github.com/evoila/meho/issues/1139)
+or a future G9.4 Initiative.
+
+**Operator threading**
+
+The [`Connector.discover_topology(self, target)`](../../backend/src/meho_backplane/connectors/base.py)
+ABC signature stays unchanged at v0.7 (out of scope for T12). The K8s
+override extends the signature with a keyword-only `operator: Operator
+| None = None` parameter; the refresh service introspects the bound
+method via [`inspect.signature`](https://docs.python.org/3/library/inspect.html#inspect.signature)
+and forwards the per-tenant system operator the scheduler synthesises
+([`_system_operator`](../../backend/src/meho_backplane/topology/scheduler.py))
+when the keyword is declared. Connectors whose override doesn't
+declare `operator` (the inherited no-op default, plus any future
+override that doesn't need credentials) are invoked verbatim. The
+forwarded operator flows through
+[`_get_api_client(target, operator)`](../../backend/src/meho_backplane/connectors/kubernetes/connector.py)
+so the operator-context Vault → kubeconfig chain reads under the
+synthesised identity (the same chain `k8s.about` and every other
+operator-aware op already use).
+
+**Where the helpers live**
+
+[`backend/src/meho_backplane/connectors/kubernetes/_topology.py`](../../backend/src/meho_backplane/connectors/kubernetes/_topology.py)
+exposes pure functions (`build_target_node_hint`,
+`namespace_node_hint`, `node_node_hint`,
+`namespace_to_target_edge`, `node_to_target_edge`,
+`build_topology_hints`) that re-use `namespace_row` / `node_row` so
+the populator and the inventory ops share their wire shape. The
+unit suite at
+[`backend/tests/test_connectors_k8s_topology.py`](../../backend/tests/test_connectors_k8s_topology.py)
+drives synthetic `V1Namespace` / `V1Node` / `VersionInfo` fixtures;
+the k3s testcontainer slice in
+[`backend/tests/integration/test_connectors_k8s_k3d.py`](../../backend/tests/integration/test_connectors_k8s_k3d.py)
+covers the live API round-trip plus the
+`(kind, name)` idempotency property the refresh service depends on.
+
 ### `k8s.ls` three-way dispatch
 
 The `k8s.ls` handler is a thin path parser:
@@ -322,6 +402,10 @@ just `len(rows)` because nothing reduces.
 
 ## References
 
+- Topology populator: [#1201 G0.14-T12](https://github.com/evoila/meho/issues/1201)
+  -- `KubernetesConnector.discover_topology` (cluster + namespaces +
+  nodes); closes the v0.6.0 release-body amendment promise on
+  `claude-rdc-hetzner-dc#697` signal 13.
 - Parent Initiative: [#320 G3.2](https://github.com/evoila/meho/issues/320)
   -- `k8s-1.x` typed connector (library: `kubernetes_asyncio`).
 - Predecessor Tasks:


### PR DESCRIPTION
## Summary

- Lands the first `Connector.discover_topology` override against a shipped connector — closes the v0.6.0 release-body amendment promise on `claude-rdc-hetzner-dc#697` signal 13 ("topology populators land in v0.7" shipped without one in v0.7.0).
- `KubernetesConnector.discover_topology(target, *, operator=None)` emits one `target` NodeHint (cluster anchor; properties carry `VersionApi.get_code()`'s `git_version` / `major` / `minor` / `platform`), one `namespace` NodeHint per namespace (properties from `namespace_row`), one `node` NodeHint per cluster node (properties from `node_row`), plus `belongs-to` EdgeHints from every namespace and every cluster node to the target. Pods / services / ingresses / deployments / volumes are **explicitly out of scope** at v0.7 — sibling Tasks land them when refresh-cost data justifies the spend.
- The refresh service forwards the per-tenant system operator the scheduler already synthesises via `inspect.signature`-based detection on the bound `discover_topology` method — `Connector` ABC stays at `(self, target)`; connectors whose override doesn't declare `operator` run verbatim.

## Test plan

- [x] `ruff check` — clean on changed files
- [x] `ruff format --check` — clean
- [x] `mypy --ignore-missing-imports` against `connectors/` + `topology/` — 108 source files, no issues
- [x] `pytest backend/tests/test_connectors_topology.py backend/tests/test_connectors_k8s_topology.py backend/tests/test_topology_refresh.py` — 52 passed
- [x] `pytest backend/tests/test_connectors_k8s_core.py backend/tests/test_connectors_k8s_dispatcher_shim.py backend/tests/test_topology_history_*` — 53 passed (no surface-area regression on existing K8s + topology suites)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers
- [x] Acceptance criterion: deleted the regression at `backend/tests/test_connectors_topology.py:231` asserting `KubernetesConnector.discover_topology is Connector.discover_topology` (the deletion is itself the test this Task ran).
- [x] Acceptance criterion: integration tests in `backend/tests/integration/test_connectors_k8s_k3d.py` exercise the populator against the existing k3s testcontainer fixture (CI-only — Docker required); two cases pin the wire shape (cluster + namespaces + nodes + `belongs-to` edges to target) and the `(kind, name)` idempotency property.
- [x] Acceptance criterion: integration cases in `backend/tests/test_topology_refresh.py` pin the refresh contract: first call `added_nodes >= 2` (≥1 target + ≥1 namespace + ≥1 node), immediate second call all-zero (idempotent diff/apply sweep), `graph_node` rows visible to `query_topology`-shape `(tenant_id, kind, name)` reads.
- [x] Acceptance criterion: `docs/codebase/connectors-kubernetes.md` grows a "Topology discovery" section naming the populator scope, the edges emitted, and the explicit out-of-scope list.
- [x] Acceptance criterion: `CHANGELOG.md` `[Unreleased]` records the v0.7.x amendment marking signal 13 closed.

## Out of scope

- Pods / services / ingresses / deployments / volumes — file sibling Tasks against #1139 or a future G9.4 Initiative when refresh-cost data on the v0.7.x deploy justifies them.
- Topology populators for other connectors (vSphere, Vault, holodeck, vROps) — the ABC docstring names them as future override candidates; not pre-filed.
- Changes to the `Connector.discover_topology` ABC signature, the `NodeKind` / `EdgeKind` enums (cross-system kinds land in G9.2, which is closed), or the refresh service's diff/apply logic.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1201


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kubernetes connector now discovers cluster topology, automatically identifying and establishing relationships between the cluster target, namespaces, and nodes. Excluded resources include pods, services, ingresses, deployments, and volumes.

* **Documentation**
  * Added documentation for Kubernetes topology discovery, including operator credential forwarding behavior and resource discovery scope.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->