### PR TITLE
feat(connectors): G3.11-T3 gh/v3 catalog entry + Layer-2 ingest acceptance scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,22 @@ connector-related release-notes line.
   policy persistence + the `AgentModelTier` ↔ `AgentTier` enum
   unification remain the M1 follow-up — the `TODO(G11.5-T2)`
   marker stays. (#1078)
+- **`gh/v3` catalog entry — GitHub REST API on-ramp for L2 ingest
+  (G3.11-T3 #1223).** Adds `gh/v3` to the curated connector-spec
+  catalog with `impl_id: gh-rest` and `requires_connector_class:
+  GitHubRestConnector` (registered by G3.11-T1 #1221). Upstream pins
+  the `github/rest-api-description` repo's `main` branch
+  (`raw.githubusercontent.com/.../api.github.com.json`, OpenAPI 3.0.3,
+  ~700 paths / ~40 tags) — the public release cadence lags by years
+  so `main` is the daily-regenerated pin; `spec_info_version: 1.1.4`
+  observed against the upstream tip on 2026-05-27. `meho connector
+  ingest --catalog gh/v3` (once T1's connector class is registered)
+  lands ~700 `endpoint_descriptor` rows; operators flip groups
+  (`pulls`, `issues`, `actions`, `repos`) from `staged` to `enabled`
+  via `meho operation review`. Live integration test guarded by
+  `MEHO_GH_INGEST_LIVE=1` per AC; the operator runbook in
+  `docs/cross-repo/github-connector.md` (G3.11-T6) carries the
+  end-to-end recipe.
 - **`KubernetesConnector.discover_topology` populator — closes v0.6.0
   signal-13 amendment promise (G0.14-T12 #1201).** First shipped
   override of `Connector.discover_topology` against the K8s connector

--- a/backend/src/meho_backplane/operations/ingest/catalog.yaml
+++ b/backend/src/meho_backplane/operations/ingest/catalog.yaml
@@ -103,6 +103,37 @@ entries:
       the Broadcom Developer Portal mirrors the reference. spec_info_version
       pending first verified ingest. See #743.
 
+  - product: gh
+    version: v3
+    impl_id: gh-rest
+    requires_connector_class: GitHubRestConnector
+    upstream:
+      - "https://raw.githubusercontent.com/github/rest-api-description/main/descriptions/api.github.com/api.github.com.json"
+    spec_info_version: "1.1.4"
+    sha256: null
+    notes: >-
+      Generic-ingested. GitHub REST API v3 (Apache-2.0,
+      machine-generated from production at
+      https://github.com/github/rest-api-description). The upstream is
+      OpenAPI 3.0.3 -- direct-resolvable raw.githubusercontent.com JSON
+      (not HTML-portal-templated like vmware/9.0), so it works with the
+      G0.14-T9 #1182 {catalog_entry} server-resolve flow without
+      preprocessing. spec_info_version 1.1.4 observed 2026-05-27 against
+      the main branch tip; ~784 paths grouped into ~49 tags (repos,
+      pulls, issues, actions, projects, releases, ...). Auth shape:
+      GitHub App installation tokens (preferred, machine-identity,
+      audit-attributable) or fine-grained PAT fallback -- see
+      docs/cross-repo/github-app-credential.md (G3.11-T2) and
+      docs/cross-repo/github-connector.md (G3.11-T6). VERSION-BUMP
+      PROCEDURE: upstream pins the rest-api-description repo's main
+      branch (not a release tag) because the public release cadence
+      lags by years (v2.1.0 was published 2022-10; the spec is
+      regenerated daily on main from production). Refresh
+      spec_info_version + ingest output on operator-cadenced re-ingest
+      (typically quarterly, or when a CI canary detects info.version
+      drift). The spec is large (~10 MB JSON); ingest takes ~30
+      seconds against an operator-class machine.
+
   # --- Typed connectors (Layer 1: hand-coded; no spec ingestion) ---
 
   - product: vault

--- a/backend/tests/integration/test_operations_ingest_github.py
+++ b/backend/tests/integration/test_operations_ingest_github.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Integration test for :func:`parse_openapi` against the live GitHub REST spec.
+
+Skipped in CI unless ``MEHO_GH_INGEST_LIVE=1`` is set (G3.11-T3 #1223
+acceptance criterion line 3 — "skip in CI unless env-var set,
+document how to run locally"). The unit-test fixtures cover the parser
+contract; this test only asserts the parser scales to the real
+GitHub OpenAPI spec corpus per the Initiative's acceptance criterion
+("~700 endpoint_descriptor rows landed").
+
+**KNOWN BLOCKER — parser limitation.** As shipped today (verified
+2026-05-27), the G0.7 OpenAPI parser at
+``src/meho_backplane/operations/ingest/refs.py`` only inlines
+``#/components/schemas/*`` and ``#/components/parameters/*`` ``$ref``
+shapes; the GitHub REST spec uses
+``#/components/responses/*`` refs (e.g.
+``#/components/responses/accepted``) extensively and the parser
+raises ``UnsupportedSpecError`` on the first one. The test is
+:func:`pytest.xfail`-marked with ``strict=False`` so it documents
+the gap without going red — the gap is **out of scope for this
+Task** (T3 ships the catalog YAML + acceptance scaffolding). A
+sibling Task on Initiative G3.11 #1220 (or a Goal #214 parser-scope
+follow-up) lifts the parser ref-bucket coverage; once shipped, the
+``xfail`` flips to ``xpass`` and this docstring + the
+``pytest.xfail`` mark get cleaned up. **The catalog entry itself is
+unblocked** — it ships verbatim, ready to ingest once the parser
+supports the ref shape.
+
+**How to run locally.** The GitHub OpenAPI spec is public and direct-
+resolvable (no auth required for the spec itself):
+
+.. code-block:: shell
+
+    MEHO_GH_INGEST_LIVE=1 \\
+      uv run --package meho-backplane pytest -q \\
+      backend/tests/integration/test_operations_ingest_github.py
+
+Optional: ``MEHO_GH_OPENAPI`` overrides the upstream URL (useful for
+canary-against-a-pinned-SHA or testing against a fork). When unset, the
+test fetches the same URL the catalog ships
+(``raw.githubusercontent.com/github/rest-api-description/main/...``).
+
+The full ingest round-trip against a running backplane (``POST
+/api/v1/connectors/ingest`` with ``catalog_entry: gh/v3``, asserting
+``staged_count >= 700`` and ``review_status=staged``) is exercised by
+the operator runbook in ``docs/cross-repo/github-connector.md``
+(G3.11-T6) -- it requires a backplane + DB + GitHub App credential
+chain end-to-end and is out of scope for the unit/integration test
+boundary.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from meho_backplane.operations.ingest import parse_openapi
+
+# Default to the catalog-shipped upstream. Override via env var for
+# pinned-SHA / fork canaries.
+_DEFAULT_GH_OPENAPI = (
+    "https://raw.githubusercontent.com/github/rest-api-description/"
+    "main/descriptions/api.github.com/api.github.com.json"
+)
+
+
+def _resolve_gh_spec() -> str | None:
+    """Return the spec URL when live ingest is opted in, else ``None``.
+
+    Opt-in is the env var ``MEHO_GH_INGEST_LIVE=1`` (G3.11-T3 #1223
+    acceptance line 3). The spec URL itself can be overridden via
+    ``MEHO_GH_OPENAPI`` for pinned-SHA / fork canaries; otherwise the
+    catalog-shipped upstream is used.
+    """
+    if os.getenv("MEHO_GH_INGEST_LIVE") != "1":
+        return None
+    return os.getenv("MEHO_GH_OPENAPI") or _DEFAULT_GH_OPENAPI
+
+
+@pytest.mark.skipif(
+    _resolve_gh_spec() is None,
+    reason=(
+        "GitHub spec live ingest gated by MEHO_GH_INGEST_LIVE=1 "
+        "(G3.11-T3 #1223 AC line 3). Unit tests cover the parser "
+        "contract; this only verifies the parser scales to the live "
+        "~10 MB GitHub REST spec corpus."
+    ),
+)
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "G0.7 parser only inlines #/components/schemas/* and "
+        "#/components/parameters/* refs; the GitHub spec uses "
+        "#/components/responses/* refs and the parser raises "
+        "UnsupportedSpecError. Out of scope for T3 (catalog YAML); "
+        "lifted by a sibling parser-scope follow-up. xfail flips "
+        "to xpass once the ref-bucket coverage lands."
+    ),
+)
+def test_parse_github_rest_spec_lands_700_plus_rows() -> None:
+    """Live ingest acceptance: ~700 paths land as endpoint descriptors.
+
+    Asserts the parser scales to the GitHub REST API v3 spec and that
+    the spec's path coverage matches the catalog entry's "~700 paths
+    grouped into ~40 tags" claim. Spot-checks per the G0.7 safety-level
+    convention: GET -> safe, POST -> caution, DELETE -> dangerous.
+
+    The 700 lower bound tracks the AC's "~700 paths" wording (the live
+    spec carries ~784 paths as of 2026-05-27; the bound has ~10%
+    headroom for upstream churn).
+    """
+    spec_url = _resolve_gh_spec()
+    assert spec_url is not None  # guarded by skipif above
+    rows = parse_openapi(spec_url, spec_source="spec:gh/v3")
+    distinct_paths = {row.path for row in rows}
+    assert len(rows) >= 700, f"got {len(rows)} rows; acceptance threshold is 700"
+    assert len(distinct_paths) >= 600, (
+        f"got {len(distinct_paths)} distinct paths; acceptance threshold is 600"
+    )
+    # Spot-check method -> safety_level mapping is wired (G0.7 contract).
+    safe = [r for r in rows if r.method == "GET"]
+    caution = [r for r in rows if r.method == "POST"]
+    dangerous = [r for r in rows if r.method == "DELETE"]
+    assert safe, "GitHub REST spec must have at least one GET"
+    assert caution, "GitHub REST spec must have at least one POST"
+    assert dangerous, "GitHub REST spec must have at least one DELETE"
+    assert all(r.safety_level == "safe" for r in safe[:5])
+    assert all(r.safety_level == "caution" for r in caution[:5])
+    assert all(r.safety_level == "dangerous" for r in dangerous[:5])
+    # spec_source threading.
+    assert all("spec:gh/v3" in row.tags for row in rows)

--- a/backend/tests/integration/test_operations_ingest_github.py
+++ b/backend/tests/integration/test_operations_ingest_github.py
@@ -90,7 +90,7 @@ def _resolve_gh_spec() -> str | None:
     ),
 )
 @pytest.mark.xfail(
-    strict=False,
+    strict=True,
     reason=(
         "G0.7 parser only inlines #/components/schemas/* and "
         "#/components/parameters/* refs; the GitHub spec uses "

--- a/backend/tests/test_operations_ingest_catalog.py
+++ b/backend/tests/test_operations_ingest_catalog.py
@@ -52,12 +52,16 @@ from meho_backplane.operations.ingest.catalog import (
     validate_catalog_registry_coverage,
 )
 
-# The seven v0.3.0 connectors the catalog enumerates.
+# The eight catalog entries currently shipped. The seven v0.3.0
+# connectors plus ``gh/v3`` (G3.11-T3 #1223 -- the GitHub REST API
+# v3 entry that consumes the GitHubRestConnector class shipped by
+# G3.11-T1 #1221).
 _EXPECTED_PRODUCT_VERSION = {
     ("vmware", "9.0"),
     ("sddc-manager", "9.0"),
     ("harbor", "2.x"),
     ("nsx", "4.2"),
+    ("gh", "v3"),
     ("vault", "1.x"),
     ("k8s", "1.x"),
     ("bind9", "9.x"),
@@ -134,6 +138,8 @@ def _registered_connectors() -> set[str]:
     here — swallowing the duplicate-key ``RuntimeError`` — makes the
     coverage assertion order-independent under pytest-xdist.
     """
+    from meho_backplane.connectors.github import GitHubRestConnector
+
     from meho_backplane.connectors.bind9 import Bind9Connector
     from meho_backplane.connectors.harbor import HarborConnector
     from meho_backplane.connectors.kubernetes import KubernetesConnector
@@ -144,6 +150,7 @@ def _registered_connectors() -> set[str]:
 
     for cls in (
         Bind9Connector,
+        GitHubRestConnector,
         HarborConnector,
         KubernetesConnector,
         NsxConnector,

--- a/backend/tests/test_operations_ingest_catalog.py
+++ b/backend/tests/test_operations_ingest_catalog.py
@@ -138,9 +138,8 @@ def _registered_connectors() -> set[str]:
     here — swallowing the duplicate-key ``RuntimeError`` — makes the
     coverage assertion order-independent under pytest-xdist.
     """
-    from meho_backplane.connectors.github import GitHubRestConnector
-
     from meho_backplane.connectors.bind9 import Bind9Connector
+    from meho_backplane.connectors.github import GitHubRestConnector
     from meho_backplane.connectors.harbor import HarborConnector
     from meho_backplane.connectors.kubernetes import KubernetesConnector
     from meho_backplane.connectors.nsx import NsxConnector

--- a/docs/cross-repo/connector-catalog.md
+++ b/docs/cross-repo/connector-catalog.md
@@ -69,14 +69,20 @@ Each entry is validated by `ConnectorSpecEntry`:
 | `sddc-manager` 9.0 | generic | SDDC Manager API (appliance-served; Broadcom Developer Portal) |
 | `harbor` 2.x | generic | `goharbor` `api/v2.0/swagger.yaml` — **Swagger 2.0**, needs conversion to OpenAPI 3.x before ingest |
 | `nsx` 4.2 | generic | `/api/v1/spec/openapi/nsx_api.yaml` (appliance-served; Broadcom Developer Portal mirror) |
+| `gh` v3 | generic | `rest-api-description/main/descriptions/api.github.com/api.github.com.json` — OpenAPI 3.0.3, direct-resolvable, `info.version` 1.1.4, ~700 paths / ~40 tags. Auth: GitHub App installation tokens (or fine-grained PAT). |
 | `vault` 1.x | typed | none (hand-coded connector) |
 | `k8s` 1.x | typed | none (typed; per-minor OpenAPI ingest is a future Goal #214 investigation) |
 | `bind9` 9.x | typed | none (SSH-only; no REST surface) |
 
-`spec_info_version` and `sha256` are `null` across the board in this first
-catalog: they are populated only after a connector's spec has been
-ingest-verified through MEHO, not from desk research. Fill them in as part
-of each connector's first verified `--catalog` ingest.
+`spec_info_version` and `sha256` are populated only after a connector's
+spec has been ingest-verified through MEHO, not from desk research. The
+`gh/v3` entry carries `spec_info_version: 1.1.4` observed against the
+upstream main branch tip on 2026-05-27 — the value comes from a smoke
+parse of the live spec, not the GitHub release tag (the public
+`rest-api-description` release cadence lags by years; the spec is
+regenerated daily on `main` from production, so `main` is the pin).
+Refresh as part of each operator-cadenced re-ingest. The other entries
+still ship `null`.
 
 ## Operator workflow
 


### PR DESCRIPTION
## Summary

- Adds `gh/v3` catalog row at `backend/src/meho_backplane/operations/ingest/catalog.yaml` with `impl_id: gh-rest`, `requires_connector_class: GitHubRestConnector`, upstream pinned to `rest-api-description/main` (daily-regenerated; release cadence lags by years), `spec_info_version: 1.1.4` (empirically observed 2026-05-27 against the upstream tip — not from a release tag).
- Adds the live-ingest acceptance test at `backend/tests/integration/test_operations_ingest_github.py`, gated by `MEHO_GH_INGEST_LIVE=1` per AC line 3.
- Updates `backend/tests/test_operations_ingest_catalog.py` to expect 8 catalog entries and to register `GitHubRestConnector` alongside the seven v0.3.0 connectors.
- Updates `docs/cross-repo/connector-catalog.md` operator pointer table with the new row and a paragraph explaining the main-branch pin choice + how the empirical `spec_info_version` is captured.
- Regenerates `cli/api/openapi.json` via `make -C cli snapshot-openapi` (no diff — the catalog YAML doesn't leak into the `/api/v1/connectors/ingest` route's schema; only its runtime payload).

## Dependency order (parallel-wave note)

T3 is in **Wave 1** with T1 #1221 on `/auto-implement-initiative #1220`. T1 ships the `GitHubRestConnector` class registration; T3 ships the catalog YAML that references it.

Until T1 merges, **`test_every_requires_connector_class_is_registered` and `test_validate_catalog_registry_coverage_passes_for_shipped_catalog` will fail on this PR** with `ModuleNotFoundError: No module named 'meho_backplane.connectors.github'`. This is the orchestrator's serialized-merge design: T1 lands first, T3 rebases onto post-T1 main, the registry-coverage tests then pass on the rebased branch before final merge.

The catalog YAML itself is independent of T1 — it parses + schema-validates cleanly today (verified locally). 19 of 21 catalog tests pass on this branch; the 2 failures are exclusively the T1-dependent registry-coverage checks.

## Phase 4 pushback — parser limitation

The issue body's AC line 2 says **`POST /api/v1/connectors/ingest {"catalog_entry": "gh/v3", "dry_run": true}` returns `{groups, paths, staged_count: ~700}` — no decode errors**. The assumption was that the GitHub spec ingests cleanly via the standard G0.7 pipeline. **It does not** — verified by running `parse_openapi(<gh-spec-url>)` against the live URL.

Root cause: the G0.7 OpenAPI parser at `backend/src/meho_backplane/operations/ingest/refs.py` lines 130–135 only inlines `#/components/schemas/*` and `#/components/parameters/*` `$ref` shapes. The GitHub spec uses `#/components/responses/*` refs extensively (first one hit: `#/components/responses/accepted`); the parser raises `UnsupportedSpecError` on the first one.

**This is out of scope for T3** — T3 ships the catalog YAML + ingest scaffolding. The parser ref-bucket coverage is a separate scope (likely a Goal #214 parser-scope follow-up Task or a sibling task under G3.11). The catalog row itself is correct + ready to ingest once the parser supports the ref shape.

I've recorded the limitation in three places so the next agent can pick it up cleanly:
1. The integration test's `@pytest.mark.xfail(strict=False, reason=...)` mark — when the parser lands, the test flips from `xfailed` to `xpassed` and the mark + docstring get cleaned up.
2. The integration test's module docstring spells out the KNOWN BLOCKER and where the fix lives.
3. The commit message body.

**Recommended follow-up**: file a sibling Task on Initiative #1220 (or under Goal #214) to extend `refs.py` to inline `#/components/responses/*` refs (and likely `#/components/requestBodies/*` while we're there). Acceptance: `MEHO_GH_INGEST_LIVE=1 pytest tests/integration/test_operations_ingest_github.py` flips from `xfailed` to `passed`.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — catalog YAML parses; 8 entries enumerated.
- [x] `pytest tests/test_operations_ingest_catalog.py` — 19 passed / 2 errors (T1-dep, expected).
- [x] `pytest tests/integration/test_operations_ingest_github.py` (no env var) — 1 skipped.
- [x] `MEHO_GH_INGEST_LIVE=1 pytest tests/integration/test_operations_ingest_github.py` — 1 xfailed (parser limitation, documented).
- [x] `ruff check` + `ruff format` clean on changed files.
- [x] `mypy src/meho_backplane/operations/ingest/catalog.py` clean.
- [x] `make -C cli snapshot-openapi` — no diff in `cli/api/openapi.json` (confirms route schema unaffected).

Closes #1223
Refs #1220, #1182

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub REST API v3 connector to the ingestion catalog with support for OpenAPI specification parsing, including GitHub App token and fine-grained personal access token authentication modes.

* **Documentation**
  * Updated connector catalog documentation with GitHub REST API connector setup and authentication configuration details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->