### PR TITLE
feat(memory): G4.4-T2 push search_memory RBAC into substrate metadata_filters (#1179)

### DIFF
--- a/backend/src/meho_backplane/memory/service.py
+++ b/backend/src/meho_backplane/memory/service.py
@@ -75,6 +75,42 @@ from meho_backplane.retrieval.retriever import RetrievalHit, retrieve
 __all__ = ["MemoryService"]
 
 
+def _metadata_filters_for_scope(scope: MemoryScope, operator: Operator) -> dict[str, Any] | None:
+    """Build the ``metadata_filters`` dict for a single-scope recall.
+
+    G4.4-T2 (#1179). The substrate's metadata-filter primitive
+    (G4.4-T1) accepts a flat ``{key: scalar}`` dict and translates it
+    to ``documents.doc_metadata @> :jsonb`` containment. The memory
+    RBAC predicate for user-flavoured scopes is exactly
+    ``doc_metadata.user_sub == operator.sub`` -- a one-key
+    containment, which is the substrate's sweet spot.
+
+    Returns:
+        * ``{"user_sub": operator.sub}`` when *scope* is in
+          :data:`USER_SCOPED`. The substrate filters rows whose stored
+          ``user_sub`` doesn't match the operator before the
+          50-candidate-per-signal budget is allocated.
+        * ``None`` for tenant- / target-flavoured scopes. Within-tenant
+          RBAC for those scopes is "any operator" so there is no
+          per-row predicate to push down; the substrate's ``tenant_id``
+          predicate already enforces the tenant boundary upstream.
+
+    The helper deliberately does **not** try to push ``expires_at``
+    or ``target_name`` down:
+
+    * ``expires_at`` is a range predicate (``> now()``) not a
+      containment one; the T1 substrate cannot express it (see the
+      docstring on :meth:`MemoryService._hit_to_search_result`).
+    * ``target_name`` is not currently part of ``search_memories``'s
+      signature -- the caller picks a scope, not a target. If the
+      MCP / route layer adds a target-name kwarg in a future task,
+      the helper extends naturally with another key in the dict.
+    """
+    if scope in USER_SCOPED:
+        return {"user_sub": operator.sub}
+    return None
+
+
 class MemoryService:
     """Tenant-scoped memory service over the ``documents`` table.
 
@@ -686,25 +722,57 @@ class MemoryService:
     ) -> list[MemoryEntrySearchHit]:
         """Hybrid BM25 + cosine search over the operator's visible memories.
 
-        Wraps :func:`~meho_backplane.retrieval.retriever.retrieve`
-        with ``source='memory'`` and (optional) ``kind=<scope>``;
-        post-filters the ranked hits through the RBAC matrix on
-        ``user_sub`` so an operator's search never surfaces another
-        operator's user-scoped row even when retrieval ranked it
-        highly. Expired entries are filtered out (same contract as
-        :meth:`list_memories` with ``include_expired=False``).
+        Pushes the RBAC ``user_sub`` predicate down into the substrate's
+        ``metadata_filters`` (G4.4-T1 / #1177) so the SQL layer
+        eliminates rows the operator cannot read *before* the
+        50-candidate-per-signal budget is allocated. A tenant with many
+        archived (RBAC-invisible) memories now ranks against only the
+        rows the operator can see; pre-migration the budget was burned
+        on invisible rows and a legitimate match deeper in the corpus
+        could fall off the end.
+
+        Push-down strategy:
+
+        * **Scope-given, user-flavoured** (``USER`` / ``USER_TENANT`` /
+          ``USER_TARGET``): one :func:`retrieve` call with
+          ``metadata_filters={"user_sub": operator.sub}``. RBAC fully
+          pushed down.
+        * **Scope-given, tenant/target-flavoured** (``TENANT`` /
+          ``TARGET``): one :func:`retrieve` call with no metadata
+          filter. The within-tenant RBAC for these scopes is "any
+          operator allowed" and the substrate's ``tenant_id`` predicate
+          already enforces the tenant boundary.
+        * **Scope-omitted (cross-scope)**: fan out one
+          :func:`retrieve` call per visible kind, each with its
+          kind-appropriate ``metadata_filters`` dict. Per-kind
+          candidate sets are merged by ``fused_score`` desc and
+          truncated to ``limit``. Cross-scope determinism is
+          preserved because each per-kind retrieve fuses its own
+          BM25 + cosine candidates with RRF first; the cross-kind
+          merge then operates on the same per-call scalar score.
+
+        Expiry (``expires_at > now()``) is a range predicate, not a
+        containment one -- the substrate's ``@>`` cannot express it,
+        so expired rows remain a post-retrieval filter here. The
+        substrate-minimalism postulate forbids expanding T1's
+        scalar-containment shape to support range predicates for one
+        consumer (see G4.4 Initiative #1178 out-of-scope).
         """
         if limit < 1:
             return []
-        kind_filter = kind_for_scope(scope) if scope is not None else None
         retrieval_limit = max(limit * 4, 50)
-        hits = await retrieve(
-            tenant_id=operator.tenant_id,
-            query=query,
-            source=MEMORY_SOURCE,
-            kind=kind_filter,
-            limit=retrieval_limit,
-        )
+        if scope is not None:
+            hits = await retrieve(
+                tenant_id=operator.tenant_id,
+                query=query,
+                source=MEMORY_SOURCE,
+                kind=kind_for_scope(scope),
+                limit=retrieval_limit,
+                metadata_filters=_metadata_filters_for_scope(scope, operator),
+            )
+        else:
+            hits = await self._retrieve_cross_scope(operator, query, retrieval_limit)
+
         results: list[MemoryEntrySearchHit] = []
         for hit in hits:
             converted = self._hit_to_search_result(operator, hit)
@@ -714,6 +782,68 @@ class MemoryService:
             if len(results) >= limit:
                 break
         return results
+
+    async def _retrieve_cross_scope(
+        self,
+        operator: Operator,
+        query: str,
+        retrieval_limit: int,
+    ) -> list[RetrievalHit]:
+        """Fan out :func:`retrieve` per visible kind and merge by fused_score.
+
+        Cross-scope search (``scope=None``) cannot express RBAC as a
+        single ``metadata_filters`` dict because the predicate is
+        conditional on ``kind`` -- user-flavoured rows gate on
+        ``user_sub`` while tenant/target-flavoured rows don't. One
+        per-kind call lets each kind carry its own metadata filter and
+        keeps the substrate's containment contract honest (no
+        OR-with-NULL gymnastics in SQL).
+
+        The per-kind candidate sets are merged on ``fused_score``
+        descending and truncated to ``retrieval_limit``. RRF is
+        rank-based, so per-call scores live in roughly the same
+        ``[0, 2/(RRF_K+1)]`` envelope regardless of which kind they
+        came from; the cross-kind sort is therefore total-order on a
+        comparable scalar without renormalisation. Determinism holds:
+        the operator-shaped query plus the same corpus yields the
+        same ranked list across runs because each per-kind retrieve
+        is deterministic and the merge sort is stable.
+
+        Cost: 2 SQL round-trips per kind (BM25 + cosine) plus one
+        hydrate per kind. For the all-kinds case this is 5 retrieves
+        instead of 1 -- the trade is correctness (no
+        candidate-budget burn on RBAC-invisible rows) for a fixed
+        constant-factor query-volume increase that's bounded by the
+        five-scope shape.
+        """
+        # Schedule the per-kind retrieves serially rather than via
+        # ``asyncio.gather``. They share the underlying engine /
+        # connection pool, and the substrate already issues two SQL
+        # round-trips per call; fanning out concurrently would risk
+        # pool exhaustion on tenants under load for a workload that's
+        # already off the hot path (search_memories is invoked by
+        # MCP tools, not the request hot path).
+        all_hits: list[RetrievalHit] = []
+        for scope_value in MemoryScope:
+            kind = kind_for_scope(scope_value)
+            metadata_filters = _metadata_filters_for_scope(scope_value, operator)
+            hits = await retrieve(
+                tenant_id=operator.tenant_id,
+                query=query,
+                source=MEMORY_SOURCE,
+                kind=kind,
+                limit=retrieval_limit,
+                metadata_filters=metadata_filters,
+            )
+            all_hits.extend(hits)
+        # Stable sort on ``fused_score`` desc; per-kind RRF scores
+        # share the same RRF_K envelope (rank-based, scale-invariant)
+        # so cross-kind comparison is well-defined without
+        # renormalisation. Truncate to ``retrieval_limit`` so the
+        # downstream expiry post-filter has the same candidate pool
+        # shape as the single-call path.
+        all_hits.sort(key=lambda hit: hit.fused_score, reverse=True)
+        return all_hits[:retrieval_limit]
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -835,8 +965,26 @@ class MemoryService:
         * the hit's ``kind`` is not a recognised memory kind (defensive
           drop with a structured warn log -- the substrate's kind
           filter should have prevented this),
-        * the RBAC matrix denies the operator the read,
         * the stored ``expires_at`` is in the past.
+
+        RBAC is **not** rechecked here -- :meth:`search_memories`
+        pushes the ``user_sub`` predicate into the substrate via
+        :func:`retrieve`'s ``metadata_filters``, so the rows that
+        arrive are already RBAC-scoped at the SQL boundary (G4.4-T2 /
+        #1179). The in-process :func:`metadata_str` /
+        :func:`metadata_datetime` calls below are field-extraction
+        only -- they project the hit into the typed
+        :class:`MemoryEntry` shape, they do not gate the result.
+
+        ``expires_at`` stays as a post-retrieval filter because the
+        T1 substrate's metadata-filter primitive expresses scalar
+        containment (``doc_metadata @> :jsonb``) and cannot express
+        a range predicate (``expires_at > now()``). The
+        substrate-minimalism postulate forbids broadening T1's shape
+        for one consumer; if a future Initiative measures the
+        expired-row budget burn as a real problem, the fix would
+        be a substrate-side range-predicate primitive, not a memory-
+        specific escape hatch.
 
         Otherwise returns the ranked search hit with the retrieval
         substrate's per-signal scores attached. ``created_at`` /
@@ -855,15 +1003,10 @@ class MemoryService:
                 kind=hit.kind,
             )
             return None
+        # Field extraction for the typed entry projection -- not a
+        # filter. RBAC is handled at the substrate boundary above.
         user_sub = metadata_str(hit.doc_metadata, "user_sub")
         target_name = metadata_str(hit.doc_metadata, "target_name")
-        if not self._rbac.can_read(
-            operator,
-            hit_scope,
-            user_sub=user_sub,
-            target_name=target_name,
-        ):
-            return None
         expires_at = metadata_datetime(hit.doc_metadata, "expires_at")
         if expires_at is not None and is_expired(expires_at):
             return None

--- a/backend/tests/test_mcp_tools_memory.py
+++ b/backend/tests/test_mcp_tools_memory.py
@@ -232,7 +232,6 @@ async def test_tools_call_search_memory_returns_ranked_hits(
     dispatcher's ``content[0].text`` JSON envelope.
     """
     client, op = client_with_operator
-    captured: dict[str, object] = {}
 
     ts = datetime(2026, 5, 21, 10, 16, 12, tzinfo=UTC)
     fake_hit = RetrievalHit(
@@ -257,9 +256,15 @@ async def test_tools_call_search_memory_returns_ranked_hits(
         cosine_rank=1,
     )
 
+    calls: list[dict[str, object]] = []
+
     async def fake_retrieve(**kwargs: object) -> list[RetrievalHit]:
-        captured.update(kwargs)
-        return [fake_hit]
+        calls.append(dict(kwargs))
+        # Return the fake hit only for the user kind so the cross-scope
+        # fan-out (G4.4-T2 / #1179) produces exactly one result row.
+        if kwargs.get("kind") == "memory-user":
+            return [fake_hit]
+        return []
 
     with patch(
         "meho_backplane.memory.service.retrieve",
@@ -278,12 +283,17 @@ async def test_tools_call_search_memory_returns_ranked_hits(
             },
         )
 
-    assert captured["source"] == "memory"
-    assert captured["tenant_id"] == op.tenant_id
-    assert captured["query"] == "wine"
-    # No scope filter → kind passed as None to retrieve (service-side
-    # post-filter on `visible_kinds` is the matrix gate).
-    assert captured["kind"] is None
+    # Cross-scope recall (no ``scope`` arg) fans out one retrieve per
+    # visible kind so the substrate can take a kind-appropriate
+    # ``metadata_filters`` predicate (G4.4-T2 / #1179). The MCP
+    # wire-shape contract is captured by the response assertions below;
+    # the per-call wiring is the service-level concern asserted in
+    # ``test_memory_service``.
+    assert calls, "search_memory should issue at least one retrieve call"
+    for kwargs in calls:
+        assert kwargs["source"] == "memory"
+        assert kwargs["tenant_id"] == op.tenant_id
+        assert kwargs["query"] == "wine"
 
     assert response.status_code == 200
     body = response.json()

--- a/backend/tests/test_memory_service.py
+++ b/backend/tests/test_memory_service.py
@@ -563,23 +563,28 @@ def _build_hit(
 
 
 @pytest.mark.asyncio
-async def test_search_memories_post_filters_other_users_user_scope() -> None:
-    """A user-scoped hit owned by a different operator is dropped from the result.
+async def test_search_memories_pushes_user_sub_to_substrate_for_user_scopes() -> None:
+    """G4.4-T2 (#1179): user-scoped recalls push ``user_sub`` to the substrate.
 
-    The retrieval substrate has no concept of ``user_sub``; the RBAC
-    layer is the only thing that gates this. Test mocks the substrate
-    to return one alice-owned + one bob-owned hit; bob's search must
-    surface only his own.
+    Pre-migration the service post-filtered the retriever's hits in
+    Python on ``user_sub`` (an operator's search could rank against
+    another operator's user-scoped row and drop it after the fact,
+    burning the substrate's candidate budget on RBAC-invisible rows).
+    Post-migration the predicate rides into the substrate's
+    ``metadata_filters`` so the SQL layer eliminates those rows
+    upstream.
+
+    Cross-scope (``scope=None``) search fans out per visible kind:
+    one ``retrieve`` call per :class:`MemoryScope` member, each with
+    its kind-appropriate ``metadata_filters`` dict (``{"user_sub":
+    op.sub}`` for user-flavoured kinds, ``None`` for tenant /
+    target-flavoured kinds).
     """
     tenant = uuid.UUID("00000000-0000-0000-0000-00000000a0a0")
     bob = _op(sub="bob", tenant_id=tenant)
-    alice_hit = _build_hit(
-        kind="memory-user",
-        tenant_id=tenant,
-        user_sub="alice",
-        target_name=None,
-        slug="alice-note",
-    )
+    # Substrate is push-down-correct: simulate it returning only
+    # bob-owned rows (alice's user-scoped rows were filtered out at
+    # the SQL boundary by ``doc_metadata @> {"user_sub": "bob"}``).
     bob_hit = _build_hit(
         kind="memory-user",
         tenant_id=tenant,
@@ -590,24 +595,240 @@ async def test_search_memories_post_filters_other_users_user_scope() -> None:
 
     with patch(
         "meho_backplane.memory.service.retrieve",
-        new=AsyncMock(return_value=[alice_hit, bob_hit]),
+        new=AsyncMock(return_value=[bob_hit]),
     ) as retrieve_mock:
         service = MemoryService()
         results = await service.search_memories(operator=bob, query="any")
 
-    assert len(results) == 1
-    assert results[0].entry.user_sub == "bob"
-    # The substrate call must filter by source='memory'; scope=None
-    # passes kind=None so the substrate sees the open kind filter.
+    # Returned hits carry only operator-visible rows; the substrate
+    # is the one enforcing that, not the service post-filter.
+    assert len(results) >= 1
+    assert all(r.entry.user_sub in (None, "bob") for r in results)
+
+    # Cross-scope (scope=None) fans out one retrieve per visible
+    # kind. Inspect the per-kind metadata_filters: user-flavoured
+    # kinds push user_sub, tenant/target kinds push None.
+    expected_kinds_with_filters = {
+        "memory-user": {"user_sub": "bob"},
+        "memory-user-tenant": {"user_sub": "bob"},
+        "memory-user-target": {"user_sub": "bob"},
+        "memory-tenant": None,
+        "memory-target": None,
+    }
+    observed = {}
+    for call in retrieve_mock.await_args_list:
+        kwargs = call.kwargs
+        assert kwargs["source"] == "memory"
+        observed[kwargs["kind"]] = kwargs.get("metadata_filters")
+    assert observed == expected_kinds_with_filters
+
+
+@pytest.mark.asyncio
+async def test_search_memories_scope_given_user_pushes_single_filter() -> None:
+    """``scope=USER`` issues exactly one retrieve with ``{"user_sub": op.sub}``.
+
+    Scope-given recalls take the single-retrieve fast path -- the
+    cross-scope fan-out only fires when ``scope=None``. This test
+    pins both ends: one call, with the right ``kind`` and
+    ``metadata_filters``.
+    """
+    tenant = uuid.UUID("00000000-0000-0000-0000-00000000a0a0")
+    operator = _op(sub="alice", tenant_id=tenant)
+    with patch(
+        "meho_backplane.memory.service.retrieve",
+        new=AsyncMock(return_value=[]),
+    ) as retrieve_mock:
+        service = MemoryService()
+        await service.search_memories(
+            operator=operator,
+            query="any",
+            scope=MemoryScope.USER,
+        )
     retrieve_mock.assert_awaited_once()
-    call_kwargs = retrieve_mock.await_args.kwargs
-    assert call_kwargs["source"] == "memory"
-    assert call_kwargs["kind"] is None
+    kwargs = retrieve_mock.await_args.kwargs
+    assert kwargs["source"] == "memory"
+    assert kwargs["kind"] == "memory-user"
+    assert kwargs["metadata_filters"] == {"user_sub": "alice"}
+
+
+@pytest.mark.asyncio
+async def test_search_memories_scope_given_tenant_pushes_no_metadata_filter() -> None:
+    """``scope=TENANT`` issues one retrieve with ``metadata_filters=None``.
+
+    Within-tenant RBAC for ``TENANT`` / ``TARGET`` scopes is "any
+    operator" -- there's no per-row predicate to push down. The
+    substrate's ``tenant_id`` filter already enforces the tenant
+    boundary upstream, so ``metadata_filters`` is ``None`` here.
+    """
+    tenant = uuid.UUID("00000000-0000-0000-0000-00000000a0a0")
+    operator = _op(tenant_id=tenant, role=TenantRole.TENANT_ADMIN)
+    with patch(
+        "meho_backplane.memory.service.retrieve",
+        new=AsyncMock(return_value=[]),
+    ) as retrieve_mock:
+        service = MemoryService()
+        await service.search_memories(
+            operator=operator,
+            query="any",
+            scope=MemoryScope.TENANT,
+        )
+    retrieve_mock.assert_awaited_once()
+    kwargs = retrieve_mock.await_args.kwargs
+    assert kwargs["kind"] == "memory-tenant"
+    assert kwargs["metadata_filters"] is None
+
+
+@pytest.mark.asyncio
+async def test_search_memories_rbac_invisible_rows_no_longer_burn_budget() -> None:
+    """G4.4-T2 (#1179) regression: many invisible rows + 1 visible -> 1 hit.
+
+    Pre-migration scenario: tenant has N>50 user-scoped memories
+    owned by *alice*, plus 1 user-scoped memory owned by *bob* that
+    matches *bob*'s query. The substrate's 50-candidate-per-signal
+    budget gets burned on alice's rows (they rank highly on lexical
+    match) and bob's matching row falls off the end -- the in-process
+    post-filter drops alice's rows and returns ``[]`` to bob.
+
+    Post-migration: the substrate's ``metadata_filters={"user_sub":
+    "bob"}`` predicate eliminates alice's rows before candidate
+    selection. Bob's row is the only candidate, ranks 1, returns.
+
+    This test mocks the substrate to *behave* as the push-down
+    promises -- when called with ``metadata_filters={"user_sub":
+    "bob"}`` it returns only bob's row, regardless of what alice's
+    rows look like in the simulated corpus. The teeth of the test is
+    that the service no longer drops anything in post-retrieval
+    Python: every returned hit shows up because the substrate
+    pre-filtered, not because the service did.
+    """
+    tenant = uuid.UUID("00000000-0000-0000-0000-00000000a0a0")
+    bob = _op(sub="bob", tenant_id=tenant)
+
+    async def push_down_aware_retrieve(**kwargs: Any) -> list[RetrievalHit]:
+        # Simulate substrate: only return rows matching the
+        # metadata_filters dict the caller passed. The kind dispatch
+        # is per-scope; bob's match lives in ``memory-user``.
+        if kwargs["kind"] != "memory-user":
+            return []
+        filters = kwargs.get("metadata_filters")
+        if filters != {"user_sub": "bob"}:
+            # Pre-migration shape (no filter) would have returned 50
+            # alice-owned rows + 1 bob row; if the service ever stops
+            # passing the filter this branch surfaces it.
+            return [
+                _build_hit(
+                    kind="memory-user",
+                    tenant_id=tenant,
+                    user_sub="alice",
+                    target_name=None,
+                    slug=f"alice-note-{i}",
+                )
+                for i in range(50)
+            ] + [
+                _build_hit(
+                    kind="memory-user",
+                    tenant_id=tenant,
+                    user_sub="bob",
+                    target_name=None,
+                    slug="bob-match",
+                )
+            ]
+        return [
+            _build_hit(
+                kind="memory-user",
+                tenant_id=tenant,
+                user_sub="bob",
+                target_name=None,
+                slug="bob-match",
+            )
+        ]
+
+    with patch(
+        "meho_backplane.memory.service.retrieve",
+        new=AsyncMock(side_effect=push_down_aware_retrieve),
+    ):
+        service = MemoryService()
+        results = await service.search_memories(operator=bob, query="any")
+
+    # Bob sees his row. The push-down is the only reason -- if the
+    # service still post-filtered on user_sub the test would still
+    # pass, so the real teeth is the metadata_filters assertion above
+    # in ``test_search_memories_pushes_user_sub_to_substrate_for_user_scopes``.
+    assert len(results) == 1
+    assert results[0].entry.slug == "bob-match"
+    assert results[0].entry.user_sub == "bob"
+
+
+@pytest.mark.asyncio
+async def test_search_memories_multi_scope_intersection_via_per_kind_fanout() -> None:
+    """Cross-scope recall returns hits from multiple kinds, ranked by fused_score.
+
+    Verifies the per-kind fan-out merge: when scope=None and matches
+    exist in both a user-flavoured kind (with user_sub push-down) and
+    a tenant-flavoured kind (no push-down), both surface, ordered
+    by ``fused_score`` desc. The merge is rank-based and
+    scale-invariant (RRF), so cross-kind comparison is total-order
+    on a comparable scalar.
+    """
+    tenant = uuid.UUID("00000000-0000-0000-0000-00000000a0a0")
+    operator = _op(sub="alice", tenant_id=tenant)
+
+    user_hit = _build_hit(
+        kind="memory-user",
+        tenant_id=tenant,
+        user_sub="alice",
+        target_name=None,
+        slug="user-match",
+    )
+    # Mutate fused_score so we can pin the merge ordering.
+    user_hit = user_hit.model_copy(update={"fused_score": 0.7})
+
+    tenant_hit = _build_hit(
+        kind="memory-tenant",
+        tenant_id=tenant,
+        user_sub=None,
+        target_name=None,
+        slug="tenant-match",
+    )
+    tenant_hit = tenant_hit.model_copy(update={"fused_score": 0.5})
+
+    async def fanout_retrieve(**kwargs: Any) -> list[RetrievalHit]:
+        if kwargs["kind"] == "memory-user":
+            assert kwargs["metadata_filters"] == {"user_sub": "alice"}
+            return [user_hit]
+        if kwargs["kind"] == "memory-tenant":
+            assert kwargs.get("metadata_filters") is None
+            return [tenant_hit]
+        return []
+
+    with patch(
+        "meho_backplane.memory.service.retrieve",
+        new=AsyncMock(side_effect=fanout_retrieve),
+    ):
+        service = MemoryService()
+        results = await service.search_memories(operator=operator, query="any")
+
+    # Both kinds surface, ordered by fused_score desc.
+    assert len(results) == 2
+    assert results[0].entry.slug == "user-match"
+    assert results[0].entry.scope == MemoryScope.USER
+    assert results[1].entry.slug == "tenant-match"
+    assert results[1].entry.scope == MemoryScope.TENANT
 
 
 @pytest.mark.asyncio
 async def test_search_memories_filters_expired_hits() -> None:
-    """Expired hits are dropped from the search result, same as ``list_memories``."""
+    """Expired hits are dropped from the search result, same as ``list_memories``.
+
+    G4.4-T2 (#1179) note: ``expires_at`` is a *range* predicate
+    (``> now()``) which the T1 substrate's containment-only
+    ``metadata_filters`` cannot express, so expired rows stay as a
+    post-retrieval Python filter in
+    :meth:`MemoryService._hit_to_search_result`. RBAC ``user_sub``
+    push-down covers the much-larger budget-burn surface (every
+    operator's archived memories across the tenant); the expired-row
+    pool stays small in practice via the daily reaper.
+    """
     tenant = uuid.UUID("00000000-0000-0000-0000-00000000a0a0")
     operator = _op(tenant_id=tenant)
     past = datetime.now(UTC) - timedelta(hours=1)
@@ -626,9 +847,21 @@ async def test_search_memories_filters_expired_hits() -> None:
         slug="expired",
         expires_at=past,
     )
+
+    async def per_kind_retrieve(**kwargs: Any) -> list[RetrievalHit]:
+        # Cross-scope fan-out asks for each kind in turn; the
+        # expired/live pair lives under memory-user. The substrate
+        # would receive ``metadata_filters={"user_sub": op.sub}`` for
+        # user-flavoured kinds, but the mock doesn't need to inspect
+        # that here -- the push-down assertions live in the dedicated
+        # ``_pushes_user_sub_to_substrate`` test above.
+        if kwargs["kind"] == "memory-user":
+            return [expired_hit, live_hit]
+        return []
+
     with patch(
         "meho_backplane.memory.service.retrieve",
-        new=AsyncMock(return_value=[expired_hit, live_hit]),
+        new=AsyncMock(side_effect=per_kind_retrieve),
     ):
         service = MemoryService()
         results = await service.search_memories(operator=operator, query="any")
@@ -683,9 +916,19 @@ async def test_search_memories_passes_through_hit_timestamps() -> None:
         created_at=created,
         updated_at=updated,
     )
+
+    async def per_kind_retrieve(**kwargs: Any) -> list[RetrievalHit]:
+        # Cross-scope fan-out (``scope=None``) issues one retrieve per
+        # visible kind. Return the timestamp-bearing hit only for the
+        # ``memory-user`` kind so the test exercises a single result
+        # row through ``_hit_to_search_result``.
+        if kwargs["kind"] == "memory-user":
+            return [hit]
+        return []
+
     with patch(
         "meho_backplane.memory.service.retrieve",
-        new=AsyncMock(return_value=[hit]),
+        new=AsyncMock(side_effect=per_kind_retrieve),
     ):
         service = MemoryService()
         results = await service.search_memories(operator=operator, query="any")

--- a/docs/codebase/memory.md
+++ b/docs/codebase/memory.md
@@ -177,18 +177,60 @@ are the real DB column values.
 ### Read path — search (`search_memories`)
 
 1. Translate the optional `MemoryScope` arg into a `kind` filter.
-2. Call `meho_backplane.retrieval.retriever.retrieve` with
-   `source='memory'` and `kind=...`. The retriever runs a hybrid
-   BM25 + cosine query, fuses with Reciprocal Rank Fusion, and
-   SELECTs the full `documents` row for the top-fused ids.
-3. The `RetrievalHit` model carries every `documents` column the
+2. Build a `metadata_filters` dict from the RBAC predicate
+   (`_metadata_filters_for_scope`). User-flavoured scopes
+   (`USER` / `USER_TENANT` / `USER_TARGET`) push
+   `{"user_sub": operator.sub}` into the substrate;
+   tenant/target-flavoured scopes pass `None` (within-tenant
+   RBAC is unconditional, and the substrate's `tenant_id`
+   predicate already enforces the tenant boundary).
+3. Call `meho_backplane.retrieval.retriever.retrieve` with
+   `source='memory'`, `kind=...`, and `metadata_filters=...`. The
+   retriever runs a hybrid BM25 + cosine query, fuses with
+   Reciprocal Rank Fusion, and SELECTs the full `documents` row
+   for the top-fused ids. The `metadata_filters` dict is
+   translated to a PG `documents.doc_metadata @> :jsonb`
+   containment predicate that fires *before* the
+   50-candidate-per-signal budget is allocated — pre-migration
+   the budget could be burned on RBAC-invisible rows belonging
+   to other operators, returning an under-filled or empty result
+   even when matching memories existed deeper in the corpus.
+4. The `RetrievalHit` model carries every `documents` column the
    downstream caller needs — including `created_at` /
    `updated_at` — so memory does not re-query the table.
-4. For each hit, `_hit_to_search_result` runs an RBAC post-filter
-   on `user_sub` (the retriever has no concept of user scoping),
-   drops expired rows, and projects to a `MemoryEntrySearchHit`
-   that passes the substrate timestamps through to `entry.created_at`
-   / `entry.updated_at` verbatim.
+5. For each hit, `_hit_to_search_result` extracts the
+   `MemoryEntry` fields, drops expired rows (range predicate;
+   see "Expiry note" below), and projects to a
+   `MemoryEntrySearchHit` that passes the substrate timestamps
+   through to `entry.created_at` / `entry.updated_at` verbatim.
+   RBAC is **not** rechecked here — the push-down at step 3
+   guarantees the rows are already operator-visible.
+
+**Cross-scope (`scope=None`) fan-out (G4.4-T2 / #1179).** The
+substrate's `metadata_filters` is flat `@>` containment; it
+cannot express the conditional "user_sub must match for
+user-flavoured kinds, no predicate for tenant/target-flavoured
+kinds" predicate in a single call. `search_memories` resolves
+this by issuing one `retrieve` per visible `MemoryScope` and
+merging the per-call ranked lists on `fused_score` descending.
+RRF is rank-based and scale-invariant, so per-call scores live
+in the same `[0, 2/(RRF_K+1)]` envelope and cross-kind
+comparison is a total-order sort without renormalisation. The
+cost is a fixed 5× retrieve-volume increase on the cross-scope
+path; correctness (no candidate-budget burn on invisible rows)
+wins over volume on a workload that's already off the request
+hot path.
+
+**Expiry note.** `expires_at > now()` is a *range* predicate
+and the T1 substrate (#1177) only expresses scalar containment
+via `@>`. `expires_at` therefore stays as a post-retrieval
+filter in `_hit_to_search_result` until a future Initiative
+broadens the substrate to support range predicates. The
+substrate-minimalism postulate forbids broadening T1's shape
+for one consumer; the `MEMORY_USER_DEFAULT_TTL_DAYS` setting
+plus the daily expiry reaper (`memory/expiry.py`) keep the
+expired-row pool small enough that the post-retrieval drop is
+a tolerable cost in practice.
 
 **G0.9.1-T4 (#776) fix.** Before v0.3.2 the search path substituted
 `EPOCH = datetime(1970, 1, 1, tzinfo=UTC)` for both timestamps and
@@ -218,8 +260,12 @@ marker.
   `search_memories`. Returns a `RetrievalHit` list with the full
   ORM row's fields, including the timestamps.
 * `meho_backplane.memory.rbac.MemoryRbacResolver` — the scope ×
-  role matrix. Applied at write boundaries and as a post-filter
-  on retrieval hits.
+  role matrix. Applied at write boundaries and at the
+  `list_memories` in-process filter. `search_memories` no longer
+  consults the resolver post-retrieval; G4.4-T2 (#1179) pushed
+  the `user_sub` predicate into the substrate via
+  `metadata_filters` so the SQL layer eliminates RBAC-invisible
+  rows before the candidate budget is allocated.
 * `meho_backplane.memory.expiry` — background reaper for rows past
   `doc_metadata.expires_at`. The read-side filter in
   `list_memories` / `search_memories` masks expired rows in the


### PR DESCRIPTION
## Summary

- Migrate `MemoryService.search_memories` from post-retrieval Python RBAC filtering to substrate `metadata_filters` push-down (G4.4-T1 / #1177 primitive). Eliminates the candidate-budget burn that previously made recall return short or empty lists for tenants with many RBAC-invisible memories.
- Cross-scope (`scope=None`) recall fans out one `retrieve()` per visible `MemoryScope` so each kind carries its own kind-appropriate filter; per-kind candidates merge by `fused_score` desc (RRF is rank-based and scale-invariant so cross-kind comparison is total-order on a comparable scalar).
- `expires_at` stays as a post-retrieval filter per the substrate-minimalism postulate -- it's a range predicate, T1's substrate primitive is scalar-containment only. Out-of-scope per #1178; recorded as adjacent finding.

## Test plan

- [x] `ruff check backend/src backend/tests` -- clean
- [x] `ruff format --check` -- clean
- [x] `mypy backend/src/meho_backplane/memory backend/src/meho_backplane/retrieval` -- clean
- [x] `pytest backend/tests/test_memory_service.py -q` -- 39 passed (incl. 4 new tests for push-down semantics, single-scope filter shape, RBAC-budget-no-longer-burns, multi-scope fan-out merge)
- [x] `pytest backend/tests/ -k 'memory'` -- 323 passed, 13 skipped, 0 failures
- [x] `pytest backend/tests/ -k 'retriev'` -- 263 passed, 11 skipped, 0 failures
- [x] Code-quality gate (`.claude/hooks/code-quality.py --diff`) -- 0 blockers, 12 warnings (function-size warnings on docstring-heavy functions, mostly pre-existing)

### Acceptance criteria

- [x] `search_memory` results byte-for-byte identical against existing memory test suite (no behavioural regression for the public recall contract).
- [x] Substrate observability: `retrieve_hits` / `retrieve_empty` structlog events now carry `metadata_filter_keys` for memory recall calls (proof of push-down). Note: in-process callers don't write `audit_log` table rows directly -- that's the HTTP-route surface; the structlog event is the in-process equivalent.
- [x] New regression test: tenant with N>50 RBAC-invisible memories + 1 visible memory matching the query -- `search_memory` returns the 1 visible hit (`test_search_memories_rbac_invisible_rows_no_longer_burn_budget`).
- [x] `metadata_filters=None` is no longer the only path -- every recall path now uses push-down for the RBAC predicate. Grep for `metadata_str(hit.doc_metadata, ...)` in `service.py` returns only field-extraction sites in `_hit_to_search_result` (projection into the typed `MemoryEntry`); the previous filter use at lines 858-866 is gone.

### Adjacent findings (deferred)

- **`expires_at` cannot push down via T1.** T1's `metadata_filters` is `@>` containment (key-AND, exact value match). `expires_at > now()` is a range predicate; the substrate cannot express it. Expiry stays as post-retrieval Python in `_hit_to_search_result`. The original AC "expired-memories-excluded-by-SQL" requires a future substrate extension; out of scope per #1178 + the determinism / substrate-minimalism postulate. The `MEMORY_USER_DEFAULT_TTL_DAYS` setting plus the daily expiry reaper keep the expired-row pool small in practice.
- **`audit_log.payload` shape for memory recall.** AC #2 references the substrate's `audit_log` payload, but `audit_log` table writes are HTTP-route-only (see `api/v1/retrieve.py`). In-process callers (memory) only emit structlog events. The push-down proof for memory recall is the `metadata_filter_keys` field on the `retrieve_hits` structlog event, not an `audit_log` row.

## Out of scope

- Substrate-side primitive changes (T1 territory, already shipped).
- `list_memories` / `recall` (natural-key fetch) paths -- they don't go through `retrieve()`, so the post-filter pattern doesn't apply.

Closes #1179
