### PR TITLE
feat(mcp): G0.14-T13 surface initialize protocol-version mismatch (signal 15)

### DIFF
--- a/backend/src/meho_backplane/api/v1/health.py
+++ b/backend/src/meho_backplane/api/v1/health.py
@@ -50,6 +50,7 @@ from pydantic import BaseModel, ConfigDict
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.db.migrations import db_migration_probe
+from meho_backplane.mcp.schemas import PROTOCOL_VERSION
 from meho_backplane.mcp.server import mcp_session_id_capture_mode
 from meho_backplane.middleware import verify_jwt_and_bind
 from meho_backplane.operations import dispatch
@@ -139,6 +140,16 @@ class HealthResponse(BaseModel):
     the same
     :func:`~meho_backplane.mcp.server.mcp_session_id_capture_mode`
     helper so both surfaces stay consistent).
+
+    ``mcp_protocol_version`` (G0.14-T13 #1202) reports the server's
+    pinned :data:`~meho_backplane.mcp.schemas.PROTOCOL_VERSION`.
+    Mirrors the ``mcp_session_id_capture`` precedent: single-field
+    operator visibility into the MCP layer's runtime state. The
+    matching ``mcp.protocol_version`` entry on ``/ready``'s features
+    block (see :func:`meho_backplane.features.build_features_block`)
+    surfaces the same value on the unauthenticated readiness probe so
+    a deploy operator can answer "which MCP revision will this server
+    negotiate with my clients?" without an authenticated GET.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -147,6 +158,7 @@ class HealthResponse(BaseModel):
     vault: VaultStatus
     db: DbStatus
     mcp_session_id_capture: str
+    mcp_protocol_version: str = PROTOCOL_VERSION
 
 
 router = APIRouter(prefix="/api/v1", tags=["health"])
@@ -282,6 +294,7 @@ async def build_health_response(operator: Operator) -> HealthResponse:
         vault=vault_status,
         db=DbStatus(migrated=db_probe_result.ok),
         mcp_session_id_capture=mcp_session_id_capture_mode(),
+        mcp_protocol_version=PROTOCOL_VERSION,
     )
 
 

--- a/backend/src/meho_backplane/features.py
+++ b/backend/src/meho_backplane/features.py
@@ -31,9 +31,11 @@ box on my deploy?". Each entry carries:
   surface still has the provenance trail to the doc that describes
   the setup). Absent on ``audit_replay`` (capture is feature-coupled
   to MCP itself, not to an admin-configurable knob — operators have
-  no separate setup doc to read) and on the transitive
-  ``approval_queue`` entry (which surfaces a ``depends_on`` field
-  pointing at ``agent_runtime`` instead).
+  no separate setup doc to read), on the ``mcp`` block (the pinned
+  ``protocol_version`` is a build-time constant, not a deploy-time
+  knob), and on the transitive ``approval_queue`` entry (which
+  surfaces a ``depends_on`` field pointing at ``agent_runtime``
+  instead).
 
 The audit-replay entry additionally exposes ``capture_mode`` —
 ``"enforced"`` until G0.14-T6 (#1147) decouples capture from
@@ -154,6 +156,58 @@ def _audit_replay_block() -> dict[str, Any]:
     }
 
 
+def _mcp_block() -> dict[str, Any]:
+    """MCP-layer runtime visibility for ``/ready``.
+
+    Today the only field is ``protocol_version`` — the spec revision the
+    server pins (currently :data:`~meho_backplane.mcp.schemas.PROTOCOL_VERSION`).
+    The block exists so an unauthenticated deploy operator can answer
+    "which MCP revision will this server negotiate with my clients?"
+    from a single GET, without an authenticated ``/api/v1/health`` call.
+    Mirrors the ``mcp_session_id_capture`` precedent (G0.14-T6 #1147):
+    single-field operator visibility into the MCP layer's runtime
+    state, with the matching field on
+    :class:`~meho_backplane.api.v1.health.HealthResponse` so both
+    surfaces stay consistent.
+
+    No env var is "missing" — :data:`PROTOCOL_VERSION` is a build-time
+    constant, not an admin-configurable knob; ``missing_env`` is
+    therefore always ``[]`` and ``configured`` is always ``True``. The
+    block does not carry a ``docs`` field for the same reason the
+    ``audit_replay`` block doesn't: there is no deploy-time setup
+    document an operator needs to read to "turn this on".
+
+    G0.14-T13 (#1202) shipped this as the **observability** half of the
+    MCP ``initialize`` mismatch handling — the behaviour half (refusing
+    / down-negotiating / version-conditional capability advertisement)
+    is explicit follow-up work, gated on demand evidence from real
+    deployments. Operators reading this field can see which revision a
+    given server pins; the matching
+    ``mcp_initialize_protocol_version_mismatch`` WARNING log (emitted
+    by :func:`~meho_backplane.mcp.server._initialize`) gives them the
+    converse — which clients are pinned to a different revision.
+    """
+    # Function-local import to break the
+    # ``features -> mcp.schemas -> mcp/__init__ -> mcp.handlers ->
+    # broadcast -> health -> features`` cycle. ``health.py`` imports
+    # ``build_features_block`` at module top-level (the ``/ready``
+    # route hands the result to ``JSONResponse``), and ``mcp/__init__.py``
+    # eagerly imports ``handlers`` to register the T3 JSON-RPC methods
+    # — both can't sit above this module without re-entering it
+    # during initial import. ``mcp.schemas`` itself is a leaf module
+    # (no imports from elsewhere in the package), so reaching for it
+    # function-locally is cheap and safe; the per-request cost of one
+    # already-cached ``import`` is negligible against the rest of
+    # ``/ready``'s probe-fanout work.
+    from meho_backplane.mcp.schemas import PROTOCOL_VERSION
+
+    return {
+        "configured": True,
+        "protocol_version": PROTOCOL_VERSION,
+        "missing_env": [],
+    }
+
+
 def _approval_queue_block(settings: Settings) -> dict[str, Any]:
     """Whether the agent-grant approval queue is operative.
 
@@ -181,14 +235,14 @@ def build_features_block(settings: Settings) -> dict[str, dict[str, Any]]:
     the attribute values under test and assert against the returned
     dict.
 
-    The four entries (``agent_runtime``, ``ui_surface``,
-    ``audit_replay``, ``approval_queue``) match the four gated
-    features the v0.6.0 release ships. The block is **closed** by
-    design: adding a new gated feature is an additive change to this
-    function and the corresponding entry in the
-    ``docs/RELEASING.md`` post-deploy enablement section; renaming
-    one is a wire-compat break for operator tooling that reads
-    ``/ready``.
+    The five entries (``agent_runtime``, ``ui_surface``,
+    ``audit_replay``, ``approval_queue``, ``mcp``) match the gated
+    features the release ships plus the MCP-layer visibility block
+    (G0.14-T13 #1202). The block is **closed** by design: adding a new
+    gated feature is an additive change to this function and the
+    corresponding entry in the ``docs/RELEASING.md`` post-deploy
+    enablement section; renaming one is a wire-compat break for
+    operator tooling that reads ``/ready``.
 
     Shape (verified by the issue body):
 
@@ -198,7 +252,8 @@ def build_features_block(settings: Settings) -> dict[str, dict[str, Any]]:
           "agent_runtime":  {"configured": <bool>, "missing_env": [...], "docs": "..."},
           "ui_surface":     {"configured": <bool>, "missing_env": [...], "docs": "..."},
           "audit_replay":   {"configured": true,   "capture_mode": "...", "missing_env": []},
-          "approval_queue": {"configured": <bool>, "depends_on": "agent_runtime"}
+          "approval_queue": {"configured": <bool>, "depends_on": "agent_runtime"},
+          "mcp":            {"configured": true,   "protocol_version": "...", "missing_env": []}
         }
     """
     return {
@@ -206,4 +261,5 @@ def build_features_block(settings: Settings) -> dict[str, dict[str, Any]]:
         "ui_surface": _ui_surface_block(settings),
         "audit_replay": _audit_replay_block(),
         "approval_queue": _approval_queue_block(settings),
+        "mcp": _mcp_block(),
     }

--- a/backend/src/meho_backplane/mcp/server.py
+++ b/backend/src/meho_backplane/mcp/server.py
@@ -228,6 +228,42 @@ class McpInvalidParamsError(Exception):
 # ---------------------------------------------------------------------------
 
 
+def _log_protocol_version_mismatch(
+    client_request: InitializeRequest,
+    operator: Operator,
+) -> None:
+    """Emit the G0.14-T13 mismatch breadcrumb when client/server revisions differ.
+
+    Extracted out of :func:`_initialize` to keep the handler under the
+    code-quality function-size budget and to give the observability
+    semantics a single, grep-friendly home. The log shape mirrors
+    ``mcp_unsupported_protocol_version`` (the existing WARNING that
+    :func:`_validate_protocol_version_header` emits when a non-
+    ``initialize`` request carries a stale ``MCP-Protocol-Version``
+    header) — operators get a uniform event-name family for both
+    handshake-time and post-handshake mismatches.
+
+    The response body is unchanged: this helper is observability-only
+    (G0.14-T13 #1202). Multi-version negotiation (refusing, down-
+    negotiating, version-conditional capability advertisement) is
+    deliberately deferred until concrete operator demand evidence
+    accumulates from the events this WARNING surfaces.
+
+    Same failure-mode genus as the v0.6.0 ``add_to_memory`` ``content``
+    → ``body`` silent rename — operators and pinned clients shouldn't
+    have to read CHANGELOGs to discover when their assumed contract no
+    longer applies.
+    """
+    if client_request.protocolVersion == PROTOCOL_VERSION:
+        return
+    _log.warning(
+        "mcp_initialize_protocol_version_mismatch",
+        client_protocol_version=client_request.protocolVersion,
+        server_protocol_version=PROTOCOL_VERSION,
+        operator_sub=operator.sub,
+    )
+
+
 async def _initialize(
     operator: Operator,
     params: dict[str, Any] | None,
@@ -245,11 +281,15 @@ async def _initialize(
     omission is loud (silent truncation of an operational rule is a
     safety bug per the issue body).
 
-    The spec requires the server to echo the client's ``protocolVersion``
-    when it supports it, or respond with another supported version
-    otherwise; T1 supports only :data:`PROTOCOL_VERSION` and always
-    responds with that. Negotiation past v0.2 (e.g. supporting an older
-    revision for legacy clients) is a v0.3 concern.
+    MEHO supports only :data:`PROTOCOL_VERSION` and always responds
+    with that — spec-compliant on the response side, but
+    indistinguishable from a silent upgrade for a client pinned to an
+    older revision. G0.14-T13 (#1202) closes the observability gap
+    via :func:`_log_protocol_version_mismatch`: a mismatched client
+    revision triggers a structured ``mcp_initialize_protocol_version_mismatch``
+    WARNING, while the response body stays unchanged. Multi-version
+    negotiation behaviour is tracked as explicit follow-up work,
+    gated on concrete operator demand.
     """
     # ``params or {}`` deliberately collapses ``None`` and ``{}``. Spec-
     # aligned: a missing ``params`` field on the JSON-RPC request and an
@@ -258,11 +298,13 @@ async def _initialize(
     # validator will then surface a clean INVALID_PARAMS for the
     # required-but-missing ``protocolVersion``.
     try:
-        InitializeRequest.model_validate(params or {})
+        client_request = InitializeRequest.model_validate(params or {})
     except ValidationError as exc:
         raise McpInvalidParamsError(
             f"initialize: {exc.error_count()} validation error(s)",
         ) from exc
+
+    _log_protocol_version_mismatch(client_request, operator)
 
     # G7.1-T4 (#316): assemble the operator's tenant session preamble
     # from ``kind='operational'`` conventions and ship it as

--- a/backend/tests/test_api_v1_health.py
+++ b/backend/tests/test_api_v1_health.py
@@ -355,12 +355,16 @@ def test_happy_path_returns_full_federation_response(
     # and ``migrated`` is True. ``mcp_session_id_capture`` reports the
     # G8.2 audit-replay capture mode (G0.14-T6 #1147); default mode is
     # ``"always"`` because ``MCP_REQUIRE_SESSION_ID`` is unset in this
-    # test fixture's env.
+    # test fixture's env. ``mcp_protocol_version`` reports the server's
+    # build-time pinned MCP revision (G0.14-T13 #1202).
+    from meho_backplane.mcp.schemas import PROTOCOL_VERSION
+
     assert body == {
         "operator": {"sub": "op-100", "name": "Alice", "email": "alice@example.com"},
         "vault": {"reachable": True, "read_ok": True, "detail": "version=11"},
         "db": {"migrated": True},
         "mcp_session_id_capture": "always",
+        "mcp_protocol_version": PROTOCOL_VERSION,
     }
 
     # Vault was hit with the configured role / mount and the operator's
@@ -669,3 +673,42 @@ def test_mcp_session_id_capture_enforced_when_env_set(
 
     assert response.status_code == 200
     assert response.json()["mcp_session_id_capture"] == "enforced"
+
+
+# ---------------------------------------------------------------------------
+# G0.14-T13 (#1202) — mcp_protocol_version field
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_protocol_version_reports_server_pinned_revision(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``GET /api/v1/health`` surfaces the server-pinned MCP protocol version.
+
+    Acceptance criterion (G0.14-T13 #1202): the health endpoint includes
+    ``mcp_protocol_version`` carrying the build-time constant
+    :data:`~meho_backplane.mcp.schemas.PROTOCOL_VERSION` so operators can
+    discover the negotiation outcome from a single authenticated GET,
+    without having to read CHANGELOGs or open an MCP handshake.
+
+    The field is sourced from the constant, not from a settings field —
+    no env-var monkeypatch is needed to exercise it. The test pins the
+    expected value to the same constant the production handler reads so
+    a future revision bump propagates without surface-test churn.
+    """
+    from meho_backplane.mcp.schemas import PROTOCOL_VERSION
+
+    key = _make_rsa_keypair("kid-protocol-version")
+    token = _mint_token(key, sub="op-protocol-version")
+    _install_fake_vault(monkeypatch, version=1)
+
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get(
+            "/api/v1/health",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["mcp_protocol_version"] == PROTOCOL_VERSION

--- a/backend/tests/test_features.py
+++ b/backend/tests/test_features.py
@@ -207,16 +207,45 @@ def test_approval_queue_configured_when_agent_runtime_configured() -> None:
 
 
 # ---------------------------------------------------------------------------
+# mcp (G0.14-T13 #1202)
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_block_reports_server_pinned_protocol_version() -> None:
+    """The ``mcp`` block surfaces the build-time pinned MCP revision.
+
+    Acceptance criterion (G0.14-T13 #1202): ``/ready`` carries a
+    ``features.mcp`` sub-block whose ``protocol_version`` field matches
+    :data:`~meho_backplane.mcp.schemas.PROTOCOL_VERSION`. The shape
+    mirrors ``audit_replay`` (no env var is "missing" — the constant
+    is build-time, not deploy-time) and is independent of any
+    :class:`Settings` field, so the assertion works against the default
+    fixture without further env-var setup.
+    """
+    from meho_backplane.mcp.schemas import PROTOCOL_VERSION
+
+    block = build_features_block(_settings_with())
+    mcp = block["mcp"]
+    assert mcp["configured"] is True
+    assert mcp["protocol_version"] == PROTOCOL_VERSION
+    assert mcp["missing_env"] == []
+    # No ``docs`` field — the pinned version is a build-time constant,
+    # not an admin-configurable knob. Same reasoning as ``audit_replay``.
+    assert "docs" not in mcp
+
+
+# ---------------------------------------------------------------------------
 # Block-level shape
 # ---------------------------------------------------------------------------
 
 
-def test_features_block_carries_all_four_entries() -> None:
-    """The block enumerates the four gated features by exact key name.
+def test_features_block_carries_all_five_entries() -> None:
+    """The block enumerates the five gated features by exact key name.
 
     Operator tooling (and downstream alerting) keys off these names.
     Renaming any of them is a wire-compat break that this assertion
-    catches at test time rather than at integration time.
+    catches at test time rather than at integration time. The ``mcp``
+    entry was added in G0.14-T13 (#1202).
     """
     block = build_features_block(_settings_with())
     assert set(block.keys()) == {
@@ -224,12 +253,13 @@ def test_features_block_carries_all_four_entries() -> None:
         "ui_surface",
         "audit_replay",
         "approval_queue",
+        "mcp",
     }
 
 
 @pytest.mark.parametrize(
     "feature",
-    ["agent_runtime", "ui_surface", "audit_replay", "approval_queue"],
+    ["agent_runtime", "ui_surface", "audit_replay", "approval_queue", "mcp"],
 )
 def test_every_feature_has_configured_bool(feature: str) -> None:
     """Each entry carries a ``configured: bool`` — the load-bearing field."""

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -211,6 +211,7 @@ def test_ready_with_empty_registry_returns_503(client: TestClient) -> None:
         "ui_surface",
         "audit_replay",
         "approval_queue",
+        "mcp",
     }
 
 
@@ -236,6 +237,7 @@ def test_ready_with_all_passing_probes_returns_200(client: TestClient) -> None:
         "ui_surface",
         "audit_replay",
         "approval_queue",
+        "mcp",
     }
 
 
@@ -318,3 +320,28 @@ def test_ready_features_block_reflects_wired_keycloak_admin(
     approval_queue = body["features"]["approval_queue"]
     assert approval_queue["configured"] is True
     assert approval_queue["depends_on"] == "agent_runtime"
+
+
+def test_ready_features_block_carries_mcp_protocol_version(
+    client: TestClient,
+) -> None:
+    """/ready surfaces the server-pinned MCP protocol revision.
+
+    Acceptance criterion (G0.14-T13 #1202): the ``features.mcp`` block
+    on ``/ready`` carries ``protocol_version`` matching the build-time
+    :data:`~meho_backplane.mcp.schemas.PROTOCOL_VERSION` constant.
+    Operators get a single unauthenticated GET that answers "which MCP
+    revision will this server pin in handshake responses?". The
+    matching :class:`~meho_backplane.api.v1.health.HealthResponse`
+    field (``mcp_protocol_version``) carries the same value on the
+    authenticated surface so both views stay consistent.
+    """
+    from meho_backplane.mcp.schemas import PROTOCOL_VERSION
+
+    response = client.get("/ready")
+
+    body = response.json()
+    mcp = body["features"]["mcp"]
+    assert mcp["configured"] is True
+    assert mcp["protocol_version"] == PROTOCOL_VERSION
+    assert mcp["missing_env"] == []

--- a/backend/tests/test_mcp_initialize_instructions.py
+++ b/backend/tests/test_mcp_initialize_instructions.py
@@ -24,6 +24,7 @@ rows whose preamble we expect to surface on ``initialize``.
 
 from __future__ import annotations
 
+import json
 import logging
 import uuid
 from datetime import UTC, datetime
@@ -336,3 +337,160 @@ async def test_initialize_against_default_tenant_carries_no_consumer_tokens(
             "default tenant -- the seed must contain no references to a specific "
             "consumer's operational discipline or repo identifiers"
         )
+
+
+# ---------------------------------------------------------------------------
+# G0.14-T13 #1202 — initialize protocolVersion mismatch observability
+# ---------------------------------------------------------------------------
+
+
+def _initialize_envelope_with_version(version: str) -> dict[str, object]:
+    """Build a valid ``initialize`` request pinning a specific protocol version.
+
+    Mirrors :func:`_initialize_envelope` but lets the caller force the
+    client-side ``protocolVersion`` to an older (or arbitrary) revision
+    so the mismatch path is exercised end-to-end through the MCP wire
+    surface.
+    """
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": version,
+            "capabilities": {},
+            "clientInfo": {"name": "test-harness", "version": "0.0.0"},
+        },
+    }
+
+
+def _parse_structlog_events(
+    captured_stdout: str,
+    *,
+    event_name: str,
+) -> list[dict[str, object]]:
+    """Filter structlog JSON-lines stdout for events matching ``event_name``.
+
+    The chassis configures structlog with :class:`PrintLoggerFactory`
+    rendering each event as a single JSON object on stdout. The test
+    surface for those events is ``capfd``'s OS-fd-level stdout
+    capture; this helper turns that raw text into a list of decoded
+    event dicts so the assertions can read attributes directly.
+    Lines that aren't valid JSON (rare interleaved warnings from
+    non-structlog sources) are silently skipped — they cannot match
+    by event name anyway, and including them would only widen the
+    parser's failure modes.
+    """
+    matches: list[dict[str, object]] = []
+    for line in captured_stdout.splitlines():
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict) and event.get("event") == event_name:
+            matches.append(event)
+    return matches
+
+
+@pytest.mark.asyncio
+async def test_initialize_logs_warning_on_protocol_version_mismatch(
+    client_with_operator: tuple[TestClient, Operator],
+    seeded_operator_tenant: None,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """Older client ``protocolVersion`` emits the mismatch WARNING + unchanged response.
+
+    Acceptance criterion (G0.14-T13 #1202): an MCP ``initialize`` call
+    with ``protocolVersion: "2025-03-26"`` (any non-``PROTOCOL_VERSION``
+    value) emits a single ``mcp_initialize_protocol_version_mismatch``
+    WARNING log line carrying ``client_protocol_version`` +
+    ``server_protocol_version``, and the response still returns
+    HTTP 200 with ``InitializeResponse.protocolVersion == PROTOCOL_VERSION``
+    (behaviour unchanged).
+
+    Capture surface: the chassis configures structlog with
+    :class:`PrintLoggerFactory`, so structured events are written to
+    stdout at the OS-fd level rather than through Python's ``logging``
+    module. ``capfd`` is the matching capture surface — same pattern
+    the existing ``test_initialize_logs_warning_on_dropped_slugs``
+    test uses on this file for the ``mcp_preamble_over_budget``
+    event. ``capture_logs()`` from ``structlog.testing`` only
+    intercepts when the project's logger factory is the testing
+    factory, which MEHO doesn't install (PrintLogger keeps
+    production parity for the test suite's wire-format assertions).
+    """
+    client, op = client_with_operator
+    older_revision = "2025-03-26"
+    assert older_revision != PROTOCOL_VERSION, (
+        "test premise broken: pinned client revision matches server"
+    )
+
+    response = post_mcp(
+        client,
+        _initialize_envelope_with_version(older_revision),
+    )
+
+    # Behaviour unchanged: HTTP 200, response echoes the server version.
+    assert response.status_code == 200
+    body = response.json()
+    assert "error" not in body
+    assert body["result"]["protocolVersion"] == PROTOCOL_VERSION
+
+    # Observability: parse PrintLogger's JSON-lines stdout for the
+    # mismatch event. Each structlog event is a single JSON document
+    # per line — scan for the expected event name + assert payload
+    # shape.
+    captured = capfd.readouterr().out
+    mismatch_events = _parse_structlog_events(
+        captured,
+        event_name="mcp_initialize_protocol_version_mismatch",
+    )
+    assert len(mismatch_events) == 1, (
+        "expected exactly one mcp_initialize_protocol_version_mismatch event; "
+        f"got captured stdout={captured!r}"
+    )
+    event = mismatch_events[0]
+    assert event["level"] == "warning"
+    assert event["client_protocol_version"] == older_revision
+    assert event["server_protocol_version"] == PROTOCOL_VERSION
+    assert event["operator_sub"] == op.sub
+
+
+@pytest.mark.asyncio
+async def test_initialize_does_not_log_mismatch_when_versions_match(
+    client_with_operator: tuple[TestClient, Operator],
+    seeded_operator_tenant: None,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """Matching client ``protocolVersion`` → no mismatch warning.
+
+    Negative complement of the mismatch test: the WARNING fires only
+    on mismatch, so clients sending the server's pinned version (the
+    typical case) leave the log stream clean. Important for log-volume
+    discipline: a noisy "every initialize logs a warning" surface
+    would train operators to ignore the event.
+    """
+    client, _op = client_with_operator
+
+    response = post_mcp(
+        client,
+        _initialize_envelope_with_version(PROTOCOL_VERSION),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "error" not in body
+    assert body["result"]["protocolVersion"] == PROTOCOL_VERSION
+
+    captured = capfd.readouterr().out
+    mismatch_events = _parse_structlog_events(
+        captured,
+        event_name="mcp_initialize_protocol_version_mismatch",
+    )
+    assert mismatch_events == [], (
+        "matching client protocolVersion must not emit the mismatch warning; "
+        f"got events={mismatch_events!r}"
+    )

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -10408,6 +10408,11 @@
           "mcp_session_id_capture": {
             "type": "string",
             "title": "Mcp Session Id Capture"
+          },
+          "mcp_protocol_version": {
+            "type": "string",
+            "title": "Mcp Protocol Version",
+            "default": "2025-06-18"
           }
         },
         "type": "object",
@@ -10418,7 +10423,7 @@
           "mcp_session_id_capture"
         ],
         "title": "HealthResponse",
-        "description": "``GET /api/v1/health`` response body.\n\n``mcp_session_id_capture`` (G0.14-T6 #1147) reports the deploy's\naudit-replay capture mode in a single field:\n\n* ``\"always\"`` \u2014 any ``Mcp-Session-Id`` header the client sends is\n  captured into ``audit_log.agent_session_id``; a missing header is\n  accepted (the row's session id lands as NULL). This is the\n  default and what G8.2 audit-replay needs to light up on a stock\n  deploy.\n* ``\"enforced\"`` \u2014 capture works the same way **plus** a missing\n  header is a JSON-RPC ``-32600`` reject before any audit row is\n  written. Flipped on by ``MCP_REQUIRE_SESSION_ID=true`` in\n  compliance deploys that forbid header-less calls.\n\nThe field is the canonical operator-facing surface for the\ncapture state until T7 #1148's ``/ready`` features block ships\nthe richer enumeration (T7's ``audit_replay`` block pulls from\nthe same\n:func:`~meho_backplane.mcp.server.mcp_session_id_capture_mode`\nhelper so both surfaces stay consistent)."
+        "description": "``GET /api/v1/health`` response body.\n\n``mcp_session_id_capture`` (G0.14-T6 #1147) reports the deploy's\naudit-replay capture mode in a single field:\n\n* ``\"always\"`` \u2014 any ``Mcp-Session-Id`` header the client sends is\n  captured into ``audit_log.agent_session_id``; a missing header is\n  accepted (the row's session id lands as NULL). This is the\n  default and what G8.2 audit-replay needs to light up on a stock\n  deploy.\n* ``\"enforced\"`` \u2014 capture works the same way **plus** a missing\n  header is a JSON-RPC ``-32600`` reject before any audit row is\n  written. Flipped on by ``MCP_REQUIRE_SESSION_ID=true`` in\n  compliance deploys that forbid header-less calls.\n\nThe field is the canonical operator-facing surface for the\ncapture state until T7 #1148's ``/ready`` features block ships\nthe richer enumeration (T7's ``audit_replay`` block pulls from\nthe same\n:func:`~meho_backplane.mcp.server.mcp_session_id_capture_mode`\nhelper so both surfaces stay consistent).\n\n``mcp_protocol_version`` (G0.14-T13 #1202) reports the server's\npinned :data:`~meho_backplane.mcp.schemas.PROTOCOL_VERSION`.\nMirrors the ``mcp_session_id_capture`` precedent: single-field\noperator visibility into the MCP layer's runtime state. The\nmatching ``mcp.protocol_version`` entry on ``/ready``'s features\nblock (see :func:`meho_backplane.features.build_features_block`)\nsurfaces the same value on the unauthenticated readiness probe so\na deploy operator can answer \"which MCP revision will this server\nnegotiate with my clients?\" without an authenticated GET."
       },
       "IngestKbRequest": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -1932,6 +1932,16 @@ type HTTPValidationError struct {
 // the same
 // :func:`~meho_backplane.mcp.server.mcp_session_id_capture_mode`
 // helper so both surfaces stay consistent).
+//
+// “mcp_protocol_version“ (G0.14-T13 #1202) reports the server's
+// pinned :data:`~meho_backplane.mcp.schemas.PROTOCOL_VERSION`.
+// Mirrors the “mcp_session_id_capture“ precedent: single-field
+// operator visibility into the MCP layer's runtime state. The
+// matching “mcp.protocol_version“ entry on “/ready“'s features
+// block (see :func:`meho_backplane.features.build_features_block`)
+// surfaces the same value on the unauthenticated readiness probe so
+// a deploy operator can answer "which MCP revision will this server
+// negotiate with my clients?" without an authenticated GET.
 type HealthResponse struct {
 	// Db Database migration status.
 	//
@@ -1946,6 +1956,7 @@ type HealthResponse struct {
 	// that were generated against the chassis-stage shape, but the
 	// handler now always populates it from the probe.
 	Db                  DbStatus `json:"db"`
+	McpProtocolVersion  *string  `json:"mcp_protocol_version,omitempty"`
 	McpSessionIdCapture string   `json:"mcp_session_id_capture"`
 
 	// Operator Operator identity surface exposed to the CLI.

--- a/docs/codebase/mcp.md
+++ b/docs/codebase/mcp.md
@@ -1,0 +1,177 @@
+# MCP server
+
+The Model Context Protocol surface in `backend/src/meho_backplane/mcp/`
+is MEHO's primary agent-facing transport. Spec-conforming clients
+connect via Streamable HTTP at `POST /mcp`, complete the
+`initialize` handshake, and then issue `tools/call` /
+`resources/read` requests against the connector + reference tool
+catalogue.
+
+Most of the surface-level architecture (router mount, dispatch table,
+audit-row shape, capability advertisement) lives in
+[`backend.md`](backend.md) under the entries tagged
+"MCP Streamable HTTP transport entrypoint", "MCP per-operation audit",
+"MCP reference tool + resource", and the broadcast-feed resources.
+This doc covers cross-cutting concerns that don't fit cleanly into a
+single Task entry.
+
+## Overview
+
+* Entry-point module: `backend/src/meho_backplane/mcp/server.py`
+* Wire schemas: `backend/src/meho_backplane/mcp/schemas.py`
+* Tool / resource registries: `register_mcp_tool` /
+  `register_mcp_resource` in `mcp/server.py`
+* Audit hook: `backend/src/meho_backplane/mcp/audit.py`
+
+The dispatch table lives at module scope and is populated at import
+time; reloading via the test fixture
+`tests/mcp_test_fixtures.isolated_registry` is the only supported way
+to mutate it between requests.
+
+## Protocol version negotiation
+
+`PROTOCOL_VERSION` in
+[`backend/src/meho_backplane/mcp/schemas.py`](../../backend/src/meho_backplane/mcp/schemas.py)
+pins the MCP revision the server implements
+(currently `"2025-06-18"`). It is a build-time constant — not a
+settings field, not env-configurable. Bumping it is an explicit
+release-cycle decision (CHANGELOG entry + release-body callout, per
+the v0.6.0 honesty-callout precedent in PR #1159).
+
+### Server behaviour
+
+The server **always** responds with
+`InitializeResponse.protocolVersion == PROTOCOL_VERSION` regardless
+of what the client sent. From the MCP 2025-06-18 spec's perspective
+this is compliant: "the server MUST respond with its own
+`protocolVersion`. If the server does not support the requested
+protocol version, it MUST respond with a version it does support
+(typically the latest version supported by the server)." MEHO
+supports exactly one revision at a time; that revision is the one
+in the response.
+
+What the spec does **not** require — and what MEHO historically did
+not provide — is a server-side signal that a downgrade or upgrade
+just occurred. A client pinned to `"2025-03-26"` receiving a
+`"2025-06-18"` response had no way to know which revision the server
+agreed to, and the operator's log stream stayed silent on the
+mismatch. The consumer-side closed-loop reporting flagged this as
+[`mcp-initialize-protocol-version-silent-upgrade`](https://github.com/evoila-bosnia/meho-internal/issues/697)
+(signal 15), and the v0.6.0 release body was amended (PR #1159) to
+call out the gap explicitly as observation-not-commitment.
+
+### G0.14-T13: observability-only
+
+[Task #1202](https://github.com/evoila/meho/issues/1202) lands the
+observability half of the gap, deliberately scoped narrow:
+
+* `_initialize` at
+  [`mcp/server.py`](../../backend/src/meho_backplane/mcp/server.py)
+  compares the validated client `protocolVersion` against
+  `PROTOCOL_VERSION` after `InitializeRequest.model_validate(...)`
+  succeeds. On mismatch it emits a single structured
+  `WARNING` log event:
+
+  ```
+  _log.warning(
+      "mcp_initialize_protocol_version_mismatch",
+      client_protocol_version=<wire value>,
+      server_protocol_version=PROTOCOL_VERSION,
+      operator_sub=operator.sub,
+  )
+  ```
+
+  The shape mirrors `mcp_unsupported_protocol_version` — the existing
+  WARNING that `_validate_protocol_version_header` already emits when
+  a non-`initialize` request carries a stale `MCP-Protocol-Version`
+  header. Operators get a uniform event-name family for both
+  handshake-time and post-handshake mismatches.
+
+* `HealthResponse` at
+  [`api/v1/health.py`](../../backend/src/meho_backplane/api/v1/health.py)
+  carries `mcp_protocol_version: str = PROTOCOL_VERSION` (mirrors the
+  `mcp_session_id_capture` precedent from G0.14-T6 #1147 — single
+  field, single source of truth, surfaced on the authenticated GET).
+
+* `/ready`'s `features` block at
+  [`features.py`](../../backend/src/meho_backplane/features.py) gains
+  an `mcp` entry of shape
+  `{"configured": true, "protocol_version": PROTOCOL_VERSION, "missing_env": []}`.
+  Mirrors the `audit_replay` block's shape (no missing env vars
+  because the field is a build-time constant, not a deploy-time
+  knob). Operators get a single unauthenticated GET that answers
+  "which MCP revision does this deploy pin?".
+
+The handshake response body itself is **unchanged**. This is
+observability-only: a pinned client requesting `"2025-03-26"` still
+gets `"2025-06-18"` back; the server just no longer keeps that
+mismatch silent.
+
+### Out of scope (deliberately)
+
+What this task **does not** do:
+
+* **Refusing mismatched clients.** Returning a JSON-RPC error on
+  mismatch would break the broad install base of clients that
+  currently negotiate against the older revision and silently
+  upgrade-tolerate.
+* **Down-negotiating to a supported older revision.** MEHO supports
+  exactly one revision per server build. Multi-version
+  capability-advertisement is a much larger surface change.
+* **Version-conditional capability advertisement.** Some MCP
+  capabilities (`resources.subscribe`, `prompts`) flip in/out across
+  revisions; advertising them conditionally on the client's
+  requested version is a per-revision compatibility matrix MEHO
+  hasn't committed to maintaining yet.
+
+Future work in any of these directions is gated on **demand
+evidence** from real deployments — the observability landed here is
+the precondition for measuring whether mismatch is actually
+happening in the wild. Operators noticing recurring
+`mcp_initialize_protocol_version_mismatch` events for the same
+client identity should file a follow-up Task on
+[`evoila/meho`](https://github.com/evoila/meho) describing the
+mismatch pattern and what behaviour change would unblock them.
+
+## Dependencies
+
+* `structlog` — every MCP log line goes through
+  `_log = structlog.get_logger()` at module scope, sharing
+  contextvar-bound fields (`operator_sub`, request-id, MCP session id
+  when present) with the rest of the request scope.
+* `pydantic` v2 — the wire schemas (`JsonRpcRequest`,
+  `InitializeRequest`, `InitializeResponse`, `ServerCapabilities`)
+  are frozen `BaseModel`s with `extra="allow"` on the envelopes per
+  MCP's forward-extensibility contract.
+* `fastapi` — the router is mounted from `mcp/server.py::router`;
+  the JWT verification + operator binding runs as a `Depends(...)`
+  on `mcp_dispatch`.
+
+## Known issues
+
+* The MCP `initialize` flow currently does not negotiate
+  capabilities (`tools`, `resources`) — they are advertised
+  unconditionally based on build-time registry state. A client
+  declining a capability on the request side has no effect; the
+  capability still appears in the response. Tracking this is
+  appropriate scope for a future Task once multi-version
+  negotiation lands.
+* `_validate_protocol_version_header` accepts an absent
+  `MCP-Protocol-Version` header on post-handshake calls as
+  transitional lenience. The strict-mode contract (header required,
+  missing → HTTP 400) is gated behind a future settings flag whose
+  rollout requires consumer migration ahead.
+
+## References
+
+* MCP spec (2025-06-18) §Initialization:
+  https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle
+* MCP spec (2025-06-18) §Streamable HTTP / Protocol Version Header:
+  https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
+* G0.14-T6 (#1147) — `mcp_session_id_capture` field on
+  `HealthResponse` (the precedent G0.14-T13 mirrors).
+* G0.14-T7 (#1148) — `/ready` `features` block (the home for
+  feature-gate visibility).
+* G0.14-T13 (#1202) — protocol-version mismatch observability
+  (this section).
+* v0.6.0 release-body amendment — PR #1159, G0.13-T6 #1136.


### PR DESCRIPTION
## Summary

- **Observability-only** for MCP `initialize` protocol-version mismatch (G0.14-T13 #1202, signal 15). When a client sends `protocolVersion: "2025-03-26"` (or any non-`PROTOCOL_VERSION` value) the server now emits a structured `mcp_initialize_protocol_version_mismatch` WARNING carrying `client_protocol_version` / `server_protocol_version` / `operator_sub`. Response body is unchanged — the server still returns its pinned `PROTOCOL_VERSION`. Mirrors the existing `mcp_unsupported_protocol_version` shape so operators get a uniform event-name family for handshake-time and post-handshake mismatches.
- Adds `mcp_protocol_version` to `HealthResponse` (`GET /api/v1/health`) and an `mcp` sub-block to `/ready`'s `features` block (via `build_features_block`). Mirrors the `mcp_session_id_capture` (G0.14-T6 #1147) and `audit_replay` (G0.14-T7 #1148) precedents — single field, single source of truth, both surfaces consistent.
- Doc lands at `docs/codebase/mcp.md` with a dedicated "Protocol version negotiation" section covering the spec-compliant-but-silent baseline, the observability G0.14-T13 ships, and what's explicitly out of scope (refusing, down-negotiating, version-conditional capability advertisement — deferred until real demand evidence accumulates).

## Test plan

- [x] `ruff check` — clean on touched files
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/` — Success: no issues found in 367 source files
- [x] `pytest tests/test_mcp_initialize_instructions.py tests/test_features.py tests/test_health.py tests/test_api_v1_health.py tests/test_mcp_server.py` — 72 passed
- [x] Broader `pytest -k "features or health or mcp or initialize or release_body"` — 550 passed, 11 skipped, 0 failed
- [x] `code-quality.py --diff` — 0 blockers (pre-existing file-size + function-size warnings on `mcp/server.py` unchanged by this PR; the new `_log_protocol_version_mismatch` helper keeps `_initialize` under the 100-line block limit)
- [x] AC: `initialize` with `protocolVersion: "2025-03-26"` emits one WARNING with the expected fields — `test_initialize_logs_warning_on_protocol_version_mismatch`
- [x] AC: same call still returns HTTP 200 with `protocolVersion == "2025-06-18"` — same test
- [x] AC: `GET /api/v1/health` carries `"mcp_protocol_version": "2025-06-18"` — `test_mcp_protocol_version_reports_server_pinned_revision`
- [x] AC: `GET /ready` carries `features.mcp.protocol_version` — `test_ready_features_block_carries_mcp_protocol_version`
- [x] AC: `docs/codebase/mcp.md` gains a "Protocol version negotiation" section — new file

## Out of scope

- Multi-version negotiation (refusing / down-negotiating / version-conditional capability advertisement) — explicitly deferred per the issue body until the observability landed here surfaces real operator demand.
- Changes to `_validate_protocol_version_header` (the header-mismatch path on non-`initialize` calls already logs correctly).
- Bumping `PROTOCOL_VERSION` itself.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1202
