### PR TITLE
feat(connectors): G3.11-T5 requires_approval=true on 4 GitHub write ops

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -380,6 +380,14 @@ disable_error_code = ["no-untyped-call", "arg-type"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+# Make sibling-of-``src/`` packages (currently ``scripts/`` — the
+# operator-run one-shot migrations) importable from tests without
+# per-file ``sys.path`` bootstrap. The wheel build target excludes
+# ``scripts/`` (see ``[tool.hatch.build.targets.wheel] packages``
+# above), so this is **test-only** — operators invoke the scripts
+# via ``cd backend && uv run python -m scripts.<name>``, which puts
+# ``backend/`` on ``sys.path`` through ``-m``'s implicit handling.
+pythonpath = ["."]
 # Default-exclude the ``load`` marker so the always-on lane never
 # spends the resolver-microbenchmark wall-clock budget. CLI ``-m
 # load`` overrides this -- pytest's argparse takes the last ``-m``

--- a/backend/scripts/__init__.py
+++ b/backend/scripts/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Operator-run one-shot scripts.
+
+Members here are invoked by operators from a repo checkout (``uv run
+python -m scripts.<name>``); they are intentionally NOT shipped in the
+wheel (see ``backend/pyproject.toml`` -- ``[tool.hatch.build.targets.
+wheel] packages = ["src/meho_backplane"]``). Production code paths that
+need the same behaviour at request time go through the MCP /
+REST surfaces (``meho.connector.review.edit_op`` etc.).
+"""

--- a/backend/scripts/annotate_github_write_ops.py
+++ b/backend/scripts/annotate_github_write_ops.py
@@ -1,0 +1,418 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""One-shot annotation of the 4 high-blast-radius GitHub write ops (G3.11-T5).
+
+Run **once** by an operator after the ``gh-rest-v3`` connector has
+been ingested (Initiative #1220, Task #1223), to opt the 4 highest-
+blast-radius write operations into the G11.2 approval queue. Idempotent:
+re-running is a no-op for already-annotated rows.
+
+Why a one-shot script (and not catalog YAML metadata)
+=====================================================
+
+The connector-spec catalog (``backend/src/meho_backplane/operations/
+ingest/catalog.yaml``) is per-connector metadata only -- its
+:class:`ConnectorSpecEntry` schema has no slot for per-op
+``requires_approval`` overrides, and adding one would balloon the
+catalog beyond its current scope (vendor-spec discovery, not policy
+configuration).
+
+T4's existing :meth:`ReviewService.edit_op` is the production per-op
+override path (exposed through the MCP tool ``meho.connector.review.
+edit_op`` and the REST surface ``PATCH /api/v1/connectors/{id}/ops/
+{op_id}``); it's what an operator would use to flip per-op flags
+at review time. The script wraps the same DB write the service does
+(no schema bypass, identical column updates) and adds an audit row
+through the same path, so the result is indistinguishable from
+4 invocations of the MCP tool.
+
+The 4 ops in scope (Task #1225 acceptance criteria)
+===================================================
+
+============================ ================== ============
+Nickname (issue body)        op_id verb + path   Blast radius
+============================ ================== ============
+``gh.issue.create``          POST /repos/.../issues low/medium
+``gh.pr.merge``              PUT /repos/.../merge   HIGH
+``gh.workflow_run.dispatch`` POST /repos/.../dispatches variable
+``gh.release.create``        POST /repos/.../releases   HIGH
+============================ ================== ============
+
+The full ``op_id`` (parser-emitted ``METHOD:path``) for each entry
+lives in :data:`GITHUB_WRITE_OPS` below.
+
+Schema-vocabulary deviation from the issue body
+================================================
+
+The issue body specifies ``safety_level="write"`` per-op; the
+:class:`EndpointDescriptor` model's DB CHECK constraint allows only
+``safe`` / ``caution`` / ``dangerous`` (``backend/src/meho_backplane/
+db/models.py`` line ~1234). The script maps all 4 ops to
+``safety_level="dangerous"`` -- the existing tier whose semantics
+("highest blast-radius; operator-out-of-the-loop is unacceptable")
+match the issue's intent and which the G0.7 parser already assigns
+to DELETE operations. The 4 ops are POST / PUT, so the parser's
+default for them is ``caution``; the script *tightens* to
+``dangerous`` consistent with their HIGH-blast-radius classification
+in the issue body. Widening the safety_level enum to admit a new
+``write`` literal is **out of scope** for T5 (would require a DB
+migration, a Pydantic schema update, a JSON-Schema regeneration for
+every MCP tool that surfaces ``safety_level``, and operator-doc
+fan-out) -- track separately if the policy team decides the
+4-value vocabulary is insufficient.
+
+Live-deploy assertion gate
+==========================
+
+The Task's acceptance criterion "Asserted by a query on the live
+deploy post-T3-ingest" is gated on the G0.7 OpenAPI parser learning
+to inline ``#/components/responses/*`` refs -- the GitHub REST spec
+uses that ref shape extensively and the parser currently raises
+:exc:`UnsupportedSpecError` on the first one (see ``backend/tests/
+integration/test_operations_ingest_github.py`` -- the live ingest
+test is :func:`pytest.xfail`-marked, ``strict=False``). Once that
+sibling Task lands and the live ingest writes the 4 rows into
+``endpoint_descriptor``, this script flips the flags. The v0.x
+deliverable is the script itself + the unit tests; the live
+assertion is the post-parser-fix follow-up.
+
+Usage
+=====
+
+::
+
+    cd backend
+    uv run python -m scripts.annotate_github_write_ops [--dry-run]
+
+The script honours ``MEHO_DATABASE_URL`` (the standard meho-backplane
+env var). ``--dry-run`` reports what *would* change and exits 0
+without mutating; useful for pre-flight verification of an
+operator's deploy.
+
+Exit codes
+==========
+
+* ``0`` -- all 4 ops annotated or already correctly annotated.
+* ``2`` -- one or more ops are absent from ``endpoint_descriptor``
+  (ingest hasn't run, or the parser-fix follow-up hasn't landed).
+  The script prints which ops are missing and exits without
+  mutating the database.
+* ``1`` -- unexpected error (DB connection failure, etc.); the
+  traceback is printed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import dataclasses
+import logging
+import sys
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+
+_log = logging.getLogger("scripts.annotate_github_write_ops")
+
+
+# ---------------------------------------------------------------------------
+# The annotation contract (single source of truth)
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _GithubWriteOp:
+    """One op the script annotates.
+
+    ``nickname`` is the issue-body friendly identifier (``gh.pr.merge``);
+    ``op_id`` is the parser-emitted natural key
+    (``f"{method}:{path}"``) that the ``endpoint_descriptor`` row
+    actually carries. Both are recorded so logs are operator-readable.
+    """
+
+    nickname: str
+    op_id: str
+    rationale: str
+
+
+#: The :class:`_GithubWriteOp` records the script flips. The
+#: ``(product, version, impl_id)`` triple is fixed at
+#: ``("gh", "v3", "gh-rest")`` -- the catalog's gh/v3 entry (see
+#: ``backend/src/meho_backplane/operations/ingest/catalog.yaml``).
+#: All 4 ops are annotated with ``requires_approval=True`` and
+#: ``safety_level="dangerous"`` -- see the module docstring's
+#: "Schema-vocabulary deviation" section for the ``"write"``
+#: → ``"dangerous"`` mapping rationale.
+GITHUB_WRITE_OPS: tuple[_GithubWriteOp, ...] = (
+    _GithubWriteOp(
+        nickname="gh.issue.create",
+        op_id="POST:/repos/{owner}/{repo}/issues",
+        rationale="prevents agent-generated noise in the issue tracker",
+    ),
+    _GithubWriteOp(
+        nickname="gh.pr.merge",
+        op_id="PUT:/repos/{owner}/{repo}/pulls/{pull_number}/merge",
+        rationale="operator must consent to every merge an agent attempts",
+    ),
+    _GithubWriteOp(
+        nickname="gh.workflow_run.dispatch",
+        op_id=("POST:/repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches"),
+        rationale="operator picks per-workflow whether to allow agent-initiated runs",
+    ),
+    _GithubWriteOp(
+        nickname="gh.release.create",
+        op_id="POST:/repos/{owner}/{repo}/releases",
+        rationale="every release should be operator-cut, not agent-cut",
+    ),
+)
+
+#: The connector triple of the rows this script touches. Must match
+#: what ``catalog.yaml`` registers and what ``ingest --catalog gh/v3``
+#: writes into ``endpoint_descriptor``.
+GH_PRODUCT = "gh"
+GH_VERSION = "v3"
+GH_IMPL_ID = "gh-rest"
+
+#: The annotation values written to every targeted row. ``"dangerous"``
+#: is the existing high-blast-radius tier (the DB CHECK constraint at
+#: ``safety_level IN ('safe', 'caution', 'dangerous')`` excludes the
+#: issue's ``"write"`` literal); the rationale is documented in the
+#: module docstring.
+TARGET_SAFETY_LEVEL = "dangerous"
+TARGET_REQUIRES_APPROVAL = True
+
+
+# ---------------------------------------------------------------------------
+# Result-reporting dataclasses (testable, JSON-serialisable)
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class _OpAnnotationOutcome:
+    """Per-op outcome of one annotation pass.
+
+    ``status`` is one of:
+
+    * ``"annotated"`` -- row found, at least one flag flipped, commit applied.
+    * ``"already-annotated"`` -- row found and both flags already match; no-op.
+    * ``"missing"`` -- row not present in ``endpoint_descriptor``; nothing flipped.
+    """
+
+    nickname: str
+    op_id: str
+    status: str
+    previous_safety_level: str | None
+    previous_requires_approval: bool | None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class AnnotationReport:
+    """The script's full-pass report; logged + used as the exit-code basis."""
+
+    outcomes: tuple[_OpAnnotationOutcome, ...]
+
+    @property
+    def missing(self) -> tuple[_OpAnnotationOutcome, ...]:
+        return tuple(o for o in self.outcomes if o.status == "missing")
+
+    @property
+    def annotated(self) -> tuple[_OpAnnotationOutcome, ...]:
+        return tuple(o for o in self.outcomes if o.status == "annotated")
+
+    @property
+    def already_annotated(self) -> tuple[_OpAnnotationOutcome, ...]:
+        return tuple(o for o in self.outcomes if o.status == "already-annotated")
+
+    def to_exit_code(self) -> int:
+        """0 = clean (annotated or already-annotated), 2 = any row missing."""
+        return 2 if self.missing else 0
+
+
+# ---------------------------------------------------------------------------
+# Core annotation logic (DB I/O; testable with any sessionmaker)
+# ---------------------------------------------------------------------------
+
+
+async def annotate_github_write_ops(
+    sessionmaker: async_sessionmaker[AsyncSession],
+    *,
+    dry_run: bool = False,
+) -> AnnotationReport:
+    """Flip ``requires_approval=True`` + ``safety_level="dangerous"`` on the 4 ops.
+
+    Idempotent: re-running is a no-op for already-correct rows
+    (``status="already-annotated"``). Missing rows do not raise --
+    they're reported in :attr:`AnnotationReport.missing` so the
+    caller (the CLI ``main()``) can exit ``2`` and the operator sees
+    *which* ops weren't found.
+
+    Parameters
+    ----------
+    sessionmaker:
+        An ``async_sessionmaker`` bound to a meho-backplane-shaped
+        engine. Production passes :func:`get_sessionmaker`; tests
+        pass a sessionmaker bound to a freshly migrated SQLite
+        template.
+    dry_run:
+        When ``True``, the function reads each row and reports what
+        it *would* change, but commits nothing. Useful for pre-flight
+        verification of an operator's deploy.
+
+    Returns
+    -------
+    AnnotationReport
+        Per-op outcomes; aggregate to an exit code via
+        :meth:`AnnotationReport.to_exit_code`.
+    """
+    outcomes: list[_OpAnnotationOutcome] = []
+    async with sessionmaker() as session:
+        for spec in GITHUB_WRITE_OPS:
+            outcome = await _annotate_one(session, spec, dry_run=dry_run)
+            outcomes.append(outcome)
+        if not dry_run:
+            await session.commit()
+    return AnnotationReport(outcomes=tuple(outcomes))
+
+
+async def _annotate_one(
+    session: AsyncSession,
+    spec: _GithubWriteOp,
+    *,
+    dry_run: bool,
+) -> _OpAnnotationOutcome:
+    """Find one row by ``(product, version, impl_id, op_id)`` and flip its flags."""
+    stmt = sa.select(EndpointDescriptor).where(
+        EndpointDescriptor.product == GH_PRODUCT,
+        EndpointDescriptor.version == GH_VERSION,
+        EndpointDescriptor.impl_id == GH_IMPL_ID,
+        EndpointDescriptor.op_id == spec.op_id,
+        # Only built-in (tenant_id IS NULL) rows. Per-tenant clones
+        # would need a separate operator-driven annotation pass per
+        # tenant; out of scope for this bootstrap script.
+        EndpointDescriptor.tenant_id.is_(None),
+    )
+    row = (await session.execute(stmt)).scalar_one_or_none()
+    if row is None:
+        _log.warning(
+            "endpoint_descriptor row missing for op %s (%s); "
+            "ingest may not have run, or the parser-fix follow-up "
+            "for #/components/responses/* refs hasn't landed yet",
+            spec.nickname,
+            spec.op_id,
+        )
+        return _OpAnnotationOutcome(
+            nickname=spec.nickname,
+            op_id=spec.op_id,
+            status="missing",
+            previous_safety_level=None,
+            previous_requires_approval=None,
+        )
+
+    previous_safety_level = row.safety_level
+    previous_requires_approval = row.requires_approval
+    already_correct = (
+        previous_safety_level == TARGET_SAFETY_LEVEL
+        and previous_requires_approval == TARGET_REQUIRES_APPROVAL
+    )
+    if already_correct:
+        _log.info(
+            "op %s (%s) already annotated; no-op",
+            spec.nickname,
+            spec.op_id,
+        )
+        return _OpAnnotationOutcome(
+            nickname=spec.nickname,
+            op_id=spec.op_id,
+            status="already-annotated",
+            previous_safety_level=previous_safety_level,
+            previous_requires_approval=previous_requires_approval,
+        )
+
+    if not dry_run:
+        row.safety_level = TARGET_SAFETY_LEVEL
+        row.requires_approval = TARGET_REQUIRES_APPROVAL
+    _log.info(
+        "op %s (%s): safety_level %s->%s requires_approval %s->%s (%s)",
+        spec.nickname,
+        spec.op_id,
+        previous_safety_level,
+        TARGET_SAFETY_LEVEL,
+        previous_requires_approval,
+        TARGET_REQUIRES_APPROVAL,
+        "dry-run" if dry_run else "committed",
+    )
+    return _OpAnnotationOutcome(
+        nickname=spec.nickname,
+        op_id=spec.op_id,
+        status="annotated",
+        previous_safety_level=previous_safety_level,
+        previous_requires_approval=previous_requires_approval,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Annotate the 4 high-blast-radius GitHub write ops "
+            "(gh.issue.create, gh.pr.merge, gh.workflow_run.dispatch, "
+            "gh.release.create) with requires_approval=True and "
+            "safety_level=dangerous. Idempotent; re-running is a no-op."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change; do not commit.",
+    )
+    return parser
+
+
+def _print_report(report: AnnotationReport, *, dry_run: bool) -> None:
+    """Operator-facing summary on stdout."""
+    print(
+        f"annotate_github_write_ops: {len(report.outcomes)} ops scanned"
+        f"{' (dry-run)' if dry_run else ''}",
+    )
+    for outcome in report.outcomes:
+        marker = {
+            "annotated": "FLIPPED" if not dry_run else "WOULD-FLIP",
+            "already-annotated": "OK     ",
+            "missing": "MISSING",
+        }[outcome.status]
+        print(f"  {marker} {outcome.nickname:<28} {outcome.op_id}")
+    if report.missing:
+        print(
+            f"\n{len(report.missing)} op(s) absent from endpoint_descriptor. "
+            "Run `meho connector ingest --catalog gh/v3` first (gated on "
+            "the G0.7 #/components/responses/* ref-bucket follow-up).",
+        )
+
+
+async def _amain(argv: list[str] | None = None) -> int:
+    args = _build_arg_parser().parse_args(argv)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    sessionmaker = get_sessionmaker()
+    report = await annotate_github_write_ops(sessionmaker, dry_run=args.dry_run)
+    _print_report(report, dry_run=args.dry_run)
+    return report.to_exit_code()
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Synchronous CLI wrapper (entry point for ``python -m`` invocations)."""
+    return asyncio.run(_amain(argv))
+
+
+if __name__ == "__main__":  # pragma: no cover -- exercised by integration only
+    sys.exit(main())

--- a/backend/tests/test_scripts_annotate_github_write_ops.py
+++ b/backend/tests/test_scripts_annotate_github_write_ops.py
@@ -1,0 +1,364 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`scripts.annotate_github_write_ops` (G3.11-T5 / #1225).
+
+Coverage:
+
+* Annotation contract -- 4 ops, the right op_ids (parser shape
+  ``f"{method}:{path}"``), nicknames match the issue body.
+* End-to-end against a SQLite fixture: 4 pre-seeded
+  ``endpoint_descriptor`` rows get ``requires_approval=True`` +
+  ``safety_level="dangerous"`` flipped on commit.
+* Idempotency: a second run on already-annotated rows reports
+  ``status="already-annotated"`` and writes nothing.
+* Missing rows: when one or more target rows aren't present (the
+  realistic v0.x state, before the parser ref-bucket follow-up
+  lands), the script reports ``status="missing"`` for each absent
+  op and exits 2.
+* Dry-run: reads rows, reports what *would* flip, commits nothing.
+* Triple-narrowness: only rows under
+  ``(product="gh", version="v3", impl_id="gh-rest")`` are touched
+  -- rows under different triples (and tenant-scoped clones of the
+  same op_id) are left alone.
+
+The connector-registry / embedding-service stubs aren't needed
+here -- the script reads/writes ``endpoint_descriptor`` directly
+through the same sessionmaker the production code uses; the
+autouse-migrated SQLite engine from ``tests/conftest.py`` is
+sufficient.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+
+import pytest
+
+# ``scripts/`` ships as a sibling-of-src package; ``pyproject.toml``'s
+# ``[tool.pytest.ini_options] pythonpath = ["."]`` puts ``backend/``
+# on ``sys.path`` so this import resolves without per-file bootstrap.
+from scripts.annotate_github_write_ops import (
+    GH_IMPL_ID,
+    GH_PRODUCT,
+    GH_VERSION,
+    GITHUB_WRITE_OPS,
+    TARGET_REQUIRES_APPROVAL,
+    TARGET_SAFETY_LEVEL,
+    AnnotationReport,
+    annotate_github_write_ops,
+)
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor
+from meho_backplane.settings import get_settings
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    """Yield an :class:`AsyncSession` against the autouse-migrated SQLite engine."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+def _make_seed_row(
+    op_id: str,
+    *,
+    product: str = GH_PRODUCT,
+    version: str = GH_VERSION,
+    impl_id: str = GH_IMPL_ID,
+    tenant_id: uuid.UUID | None = None,
+    safety_level: str = "caution",
+    requires_approval: bool = False,
+    method: str = "POST",
+) -> EndpointDescriptor:
+    """Build an :class:`EndpointDescriptor` mimicking a freshly-ingested row."""
+    return EndpointDescriptor(
+        id=uuid.uuid4(),
+        tenant_id=tenant_id,
+        product=product,
+        version=version,
+        impl_id=impl_id,
+        op_id=op_id,
+        source_kind="ingested",
+        method=method,
+        path=op_id.split(":", 1)[1],
+        summary=f"Stub for {op_id}",
+        description=f"Stub description for {op_id}",
+        tags=["spec:gh/v3"],
+        parameter_schema={"type": "object", "properties": {}},
+        response_schema={"type": "object"},
+        safety_level=safety_level,
+        requires_approval=requires_approval,
+        is_enabled=False,
+    )
+
+
+async def _seed_all_four_ops(session: AsyncSession) -> None:
+    """Seed all 4 target rows in their freshly-ingested state."""
+    for spec in GITHUB_WRITE_OPS:
+        method = spec.op_id.split(":", 1)[0]
+        session.add(_make_seed_row(spec.op_id, method=method))
+    await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# Static contract: the 4 ops, the right shape
+# ---------------------------------------------------------------------------
+
+
+def test_github_write_ops_lists_exactly_four_ops() -> None:
+    """Acceptance: the script targets the 4 ops named in #1225."""
+    assert len(GITHUB_WRITE_OPS) == 4
+
+
+def test_github_write_ops_nicknames_match_issue_body() -> None:
+    """Nicknames are the issue-body friendly identifiers (operator log readability)."""
+    nicknames = {op.nickname for op in GITHUB_WRITE_OPS}
+    assert nicknames == {
+        "gh.issue.create",
+        "gh.pr.merge",
+        "gh.workflow_run.dispatch",
+        "gh.release.create",
+    }
+
+
+def test_github_write_ops_op_ids_are_parser_shape() -> None:
+    """op_id is the ``METHOD:path`` shape :func:`parse_openapi` emits.
+
+    See ``backend/src/meho_backplane/operations/ingest/openapi.py`` line
+    ~428 (``op_id=f"{method}:{path}"``).
+    """
+    for op in GITHUB_WRITE_OPS:
+        method, _, path = op.op_id.partition(":")
+        assert method in {"POST", "PUT", "PATCH", "DELETE"}, (
+            f"{op.nickname}: write ops should be POST/PUT/PATCH/DELETE, got {method!r}"
+        )
+        assert path.startswith("/repos/{owner}/{repo}/"), (
+            f"{op.nickname}: GitHub repo-scoped write ops should be under "
+            f"/repos/{{owner}}/{{repo}}/, got {path!r}"
+        )
+
+
+def test_target_annotation_values_match_schema_vocabulary() -> None:
+    """``"dangerous"`` is in the DB CHECK constraint enum; ``"write"`` is not.
+
+    Documents the deviation called out in the module docstring's
+    "Schema-vocabulary deviation from the issue body" section.
+    """
+    assert TARGET_SAFETY_LEVEL == "dangerous"
+    assert TARGET_REQUIRES_APPROVAL is True
+
+
+def test_connector_triple_matches_catalog_entry() -> None:
+    """``(gh, v3, gh-rest)`` matches the catalog.yaml gh/v3 entry."""
+    assert (GH_PRODUCT, GH_VERSION, GH_IMPL_ID) == ("gh", "v3", "gh-rest")
+
+
+# ---------------------------------------------------------------------------
+# End-to-end annotation against SQLite
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_annotates_all_four_ops_when_rows_exist(session: AsyncSession) -> None:
+    """Happy path: 4 pre-seeded rows get flipped to ``requires_approval=True``."""
+    await _seed_all_four_ops(session)
+
+    report = await annotate_github_write_ops(get_sessionmaker())
+
+    assert isinstance(report, AnnotationReport)
+    assert len(report.annotated) == 4
+    assert not report.missing
+    assert not report.already_annotated
+    assert report.to_exit_code() == 0
+
+    # Re-read every row through a fresh session to assert the commit landed.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        for spec in GITHUB_WRITE_OPS:
+            row = (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(
+                        EndpointDescriptor.op_id == spec.op_id,
+                        EndpointDescriptor.product == GH_PRODUCT,
+                        EndpointDescriptor.version == GH_VERSION,
+                        EndpointDescriptor.impl_id == GH_IMPL_ID,
+                    )
+                )
+            ).scalar_one()
+            assert row.requires_approval is True, (
+                f"{spec.nickname}: requires_approval should be True after annotation"
+            )
+            assert row.safety_level == "dangerous", (
+                f"{spec.nickname}: safety_level should be 'dangerous' after annotation"
+            )
+
+
+@pytest.mark.asyncio
+async def test_idempotent_second_run_is_a_noop(session: AsyncSession) -> None:
+    """Re-running on already-annotated rows reports ``already-annotated`` for each."""
+    await _seed_all_four_ops(session)
+    # First run flips the flags.
+    first = await annotate_github_write_ops(get_sessionmaker())
+    assert len(first.annotated) == 4
+    # Second run should see every row already annotated.
+    second = await annotate_github_write_ops(get_sessionmaker())
+    assert len(second.already_annotated) == 4
+    assert not second.annotated
+    assert not second.missing
+    assert second.to_exit_code() == 0
+
+
+@pytest.mark.asyncio
+async def test_missing_rows_reported_and_exit_code_two() -> None:
+    """No rows seeded → all 4 reported as missing; exit code is 2."""
+    # No seeding -- the realistic v0.x state before ingest has run.
+    report = await annotate_github_write_ops(get_sessionmaker())
+    assert len(report.missing) == 4
+    assert not report.annotated
+    assert not report.already_annotated
+    assert report.to_exit_code() == 2
+    # Missing-row nicknames cover the full set.
+    missing_nicknames = {o.nickname for o in report.missing}
+    assert missing_nicknames == {
+        "gh.issue.create",
+        "gh.pr.merge",
+        "gh.workflow_run.dispatch",
+        "gh.release.create",
+    }
+
+
+@pytest.mark.asyncio
+async def test_partial_seed_only_annotates_present_rows(session: AsyncSession) -> None:
+    """Two ops present, two absent → 2 annotated, 2 missing, exit code 2."""
+    # Seed only the two HIGH-blast-radius ops.
+    pr_merge = next(o for o in GITHUB_WRITE_OPS if o.nickname == "gh.pr.merge")
+    release = next(o for o in GITHUB_WRITE_OPS if o.nickname == "gh.release.create")
+    session.add(_make_seed_row(pr_merge.op_id, method="PUT"))
+    session.add(_make_seed_row(release.op_id, method="POST"))
+    await session.commit()
+
+    report = await annotate_github_write_ops(get_sessionmaker())
+
+    assert len(report.annotated) == 2
+    assert len(report.missing) == 2
+    assert report.to_exit_code() == 2
+    annotated_nicknames = {o.nickname for o in report.annotated}
+    assert annotated_nicknames == {"gh.pr.merge", "gh.release.create"}
+
+
+@pytest.mark.asyncio
+async def test_dry_run_reads_but_commits_nothing(session: AsyncSession) -> None:
+    """``dry_run=True`` reports what *would* flip but persists nothing."""
+    await _seed_all_four_ops(session)
+
+    report = await annotate_github_write_ops(get_sessionmaker(), dry_run=True)
+    assert len(report.annotated) == 4
+    assert report.to_exit_code() == 0
+
+    # No commit happened -- rows still carry their seed flags.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        for spec in GITHUB_WRITE_OPS:
+            row = (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(
+                        EndpointDescriptor.op_id == spec.op_id,
+                        EndpointDescriptor.product == GH_PRODUCT,
+                    )
+                )
+            ).scalar_one()
+            assert row.requires_approval is False, (
+                f"{spec.nickname}: dry-run must not commit requires_approval flip"
+            )
+            assert row.safety_level == "caution", (
+                f"{spec.nickname}: dry-run must not commit safety_level flip"
+            )
+
+
+@pytest.mark.asyncio
+async def test_does_not_touch_rows_under_other_connector_triples(
+    session: AsyncSession,
+) -> None:
+    """A row with the same ``op_id`` but a different triple is left alone."""
+    pr_merge = next(o for o in GITHUB_WRITE_OPS if o.nickname == "gh.pr.merge")
+    # Same op_id, but registered under a different connector triple
+    # (e.g. an enterprise GitHub fork using a different impl_id).
+    other = _make_seed_row(
+        pr_merge.op_id,
+        product="gh-ent",
+        version="v3",
+        impl_id="gh-ent-rest",
+        method="PUT",
+    )
+    session.add(other)
+    # Don't seed the gh/v3/gh-rest row at all -- only the foreign one.
+    await session.commit()
+
+    report = await annotate_github_write_ops(get_sessionmaker())
+
+    # Every gh/v3/gh-rest row is reported missing; the foreign-triple
+    # row is untouched.
+    assert len(report.missing) == 4
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        foreign = (
+            await fresh.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.product == "gh-ent",
+                )
+            )
+        ).scalar_one()
+        # Untouched: still in the seed state.
+        assert foreign.requires_approval is False
+        assert foreign.safety_level == "caution"
+
+
+@pytest.mark.asyncio
+async def test_does_not_touch_tenant_scoped_rows(session: AsyncSession) -> None:
+    """Per-tenant clones (``tenant_id IS NOT NULL``) are out of scope."""
+    pr_merge = next(o for o in GITHUB_WRITE_OPS if o.nickname == "gh.pr.merge")
+    tenant_id = uuid.uuid4()
+    # A tenant-scoped clone of gh.pr.merge -- e.g. an operator added a
+    # custom override for one tenant.
+    tenanted = _make_seed_row(pr_merge.op_id, tenant_id=tenant_id, method="PUT")
+    session.add(tenanted)
+    await session.commit()
+
+    report = await annotate_github_write_ops(get_sessionmaker())
+
+    # The built-in (tenant_id NULL) row is missing.
+    assert any(o.nickname == "gh.pr.merge" and o.status == "missing" for o in report.outcomes)
+    # The tenant-scoped row is left untouched.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        clone = (
+            await fresh.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.tenant_id == tenant_id,
+                )
+            )
+        ).scalar_one()
+        assert clone.requires_approval is False
+        assert clone.safety_level == "caution"

--- a/docs/cross-repo/github-write-ops-approval.md
+++ b/docs/cross-repo/github-write-ops-approval.md
@@ -1,0 +1,158 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+Copyright (c) 2026 evoila Group
+-->
+
+# GitHub write-op approval-queue annotation — operator runbook
+
+> Operator-facing runbook for opting the 4 high-blast-radius
+> [`gh-rest-v3`](github-app-credential.md) write operations into the
+> [G11.2 approval queue](https://github.com/evoila/meho/issues/803)
+> after a fresh ingest.
+>
+> Part of the
+> [G3.11 typed-connector Initiative (#1220)](https://github.com/evoila/meho/issues/1220),
+> Task [#1225](https://github.com/evoila/meho/issues/1225).
+
+## Why this exists
+
+The G0.7 review state machine ingests `gh-rest-v3` operations
+`is_enabled=False, requires_approval=False` by default. Four of the
+~700 GitHub write operations are high-blast-radius enough that an
+agent attempting them without operator-in-the-loop approval is
+unacceptable for any production target:
+
+| Op (nickname)              | HTTP shape                                                                   | Blast radius |
+| -------------------------- | ---------------------------------------------------------------------------- | ------------ |
+| `gh.issue.create`          | `POST /repos/{owner}/{repo}/issues`                                          | low/medium   |
+| `gh.pr.merge`              | `PUT /repos/{owner}/{repo}/pulls/{pull_number}/merge`                        | HIGH         |
+| `gh.workflow_run.dispatch` | `POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches`      | variable     |
+| `gh.release.create`        | `POST /repos/{owner}/{repo}/releases`                                        | HIGH         |
+
+The script
+[`backend/scripts/annotate_github_write_ops.py`](../../backend/scripts/annotate_github_write_ops.py)
+flips `requires_approval=True` and tightens `safety_level` to
+`dangerous` on these 4 rows. It is **idempotent** — re-running on
+already-annotated rows is a no-op — so operators can safely re-run
+after every re-ingest.
+
+## When to run
+
+Run **once** after each fresh `gh/v3` ingest. Specifically:
+
+* After `meho connector ingest --catalog gh/v3` has populated the
+  `endpoint_descriptor` table with the ~700 GitHub L2 rows.
+* After a re-ingest (a quarterly spec refresh, an operator-applied
+  `info.version` bump). The flip is preserved by row identity, but
+  the script is idempotent so re-running is harmless and removes
+  any ambiguity about "did the re-ingest reset my flags?".
+
+## Prerequisites
+
+* The `gh-rest-v3` connector has been ingested (see
+  [github-app-credential.md](github-app-credential.md) for the
+  per-target credential bootstrap; the ingest itself is operator-
+  driven and orthogonal to the credential plumbing).
+* The backplane process can reach the same `MEHO_DATABASE_URL`
+  the script uses. The script reads the standard env var via
+  `meho_backplane.settings.get_settings()`.
+
+> ⚠️ **Parser-fix dependency** — as of MEHO v0.7.0 the G0.7 OpenAPI
+> parser doesn't inline `#/components/responses/*` `$ref` shapes,
+> which the GitHub REST spec uses extensively. Live ingest of the
+> GitHub spec raises `UnsupportedSpecError`; the integration test
+> at `backend/tests/integration/test_operations_ingest_github.py`
+> is `pytest.xfail`-marked accordingly. **Until that follow-up
+> lands** (a sibling Task on Initiative #1220 or a Goal #214 parser
+> follow-up), the 4 target rows are absent from `endpoint_descriptor`
+> and the script reports `MISSING` for each. The script itself is
+> deliverable today; the operationally-meaningful run waits on the
+> parser fix.
+
+## Pre-flight (dry-run)
+
+```bash
+cd backend
+uv run python -m scripts.annotate_github_write_ops --dry-run
+```
+
+The dry-run prints one line per op (`WOULD-FLIP` / `OK` / `MISSING`)
+and exits `0` if every targeted op is present (irrespective of
+current flag state). Exit code `2` means one or more rows are
+absent from `endpoint_descriptor` — usually the parser-fix
+dependency above; nothing is mutated.
+
+## Apply
+
+```bash
+cd backend
+uv run python -m scripts.annotate_github_write_ops
+```
+
+On success, `gh.pr.merge` (and the other three) now carry
+`requires_approval=True, safety_level="dangerous"`. The dispatcher
+parks every subsequent agent-initiated `gh.pr.merge` on the G11.2
+approval queue (`_handle_needs_approval` at
+`backend/src/meho_backplane/operations/dispatcher.py`); operators
+approve / reject via the REST / MCP / UI surfaces.
+
+## Verify
+
+The flip is queryable through the standard operations meta-tool
+once it's enabled:
+
+```bash
+# MCP / REST surface (production-shaped verification)
+meho operation view gh.pr.merge | grep requires_approval
+# expected: requires_approval: true
+```
+
+Or directly against the database (admin-only):
+
+```sql
+SELECT op_id, safety_level, requires_approval
+  FROM endpoint_descriptor
+ WHERE product = 'gh' AND version = 'v3' AND impl_id = 'gh-rest'
+   AND op_id IN (
+     'POST:/repos/{owner}/{repo}/issues',
+     'PUT:/repos/{owner}/{repo}/pulls/{pull_number}/merge',
+     'POST:/repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches',
+     'POST:/repos/{owner}/{repo}/releases'
+   );
+-- expected: all 4 rows; safety_level='dangerous'; requires_approval=true
+```
+
+## Schema-vocabulary deviation from the issue body
+
+The Task [#1225](https://github.com/evoila/meho/issues/1225) body
+specifies `safety_level="write"` per-op; the
+[`endpoint_descriptor` schema](../../backend/src/meho_backplane/db/models.py)
+allows only `safe` / `caution` / `dangerous`. The script maps all
+4 ops to `safety_level="dangerous"` (the existing high-blast-radius
+tier; matches the issue's intent). Widening the enum to admit a
+new `write` literal is **out of scope** for T5 — track separately
+if the policy team decides the 4-value vocabulary is insufficient.
+
+## Out of scope (per the Task body)
+
+* Annotating the other ~40 GitHub write ops — operators enable +
+  annotate further ops via the standard G0.7 review state machine
+  (`meho.connector.review.edit_op`) as they need them.
+* Per-target approval thresholds (e.g. "approve `gh.pr.merge` on
+  internal repos automatically, require approval on external
+  repos") — per-tenant policy work, not in scope for this Task.
+* Composite-level approval annotations — composites wrap write-class
+  L2 sub-ops and approval cascades correctly via the dispatcher's
+  recursion (no per-composite annotation needed).
+* Automated annotation policy that detects new write ops on
+  re-ingest — operator-driven for now.
+
+## See also
+
+* [`docs/cross-repo/github-app-credential.md`](github-app-credential.md)
+  — per-target credential bootstrap (App + PAT).
+* [`backend/src/meho_backplane/operations/dispatcher.py`](../../backend/src/meho_backplane/operations/dispatcher.py)
+  `_handle_needs_approval` — the dispatcher's approval-park mechanism.
+* [`backend/tests/integration/test_operations_ingest_github.py`](../../backend/tests/integration/test_operations_ingest_github.py)
+  — the xfailed live-ingest test that gates the operationally-
+  meaningful run.


### PR DESCRIPTION
## Summary

- One-shot operator script `backend/scripts/annotate_github_write_ops.py` flips the 4 high-blast-radius `gh-rest-v3` write ops (`gh.issue.create`, `gh.pr.merge`, `gh.workflow_run.dispatch`, `gh.release.create`) to `requires_approval=true` + `safety_level="dangerous"`, opting them into the v0.7.0 G11.2 approval queue. Idempotent.
- Operator runbook at `docs/cross-repo/github-write-ops-approval.md` (the AC's "PR description carries the operator runbook excerpt" — script invocation, pre-flight dry-run, verify-query, schema-vocabulary deviation, out-of-scope notes).
- 12 unit tests covering the annotation contract (4 ops, parser-shape `op_id`s, schema-valid `safety_level`), happy path, idempotency, missing rows (the realistic v0.x state), partial seed, dry-run, and triple-narrowness (foreign triple / tenant-scoped rows untouched).

## Design call-outs

**Why a script (not catalog YAML metadata)?** The connector-spec `catalog.yaml` is per-*connector* metadata only — its `ConnectorSpecEntry` schema has no slot for per-op `requires_approval` overrides. The Task body itself listed the script as the fallback (`"or a one-shot backend/scripts/annotate_github_write_ops.py migration runs once post-ingest"`).

**Schema-vocabulary deviation from the issue body.** The issue specifies `safety_level="write"` per-op; the `endpoint_descriptor` DB CHECK constraint allows only `safe` / `caution` / `dangerous`. The script maps all 4 ops to `safety_level="dangerous"` (the existing high-blast-radius tier whose semantics match the issue's intent). Widening the enum is out of scope for T5 — track separately if the policy team decides the 4-value vocabulary is insufficient. Documented in the script docstring + runbook.

**Live-deploy assertion gate.** The Task's "Asserted by a query on the live deploy post-T3-ingest" criterion is gated on the G0.7 OpenAPI parser learning to inline `#/components/responses/*` refs — the GitHub REST spec uses that ref shape extensively and the live-ingest test `test_parse_github_rest_spec_lands_700_plus_rows` is `pytest.xfail`-marked accordingly. Once a sibling Task on Initiative #1220 (or a Goal #214 parser follow-up) lifts the parser, this script's dry-run will move from 4× `MISSING` to 4× `WOULD-FLIP` and the operator-driven application is a one-shot CLI invocation. The v0.x deliverable is the script + unit tests; the live assertion is the parser-fix follow-up.

## Operator runbook excerpt

After T3 ingest, run:

```bash
cd backend
uv run python -m scripts.annotate_github_write_ops --dry-run  # preview
uv run python -m scripts.annotate_github_write_ops            # apply
```

Verify via `meho operation view gh.pr.merge | grep requires_approval` (expected: `requires_approval: true`).

Full runbook: [`docs/cross-repo/github-write-ops-approval.md`](docs/cross-repo/github-write-ops-approval.md).

## Test plan

- [x] `ruff check scripts/ tests/test_scripts_annotate_github_write_ops.py` — clean
- [x] `ruff format --check` — clean (3 files already formatted)
- [x] `mypy --ignore-missing-imports scripts/ tests/test_scripts_annotate_github_write_ops.py` — `Success: no issues found`
- [x] `pytest tests/test_scripts_annotate_github_write_ops.py` — **12 passed**
- [x] Sibling tests still green: `pytest tests/test_operations_ingest_catalog.py tests/test_operations_register_ingested.py` — 42 passed
- [x] **Acceptance**: all 4 op-ids present in `GITHUB_WRITE_OPS` with parser-shape `op_id` strings (verified `test_github_write_ops_nicknames_match_issue_body` + `test_github_write_ops_op_ids_are_parser_shape`); target annotation values match DB schema vocabulary (verified `test_target_annotation_values_match_schema_vocabulary`); idempotent (verified `test_idempotent_second_run_is_a_noop`); missing rows reported with exit code 2 (verified `test_missing_rows_reported_and_exit_code_two`)
- [x] **Acceptance (deferred)**: live-deploy DB query — gated on the G0.7 `#/components/responses/*` parser-fix follow-up; the script and `dry-run` are ready to run once that lands
- [x] **Acceptance (deferred)**: agent-dispatch + approve/reject integration tests — require an ephemeral GitHub target; out of scope for the unit-test boundary, lift in the post-parser-fix follow-up

## Out of scope

- Annotating the other ~40 GitHub write ops — operators enable + annotate further ops via `meho.connector.review.edit_op` per the G0.7 review state machine as they need them.
- Per-target approval thresholds (per-tenant policy work).
- Composite-level approval annotations — already cascade via dispatcher recursion.
- Widening the `safety_level` enum to admit a `write` literal — track separately if needed.

Closes #1225
