### PR TITLE
feat(connectors): G3.11-T4 gh.composite.pr_status_summary -- first L1 composite

### DIFF
--- a/backend/src/meho_backplane/connectors/github/__init__.py
+++ b/backend/src/meho_backplane/connectors/github/__init__.py
@@ -121,3 +121,10 @@ register_connector_v2(
 # Queue the typed-op registrar onto the lifespan-driven list. T1 ships
 # a no-op; T3 will fill in the body once the catalog entry lands.
 register_typed_op_registrar(register_github_typed_operations)
+
+# Side-effect import: the composites subpackage's ``__init__`` queues
+# its own registrar onto the lifespan list (T4 #1224 ships the first L1
+# composite ``gh.composite.pr_status_summary``). Import-after-typed-
+# registrar ordering matches the vmware-rest precedent so the lifespan
+# runs the typed registrar before the composite registrar.
+import meho_backplane.connectors.github.composites  # noqa: E402,F401  -- side-effect

--- a/backend/src/meho_backplane/connectors/github/_catalog_command.py
+++ b/backend/src/meho_backplane/connectors/github/_catalog_command.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Catalog-command helper for the gh-rest connector.
+
+Mirrors :mod:`meho_backplane.connectors.vmware_rest._catalog_command`
+(G0.14-T10 / #1183). The
+:func:`~meho_backplane.connectors.github.composites._preflight.preflight_l2_dependencies`
+helper raises a
+:class:`~meho_backplane.operations.composite.CompositeL2DependencyMissing`
+exception when one of a composite's L2 sub-ops is not registered. That
+exception carries the operator-facing CLI command to run to ingest the
+catalog entry that lands the missing ops.
+
+The catalog row for the GitHub REST API is keyed under ``product=gh,
+version=v3, impl_id=gh-rest`` (see
+``backend/src/meho_backplane/operations/ingest/catalog.yaml`` row added
+by G3.11-T3 #1228). The operator command shape matches the verb shipped
+in #405 (G0.7-T5) and re-affirmed by T9 (#1182):
+
+    meho connector ingest --catalog gh/v3
+
+The catalog version label (``v3``) intentionally differs from the
+connector-registry version slot (``3``) -- the latter is constrained by
+:func:`~meho_backplane.operations._lookup.parse_connector_id`'s
+digit-prefix regex (``^[0-9][A-Za-z0-9._]*$``) while the catalog YAML
+preserves the operator-visible "v3" label GitHub itself uses for its
+REST API. The helper takes the catalog label as input (not the registry
+slot) so a future version bump ships in one place.
+"""
+
+from __future__ import annotations
+
+__all__ = ["catalog_command_for_github_rest"]
+
+
+def catalog_command_for_github_rest(catalog_version: str = "v3") -> str:
+    """Return the ``meho connector ingest --catalog gh/<version>`` command.
+
+    Parameters
+    ----------
+    catalog_version:
+        The catalog row's ``version`` label (``"v3"`` for the v0.7.x
+        default that matches the row in ``catalog.yaml`` G3.11-T3
+        #1228). Pass-through to the ``--catalog`` argument value
+        (``gh/v3``). Distinct from the registry's digit-prefix version
+        slot (``"3"``) the parser requires; the catalog label is what
+        operators type at the CLI.
+
+    Returns
+    -------
+    str
+        The exact CLI invocation an operator should run, with the
+        catalog argument resolved. Used in the
+        :class:`CompositeL2DependencyMissing` exception text and in the
+        :func:`~meho_backplane.operations._errors.result_composite_l2_missing`
+        result's structured ``catalog_command`` field.
+    """
+    return f"meho connector ingest --catalog gh/{catalog_version}"

--- a/backend/src/meho_backplane/connectors/github/composites/__init__.py
+++ b/backend/src/meho_backplane/connectors/github/composites/__init__.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""meho_backplane.connectors.github.composites -- gh-rest composites.
+
+Side-effect import: this package's ``__init__`` queues
+:func:`register_github_composite_operations` onto the lifespan-driven
+registrar list via
+:func:`~meho_backplane.operations.typed_register.register_typed_op_registrar`.
+
+The chassis lifespan's
+:func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+invokes every registered registrar in registration order after
+:func:`~meho_backplane.connectors.registry._eager_import_connectors`
+has walked every ``connectors/<product>/`` subpackage, so the
+``endpoint_descriptor`` upsert for the T4 composite lands before any
+dispatch can fire.
+
+Layout mirrors the vmware-rest composites package: ``__init__`` wires
+the registrar; ``_register.py`` carries per-composite registration
+metadata; ``_read.py`` carries handler implementations; ``schemas.py``
+carries the JSON Schema 2020-12 parameter + response contracts;
+``_preflight.py`` carries the L2 sub-op dependency check.
+
+Scope at T4 (#1224): 1 read composite --
+``gh.composite.pr_status_summary``. Future T7+ Tasks add write
+composites under this package.
+"""
+
+from meho_backplane.connectors.github.composites._preflight import (
+    preflight_l2_dependencies,
+    reset_preflight_cache,
+)
+from meho_backplane.connectors.github.composites._read import (
+    pr_status_summary_composite,
+)
+from meho_backplane.connectors.github.composites._register import (
+    register_github_composite_operations,
+)
+from meho_backplane.operations.typed_register import register_typed_op_registrar
+
+# Queue the composite-op upsert onto the lifespan-driven registrar list.
+# The lifespan calls ``run_typed_op_registrars`` after
+# ``_eager_import_connectors`` so every connector subpackage has self-
+# registered by the time the runner iterates.
+register_typed_op_registrar(register_github_composite_operations)
+
+__all__ = [
+    "pr_status_summary_composite",
+    "preflight_l2_dependencies",
+    "register_github_composite_operations",
+    "reset_preflight_cache",
+]

--- a/backend/src/meho_backplane/connectors/github/composites/_preflight.py
+++ b/backend/src/meho_backplane/connectors/github/composites/_preflight.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""L2 sub-op pre-flight check for gh-rest composite handlers.
+
+Mirrors :mod:`meho_backplane.connectors.vmware_rest.composites._preflight`
+(G0.14-T10 / #1183). The gh-rest connector advertises L1 composites
+(``gh.composite.*``) that dispatch into raw-REST L2 primitives
+(``GET:/repos/{owner}/{repo}/pulls/{pull_number}`` etc.). The L2 ops
+ship as ``ingested`` descriptors -- they only land in
+``endpoint_descriptor`` after an operator runs
+``meho connector ingest --catalog gh/v3``.
+
+A composite handler that calls
+:func:`~meho_backplane.operations.composite.DispatchChild` against an
+unregistered L2 op gets back the dispatcher's generic
+``OperationResult(status='error', error='unknown_op: ...')`` shape,
+which the handler's ``_require_ok`` helper then re-raises. This module
+turns that into a structured ``composite_l2_missing`` error per the
+``docs/codebase/error-message-shape.md`` convention (G0.14-T11 #1141),
+carrying the missing op-ids plus the catalog command the operator
+should run to fix the gap.
+
+Why lazy (Option B) and not eager
+---------------------------------
+
+Same trade-offs as the vmware-rest precedent (see that module's docstring
+for the full Option-A/B/C analysis):
+
+* Composites self-register during the chassis lifespan, before any
+  operator has had a chance to run ``meho connector ingest``. Eager
+  validation (Option A) would crash the lifespan.
+* Auto-ingesting the catalog at boot (Option C) inverts the
+  operator-driven posture of the v0.5.1 / v0.6.0 / v0.7.x catalog
+  design and couples to T9 (#1182).
+
+Lazy pre-resolve (this module) validates at first call, caches the
+all-present result, and surfaces a remediation-bearing error when
+any sub-op is missing. Same trade-offs apply here.
+
+Cache shape
+-----------
+
+Cache is per-process and keyed on the composite op_id. Same rationale
+as the vmware module: L2 descriptors are global
+(``tenant_id IS NULL``), and a stale negative would defeat the
+operator's expected workflow (see the error -> run the catalog
+command -> retry). Negative results are NOT cached.
+
+A separate cache per connector keeps the gh-rest pre-flight state from
+colliding with the vmware-rest pre-flight state (and vice versa) so a
+test that resets one does not invalidate the other.
+
+References
+----------
+
+* G0.14-T10 #1183 -- vmware-rest precedent.
+* G0.14-T11 #1141 -- error-message-shape convention.
+* G3.11-T1 #1221 -- connector substrate.
+* G3.11-T3 #1228 -- catalog row + ingest acceptance scaffolding.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.connectors.github._catalog_command import (
+    catalog_command_for_github_rest,
+)
+from meho_backplane.operations._lookup import lookup_descriptor, parse_connector_id
+from meho_backplane.operations.composite import CompositeL2DependencyMissing
+
+__all__ = [
+    "preflight_l2_dependencies",
+    "reset_preflight_cache",
+]
+
+
+#: Per-process cache of composite op_ids that have already passed the
+#: pre-flight walk. Populated on cache miss (all sub-ops present); cleared
+#: by :func:`reset_preflight_cache` (test seam). Separate from the
+#: vmware-rest module's cache so cross-connector test isolation holds.
+_PREFLIGHT_CACHE: set[str] = set()
+
+
+async def preflight_l2_dependencies(
+    *,
+    composite_op_id: str,
+    sub_op_ids: tuple[str, ...],
+    connector_id: str,
+    tenant_id: object,
+) -> None:
+    """Validate every sub-op_id resolves to a registered descriptor.
+
+    Called from the top of each gh-rest composite handler with the
+    handler's own op_id and the declared sub-op-id constants. On a cache
+    hit (this composite already passed the walk), returns immediately
+    with no DB round-trip. On a cache miss, walks each sub-op-id through
+    :func:`~meho_backplane.operations._lookup.lookup_descriptor` and
+    raises
+    :class:`~meho_backplane.operations.composite.CompositeL2DependencyMissing`
+    listing every absent sub-op + the catalog command.
+
+    Parameters
+    ----------
+    composite_op_id:
+        The composite's own op_id (``gh.composite.pr_status_summary``
+        etc.). Used as the cache key and surfaced in the exception.
+    sub_op_ids:
+        Tuple of L2 sub-op-ids the composite dispatches into. Order does
+        not matter -- the walk reports every miss in one exception
+        payload so the operator sees the full gap in one go.
+    connector_id:
+        The connector_id the handler dispatches against
+        (``"gh-rest-3"``). Parsed into ``(product, version, impl_id)``
+        for the descriptor lookup.
+    tenant_id:
+        The composite's operator tenant_id. Forwarded to
+        ``lookup_descriptor``'s tenant-scoped-then-global fallback shape;
+        L2 descriptors are global so the global fallback hit is the
+        common case. Typed as :class:`object` to keep this module
+        importable from handler files without pulling in the auth
+        package (avoids the Operator -> settings -> DB import cycle).
+
+    Raises
+    ------
+    CompositeL2DependencyMissing
+        One or more sub-op-ids are not registered. The exception's
+        ``missing_op_ids`` lists every absent sub-op (not just the
+        first-found), and ``catalog_command`` carries the
+        ``meho connector ingest --catalog gh/v3`` invocation operators
+        must run.
+
+    Notes
+    -----
+    * Sub-op-ids that begin with ``gh.composite.`` are skipped -- those
+      are composite-to-composite recursion (a future composite that
+      calls ``gh.composite.pr_status_summary`` as a sub-step). Their
+      registration is guaranteed by the lifespan registrar that brought
+      us here. Only raw-REST primitives (``GET:/...`` / ``POST:/...``
+      etc.) get validated.
+    """
+    if composite_op_id in _PREFLIGHT_CACHE:
+        return
+    raw_sub_ops = tuple(op for op in sub_op_ids if not op.startswith("gh.composite."))
+    if not raw_sub_ops:
+        _PREFLIGHT_CACHE.add(composite_op_id)
+        return
+
+    product, version, impl_id = parse_connector_id(connector_id)
+    missing: list[str] = []
+    for sub_op_id in raw_sub_ops:
+        descriptor = await lookup_descriptor(
+            tenant_id=tenant_id,  # type: ignore[arg-type]
+            product=product,
+            version=version,
+            impl_id=impl_id,
+            op_id=sub_op_id,
+        )
+        if descriptor is None:
+            missing.append(sub_op_id)
+    if missing:
+        # Do NOT cache a negative result: the operator's expected next
+        # action is to run the catalog command and retry, and we want
+        # the retry to see fresh state from the DB.
+        raise CompositeL2DependencyMissing(
+            composite_op_id=composite_op_id,
+            missing_op_ids=tuple(missing),
+            catalog_command=catalog_command_for_github_rest(),
+        )
+    _PREFLIGHT_CACHE.add(composite_op_id)
+
+
+def reset_preflight_cache() -> None:
+    """Clear the per-process gh-rest preflight cache.
+
+    Test seam (so a unit test can prime the cache, then invalidate it to
+    exercise the cache-miss path again). Not called from production
+    code; a future operator-initiated catalog-ingest signal hook would
+    call this to force the next composite dispatch to re-check.
+    """
+    _PREFLIGHT_CACHE.clear()

--- a/backend/src/meho_backplane/connectors/github/composites/_read.py
+++ b/backend/src/meho_backplane/connectors/github/composites/_read.py
@@ -1,0 +1,390 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Read-only ``gh.composite.*`` handler functions (1 composite at T4).
+
+T4 (#1224) ships the first L1 composite for the gh-rest connector:
+``gh.composite.pr_status_summary``. The pattern mirrors the vmware-rest
+composites at
+:mod:`meho_backplane.connectors.vmware_rest.composites._read` -- module-
+level async functions that take the dispatcher's composite-branch
+keyword args and route every sub-call through the injected
+``dispatch_child`` (the
+:class:`~meho_backplane.operations.composite.DispatchChild` callable).
+
+Why module-level functions
+--------------------------
+
+:func:`~meho_backplane.operations.typed_register.derive_handler_ref`
+rejects closures, ``functools.partial``, and lambdas at registration
+time. Module-level ``async def`` is the only shape the dispatcher can
+resolve via ``importlib.import_module`` + chained ``getattr`` at first-
+dispatch time.
+
+Why ``dispatch_child`` not direct httpx
+---------------------------------------
+
+The four invariants documented on the vmware-rest precedent apply
+verbatim:
+
+1. **Audit-tree linkage** -- ``dispatch_child`` binds
+   ``parent_audit_id_var`` so every sub-op's audit row carries the
+   composite parent's id.
+2. **Bounded recursion** -- ``composite_depth_var`` enforces
+   ``Settings.composite_max_depth``.
+3. **Policy + broadcast** -- the dispatcher's policy gate and broadcast
+   publish run on every dispatched sub-op.
+4. **Param validation** -- each sub-op's ``parameter_schema`` validates
+   inbound params at dispatch time.
+
+Partial-failure tolerance
+-------------------------
+
+The composite degrades gracefully on the two *secondary* sub-calls:
+
+* If ``GET:/repos/{owner}/{repo}/commits/{ref}/check-runs`` fails (e.g.
+  the repo has no checks configured -> 404), the composite returns
+  ``checks=None`` + ``checks_status="unknown"`` and continues.
+* If ``GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews`` fails,
+  the composite returns ``reviews=None`` + ``review_status="unknown"``
+  and continues.
+
+The *primary* sub-call (``GET:/repos/{owner}/{repo}/pulls/
+{pull_number}``) is non-optional -- the composite cannot extract the
+head SHA without it, so a failure there raises ``RuntimeError`` and the
+dispatcher's outer exception branch wraps it as ``connector_error``.
+
+The graceful-degradation design matches the issue body's acceptance
+criterion: "if ``gh.pr.get_checks`` 404s (no checks configured for the
+repo), the composite still returns the PR + reviews + ``checks: null``
+cleanly -- does NOT bail mid-flight."
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from meho_backplane.auth.operator import Operator
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.github.composites._preflight import (
+    preflight_l2_dependencies,
+)
+from meho_backplane.operations.composite import DispatchChild
+
+__all__ = ["pr_status_summary_composite"]
+
+
+# Connector-id constant: matches what the connector registers via
+# ``register_connector_v2(product="gh", version="3", impl_id="gh-rest")``
+# in the package ``__init__``. The version slot is the digit-prefix
+# ``"3"`` (the parse_connector_id regex's constraint), and the
+# operator-visible "v3" label lives in the catalog YAML and in docs.
+_CONNECTOR_ID = "gh-rest-3"
+
+# L2 sub-op-ids. The ingest pipeline emits op_ids as ``METHOD:/path``
+# strings (see :func:`~meho_backplane.operations.ingest.openapi.parse_openapi`).
+_OP_GET_PULL = "GET:/repos/{owner}/{repo}/pulls/{pull_number}"
+_OP_GET_CHECK_RUNS = "GET:/repos/{owner}/{repo}/commits/{ref}/check-runs"
+_OP_LIST_REVIEWS = "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews"
+
+# Composite op_id constants -- used by the preflight cache key. Mirrors
+# the vmware-rest module's pattern so the test-side coverage assertion
+# (every registered composite has both a sub-op_id tuple and a cache-key
+# constant) can read them by name.
+_COMPOSITE_OP_ID_PR_STATUS_SUMMARY = "gh.composite.pr_status_summary"
+
+# Per-composite sub-op-id tuple consumed by the L2 pre-flight check.
+# Ordered to match the dispatch sequence (PR first, then the parallel
+# pair) for readability when the exception payload surfaces the missing
+# ops in declaration order.
+_SUB_OPS_PR_STATUS_SUMMARY: tuple[str, ...] = (
+    _OP_GET_PULL,
+    _OP_GET_CHECK_RUNS,
+    _OP_LIST_REVIEWS,
+)
+
+
+def _require_ok(result: OperationResult) -> Any:
+    """Return :attr:`OperationResult.result` or raise on a non-OK status.
+
+    Used for the *primary* sub-call only. The composite cannot proceed
+    without the PR payload (the head SHA drives the checks call), so
+    the all-or-nothing semantics are appropriate here -- the dispatcher
+    wraps the raised ``RuntimeError`` into a ``connector_error`` for
+    the composite parent.
+    """
+    if result.status != "ok":
+        raise RuntimeError(
+            f"composite sub-op {result.op_id!r} returned status="
+            f"{result.status!r}: {result.error or '<no error message>'}"
+        )
+    return result.result
+
+
+def _summarize_checks(checks_payload: Any) -> str:
+    """Collapse the check-runs array into an agent-actionable status.
+
+    GitHub returns ``{"total_count": N, "check_runs": [...]}``. Each
+    run has a ``status`` (``queued`` / ``in_progress`` / ``completed``)
+    and a ``conclusion`` (``success`` / ``failure`` / ``neutral`` /
+    ``cancelled`` / ``skipped`` / ``timed_out`` / ``action_required`` /
+    ``stale`` / null).
+
+    Returns
+    -------
+    ``"all_passed"``
+        Every check is completed with conclusion in ``{success, neutral,
+        skipped}``.
+    ``"any_failed"``
+        At least one completed check has conclusion in ``{failure,
+        cancelled, timed_out, action_required, stale}``.
+    ``"pending"``
+        At least one check is not yet completed (status != "completed")
+        and no completed-fail check is present.
+    ``"no_checks"``
+        Empty ``check_runs`` array (repo has no checks configured /
+        none ran for this commit).
+    ``"unknown"``
+        Payload shape was unexpected (e.g. not a dict, or
+        ``check_runs`` missing). Caller treats this as
+        "could not determine".
+    """
+    if not isinstance(checks_payload, dict):
+        return "unknown"
+    runs = checks_payload.get("check_runs")
+    if not isinstance(runs, list):
+        return "unknown"
+    if not runs:
+        return "no_checks"
+    fail_conclusions = {
+        "failure",
+        "cancelled",
+        "timed_out",
+        "action_required",
+        "stale",
+    }
+    pass_conclusions = {"success", "neutral", "skipped"}
+    has_pending = False
+    for run in runs:
+        if not isinstance(run, dict):
+            return "unknown"
+        status = run.get("status")
+        conclusion = run.get("conclusion")
+        if status != "completed":
+            has_pending = True
+            continue
+        if conclusion in fail_conclusions:
+            return "any_failed"
+        if conclusion not in pass_conclusions:
+            # A completed run with an unexpected conclusion (e.g. null
+            # when GitHub flips a check to completed before populating
+            # conclusion). Be conservative: treat as pending.
+            has_pending = True
+    return "pending" if has_pending else "all_passed"
+
+
+def _summarize_reviews(reviews_payload: Any) -> str:
+    """Collapse the reviews array into an agent-actionable status.
+
+    GitHub returns a list of review records, each with ``user.login``
+    and ``state`` (``APPROVED`` / ``CHANGES_REQUESTED`` / ``COMMENTED``
+    / ``PENDING`` / ``DISMISSED``). The list is in chronological order;
+    the *latest* review per reviewer is what matters for the merge
+    decision.
+
+    Returns
+    -------
+    ``"changes_requested"``
+        Any reviewer's latest review is ``CHANGES_REQUESTED``. A single
+        outstanding "request changes" vetoes the PR.
+    ``"approved"``
+        At least one reviewer's latest is ``APPROVED`` and no reviewer
+        has an outstanding ``CHANGES_REQUESTED``.
+    ``"commented"``
+        Reviewers have commented but no approval / changes-requested
+        verdict is on file.
+    ``"pending"``
+        Only ``PENDING`` reviews exist (drafts the reviewer hasn't
+        submitted).
+    ``"no_reviews"``
+        Empty array (no reviews yet).
+    ``"unknown"``
+        Payload was not a list (call failed earlier, or the upstream
+        returned an unexpected shape).
+    """
+    if not isinstance(reviews_payload, list):
+        return "unknown"
+    if not reviews_payload:
+        return "no_reviews"
+    # Latest review per reviewer login wins -- the list is chronological
+    # so iterating left-to-right and overwriting yields the latest.
+    # ``DISMISSED`` reviews drop out of the tally (the dismissing UI
+    # event is itself recorded as a state change; the dismissed entry
+    # no longer counts).
+    latest_per_reviewer: dict[str, str] = {}
+    for review in reviews_payload:
+        if not isinstance(review, dict):
+            return "unknown"
+        state = review.get("state")
+        if not isinstance(state, str):
+            continue
+        login = _review_login(review)
+        if login is None:
+            continue
+        if state == "DISMISSED":
+            latest_per_reviewer.pop(login, None)
+            continue
+        latest_per_reviewer[login] = state
+    if not latest_per_reviewer:
+        return "no_reviews"
+    states = set(latest_per_reviewer.values())
+    if "CHANGES_REQUESTED" in states:
+        return "changes_requested"
+    if "APPROVED" in states:
+        return "approved"
+    if "COMMENTED" in states:
+        return "commented"
+    if "PENDING" in states:
+        return "pending"
+    return "unknown"
+
+
+def _review_login(review: dict[str, Any]) -> str | None:
+    """Extract the reviewer login from a review record, defensively."""
+    user = review.get("user")
+    if not isinstance(user, dict):
+        return None
+    login = user.get("login")
+    return login if isinstance(login, str) else None
+
+
+def _extract_head_sha(pr_payload: Any) -> str | None:
+    """Return ``pr.head.sha`` or ``None`` when the shape is unexpected.
+
+    The PR sub-call's response shape is the GitHub PR object; the head
+    SHA lives at ``head.sha``. Defensive shape checks let the composite
+    surface a typed error if the upstream returns a malformed payload
+    rather than crashing on a chained ``[...]`` lookup.
+    """
+    if not isinstance(pr_payload, dict):
+        return None
+    head = pr_payload.get("head")
+    if not isinstance(head, dict):
+        return None
+    sha = head.get("sha")
+    return sha if isinstance(sha, str) and sha else None
+
+
+async def pr_status_summary_composite(
+    *,
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+    dispatch_child: DispatchChild,
+) -> dict[str, Any]:
+    """Aggregate PR metadata + checks + reviews + mergeable in one envelope.
+
+    Op-id: ``gh.composite.pr_status_summary``.
+
+    Sub-ops dispatched:
+
+    1. ``GET:/repos/{owner}/{repo}/pulls/{pull_number}`` -- the PR
+       payload. Required; failure raises ``RuntimeError``.
+    2. ``GET:/repos/{owner}/{repo}/commits/{ref}/check-runs`` against
+       the head SHA from step 1. Optional; failure surfaces as
+       ``checks=None`` + ``checks_status="unknown"``.
+    3. ``GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews`` --
+       reviews list. Optional; failure surfaces as ``reviews=None`` +
+       ``review_status="unknown"``.
+
+    Steps 2 and 3 fire in parallel via :func:`asyncio.gather` -- they
+    are independent (neither depends on the other's output) and run
+    over the same authenticated session, so a parallel fanout halves
+    the operator-perceived latency vs. sequential dispatch.
+
+    Returns
+    -------
+    dict[str, Any]
+        ``{"pr": <PR payload>, "checks": <check-runs payload | None>,
+        "reviews": <reviews list | None>, "mergeable": <bool | None>,
+        "mergeable_state": <str | None>, "checks_status": <enum>,
+        "review_status": <enum>}``. See
+        :data:`schemas.PR_STATUS_SUMMARY_RESPONSE_SCHEMA` for the
+        per-key contract.
+
+    Raises
+    ------
+    CompositeL2DependencyMissing
+        Pre-flight detected that at least one of the three L2 sub-ops
+        is not registered in ``endpoint_descriptor``. The exception
+        carries the missing op-ids + the catalog command to run.
+        Surfaced to the operator as a structured
+        ``composite_l2_missing`` :class:`OperationResult` by the
+        dispatcher's exception branch.
+    RuntimeError
+        The primary PR sub-call failed, or the PR payload was malformed
+        (no head SHA extractable). Wrapped into a ``connector_error``
+        :class:`OperationResult` by the dispatcher's outer exception
+        branch.
+    """
+    await preflight_l2_dependencies(
+        composite_op_id=_COMPOSITE_OP_ID_PR_STATUS_SUMMARY,
+        sub_op_ids=_SUB_OPS_PR_STATUS_SUMMARY,
+        connector_id=_CONNECTOR_ID,
+        tenant_id=operator.tenant_id,
+    )
+    owner = params["owner"]
+    repo = params["repo"]
+    pull_number = params["pull_number"]
+    pr_params = {"owner": owner, "repo": repo, "pull_number": pull_number}
+
+    pr_payload = _require_ok(
+        await dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_GET_PULL,
+            params=pr_params,
+        )
+    )
+    head_sha = _extract_head_sha(pr_payload)
+    if head_sha is None:
+        # The PR call succeeded but the response shape is unexpected.
+        # Surface as RuntimeError rather than silently using a stale /
+        # empty SHA; the dispatcher's outer branch wraps it cleanly.
+        raise RuntimeError(
+            f"pr_status_summary: PR payload from {_OP_GET_PULL!r} did not carry a head.sha "
+            f"string for {owner}/{repo}#{pull_number}; got payload type "
+            f"{type(pr_payload).__name__}"
+        )
+
+    checks_result, reviews_result = await asyncio.gather(
+        dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_GET_CHECK_RUNS,
+            params={"owner": owner, "repo": repo, "ref": head_sha},
+        ),
+        dispatch_child(
+            connector_id=_CONNECTOR_ID,
+            op_id=_OP_LIST_REVIEWS,
+            params=pr_params,
+        ),
+        return_exceptions=False,
+    )
+
+    checks_payload: Any = checks_result.result if checks_result.status == "ok" else None
+    reviews_payload: Any = reviews_result.result if reviews_result.status == "ok" else None
+
+    pr_dict = pr_payload if isinstance(pr_payload, dict) else {}
+    return {
+        "pr": pr_payload,
+        "checks": checks_payload,
+        "reviews": reviews_payload,
+        "mergeable": pr_dict.get("mergeable"),
+        "mergeable_state": pr_dict.get("mergeable_state"),
+        "checks_status": (
+            _summarize_checks(checks_payload) if checks_payload is not None else "unknown"
+        ),
+        "review_status": (
+            _summarize_reviews(reviews_payload) if reviews_payload is not None else "unknown"
+        ),
+    }

--- a/backend/src/meho_backplane/connectors/github/composites/_register.py
+++ b/backend/src/meho_backplane/connectors/github/composites/_register.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""``register_github_composite_operations`` -- registrar for gh-rest composites.
+
+Module-level async function called from the lifespan-driven
+:func:`~meho_backplane.operations.typed_register.run_typed_op_registrars`
+after the registrar list is populated by the
+:mod:`meho_backplane.connectors.github.composites` package's
+``__init__`` (which appends this function via
+:func:`register_typed_op_registrar`).
+
+Mirrors the vmware-rest precedent
+(:mod:`meho_backplane.connectors.vmware_rest.composites._register`):
+per-composite arguments (summary / description / group_key / tags /
+``parameter_schema`` / ``safety_level`` / ``requires_approval``) live
+in this module so a future shape change touches one file. The helper
+:func:`~meho_backplane.operations.typed_register.register_composite_operation`
+handles upsert, body-hash dedupe, embedding pipeline, and
+``source_kind="composite"`` persistence.
+
+Scope at T4 (#1224)
+-------------------
+
+One composite ships: ``gh.composite.pr_status_summary``. It is read-
+only (``safety_level="read"`` / ``requires_approval=False``) -- the
+issue body's mandatory posture for the trigger use case (the operator
+asks "is PR #N ready to merge?" and gets a structured answer without
+mutating anything).
+
+The composite-helper's defaults are ``safety_level="dangerous"`` +
+``requires_approval=True`` (suited to write composites); the read
+composite explicitly overrides both. Future T7+ write composites will
+omit the override and inherit the helper's safe-by-default policy.
+
+``safety_level`` value note
+---------------------------
+
+The issue body specifies ``safety_level="read"``. The
+:func:`~meho_backplane.operations.typed_register.register_composite_operation`
+helper validates against the enum ``{"safe", "caution", "dangerous"}``
+(see the ``Literal`` annotation on its signature). ``"safe"`` is the
+register-time equivalent of the operator-visible "read" label -- the
+descriptor row stores ``safety_level="safe"`` and ``op_class="read"``
+is computed elsewhere from method semantics. The registrar passes
+``"safe"``; the issue body's "read" wording maps to this verbatim.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, Literal, NamedTuple
+
+from meho_backplane.connectors.github.composites._read import (
+    pr_status_summary_composite,
+)
+from meho_backplane.connectors.github.composites.schemas import (
+    PR_STATUS_SUMMARY_PARAMETER_SCHEMA,
+    PR_STATUS_SUMMARY_RESPONSE_SCHEMA,
+)
+from meho_backplane.operations.typed_register import register_composite_operation
+from meho_backplane.retrieval.embedding import EmbeddingService
+
+__all__ = ["register_github_composite_operations"]
+
+
+# Natural-key shorthand. Every gh-rest composite registers against the
+# same triple the connector advertises -- ``register_connector_v2(
+# product="gh", version="3", impl_id="gh-rest", ...)`` in the package
+# ``__init__`` -- so the dispatcher's ``connector_id="gh-rest-3"``
+# lookup resolves the composite alongside the ingested L2 ops.
+_PRODUCT = "gh"
+_VERSION = "3"
+_IMPL_ID = "gh-rest"
+
+
+#: Curated agent-actionable group selectors for the gh-rest composite
+#: surface, surfaced verbatim by ``list_operation_groups`` so the LLM
+#: client picks the right composite group before drilling into
+#: ``search_operations``. T4 ships exactly one composite (the ``pulls``
+#: group); future T7+ composites populate ``release``, ``board``, etc.
+_WHEN_TO_USE_BY_GROUP: dict[str, str] = {
+    "pulls": (
+        "Use for one-call PR-status questions: 'is PR #N ready to "
+        "merge?' / 'what is the CI state on the head commit?' / 'who "
+        "approved this PR?'. The composite gathers PR metadata, "
+        "head-commit check runs, reviews, and the mergeable state in "
+        "a single envelope so the LLM client does not have to "
+        "orchestrate three separate L2 calls. Read-only. Pair with the "
+        "ingested L2 ops (gh.pr.get_files, gh.pr.get_commits, etc.) "
+        "when drill-in beyond the summary is needed."
+    ),
+}
+
+
+class _CompositeSpec(NamedTuple):
+    """Per-composite registration arguments.
+
+    Field-table form rather than per-composite kwargs blocks: keeps the
+    op_id / handler / schemas / group / tags / policy posture adjacent
+    so a future maintainer reading the registrar sees the whole row at
+    a glance. Common fields (``product`` / ``version`` / ``impl_id``)
+    live on the call site below.
+    """
+
+    op_id: str
+    handler: Callable[..., Awaitable[dict[str, Any]]]
+    summary: str
+    description: str
+    parameter_schema: dict[str, Any]
+    response_schema: dict[str, Any]
+    group_key: str
+    tags: list[str]
+    safety_level: Literal["safe", "caution", "dangerous"]
+    requires_approval: bool
+
+
+_COMPOSITES: tuple[_CompositeSpec, ...] = (
+    _CompositeSpec(
+        op_id="gh.composite.pr_status_summary",
+        handler=pr_status_summary_composite,
+        summary="Return PR metadata + checks + reviews + mergeable in one call.",
+        description=(
+            "Composes three L2 sub-ops -- GET:/repos/{owner}/{repo}/"
+            "pulls/{pull_number}, GET:/repos/{owner}/{repo}/commits/"
+            "{ref}/check-runs (against the PR's head SHA), and "
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews -- "
+            "into a single envelope. Answers 'is this PR ready to "
+            "merge?' without three separate L2 calls. Read-only; "
+            "degrades gracefully when the checks or reviews sub-call "
+            "fails (the failed field surfaces as null + a "
+            "checks_status / review_status of 'unknown'). Equivalent "
+            "of 'gh pr view <n> --json ...' for an LLM client that "
+            "needs the answer in one round-trip through MEHO. The "
+            "primary PR sub-call is non-optional -- a 404 / 401 on "
+            "that call propagates to the operator as a connector "
+            "error."
+        ),
+        parameter_schema=PR_STATUS_SUMMARY_PARAMETER_SCHEMA,
+        response_schema=PR_STATUS_SUMMARY_RESPONSE_SCHEMA,
+        group_key="pulls",
+        tags=["composite", "read-only", "pulls", "status"],
+        safety_level="safe",
+        requires_approval=False,
+    ),
+)
+
+
+async def register_github_composite_operations(
+    *,
+    embedding_service: EmbeddingService | None = None,
+) -> None:
+    """Upsert every gh-rest composite into ``endpoint_descriptor``.
+
+    Idempotent: a second invocation against unchanged descriptions is a
+    no-op for the embedding pipeline (the body-hash skip path in
+    :func:`_register_in_session`). The runner
+    (:func:`run_typed_op_registrars`) calls every registered registrar
+    on every lifespan startup; the skip-re-embed branch keeps that
+    cheap.
+
+    Scope at T4: one composite -- ``gh.composite.pr_status_summary`` --
+    with ``safety_level="safe"`` (the register-time equivalent of the
+    operator-visible "read" label per the issue body) and
+    ``requires_approval=False``. Future T7+ Tasks add write composites
+    that inherit the helper's safe-by-default ``dangerous`` /
+    ``requires_approval=True`` posture.
+
+    Test seam: ``embedding_service`` lets test fixtures inject a stub
+    so unit tests don't load the ONNX model. Production callers leave
+    it ``None`` and each registration resolves the process-wide
+    singleton.
+    """
+    for spec in _COMPOSITES:
+        await register_composite_operation(
+            product=_PRODUCT,
+            version=_VERSION,
+            impl_id=_IMPL_ID,
+            op_id=spec.op_id,
+            handler=spec.handler,
+            summary=spec.summary,
+            description=spec.description,
+            parameter_schema=spec.parameter_schema,
+            response_schema=spec.response_schema,
+            group_key=spec.group_key,
+            when_to_use=_WHEN_TO_USE_BY_GROUP[spec.group_key],
+            tags=spec.tags,
+            safety_level=spec.safety_level,
+            requires_approval=spec.requires_approval,
+            embedding_service=embedding_service,
+        )

--- a/backend/src/meho_backplane/connectors/github/composites/schemas.py
+++ b/backend/src/meho_backplane/connectors/github/composites/schemas.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""JSON Schema 2020-12 parameter + response schemas for gh-rest composites.
+
+Same conventions as the vmware-rest composite schemas module
+(G3.1-T5 #508 / T6 #509):
+
+* ``additionalProperties=False`` on every parameter schema so an
+  operator typo on an optional key surfaces as a clear validation error
+  rather than disappearing through a permissive shape.
+* Schemas declare only what the handler reads. Per-composite
+  documentation lives on ``description`` keys; ``describe_operation``
+  surfaces the schema verbatim to LLM clients.
+* T4 ships exactly one composite -- ``gh.composite.pr_status_summary``
+  -- which is read-only (``safety_level="read"`` /
+  ``requires_approval=False`` per the issue body). Future T7+ Tasks
+  add write composites and reuse this module's pattern.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "PR_STATUS_SUMMARY_PARAMETER_SCHEMA",
+    "PR_STATUS_SUMMARY_RESPONSE_SCHEMA",
+]
+
+
+PR_STATUS_SUMMARY_PARAMETER_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["owner", "repo", "pull_number"],
+    "properties": {
+        "owner": {
+            "type": "string",
+            "minLength": 1,
+            "description": "GitHub repository owner (user or organisation login).",
+        },
+        "repo": {
+            "type": "string",
+            "minLength": 1,
+            "description": "GitHub repository name (without the owner prefix).",
+        },
+        "pull_number": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "The pull-request number (the integer suffix in /pull/<N> URLs).",
+        },
+    },
+    "description": (
+        "Parameters for gh.composite.pr_status_summary. Returns the PR "
+        "metadata, the head-commit check runs, the reviews, and the "
+        "mergeable state in a single envelope -- answers 'is this PR "
+        "ready to merge?' without three separate L2 calls."
+    ),
+}
+
+
+PR_STATUS_SUMMARY_RESPONSE_SCHEMA: dict[str, Any] = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": [
+        "pr",
+        "checks",
+        "reviews",
+        "mergeable",
+        "mergeable_state",
+        "checks_status",
+        "review_status",
+    ],
+    "properties": {
+        "pr": {
+            "description": (
+                "Pull-request payload from GET /repos/{owner}/{repo}/pulls/"
+                "{pull_number}. The composite surfaces it verbatim so an "
+                "operator can read any field the upstream returns. Required "
+                "(the composite errors out when the PR itself cannot be "
+                "fetched -- partial-failure tolerance applies only to the "
+                "checks and reviews sub-calls)."
+            ),
+        },
+        "checks": {
+            "description": (
+                "Response from GET /repos/{owner}/{repo}/commits/{ref}/"
+                "check-runs against the PR's head SHA. ``null`` when the "
+                "sub-call failed (e.g. 404 because the repo has no checks "
+                "configured); the composite degrades gracefully on this "
+                "particular sub-call rather than aborting the whole "
+                "envelope. ``checks_status`` summarises whether checks "
+                "are all-passing / any-failed / pending / unknown."
+            ),
+        },
+        "reviews": {
+            "description": (
+                "List of review records from GET /repos/{owner}/{repo}/"
+                "pulls/{pull_number}/reviews. ``null`` when the sub-call "
+                "failed; the composite degrades gracefully here too. "
+                "``review_status`` summarises the latest disposition per "
+                "reviewer (approved / changes_requested / commented / "
+                "pending / unknown)."
+            ),
+        },
+        "mergeable": {
+            "type": ["boolean", "null"],
+            "description": (
+                "PR's ``mergeable`` field. GitHub computes this "
+                "asynchronously after a push and returns ``null`` until "
+                "the background job runs; the composite passes that "
+                "tri-state through verbatim."
+            ),
+        },
+        "mergeable_state": {
+            "type": ["string", "null"],
+            "description": (
+                "PR's ``mergeable_state`` (``clean``, ``dirty``, "
+                "``blocked``, ``behind``, ``unknown``, etc.). "
+                "Pass-through from the upstream payload."
+            ),
+        },
+        "checks_status": {
+            "type": "string",
+            "enum": [
+                "all_passed",
+                "any_failed",
+                "pending",
+                "no_checks",
+                "unknown",
+            ],
+            "description": (
+                "Composite-computed summary of the check-runs payload. "
+                "``unknown`` when the checks sub-call failed; "
+                "``no_checks`` when the call succeeded but returned an "
+                "empty array; otherwise derived from the per-run "
+                "``conclusion`` / ``status`` fields."
+            ),
+        },
+        "review_status": {
+            "type": "string",
+            "enum": [
+                "approved",
+                "changes_requested",
+                "commented",
+                "pending",
+                "no_reviews",
+                "unknown",
+            ],
+            "description": (
+                "Composite-computed summary of the reviews payload. "
+                "``unknown`` when the reviews sub-call failed; "
+                "``no_reviews`` when it returned an empty array; "
+                "otherwise derived from the latest-per-reviewer "
+                "disposition with ``changes_requested`` as the dominant "
+                "veto."
+            ),
+        },
+    },
+    "description": (
+        "Aggregated PR-status envelope. Designed for the 'is this PR "
+        "ready to merge?' agent question -- one composite call yields "
+        "the four signals the LLM client needs (metadata, checks, "
+        "reviews, mergeable) plus two pre-computed summaries that "
+        "collapse the per-record arrays into agent-actionable states."
+    ),
+}

--- a/backend/tests/integration/test_github_composite_dispatch.py
+++ b/backend/tests/integration/test_github_composite_dispatch.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Live-ingest dispatch acceptance for ``gh.composite.pr_status_summary`` (G3.11-T4 #1224).
+
+Gated on ``MEHO_GH_INGEST_LIVE=1`` (same env var as
+``tests/integration/test_operations_ingest_github.py`` from G3.11-T3
+#1228). When the env var is unset the test is skipped; when it is set,
+the test is currently :func:`pytest.xfail`-marked with ``strict=True``
+because of an upstream parser limitation documented below.
+
+**KNOWN PARSER-LIMITATION DEPENDENCY.**
+
+The G0.7 OpenAPI parser at
+``backend/src/meho_backplane/operations/ingest/refs.py`` only inlines
+``#/components/schemas/*`` and ``#/components/parameters/*`` ``$ref``
+shapes. The GitHub REST spec uses ``#/components/responses/*`` refs
+extensively (e.g. ``#/components/responses/accepted``), and the parser
+raises ``UnsupportedSpecError`` on the first one. This blocks T4's
+acceptance criterion #1 ("``gh.composite.pr_status_summary`` registered
++ dispatchable") from running end-to-end against the live spec until a
+sibling parser-scope follow-up Task lifts the ref-bucket coverage.
+
+The composite *registration* itself is not blocked -- the unit tests in
+``tests/test_connectors_github_composites_register.py`` exercise the
+register path without ingest, and the unit tests in
+``tests/test_connectors_github_composites_read.py`` cover the handler's
+dispatch logic with mocked ``dispatch_child``. What is xfailed here is
+the *L1-on-top-of-L2 dispatch* round-trip against a real running
+backplane + a real GitHub PR.
+
+Once the parser-scope follow-up lands and the catalog ingests cleanly,
+this test's ``xfail(strict=True)`` flips to ``xpass`` and CI fails
+loudly -- prompting the maintainer to remove the xfail mark and re-
+qualify the docstring. That's the desired hand-off shape: the test
+self-advertises when its blocker has lifted.
+
+**How to run locally.** Once the parser fix lands, with a backplane up,
+a GitHub App credential provisioned in Vault, and the catalog ingested::
+
+    MEHO_GH_INGEST_LIVE=1 \\
+      uv run --package meho-backplane pytest -q \\
+      backend/tests/integration/test_github_composite_dispatch.py
+
+The full ingest round-trip (``POST /api/v1/connectors/ingest`` with
+``catalog_entry: gh/v3``) is exercised by the operator runbook in
+``docs/cross-repo/github-connector.md`` (G3.11-T6); this test only
+covers the composite-dispatch leg downstream of that.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+def _live_ingest_opted_in() -> bool:
+    """Return ``True`` when ``MEHO_GH_INGEST_LIVE=1`` is set."""
+    return os.getenv("MEHO_GH_INGEST_LIVE") == "1"
+
+
+@pytest.mark.skipif(
+    not _live_ingest_opted_in(),
+    reason=(
+        "GitHub live composite dispatch gated by MEHO_GH_INGEST_LIVE=1 "
+        "(G3.11-T4 #1224 acceptance criterion #2). Unit tests cover the "
+        "composite handler + register paths; this test verifies "
+        "end-to-end L1+L2 dispatch against a live spec ingest."
+    ),
+)
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "G0.7 parser only inlines #/components/schemas/* and "
+        "#/components/parameters/* refs; the GitHub spec uses "
+        "#/components/responses/* refs and the parser raises "
+        "UnsupportedSpecError on ingest. Out of scope for T4 (composite "
+        "implementation); a sibling parser-scope follow-up lifts the "
+        "ref-bucket coverage. xfail flips to xpass once that lands -- "
+        "remove the mark + this rationale block then."
+    ),
+)
+def test_pr_status_summary_dispatches_against_live_pr() -> None:
+    """Composite end-to-end dispatch against a real GitHub PR.
+
+    The intended shape, once the parser fix lands:
+
+    1. Ingest the catalog entry ``gh/v3`` (registers ~700 L2 ops).
+    2. Dispatch ``gh.composite.pr_status_summary`` with ``owner=evoila,
+       repo=meho, pull_number=754`` (or another live PR on a repo the
+       App can read).
+    3. Assert the result envelope carries ``pr``, ``checks``, ``reviews``,
+       ``mergeable``, ``mergeable_state``, ``checks_status``, and
+       ``review_status`` keys.
+    4. Assert ``checks_status`` is one of the enum values from the
+       response schema (not "unknown" -- the live PR has CI configured).
+
+    Until the parser limitation is lifted, this body short-circuits via
+    the ``xfail(strict=True)`` mark above so the test documents the
+    dependency without claiming to pass.
+    """
+    # When the parser fix lands and the catalog ingests cleanly, this
+    # body fills in with the dispatch + assertions sketched above. For
+    # now, the xfail mark short-circuits the test; we still raise here
+    # to make strict=True meaningful (the body fails until the parser
+    # is fixed).
+    raise NotImplementedError(
+        "gh.composite.pr_status_summary live dispatch is xfailed pending "
+        "G0.7 parser support for #/components/responses/* refs; see the "
+        "module docstring for the dependency + run instructions."
+    )

--- a/backend/tests/test_connectors_github_composites_l2_preflight.py
+++ b/backend/tests/test_connectors_github_composites_l2_preflight.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the gh-rest L2 dependency pre-flight check (G3.11-T4 #1224).
+
+Mirrors :mod:`tests.test_connectors_vmware_rest_composites_l2_preflight`
+(the G0.14-T10 / #1183 precedent). Coverage matrix:
+
+* Cache miss + all L2 sub-ops present -> :func:`preflight_l2_dependencies`
+  returns ``None`` and populates the cache; second call short-circuits.
+* Cache miss + at least one L2 sub-op missing -> raises
+  :class:`CompositeL2DependencyMissing` with every missing op_id listed
+  and the catalog command resolved.
+* Negative result is NOT cached -- a subsequent call after the catalog
+  is ingested sees the up-to-date state.
+* Composite-to-composite sub-ops (``gh.composite.*``) are skipped by
+  the pre-flight (they cannot fail this way; their handlers run their
+  own pre-flight).
+* The pre-flight runs once per composite-op_id per process -- repeated
+  calls for the same composite are O(1) cache hits.
+
+The tests stub :func:`~meho_backplane.operations._lookup.lookup_descriptor`
+via :class:`monkeypatch.setattr` so they don't require a populated
+``endpoint_descriptor`` table; the contract under test is the helper's
+walk + caching, not the descriptor table.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from meho_backplane.connectors.github.composites import _preflight
+from meho_backplane.connectors.github.composites._preflight import (
+    preflight_l2_dependencies,
+    reset_preflight_cache,
+)
+from meho_backplane.operations import CompositeL2DependencyMissing
+
+_TENANT_ID = UUID("00000000-0000-0000-0000-00000000beef")
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache_around_each_test() -> Iterator[None]:
+    """Empty the pre-flight cache before + after every test in this module."""
+    reset_preflight_cache()
+    yield
+    reset_preflight_cache()
+
+
+def _patch_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    present: set[str],
+) -> list[str]:
+    """Stub :func:`lookup_descriptor` to behave as if ``present`` is the registered set."""
+    calls: list[str] = []
+
+    async def _stub_lookup_descriptor(
+        *, tenant_id: Any, product: str, version: str, impl_id: str, op_id: str
+    ) -> object | None:
+        calls.append(op_id)
+        if op_id in present:
+            return object()  # truthy non-None descriptor stand-in
+        return None
+
+    monkeypatch.setattr(_preflight, "lookup_descriptor", _stub_lookup_descriptor)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_preflight_all_sub_ops_present_returns_and_caches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Happy path: every sub-op resolves; second call is a cache hit."""
+    sub_ops: tuple[str, ...] = (
+        "GET:/repos/{owner}/{repo}/pulls/{pull_number}",
+        "GET:/repos/{owner}/{repo}/commits/{ref}/check-runs",
+        "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+    )
+    calls = _patch_lookup(monkeypatch, present=set(sub_ops))
+    composite_op_id = "gh.composite.pr_status_summary"
+
+    await preflight_l2_dependencies(
+        composite_op_id=composite_op_id,
+        sub_op_ids=sub_ops,
+        connector_id="gh-rest-3",
+        tenant_id=_TENANT_ID,
+    )
+    assert calls == list(sub_ops)
+    assert composite_op_id in _preflight._PREFLIGHT_CACHE
+
+    # Second call: cache hit, no extra lookups.
+    await preflight_l2_dependencies(
+        composite_op_id=composite_op_id,
+        sub_op_ids=sub_ops,
+        connector_id="gh-rest-3",
+        tenant_id=_TENANT_ID,
+    )
+    assert calls == list(sub_ops), "cache hit on second call -> no extra lookups"
+
+
+@pytest.mark.asyncio
+async def test_preflight_missing_sub_op_raises_with_full_missing_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing L2: every absent op_id surfaces in one exception payload."""
+    _patch_lookup(
+        monkeypatch,
+        present={"GET:/repos/{owner}/{repo}/pulls/{pull_number}"},  # only one of three
+    )
+    sub_ops: tuple[str, ...] = (
+        "GET:/repos/{owner}/{repo}/pulls/{pull_number}",
+        "GET:/repos/{owner}/{repo}/commits/{ref}/check-runs",
+        "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+    )
+    with pytest.raises(CompositeL2DependencyMissing) as exc_info:
+        await preflight_l2_dependencies(
+            composite_op_id="gh.composite.pr_status_summary",
+            sub_op_ids=sub_ops,
+            connector_id="gh-rest-3",
+            tenant_id=_TENANT_ID,
+        )
+    exc = exc_info.value
+    assert exc.composite_op_id == "gh.composite.pr_status_summary"
+    # Both missing ops surfaced; ordering matches sub-op declaration.
+    assert exc.missing_op_ids == (
+        "GET:/repos/{owner}/{repo}/commits/{ref}/check-runs",
+        "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+    )
+    assert exc.catalog_command == "meho connector ingest --catalog gh/v3"
+    # Negative result NOT cached: a retry after operator ingestion must
+    # re-walk and pass.
+    assert "gh.composite.pr_status_summary" not in _preflight._PREFLIGHT_CACHE
+
+
+@pytest.mark.asyncio
+async def test_preflight_skips_composite_sub_ops(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``gh.composite.*`` sub-ops are not walked (no DB calls)."""
+    calls = _patch_lookup(monkeypatch, present=set())
+    await preflight_l2_dependencies(
+        composite_op_id="gh.composite.future_recursive",
+        sub_op_ids=("gh.composite.pr_status_summary",),
+        connector_id="gh-rest-3",
+        tenant_id=_TENANT_ID,
+    )
+    assert calls == [], "composite sub-ops are skipped, not walked"
+    # Cache key still landed (subsequent calls are O(1)).
+    assert "gh.composite.future_recursive" in _preflight._PREFLIGHT_CACHE
+
+
+@pytest.mark.asyncio
+async def test_preflight_re_runs_after_cache_reset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test seam: clearing the cache forces a re-walk on the next call."""
+    sub_ops: tuple[str, ...] = ("GET:/repos/{owner}/{repo}/pulls/{pull_number}",)
+    calls = _patch_lookup(monkeypatch, present=set(sub_ops))
+    composite_op_id = "gh.composite.pr_status_summary"
+
+    await preflight_l2_dependencies(
+        composite_op_id=composite_op_id,
+        sub_op_ids=sub_ops,
+        connector_id="gh-rest-3",
+        tenant_id=_TENANT_ID,
+    )
+    assert calls == list(sub_ops)
+    reset_preflight_cache()
+    await preflight_l2_dependencies(
+        composite_op_id=composite_op_id,
+        sub_op_ids=sub_ops,
+        connector_id="gh-rest-3",
+        tenant_id=_TENANT_ID,
+    )
+    # Reset forced a second walk -- same op observed twice.
+    assert calls == list(sub_ops) + list(sub_ops)

--- a/backend/tests/test_connectors_github_composites_read.py
+++ b/backend/tests/test_connectors_github_composites_read.py
@@ -1,0 +1,534 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Unit tests for ``gh.composite.pr_status_summary`` (G3.11-T4 #1224).
+
+Coverage matrix:
+
+* Happy path -- three sub-ops fire in the expected order with the right
+  params; head SHA flows from the PR sub-call into the check-runs call;
+  the aggregated envelope matches the documented shape.
+* Parallelism -- the two secondary sub-ops fire concurrently
+  (``asyncio.gather``) rather than sequentially.
+* Partial-failure tolerance:
+  * Checks sub-call errors -> ``checks=None`` + ``checks_status="unknown"``;
+    composite still returns the PR + reviews cleanly.
+  * Reviews sub-call errors -> ``reviews=None`` + ``review_status="unknown"``;
+    composite still returns the PR + checks cleanly.
+  * Both secondaries fail -> composite still returns the PR with the
+    two None / "unknown" payloads.
+* Primary failure -- PR sub-call returns ``status="error"`` raises
+  ``RuntimeError`` (load-bearing for the dispatcher's
+  ``connector_error`` wrapping at the composite parent).
+* Malformed PR payload (no head.sha) raises ``RuntimeError``.
+* Status summarisers (``_summarize_checks`` / ``_summarize_reviews``)
+  collapse the raw arrays into the agent-actionable enum values.
+
+The L2 pre-flight is exercised separately in
+``test_connectors_github_composites_l2_preflight.py``; this module
+primes the pre-flight cache so handler-direct tests skip the DB walk.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.github.composites import _preflight
+from meho_backplane.connectors.github.composites._read import (
+    _summarize_checks,
+    _summarize_reviews,
+    pr_status_summary_composite,
+)
+
+
+@pytest.fixture(autouse=True)
+def _prime_preflight_cache() -> Iterator[None]:
+    """Prime the L2 pre-flight cache so handler-direct tests skip the DB walk.
+
+    Same pattern as the vmware-rest read-composite tests. The pre-flight
+    behaviour (cache miss + DB walk; missing-L2 -> structured exception)
+    is exercised in the dedicated preflight test module where a stub
+    ``lookup_descriptor`` covers both code paths.
+    """
+    _preflight.reset_preflight_cache()
+    _preflight._PREFLIGHT_CACHE.add("gh.composite.pr_status_summary")
+    yield
+    _preflight.reset_preflight_cache()
+
+
+def _make_operator() -> Operator:
+    """Synthetic operator for composite-handler unit tests."""
+    return Operator(
+        sub="op-gh-composite-read",
+        name="GH Composite Read Test",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0a0"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+def _ok_result(op_id: str, result: Any) -> OperationResult:
+    return OperationResult(status="ok", op_id=op_id, result=result, duration_ms=1.0)
+
+
+def _err_result(op_id: str, error: str) -> OperationResult:
+    return OperationResult(status="error", op_id=op_id, error=error, duration_ms=1.0)
+
+
+class _RecordingDispatchChild:
+    """Lightweight ``dispatch_child`` stub matching the DispatchChild Protocol.
+
+    Maps op_id -> canned :class:`OperationResult` (or raw payload, in
+    which case it's wrapped as ``status="ok"``). Records every call's
+    keyword args so the test can assert call-shape and parallelism.
+    """
+
+    def __init__(self, responses: dict[str, Any]) -> None:
+        self._responses = responses
+        self.calls: list[dict[str, Any]] = []
+        # Allows simulating gather() concurrency by holding both
+        # secondary calls until the second one arrives.
+        self.barrier: asyncio.Event | None = None
+        self._gather_targets: set[str] = set()
+
+    def set_gather_barrier(self, op_ids: set[str]) -> None:
+        """Hold every dispatch of these op_ids until both have entered.
+
+        Used by ``test_secondary_sub_ops_run_in_parallel`` to demonstrate
+        that the handler issues both secondary calls concurrently. The
+        barrier releases when ``len(in_flight) == len(op_ids)``; a
+        sequential handler would deadlock on the first call.
+        """
+        self.barrier = asyncio.Event()
+        self._gather_targets = set(op_ids)
+        self._in_flight: list[str] = []
+
+    async def __call__(
+        self,
+        *,
+        connector_id: str,
+        op_id: str,
+        params: dict[str, Any],
+        target: Any = None,
+    ) -> OperationResult:
+        self.calls.append(
+            {"connector_id": connector_id, "op_id": op_id, "params": dict(params), "target": target}
+        )
+        if self.barrier is not None and op_id in self._gather_targets:
+            self._in_flight.append(op_id)
+            if len(self._in_flight) >= len(self._gather_targets):
+                self.barrier.set()
+            await self.barrier.wait()
+        payload = self._responses[op_id]
+        if isinstance(payload, OperationResult):
+            return payload
+        return _ok_result(op_id, payload)
+
+
+def _pr_payload(head_sha: str = "abc123", **overrides: Any) -> dict[str, Any]:
+    """Build a minimal GitHub PR payload with the head.sha field populated."""
+    payload: dict[str, Any] = {
+        "number": 754,
+        "head": {"sha": head_sha, "ref": "feat/x"},
+        "mergeable": True,
+        "mergeable_state": "clean",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _checks_payload(*runs: dict[str, Any]) -> dict[str, Any]:
+    return {"total_count": len(runs), "check_runs": list(runs)}
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pr_status_summary_dispatches_three_sub_ops_in_order() -> None:
+    """PR first, then checks + reviews; head SHA flows into the checks call."""
+    pr = _pr_payload(head_sha="76065a0")
+    checks = _checks_payload(
+        {"name": "build", "status": "completed", "conclusion": "success"},
+        {"name": "test", "status": "completed", "conclusion": "success"},
+    )
+    reviews = [
+        {"user": {"login": "reviewer-a"}, "state": "APPROVED"},
+    ]
+    dispatch = _RecordingDispatchChild(
+        {
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}": pr,
+            "GET:/repos/{owner}/{repo}/commits/{ref}/check-runs": checks,
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews": reviews,
+        }
+    )
+    out = await pr_status_summary_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"owner": "evoila", "repo": "meho", "pull_number": 754},
+        dispatch_child=dispatch,
+    )
+    # PR call fires first; the two secondaries can land in either order
+    # (asyncio.gather is not order-preserving for entry order).
+    assert dispatch.calls[0]["op_id"] == "GET:/repos/{owner}/{repo}/pulls/{pull_number}"
+    sub_op_ids = {c["op_id"] for c in dispatch.calls[1:]}
+    assert sub_op_ids == {
+        "GET:/repos/{owner}/{repo}/commits/{ref}/check-runs",
+        "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+    }
+    # head SHA threaded into the checks call's ref param.
+    checks_call = next(
+        c
+        for c in dispatch.calls
+        if c["op_id"] == "GET:/repos/{owner}/{repo}/commits/{ref}/check-runs"
+    )
+    assert checks_call["params"] == {"owner": "evoila", "repo": "meho", "ref": "76065a0"}
+    # Aggregated envelope.
+    assert out["pr"] == pr
+    assert out["checks"] == checks
+    assert out["reviews"] == reviews
+    assert out["mergeable"] is True
+    assert out["mergeable_state"] == "clean"
+    assert out["checks_status"] == "all_passed"
+    assert out["review_status"] == "approved"
+    # All calls carry the connector id.
+    assert all(c["connector_id"] == "gh-rest-3" for c in dispatch.calls)
+
+
+@pytest.mark.asyncio
+async def test_pr_call_params_pass_through() -> None:
+    """``owner`` / ``repo`` / ``pull_number`` flow into the PR sub-call params."""
+    dispatch = _RecordingDispatchChild(
+        {
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}": _pr_payload(),
+            "GET:/repos/{owner}/{repo}/commits/{ref}/check-runs": _checks_payload(),
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews": [],
+        }
+    )
+    await pr_status_summary_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"owner": "octocat", "repo": "hello-world", "pull_number": 42},
+        dispatch_child=dispatch,
+    )
+    pr_call = dispatch.calls[0]
+    assert pr_call["params"] == {"owner": "octocat", "repo": "hello-world", "pull_number": 42}
+    reviews_call = next(
+        c
+        for c in dispatch.calls
+        if c["op_id"] == "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews"
+    )
+    assert reviews_call["params"] == {"owner": "octocat", "repo": "hello-world", "pull_number": 42}
+
+
+# ---------------------------------------------------------------------------
+# Parallelism
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_secondary_sub_ops_run_in_parallel() -> None:
+    """The checks + reviews sub-calls fire concurrently via asyncio.gather.
+
+    Set a barrier that both secondary calls must enter before either may
+    return. A sequential handler would deadlock; the gather()-based
+    handler unblocks cleanly because both calls land before either
+    awaits the barrier.
+    """
+    dispatch = _RecordingDispatchChild(
+        {
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}": _pr_payload(),
+            "GET:/repos/{owner}/{repo}/commits/{ref}/check-runs": _checks_payload(),
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews": [],
+        }
+    )
+    dispatch.set_gather_barrier(
+        {
+            "GET:/repos/{owner}/{repo}/commits/{ref}/check-runs",
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews",
+        }
+    )
+    out = await asyncio.wait_for(
+        pr_status_summary_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={"owner": "evoila", "repo": "meho", "pull_number": 754},
+            dispatch_child=dispatch,
+        ),
+        timeout=2.0,
+    )
+    assert out["pr"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Partial-failure tolerance (acceptance criterion #3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_checks_sub_op_failure_does_not_bail() -> None:
+    """A 404 on the checks call surfaces as ``checks=None`` + ``checks_status='unknown'``."""
+    dispatch = _RecordingDispatchChild(
+        {
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}": _pr_payload(),
+            "GET:/repos/{owner}/{repo}/commits/{ref}/check-runs": _err_result(
+                "GET:/repos/{owner}/{repo}/commits/{ref}/check-runs", "not_found: 404"
+            ),
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews": [
+                {"user": {"login": "r1"}, "state": "APPROVED"},
+            ],
+        }
+    )
+    out = await pr_status_summary_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"owner": "evoila", "repo": "meho", "pull_number": 754},
+        dispatch_child=dispatch,
+    )
+    assert out["checks"] is None
+    assert out["checks_status"] == "unknown"
+    # Reviews + PR still flow through cleanly.
+    assert out["reviews"] is not None
+    assert out["review_status"] == "approved"
+    assert out["pr"] is not None
+
+
+@pytest.mark.asyncio
+async def test_reviews_sub_op_failure_does_not_bail() -> None:
+    """Reviews call failure surfaces as ``reviews=None`` + ``review_status='unknown'``."""
+    dispatch = _RecordingDispatchChild(
+        {
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}": _pr_payload(),
+            "GET:/repos/{owner}/{repo}/commits/{ref}/check-runs": _checks_payload(
+                {"name": "build", "status": "completed", "conclusion": "success"},
+            ),
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews": _err_result(
+                "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews", "unauthorized: 401"
+            ),
+        }
+    )
+    out = await pr_status_summary_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"owner": "evoila", "repo": "meho", "pull_number": 754},
+        dispatch_child=dispatch,
+    )
+    assert out["reviews"] is None
+    assert out["review_status"] == "unknown"
+    assert out["checks"] is not None
+    assert out["checks_status"] == "all_passed"
+    assert out["pr"] is not None
+
+
+@pytest.mark.asyncio
+async def test_both_secondary_sub_ops_failing_still_returns_pr() -> None:
+    """If both secondaries fail, the composite still surfaces the PR + 'unknown' states."""
+    dispatch = _RecordingDispatchChild(
+        {
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}": _pr_payload(),
+            "GET:/repos/{owner}/{repo}/commits/{ref}/check-runs": _err_result(
+                "GET:/repos/{owner}/{repo}/commits/{ref}/check-runs", "rate_limited"
+            ),
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews": _err_result(
+                "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews", "rate_limited"
+            ),
+        }
+    )
+    out = await pr_status_summary_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"owner": "evoila", "repo": "meho", "pull_number": 754},
+        dispatch_child=dispatch,
+    )
+    assert out["pr"] is not None
+    assert out["checks"] is None
+    assert out["reviews"] is None
+    assert out["checks_status"] == "unknown"
+    assert out["review_status"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Primary failure -- composite must NOT swallow this
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pr_sub_op_failure_raises_runtime_error() -> None:
+    """PR sub-call error -> ``RuntimeError`` (dispatcher wraps as connector_error)."""
+    dispatch = _RecordingDispatchChild(
+        {
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}": _err_result(
+                "GET:/repos/{owner}/{repo}/pulls/{pull_number}", "not_found: 404"
+            ),
+        }
+    )
+    with pytest.raises(RuntimeError, match="status='error'"):
+        await pr_status_summary_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={"owner": "evoila", "repo": "meho", "pull_number": 754},
+            dispatch_child=dispatch,
+        )
+    # The composite bailed before issuing the secondary calls.
+    assert len(dispatch.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_pr_payload_missing_head_sha_raises_runtime_error() -> None:
+    """A PR payload with no head.sha cannot drive the checks call -> error."""
+    dispatch = _RecordingDispatchChild(
+        {
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}": {
+                "number": 754,
+                # No head -> no head.sha extractable.
+            },
+        }
+    )
+    with pytest.raises(RuntimeError, match=r"head\.sha"):
+        await pr_status_summary_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={"owner": "evoila", "repo": "meho", "pull_number": 754},
+            dispatch_child=dispatch,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Mergeable / mergeable_state pass-through
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mergeable_null_is_passed_through_verbatim() -> None:
+    """``mergeable=None`` (GitHub still computing) flows through as-is."""
+    dispatch = _RecordingDispatchChild(
+        {
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}": _pr_payload(
+                mergeable=None, mergeable_state="unknown"
+            ),
+            "GET:/repos/{owner}/{repo}/commits/{ref}/check-runs": _checks_payload(),
+            "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews": [],
+        }
+    )
+    out = await pr_status_summary_composite(
+        operator=_make_operator(),
+        target=object(),
+        params={"owner": "evoila", "repo": "meho", "pull_number": 754},
+        dispatch_child=dispatch,
+    )
+    assert out["mergeable"] is None
+    assert out["mergeable_state"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Checks summariser
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_checks_all_passed() -> None:
+    payload = _checks_payload(
+        {"status": "completed", "conclusion": "success"},
+        {"status": "completed", "conclusion": "skipped"},
+        {"status": "completed", "conclusion": "neutral"},
+    )
+    assert _summarize_checks(payload) == "all_passed"
+
+
+def test_summarize_checks_any_failed() -> None:
+    payload = _checks_payload(
+        {"status": "completed", "conclusion": "success"},
+        {"status": "completed", "conclusion": "failure"},
+    )
+    assert _summarize_checks(payload) == "any_failed"
+
+
+def test_summarize_checks_pending() -> None:
+    payload = _checks_payload(
+        {"status": "completed", "conclusion": "success"},
+        {"status": "in_progress", "conclusion": None},
+    )
+    assert _summarize_checks(payload) == "pending"
+
+
+def test_summarize_checks_no_checks() -> None:
+    assert _summarize_checks(_checks_payload()) == "no_checks"
+
+
+def test_summarize_checks_unknown_shape() -> None:
+    assert _summarize_checks(None) == "unknown"
+    assert _summarize_checks({"check_runs": "not-a-list"}) == "unknown"
+
+
+def test_summarize_checks_treats_unexpected_conclusion_as_pending() -> None:
+    """A completed run with a null/unexpected conclusion is conservative -> pending."""
+    payload = _checks_payload(
+        {"status": "completed", "conclusion": None},
+    )
+    assert _summarize_checks(payload) == "pending"
+
+
+# ---------------------------------------------------------------------------
+# Reviews summariser
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_reviews_changes_requested_vetoes() -> None:
+    """A single CHANGES_REQUESTED outranks any APPROVED."""
+    reviews = [
+        {"user": {"login": "a"}, "state": "APPROVED"},
+        {"user": {"login": "b"}, "state": "CHANGES_REQUESTED"},
+    ]
+    assert _summarize_reviews(reviews) == "changes_requested"
+
+
+def test_summarize_reviews_approved_when_no_changes_requested() -> None:
+    reviews = [
+        {"user": {"login": "a"}, "state": "APPROVED"},
+        {"user": {"login": "b"}, "state": "COMMENTED"},
+    ]
+    assert _summarize_reviews(reviews) == "approved"
+
+
+def test_summarize_reviews_latest_per_reviewer_wins() -> None:
+    """Chronological list: the same reviewer's APPROVED supersedes earlier CHANGES_REQUESTED."""
+    reviews = [
+        {"user": {"login": "a"}, "state": "CHANGES_REQUESTED"},
+        {"user": {"login": "a"}, "state": "APPROVED"},
+    ]
+    assert _summarize_reviews(reviews) == "approved"
+
+
+def test_summarize_reviews_dismissed_drops_reviewer() -> None:
+    """DISMISSED removes the reviewer's prior verdict from the tally."""
+    reviews = [
+        {"user": {"login": "a"}, "state": "CHANGES_REQUESTED"},
+        {"user": {"login": "a"}, "state": "DISMISSED"},
+        {"user": {"login": "b"}, "state": "APPROVED"},
+    ]
+    assert _summarize_reviews(reviews) == "approved"
+
+
+def test_summarize_reviews_commented_when_no_verdict() -> None:
+    reviews = [
+        {"user": {"login": "a"}, "state": "COMMENTED"},
+    ]
+    assert _summarize_reviews(reviews) == "commented"
+
+
+def test_summarize_reviews_no_reviews() -> None:
+    assert _summarize_reviews([]) == "no_reviews"
+
+
+def test_summarize_reviews_unknown_shape() -> None:
+    assert _summarize_reviews(None) == "unknown"
+    assert _summarize_reviews("not-a-list") == "unknown"

--- a/backend/tests/test_connectors_github_composites_register.py
+++ b/backend/tests/test_connectors_github_composites_register.py
@@ -1,0 +1,347 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Registration tests for the gh-rest composites (G3.11-T4 #1224).
+
+Mirrors :mod:`tests.test_connectors_vmware_rest_composites_register`.
+T4 ships exactly one composite -- ``gh.composite.pr_status_summary`` --
+so the coverage scope is narrower than the vmware-rest precedent but
+the per-composite assertions are identical: ``source_kind="composite"``
+row, ``safety_level="safe"`` + ``requires_approval=False`` overrides,
+canonical module-level ``handler_ref``, group resolution into
+``pulls``, parameter schema round-trips with ``required`` keys and
+``additionalProperties:false``, response schema persists, tags include
+``composite`` + ``read-only``, idempotent re-registration, and the
+side-effect import wires the registrar onto the lifespan list.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.connectors.github.composites import (
+    pr_status_summary_composite,
+    register_github_composite_operations,
+)
+from meho_backplane.connectors.registry import clear_registry
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import EndpointDescriptor, OperationGroup
+from meho_backplane.operations import reset_dispatcher_caches
+from meho_backplane.operations.typed_register import (
+    _TYPED_OP_REGISTRARS,
+    clear_typed_op_registrars,
+)
+from meho_backplane.settings import get_settings
+
+_EXPECTED_OP_IDS: tuple[str, ...] = ("gh.composite.pr_status_summary",)
+
+_EXPECTED_HANDLER_REF_BY_OP: dict[str, str] = {
+    "gh.composite.pr_status_summary": (
+        "meho_backplane.connectors.github.composites._read.pr_status_summary_composite"
+    ),
+}
+
+_EXPECTED_GROUP_KEY_BY_OP: dict[str, str] = {
+    "gh.composite.pr_status_summary": "pulls",
+}
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin every env var :class:`Settings` requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Snapshot+restore the typed-op registrar list around each test.
+
+    Same discipline as the vmware-rest register test: a registrar-
+    reload test mutates the list permanently and would mis-wire other
+    lifespan-driven tests later in the session.
+    """
+    saved_registrars = list(_TYPED_OP_REGISTRARS)
+    reset_dispatcher_caches()
+    clear_registry()
+    yield
+    reset_dispatcher_caches()
+    clear_registry()
+    _TYPED_OP_REGISTRARS[:] = saved_registrars
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Deterministic embedding stub so the upsert doesn't pull ONNX."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.1] * 384
+    service.encode.return_value = [[0.1] * 384]
+    service.dimension = 384
+    return service
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+# ---------------------------------------------------------------------------
+# Composite lands with the right shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_github_composite_operations_inserts_pr_status_summary(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The registrar lands ``gh.composite.pr_status_summary`` in ``endpoint_descriptor``."""
+    await register_github_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_EXPECTED_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert {row.op_id for row in rows} == set(_EXPECTED_OP_IDS)
+    assert stub_embedding_service.encode_one.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_composite_row_uses_safe_no_approval_overrides(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Row carries ``safety_level="safe"`` + ``requires_approval=False`` (issue body AC #5)."""
+    await register_github_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        row = (
+            await fresh.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.op_id == "gh.composite.pr_status_summary"
+                )
+            )
+        ).scalar_one()
+    assert row.safety_level == "safe", f"expected safe, got {row.safety_level!r}"
+    assert row.requires_approval is False, (
+        f"expected requires_approval=False, got {row.requires_approval!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_composite_row_carries_composite_source_kind(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Row has ``source_kind="composite"`` so the dispatcher routes to the composite branch."""
+    await register_github_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        row = (
+            await fresh.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.op_id == "gh.composite.pr_status_summary"
+                )
+            )
+        ).scalar_one()
+    assert row.source_kind == "composite"
+    assert row.tenant_id is None
+    assert row.is_enabled is True
+    assert row.method is None
+    assert row.path is None
+    # Connector key triple matches the connector's v2 registration.
+    assert row.product == "gh"
+    assert row.version == "3"
+    assert row.impl_id == "gh-rest"
+
+
+@pytest.mark.asyncio
+async def test_handler_ref_round_trips_to_module_level_dotted_path(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The persisted ``handler_ref`` is the canonical module-level dotted path."""
+    await register_github_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        row = (
+            await fresh.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.op_id == "gh.composite.pr_status_summary"
+                )
+            )
+        ).scalar_one()
+    assert row.handler_ref == _EXPECTED_HANDLER_REF_BY_OP["gh.composite.pr_status_summary"]
+
+
+@pytest.mark.asyncio
+async def test_group_resolution_lands_composite_in_pulls_group(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The composite lands in the ``pulls`` operation group."""
+    await register_github_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        descriptor = (
+            await fresh.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.op_id == "gh.composite.pr_status_summary"
+                )
+            )
+        ).scalar_one()
+        group_rows = (await fresh.execute(select(OperationGroup))).scalars().all()
+    assert descriptor.group_id is not None
+    group = next(g for g in group_rows if g.id == descriptor.group_id)
+    assert group.group_key == "pulls"
+    assert group.product == "gh"
+    assert group.version == "3"
+    assert group.impl_id == "gh-rest"
+
+
+@pytest.mark.asyncio
+async def test_parameter_schema_persists_with_required_fields(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """``parameter_schema`` round-trips with ``required`` + ``additionalProperties:false``."""
+    await register_github_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        row = (
+            await fresh.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.op_id == "gh.composite.pr_status_summary"
+                )
+            )
+        ).scalar_one()
+    schema: dict[str, Any] = dict(row.parameter_schema)
+    assert set(schema["required"]) == {"owner", "repo", "pull_number"}
+    assert schema["additionalProperties"] is False
+    props = dict(schema["properties"])
+    assert {"owner", "repo", "pull_number"} <= set(props)
+
+
+@pytest.mark.asyncio
+async def test_response_schema_persists_with_documented_keys(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """``response_schema`` carries the seven top-level keys the handler returns."""
+    await register_github_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        row = (
+            await fresh.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.op_id == "gh.composite.pr_status_summary"
+                )
+            )
+        ).scalar_one()
+    schema: dict[str, Any] = dict(row.response_schema)
+    assert schema.get("type") == "object"
+    expected_keys = {
+        "pr",
+        "checks",
+        "reviews",
+        "mergeable",
+        "mergeable_state",
+        "checks_status",
+        "review_status",
+    }
+    assert expected_keys <= set(dict(schema["properties"]))
+    assert set(schema["required"]) == expected_keys
+
+
+@pytest.mark.asyncio
+async def test_tags_include_composite_and_read_only(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The composite row's tags include ``composite`` + ``read-only`` for filtering."""
+    await register_github_composite_operations(embedding_service=stub_embedding_service)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        row = (
+            await fresh.execute(
+                select(EndpointDescriptor).where(
+                    EndpointDescriptor.op_id == "gh.composite.pr_status_summary"
+                )
+            )
+        ).scalar_one()
+    assert "composite" in row.tags
+    assert "read-only" in row.tags
+    assert "pulls" in row.tags
+
+
+@pytest.mark.asyncio
+async def test_register_github_composite_operations_is_idempotent(
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Running the registrar twice -> 1 row persists; embedding stays at 1 (skip-re-embed)."""
+    await register_github_composite_operations(embedding_service=stub_embedding_service)
+    first_count = stub_embedding_service.encode_one.call_count
+    assert first_count == 1
+
+    await register_github_composite_operations(embedding_service=stub_embedding_service)
+    assert stub_embedding_service.encode_one.call_count == first_count, (
+        "second run should hit the body-hash skip path"
+    )
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as fresh:
+        rows = (
+            (
+                await fresh.execute(
+                    select(EndpointDescriptor).where(EndpointDescriptor.op_id.in_(_EXPECTED_OP_IDS))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# Side-effect import wires the registrar into the lifespan list
+# ---------------------------------------------------------------------------
+
+
+def test_importing_github_composites_queues_registrar() -> None:
+    """Importing :mod:`meho_backplane.connectors.github.composites` queues the registrar."""
+    clear_typed_op_registrars()
+    import meho_backplane.connectors.github.composites as composites_pkg
+
+    importlib.reload(composites_pkg)
+
+    assert any(
+        r.__name__ == "register_github_composite_operations" for r in _TYPED_OP_REGISTRARS
+    ), (
+        "expected register_github_composite_operations on the typed-op "
+        f"registrar list, got names "
+        f"{[getattr(r, '__name__', repr(r)) for r in _TYPED_OP_REGISTRARS]}"
+    )
+
+
+def test_handler_is_module_level_coroutine_function() -> None:
+    """The handler is a plain module-level ``async def`` -- no closures / partials / lambdas.
+
+    ``derive_handler_ref()`` rejects those at registration time, so a
+    regression here would surface before the registrar even runs.
+    """
+    import inspect
+
+    assert inspect.iscoroutinefunction(pr_status_summary_composite)
+    assert "<locals>" not in pr_status_summary_composite.__qualname__
+    assert pr_status_summary_composite.__qualname__ != "<lambda>"

--- a/docs/codebase/connectors-github.md
+++ b/docs/codebase/connectors-github.md
@@ -19,6 +19,65 @@ highest-blast-radius write ops land in T5 (#1225).
 
 Source: `backend/src/meho_backplane/connectors/github/`.
 
+### Layer-1 composites (T4 #1224)
+
+The `composites/` subpackage hosts hand-coded L1 composites that wrap
+multiple L2 sub-ops into one governed call. T4 ships the first one,
+`gh.composite.pr_status_summary`, mirroring the layout precedent at
+`backend/src/meho_backplane/connectors/vmware_rest/composites/`:
+
+- **`composites/_register.py`** — `_COMPOSITES` tuple and the
+  `register_github_composite_operations` async registrar. T4 ships
+  exactly one row; future T7+ Tasks add `release_health`,
+  `board_snapshot`, etc., on the same pattern.
+- **`composites/_read.py`** — module-level `async def` handlers. The
+  T4 handler `pr_status_summary_composite` dispatches three L2 sub-ops:
+  the PR call sequentially (drives the head SHA used in the next step),
+  then the check-runs and reviews calls in parallel via
+  `asyncio.gather`. Partial-failure tolerance is part of the contract
+  — a failure on either secondary surfaces as `null` for that field
+  plus `checks_status="unknown"` / `review_status="unknown"`, never
+  bailing mid-flight. The PR sub-call itself is non-optional.
+- **`composites/schemas.py`** — JSON-Schema 2020-12 parameter and
+  response contracts. `additionalProperties=False` on params so operator
+  typos surface as clear validation errors; response schemas describe
+  the seven-key envelope and the two pre-computed status enums.
+- **`composites/_preflight.py`** — per-process cache of which composites
+  have already validated that every declared L2 sub-op is registered in
+  `endpoint_descriptor`. Same lazy-resolve design as the vmware-rest
+  precedent (G0.14-T10 #1183): if any sub-op is missing, the helper
+  raises `CompositeL2DependencyMissing` with the missing op-ids plus
+  the catalog command `meho connector ingest --catalog gh/v3`. The
+  dispatcher catches it and surfaces it as a structured
+  `composite_l2_missing` error per `docs/codebase/error-message-shape.md`.
+- **`composites/__init__.py`** — side-effect import that queues
+  `register_github_composite_operations` onto the lifespan registrar
+  list. The parent `github/__init__.py` imports this subpackage so the
+  registrar lands during `_eager_import_connectors`.
+
+Both summarisers — `_summarize_checks` and `_summarize_reviews` — are
+intentionally conservative: an unexpected payload shape collapses to
+`"unknown"` rather than guessing, and `_summarize_reviews` honours
+GitHub's "latest review per reviewer" rule (a single
+`CHANGES_REQUESTED` vetoes the PR; a `DISMISSED` entry pops the
+reviewer's prior verdict).
+
+The composite is registered with `safety_level="safe"` (the
+register-time equivalent of the operator-visible "read" label per the
+issue body) and `requires_approval=False`, overriding
+`register_composite_operation`'s `dangerous` / `True` defaults the same
+way the vmware-rest read composites do.
+
+**Known T4 dependency on the parser fix.** The catalog ingest (T3) is
+xfail-strict against the live spec because the G0.7 OpenAPI parser does
+not inline `#/components/responses/*` refs (GitHub uses these
+extensively). The composite registration is *not* blocked — the unit
+tests run unconditionally — but the live L1+L2 dispatch acceptance test
+at `backend/tests/integration/test_github_composite_dispatch.py` is
+xfail-strict pending a sibling parser-scope follow-up. Once that lands,
+both the T3 ingest test and the T4 dispatch test flip from xfail to
+xpass, and CI prompts the maintainer to remove the marks.
+
 ## Key types
 
 - **`GitHubRestConnector`** (`connector.py`) — `HttpConnector` subclass


### PR DESCRIPTION
## Summary

- Lands the first L1 composite for the gh-rest typed connector: `gh.composite.pr_status_summary`. Composes three L2 sub-ops (PR get, head-commit check-runs, PR reviews) into a single envelope so an agent or operator can answer "is this PR ready to merge?" without three separate dispatcher calls. Read-only (`safety_level="safe"` / `requires_approval=False`).
- Mirrors the vmware-rest composites layout (G3.1-T5 #508 / G0.14-T10 #1183): `composites/_register.py` (registrar tuple), `composites/_read.py` (handler), `composites/schemas.py` (JSON-Schema 2020-12), `composites/_preflight.py` (L2 dependency check), `composites/__init__.py` (side-effect import queues the registrar). Side-effect import wired into `connectors/github/__init__.py`.
- Partial-failure tolerance per the issue body's AC #3: if the checks or reviews sub-call fails, the composite returns `null` for that field + a `"unknown"` status summary and continues. The PR sub-call itself is non-optional — a failure there raises `RuntimeError` and the dispatcher wraps it as `connector_error`. The two pre-computed enums (`checks_status` / `review_status`) collapse the raw arrays into agent-actionable states.
- L2 pre-flight: composite walks its sub-op-ids on first call; if any are missing, raises `CompositeL2DependencyMissing` with the missing op-ids plus `catalog_command="meho connector ingest --catalog gh/v3"`. Dispatcher surfaces this as a structured `composite_l2_missing` error per G0.14-T11 #1141.

## Test plan

- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run mypy src/meho_backplane/connectors/github/` — clean
- [x] AC #1 (composite registered + dispatchable): 11 register tests assert the row lands in `endpoint_descriptor` with `source_kind="composite"`, canonical `handler_ref`, group resolution into `pulls`, parameter+response schemas round-trip.
- [x] AC #2 (live envelope shape): integration test at `backend/tests/integration/test_github_composite_dispatch.py`, gated on `MEHO_GH_INGEST_LIVE=1`, `xfail(strict=True)` pending the G0.7 parser fix for `#/components/responses/*` refs (same upstream limitation T3 #1228 surfaced).
- [x] AC #3 (partial-failure shape): handler tests cover checks-fails-only, reviews-fails-only, and both-fail cases; all return the PR cleanly with `null` payload + `"unknown"` status.
- [x] AC #4 (L2 pre-flight): 4 preflight tests exercise cache hit, missing-sub-op with full missing list, negative-result-not-cached, composite-recursion skip.
- [x] AC #5 (`safety_level="read"` + `requires_approval=False`): register test asserts `safety_level="safe"` (the register-time equivalent of the operator-visible "read" label per the helper's enum) and `requires_approval=False`.
- [x] AC #6 (`search_operations` finds the composite): the row carries `composite` + `read-only` + `pulls` tags + an embedded description; tag-filter test asserts tag presence.
- [x] vmware-rest composite tests still pass (39 tests) — no regression from the shared composite scaffolding.

## Known dependency

The live integration test is `xfail(strict=True)` pending a sibling parser-scope Task that lifts the G0.7 OpenAPI parser's ref-bucket coverage (`refs.py` only inlines `#/components/schemas/*` and `#/components/parameters/*` today; the GitHub spec uses `#/components/responses/*` extensively). The composite registration itself is **not** blocked — unit tests run unconditionally, the registrar lands cleanly, and the only path gated by the parser limitation is the live end-to-end L1+L2 dispatch. Documented in the integration test's module docstring and `docs/codebase/connectors-github.md`. Once the parser fix lands, the xfail flips to xpass and CI prompts the mark removal.

## Out of scope

- Other PR composites (`gh.composite.pr_open`, `gh.composite.pr_merge_with_checks`, etc.) — future Tasks under Initiative #1220.
- Release / board / workflow composites (T7+ in the Initiative DoD).
- Webhook-driven push-to-meho — pull-based composite only.
- `pagination_hint` for the underlying L2 calls — G0.15-T8's scope.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1224
