### PR TITLE
fix(ingest): G0.15-T2 reject HTML-portal upstreams with structured 422 (sub-signal B)

### DIFF
--- a/backend/src/meho_backplane/api/v1/connectors_ingest.py
+++ b/backend/src/meho_backplane/api/v1/connectors_ingest.py
@@ -143,10 +143,13 @@ from meho_backplane.operations.ingest import (
     SpecSource,
     UncoveredVersionLabel,
     UnsupportedSpecError,
+    UpstreamNotSpecError,
     VersionMismatchError,
     build_catalog_entry_malformed_detail,
     build_catalog_entry_not_found_detail,
     build_catalog_entry_typed_connector_detail,
+    build_catalog_entry_upstream_not_spec_detail,
+    build_upstream_not_spec_detail,
     build_version_mismatch_detail,
     default_llm_client_factory,
     list_ingested_connectors,
@@ -250,12 +253,25 @@ async def ingest_endpoint(
     by hitting :class:`IngestionPipelineService` directly with
     ``tenant_id=None``.
     """
+    # Remember the original ``catalog_entry`` (pre-resolution) so the
+    # ``UpstreamNotSpecError`` path -- raised deep inside the parser
+    # when an HTML developer-portal page comes back instead of an
+    # OpenAPI spec -- can include the catalog reference in its 422
+    # envelope. ``_resolve_catalog_entry_if_set`` returns an explicit-
+    # quadruple body with ``catalog_entry=None``, so we have to snapshot
+    # before resolution.
+    catalog_entry = body.catalog_entry
     resolved = _resolve_catalog_entry_if_set(body)
     service = IngestionPipelineService(
         operator=operator,
         llm_client_factory=llm_client_factory,
     )
-    result = await _run_ingest_with_http_mapping(service=service, body=resolved, operator=operator)
+    result = await _run_ingest_with_http_mapping(
+        service=service,
+        body=resolved,
+        operator=operator,
+        catalog_entry=catalog_entry,
+    )
     ingestion_model, grouping_model = result.to_api_models()
     return IngestResponse(ingestion=ingestion_model, grouping=grouping_model)
 
@@ -392,26 +408,66 @@ def _reject_unusable_entry(
         )
 
 
+def _upstream_not_spec_http_exception(
+    exc: UpstreamNotSpecError,
+    *,
+    catalog_entry: str | None,
+) -> HTTPException:
+    """Map :exc:`UpstreamNotSpecError` onto the 422 envelope shape.
+
+    G0.15-T2 (#1211). The HTTP fetch succeeded (2xx) but the upstream
+    URL returned non-spec content -- typically the Broadcom Developer
+    Portal landing page for ``vmware/9.0`` and ``sddc-manager/9.0``,
+    which serves HTML rather than OpenAPI YAML/JSON. Before this
+    branch, the bytes fell through to the YAML decoder and surfaced
+    as an opaque ``could not decode spec: ... line 33`` 400. The
+    structured 422 carries the catalog_entry (when the request
+    started as catalog-driven), the upstream URL, and the
+    Content-Type so an agent / operator can branch on the diagnostic
+    and switch to the explicit-quadruple shape with a local spec
+    file. Extracted from the mapping helper below so its body stays
+    inside the code-quality function-size budget.
+    """
+    if catalog_entry is not None:
+        detail: dict[str, object] = build_catalog_entry_upstream_not_spec_detail(
+            catalog_entry=catalog_entry,
+            upstream_url=exc.upstream_url,
+            content_type=exc.content_type,
+        )
+    else:
+        detail = build_upstream_not_spec_detail(
+            upstream_url=exc.upstream_url,
+            content_type=exc.content_type,
+        )
+    return HTTPException(
+        status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+        detail=detail,
+    )
+
+
 async def _run_ingest_with_http_mapping(
     *,
     service: IngestionPipelineService,
     body: IngestRequest,
     operator: Operator,
+    catalog_entry: str | None = None,
 ) -> IngestionPipelineResult:
     """Drive :meth:`IngestionPipelineService.ingest` and map domain errors to HTTP.
-
-    Extracted from :func:`ingest_endpoint` so the handler body stays
-    under the code-quality function-size threshold; the mapping
-    table itself is the load-bearing contract documented at the top
-    of the module.
 
     Pre-condition: ``body`` is in the explicit-quadruple shape
     (``product`` / ``version`` / ``impl_id`` / ``specs`` populated).
     The catalog-driven shape is resolved upstream by
     :func:`_resolve_catalog_entry_if_set`; the asserts below pin the
     invariant so a future refactor that bypasses that helper trips
-    at the boundary rather than landing a half-populated ingest
-    against ``product=None`` / ``version=None`` / ``impl_id=None``.
+    at the boundary rather than landing a half-populated ingest.
+
+    ``catalog_entry`` carries the operator's original
+    ``"<product>/<version>"`` reference when the request started as
+    the catalog-driven shape; ``None`` for explicit-quadruple
+    requests. Used only on the :exc:`UpstreamNotSpecError` path so
+    the 422 envelope can include the catalog reference
+    (G0.15-T2 / #1211). The full exception-to-status table is the
+    load-bearing contract documented at the top of the module.
     """
     assert body.product is not None, "post-resolution invariant: product must be set"
     assert body.version is not None, "post-resolution invariant: version must be set"
@@ -427,44 +483,30 @@ async def _run_ingest_with_http_mapping(
             dry_run=body.dry_run,
         )
     except LlmClientUnavailable as exc:
-        raise HTTPException(
-            status_code=http_status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail=str(exc),
-        ) from exc
+        raise HTTPException(http_status.HTTP_503_SERVICE_UNAVAILABLE, str(exc)) from exc
     except PermissionError as exc:
-        # Defence-in-depth — the route's _require_admin already
-        # gates this, but the service-level guard might catch a
-        # cross-tenant write that slipped through.
-        raise HTTPException(
-            status_code=http_status.HTTP_403_FORBIDDEN,
-            detail=str(exc),
-        ) from exc
+        # Defence-in-depth — the route's _require_admin already gates this,
+        # but the service-level guard might catch a cross-tenant write that
+        # slipped through.
+        raise HTTPException(http_status.HTTP_403_FORBIDDEN, str(exc)) from exc
     except VersionMismatchError as exc:
-        # G0.9-T8 (#740). 422 (not 400) because the request was
-        # syntactically valid but semantically refuses the spec-vs-label
-        # cross-check. The structured detail names both versions so the
-        # operator's error message tells them exactly what to fix. The
-        # detail builder is shared with the MCP path
-        # (:mod:`meho_backplane.operations.ingest.error_envelopes`,
-        # G0.9.1-T5 #777) so the REST 422 body and the MCP -32602
-        # ``data`` member can't drift.
+        # G0.9-T8 (#740). 422 (not 400) because the request was syntactically
+        # valid but semantically refuses the spec-vs-label cross-check.
+        # Detail builder is shared with the MCP path
+        # (operations/ingest/error_envelopes.py, G0.9.1-T5 #777) so the REST
+        # 422 body and the MCP -32602 ``data`` member can't drift.
         raise HTTPException(
-            status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=build_version_mismatch_detail(exc),
+            http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+            build_version_mismatch_detail(exc),
         ) from exc
     except UncoveredVersionLabel as exc:
-        # G0.9-T9 (#741). The request body parsed fine (Pydantic
-        # accepted shape + length bounds), but the operator's
-        # ``version`` label is semantically outside every registered
-        # connector class's ``supported_version_range`` for the
-        # ``(product, impl_id)`` pair — orphan-at-ingest. 422
-        # Unprocessable Entity is the right code: structurally valid,
-        # semantically rejected. Listed BEFORE the generic ValueError-
+        # G0.9-T9 (#741). Structurally valid (Pydantic accepted), semantically
+        # rejected (label outside every registered class's
+        # ``supported_version_range``). Listed BEFORE the generic ValueError-
         # family catch below so the more-specific exception wins.
-        raise HTTPException(
-            status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=str(exc),
-        ) from exc
+        raise HTTPException(http_status.HTTP_422_UNPROCESSABLE_CONTENT, str(exc)) from exc
+    except UpstreamNotSpecError as exc:
+        raise _upstream_not_spec_http_exception(exc, catalog_entry=catalog_entry) from exc
     except (
         InvalidSpecError,
         UnsupportedSpecError,
@@ -472,27 +514,23 @@ async def _run_ingest_with_http_mapping(
         OpIdCollision,
         LlmOutputInvalid,
     ) as exc:
-        raise HTTPException(
-            status_code=http_status.HTTP_400_BAD_REQUEST,
-            detail=str(exc),
-        ) from exc
+        raise HTTPException(http_status.HTTP_400_BAD_REQUEST, str(exc)) from exc
     except (yaml.YAMLError, JSONDecodeError) as exc:
-        # The parser passes malformed YAML / JSON bubble-up by design
-        # (per parse_openapi's docstring) so the loader's structured
-        # error message survives to the operator. Route maps to 400.
+        # The parser passes malformed YAML / JSON bubble-up by design (per
+        # parse_openapi's docstring) so the loader's structured error message
+        # survives to the operator. Route maps to 400.
         raise HTTPException(
-            status_code=http_status.HTTP_400_BAD_REQUEST,
-            detail=f"could not decode spec: {exc}",
+            http_status.HTTP_400_BAD_REQUEST,
+            f"could not decode spec: {exc}",
         ) from exc
     except httpx.HTTPError as exc:
-        # HTTP(S) fetch failures for URL specs surface as
-        # ``httpx.HTTPError`` per :func:`parse_openapi`'s contract.
-        # 502 Bad Gateway is the closest semantic fit: the operator's
-        # request is fine but an upstream the route had to reach
-        # didn't respond cleanly.
+        # HTTP(S) fetch failures for URL specs surface as ``httpx.HTTPError``
+        # per :func:`parse_openapi`'s contract. 502 Bad Gateway is the closest
+        # semantic fit: the operator's request is fine but an upstream the
+        # route had to reach didn't respond cleanly.
         raise HTTPException(
-            status_code=http_status.HTTP_502_BAD_GATEWAY,
-            detail=f"upstream spec fetch failed: {exc}",
+            http_status.HTTP_502_BAD_GATEWAY,
+            f"upstream spec fetch failed: {exc}",
         ) from exc
 
 

--- a/backend/src/meho_backplane/operations/ingest/__init__.py
+++ b/backend/src/meho_backplane/operations/ingest/__init__.py
@@ -46,7 +46,9 @@ from meho_backplane.operations.ingest.error_envelopes import (
     build_catalog_entry_malformed_detail,
     build_catalog_entry_not_found_detail,
     build_catalog_entry_typed_connector_detail,
+    build_catalog_entry_upstream_not_spec_detail,
     build_uncovered_version_label_detail,
+    build_upstream_not_spec_detail,
     build_version_mismatch_detail,
 )
 from meho_backplane.operations.ingest.exceptions import (
@@ -58,6 +60,7 @@ from meho_backplane.operations.ingest.exceptions import (
     OpIdCollision,
     UncoveredVersionLabel,
     UnsupportedSpecError,
+    UpstreamNotSpecError,
     VersionMismatchError,
 )
 from meho_backplane.operations.ingest.list_connectors import (
@@ -137,11 +140,14 @@ __all__ = [
     "SpecSource",
     "UncoveredVersionLabel",
     "UnsupportedSpecError",
+    "UpstreamNotSpecError",
     "VersionMismatchError",
     "build_catalog_entry_malformed_detail",
     "build_catalog_entry_not_found_detail",
     "build_catalog_entry_typed_connector_detail",
+    "build_catalog_entry_upstream_not_spec_detail",
     "build_uncovered_version_label_detail",
+    "build_upstream_not_spec_detail",
     "build_version_mismatch_detail",
     "check_version_covered_by_registered_class",
     "default_llm_client_factory",

--- a/backend/src/meho_backplane/operations/ingest/catalog.yaml
+++ b/backend/src/meho_backplane/operations/ingest/catalog.yaml
@@ -56,7 +56,13 @@ entries:
       connector triple: vcenter.yaml (modern REST automation API, ~961 paths)
       and vi-json.yaml (Performance Manager, snapshots, host ops, ~2,195
       paths). Both are served by the appliance at https://<vcenter-fqdn>/ and
-      mirrored on the Broadcom Developer Portal (links above). spec_info_version
+      mirrored on the Broadcom Developer Portal (links above). SHARP EDGE:
+      the upstream URLs above are HTML developer-portal landing pages, not
+      raw OpenAPI YAML/JSON, so catalog-driven ingest via
+      `meho connector ingest --catalog vmware/9.0` returns HTTP 422
+      `catalog_entry_upstream_not_spec` (G0.15-T2 #1211); fetch the raw
+      specs manually from the appliance (https://<vcenter-fqdn>/api/...)
+      and pass them via the explicit-quadruple shape. spec_info_version
       pending the first MEHO-verified ingest. See #743 / connector-ingestion.md.
 
   - product: sddc-manager
@@ -70,7 +76,13 @@ entries:
     notes: >-
       Generic-ingested. The SDDC Manager API is served by the appliance at
       https://<sddc-manager-fqdn>/v1/ and documented on the Broadcom Developer
-      Portal (link above). spec_info_version pending first verified ingest.
+      Portal (link above). SHARP EDGE: the upstream URL above is an HTML
+      developer-portal landing page, not raw OpenAPI YAML/JSON, so
+      catalog-driven ingest via
+      `meho connector ingest --catalog sddc-manager/9.0` returns HTTP 422
+      `catalog_entry_upstream_not_spec` (G0.15-T2 #1211); fetch the raw
+      spec manually from the appliance and pass it via the explicit-
+      quadruple shape. spec_info_version pending first verified ingest.
       See #743.
 
   - product: harbor

--- a/backend/src/meho_backplane/operations/ingest/error_envelopes.py
+++ b/backend/src/meho_backplane/operations/ingest/error_envelopes.py
@@ -41,7 +41,9 @@ __all__ = [
     "build_catalog_entry_malformed_detail",
     "build_catalog_entry_not_found_detail",
     "build_catalog_entry_typed_connector_detail",
+    "build_catalog_entry_upstream_not_spec_detail",
     "build_uncovered_version_label_detail",
+    "build_upstream_not_spec_detail",
     "build_version_mismatch_detail",
 ]
 
@@ -168,6 +170,91 @@ def build_catalog_entry_typed_connector_detail(
             f"catalog_entry_typed_connector: {catalog_entry!r} is a typed "
             f"connector ({product}/{version}/{impl_id}) with no ingestable "
             "spec; nothing to ingest. See docs/cross-repo/connector-catalog.md. "
+            "See docs/codebase/error-message-shape.md."
+        ),
+    }
+
+
+def build_catalog_entry_upstream_not_spec_detail(
+    *,
+    catalog_entry: str,
+    upstream_url: str,
+    content_type: str | None,
+) -> dict[str, Any]:
+    """Structured 422 detail for catalog-driven ingest when the upstream URL
+    served non-spec content (HTML developer portal, etc.) -- G0.15-T2 / #1211.
+
+    Concrete trigger: ``vmware/9.0`` and ``sddc-manager/9.0`` upstream URLs
+    point at the Broadcom Developer Portal landing pages, which return HTML,
+    not OpenAPI YAML/JSON. Before this envelope, the route fell through to
+    the parser's generic ``could not decode spec`` 400 ("while scanning for
+    the next token found character that cannot start any token in '<file>',
+    line 33, column 1") -- a true statement about the bytes but a useless
+    one for the operator. T11 convention says: name the values, name the
+    remediation, point at the doc.
+
+    Body shape (T11 convention, see
+    :doc:`docs/codebase/error-message-shape.md`):
+
+    * ``detail`` -- stable ``snake_case`` classifier
+      ``"catalog_entry_upstream_not_spec"`` so callers branch without
+      re-parsing the message.
+    * ``catalog_entry`` -- the operator-supplied
+      ``"<product>/<version>"`` reference, echoed back so an agent does
+      not need to re-thread it from its own prompt.
+    * ``upstream_url`` -- the URL the route fetched and rejected.
+    * ``content_type`` -- the verbatim ``Content-Type`` header the
+      server returned (e.g. ``"text/html; charset=utf-8"``). ``null``
+      when the server omitted the header entirely.
+    * ``message`` -- the rendered human-readable detail with the
+      remediation step (fetch the spec manually, pass via the explicit-
+      quadruple shape) for clients that ignore the structured fields.
+    """
+    rendered_ct = repr(content_type) if content_type is not None else "<missing>"
+    return {
+        "detail": "catalog_entry_upstream_not_spec",
+        "catalog_entry": catalog_entry,
+        "upstream_url": upstream_url,
+        "content_type": content_type,
+        "message": (
+            f"catalog_entry_upstream_not_spec: {catalog_entry!r} upstream "
+            f"{upstream_url!r} returned non-spec content "
+            f"(Content-Type={rendered_ct}); the URL serves a developer-portal "
+            "landing page or other non-OpenAPI content, not raw YAML/JSON. "
+            "Fetch the spec manually and pass it via the explicit-quadruple "
+            "shape (product/version/impl_id/specs[]) -- the operator's "
+            "checked-out clone, an appliance URL, or a mirrored file path. "
+            "See docs/cross-repo/connector-catalog.md. "
+            "See docs/codebase/error-message-shape.md."
+        ),
+    }
+
+
+def build_upstream_not_spec_detail(
+    *,
+    upstream_url: str,
+    content_type: str | None,
+) -> dict[str, Any]:
+    """Structured 422 detail for explicit-quadruple ingest when an
+    operator-supplied spec URL served non-spec content -- G0.15-T2 / #1211.
+
+    Same diagnostic as :func:`build_catalog_entry_upstream_not_spec_detail`
+    but without the ``catalog_entry`` field -- explicit-quadruple requests
+    pass spec URIs directly via ``specs[]``, so there is no catalog reference
+    to echo back. The route layer picks whichever builder the request shape
+    produced.
+    """
+    rendered_ct = repr(content_type) if content_type is not None else "<missing>"
+    return {
+        "detail": "upstream_not_spec",
+        "upstream_url": upstream_url,
+        "content_type": content_type,
+        "message": (
+            f"upstream_not_spec: upstream {upstream_url!r} returned "
+            f"non-spec content (Content-Type={rendered_ct}); the URL serves "
+            "a developer-portal landing page or other non-OpenAPI content, "
+            "not raw YAML/JSON. Supply a URL that serves OpenAPI YAML/JSON "
+            "directly, or pass a local file path. "
             "See docs/codebase/error-message-shape.md."
         ),
     }

--- a/backend/src/meho_backplane/operations/ingest/exceptions.py
+++ b/backend/src/meho_backplane/operations/ingest/exceptions.py
@@ -97,6 +97,7 @@ __all__ = [
     "OpIdCollision",
     "UncoveredVersionLabel",
     "UnsupportedSpecError",
+    "UpstreamNotSpecError",
     "VersionMismatchError",
 ]
 
@@ -119,6 +120,61 @@ class UnsupportedSpecError(ValueError):
     names the offending shape so the operator can decide whether to
     file a v0.2.next request or pre-process the spec.
     """
+
+
+class UpstreamNotSpecError(ValueError):
+    """The upstream URL served non-spec content (HTML developer portal, etc.).
+
+    Raised by :func:`~meho_backplane.operations.ingest.openapi.parse_openapi`'s
+    HTTP fetch path (and the lightweight :func:`read_spec_info_version`
+    sibling) when the response's ``Content-Type`` declares a media type
+    that is not OpenAPI-spec-shaped (e.g. ``text/html``,
+    ``application/octet-stream`` with HTML body). Before this exception,
+    that case fell through to ``_decode_spec`` and surfaced as an opaque
+    ``yaml.YAMLError`` -- "could not decode spec: while scanning for the
+    next token found character that cannot start any token in '<file>',
+    line 33, column 1" -- which is a true statement about the bytes but
+    a useless one for the operator looking at the symptom.
+
+    Concrete trigger: the catalog's ``vmware/9.0`` and ``sddc-manager/9.0``
+    upstream URLs point at the Broadcom Developer Portal landing pages
+    (``https://developer.broadcom.com/xapis/...``), which return HTML
+    documentation, not raw OpenAPI YAML/JSON. The route layer maps this
+    exception onto HTTP 422 (not 400) with a structured
+    ``catalog_entry_upstream_not_spec`` envelope so an operator/agent
+    can branch on the diagnostic without re-parsing the message.
+
+    Attributes
+    ----------
+    upstream_url:
+        The URL that was fetched. Surfaced on the exception so the
+        operator-facing CLI / API can render a complete diagnostic
+        without re-threading the URL from the call site.
+    content_type:
+        The verbatim ``Content-Type`` header value the server returned
+        (e.g. ``"text/html; charset=utf-8"``). ``None`` when the response
+        omitted the header entirely -- still treated as non-spec because
+        every legitimate spec host serves the header.
+
+    Inherits from :class:`ValueError` so callers that already catch
+    parser-shaped errors via ``except ValueError`` keep working. The
+    REST router catches this specifically before the generic
+    ``InvalidSpecError`` → 400 mapping so the 422 wins.
+    """
+
+    def __init__(
+        self,
+        *,
+        upstream_url: str,
+        content_type: str | None,
+    ) -> None:
+        self.upstream_url = upstream_url
+        self.content_type = content_type
+        rendered_ct = content_type if content_type is not None else "<missing>"
+        super().__init__(
+            f"upstream {upstream_url!r} returned non-spec content "
+            f"(Content-Type={rendered_ct!r}); expected OpenAPI YAML or JSON"
+        )
 
 
 class InvalidSchemaError(ValueError):

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -59,6 +59,7 @@ from meho_backplane.operations.ingest.exceptions import (
     InvalidSchemaError,
     InvalidSpecError,
     UnsupportedSpecError,
+    UpstreamNotSpecError,
 )
 from meho_backplane.operations.ingest.refs import (
     normalize_boolean_schema as _normalize_boolean_schema,
@@ -78,6 +79,7 @@ __all__ = [
     "InvalidSchemaError",
     "InvalidSpecError",
     "UnsupportedSpecError",
+    "UpstreamNotSpecError",
     "detect_spec_format",
     "parse_openapi",
     "read_spec_info_version",
@@ -116,6 +118,25 @@ _DANGEROUS_VERBS = frozenset({"DELETE"})
 # and rarely take more than a couple of seconds; a 30 s ceiling keeps
 # pathological cases from hanging an ingest.
 _HTTP_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+
+
+# Content-Type prefixes the upstream-fetch path accepts as spec-shaped.
+# OpenAPI specs are served as ``application/json`` (the modern default),
+# ``application/x-yaml`` / ``application/yaml`` / ``text/yaml`` /
+# ``text/x-yaml`` (YAML's wandering history of registered + provisional
+# media types), or ``text/plain`` (the GitHub-raw fallback most CI specs
+# end up on). Anything else -- ``text/html`` from a developer-portal
+# landing page, ``application/octet-stream`` from a misconfigured host
+# -- is rejected with :exc:`UpstreamNotSpecError` so the operator gets
+# a structured 422 instead of an opaque YAML parse error at line 33.
+_ACCEPTED_SPEC_CONTENT_TYPES: tuple[str, ...] = (
+    "application/json",
+    "application/yaml",
+    "application/x-yaml",
+    "text/yaml",
+    "text/x-yaml",
+    "text/plain",  # raw.githubusercontent.com serves YAML as text/plain
+)
 
 
 def detect_spec_format(content: bytes) -> str:
@@ -171,6 +192,12 @@ def parse_openapi(
             are a transport concern.
         UnsupportedSpecError: Spec version is not 3.0.x / 3.1.x, or the
             document references a cross-document ``$ref``.
+        UpstreamNotSpecError: HTTP fetch succeeded (2xx) but the
+            response's ``Content-Type`` declared a non-spec media type
+            (e.g. ``text/html`` from a developer-portal landing page).
+            Raised before any decoding so callers see a precise
+            "upstream isn't a spec" diagnostic instead of an opaque
+            YAML / JSON parse error.
         InvalidSchemaError: A local ``$ref`` points at a missing
             component, or a structurally unsupported shape is used.
         yaml.YAMLError: Malformed YAML — bubbles up from the loader.
@@ -244,6 +271,10 @@ def read_spec_info_version(spec_path_or_uri: str) -> str | None:
         UnsupportedSpecError: Spec version is not 3.0.x / 3.1.x — the
             same gate the parser enforces; surfaced here so callers
             can fail fast before touching ``info.version``.
+        UpstreamNotSpecError: HTTP fetch succeeded but the response
+            declared a non-spec media type. Same shape
+            :func:`parse_openapi` raises; see that function's
+            docstring for context.
         yaml.YAMLError: Malformed YAML — bubbles up from the loader.
         json.JSONDecodeError: Malformed JSON — bubbles up.
         httpx.HTTPError: HTTP fetch failure for URL inputs.
@@ -272,11 +303,26 @@ def _load_spec_bytes(spec_path_or_uri: str) -> bytes:
     :exc:`httpx.HTTPStatusError` (an :exc:`httpx.HTTPError` subclass)
     unwrapped — fetch failures are a transport concern, not a spec
     concern.
+
+    After a 2xx HTTP fetch we additionally inspect ``Content-Type``: a
+    non-spec media type (HTML developer portal, generic
+    ``application/octet-stream``, etc.) raises
+    :exc:`UpstreamNotSpecError` instead of falling through to YAML
+    decoding. Local files are not gated on content-type — the operator
+    chose the path and a stray ``.html`` next to ``.yaml`` is on them
+    to notice; the YAML / JSON decoder still produces a usable error
+    in that case. The HTTP gate exists because catalog-driven ingest
+    against the Broadcom Developer Portal (vmware/9.0, sddc-manager/9.0)
+    returned HTML and surfaced as a useless YAML parse error at line 33.
     """
     parsed = urlparse(spec_path_or_uri)
     if parsed.scheme in {"http", "https"}:
         response = httpx.get(spec_path_or_uri, timeout=_HTTP_TIMEOUT, follow_redirects=True)
         response.raise_for_status()
+        _reject_non_spec_content_type(
+            upstream_url=spec_path_or_uri,
+            content_type=response.headers.get("content-type"),
+        )
         return response.content
     # Treat everything else as a local file path. ``Path`` handles
     # both relative and absolute paths cleanly; ``file://`` URIs go
@@ -291,6 +337,34 @@ def _load_spec_bytes(spec_path_or_uri: str) -> bytes:
         return path.read_bytes()
     except (FileNotFoundError, IsADirectoryError, PermissionError, OSError) as exc:
         raise InvalidSpecError(f"could not read spec from {spec_path_or_uri!r}: {exc}") from exc
+
+
+def _reject_non_spec_content_type(
+    *,
+    upstream_url: str,
+    content_type: str | None,
+) -> None:
+    """Raise :exc:`UpstreamNotSpecError` when ``content_type`` is not spec-shaped.
+
+    The check is intentionally a prefix match against
+    :data:`_ACCEPTED_SPEC_CONTENT_TYPES` -- servers tack
+    ``; charset=utf-8`` (or stricter media-type parameters) onto the
+    base type, and the parameters are irrelevant to "is this YAML/JSON".
+
+    A missing header (``content_type is None``) is treated as non-spec
+    -- every legitimate spec host (raw.githubusercontent.com, vendor
+    appliances) sets the header, and the alternative is silently
+    accepting the HTML developer-portal pages that motivated this
+    check.
+    """
+    if content_type is None:
+        raise UpstreamNotSpecError(upstream_url=upstream_url, content_type=None)
+    # Lowercase before prefix check so ``Content-Type: TEXT/HTML`` is
+    # caught the same as ``text/html``; HTTP media types are
+    # case-insensitive per RFC 9110 §8.3.1.
+    normalized = content_type.lower().split(";", 1)[0].strip()
+    if not any(normalized == accepted for accepted in _ACCEPTED_SPEC_CONTENT_TYPES):
+        raise UpstreamNotSpecError(upstream_url=upstream_url, content_type=content_type)
 
 
 def _decode_spec(content: bytes) -> dict[str, Any]:

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -39,6 +39,7 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 from uuid import UUID
 
+import httpx
 import pytest
 import respx
 from fastapi import FastAPI
@@ -2305,6 +2306,206 @@ def test_ingest_catalog_entry_templated_upstream_returns_422(
     assert detail["templated_upstream"] == [
         "https://<nsx-mgr-fqdn>/api/v1/spec/openapi/nsx_api.yaml",
     ]
+
+
+def test_ingest_catalog_entry_vmware_9_0_html_portal_returns_422(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """G0.15-T2 (#1211): ``catalog_entry: vmware/9.0`` whose upstream serves
+    HTML returns a structured 422 ``catalog_entry_upstream_not_spec`` envelope.
+
+    Before this Task, the Broadcom Developer Portal landing page bytes fell
+    through to the YAML decoder and surfaced as ``could not decode spec:
+    while scanning for the next token found character that cannot start
+    any token in '<file>', line 33, column 1`` -- the HTML doctype on line
+    1, opening tags around line 33. The structured envelope replaces that
+    with a T11-compliant detail body the operator can act on without
+    cross-referencing the byte stream.
+    """
+    portal_url = "https://developer.broadcom.com/xapis/vsphere-automation-api/latest/"
+    _patch_catalog(
+        monkeypatch,
+        entries=[
+            {
+                "product": "vmware-t1211",
+                "version": "9.0",
+                "impl_id": "vmware-rest-t1211",
+                "requires_connector_class": "VmwareRestConnector",
+                "upstream": (portal_url,),
+            },
+        ],
+    )
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        # The Broadcom Developer Portal returns HTML with a 200, not a
+        # spec-shaped media type. Mock the fetch so the test exercises
+        # the content-type guard without hitting the public internet.
+        mock_router.get(portal_url).mock(
+            return_value=httpx.Response(
+                200,
+                headers={"content-type": "text/html; charset=utf-8"},
+                content=(
+                    b"<!doctype html><html><head><title>Broadcom</title></head><body></body></html>"
+                ),
+            ),
+        )
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={"catalog_entry": "vmware-t1211/9.0"},
+            headers=_authed(token),
+        )
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert detail["detail"] == "catalog_entry_upstream_not_spec"
+    assert detail["catalog_entry"] == "vmware-t1211/9.0"
+    assert detail["upstream_url"] == portal_url
+    assert detail["content_type"] == "text/html; charset=utf-8"
+    # T11 convention: the human-readable message names the values, the
+    # remediation imperative, and the doc reference.
+    assert "explicit-quadruple shape" in detail["message"]
+    assert "error-message-shape" in detail["message"]
+
+
+def test_ingest_catalog_entry_sddc_manager_9_0_html_portal_returns_422(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """G0.15-T2 (#1211): ``catalog_entry: sddc-manager/9.0`` has the same
+    HTML-portal trap as ``vmware/9.0`` and surfaces the same structured 422.
+
+    The two entries are the cycle's two confirmed offenders per
+    ``claude-rdc-hetzner-dc#753`` sub-signal B; pinning both shapes in
+    distinct tests guards against a future refactor that splits the
+    detection logic by product.
+    """
+    portal_url = "https://developer.broadcom.com/xapis/sddc-manager-api/latest/"
+    _patch_catalog(
+        monkeypatch,
+        entries=[
+            {
+                "product": "sddc-manager-t1211",
+                "version": "9.0",
+                "impl_id": "sddc-rest-t1211",
+                "requires_connector_class": "SddcManagerConnector",
+                "upstream": (portal_url,),
+            },
+        ],
+    )
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        mock_router.get(portal_url).mock(
+            return_value=httpx.Response(
+                200,
+                headers={"content-type": "text/html; charset=utf-8"},
+                content=b"<!doctype html><html></html>",
+            ),
+        )
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={"catalog_entry": "sddc-manager-t1211/9.0"},
+            headers=_authed(token),
+        )
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert detail["detail"] == "catalog_entry_upstream_not_spec"
+    assert detail["catalog_entry"] == "sddc-manager-t1211/9.0"
+    assert detail["upstream_url"] == portal_url
+    assert detail["content_type"] == "text/html; charset=utf-8"
+
+
+def test_ingest_explicit_quadruple_html_upstream_returns_422_without_catalog_field(
+    client: TestClient,
+) -> None:
+    """G0.15-T2 (#1211): an explicit-quadruple request whose spec URL serves
+    HTML returns the bare ``upstream_not_spec`` envelope (no ``catalog_entry``).
+
+    Same guard, different envelope shape -- the route layer picks
+    :func:`build_upstream_not_spec_detail` vs
+    :func:`build_catalog_entry_upstream_not_spec_detail` based on
+    whether the request started as catalog-driven. This test pins the
+    bare shape; the catalog-driven shape is covered by the two tests
+    above.
+    """
+    portal_url = "https://example.lab/not-a-spec.html"
+    key, token = _admin_token()
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        mock_router.get(portal_url).mock(
+            return_value=httpx.Response(
+                200,
+                headers={"content-type": "text/html"},
+                content=b"<!doctype html><html></html>",
+            ),
+        )
+        response = client.post(
+            "/api/v1/connectors/ingest",
+            json={
+                "product": "explicit-quad",
+                "version": "1.0",
+                "impl_id": "explicit-quad",
+                "specs": [{"uri": portal_url}],
+                "dry_run": True,
+            },
+            headers=_authed(token),
+        )
+    assert response.status_code == 422, response.text
+    detail = response.json()["detail"]
+    assert detail["detail"] == "upstream_not_spec"
+    assert "catalog_entry" not in detail
+    assert detail["upstream_url"] == portal_url
+    assert detail["content_type"] == "text/html"
+
+
+def test_ingest_packaged_catalog_html_portal_entries_carry_warning_notes() -> None:
+    """G0.15-T2 (#1211) audit: every ``spec_info_version: null`` catalog
+    entry whose ``upstream`` would reach the fetch path carries the
+    "HTML-portal upstream; manual ingest required" warning in ``notes``.
+
+    Sweep over the packaged catalog confirms ``vmware/9.0`` and
+    ``sddc-manager/9.0`` -- the two confirmed offenders -- both carry
+    the warning mirroring the ``harbor/2.x`` Swagger-2.0 precedent. The
+    other ``spec_info_version: null`` entries are excluded by earlier
+    422 gates -- ``nsx/4.2`` via ``catalog_entry_templated_upstream``
+    (FQDN placeholder), the three typed connectors (``vault/1.x``,
+    ``k8s/1.x``, ``bind9/9.x``) via ``catalog_entry_typed_connector``
+    (``upstream: null``) -- so they never reach the fetch path the
+    HTML-portal guard sits on. Test exists so a future contributor
+    adding a third HTML-portal-style entry without the note tripping
+    catches the omission at PR-review time.
+    """
+    from meho_backplane.operations.ingest.catalog import load_catalog
+
+    catalog = load_catalog()
+
+    # An entry reaches the HTTP fetch path only if every upstream URL
+    # is non-templated; entries with any FQDN-templated URL (NSX) are
+    # refused earlier by ``catalog_entry_templated_upstream`` (422)
+    # before ``_load_spec_bytes`` runs, so they never trigger the
+    # HTML-portal guard.
+    def _reaches_fetch_path(urls: tuple[str, ...]) -> bool:
+        return all(("<" not in url and ">" not in url) for url in urls)
+
+    html_portal_entries = {
+        (e.product, e.version)
+        for e in catalog.entries
+        if e.spec_info_version is None
+        and e.upstream is not None
+        and _reaches_fetch_path(e.upstream)
+        and any(url.startswith("https://developer.broadcom.com/") for url in e.upstream)
+    }
+    assert ("vmware", "9.0") in html_portal_entries
+    assert ("sddc-manager", "9.0") in html_portal_entries
+    for product, version in html_portal_entries:
+        entry = catalog.get(product, version)
+        assert entry is not None
+        assert "catalog_entry_upstream_not_spec" in entry.notes, (
+            f"{product}/{version} upstream points at the Broadcom Developer "
+            f"Portal but notes don't reference the 422 error code -- mirror "
+            "the harbor/2.x Swagger-2.0 precedent."
+        )
 
 
 def test_ingest_explicit_quadruple_still_works_regression(

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -24,6 +24,7 @@ from meho_backplane.operations.ingest import (
     InvalidSchemaError,
     InvalidSpecError,
     UnsupportedSpecError,
+    UpstreamNotSpecError,
     detect_spec_format,
     parse_openapi,
     read_spec_info_version,
@@ -631,6 +632,112 @@ def test_http_fetch_404_raises() -> None:
         )
         with pytest.raises(httpx.HTTPStatusError):
             parse_openapi("https://example.test/missing.yaml")
+
+
+def test_http_fetch_html_content_type_raises_upstream_not_spec() -> None:
+    """G0.15-T2 (#1211): a 2xx response carrying ``text/html`` (Broadcom
+    Developer Portal) raises :exc:`UpstreamNotSpecError` instead of
+    falling through to the YAML decoder.
+
+    The carried ``upstream_url`` + ``content_type`` attributes are what
+    the route layer builds the structured 422 envelope from; they must
+    survive the exception flight intact.
+    """
+    portal_url = "https://developer.broadcom.com/xapis/vsphere-automation-api/latest/"
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(portal_url).mock(
+            return_value=httpx.Response(
+                200,
+                content=b"<!doctype html><html></html>",
+                headers={"content-type": "text/html; charset=utf-8"},
+            )
+        )
+        with pytest.raises(UpstreamNotSpecError) as exc_info:
+            parse_openapi(portal_url)
+    assert exc_info.value.upstream_url == portal_url
+    assert exc_info.value.content_type == "text/html; charset=utf-8"
+
+
+def test_http_fetch_missing_content_type_raises_upstream_not_spec() -> None:
+    """G0.15-T2 (#1211): a 2xx response that omits ``Content-Type`` is
+    treated as non-spec.
+
+    Every legitimate spec host sets the header; absence is the
+    fingerprint of a misconfigured upstream (or a default file server),
+    so the guard fires fail-closed rather than guessing at the body.
+    """
+    url = "https://example.test/no-content-type.yaml"
+    with respx.mock(assert_all_called=False) as mock_router:
+        # ``httpx.Response(200, content=...)`` does not synthesize a
+        # ``Content-Type`` header at transport time -- the receiving
+        # side sees ``None``, which is exactly the missing-header case
+        # the guard fails closed on.
+        mock_router.get(url).mock(
+            return_value=httpx.Response(200, content=b"openapi: 3.0.3\n"),
+        )
+        with pytest.raises(UpstreamNotSpecError) as exc_info:
+            parse_openapi(url)
+    assert exc_info.value.upstream_url == url
+    assert exc_info.value.content_type is None
+
+
+def test_http_fetch_application_yaml_content_type_accepted(
+    tmp_path: Path,
+) -> None:
+    """G0.15-T2 (#1211): a 2xx response with ``application/yaml`` proceeds
+    through the parser unchanged.
+
+    Regression guard against the content-type allow-list being too
+    narrow. The companion happy-path test
+    :func:`test_http_fetch_round_trip` already pins this for
+    ``application/yaml``; the parametrised variants below pin the rest
+    of the allow-list so a future tightening of the allow-list can't
+    silently break a working spec host.
+    """
+    url = "https://example.test/spec.yaml"
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(url).mock(
+            return_value=httpx.Response(
+                200,
+                content=PETSTORE_31_YAML.read_bytes(),
+                headers={"content-type": "application/yaml; charset=utf-8"},
+            )
+        )
+        rows = parse_openapi(url)
+    assert rows  # any non-empty result is enough — happy path is covered elsewhere
+
+
+@pytest.mark.parametrize(
+    "content_type",
+    [
+        "application/json",
+        "application/yaml",
+        "application/x-yaml",
+        "text/yaml",
+        "text/x-yaml",
+        "text/plain",  # raw.githubusercontent.com
+        "Application/JSON",  # case-insensitivity
+    ],
+)
+def test_http_fetch_accepted_content_types_proceed(content_type: str) -> None:
+    """G0.15-T2 (#1211): every entry in the accepted content-type allow-list
+    survives the guard.
+
+    A YAML body with a varying ``Content-Type`` header proves the guard
+    only branches on the header value, not on the bytes -- the existing
+    sniffer in ``detect_spec_format`` handles the bytes downstream.
+    """
+    url = f"https://example.test/spec-{content_type.replace('/', '-')}.yaml"
+    with respx.mock(assert_all_called=False) as mock_router:
+        mock_router.get(url).mock(
+            return_value=httpx.Response(
+                200,
+                content=PETSTORE_31_YAML.read_bytes(),
+                headers={"content-type": content_type},
+            )
+        )
+        rows = parse_openapi(url)
+    assert rows
 
 
 # -- read_spec_info_version ------------------------------------------------

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -113,13 +113,46 @@ catalog-driven body shape directly — one canonical resolution
 path, no client-side catalog cache to drift against the server's
 package data.
 
-The four catalog-side validation outcomes (`catalog_entry_malformed`,
-`catalog_entry_not_found`, `catalog_entry_typed_connector`,
-`catalog_entry_templated_upstream`) ship through
-`build_catalog_entry_*_detail` helpers in `error_envelopes.py` so
-the REST 422 envelope can't drift from any future MCP equivalent
-(same shared-builder pattern G0.9.1-T5 / #777 used for
-`VersionMismatchError`).
+The four pre-fetch catalog-side validation outcomes
+(`catalog_entry_malformed`, `catalog_entry_not_found`,
+`catalog_entry_typed_connector`, `catalog_entry_templated_upstream`)
+ship through `build_catalog_entry_*_detail` helpers in
+`error_envelopes.py` so the REST 422 envelope can't drift from any
+future MCP equivalent (same shared-builder pattern G0.9.1-T5 / #777
+used for `VersionMismatchError`).
+
+The fifth catalog-side outcome surfaces at fetch time:
+`catalog_entry_upstream_not_spec` (G0.15-T2 / #1211). The catalog's
+`vmware/9.0` and `sddc-manager/9.0` upstream URLs point at Broadcom
+Developer Portal landing pages -- HTML, not raw OpenAPI YAML/JSON --
+so the route's `httpx.get` succeeds with a 2xx response whose
+`Content-Type` is `text/html`. Before #1211 the bytes fell through to
+the YAML decoder and surfaced as `could not decode spec: while
+scanning for the next token found character that cannot start any
+token in '<file>', line 33, column 1` (HTML doctype at line 1,
+opening tags around line 33) -- a true statement about the bytes but
+a useless one for the operator. `_load_spec_bytes` in `openapi.py`
+now inspects `Content-Type` against an allow-list
+(`application/json`, `application/yaml`,
+`application/x-yaml`, `text/yaml`, `text/x-yaml`, `text/plain` for
+`raw.githubusercontent.com` mirrors) and raises
+`UpstreamNotSpecError` -- caught in the route and mapped to HTTP 422
+with the `build_catalog_entry_upstream_not_spec_detail` envelope
+(catalog reference, upstream URL, Content-Type, remediation: fetch
+the spec manually, pass via the explicit-quadruple shape).
+Explicit-quadruple requests that hit the same trap get the bare
+`build_upstream_not_spec_detail` envelope without the
+`catalog_entry` field.
+
+The catalog's `notes` on the two affected entries carry the
+"HTML-portal upstream; manual ingest required" warning, mirroring
+the `harbor/2.x` Swagger-2.0 precedent. The only other
+`spec_info_version: null` catalog entries (`nsx/4.2`, `vault/1.x`,
+`k8s/1.x`, `bind9/9.x`) refuse the catalog-driven shape earlier --
+NSX via `catalog_entry_templated_upstream` (the URL is FQDN-templated),
+the three typed connectors via `catalog_entry_typed_connector`
+(`upstream: null`) -- so they never reach the fetch path that
+`UpstreamNotSpecError` guards.
 
 T1 produces the proto shape every other stage consumes; T2 is the
 single write path into `endpoint_descriptor` for ingested rows; T3


### PR DESCRIPTION
## Summary

- `vmware/9.0` and `sddc-manager/9.0` catalog-driven ingest used to fail with an opaque `400 could not decode spec: while scanning for the next token found character that cannot start any token in '<file>', line 33, column 1`. The upstream URLs point at the Broadcom Developer Portal landing pages — HTML, not OpenAPI YAML/JSON. The bytes fell through to the YAML decoder which then complained about the HTML doctype.
- Add a content-type guard in `_load_spec_bytes` (`openapi.py`) that raises a new `UpstreamNotSpecError` when a 2xx HTTP fetch returns a non-spec media type. The route maps it to a structured `422 catalog_entry_upstream_not_spec` envelope (catalog reference + upstream URL + content-type + remediation) for catalog-driven requests, or the bare `upstream_not_spec` envelope for explicit-quadruple requests — both per the T11 [error-message-shape](docs/codebase/error-message-shape.md) convention used by every other `catalog_entry_*` 422.
- Update catalog `notes` on both affected entries to mirror the `harbor/2.x` Swagger-2.0 warning precedent (`SHARP EDGE: ... returns HTTP 422 catalog_entry_upstream_not_spec; fetch the raw spec manually and pass it via the explicit-quadruple shape`).

## `spec_info_version: null` audit

Sweep over the packaged catalog confirms only `vmware/9.0` and `sddc-manager/9.0` reach the HTTP fetch path with HTML-portal upstreams. The other `spec_info_version: null` entries are refused earlier by existing 422 gates so they never trigger the HTML-portal trap:

| Entry | upstream shape | Refused by |
|---|---|---|
| `vmware/9.0` | `developer.broadcom.com/...` (HTML portal) | **new** `catalog_entry_upstream_not_spec` |
| `sddc-manager/9.0` | `developer.broadcom.com/...` (HTML portal) | **new** `catalog_entry_upstream_not_spec` |
| `harbor/2.x` | `raw.githubusercontent.com/.../swagger.yaml` (Swagger 2.0; existing warning) | `UnsupportedSpecError` on `swagger: "2.0"` |
| `nsx/4.2` | `https://<nsx-mgr-fqdn>/...` (FQDN-templated) + `developer.broadcom.com/...` | `catalog_entry_templated_upstream` (template seen first) |
| `vault/1.x`, `k8s/1.x`, `bind9/9.x` | `null` (typed connector) | `catalog_entry_typed_connector` |

Test `test_ingest_packaged_catalog_html_portal_entries_carry_warning_notes` mechanizes the audit so a future contributor adding a third HTML-portal-style entry without the warning note trips at PR review.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/ --ignore-missing-imports` — Success: no issues found in 369 source files
- [x] `pytest tests/test_api_v1_connectors_ingest.py tests/test_operations_ingest_openapi.py` — 116 passed
- [x] `pytest tests/test_operations_ingest_catalog.py` — 21 passed
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers, 6 pre-existing warnings
- [x] Acceptance criterion: `POST /api/v1/connectors/ingest {"catalog_entry":"vmware-t1211/9.0","dry_run":true}` against an HTML-serving upstream returns 422 with the structured `catalog_entry_upstream_not_spec` envelope — asserted by `test_ingest_catalog_entry_vmware_9_0_html_portal_returns_422`.
- [x] Acceptance criterion: same shape for `sddc-manager/9.0` — asserted by `test_ingest_catalog_entry_sddc_manager_9_0_html_portal_returns_422`.
- [x] Acceptance criterion: catalog `notes` on both entries carry the HTML-portal warning — asserted by `test_ingest_packaged_catalog_html_portal_entries_carry_warning_notes`.
- [x] Acceptance criterion: `spec_info_version: null` audit listed in this PR description (table above).

## Out of scope

- Replacing the Broadcom Developer Portal URLs with directly-resolvable spec URLs (Option A in the task body) — separate scope if/when Broadcom publishes a spec mirror.
- Automated content-type re-check on every ingest call — the catalog is static; check at catalog-curation time (this Task) and at fetch time (the new guard), not as a recurring sweep.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1211
