### PR TITLE
feat(ingest): G3.11-T7 inline #/components/responses/* and #/components/requestBodies/* refs (unblocks gh/v3 live ingest)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,25 @@ connector-related release-notes line.
   policy persistence + the `AgentModelTier` ↔ `AgentTier` enum
   unification remain the M1 follow-up — the `TODO(G11.5-T2)`
   marker stays. (#1078)
+- **OpenAPI parser inlines `#/components/responses/*` and
+  `#/components/requestBodies/*` refs (G3.11-T7 #1241).** Unblocks
+  the GitHub REST spec's live ingest: the upstream spec at
+  `raw.githubusercontent.com/github/rest-api-description/main/...`
+  uses `#/components/responses/*` refs extensively (1929 hits across
+  the spec; every shared envelope — `accepted`, `not_found`,
+  `validation_failed` etc — is a responses ref). The parser
+  previously raised `UnsupportedSpecError` on the first one,
+  short-circuiting the Initiative #1220 G3.11 ingest acceptance.
+  `resolve_shallow_ref` now opts into both new buckets via
+  `component_responses` / `component_request_bodies` kwargs (mirrors
+  the existing opt-in pattern for `component_parameters` from T11
+  #501); `parse_openapi` threads all four buckets uniformly. The
+  residual `UnsupportedSpecError` envelope is preserved for
+  remaining buckets (headers / securitySchemes / links / callbacks /
+  examples) so future gaps stay diagnosable. The xfail mark on
+  `tests/integration/test_operations_ingest_github.py` (G3.11-T3
+  #1223) was removed; the test runs cleanly under
+  `MEHO_GH_INGEST_LIVE=1`. (#1241)
 - **`gh/v3` catalog entry — GitHub REST API on-ramp for L2 ingest
   (G3.11-T3 #1223).** Adds `gh/v3` to the curated connector-spec
   catalog with `impl_id: gh-rest` and `requires_connector_class:

--- a/backend/src/meho_backplane/operations/ingest/openapi.py
+++ b/backend/src/meho_backplane/operations/ingest/openapi.py
@@ -227,12 +227,25 @@ def parse_openapi(
         raise InvalidSpecError(
             f"'components.parameters' must be a mapping, got {type(component_parameters).__name__}"
         )
+    component_responses = components.get("responses") or {}
+    if not isinstance(component_responses, dict):
+        raise InvalidSpecError(
+            f"'components.responses' must be a mapping, got {type(component_responses).__name__}"
+        )
+    component_request_bodies = components.get("requestBodies") or {}
+    if not isinstance(component_request_bodies, dict):
+        raise InvalidSpecError(
+            f"'components.requestBodies' must be a mapping, got "
+            f"{type(component_request_bodies).__name__}"
+        )
 
     return list(
         _iter_operations(
             paths=paths,
             component_schemas=cast(dict[str, Any], component_schemas),
             component_parameters=cast(dict[str, Any], component_parameters),
+            component_responses=cast(dict[str, Any], component_responses),
+            component_request_bodies=cast(dict[str, Any], component_request_bodies),
             spec_source=spec_source,
         )
     )
@@ -419,6 +432,8 @@ def _iter_operations(
     paths: dict[str, Any],
     component_schemas: dict[str, Any],
     component_parameters: dict[str, Any],
+    component_responses: dict[str, Any],
+    component_request_bodies: dict[str, Any],
     spec_source: str | None,
 ) -> Iterable[EndpointDescriptorProto]:
     """Yield one :class:`EndpointDescriptorProto` per (method, path)."""
@@ -446,6 +461,8 @@ def _iter_operations(
                 path_level_params=path_level_params,
                 component_schemas=component_schemas,
                 component_parameters=component_parameters,
+                component_responses=component_responses,
+                component_request_bodies=component_request_bodies,
                 spec_source=spec_source,
             )
 
@@ -458,6 +475,8 @@ def _build_proto(
     path_level_params: list[Any],
     component_schemas: dict[str, Any],
     component_parameters: dict[str, Any],
+    component_responses: dict[str, Any],
+    component_request_bodies: dict[str, Any],
     spec_source: str | None,
 ) -> EndpointDescriptorProto:
     """Assemble a single :class:`EndpointDescriptorProto`."""
@@ -476,10 +495,12 @@ def _build_proto(
         request_body=operation.get("requestBody"),
         component_schemas=component_schemas,
         component_parameters=component_parameters,
+        component_request_bodies=component_request_bodies,
     )
     response_schema = _extract_response_schema(
         responses=operation.get("responses") or {},
         component_schemas=component_schemas,
+        component_responses=component_responses,
     )
 
     raw_tags = operation.get("tags")
@@ -539,6 +560,7 @@ def _build_parameter_schema(
     request_body: Any,
     component_schemas: dict[str, Any],
     component_parameters: dict[str, Any],
+    component_request_bodies: dict[str, Any],
 ) -> dict[str, object]:
     """Flatten path + operation parameters + request body into one JSON Schema object.
 
@@ -595,7 +617,7 @@ def _build_parameter_schema(
         if is_required and name not in required:
             required.append(name)
 
-    body_property = _build_body_property(request_body, component_schemas)
+    body_property = _build_body_property(request_body, component_schemas, component_request_bodies)
     if body_property is not None:
         body_schema = dict(body_property["schema"])
         body_schema["x-meho-param-loc"] = "body"
@@ -656,11 +678,24 @@ def _build_param_property(
 def _build_body_property(
     request_body: Any,
     component_schemas: dict[str, Any],
+    component_request_bodies: dict[str, Any],
 ) -> dict[str, Any] | None:
-    """Return the ``{"schema": ..., "required": bool}`` body slot, or ``None``."""
+    """Return the ``{"schema": ..., "required": bool}`` body slot, or ``None``.
+
+    The ``request_body`` argument may be an inline Request Body Object
+    or a ``{"$ref": "#/components/requestBodies/<name>"}`` pointer
+    (OpenAPI 3.0 §4.7.10 / 3.1 §4.8.13). The latter is uncommon in the
+    v0.x catalogue today but is a first-class component bucket per the
+    spec, so the resolver opts into the bucket via
+    ``component_request_bodies``.
+    """
     if not isinstance(request_body, dict):
         return None
-    resolved = _resolve_shallow_ref(request_body, component_schemas)
+    resolved = _resolve_shallow_ref(
+        request_body,
+        component_schemas,
+        component_request_bodies=component_request_bodies,
+    )
     if not isinstance(resolved, dict):
         return None
     content = resolved.get("content")
@@ -702,12 +737,25 @@ def _extract_response_schema(
     *,
     responses: dict[str, Any],
     component_schemas: dict[str, Any],
+    component_responses: dict[str, Any],
 ) -> dict[str, object] | None:
-    """Pick the success response's schema, preferring ``200`` over ``201`` over wildcard."""
+    """Pick the success response's schema, preferring ``200`` over ``201`` over wildcard.
+
+    Each ``responses.<code>`` entry may be an inline Response Object
+    or a ``{"$ref": "#/components/responses/<name>"}`` pointer
+    (OpenAPI 3.0 §4.7.7 / 3.1 §4.8.16). The GitHub REST API spec uses
+    response refs for every shared envelope (``accepted``,
+    ``not_found``, ``validation_failed`` etc), so the resolver opts
+    into the bucket via ``component_responses``.
+    """
     if not isinstance(responses, dict):
         return None
     for code in _collect_2xx_response_codes(responses):
-        response = _resolve_shallow_ref(responses[code], component_schemas)
+        response = _resolve_shallow_ref(
+            responses[code],
+            component_schemas,
+            component_responses=component_responses,
+        )
         if not isinstance(response, dict):
             continue
         content = response.get("content")

--- a/backend/src/meho_backplane/operations/ingest/refs.py
+++ b/backend/src/meho_backplane/operations/ingest/refs.py
@@ -69,10 +69,12 @@ def resolve_shallow_ref(
     obj: Any,
     component_schemas: dict[str, Any],
     component_parameters: dict[str, Any] | None = None,
+    component_responses: dict[str, Any] | None = None,
+    component_request_bodies: dict[str, Any] | None = None,
 ) -> Any:
     """Inline one level of ``$ref``; preserve any nested refs unchanged.
 
-    Supports refs to two OpenAPI 3.x component buckets:
+    Supports refs to four OpenAPI 3.x component buckets:
 
     * ``$ref: "#/components/schemas/X"`` — JSON Schema components.
       The resolved schema is returned verbatim (a copy is NOT taken —
@@ -81,14 +83,26 @@ def resolve_shallow_ref(
       components (OpenAPI 3.0 §4.7.12 / 3.1 §4.8.7). Same return
       semantics. ``vi-json.yaml`` uses this on every operation via the
       shared ``moId`` path parameter.
+    * ``$ref: "#/components/responses/X"`` — Response Object
+      components (OpenAPI 3.0 §4.7.7 / 3.1 §4.8.16). The GitHub REST
+      API spec uses this for every shared response shape
+      (``accepted``, ``not_found``, ``validation_failed`` etc) —
+      1929 ref hits across the spec as of 2026-05-27.
+    * ``$ref: "#/components/requestBodies/X"`` — Request Body Object
+      components (OpenAPI 3.0 §4.7.10 / 3.1 §4.8.13). Not used by
+      GitHub's spec, but in scope for parser parity since it's a
+      first-class component bucket per the OpenAPI 3.x spec and
+      future-onboarded vendors may use it.
 
-    ``component_parameters`` defaults to ``None`` so existing callers
-    that only need schema-ref resolution don't have to thread the
-    extra arg. Passing ``None`` keeps the legacy behaviour
-    (parameter refs raise :exc:`UnsupportedSpecError`); passing a
-    dict — even an empty one — opts in to the parameter-bucket branch.
+    Each opt-in kwarg defaults to ``None`` so existing callers that
+    only need schema-ref resolution don't have to thread the extra
+    arg. Passing ``None`` keeps the legacy behaviour for that bucket
+    (refs raise :exc:`UnsupportedSpecError`); passing a dict — even
+    an empty one — opts in to the bucket branch. ``parse_openapi``
+    always threads the full set (even empty dicts) so the full
+    pipeline never trips the opt-out branch.
 
-    Component-path drill-down refs into either bucket
+    Component-path drill-down refs into any bucket
     (``"#/components/schemas/X/properties/Y"`` or
     ``"#/components/parameters/X/schema"``) raise
     :exc:`InvalidSchemaError` — the OpenAPI spec only declares fragment
@@ -123,15 +137,38 @@ def resolve_shallow_ref(
             bucket=component_parameters,
             prefix="#/components/parameters/",
         )
-    # Anything else — external file refs, response refs, requestBody
-    # refs, or fragment-walk refs into other component buckets — is
-    # out of scope for v0.2. The dispatcher will not validate against
+    if ref.startswith("#/components/responses/"):
+        if component_responses is None:
+            raise UnsupportedSpecError(
+                f"$ref to #/components/responses/* requires the caller to pass "
+                f"component_responses (got {ref!r})"
+            )
+        return _resolve_named_component(
+            ref=ref,
+            bucket=component_responses,
+            prefix="#/components/responses/",
+        )
+    if ref.startswith("#/components/requestBodies/"):
+        if component_request_bodies is None:
+            raise UnsupportedSpecError(
+                f"$ref to #/components/requestBodies/* requires the caller to pass "
+                f"component_request_bodies (got {ref!r})"
+            )
+        return _resolve_named_component(
+            ref=ref,
+            bucket=component_request_bodies,
+            prefix="#/components/requestBodies/",
+        )
+    # Anything else — external file refs, refs into other component
+    # buckets (headers, securitySchemes, links, callbacks, examples)
+    # — is out of scope. The dispatcher will not validate against
     # them.
     if not ref.startswith("#/"):
         raise UnsupportedSpecError(f"cross-document $ref is not supported (got {ref!r})")
     raise UnsupportedSpecError(
-        f"$ref to non-schema/non-parameter component is not supported (got {ref!r}); "
-        f"v0.2 only inlines #/components/schemas/* and #/components/parameters/* refs"
+        f"$ref to unsupported component bucket (got {ref!r}); "
+        f"parser inlines #/components/schemas/*, #/components/parameters/*, "
+        f"#/components/responses/*, and #/components/requestBodies/* only"
     )
 
 

--- a/backend/tests/fixtures/openapi/request_body_refs_30.yaml
+++ b/backend/tests/fixtures/openapi/request_body_refs_30.yaml
@@ -1,0 +1,64 @@
+openapi: 3.0.3
+info:
+  title: RequestBody-ref fixture
+  version: 1.0.0
+# Symmetric to response_refs_30: shared request body envelopes
+# referenced via ``$ref: '#/components/requestBodies/<name>'``.
+# Less common than response refs in real-world specs (GitHub's REST
+# spec uses zero requestBodies refs as of 2026-05-27) but a
+# first-class OpenAPI 3.x component bucket, so the parser supports
+# it for spec-coverage parity.
+paths:
+  /widgets:
+    post:
+      summary: Create a widget
+      requestBody:
+        $ref: "#/components/requestBodies/WidgetCreate"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Widget"
+  /widgets/{id}:
+    put:
+      summary: Replace a widget
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        $ref: "#/components/requestBodies/WidgetCreate"
+      responses:
+        "200":
+          description: Replaced
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Widget"
+components:
+  requestBodies:
+    WidgetCreate:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/WidgetCreate"
+  schemas:
+    Widget:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+    WidgetCreate:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string

--- a/backend/tests/fixtures/openapi/response_refs_30.yaml
+++ b/backend/tests/fixtures/openapi/response_refs_30.yaml
@@ -1,0 +1,65 @@
+openapi: 3.0.3
+info:
+  title: Response-ref fixture
+  version: 1.0.0
+# Models the GitHub REST spec shape: shared response envelopes
+# referenced from operations via ``$ref:
+# '#/components/responses/<name>'``. G3.11-T7 #1241 flips this from
+# rejected to accepted.
+paths:
+  /widgets:
+    get:
+      summary: List widgets
+      responses:
+        "200":
+          $ref: "#/components/responses/WidgetList"
+  /widgets/{id}:
+    get:
+      summary: Read one widget
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          $ref: "#/components/responses/Widget"
+        "404":
+          $ref: "#/components/responses/NotFound"
+components:
+  responses:
+    WidgetList:
+      description: Page of widgets
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/Widget"
+    Widget:
+      description: One widget
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Widget"
+    NotFound:
+      description: Widget not found
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+  schemas:
+    Widget:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+        name:
+          type: string

--- a/backend/tests/integration/test_github_composite_dispatch.py
+++ b/backend/tests/integration/test_github_composite_dispatch.py
@@ -7,36 +7,36 @@ Gated on ``MEHO_GH_INGEST_LIVE=1`` (same env var as
 ``tests/integration/test_operations_ingest_github.py`` from G3.11-T3
 #1228). When the env var is unset the test is skipped; when it is set,
 the test is currently :func:`pytest.xfail`-marked with ``strict=True``
-because of an upstream parser limitation documented below.
+because the composite-dispatch body itself is not yet wired against a
+live backplane.
 
-**KNOWN PARSER-LIMITATION DEPENDENCY.**
+**STATUS.**
 
-The G0.7 OpenAPI parser at
-``backend/src/meho_backplane/operations/ingest/refs.py`` only inlines
-``#/components/schemas/*`` and ``#/components/parameters/*`` ``$ref``
-shapes. The GitHub REST spec uses ``#/components/responses/*`` refs
-extensively (e.g. ``#/components/responses/accepted``), and the parser
-raises ``UnsupportedSpecError`` on the first one. This blocks T4's
-acceptance criterion #1 ("``gh.composite.pr_status_summary`` registered
-+ dispatchable") from running end-to-end against the live spec until a
-sibling parser-scope follow-up Task lifts the ref-bucket coverage.
+* G3.11-T7 #1241 lifted the upstream parser limitation — the parser
+  now inlines ``#/components/responses/*`` and
+  ``#/components/requestBodies/*`` refs, so catalog ingest against
+  the live GitHub spec succeeds end-to-end.
+* What is still xfailed here is T4's own composite-dispatch body:
+  the round-trip from ``gh.composite.pr_status_summary`` through
+  L2 child ops against a real running backplane + a real GitHub PR
+  requires a backplane process up, a GitHub App credential
+  provisioned in Vault, and the catalog ingested, none of which the
+  unit-test sandbox has. The body raises ``NotImplementedError`` to
+  keep ``strict=True`` honest until the dispatch sketch is filled in.
 
-The composite *registration* itself is not blocked -- the unit tests in
+The composite *registration* itself is unblocked -- the unit tests in
 ``tests/test_connectors_github_composites_register.py`` exercise the
 register path without ingest, and the unit tests in
 ``tests/test_connectors_github_composites_read.py`` cover the handler's
-dispatch logic with mocked ``dispatch_child``. What is xfailed here is
-the *L1-on-top-of-L2 dispatch* round-trip against a real running
-backplane + a real GitHub PR.
+dispatch logic with mocked ``dispatch_child``.
 
-Once the parser-scope follow-up lands and the catalog ingests cleanly,
-this test's ``xfail(strict=True)`` flips to ``xpass`` and CI fails
-loudly -- prompting the maintainer to remove the xfail mark and re-
-qualify the docstring. That's the desired hand-off shape: the test
-self-advertises when its blocker has lifted.
+Once the dispatch body is wired (separate follow-up Task on Initiative
+G3.11 #1220), this test's ``xfail(strict=True)`` flips to ``xpass`` and
+CI fails loudly -- prompting the maintainer to remove the xfail mark
+and re-qualify the docstring.
 
-**How to run locally.** Once the parser fix lands, with a backplane up,
-a GitHub App credential provisioned in Vault, and the catalog ingested::
+**How to run locally.** With a backplane up, a GitHub App credential
+provisioned in Vault, and the catalog ingested::
 
     MEHO_GH_INGEST_LIVE=1 \\
       uv run --package meho-backplane pytest -q \\
@@ -72,19 +72,18 @@ def _live_ingest_opted_in() -> bool:
 @pytest.mark.xfail(
     strict=True,
     reason=(
-        "G0.7 parser only inlines #/components/schemas/* and "
-        "#/components/parameters/* refs; the GitHub spec uses "
-        "#/components/responses/* refs and the parser raises "
-        "UnsupportedSpecError on ingest. Out of scope for T4 (composite "
-        "implementation); a sibling parser-scope follow-up lifts the "
-        "ref-bucket coverage. xfail flips to xpass once that lands -- "
-        "remove the mark + this rationale block then."
+        "Composite-dispatch body not yet wired against a live backplane "
+        "(needs backplane up + GitHub App credential in Vault + catalog "
+        "ingested). The upstream parser ref-bucket gap that previously "
+        "blocked this test was lifted by G3.11-T7 #1241; what remains "
+        "is T4's own dispatch sketch. xfail flips to xpass once the "
+        "body is filled in -- remove the mark + this rationale then."
     ),
 )
 def test_pr_status_summary_dispatches_against_live_pr() -> None:
     """Composite end-to-end dispatch against a real GitHub PR.
 
-    The intended shape, once the parser fix lands:
+    The intended shape, once the dispatch body is wired:
 
     1. Ingest the catalog entry ``gh/v3`` (registers ~700 L2 ops).
     2. Dispatch ``gh.composite.pr_status_summary`` with ``owner=evoila,
@@ -96,17 +95,16 @@ def test_pr_status_summary_dispatches_against_live_pr() -> None:
     4. Assert ``checks_status`` is one of the enum values from the
        response schema (not "unknown" -- the live PR has CI configured).
 
-    Until the parser limitation is lifted, this body short-circuits via
+    Until the dispatch body is filled in, this body short-circuits via
     the ``xfail(strict=True)`` mark above so the test documents the
     dependency without claiming to pass.
     """
-    # When the parser fix lands and the catalog ingests cleanly, this
-    # body fills in with the dispatch + assertions sketched above. For
-    # now, the xfail mark short-circuits the test; we still raise here
-    # to make strict=True meaningful (the body fails until the parser
-    # is fixed).
+    # When the dispatch body lands, this body fills in with the
+    # dispatch + assertions sketched above. For now, the xfail mark
+    # short-circuits the test; we still raise here to make
+    # strict=True meaningful.
     raise NotImplementedError(
-        "gh.composite.pr_status_summary live dispatch is xfailed pending "
-        "G0.7 parser support for #/components/responses/* refs; see the "
-        "module docstring for the dependency + run instructions."
+        "gh.composite.pr_status_summary live dispatch body is not yet "
+        "wired; see the module docstring for the dependency + run "
+        "instructions."
     )

--- a/backend/tests/integration/test_operations_ingest_github.py
+++ b/backend/tests/integration/test_operations_ingest_github.py
@@ -10,23 +10,21 @@ contract; this test only asserts the parser scales to the real
 GitHub OpenAPI spec corpus per the Initiative's acceptance criterion
 ("~700 endpoint_descriptor rows landed").
 
-**KNOWN BLOCKER — parser limitation.** As shipped today (verified
-2026-05-27), the G0.7 OpenAPI parser at
-``src/meho_backplane/operations/ingest/refs.py`` only inlines
-``#/components/schemas/*`` and ``#/components/parameters/*`` ``$ref``
-shapes; the GitHub REST spec uses
-``#/components/responses/*`` refs (e.g.
-``#/components/responses/accepted``) extensively and the parser
-raises ``UnsupportedSpecError`` on the first one. The test is
-:func:`pytest.xfail`-marked with ``strict=False`` so it documents
-the gap without going red — the gap is **out of scope for this
-Task** (T3 ships the catalog YAML + acceptance scaffolding). A
-sibling Task on Initiative G3.11 #1220 (or a Goal #214 parser-scope
-follow-up) lifts the parser ref-bucket coverage; once shipped, the
-``xfail`` flips to ``xpass`` and this docstring + the
-``pytest.xfail`` mark get cleaned up. **The catalog entry itself is
-unblocked** — it ships verbatim, ready to ingest once the parser
-supports the ref shape.
+G3.11-T7 #1241 lifted the parser ref-bucket gap: the parser now
+inlines ``#/components/responses/*`` and
+``#/components/requestBodies/*`` refs alongside the existing schemas
+and parameters paths. This test was previously ``xfail(strict=True)``
+gated on that limitation; once the parser fix landed, the xfail was
+removed and the test runs cleanly under the env-var gate.
+
+**Note on downstream dispatch (out of scope here).** The T1↔T3
+version-string drift (catalog ``version: v3`` vs registry
+``version: "3"``) means that a full
+``meho connector ingest --catalog gh/v3 --dry-run`` end-to-end run
+will succeed at parsing but currently misses the connector-class
+lookup. That's tracked under G3.11-T8 (#1242). This integration
+test verifies the parsing layer only — row count + spot-checks on
+the parsed descriptors — so it is independent of that drift.
 
 **How to run locally.** The GitHub OpenAPI spec is public and direct-
 resolvable (no auth required for the spec itself):
@@ -87,17 +85,6 @@ def _resolve_gh_spec() -> str | None:
         "(G3.11-T3 #1223 AC line 3). Unit tests cover the parser "
         "contract; this only verifies the parser scales to the live "
         "~10 MB GitHub REST spec corpus."
-    ),
-)
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "G0.7 parser only inlines #/components/schemas/* and "
-        "#/components/parameters/* refs; the GitHub spec uses "
-        "#/components/responses/* refs and the parser raises "
-        "UnsupportedSpecError. Out of scope for T3 (catalog YAML); "
-        "lifted by a sibling parser-scope follow-up. xfail flips "
-        "to xpass once the ref-bucket coverage lands."
     ),
 )
 def test_parse_github_rest_spec_lands_700_plus_rows() -> None:

--- a/backend/tests/test_operations_ingest_openapi.py
+++ b/backend/tests/test_operations_ingest_openapi.py
@@ -35,6 +35,8 @@ PETSTORE_30 = FIXTURES / "petstore_30.yaml"
 PETSTORE_31_YAML = FIXTURES / "petstore_31.yaml"
 PETSTORE_31_JSON = FIXTURES / "petstore_31.json"
 PARAMETER_REFS_30 = FIXTURES / "parameter_refs_30.yaml"
+RESPONSE_REFS_30 = FIXTURES / "response_refs_30.yaml"
+REQUEST_BODY_REFS_30 = FIXTURES / "request_body_refs_30.yaml"
 
 
 def _by_op_id(rows: list[EndpointDescriptorProto]) -> dict[str, EndpointDescriptorProto]:
@@ -379,31 +381,39 @@ components:
         parse_openapi(str(spec))
 
 
-def test_non_parameter_local_ref_raises(tmp_path: Path) -> None:
-    """Refs to component buckets we don't support (e.g. ``requestBodies``) stay rejected."""
-    spec = tmp_path / "request_body_ref.yaml"
+def test_unsupported_component_bucket_ref_raises(tmp_path: Path) -> None:
+    """Refs to component buckets the parser doesn't inline stay rejected.
+
+    Headers refs are the canonical example: OpenAPI 3.x defines them
+    as a component bucket, but the parser pipeline doesn't traverse
+    ``responses.<code>.headers.<Name>`` slots (the slot's payload is
+    metadata about the response envelope, not the operation's
+    schema). A spec that puts a headers ref in a position the parser
+    *does* traverse — e.g. inside the response slot itself, which is
+    a malformed shape per OpenAPI 3.0 §4.7.16 (the response slot
+    accepts only Response Object or a ref to one) — surfaces the
+    residual ``UnsupportedSpecError`` envelope. The envelope shape is
+    asserted here so future bucket gaps stay diagnosable.
+    """
+    spec = tmp_path / "headers_ref.yaml"
     spec.write_text(
         """
 openapi: '3.0.3'
 info: {title: x, version: '1'}
 paths:
   /x:
-    post:
-      requestBody:
-        $ref: '#/components/requestBodies/SharedBody'
+    get:
       responses:
         "200":
-          description: ok
+          $ref: '#/components/headers/X-Rate-Limit'
 components:
-  requestBodies:
-    SharedBody:
-      content:
-        application/json:
-          schema:
-            type: object
+  headers:
+    X-Rate-Limit:
+      schema:
+        type: integer
         """.lstrip()
     )
-    with pytest.raises(UnsupportedSpecError, match="non-schema/non-parameter component"):
+    with pytest.raises(UnsupportedSpecError, match="unsupported component bucket"):
         parse_openapi(str(spec))
 
 
@@ -458,6 +468,204 @@ def test_parse_parameter_refs_30_fixture() -> None:
     assert isinstance(properties, dict)
     assert "timeout" in properties
     assert properties["timeout"]["x-meho-param-loc"] == "query"
+
+
+def test_resolve_shallow_ref_response_ref_opt_in() -> None:
+    """Direct-call contract: response refs require ``component_responses`` to opt in.
+
+    Mirrors :func:`test_resolve_shallow_ref_parameter_ref_opt_in` for
+    the response bucket. ``parse_openapi`` always threads the dict
+    (even when empty), so the full pipeline never trips the opt-out
+    branch — but the function is exported and the contract must be
+    explicit for direct callers.
+    """
+    from meho_backplane.operations.ingest.refs import resolve_shallow_ref
+
+    ref = {"$ref": "#/components/responses/Accepted"}
+    responses = {
+        "Accepted": {
+            "description": "Accepted",
+            "content": {"application/json": {"schema": {"type": "object"}}},
+        }
+    }
+
+    resolved = resolve_shallow_ref(ref, {}, component_responses=responses)
+    assert resolved == responses["Accepted"]
+
+    with pytest.raises(UnsupportedSpecError, match="component_responses"):
+        resolve_shallow_ref(ref, {})
+
+
+def test_resolve_shallow_ref_request_body_ref_opt_in() -> None:
+    """Direct-call contract: requestBody refs require ``component_request_bodies``."""
+    from meho_backplane.operations.ingest.refs import resolve_shallow_ref
+
+    ref = {"$ref": "#/components/requestBodies/CreateBody"}
+    request_bodies = {
+        "CreateBody": {
+            "required": True,
+            "content": {"application/json": {"schema": {"type": "object"}}},
+        }
+    }
+
+    resolved = resolve_shallow_ref(ref, {}, component_request_bodies=request_bodies)
+    assert resolved == request_bodies["CreateBody"]
+
+    with pytest.raises(UnsupportedSpecError, match="component_request_bodies"):
+        resolve_shallow_ref(ref, {})
+
+
+def test_parse_response_refs_30_fixture() -> None:
+    """End-to-end: GitHub-shaped response refs splice through cleanly.
+
+    Models the GitHub REST spec's shape: shared response envelopes
+    under ``components.responses`` referenced from operations via
+    ``$ref: '#/components/responses/<name>'``. The success response's
+    schema must end up extracted on each row — the splice happens
+    transparently, the rest of the parser sees the resolved
+    Response Object.
+    """
+    rows = parse_openapi(str(RESPONSE_REFS_30))
+    by_op = _by_op_id(rows)
+    assert set(by_op) == {"GET:/widgets", "GET:/widgets/{id}"}
+
+    # List op: response ref resolves to an array of Widget; the
+    # inner ``items`` $ref stays unresolved (shallow) — the
+    # dispatcher walks nested refs lazily.
+    list_op = by_op["GET:/widgets"]
+    list_schema = list_op.response_schema
+    assert isinstance(list_schema, dict)
+    assert list_schema["type"] == "array"
+    assert list_schema["items"] == {"$ref": "#/components/schemas/Widget"}
+
+    # Single op: response ref resolves through to the Widget schema
+    # via two-hop ($ref → content schema $ref). The parser inlines one
+    # ref level per slot; the resolved response's
+    # content.<media>.schema field itself carries a ref, which the
+    # media-type extractor's existing schema-ref resolution handles.
+    one_op = by_op["GET:/widgets/{id}"]
+    one_schema = one_op.response_schema
+    assert isinstance(one_schema, dict)
+    assert one_schema["type"] == "object"
+    assert "id" in one_schema["properties"]
+    assert "name" in one_schema["properties"]
+
+
+def test_parse_request_body_refs_30_fixture() -> None:
+    """End-to-end: requestBody refs splice through cleanly.
+
+    First-class component bucket per OpenAPI 3.x §4.7.10. Resolved
+    request body's ``content.<media>.schema`` becomes the operation's
+    ``body`` property with ``x-meho-param-loc='body'`` and
+    ``required=True`` because the resolved Request Body Object's
+    ``required`` field is ``True``.
+    """
+    rows = parse_openapi(str(REQUEST_BODY_REFS_30))
+    by_op = _by_op_id(rows)
+    assert set(by_op) == {"POST:/widgets", "PUT:/widgets/{id}"}
+
+    for op_id in ("POST:/widgets", "PUT:/widgets/{id}"):
+        op = by_op[op_id]
+        properties = op.parameter_schema["properties"]
+        assert isinstance(properties, dict), f"{op_id}: properties must be dict"
+        assert "body" in properties, f"{op_id}: body missing after requestBody ref resolution"
+        body = properties["body"]
+        assert body["x-meho-param-loc"] == "body"
+        # Resolved body schema is the WidgetCreate envelope (name only).
+        assert body["type"] == "object"
+        assert "name" in body["properties"]
+        required = op.parameter_schema["required"]
+        assert "body" in required, f"{op_id}: body must be required (requestBody.required=True)"
+
+
+def test_parse_github_shaped_response_ref_with_inline_schema(tmp_path: Path) -> None:
+    """Tightest reproduction of the GitHub spec's `responses/accepted` shape.
+
+    GitHub's spec defines ``components.responses.accepted`` with a
+    bare ``schema: {type: object}`` inside ``content.application/json``
+    — no nested ``$ref``. Locks the simplest case so future
+    refactors don't lose it.
+    """
+    spec = tmp_path / "gh_accepted.yaml"
+    spec.write_text(
+        """
+openapi: '3.0.3'
+info: {title: x, version: '1'}
+paths:
+  /op:
+    post:
+      summary: trigger an async op
+      responses:
+        "202":
+          $ref: '#/components/responses/accepted'
+components:
+  responses:
+    accepted:
+      description: Accepted
+      content:
+        application/json:
+          schema:
+            type: object
+        """.lstrip()
+    )
+    rows = parse_openapi(str(spec))
+    assert len(rows) == 1
+    assert rows[0].response_schema == {"type": "object"}
+
+
+def test_missing_response_ref_raises(tmp_path: Path) -> None:
+    """A ref to an unknown response component raises ``InvalidSchemaError``."""
+    spec = tmp_path / "dangling_response.yaml"
+    spec.write_text(
+        """
+openapi: '3.0.3'
+info: {title: x, version: '1'}
+paths:
+  /x:
+    get:
+      responses:
+        "200":
+          $ref: '#/components/responses/Missing'
+components:
+  responses:
+    Present:
+      description: Present
+      content:
+        application/json:
+          schema:
+            type: string
+        """.lstrip()
+    )
+    with pytest.raises(InvalidSchemaError, match="missing component"):
+        parse_openapi(str(spec))
+
+
+def test_missing_request_body_ref_raises(tmp_path: Path) -> None:
+    """A ref to an unknown requestBody component raises ``InvalidSchemaError``."""
+    spec = tmp_path / "dangling_requestbody.yaml"
+    spec.write_text(
+        """
+openapi: '3.0.3'
+info: {title: x, version: '1'}
+paths:
+  /x:
+    post:
+      requestBody:
+        $ref: '#/components/requestBodies/Missing'
+      responses:
+        "201":
+          description: ok
+components:
+  requestBodies:
+    Present:
+      content:
+        application/json:
+          schema:
+            type: string
+        """.lstrip()
+    )
+    with pytest.raises(InvalidSchemaError, match="missing component"):
+        parse_openapi(str(spec))
 
 
 def test_missing_schema_ref_raises(tmp_path: Path) -> None:

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -668,6 +668,16 @@ JSON-Schema validator to validate the immediate parameter shape;
 deeper schema dereferencing (chasing nested `$ref`s) is the
 dispatcher's concern (G0.6-T5 + T2's tracking of `components.schemas`).
 
+The four supported component buckets are: `#/components/schemas/*`,
+`#/components/parameters/*` (vi-json.yaml's shared `moId`),
+`#/components/responses/*` (the GitHub REST spec's 1.9k shared
+response envelopes — `accepted`, `not_found`, `validation_failed`
+etc), and `#/components/requestBodies/*` (parity bucket for future
+vendor specs; not yet used in the v0.x catalogue). Each opts in via
+a separate kwarg on `resolve_shallow_ref`; `parse_openapi` threads
+all four dicts uniformly so the full pipeline never trips the
+opt-out branch.
+
 ### T2 control flow
 
 ```text
@@ -781,13 +791,19 @@ operations go live.
   never use this combination. T2 will log a warning if it spots a
   collision after upsert.
 * **Other-bucket `$ref` rejected.** `$ref:
-  "#/components/requestBodies/X"`, `$ref:
-  "#/components/responses/X"`, `$ref: "#/components/headers/X"`
-  raise `UnsupportedSpecError`. Not used by any currently-targeted
-  vendor spec (vcenter.yaml, vi-json.yaml, NSX, SDDC Manager);
-  defer until a real spec needs them. (T11 / #501 landed the
-  `#/components/parameters/*` resolver — see the T8 paragraph
-  above and `docs/architecture/spec-ingestion.md` §T1.)
+  "#/components/headers/X"`, `$ref: "#/components/securitySchemes/X"`,
+  `$ref: "#/components/links/X"`, `$ref:
+  "#/components/callbacks/X"`, and `$ref: "#/components/examples/X"`
+  raise `UnsupportedSpecError` when they appear in a parser-traversed
+  slot. None of these buckets are used by a currently-targeted vendor
+  spec in a parser-traversed position (most appear inside
+  `responses.<code>.headers.<name>` or `content.<media>.examples`,
+  which the parser doesn't walk); defer until a real spec needs them.
+  G3.11-T7 #1241 landed the `#/components/responses/*` and
+  `#/components/requestBodies/*` resolvers (unblocked the GitHub REST
+  spec's live ingest); T11 #501 landed the
+  `#/components/parameters/*` resolver — see the T8 paragraph above
+  and `docs/architecture/spec-ingestion.md` §T1.
 * **Cross-document `$ref` rejected.** External files
   (`other.yaml#/...`) raise `UnsupportedSpecError`. Same v0.2.next
   note.


### PR DESCRIPTION
## Summary

- Extends the OpenAPI parser's `$ref` resolver to inline `#/components/responses/*` and `#/components/requestBodies/*` refs alongside the existing schemas + parameters paths.
- Unblocks live ingest of the GitHub REST spec — the upstream uses 1929 `#/components/responses/*` refs (every shared envelope: `accepted`, `not_found`, `validation_failed`, etc) which previously tripped `UnsupportedSpecError` on the first hit and short-circuited Initiative #1220 G3.11.
- Mirrors T11 #501's opt-in pattern: `resolve_shallow_ref` gains `component_responses` / `component_request_bodies` kwargs, both defaulting to `None`. `parse_openapi` threads all four buckets uniformly. Residual `UnsupportedSpecError` envelope preserved for remaining buckets (headers / securitySchemes / links / callbacks / examples).

## Test plan

- [x] `ruff check` — clean on edited files; pre-existing unrelated finding in `alembic/versions/0023_create_approval_request.py` left untouched (out of scope).
- [x] `ruff format` — clean.
- [x] `mypy src/meho_backplane/operations/ingest/ --ignore-missing-imports` — `Success: no issues found in 20 source files`.
- [x] `pytest tests/test_operations_ingest_openapi.py` — 69 passed (6 new tests added).
- [x] `MEHO_GH_INGEST_LIVE=1 pytest tests/integration/test_operations_ingest_github.py` — **1 passed** (was `xfail(strict=True)` before this PR; xfail decorator removed; live GitHub spec ~784 paths parse end-to-end).
- [x] `MEHO_GH_INGEST_LIVE=1 pytest tests/integration/test_github_composite_dispatch.py` — 1 xfailed as planned; T4's composite-dispatch body wiring is separate follow-up scope. Rationale block + xfail reason updated to drop the parser-limitation reference.
- [x] Regression sweep across ingest + connector paths (`test_operations_ingest_*`, `test_api_v1_connectors_ingest`, `test_operations_ingest_vi_json`, `test_operations_ingest_vcenter`) — **259 passed, 3 skipped**. No regressions in existing connector ingests (vmware-rest, vault, kubernetes, harbor, sddc-manager, nsx, vcf-*, hetzner-robot, bind9).
- [x] Per-bucket unit fixture coverage: `tests/fixtures/openapi/response_refs_30.yaml` + `request_body_refs_30.yaml` (small focused specs; do not gate the unit lane on the live 10 MB GitHub spec).
- [x] Missing-component tests for both new buckets confirm symmetric `InvalidSchemaError` envelope.
- [x] Unsupported-bucket envelope shape locked: new `test_unsupported_component_bucket_ref_raises` covers a headers-ref-in-response-slot to assert the residual `UnsupportedSpecError` message names the diagnostic cleanly.

## Acceptance criteria

- [x] `refs.py` inlines `#/components/responses/*` and `#/components/requestBodies/*` refs alongside existing schemas + parameters paths.
- [x] `MEHO_GH_INGEST_LIVE=1 pytest backend/tests/integration/test_operations_ingest_github.py` flips from xfailed to passed; `xfail` decorator + KNOWN BLOCKER docstring removed.
- [x] T4 #1224's composite integration test xfail rationale updated to reflect new parser state. The test body still raises `NotImplementedError` (T4's own composite-dispatch sketch — out of scope here), so `xfail(strict=True)` stays in place; flipping to xpass requires the dispatch body to be wired in a separate follow-up.
- [x] No regression in existing connector ingests — full ingest test suite green.
- [x] Unsupported-ref-bucket envelope shape preserved for buckets still out of scope.

## Out of scope

- T1↔T3 version-string drift between catalog `version: v3` and registry `version: "3"` — tracked separately as G3.11-T8 #1242. The parsing-layer integration test asserted here passes; the full catalog→registry tuple lookup remains gated by T8.
- T4's composite-dispatch body wiring (`gh.composite.pr_status_summary` against a live backplane) — separate follow-up.
- Speculative coverage of `#/components/headers/*`, `#/components/securitySchemes/*`, `#/components/links/*`, `#/components/callbacks/*`, `#/components/examples/*` — none used in a parser-traversed slot by any vendor spec in the v0.x catalogue. Defer until a real spec needs them.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1241


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OpenAPI parser now supports inline resolution of response and request body component references, enabling parsing of live GitHub REST API specifications.

* **Tests**
  * Added test fixtures validating response and request body reference resolution.
  * Removed expected failure marker from GitHub REST API spec ingestion test.

* **Documentation**
  * Updated specification ingestion documentation to reflect newly supported OpenAPI component reference types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->