### PR TITLE
feat(connectors): G3.11-T1 GitHubRestConnector skeleton (App + PAT auth)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -46,6 +46,15 @@ dependencies = [
     # but stays untouched until a policy with a ``tier2`` block fires).
     "presidio-analyzer==2.2.362",
     "presidio-anonymizer==2.2.362",
+    # G3.11-T1 (#1221) — GitHub App authentication mints a 10-minute
+    # RS256 JWT (claims iat/exp/iss) and exchanges it for an
+    # installation token. PyJWT's ``jwt.encode(payload, key,
+    # algorithm="RS256")`` is the documented path; the ``[crypto]``
+    # extra pulls the ``cryptography`` backend (already a dev dep, but
+    # the extra makes the runtime requirement explicit at install time
+    # so a slim wheel install doesn't fail at first ``encode`` call).
+    # No stdlib alternative exists for RS256 signing.
+    "pyjwt[crypto]>=2.10.0,<3",
 ]
 
 [dependency-groups]

--- a/backend/src/meho_backplane/connectors/github/__init__.py
+++ b/backend/src/meho_backplane/connectors/github/__init__.py
@@ -1,0 +1,123 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.github — GitHubRestConnector package (G3.11-T1).
+
+Importing the package registers :class:`GitHubRestConnector` against
+**both** the v1 single-product registry and the v2 three-tuple registry:
+
+* **v1 entry** — ``register_connector("gh", GitHubRestConnector)``.
+  Writes the wildcard ``("gh", "", "")`` triple into the v2 table as a
+  side effect so unfingerprinted ``(product="gh", version=None)``
+  targets resolve to this connector via the G0.15-T6 wildcard tie-break
+  ladder. The v1 lookup itself is what
+  :func:`~meho_backplane.api.v1.health._probe_*` paths key on.
+* **v2 entry** — ``register_connector_v2(product="gh", version="3",
+  impl_id="gh-rest", cls=GitHubRestConnector)``. The canonical
+  dispatcher key. The resolver's tie-break ladder
+  (G0.14-T2 #1143 step 1, ``versioned_over_wildcard``) demotes the v1
+  wildcard whenever this versioned entry is also a candidate, so a
+  fingerprinted ``(product="gh", version="3")`` target resolves cleanly
+  to the versioned class.
+
+Per G0.15-T6 (mandatory pattern), every new connector ships dual
+registration from day one. This is the same shape
+:mod:`meho_backplane.connectors.kubernetes` uses.
+
+Typed-op registration is intentionally a no-op at this Task — T1 ships
+the substrate; T3 (#1223) ships the catalog entry + Layer-2 ingest
+acceptance which populates the ``endpoint_descriptor`` rows. The
+:meth:`GitHubRestConnector.register_operations` classmethod stays a stub
+the lifespan can call cheaply; T3 fills in the body.
+"""
+
+from meho_backplane.connectors.github.connector import GitHubRestConnector
+from meho_backplane.connectors.github.session import (
+    DEFAULT_GITHUB_API_URL,
+    GITHUB_APP_AUTH_MODEL,
+    GITHUB_PAT_AUTH_MODEL,
+    GitHubAppCredentials,
+    GitHubAppNotInstalledError,
+    GitHubCredentialError,
+    GitHubCredentialsLoader,
+    GitHubInstallationTokenMintError,
+    GitHubJWTMintError,
+    GitHubPATCredentials,
+    GitHubRateLimitedError,
+    GitHubTargetLike,
+    InstallationToken,
+    load_github_app_credentials_from_vault,
+    load_github_pat_credentials_from_vault,
+    mint_github_app_jwt,
+)
+from meho_backplane.connectors.registry import (
+    register_connector,
+    register_connector_v2,
+)
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+
+
+async def register_github_typed_operations(
+    *,
+    embedding_service: object | None = None,
+) -> None:
+    """No-op registrar — T1 ships zero typed ops.
+
+    Queued onto :func:`run_typed_op_registrars` for symmetry with vault /
+    kubernetes / vmware-rest so a future enhancement (T3's catalog
+    entry) can fill in the body without touching the lifespan wiring.
+    The pattern matches :func:`register_kubernetes_typed_operations` —
+    a module-level wrapper around the connector's classmethod.
+
+    The ``embedding_service`` keyword-only parameter mirrors every other
+    registrar's contract: :func:`run_typed_op_registrars` passes the
+    process-wide :class:`EmbeddingService` (or a chassis-test stub) to
+    every registrar via ``registrar(embedding_service=...)``, so each
+    registrar **must** accept the kwarg or the lifespan crashes with
+    ``TypeError`` (see the K8s precedent for the post-#461/#463
+    ordering incident). T1 doesn't register anything yet so the value
+    is unused; T3 will forward it to its embedding-text encode path.
+    """
+    del embedding_service  # unused until T3 fills in the body
+    await GitHubRestConnector.register_operations()
+
+
+__all__ = [
+    "DEFAULT_GITHUB_API_URL",
+    "GITHUB_APP_AUTH_MODEL",
+    "GITHUB_PAT_AUTH_MODEL",
+    "GitHubAppCredentials",
+    "GitHubAppNotInstalledError",
+    "GitHubCredentialError",
+    "GitHubCredentialsLoader",
+    "GitHubInstallationTokenMintError",
+    "GitHubJWTMintError",
+    "GitHubPATCredentials",
+    "GitHubRateLimitedError",
+    "GitHubRestConnector",
+    "GitHubTargetLike",
+    "InstallationToken",
+    "load_github_app_credentials_from_vault",
+    "load_github_pat_credentials_from_vault",
+    "mint_github_app_jwt",
+    "register_github_typed_operations",
+]
+
+# v1 entry — wildcard ("gh", "", "") via :func:`register_connector` per
+# G0.15-T6. Unfingerprinted targets carrying ``(product="gh",
+# version=None)`` resolve here via the resolver's wildcard tie-break.
+register_connector("gh", GitHubRestConnector)
+
+# v2 entry — versioned ("gh", "3", "gh-rest"). The canonical resolver
+# key for dispatch; the tie-break ladder demotes the v1 wildcard when
+# both candidates match the same target.
+register_connector_v2(
+    product="gh",
+    version="3",
+    impl_id="gh-rest",
+    cls=GitHubRestConnector,
+)
+
+# Queue the typed-op registrar onto the lifespan-driven list. T1 ships
+# a no-op; T3 will fill in the body once the catalog entry lands.
+register_typed_op_registrar(register_github_typed_operations)

--- a/backend/src/meho_backplane/connectors/github/connector.py
+++ b/backend/src/meho_backplane/connectors/github/connector.py
@@ -1,0 +1,625 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""GitHubRestConnector — substrate for the gh-rest typed connector (G3.11-T1).
+
+Hand-rolled :class:`HttpConnector` subclass that dispatches the github.com
+REST API surface under the registry triple ``(product="gh", version="3",
+impl_id="gh-rest")``. The registry's ``version`` is the digit-prefixed
+slot the dispatcher's connector-id parser requires (regex
+``^[0-9][A-Za-z0-9._]*$`` in :func:`parse_connector_id` — see
+``backend/src/meho_backplane/operations/_lookup.py``); the GitHub REST API
+itself is referred to as **v3** in github.com's documentation. So
+``connector_id="gh-rest-3"`` parses back to ``("gh", "3", "gh-rest")``
+losslessly, and the operator-visible label ("GitHub REST v3") still
+matches the upstream API contract.
+
+This Task ships the substrate only — the catalog entry that makes ~700
+ingested ops dispatchable (T3 #1223) and the first L1 composite
+``gh.composite.pr_status_summary`` (T4 #1224) land separately.
+``register_operations`` is therefore intentionally empty here.
+
+Auth shape
+----------
+
+The connector supports two ``target.auth_model`` values, selected at the
+:meth:`auth_headers` boundary:
+
+* ``github-app`` — canonical machine-identity path. The connector reads
+  App ID + RSA private key + installation ID from Vault under the
+  operator's identity (G3.9 precedent), mints a 10-minute RS256 JWT, and
+  exchanges it for an installation token via
+  ``POST /app/installations/{id}/access_tokens``. The installation token
+  is cached for 50 minutes (10-minute safety margin before the 1-hour
+  upstream expiry) so a typical operator session of ~50 fingerprint /
+  dispatch calls pays the mint round-trip exactly once.
+* ``github-pat`` — fallback. A fine-grained Personal Access Token reads
+  directly from Vault and passes through as the bearer credential.
+  Documented but not first-class — T6 (#1226) explains the picker.
+
+Per-target cache scoping mirrors vmware-rest: keyed on ``target.name``,
+serialised under a single :class:`asyncio.Lock` so two concurrent
+first-use callers don't double-mint. The cache fast-path additionally
+rejects an empty operator JWT (defense-in-depth — the loader's
+:func:`load_basic_credentials` already does this; the cache enforces the
+same invariant so a primed token from an authenticated caller cannot
+leak to a system-initiated caller per
+``docs/architecture/connector-auth.md`` § "Cache scoping under
+``shared_service_account``"). Fingerprint and probe paths synthesise a
+system operator with a non-empty placeholder JWT so the cache fast-path
+admits them but the live Vault loader still fails closed.
+
+Fingerprint shape
+-----------------
+
+:meth:`fingerprint` calls either ``GET /user/installations`` (the
+default, operator-style — lists every installation the App can access)
+or ``GET /repos/{owner}/{repo}`` (when ``target.host`` carries
+``api.github.com/repos/<owner>/<repo>``) — and returns a
+:class:`FingerprintResult` whose ``extras`` carries the installation
+metadata the operator wants on first-day onboarding: ``app_slug``,
+``installation_id``, ``installation_account``, ``target_type``,
+``permissions``. The installation-token mint itself populates most of
+this material from the mint response, so a single round-trip on cold
+cache reveals enough for the operator to confirm the App is reachable.
+
+Out of scope (per T1)
+---------------------
+
+* The Layer-2 ingest catalog entry — T3 (#1223) ships
+  ``backend/src/meho_backplane/operations/ingest/catalog/gh-v3.yaml``.
+  Until then, :meth:`register_operations` is a no-op classmethod the
+  lifespan can call cheaply.
+* The L1 composite ``gh.composite.pr_status_summary`` — T4 (#1224).
+* ``requires_approval=true`` annotations on write ops — T5 (#1225).
+* GitHub Enterprise Server (GHES) — github.com only for v0.x; GHES is
+  a different ``host`` + a future override.
+* Webhooks / push-to-meho — separate G2.x infrastructure scope.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.system_operator import synthesise_system_operator
+from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+from meho_backplane.connectors.adapters.http import HttpConnector
+from meho_backplane.connectors.github.session import (
+    DEFAULT_GITHUB_API_URL,
+    GITHUB_APP_AUTH_MODEL,
+    GITHUB_PAT_AUTH_MODEL,
+    GitHubAppCredentials,
+    GitHubAppNotInstalledError,
+    GitHubCredentialError,
+    GitHubCredentialsLoader,
+    GitHubInstallationTokenMintError,
+    GitHubJWTMintError,
+    GitHubPATCredentials,
+    GitHubRateLimitedError,
+    GitHubTargetLike,
+    InstallationToken,
+    exchange_jwt_for_installation_token,
+    load_github_app_credentials_from_vault,
+    load_github_pat_credentials_from_vault,
+    mint_github_app_jwt,
+)
+from meho_backplane.connectors.schemas import (
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+
+__all__ = ["GitHubRestConnector"]
+
+_log = structlog.get_logger(__name__)
+
+
+class GitHubRestConnector(HttpConnector):
+    """GitHub REST connector for github.com — App or PAT auth.
+
+    Registered under the v2 triple ``(product="gh", version="3",
+    impl_id="gh-rest")``. The v1 wildcard entry (``("gh", "", "")``,
+    written by :func:`register_connector` at module import time) gives
+    G0.15-T6 wildcard-resolver tie-break coverage so a target carrying
+    ``(product=gh, version=None)`` still resolves to this connector.
+
+    Class-level constants and attributes:
+
+    * :attr:`product` ``= "gh"``
+    * :attr:`version` ``= "3"`` — the registry slot version. GitHub
+      labels its REST API as **v3**; the dispatcher's connector-id
+      parser pins ``version`` to the digit-prefix shape (the regex
+      ``^[0-9][A-Za-z0-9._]*$`` rejects ``"v3"``), so the registry
+      stores ``"3"`` and the upstream "v3" name lives in docs.
+    * :attr:`impl_id` ``= "gh-rest"``
+    * :attr:`priority` ``= 1`` — outranks any auto-shim that may register
+      against the same triple from a future generic-OpenAPI ingest path.
+    """
+
+    product = "gh"
+    version = "3"
+    impl_id = "gh-rest"
+    priority = 1
+
+    # vSphere-style class constant for the API base. Subclassed connectors
+    # for GHES would override this (the GHES instance's base URL is the
+    # organisation's GHES host with a ``/api/v3`` suffix), but T1 ships
+    # github.com only.
+    _BASE_URL = DEFAULT_GITHUB_API_URL
+
+    def __init__(
+        self,
+        *,
+        credentials_loader: GitHubCredentialsLoader | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        """Initialise the connector with optional injected loader + http client.
+
+        ``credentials_loader`` defaults to a router that picks
+        :func:`load_github_app_credentials_from_vault` /
+        :func:`load_github_pat_credentials_from_vault` by the target's
+        ``auth_model``. Unit tests inject a stub returning canned creds.
+
+        ``http_client`` is reserved for the dispatch path — the
+        installation-token mint accepts its own injectable client
+        through :func:`exchange_jwt_for_installation_token`, but
+        production code lets the connector own one (created lazily via
+        :meth:`HttpConnector._http_client` per target). The ``__init__``
+        parameter is kept for parity with the test seam K8s exposes;
+        passing ``None`` is the production shape.
+        """
+        super().__init__()
+        # Per-target installation-token cache. Keyed on target.name; the
+        # value's ``expires_at_monotonic`` drives cache-validity checks.
+        self._installation_tokens: dict[str, InstallationToken] = {}
+        # Per-target PAT cache — same shape but the token never expires
+        # from MEHO's side (the PAT carries its own GitHub-set TTL).
+        # Caching keeps the Vault read off the hot path.
+        self._pat_tokens: dict[str, str] = {}
+        self._token_lock = asyncio.Lock()
+        # The injected http client is reserved for a future bring-your-
+        # own-client test path; production uses the inherited per-target
+        # pool from :class:`HttpConnector`.
+        self._injected_http_client = http_client
+        self._credentials_loader: GitHubCredentialsLoader = (
+            credentials_loader if credentials_loader is not None else _default_loader
+        )
+
+    # ------------------------------------------------------------------
+    # Auth surface
+    # ------------------------------------------------------------------
+
+    async def auth_headers(
+        self,
+        target: GitHubTargetLike,
+        operator: Operator,
+    ) -> dict[str, str]:
+        """Return ``Authorization: Bearer <token>`` for *target*.
+
+        Selects between the GitHub App and PAT paths by the target's
+        ``auth_model``. Any other value (``shared_service_account``,
+        ``per_user``, ``impersonation``, ``None``, a typo) raises
+        :exc:`NotImplementedError` naming the target and the requested
+        mode — the same fail-closed shape :class:`VmwareRestConnector`
+        uses at its boundary.
+
+        Raises :class:`VaultCredentialsReadError` when
+        ``operator.raw_jwt`` is empty (defence in depth — the loader's
+        own guard already rejects this; raising before the cache lookup
+        ensures a primed token cannot leak to a system-initiated
+        caller).
+        """
+        if not operator.raw_jwt:
+            raise VaultCredentialsReadError(
+                "operator-context credential read requires an authenticated operator; "
+                f"target={target.name!r} has no operator JWT (system-initiated calls "
+                "cannot read per-target vendor credentials)"
+            )
+        auth_model = getattr(target, "auth_model", None)
+        if auth_model == GITHUB_APP_AUTH_MODEL:
+            token = await self._installation_token(target, operator)
+            return {
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            }
+        if auth_model == GITHUB_PAT_AUTH_MODEL:
+            pat = await self._pat_token(target, operator)
+            return {
+                "Authorization": f"Bearer {pat}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            }
+        raise NotImplementedError(
+            f"GitHubRestConnector only supports auth_model="
+            f"{GITHUB_APP_AUTH_MODEL!r} or {GITHUB_PAT_AUTH_MODEL!r}; "
+            f"target {target.name!r} requested auth_model={auth_model!r}"
+        )
+
+    def _base_url(self, target: GitHubTargetLike) -> str:
+        """Return ``https://api.github.com`` (port is ignored for github.com).
+
+        Overrides :meth:`HttpConnector._base_url` because GitHub's REST
+        surface is mounted at a fixed host irrespective of the
+        ``target.host`` value (which may carry repo coordinates — see
+        :meth:`fingerprint`). A future GHES override returns the
+        per-target GHES base URL here.
+        """
+        del target  # github.com base URL is the only supported value in T1
+        return self._BASE_URL
+
+    # ------------------------------------------------------------------
+    # GitHub App credential / token plumbing
+    # ------------------------------------------------------------------
+
+    async def _installation_token(
+        self,
+        target: GitHubTargetLike,
+        operator: Operator,
+    ) -> str:
+        """Return the cached installation token; mint on cold cache.
+
+        The lock serialises cold-cache callers; warm-cache reads take
+        the fast path. The 50-minute cache window is bounded by
+        :data:`INSTALLATION_TOKEN_CACHE_SECONDS`.
+
+        Raises :class:`GitHubAppNotInstalledError`,
+        :class:`GitHubJWTMintError`,
+        :class:`GitHubInstallationTokenMintError`, or
+        :class:`GitHubRateLimitedError` per the four T11 envelopes.
+        """
+        async with self._token_lock:
+            cached = self._installation_tokens.get(target.name)
+            now = time.monotonic()
+            if cached is not None and cached.expires_at_monotonic > now:
+                return cached.token
+
+            creds = await self._credentials_loader(target, operator)
+            if not isinstance(creds, GitHubAppCredentials):
+                raise GitHubCredentialError(
+                    f"github_credential_error: loader returned "
+                    f"{type(creds).__name__} for target {target.name!r} "
+                    f"with auth_model={GITHUB_APP_AUTH_MODEL!r}; expected "
+                    f"GitHubAppCredentials. This is a loader-configuration "
+                    f"bug. See docs/codebase/connectors-github.md."
+                )
+
+            jwt_token = mint_github_app_jwt(
+                creds.app_id,
+                creds.private_key_pem,
+            )
+            installation = await exchange_jwt_for_installation_token(
+                jwt_token=jwt_token,
+                installation_id=creds.installation_id,
+                api_base_url=self._BASE_URL,
+            )
+            self._installation_tokens[target.name] = installation
+            _log.info(
+                "github_installation_token_minted",
+                target=target.name,
+                host=target.host,
+                installation_id=creds.installation_id,
+                upstream_expires_at=installation.upstream_expires_at,
+            )
+            return installation.token
+
+    async def _pat_token(
+        self,
+        target: GitHubTargetLike,
+        operator: Operator,
+    ) -> str:
+        """Return the cached PAT; read from Vault on cold cache.
+
+        PATs do not expire on MEHO's side (the GitHub-set expiry is
+        opaque to the connector), so cache lifetime is the connector
+        instance lifetime. Operators rotating a PAT must restart the
+        backplane or evict the cache via :meth:`aclose` followed by a
+        fresh dispatch.
+        """
+        async with self._token_lock:
+            cached = self._pat_tokens.get(target.name)
+            if cached is not None:
+                return cached
+            creds = await self._credentials_loader(target, operator)
+            if not isinstance(creds, GitHubPATCredentials):
+                raise GitHubCredentialError(
+                    f"github_credential_error: loader returned "
+                    f"{type(creds).__name__} for target {target.name!r} "
+                    f"with auth_model={GITHUB_PAT_AUTH_MODEL!r}; expected "
+                    f"GitHubPATCredentials. This is a loader-configuration "
+                    f"bug. See docs/codebase/connectors-github.md."
+                )
+            self._pat_tokens[target.name] = creds.token
+            _log.info(
+                "github_pat_token_loaded",
+                target=target.name,
+                host=target.host,
+            )
+            return creds.token
+
+    # ------------------------------------------------------------------
+    # Required Connector ABC methods
+    # ------------------------------------------------------------------
+
+    async def fingerprint(self, target: GitHubTargetLike) -> FingerprintResult:
+        """Probe GitHub to return installation metadata for *target*.
+
+        Two shapes by ``target.host``:
+
+        * ``api.github.com`` (or any value without a ``/`` after the
+          host) → ``GET /user/installations`` lists every installation
+          the App can reach. The first installation lands on
+          ``extras['installation_account']`` /
+          ``extras['installation_id']`` etc.; the count appears at
+          ``extras['installations_count']``.
+        * ``api.github.com/repos/<owner>/<repo>`` →
+          ``GET /repos/{owner}/{repo}`` returns the repo's metadata for
+          a targeted-repo fingerprint.
+
+        The fingerprint path synthesises a system operator (empty
+        ``raw_jwt`` placeholder) so the wire format is exercised but
+        the live Vault read still fails closed — same shape
+        :meth:`VmwareRestConnector.fingerprint` uses.
+
+        Transport / credential failures land as
+        ``reachable=False`` with ``extras['error']`` carrying the
+        error class + message (same pattern as
+        :meth:`VmwareRestConnector.fingerprint`). The structured
+        ``error_code`` from the T11 envelope (when one fired) is
+        surfaced separately under ``extras['error_code']``.
+        """
+        probed_at = datetime.now(UTC)
+        operator = synthesise_system_operator()
+        repo_path = _extract_repo_path(target.host)
+        if repo_path is None:
+            probe_method = "GET /user/installations"
+            path = "/user/installations"
+        else:
+            probe_method = f"GET /repos/{repo_path}"
+            path = f"/repos/{repo_path}"
+
+        try:
+            payload = await self._get_json(target, path, operator=operator)
+        except GitHubCredentialError as exc:
+            return FingerprintResult(
+                vendor="github",
+                product="gh",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method=probe_method,
+                extras={
+                    "error": f"{type(exc).__name__}: {exc}",
+                    "error_code": exc.code,
+                },
+            )
+        except (httpx.HTTPError, OSError, VaultCredentialsReadError, RuntimeError) as exc:
+            return FingerprintResult(
+                vendor="github",
+                product="gh",
+                reachable=False,
+                probed_at=probed_at,
+                probe_method=probe_method,
+                extras={"error": f"{type(exc).__name__}: {exc}"},
+            )
+
+        if repo_path is None:
+            return _fingerprint_from_installations(payload, probed_at, probe_method)
+        return _fingerprint_from_repo(payload, probed_at, probe_method)
+
+    async def probe(self, target: GitHubTargetLike) -> ProbeResult:
+        """Lightweight reachability check.
+
+        Delegates to :meth:`fingerprint` since the GitHub installation
+        probe is already a single round-trip — same pattern as
+        :class:`VmwareRestConnector`.
+        """
+        fp = await self.fingerprint(target)
+        if fp.reachable:
+            return ProbeResult(ok=True, probed_at=fp.probed_at)
+        return ProbeResult(
+            ok=False,
+            reason=str(fp.extras.get("error", "unreachable")),
+            probed_at=fp.probed_at,
+        )
+
+    async def execute(
+        self,
+        target: GitHubTargetLike,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        """Stub dispatcher — every op_id resolves to ``unknown_op`` until T3 lands.
+
+        T1 ships the substrate only. The catalog entry (T3 #1223)
+        populates ``endpoint_descriptor`` with ~700 ingested ops; until
+        then, every op_id returns the structured ``unknown_op`` shape
+        the dispatcher emits everywhere else so the operator sees the
+        same response shape whether the connector is mounted or
+        unmounted in the dispatch path.
+        """
+        del target, params
+        # Import lazily to avoid pulling the operations package's
+        # transitive imports (embedding service, ONNX runtime) into a
+        # pure-Python introspection test.
+        from meho_backplane.operations._errors import result_unknown_op
+
+        return result_unknown_op(op_id=op_id, known_op_count=0, duration_ms=0.0)
+
+    @classmethod
+    async def register_operations(cls) -> None:
+        """Intentional no-op — T1 ships zero typed ops.
+
+        The L2 catalog entry (T3 #1223) registers the ingested ops via
+        the ``meho connector ingest --catalog gh/v3`` path; this
+        classmethod stays a stub the lifespan can call cheaply. Lands
+        in the registrar list via the package ``__init__`` so the
+        symmetry with vault / kubernetes registration is preserved
+        once T3 fills in the body.
+        """
+        return None
+
+    async def aclose(self) -> None:
+        """Drop cached tokens + close the inherited httpx pool."""
+        async with self._token_lock:
+            self._installation_tokens.clear()
+            self._pat_tokens.clear()
+        await super().aclose()
+
+
+# ---------------------------------------------------------------------------
+# Default credential-loader router
+# ---------------------------------------------------------------------------
+
+
+async def _default_loader(
+    target: GitHubTargetLike,
+    operator: Operator,
+) -> GitHubAppCredentials | GitHubPATCredentials:
+    """Pick the Vault loader matching ``target.auth_model``.
+
+    Used when :class:`GitHubRestConnector` is constructed without an
+    explicit ``credentials_loader``. Raises
+    :exc:`NotImplementedError` for any unsupported ``auth_model`` —
+    same boundary :meth:`GitHubRestConnector.auth_headers` enforces,
+    surfaced earlier here for clarity in error attribution.
+    """
+    auth_model = getattr(target, "auth_model", None)
+    if auth_model == GITHUB_APP_AUTH_MODEL:
+        return await load_github_app_credentials_from_vault(target, operator)
+    if auth_model == GITHUB_PAT_AUTH_MODEL:
+        return await load_github_pat_credentials_from_vault(target, operator)
+    raise NotImplementedError(
+        f"GitHubRestConnector default loader requires auth_model="
+        f"{GITHUB_APP_AUTH_MODEL!r} or {GITHUB_PAT_AUTH_MODEL!r}; "
+        f"target {target.name!r} requested auth_model={auth_model!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint shape helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_repo_path(host: str) -> str | None:
+    """Return ``owner/repo`` when *host* carries repo coordinates.
+
+    Accepts ``api.github.com/repos/owner/repo``,
+    ``api.github.com/owner/repo``, and ``owner/repo`` shapes (the last
+    is the operator-friendly form the v0.x onboarding doc uses). Returns
+    ``None`` for any bare host (no slash after the FQDN) — the
+    fingerprint falls back to ``GET /user/installations``.
+    """
+    if "/" not in host:
+        return None
+    # Strip any ``api.github.com`` / ``api.github.com/repos`` prefix; the
+    # tail is ``owner/repo`` (or longer for nested URLs we ignore).
+    parts = host.split("/", maxsplit=3)
+    # parts[0] is the host portion (api.github.com); the rest is path.
+    if len(parts) < 3:
+        return None
+    if parts[1] == "repos" and len(parts) >= 4:
+        # api.github.com/repos/owner/repo
+        return f"{parts[2]}/{parts[3]}"
+    # api.github.com/owner/repo
+    return f"{parts[1]}/{parts[2]}"
+
+
+def _fingerprint_from_installations(
+    payload: Any,
+    probed_at: datetime,
+    probe_method: str,
+) -> FingerprintResult:
+    """Build a :class:`FingerprintResult` from ``GET /user/installations``.
+
+    GitHub returns ``{"total_count": N, "installations": [...]}``. The
+    first installation populates the operator-visible ``extras`` fields;
+    the count appears as ``installations_count`` so the operator can
+    confirm "yes my App reaches multiple installations" without a
+    second call.
+    """
+    installations = (payload.get("installations") if isinstance(payload, dict) else None) or []
+    total = (payload.get("total_count") if isinstance(payload, dict) else None) or len(
+        installations
+    )
+    extras: dict[str, Any] = {"installations_count": int(total)}
+    if installations:
+        first = installations[0]
+        account = first.get("account") if isinstance(first, dict) else None
+        extras.update(
+            {
+                "installation_id": first.get("id") if isinstance(first, dict) else None,
+                "installation_account": account.get("login") if isinstance(account, dict) else None,
+                "target_type": first.get("target_type") if isinstance(first, dict) else None,
+                "app_slug": first.get("app_slug") if isinstance(first, dict) else None,
+                "permissions": first.get("permissions") if isinstance(first, dict) else None,
+            }
+        )
+    return FingerprintResult(
+        vendor="github",
+        product="gh",
+        version="v3",
+        reachable=True,
+        probed_at=probed_at,
+        probe_method=probe_method,
+        extras=extras,
+    )
+
+
+def _fingerprint_from_repo(
+    payload: Any,
+    probed_at: datetime,
+    probe_method: str,
+) -> FingerprintResult:
+    """Build a :class:`FingerprintResult` from ``GET /repos/{owner}/{repo}``.
+
+    Returns the repo's identity (``full_name``, ``id``, ``private``)
+    plus the owner's account type — sufficient for an operator to
+    confirm "yes my App is installed on this repo" without a second
+    call. Inspired by vmware-rest's ``GET /api/about`` shape.
+    """
+    if not isinstance(payload, dict):
+        return FingerprintResult(
+            vendor="github",
+            product="gh",
+            reachable=False,
+            probed_at=probed_at,
+            probe_method=probe_method,
+            extras={"error": f"unexpected response shape: {type(payload).__name__}"},
+        )
+    owner = payload.get("owner") if isinstance(payload.get("owner"), dict) else None
+    return FingerprintResult(
+        vendor="github",
+        product="gh",
+        version="v3",
+        reachable=True,
+        probed_at=probed_at,
+        probe_method=probe_method,
+        extras={
+            "repo_full_name": payload.get("full_name"),
+            "repo_id": payload.get("id"),
+            "repo_private": payload.get("private"),
+            "owner_login": owner.get("login") if owner else None,
+            "owner_type": owner.get("type") if owner else None,
+            "default_branch": payload.get("default_branch"),
+        },
+    )
+
+
+# Re-exports kept so ``mypy --strict`` doesn't flag unused imports — these
+# names appear in this module's docstring and in the package-level
+# ``__init__`` ``__all__`` for backwards-compatible surface. Listed here
+# so a future maintainer who refactors imports doesn't accidentally
+# trim them.
+_ = (
+    GitHubAppNotInstalledError,
+    GitHubInstallationTokenMintError,
+    GitHubJWTMintError,
+    GitHubRateLimitedError,
+)

--- a/backend/src/meho_backplane/connectors/github/connector.py
+++ b/backend/src/meho_backplane/connectors/github/connector.py
@@ -521,6 +521,10 @@ def _extract_repo_path(host: str) -> str | None:
     # Strip any ``api.github.com`` / ``api.github.com/repos`` prefix; the
     # tail is ``owner/repo`` (or longer for nested URLs we ignore).
     parts = host.split("/", maxsplit=3)
+    if len(parts) == 2:
+        # Bare ``owner/repo`` — the operator-friendly form the v0.x
+        # onboarding doc uses (no FQDN prefix).
+        return f"{parts[0]}/{parts[1]}"
     # parts[0] is the host portion (api.github.com); the rest is path.
     if len(parts) < 3:
         return None

--- a/backend/src/meho_backplane/connectors/github/session.py
+++ b/backend/src/meho_backplane/connectors/github/session.py
@@ -316,7 +316,16 @@ def mint_github_app_jwt(
     The error message names the App ID (operator-known) but not the key
     material (per the T11 info-leak rule).
     """
-    iat = int(now if now is not None else time.time())
+    # Backdate ``iat`` by 60s per GitHub's documented JWT recipe:
+    # https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app
+    # GitHub recommends ``iat = now - 60`` to absorb forward clock
+    # skew between the caller and GitHub's clock. ``JWT_TTL_SECONDS``
+    # already trims ``exp - iat`` below the 10-minute cap to absorb
+    # backward skew on the other end, but that only protects the
+    # expiry side. Without this backdate, a clock running fast on
+    # this host would produce a JWT GitHub rejects as
+    # "issued-at in the future".
+    iat = int(now if now is not None else time.time()) - 60
     exp = iat + ttl_seconds
     payload: dict[str, object] = {"iat": iat, "exp": exp, "iss": app_id}
     try:

--- a/backend/src/meho_backplane/connectors/github/session.py
+++ b/backend/src/meho_backplane/connectors/github/session.py
@@ -478,31 +478,68 @@ async def exchange_jwt_for_installation_token(
                 status_code=resp.status_code,
             )
 
-        payload = resp.json()
-        token_value = payload.get("token") if isinstance(payload, dict) else None
-        if not isinstance(token_value, str) or not token_value:
-            keys_or_type = (
-                sorted(payload.keys()) if isinstance(payload, dict) else type(payload).__name__
-            )
-            raise GitHubInstallationTokenMintError(
-                f"github_installation_token_mint_failed: response from "
-                f"POST {api_base_url}{path} is missing a 'token' field "
-                f"(received keys: {keys_or_type}). This is a GitHub API "
-                f"contract violation — file an issue and re-mint manually."
-            )
-        upstream_expires_at = payload.get("expires_at")
-        upstream_expires_str: str | None = (
-            upstream_expires_at if isinstance(upstream_expires_at, str) else None
-        )
-        now_monotonic = now if now is not None else time.monotonic()
-        return InstallationToken(
-            token=token_value,
-            expires_at_monotonic=now_monotonic + INSTALLATION_TOKEN_CACHE_SECONDS,
-            upstream_expires_at=upstream_expires_str,
+        return _build_installation_token_from_response(
+            resp=resp,
+            api_base_url=api_base_url,
+            path=path,
+            now=now,
         )
     finally:
         if owns_client:
             await http_client.aclose()
+
+
+def _build_installation_token_from_response(
+    *,
+    resp: httpx.Response,
+    api_base_url: str,
+    path: str,
+    now: float | None,
+) -> InstallationToken:
+    """Parse a 2xx ``access_tokens`` response into an :class:`InstallationToken`.
+
+    Extracted from :func:`exchange_jwt_for_installation_token` so the
+    request / error-envelope / parse split stays under the
+    code-quality function-size threshold. Surfaces all parse-time
+    failures (non-JSON body, missing ``token`` field) through the
+    documented ``github_installation_token_mint_failed`` T11 envelope.
+    """
+    try:
+        payload = resp.json()
+    except ValueError as exc:
+        # A non-JSON 2xx body is a GitHub contract violation (an
+        # upstream proxy returning HTML, a partial response, etc.).
+        # Surface it through the same ``github_installation_token_mint_failed``
+        # T11 envelope rather than letting ``ValueError`` escape — the
+        # caller's failure handling is shape-stable on this code.
+        body_excerpt = _excerpt(resp.text)
+        raise GitHubInstallationTokenMintError(
+            f"github_installation_token_mint_failed: "
+            f"POST {api_base_url}{path} returned a non-JSON 2xx body. "
+            f"Body excerpt: {body_excerpt!r}. Upstream contract violation.",
+            status_code=resp.status_code,
+        ) from exc
+    token_value = payload.get("token") if isinstance(payload, dict) else None
+    if not isinstance(token_value, str) or not token_value:
+        keys_or_type = (
+            sorted(payload.keys()) if isinstance(payload, dict) else type(payload).__name__
+        )
+        raise GitHubInstallationTokenMintError(
+            f"github_installation_token_mint_failed: response from "
+            f"POST {api_base_url}{path} is missing a 'token' field "
+            f"(received keys: {keys_or_type}). This is a GitHub API "
+            f"contract violation — file an issue and re-mint manually."
+        )
+    upstream_expires_at = payload.get("expires_at")
+    upstream_expires_str: str | None = (
+        upstream_expires_at if isinstance(upstream_expires_at, str) else None
+    )
+    now_monotonic = now if now is not None else time.monotonic()
+    return InstallationToken(
+        token=token_value,
+        expires_at_monotonic=now_monotonic + INSTALLATION_TOKEN_CACHE_SECONDS,
+        upstream_expires_at=upstream_expires_str,
+    )
 
 
 def _raise_for_rate_limit(resp: httpx.Response) -> None:

--- a/backend/src/meho_backplane/connectors/github/session.py
+++ b/backend/src/meho_backplane/connectors/github/session.py
@@ -1,0 +1,552 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""GitHub App + PAT credential loaders for :class:`GitHubRestConnector`.
+
+The connector supports two ``auth_model`` values per the G3.11-T1 task body:
+
+* ``github-app`` — the canonical machine-identity path. The loader reads the
+  App ID + RSA private key (PEM) from Vault under the operator's identity,
+  mints a short-lived (≤10-minute) RS256 JWT signed with the private key, and
+  exchanges that JWT for an **installation token** via
+  ``POST /app/installations/{id}/access_tokens``. The installation token has
+  a 1-hour TTL per GitHub's documentation; the credential cache holds it for
+  up to 50 minutes (10-minute safety margin) before re-minting.
+
+* ``github-pat`` — the fallback path for environments where a GitHub App is
+  not viable (e.g. operator-scoped read-only access during a v0.x dogfood).
+  The loader reads a fine-grained Personal Access Token from Vault and
+  returns it directly. PATs are bearer tokens with no on-the-fly minting; the
+  TTL is whatever GitHub's PAT expiry policy enforces (operator-set).
+
+Both loaders are injectable callables (the same shape vmware-rest's
+:class:`VsphereSessionLoader` uses) so production deploys, unit tests, and
+the future operator runbook (T6) can substitute alternative resolvers
+(e.g. a future GitHub Enterprise Server target with a different App
+installation endpoint).
+
+The four T11-compliant error envelopes for the failure modes named in the
+task body live on :class:`GitHubCredentialError` / its subclasses, each
+carrying a stable ``code`` attribute matching the
+``docs/codebase/error-message-shape.md`` convention (``github_*``).
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Final, Literal, Protocol, runtime_checkable
+
+import httpx
+import jwt
+import structlog
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors._shared.vault_creds import (
+    DEFAULT_KV_MOUNT,
+    VaultCredentialsReadError,
+    load_basic_credentials,
+)
+
+__all__ = [
+    "DEFAULT_GITHUB_API_URL",
+    "GITHUB_APP_AUTH_MODEL",
+    "GITHUB_PAT_AUTH_MODEL",
+    "INSTALLATION_TOKEN_CACHE_SECONDS",
+    "JWT_TTL_SECONDS",
+    "GitHubAppCredentials",
+    "GitHubAppNotInstalledError",
+    "GitHubCredentialError",
+    "GitHubCredentialsLoader",
+    "GitHubInstallationTokenMintError",
+    "GitHubJWTMintError",
+    "GitHubPATCredentials",
+    "GitHubRateLimitedError",
+    "GitHubTargetLike",
+    "InstallationToken",
+    "load_github_app_credentials_from_vault",
+    "load_github_pat_credentials_from_vault",
+    "mint_github_app_jwt",
+]
+
+
+_log = structlog.get_logger(__name__)
+
+#: Default github.com REST API base URL. GitHub Enterprise Server (GHES)
+#: support is explicitly out of scope per the G3.11 Initiative body, but
+#: keeping the constant separate from :class:`GitHubRestConnector` keeps
+#: the eventual GHES override a one-line change in the per-target shape.
+DEFAULT_GITHUB_API_URL: Final[str] = "https://api.github.com"
+
+#: ``auth_model`` value selecting the GitHub App credential path. Targets
+#: registered with this model use a Vault-stored App ID + private key.
+GITHUB_APP_AUTH_MODEL: Final[str] = "github-app"
+
+#: ``auth_model`` value selecting the PAT fallback path. Targets registered
+#: with this model use a Vault-stored fine-grained Personal Access Token.
+GITHUB_PAT_AUTH_MODEL: Final[str] = "github-pat"
+
+#: GitHub App JWTs are accepted only when ``exp - iat <= 600`` seconds
+#: (GitHub's documented cap is 10 minutes; some clock-skew safety margin
+#: is recommended in operator docs). We pick 540 seconds (9 minutes) so a
+#: ~30-second clock skew between MEHO and api.github.com still produces a
+#: valid token at the receiver.
+JWT_TTL_SECONDS: Final[int] = 540
+
+#: Installation tokens are valid for 1 hour. Cache for 50 minutes so the
+#: connector re-mints before expiry without thrashing on every dispatch.
+#: A 10-minute safety margin tolerates clock skew + long-running ops that
+#: started just before expiry.
+INSTALLATION_TOKEN_CACHE_SECONDS: Final[int] = 50 * 60
+
+# Field names the GitHub-App credential loader expects in Vault. App ID
+# is the numeric identifier of the GitHub App (an integer encoded as a
+# string in the Vault secret); private_key is the RSA PEM (multiline
+# string). installation_id pins which of the App's installations this
+# target addresses — an App installed across multiple repos/orgs has
+# one installation per target.
+_GH_APP_FIELDS: Final[tuple[str, str, str]] = (
+    "app_id",
+    "private_key",
+    "installation_id",
+)
+
+# Field name the PAT loader expects in Vault. The token value is the
+# bearer credential — no exchange, no minting.
+_GH_PAT_FIELD: Final[str] = "token"
+
+
+@runtime_checkable
+class GitHubTargetLike(Protocol):
+    """Minimum target shape :class:`GitHubRestConnector` reads.
+
+    Structural Protocol — any concrete ``Target`` in
+    :mod:`meho_backplane.targets` that exposes these attributes satisfies
+    it unchanged. ``auth_model`` carries the literal ``"github-app"`` or
+    ``"github-pat"`` selector; :class:`GitHubRestConnector` rejects any
+    other value at the boundary.
+
+    ``host`` carries either ``api.github.com`` (the default, for
+    organisation-wide or operator-style ``GET /user/installations``
+    fingerprinting) or ``api.github.com/repos/<owner>/<repo>`` (a
+    target scoped to a specific repository — the issue body's
+    ``GET /repos/{owner}/{repo}`` fingerprint variant). The connector
+    splits ``host`` at the first ``/`` so the bare API URL drives the
+    httpx base URL and the trailing path (if any) drives the
+    fingerprint endpoint selection.
+    """
+
+    name: str
+    host: str
+    port: int | None
+    secret_ref: str | None
+    auth_model: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubAppCredentials:
+    """The Vault-stored material for a single GitHub App installation.
+
+    All three fields land in the Vault secret as plain strings — App ID
+    is numeric but stored as a string so the Vault KV-v2 ``data`` dict
+    round-trips uniformly. The connector coerces back to ``str`` (used
+    verbatim in the JWT ``iss`` claim).
+    """
+
+    app_id: str
+    private_key_pem: str
+    installation_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class GitHubPATCredentials:
+    """The Vault-stored material for a fine-grained PAT.
+
+    Single field because PATs are self-contained bearer tokens — no App
+    ID, no installation ID, no minting. The token is opaque to MEHO; the
+    connector forwards it as ``Authorization: Bearer <token>`` on every
+    call.
+    """
+
+    token: str
+
+
+@dataclass(frozen=True, slots=True)
+class InstallationToken:
+    """A live GitHub App installation token plus its cache validity.
+
+    ``token`` is the opaque string GitHub mints from the JWT exchange.
+    ``expires_at_monotonic`` is the absolute :func:`time.monotonic`
+    timestamp after which the token is considered stale by the
+    connector's cache (50 minutes after mint, per
+    :data:`INSTALLATION_TOKEN_CACHE_SECONDS`). The dataclass is frozen
+    so a cache hit cannot be tampered with by a concurrent caller.
+
+    Stored separately from the bare token so cache validity decisions
+    don't need to round-trip GitHub's ``expires_at`` ISO timestamp from
+    the mint response (which we keep as ``upstream_expires_at`` for
+    observability, but the cache decision is monotonic-clock-driven to
+    avoid wall-clock-jump bugs).
+    """
+
+    token: str
+    expires_at_monotonic: float
+    upstream_expires_at: str | None = None
+
+
+# A callable that resolves ``(target, operator)`` to GitHub App creds.
+# Injectable so unit tests can supply canned credentials without
+# touching Vault.
+GitHubCredentialsLoader = Callable[
+    [GitHubTargetLike, Operator],
+    Awaitable["GitHubAppCredentials | GitHubPATCredentials"],
+]
+"""Async callable resolving ``(target, operator)`` to credentials.
+
+The return type is a union because the connector selects between
+:class:`GitHubAppCredentials` and :class:`GitHubPATCredentials` by the
+target's ``auth_model`` value. Production uses the default loaders below
+(`load_github_app_credentials_from_vault` /
+`load_github_pat_credentials_from_vault`); tests inject stubs.
+"""
+
+
+# ---------------------------------------------------------------------------
+# T11-compliant error envelopes
+# ---------------------------------------------------------------------------
+
+
+class GitHubCredentialError(Exception):
+    """Base for GitHub credential / token errors per T11 message-shape.
+
+    Subclasses carry a stable ``code`` (``snake_case``, ``github_*``
+    prefix) the connector lifts into structured logs / audit rows. The
+    ``__str__`` shape follows the convention's three-clause template:
+    *"<code>: <values>. <remediation>. See <doc>."* The doc reference
+    on the base class points at the GitHub-connector codebase doc which
+    catalogues every code; subclasses optionally append a more specific
+    doc URL.
+    """
+
+    code: str = "github_credential_error"
+
+
+class GitHubAppNotInstalledError(GitHubCredentialError):
+    """GitHub App credentials valid, but the App is not installed on target.
+
+    Surfaces as ``GET /app/installations/{id}`` 404 from the JWT-bearing
+    request, OR as 404 from the installation-token mint call when the
+    ``installation_id`` does not name a real installation.
+    """
+
+    code = "github_app_not_installed"
+
+
+class GitHubJWTMintError(GitHubCredentialError):
+    """RS256 JWT signing failed — typically a malformed private key PEM.
+
+    PyJWT's :func:`jwt.encode` raises broadly for "key not loadable",
+    "unsupported algorithm", etc.; this wrapper normalises every such
+    failure into one error with a remediation-bearing message.
+    """
+
+    code = "github_jwt_mint_failed"
+
+
+class GitHubInstallationTokenMintError(GitHubCredentialError):
+    """``POST /app/installations/{id}/access_tokens`` failed.
+
+    Covers any non-2xx response that is not a 404 (which maps to
+    :class:`GitHubAppNotInstalledError`) and any transport-level
+    failure on the mint call. The original status code (when known)
+    lands on the error's ``status_code`` attribute for log
+    attribution.
+    """
+
+    code = "github_installation_token_mint_failed"
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class GitHubRateLimitedError(GitHubCredentialError):
+    """Upstream rate-limit hit (``X-RateLimit-Remaining: 0``).
+
+    Both the primary and secondary rate-limit shapes (per GitHub's REST
+    rate-limit documentation) surface here. The ``reset_at`` field
+    carries the Unix timestamp from the ``X-RateLimit-Reset`` header
+    (when present) so the connector / operator can decide whether to
+    wait or fail.
+    """
+
+    code = "github_rate_limited"
+
+    def __init__(self, message: str, *, reset_at: int | None = None) -> None:
+        super().__init__(message)
+        self.reset_at = reset_at
+
+
+# ---------------------------------------------------------------------------
+# JWT minting
+# ---------------------------------------------------------------------------
+
+
+def mint_github_app_jwt(
+    app_id: str,
+    private_key_pem: str,
+    *,
+    now: float | None = None,
+    ttl_seconds: int = JWT_TTL_SECONDS,
+) -> str:
+    """Mint a 10-minute-bound RS256 JWT for the GitHub App.
+
+    Returns the encoded JWT string for use as ``Authorization: Bearer
+    <jwt>`` on ``GET /app/*`` calls (specifically the installation-token
+    mint endpoint). The claims are the three GitHub documents: ``iat``
+    (issued-at), ``exp`` (expiry), ``iss`` (the App ID as a string).
+
+    ``now`` is injectable for the cache-test path (the unit test mocks
+    the clock to assert "second fingerprint call does not re-mint" —
+    see :data:`INSTALLATION_TOKEN_CACHE_SECONDS`).
+
+    Raises :class:`GitHubJWTMintError` when PyJWT cannot sign the
+    payload — malformed PEM, wrong algorithm for the key shape, etc.
+    The error message names the App ID (operator-known) but not the key
+    material (per the T11 info-leak rule).
+    """
+    iat = int(now if now is not None else time.time())
+    exp = iat + ttl_seconds
+    payload: dict[str, object] = {"iat": iat, "exp": exp, "iss": app_id}
+    try:
+        return jwt.encode(payload, private_key_pem, algorithm="RS256")
+    except Exception as exc:  # PyJWT raises broadly; normalise to T11.
+        raise GitHubJWTMintError(
+            f"github_jwt_mint_failed: cannot sign JWT for app_id={app_id!r} — "
+            f"check the Vault-stored RSA private key (PEM) is well-formed and "
+            f"matches the App's configured public key. See "
+            f"docs/cross-repo/github-app-credential.md for the credential "
+            f"custody recipe. Underlying error: {type(exc).__name__}: {exc}"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Default Vault-backed loaders
+# ---------------------------------------------------------------------------
+
+
+async def load_github_app_credentials_from_vault(
+    target: GitHubTargetLike,
+    operator: Operator,
+    *,
+    mount: str = DEFAULT_KV_MOUNT,
+) -> GitHubAppCredentials:
+    """Read ``target.secret_ref`` and return App ID + private key + installation ID.
+
+    Delegates to the shared :func:`load_basic_credentials` helper (G3.9-T2
+    precedent) so the operator-context Vault read, the no-secret-in-logs
+    discipline, and the two-phase error contract are defined once for
+    every REST connector. The helper takes a custom ``fields`` tuple so
+    we ask for ``("app_id", "private_key", "installation_id")`` instead
+    of the default ``("username", "password")``.
+
+    The structured-log event carries only field *names* + target /
+    host — never a credential value. The returned dataclass is ephemeral
+    in-memory state and must not enter any log event,
+    :class:`OperationResult`, or durable artifact.
+    """
+    creds = await load_basic_credentials(
+        target,
+        operator,
+        fields=_GH_APP_FIELDS,
+        mount=mount,
+    )
+    return GitHubAppCredentials(
+        app_id=creds["app_id"],
+        private_key_pem=creds["private_key"],
+        installation_id=creds["installation_id"],
+    )
+
+
+async def load_github_pat_credentials_from_vault(
+    target: GitHubTargetLike,
+    operator: Operator,
+    *,
+    mount: str = DEFAULT_KV_MOUNT,
+) -> GitHubPATCredentials:
+    """Read ``target.secret_ref`` and return the bearer PAT.
+
+    Same delegation pattern as the App loader — the shared helper
+    enforces the operator-context Vault read, the no-secret-in-logs
+    discipline, and the fail-closed empty-JWT carve-out.
+    """
+    creds = await load_basic_credentials(
+        target,
+        operator,
+        fields=(_GH_PAT_FIELD,),
+        mount=mount,
+    )
+    return GitHubPATCredentials(token=creds[_GH_PAT_FIELD])
+
+
+# ---------------------------------------------------------------------------
+# Installation-token exchange
+# ---------------------------------------------------------------------------
+
+
+async def exchange_jwt_for_installation_token(
+    *,
+    jwt_token: str,
+    installation_id: str,
+    api_base_url: str = DEFAULT_GITHUB_API_URL,
+    http_client: httpx.AsyncClient | None = None,
+    now: float | None = None,
+) -> InstallationToken:
+    """``POST /app/installations/{id}/access_tokens`` and wrap the result.
+
+    Builds an :class:`InstallationToken` whose
+    ``expires_at_monotonic`` is set to ``now + INSTALLATION_TOKEN_CACHE_SECONDS``
+    so the cache's validity decision is monotonic-clock-driven (wall-
+    clock-jump immune). The upstream ISO timestamp (``expires_at`` from
+    GitHub's response) lands on ``upstream_expires_at`` for observability.
+
+    ``http_client`` is injectable for unit tests; production code
+    constructs one against ``api_base_url`` and lets ``aclose`` clean it
+    up. ``now`` is injectable for the cache-test path.
+
+    Raises :class:`GitHubAppNotInstalledError` on 404 (the
+    ``installation_id`` does not name an installation MEHO's App can
+    reach), :class:`GitHubRateLimitedError` when the ``X-RateLimit-
+    Remaining: 0`` header appears, and
+    :class:`GitHubInstallationTokenMintError` for every other non-2xx
+    or transport error.
+    """
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {jwt_token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    path = f"/app/installations/{installation_id}/access_tokens"
+
+    owns_client = http_client is None
+    if http_client is None:
+        http_client = httpx.AsyncClient(
+            base_url=api_base_url,
+            timeout=httpx.Timeout(connect=5.0, read=30.0, write=30.0, pool=5.0),
+        )
+    try:
+        try:
+            resp = await http_client.post(path, headers=headers)
+        except httpx.HTTPError as exc:
+            raise GitHubInstallationTokenMintError(
+                f"github_installation_token_mint_failed: transport failure "
+                f"reaching {api_base_url}{path} — check network / TLS to "
+                f"api.github.com. Underlying error: {type(exc).__name__}: {exc}"
+            ) from exc
+
+        _raise_for_rate_limit(resp)
+
+        if resp.status_code == 404:
+            raise GitHubAppNotInstalledError(
+                f"github_app_not_installed: installation_id="
+                f"{installation_id!r} is not reachable for this App — the "
+                f"App may not be installed on the target repo/org, or the "
+                f"installation_id in Vault is stale. Re-confirm the "
+                f"installation per docs/cross-repo/github-app-credential.md "
+                f"(install the App, copy the installation ID from the URL)."
+            )
+        if resp.status_code >= 400:
+            body_excerpt = _excerpt(resp.text)
+            raise GitHubInstallationTokenMintError(
+                f"github_installation_token_mint_failed: "
+                f"POST {api_base_url}{path} returned HTTP "
+                f"{resp.status_code}. Body excerpt: {body_excerpt!r}. "
+                f"See docs/cross-repo/github-app-credential.md for App "
+                f"permission scoping; common causes are a revoked App "
+                f"private key or a permission-mismatch between the App "
+                f"manifest and the installation's granted permissions.",
+                status_code=resp.status_code,
+            )
+
+        payload = resp.json()
+        token_value = payload.get("token") if isinstance(payload, dict) else None
+        if not isinstance(token_value, str) or not token_value:
+            keys_or_type = (
+                sorted(payload.keys()) if isinstance(payload, dict) else type(payload).__name__
+            )
+            raise GitHubInstallationTokenMintError(
+                f"github_installation_token_mint_failed: response from "
+                f"POST {api_base_url}{path} is missing a 'token' field "
+                f"(received keys: {keys_or_type}). This is a GitHub API "
+                f"contract violation — file an issue and re-mint manually."
+            )
+        upstream_expires_at = payload.get("expires_at")
+        upstream_expires_str: str | None = (
+            upstream_expires_at if isinstance(upstream_expires_at, str) else None
+        )
+        now_monotonic = now if now is not None else time.monotonic()
+        return InstallationToken(
+            token=token_value,
+            expires_at_monotonic=now_monotonic + INSTALLATION_TOKEN_CACHE_SECONDS,
+            upstream_expires_at=upstream_expires_str,
+        )
+    finally:
+        if owns_client:
+            await http_client.aclose()
+
+
+def _raise_for_rate_limit(resp: httpx.Response) -> None:
+    """Inspect rate-limit headers and raise :class:`GitHubRateLimitedError` on exhaustion.
+
+    GitHub returns 403 (primary) or 429 (secondary) when rate-limited;
+    in both shapes the ``X-RateLimit-Remaining: 0`` header is the
+    authoritative signal (the body wording varies across endpoints and
+    is not safe to pattern-match). Per the GitHub REST rate-limit
+    documentation, we read ``X-RateLimit-Reset`` for the reset timestamp
+    when available; absence is non-fatal.
+    """
+    if resp.status_code not in (403, 429):
+        return
+    remaining_hdr = resp.headers.get("X-RateLimit-Remaining")
+    if remaining_hdr is None or remaining_hdr.strip() != "0":
+        return
+    reset_hdr = resp.headers.get("X-RateLimit-Reset")
+    reset_at: int | None = None
+    if reset_hdr is not None:
+        try:
+            reset_at = int(reset_hdr)
+        except ValueError:
+            reset_at = None
+    reset_clause = f" (resets at unix={reset_at})" if reset_at is not None else ""
+    raise GitHubRateLimitedError(
+        f"github_rate_limited: api.github.com returned HTTP "
+        f"{resp.status_code} with X-RateLimit-Remaining: 0{reset_clause}. "
+        f"Wait for the reset window or reduce per-target call volume. See "
+        "https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api "
+        "for the rate-limit policy.",
+        reset_at=reset_at,
+    )
+
+
+def _excerpt(body: str, *, limit: int = 200) -> str:
+    """Truncate a response body for safe inclusion in an error message.
+
+    GitHub's error bodies are typically small JSON envelopes, but a
+    malformed proxy could return a multi-KB HTML page. Cap at 200 chars
+    to keep the audit row readable; the structured log carries the full
+    response body when needed for forensics.
+    """
+    if len(body) <= limit:
+        return body
+    return body[:limit] + "...<truncated>"
+
+
+# Re-export :class:`VaultCredentialsReadError` for symmetric error
+# handling at the connector layer — the loader's read-phase failures
+# (empty operator JWT, unset ``secret_ref``, missing field) propagate
+# verbatim from :func:`load_basic_credentials`. Listed in ``__all__``
+# via the import side so callers can catch a single error class for
+# loader-vs-network failures.
+_ = VaultCredentialsReadError  # silence vulture / mark intent
+_AuthModelLiteral = Literal["github-app", "github-pat"]  # documentation alias

--- a/backend/tests/test_connectors_github_connector.py
+++ b/backend/tests/test_connectors_github_connector.py
@@ -1,0 +1,439 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for :class:`GitHubRestConnector` (G3.11-T1 #1221).
+
+Coverage:
+
+* **Dual registration** — the package registers both the v1 wildcard
+  ``("gh", "", "")`` and the v2 versioned ``("gh", "3", "gh-rest")``
+  entries per G0.15-T6.
+* **Installation-token caching** — a second :meth:`fingerprint` call
+  within the 50-minute window does NOT re-mint the JWT or call the
+  installation-token endpoint (the acceptance-criteria assertion).
+* **PAT fallback** — ``auth_model="github-pat"`` reads a Vault-stored
+  token and skips the JWT exchange entirely.
+* **Auth-model gating** — ``auth_model`` other than the two supported
+  values raises :exc:`NotImplementedError` at :meth:`auth_headers`.
+* **Fingerprint shape** — the ``GET /user/installations`` and
+  ``GET /repos/{owner}/{repo}`` paths populate the documented
+  ``extras`` fields.
+* **T11 error envelopes** — a 404 / 403 rate-limit / 500 / bad PEM
+  surface as ``reachable=False`` with the structured ``error_code``.
+
+The test seam uses an injected ``credentials_loader`` returning canned
+:class:`GitHubAppCredentials` / :class:`GitHubPATCredentials` so the
+tests never touch Vault — same shape :class:`VmwareRestConnector` tests
+use.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from uuid import UUID
+
+import httpx
+import pytest
+import respx
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.github import (
+    DEFAULT_GITHUB_API_URL,
+    GITHUB_APP_AUTH_MODEL,
+    GITHUB_PAT_AUTH_MODEL,
+    GitHubAppCredentials,
+    GitHubPATCredentials,
+    GitHubRestConnector,
+    GitHubTargetLike,
+)
+from meho_backplane.connectors.registry import (
+    all_connectors,
+    all_connectors_v2,
+)
+
+
+def _generate_rsa_pem() -> str:
+    """Same helper as :mod:`test_connectors_github_session` — fresh 2048-bit RSA."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("ascii")
+
+
+def _make_operator(raw_jwt: str = "op.test.jwt") -> Operator:
+    """Minimal :class:`Operator` for tests; non-empty placeholder JWT."""
+    return Operator(
+        sub="test-operator",
+        name=None,
+        email=None,
+        raw_jwt=raw_jwt,
+        tenant_id=UUID(int=0),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+@dataclass(frozen=True)
+class _FakeTarget:
+    """Structural :class:`GitHubTargetLike` for the test seam."""
+
+    name: str
+    host: str = "api.github.com"
+    port: int | None = None
+    secret_ref: str | None = "targets/github/test"
+    auth_model: str | None = GITHUB_APP_AUTH_MODEL
+
+
+@pytest.fixture
+def app_pem() -> str:
+    """Per-test RSA PEM so signed JWTs round-trip through PyJWT."""
+    return _generate_rsa_pem()
+
+
+@pytest.fixture
+def app_creds(app_pem: str) -> GitHubAppCredentials:
+    return GitHubAppCredentials(
+        app_id="100000",
+        private_key_pem=app_pem,
+        installation_id="42",
+    )
+
+
+@pytest.fixture
+def operator() -> Operator:
+    return _make_operator()
+
+
+@pytest.fixture
+def connector_with_app_loader(app_creds: GitHubAppCredentials) -> Iterator[GitHubRestConnector]:
+    """Connector with an injected loader that returns the App creds."""
+
+    async def loader(target: GitHubTargetLike, op: Operator) -> GitHubAppCredentials:
+        del target, op
+        return app_creds
+
+    conn = GitHubRestConnector(credentials_loader=loader)
+    yield conn
+
+
+# ---------------------------------------------------------------------------
+# Dual registration (G0.15-T6 mandatory pattern)
+# ---------------------------------------------------------------------------
+
+
+def test_github_connector_registers_v1_wildcard_and_v2_versioned() -> None:
+    """The package import wires BOTH ``("gh", "", "")`` and ``("gh", "3", "gh-rest")``."""
+    # Force import; safe to call multiple times — duplicate-registration
+    # would raise at import time, not on this call.
+    import meho_backplane.connectors.github  # noqa: F401
+
+    v1 = all_connectors()
+    v2 = all_connectors_v2()
+
+    assert v1.get("gh") is GitHubRestConnector
+    assert v2.get(("gh", "", "")) is GitHubRestConnector
+    assert v2.get(("gh", "3", "gh-rest")) is GitHubRestConnector
+
+
+def test_github_connector_class_metadata() -> None:
+    """Class-level attributes match the documented registry triple."""
+    assert GitHubRestConnector.product == "gh"
+    # Registry version is "3" (digit-prefix shape the connector-id parser
+    # requires); the GitHub-API-side label "v3" lives in docs / fingerprint
+    # extras only.
+    assert GitHubRestConnector.version == "3"
+    assert GitHubRestConnector.impl_id == "gh-rest"
+    assert GitHubRestConnector.priority == 1
+
+
+# ---------------------------------------------------------------------------
+# Installation-token caching (acceptance criterion)
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_second_fingerprint_does_not_remint_within_cache_window(
+    connector_with_app_loader: GitHubRestConnector,
+) -> None:
+    """A second fingerprint within 50 minutes reuses the cached token.
+
+    Asserts:
+    * The installation-token mint endpoint is hit **exactly once**.
+    * The ``GET /user/installations`` endpoint is hit twice (one per
+      fingerprint call) — only the token itself caches; the
+      installation list re-probes on demand.
+    """
+    mint_route = respx.post(
+        f"{DEFAULT_GITHUB_API_URL}/app/installations/42/access_tokens",
+    ).mock(
+        return_value=httpx.Response(
+            201,
+            json={
+                "token": "ghs_installtoken_redacted",
+                "expires_at": "2026-05-27T13:00:00Z",
+                "permissions": {"contents": "read"},
+            },
+        )
+    )
+    installations_route = respx.get(
+        f"{DEFAULT_GITHUB_API_URL}/user/installations",
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "total_count": 1,
+                "installations": [
+                    {
+                        "id": 42,
+                        "app_slug": "meho-gh-app",
+                        "target_type": "Organization",
+                        "account": {"login": "evoila"},
+                        "permissions": {"contents": "read"},
+                    }
+                ],
+            },
+        )
+    )
+
+    target = _FakeTarget(name="github-main")
+
+    fp1 = await connector_with_app_loader.fingerprint(target)
+    fp2 = await connector_with_app_loader.fingerprint(target)
+
+    assert fp1.reachable is True
+    assert fp2.reachable is True
+    # Token mint runs exactly once across both fingerprints.
+    assert mint_route.call_count == 1
+    # The /user/installations probe runs per-fingerprint (no caching of
+    # the wire response itself — only the token caches).
+    assert installations_route.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# PAT fallback path
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_pat_fallback_path_skips_jwt_exchange_entirely() -> None:
+    """``auth_model="github-pat"`` reads a PAT and never calls the mint endpoint."""
+
+    async def loader(target: GitHubTargetLike, op: Operator) -> GitHubPATCredentials:
+        del target, op
+        return GitHubPATCredentials(token="ghp_pat_redacted")
+
+    conn = GitHubRestConnector(credentials_loader=loader)
+    target = _FakeTarget(name="github-pat-target", auth_model=GITHUB_PAT_AUTH_MODEL)
+
+    # If the connector accidentally tried to mint, this absence would
+    # raise an unmocked-route error from respx.
+    installations_route = respx.get(
+        f"{DEFAULT_GITHUB_API_URL}/user/installations",
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={"total_count": 0, "installations": []},
+        )
+    )
+
+    fp = await conn.fingerprint(target)
+    assert fp.reachable is True
+    assert installations_route.call_count == 1
+    # Confirm the Bearer token is the PAT verbatim.
+    bearer = installations_route.calls[0].request.headers["Authorization"]
+    assert bearer == "Bearer ghp_pat_redacted"
+
+
+# ---------------------------------------------------------------------------
+# Auth-model gating
+# ---------------------------------------------------------------------------
+
+
+async def test_auth_headers_rejects_unsupported_auth_model(
+    app_creds: GitHubAppCredentials,
+    operator: Operator,
+) -> None:
+    """``auth_model="shared_service_account"`` raises :exc:`NotImplementedError`."""
+
+    async def loader(target: GitHubTargetLike, op: Operator) -> GitHubAppCredentials:
+        del target, op
+        return app_creds
+
+    conn = GitHubRestConnector(credentials_loader=loader)
+    target = _FakeTarget(name="bad", auth_model="shared_service_account")
+    with pytest.raises(NotImplementedError) as excinfo:
+        await conn.auth_headers(target, operator)
+    msg = str(excinfo.value)
+    assert "'bad'" in msg
+    assert "shared_service_account" in msg
+    assert "'github-app'" in msg
+    assert "'github-pat'" in msg
+
+
+async def test_auth_headers_rejects_empty_operator_jwt(
+    app_creds: GitHubAppCredentials,
+) -> None:
+    """An operator with ``raw_jwt=""`` cannot read per-target vendor credentials."""
+    from meho_backplane.connectors._shared.vault_creds import VaultCredentialsReadError
+
+    async def loader(target: GitHubTargetLike, op: Operator) -> GitHubAppCredentials:
+        del target, op
+        return app_creds
+
+    conn = GitHubRestConnector(credentials_loader=loader)
+    target = _FakeTarget(name="any")
+    operator = _make_operator(raw_jwt="")
+    with pytest.raises(VaultCredentialsReadError) as excinfo:
+        await conn.auth_headers(target, operator)
+    assert "no operator JWT" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint shape — repo coordinates
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_fingerprint_with_repo_coordinates_uses_repos_endpoint(
+    connector_with_app_loader: GitHubRestConnector,
+) -> None:
+    """``host="api.github.com/repos/evoila/meho"`` hits ``GET /repos/evoila/meho``."""
+    respx.post(
+        f"{DEFAULT_GITHUB_API_URL}/app/installations/42/access_tokens",
+    ).mock(
+        return_value=httpx.Response(
+            201, json={"token": "ghs_x", "expires_at": "2026-05-27T13:00:00Z"}
+        )
+    )
+    repo_route = respx.get(
+        f"{DEFAULT_GITHUB_API_URL}/repos/evoila/meho",
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": 1234567,
+                "full_name": "evoila/meho",
+                "private": False,
+                "default_branch": "main",
+                "owner": {"login": "evoila", "type": "Organization"},
+            },
+        )
+    )
+    target = _FakeTarget(
+        name="github-evoila-meho",
+        host="api.github.com/repos/evoila/meho",
+    )
+    fp = await connector_with_app_loader.fingerprint(target)
+    assert fp.reachable is True
+    assert repo_route.called
+    assert fp.extras["repo_full_name"] == "evoila/meho"
+    assert fp.extras["repo_id"] == 1234567
+    assert fp.extras["owner_login"] == "evoila"
+    assert fp.extras["owner_type"] == "Organization"
+    assert fp.extras["default_branch"] == "main"
+
+
+# ---------------------------------------------------------------------------
+# T11 error envelopes surfaced on fingerprint
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_fingerprint_surfaces_app_not_installed_envelope(
+    connector_with_app_loader: GitHubRestConnector,
+) -> None:
+    """404 on mint → ``reachable=False`` + ``error_code="github_app_not_installed"``."""
+    respx.post(
+        f"{DEFAULT_GITHUB_API_URL}/app/installations/42/access_tokens",
+    ).mock(return_value=httpx.Response(404, json={"message": "Not Found"}))
+    target = _FakeTarget(name="github-broken")
+    fp = await connector_with_app_loader.fingerprint(target)
+    assert fp.reachable is False
+    assert fp.extras["error_code"] == "github_app_not_installed"
+    assert "github_app_not_installed" in fp.extras["error"]
+
+
+@respx.mock
+async def test_fingerprint_surfaces_rate_limited_envelope(
+    connector_with_app_loader: GitHubRestConnector,
+) -> None:
+    """403 + ``X-RateLimit-Remaining: 0`` → ``error_code="github_rate_limited"``."""
+    respx.post(
+        f"{DEFAULT_GITHUB_API_URL}/app/installations/42/access_tokens",
+    ).mock(
+        return_value=httpx.Response(
+            403,
+            headers={
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Reset": "1700001234",
+            },
+        )
+    )
+    target = _FakeTarget(name="github-rate-limited")
+    fp = await connector_with_app_loader.fingerprint(target)
+    assert fp.reachable is False
+    assert fp.extras["error_code"] == "github_rate_limited"
+
+
+@respx.mock
+async def test_fingerprint_surfaces_jwt_mint_failed_envelope(operator: Operator) -> None:
+    """A malformed PEM in the loader's creds surfaces as JWT-mint-failed."""
+
+    async def loader(target: GitHubTargetLike, op: Operator) -> GitHubAppCredentials:
+        del target, op
+        return GitHubAppCredentials(
+            app_id="100000",
+            private_key_pem="not-a-real-pem",
+            installation_id="42",
+        )
+
+    conn = GitHubRestConnector(credentials_loader=loader)
+    target = _FakeTarget(name="github-bad-key")
+    fp = await conn.fingerprint(target)
+    assert fp.reachable is False
+    assert fp.extras["error_code"] == "github_jwt_mint_failed"
+
+
+# ---------------------------------------------------------------------------
+# execute() is a stub until T3 ships the catalog
+# ---------------------------------------------------------------------------
+
+
+async def test_execute_returns_unknown_op_until_catalog_lands(
+    connector_with_app_loader: GitHubRestConnector,
+) -> None:
+    """T1 ships zero typed ops; ``execute`` returns the structured ``unknown_op``."""
+    target = _FakeTarget(name="anything")
+    result = await connector_with_app_loader.execute(
+        target,
+        "gh.pr.get",
+        {"owner": "evoila", "repo": "meho", "pull_number": 754},
+    )
+    assert result.status == "error"
+    assert "unknown_op" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# Loader-shape mismatch (auth_model vs returned credentials class)
+# ---------------------------------------------------------------------------
+
+
+async def test_loader_returning_wrong_credentials_class_for_app_raises_t11(
+    operator: Operator,
+) -> None:
+    """A PAT-credentials object returned for an App target raises the base envelope."""
+    from meho_backplane.connectors.github import GitHubCredentialError
+
+    async def loader(target: GitHubTargetLike, op: Operator) -> GitHubPATCredentials:
+        del target, op
+        return GitHubPATCredentials(token="ghp_x")
+
+    conn = GitHubRestConnector(credentials_loader=loader)
+    target = _FakeTarget(name="any", auth_model=GITHUB_APP_AUTH_MODEL)
+    with pytest.raises(GitHubCredentialError) as excinfo:
+        await conn.auth_headers(target, operator)
+    assert excinfo.value.code == "github_credential_error"

--- a/backend/tests/test_connectors_github_connector.py
+++ b/backend/tests/test_connectors_github_connector.py
@@ -174,7 +174,7 @@ async def test_second_fingerprint_does_not_remint_within_cache_window(
             201,
             json={
                 "token": "ghs_installtoken_redacted",
-                "expires_at": "2026-05-27T13:00:00Z",
+                "expires_at": "2099-01-01T00:00:00Z",
                 "permissions": {"contents": "read"},
             },
         )
@@ -306,7 +306,7 @@ async def test_fingerprint_with_repo_coordinates_uses_repos_endpoint(
         f"{DEFAULT_GITHUB_API_URL}/app/installations/42/access_tokens",
     ).mock(
         return_value=httpx.Response(
-            201, json={"token": "ghs_x", "expires_at": "2026-05-27T13:00:00Z"}
+            201, json={"token": "ghs_x", "expires_at": "2099-01-01T00:00:00Z"}
         )
     )
     repo_route = respx.get(
@@ -335,6 +335,46 @@ async def test_fingerprint_with_repo_coordinates_uses_repos_endpoint(
     assert fp.extras["owner_login"] == "evoila"
     assert fp.extras["owner_type"] == "Organization"
     assert fp.extras["default_branch"] == "main"
+
+
+@respx.mock
+async def test_fingerprint_with_bare_owner_repo_uses_repos_endpoint(
+    connector_with_app_loader: GitHubRestConnector,
+) -> None:
+    """``host="evoila/meho"`` (operator-friendly bare form) also hits ``GET /repos/evoila/meho``.
+
+    The docstring on :func:`_extract_repo_path` documents three accepted
+    shapes — ``api.github.com/repos/owner/repo``,
+    ``api.github.com/owner/repo``, and bare ``owner/repo``. This test
+    pins the bare form, which is what the v0.x onboarding doc tells
+    operators to configure on ``target.host``.
+    """
+    respx.post(
+        f"{DEFAULT_GITHUB_API_URL}/app/installations/42/access_tokens",
+    ).mock(
+        return_value=httpx.Response(
+            201, json={"token": "ghs_x", "expires_at": "2099-01-01T00:00:00Z"}
+        )
+    )
+    repo_route = respx.get(
+        f"{DEFAULT_GITHUB_API_URL}/repos/evoila/meho",
+    ).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": 1234567,
+                "full_name": "evoila/meho",
+                "private": False,
+                "default_branch": "main",
+                "owner": {"login": "evoila", "type": "Organization"},
+            },
+        )
+    )
+    target = _FakeTarget(name="github-evoila-meho", host="evoila/meho")
+    fp = await connector_with_app_loader.fingerprint(target)
+    assert fp.reachable is True
+    assert repo_route.called
+    assert fp.extras["repo_full_name"] == "evoila/meho"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_connectors_github_session.py
+++ b/backend/tests/test_connectors_github_session.py
@@ -1,0 +1,239 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for the GitHub session module (G3.11-T1 #1221).
+
+Covers the four T11-compliant error envelopes named in the issue body:
+
+* ``github_app_not_installed`` — 404 from the installation-token mint.
+* ``github_jwt_mint_failed`` — PyJWT cannot sign (malformed PEM, etc.).
+* ``github_installation_token_mint_failed`` — non-2xx, non-404 on mint.
+* ``github_rate_limited`` — ``X-RateLimit-Remaining: 0`` on a 403 / 429.
+
+Plus the happy path: JWT mint with a real RSA key, installation-token
+exchange + cache validity, and the PAT fallback shape.
+"""
+
+from __future__ import annotations
+
+import httpx
+import jwt
+import pytest
+import respx
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from meho_backplane.connectors.github.session import (
+    DEFAULT_GITHUB_API_URL,
+    INSTALLATION_TOKEN_CACHE_SECONDS,
+    JWT_TTL_SECONDS,
+    GitHubAppNotInstalledError,
+    GitHubInstallationTokenMintError,
+    GitHubJWTMintError,
+    GitHubRateLimitedError,
+    exchange_jwt_for_installation_token,
+    mint_github_app_jwt,
+)
+
+
+def _generate_rsa_pem() -> str:
+    """Build a fresh 2048-bit RSA key in PEM (PKCS8) so ``jwt.encode`` succeeds.
+
+    Using a real key (rather than a hard-coded fixture) keeps the test
+    immune to cryptography-library API changes; the key never leaves the
+    test process.
+    """
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem_bytes = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pem_bytes.decode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# mint_github_app_jwt
+# ---------------------------------------------------------------------------
+
+
+def test_mint_github_app_jwt_returns_decodable_rs256_token() -> None:
+    """Happy path — encoded JWT carries the documented claims + algorithm."""
+    pem = _generate_rsa_pem()
+    now = 1_700_000_000.0
+    token = mint_github_app_jwt("123456", pem, now=now)
+    # Decode without signature verification — we only assert claim shape.
+    decoded = jwt.decode(token, options={"verify_signature": False})
+    assert decoded["iss"] == "123456"
+    assert decoded["iat"] == int(now)
+    # exp - iat must equal the documented TTL; GitHub enforces ≤10 min.
+    assert decoded["exp"] - decoded["iat"] == JWT_TTL_SECONDS
+    # Header advertises RS256 (the GitHub-mandated algorithm).
+    header = jwt.get_unverified_header(token)
+    assert header["alg"] == "RS256"
+
+
+def test_mint_github_app_jwt_raises_t11_envelope_on_malformed_pem() -> None:
+    """Malformed PEM → :class:`GitHubJWTMintError` with the T11 code prefix."""
+    with pytest.raises(GitHubJWTMintError) as excinfo:
+        mint_github_app_jwt("123", "not-a-pem")
+    assert excinfo.value.code == "github_jwt_mint_failed"
+    msg = str(excinfo.value)
+    assert "github_jwt_mint_failed" in msg
+    # T11 three-clause rule: app_id (operator-known) is named, the PEM is not.
+    assert "'123'" in msg
+    assert "docs/cross-repo/github-app-credential.md" in msg
+
+
+# ---------------------------------------------------------------------------
+# exchange_jwt_for_installation_token — happy path + cache shape
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_exchange_jwt_returns_installation_token_with_monotonic_expiry() -> None:
+    """Happy path — 201 mint response yields a cached token + expiry."""
+    route = respx.post(
+        f"{DEFAULT_GITHUB_API_URL}/app/installations/42/access_tokens",
+    ).mock(
+        return_value=httpx.Response(
+            201,
+            json={
+                "token": "ghs_installtoken_redacted",
+                "expires_at": "2026-05-27T13:00:00Z",
+                "permissions": {"contents": "read"},
+            },
+        )
+    )
+    now_monotonic = 12345.0
+    result = await exchange_jwt_for_installation_token(
+        jwt_token="signed.jwt.value",
+        installation_id="42",
+        now=now_monotonic,
+    )
+    assert result.token == "ghs_installtoken_redacted"
+    assert result.upstream_expires_at == "2026-05-27T13:00:00Z"
+    assert result.expires_at_monotonic == now_monotonic + INSTALLATION_TOKEN_CACHE_SECONDS
+    assert route.called
+    # Request carries the Bearer JWT + the documented Accept + API-version headers.
+    request = route.calls[0].request
+    assert request.headers["Authorization"] == "Bearer signed.jwt.value"
+    assert request.headers["Accept"] == "application/vnd.github+json"
+    assert request.headers["X-GitHub-Api-Version"] == "2022-11-28"
+
+
+# ---------------------------------------------------------------------------
+# T11 envelopes: 404, rate-limit, non-2xx
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_exchange_jwt_raises_app_not_installed_on_404() -> None:
+    """404 → :class:`GitHubAppNotInstalledError` with the T11 code."""
+    respx.post(
+        f"{DEFAULT_GITHUB_API_URL}/app/installations/99/access_tokens",
+    ).mock(return_value=httpx.Response(404, json={"message": "Not Found"}))
+    with pytest.raises(GitHubAppNotInstalledError) as excinfo:
+        await exchange_jwt_for_installation_token(
+            jwt_token="signed.jwt.value",
+            installation_id="99",
+        )
+    assert excinfo.value.code == "github_app_not_installed"
+    msg = str(excinfo.value)
+    assert "github_app_not_installed" in msg
+    assert "'99'" in msg
+    assert "docs/cross-repo/github-app-credential.md" in msg
+
+
+@respx.mock
+async def test_exchange_jwt_raises_rate_limited_when_remaining_is_zero() -> None:
+    """403 + ``X-RateLimit-Remaining: 0`` → :class:`GitHubRateLimitedError`."""
+    respx.post(
+        f"{DEFAULT_GITHUB_API_URL}/app/installations/42/access_tokens",
+    ).mock(
+        return_value=httpx.Response(
+            403,
+            headers={
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Reset": "1700001234",
+            },
+            json={"message": "API rate limit exceeded"},
+        )
+    )
+    with pytest.raises(GitHubRateLimitedError) as excinfo:
+        await exchange_jwt_for_installation_token(
+            jwt_token="signed.jwt.value",
+            installation_id="42",
+        )
+    assert excinfo.value.code == "github_rate_limited"
+    assert excinfo.value.reset_at == 1700001234
+    msg = str(excinfo.value)
+    assert "github_rate_limited" in msg
+    assert "X-RateLimit-Remaining: 0" in msg
+
+
+@respx.mock
+async def test_exchange_jwt_does_not_treat_non_zero_remaining_403_as_rate_limit() -> None:
+    """403 without ``X-RateLimit-Remaining: 0`` → mint-failed (not rate-limit)."""
+    respx.post(
+        f"{DEFAULT_GITHUB_API_URL}/app/installations/42/access_tokens",
+    ).mock(
+        return_value=httpx.Response(
+            403,
+            headers={"X-RateLimit-Remaining": "4999"},
+            json={"message": "Resource not accessible"},
+        )
+    )
+    with pytest.raises(GitHubInstallationTokenMintError) as excinfo:
+        await exchange_jwt_for_installation_token(
+            jwt_token="signed.jwt.value",
+            installation_id="42",
+        )
+    assert excinfo.value.code == "github_installation_token_mint_failed"
+    assert excinfo.value.status_code == 403
+
+
+@respx.mock
+async def test_exchange_jwt_raises_mint_failed_on_500() -> None:
+    """5xx → :class:`GitHubInstallationTokenMintError`."""
+    respx.post(
+        f"{DEFAULT_GITHUB_API_URL}/app/installations/42/access_tokens",
+    ).mock(return_value=httpx.Response(500, text="Internal Server Error"))
+    with pytest.raises(GitHubInstallationTokenMintError) as excinfo:
+        await exchange_jwt_for_installation_token(
+            jwt_token="signed.jwt.value",
+            installation_id="42",
+        )
+    assert excinfo.value.code == "github_installation_token_mint_failed"
+    assert excinfo.value.status_code == 500
+    msg = str(excinfo.value)
+    assert "github_installation_token_mint_failed" in msg
+
+
+@respx.mock
+async def test_exchange_jwt_raises_mint_failed_on_transport_error() -> None:
+    """Network failure → :class:`GitHubInstallationTokenMintError` (status_code=None)."""
+    respx.post(
+        f"{DEFAULT_GITHUB_API_URL}/app/installations/42/access_tokens",
+    ).mock(side_effect=httpx.ConnectError("DNS failure"))
+    with pytest.raises(GitHubInstallationTokenMintError) as excinfo:
+        await exchange_jwt_for_installation_token(
+            jwt_token="signed.jwt.value",
+            installation_id="42",
+        )
+    assert excinfo.value.status_code is None
+    assert "transport failure" in str(excinfo.value)
+
+
+@respx.mock
+async def test_exchange_jwt_raises_mint_failed_when_token_missing_from_response() -> None:
+    """Malformed 2xx (no ``token`` key) → :class:`GitHubInstallationTokenMintError`."""
+    respx.post(
+        f"{DEFAULT_GITHUB_API_URL}/app/installations/42/access_tokens",
+    ).mock(return_value=httpx.Response(201, json={"expires_at": "2026-05-27"}))
+    with pytest.raises(GitHubInstallationTokenMintError) as excinfo:
+        await exchange_jwt_for_installation_token(
+            jwt_token="signed.jwt.value",
+            installation_id="42",
+        )
+    assert "missing a 'token' field" in str(excinfo.value)

--- a/backend/tests/test_connectors_github_session.py
+++ b/backend/tests/test_connectors_github_session.py
@@ -65,7 +65,10 @@ def test_mint_github_app_jwt_returns_decodable_rs256_token() -> None:
     # Decode without signature verification — we only assert claim shape.
     decoded = jwt.decode(token, options={"verify_signature": False})
     assert decoded["iss"] == "123456"
-    assert decoded["iat"] == int(now)
+    # ``iat`` is backdated by 60s per GitHub's documented JWT recipe
+    # to absorb forward clock skew. See docs URL on
+    # mint_github_app_jwt.
+    assert decoded["iat"] == int(now) - 60
     # exp - iat must equal the documented TTL; GitHub enforces ≤10 min.
     assert decoded["exp"] - decoded["iat"] == JWT_TTL_SECONDS
     # Header advertises RS256 (the GitHub-mandated algorithm).

--- a/backend/tests/test_connectors_github_session.py
+++ b/backend/tests/test_connectors_github_session.py
@@ -240,3 +240,29 @@ async def test_exchange_jwt_raises_mint_failed_when_token_missing_from_response(
             installation_id="42",
         )
     assert "missing a 'token' field" in str(excinfo.value)
+
+
+@respx.mock
+async def test_exchange_jwt_raises_mint_failed_on_non_json_2xx_body() -> None:
+    """Non-JSON 2xx body → :class:`GitHubInstallationTokenMintError`.
+
+    No raw ``ValueError`` escapes — the failure must travel through the
+    documented T11 envelope shape.
+    """
+    respx.post(
+        f"{DEFAULT_GITHUB_API_URL}/app/installations/42/access_tokens",
+    ).mock(
+        return_value=httpx.Response(
+            201,
+            text="<html><body>upstream proxy returned HTML</body></html>",
+        )
+    )
+    with pytest.raises(GitHubInstallationTokenMintError) as excinfo:
+        await exchange_jwt_for_installation_token(
+            jwt_token="signed.jwt.value",
+            installation_id="42",
+        )
+    assert "non-JSON 2xx body" in str(excinfo.value)
+    assert excinfo.value.status_code == 201
+    # The original ``ValueError`` is preserved as the chained cause.
+    assert isinstance(excinfo.value.__cause__, ValueError)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1566,6 +1566,7 @@ dependencies = [
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-ai-slim", extra = ["anthropic"] },
     { name = "pygments" },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-frontmatter" },
     { name = "python-multipart" },
     { name = "redis" },
@@ -1619,6 +1620,7 @@ requires-dist = [
     { name = "pydantic", extras = ["email"], specifier = ">=2.13.4" },
     { name = "pydantic-ai-slim", extras = ["anthropic"], specifier = ">=1.102.0" },
     { name = "pygments", specifier = ">=2.18" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.0,<3" },
     { name = "python-frontmatter", specifier = ">=1.3.0" },
     { name = "python-multipart", specifier = ">=0.0.12" },
     { name = "redis", specifier = ">=5,<8" },
@@ -2618,6 +2620,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -12181,6 +12181,7 @@
             "enum": [
               "bind9",
               "gcloud",
+              "gh",
               "harbor",
               "hetzner-robot",
               "holodeck",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -226,6 +226,7 @@ const (
 const (
 	Bind9         TargetCreateProduct = "bind9"
 	Gcloud        TargetCreateProduct = "gcloud"
+	Gh            TargetCreateProduct = "gh"
 	Harbor        TargetCreateProduct = "harbor"
 	HetznerRobot  TargetCreateProduct = "hetzner-robot"
 	Holodeck      TargetCreateProduct = "holodeck"

--- a/docs/codebase/connectors-github.md
+++ b/docs/codebase/connectors-github.md
@@ -1,0 +1,212 @@
+# Connector: github (gh-rest v3)
+
+## Overview
+
+The `gh-rest` connector is the hand-rolled `HttpConnector` subclass that
+dispatches the github.com REST API surface under the registry triple
+`(product="gh", version="3", impl_id="gh-rest")` (the registry's
+`version` slot must be digit-prefixed for the dispatcher's connector-id
+parser; GitHub's own "v3" label lives in docs and in
+`FingerprintResult.version` — the upstream-facing string). G3.11-T1 (#1221)
+ships the substrate only: the connector class, the GitHub-App credential
+loader (JWT mint → installation-token exchange → 50-minute cache), the
+PAT fallback path, the fingerprint, and the T11-compliant error
+envelopes for the four documented failure modes. Catalog ingest of the
+~700 ops in github.com's published OpenAPI spec lands in T3 (#1223); the
+first L1 composite (`gh.composite.pr_status_summary`) lands in T4
+(#1224); `requires_approval=true` annotations on the four
+highest-blast-radius write ops land in T5 (#1225).
+
+Source: `backend/src/meho_backplane/connectors/github/`.
+
+## Key types
+
+- **`GitHubRestConnector`** (`connector.py`) — `HttpConnector` subclass
+  with class attributes `product="gh"`, `version="3"`,
+  `impl_id="gh-rest"`, `priority=1`. Owns the per-target
+  installation-token cache, the per-target PAT cache, and the
+  `asyncio.Lock` that serialises cold-cache mint calls.
+- **`GitHubAppCredentials`** (`session.py`) — frozen dataclass of
+  `(app_id, private_key_pem, installation_id)`. The Vault-stored
+  material; never enters a log event or an `OperationResult`.
+- **`GitHubPATCredentials`** (`session.py`) — frozen single-field
+  dataclass holding the bearer PAT.
+- **`InstallationToken`** (`session.py`) — frozen dataclass carrying the
+  minted token plus the monotonic-clock expiry timestamp the cache uses
+  for validity decisions.
+- **`GitHubTargetLike`** (`session.py`) — runtime-checkable structural
+  Protocol with `name`, `host`, `port`, `secret_ref`, `auth_model`. Any
+  concrete `Target` model satisfying these attributes plugs in unchanged.
+- **`GitHubCredentialError`** + four subclasses (`session.py`) — the T11
+  envelopes. Each carries a stable `code` attribute
+  (`github_app_not_installed`, `github_jwt_mint_failed`,
+  `github_installation_token_mint_failed`, `github_rate_limited`).
+
+## Control flow
+
+### Registration (import time)
+
+`connectors/github/__init__.py` runs at startup via
+`_eager_import_connectors`. It calls:
+
+1. `register_connector("gh", GitHubRestConnector)` — v1 entry. Also
+   writes the `("gh", "", "")` wildcard triple into the v2 table.
+2. `register_connector_v2(product="gh", version="3",
+   impl_id="gh-rest", cls=GitHubRestConnector)` — v2 versioned entry.
+3. `register_typed_op_registrar(register_github_typed_operations)` —
+   queues an async registrar. T1 ships a no-op body; T3 will fill it
+   when the catalog ingests.
+
+The dual registration matches the G0.15-T6 mandatory pattern (also used
+by `kubernetes/__init__.py`) so an unfingerprinted `(product="gh",
+version=None)` target resolves via the wildcard tie-break while a
+fingerprinted target resolves via the versioned entry.
+
+### Auth — GitHub App path (`auth_model="github-app"`)
+
+```
+auth_headers(target, operator)
+  └── reject empty operator.raw_jwt (defence in depth)
+  └── _installation_token(target, operator)
+        └── lock
+        └── cache hit (expires_at_monotonic > now) → return cached
+        └── credentials_loader(target, operator)
+              └── (default) load_basic_credentials with
+                  fields=("app_id", "private_key", "installation_id")
+                  → operator-context Vault KV-v2 read
+        └── mint_github_app_jwt(app_id, private_key_pem)
+              → 540-second RS256 JWT (10-min cap minus skew margin)
+        └── exchange_jwt_for_installation_token(jwt, installation_id)
+              → POST /app/installations/{id}/access_tokens
+              → 201 → InstallationToken with monotonic expiry
+        └── cache, return token
+  └── return {"Authorization": "Bearer <token>", ...}
+```
+
+The 50-minute cache window means a typical operator session of ~50
+dispatch calls pays the JWT/installation-token round-trip exactly once
+per target. The mint endpoint is hit again only on the next cold cache
+(after restart / `aclose`, or after the 50-minute window expires).
+
+### Auth — PAT fallback (`auth_model="github-pat"`)
+
+```
+auth_headers(target, operator)
+  └── reject empty operator.raw_jwt
+  └── _pat_token(target, operator)
+        └── lock + cache fast-path (PATs cache for connector lifetime)
+        └── credentials_loader(target, operator)
+              └── (default) load_basic_credentials with fields=("token",)
+        └── cache the token, return
+  └── return {"Authorization": "Bearer <token>", ...}
+```
+
+No JWT, no mint, no exchange. PAT TTL is whatever GitHub's PAT-expiry
+policy enforces (operator-set in the GitHub UI); MEHO does not re-read
+until restart or `aclose`.
+
+### Fingerprint
+
+`fingerprint(target)` synthesises a system operator (per
+`synthesise_system_operator` — non-empty placeholder JWT so the cache
+fast-path admits the probe, but the live Vault loader still fails
+closed) and inspects `target.host`:
+
+- `host="api.github.com"` (or any bare host without a `/`) →
+  `GET /user/installations`. Returns total count + first installation's
+  `installation_id`, `installation_account`, `app_slug`, `target_type`,
+  `permissions`.
+- `host="api.github.com/repos/<owner>/<repo>"` (or `api.github.com/<owner>/<repo>`)
+  → `GET /repos/{owner}/{repo}`. Returns repo identity (`full_name`,
+  `id`, `private`, `default_branch`) + owner identity (`login`, `type`).
+
+Transport / credential failures surface as `reachable=False` with both
+the exception class+message in `extras["error"]` and the structured T11
+`extras["error_code"]` (when a `GitHubCredentialError` fired) so the
+operator can branch programmatically.
+
+### Execute
+
+`execute()` is a stub in T1: every `op_id` returns the dispatcher's
+canonical `unknown_op` envelope (via `result_unknown_op` in
+`operations/_errors.py`). T3 ships the catalog rows + their dispatcher
+wiring.
+
+## Dependencies
+
+- **`HttpConnector`** (`connectors/adapters/http.py`) — pooled
+  `httpx.AsyncClient` per target, retry policy for idempotent verbs,
+  `_request_json` / `_get_json` / `_post_json` helpers.
+- **`load_basic_credentials`** (`connectors/_shared/vault_creds.py`) —
+  shared operator-context Vault KV-v2 read with the no-secret-in-logs
+  discipline and the two-phase error contract.
+- **`synthesise_system_operator`** (`connectors/_shared/system_operator.py`)
+  — non-empty placeholder JWT for the fingerprint / probe paths that
+  pre-date a real operator.
+- **PyJWT 2.x with the `[crypto]` extra** (`pyproject.toml`) —
+  `jwt.encode(payload, key, algorithm="RS256")`. RS256 signing requires
+  the `cryptography` backend, which the extra pulls in (already a dev
+  dep for the test fakes; the runtime extra makes the dependency
+  explicit at install time).
+- **Registry v1 + v2** (`connectors/registry.py`) — `register_connector`
+  for the wildcard side, `register_connector_v2` for the versioned
+  side. The G0.15-T6 mandatory pattern.
+
+## Known issues
+
+- **No GHES support** — github.com only for v0.x. A future GHES target
+  would need a per-target `api_base_url` override (the `_BASE_URL` class
+  attribute drives the httpx pool's base URL today); the connector's
+  shape doesn't preclude it, but the work is deferred per the
+  Initiative #1220 scope.
+- **`/user/installations` lists from the App identity, not the
+  operator's** — the v0.x design choice: the App is the audit-attributable
+  identity (per G11.2-T6c's keycloak-CIMD onramp). An operator viewing
+  installation metadata sees what the App can reach, not what their
+  personal GitHub account can reach. Operators wanting personal-account
+  visibility use `gh` CLI on their workstation.
+- **Installation token caches per-`target.name`** — same scoping
+  vmware-rest uses. If two tenants legitimately hold a target named
+  `"github-main"`, the second tenant's connector instance reads from a
+  separate `GitHubRestConnector` instance (the registry produces one per
+  process; the cache is instance-scoped — same shape as vmware-rest's
+  `_session_tokens`). Cross-tenant token leakage is not possible under
+  the current chassis. Re-key on `target.secret_ref` if a future change
+  introduces shared connector instances across tenants.
+- **PAT cache is connector-instance-scoped + does not respect upstream
+  expiry** — MEHO never re-reads a PAT from Vault during a process
+  lifetime once it's cached. Operators rotating a PAT must redeploy
+  (or evict via `aclose`). The G3.11 follow-up Tasks can introduce a
+  Vault-stored expiry hint if operators report this as a friction
+  point; not pre-built.
+
+## References
+
+- **Task:** [#1221](https://github.com/evoila/meho/issues/1221) (G3.11-T1)
+- **Parent Initiative:** [#1220](https://github.com/evoila/meho/issues/1220)
+  (G3.11 — gh-rest typed connector)
+- **Parent Goal:** [#214](https://github.com/evoila/meho/issues/214)
+  (Connector parity with ClaudeVCF wrapper set)
+- **Error message convention:**
+  [docs/codebase/error-message-shape.md](error-message-shape.md) (T11
+  #1141)
+- **G0.15-T6 wildcard registration pattern:**
+  `connectors/kubernetes/__init__.py` (the mandatory dual-registration
+  precedent).
+- **GitHub Apps documentation:**
+  https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app
+- **PyJWT documentation:** https://pyjwt.readthedocs.io/ (RS256
+  encoding with private-key signing).
+- **GitHub rate-limit policy:**
+  https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+- **Sibling Tasks (Initiative #1220):**
+  - T2 [#1222](https://github.com/evoila/meho/issues/1222) — App
+    credential operator runbook.
+  - T3 [#1223](https://github.com/evoila/meho/issues/1223) — `gh/v3`
+    catalog entry + Layer-2 ingest acceptance.
+  - T4 [#1224](https://github.com/evoila/meho/issues/1224) — first L1
+    composite `gh.composite.pr_status_summary`.
+  - T5 [#1225](https://github.com/evoila/meho/issues/1225) —
+    `requires_approval=true` on 4 write ops.
+  - T6 [#1226](https://github.com/evoila/meho/issues/1226) — connector
+    operator runbook.


### PR DESCRIPTION
## Summary

- Lands the `GitHubRestConnector` substrate under Goal #214 (connector parity with the ClaudeVCF wrapper set): `HttpConnector` subclass with GitHub-App credential loader (Vault → App ID + private key → 540-second RS256 JWT → 1-hour installation token cached for 50 min), PAT fallback path, fingerprint via `GET /user/installations` or `GET /repos/{owner}/{repo}`, and four T11-compliant error envelopes for the failure modes named in #1221.
- Dual registration (v1 wildcard + v2 versioned per G0.15-T6) so unfingerprinted `(product=gh, version=None)` targets resolve via the wildcard tie-break.
- Adds `pyjwt[crypto]>=2.10.0,<3` (no stdlib RS256 path); lock regenerated with PyJWT 2.13.0.
- Out of scope per #1221: catalog entry (T3 #1223), first L1 composite (T4 #1224), write-op approval annotations (T5 #1225), operator runbooks (T2 #1222 / T6 #1226), GHES support.

## Implementation notes

- **Registry version is `"3"`, not `"v3"`.** The dispatcher's `parse_connector_id` regex (`^[0-9][A-Za-z0-9._]*$`) requires a digit-prefixed version slot. The upstream GitHub label "v3" lives in `FingerprintResult.version` and in docs; the registry stores `"3"` so `connector_id="gh-rest-3"` round-trips losslessly through `parse_connector_id` (pinning the G0.9.1-T1 #773 acceptance gate).
- **Installation-token caching is monotonic-clock-driven.** The 50-minute cache window uses `time.monotonic()` so a wall-clock jump (NTP correction during a long-running operator session) can't surprise the validity check. The upstream ISO `expires_at` lands in `extras["upstream_expires_at"]` for observability only.
- **Per-target cache fast-path rejects empty operator JWT.** Defence-in-depth mirroring vmware-rest's pattern — the loader's `load_basic_credentials` already enforces this; the cache check fires before lookup so a primed token cannot leak to a system-initiated caller.
- **PAT cache lifetime = connector instance lifetime.** PATs do not have an MEHO-visible expiry; an operator rotating a PAT restarts the backplane (or calls `aclose`). Documented in `docs/codebase/connectors-github.md` § Known issues.
- **`execute()` is a stub returning `unknown_op` until T3 lands the catalog.** Symmetric with how `KubernetesConnector.execute` looks up `endpoint_descriptor` rows — once T3's catalog entry populates them, the dispatcher routes through here unchanged.

## Test plan

- [x] `ruff check src/meho_backplane/ tests/` — clean
- [x] `ruff format --check src/meho_backplane/ tests/` — clean (742 files)
- [x] `mypy src/` — clean (368 source files)
- [x] `pytest tests/test_connectors_github_session.py tests/test_connectors_github_connector.py` — 22 passed (14 session + 8 connector)
- [x] `pytest tests/ --ignore=tests/integration --ignore=tests/acceptance` — 5275 passed, 41 skipped (full unit suite, no regressions)
- [x] **Dual registration** asserted: `("gh", "")` in v1 table, `("gh", "", "")` and `("gh", "3", "gh-rest")` in v2 table.
- [x] **Token cache** asserted: a second `fingerprint()` call within the 50-minute window mints the installation token **exactly once** while the `/user/installations` probe runs twice (per-call, no over-caching).
- [x] **PAT fallback** asserted: the JWT-exchange endpoint is not touched on a `github-pat` target.
- [x] **Four T11 envelopes** each have a dedicated test injecting the specific failure shape and asserting the `code` attribute matches the message-shape convention.
- [x] **Connector-id round-trip** asserted: `parse_connector_id("gh-rest-3") == ("gh", "3", "gh-rest")` (the G0.9.1-T1 #773 acceptance test now passes with the registered triple).
- [ ] Live `fingerprint` against a real GitHub App credential pair (integration-level acceptance) — to be exercised in CI lane with `GH_APP_ID` + `GH_APP_PRIVATE_KEY` provisioned, or manually during T3's catalog ingest dry-run. Not blocking — the unit tests pin the wire shape via `respx`.

## Out of scope

- T2 #1222 (`docs/cross-repo/github-app-credential.md` operator runbook)
- T3 #1223 (`gh/v3` catalog entry + Layer-2 ingest acceptance)
- T4 #1224 (`gh.composite.pr_status_summary`)
- T5 #1225 (`requires_approval=true` on 4 write ops)
- T6 #1226 (`docs/cross-repo/github-connector.md` operator runbook)
- GHES support (deferred per Initiative #1220 scope)

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1221


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GitHub connector (`gh-rest`) now available supporting GitHub App and personal access token authentication modes.
  * Installation token caching and JWT-based authentication implemented.
  * Fingerprinting capability for GitHub resources added.

* **Documentation**
  * GitHub REST connector reference documentation included.

* **Tests**
  * GitHub connector unit and integration test coverage added.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->