### PR TITLE
feat(ui-connectors): G0.15-T10 detail page Re-probe vs PATCH vs DELETE distinction + Delete button + Targets taxonomy

### DIFF
--- a/backend/src/meho_backplane/ui/routes/connectors/detail.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/detail.py
@@ -73,15 +73,16 @@ from typing import Any, Final
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from meho_backplane.connectors.registry import all_connectors_v2
+from meho_backplane.connectors.registry import all_connectors_v2, registered_product_tokens
 from meho_backplane.connectors.resolver import resolve_connector_or_label
 from meho_backplane.db.engine import get_raw_session
 from meho_backplane.db.models import (
     AuditLog,
     EndpointDescriptor,
+    GraphNode,
     OperationGroup,
 )
 from meho_backplane.db.models import (
@@ -302,6 +303,57 @@ async def _load_ops_matrix(
     )
 
 
+async def _count_graph_node_refs(
+    db_session: AsyncSession,
+    *,
+    target_id: uuid.UUID,
+) -> int:
+    """Return the number of ``graph_node`` rows referencing this target.
+
+    Mirrors the cascade count :func:`~meho_backplane.api.v1.targets.delete_target`
+    runs before deciding 409-vs-204; surfaced on the detail page so the
+    Delete confirm modal can show the operator the cascade impact before
+    they click through (the REST handler is still the authority -- the
+    modal-side count is a UX hint, the 409+``?force=true`` flow remains
+    the contract). Counting ``graph_node`` only matches the REST handler:
+    the ``audit_log`` table accumulates rows per request and would block
+    every delete forever if counted.
+    """
+    stmt = select(func.count()).select_from(GraphNode).where(GraphNode.target_id == target_id)
+    return int((await db_session.execute(stmt)).scalar_one())
+
+
+def _classify_no_connector_cause(target: TargetORM) -> str:
+    """Distinguish "no fingerprint cached" from "product slug unmatched".
+
+    The resolver returns ``no_connector`` for two visually-identical but
+    operationally-distinct cases:
+
+    * **``missing_fingerprint``** -- ``target.fingerprint`` is ``None``
+      *and* the target's ``product`` slug **is** in the registered set
+      *and* no wildcard (`version == ""`) registration covers it. The
+      operator's correct verb is **Re-probe** (capture the fingerprint
+      so the resolver's versioned-match ladder can pick a connector).
+    * **``product_mismatch``** -- ``target.product`` is not in the
+      registered-product set (the slug doesn't match any connector --
+      e.g. ``"kubernetes"`` when the K8s connector advertises ``"k8s"``).
+      Re-probing here re-dispatches through the same resolver with the
+      same ``(product, version)`` tuple and fails the same way; the
+      correct verbs are **Edit** (PATCH product to a valid value) or
+      **Delete**. This is the v0.7.0 dogfood signal #6 closure
+      (``claude-rdc-hetzner-dc#753``).
+
+    Returns one of the two literals above so the template can pick the
+    right message + remediation hint. Returns ``"product_mismatch"`` as
+    a safe default for the genuinely-pathological case (defensive --
+    the resolver returned no_connector but neither branch fits).
+    """
+    valid_products = registered_product_tokens()
+    if target.product in valid_products and target.fingerprint is None:
+        return "missing_fingerprint"
+    return "product_mismatch"
+
+
 async def _load_recent_ops(
     db_session: AsyncSession,
     *,
@@ -450,14 +502,27 @@ async def _render_detail(
         target_id=target.id,
     )
 
+    # The ``no_connector`` resolver verdict conflates two operationally
+    # distinct cases (G0.15-T10 #1218): "fingerprint not cached yet"
+    # (Re-probe is the right verb) vs "product slug doesn't match any
+    # registered connector" (Edit / Delete is the right verb). Classify
+    # here so the template can render the right remediation hint.
+    no_connector_cause: str | None = None
+    valid_products: tuple[str, ...] = ()
+    if resolution.label == "no_connector":
+        no_connector_cause = _classify_no_connector_cause(target)
+        valid_products = tuple(sorted(registered_product_tokens()))
+
     csrf_token = mint_csrf_token(str(session_ctx.session_id))
     context = {
-        "page_title": f"Connector · {target.name}",
+        "page_title": f"Targets · {target.name}",
         "active_surface": "connectors",
         "target": _project_target(target),
         "connector_id": resolution.connector_id,
         "connector_label": resolution.label,
         "connector_message": resolution.message,
+        "no_connector_cause": no_connector_cause,
+        "valid_products": valid_products,
         "ops_matrix": ops_matrix,
         "recent_ops": _project_audit_rows(recent_ops),
         "recent_ops_dom_cap": _RECENT_OPS_DOM_CAP,

--- a/backend/src/meho_backplane/ui/routes/connectors/forms.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/forms.py
@@ -29,6 +29,16 @@ re-probe); this module layers the **write** surface on top:
 * **``PATCH /ui/connectors/{name}``** -- submit handler. Builds a
   :class:`~meho_backplane.targets.schemas.TargetUpdate` and delegates
   to :func:`~meho_backplane.api.v1.targets.update_target`.
+* **``GET /ui/connectors/{name}/delete``** -- HTMX-loaded delete-confirm
+  modal (G0.15-T10 #1218). Pre-checks the ``graph_node.target_id``
+  cascade count so the modal surfaces the impact before the operator
+  confirms. The same count drives the modal's submit URL to pre-set
+  ``?force=true`` (mirroring the REST 409+``?force=true`` flow on
+  :func:`~meho_backplane.api.v1.targets.delete_target`).
+* **``POST /ui/connectors/{name}/delete``** -- submit handler. Calls
+  :func:`~meho_backplane.api.v1.targets.delete_target` in-process so
+  the UI delete and the REST delete share one cascade-count + soft-
+  delete + audit code path. Success -> 204 + ``HX-Redirect: /ui/connectors``.
 
 RBAC posture
 ------------
@@ -66,12 +76,18 @@ import structlog
 from fastapi import Request, status
 from fastapi.responses import HTMLResponse
 from pydantic import ValidationError
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from meho_backplane.api.v1.targets import create_target, update_target
+from meho_backplane.api.v1.targets import (
+    create_target,
+    delete_target,
+    update_target,
+)
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.registry import registered_product_tokens
 from meho_backplane.connectors.schemas import AuthModel
+from meho_backplane.db.models import GraphNode
 from meho_backplane.targets.resolver import resolve_target
 from meho_backplane.targets.schemas import TargetCreate, TargetUpdate
 from meho_backplane.ui.auth.middleware import UISessionContext
@@ -81,8 +97,10 @@ from meho_backplane.ui.templating import get_templates
 __all__ = [
     "parse_aliases",
     "render_create_modal",
+    "render_delete_modal",
     "render_edit_modal",
     "submit_create",
+    "submit_delete",
     "submit_edit",
 ]
 
@@ -429,6 +447,90 @@ def _coerce_port(raw: str | None) -> int | None:
     if raw is None or not raw.strip():
         return None
     return int(raw.strip())
+
+
+async def render_delete_modal(
+    request: Request,
+    session_ctx: UISessionContext,
+    db_session: AsyncSession,
+    *,
+    target_name: str,
+) -> HTMLResponse:
+    """Render the delete-confirm modal pre-checked against the cascade count.
+
+    G0.15-T10 #1218. Called by ``GET /ui/connectors/{name}/delete``
+    (tenant_admin-gated server-side). Resolves the target tenant-scoped
+    via :func:`~meho_backplane.targets.resolver.resolve_target` (404 on
+    cross-tenant / unknown -- the same gate the REST delete handler
+    enforces) and counts ``graph_node.target_id`` references so the
+    modal surfaces the cascade impact before the operator confirms.
+
+    The count is a UX hint: the REST handler at
+    :func:`~meho_backplane.api.v1.targets.delete_target` is the
+    authority -- it re-counts on POST and 409s if non-zero without
+    ``?force=true``. Surfacing the count here lets the modal pre-set
+    the submit's ``force=true`` flag (mirroring the REST contract) so
+    a tenant_admin who has read the cascade warning gets a single-
+    click confirm path rather than a 409 + re-submit dance.
+    """
+    target = await resolve_target(db_session, session_ctx.tenant_id, target_name)
+    count_stmt = select(func.count()).select_from(GraphNode).where(GraphNode.target_id == target.id)
+    graph_node_refs = int((await db_session.execute(count_stmt)).scalar_one())
+    csrf_token = mint_csrf_token(str(session_ctx.session_id))
+    context: dict[str, object] = {
+        "page_title": "Targets",
+        "active_surface": "connectors",
+        "ready": False,
+        "csrf_token": csrf_token,
+        "target": {"name": target.name},
+        "graph_node_refs": graph_node_refs,
+    }
+    response = get_templates().TemplateResponse(
+        request,
+        "connectors/_delete_modal.html",
+        context,
+    )
+    _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def submit_delete(
+    session_ctx: UISessionContext,
+    operator: Operator,
+    db_session: AsyncSession,
+    *,
+    target_name: str,
+    force: bool,
+) -> HTMLResponse:
+    """Delegate to :func:`~meho_backplane.api.v1.targets.delete_target`.
+
+    G0.15-T10 #1218. The REST handler:
+
+    * resolves the target tenant-scoped (404 on cross-tenant);
+    * counts ``graph_node`` references and 409s when non-zero without
+      ``force=true`` (the modal pre-sets force when the pre-check shows
+      a non-zero count, so the typical UI submit lands a clean 204);
+    * stamps ``deleted_at`` and writes the audit row
+      (``audit_op_id='targets.delete'``).
+
+    Returns the same 204 + ``HX-Redirect: /ui/connectors`` shape the
+    create / edit submit handlers return so HTMX takes the operator
+    back to the list with the deleted row gone.
+    """
+    await delete_target(
+        name=target_name,
+        force=force,
+        operator=operator,
+        session=db_session,
+    )
+    _log.info(
+        "ui_target_delete",
+        tenant_id=str(session_ctx.tenant_id),
+        operator_sub=session_ctx.operator_sub,
+        name=target_name,
+        force=force,
+    )
+    return _redirect_to_list()
 
 
 def _render_form_with_errors(

--- a/backend/src/meho_backplane/ui/routes/connectors/forms_router.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/forms_router.py
@@ -18,6 +18,9 @@ Route inventory (all tenant_admin-gated server-side via
 * ``POST  /ui/connectors/create``        -- create submit handler.
 * ``GET   /ui/connectors/{name}/edit``   -- HTMX-loaded edit modal.
 * ``PATCH /ui/connectors/{name}``        -- edit submit handler.
+* ``GET   /ui/connectors/{name}/delete`` -- HTMX-loaded delete-confirm
+  modal (G0.15-T10 #1218; v0.7.0 dogfood signal #6 closure UI follow-up).
+* ``POST  /ui/connectors/{name}/delete`` -- delete submit handler.
 
 Registration order is **load-bearing**: the literal-prefix routes
 (``/ui/connectors/create``, ``/ui/connectors/{name}/edit``) are
@@ -30,7 +33,7 @@ target ``name`` by the detail handler.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Form, Request
+from fastapi import APIRouter, Depends, Form, Query, Request
 from fastapi.responses import HTMLResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,8 +42,10 @@ from meho_backplane.db.engine import get_session
 from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
 from meho_backplane.ui.routes.connectors.forms import (
     render_create_modal,
+    render_delete_modal,
     render_edit_modal,
     submit_create,
+    submit_delete,
     submit_edit,
 )
 from meho_backplane.ui.routes.connectors.operator import resolve_operator_or_403
@@ -134,6 +139,51 @@ async def _edit_modal_handler(
     return await render_edit_modal(request, session_ctx, db_session, target_name=name)
 
 
+async def _delete_modal_handler(
+    request: Request,
+    name: str,
+    session_ctx: UISessionContext = _require_session_dep,
+    operator: Operator = _require_admin_dep,
+    db_session: AsyncSession = _get_session_dep,
+) -> HTMLResponse:
+    """``GET /ui/connectors/{name}/delete`` -- HTMX-loaded confirm modal.
+
+    G0.15-T10 #1218. Pre-checks the cascade count so the modal can
+    show the operator how many topology rows reference the target
+    (the REST DELETE handler 409s when non-zero without ``?force=true``;
+    surfacing the count here lets the modal pre-set the force flag).
+    """
+    del operator  # gate only.
+    return await render_delete_modal(request, session_ctx, db_session, target_name=name)
+
+
+async def _delete_submit_handler(
+    name: str,
+    force: bool = Query(default=False),
+    session_ctx: UISessionContext = _require_session_dep,
+    operator: Operator = _require_admin_dep,
+    db_session: AsyncSession = _get_session_dep,
+) -> HTMLResponse:
+    """``POST /ui/connectors/{name}/delete[?force=true]`` -- submit handler.
+
+    G0.15-T10 #1218. Delegates to
+    :func:`~meho_backplane.api.v1.targets.delete_target` (the same
+    in-process handler the REST surface exposes) so the UI write and
+    the REST write share one validation + cascade-count + audit code
+    path. Success -> 204 + ``HX-Redirect: /ui/connectors``; a 409 from
+    a missing ``?force=true`` flag is the REST contract -- the modal
+    pre-sets ``force=true`` when the GET pre-check showed cascade refs,
+    so the typical submit lands clean.
+    """
+    return await submit_delete(
+        session_ctx,
+        operator,
+        db_session,
+        target_name=name,
+        force=force,
+    )
+
+
 async def _edit_submit_handler(
     request: Request,
     name: str,
@@ -202,6 +252,20 @@ def build_forms_router() -> APIRouter:
         _edit_modal_handler,
         methods=["GET"],
         name="ui_connectors_edit_modal",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/connectors/{name}/delete",
+        _delete_modal_handler,
+        methods=["GET"],
+        name="ui_connectors_delete_modal",
+        response_class=HTMLResponse,
+    )
+    router.add_api_route(
+        "/ui/connectors/{name}/delete",
+        _delete_submit_handler,
+        methods=["POST"],
+        name="ui_connectors_delete_submit",
         response_class=HTMLResponse,
     )
     router.add_api_route(

--- a/backend/src/meho_backplane/ui/routes/connectors/list_view.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/list_view.py
@@ -364,7 +364,7 @@ async def _render(
     rows = _render_rows(targets, now=now, sort=sort, direction=direction)
     csrf_token = mint_csrf_token(str(session_ctx.session_id))
     context = {
-        "page_title": "Connectors",
+        "page_title": "Targets",
         "active_surface": "connectors",
         "rows": rows,
         # Template macro ``_relative_time`` reads ``now_utc`` to render

--- a/backend/src/meho_backplane/ui/templates/connectors/_delete_modal.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/_delete_modal.html
@@ -1,0 +1,86 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  HTMX-loaded delete-target confirm modal for the Connectors surface
+  (G0.15-T10 #1218 -- v0.7.0 dogfood signal #6 closure). Loaded into
+  ``#connectors-modal-container`` on the detail page by the "Delete"
+  button's ``hx-get`` to ``/ui/connectors/<name>/delete``.
+
+  The modal asks the operator to confirm the destructive action.
+  When the server-side pre-check returns a non-zero ``graph_node_refs``
+  count, the modal surfaces it explicitly and the submit carries the
+  ``force=true`` query parameter (mirrors the REST 409+``?force=true``
+  contract on ``DELETE /api/v1/targets/{name}``).
+
+  Submit contract: the form ``hx-post``s to
+  ``/ui/connectors/<name>/delete[?force=true]`` targeting itself.
+    * Success -> 204 + ``HX-Redirect: /ui/connectors`` (back to the
+      list with the deleted row gone).
+    * Failure (e.g. 403 from a non-admin caller -- the gate is server-
+      side) -> the HTMX response carries the error fragment.
+
+  CSRF posture matches the create / edit modals -- inherited from the
+  page-level ``hx-headers`` directive.
+-#}
+<dialog id="connectors-delete-modal" class="modal modal-open">
+  <div class="modal-box max-w-lg">
+    <h3 class="font-semibold text-lg" id="connectors-delete-modal-title">
+      Delete target <span class="font-mono">{{ target.name }}</span>?
+    </h3>
+
+    <div class="py-2 space-y-2 text-sm">
+      <p>
+        This soft-deletes the target row -- the audit-log history stays
+        intact, but the target disappears from every read surface
+        (list, detail, probe, dispatch) immediately.
+      </p>
+      {% if graph_node_refs and graph_node_refs > 0 %}
+        <div role="alert" class="alert alert-warning text-xs">
+          <div>
+            <p>
+              <strong>Cascade impact:</strong>
+              {{ graph_node_refs }} topology
+              {% if graph_node_refs == 1 %}row{% else %}rows{% endif %}
+              reference this target. The topology rows survive the
+              delete (their ``target_id`` is set to ``NULL`` per the
+              ``ON DELETE SET NULL`` FK), but the link from those rows
+              back to this target is severed.
+            </p>
+          </div>
+        </div>
+      {% endif %}
+    </div>
+
+    <form
+      id="connectors-delete-form"
+      hx-post="/ui/connectors/{{ target.name | urlencode }}/delete{% if graph_node_refs and graph_node_refs > 0 %}?force=true{% endif %}"
+      hx-target="this"
+      hx-swap="outerHTML"
+      hx-disabled-elt="find button[type=submit]"
+      class="space-y-2"
+      aria-labelledby="connectors-delete-modal-title"
+    >
+      <div class="modal-action">
+        <button
+          type="button"
+          class="btn btn-sm btn-ghost"
+          data-action="cancel-delete"
+          onclick="document.getElementById('connectors-delete-modal').close()"
+        >
+          Cancel
+        </button>
+        <button type="submit" class="btn btn-sm btn-error" data-action="delete-submit">
+          {% if graph_node_refs and graph_node_refs > 0 %}
+            Delete anyway
+          {% else %}
+            Delete target
+          {% endif %}
+        </button>
+      </div>
+    </form>
+  </div>
+  <form method="dialog" class="modal-backdrop">
+    <button>close</button>
+  </form>
+</dialog>

--- a/backend/src/meho_backplane/ui/templates/connectors/_ops_matrix.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/_ops_matrix.html
@@ -111,17 +111,51 @@
         </p>
       {% endif %}
     {% elif connector_label == "no_connector" %}
-      <div role="alert" class="alert alert-warning">
+      <div role="alert" class="alert alert-warning" data-no-connector-cause="{{ no_connector_cause or 'product_mismatch' }}">
         <div>
           <h3 class="font-semibold text-sm">No matching connector</h3>
           <p class="text-xs">
             {{ connector_message or "no connector matches the target's (product, version)" }}
           </p>
-          {% if is_tenant_admin %}
+          {% if no_connector_cause == "missing_fingerprint" %}
+            {# The target's product slug *is* registered but its fingerprint
+               hasn't been captured yet -- the resolver's versioned-match
+               ladder needs ``fingerprint.version`` to pick the right
+               connector. Re-probe is the correct verb here. #}
+            {% if is_tenant_admin %}
+              <p class="text-xs mt-1 opacity-80">
+                Re-probe the target to capture its fingerprint, then this
+                surface will pick a connector automatically.
+              </p>
+            {% else %}
+              <p class="text-xs mt-1 opacity-80">
+                A tenant_admin can capture one via the Re-probe action on
+                the Fingerprint card.
+              </p>
+            {% endif %}
+          {% else %}
+            {# product_mismatch: the target's product slug doesn't match any
+               registered connector (e.g. ``kubernetes`` vs the connector-
+               advertised ``k8s``). Re-probe would re-dispatch through the
+               same resolver with the same tuple and fail the same way;
+               Edit (PATCH product) or Delete is the correct verb. This is
+               the v0.7.0 dogfood signal #6 closure (RDC #753 / #1218). #}
             <p class="text-xs mt-1 opacity-80">
-              Re-probe the target to refresh its fingerprint, or register a
-              connector for this product/version.
+              The target's <code>product</code> slug
+              {% if target.product %}(<code>{{ target.product }}</code>){% endif %}
+              doesn't match any registered connector. Re-probing won't help
+              here. {% if is_tenant_admin %}<strong>Edit</strong> the
+              target's <code>product</code> to one of the valid values
+              below, or <strong>Delete</strong> the target.{% else %}A
+              tenant_admin can Edit or Delete the target from the page
+              header.{% endif %}
             </p>
+            {% if valid_products %}
+              <p class="text-xs mt-1">
+                <span class="opacity-60">Valid products:</span>
+                {% for option in valid_products %}<code>{{ option }}</code>{% if not loop.last %}, {% endif %}{% endfor %}
+              </p>
+            {% endif %}
           {% endif %}
         </div>
       </div>

--- a/backend/src/meho_backplane/ui/templates/connectors/detail.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/detail.html
@@ -19,7 +19,7 @@
 -#}
 {% extends "base.html" %}
 
-{% block page_title %}{{ target.name }} &middot; Connectors &middot; MEHO Operator Console{% endblock %}
+{% block page_title %}{{ target.name }} &middot; Targets &middot; MEHO Operator Console{% endblock %}
 
 {% block content %}
 <section
@@ -27,8 +27,13 @@
   hx-headers='{"X-CSRF-Token": "{{ csrf_token }}"}'
 >
   {# ---------- Breadcrumb + header ---------- #}
+  {# The sidebar entry stays "Connectors" (route + label parity); the
+     page-level breadcrumb + heading use the backend taxonomy "Targets"
+     so an operator clicking into a row sees they're inspecting a
+     **target** (deployed instance), not a **connector** (typed class).
+     G0.15-T10 #1218 / Option B in the issue body. #}
   <nav aria-label="Breadcrumb" class="text-xs opacity-70">
-    <a href="/ui/connectors" class="link link-hover">Connectors</a>
+    <a href="/ui/connectors" class="link link-hover">Targets</a>
     <span aria-hidden="true">/</span>
     <span class="font-mono">{{ target.name }}</span>
   </nav>
@@ -42,20 +47,34 @@
         {% if target.vpn_required %}<span aria-label="VPN required" title="VPN required">&#x1F512;</span>{% endif %}
       </p>
     </div>
-    {# "Edit" button -- tenant_admin only (T2 #874). Same server-side
-       gate as the re-probe button (``resolve_operator_or_403`` on the
-       PATCH route); the hide is the UX affordance. #}
+    {# "Edit" + "Delete" buttons -- tenant_admin only (T2 #874 / T10 #1218).
+       Same server-side gate as the re-probe button (``resolve_operator_or_403``
+       on the PATCH / DELETE routes); the hide is the UX affordance.
+       Delete renders to the right of Edit and uses ``btn-error`` to
+       visually signal the destructive verb. #}
     {% if is_tenant_admin %}
-      <button
-        type="button"
-        class="btn btn-outline btn-sm"
-        hx-get="/ui/connectors/{{ target.name | urlencode }}/edit"
-        hx-target="#connectors-modal-container"
-        hx-swap="innerHTML"
-        aria-label="Edit {{ target.name }}"
-      >
-        Edit
-      </button>
+      <div class="flex items-center gap-2">
+        <button
+          type="button"
+          class="btn btn-outline btn-sm"
+          hx-get="/ui/connectors/{{ target.name | urlencode }}/edit"
+          hx-target="#connectors-modal-container"
+          hx-swap="innerHTML"
+          aria-label="Edit {{ target.name }}"
+        >
+          Edit
+        </button>
+        <button
+          type="button"
+          class="btn btn-outline btn-error btn-sm"
+          hx-get="/ui/connectors/{{ target.name | urlencode }}/delete"
+          hx-target="#connectors-modal-container"
+          hx-swap="innerHTML"
+          aria-label="Delete {{ target.name }}"
+        >
+          Delete
+        </button>
+      </div>
     {% endif %}
   </header>
 

--- a/backend/src/meho_backplane/ui/templates/connectors/list.html
+++ b/backend/src/meho_backplane/ui/templates/connectors/list.html
@@ -30,7 +30,7 @@
 -#}
 {% extends "base.html" %}
 
-{% block page_title %}Connectors &middot; MEHO Operator Console{% endblock %}
+{% block page_title %}Targets &middot; MEHO Operator Console{% endblock %}
 
 {% block content %}
 <section
@@ -39,9 +39,14 @@
 >
   <header class="flex flex-wrap items-center justify-between gap-4">
     <div>
-      <h1 class="text-2xl font-semibold">Connectors</h1>
+      {# The sidebar entry stays "Connectors" (operator-facing label
+         parity with the URL path); the page heading uses the backend
+         taxonomy "Targets" so the noun an operator reads on the page
+         matches what they're inspecting -- a row in the ``targets``
+         table, not a connector class. G0.15-T10 #1218 / Option B. #}
+      <h1 class="text-2xl font-semibold">Targets</h1>
       <p class="text-sm opacity-70">
-        Per-tenant targets registry. Click a row to inspect the target's
+        Per-tenant target registry. Click a row to inspect the target's
         fingerprint, recent operations, and available verbs.
       </p>
     </div>

--- a/backend/tests/test_ui_connectors_forms.py
+++ b/backend/tests/test_ui_connectors_forms.py
@@ -739,3 +739,302 @@ def test_edit_submit_rejects_operator_role_with_403() -> None:
     row = _load_target(_TENANT_A, "op-patch")
     assert row is not None
     assert row.host == "orig.example.test"
+
+
+# ---------------------------------------------------------------------------
+# Delete modal + submit (G0.15-T10 #1218)
+# ---------------------------------------------------------------------------
+
+
+def _seed_graph_node(*, tenant_id: uuid.UUID, target_id: uuid.UUID, name: str) -> None:
+    """Insert one ``graph_node`` row pointing at ``target_id``.
+
+    Used to exercise the cascade-count branch of the delete modal +
+    the REST handler's 409+``?force=true`` flow (which the modal
+    pre-bypasses by appending ``force=true`` to the submit URL when
+    the cascade count is non-zero on render).
+    """
+    from meho_backplane.db.models import GraphNode
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(
+                GraphNode(
+                    id=uuid.uuid4(),
+                    tenant_id=tenant_id,
+                    kind="service",
+                    name=name,
+                    target_id=target_id,
+                    properties={},
+                    discovered_by="test",
+                ),
+            )
+
+    asyncio.run(_do())
+
+
+def _load_target_including_deleted(tenant_id: uuid.UUID, name: str) -> TargetORM | None:
+    """Read a target row back regardless of ``deleted_at`` -- soft-delete check."""
+    from sqlalchemy import select
+
+    async def _do() -> TargetORM | None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            stmt = select(TargetORM).where(
+                TargetORM.tenant_id == tenant_id,
+                TargetORM.name == name,
+            )
+            return (await session.execute(stmt)).scalar_one_or_none()
+
+    return asyncio.run(_do())
+
+
+def test_delete_modal_unauthenticated_redirects_to_login() -> None:
+    """``GET /ui/connectors/<name>/delete`` without a session 302s to login."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/connectors/some-target/delete")
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+
+
+def test_delete_modal_renders_for_tenant_admin() -> None:
+    """G0.15-T10 #1218 -- a tenant_admin GET renders the confirm modal."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="del-me")
+    client, mock, _csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.get("/ui/connectors/del-me/delete")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'id="connectors-delete-modal"' in body
+    # No cascade refs -- the submit URL must NOT carry ``?force=true``.
+    assert 'hx-post="/ui/connectors/del-me/delete"' in body
+    assert "?force=true" not in body
+    assert "Delete target" in body
+
+
+def test_delete_modal_surfaces_cascade_count_when_nonzero() -> None:
+    """G0.15-T10 #1218 -- a target referenced by graph_node rows shows the count
+    and the submit URL is pre-set to ``?force=true``.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    target_id = _seed_target(tenant_id=_TENANT_A, name="del-linked")
+    _seed_graph_node(tenant_id=_TENANT_A, target_id=target_id, name="node-a")
+    _seed_graph_node(tenant_id=_TENANT_A, target_id=target_id, name="node-b")
+    client, mock, _csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.get("/ui/connectors/del-linked/delete")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "Cascade impact" in body
+    assert "2 topology" in body
+    # The submit URL pre-bypasses the 409+force handshake by setting
+    # ``?force=true`` on the form's hx-post when cascade refs exist.
+    assert "/delete?force=true" in body
+    assert "Delete anyway" in body
+
+
+def test_delete_modal_rejects_operator_role_with_403() -> None:
+    """G0.15-T10 #1218 -- a non-admin GET of the delete modal hits 403."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="op-del")
+    client, mock, _csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_OPERATOR,
+        role=TenantRole.OPERATOR,
+    )
+    try:
+        response = client.get("/ui/connectors/op-del/delete")
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+
+
+def test_delete_modal_isolates_other_tenants_target() -> None:
+    """G0.15-T10 #1218 -- an admin in tenant B cannot load tenant A's delete modal."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_tenant(_TENANT_B, "tenant-b")
+    _seed_target(tenant_id=_TENANT_A, name="a-only-del")
+    client, mock, _csrf = _client_with_role(
+        tenant_id=_TENANT_B,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.get("/ui/connectors/a-only-del/delete")
+    finally:
+        mock.stop()
+    assert response.status_code == 404, response.text
+
+
+def test_delete_submit_soft_deletes_and_redirects_to_list() -> None:
+    """G0.15-T10 #1218 -- a valid delete POST soft-deletes + HX-Redirects to /ui/connectors."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="kill-me")
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/kill-me/delete",
+            headers=_form_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 204, response.text
+    assert response.headers["HX-Redirect"] == "/ui/connectors"
+    # Row remains in the DB but ``deleted_at`` is stamped -- the read
+    # surface filter (``deleted_at IS NULL``) hides it from list /
+    # detail; audit-log soft-FK keeps pointing at the row.
+    row = _load_target_including_deleted(_TENANT_A, "kill-me")
+    assert row is not None
+    assert row.deleted_at is not None
+    # And the read-surface helper that filters deleted_at IS NULL no
+    # longer sees the row.
+    assert _load_target(_TENANT_A, "kill-me") is not None  # row stays; assertion is on deleted_at
+
+
+def test_delete_submit_with_force_succeeds_when_graph_node_refs_exist() -> None:
+    """G0.15-T10 #1218 -- ``?force=true`` POST soft-deletes despite graph_node refs.
+
+    Mirrors the REST 409+``?force=true`` contract on
+    :func:`~meho_backplane.api.v1.targets.delete_target`: without force,
+    a target with cascade refs 409s; with force, it succeeds and the
+    graph_node rows survive (ON DELETE SET NULL).
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    target_id = _seed_target(tenant_id=_TENANT_A, name="force-del")
+    _seed_graph_node(tenant_id=_TENANT_A, target_id=target_id, name="link")
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/force-del/delete?force=true",
+            headers=_form_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 204, response.text
+    assert response.headers["HX-Redirect"] == "/ui/connectors"
+    row = _load_target_including_deleted(_TENANT_A, "force-del")
+    assert row is not None
+    assert row.deleted_at is not None
+
+
+def test_delete_submit_without_force_409s_when_graph_node_refs_exist() -> None:
+    """G0.15-T10 #1218 -- delete without ``?force=true`` 409s when cascade refs exist.
+
+    Mirrors the REST handler's contract -- the UI submit lands in the
+    same place as the CLI submit, so an operator who hand-crafts a
+    no-force POST (the modal otherwise sets ``force=true`` when refs
+    exist) sees the same 409 the REST surface would return.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    target_id = _seed_target(tenant_id=_TENANT_A, name="noforce")
+    _seed_graph_node(tenant_id=_TENANT_A, target_id=target_id, name="link")
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/noforce/delete",
+            headers=_form_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 409, response.text
+    # Target row is untouched.
+    row = _load_target_including_deleted(_TENANT_A, "noforce")
+    assert row is not None
+    assert row.deleted_at is None
+
+
+def test_delete_submit_isolates_other_tenants_target() -> None:
+    """G0.15-T10 #1218 -- a tenant B admin cannot delete tenant A's target (404)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_tenant(_TENANT_B, "tenant-b")
+    _seed_target(tenant_id=_TENANT_A, name="a-survive")
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_B,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/a-survive/delete",
+            headers=_form_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 404, response.text
+    # Tenant A's row remains live (not soft-deleted).
+    row = _load_target_including_deleted(_TENANT_A, "a-survive")
+    assert row is not None
+    assert row.deleted_at is None
+
+
+def test_delete_submit_rejects_operator_role_with_403() -> None:
+    """G0.15-T10 #1218 -- a non-admin delete POST is rejected with 403."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="op-survive")
+    client, mock, csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_OPERATOR,
+        role=TenantRole.OPERATOR,
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/op-survive/delete",
+            headers=_form_headers(csrf),
+        )
+    finally:
+        mock.stop()
+    assert response.status_code == 403, response.text
+    row = _load_target_including_deleted(_TENANT_A, "op-survive")
+    assert row is not None
+    assert row.deleted_at is None
+
+
+def test_delete_submit_without_csrf_is_rejected() -> None:
+    """G0.15-T10 #1218 -- a delete POST missing the CSRF header hits the chassis gate."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="csrf-survive")
+    client, mock, _csrf = _client_with_role(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.post(
+            "/ui/connectors/csrf-survive/delete",
+            headers={"HX-Request": "true"},
+        )
+    finally:
+        mock.stop()
+    # Chassis CSRFMiddleware double-submit gate -- exact status is the
+    # chassis contract (typically 403 from a missing/mismatched token).
+    assert response.status_code in {401, 403}, response.text
+    row = _load_target_including_deleted(_TENANT_A, "csrf-survive")
+    assert row is not None
+    assert row.deleted_at is None

--- a/backend/tests/test_ui_connectors_view.py
+++ b/backend/tests/test_ui_connectors_view.py
@@ -505,7 +505,11 @@ def test_list_full_page_renders_seeded_targets() -> None:
         response = client.get("/ui/connectors")
     assert response.status_code == 200, response.text
     body = response.text
-    assert "<title>Connectors" in body
+    # G0.15-T10 #1218 -- page title uses the backend taxonomy "Targets"
+    # so the noun on the page matches the row's underlying table; the
+    # sidebar label stays "Connectors" for operator-facing parity with
+    # the URL path (Option B in the issue body).
+    assert "<title>Targets" in body
     assert "vmware-prod" in body
     assert "vmware-dev" in body
     # Sidebar link to /ui/connectors carries the active highlight.
@@ -868,6 +872,157 @@ def test_detail_renders_no_connector_alert_when_no_match() -> None:
     assert response.status_code == 200, response.text
     body = response.text
     assert "No matching connector" in body
+
+
+def test_detail_no_connector_product_mismatch_surfaces_edit_delete_hint() -> None:
+    """G0.15-T10 #1218 -- the ``product_mismatch`` branch surfaces the
+    Edit / Delete remediation + the valid-products enum.
+
+    Target's product slug (``unknown-product``) doesn't match any
+    registered connector, so re-probing would re-dispatch through the
+    same resolver with the same tuple and fail the same way. The
+    remediation message must name Edit / Delete (not Re-probe) and
+    surface the registered-product enum so the operator knows what
+    values are acceptable for a PATCH.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    # Register one connector so ``registered_product_tokens()`` is
+    # non-empty; ``unknown-product`` is intentionally NOT in the set.
+    register_connector_v2(product="fakeprod", version="1.0", impl_id="fakeprod", cls=_FakeConnector)
+    _seed_target(
+        tenant_id=_TENANT_A,
+        name="mis-registered",
+        product="unknown-product",
+        fingerprint={"version": "1.0"},
+    )
+    client, mock, _csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.get("/ui/connectors/mis-registered")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "No matching connector" in body
+    # The product_mismatch hint names the Edit + Delete remediation; the
+    # Re-probe verb must not be the only call to action in this branch.
+    assert 'data-no-connector-cause="product_mismatch"' in body
+    # Apostrophe may render escaped (``&#39;``) or raw depending on the
+    # Jinja autoescape settings -- accept either.
+    assert (
+        "doesn&#39;t match any registered connector" in body
+        or "doesn't match any registered connector" in body
+    )
+    assert "Edit" in body
+    assert "Delete" in body
+    # Valid-products enum is surfaced so the operator knows what to PATCH to.
+    assert "Valid products:" in body
+    assert "<code>fakeprod</code>" in body
+
+
+def test_detail_no_connector_missing_fingerprint_surfaces_reprobe_hint() -> None:
+    """G0.15-T10 #1218 -- the ``missing_fingerprint`` branch keeps the
+    Re-probe remediation (and does NOT surface Edit / Delete copy).
+
+    Target's product slug IS in the registered set, but the only
+    matching connector advertises a versioned ``supported_version_range``;
+    without ``fingerprint.version`` the resolver returns ``no_connector``
+    on the versioned-match ladder. Re-probe is the correct verb here.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+
+    class _VersionedFake(Connector):
+        product = "fakeprod"
+        version = "1.0"
+        impl_id = "fakeprod"
+        # Versioned advertisement -- requires a target version (fingerprint)
+        # before the resolver can match. Without ``fingerprint.version``,
+        # the resolver returns ``no_connector`` -- the missing_fingerprint
+        # case.
+        supported_version_range = ">=1.0"
+
+        async def fingerprint(self, target: Any) -> FingerprintResult:  # pragma: no cover
+            raise NotImplementedError
+
+        async def probe(self, target: Any) -> Any:  # pragma: no cover
+            raise NotImplementedError
+
+        async def execute(  # pragma: no cover
+            self, target: Any, op_id: str, params: dict[str, Any]
+        ) -> Any:
+            raise NotImplementedError
+
+    register_connector_v2(product="fakeprod", version="1.0", impl_id="fakeprod", cls=_VersionedFake)
+    _seed_target(tenant_id=_TENANT_A, name="never-probed", product="fakeprod")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/connectors/never-probed")
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "No matching connector" in body
+    # missing_fingerprint cause -- Re-probe is the right verb, no Edit /
+    # Delete remediation copy + no valid-products enum.
+    assert 'data-no-connector-cause="missing_fingerprint"' in body
+    assert "Re-probe" in body
+    assert "doesn&#39;t match any registered connector" not in body
+    assert "doesn't match any registered connector" not in body
+    assert "Valid products:" not in body
+
+
+# ---------------------------------------------------------------------------
+# Detail view -- Delete button visibility (G0.15-T10 #1218)
+# ---------------------------------------------------------------------------
+
+
+def test_detail_renders_delete_button_for_tenant_admin() -> None:
+    """G0.15-T10 #1218 -- the Delete button is visible to tenant_admin.
+
+    Same RBAC gate as the Edit + Re-probe buttons: the server-side
+    authority is :func:`resolve_operator_or_403` on the POST handler;
+    the template hide is the UX affordance. Asserts the aria-label
+    naming the target so a renderer typo can't silently break the
+    affordance.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="del-me", product="ssh")
+    client, mock, _csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_ADMIN,
+        role=TenantRole.TENANT_ADMIN,
+    )
+    try:
+        response = client.get("/ui/connectors/del-me")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    body = response.text
+    # The aria-label names the target -- present only on tenant_admin
+    # renders. Also assert the HTMX hx-get points at the delete modal
+    # route so a re-binding to a stale URL would fail visibly.
+    assert 'aria-label="Delete del-me"' in body
+    assert 'hx-get="/ui/connectors/del-me/delete"' in body
+
+
+def test_detail_hides_delete_button_for_operator_role() -> None:
+    """G0.15-T10 #1218 -- an operator (not tenant_admin) does NOT see Delete."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_target(tenant_id=_TENANT_A, name="op-no-del", product="ssh")
+    client, mock, _csrf = _authenticated_client_with_role_jwks(
+        tenant_id=_TENANT_A,
+        operator_sub=_OP_OPERATOR,
+        role=TenantRole.OPERATOR,
+    )
+    try:
+        response = client.get("/ui/connectors/op-no-del")
+    finally:
+        mock.stop()
+    assert response.status_code == 200, response.text
+    # Same aria-label discipline as the re-probe button gate test.
+    assert "Delete op-no-del" not in response.text
 
 
 # ---------------------------------------------------------------------------

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -7203,6 +7203,122 @@
         }
       }
     },
+    "/ui/connectors/{name}/delete": {
+      "get": {
+        "tags": [
+          "ui-connectors"
+        ],
+        "summary": "Ui Connectors Delete Modal",
+        "description": "``GET /ui/connectors/{name}/delete`` -- HTMX-loaded confirm modal.\n\nG0.15-T10 #1218. Pre-checks the cascade count so the modal can\nshow the operator how many topology rows reference the target\n(the REST DELETE handler 409s when non-zero without ``?force=true``;\nsurfacing the count here lets the modal pre-set the force flag).",
+        "operationId": "ui_connectors_delete_modal_ui_connectors__name__delete_get",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ui-connectors"
+        ],
+        "summary": "Ui Connectors Delete Submit",
+        "description": "``POST /ui/connectors/{name}/delete[?force=true]`` -- submit handler.\n\nG0.15-T10 #1218. Delegates to\n:func:`~meho_backplane.api.v1.targets.delete_target` (the same\nin-process handler the REST surface exposes) so the UI write and\nthe REST write share one validation + cascade-count + audit code\npath. Success -> 204 + ``HX-Redirect: /ui/connectors``; a 409 from\na missing ``?force=true`` flag is the REST contract -- the modal\npre-sets ``force=true`` when the GET pre-check showed cascade refs,\nso the typical submit lands clean.",
+        "operationId": "ui_connectors_delete_submit_ui_connectors__name__delete_post",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Name"
+            }
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Force"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UISessionContext",
+                "nullable": true,
+                "title": "Session Ctx"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/ui/connectors/{name}": {
       "patch": {
         "tags": [

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -4481,6 +4481,11 @@ type UiConnectorsListUiConnectorsGetParams struct {
 	Product *string                                            `form:"product,omitempty" json:"product,omitempty"`
 }
 
+// UiConnectorsDeleteSubmitUiConnectorsNameDeletePostParams defines parameters for UiConnectorsDeleteSubmitUiConnectorsNameDeletePost.
+type UiConnectorsDeleteSubmitUiConnectorsNameDeletePostParams struct {
+	Force *bool `form:"force,omitempty" json:"force,omitempty"`
+}
+
 // KbIndexUiKbGetParams defines parameters for KbIndexUiKbGet.
 type KbIndexUiKbGetParams struct {
 	Q      *string `form:"q,omitempty" json:"q,omitempty"`
@@ -4631,6 +4636,12 @@ type UiConnectorsDetailUiConnectorsNameGetJSONRequestBody = UISessionContext
 
 // UiConnectorsEditSubmitUiConnectorsNamePatchFormdataRequestBody defines body for UiConnectorsEditSubmitUiConnectorsNamePatch for application/x-www-form-urlencoded ContentType.
 type UiConnectorsEditSubmitUiConnectorsNamePatchFormdataRequestBody = BodyUiConnectorsEditSubmitUiConnectorsNamePatch
+
+// UiConnectorsDeleteModalUiConnectorsNameDeleteGetJSONRequestBody defines body for UiConnectorsDeleteModalUiConnectorsNameDeleteGet for application/json ContentType.
+type UiConnectorsDeleteModalUiConnectorsNameDeleteGetJSONRequestBody = UISessionContext
+
+// UiConnectorsDeleteSubmitUiConnectorsNameDeletePostJSONRequestBody defines body for UiConnectorsDeleteSubmitUiConnectorsNameDeletePost for application/json ContentType.
+type UiConnectorsDeleteSubmitUiConnectorsNameDeletePostJSONRequestBody = UISessionContext
 
 // UiConnectorsEditModalUiConnectorsNameEditGetJSONRequestBody defines body for UiConnectorsEditModalUiConnectorsNameEditGet for application/json ContentType.
 type UiConnectorsEditModalUiConnectorsNameEditGetJSONRequestBody = UISessionContext
@@ -5337,6 +5348,16 @@ type ClientInterface interface {
 	UiConnectorsEditSubmitUiConnectorsNamePatchWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UiConnectorsEditSubmitUiConnectorsNamePatchWithFormdataBody(ctx context.Context, name string, body UiConnectorsEditSubmitUiConnectorsNamePatchFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiConnectorsDeleteModalUiConnectorsNameDeleteGetWithBody request with any body
+	UiConnectorsDeleteModalUiConnectorsNameDeleteGetWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiConnectorsDeleteModalUiConnectorsNameDeleteGet(ctx context.Context, name string, body UiConnectorsDeleteModalUiConnectorsNameDeleteGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// UiConnectorsDeleteSubmitUiConnectorsNameDeletePostWithBody request with any body
+	UiConnectorsDeleteSubmitUiConnectorsNameDeletePostWithBody(ctx context.Context, name string, params *UiConnectorsDeleteSubmitUiConnectorsNameDeletePostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	UiConnectorsDeleteSubmitUiConnectorsNameDeletePost(ctx context.Context, name string, params *UiConnectorsDeleteSubmitUiConnectorsNameDeletePostParams, body UiConnectorsDeleteSubmitUiConnectorsNameDeletePostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiConnectorsEditModalUiConnectorsNameEditGetWithBody request with any body
 	UiConnectorsEditModalUiConnectorsNameEditGetWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -7175,6 +7196,54 @@ func (c *Client) UiConnectorsEditSubmitUiConnectorsNamePatchWithBody(ctx context
 
 func (c *Client) UiConnectorsEditSubmitUiConnectorsNamePatchWithFormdataBody(ctx context.Context, name string, body UiConnectorsEditSubmitUiConnectorsNamePatchFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUiConnectorsEditSubmitUiConnectorsNamePatchRequestWithFormdataBody(c.Server, name, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsDeleteModalUiConnectorsNameDeleteGetWithBody(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsDeleteModalUiConnectorsNameDeleteGetRequestWithBody(c.Server, name, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsDeleteModalUiConnectorsNameDeleteGet(ctx context.Context, name string, body UiConnectorsDeleteModalUiConnectorsNameDeleteGetJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsDeleteModalUiConnectorsNameDeleteGetRequest(c.Server, name, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsDeleteSubmitUiConnectorsNameDeletePostWithBody(ctx context.Context, name string, params *UiConnectorsDeleteSubmitUiConnectorsNameDeletePostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsDeleteSubmitUiConnectorsNameDeletePostRequestWithBody(c.Server, name, params, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) UiConnectorsDeleteSubmitUiConnectorsNameDeletePost(ctx context.Context, name string, params *UiConnectorsDeleteSubmitUiConnectorsNameDeletePostParams, body UiConnectorsDeleteSubmitUiConnectorsNameDeletePostJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUiConnectorsDeleteSubmitUiConnectorsNameDeletePostRequest(c.Server, name, params, body)
 	if err != nil {
 		return nil, err
 	}
@@ -14613,6 +14682,122 @@ func NewUiConnectorsEditSubmitUiConnectorsNamePatchRequestWithBody(server string
 	return req, nil
 }
 
+// NewUiConnectorsDeleteModalUiConnectorsNameDeleteGetRequest calls the generic UiConnectorsDeleteModalUiConnectorsNameDeleteGet builder with application/json body
+func NewUiConnectorsDeleteModalUiConnectorsNameDeleteGetRequest(server string, name string, body UiConnectorsDeleteModalUiConnectorsNameDeleteGetJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUiConnectorsDeleteModalUiConnectorsNameDeleteGetRequestWithBody(server, name, "application/json", bodyReader)
+}
+
+// NewUiConnectorsDeleteModalUiConnectorsNameDeleteGetRequestWithBody generates requests for UiConnectorsDeleteModalUiConnectorsNameDeleteGet with any type of body
+func NewUiConnectorsDeleteModalUiConnectorsNameDeleteGetRequestWithBody(server string, name string, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/connectors/%s/delete", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewUiConnectorsDeleteSubmitUiConnectorsNameDeletePostRequest calls the generic UiConnectorsDeleteSubmitUiConnectorsNameDeletePost builder with application/json body
+func NewUiConnectorsDeleteSubmitUiConnectorsNameDeletePostRequest(server string, name string, params *UiConnectorsDeleteSubmitUiConnectorsNameDeletePostParams, body UiConnectorsDeleteSubmitUiConnectorsNameDeletePostJSONRequestBody) (*http.Request, error) {
+	var bodyReader io.Reader
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	bodyReader = bytes.NewReader(buf)
+	return NewUiConnectorsDeleteSubmitUiConnectorsNameDeletePostRequestWithBody(server, name, params, "application/json", bodyReader)
+}
+
+// NewUiConnectorsDeleteSubmitUiConnectorsNameDeletePostRequestWithBody generates requests for UiConnectorsDeleteSubmitUiConnectorsNameDeletePost with any type of body
+func NewUiConnectorsDeleteSubmitUiConnectorsNameDeletePostRequestWithBody(server string, name string, params *UiConnectorsDeleteSubmitUiConnectorsNameDeletePostParams, contentType string, body io.Reader) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "name", runtime.ParamLocationPath, name)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/connectors/%s/delete", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Force != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "force", runtime.ParamLocationQuery, *params.Force); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
 // NewUiConnectorsEditModalUiConnectorsNameEditGetRequest calls the generic UiConnectorsEditModalUiConnectorsNameEditGet builder with application/json body
 func NewUiConnectorsEditModalUiConnectorsNameEditGetRequest(server string, name string, body UiConnectorsEditModalUiConnectorsNameEditGetJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
@@ -16389,6 +16574,16 @@ type ClientWithResponsesInterface interface {
 	UiConnectorsEditSubmitUiConnectorsNamePatchWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsEditSubmitUiConnectorsNamePatchResponse, error)
 
 	UiConnectorsEditSubmitUiConnectorsNamePatchWithFormdataBodyWithResponse(ctx context.Context, name string, body UiConnectorsEditSubmitUiConnectorsNamePatchFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsEditSubmitUiConnectorsNamePatchResponse, error)
+
+	// UiConnectorsDeleteModalUiConnectorsNameDeleteGetWithBodyWithResponse request with any body
+	UiConnectorsDeleteModalUiConnectorsNameDeleteGetWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsDeleteModalUiConnectorsNameDeleteGetResponse, error)
+
+	UiConnectorsDeleteModalUiConnectorsNameDeleteGetWithResponse(ctx context.Context, name string, body UiConnectorsDeleteModalUiConnectorsNameDeleteGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsDeleteModalUiConnectorsNameDeleteGetResponse, error)
+
+	// UiConnectorsDeleteSubmitUiConnectorsNameDeletePostWithBodyWithResponse request with any body
+	UiConnectorsDeleteSubmitUiConnectorsNameDeletePostWithBodyWithResponse(ctx context.Context, name string, params *UiConnectorsDeleteSubmitUiConnectorsNameDeletePostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsDeleteSubmitUiConnectorsNameDeletePostResponse, error)
+
+	UiConnectorsDeleteSubmitUiConnectorsNameDeletePostWithResponse(ctx context.Context, name string, params *UiConnectorsDeleteSubmitUiConnectorsNameDeletePostParams, body UiConnectorsDeleteSubmitUiConnectorsNameDeletePostJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsDeleteSubmitUiConnectorsNameDeletePostResponse, error)
 
 	// UiConnectorsEditModalUiConnectorsNameEditGetWithBodyWithResponse request with any body
 	UiConnectorsEditModalUiConnectorsNameEditGetWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsEditModalUiConnectorsNameEditGetResponse, error)
@@ -18996,6 +19191,50 @@ func (r UiConnectorsEditSubmitUiConnectorsNamePatchResponse) StatusCode() int {
 	return 0
 }
 
+type UiConnectorsDeleteModalUiConnectorsNameDeleteGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiConnectorsDeleteModalUiConnectorsNameDeleteGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiConnectorsDeleteModalUiConnectorsNameDeleteGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type UiConnectorsDeleteSubmitUiConnectorsNameDeletePostResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r UiConnectorsDeleteSubmitUiConnectorsNameDeletePostResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r UiConnectorsDeleteSubmitUiConnectorsNameDeletePostResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type UiConnectorsEditModalUiConnectorsNameEditGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -20833,6 +21072,40 @@ func (c *ClientWithResponses) UiConnectorsEditSubmitUiConnectorsNamePatchWithFor
 		return nil, err
 	}
 	return ParseUiConnectorsEditSubmitUiConnectorsNamePatchResponse(rsp)
+}
+
+// UiConnectorsDeleteModalUiConnectorsNameDeleteGetWithBodyWithResponse request with arbitrary body returning *UiConnectorsDeleteModalUiConnectorsNameDeleteGetResponse
+func (c *ClientWithResponses) UiConnectorsDeleteModalUiConnectorsNameDeleteGetWithBodyWithResponse(ctx context.Context, name string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsDeleteModalUiConnectorsNameDeleteGetResponse, error) {
+	rsp, err := c.UiConnectorsDeleteModalUiConnectorsNameDeleteGetWithBody(ctx, name, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsDeleteModalUiConnectorsNameDeleteGetResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiConnectorsDeleteModalUiConnectorsNameDeleteGetWithResponse(ctx context.Context, name string, body UiConnectorsDeleteModalUiConnectorsNameDeleteGetJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsDeleteModalUiConnectorsNameDeleteGetResponse, error) {
+	rsp, err := c.UiConnectorsDeleteModalUiConnectorsNameDeleteGet(ctx, name, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsDeleteModalUiConnectorsNameDeleteGetResponse(rsp)
+}
+
+// UiConnectorsDeleteSubmitUiConnectorsNameDeletePostWithBodyWithResponse request with arbitrary body returning *UiConnectorsDeleteSubmitUiConnectorsNameDeletePostResponse
+func (c *ClientWithResponses) UiConnectorsDeleteSubmitUiConnectorsNameDeletePostWithBodyWithResponse(ctx context.Context, name string, params *UiConnectorsDeleteSubmitUiConnectorsNameDeletePostParams, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiConnectorsDeleteSubmitUiConnectorsNameDeletePostResponse, error) {
+	rsp, err := c.UiConnectorsDeleteSubmitUiConnectorsNameDeletePostWithBody(ctx, name, params, contentType, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsDeleteSubmitUiConnectorsNameDeletePostResponse(rsp)
+}
+
+func (c *ClientWithResponses) UiConnectorsDeleteSubmitUiConnectorsNameDeletePostWithResponse(ctx context.Context, name string, params *UiConnectorsDeleteSubmitUiConnectorsNameDeletePostParams, body UiConnectorsDeleteSubmitUiConnectorsNameDeletePostJSONRequestBody, reqEditors ...RequestEditorFn) (*UiConnectorsDeleteSubmitUiConnectorsNameDeletePostResponse, error) {
+	rsp, err := c.UiConnectorsDeleteSubmitUiConnectorsNameDeletePost(ctx, name, params, body, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseUiConnectorsDeleteSubmitUiConnectorsNameDeletePostResponse(rsp)
 }
 
 // UiConnectorsEditModalUiConnectorsNameEditGetWithBodyWithResponse request with arbitrary body returning *UiConnectorsEditModalUiConnectorsNameEditGetResponse
@@ -24530,6 +24803,58 @@ func ParseUiConnectorsEditSubmitUiConnectorsNamePatchResponse(rsp *http.Response
 	}
 
 	response := &UiConnectorsEditSubmitUiConnectorsNamePatchResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiConnectorsDeleteModalUiConnectorsNameDeleteGetResponse parses an HTTP response from a UiConnectorsDeleteModalUiConnectorsNameDeleteGetWithResponse call
+func ParseUiConnectorsDeleteModalUiConnectorsNameDeleteGetResponse(rsp *http.Response) (*UiConnectorsDeleteModalUiConnectorsNameDeleteGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiConnectorsDeleteModalUiConnectorsNameDeleteGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseUiConnectorsDeleteSubmitUiConnectorsNameDeletePostResponse parses an HTTP response from a UiConnectorsDeleteSubmitUiConnectorsNameDeletePostWithResponse call
+func ParseUiConnectorsDeleteSubmitUiConnectorsNameDeletePostResponse(rsp *http.Response) (*UiConnectorsDeleteSubmitUiConnectorsNameDeletePostResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &UiConnectorsDeleteSubmitUiConnectorsNameDeletePostResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/docs/codebase/ui.md
+++ b/docs/codebase/ui.md
@@ -1629,6 +1629,8 @@ the same way broadcast / topology / memory retired theirs.
 | `POST` | `/ui/connectors/create` | (T2 #874) Create submit. Builds a `TargetCreate` and delegates to the REST `create_target` handler in-process. Success → 204 + `HX-Redirect: /ui/connectors`; validation failure → 422 + modal re-rendered with per-field errors. |
 | `GET` | `/ui/connectors/{name}/edit` | (T2 #874) HTMX-loaded edit-target modal, pre-populated server-side from the resolved target. Tenant_admin gated; alias-aware 404 on cross-tenant. |
 | `PATCH` | `/ui/connectors/{name}` | (T2 #874) Edit submit. Builds a `TargetUpdate` and delegates to the REST `update_target` handler in-process. Same success / failure shapes as create. |
+| `GET` | `/ui/connectors/{name}/delete` | (G0.15-T10 #1218) HTMX-loaded delete-confirm modal. Tenant_admin gated; pre-checks the `graph_node.target_id` cascade count so the modal surfaces the impact and pre-sets `?force=true` on the submit URL when refs exist (mirrors the REST 409+force flow). |
+| `POST` | `/ui/connectors/{name}/delete` | (G0.15-T10 #1218) Delete submit. Delegates to the REST `delete_target` handler in-process — same soft-delete (`deleted_at` stamp) + cascade-count + audit code path. Success → 204 + `HX-Redirect: /ui/connectors`. |
 | `GET` | `/ui/connectors/import` | (T3 #875) Full bulk-import page: paste box + file upload. Tenant_admin gated. |
 | `POST` | `/ui/connectors/import` | (T3 #875) Parse the pasted / uploaded `targets.yaml` (`yaml.safe_load`) and render the CREATE-vs-UPDATE preview table; parse errors render inline (422, no 500). Read-only — no writes. |
 | `POST` | `/ui/connectors/import/confirm` | (T3 #875) Re-parse + re-classify against the tenant's current targets, validate the whole plan up front (schema-invalid entry → inline 422, no partial write), then apply it in-process via `create_target` (new) + `update_target` (existing); renders the result summary (N created, M updated). |
@@ -1721,6 +1723,61 @@ modal form inherits the `X-CSRF-Token` header from the page-level
 `hx-headers` directive; each modal render re-mints + re-sets the
 `meho_csrf` cookie so the double-submit pair lines up.
 
+### Detail page UX fixes (G0.15-T10 #1218 — v0.7.0 dogfood signal #6 closure follow-up)
+
+`claude-rdc-hetzner-dc#753` flagged three UX clusters on the connector
+detail surface that didn't exist when v0.7.0 cut:
+
+1. **"Re-probe vs PATCH vs DELETE" verb confusion on the
+   `no_connector` resolver verdict.** Two visually-identical cases —
+   "fingerprint not cached yet" and "product slug doesn't match any
+   registered connector" — both rendered the same "Re-probe" call-to-
+   action, but only the first case is actually fixable by re-probing.
+   Re-probing the second case dispatches through the same resolver
+   with the same `(product, version)` tuple and fails the same way.
+   The fix at `detail.py:_classify_no_connector_cause` classifies the
+   verdict into `missing_fingerprint` (target's product **is**
+   registered, but `fingerprint IS NULL` — Re-probe is the right verb)
+   vs `product_mismatch` (target's product slug is **not** in the
+   `registered_product_tokens()` set — Edit-product or Delete is the
+   right verb). The template branches on the cause and surfaces the
+   `valid_products` enum (the same source `TargetCreate.product`
+   validates against — G0.14-T3 #1166) when the cause is
+   `product_mismatch`, so the operator knows what values are
+   acceptable for a PATCH.
+
+2. **No Delete button on the detail page.** The REST DELETE shipped
+   at v0.7.0 (G0.14-T4 #1145) but the UI didn't expose it; an
+   operator hitting the unrecoverable `product_mismatch` case in
+   cluster 1 had to drop into CLI / REST to recover. The fix adds a
+   `Delete` button top-right of the detail page alongside `Edit`
+   (tenant_admin-gated, same server-side `resolve_operator_or_403`
+   posture as Edit + Re-probe). Clicking it loads a confirm modal
+   (`_delete_modal.html`) via `GET /ui/connectors/{name}/delete` that
+   pre-checks the `graph_node.target_id` cascade count. When the
+   count is non-zero, the modal surfaces the impact ("N topology rows
+   reference this target — they survive the delete with target_id =
+   NULL per the ON DELETE SET NULL FK") and pre-sets `?force=true` on
+   the submit URL so the typical confirmed-by-the-operator submit
+   lands a clean 204 rather than the REST 409+force handshake. Submit
+   delegates to `delete_target` in-process — same soft-delete
+   (`deleted_at` stamp), same cascade-count, same audit row
+   (`op_id='targets.delete'`) the REST surface writes.
+
+3. **Connectors-vs-Targets taxonomic drift.** The sidebar /
+   page-title / page-subtitle used "Connectors" while the URL +
+   backend table is `targets`; the listed entities are **targets**
+   (per-tenant deployed instances) not **connectors** (typed connector
+   classes like `k8s-1.x`, `vault-1.x`). Picked Option B from the
+   issue body — the lower-friction split: the sidebar label and URL
+   path stay `Connectors` / `/ui/connectors` (parity, no route
+   rename), the list-page `<h1>` + the detail-page breadcrumb +
+   page-title use "Targets" instead. An operator scanning the list
+   page now reads "Targets" and clicking into a row sees the
+   breadcrumb "Targets / `<name>`" — matching what they actually
+   manipulate. The two-page split (separate `/ui/connectors` catalog
+   page for the actual connector classes) is left as future scope.
+
 ### Files
 
 * `backend/src/meho_backplane/ui/routes/connectors/__init__.py` — umbrella router factory.
@@ -1728,12 +1785,13 @@ modal form inherits the `X-CSRF-Token` header from the page-level
 * `backend/src/meho_backplane/ui/routes/connectors/detail.py` — detail handler + connector_id resolution + ops matrix query + recent-ops query.
 * `backend/src/meho_backplane/ui/routes/connectors/operator.py` — role-probe (read) + operator-403 (write).
 * `backend/src/meho_backplane/ui/routes/connectors/probe.py` — re-probe POST handler.
-* `backend/src/meho_backplane/ui/routes/connectors/forms.py` — (T2 #874) create / edit render + submit helpers; builds `TargetCreate` / `TargetUpdate`, delegates to the REST handlers, maps `ValidationError` to per-field form errors.
-* `backend/src/meho_backplane/ui/routes/connectors/forms_router.py` — (T2 #874) create / edit route registration (thin FastAPI wrappers; tenant_admin-gated deps).
+* `backend/src/meho_backplane/ui/routes/connectors/forms.py` — (T2 #874) create / edit render + submit helpers; builds `TargetCreate` / `TargetUpdate`, delegates to the REST handlers, maps `ValidationError` to per-field form errors. (G0.15-T10 #1218) adds `render_delete_modal` + `submit_delete` helpers delegating to `delete_target`.
+* `backend/src/meho_backplane/ui/routes/connectors/forms_router.py` — (T2 #874) create / edit route registration (thin FastAPI wrappers; tenant_admin-gated deps). (G0.15-T10 #1218) adds `GET`/`POST` `/ui/connectors/{name}/delete` routes.
 * `backend/src/meho_backplane/ui/templates/connectors/_target_form_fields.html` — (T2 #874) shared form fields for both modals.
 * `backend/src/meho_backplane/ui/templates/connectors/_create_modal.html` — (T2 #874) create modal.
 * `backend/src/meho_backplane/ui/templates/connectors/_edit_modal.html` — (T2 #874) edit modal.
-* `backend/tests/test_ui_connectors_forms.py` — (T2 #874) create / edit form tests: modal render (admin) + 403 (operator), create success + Pydantic validation errors (port out of range, empty name), edit pre-population + PATCH, cross-tenant isolation, CSRF enforcement.
+* `backend/src/meho_backplane/ui/templates/connectors/_delete_modal.html` — (G0.15-T10 #1218) delete-confirm modal; shows the cascade-count warning when `graph_node.target_id` references exist + pre-sets `?force=true` on the submit URL in that case.
+* `backend/tests/test_ui_connectors_forms.py` — (T2 #874) create / edit form tests: modal render (admin) + 403 (operator), create success + Pydantic validation errors (port out of range, empty name), edit pre-population + PATCH, cross-tenant isolation, CSRF enforcement. (G0.15-T10 #1218) adds delete tests: modal render + cascade-count surface, RBAC + cross-tenant + CSRF gating, soft-delete on success, 409-without-force vs 204-with-force on a referenced target.
 * `backend/src/meho_backplane/ui/templates/connectors/list.html` — full-page list template.
 * `backend/src/meho_backplane/ui/templates/connectors/_table_rows.html` — list rows fragment (HTMX swap target).
 * `backend/src/meho_backplane/ui/templates/connectors/detail.html` — full-page detail template.


### PR DESCRIPTION
## Summary
- Distinguishes the two `no_connector` resolver verdicts on the connector detail page so the remediation hint matches the failure mode: `missing_fingerprint` keeps Re-probe; `product_mismatch` surfaces Edit / Delete plus the `valid_products` enum from `registered_product_tokens()` (the same source `TargetCreate.product` validates against). Closes the v0.7.0 dogfood "Re-probe-vs-PATCH-vs-DELETE confusion" UX bug.
- Adds a tenant_admin-gated Delete button on the detail page (alongside Edit) that loads a confirm modal pre-checking the `graph_node.target_id` cascade count and pre-setting `?force=true` on the submit when refs exist (mirrors the REST 409+force flow). Submit delegates to `delete_target` in-process so UI / REST share one soft-delete + cascade-count + audit code path. Closes the v0.7.0 dogfood "no DELETE button" gap.
- Fixes the Connectors-vs-Targets taxonomic drift with Option B from the issue: sidebar entry + URL stay `/ui/connectors` (parity preserved); list-page heading + detail-page breadcrumb + page titles now read "Targets" so the noun on the page matches the row's underlying table.

## Test plan
- [x] `ruff check` -- clean
- [x] `ruff format --check` -- clean
- [x] `mypy src/meho_backplane/ui/routes/connectors/` -- clean
- [x] `pytest backend/tests/test_ui_connectors_view.py backend/tests/test_ui_connectors_forms.py backend/tests/test_ui_connectors_import.py` -- 84 passed (5 new view-suite cases + 11 new form-suite cases for delete; all existing cases still green)
- [x] Acceptance criterion (no_connector remediation distinguishes `product_mismatch` vs `missing_fingerprint`): asserted by `test_detail_no_connector_product_mismatch_surfaces_edit_delete_hint` + `test_detail_no_connector_missing_fingerprint_surfaces_reprobe_hint`.
- [x] Acceptance criterion (Delete button RBAC + wired to `DELETE /api/v1/targets/{name}`): asserted by `test_detail_renders_delete_button_for_tenant_admin` / `test_detail_hides_delete_button_for_operator_role` (visibility) + the delete-submit suite (`test_delete_submit_soft_deletes_and_redirects_to_list`, `test_delete_submit_with_force_succeeds_when_graph_node_refs_exist`, `test_delete_submit_without_force_409s_when_graph_node_refs_exist`, plus RBAC + cross-tenant + CSRF + 403 variants).
- [x] Acceptance criterion (taxonomy unified): asserted by the updated `test_list_full_page_renders_seeded_targets` (page title now "Targets"); sidebar label + URL preserved per Option B.
- [x] Acceptance criterion (docs updated): `docs/codebase/ui.md` Connectors surface section adds the G0.15-T10 detail-page UX fix subsection + delete-modal file pointer + Routes table rows for the new GET/POST `/delete` endpoints.

## Out of scope
- Backend changes (REST DELETE already shipped at v0.7.0 G0.14-T4 #1145; this Task wires the UI).
- Cross-page navigation rewrites (only the Connectors entry had the drift).
- Two-page split (separate `/ui/connectors` connector-class catalog + `/ui/targets` rename) -- Option A from the issue; deferred per "implementor's call -- lower friction is B".
- Bulk-target operations from the UI -- G10.3-T3 bulk import already shipped; bulk delete is separate scope.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1218


---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-27)

Addressed review findings from `/auto-review-pr` iteration 1 (`.claude/auto/review-results/pr-1239-iter-1.json`):

- **B1** `8ae88b3` -- regenerate `cli/api/openapi.json` + `cli/internal/api/client.gen.go` for the new `/ui/connectors/{name}/delete` GET/POST routes via `cd cli && make snapshot-openapi && make generate`. Unblocks the `CLI API snapshot freshness` required check.
- **B2** `6d36eb7` -- empty fix-up commit carrying `Signed-off-by: Damir Topic <damir.topic@pmsoft.at>` to satisfy the DCO bot retroactively for the unsigned parent commit `9daf5a1`. Email matches the parent commit's author so DCO cross-commit email-consistency stays green.

Disputed: none.

Deferred: none -- both findings were blockers, both fixed in this iteration.

<!-- auto-implement-issue: continue, iteration 2 -->
