### PR TITLE
fix(mcp): G0.15-T4 issue Mcp-Session-Id on initialize (#1213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,21 @@ connector-related release-notes line.
   follow-up reconciles them; the resolver remains exercised via
   direct programmatic construction in v0.7.x. (#1076)
 
+### Fixed
+
+- MCP server now issues an `Mcp-Session-Id` response header on every
+  successful `initialize` per MCP 2025-06-18 Streamable HTTP §"Session
+  Management" rule 1, closing the v0.7.0 release-body's G0.14-T6 #1147
+  audit-replay promise that was inert end-to-end. The capture chain
+  (header → contextvar → `audit_log.agent_session_id`) already worked;
+  what was missing was the issuance half, since spec-conforming MCP
+  clients (Claude Code, MCP Inspector) only emit the header when the
+  server first sent one. Result: every MCP audit row now carries
+  `agent_session_id`, lighting up the G8.2 audit-replay
+  `query_audit shape=tree agent_session_id=<id>` flow that the v0.7.0
+  rolling dogfood (`claude-rdc-hetzner-dc#753` finding 2) found inert
+  on the rke2-infra deploy. (G0.15-T4 #1213)
+
 ## [0.7.0] - 2026-05-27
 
 **MVP6 — agent runtime floor (P1 + P2 + P3) + safety (C1 sanitization)

--- a/backend/src/meho_backplane/mcp/server.py
+++ b/backend/src/meho_backplane/mcp/server.py
@@ -575,6 +575,19 @@ def mcp_session_id_capture_mode() -> str:
     enforcement** — whether a missing header is a 400 reject. It does
     not gate capture.
 
+    Crucially, the capture chain is only useful **when clients actually
+    send the header**. Per the MCP 2025-06-18 Streamable HTTP transport
+    §"Session Management" the client only emits ``Mcp-Session-Id`` on
+    subsequent requests when the server assigned one in an
+    ``Mcp-Session-Id`` **response header** on the ``InitializeResult``
+    (spec rule 2: *"If an ``Mcp-Session-Id`` is returned by the server
+    during initialization, clients … **MUST** include it"*). G0.15-T4
+    (#1213) closes the regression where MEHO captured the header end
+    of the chain but never issued one — leaving every Claude Code MCP
+    audit row's ``agent_session_id`` as NULL despite this helper
+    reporting ``"always"``. See :func:`_issue_mcp_session_id` for the
+    issuance side.
+
     Operators can introspect the current mode via
     :func:`~meho_backplane.api.v1.health.authenticated_health` (Task
     G0.14-T6 #1147) so the deploy-time observability story for the
@@ -589,6 +602,96 @@ def mcp_session_id_capture_mode() -> str:
     G8.2 replay route filters NULLs out of session walks naturally).
     """
     return "enforced" if get_settings().mcp_require_session_id else "always"
+
+
+#: Lowercase HTTP header name for the MCP session id, used on both the
+#: inbound request (read by :func:`_bind_mcp_session_id`) and the
+#: outbound ``initialize`` response (set by :func:`_issue_mcp_session_id`).
+#: Defining it once keeps the wire spelling consistent and grep-able.
+_MCP_SESSION_HEADER: Final[str] = "mcp-session-id"
+
+
+def _issue_mcp_session_id(response: Response) -> uuid.UUID:
+    """Stamp a fresh ``Mcp-Session-Id`` response header on an ``initialize`` reply.
+
+    Per MCP 2025-06-18 Streamable HTTP §"Session Management" rule 1, a
+    server **MAY** assign a session id at initialization by returning
+    it in an ``Mcp-Session-Id`` response header on the
+    ``InitializeResult``; rule 2 then requires the client to echo that
+    id on every subsequent HTTP POST to the MCP endpoint. The handshake
+    is therefore strictly **server-driven** — clients do not invent
+    session ids, they only relay one the server gave them.
+
+    G0.15-T4 (#1213) closed the regression where MEHO's chain captured
+    the inbound header into the structlog contextvar (and from there
+    into ``audit_log.agent_session_id``) but never **issued** one to
+    begin with. The visible symptom on `claude-rdc-hetzner-dc#753`
+    finding 2 was eight Claude Code MCP rows with
+    ``agent_session_id: null`` despite ``meho_status`` /
+    ``/ready.features.audit_replay`` advertising ``capture_mode:
+    "always"`` — both surfaces correctly reported the **capture**
+    config; nothing populated the column because no client had a
+    server-assigned session id to send back.
+
+    The issued value is a fresh :func:`uuid.uuid4` rendered as the
+    canonical UUID string (the same shape :func:`_bind_mcp_session_id`
+    parses on subsequent requests, so the round-trip lands cleanly on
+    ``audit_log.agent_session_id``). MEHO holds **no stateful session
+    store** in v0.2 — the id exists purely for audit correlation, so
+    no registry-side allocation is needed: the server assigns + emits +
+    forgets, and the audit-log linkage is the only persistence. The
+    spec's optional terminate-via-DELETE flow (rule 5) and the
+    404-on-stale-id rejection (rule 3) are therefore both out of
+    scope; MEHO accepts any well-formed UUID the client returns,
+    which is also the lenient posture the v0.2 capture path already
+    documents.
+
+    Returns the issued :class:`uuid.UUID` so the caller can mirror it
+    into the structlog contextvar — useful for structlog log lines
+    emitted from inside the ``initialize`` handler (the handler itself
+    writes no audit row, but its log entries get the same
+    correlation key the subsequent ``tools/call`` audit rows will
+    carry).
+    """
+    issued = uuid.uuid4()
+    response.headers[_MCP_SESSION_HEADER] = str(issued)
+    return issued
+
+
+def _response_is_jsonrpc_error(response: Response) -> bool:
+    """Return ``True`` when *response* carries a JSON-RPC ``error`` envelope.
+
+    JSON-RPC-level errors (parse / invalid-request / method-not-found /
+    invalid-params / internal) ride on HTTP 200 by design — the failure
+    is encoded inside the body's ``error`` member, not on the HTTP
+    status. :func:`mcp_dispatch`'s post-dispatch session-id-issuance
+    gate (G0.15-T4 #1213) therefore can't filter on
+    ``response.status_code`` alone: a JSON-RPC failure of ``initialize``
+    (e.g. an invalid ``protocolVersion`` body) returns HTTP 200 with
+    ``error.code``, and the spec wants no session pinned to that
+    degenerate exchange.
+
+    The implementation peeks at the rendered body bytes. ``JSONResponse``
+    fixes ``response.body`` at construction time (Starlette renders the
+    content into bytes in ``JSONResponse.__init__``), so this read is
+    safe pre-stream. A non-``JSONResponse`` shape (the spec-driven HTTP
+    202 notifications path returns a bare :class:`Response`) carries
+    no JSON-RPC envelope and is treated as "not an error" — the caller
+    further gates on ``is_notification`` anyway.
+
+    Defensive: any decode failure (truncated body, unexpected encoding)
+    is treated as "looks like an error" so the issuance side stays
+    fail-closed — a malformed body is not a valid initialize result and
+    must not seed a session id either.
+    """
+    body = getattr(response, "body", None)
+    if not body:
+        return False
+    try:
+        envelope = json.loads(body)
+    except (ValueError, TypeError):
+        return True
+    return isinstance(envelope, dict) and "error" in envelope
 
 
 def _bind_mcp_session_id(
@@ -855,4 +958,56 @@ async def mcp_dispatch(
     # are spec-defined as notification-only, so the server treats it
     # as such regardless of the envelope's id field.
     is_notification = "id" not in payload or jrpc.method.startswith("notifications/")
-    return await _dispatch_to_handler(jrpc, is_notification, operator)
+    response = await _dispatch_to_handler(jrpc, is_notification, operator)
+    _maybe_issue_initialize_session_id(request, jrpc.method, is_notification, response)
+    return response
+
+
+def _maybe_issue_initialize_session_id(
+    request: Request,
+    method: str,
+    is_notification: bool,
+    response: Response,
+) -> None:
+    """Stamp an ``Mcp-Session-Id`` response header on a successful initialize.
+
+    G0.15-T4 (#1213): closes the regression on the v0.7.0 release-body's
+    G0.14-T6 #1147 promise — the capture chain (header → contextvar →
+    ``audit_log.agent_session_id``) already worked; what was missing is
+    the **issuance** half, since MCP 2025-06-18 Streamable HTTP
+    §"Session Management" rule 2 says clients only emit the header when
+    the server first sent one. Gates:
+
+    * Method is ``initialize`` and it's a *request*, not a notification
+      — the spec scopes session assignment to the handshake exchange.
+    * Response is HTTP 2xx **and** the JSON-RPC envelope has no
+      ``error`` member — a failed initialize (transport-level reject or
+      JSON-RPC ``error``) must not leak a session id, since the spec
+      wants the id pinned to a real session, not a degenerate one.
+    * The client did not already send an ``Mcp-Session-Id`` header
+      inbound — a resume / replay attempt where the client carries an
+      id is accepted lenient (MEHO holds no session-state to validate
+      against in v0.2), and we do not overwrite the client's
+      correlation key on the response.
+
+    On the success path the issued id is also bound into structlog
+    contextvars so any post-issue log line in the same async task
+    (e.g. the ``request_completed`` log from
+    :class:`~meho_backplane.middleware.RequestContextMiddleware`)
+    carries the same correlation key the client will echo on the next
+    request. The initialize call itself writes no audit row (chassis
+    ``AuditMiddleware`` skips ``/mcp`` and the MCP-side audit path only
+    fires for ``tools/call`` / ``resources/read``), so this binding is
+    purely log-side. See :func:`_issue_mcp_session_id` for the
+    issuance contract.
+    """
+    if method != "initialize" or is_notification:
+        return
+    if not (200 <= response.status_code < 300):
+        return
+    if _response_is_jsonrpc_error(response):
+        return
+    if request.headers.get(_MCP_SESSION_HEADER) not in (None, ""):
+        return
+    issued = _issue_mcp_session_id(response)
+    structlog.contextvars.bind_contextvars(mcp_session_id=str(issued))

--- a/backend/tests/test_mcp_audit.py
+++ b/backend/tests/test_mcp_audit.py
@@ -831,3 +831,87 @@ async def test_call_operation_tool_definition_carries_tool_call_op_class() -> No
     assert entry is not None
     defn, _handler = entry
     assert defn.op_class == "tool_call"
+
+
+# ---------------------------------------------------------------------------
+# G0.15-T4 (#1213): end-to-end roundtrip — server issues Mcp-Session-Id on
+# initialize, client echoes it on tools/call, audit row lands the UUID.
+#
+# The positive-path acceptance test for the issuance+capture+write chain
+# the v0.7.0 release-body's G0.14-T6 #1147 callout promised. The unit
+# tests in :mod:`tests.test_mcp_server` cover the issuance half in
+# isolation; this test exercises the full end-to-end contract any
+# spec-conforming MCP client would drive (server assigns id on
+# initialize → client echoes on every later POST → row carries it).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_initialize_issued_session_id_round_trips_to_audit_row(
+    client_with_operator: tuple[TestClient, Operator],
+) -> None:
+    """End-to-end: server-issued session id propagates onto ``audit_log.agent_session_id``.
+
+    The chain under test:
+
+    1. Client POSTs ``initialize`` to ``/mcp`` (no inbound session header).
+    2. Server stamps an ``Mcp-Session-Id`` response header per MCP
+       2025-06-18 §"Session Management" rule 1.
+    3. Client echoes that id on a subsequent ``tools/call`` per rule 2.
+    4. Server's :func:`~meho_backplane.mcp.server._bind_mcp_session_id`
+       captures the inbound header into the structlog contextvar.
+    5. :func:`~meho_backplane.mcp.audit.write_mcp_audit_row` reads the
+       contextvar and writes ``audit_log.agent_session_id``.
+
+    Before G0.15-T4 #1213, step 2 didn't happen — the client had no
+    server-assigned id to echo back, so steps 4 and 5 saw an empty
+    inbound header and the column landed NULL despite ``meho_status``
+    advertising ``mcp_session_id_capture: "always"``. This test
+    regression-locks the full chain so the next consumer-side dogfood
+    cycle doesn't relive `claude-rdc-hetzner-dc#753` finding 2.
+    """
+    from uuid import UUID
+
+    client, _op = client_with_operator
+
+    # 1+2. Initialize handshake — server issues the session id.
+    init = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "0.0.1"},
+            },
+        },
+    )
+    assert init.status_code == 200
+    issued_header = init.headers.get("mcp-session-id")
+    assert issued_header, (
+        "initialize must issue an Mcp-Session-Id response header per MCP "
+        "2025-06-18 §Session Management rule 1 — G0.15-T4 #1213 contract"
+    )
+    session_uuid = UUID(issued_header)
+
+    # 3+4+5. Subsequent tools/call echoes the issued id — captured into
+    # the contextvar by ``_bind_mcp_session_id``, written onto the row
+    # by ``write_mcp_audit_row``.
+    call = post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "meho.status", "arguments": {}},
+        },
+        headers={"Mcp-Session-Id": issued_header},
+    )
+    assert call.status_code == 200
+
+    rows = await _audit_rows()
+    mcp_rows = [r for r in rows if r.method == "MCP"]
+    assert len(mcp_rows) == 1
+    assert mcp_rows[0].agent_session_id == session_uuid

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -186,6 +186,171 @@ def test_initialize_without_protocol_version_returns_invalid_params(
 
 
 # ---------------------------------------------------------------------------
+# G0.15-T4 (#1213): server-side Mcp-Session-Id issuance on initialize
+#
+# MCP 2025-06-18 §"Session Management" rule 1: the server MAY assign a
+# session id at initialization by returning it in an ``Mcp-Session-Id``
+# response header on the ``InitializeResult``. Rule 2: if the server
+# did so, clients MUST include the header on every subsequent request.
+# The capture-and-write chain
+# (:func:`~meho_backplane.mcp.server._bind_mcp_session_id` →
+# :func:`~meho_backplane.mcp.audit._resolve_uuid_contextvar` →
+# ``audit_log.agent_session_id``) was already in place; the regression
+# the v0.7.0 release-body's G0.14-T6 #1147 callout promised was inert
+# because MEHO never issued an id — clients (Claude Code by default,
+# per `claude-rdc-hetzner-dc#753` finding 2) therefore had nothing to
+# echo back, so every MCP audit row landed with ``agent_session_id:
+# null`` regardless of the ``capture_mode: "always"`` advertisement.
+# ---------------------------------------------------------------------------
+
+
+def test_initialize_issues_mcp_session_id_response_header(
+    client: TestClient,
+) -> None:
+    """AC: a successful ``initialize`` returns an ``Mcp-Session-Id`` response header.
+
+    Per MCP 2025-06-18 §"Session Management" rule 1 the server is the
+    only side that may assign session ids; clients (rule 2) only echo
+    what the server gave them. G0.15-T4 #1213 makes MEHO stamp the
+    header so the capture chain has something to capture.
+    """
+    response = _post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "0.0.1"},
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    header = response.headers.get("mcp-session-id")
+    assert header, "initialize must emit an Mcp-Session-Id response header"
+    # Canonical UUID string — the same shape ``_bind_mcp_session_id``
+    # parses on subsequent requests and ``_resolve_uuid_contextvar``
+    # writes to ``audit_log.agent_session_id``.
+    UUID(header)
+
+
+def test_initialize_session_ids_are_unique_per_handshake(
+    client: TestClient,
+) -> None:
+    """Two initialize calls → two distinct session ids.
+
+    The issuance helper is a fresh :func:`uuid.uuid4` per call. A
+    deterministic / shared id would have it collide across concurrent
+    Claude Code sessions and merge their audit-replay walks (G8.2)
+    into one false-positive bundle.
+    """
+    envelope = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {},
+            "clientInfo": {"name": "test-client", "version": "0.0.1"},
+        },
+    }
+    first = _post_mcp(client, envelope).headers.get("mcp-session-id")
+    second = _post_mcp(client, envelope).headers.get("mcp-session-id")
+
+    assert first and second
+    assert first != second
+
+
+def test_initialize_does_not_overwrite_client_supplied_session_id(
+    client: TestClient,
+) -> None:
+    """A resume / replay attempt that carries an inbound ``Mcp-Session-Id``
+    is not overwritten by the server's issuance side.
+
+    Rationale: MEHO holds no session-state to validate against (v0.2
+    has no session registry), so the lenient posture is to accept the
+    client-supplied id (it's already on the contextvar via the
+    earlier ``_bind_mcp_session_id``) and not overwrite it on the
+    response. This preserves the client's correlation key across a
+    re-initialize handshake on the same logical session.
+    """
+    client_session = "11111111-2222-3333-4444-555555555555"
+    response = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "test-client", "version": "0.0.1"},
+            },
+        },
+        headers={"Mcp-Session-Id": client_session},
+    )
+
+    assert response.status_code == 200
+    # Server didn't overwrite — either it echoed nothing back (no
+    # outbound header) or it preserved the inbound one. We accept
+    # both shapes here because the absence of an outbound header is
+    # spec-conformant (rule 1 is MAY, not MUST), and is the cheaper
+    # path; what matters is that the server did not invent a new
+    # one in defiance of the client's already-supplied correlation
+    # key.
+    outbound = response.headers.get("mcp-session-id")
+    assert outbound is None or outbound == client_session
+
+
+def test_initialize_jsonrpc_error_does_not_issue_session_id(
+    client: TestClient,
+) -> None:
+    """A failed ``initialize`` (missing ``protocolVersion``) must not leak a session id.
+
+    The spec wants the id pinned to a real session; a degenerate
+    handshake (JSON-RPC ``error`` envelope) has no real session to
+    pin to.
+    """
+    response = _post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"capabilities": {}},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "error" in body
+    assert response.headers.get("mcp-session-id") is None
+
+
+def test_non_initialize_methods_do_not_issue_session_id(
+    client: TestClient,
+) -> None:
+    """``tools/list`` / ``ping`` / etc. must not stamp a fresh session id.
+
+    Only ``initialize`` is the handshake the spec permits the server
+    to use for assignment. A later RPC has no contract to renegotiate
+    a session mid-flight; if the client already has an id it sends
+    it inbound (and we capture it), and if it doesn't, the audit row
+    stays NULL.
+    """
+    response = _post_mcp(
+        client,
+        {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers.get("mcp-session-id") is None
+
+
+# ---------------------------------------------------------------------------
 # notifications/initialized
 # ---------------------------------------------------------------------------
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -171,10 +171,18 @@ The push fans out to `cli-release.yml`, `image.yml`, `chart.yml`.
 - [ ] Deploy to `rke2-infra`.
 - [ ] Run smoke; confirm **smoke-green** (same pattern as
   v0.2.0 / v0.3.0 / v0.3.1).
-- [ ] Audit replay (G8.2) auto-lights-up when MCP clients send
-  `Mcp-Session-Id` — no env var required after G0.14-T6 #1147.
-  Older clients that don't send the header continue to work; audit
-  rows just won't carry `agent_session_id`. To confirm the deploy is
+- [ ] Audit replay (G8.2) auto-lights-up: the backplane **issues** an
+  `Mcp-Session-Id` response header on every `initialize` per MCP
+  2025-06-18 §"Session Management" rule 1 (G0.15-T4 #1213), and
+  spec-conforming MCP clients (Claude Code, MCP Inspector, Cline)
+  echo it on every subsequent POST (rule 2). The capture path then
+  lands the id in `audit_log.agent_session_id`. No env var required
+  after G0.14-T6 #1147 — capture is unconditional and issuance is
+  unconditional. Pre-G0.15-T4 deploys (≤ v0.7.0) captured the header
+  but never issued one, so audit rows from MCP clients that wait for
+  a server-assigned id (the spec-compliant default) landed
+  `agent_session_id: null` regardless of the `capture_mode: "always"`
+  advertisement; v0.7.1+ closes this gap. To confirm the deploy is
   in the expected capture mode (`always` by default; `enforced` when
   `MCP_REQUIRE_SESSION_ID=true`), inspect
   `GET /api/v1/health`'s `mcp_session_id_capture` field.
@@ -237,6 +245,13 @@ Walk the four gates in the order an operator hits them:
   exposes the current state — `"enforced"` pre-T6,
   `"always"` post-T6. Operators tracking the audit-replay readiness
   signal off `/ready` get a stable contract across the T6 transition.
+  G0.15-T4 (#1213) added the **issuance** half — the server now
+  emits `Mcp-Session-Id` on `initialize` per MCP 2025-06-18
+  §"Session Management" rule 1, so clients have something to echo
+  back on the capture side. Without issuance (≤ v0.7.0), spec-
+  conforming MCP clients never sent the header and every row landed
+  with `agent_session_id: null` despite `capture_mode` advertising
+  `"always"`; v0.7.1+ closes the inert-promise regression.
 
 - [ ] **Approval queue** (agent-grant approval surface;
   `POST /api/v1/agents/grants` and the agent grant lifecycle). No

--- a/docs/architecture/mcp.md
+++ b/docs/architecture/mcp.md
@@ -30,15 +30,27 @@ The locked decision (#7 in [v0.2-decisions.md](../planning/v0.2-decisions.md)) w
 
 **Streamable HTTP**, not stdio. MEHO is a hosted server, not a local subprocess. The `/mcp` route accepts JSON-RPC 2.0 POST requests with a single envelope per body (batch arrays are unsupported — MCP Streamable HTTP transport mandates single envelopes).
 
-### Session id capture (audit correlation)
+### Session id issuance + capture (audit correlation)
 
-Per the spec's *Session Management* section, a server MAY assign a session id at `initialize` that the client echoes in the `Mcp-Session-Id` header on later requests. MEHO runs **no** stateful session store in v0.2 — it captures the header purely for **audit correlation** so per-session replay (`meho audit replay <session-id>`, G8.2) can reconstruct one agent's full operation trace. On every `POST /mcp`, [`_bind_mcp_session_id`](../../backend/src/meho_backplane/mcp/server.py) binds an `mcp_session_id` structlog contextvar (G8.2-T2 #1010):
+Per the spec's *Session Management* section, a server MAY assign a session id at `initialize` by returning it in an `Mcp-Session-Id` **response header** on the `InitializeResult`; the client MUST then include the header on every subsequent HTTP POST to the MCP endpoint. The handshake is strictly **server-driven** — clients do not invent session ids, they only relay what the server gave them. MEHO runs **no** stateful session store in v0.2 — the id exists purely for **audit correlation** so per-session replay (`meho audit replay <session-id>`, G8.2) can reconstruct one agent's full operation trace.
+
+**Issuance side (G0.15-T4 #1213).** On a successful `initialize` reply, [`_maybe_issue_initialize_session_id`](../../backend/src/meho_backplane/mcp/server.py) stamps a fresh `uuid4()` onto the response's `Mcp-Session-Id` header (and binds the same id into a structlog `mcp_session_id` contextvar so any post-issue log line carries the same correlation key). The issuance is gated on:
+
+- Method is `initialize` and it's a *request*, not a notification.
+- The dispatched response is HTTP 2xx **and** the JSON-RPC envelope has no `error` member — a failed initialize must not seed a session id.
+- The client did not already send an `Mcp-Session-Id` header inbound (a resume / replay attempt where the client carries an id is accepted lenient; MEHO does not overwrite the client's correlation key).
+
+Before G0.15-T4 #1213, MEHO captured the header end of the chain but never issued one. The visible symptom (`claude-rdc-hetzner-dc#753` finding 2) was every Claude Code MCP audit row landing with `agent_session_id: null` despite [`meho_status`](../../backend/src/meho_backplane/api/v1/health.py) / [`/ready.features.audit_replay.capture_mode`](../../backend/src/meho_backplane/api/v1/health.py) advertising `"always"` — both surfaces correctly reported the **capture** config; nothing populated the column because no client had a server-assigned session id to send back.
+
+**Capture side.** On every `POST /mcp`, [`_bind_mcp_session_id`](../../backend/src/meho_backplane/mcp/server.py) binds an `mcp_session_id` structlog contextvar (G8.2-T2 #1010):
 
 - Header present and a parseable UUID → bind it.
-- Header present but malformed (non-UUID) → treated as absent (a malformed *client* header never 500s the call; a non-UUID can't go in a `uuid` column).
-- Header absent/empty → fresh `uuid4()` for the single-call duration, so the audit row still carries a stable, non-NULL session id (the spec permits servers to not require sessions).
+- Header present but malformed (non-UUID) → treated as absent (a malformed *client* header never 500s the call; a non-UUID can't go in a `uuid` column). The audit row's `agent_session_id` lands as NULL.
+- Header absent/empty → contextvar stays unbound. The audit row's `agent_session_id` lands as NULL; the G8.2 replay route's session walk treats NULLs as "not part of any session," which is correct for a stateless-client call.
 
-`MCP_REQUIRE_SESSION_ID=true` ([`Settings.mcp_require_session_id`](../../backend/src/meho_backplane/settings.py), default `false`) turns a missing/empty header into a JSON-RPC `-32600` Invalid Request **before** dispatch — no audit row is written for the rejected call. A present-but-malformed header is not a rejection in require-mode (the client did send an id); it falls back to a fresh `uuid4()` as in the default mode.
+[`write_mcp_audit_row`](../../backend/src/meho_backplane/mcp/audit.py) reads the contextvar via [`_resolve_uuid_contextvar`](../../backend/src/meho_backplane/mcp/audit.py) and writes `audit_log.agent_session_id`. The structlog contextvar propagates down the async call chain inside one request, so the write picks up the binding without threading the value through every handler signature.
+
+`MCP_REQUIRE_SESSION_ID=true` ([`Settings.mcp_require_session_id`](../../backend/src/meho_backplane/settings.py), default `false`) turns a missing/empty header into a JSON-RPC `-32600` Invalid Request **before** dispatch — no audit row is written for the rejected call. A present-but-malformed header is not a rejection in require-mode (the client did send an id, just an unparseable one); the audit row lands NULL and a structured `mcp_malformed_session_id` warning surfaces the misbehaving client without breaking client retry logic.
 
 Response shapes per the spec's *Sending Messages to the Server* section:
 
@@ -142,7 +154,7 @@ The per-operation writer is [`mcp/audit.py::write_mcp_audit_row`](../../backend/
 ```text
 operator_sub     ← from JWT (validated by /mcp auth chain)
 tenant_id        ← operator.tenant_id
-agent_session_id ← Mcp-Session-Id header (or fresh uuid4); NULL on chassis HTTP rows (G8.2-T2)
+agent_session_id ← Mcp-Session-Id header (issued by server on initialize per G0.15-T4 #1213, echoed by client); NULL when the client didn't echo one back, and on chassis HTTP rows (G8.2-T2)
 parent_audit_id  ← parent_audit_id contextvar (forward-compat; unbound in v0.2)
 request_id       ← from RequestContextMiddleware (still runs)
 method           ← "MCP"


### PR DESCRIPTION
## Summary

- **Failure mode (c-other):** MEHO captured `Mcp-Session-Id` end-to-end correctly but never **issued** one. Per MCP 2025-06-18 Streamable HTTP §"Session Management" rule 1 the server MAY assign a session id at `initialize` via a response header; rule 2 says clients MUST echo it on later requests **only if** the server first sent one. Spec-conforming clients (Claude Code, MCP Inspector) therefore never sent the header — every MCP audit row landed `agent_session_id: null` despite `meho_status` / `/ready.features.audit_replay.capture_mode` advertising `"always"`.
- **Fix:** `_maybe_issue_initialize_session_id` in `backend/src/meho_backplane/mcp/server.py` stamps a fresh `uuid4()` into the `Mcp-Session-Id` response header on every successful `initialize`. Issuance is gated on a 2xx response with no JSON-RPC `error` envelope, and on the client not already having supplied a session id inbound (resume / replay is accepted lenient — MEHO doesn't overwrite the client's correlation key).
- **Audit-row roundtrip lands now:** the existing `_bind_mcp_session_id` → `_resolve_uuid_contextvar` → `audit_log.agent_session_id` chain now has a server-assigned id to consume on the client's next POST.

## Evidence

The failure mode classification is **(c-other)** — not (a) or (b) from the issue body:

- Not **(a)** "Claude Code's transport doesn't send the header" — the MCP 2025-06-18 spec is clear that clients only relay what the server gave them; the client follows the spec strictly.
- Not **(b)** "capture path break" — `_bind_mcp_session_id` (server.py:613-633) reads the inbound header into the structlog contextvar; `_resolve_uuid_contextvar` (audit.py:113-124) reads it back at audit-write time. The existing `test_session_header_propagates_to_agent_session_id` already covered this end of the chain.
- **(c-other)** is the real gap: the server side of MCP §"Session Management" rule 1 was never implemented. The release-body's "G8.2 audit-replay therefore lights up automatically … (Claude Code does by default)" claim was true about the capture config but untrue about the protocol-level behaviour, because no client ever had an id to echo back.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (737 files)
- [x] `mypy src/meho_backplane/` — clean (365 source files)
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers
- [x] `pytest tests/test_mcp_server.py tests/test_mcp_audit.py` — 48 passed (was 42; 6 new tests)
- [x] `pytest tests/` (full backend) — **5281 passed, 370 skipped, 0 failed** (645s)
- [x] **AC 1** PR description names the failure mode (c-other) with concrete protocol-level evidence — see "Evidence" above.
- [x] **AC 2** Fix lands (server now issues the header) + regression test `test_initialize_issues_mcp_session_id_response_header` (plus the four sibling unit tests for the gates) asserts the fixed behaviour holds.
- [x] **AC 3** End-to-end roundtrip test `test_initialize_issued_session_id_round_trips_to_audit_row` proves `query_audit shape=tree agent_session_id=<issued-id>` would return non-empty against an MCP session: the test asserts the issued id from `initialize`'s response header lands verbatim on `audit_log.agent_session_id` for the subsequent `tools/call`.
- [x] **AC 4** `docs/RELEASING.md` updated — both §6 (deploy smoke) and §6a (post-deploy enablement audit-replay paragraph) reflect the issuance side. `docs/architecture/mcp.md` rewrote the session-id section: "Session id capture" → "Session id issuance + capture", and fixed a stale "fresh uuid4() on absent header" doc that no longer matched the code.
- [x] **AC 5** Not applicable — failure mode is (c-other), not (a), so no operator-facing WARNING-log-on-null path is needed. The `agent_session_id` column populates whenever any spec-conforming MCP client is the caller.

## Out of scope

- `parent_audit_id` substrate / usage — deferred to G8.2 #377 per the issue body.
- Other MCP clients (Cursor, Continue, etc.) — once the server emits the header per spec, every spec-conforming client lights up; per-client follow-ups are unnecessary.
- Restructuring the MCP session-id capture architecture — surgical fix to the observed gap, no redesign.
- Stateful session store / DELETE-to-terminate flow (MCP §"Session Management" rule 5) — MEHO holds no session state in v0.2 by design; the audit-log linkage is the only persistence.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1213
