### PR TITLE
feat(jsonflux): G0.15-T8 handle envelope adds fetch_more + audit-row handle metadata

### DIFF
--- a/backend/src/meho_backplane/connectors/kubernetes/ops_events.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_events.py
@@ -331,6 +331,43 @@ K8S_EVENT_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
 }
 
 
+#: ``k8s.event.list`` does not surface a server-side ``_continue``
+#: token through this connector -- ``limit`` truncates the
+#: most-recent-first sort, so paging across older events is done by
+#: narrowing ``field_selector`` (event type / involved object / source
+#: component) rather than walking a cursor. G0.15-T8 (#1219). The hint
+#: documents that contract so consumers don't reach for
+#: ``continue_token`` here as they would on pod / deployment lists.
+K8S_EVENT_LIST_PAGINATION_HINT: dict[str, Any] = {
+    "params": {
+        "field_selector": (
+            "K8s field-selector string. Common narrowings: "
+            "'type=Warning' (operator-actionable events only), "
+            "'involvedObject.kind=Pod', 'involvedObject.name=<pod>', "
+            "'source.component=<controller>'. Multiple filters "
+            "comma-separated."
+        ),
+        "namespace": "Switch to a different namespace's event feed.",
+        "limit": (
+            f"Cap rows per response (default {DEFAULT_EVENT_LIMIT}, "
+            f"capped at {MAX_EVENT_LIMIT}). Sort + truncate keeps the "
+            "N most-recent."
+        ),
+    },
+    "example_next_call": {
+        "tool": "call_operation",
+        "args": {
+            "op_id": "k8s.event.list",
+            "params": {
+                "namespace": "kube-system",
+                "field_selector": "type=Warning",
+                "limit": 50,
+            },
+        },
+    },
+}
+
+
 K8S_EVENT_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
     "when_to_use": (
         "Call when the operator asks 'what's recently happened in "
@@ -360,6 +397,7 @@ K8S_EVENT_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
         "times the event has fired; ``last_seen_seconds`` is how "
         "long ago the event was last observed."
     ),
+    "pagination_hint": K8S_EVENT_LIST_PAGINATION_HINT,
 }
 
 

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_workload.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_workload.py
@@ -928,6 +928,46 @@ K8S_DEPLOYMENT_INFO_PARAMETER_SCHEMA: dict[str, Any] = {
 }
 
 
+#: Pagination hint surfaced by the JsonFlux reducer on every reducing
+#: ``k8s.pod.list`` response. G0.15-T8 (#1219): consumers reading the
+#: reduced envelope's ``fetch_more.native_pagination`` block see the
+#: param vocabulary + a curated example next call without re-deriving
+#: the contract. ``continue_token`` is the connector-side name for the
+#: server's ``_continue`` cursor (the connector renames it on the way
+#: out so the operator-facing surface stays kubectl-shaped); the hint
+#: documents both so a consumer can map either direction.
+K8S_POD_LIST_PAGINATION_HINT: dict[str, Any] = {
+    "params": {
+        "continue_token": (
+            "Server-emitted pagination cursor from the prior response's "
+            "``next_continue`` field. Pass back unchanged to fetch the "
+            "next page; stale tokens (>5..15 min) return 410 -- restart "
+            "the list without it."
+        ),
+        "label_selector": (
+            "Standard k8s label selector (e.g. ``app=argocd-server``, "
+            "``app in (frontend,backend)``). Forwarded server-side."
+        ),
+        "field_selector": (
+            "Standard k8s field selector (e.g. ``status.phase=Running``, "
+            "``spec.nodeName=node-1``). Forwarded server-side."
+        ),
+        "namespace": "Narrow to one namespace.",
+        "limit": "Server-side page size (1..1000).",
+    },
+    "example_next_call": {
+        "tool": "call_operation",
+        "args": {
+            "op_id": "k8s.pod.list",
+            "params": {
+                "all_namespaces": True,
+                "field_selector": "status.phase!=Running",
+            },
+        },
+    },
+}
+
+
 K8S_POD_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
     "when_to_use": (
         "Call when the operator asks 'what pods are running?' or wants "
@@ -954,6 +994,7 @@ K8S_POD_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
         "``restarts`` is the sum across main containers. "
         "``next_continue`` is present iff the server has more pages."
     ),
+    "pagination_hint": K8S_POD_LIST_PAGINATION_HINT,
 }
 
 
@@ -980,6 +1021,36 @@ K8S_POD_INFO_LLM_INSTRUCTIONS: dict[str, Any] = {
 }
 
 
+#: Same shape as :data:`K8S_POD_LIST_PAGINATION_HINT` -- the k8s server-
+#: side pagination contract is identical across list ops. G0.15-T8
+#: (#1219). The example_next_call uses a deployment-shaped narrowing
+#: filter so an agent reading this hint doesn't carry pod-shaped
+#: intuition over.
+K8S_DEPLOYMENT_LIST_PAGINATION_HINT: dict[str, Any] = {
+    "params": {
+        "continue_token": (
+            "Server-emitted pagination cursor from the prior response's "
+            "``next_continue`` field. Pass back unchanged to fetch the "
+            "next page; stale tokens return 410."
+        ),
+        "label_selector": "Standard k8s label selector. Forwarded server-side.",
+        "field_selector": "Standard k8s field selector. Forwarded server-side.",
+        "namespace": "Narrow to one namespace.",
+        "limit": "Server-side page size (1..1000).",
+    },
+    "example_next_call": {
+        "tool": "call_operation",
+        "args": {
+            "op_id": "k8s.deployment.list",
+            "params": {
+                "namespace": "kube-system",
+                "label_selector": "app in (coredns,kube-proxy)",
+            },
+        },
+    },
+}
+
+
 K8S_DEPLOYMENT_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
     "when_to_use": (
         "Call when the operator asks 'what's deployed in <ns>?' or "
@@ -1001,6 +1072,7 @@ K8S_DEPLOYMENT_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
         "'next_continue'?}. ``image`` is the first container's image "
         "(kubectl convention); full template is on the info path."
     ),
+    "pagination_hint": K8S_DEPLOYMENT_LIST_PAGINATION_HINT,
 }
 
 

--- a/backend/src/meho_backplane/connectors/schemas.py
+++ b/backend/src/meho_backplane/connectors/schemas.py
@@ -41,10 +41,14 @@ __all__ = [
     "CandidateHint",
     "EdgeHint",
     "EdgeKind",
+    "FetchMore",
+    "FetchMoreDrillIn",
+    "FetchMoreNativePagination",
     "FingerprintResult",
     "NodeHint",
     "NodeKind",
     "OperationResult",
+    "PaginationHint",
     "ProbeResult",
     "ResultHandle",
     "TopologyHints",
@@ -129,6 +133,205 @@ class ProbeResult(BaseModel):
     probed_at: datetime
 
 
+class FetchMoreDrillIn(BaseModel):
+    """Drill-in branch of :class:`FetchMore` -- "can the agent fetch more rows from this handle?"
+
+    G0.15-T8 (#1219). The reducer mints a handle but the v0.2/0.7 substrate
+    exposes **no** drill-in surface (no MCP tool, resource URI, REST route,
+    or CLI verb), so ``available`` is currently always ``False`` -- the
+    field exists today so a future Task that ships the fetch-back path
+    can flip it to ``True`` and populate ``mcp_resource_uri`` /
+    ``mcp_tool`` / ``example_call`` / ``expires_at`` without breaking
+    any consumer that already parses the envelope. The contract is
+    self-documenting per the consumer's recommendation in
+    ``claude-rdc-hetzner-dc#753``: *"the reduced response itself should
+    tell the agent how to fetch more"*.
+
+    ``rationale`` is the operator/agent-facing string explaining the
+    current state -- for ``available=False`` it describes the
+    workaround (re-call with narrower params); for ``available=True``
+    a future Task would surface the addressable resource.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    available: bool
+    rationale: str = Field(
+        description=(
+            "Free-form prose explaining the current drill-in state. "
+            "For ``available=False`` this names the workaround (typically "
+            "re-call with native pagination); for ``available=True`` a "
+            "future Task surfaces the resource URI / tool name here."
+        ),
+    )
+
+
+class FetchMoreNativePagination(BaseModel):
+    """Native-pagination branch of :class:`FetchMore`.
+
+    Answers *"what params let the underlying op return the next slice?"*
+
+    G0.15-T8 (#1219). When the underlying op has documented native
+    pagination support (k8s server-side ``label_selector`` / ``limit`` /
+    ``_continue``, REST APIs with ``offset`` / ``cursor`` knobs, etc.),
+    the reducer surfaces those param names + a curated
+    ``example_next_call`` so an agent can keep iterating without
+    re-discovering the contract every time it sees a handle.
+
+    The reducer reads :class:`PaginationHint` from the op's registration
+    metadata (carried through the dispatcher via ``context``). When no
+    hint exists, ``available=False`` with the rationale "op has no
+    documented native pagination support" -- the same response shape so
+    consumers parse one branch regardless of source.
+
+    ``params`` and ``example_next_call`` are mappings so the wire format
+    is stable JSON; immutability is enforced via
+    :class:`types.MappingProxyType` in :meth:`_freeze_nested` per the
+    sibling pattern.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    available: bool
+    rationale: str | None = None
+    params: Mapping[str, str] | None = Field(
+        default=None,
+        description=(
+            "Mapping of pagination-param name -> short description. The "
+            "agent picks the relevant subset when constructing the next "
+            "call. Omitted when ``available=False``."
+        ),
+    )
+    example_next_call: Mapping[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Curated next-call template the agent can adapt. Shape is "
+            "free-form by design (each connector picks the surface it "
+            "wants to teach -- MCP tool name + args, REST verb + path, "
+            "CLI invocation). Omitted when ``available=False``."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _freeze_nested(self) -> "FetchMoreNativePagination":
+        if self.params is not None:
+            object.__setattr__(self, "params", MappingProxyType(dict(self.params)))
+        if self.example_next_call is not None:
+            object.__setattr__(
+                self,
+                "example_next_call",
+                MappingProxyType(dict(self.example_next_call)),
+            )
+        return self
+
+    @field_serializer("params")
+    def _serialize_params(self, value: Mapping[str, str] | None) -> dict[str, str] | None:
+        if value is None:
+            return None
+        return dict(value)
+
+    @field_serializer("example_next_call")
+    def _serialize_example_next_call(
+        self, value: Mapping[str, Any] | None
+    ) -> dict[str, Any] | None:
+        if value is None:
+            return None
+        return dict(value)
+
+
+class FetchMore(BaseModel):
+    """Self-documenting "how do I fetch more rows from this handle?" envelope.
+
+    G0.15-T8 (#1219). Shipped on every :class:`ResultHandle` the reducer
+    mints so an agent reading the envelope can answer
+    *"how do I get the next slice"* from the response itself -- without
+    a discovery dance across MCP tools / resource URIs / REST routes /
+    CLI verbs. Two branches because the answer has two independent
+    parts:
+
+    * :class:`FetchMoreDrillIn` -- can the agent fetch more rows from
+      the handle directly (resource URI / tool name)? Currently always
+      ``available=False`` in v0.7.x; flips to ``True`` when the drill-in
+      route ships (deferred to v0.8/0.9 per the issue body's
+      out-of-scope clause).
+    * :class:`FetchMoreNativePagination` -- can the agent re-call the
+      original op with narrower params (k8s ``label_selector``,
+      ``_continue`` token, etc.)? Populated from the op's
+      :class:`PaginationHint` registration metadata; ``available=False``
+      with rationale when no hint exists.
+
+    The shape is documentation-as-data, matching the established
+    precedents the consumer cited:
+    :attr:`~meho_backplane.db.models.ConnectorRegistration.next_step`
+    (G0.13-T3 #1153), ``/ready.features`` (G0.14-T7),
+    ``/retrieve/usage.counted_surfaces`` -- every reduced response
+    teaches the agent how to act on it next.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    drill_in: FetchMoreDrillIn
+    native_pagination: FetchMoreNativePagination
+
+
+class PaginationHint(BaseModel):
+    """Op-registration metadata describing the underlying op's native pagination contract.
+
+    G0.15-T8 (#1219). Connectors that ship pagination-aware ops attach
+    a :class:`PaginationHint` to the op's ``llm_instructions`` payload
+    under the ``pagination_hint`` key; the dispatcher forwards it to
+    the reducer via the reduce ``context``, and the reducer emits the
+    :attr:`FetchMore.native_pagination` block from it. Ops without a
+    hint emit ``native_pagination.available=False`` with a rationale.
+
+    Reading from ``llm_instructions`` (rather than a new column) keeps
+    the contract additive: no DB migration, no
+    :class:`~meho_backplane.db.models.EndpointDescriptor` schema
+    change. The validation lives at the Pydantic boundary so a malformed
+    hint surfaces at op-registration time, not first reduce.
+
+    ``params`` and ``example_next_call`` mirror the wire shape of
+    :class:`FetchMoreNativePagination`; the reducer copies the validated
+    hint into the envelope verbatim.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    params: Mapping[str, str] = Field(
+        description=(
+            "Mapping of pagination-param name -> short description. "
+            "Surfaced verbatim by the reducer's "
+            ":attr:`FetchMore.native_pagination.params` envelope."
+        ),
+    )
+    example_next_call: Mapping[str, Any] = Field(
+        description=(
+            "Curated next-call template the reducer surfaces verbatim "
+            "via :attr:`FetchMore.native_pagination.example_next_call`. "
+            "Free-form shape; connectors pick the surface (MCP tool, "
+            "REST verb, CLI invocation) the most-likely consumer reads."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _freeze_nested(self) -> "PaginationHint":
+        object.__setattr__(self, "params", MappingProxyType(dict(self.params)))
+        object.__setattr__(
+            self,
+            "example_next_call",
+            MappingProxyType(dict(self.example_next_call)),
+        )
+        return self
+
+    @field_serializer("params")
+    def _serialize_params(self, value: Mapping[str, str]) -> dict[str, str]:
+        return dict(value)
+
+    @field_serializer("example_next_call")
+    def _serialize_example_next_call(self, value: Mapping[str, Any]) -> dict[str, Any]:
+        return dict(value)
+
+
 class ResultHandle(BaseModel):
     """Reference to a set-shaped payload stored out-of-band (MinIO / S3 / …).
 
@@ -153,6 +356,14 @@ class ResultHandle(BaseModel):
     ``sample_rows`` list (mirrors the sibling-models'
     :attr:`FingerprintResult.extras` / :attr:`OperationResult.extras`
     pattern).
+
+    ``fetch_more`` is the G0.15-T8 self-documenting drill-in / pagination
+    envelope -- every handle the reducer mints carries it so an agent
+    reading the response can answer *"how do I get more rows"* without a
+    discovery dance. ``None`` only on legacy code paths that construct
+    a :class:`ResultHandle` directly without going through the reducer
+    (test fixtures, future spill backends that have already enriched
+    the envelope); production reduce paths always populate it.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -165,6 +376,7 @@ class ResultHandle(BaseModel):
     total_rows: int | None = None
     sample_rows: tuple[Mapping[str, Any], ...] | None = None
     ttl_seconds: int
+    fetch_more: FetchMore | None = None
 
     @model_validator(mode="after")
     def _freeze_nested(self) -> "ResultHandle":

--- a/backend/src/meho_backplane/operations/_audit.py
+++ b/backend/src/meho_backplane/operations/_audit.py
@@ -191,6 +191,7 @@ def _build_audit_payload(
     result_status: str,
     *,
     redaction_policy_id: str | None = None,
+    handle_metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Compose the ``audit_log.payload`` dict for the dispatcher row.
 
@@ -221,6 +222,15 @@ def _build_audit_payload(
     (migration ``0030``), but mirroring the policy id into the
     JSON payload keeps the broadcast-event surface (which serialises
     ``payload``, not the dedicated columns) attribution-complete.
+
+    *handle_metadata* is the JsonFlux reducer's per-dispatch handle
+    summary (G0.15-T8 #1219) -- ``handle_id`` + ``total_rows`` +
+    ``sample_rows_returned``. Present on the success path of any
+    reducing dispatch; ``None`` on pass-through reduces (small
+    payloads) and on every error-path audit write. The keys land
+    verbatim under the audit payload so a consumer reading one row
+    attributes *"the agent saw N of M rows materialized as handle
+    <uuid>"* without joining the reducer's in-memory state.
     """
     payload: dict[str, Any] = {
         "op_id": descriptor.op_id,
@@ -236,6 +246,11 @@ def _build_audit_payload(
         payload["parent_audit_id"] = str(parent_audit_id)
     if redaction_policy_id is not None:
         payload["redaction_policy_id"] = redaction_policy_id
+    if handle_metadata is not None:
+        # The reducer ships pre-coerced primitives (``handle_id`` already
+        # a UUID-as-str, ``total_rows`` an int, ``sample_rows_returned``
+        # an int) so the dict merges into the JSON payload verbatim.
+        payload.update(handle_metadata)
     # G11.4-T5 #1074 -- agent-run attribution. The session id mirror in
     # the JSON payload is for the broadcast-event surface (consumers
     # parse ``payload``); the canonical lineage key lives in the real
@@ -291,6 +306,7 @@ async def write_audit_row(
     raw_payload: Any | None = None,
     redaction_manifest: list[dict[str, Any]] | None = None,
     redaction_policy_id: str | None = None,
+    handle_metadata: dict[str, Any] | None = None,
 ) -> None:
     """Insert one ``audit_log`` row for this dispatch.
 
@@ -315,6 +331,7 @@ async def write_audit_row(
         params_hash,
         result_status,
         redaction_policy_id=redaction_policy_id,
+        handle_metadata=handle_metadata,
     )
     target_id = _resolve_target_id(target)
     parent_audit_id = parent_audit_id_var.get()
@@ -394,6 +411,7 @@ async def audit_and_broadcast_safe(
     raw_payload: Any | None = None,
     redaction_manifest: list[dict[str, Any]] | None = None,
     redaction_policy_id: str | None = None,
+    handle_metadata: dict[str, Any] | None = None,
 ) -> None:
     """Write the audit row + publish broadcast; swallow internal failures.
 
@@ -434,6 +452,7 @@ async def audit_and_broadcast_safe(
             raw_payload=raw_payload,
             redaction_manifest=redaction_manifest,
             redaction_policy_id=redaction_policy_id,
+            handle_metadata=handle_metadata,
         )
     except Exception:
         _log.exception(

--- a/backend/src/meho_backplane/operations/dispatcher.py
+++ b/backend/src/meho_backplane/operations/dispatcher.py
@@ -546,6 +546,7 @@ async def _reduce_and_audit_success(
         raw_payload=redaction.raw,
         redaction_manifest=serialised_manifest,
         redaction_policy_id=redaction.policy_id,
+        handle_metadata=_handle_metadata_for_audit(handle),
     )
     return wrap_ok_result(op_id, summary, duration_ms, handle)
 
@@ -674,6 +675,59 @@ def _apply_redaction_middleware(
         return result_connector_error(op_id, exc, 0.0)
 
 
+def _handle_metadata_for_audit(handle: ResultHandle | None) -> dict[str, Any] | None:
+    """Build the audit-payload hoist dict for a reducer's ``ResultHandle``.
+
+    G0.15-T8 (#1219). Returns the ``handle_id`` (canonical UUID string),
+    ``total_rows`` (int), and ``sample_rows_returned`` (int) the audit
+    writer hoists into ``audit_log.payload``. ``None`` when the reducer
+    did not materialize -- a pass-through reduce leaves the audit row's
+    handle keys absent, which is the right signal for downstream
+    consumers (audit-replay G8.2, the audit-query API) that "the
+    operator/agent saw the full payload inline; no handle was minted".
+
+    Pulled into a dispatcher helper rather than the reducer so the
+    reducer stays decoupled from the audit-write contract (the
+    :class:`~meho_backplane.operations.reducer.Reducer` Protocol does
+    not surface audit metadata, and the dispatcher already owns the
+    redact-reduce-audit ordering).
+    """
+    if handle is None:
+        return None
+    sample_count = len(handle.sample_rows) if handle.sample_rows is not None else 0
+    return {
+        "handle_id": str(handle.handle_id),
+        "total_rows": handle.total_rows,
+        "sample_rows_returned": sample_count,
+    }
+
+
+def _pagination_hint_from_descriptor(descriptor: EndpointDescriptor) -> dict[str, Any] | None:
+    """Extract ``pagination_hint`` from a descriptor's ``llm_instructions``.
+
+    G0.15-T8 (#1219). Connectors that ship pagination-aware ops attach
+    a :class:`~meho_backplane.connectors.schemas.PaginationHint`-shaped
+    dict under ``llm_instructions.pagination_hint``; the reducer reads
+    it via the dispatcher-supplied context to build the
+    ``fetch_more.native_pagination`` envelope. Returning a plain dict
+    (rather than the validated :class:`PaginationHint`) keeps this
+    layer free of a Pydantic-import dependency on the connectors
+    schema; the reducer validates at consumption time.
+
+    ``None`` outcomes (op didn't register a hint, ``llm_instructions``
+    itself is ``None``, or the slot's value is not a dict) all flow
+    to the reducer as "no hint" -- the reducer emits the unavailable
+    branch with a curated rationale.
+    """
+    instructions = descriptor.llm_instructions
+    if not isinstance(instructions, dict):
+        return None
+    raw = instructions.get("pagination_hint")
+    if isinstance(raw, dict):
+        return raw
+    return None
+
+
 async def _reduce_or_error(
     *,
     op_id: str,
@@ -719,6 +773,17 @@ async def _reduce_or_error(
     target_id = getattr(target, "id", None)
     if target_id is not None:
         reducer_context["target_id"] = str(target_id)
+    # G0.15-T8 (#1219): forward the op's pagination hint (when the
+    # connector author registered one via ``llm_instructions``) into
+    # the reducer context so :class:`JsonFluxReducer` can emit the
+    # ``fetch_more.native_pagination`` envelope verbatim. ``None`` on
+    # ops without a hint -- the reducer falls back to
+    # ``available=False`` with a curated rationale. Pulled here (vs.
+    # in the reducer) so the reducer stays decoupled from
+    # :class:`EndpointDescriptor`'s shape.
+    pagination_hint = _pagination_hint_from_descriptor(descriptor)
+    if pagination_hint is not None:
+        reducer_context["pagination_hint"] = pagination_hint
     try:
         return await _DEFAULT_REDUCER.reduce(
             raw,

--- a/backend/src/meho_backplane/operations/jsonflux_reducer.py
+++ b/backend/src/meho_backplane/operations/jsonflux_reducer.py
@@ -48,11 +48,42 @@ import uuid
 from typing import Any
 
 import msgspec
+import structlog
+from pydantic import ValidationError
 
-from meho_backplane.connectors.schemas import ResultHandle
+from meho_backplane.connectors.schemas import (
+    FetchMore,
+    FetchMoreDrillIn,
+    FetchMoreNativePagination,
+    PaginationHint,
+    ResultHandle,
+)
 from meho_backplane.jsonflux.query.engine import QueryEngine
 
 __all__ = ["JsonFluxReducer"]
+
+_log = structlog.get_logger(__name__)
+
+#: Rationale strings the reducer surfaces verbatim on the
+#: :attr:`FetchMore.drill_in` and :attr:`FetchMore.native_pagination`
+#: branches. Module-level constants so the wording stays consistent
+#: across every reducing dispatch (the agent / consumer sees the same
+#: prose every time) and so the tests can assert against a stable
+#: anchor.
+_DRILL_IN_UNAVAILABLE_RATIONALE: str = (
+    "No JsonFlux drill-in path is exposed in this meho version. To act "
+    "on more than the sample, re-call the operation with narrower "
+    "params (see ``native_pagination`` below) or wait for a future "
+    "release that surfaces the handle via an MCP tool / resource URI / "
+    "REST route."
+)
+_NATIVE_PAGINATION_UNAVAILABLE_RATIONALE: str = (
+    "The underlying op did not register a ``pagination_hint`` in its "
+    "metadata; native pagination params for this op are not documented "
+    "here. The connector author may register one via the typed-op "
+    "registration ``llm_instructions.pagination_hint`` slot to surface "
+    "specific param names + an example next call."
+)
 
 #: In-memory DuckDB table name the reducer registers each payload under.
 #: One :class:`QueryEngine` is created per :meth:`JsonFluxReducer.reduce`
@@ -146,11 +177,15 @@ class JsonFluxReducer:
         """Return ``(payload, None)`` or ``(summary, ResultHandle)``.
 
         See the class docstring for the threshold + collection-detection
-        contract. ``schema`` and ``context`` are accepted to satisfy the
-        Protocol; the reducer infers the materialized schema from the
-        DuckDB-registered table rather than the descriptor schema.
+        contract. ``schema`` is accepted to satisfy the Protocol; the
+        reducer infers the materialized schema from the DuckDB-registered
+        table rather than the descriptor schema. ``context`` carries the
+        op's :class:`~meho_backplane.connectors.schemas.PaginationHint`
+        (under the ``pagination_hint`` key) when the op registered one
+        via its ``llm_instructions``; the reducer copies the hint
+        verbatim into :attr:`ResultHandle.fetch_more.native_pagination`.
         """
-        del schema, context  # schema is inferred from the registered table
+        del schema  # schema is inferred from the registered table
 
         envelope_key, rows = _detect_collection(payload)
         if rows is None:
@@ -161,7 +196,7 @@ class JsonFluxReducer:
         if not self._over_threshold(rows, payload):
             return payload, None
 
-        return self._materialize(payload, envelope_key, rows)
+        return self._materialize(payload, envelope_key, rows, context)
 
     def _over_threshold(self, rows: list[Any], payload: Any) -> bool:
         """True when *rows* exceeds the row OR byte threshold.
@@ -181,12 +216,21 @@ class JsonFluxReducer:
         payload: Any,
         envelope_key: str | None,
         rows: list[Any],
+        context: dict[str, Any] | None,
     ) -> tuple[dict[str, Any], ResultHandle]:
         """Register *rows* in DuckDB and mint a handle + inline summary.
 
         A fresh :class:`QueryEngine` is created per call (in-memory,
         per-payload isolation) and closed before returning so no DuckDB
         connection leaks across dispatches.
+
+        ``context`` carries the dispatcher's per-call extras --
+        ``op_id``, ``operator_sub``, ``source_kind``, ``target_id``,
+        ``pagination_hint`` (when the op registered one). The reducer
+        reads ``pagination_hint`` to build
+        :attr:`FetchMore.native_pagination`; the rest of the context is
+        currently informational (future routing decisions can read it
+        without breaking the contract).
         """
         table_rows = _normalize_rows(rows)
         engine = QueryEngine()
@@ -199,13 +243,17 @@ class JsonFluxReducer:
         finally:
             engine.close()
 
+        fetch_more = _build_fetch_more(context)
+        handle_id = uuid.uuid4()
+        sample_rows_tuple = tuple(sample_rows) if sample_rows else None
         handle = ResultHandle(
-            handle_id=uuid.uuid4(),
+            handle_id=handle_id,
             summary_md=f"{total_rows} rows materialized as a JSONFlux handle.\n\n{summary_md}",
             schema_=schema_,
             total_rows=total_rows,
-            sample_rows=tuple(sample_rows) if sample_rows else None,
+            sample_rows=sample_rows_tuple,
             ttl_seconds=self._ttl_seconds,
+            fetch_more=fetch_more,
         )
         summary = {
             "row_count": total_rows,
@@ -306,3 +354,112 @@ def _serialize(payload: Any) -> bytes:
         return msgspec.json.encode(payload)
     except (TypeError, msgspec.EncodeError):
         return str(payload).encode("utf-8", "replace")
+
+
+def _build_fetch_more(context: dict[str, Any] | None) -> FetchMore:
+    """Build the :class:`FetchMore` envelope from the reducer's *context*.
+
+    G0.15-T8 (#1219). The contract is **always shipped** on a
+    reducing-response handle so the agent never has to guess whether
+    the envelope teaches it how to fetch more rows. Two branches:
+
+    * ``drill_in.available`` is always ``False`` in this meho version --
+      no MCP tool / resource URI / REST route / CLI verb addresses the
+      handle. The rationale string surfaces the workaround verbatim
+      (re-call with narrower params via ``native_pagination``). When
+      a future Task ships the drill-in surface, it flips
+      ``available=True`` and populates ``mcp_resource_uri`` /
+      ``mcp_tool`` / ``example_call`` / ``expires_at`` in the same
+      envelope -- no consumer needs to re-parse.
+    * ``native_pagination`` is populated from the op's
+      :class:`PaginationHint` (registered under
+      ``llm_instructions.pagination_hint`` and threaded through the
+      dispatcher as ``context["pagination_hint"]``). When no hint
+      exists -- or the hint cannot be validated -- the envelope still
+      ships, with ``available=False`` and a curated rationale; the
+      response shape is uniform regardless of source.
+
+    Invalid pagination hints (a connector authored a malformed dict)
+    do **not** raise here: the reducer logs a structured warning and
+    falls back to the unavailable branch. A reduce-time exception
+    would otherwise convert into a ``connector_error``
+    :class:`~meho_backplane.connectors.OperationResult` via the
+    dispatcher's :func:`~meho_backplane.operations.dispatcher._reduce_or_error`
+    guard -- failing a real read because an operator-facing metadata
+    field had a typo is the wrong fail mode. The validation surfaces
+    instead at op-registration time (the connector author writes the
+    hint as a :class:`PaginationHint` literal there, not as a free
+    dict).
+    """
+    drill_in = FetchMoreDrillIn(
+        available=False,
+        rationale=_DRILL_IN_UNAVAILABLE_RATIONALE,
+    )
+    native = _native_pagination_from_context(context)
+    return FetchMore(drill_in=drill_in, native_pagination=native)
+
+
+def _native_pagination_from_context(
+    context: dict[str, Any] | None,
+) -> FetchMoreNativePagination:
+    """Return the :class:`FetchMoreNativePagination` branch for *context*.
+
+    Pull order:
+
+    1. ``context["pagination_hint"]`` already-validated
+       :class:`PaginationHint` instance -- the reducer copies its
+       ``params`` + ``example_next_call`` verbatim.
+    2. ``context["pagination_hint"]`` plain dict (the dispatcher reads
+       the descriptor's ``llm_instructions`` JSON, which lives as
+       primitive Python types) -- validated through
+       :class:`PaginationHint` here; the dispatcher does not import
+       Pydantic for this codepath.
+    3. Absent / invalid -- ``available=False`` with the curated
+       rationale.
+    """
+    hint = _resolve_pagination_hint(context)
+    if hint is None:
+        return FetchMoreNativePagination(
+            available=False,
+            rationale=_NATIVE_PAGINATION_UNAVAILABLE_RATIONALE,
+        )
+    return FetchMoreNativePagination(
+        available=True,
+        params=hint.params,
+        example_next_call=hint.example_next_call,
+    )
+
+
+def _resolve_pagination_hint(context: dict[str, Any] | None) -> PaginationHint | None:
+    """Coerce ``context['pagination_hint']`` into a :class:`PaginationHint` or ``None``.
+
+    Tolerates three shapes per :func:`_native_pagination_from_context`'s
+    pull order. A validation failure on the dict branch is logged at
+    warning level and converted to ``None`` -- the reduce path stays
+    on the happy path; the connector author sees the warning in
+    structured logs and fixes the metadata. The op_id (when carried
+    in *context*) names the offender so the warning is actionable.
+    """
+    if not context:
+        return None
+    raw = context.get("pagination_hint")
+    if raw is None:
+        return None
+    if isinstance(raw, PaginationHint):
+        return raw
+    if not isinstance(raw, dict):
+        _log.warning(
+            "jsonflux_pagination_hint_invalid_shape",
+            op_id=context.get("op_id"),
+            received_type=type(raw).__name__,
+        )
+        return None
+    try:
+        return PaginationHint.model_validate(raw)
+    except ValidationError as exc:
+        _log.warning(
+            "jsonflux_pagination_hint_validation_failed",
+            op_id=context.get("op_id"),
+            errors=exc.errors(),
+        )
+        return None

--- a/backend/tests/test_operations_jsonflux_reducer.py
+++ b/backend/tests/test_operations_jsonflux_reducer.py
@@ -45,7 +45,11 @@ from meho_backplane.connectors import OperationResult
 from meho_backplane.connectors.base import Connector
 from meho_backplane.connectors.registry import clear_registry, register_connector_v2
 from meho_backplane.connectors.schemas import (
+    FetchMore,
+    FetchMoreDrillIn,
+    FetchMoreNativePagination,
     FingerprintResult,
+    PaginationHint,
     ProbeResult,
     ResultHandle,
 )
@@ -392,4 +396,203 @@ async def test_reducer_exception_yields_connector_error_via_dispatcher(
     assert rows[0].payload["result_status"] == "error"
 
     assert len(captured_events) == 1
-    assert captured_events[0].result_status == "error"
+
+
+# ---------------------------------------------------------------------------
+# G0.15-T8 (#1219) — fetch_more envelope + audit-row handle metadata
+# ---------------------------------------------------------------------------
+
+
+async def test_handle_carries_fetch_more_unavailable_branches_without_context() -> None:
+    """Every reducing-response handle ships a ``fetch_more`` block.
+
+    With no ``pagination_hint`` in the reducer context, **both** branches
+    return ``available=False`` with a non-empty rationale -- the contract
+    is self-documenting regardless of whether a hint exists. This pins
+    the v0.7.x state where the drill-in route is deferred to v0.8/0.9
+    and most ops don't yet register a ``pagination_hint``.
+    """
+    reducer = JsonFluxReducer()
+    rows = [{"id": f"row-{i}", "label": f"item-{i}"} for i in range(60)]
+    payload = {"results": rows}
+
+    _reduced, handle = await reducer.reduce(payload, None)
+
+    assert handle is not None
+    assert isinstance(handle.fetch_more, FetchMore)
+    assert isinstance(handle.fetch_more.drill_in, FetchMoreDrillIn)
+    assert handle.fetch_more.drill_in.available is False
+    assert handle.fetch_more.drill_in.rationale, (
+        "the drill_in branch must carry a non-empty rationale explaining the workaround"
+    )
+    assert "drill-in" in handle.fetch_more.drill_in.rationale.lower()
+
+    assert isinstance(handle.fetch_more.native_pagination, FetchMoreNativePagination)
+    assert handle.fetch_more.native_pagination.available is False
+    assert handle.fetch_more.native_pagination.params is None
+    assert handle.fetch_more.native_pagination.example_next_call is None
+    assert handle.fetch_more.native_pagination.rationale, (
+        "native_pagination must carry a rationale when available=False"
+    )
+
+
+async def test_handle_fetch_more_native_pagination_populated_from_context_hint() -> None:
+    """``context['pagination_hint']`` populates the ``native_pagination`` branch verbatim.
+
+    The reducer accepts both the validated :class:`PaginationHint` and a
+    plain dict shape (the dispatcher reads ``llm_instructions`` as
+    primitive JSON). Both paths produce ``available=True`` with the
+    hint's ``params`` + ``example_next_call`` copied through.
+    """
+    reducer = JsonFluxReducer()
+    rows = [{"vm": f"vm-{i}", "power": "on"} for i in range(80)]
+    payload = {"value": rows}
+    hint_dict = {
+        "params": {
+            "continue_token": "Server-emitted cursor.",
+            "label_selector": "k8s label selector.",
+        },
+        "example_next_call": {
+            "tool": "call_operation",
+            "args": {"op_id": "k8s.pod.list", "params": {"all_namespaces": True}},
+        },
+    }
+
+    # Dict path (the dispatcher's natural shape).
+    _reduced, handle = await reducer.reduce(
+        payload, None, {"op_id": "k8s.pod.list", "pagination_hint": hint_dict}
+    )
+
+    assert handle is not None
+    native = handle.fetch_more.native_pagination
+    assert native.available is True
+    assert native.params is not None and dict(native.params) == hint_dict["params"]
+    assert (
+        native.example_next_call is not None
+        and dict(native.example_next_call) == hint_dict["example_next_call"]
+    )
+
+    # Validated-instance path (callers that wire PaginationHint themselves).
+    hint = PaginationHint.model_validate(hint_dict)
+    _r2, handle2 = await reducer.reduce(
+        payload, None, {"op_id": "k8s.pod.list", "pagination_hint": hint}
+    )
+    assert handle2 is not None
+    assert handle2.fetch_more.native_pagination.available is True
+    assert dict(handle2.fetch_more.native_pagination.params or {}) == hint_dict["params"]
+
+
+async def test_handle_fetch_more_malformed_pagination_hint_falls_back_to_unavailable() -> None:
+    """A malformed ``pagination_hint`` dict does not raise; the reducer logs and falls back.
+
+    A reduce-time exception would otherwise convert into a
+    ``connector_error`` ``OperationResult`` via the dispatcher's
+    ``_reduce_or_error`` guard -- failing a real read because an
+    operator-facing metadata field had a typo is the wrong fail mode.
+    The validation surfaces at op-registration time when a connector
+    author writes the hint as a :class:`PaginationHint` literal there.
+    """
+    reducer = JsonFluxReducer()
+    rows = [{"id": i} for i in range(60)]
+    payload = {"results": rows}
+
+    # ``params`` must be a dict; the connector author typoed.
+    bad_hint = {"params": "not-a-dict", "example_next_call": {"tool": "x"}}
+    _reduced, handle = await reducer.reduce(
+        payload, None, {"op_id": "broken.op", "pagination_hint": bad_hint}
+    )
+
+    assert handle is not None
+    native = handle.fetch_more.native_pagination
+    assert native.available is False, (
+        "a malformed hint must collapse to the unavailable branch -- "
+        "raising would lose the user-visible read result"
+    )
+    assert native.rationale, "unavailable branch must still carry a rationale"
+
+
+async def _set_shaped_handler(
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Module-level handler returning a 60-row set so JsonFluxReducer materializes."""
+    del target, params
+    return {"results": [{"k": f"k-{i}", "v": i} for i in range(60)]}
+
+
+@pytest.fixture
+async def _registered_set_shaped_op(
+    stub_embedding_service: AsyncMock,
+) -> AsyncIterator[None]:
+    """Register the connector + a typed op the audit-hoist test dispatches.
+
+    Returns a 60-row payload so the production-default
+    :class:`JsonFluxReducer` actually materializes a handle (the
+    fixture used by other dispatcher tests returns a 1-row payload
+    that passes through). The op_id is intentionally distinct so it
+    doesn't share state with :func:`_registered_typed_op`.
+    """
+    register_connector_v2(product="vault", version="", impl_id="", cls=_NoOpVaultConnector)
+    await register_typed_operation(
+        product="vault",
+        version="1.x",
+        impl_id="vault",
+        op_id="vault.kv.list.bulk",
+        handler=_set_shaped_handler,
+        summary="List many secrets.",
+        description="List many secrets.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+    yield
+
+
+async def test_reducing_dispatch_writes_handle_metadata_into_audit_payload(
+    _registered_set_shaped_op: None,
+    captured_events: list[BroadcastEvent],
+) -> None:
+    """A reducing dispatch hoists ``handle_id`` / ``total_rows`` / ``sample_rows_returned``.
+
+    G0.15-T8 (#1219). The reducer binds three ``audit_*`` contextvars
+    and the dispatcher's audit writer hoists them into the
+    ``audit_log.payload`` JSON via the existing
+    ``_resolve_audit_extras_from_contextvars`` sweep -- a consumer
+    reading the audit row attributes *"what the agent saw"* (the
+    handle id + total rows + the bounded sample size) without
+    joining against the reducer's in-memory state.
+    """
+    set_default_reducer(JsonFluxReducer(sample_size=5))
+    try:
+        result = await dispatch(
+            operator=_make_operator(),
+            connector_id="vault-1.x",
+            op_id="vault.kv.list.bulk",
+            target=_FakeTarget(),
+            params={"path": "/secret"},
+        )
+    finally:
+        set_default_reducer(PassThroughReducer())
+
+    assert result.status == "ok", (
+        f"expected ok; got status={result.status!r} error={result.error!r}"
+    )
+    assert result.handle is not None, "a 60-row response must materialize through JsonFluxReducer"
+
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            (await session.execute(select(AuditLog).where(AuditLog.path == "vault.kv.list.bulk")))
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    payload = rows[0].payload
+    assert payload["result_status"] == "ok"
+    assert payload["handle_id"] == str(result.handle.handle_id)
+    assert payload["total_rows"] == 60
+    assert payload["sample_rows_returned"] == 5
+
+    # The broadcast event also fired.
+    assert len(captured_events) == 1
+    assert captured_events[0].result_status == "ok"

--- a/backend/tests/test_operations_jsonflux_reducer.py
+++ b/backend/tests/test_operations_jsonflux_reducer.py
@@ -554,13 +554,17 @@ async def test_reducing_dispatch_writes_handle_metadata_into_audit_payload(
 ) -> None:
     """A reducing dispatch hoists ``handle_id`` / ``total_rows`` / ``sample_rows_returned``.
 
-    G0.15-T8 (#1219). The reducer binds three ``audit_*`` contextvars
-    and the dispatcher's audit writer hoists them into the
-    ``audit_log.payload`` JSON via the existing
-    ``_resolve_audit_extras_from_contextvars`` sweep -- a consumer
-    reading the audit row attributes *"what the agent saw"* (the
-    handle id + total rows + the bounded sample size) without
-    joining against the reducer's in-memory state.
+    G0.15-T8 (#1219). After the reducer materializes, the dispatcher
+    derives the audit-payload hoist dict via
+    ``_handle_metadata_for_audit(handle)`` and threads it through
+    ``audit_and_broadcast_safe(..., handle_metadata=...)`` →
+    ``write_audit_row(..., handle_metadata=...)`` →
+    ``_build_audit_payload(..., handle_metadata=...)``, where
+    ``payload.update(handle_metadata)`` merges the three keys onto the
+    ``audit_log.payload`` JSON. A consumer reading the audit row
+    attributes *"what the agent saw"* (the handle id + total rows +
+    the bounded sample size) without joining against the reducer's
+    in-memory state.
     """
     set_default_reducer(JsonFluxReducer(sample_size=5))
     try:

--- a/docs/architecture/jsonflux.md
+++ b/docs/architecture/jsonflux.md
@@ -216,6 +216,94 @@ All four are keyword-only. The defaults match v0.1-spec §4 (50 rows /
 4 KB). Empty collections never materialize — a 0-row handle carries no
 information a pass-through doesn't.
 
+### `fetch_more` envelope (G0.15-T8, #1219)
+
+Every `ResultHandle` the adapter mints carries a `fetch_more` envelope
+so an agent reading the response can answer *"how do I get the next
+slice"* from the response itself — without a discovery dance across
+MCP tools / resource URIs / REST routes / CLI verbs. The shape is
+documentation-as-data, matching the established precedents:
+`ConnectorRegistration.next_step` (G0.13-T3 #1153),
+`/ready.features` (G0.14-T7 #1186),
+`/retrieve/usage.counted_surfaces` — every reduced response teaches
+the agent how to act on it next.
+
+`FetchMore` (defined in
+[`connectors/schemas.py`](../../backend/src/meho_backplane/connectors/schemas.py))
+has two independent branches; both are always present so consumers
+parse one shape regardless of source.
+
+**`drill_in: FetchMoreDrillIn`** — *"can the agent fetch more rows
+from the handle directly?"* In v0.7.x `available` is **always
+`False`** — the substrate exposes no drill-in surface (no MCP tool,
+resource URI, REST route, or CLI verb for round-tripping a handle
+back to the reducer's in-memory DuckDB table). The deferred
+`available=True` branch is reserved for the v0.8 / v0.9 fetch-back
+Task that ships the addressable spill backing store + the
+`result_query` / `result_aggregate` / `result_export` /
+`result_describe` meta-tools; landing the field today means that
+Task flips a bool and populates the (already-defined) `mcp_resource_uri`
+/ `mcp_tool` / `example_call` / `expires_at` fields without breaking
+any consumer that already parses the envelope. `rationale` carries
+the operator/agent-facing prose explaining the current state —
+today, the workaround pointer ("re-call with native pagination /
+narrower params"); tomorrow, the surfaced resource URI.
+
+**`native_pagination: FetchMoreNativePagination`** — *"what params
+let the underlying op return the next slice?"* When the op
+registered a `PaginationHint` (next paragraph), `available=True`
+and `params` / `example_next_call` are populated verbatim from the
+hint. When no hint exists, `available=False` with the rationale
+*"the underlying op did not register a `pagination_hint` in its
+`llm_instructions`"* and a curated pointer to the registration
+slot — useful for connector authors reading the response during
+development.
+
+The `pagination_hint` slot under `llm_instructions`. Connector
+authors that ship pagination-aware ops attach a `PaginationHint`
+to the op's registration `llm_instructions` payload under the
+`pagination_hint` key:
+
+```python
+register_typed_operation(
+    op_id="vault.kv.list.bulk",
+    ...,
+    llm_instructions={
+        "pagination_hint": {
+            "params": {"path": "directory prefix to list"},
+            "example_next_call": {
+                "op_id": "vault.kv.list.bulk",
+                "params": {"path": "/secret/team-a/"},
+            },
+        },
+        # ...other llm_instructions slots...
+    },
+)
+```
+
+Reading from `llm_instructions` (rather than adding a new
+`endpoint_descriptor` column) keeps the contract additive — no DB
+migration, no `EndpointDescriptor` schema change.
+
+`dispatcher._pagination_hint_from_descriptor(descriptor)` extracts
+the raw dict from `descriptor.llm_instructions["pagination_hint"]`
+and threads it through `reducer_context["pagination_hint"]` (see
+`dispatcher._reduce_or_error`). The reducer's
+`_resolve_pagination_hint` coerces the context value to a
+`PaginationHint` instance (accepting both already-validated
+`PaginationHint` instances and plain dicts the dispatcher reads
+from JSON-deserialised descriptors); a `ValidationError` on a
+malformed dict is **caught**, a warning is logged, and the reducer
+falls back to `native_pagination.available=False` with the same
+"no hint" rationale — so a connector author shipping a broken
+hint doesn't break the operator's read at runtime. Returning a
+plain dict from the dispatcher helper keeps the dispatcher layer
+free of a Pydantic-import dependency on the connectors schema;
+the reducer owns the validation boundary.
+
+For the wire shape of `fetch_more` on a serialized `ResultHandle`,
+see [`operations-substrate.md` § `ResultHandle` shape](operations-substrate.md#resulthandle-shape-future-facing).
+
 For how the dispatcher invokes the reducer (the `try/except` wrap that
 turns a reducer exception into `connector_error` with audit + broadcast
 still firing, and the `ResultHandle` shape), see

--- a/docs/architecture/operations-substrate.md
+++ b/docs/architecture/operations-substrate.md
@@ -359,11 +359,14 @@ class ResultHandle(BaseModel):
     total_rows: int | None = None
     sample_rows: tuple[Mapping[str, Any], ...] | None = None  # frozen
     ttl_seconds: int
+    fetch_more: FetchMore | None = None                       # G0.15-T8 (#1219)
 ```
 
 Frozen Pydantic model with `MappingProxyType`-wrapped nested mappings (via `@model_validator(mode="after")` calling `object.__setattr__` to bypass `frozen=True`'s field guard). Pydantic v2's `frozen=True` is "faux immutability" — it blocks field reassignment but not nested-dict mutation; the wrapping closes that hole so callers can't tamper with a handle post-construction. Matches the sibling `FingerprintResult.extras` / `OperationResult.extras` pattern.
 
 `schema_` carries a trailing underscore to avoid collision with Pydantic's deprecated `BaseModel.schema()` API; it serialises as `schema_` on the wire.
+
+`fetch_more` is the G0.15-T8 (#1219) self-documenting drill-in / pagination envelope. Every handle the production reducer mints carries it (the two branches `drill_in` and `native_pagination` are always populated) so an agent reading the response can answer *"how do I get more rows"* from the envelope itself — no MCP-tool / resource-URI / REST-route discovery dance. The shape, the deferred drill-in branch (`available=False` in v0.7.x, flipped by the v0.8/0.9 fetch-back Task), and the `llm_instructions.pagination_hint` registration slot the reducer reads to build `native_pagination` are documented in [`jsonflux.md` § fetch_more envelope](jsonflux.md#fetch_more-envelope-g015-t8-1219). `None` only on legacy code paths that build a `ResultHandle` directly without going through the reducer (test fixtures, future spill backends that have already enriched the envelope); production reduce paths always populate it.
 
 `JsonFluxReducer` now populates `handle` for large set-shaped responses (G0.6.1, #750). The `result_query` / `result_aggregate` / `result_export` / `result_describe` meta-tools that read handles back from the backing store are still a follow-on Initiative.
 


### PR DESCRIPTION
## Summary
- Every reducing-response `ResultHandle` now ships a `fetch_more` block that self-documents how an agent fetches more rows: `drill_in.available=False` (the drill-in surface is deferred to v0.8/0.9) with a curated rationale, plus `native_pagination` populated verbatim from the underlying op's `pagination_hint` registration metadata. Matches the documentation-as-data pattern the consumer's v0.7.0 dogfood cycle cited (`next_step` on registered connectors, `/ready.features`, `/retrieve/usage.counted_surfaces`).
- Three k8s ops (`k8s.pod.list`, `k8s.deployment.list`, `k8s.event.list`) carry `pagination_hint` entries on `llm_instructions` -- the test target + the consumer's live reproduction case. Hints flow through the dispatcher's reducer context, validated by `PaginationHint` at the reducer boundary so malformed hints log + fall back rather than failing a read.
- Audit-row payload now hoists `handle_id` / `total_rows` / `sample_rows_returned` via an explicit `handle_metadata` parameter threaded through `audit_and_broadcast_safe` → `write_audit_row` → `_build_audit_payload`. Forensically self-contained: one row attributes "agent saw N of M rows reduced as handle `<uuid>`" without joining reducer state.

## Test plan
- [x] `ruff check` / `ruff format --check` clean on all touched files.
- [x] `mypy src/meho_backplane/operations/ src/meho_backplane/connectors/schemas.py src/meho_backplane/connectors/kubernetes/ --ignore-missing-imports` — 51 source files clean.
- [x] `pytest tests/test_operations_jsonflux_reducer.py` — 8 passed (4 new + 4 pre-existing); covers (a) fetch_more both-branches-unavailable shape, (b) native_pagination populated from dict hint *and* validated `PaginationHint` instance, (c) malformed hint falls back to unavailable, (d) reducing dispatch writes `handle_id` / `total_rows` / `sample_rows_returned` into `audit_log.payload`.
- [x] Wider regression sweep: `pytest tests/test_operations_dispatcher.py tests/test_operations_reducer.py tests/test_operations_jsonflux_reducer.py tests/test_vault_kv_list_jsonflux.py tests/test_connectors_k8s_workload.py tests/test_connectors_k8s_core.py tests/acceptance/test_g3{5,6,7}_*_jsonflux_force_handle.py tests/acceptance/test_vmware_rest_jsonflux_force_handle.py tests/test_audit_middleware.py tests/test_mcp_audit.py tests/test_redaction_engine.py tests/test_redaction_shadow_mode.py tests/test_redaction_patterns.py` — 204 passed, 6 skipped.
- [x] `cli && make snapshot-openapi` — snapshot unchanged (handle envelope is dispatcher-internal; no FastAPI route exposes `OperationResult` / `ResultHandle`).

## Acceptance criteria
- [x] **Every reducing-response handle envelope carries `fetch_more`** — asserted by `test_handle_carries_fetch_more_unavailable_branches_without_context` in `backend/tests/test_operations_jsonflux_reducer.py`.
- [x] **`fetch_more.drill_in.available=False` + non-empty rationale** in this version — same test pins both fields.
- [x] **`native_pagination.params` + `example_next_call` populated when the op has a `pagination_hint`; `available=False` + rationale when not** — covered by `test_handle_fetch_more_native_pagination_populated_from_context_hint` + the prior test.
- [x] **3 typed ops have `pagination_hint`** — `k8s.pod.list` / `k8s.deployment.list` / `k8s.event.list` register hints in `K8S_POD_LIST_LLM_INSTRUCTIONS` / `K8S_DEPLOYMENT_LIST_LLM_INSTRUCTIONS` / `K8S_EVENT_LIST_LLM_INSTRUCTIONS`.
- [x] **Audit row payload carries `handle_id` / `total_rows` / `sample_rows_returned`** — asserted by `test_reducing_dispatch_writes_handle_metadata_into_audit_payload`.

## Out of scope
- **Drill-in route/tool/resource implementation** — separate Task, v0.8/v0.9. This PR ships only the contract; `drill_in.available=True` branch fills in when the fetch endpoint exists.
- **`pagination_hint` rollout across every typed op** — start with the 3 k8s ops; per-connector sweeps land per the issue body's note.
- **`/ready.features.jsonflux` block** — deferred per the issue body (consumer marked it "less load-bearing once `fetch_more` lands").

Closes #1219
