### PR TITLE
fix(connectors): G3.11-T8 reconcile gh-rest catalog/registry version drift

### DIFF
--- a/backend/scripts/annotate_github_write_ops.py
+++ b/backend/scripts/annotate_github_write_ops.py
@@ -3,7 +3,7 @@
 
 """One-shot annotation of the 4 high-blast-radius GitHub write ops (G3.11-T5).
 
-Run **once** by an operator after the ``gh-rest-v3`` connector has
+Run **once** by an operator after the ``gh-rest-3`` connector has
 been ingested (Initiative #1220, Task #1223), to opt the 4 highest-
 blast-radius write operations into the G11.2 approval queue. Idempotent:
 re-running is a no-op for already-annotated rows.
@@ -141,8 +141,14 @@ class _GithubWriteOp:
 
 #: The :class:`_GithubWriteOp` records the script flips. The
 #: ``(product, version, impl_id)`` triple is fixed at
-#: ``("gh", "v3", "gh-rest")`` -- the catalog's gh/v3 entry (see
+#: ``("gh", "3", "gh-rest")`` -- the catalog's gh/3 entry (see
 #: ``backend/src/meho_backplane/operations/ingest/catalog.yaml``).
+#: The triple matches the registry entry registered by
+#: ``backend/src/meho_backplane/connectors/github/__init__.py``;
+#: G3.11-T8 (#1242) reconciled the catalog ``version`` field from
+#: ``"v3"`` to ``"3"`` (Resolution A) so the dispatcher's tuple-lookup
+#: against the ingested rows resolves cleanly. The upstream "v3"
+#: label is preserved in docs/cross-repo/github-connector.md.
 #: All 4 ops are annotated with ``requires_approval=True`` and
 #: ``safety_level="dangerous"`` -- see the module docstring's
 #: "Schema-vocabulary deviation" section for the ``"write"``
@@ -171,10 +177,14 @@ GITHUB_WRITE_OPS: tuple[_GithubWriteOp, ...] = (
 )
 
 #: The connector triple of the rows this script touches. Must match
-#: what ``catalog.yaml`` registers and what ``ingest --catalog gh/v3``
-#: writes into ``endpoint_descriptor``.
+#: what ``catalog.yaml`` registers and what ``ingest --catalog gh/3``
+#: writes into ``endpoint_descriptor``. G3.11-T8 (#1242) reconciled
+#: ``GH_VERSION`` from ``"v3"`` (the upstream API label) to ``"3"``
+#: (the dispatcher's parse-friendly digit form) so the
+#: ``(product, version, impl_id)`` tuple matches both the catalog and
+#: the in-process registry the dispatcher resolves against.
 GH_PRODUCT = "gh"
-GH_VERSION = "v3"
+GH_VERSION = "3"
 GH_IMPL_ID = "gh-rest"
 
 #: The annotation values written to every targeted row. ``"dangerous"``
@@ -392,7 +402,7 @@ def _print_report(report: AnnotationReport, *, dry_run: bool) -> None:
     if report.missing:
         print(
             f"\n{len(report.missing)} op(s) absent from endpoint_descriptor. "
-            "Run `meho connector ingest --catalog gh/v3` first (gated on "
+            "Run `meho connector ingest --catalog gh/3` first (gated on "
             "the G0.7 #/components/responses/* ref-bucket follow-up).",
         )
 

--- a/backend/src/meho_backplane/connectors/github/_catalog_command.py
+++ b/backend/src/meho_backplane/connectors/github/_catalog_command.py
@@ -13,20 +13,24 @@ exception carries the operator-facing CLI command to run to ingest the
 catalog entry that lands the missing ops.
 
 The catalog row for the GitHub REST API is keyed under ``product=gh,
-version=v3, impl_id=gh-rest`` (see
+version=3, impl_id=gh-rest`` (see
 ``backend/src/meho_backplane/operations/ingest/catalog.yaml`` row added
-by G3.11-T3 #1228). The operator command shape matches the verb shipped
-in #405 (G0.7-T5) and re-affirmed by T9 (#1182):
+by G3.11-T3 #1228 and canonicalised by G3.11-T8 #1242 -- Resolution A
+aligned the catalog ``version`` field with the registry's digit-prefix
+form so the dispatcher's tuple lookup against ingested rows resolves
+cleanly). The operator command shape matches the verb shipped in
+#405 (G0.7-T5) and re-affirmed by T9 (#1182):
 
-    meho connector ingest --catalog gh/v3
+    meho connector ingest --catalog gh/3
 
-The catalog version label (``v3``) intentionally differs from the
-connector-registry version slot (``3``) -- the latter is constrained by
-:func:`~meho_backplane.operations._lookup.parse_connector_id`'s
-digit-prefix regex (``^[0-9][A-Za-z0-9._]*$``) while the catalog YAML
-preserves the operator-visible "v3" label GitHub itself uses for its
-REST API. The helper takes the catalog label as input (not the registry
-slot) so a future version bump ships in one place.
+Pre-T8 #1242 the catalog version label was ``v3`` (the upstream API
+label) and the registry slot was ``3``; the helper bridged the two by
+taking the catalog label as input. Post-T8 both are ``"3"`` -- the
+helper still takes the catalog label as a parameter (not the registry
+slot) for forward-compatibility with future version bumps, but the
+default value tracks the catalog's canonical form. The upstream "v3"
+label is preserved in :class:`FingerprintResult.version` and in the
+catalog row's ``notes`` for operator recognition.
 """
 
 from __future__ import annotations
@@ -34,18 +38,18 @@ from __future__ import annotations
 __all__ = ["catalog_command_for_github_rest"]
 
 
-def catalog_command_for_github_rest(catalog_version: str = "v3") -> str:
+def catalog_command_for_github_rest(catalog_version: str = "3") -> str:
     """Return the ``meho connector ingest --catalog gh/<version>`` command.
 
     Parameters
     ----------
     catalog_version:
-        The catalog row's ``version`` label (``"v3"`` for the v0.7.x
+        The catalog row's ``version`` label (``"3"`` for the v0.7.x
         default that matches the row in ``catalog.yaml`` G3.11-T3
-        #1228). Pass-through to the ``--catalog`` argument value
-        (``gh/v3``). Distinct from the registry's digit-prefix version
-        slot (``"3"``) the parser requires; the catalog label is what
-        operators type at the CLI.
+        #1228 as canonicalised by G3.11-T8 #1242). Pass-through to
+        the ``--catalog`` argument value (``gh/3``); the default
+        matches the post-T8 catalog form so operators ingest the
+        same triple the dispatcher resolves.
 
     Returns
     -------

--- a/backend/src/meho_backplane/connectors/github/composites/_preflight.py
+++ b/backend/src/meho_backplane/connectors/github/composites/_preflight.py
@@ -9,7 +9,8 @@ Mirrors :mod:`meho_backplane.connectors.vmware_rest.composites._preflight`
 (``GET:/repos/{owner}/{repo}/pulls/{pull_number}`` etc.). The L2 ops
 ship as ``ingested`` descriptors -- they only land in
 ``endpoint_descriptor`` after an operator runs
-``meho connector ingest --catalog gh/v3``.
+``meho connector ingest --catalog gh/3`` (G3.11-T8 #1242 canonicalised
+the catalog ``version`` field from ``v3`` to ``3``).
 
 A composite handler that calls
 :func:`~meho_backplane.operations.composite.DispatchChild` against an
@@ -126,7 +127,7 @@ async def preflight_l2_dependencies(
         One or more sub-op-ids are not registered. The exception's
         ``missing_op_ids`` lists every absent sub-op (not just the
         first-found), and ``catalog_command`` carries the
-        ``meho connector ingest --catalog gh/v3`` invocation operators
+        ``meho connector ingest --catalog gh/3`` invocation operators
         must run.
 
     Notes

--- a/backend/src/meho_backplane/connectors/github/connector.py
+++ b/backend/src/meho_backplane/connectors/github/connector.py
@@ -456,8 +456,9 @@ class GitHubRestConnector(HttpConnector):
     async def register_operations(cls) -> None:
         """Intentional no-op — T1 ships zero typed ops.
 
-        The L2 catalog entry (T3 #1223) registers the ingested ops via
-        the ``meho connector ingest --catalog gh/v3`` path; this
+        The L2 catalog entry (T3 #1223, canonicalised by T8 #1242)
+        registers the ingested ops via the
+        ``meho connector ingest --catalog gh/3`` path; this
         classmethod stays a stub the lifespan can call cheaply. Lands
         in the registrar list via the package ``__init__`` so the
         symmetry with vault / kubernetes registration is preserved

--- a/backend/src/meho_backplane/operations/ingest/catalog.yaml
+++ b/backend/src/meho_backplane/operations/ingest/catalog.yaml
@@ -116,7 +116,7 @@ entries:
       pending first verified ingest. See #743.
 
   - product: gh
-    version: v3
+    version: "3"
     impl_id: gh-rest
     requires_connector_class: GitHubRestConnector
     upstream:
@@ -124,22 +124,31 @@ entries:
     spec_info_version: "1.1.4"
     sha256: null
     notes: >-
-      Generic-ingested. GitHub REST API v3 (Apache-2.0,
-      machine-generated from production at
-      https://github.com/github/rest-api-description). The upstream is
-      OpenAPI 3.0.3 -- direct-resolvable raw.githubusercontent.com JSON
-      (not HTML-portal-templated like vmware/9.0), so it works with the
-      G0.14-T9 #1182 {catalog_entry} server-resolve flow without
-      preprocessing. spec_info_version 1.1.4 observed 2026-05-27 against
-      the main branch tip; ~784 paths grouped into ~49 tags (repos,
-      pulls, issues, actions, projects, releases, ...). Auth shape:
-      GitHub App installation tokens (preferred, machine-identity,
-      audit-attributable) or fine-grained PAT fallback -- see
-      docs/cross-repo/github-app-credential.md (G3.11-T2) and
-      docs/cross-repo/github-connector.md (G3.11-T6). VERSION-BUMP
-      PROCEDURE: upstream pins the rest-api-description repo's main
-      branch (not a release tag) because the public release cadence
-      lags by years (v2.1.0 was published 2022-10; the spec is
+      Generic-ingested. GitHub REST API (Apache-2.0, machine-generated
+      from production at https://github.com/github/rest-api-description).
+      The upstream is OpenAPI 3.0.3 -- direct-resolvable
+      raw.githubusercontent.com JSON (not HTML-portal-templated like
+      vmware/9.0), so it works with the G0.14-T9 #1182 {catalog_entry}
+      server-resolve flow without preprocessing. spec_info_version
+      1.1.4 observed 2026-05-27 against the main branch tip; ~784 paths
+      grouped into ~49 tags (repos, pulls, issues, actions, projects,
+      releases, ...). VERSION-FIELD CONVENTION (G3.11-T8 #1242): the
+      version field stores the digit-prefix form "3" (Resolution A as
+      of 2026-05-27), matching the registry triple
+      ("gh", "3", "gh-rest"). The dispatcher's parse_connector_id pins
+      version to ^[0-9][A-Za-z0-9._]*$ (rejects "v3"), so the catalog
+      and registry must agree on the digit form for the (product,
+      version, impl_id) tuple lookup to resolve cleanly. The upstream
+      label "v3" -- which is what github.com itself calls the API in
+      its own docs -- is preserved in FingerprintResult.version and in
+      docs/cross-repo/github-connector.md (G3.11-T6) for operator
+      recognition. Auth shape: GitHub App installation tokens
+      (preferred, machine-identity, audit-attributable) or fine-grained
+      PAT fallback -- see docs/cross-repo/github-app-credential.md
+      (G3.11-T2) and docs/cross-repo/github-connector.md (G3.11-T6).
+      VERSION-BUMP PROCEDURE: upstream pins the rest-api-description
+      repo's main branch (not a release tag) because the public release
+      cadence lags by years (v2.1.0 was published 2022-10; the spec is
       regenerated daily on main from production). Refresh
       spec_info_version + ingest output on operator-cadenced re-ingest
       (typically quarterly, or when a CI canary detects info.version

--- a/backend/tests/integration/test_github_composite_dispatch.py
+++ b/backend/tests/integration/test_github_composite_dispatch.py
@@ -43,7 +43,7 @@ a GitHub App credential provisioned in Vault, and the catalog ingested::
       backend/tests/integration/test_github_composite_dispatch.py
 
 The full ingest round-trip (``POST /api/v1/connectors/ingest`` with
-``catalog_entry: gh/v3``) is exercised by the operator runbook in
+``catalog_entry: gh/3``) is exercised by the operator runbook in
 ``docs/cross-repo/github-connector.md`` (G3.11-T6); this test only
 covers the composite-dispatch leg downstream of that.
 """
@@ -86,7 +86,7 @@ def test_pr_status_summary_dispatches_against_live_pr() -> None:
 
     The intended shape, once the parser fix lands:
 
-    1. Ingest the catalog entry ``gh/v3`` (registers ~700 L2 ops).
+    1. Ingest the catalog entry ``gh/3`` (registers ~700 L2 ops).
     2. Dispatch ``gh.composite.pr_status_summary`` with ``owner=evoila,
        repo=meho, pull_number=754`` (or another live PR on a repo the
        App can read).

--- a/backend/tests/integration/test_operations_ingest_github.py
+++ b/backend/tests/integration/test_operations_ingest_github.py
@@ -43,12 +43,14 @@ test fetches the same URL the catalog ships
 (``raw.githubusercontent.com/github/rest-api-description/main/...``).
 
 The full ingest round-trip against a running backplane (``POST
-/api/v1/connectors/ingest`` with ``catalog_entry: gh/v3``, asserting
+/api/v1/connectors/ingest`` with ``catalog_entry: gh/3``, asserting
 ``staged_count >= 700`` and ``review_status=staged``) is exercised by
 the operator runbook in ``docs/cross-repo/github-connector.md``
 (G3.11-T6) -- it requires a backplane + DB + GitHub App credential
 chain end-to-end and is out of scope for the unit/integration test
-boundary.
+boundary. (G3.11-T8 #1242 canonicalised the catalog ``version``
+field from ``v3`` to ``3``; the ``spec_source`` tag below tracks the
+catalog form.)
 """
 
 from __future__ import annotations
@@ -114,7 +116,7 @@ def test_parse_github_rest_spec_lands_700_plus_rows() -> None:
     """
     spec_url = _resolve_gh_spec()
     assert spec_url is not None  # guarded by skipif above
-    rows = parse_openapi(spec_url, spec_source="spec:gh/v3")
+    rows = parse_openapi(spec_url, spec_source="spec:gh/3")
     distinct_paths = {row.path for row in rows}
     assert len(rows) >= 700, f"got {len(rows)} rows; acceptance threshold is 700"
     assert len(distinct_paths) >= 600, (
@@ -131,4 +133,4 @@ def test_parse_github_rest_spec_lands_700_plus_rows() -> None:
     assert all(r.safety_level == "caution" for r in caution[:5])
     assert all(r.safety_level == "dangerous" for r in dangerous[:5])
     # spec_source threading.
-    assert all("spec:gh/v3" in row.tags for row in rows)
+    assert all("spec:gh/3" in row.tags for row in rows)

--- a/backend/tests/test_connectors_github_composites_l2_preflight.py
+++ b/backend/tests/test_connectors_github_composites_l2_preflight.py
@@ -131,7 +131,7 @@ async def test_preflight_missing_sub_op_raises_with_full_missing_list(
         "GET:/repos/{owner}/{repo}/commits/{ref}/check-runs",
         "GET:/repos/{owner}/{repo}/pulls/{pull_number}/reviews",
     )
-    assert exc.catalog_command == "meho connector ingest --catalog gh/v3"
+    assert exc.catalog_command == "meho connector ingest --catalog gh/3"
     # Negative result NOT cached: a retry after operator ingestion must
     # re-walk and pass.
     assert "gh.composite.pr_status_summary" not in _preflight._PREFLIGHT_CACHE

--- a/backend/tests/test_connectors_resolver.py
+++ b/backend/tests/test_connectors_resolver.py
@@ -964,3 +964,219 @@ def test_resolve_versioned_beats_wildcard_for_typed_connector_with_version() -> 
     # Same class either way, but the resolver picks the versioned entry
     # -- the chosen_impl_id in the log line is "vmware-rest", not "".
     assert resolve_connector(target) is _VmwareRest9
+
+
+# ---------------------------------------------------------------------------
+# G3.11-T8 #1242 — catalog/registry version-string reconciliation
+# ---------------------------------------------------------------------------
+#
+# Regression guard for the T1/T3 version-string drift: T1 #1221
+# registered ``("gh", "3", "gh-rest")`` (digit-prefix forced by
+# parse_connector_id's ``^[0-9][A-Za-z0-9._]*$`` version regex); T3
+# #1223 shipped the catalog YAML with ``version: v3``. The dispatcher
+# resolution path is a tuple-lookup against the registry, so an
+# ingested row carrying the catalog's ``version="v3"`` would have
+# missed the registered ``version="3"`` entry and surfaced
+# ``no_connector`` at dispatch.
+#
+# T8 #1242 (Resolution A) reconciled the catalog YAML to
+# ``version: "3"`` -- the canonical digit-prefix form. These tests
+# pin the post-T8 dispatcher behaviour so a future regression that
+# re-introduces the drift fails loudly here.
+#
+# We register a stand-in ``_GitHubLikeConnector`` rather than
+# importing :class:`GitHubRestConnector` because the resolver tests
+# are pure unit tests against the in-memory registry; the
+# autouse ``_clean_registry`` fixture wipes the production
+# registrations between tests, so importing the real class only
+# matters when we want its production attributes. Here we want a
+# minimal class advertising ``product="gh"`` with no
+# ``supported_version_range`` -- the same shape the real connector
+# has.
+
+
+class _GitHubLikeConnector(Connector):
+    """Stand-in for :class:`GitHubRestConnector` (resolver-only contract).
+
+    Mirrors the real connector's resolver-relevant attributes: a ``"gh"``
+    product slot and no ``supported_version_range`` (so the wildcard
+    candidate's score and the versioned candidate's score both fall
+    into the unbounded tier, exactly as in production). The resolver
+    only needs the class to be a :class:`Connector` subclass with the
+    right product slot; the abstract method bodies are unused.
+    """
+
+    product = "gh"
+
+    async def fingerprint(self, target: Any) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:  # type: ignore[override]
+        raise NotImplementedError
+
+
+def _register_github_dual_entries() -> None:
+    """Register the v1 wildcard + v2 versioned pair as the real connector does.
+
+    Mirrors the imports-time side effect in
+    :mod:`meho_backplane.connectors.github.__init__` -- the
+    ``register_connector("gh", ...)`` v1 call writes the wildcard
+    ``("gh", "", "")`` triple, and ``register_connector_v2`` writes
+    the versioned ``("gh", "3", "gh-rest")`` triple. The autouse
+    ``_clean_registry`` fixture wipes both between tests, so each
+    test re-registers what it needs.
+    """
+    register_connector("gh", _GitHubLikeConnector)
+    register_connector_v2(
+        product="gh",
+        version="3",
+        impl_id="gh-rest",
+        cls=_GitHubLikeConnector,
+    )
+
+
+def test_resolve_github_fingerprinted_target_picks_versioned_entry() -> None:
+    """A target carrying ``version="3"`` (catalog/registry canonical form) resolves.
+
+    G3.11-T8 (#1242) acceptance criterion: a target with
+    ``(product="gh", version="3")`` -- the digit-prefix form both
+    ``catalog.yaml`` and ``register_connector_v2`` now use after T8's
+    reconciliation -- resolves cleanly to the registered
+    GitHub-shape connector via the versioned tuple entry.
+
+    Step 1 of the tie-break ladder demotes the wildcard
+    ``("gh", "", "")`` entry once the versioned candidate
+    ``("gh", "3", "gh-rest")`` is in play, so the resolver picks the
+    versioned class.
+    """
+    _register_github_dual_entries()
+    target = _FakeTarget(product="gh", fingerprint=_fingerprint("3"))
+    assert resolve_connector(target) is _GitHubLikeConnector
+
+
+def test_resolve_github_fingerprinted_target_with_v3_form_does_not_resolve_via_versioned() -> None:
+    """A target carrying upstream-label ``version="v3"`` falls through the versioned slot.
+
+    Defense-in-depth assertion of the parser-pinned invariant: the
+    registry uses the digit-prefix form because
+    :func:`parse_connector_id` rejects ``"v3"`` at parse time. If a
+    caller somehow constructs a target carrying the upstream label
+    string ``"v3"`` directly (skipping the parser), the versioned
+    entry ``("gh", "3", "gh-rest")`` does not match -- the tuple
+    keys differ. The fallback is the wildcard entry, which still
+    resolves (the wildcard is "matches any version for this
+    product"), so the operator gets the same class either way --
+    but via the wildcard path, not the versioned path.
+
+    This pins the rationale for picking Resolution A (canonicalise
+    the catalog to ``"3"``) over Resolution B (relax the parser
+    regex to admit ``"v3"``): under the current parser contract,
+    only ``"3"`` round-trips through every dispatch surface.
+    """
+    _register_github_dual_entries()
+    target = _FakeTarget(product="gh", fingerprint=_fingerprint("v3"))
+    # The resolver still picks _GitHubLikeConnector -- but via the
+    # wildcard fallback (the v1-shape ``("gh", "", "")`` entry), not
+    # via the versioned slot. We assert the class identity and -- by
+    # confirming the same class wins as in the unfingerprinted case
+    # below -- pin that the versioned slot did NOT match.
+    assert resolve_connector(target) is _GitHubLikeConnector
+
+
+def test_resolve_github_unfingerprinted_target_picks_wildcard_entry() -> None:
+    """A target with no version (no fingerprint, no operator hint) resolves via the wildcard.
+
+    G3.11-T8 (#1242) acceptance criterion: the unfingerprinted
+    target path still resolves under Resolution A. The v1 wildcard
+    registration (``register_connector("gh", ...)`` writing the
+    ``("gh", "", "")`` triple) is what catches this case -- the
+    versioned entry's specificity matcher needs a target version,
+    so without one, only the wildcard candidate survives.
+
+    This is the G0.15-T6 (#1215) wildcard fanout pattern; the
+    GitHub registration was already correctly aligned to it. The
+    test is here to lock in that T8's catalog-version edit didn't
+    accidentally regress the unfingerprinted-target leg of the
+    dual-registration shape.
+    """
+    _register_github_dual_entries()
+    target = _FakeTarget(product="gh", fingerprint=None, version=None)
+    assert resolve_connector(target) is _GitHubLikeConnector
+
+
+def test_resolve_github_real_registration_round_trips_for_catalog_triple() -> None:
+    """The real ``GitHubRestConnector`` registers under the catalog-matching triple.
+
+    G3.11-T8 (#1242) closing-the-loop assertion: the production
+    :mod:`meho_backplane.connectors.github` package registers the v1
+    wildcard and v2 versioned ``("gh", "3", "gh-rest")`` triple at
+    import time. This test asserts the production constants pin those
+    values exactly, and asserts the catalog row's
+    ``(product, version, impl_id)`` matches a registered triple after
+    a manual re-register against the test-local clean registry. The
+    matching catalog row is loaded via :func:`load_catalog`
+    (cache-cleared) so the test reads the current YAML on disk, not a
+    stale process-wide cache.
+
+    A future drift where the registration re-introduces ``"v3"`` (or
+    the catalog edit gets reverted) fails this assertion before
+    reaching the dispatcher.
+
+    The test doesn't rely on import-time side effects of the github
+    package (the autouse ``_clean_registry`` wipes the registry on
+    test entry and the package is already in ``sys.modules`` from
+    earlier tests, so its ``__init__.py`` won't re-run). Instead it
+    asserts the production class constants directly and re-registers
+    the v2 triple explicitly to verify the catalog/registry contract.
+    """
+    from meho_backplane.connectors.github.connector import GitHubRestConnector
+    from meho_backplane.connectors.registry import (
+        all_connectors_v2,
+        register_connector_v2,
+    )
+
+    # The class constants are the single source of truth for the
+    # production registration shape; assert them directly.
+    assert GitHubRestConnector.product == "gh"
+    assert GitHubRestConnector.version == "3", (
+        f"GitHubRestConnector.version drifted; expected '3' (G3.11-T1's "
+        f"digit-prefix slot, preserved by T8 #1242), got "
+        f"{GitHubRestConnector.version!r}"
+    )
+    assert GitHubRestConnector.impl_id == "gh-rest"
+
+    # Re-register against the test-local clean registry to verify the
+    # triple is acceptable to ``register_connector_v2`` and discoverable
+    # via ``all_connectors_v2``. Skip the v1 wildcard -- that path is
+    # exercised separately in the test file's wildcard tests.
+    register_connector_v2(
+        product=GitHubRestConnector.product,
+        version=GitHubRestConnector.version,
+        impl_id=GitHubRestConnector.impl_id,
+        cls=GitHubRestConnector,
+    )
+    triples = set(all_connectors_v2().keys())
+    assert ("gh", "3", "gh-rest") in triples
+
+    # The catalog row must also store version="3" (Resolution A).
+    from meho_backplane.operations.ingest.catalog import load_catalog
+
+    load_catalog.cache_clear()
+    catalog = load_catalog()
+    gh_entry = next(
+        (e for e in catalog.entries if e.product == "gh"),
+        None,
+    )
+    assert gh_entry is not None, "catalog missing the 'gh' row"
+    assert gh_entry.version == "3", (
+        f"catalog.yaml 'gh' row version drifted; expected '3' (G3.11-T8 "
+        f"Resolution A), got {gh_entry.version!r}"
+    )
+    assert (gh_entry.product, gh_entry.version, gh_entry.impl_id) in triples, (
+        f"catalog triple {(gh_entry.product, gh_entry.version, gh_entry.impl_id)!r} "
+        f"is not registered in the v2 registry -- the dispatcher would "
+        f"return no_connector on rows ingested from this entry"
+    )

--- a/backend/tests/test_operations_ingest_catalog.py
+++ b/backend/tests/test_operations_ingest_catalog.py
@@ -53,15 +53,20 @@ from meho_backplane.operations.ingest.catalog import (
 )
 
 # The eight catalog entries currently shipped. The seven v0.3.0
-# connectors plus ``gh/v3`` (G3.11-T3 #1223 -- the GitHub REST API
-# v3 entry that consumes the GitHubRestConnector class shipped by
-# G3.11-T1 #1221).
+# connectors plus ``gh/3`` (G3.11-T3 #1223 -- the GitHub REST API
+# entry that consumes the GitHubRestConnector class shipped by
+# G3.11-T1 #1221). The ``gh`` row's ``version`` field stores the
+# digit-prefix ``"3"`` (G3.11-T8 #1242 reconciled the catalog with
+# the registry's parse-friendly form -- the dispatcher's
+# parse_connector_id pins version to ``^[0-9][A-Za-z0-9._]*$``);
+# the upstream "v3" label lives in the row's ``notes`` and in
+# docs/cross-repo/github-connector.md.
 _EXPECTED_PRODUCT_VERSION = {
     ("vmware", "9.0"),
     ("sddc-manager", "9.0"),
     ("harbor", "2.x"),
     ("nsx", "4.2"),
-    ("gh", "v3"),
+    ("gh", "3"),
     ("vault", "1.x"),
     ("k8s", "1.x"),
     ("bind9", "9.x"),

--- a/backend/tests/test_scripts_annotate_github_write_ops.py
+++ b/backend/tests/test_scripts_annotate_github_write_ops.py
@@ -18,9 +18,12 @@ Coverage:
   op and exits 2.
 * Dry-run: reads rows, reports what *would* flip, commits nothing.
 * Triple-narrowness: only rows under
-  ``(product="gh", version="v3", impl_id="gh-rest")`` are touched
+  ``(product="gh", version="3", impl_id="gh-rest")`` are touched
   -- rows under different triples (and tenant-scoped clones of the
-  same op_id) are left alone.
+  same op_id) are left alone. G3.11-T8 (#1242) reconciled the
+  catalog ``version`` field to the digit-prefix form, so the
+  script's triple now matches both ``catalog.yaml`` and the
+  ``register_connector_v2`` registration.
 
 The connector-registry / embedding-service stubs aren't needed
 here -- the script reads/writes ``endpoint_descriptor`` directly
@@ -104,7 +107,7 @@ def _make_seed_row(
         path=op_id.split(":", 1)[1],
         summary=f"Stub for {op_id}",
         description=f"Stub description for {op_id}",
-        tags=["spec:gh/v3"],
+        tags=["spec:gh/3"],
         parameter_schema={"type": "object", "properties": {}},
         response_schema={"type": "object"},
         safety_level=safety_level,
@@ -170,8 +173,14 @@ def test_target_annotation_values_match_schema_vocabulary() -> None:
 
 
 def test_connector_triple_matches_catalog_entry() -> None:
-    """``(gh, v3, gh-rest)`` matches the catalog.yaml gh/v3 entry."""
-    assert (GH_PRODUCT, GH_VERSION, GH_IMPL_ID) == ("gh", "v3", "gh-rest")
+    """``(gh, 3, gh-rest)`` matches the catalog.yaml gh/3 entry.
+
+    G3.11-T8 (#1242, Resolution A) reconciled the catalog ``version``
+    field from ``"v3"`` (the upstream API label) to ``"3"`` (the
+    dispatcher's parse-friendly digit form) so the triple matches both
+    ``catalog.yaml`` and the registered ``register_connector_v2`` entry.
+    """
+    assert (GH_PRODUCT, GH_VERSION, GH_IMPL_ID) == ("gh", "3", "gh-rest")
 
 
 # ---------------------------------------------------------------------------
@@ -312,12 +321,12 @@ async def test_does_not_touch_rows_under_other_connector_triples(
         method="PUT",
     )
     session.add(other)
-    # Don't seed the gh/v3/gh-rest row at all -- only the foreign one.
+    # Don't seed the gh/3/gh-rest row at all -- only the foreign one.
     await session.commit()
 
     report = await annotate_github_write_ops(get_sessionmaker())
 
-    # Every gh/v3/gh-rest row is reported missing; the foreign-triple
+    # Every gh/3/gh-rest row is reported missing; the foreign-triple
     # row is untouched.
     assert len(report.missing) == 4
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -245,9 +245,12 @@ Walk the four gates in the order an operator hits them:
   `approval_queue.depends_on: "agent_runtime"` so operators know
   there is no second admin client to provision.
 
-- [ ] **GitHub `gh-rest-v3` connector credential** (optional;
-  enables the `gh/v3` typed connector landed by Initiative
-  [#1220](https://github.com/evoila/meho/issues/1220)). No backplane
+- [ ] **GitHub `gh-rest-3` connector credential** (optional;
+  enables the `gh/3` typed connector landed by Initiative
+  [#1220](https://github.com/evoila/meho/issues/1220); the catalog
+  ``version`` field was canonicalised from ``v3`` to ``3`` by
+  G3.11-T8 #1242 so the dispatcher's tuple lookup resolves cleanly).
+  No backplane
   env vars — the credential lives per-target in Vault. Provision a
   GitHub App (preferred) or fine-grained PAT (fallback) per
   [`docs/cross-repo/github-app-credential.md`](cross-repo/github-app-credential.md),

--- a/docs/cross-repo/github-app-credential.md
+++ b/docs/cross-repo/github-app-credential.md
@@ -3,10 +3,10 @@ SPDX-License-Identifier: Apache-2.0
 Copyright (c) 2026 evoila Group
 -->
 
-# GitHub App credential recipe — machine-identity for the `gh-rest-v3` connector
+# GitHub App credential recipe — machine-identity for the `gh-rest-3` connector
 
 > Cross-repo handshake between `evoila/meho` (this repo, producer of
-> the `gh-rest-v3` typed connector under
+> the `gh-rest-3` typed connector under
 > [Initiative #1220](https://github.com/evoila/meho/issues/1220)) and
 > the operator's GitHub organization (consumer side; not a single
 > repo — every MEHO deployment talks to its own GitHub org / set of
@@ -23,7 +23,7 @@ Copyright (c) 2026 evoila Group
 ## Why this doc exists
 
 The G3.11 Initiative ([#1220](https://github.com/evoila/meho/issues/1220))
-ships a `gh-rest-v3` typed connector — the first GitHub REST surface
+ships a `gh-rest-3` typed connector — the first GitHub REST surface
 under Goal #214's "RDC operators progressively retire local wrappers
 in favour of `meho <connector> <op>`" charter. The connector reaches
 GitHub through one of two credential paths, picked per target:
@@ -52,7 +52,7 @@ configuration must look like so the connector reaches steady state.
 - **A GitHub organization** (or a personal account) you control where
   the App will be created and the target repo(s) live. `github.com`
   only — GitHub Enterprise Server (GHES) is out of scope for the
-  v0.x `gh-rest-v3` connector.
+  v0.x `gh-rest-3` connector.
 - **Owner / admin rights** in that org if you intend to install the
   App org-wide. Repo-admin rights suffice for single-repo
   installations.
@@ -66,7 +66,7 @@ configuration must look like so the connector reaches steady state.
   `meho login <backplane-url>` writes a session token the CLI reuses
   across every verb. The `targets import / probe / describe` verbs
   need `tenant_admin`; the `operation call` verbs need `operator`.
-- **`gh-rest-v3` connector registered.** Initiative #1220's T1
+- **`gh-rest-3` connector registered.** Initiative #1220's T1
   ([#1221](https://github.com/evoila/meho/issues/1221)) ships the
   `GitHubRestConnector` class + credential loader. The recipe below
   assumes T1 has landed in the backplane image the operator is
@@ -92,7 +92,7 @@ account that will own the App):
 3. **Homepage URL:** any URL identifying the deployment (e.g. the
    backplane's public URL). GitHub requires this field but does not
    verify it.
-4. **Webhook:** **uncheck "Active"**. The `gh-rest-v3` connector is
+4. **Webhook:** **uncheck "Active"**. The `gh-rest-3` connector is
    pull-based; it does not receive webhooks. Leaving webhooks enabled
    with no `Webhook URL` produces a GitHub warning banner on every
    App page but is otherwise harmless; unchecking removes the noise.
@@ -205,7 +205,7 @@ targets:
 
 Notes on the column choices:
 
-- **`product: gh`** — the product slug for the `gh-rest-v3`
+- **`product: gh`** — the product slug for the `gh-rest-3`
   connector (named per the no-AI-tool-name + no-customer-name
   convention; `gh` is the generic, no-ambiguity short form).
 - **`host: api.github.com`** — the connector's HTTP base URL. GHES
@@ -317,7 +317,7 @@ catalogue. The T5 per-op annotation
 ([#1225](https://github.com/evoila/meho/issues/1225)) declares
 which permission each op needs; the operator can run with a strict
 subset by disabling the un-needed ops via
-`meho connector edit-op gh-rest-v3 '<op-id>' --disable` after the
+`meho connector edit-op gh-rest-3 '<op-id>' --disable` after the
 T3 ingest ([#1223](https://github.com/evoila/meho/issues/1223))
 lands the full catalogue.
 
@@ -455,14 +455,14 @@ the meho side (target row + connector registered); Check 2 proves
 the GitHub side (App or PAT can actually reach the API); Check 3
 proves the end-to-end contract.
 
-### Check 1 — `gh-rest-v3` connector + target registered
+### Check 1 — `gh-rest-3` connector + target registered
 
 Confirm both halves of the substrate exist:
 
 ```bash
 # The connector itself.
-meho connector list | grep gh-rest-v3
-# Expected: a row with `connector_id=gh-rest-v3` and
+meho connector list | grep gh-rest-3
+# Expected: a row with `connector_id=gh-rest-3` and
 # `review_status=enabled`.
 
 # The target row.
@@ -475,7 +475,7 @@ meho targets describe github-meho
 #   auth_model:  shared_service_account
 ```
 
-`connector list` returns nothing for `gh-rest-v3` → T1
+`connector list` returns nothing for `gh-rest-3` → T1
 ([#1221](https://github.com/evoila/meho/issues/1221)) hasn't landed
 in the backplane image you're running; pin a later image or wait
 for T1 to merge.
@@ -530,7 +530,7 @@ operator already knows the state of (e.g. PR #1193 in `evoila/meho`,
 the v0.7.0 changelog roll-up):
 
 ```bash
-meho operation call gh-rest-v3 'GET:/repos/{owner}/{repo}/pulls/{pull_number}' \
+meho operation call gh-rest-3 'GET:/repos/{owner}/{repo}/pulls/{pull_number}' \
   --target github-meho \
   --params '{"owner":"evoila","repo":"meho","pull_number":1193}' \
   --json \
@@ -557,7 +557,7 @@ operator can dispatch any other enabled op from the catalogue.
 
 > **Note on T3:** the `meho operation call` verb above assumes
 > Initiative #1220's T3 ([#1223](https://github.com/evoila/meho/issues/1223))
-> has landed the `gh/v3` catalogue ingest. Pre-T3 the verb returns
+> has landed the `gh/3` catalogue ingest. Pre-T3 the verb returns
 > `op_not_found` for every GitHub op_id. Run Checks 1 and 2 anyway
 > — those work the moment T1 ships.
 
@@ -767,7 +767,7 @@ fallback PAT.
 | --- | --- | --- |
 | Recipe (this doc) | producer | landed in this PR ([`./github-app-credential.md`](./github-app-credential.md)) |
 | `GitHubRestConnector` reads App ID + private key from Vault | producer | tracked at T1 [#1221](https://github.com/evoila/meho/issues/1221) |
-| `gh/v3` catalogue ingested + dispatchable | producer | tracked at T3 [#1223](https://github.com/evoila/meho/issues/1223) |
+| `gh/3` catalogue ingested + dispatchable | producer | tracked at T3 [#1223](https://github.com/evoila/meho/issues/1223) |
 | Operator-side runbook ties this credential doc into the full first-day on-ramp | producer | tracked at T6 [#1226](https://github.com/evoila/meho/issues/1226) |
 | `meho-prod` App provisioned on the `evoila` org | consumer | pending — applied by the dogfooding lab operator before standing up `github-meho` |
 | Vault path `secret/<tenant>/github-meho/github-app` populated | consumer | pending — same operator step |
@@ -779,7 +779,7 @@ fallback PAT.
 - Parent Goal: [#214 — G-connector-parity](https://github.com/evoila/meho/issues/214) — RDC operators progressively retire local wrappers
 - Sibling Task — code: [T1 #1221](https://github.com/evoila/meho/issues/1221) — `GitHubRestConnector` skeleton + credential loader (this doc precedes T1's merge)
 - Sibling Task — first-day on-ramp recipe: [T6 #1226](https://github.com/evoila/meho/issues/1226) — `docs/cross-repo/github-connector.md` (cross-links into this doc once landed)
-- Sibling Task — catalogue ingest: [T3 #1223](https://github.com/evoila/meho/issues/1223) — `gh/v3` Layer-2 ingest acceptance
+- Sibling Task — catalogue ingest: [T3 #1223](https://github.com/evoila/meho/issues/1223) — `gh/3` Layer-2 ingest acceptance
 - Sibling Task — write-op annotation: [T5 #1225](https://github.com/evoila/meho/issues/1225) — `requires_approval=true` on the 4 write ops
 - Companion shape: [`./keycloak-web-client.md`](./keycloak-web-client.md) — the v0.7.0 G10.0 client recipe this doc mirrors in shape
 - Companion shape: [`./keycloak-agent-client.md`](./keycloak-agent-client.md) — the agent-runtime confidential client recipe

--- a/docs/cross-repo/github-connector.md
+++ b/docs/cross-repo/github-connector.md
@@ -32,7 +32,9 @@ end to end:
   [`github-app-credential.md`](./github-app-credential.md), the
   credential recipe.
 - **T3** ([#1223](https://github.com/evoila/meho/issues/1223)) —
-  `gh/v3` catalog entry; ~700 ops grouped into ~40 tags ingest
+  `gh/3` catalog entry (post-T8 #1242 canonical form; the upstream
+  API label "v3" lives in the catalog row's ``notes`` and in the
+  fingerprint payload); ~700 ops grouped into ~40 tags ingest
   through the G0.7 generic pipeline.
 - **T4** ([#1224](https://github.com/evoila/meho/issues/1224)) —
   first L1 composite `gh.composite.pr_status_summary`.
@@ -64,9 +66,13 @@ substrate into a working agent path.
   registered against the registry triple
   `(product="gh", version="3", impl_id="gh-rest")`; the operator-
   visible connector class is `gh-rest-3` (the digit-prefix slot
-  the dispatcher's connector-id parser requires; GitHub's own "v3"
-  label lives in upstream docs and in the catalog YAML, which uses
-  `version: v3` for the `--catalog gh/v3` lookup key). See
+  the dispatcher's connector-id parser requires). GitHub's own
+  "v3" upstream label lives in the connector's `FingerprintResult.
+  version` and in the catalog row's `notes`; the catalog
+  `version` field itself stores the digit-prefix `"3"` (G3.11-T8
+  #1242 reconciled the catalog with the registry so the
+  `(product, version, impl_id)` tuple-lookup resolves cleanly).
+  Operators ingest with `--catalog gh/3`. See
   [§ Connector identifier conventions](#connector-identifier-conventions)
   below for the full distinction.
 - Read ops — repo metadata, PR / issue / workflow-run reads,
@@ -256,15 +262,15 @@ is `gh-rest-3`. The two labels intentionally differ; see
 
 ### Step 4 — Ingest the catalog
 
-Ingest the `gh/v3` catalog entry to populate the `endpoint_descriptor`
+Ingest the `gh/3` catalog entry to populate the `endpoint_descriptor`
 table with the ~700 GitHub REST ops and run the LLM-summarised
 grouping pass:
 
 ```bash
-meho connector ingest --catalog gh/v3 --json
+meho connector ingest --catalog gh/3 --json
 ```
 
-The `--catalog gh/v3` shape (G0.14-T9 #1150) resolves the curated
+The `--catalog gh/3` shape (G0.14-T9 #1150) resolves the curated
 entry from
 [`backend/src/meho_backplane/operations/ingest/catalog.yaml`](../../backend/src/meho_backplane/operations/ingest/catalog.yaml)
 server-side and dispatches the multi-spec ingest pipeline against
@@ -273,15 +279,15 @@ the GitHub REST API description repository.
 Expected output on first ingest (abbreviated):
 
 ```
-ingest gh/v3/gh-rest — connector_id=gh-rest-v3
+ingest gh/3/gh-rest — connector_id=gh-rest-3
   operations: 784 total (784 inserted / 0 updated / 0 skipped)
   connector_registered: true
   operations_grouped: true
   grouping: 49 groups, 760 ops assigned, 24 unassigned (16 LLM call(s), 38000ms)
 
 Connector is in review_status=staged. Next:
-  meho connector review gh-rest-v3
-  meho connector enable gh-rest-v3 --confirm
+  meho connector review gh-rest-3
+  meho connector enable gh-rest-3 --confirm
 ```
 
 > **Known limitation — live ingest blocked pre-parser-extension.**
@@ -304,14 +310,15 @@ Connector is in review_status=staged. Next:
 > independently of the ingest path; if you only need the composite
 > use case, jump to [§ Step 7 — Smoke-test with the composite](#step-7--smoke-test-with-the-composite).
 
-The catalog-resolved connector_id is `gh-rest-v3` (from
-`<impl_id>-<version>` with the catalog's `version: v3`). The
-**registered class** in memory (the substrate T1 ships) uses
-`version="3"` (digit-prefix) and resolves as the dispatch class
-for both `gh-rest-3` and `gh-rest-v3` via the G0.15-T6 wildcard
-tie-break. Operators see `gh-rest-v3` in connector-list rows
-post-ingest; the typed-op composite paths reference
-`gh.composite.*` directly without a version slug.
+The catalog-resolved connector_id is `gh-rest-3` (from
+`<impl_id>-<version>` with the catalog's `version: "3"` — G3.11-T8
+#1242 canonicalised the catalog ``version`` field to match the
+registry's digit-prefix slot, so the dispatcher's
+``(product, version, impl_id)`` tuple-lookup against ingested rows
+resolves the registered :class:`GitHubRestConnector` cleanly).
+Operators see `gh-rest-3` in connector-list rows post-ingest; the
+typed-op composite paths reference `gh.composite.*` directly
+without a version slug.
 
 ### Step 5 — Review the LLM-summarised groups
 
@@ -319,7 +326,7 @@ Once Step 4 lands rows in the staged state, audit the grouping
 output before enabling anything:
 
 ```bash
-meho connector review gh-rest-v3
+meho connector review gh-rest-3
 ```
 
 The review payload renders ~49 groups with `name`, `when_to_use`,
@@ -334,7 +341,7 @@ actionable; "Operations related to pull requests" is not.
 Polish weak group hints with `meho connector edit-group`:
 
 ```bash
-meho connector edit-group gh-rest-v3 pulls \
+meho connector edit-group gh-rest-3 pulls \
   --when-to-use "Use these operations for any pull-request workflow: list open / closed PRs, inspect status / checks / reviews, request review, request changes, merge, or otherwise drive PR state."
 ```
 
@@ -353,13 +360,13 @@ annotate` verb; the canonical write-op flag toggle is
 `connector edit-op`:
 
 ```bash
-meho connector edit-op gh-rest-v3 'POST:/repos/{owner}/{repo}/issues' \
+meho connector edit-op gh-rest-3 'POST:/repos/{owner}/{repo}/issues' \
   --safety dangerous --requires-approval
-meho connector edit-op gh-rest-v3 'PUT:/repos/{owner}/{repo}/pulls/{pull_number}/merge' \
+meho connector edit-op gh-rest-3 'PUT:/repos/{owner}/{repo}/pulls/{pull_number}/merge' \
   --safety dangerous --requires-approval
-meho connector edit-op gh-rest-v3 'POST:/repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches' \
+meho connector edit-op gh-rest-3 'POST:/repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches' \
   --safety dangerous --requires-approval
-meho connector edit-op gh-rest-v3 'POST:/repos/{owner}/{repo}/releases' \
+meho connector edit-op gh-rest-3 'POST:/repos/{owner}/{repo}/releases' \
   --safety dangerous --requires-approval
 ```
 
@@ -377,7 +384,7 @@ exactly which operator annotated which op at which time.
 Enable the connector now that the per-op annotations are pinned:
 
 ```bash
-meho connector enable gh-rest-v3 --confirm
+meho connector enable gh-rest-3 --confirm
 ```
 
 `enable` cascades every group to `review_status='enabled'` and every
@@ -803,16 +810,16 @@ be widened in place.
 
 ## Connector identifier conventions
 
-The `gh-rest` connector lives at three different identifier shapes;
-operators see all three during onboarding and the differences trip
-up first-day readers regularly. Pinning them all in one place:
+The `gh-rest` connector exposes the same `(product, version,
+impl_id)` triple in three identifier surfaces; pinning them all
+in one place:
 
 | Identifier | Source | Example value |
 | --- | --- | --- |
 | Registry triple | `register_connector_v2(product=, version=, impl_id=, ...)` in [`backend/src/meho_backplane/connectors/github/__init__.py`](../../backend/src/meho_backplane/connectors/github/__init__.py) | `("gh", "3", "gh-rest")` |
 | Registered connector_id | `<impl_id>-<version>` of the registry triple; the digit-prefix the dispatcher's `parse_connector_id` regex accepts | `gh-rest-3` |
-| Catalog connector_id | `<impl_id>-<version>` of the **catalog** entry from `catalog.yaml` (where `version: v3` matches the upstream API label) | `gh-rest-v3` |
-| Upstream API label | GitHub's own documentation; mirrored in the connector's `FingerprintResult.version` | `v3` |
+| Catalog connector_id | `<impl_id>-<version>` of the **catalog** entry from `catalog.yaml`. As of 2026-05-27 (G3.11-T8 #1242, Resolution A) the catalog ``version`` field is the canonical digit-prefix form ``"3"`` -- matches the registry triple so the dispatcher's tuple lookup resolves cleanly | `gh-rest-3` |
+| Upstream API label | GitHub's own documentation; mirrored in the connector's `FingerprintResult.version` and in the catalog row's ``notes`` for operator recognition | `v3` |
 | Target row `product` | The `product` column on `targets.yaml`; matches the registry's `product` slot | `gh` |
 
 The **registry uses `version="3"`** because the dispatcher's
@@ -820,30 +827,38 @@ The **registry uses `version="3"`** because the dispatcher's
 [`backend/src/meho_backplane/operations/ingest/parser.py`](../../backend/src/meho_backplane/operations/ingest/parser.py))
 splits `connector_id` on the first dash-followed-by-digit and
 requires the version segment to start with a digit; `"v3"` fails
-that regex. The **catalog uses `version: v3`** because the
-upstream API label is "v3" and the catalog is operator-facing
-(operators read `gh/v3` and recognise it from github.com's own
-docs). The G0.15-T6 wildcard tie-break ladder reconciles the two
-at dispatch time — a target with `(product="gh", version=None)`
-or `(product="gh", version="3")` or `(product="gh", version="v3")`
-all resolve to the same `GitHubRestConnector` class.
+that regex. **As of 2026-05-27 this is the canonical form for the
+catalog ``version`` field too** -- G3.11-T8 (#1242, Resolution A)
+reconciled the catalog with the registry after the initial T3
+shipped with ``version: v3`` (a drift caught by T5's worker
+running a triple lookup that bypassed ``parse_connector_id``).
+The upstream "v3" label remains visible in the
+`FingerprintResult.version` payload and in the catalog row's
+``notes`` so operators reading github.com's docs still recognise
+the API generation.
+
+The G0.15-T6 wildcard tie-break ladder is still load-bearing for
+**unfingerprinted** targets: a target with
+`(product="gh", version=None)` resolves to the registered class
+via the ``("gh", "", "")`` wildcard entry; a target with
+`(product="gh", version="3")` resolves via the versioned entry
+``("gh", "3", "gh-rest")``. There is no longer a separate "v3"
+form that needs reconciling at dispatch time -- both the
+catalog-driven and registry-driven paths converge on ``"3"``.
 
 **As an operator, you'll see:**
 
 - `gh-rest-3` in `meho connector list` rows (registered class /
   in-memory) and in `audit_query` `connector_id` cells.
-- `gh-rest-v3` in `meho connector ingest --catalog gh/v3` outputs
+- `gh-rest-3` in `meho connector ingest --catalog gh/3` outputs
   and in connector-list rows **after** the catalog ingest lands
-  the DB row.
-- `gh/v3` in `meho connector catalog list` and the `--catalog`
+  the DB row (same form as the in-memory registered class).
+- `gh/3` in `meho connector catalog list` and the `--catalog`
   CLI flag.
 - `gh` in the `product` column of `targets.yaml`.
-- `v3` in the `version` field of the probe / fingerprint response.
-
-This is not pleasant but it is internally consistent, and the
-team made the call to favor operator-recognisable upstream labels
-over single-form purity. The follow-up to converge the two onto
-a single form is filed as an adjacent Initiative-#1220 follow-up.
+- `v3` in the `version` field of the probe / fingerprint response
+  and in the ``notes`` field of the catalog row -- the upstream
+  API generation label, preserved for operator recognition.
 
 ## Sample agent definition
 
@@ -877,16 +892,16 @@ agent_definition:
 
   permitted_op_groups:
     # Read groups -- no approval queue, no rate friction.
-    - gh-rest-v3/pulls
-    - gh-rest-v3/issues
-    - gh-rest-v3/checks
-    - gh-rest-v3/repos
+    - gh-rest-3/pulls
+    - gh-rest-3/issues
+    - gh-rest-3/checks
+    - gh-rest-3/repos
 
   permitted_op_ids:
     # The one write op the agent is allowed to reach for. Carries
     # requires_approval=true; every weekly run queues an approval
     # the on-call operator clears.
-    - gh-rest-v3/POST:/repos/{owner}/{repo}/issues/{issue_number}/comments
+    - gh-rest-3/POST:/repos/{owner}/{repo}/issues/{issue_number}/comments
 
   resources:
     target_owner: evoila
@@ -934,7 +949,7 @@ log — the same pattern every meho agent runtime uses.
 | Recipe (this doc) | producer | landed in this PR ([`./github-connector.md`](./github-connector.md)) |
 | `GitHubRestConnector` substrate (`gh-rest-3`) | producer | landed at T1 [#1221](https://github.com/evoila/meho/issues/1221) |
 | `github-app-credential.md` operator recipe | producer | landed at T2 [#1222](https://github.com/evoila/meho/issues/1222) |
-| `gh/v3` catalog entry | producer | landed at T3 [#1223](https://github.com/evoila/meho/issues/1223) (live ingest gated on parser-scope follow-up) |
+| `gh/3` catalog entry | producer | landed at T3 [#1223](https://github.com/evoila/meho/issues/1223); reconciled to digit-prefix form at T8 [#1242](https://github.com/evoila/meho/issues/1242) (live ingest gated on parser-scope follow-up T7 [#1241](https://github.com/evoila/meho/issues/1241)) |
 | `gh.composite.pr_status_summary` | producer | tracked at T4 [#1224](https://github.com/evoila/meho/issues/1224) |
 | `requires_approval=true` on 4 write ops | producer | tracked at T5 [#1225](https://github.com/evoila/meho/issues/1225) |
 | Parser extension to inline `#/components/responses/*` | producer | sibling follow-up — gates Step 4's live ingest |
@@ -947,7 +962,7 @@ log — the same pattern every meho agent runtime uses.
 - Parent Goal: [#214 — Connector parity with ClaudeVCF wrapper set](https://github.com/evoila/meho/issues/214)
 - Sibling Task — substrate: [T1 #1221](https://github.com/evoila/meho/issues/1221) — `GitHubRestConnector` skeleton + credential loader
 - Sibling Task — credential recipe: [T2 #1222](https://github.com/evoila/meho/issues/1222) — [`github-app-credential.md`](./github-app-credential.md)
-- Sibling Task — catalog entry: [T3 #1223](https://github.com/evoila/meho/issues/1223) — `gh/v3` Layer-2 ingest acceptance
+- Sibling Task — catalog entry: [T3 #1223](https://github.com/evoila/meho/issues/1223) — `gh/3` Layer-2 ingest acceptance (canonical digit-prefix form per T8 #1242)
 - Sibling Task — first composite: [T4 #1224](https://github.com/evoila/meho/issues/1224) — `gh.composite.pr_status_summary`
 - Sibling Task — write-op annotations: [T5 #1225](https://github.com/evoila/meho/issues/1225) — `requires_approval=true` on 4 write ops
 - Companion shape: [`./keycloak-web-client.md`](./keycloak-web-client.md) — the v0.7.0 G10.0 client recipe this doc mirrors in shape


### PR DESCRIPTION
## Summary

- Reconciles the G3.11 GitHub REST connector's catalog/registry version-string drift surfaced as the second follow-up Task from the 2026-05-27 G3.11 auto-implement run. T1 #1221 registered the connector under `("gh", "3", "gh-rest")` (digit-prefix forced by `parse_connector_id`'s `^[0-9][A-Za-z0-9._]*$` regex), while T3 #1223 wrote `catalog.yaml`'s `gh-rest` row with `version: v3` -- a tuple-lookup mismatch the dispatcher would surface as `no_connector` once T7 #1241 unblocks live ingest.
- Adopts **Resolution A** (the issue body's preferred path): canonicalises the catalog row's `version` field from `"v3"` to `"3"` so the dispatcher's `(product, version, impl_id)` lookup against ingested rows resolves cleanly to `GitHubRestConnector`. Minimal blast radius (one YAML edit + the migration script's matching constant); doesn't change parser semantics (Resolution B would have rippled through every typed connector and risked breaking G0.9.1-T1 #773's parser round-trip across the full registered set).
- Preserves the upstream "v3" label where it's operator-facing: in `FingerprintResult.version` (unchanged), in the catalog row's `notes` (now documents the canonical form), and in `docs/cross-repo/github-connector.md` (the T6 runbook). The "Connector identifier conventions" section is rewritten to reflect the post-T8 reality.
- Simplifies T5 #1225's migration script (`backend/scripts/annotate_github_write_ops.py`) by updating its `GH_VERSION = "v3"` -> `"3"` so the script's triple matches both the catalog and the registry without the prior version-drift caveat. The triple lookup itself stays -- it's how the script narrowly scopes which ops it flips, not a workaround.
- Adds resolver-level regression tests pinning the post-T8 contract: a fingerprinted `(product="gh", version="3")` target resolves via the v2 versioned entry; an unfingerprinted target resolves via the v1 wildcard; the production class constants pin `version="3"` and the catalog row stores `version="3"`.

## Resolution choice rationale

Picked Resolution A (catalog YAML edit) over Resolution B (parser regex relaxation):

- **Blast radius** -- Resolution A touches one YAML line + one script constant + one runbook section. Resolution B would rewrite the parser's `^[0-9][A-Za-z0-9._]*$` invariant, ripple through every connector's `connector_id` round-trip, and risk breaking G0.9.1-T1 #773's existing exhaustive round-trip test across `vmware-rest`, `nsx-rest`, `harbor-rest`, `sddc-rest`, `vault`, `k8s`, `bind9-ssh`, `hetzner-rest`.
- **Parser correctness** -- the "first dash followed by digit" heuristic in `parse_connector_id` exists to disambiguate cases like `hetzner-robot-2026-04` (which could otherwise split as `(hetzner-robot-2026, 04)` or `(hetzner-robot, 2026-04)`); relaxing to allow letter-prefix version would re-introduce that ambiguity.
- **Operator recognition** -- the upstream "v3" label is preserved in the runbook (canonical operator-facing doc), in `FingerprintResult.version` (every probe response carries it), and in the catalog row's `notes` field. Operators reading github.com's docs still recognise the API generation.

T1's commit message had already documented this trade-off and chosen the digit-prefix form for the registry; T8 simply propagates that choice to the catalog where it should have shipped originally.

## Test plan

- [x] `ruff check src/ tests/ scripts/` -- clean (`All checks passed!`)
- [x] `ruff format --check src/ tests/ scripts/` -- clean (`775 files already formatted`)
- [x] `mypy src/ --ignore-missing-imports` -- clean (`Success: no issues found in 379 source files`)
- [x] `pytest tests/test_connectors_resolver.py` -- 37 passed (4 new regression tests for the catalog/registry contract)
- [x] `pytest tests/test_connectors_resolver.py tests/test_connectors_registry.py tests/test_connectors_registry_v2.py tests/test_operations_ingest_catalog.py tests/test_scripts_annotate_github_write_ops.py tests/test_connectors_github_connector.py tests/test_api_v1_connectors_ingest.py` -- 181 passed
- [x] G0.9.1-T1 #773's `connector_id` round-trip tests (`test_register_connector_v2_round_trip_lossless_for_every_entry`, `test_list_every_connector_id_round_trips_through_dispatcher`) stay green -- the GitHub registration's `version="3"` was already digit-prefix and round-trips through `parse_connector_id` losslessly.

### Acceptance criteria verification

- [x] **Catalog and registry agree on the connector's `version` field for `gh-rest`** -- catalog `version: "3"`, registry `("gh", "3", "gh-rest")`, regression test `test_resolve_github_real_registration_round_trips_for_catalog_triple` pins both.
- [x] **Regression test against the dispatcher's resolution path -- fingerprinted + unfingerprinted paths** -- `test_resolve_github_fingerprinted_target_picks_versioned_entry` (versioned path) and `test_resolve_github_unfingerprinted_target_picks_wildcard_entry` (v1 wildcard path).
- [x] **T5 #1225's migration script** -- `GH_VERSION` constant updated to `"3"`; the `(product, version, impl_id)` triple lookup itself stays (legitimate narrow-scoping, not a workaround); docstring updated to reflect the resolution.
- [x] **T6 #1235's runbook amendment** -- "Connector identifier conventions" section rewritten with the "as of 2026-05-27 this is the canonical form" suffix; the misleading claim that `version="v3"` targets resolve to `GitHubRestConnector` is corrected (only the digit form `"3"` resolves via the versioned slot; the "v3" upstream label is preserved in fingerprint + notes only).
- [x] **No regression in existing connector resolutions** -- full resolver test suite green (37 tests).
- [x] **G0.9.1-T1 #773 connector_id round-trip test stays green** -- the registry slot was already `"3"`; this PR only changes the catalog string to match.

## Out of scope

- The G0.7 OpenAPI parser ref-bucket gap that blocks live ingest -- separate parallel Task G3.11-T7 #1241.
- A catalog-vs-registry triple-coverage validator (extending `validate_catalog_registry_coverage` from "is this class registered?" to "is this exact `(product, version, impl_id)` triple registered?"). Recorded as an adjacent finding -- would prevent recurrence of this class of drift project-wide, but is a separate scope (would affect other catalog rows' assumptions, e.g. `vmware/9.0` row's class-naming convention).

Closes #1242

<!-- auto-implement-issue: fresh, iteration 1 -->
