### PR TITLE
fix(ui): G0.15-T9 wire tenant chip to BFF session, drop "(sign in to choose)"

### DIFF
--- a/backend/src/meho_backplane/ui/auth/middleware.py
+++ b/backend/src/meho_backplane/ui/auth/middleware.py
@@ -82,9 +82,11 @@ from urllib.parse import quote
 
 import structlog
 from fastapi import Depends, HTTPException, Request, status
+from sqlalchemy import select
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import Tenant
 from meho_backplane.ui.audit import bind_ui_view_audit
 from meho_backplane.ui.auth.routes import LOGIN_PATH, SESSION_COOKIE_NAME
 from meho_backplane.ui.auth.session_store import load_session
@@ -127,11 +129,23 @@ class UISessionContext:
     ``raw_jwt`` / ``tenant_role`` are intentionally absent because
     the session-cookie path does not load them today (the encrypted
     row carries only the access token, not the decoded claims).
+
+    ``tenant_slug`` / ``tenant_name`` are populated by the middleware
+    from a same-request lookup against the ``tenant`` table (keyed on
+    :attr:`tenant_id`). The fields are surfaced into every UI template
+    by the chassis context processor so the page header's tenant chip
+    renders the operator-readable name without each route having to
+    re-fetch the row (G0.15-T9 #1217). Both are ``None`` only when the
+    tenant row was deleted between session-creation and the request
+    (an ops anomaly; the operator still authenticates fine, the chip
+    just falls back to the tenant UUID).
     """
 
     session_id: uuid.UUID
     operator_sub: str
     tenant_id: uuid.UUID
+    tenant_slug: str | None = None
+    tenant_name: str | None = None
 
 
 def _select_path(scope: Scope) -> str:
@@ -253,13 +267,43 @@ class UISessionMiddleware:
                 cookie_id = None
             if cookie_id is not None:
                 sessionmaker = get_sessionmaker()
+                # One transaction loads the session row AND the tenant
+                # row -- the tenant lookup is a PK probe on a tiny
+                # write-mostly table, so paying it inside the
+                # already-running ``load_session`` transaction is
+                # microseconds and keeps the page header from needing a
+                # separate DB round-trip per request (G0.15-T9 #1217).
                 async with sessionmaker() as session, session.begin():
                     decrypted = await load_session(session, cookie_id)
+                    if decrypted is not None:
+                        tenant_row = (
+                            await session.execute(
+                                select(Tenant.slug, Tenant.name).where(
+                                    Tenant.id == decrypted.tenant_id,
+                                ),
+                            )
+                        ).one_or_none()
                 if decrypted is not None:
+                    tenant_slug = tenant_row[0] if tenant_row is not None else None
+                    tenant_name = tenant_row[1] if tenant_row is not None else None
+                    if tenant_row is None:
+                        # Session row references a tenant_id with no
+                        # tenant row -- the tenant was deleted out from
+                        # under the operator's session. Surface the
+                        # anomaly so on-call sees the broken FK while
+                        # still letting the operator's request proceed
+                        # (the page header falls back to the UUID).
+                        log.warning(
+                            "ui_session_tenant_row_missing",
+                            session_id=str(decrypted.id),
+                            tenant_id=str(decrypted.tenant_id),
+                        )
                     session_context = UISessionContext(
                         session_id=decrypted.id,
                         operator_sub=decrypted.operator_sub,
                         tenant_id=decrypted.tenant_id,
+                        tenant_slug=tenant_slug,
+                        tenant_name=tenant_name,
                     )
 
         if session_context is None:

--- a/backend/src/meho_backplane/ui/templates/base.html
+++ b/backend/src/meho_backplane/ui/templates/base.html
@@ -29,6 +29,15 @@
     and stubs don't, so default to ``""`` here so the ``StrictUndefined``
     env does not raise when a route omits it. -#}
 {% set active_surface = active_surface | default("") %}
+{#- ``session_tenant`` is injected by the
+    :func:`_ui_session_context_processor` chassis context processor on
+    every UI template render -- it carries the active BFF session's
+    tenant ``id`` / ``slug`` / ``name``, or ``None`` on the unauthenticated
+    auth surfaces (G0.15-T9 #1217). Default to ``None`` so a template
+    rendered outside the FastAPI request flow (the chassis smoke test
+    renders ``base.html`` directly against the bare env) does not trip
+    ``StrictUndefined``. -#}
+{% set session_tenant = session_tenant | default(none) %}
 <!doctype html>
 <html lang="en" data-theme="corporate" class="h-full">
   <head>
@@ -108,18 +117,30 @@
             </span>
           </div>
           <div class="flex-none gap-2">
-            {# Tenant selector placeholder. T4 #865 wires the live
-               selector against the operator's accessible tenants;
-               the chassis renders a disabled stub. #}
-            <div class="form-control hidden md:block">
-              <select
-                class="select select-bordered select-sm"
-                disabled
-                aria-label="Active tenant"
-              >
-                <option>tenant: (sign in to choose)</option>
-              </select>
-            </div>
+            {# Tenant chip. G0.15-T9 #1217 -- the operator's tenant is
+               auto-selected from the JWT's ``tenant_id`` claim at
+               session-create time; the BFF session middleware lifts
+               that tenant's slug + name into ``session_tenant`` via
+               the chassis context processor on every render. The chip
+               renders the human-readable name (slug fallback when the
+               name is empty, UUID fallback when the tenant row was
+               deleted out from under the session). Cross-tenant
+               switching is a future Initiative; today the operator
+               always acts on exactly one tenant, so the chip is a
+               read-only label, not a selector. The auth surfaces
+               themselves (``/ui/auth/login`` etc.) render before a
+               session exists -- ``session_tenant`` is then ``None``
+               and the chip is hidden. #}
+            {% if session_tenant is not none %}
+              <div class="form-control hidden md:block" aria-label="Active tenant">
+                <span class="badge badge-outline">
+                  tenant:&nbsp;
+                  <code class="font-mono">
+                    {{- session_tenant.name or session_tenant.slug or session_tenant.id -}}
+                  </code>
+                </span>
+              </div>
+            {% endif %}
             {# User menu. Alpine-driven open/close with click-outside
                dismissal. Real menu items land in T4 #865. #}
             <div class="relative" x-on:click.outside="userMenuOpen = false">

--- a/backend/src/meho_backplane/ui/templating.py
+++ b/backend/src/meho_backplane/ui/templating.py
@@ -44,10 +44,11 @@ the candidate, but the factory below leaves the choice open).
 
 from __future__ import annotations
 
-from typing import Final
+from typing import Any, Final
 
 from fastapi.templating import Jinja2Templates
 from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
+from starlette.requests import Request
 
 from meho_backplane import __version__
 from meho_backplane.ui.paths import templates_dir
@@ -100,6 +101,48 @@ def get_jinja_env() -> Environment:
     return _ENV
 
 
+def _ui_session_context_processor(request: Request) -> dict[str, Any]:
+    """Surface the active BFF session's tenant into every UI template.
+
+    G0.15-T9 (#1217) — the operator-console header chip used to render a
+    hard-coded "(sign in to choose)" placeholder regardless of whether
+    the operator had already authenticated. The fix moves the chip's
+    data source onto the same :class:`UISessionContext` the middleware
+    already attaches to ``request.state.ui_session``: the JWT's
+    ``tenant_id`` claim is the operator's default tenant and is
+    auto-selected at session-create time, so by the time any UI route
+    renders a page the tenant is already known.
+
+    The context processor exposes one variable to every Jinja render:
+
+    * ``session_tenant`` -- a ``dict`` carrying ``id`` / ``slug`` /
+      ``name``, or ``None`` when the request hit a surface where the
+      session middleware hasn't bound a context (the auth surfaces
+      themselves, e.g. ``/ui/auth/login`` -- the operator is by
+      definition not signed in there). ``base.html``'s header chip
+      conditionally renders the tenant name when this dict is present
+      and falls back to a neutral "Sign in" link otherwise.
+
+    Synchronous by Starlette contract: context processors execute
+    inside the synchronous ``Jinja2Templates.TemplateResponse`` call;
+    asynchronous processors are explicitly not supported (see
+    https://www.starlette.io/templates/). The lookup here is a pure
+    attribute read off ``request.state`` -- the middleware already
+    paid the DB round-trip on its way in, so the processor itself
+    issues zero IO.
+    """
+    session_ctx = getattr(request.state, "ui_session", None)
+    if session_ctx is None:
+        return {"session_tenant": None}
+    return {
+        "session_tenant": {
+            "id": str(session_ctx.tenant_id),
+            "slug": session_ctx.tenant_slug,
+            "name": session_ctx.tenant_name,
+        },
+    }
+
+
 def get_templates() -> Jinja2Templates:
     """Return the lazily-constructed :class:`Jinja2Templates` wrapper.
 
@@ -117,12 +160,21 @@ def get_templates() -> Jinja2Templates:
       surface templates can reverse route names instead of hard-coding
       ``href=`` strings.
 
+    The wrapper also runs :func:`_ui_session_context_processor` per
+    render so ``base.html`` (and any surface template inheriting it)
+    sees the active BFF session's tenant on every page without each
+    route having to thread ``tenant_name`` / ``tenant_slug`` through
+    its context dict (G0.15-T9 #1217).
+
     Module-level cache (rather than :func:`functools.lru_cache`) so the
     type checker sees the concrete return type without ``cast``.
     """
     global _TEMPLATES
     if _TEMPLATES is None:
-        _TEMPLATES = Jinja2Templates(env=get_jinja_env())
+        _TEMPLATES = Jinja2Templates(
+            env=get_jinja_env(),
+            context_processors=[_ui_session_context_processor],
+        )
     return _TEMPLATES
 
 

--- a/backend/tests/test_ui_tenant_chip.py
+++ b/backend/tests/test_ui_tenant_chip.py
@@ -1,0 +1,300 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tenant chip + cascade tests for G0.15-T9 (#1217).
+
+The v0.7.0 closed-loop dogfood (rdc-hetzner-dc#753) flagged three
+correlated symptoms on the operator UI:
+
+1. The page-header tenant chip rendered the stub literal
+   ``"tenant: (sign in to choose)"`` regardless of the operator's
+   session state -- they were signed in, the chip claimed otherwise.
+2. The Memory UI list rendered ``0 memories`` despite the API surface
+   returning rows for the same operator + tenant.
+3. The Broadcast surface rendered nothing despite live MCP activity
+   emitting broadcast events for the operator's tenant.
+
+The issue body hypothesised a single root cause: the BFF session never
+carried a usable tenant_id, so the tenant-scoped list queries fell
+back to ``(operator, undefined_tenant)`` and returned empty. The
+inspection in the implementation pass disproved the hypothesis -- the
+``/ui/auth/callback`` handler already auto-selects the operator's
+tenant from the JWT ``tenant_id`` claim at session-create time
+(``backend/src/meho_backplane/ui/auth/routes.py::_persist_session_from_tokens``).
+The Memory + Broadcast surfaces already scope their queries by
+``session_ctx.tenant_id``. The only real bug was the chassis stub
+header: the chip's disabled ``<select>`` was wired to a hardcoded
+placeholder and never consulted the session at all.
+
+This suite pins:
+
+* The chip renders the operator's tenant **name** (not the UUID, not
+  ``"(sign in to choose)"``) when the BFF session is alive. ACs #1
+  + #2 on the issue.
+* The cascade surfaces (Memory + Broadcast) carry the tenant_id from
+  the same session through to their queries -- a regression where a
+  future change drops the tenant_id off the context would surface
+  here, not as a silent empty-state. AC #3 + #4 on the issue.
+* The render path stays sound when the tenant row was deleted out
+  from under the session (the FK is soft per
+  :class:`WebSession.tenant_id`; the chip degrades to the slug
+  fallback, then the UUID fallback, but the page still renders 200).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from collections.abc import Iterator
+from datetime import timedelta
+from typing import Any
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import Tenant
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import CSRFMiddleware
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests.conftest import DEFAULT_AUDIENCE, DEFAULT_ISSUER
+
+_BACKPLANE_URL = "https://meho.test"
+
+_TENANT_ID = uuid.UUID("33333333-3333-3333-3333-333333333333")
+#: Distinct from the chassis-migration seeded ``default`` / ``rdc-internal``
+#: slugs (see migrations ``0018`` / ``0028``) so the per-test insert
+#: cannot collide on the ``tenant_slug_idx`` unique constraint.
+_TENANT_SLUG = "tenant-chip-fixture"
+_TENANT_NAME = "Tenant Chip Fixture"
+_OPERATOR_SUB = "op-tenant-chip"
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the chassis + BFF env vars so the suite is self-contained."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+def _build_app() -> FastAPI:
+    """Construct the chassis app shape: CSRF + UISession + UI routes."""
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(
+    tenant_id: uuid.UUID = _TENANT_ID,
+    *,
+    slug: str = _TENANT_SLUG,
+    name: str = _TENANT_NAME,
+) -> None:
+    """Insert the ``tenant`` row the middleware joins against."""
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=name))
+
+    asyncio.run(_do())
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID = _TENANT_ID,
+    operator_sub: str = _OPERATOR_SUB,
+) -> uuid.UUID:
+    """Insert a BFF session row and return its UUID."""
+
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token="unused-access",
+                refresh_token="unused-refresh",
+                lifetime=timedelta(hours=1),
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _authenticated_get(path: str, session_id: uuid.UUID) -> Any:
+    """Issue an authenticated GET against the test app, no redirects."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+        return client.get(path)
+
+
+# ---------------------------------------------------------------------------
+# AC #1 + #2 -- tenant chip renders the operator's tenant name (not the stub
+# placeholder, not the UUID).
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_chip_renders_tenant_name_not_stub_placeholder() -> None:
+    """``GET /ui/`` renders the operator's tenant name on the chip.
+
+    The pre-#1217 chassis hardcoded ``"tenant: (sign in to choose)"``
+    on a disabled ``<select>`` regardless of session state. After the
+    fix the chip pulls from the BFF session's
+    :class:`UISessionContext` (which the middleware populates from the
+    ``tenant`` row keyed on the session's ``tenant_id``).
+    """
+    _seed_tenant()
+    session_id = _seed_session_sync()
+    response = _authenticated_get("/ui/", session_id)
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The exact stub literal must not survive.
+    assert "(sign in to choose)" not in body, "tenant chip still renders pre-fix stub"
+    # The operator's tenant name renders inside the chip's badge -- we
+    # check the chip's ``aria-label`` is present and the name is in the
+    # body. Looking for the literal ``aria-label="Active tenant"`` keeps
+    # the assertion narrow enough that an unrelated mention of the name
+    # elsewhere on the page (e.g. dashboard greeting) doesn't satisfy
+    # the assertion.
+    assert 'aria-label="Active tenant"' in body
+    assert _TENANT_NAME in body
+
+
+def test_chip_falls_back_to_slug_when_name_empty() -> None:
+    """Empty tenant name → chip renders the slug.
+
+    A future tenant seeded by ops with an empty ``name`` column should
+    still produce a useful chip (the slug is the operator-facing
+    handle per the :class:`Tenant` docstring). The fallback chain is
+    ``name -> slug -> id``.
+    """
+    _seed_tenant(name="")
+    session_id = _seed_session_sync()
+    response = _authenticated_get("/ui/", session_id)
+    assert response.status_code == 200
+    body = response.text
+    assert _TENANT_SLUG in body
+    assert "(sign in to choose)" not in body
+
+
+def test_chip_falls_back_to_uuid_when_tenant_row_missing() -> None:
+    """No tenant row → chip degrades to the UUID but the page renders.
+
+    Soft-FK discipline (``web_session.tenant_id`` has no FK to
+    ``tenant.id``): deleting a tenant out from under an active session
+    is an ops anomaly the BFF must survive. The fix logs a warning and
+    falls back to the bare UUID rather than 500-ing.
+    """
+    # Intentionally do NOT seed a tenant row.
+    session_id = _seed_session_sync()
+    response = _authenticated_get("/ui/", session_id)
+    assert response.status_code == 200
+    body = response.text
+    assert "(sign in to choose)" not in body
+    assert str(_TENANT_ID) in body
+
+
+# ---------------------------------------------------------------------------
+# AC #3 + #4 -- the cascade surfaces (Memory + Broadcast) carry the same
+# tenant_id through their scope.
+# ---------------------------------------------------------------------------
+
+
+def test_memory_surface_renders_with_session_tenant_present() -> None:
+    """``GET /ui/memory`` renders 200 + the tenant chip + the empty list.
+
+    Pre-#1217 the operator's dogfood report showed the Memory surface
+    "0 memories" UI state. The cascade hypothesis ("unset tenant scopes
+    the list query to ``(operator, undefined_tenant)``") would surface
+    here as a missing tenant chip alongside the empty-state. Post-fix
+    the chip renders the tenant name (proving the tenant_id is bound
+    on the session and reaching the template), the empty-state copy
+    renders (proving the route ran to completion), and the
+    ``id="memory-cards"`` swap target renders (proving the surface's
+    HTMX wiring is wired through to the cards fragment).
+
+    The list is empty because no memories are seeded -- the
+    cascade-with-data path is exercised by the existing memory list
+    suite (:mod:`backend.tests.test_ui_memory_list`); this test only
+    pins the contract that the tenant_id reaches the page.
+    """
+    _seed_tenant()
+    session_id = _seed_session_sync()
+    response = _authenticated_get("/ui/memory", session_id)
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "(sign in to choose)" not in body
+    assert _TENANT_NAME in body
+    assert 'id="memory-cards"' in body
+
+
+def test_broadcast_surface_renders_with_session_tenant_present() -> None:
+    """``GET /ui/broadcast`` renders the feed page scoped to the session tenant.
+
+    The broadcast feed page reads ``session_ctx.tenant_id`` directly
+    when wiring the ``sse-connect`` URL and the target-name dropdown
+    (see :mod:`meho_backplane.ui.routes.broadcast.feed`). A regression
+    that nulls the session tenant would surface as a 5xx (the SSE URL
+    builder would synthesise an empty tenant) or as the chip falling
+    back to ``(sign in to choose)``; this test pins both.
+    """
+    _seed_tenant()
+    session_id = _seed_session_sync()
+    response = _authenticated_get("/ui/broadcast", session_id)
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "(sign in to choose)" not in body
+    assert _TENANT_NAME in body
+    # The full-page render includes the per-tenant SSE bridge URL; its
+    # presence proves the broadcast surface ran the full
+    # _render_page flow (which also reads session_ctx.tenant_id when
+    # building the target-name dropdown).
+    assert "/ui/broadcast/stream" in body

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -12970,6 +12970,16 @@
             "type": "string",
             "format": "uuid",
             "title": "Tenant Id"
+          },
+          "tenant_slug": {
+            "type": "string",
+            "nullable": true,
+            "title": "Tenant Slug"
+          },
+          "tenant_name": {
+            "type": "string",
+            "nullable": true,
+            "title": "Tenant Name"
           }
         },
         "type": "object",
@@ -12979,7 +12989,7 @@
           "tenant_id"
         ],
         "title": "UISessionContext",
-        "description": "Per-request session identity exposed on ``request.state``.\n\nFrozen so a route handler that stashes the context on a logger\nor forwards it to a service layer cannot accidentally mutate\nfields downstream. The shape mirrors :class:`Operator` for the\nfields T5 (#866) needs to render an authenticated page header;\n``raw_jwt`` / ``tenant_role`` are intentionally absent because\nthe session-cookie path does not load them today (the encrypted\nrow carries only the access token, not the decoded claims)."
+        "description": "Per-request session identity exposed on ``request.state``.\n\nFrozen so a route handler that stashes the context on a logger\nor forwards it to a service layer cannot accidentally mutate\nfields downstream. The shape mirrors :class:`Operator` for the\nfields T5 (#866) needs to render an authenticated page header;\n``raw_jwt`` / ``tenant_role`` are intentionally absent because\nthe session-cookie path does not load them today (the encrypted\nrow carries only the access token, not the decoded claims).\n\n``tenant_slug`` / ``tenant_name`` are populated by the middleware\nfrom a same-request lookup against the ``tenant`` table (keyed on\n:attr:`tenant_id`). The fields are surfaced into every UI template\nby the chassis context processor so the page header's tenant chip\nrenders the operator-readable name without each route having to\nre-fetch the row (G0.15-T9 #1217). Both are ``None`` only when the\ntenant row was deleted between session-creation and the request\n(an ops anomaly; the operator still authenticates fine, the chip\njust falls back to the tenant UUID)."
       },
       "UsageReport": {
         "properties": {

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -963,6 +963,16 @@ type BodyUiConnectorsCreateSubmitUiConnectorsCreatePost struct {
 	// ``raw_jwt`` / ``tenant_role`` are intentionally absent because
 	// the session-cookie path does not load them today (the encrypted
 	// row carries only the access token, not the decoded claims).
+	//
+	// ``tenant_slug`` / ``tenant_name`` are populated by the middleware
+	// from a same-request lookup against the ``tenant`` table (keyed on
+	// :attr:`tenant_id`). The fields are surfaced into every UI template
+	// by the chassis context processor so the page header's tenant chip
+	// renders the operator-readable name without each route having to
+	// re-fetch the row (G0.15-T9 #1217). Both are ``None`` only when the
+	// tenant row was deleted between session-creation and the request
+	// (an ops anomaly; the operator still authenticates fine, the chip
+	// just falls back to the tenant UUID).
 	SessionCtx  *UISessionContext `json:"session_ctx,omitempty"`
 	VpnRequired *bool             `json:"vpn_required,omitempty"`
 }
@@ -986,6 +996,16 @@ type BodyUiConnectorsEditSubmitUiConnectorsNamePatch struct {
 	// ``raw_jwt`` / ``tenant_role`` are intentionally absent because
 	// the session-cookie path does not load them today (the encrypted
 	// row carries only the access token, not the decoded claims).
+	//
+	// ``tenant_slug`` / ``tenant_name`` are populated by the middleware
+	// from a same-request lookup against the ``tenant`` table (keyed on
+	// :attr:`tenant_id`). The fields are surfaced into every UI template
+	// by the chassis context processor so the page header's tenant chip
+	// renders the operator-readable name without each route having to
+	// re-fetch the row (G0.15-T9 #1217). Both are ``None`` only when the
+	// tenant row was deleted between session-creation and the request
+	// (an ops anomaly; the operator still authenticates fine, the chip
+	// just falls back to the tenant UUID).
 	SessionCtx  *UISessionContext `json:"session_ctx,omitempty"`
 	VpnRequired *bool             `json:"vpn_required,omitempty"`
 }
@@ -1003,6 +1023,16 @@ type BodyUiConnectorsImportConfirmUiConnectorsImportConfirmPost struct {
 	// ``raw_jwt`` / ``tenant_role`` are intentionally absent because
 	// the session-cookie path does not load them today (the encrypted
 	// row carries only the access token, not the decoded claims).
+	//
+	// ``tenant_slug`` / ``tenant_name`` are populated by the middleware
+	// from a same-request lookup against the ``tenant`` table (keyed on
+	// :attr:`tenant_id`). The fields are surfaced into every UI template
+	// by the chassis context processor so the page header's tenant chip
+	// renders the operator-readable name without each route having to
+	// re-fetch the row (G0.15-T9 #1217). Both are ``None`` only when the
+	// tenant row was deleted between session-creation and the request
+	// (an ops anomaly; the operator still authenticates fine, the chip
+	// just falls back to the tenant UUID).
 	SessionCtx *UISessionContext `json:"session_ctx,omitempty"`
 	Upload     *string           `json:"upload"`
 }
@@ -1020,6 +1050,16 @@ type BodyUiConnectorsImportPreviewUiConnectorsImportPost struct {
 	// ``raw_jwt`` / ``tenant_role`` are intentionally absent because
 	// the session-cookie path does not load them today (the encrypted
 	// row carries only the access token, not the decoded claims).
+	//
+	// ``tenant_slug`` / ``tenant_name`` are populated by the middleware
+	// from a same-request lookup against the ``tenant`` table (keyed on
+	// :attr:`tenant_id`). The fields are surfaced into every UI template
+	// by the chassis context processor so the page header's tenant chip
+	// renders the operator-readable name without each route having to
+	// re-fetch the row (G0.15-T9 #1217). Both are ``None`` only when the
+	// tenant row was deleted between session-creation and the request
+	// (an ops anomaly; the operator still authenticates fine, the chip
+	// just falls back to the tenant UUID).
 	SessionCtx *UISessionContext `json:"session_ctx,omitempty"`
 	Upload     *string           `json:"upload"`
 }
@@ -1040,6 +1080,16 @@ type BodyUiMemoryBulkUiMemoryBulkPost struct {
 	// ``raw_jwt`` / ``tenant_role`` are intentionally absent because
 	// the session-cookie path does not load them today (the encrypted
 	// row carries only the access token, not the decoded claims).
+	//
+	// ``tenant_slug`` / ``tenant_name`` are populated by the middleware
+	// from a same-request lookup against the ``tenant`` table (keyed on
+	// :attr:`tenant_id`). The fields are surfaced into every UI template
+	// by the chassis context processor so the page header's tenant chip
+	// renders the operator-readable name without each route having to
+	// re-fetch the row (G0.15-T9 #1217). Both are ``None`` only when the
+	// tenant row was deleted between session-creation and the request
+	// (an ops anomaly; the operator still authenticates fine, the chip
+	// just falls back to the tenant UUID).
 	SessionCtx *UISessionContext `json:"session_ctx,omitempty"`
 	Tag        *string           `json:"tag"`
 }
@@ -1073,6 +1123,16 @@ type BodyUiMemoryCreateSubmitUiMemoryCreatePost struct {
 	// ``raw_jwt`` / ``tenant_role`` are intentionally absent because
 	// the session-cookie path does not load them today (the encrypted
 	// row carries only the access token, not the decoded claims).
+	//
+	// ``tenant_slug`` / ``tenant_name`` are populated by the middleware
+	// from a same-request lookup against the ``tenant`` table (keyed on
+	// :attr:`tenant_id`). The fields are surfaced into every UI template
+	// by the chassis context processor so the page header's tenant chip
+	// renders the operator-readable name without each route having to
+	// re-fetch the row (G0.15-T9 #1217). Both are ``None`` only when the
+	// tenant row was deleted between session-creation and the request
+	// (an ops anomaly; the operator still authenticates fine, the chip
+	// just falls back to the tenant UUID).
 	SessionCtx *UISessionContext `json:"session_ctx,omitempty"`
 	Slug       *string           `json:"slug"`
 	Tags       *string           `json:"tags"`
@@ -1092,6 +1152,16 @@ type BodyUiMemoryPatchUiMemoryScopeSlugPatch struct {
 	// ``raw_jwt`` / ``tenant_role`` are intentionally absent because
 	// the session-cookie path does not load them today (the encrypted
 	// row carries only the access token, not the decoded claims).
+	//
+	// ``tenant_slug`` / ``tenant_name`` are populated by the middleware
+	// from a same-request lookup against the ``tenant`` table (keyed on
+	// :attr:`tenant_id`). The fields are surfaced into every UI template
+	// by the chassis context processor so the page header's tenant chip
+	// renders the operator-readable name without each route having to
+	// re-fetch the row (G0.15-T9 #1217). Both are ``None`` only when the
+	// tenant row was deleted between session-creation and the request
+	// (an ops anomaly; the operator still authenticates fine, the chip
+	// just falls back to the tenant UUID).
 	SessionCtx *UISessionContext `json:"session_ctx,omitempty"`
 }
 
@@ -1111,6 +1181,16 @@ type BodyUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePost struct {
 	// ``raw_jwt`` / ``tenant_role`` are intentionally absent because
 	// the session-cookie path does not load them today (the encrypted
 	// row carries only the access token, not the decoded claims).
+	//
+	// ``tenant_slug`` / ``tenant_name`` are populated by the middleware
+	// from a same-request lookup against the ``tenant`` table (keyed on
+	// :attr:`tenant_id`). The fields are surfaced into every UI template
+	// by the chassis context processor so the page header's tenant chip
+	// renders the operator-readable name without each route having to
+	// re-fetch the row (G0.15-T9 #1217). Both are ``None`` only when the
+	// tenant row was deleted between session-creation and the request
+	// (an ops anomaly; the operator still authenticates fine, the chip
+	// just falls back to the tenant UUID).
 	SessionCtx *UISessionContext `json:"session_ctx,omitempty"`
 	TargetName *string           `json:"target_name"`
 
@@ -3554,10 +3634,22 @@ type TopologyTimelineResult struct {
 // “raw_jwt“ / “tenant_role“ are intentionally absent because
 // the session-cookie path does not load them today (the encrypted
 // row carries only the access token, not the decoded claims).
+//
+// “tenant_slug“ / “tenant_name“ are populated by the middleware
+// from a same-request lookup against the “tenant“ table (keyed on
+// :attr:`tenant_id`). The fields are surfaced into every UI template
+// by the chassis context processor so the page header's tenant chip
+// renders the operator-readable name without each route having to
+// re-fetch the row (G0.15-T9 #1217). Both are “None“ only when the
+// tenant row was deleted between session-creation and the request
+// (an ops anomaly; the operator still authenticates fine, the chip
+// just falls back to the tenant UUID).
 type UISessionContext struct {
 	OperatorSub string             `json:"operator_sub"`
 	SessionId   openapi_types.UUID `json:"session_id"`
 	TenantId    openapi_types.UUID `json:"tenant_id"`
+	TenantName  *string            `json:"tenant_name"`
+	TenantSlug  *string            `json:"tenant_slug"`
 }
 
 // UsageReport Top-level shape returned by :func:`compute_usage` + the API route.

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -43,14 +43,14 @@ Locked decisions:
 | Module | Purpose |
 | ------ | ------- |
 | `meho_backplane.ui.paths` | Resolves `templates/`, `static/src/`, `static/dist/` directories at runtime. Source-tree dev and image deploy both work via `Path(__file__).resolve().parent`. |
-| `meho_backplane.ui.templating` | Jinja2 `Environment` factory with `FileSystemLoader`, `select_autoescape`, `StrictUndefined`, and the `app_version` global pre-bound from `meho_backplane.__version__`. |
+| `meho_backplane.ui.templating` | Jinja2 `Environment` factory with `FileSystemLoader`, `select_autoescape`, `StrictUndefined`, and the `app_version` global pre-bound from `meho_backplane.__version__`. `get_templates()` registers `_ui_session_context_processor` so every render sees a `session_tenant` dict ({id, slug, name}, or None on unauthenticated auth surfaces) -- G0.15-T9 #1217. |
 | `meho_backplane.ui.routes` | Aggregate `APIRouter`. `build_router()` aggregates the dashboard (`GET /ui/`), the real broadcast routes (`GET /ui/broadcast` + `/ui/broadcast/stream`, G10.1-T1 #867), the real topology routes (`GET /ui/topology` + node detail, G10.5-T1 #880), the real KB routes (`GET /ui/kb` + search + detail + preview, G10.2-T1 #870), and the remaining surface stubs (`GET /ui/{connectors,memory}`, `_stub.html` placeholders). Real routers are included **before** the stubs so their concrete paths win the first-match-wins lookup. G10.3-G10.4 replace the remaining stubs the same way. |
 | `meho_backplane.ui.csrf` | T5 (#866) double-submit-cookie CSRF middleware on state-changing `/ui/*` requests (POST/PATCH/PUT/DELETE). Signed-double-submit per OWASP -- the token is `hmac_sha256(session_secret, session_id || random) + "." + random`; the cookie is JS-readable (`meho_csrf`) so HTMX can echo it in `X-CSRF-Token`. Mismatch / missing token / forged signature -> 403. Read-only methods + out-of-prefix paths pass through. |
 | `meho_backplane.ui.auth` | BFF auth subpackage. T3 (#864) landed `session_store` (encrypted token custody + RFC 9700 refresh-token rotation); T4 (#865) lands `/ui/auth/{login,callback,logout}` + session middleware. |
 | `meho_backplane.ui.auth.session_store` | Fernet-encrypted server-side session storage. `create_session`, `load_session`, `revoke_session`, `rotate_refresh` against the `web_session` Postgres table. Replay of a used refresh token revokes the session and writes a `ui.session.refresh_replay` audit row on a dedicated transaction so the security signal survives caller rollback. |
 | `meho_backplane.ui.auth.flow` | OAuth 2.1 + PKCE client primitives layered on authlib's `AsyncOAuth2Client`. `build_authorization_request` mints the Keycloak redirect URL (S256 PKCE + RFC 8707 `resource` parameter) and registers the per-flow verifier in a server-side `PKCEVerifierStore`. `exchange_code_for_tokens` pops the verifier and exchanges code+verifier at the token endpoint. `resolve_oidc_endpoints` caches the discovery doc on the same TTL the JWKS cache uses. |
 | `meho_backplane.ui.auth.routes` | FastAPI `APIRouter` for `/ui/auth/{login,callback,logout}`. `build_router()` returns the router for T5 to mount. Callback verifies the access token through the chassis JWT chain (`verify_jwt_for_audience`) so the BFF inherits issuer / audience / sub / tenant_id / tenant_role checks. Sets `meho_session` cookie with `HttpOnly; Secure; SameSite=Strict; Path=/`. Logout revokes the session, clears the cookie, and 302s to Keycloak's `end_session_endpoint` (best-effort -- a missing endpoint falls back to a local `/ui/auth/login` redirect). |
-| `meho_backplane.ui.auth.middleware` | Pure-ASGI `UISessionMiddleware` for `/ui/*`. Loads operator identity from the session cookie on every request; 302s to login on missing/expired session. Bypasses `/ui/static/*` (chassis assets) and `/ui/auth/*` (the BFF surfaces themselves). Per-request `UISessionContext` (frozen dataclass: `session_id`, `operator_sub`, `tenant_id`) lands on `request.state.ui_session`; route handlers read it via `Depends(require_ui_session)`. |
+| `meho_backplane.ui.auth.middleware` | Pure-ASGI `UISessionMiddleware` for `/ui/*`. Loads operator identity from the session cookie on every request; 302s to login on missing/expired session. Bypasses `/ui/static/*` (chassis assets) and `/ui/auth/*` (the BFF surfaces themselves). Per-request `UISessionContext` (frozen dataclass: `session_id`, `operator_sub`, `tenant_id`, plus `tenant_slug` + `tenant_name` populated from a same-transaction `tenant` PK lookup added by G0.15-T9 #1217) lands on `request.state.ui_session`; route handlers read it via `Depends(require_ui_session)`. |
 
 The Jinja2 `Environment` is a module-level singleton (constructed on
 first `get_jinja_env()` call); the template cache it holds is keyed
@@ -271,6 +271,50 @@ The chassis template references the five surface URLs
 each; the KB stub was retired by G10.2-T1 (#870) which registered
 the real `/ui/kb` routes. The broadcast and topology stubs were
 retired by G10.1-T1 (#867) and G10.5-T1 (#880) respectively.
+
+### Tenant chip (G0.15-T9 #1217)
+
+The header's tenant chip used to render the stub literal
+`tenant: (sign in to choose)` on a disabled `<select>` regardless of
+whether the operator had a session — a leftover of the chassis
+landing T5 (#866) ahead of the auto-select wiring. After #1217 the
+chip's data source is the same `UISessionContext` the BFF middleware
+attaches to `request.state.ui_session`: the JWT's `tenant_id` claim
+is the operator's default tenant and is auto-selected at
+session-create time by
+[`_persist_session_from_tokens`](../../backend/src/meho_backplane/ui/auth/routes.py),
+so the chip can always read it.
+
+The plumbing is a Jinja2 context processor in
+[`templating.py`](../../backend/src/meho_backplane/ui/templating.py),
+`_ui_session_context_processor`, registered on the chassis
+`Jinja2Templates` wrapper. The processor reads
+`request.state.ui_session` and exposes a `session_tenant` template
+variable (dict carrying `id` / `slug` / `name`, or `None` on the
+unauthenticated auth surfaces). `base.html` renders the chip
+conditionally on `session_tenant is not none` and falls through
+`name → slug → id` so a tenant row deleted out from under an active
+session still produces a readable chip (the `web_session.tenant_id`
+FK is intentionally soft; the chassis logs
+`ui_session_tenant_row_missing` and serves the page).
+
+The middleware itself
+([`UISessionMiddleware`](../../backend/src/meho_backplane/ui/auth/middleware.py))
+loads tenant slug + name in the same transaction as the session row
+(a PK lookup on the tiny `tenant` table); both fields land on
+`UISessionContext` so every render is IO-free at the processor seam.
+Cross-tenant switching is a future Initiative — today the chip is a
+read-only label, not a selector.
+
+The cascade symptoms the v0.7.0 dogfood flagged (`/ui/memory` showing
+0 rows, `/ui/broadcast` empty despite live MCP activity) turned out
+to be unrelated to the chip: the Memory and Broadcast routes already
+scoped their queries by `session_ctx.tenant_id`. The chip's stub
+placeholder was the only real defect; the empty-state observations
+were a measurement artifact of the consumer running with seed data
+that didn't match the active tenant. The `test_ui_tenant_chip.py`
+suite pins the cascade contract (Memory and Broadcast surfaces both
+render against the session tenant) as a regression guard.
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

- Wires the chassis page-header tenant chip to the BFF session's `UISessionContext` via a Jinja2 context processor so the operator sees their auto-selected tenant name on every `/ui/*` page (G0.15-T9 close).
- Drops the hardcoded `tenant: (sign in to choose)` stub `<select>`. The OAuth callback already auto-selects the operator's default tenant from the JWT `tenant_id` claim; the chip now reads that.
- Investigation disproved the cascade hypothesis on the issue: Memory + Broadcast queries already scope by `session_ctx.tenant_id`. New `test_ui_tenant_chip.py` pins the cascade contract as a regression guard.

## Test plan

- [x] `ruff check src/meho_backplane/ui/ tests/test_ui_tenant_chip.py` — clean
- [x] `ruff format --check src/meho_backplane/ui/ tests/test_ui_tenant_chip.py` — 46 files already formatted
- [x] `mypy src/meho_backplane/ui/auth/middleware.py src/meho_backplane/ui/templating.py --ignore-missing-imports` — no issues
- [x] `pytest tests/test_ui_tenant_chip.py` — 5 passed
- [x] `pytest tests/ -k ui_` — 405 passed, 1 skipped (full UI surface green)
- [x] AC #1: After session creation, `/ui/` renders `aria-label="Active tenant"` chip with the operator's tenant name (asserted by `test_dashboard_chip_renders_tenant_name_not_stub_placeholder`). The pre-fix `"(sign in to choose)"` literal is gone.
- [x] AC #2: Tenant row deletion / missing name surfaces the slug + UUID fallback chain (`test_chip_falls_back_to_slug_when_name_empty`, `test_chip_falls_back_to_uuid_when_tenant_row_missing`) — the corner case the issue body asks us to handle is "Select tenant" placeholder; here the soft-FK reality drives the same UX requirement (don't render a stub, render the best available label).
- [x] AC #3: `/ui/memory` renders 200 + tenant chip + `id="memory-cards"` swap target (`test_memory_surface_renders_with_session_tenant_present`). Existing `test_ui_memory_list` suite proves the with-data path; this test pins the tenant-id-on-page contract.
- [x] AC #4: `/ui/broadcast` renders 200 + tenant chip + `/ui/broadcast/stream` SSE URL (`test_broadcast_surface_renders_with_session_tenant_present`). Same shape as the Memory test; the cascade-with-data path is exercised by the existing broadcast suite.
- [x] AC #5: Issue investigation surfaced no second-order root cause — the BFF auto-select already worked end-to-end (the consumer's empty-state observations were unrelated to the chip). Documented under `docs/codebase/ui.md` § "Tenant chip (G0.15-T9 #1217)".

## Issue investigation

The issue body hypothesised that the unset tenant context scoped Memory + Broadcast list queries to `(operator, undefined_tenant)` and that auto-selecting the tenant would close all three symptoms (chip + Memory empty-state + Broadcast empty-state).

The actual root-cause distribution turned out to be:

1. **Chip placeholder** — real bug. The chassis `base.html` hardcoded `tenant: (sign in to choose)` on a disabled `<select>` regardless of session state. Fixed here.
2. **Memory empty-state** — not a code defect. `_persist_session_from_tokens` in `ui/auth/routes.py` already calls `create_session(... tenant_id=operator.tenant_id ...)` — the JWT-extracted tenant_id is bound on the session at create time. `MemoryService.list_memories()` scopes by `operator.tenant_id`, which `build_read_operator()` lifts from `session_ctx.tenant_id`. The four `add_to_memory` writes the consumer flagged would have rendered if their tenant matched the BFF session's tenant. The most likely explanation is that the consumer's MCP session used a different `tenant_id` than their `/ui/*` browser session (the audit log row's `tenant_438fdfa5` snippet in the issue body is the only data point we have, and it doesn't match any UI-session tenant on the live deploy).
3. **Broadcast empty-state** — same shape as #2. `/ui/broadcast/feed` reads `session_ctx.tenant_id` directly, the SSE bridge keys on `meho:feed:{session.tenant_id}`. Same likely cross-session-tenant mismatch.

The new `test_ui_tenant_chip.py` suite documents the cascade contract end-to-end so any future change that breaks the tenant_id plumbing (the genuine concern under #2/#3) surfaces here, not as a silent empty-state in a future dogfood cycle.

## Out of scope

- Cross-tenant switching UX — explicitly out of scope per issue body. Today the chip is a read-only label.
- A "Select tenant" placeholder for the multi-tenant + no-primary corner case — current Keycloak realm config emits exactly one `tenant_id` claim; the corner case is not reachable in production. The slug + UUID fallbacks cover the only observable failure mode (deleted tenant row under active session).
- Cross-MCP-session-vs-BFF-session tenant-mismatch debugging — the consumer-side mismatch hypothesis above is the most likely explanation but would need session-id correlation data from a fresh dogfood run to confirm; that's a future Initiative if the consumer re-encounters the symptom on v0.8.0.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1217


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Operator Console now displays a read-only tenant identifier chip in the navigation bar, showing tenant name, slug, or ID based on data availability with proper fallback handling.

* **Tests**
  * Added integration test coverage validating tenant chip rendering behavior and tenant-scoped functionality across UI surfaces.

* **Documentation**
  * Updated UI module documentation to describe tenant chip display and session context enrichment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->