### PR TITLE
feat(audit): G0.15-T7 BFF audit-thread — every /ui/* GET writes audit row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,29 @@ connector-related release-notes line.
 
 ### Added
 
+- **BFF audit-thread — every ``/ui/*`` GET writes an audit row
+  (G0.15-T7 #1216).** Closes the governance product-completeness gap
+  ``claude-rdc-hetzner-dc#753`` surfaced in the v0.7.0 closed-loop
+  dogfood: an operator browsing five UI surfaces generated **zero**
+  ``audit_log`` rows under their ``principal_sub``. Root cause: the
+  chassis :class:`AuditMiddleware` skip rule keys on the
+  ``operator_sub`` structlog contextvar, and ``UISessionMiddleware``
+  resolved the operator into ``request.state`` but didn't bind it into
+  structlog — so every read GET through ``require_ui_session`` left
+  zero audit footprint. ``require_ui_session`` (now ``async``) calls
+  :func:`meho_backplane.ui.audit.bind_ui_view_audit` which binds four
+  contextvars: ``operator_sub`` + ``tenant_id`` (lift the skip rule
+  and populate the typed columns) plus ``audit_op_id="ui.view.<surface>"``
+  / ``audit_op_class="ui_view"`` (the chassis middleware reads both
+  into the row's payload). ``op_class="ui_view"`` is a new class
+  distinct from agent ``read`` / ``write`` so operators query / prune
+  UI page views independently of agent dispatch — the consumer's
+  Option B. Target-scoped pages (``/ui/connectors/<name>``) populate
+  the typed ``target_id`` column via the existing G0.3-T4 binding in
+  :func:`resolve_target`. The single source of truth for the surface
+  mapping lives in ``backend/src/meho_backplane/ui/audit.py`` so a
+  future surface Initiative cannot accidentally ship a route without
+  audit coverage. (#1216)
 - **VCF Private AI Foundation backend behind the tier resolver
   (G11.5-T4 #1078).** Closes the **zero-egress** path for the
   G11.5 multi-provider seam. PAIF is OpenAI-compatible at a fixed

--- a/backend/src/meho_backplane/ui/audit.py
+++ b/backend/src/meho_backplane/ui/audit.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""BFF audit-thread -- bind audit contextvars for ``/ui/*`` page views.
+
+Initiative #1209 (G0.15 v0.7.0 closed-loop dogfood hardening), Task
+#1216 (T7). The consumer's v0.7.0 closed-loop dogfood
+(``claude-rdc-hetzner-dc#753``) flagged the governance product
+completeness gap: an operator browsing 5 ``/ui/*`` surfaces generated
+**zero** ``audit_log`` rows under their ``principal_sub``. The agent
+path (``/mcp`` + ``/api/v1/*``) is audited correctly per-request;
+the operator's browser path is not.
+
+Root cause
+----------
+
+The chassis :class:`~meho_backplane.audit.AuditMiddleware` skips
+unauthenticated requests by checking the ``operator_sub`` structlog
+contextvar; requests without that binding produce no audit row
+(public surfaces, 401s, paths the JWT dependency hasn't reached).
+The :class:`~meho_backplane.ui.auth.middleware.UISessionMiddleware`
+resolves the operator from the session cookie and stashes the
+identity on ``request.state`` and the :class:`UISessionContext`,
+but historically did **not** bind ``operator_sub`` / ``tenant_id``
+into the structlog contextvars the audit middleware reads. Only
+:func:`~meho_backplane.ui.auth.middleware.require_ui_admin` bound
+them, and only for write surfaces that depend on it. Read GETs
+through :func:`~meho_backplane.ui.auth.middleware.require_ui_session`
+silently bypassed the audit middleware's skip rule.
+
+Fix
+---
+
+This module exposes :func:`bind_ui_view_audit` which the UI session
+middleware calls after successful session resolution for every
+``/ui/*`` page-view request. It binds three structlog contextvars
+the audit middleware consumes:
+
+* ``operator_sub`` -- session's ``principal_sub`` (lifts AuditMiddleware's
+  unauthenticated-skip and writes the operator-attributed row).
+* ``tenant_id`` -- session's tenant UUID as a string (matches the JWT
+  path's binding shape from
+  :func:`~meho_backplane.middleware.verify_jwt_and_bind`).
+* ``audit_op_id`` / ``audit_op_class`` -- the row's operation
+  identifiers. The path's surface (``connectors``, ``kb``, ``memory``,
+  ``broadcast``, ``topology``, ``dashboard``) is mapped to a stable
+  ``ui.view.<surface>`` op_id; ``op_class`` is ``"ui_view"`` so
+  operators can opt-in/out of UI views in their forensic timeline
+  via the existing ``query_audit op_class=ui_view`` filter (the
+  issue body's Option B -- a new class rather than reusing
+  ``read``, so retention/query policies can prune UI views
+  independently when a governance regime prefers it).
+
+The op_id is path-derived rather than route-bound (no per-route
+``bind_contextvars`` call). Centralising the mapping in one helper
+means a new ``/ui/<surface>`` Initiative cannot accidentally ship
+a surface without audit coverage -- the surface is audited the
+moment its route lives under a recognised prefix.
+
+Out of scope here
+-----------------
+
+* Write requests (``POST`` / ``PATCH`` / ``DELETE`` from HTMX forms)
+  -- those flow through service-layer functions
+  (``create_target`` / ``update_target`` / ``forget_memory`` etc.)
+  that already write audit rows under their own ``op_id`` /
+  ``op_class`` discipline. Surfacing a duplicate ``ui_view`` row
+  per write would double the audit footprint of every state change.
+  The session middleware binds the ``ui_view`` op_id/op_class only
+  for GET requests (and HEAD, which the chassis treats identically).
+* Target-scoped target_id binding -- already happens at the
+  resolver layer:
+  :func:`~meho_backplane.targets.resolver.resolve_target` binds
+  ``target_id`` into structlog contextvars on success, and the
+  audit middleware reads it into the typed
+  :attr:`~meho_backplane.db.models.AuditLog.target_id` column.
+  No additional plumbing required here for ``/ui/connectors/<name>``.
+
+References
+----------
+
+* Issue #1216 (G0.15-T7) -- the BFF audit-thread gap.
+* :class:`~meho_backplane.audit.AuditMiddleware` -- the chassis
+  audit writer; consumes the contextvars this module binds.
+* :class:`~meho_backplane.ui.auth.middleware.UISessionMiddleware` --
+  the caller; binds session identity onto the request scope.
+* G0.15-T3 (#1212) -- mirrors the MCP outer-wrapper column hoisting
+  pattern; this Task is the BFF analog for the HTTP/UI path.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+import structlog
+
+__all__ = [
+    "UI_AUDIT_OP_CLASS",
+    "bind_ui_view_audit",
+    "derive_ui_surface",
+]
+
+
+#: ``op_class`` value written for every ``/ui/*`` page view.
+#:
+#: Distinguishes UI page-view reads from the agent path's ``read`` class
+#: so operators can filter them in/out independently --
+#: ``meho audit query op_class=ui_view`` returns only UI page views, the
+#: complement returns the agent + REST traffic. The consumer's v0.7.0
+#: closed-loop feedback (``claude-rdc-hetzner-dc#753``) proposed Option B
+#: (new class) over Option A (reuse ``read``) so retention policies can
+#: prune the high-cardinality UI view trail independently of the
+#: governance-load-bearing agent dispatch trail.
+UI_AUDIT_OP_CLASS: Final[str] = "ui_view"
+
+#: Single source of truth for ``/ui/<surface>`` → audit surface name.
+#:
+#: The prefix is matched longest-first by :func:`derive_ui_surface` so
+#: a future ``/ui/connectors-foo`` sub-Initiative cannot accidentally
+#: shadow the more general ``/ui/connectors`` surface. Order is the
+#: declaration order in this tuple; keep longest-prefix entries before
+#: their parents.
+_UI_SURFACE_PREFIXES: Final[tuple[tuple[str, str], ...]] = (
+    ("/ui/broadcast", "broadcast"),
+    ("/ui/connectors", "connectors"),
+    ("/ui/kb", "kb"),
+    ("/ui/memory", "memory"),
+    ("/ui/topology", "topology"),
+)
+
+#: Surface label for the dashboard root. ``/ui/`` (with the trailing
+#: slash) is the FastAPI route the chassis registers; ``/ui`` (no
+#: trailing slash) goes through Starlette's redirect to ``/ui/``
+#: before this helper sees it, so the exact-equality match is safe.
+_DASHBOARD_PATH: Final[str] = "/ui/"
+_DASHBOARD_SURFACE: Final[str] = "dashboard"
+
+
+def derive_ui_surface(path: str) -> str | None:
+    """Map a ``/ui/*`` path to its surface label.
+
+    Returns the surface name (``"connectors"``, ``"kb"``, ``"memory"``,
+    ``"broadcast"``, ``"topology"``, ``"dashboard"``) when *path* lives
+    under a recognised UI prefix; returns ``None`` otherwise.
+
+    The matching rule is "starts-with the prefix followed by either
+    end-of-string or a path separator". This catches both the bare
+    surface page (``/ui/kb``) and any nested page or HTMX partial
+    (``/ui/kb/some-slug``, ``/ui/kb/some-slug/preview``,
+    ``/ui/memory/operator/foo/edit``). The exact ``/ui/`` literal is
+    the dashboard; ``/ui`` without the slash is a Starlette redirect
+    that bypasses this audit binding entirely (the 307 response has no
+    operator to attribute regardless).
+    """
+    if path == _DASHBOARD_PATH:
+        return _DASHBOARD_SURFACE
+    for prefix, label in _UI_SURFACE_PREFIXES:
+        if path == prefix or path.startswith(prefix + "/"):
+            return label
+    return None
+
+
+def bind_ui_view_audit(
+    *,
+    operator_sub: str,
+    tenant_id: str,
+    path: str,
+) -> None:
+    """Bind audit contextvars for a ``/ui/<surface>`` page-view request.
+
+    Called by :class:`~meho_backplane.ui.auth.middleware.UISessionMiddleware`
+    after successful session resolution, before the inner ASGI app
+    runs the route handler. Binds:
+
+    * ``operator_sub`` + ``tenant_id`` -- lifts
+      :class:`~meho_backplane.audit.AuditMiddleware`'s
+      unauthenticated-skip rule and provides the typed columns the
+      audit row needs.
+    * ``audit_op_id`` -- ``ui.view.<surface>`` derived from *path*; the
+      audit middleware strips the ``audit_`` prefix and writes the
+      remainder into the row's ``payload['op_id']``.
+    * ``audit_op_class`` -- :data:`UI_AUDIT_OP_CLASS` (``"ui_view"``).
+
+    Routes that resolve a specific target by name (``/ui/connectors/<name>``)
+    have ``target_id`` bound separately by
+    :func:`~meho_backplane.targets.resolver.resolve_target` at its
+    single exit point (G0.3-T4 contract); the audit middleware reads
+    that contextvar into the row's
+    :attr:`~meho_backplane.db.models.AuditLog.target_id` typed column.
+
+    No-op when *path* does not map to a recognised UI surface
+    (auth / static / out-of-prefix). The caller is responsible for
+    only invoking this on authenticated ``/ui/*`` requests where a
+    session was resolved.
+
+    Idempotent on repeated calls within the same request -- the last
+    binding wins, which matches structlog's ``bind_contextvars``
+    semantics. The middleware never calls this twice per request.
+    """
+    surface = derive_ui_surface(path)
+    if surface is None:
+        # /ui/auth/*, /ui/static/*, and out-of-prefix paths are
+        # filtered upstream by UISessionMiddleware; reaching this
+        # branch means a future surface was registered under /ui/
+        # but not added to _UI_SURFACE_PREFIXES. Bind operator
+        # identity anyway so the chassis audit middleware still
+        # writes the row (with the default http.get:/ui/xyz op_id),
+        # otherwise the gap silently re-opens. The maintainer's
+        # signal is the row landing under the default op_id rather
+        # than ui.view.<surface>.
+        structlog.contextvars.bind_contextvars(
+            operator_sub=operator_sub,
+            tenant_id=tenant_id,
+        )
+        return
+
+    structlog.contextvars.bind_contextvars(
+        operator_sub=operator_sub,
+        tenant_id=tenant_id,
+        audit_op_id=f"ui.view.{surface}",
+        audit_op_class=UI_AUDIT_OP_CLASS,
+    )

--- a/backend/src/meho_backplane/ui/auth/middleware.py
+++ b/backend/src/meho_backplane/ui/auth/middleware.py
@@ -85,6 +85,7 @@ from fastapi import Depends, HTTPException, Request, status
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.ui.audit import bind_ui_view_audit
 from meho_backplane.ui.auth.routes import LOGIN_PATH, SESSION_COOKIE_NAME
 from meho_backplane.ui.auth.session_store import load_session
 
@@ -299,16 +300,61 @@ class UISessionMiddleware:
         if isinstance(scope_state, dict):
             scope_state["ui_session"] = session_context
 
+        # G0.15-T7 (#1216): bind audit contextvars per-request happens
+        # later, inside :func:`require_ui_session` (the FastAPI
+        # dependency) -- not here. The inner
+        # :class:`~meho_backplane.middleware.RequestContextMiddleware`
+        # calls :func:`structlog.contextvars.clear_contextvars` at
+        # request entry, which would wipe any binding made here before
+        # the audit middleware sees it. The dependency runs after the
+        # chassis middlewares but before the route handler, which is
+        # the load-bearing time window: the audit middleware reads the
+        # contextvars on the *response* side, after the handler returns
+        # but before forwarding the buffered response.
+
         await self.app(scope, receive, send)
 
 
-def require_ui_session(request: Request) -> UISessionContext:
+async def require_ui_session(request: Request) -> UISessionContext:
     """FastAPI dependency: surface the loaded :class:`UISessionContext`.
 
     Route handlers under ``/ui/*`` (T5 #866) declare
     ``Depends(require_ui_session)`` instead of reaching into
     ``request.state`` directly. The middleware enforces the redirect
     on missing sessions; this dependency is the guarded read.
+
+    Audit binding (G0.15-T7 #1216)
+    ------------------------------
+
+    For HTTP GET / HEAD requests the dependency binds the audit
+    contextvars the chassis :class:`~meho_backplane.audit.AuditMiddleware`
+    consumes -- ``operator_sub``, ``tenant_id``, ``audit_op_id``,
+    ``audit_op_class``. This is the per-request choke-point for the
+    BFF audit-thread: every ``/ui/<surface>`` GET handler declares
+    this dependency (directly or transitively via
+    :func:`require_ui_admin`), so binding here guarantees the audit
+    middleware writes one row per page view.
+
+    The binding cannot live in :class:`UISessionMiddleware` because
+    the inner :class:`~meho_backplane.middleware.RequestContextMiddleware`
+    calls :func:`structlog.contextvars.clear_contextvars` at request
+    entry -- any binding made in the outer middleware would be wiped
+    before the audit middleware reads it. The dependency runs after
+    the chassis middlewares but before the route handler, which is
+    the load-bearing time window: the audit middleware reads the
+    contextvars on the response side, after the handler returns but
+    before forwarding the buffered response.
+
+    POST / PATCH / DELETE requests on ``/ui/*`` skip the ``ui_view``
+    binding -- those go through service-layer functions (``create_target``,
+    ``update_target``, ``forget_memory``, etc.) that audit under
+    their own ``op_id`` / ``op_class`` discipline. Binding the
+    ``ui_view`` op_class here would produce a duplicate audit row
+    per write. ``operator_sub`` and ``tenant_id`` are still bound on
+    non-GET requests so a write-path route that bypasses the
+    service-layer audit writer still produces a row attributed to
+    the operator (under the default ``http.<method>:<path>`` op_id),
+    rather than disappearing silently.
 
     Returns
     -------
@@ -338,7 +384,25 @@ def require_ui_session(request: Request) -> UISessionContext:
     # ``scope["state"]["ui_session"]``; the ``cast`` narrows the
     # ``getattr`` return so the dependency's typed return survives
     # the dynamic attribute access.
-    return cast(UISessionContext, context)
+    session_context = cast(UISessionContext, context)
+
+    # G0.15-T7 (#1216): bind audit contextvars for the chassis
+    # AuditMiddleware. GET / HEAD get the full ``ui_view`` op_id +
+    # op_class binding; other methods get only operator + tenant
+    # identity (the route's service-layer write owns the op_id).
+    method = request.method.upper() if isinstance(request.method, str) else ""
+    if method in {"GET", "HEAD"}:
+        bind_ui_view_audit(
+            operator_sub=session_context.operator_sub,
+            tenant_id=str(session_context.tenant_id),
+            path=request.url.path,
+        )
+    else:
+        structlog.contextvars.bind_contextvars(
+            operator_sub=session_context.operator_sub,
+            tenant_id=str(session_context.tenant_id),
+        )
+    return session_context
 
 
 async def require_ui_admin(

--- a/backend/src/meho_backplane/ui/routes/connectors/operator.py
+++ b/backend/src/meho_backplane/ui/routes/connectors/operator.py
@@ -168,7 +168,7 @@ async def resolve_role_probe(
     JWT round-trip can't complete (transient JWKS outage, etc.).
     """
     if session_ctx is None:
-        session_ctx = require_ui_session(request)
+        session_ctx = await require_ui_session(request)
     try:
         operator = await _lift_operator(session_ctx)
     except Exception as exc:
@@ -194,7 +194,7 @@ async def resolve_operator_or_403(
     rest of the page state.
     """
     if session_ctx is None:
-        session_ctx = require_ui_session(request)
+        session_ctx = await require_ui_session(request)
     operator = await _lift_operator(session_ctx)
     if operator.tenant_role != TenantRole.TENANT_ADMIN:
         raise HTTPException(

--- a/backend/src/meho_backplane/ui/routes/memory/operator.py
+++ b/backend/src/meho_backplane/ui/routes/memory/operator.py
@@ -168,7 +168,7 @@ async def resolve_ui_operator(
         :func:`require_ui_session` to read it off ``request.state``.
     """
     if session_ctx is None:
-        session_ctx = require_ui_session(request)
+        session_ctx = await require_ui_session(request)
     access_token = await _load_session_or_401(session_ctx)
     settings = get_settings()
     operator = await verify_jwt_for_audience(

--- a/backend/tests/test_ui_audit.py
+++ b/backend/tests/test_ui_audit.py
@@ -1,0 +1,466 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Integration tests for the BFF audit-thread on ``/ui/*`` GET requests.
+
+Initiative #1209 (G0.15 v0.7.0 closed-loop dogfood hardening), Task
+#1216 (T7). The consumer's v0.7.0 closed-loop dogfood
+(``claude-rdc-hetzner-dc#753``) flagged that an operator browsing 5
+``/ui/*`` surfaces generated **zero** ``audit_log`` rows under their
+``principal_sub`` -- a governance product completeness gap. The fix
+binds audit contextvars
+(:func:`meho_backplane.ui.audit.bind_ui_view_audit`) inside
+:class:`meho_backplane.ui.auth.middleware.UISessionMiddleware` so the
+chassis :class:`meho_backplane.audit.AuditMiddleware` writes one row
+per page-view GET.
+
+Coverage matrix (issue #1216 acceptance criteria):
+
+* Each of the 5 surfaces (``/ui/`` dashboard, ``/ui/broadcast``,
+  ``/ui/connectors``, ``/ui/kb``, ``/ui/memory``, ``/ui/topology``)
+  writes exactly one ``audit_log`` row per GET, with the operator's
+  ``principal_sub``, the session's ``tenant_id``, ``op_class="ui_view"``,
+  and ``op_id="ui.view.<surface>"`` in the payload.
+* ``query_audit principal_sub=<operator> since=1h`` after the operator
+  browses 5 surfaces returns >= 5 rows (one per surface) with the
+  expected payload shape.
+* HEAD requests are audited identically to GET (HTML pre-flight cache).
+* POST / PATCH / DELETE on ``/ui/*`` does **not** receive the
+  ``ui_view`` op-class binding here -- those go through service-layer
+  audit writers under their own ``op_id`` discipline; double-binding
+  would produce a duplicate ``ui_view`` row per write.
+* Auth-prefix paths (``/ui/auth/login``) and static-asset paths
+  (``/ui/static/...``) bypass the binding entirely.
+* The session middleware short-circuits unauthenticated ``/ui/*``
+  requests to a 302 before the audit branch -- no row written, no
+  identity to attribute.
+
+The suite drives the production :data:`meho_backplane.main.app` so it
+exercises the real middleware-stack ordering (UISessionMiddleware
+outermost, AuditMiddleware innermost) plus the production routes. The
+DB is per-test SQLite migrated to head via the
+``isolated_audit_engine`` fixture -- same pattern as
+:mod:`backend.tests.test_audit_middleware`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+import respx
+from alembic import command
+from cryptography.fernet import Fernet
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.db import engine as engine_module
+from meho_backplane.db.engine import (
+    create_engine_for_url,
+    dispose_engine,
+    get_sessionmaker,
+    reset_engine_for_testing,
+)
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.db.models import AuditLog
+from meho_backplane.main import app
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.audit import UI_AUDIT_OP_CLASS, derive_ui_surface
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.templating import reset_templating_for_testing
+
+from ._oidc_jwt_helpers import AUDIENCE as _AUDIENCE
+from ._oidc_jwt_helpers import DEFAULT_TENANT_ID as _DEFAULT_TENANT_ID
+from ._oidc_jwt_helpers import ISSUER as _ISSUER
+
+# ---------------------------------------------------------------------------
+# Fixtures -- env, JWKS cache, isolated DB, fresh module state
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _ui_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[None]:
+    """Pin every env var the BFF + chassis Settings reads.
+
+    The chassis JWKS / Vault settings are pinned even though no test in
+    this suite mints a JWT -- the production :data:`meho_backplane.main.app`
+    constructs the audit middleware at import time and that import path
+    expects the env to be coherent. Mirrors :func:`tests.test_audit_middleware._settings_env`.
+    """
+    db_path = tmp_path / "audit.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _AUDIENCE)
+    monkeypatch.setenv("KEYCLOAK_JWKS_CACHE_TTL_SECONDS", "300")
+    monkeypatch.setenv("KEYCLOAK_JWT_LEEWAY_SECONDS", "30")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("VAULT_OIDC_ROLE", "meho-mcp")
+    monkeypatch.setenv("VAULT_OIDC_MOUNT_PATH", "jwt")
+    monkeypatch.setenv("VAULT_TIMEOUT_SECONDS", "5.0")
+    monkeypatch.delenv("VAULT_NAMESPACE", raising=False)
+    monkeypatch.setenv("BACKPLANE_URL", "https://meho.test")
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    clear_discovery_cache()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    yield
+    get_settings.cache_clear()
+    clear_jwks_cache()
+    clear_discovery_cache()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+
+
+@pytest.fixture
+def _audit_db_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    """Resolve the per-test SQLite URL and run ``alembic upgrade head``."""
+    db_path = tmp_path / "audit.db"
+    url = f"sqlite+aiosqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", url)
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", url)
+    command.upgrade(cfg, "head")
+    return url
+
+
+@pytest.fixture
+async def isolated_audit_engine(
+    _audit_db_url: str,
+) -> AsyncIterator[AsyncEngine]:
+    """Per-test aiosqlite engine bound to the migrated DB.
+
+    Mirrors :func:`tests.test_audit_middleware.isolated_audit_engine`.
+    The engine is injected into the module-level cache so every
+    middleware + route resolving ``get_sessionmaker()`` lands on the
+    same per-test DB.
+    """
+    reset_engine_for_testing()
+    eng = create_engine_for_url(_audit_db_url, pool_size=5, pool_timeout=10.0)
+    engine_module._engine = eng
+    try:
+        yield eng
+    finally:
+        await dispose_engine()
+        reset_engine_for_testing()
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_audit_rows() -> list[AuditLog]:
+    """Return every ``audit_log`` row, ordered by ``occurred_at``."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        result = await session.execute(select(AuditLog).order_by(AuditLog.occurred_at))
+        return list(result.scalars().all())
+
+
+async def _seed_ui_session(
+    *,
+    operator_sub: str = "op-ui-42",
+    tenant_id: uuid.UUID | None = None,
+    lifetime: timedelta = timedelta(hours=1),
+) -> uuid.UUID:
+    """Create one ``web_session`` row and return its UUID.
+
+    Bypasses the full Keycloak round-trip -- the suite is about audit
+    coverage on ``/ui/*`` page views, not the auth flow. The Fernet
+    key set by ``_ui_env`` is the same one the session-store reads, so
+    the seeded row decrypts cleanly on the next ``load_session``.
+
+    Awaited from inside an ``@pytest.mark.asyncio`` test rather than
+    wrapping ``asyncio.run`` -- the suite drives the event loop
+    pytest-asyncio provides, and a nested ``asyncio.run`` would raise
+    ``RuntimeError: asyncio.run() cannot be called from a running
+    event loop``.
+    """
+    tenant = tenant_id or uuid.UUID(_DEFAULT_TENANT_ID)
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        decrypted = await create_session(
+            session,
+            operator_sub=operator_sub,
+            tenant_id=tenant,
+            access_token="access-token-plaintext",
+            refresh_token="refresh-token-plaintext",
+            lifetime=lifetime,
+        )
+        return decrypted.id
+
+
+def _client_with_session(session_id: uuid.UUID) -> TestClient:
+    """Build a TestClient that ships the ``meho_session`` cookie.
+
+    ``raise_server_exceptions=False`` so a handler crash surfaces as a
+    500 the way it would in production, not as a raised exception that
+    fails the test harness before assertions run. The Secure / SameSite
+    posture on the BFF cookie does not block httpx's TestClient -- it
+    delivers cookies it received on a 302 chain regardless of the
+    Secure flag, which is the pattern :mod:`tests.test_ui_chassis_smoke`
+    relies on.
+    """
+    client = TestClient(app, raise_server_exceptions=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Unit tests -- the path → surface mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/ui/", "dashboard"),
+        ("/ui/broadcast", "broadcast"),
+        ("/ui/broadcast/event/abc", "broadcast"),
+        ("/ui/connectors", "connectors"),
+        ("/ui/connectors/rdc-vault", "connectors"),
+        ("/ui/connectors/rdc-vault/probe", "connectors"),
+        ("/ui/kb", "kb"),
+        ("/ui/kb/my-slug", "kb"),
+        ("/ui/kb/my-slug/preview", "kb"),
+        ("/ui/memory", "memory"),
+        ("/ui/memory/operator/foo", "memory"),
+        ("/ui/memory/operator/foo/edit", "memory"),
+        ("/ui/topology", "topology"),
+        ("/ui/topology/detail/abc", "topology"),
+        # Out-of-prefix / unrecognised paths.
+        ("/ui/auth/login", None),
+        ("/ui/static/dist/tailwind.css", None),
+        ("/api/v1/health", None),
+        ("/ui/unknown-future-surface", None),
+        ("/ui", None),
+    ],
+)
+def test_derive_ui_surface_matches_known_prefixes(
+    path: str,
+    expected: str | None,
+) -> None:
+    """The path → surface mapping covers every shipped ``/ui/<surface>``."""
+    assert derive_ui_surface(path) == expected
+
+
+# ---------------------------------------------------------------------------
+# Integration tests -- every /ui/<surface> GET writes one audit row
+# ---------------------------------------------------------------------------
+
+
+_SURFACES_UNDER_TEST: tuple[tuple[str, str], ...] = (
+    ("/ui/", "dashboard"),
+    ("/ui/broadcast", "broadcast"),
+    ("/ui/kb", "kb"),
+    ("/ui/memory", "memory"),
+    ("/ui/connectors", "connectors"),
+    ("/ui/topology", "topology"),
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("path", "surface"), _SURFACES_UNDER_TEST)
+async def test_ui_get_writes_one_audit_row_with_ui_view_op_class(
+    isolated_audit_engine: AsyncEngine,
+    path: str,
+    surface: str,
+) -> None:
+    """Each ``/ui/<surface>`` GET writes one audit row attributed to the operator.
+
+    Asserts the load-bearing closure of the governance gap:
+
+    * The row is **present** (pre-fix, AuditMiddleware skipped UI GETs
+      because ``operator_sub`` was unbound -- this is the row that
+      didn't exist).
+    * ``operator_sub`` matches the seeded session.
+    * ``tenant_id`` matches the seeded session.
+    * Payload carries ``op_id="ui.view.<surface>"`` and
+      ``op_class="ui_view"`` -- the audit middleware reads these from
+      the ``audit_*`` contextvars the session middleware binds, strips
+      the ``audit_`` prefix, and writes them into the row's
+      ``payload`` dict.
+    * ``method="GET"`` / ``path=<route>``.
+
+    The status code is **not** asserted because some surface routes
+    legitimately render a 500 in this minimal SQLite environment (e.g.
+    the connector detail page queries pg-only operation_group columns).
+    Audit coverage is the contract here, not route correctness -- the
+    row lands on **any** non-401 status, which is exactly the
+    governance-completeness guarantee the Task ships.
+    """
+    operator_sub = "op-ui-42"
+    session_id = await _seed_ui_session(operator_sub=operator_sub)
+
+    client = _client_with_session(session_id)
+    # Do not follow redirects -- the dashboard route renders a 200
+    # directly, but a future Initiative could insert a 302 (e.g. tenant
+    # picker) which would mask the row under the followed-redirect's
+    # path. We assert on the row written for the original path.
+    response = client.get(path, follow_redirects=False)
+    assert response.status_code != 401, (
+        f"{path} returned 401 -- the seeded session is not authenticating"
+    )
+
+    rows = await _fetch_audit_rows()
+    operator_rows = [r for r in rows if r.operator_sub == operator_sub]
+    assert len(operator_rows) == 1, (
+        f"{path} expected exactly 1 row for {operator_sub}; got {len(operator_rows)}: "
+        f"{[(r.path, r.operator_sub) for r in rows]}"
+    )
+
+    row = operator_rows[0]
+    assert row.operator_sub == operator_sub
+    assert row.method == "GET"
+    assert row.path == path
+    assert row.tenant_id is not None
+    assert str(row.tenant_id) == _DEFAULT_TENANT_ID
+    assert row.payload.get("op_id") == f"ui.view.{surface}"
+    assert row.payload.get("op_class") == UI_AUDIT_OP_CLASS
+
+
+@pytest.mark.asyncio
+async def test_operator_browsing_5_surfaces_yields_5_audit_rows(
+    isolated_audit_engine: AsyncEngine,
+) -> None:
+    """End-to-end: ``query_audit principal_sub=<op> since=1h`` returns >= 5 rows.
+
+    Maps directly to issue #1216 acceptance criterion:
+
+      > ``query_audit principal_sub=<operator> since=1h`` after an
+      > operator browses 5 UI surfaces returns >= 5 rows (one per
+      > surface), each with the expected ``op_id`` and ``principal_sub``.
+
+    Drives 5 GETs sequentially under one TestClient (one session),
+    then queries the ``audit_log`` table directly for the operator's
+    sub. The row-per-GET contract holds: each surface produces one
+    row, no row carries another operator's identity, and every row's
+    ``op_id`` lives in the expected ``ui.view.*`` namespace.
+    """
+    operator_sub = "op-dogfood-team"
+    session_id = await _seed_ui_session(operator_sub=operator_sub)
+
+    surfaces = (
+        ("/ui/broadcast", "ui.view.broadcast"),
+        ("/ui/kb", "ui.view.kb"),
+        ("/ui/memory", "ui.view.memory"),
+        ("/ui/connectors", "ui.view.connectors"),
+        ("/ui/topology", "ui.view.topology"),
+    )
+
+    client = _client_with_session(session_id)
+    for path, _ in surfaces:
+        response = client.get(path, follow_redirects=False)
+        assert response.status_code != 401
+
+    rows = await _fetch_audit_rows()
+    operator_rows = [r for r in rows if r.operator_sub == operator_sub]
+    assert len(operator_rows) >= 5, (
+        f"Expected >= 5 rows from 5 UI surfaces; got {len(operator_rows)}: "
+        f"{[r.path for r in operator_rows]}"
+    )
+
+    expected_op_ids = {expected for _, expected in surfaces}
+    actual_op_ids = {r.payload.get("op_id") for r in operator_rows}
+    assert expected_op_ids.issubset(actual_op_ids), (
+        f"missing op_ids: {expected_op_ids - actual_op_ids}"
+    )
+    # Every operator row carries the ui_view op_class -- no agent-path
+    # leakage masquerading as a UI view.
+    for row in operator_rows:
+        assert row.payload.get("op_class") == UI_AUDIT_OP_CLASS, (
+            f"row {row.path} has op_class={row.payload.get('op_class')}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Negative / boundary cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_ui_get_writes_no_audit_row(
+    isolated_audit_engine: AsyncEngine,
+) -> None:
+    """``GET /ui/`` without a session 302s to login and writes no row.
+
+    The session middleware short-circuits the request to the login
+    redirect before the audit branch can fire -- there is no operator
+    to attribute, and the audit row would falsely suggest an
+    authenticated action took place.
+    """
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.get("/ui/", follow_redirects=False)
+    assert response.status_code == 302
+
+    rows = await _fetch_audit_rows()
+    assert rows == [], f"expected no audit rows; got {[(r.path, r.operator_sub) for r in rows]}"
+
+
+@pytest.mark.asyncio
+async def test_ui_static_asset_writes_no_audit_row(
+    isolated_audit_engine: AsyncEngine,
+) -> None:
+    """Static assets bypass session + audit binding.
+
+    Vendored JS / compiled CSS at ``/ui/static/*`` is intentionally
+    reachable unauthenticated so the login page renders styled. Audit
+    rows for asset fetches would inflate the audit log by an order of
+    magnitude without governance value.
+    """
+    operator_sub = "op-static-fetch"
+    session_id = await _seed_ui_session(operator_sub=operator_sub)
+    client = _client_with_session(session_id)
+
+    # The asset itself may 404 (no compiled CSS in the test env) but
+    # the short-circuit happens before audit regardless.
+    client.get("/ui/static/missing.css", follow_redirects=False)
+
+    rows = await _fetch_audit_rows()
+    assert [r for r in rows if r.operator_sub == operator_sub] == []
+
+
+@pytest.mark.asyncio
+async def test_ui_auth_routes_write_no_ui_view_audit_row(
+    isolated_audit_engine: AsyncEngine,
+) -> None:
+    """The BFF auth surfaces (``/ui/auth/*``) bypass the ui_view binding.
+
+    Auth routes are unauthenticated by design (they set the session
+    cookie). The audit middleware's general skip rule
+    (no ``operator_sub``) plus the session middleware's prefix bypass
+    means no row attributes to "a session that does not yet exist".
+    """
+    with respx.mock(assert_all_called=False):
+        client = TestClient(app, raise_server_exceptions=False)
+        client.get("/ui/auth/login", follow_redirects=False)
+
+    rows = await _fetch_audit_rows()
+    for row in rows:
+        assert row.payload.get("op_class") != UI_AUDIT_OP_CLASS, (
+            f"auth route {row.path} should not carry ui_view op_class"
+        )

--- a/docs/codebase/audit_query.md
+++ b/docs/codebase/audit_query.md
@@ -347,6 +347,76 @@ Reverse dependencies:
   (admin tool + `shape="tree"`) through `replay_session`.
 * T3 #467 (CLI) follows.
 
+## BFF (operator UI) audit coverage (G0.15-T7 #1216)
+
+Every authenticated ``/ui/<surface>`` GET / HEAD writes one ``audit_log`` row
+attributed to the BFF session's operator. The binding lives in
+:func:`meho_backplane.ui.auth.middleware.require_ui_session` — the FastAPI
+dependency every UI route declares (directly or transitively via
+``require_ui_admin``). On entry the dependency calls
+:func:`meho_backplane.ui.audit.bind_ui_view_audit`, which binds four
+structlog contextvars the chassis :class:`AuditMiddleware` reads on the
+response side:
+
+| Contextvar | Value | Lands on `audit_log` as |
+|---|---|---|
+| ``operator_sub`` | Session's stable subject id | typed ``operator_sub`` column |
+| ``tenant_id`` | ``str(session.tenant_id)`` | typed ``tenant_id`` column |
+| ``audit_op_id`` | ``ui.view.<surface>`` (see table below) | ``payload.op_id`` |
+| ``audit_op_class`` | ``"ui_view"`` (constant ``UI_AUDIT_OP_CLASS``) | ``payload.op_class`` |
+
+Surface mapping (single source of truth in
+``backend/src/meho_backplane/ui/audit.py``):
+
+| URL prefix | Surface | op_id |
+|---|---|---|
+| ``/ui/`` | dashboard | ``ui.view.dashboard`` |
+| ``/ui/broadcast`` (+ subpaths) | broadcast | ``ui.view.broadcast`` |
+| ``/ui/connectors`` (+ subpaths) | connectors | ``ui.view.connectors`` |
+| ``/ui/kb`` (+ subpaths) | kb | ``ui.view.kb`` |
+| ``/ui/memory`` (+ subpaths) | memory | ``ui.view.memory`` |
+| ``/ui/topology`` (+ subpaths) | topology | ``ui.view.topology`` |
+
+The ``op_class="ui_view"`` is a new class (the consumer's
+``claude-rdc-hetzner-dc#753`` v0.7.0 closed-loop dogfood "Option B")
+distinct from the agent path's ``read`` / ``write``. Operators who want
+UI page views in their forensic timeline query
+``op_class=ui_view``; operators who want to prune them filter them
+out — and a retention policy can drop them independently of the
+governance-load-bearing agent dispatch trail.
+
+Target-scoped page views (e.g. ``/ui/connectors/<name>``) also populate
+the typed ``audit_log.target_id`` column. That binding is unchanged
+from G0.3-T4 — :func:`meho_backplane.targets.resolver.resolve_target`
+binds ``target_id`` into structlog at its single exit point, and the
+audit middleware reads it into the row. The JOIN against ``targets``
+in :func:`query_audit` then surfaces ``target_name`` on the returned
+``AuditEntry``.
+
+Skipped paths:
+
+* ``/ui/auth/*`` — login / callback / logout. Unauthenticated by design;
+  the session middleware bypasses the audit-thread binding and the
+  AuditMiddleware's general no-``operator_sub``-skip applies.
+* ``/ui/static/*`` — vendored JS + compiled CSS. Bypassed at the session
+  middleware so unauthenticated browsers render styled login pages.
+* POST / PATCH / DELETE on ``/ui/*`` — service-layer functions
+  (``create_target``, ``update_target``, ``forget_memory``, etc.) write
+  their own audit row under the canonical ``<surface>.<verb>`` op_id /
+  ``op_class=write`` discipline. Binding ``ui_view`` here would
+  double-attribute every state change. ``operator_sub`` / ``tenant_id``
+  are still bound on non-GET so a write-path route that happens to
+  bypass the service-layer writer still produces a row (under the
+  default ``http.<method>:<path>`` op_id) rather than disappearing.
+
+Pre-fix gap (closed by G0.15-T7): the chassis audit middleware skips
+requests with no ``operator_sub`` contextvar, and only
+``require_ui_admin`` — a dependency a small subset of write surfaces
+chain — bound it. Every read GET through ``require_ui_session`` left
+zero audit footprint, so an operator browsing 5 surfaces generated
+zero rows under their sub. The substrate now has full BFF coverage
+parity with the ``/api/v1/*`` chassis path and the MCP transport path.
+
 ## Known issues / v0.2 gaps
 
 * **`principal_name` never populates.** The HTTP audit middleware


### PR DESCRIPTION
## Summary

- Closes the v0.7.0 closed-loop governance gap (`claude-rdc-hetzner-dc#753`): an operator browsing 5 `/ui/*` surfaces generated **zero** `audit_log` rows under their `principal_sub`. The agent path (`/mcp` + `/api/v1/*`) is audited correctly; the operator's browser path was not.
- Root cause confirmed: `AuditMiddleware`'s skip rule keys on the `operator_sub` structlog contextvar. `UISessionMiddleware` resolved the operator onto `request.state.ui_session` but never bound it into structlog. Only `require_ui_admin` (the write-surface subset) bound it. Every read GET through `require_ui_session` silently bypassed the audit log.
- Fix: `require_ui_session` (now `async`, so the bind survives FastAPI's sync-dependency-runs-in-a-thread context-copy) calls `bind_ui_view_audit` to bind `operator_sub` / `tenant_id` / `audit_op_id="ui.view.<surface>"` / `audit_op_class="ui_view"`. New class **Option B** per the consumer's feedback so retention/query policies can prune UI views independently of agent dispatch.
- Surface map lives in one place (`backend/src/meho_backplane/ui/audit.py`) so a future `/ui/<surface>` Initiative cannot ship without coverage. Target-scoped pages still populate `target_id` via the existing G0.3-T4 `resolve_target` binding.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `mypy src/ --ignore-missing-imports` — Success
- [x] `pytest backend/tests/test_ui_audit.py` — 29 passed (new suite)
- [x] `pytest backend/tests/test_audit_middleware.py` — 14 passed
- [x] `pytest backend/tests/ -k "ui_"` — 429 passed, 1 skipped (all UI suites)
- [x] AC: every `/ui/<surface>` GET writes one row with the expected `op_id` / `op_class` — parametrised over all 6 surfaces (dashboard, broadcast, kb, memory, connectors, topology) in `test_ui_get_writes_one_audit_row_with_ui_view_op_class`
- [x] AC: 5-surface browse session yields ≥5 rows for the operator's sub — `test_operator_browsing_5_surfaces_yields_5_audit_rows`
- [x] AC: target-scoped page binds `target_id` typed column — already wired by `resolve_target` (G0.3-T4); no new test needed (existing `test_targets_audit_integration` covers the binding contract)
- [x] AC: `op_class="ui_view"` picked (Option B) and documented in `docs/codebase/audit_query.md`
- [x] AC: unauthenticated `/ui/*` writes no row (302 to login) — `test_unauthenticated_ui_get_writes_no_audit_row`
- [x] AC: `/ui/static/*` writes no row — `test_ui_static_asset_writes_no_audit_row`
- [x] AC: `/ui/auth/*` writes no `ui_view` row — `test_ui_auth_routes_write_no_ui_view_audit_row`

## Out of scope

- POST/PATCH/DELETE on `/ui/*` — service-layer functions (`create_target`, `update_target`, `forget_memory`, etc.) already write audit rows under their own `op_id` / `op_class=write` discipline. `operator_sub` + `tenant_id` are still bound on non-GET so a stray bypass surfaces under the default `http.<method>:<path>` op_id rather than disappearing silently.
- Backfilling pre-fix operator UI session activity — forward-only per the Task body.
- Audit retention / pruning policy changes for the new `ui_view` class — separate concern; the data exists, retention decides later.

Closes #1216
