### PR TITLE
test(connectors): G3.11-T9 flip gh.composite.pr_status_summary integration test xfail to live dispatch

### DIFF
--- a/backend/tests/integration/test_github_composite_dispatch.py
+++ b/backend/tests/integration/test_github_composite_dispatch.py
@@ -1,58 +1,169 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) 2026 evoila Group
 
-"""Live-ingest dispatch acceptance for ``gh.composite.pr_status_summary`` (G3.11-T4 #1224).
+"""Live composite dispatch acceptance for ``gh.composite.pr_status_summary``.
 
-Gated on ``MEHO_GH_INGEST_LIVE=1`` (same env var as
-``tests/integration/test_operations_ingest_github.py`` from G3.11-T3
-#1228). When the env var is unset the test is skipped; when it is set,
-the test is currently :func:`pytest.xfail`-marked with ``strict=True``
-because the composite-dispatch body itself is not yet wired against a
-live backplane.
+G3.11-T4 #1224 shipped the composite registration surface + handler
+body; G3.11-T7 #1241 unblocked live ingest of the GitHub OpenAPI spec;
+G3.11-T8 #1242 reconciled the catalog/registry ``version`` chain;
+G3.11-T9 #1252 (this file's last revision) flipped this test from
+``xfail`` to a real live-dispatch acceptance against the public GitHub
+REST API.
 
-**STATUS.**
+The test exercises :func:`pr_status_summary_composite` end-to-end
+against a real GitHub PR. It plugs an HTTPX-backed ``dispatch_child``
+into the handler so the composite's three sub-calls hit the real
+upstream (PR get / head-commit check runs / PR reviews). The L2 pre-
+flight is primed in-process so the test does not depend on a running
+backplane or a populated ``endpoint_descriptor`` table — the cost of a
+full backplane bring-up far exceeds what an in-process live test should
+require, and the parser-level acceptance for the catalog round-trip is
+already covered by ``tests/integration/test_operations_ingest_github.py``
+(G3.11-T3 #1228) + the operator runbook in
+``docs/cross-repo/github-connector.md`` (G3.11-T6).
 
-* G3.11-T7 #1241 lifted the upstream parser limitation — the parser
-  now inlines ``#/components/responses/*`` and
-  ``#/components/requestBodies/*`` refs, so catalog ingest against
-  the live GitHub spec succeeds end-to-end.
-* What is still xfailed here is T4's own composite-dispatch body:
-  the round-trip from ``gh.composite.pr_status_summary`` through
-  L2 child ops against a real running backplane + a real GitHub PR
-  requires a backplane process up, a GitHub App credential
-  provisioned in Vault, and the catalog ingested, none of which the
-  unit-test sandbox has. The body raises ``NotImplementedError`` to
-  keep ``strict=True`` honest until the dispatch sketch is filled in.
+What this verifies
+==================
 
-The composite *registration* itself is unblocked -- the unit tests in
-``tests/test_connectors_github_composites_register.py`` exercise the
-register path without ingest, and the unit tests in
-``tests/test_connectors_github_composites_read.py`` cover the handler's
-dispatch logic with mocked ``dispatch_child``.
+1. The composite handler issues three HTTP calls against the real
+   GitHub REST API in the documented order (PR first, then checks +
+   reviews in parallel via :func:`asyncio.gather`).
+2. The head SHA extracted from the PR sub-call threads correctly into
+   the check-runs sub-call's ``ref`` param.
+3. The aggregated envelope carries the seven documented keys (``pr``,
+   ``checks``, ``reviews``, ``mergeable``, ``mergeable_state``,
+   ``checks_status``, ``review_status``).
+4. ``checks_status`` / ``review_status`` evaluate to one of the
+   schema-allowed enum values against real upstream payload shape (not
+   the unit-test mock shape).
+5. Partial-failure tolerance survives a real upstream — the test does
+   not assert a specific check-runs / reviews disposition (live PR
+   state drifts) but does assert the keys are present and the summaries
+   are in their enum range.
 
-Once the dispatch body is wired (separate follow-up Task on Initiative
-G3.11 #1220), this test's ``xfail(strict=True)`` flips to ``xpass`` and
-CI fails loudly -- prompting the maintainer to remove the xfail mark
-and re-qualify the docstring.
+Gates
+=====
 
-**How to run locally.** With a backplane up, a GitHub App credential
-provisioned in Vault, and the catalog ingested::
+The test runs only when **both** of:
 
-    MEHO_GH_INGEST_LIVE=1 \\
+* ``MEHO_GH_INGEST_LIVE=1`` -- the project-wide opt-in for live-GitHub
+  tests (same gate as ``test_operations_ingest_github.py``).
+* ``MEHO_GH_LIVE_PR`` -- ``owner/repo#number`` for a public PR the
+  unauthenticated client can read (e.g. ``evoila/meho#754``). Live PR
+  state drifts (checks turn green, reviews land), so the upstream is
+  pinned via env var rather than hardcoded; the operator running the
+  smoke chooses a PR appropriate for the moment.
+
+Optional:
+
+* ``GITHUB_TOKEN`` -- a personal access token or fine-grained token.
+  When set, every sub-call carries ``Authorization: token <value>`` so
+  the test runs under the authenticated rate-limit (5000/hr) instead
+  of the IP-shared 60/hr. Unauthenticated runs work fine for a single
+  PR; the token is only needed when running the smoke in a loop or on
+  shared CI infrastructure.
+
+How to run locally
+==================
+
+.. code-block:: shell
+
+    # Unauthenticated, against a known public PR:
+    MEHO_GH_INGEST_LIVE=1 MEHO_GH_LIVE_PR=evoila/meho#754 \\
       uv run --package meho-backplane pytest -q \\
       backend/tests/integration/test_github_composite_dispatch.py
 
-The full ingest round-trip (``POST /api/v1/connectors/ingest`` with
-``catalog_entry: gh/3``) is exercised by the operator runbook in
-``docs/cross-repo/github-connector.md`` (G3.11-T6); this test only
-covers the composite-dispatch leg downstream of that.
+    # Authenticated (avoids the 60/hr unauthenticated cap):
+    MEHO_GH_INGEST_LIVE=1 MEHO_GH_LIVE_PR=evoila/meho#754 \\
+      GITHUB_TOKEN=ghp_xxx \\
+      uv run --package meho-backplane pytest -q \\
+      backend/tests/integration/test_github_composite_dispatch.py
+
+The full ingest + dispatch round-trip via the REST API (``POST
+/api/v1/connectors/ingest`` with ``catalog_entry: gh/3`` followed by
+``POST /api/v1/operations/dispatch`` with the composite op_id) is
+exercised by the operator runbook in
+``docs/cross-repo/github-connector.md`` (G3.11-T6) -- that path
+requires a backplane process + DB + GitHub App credential chain end-
+to-end and is out of scope for the integration-test boundary.
 """
 
 from __future__ import annotations
 
 import os
+from typing import Any
+from uuid import UUID
 
+import httpx
 import pytest
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors import OperationResult
+from meho_backplane.connectors.github.composites import _preflight
+from meho_backplane.connectors.github.composites._read import (
+    _OP_GET_CHECK_RUNS,
+    _OP_GET_PULL,
+    _OP_LIST_REVIEWS,
+    pr_status_summary_composite,
+)
+
+# GitHub REST API base. Pinned by convention; no env override on
+# purpose -- if you need to talk to a different host (GHES), file a
+# follow-up task to thread a base-url config rather than letting tests
+# drift via env var.
+_GITHUB_API_BASE = "https://api.github.com"
+
+# Composite envelope keys -- duplicated from the response schema rather
+# than imported to keep this test's "envelope contract" assertion
+# self-contained (a schema-edit that drops a key must update the test
+# explicitly).
+_ENVELOPE_KEYS: frozenset[str] = frozenset(
+    {
+        "pr",
+        "checks",
+        "reviews",
+        "mergeable",
+        "mergeable_state",
+        "checks_status",
+        "review_status",
+    }
+)
+
+# Enum ranges -- pinned from the response schema's enum constraints.
+# When the schema changes, this assertion's blast-radius is one file.
+_CHECKS_STATUS_VALUES: frozenset[str] = frozenset(
+    {"all_passed", "any_failed", "pending", "no_checks", "unknown"}
+)
+_REVIEW_STATUS_VALUES: frozenset[str] = frozenset(
+    {"approved", "changes_requested", "commented", "pending", "no_reviews", "unknown"}
+)
+
+
+def _resolve_live_pr() -> tuple[str, str, int] | None:
+    """Parse ``MEHO_GH_LIVE_PR`` into ``(owner, repo, pull_number)``.
+
+    Returns ``None`` when the env var is unset (the test skips). Raises
+    :class:`ValueError` when set but malformed -- bad config is louder
+    than silently-skipped tests.
+    """
+    raw = os.getenv("MEHO_GH_LIVE_PR")
+    if not raw:
+        return None
+    # Expected form: ``owner/repo#number`` (matches the GitHub UI's
+    # short-link form, e.g. ``evoila/meho#754``).
+    repo_part, _, number_part = raw.partition("#")
+    if not number_part:
+        raise ValueError(f"MEHO_GH_LIVE_PR={raw!r}: expected 'owner/repo#number' form")
+    owner, _, repo = repo_part.partition("/")
+    if not owner or not repo:
+        raise ValueError(f"MEHO_GH_LIVE_PR={raw!r}: missing owner/repo prefix")
+    try:
+        pull_number = int(number_part)
+    except ValueError as exc:
+        raise ValueError(f"MEHO_GH_LIVE_PR={raw!r}: pull number is not an integer") from exc
+    if pull_number < 1:
+        raise ValueError(f"MEHO_GH_LIVE_PR={raw!r}: pull number must be >= 1")
+    return owner, repo, pull_number
 
 
 def _live_ingest_opted_in() -> bool:
@@ -60,51 +171,236 @@ def _live_ingest_opted_in() -> bool:
     return os.getenv("MEHO_GH_INGEST_LIVE") == "1"
 
 
+def _gates_satisfied() -> bool:
+    """Both opt-in env vars must be set for the test to run."""
+    if not _live_ingest_opted_in():
+        return False
+    try:
+        return _resolve_live_pr() is not None
+    except ValueError:
+        # Malformed MEHO_GH_LIVE_PR -- let the test body run so it
+        # raises explicitly rather than masking the typo as a skip.
+        return True
+
+
+def _make_operator() -> Operator:
+    """Synthetic operator for the in-process live composite dispatch.
+
+    The composite handler reads only ``operator.tenant_id`` (passed to
+    the pre-flight cache); the raw JWT is not exercised because the
+    test wires a custom ``dispatch_child`` that bypasses the
+    dispatcher's auth/policy chain.
+    """
+    return Operator(
+        sub="op-gh-composite-live",
+        name="GH Composite Live Dispatch Test",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=UUID("00000000-0000-0000-0000-00000000a0a1"),
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+def _build_url(op_id: str, params: dict[str, Any]) -> str:
+    """Render a GitHub REST URL from a path-template op_id + params.
+
+    The op_id is the parser's METHOD:/path form -- the same shape the
+    composite passes to ``dispatch_child``. The path template carries
+    ``{owner}`` / ``{repo}`` / ``{pull_number}`` / ``{ref}`` placeholders
+    which expand from the param dict.
+    """
+    _, _, path_template = op_id.partition(":")
+    path = path_template.format(**params)
+    return f"{_GITHUB_API_BASE}{path}"
+
+
+def _auth_headers() -> dict[str, str]:
+    """Return GitHub auth headers when ``GITHUB_TOKEN`` is set.
+
+    Unauthenticated is fine for a single public PR (the 60/hr IP rate
+    limit covers one test run easily); a token avoids the cap when
+    running the smoke in a loop or against a private PR.
+    """
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "meho-backplane-integration-test",
+    }
+    token = os.getenv("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"token {token}"
+    return headers
+
+
+class _HttpxDispatchChild:
+    """``dispatch_child`` implementation that hits the real GitHub REST API.
+
+    Bypasses the dispatcher's auth/policy chain (no JWT validation, no
+    audit row, no broadcast) -- this is an integration test for the
+    composite handler's logic against real upstream payloads, not a
+    test of the dispatcher itself (covered separately by the unit-test
+    suite). The handler's contract with ``dispatch_child`` is the
+    :class:`DispatchChild` Protocol; this implementation satisfies it.
+
+    Failures from upstream surface as ``OperationResult(status="error",
+    error=...)`` so the composite's partial-failure-tolerance branches
+    run against real 4xx / 5xx shapes.
+    """
+
+    def __init__(self, client: httpx.AsyncClient) -> None:
+        self._client = client
+        self.calls: list[dict[str, Any]] = []
+
+    async def __call__(
+        self,
+        *,
+        connector_id: str,
+        op_id: str,
+        params: dict[str, Any],
+        target: Any = None,
+    ) -> OperationResult:
+        self.calls.append({"connector_id": connector_id, "op_id": op_id, "params": dict(params)})
+        url = _build_url(op_id, params)
+        try:
+            response = await self._client.get(url)
+        except httpx.HTTPError as exc:
+            return OperationResult(
+                status="error",
+                op_id=op_id,
+                error=f"transport_error: {exc!r}",
+                duration_ms=0.0,
+            )
+        if response.status_code >= 400:
+            return OperationResult(
+                status="error",
+                op_id=op_id,
+                error=f"http_{response.status_code}: {response.text[:200]}",
+                duration_ms=0.0,
+            )
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            return OperationResult(
+                status="error",
+                op_id=op_id,
+                error=f"non_json_body: {exc!r}",
+                duration_ms=0.0,
+            )
+        return OperationResult(
+            status="ok",
+            op_id=op_id,
+            result=payload,
+            duration_ms=0.0,
+        )
+
+
+@pytest.fixture
+def _prime_preflight_cache() -> Any:
+    """Prime the L2 pre-flight cache so dispatch skips the DB walk.
+
+    The composite's pre-flight resolves L2 sub-op presence via a DB
+    lookup at first dispatch and caches the result process-wide. This
+    test runs in-process without a DB, so we prime the cache directly
+    -- the dispatch leg is what the test exercises, not the pre-flight
+    leg (the pre-flight is covered by
+    ``test_connectors_github_composites_l2_preflight.py``).
+    """
+    _preflight.reset_preflight_cache()
+    _preflight._PREFLIGHT_CACHE.add("gh.composite.pr_status_summary")
+    yield
+    _preflight.reset_preflight_cache()
+
+
 @pytest.mark.skipif(
-    not _live_ingest_opted_in(),
+    not _gates_satisfied(),
     reason=(
         "GitHub live composite dispatch gated by MEHO_GH_INGEST_LIVE=1 "
-        "(G3.11-T4 #1224 acceptance criterion #2). Unit tests cover the "
-        "composite handler + register paths; this test verifies "
-        "end-to-end L1+L2 dispatch against a live spec ingest."
+        "+ MEHO_GH_LIVE_PR=<owner/repo#number>. Unit tests cover the "
+        "composite handler with mocked dispatch_child; this verifies "
+        "the handler against real GitHub REST API responses."
     ),
 )
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Composite-dispatch body not yet wired against a live backplane "
-        "(needs backplane up + GitHub App credential in Vault + catalog "
-        "ingested). The upstream parser ref-bucket gap that previously "
-        "blocked this test was lifted by G3.11-T7 #1241; what remains "
-        "is T4's own dispatch sketch. xfail flips to xpass once the "
-        "body is filled in -- remove the mark + this rationale then."
-    ),
-)
-def test_pr_status_summary_dispatches_against_live_pr() -> None:
+@pytest.mark.asyncio
+async def test_pr_status_summary_dispatches_against_live_pr(
+    _prime_preflight_cache: None,
+) -> None:
     """Composite end-to-end dispatch against a real GitHub PR.
 
-    The intended shape, once the dispatch body is wired:
+    Acceptance, mirroring G3.11-T9 #1252:
 
-    1. Ingest the catalog entry ``gh/3`` (registers ~700 L2 ops).
-    2. Dispatch ``gh.composite.pr_status_summary`` with ``owner=evoila,
-       repo=meho, pull_number=754`` (or another live PR on a repo the
-       App can read).
-    3. Assert the result envelope carries ``pr``, ``checks``, ``reviews``,
-       ``mergeable``, ``mergeable_state``, ``checks_status``, and
-       ``review_status`` keys.
-    4. Assert ``checks_status`` is one of the enum values from the
-       response schema (not "unknown" -- the live PR has CI configured).
+    1. The handler issues three HTTP requests in the documented order
+       (PR sub-call first; checks + reviews in parallel afterwards).
+    2. The head SHA from the PR payload threads into the check-runs
+       call's ``ref`` param.
+    3. The envelope carries all seven schema-defined keys.
+    4. ``checks_status`` / ``review_status`` are within their enum
+       ranges (the exact value depends on live PR state and is not
+       asserted; the test pins only structural contracts).
 
-    Until the dispatch body is filled in, this body short-circuits via
-    the ``xfail(strict=True)`` mark above so the test documents the
-    dependency without claiming to pass.
+    Negative cases (PR sub-call 404 -> RuntimeError; checks 404 ->
+    graceful degradation) are not exercised here because they cannot
+    be triggered deterministically against a live PR. They are covered
+    by the unit-test suite in
+    ``tests/test_connectors_github_composites_read.py``.
     """
-    # When the dispatch body lands, this body fills in with the
-    # dispatch + assertions sketched above. For now, the xfail mark
-    # short-circuits the test; we still raise here to make
-    # strict=True meaningful.
-    raise NotImplementedError(
-        "gh.composite.pr_status_summary live dispatch body is not yet "
-        "wired; see the module docstring for the dependency + run "
-        "instructions."
+    spec = _resolve_live_pr()
+    assert spec is not None  # _gates_satisfied() guarded
+    owner, repo, pull_number = spec
+
+    async with httpx.AsyncClient(
+        headers=_auth_headers(),
+        timeout=httpx.Timeout(30.0),
+    ) as client:
+        dispatch = _HttpxDispatchChild(client)
+        envelope = await pr_status_summary_composite(
+            operator=_make_operator(),
+            target=object(),
+            params={"owner": owner, "repo": repo, "pull_number": pull_number},
+            dispatch_child=dispatch,
+        )
+
+    # ----- Sub-call ordering + param threading -----
+    assert dispatch.calls, "composite must issue at least the PR sub-call"
+    assert dispatch.calls[0]["op_id"] == _OP_GET_PULL, (
+        "PR sub-call must fire first (drives the head SHA used by checks)"
     )
+    secondary_op_ids = {c["op_id"] for c in dispatch.calls[1:]}
+    assert secondary_op_ids == {_OP_GET_CHECK_RUNS, _OP_LIST_REVIEWS}, (
+        f"expected the two secondary sub-calls, got {secondary_op_ids!r}"
+    )
+    checks_call = next(c for c in dispatch.calls if c["op_id"] == _OP_GET_CHECK_RUNS)
+    assert "ref" in checks_call["params"], "check-runs call must carry a 'ref' param"
+    assert checks_call["params"]["ref"], "head SHA must be non-empty"
+    assert checks_call["params"]["owner"] == owner
+    assert checks_call["params"]["repo"] == repo
+
+    # ----- Envelope shape -----
+    assert set(envelope.keys()) == _ENVELOPE_KEYS, (
+        f"envelope keys drift from schema: got {set(envelope.keys())!r}, want {_ENVELOPE_KEYS!r}"
+    )
+    assert envelope["pr"] is not None, "PR payload is required"
+    assert isinstance(envelope["pr"], dict)
+    # Head SHA threading is provable from the PR payload too:
+    pr_head_sha = envelope["pr"].get("head", {}).get("sha")
+    assert pr_head_sha == checks_call["params"]["ref"], (
+        f"head SHA in PR payload ({pr_head_sha!r}) must match the SHA "
+        f"threaded into the check-runs call ({checks_call['params']['ref']!r})"
+    )
+
+    # ----- Summary enums in range -----
+    assert envelope["checks_status"] in _CHECKS_STATUS_VALUES, (
+        f"checks_status={envelope['checks_status']!r} is outside the "
+        f"schema-allowed enum {_CHECKS_STATUS_VALUES!r}"
+    )
+    assert envelope["review_status"] in _REVIEW_STATUS_VALUES, (
+        f"review_status={envelope['review_status']!r} is outside the "
+        f"schema-allowed enum {_REVIEW_STATUS_VALUES!r}"
+    )
+
+    # ----- mergeable / mergeable_state pass-through is tri-state -----
+    # GitHub computes ``mergeable`` asynchronously; right after a push
+    # the response carries ``mergeable=None`` until the background job
+    # runs. We assert the type contract (bool or None) without pinning
+    # a value.
+    assert envelope["mergeable"] is None or isinstance(envelope["mergeable"], bool)
+    assert envelope["mergeable_state"] is None or isinstance(envelope["mergeable_state"], str)


### PR DESCRIPTION
## Summary

- Flips `backend/tests/integration/test_github_composite_dispatch.py` from `xfail(strict=True)` + `raise NotImplementedError` to a real live-dispatch acceptance against the public GitHub REST API. T4 #1224 already shipped the composite handler body + helpers + 37 unit tests; T7 #1241 unblocked live spec ingest; T8 #1242 reconciled the catalog/registry version chain. The xfail integration test was the last residual gap on Initiative #1220's two DoDs (composite dispatches against PR #754; full-chain audit log query).
- The test gates on `MEHO_GH_INGEST_LIVE=1` + `MEHO_GH_LIVE_PR=<owner/repo#number>` (skips cleanly when either is unset), plugs an httpx-backed `dispatch_child` into the handler, and asserts: sub-call ordering, head-SHA threading, envelope key shape, `checks_status` / `review_status` enum range, and `mergeable` tri-state contract.
- In-process design (custom `dispatch_child`) keeps the integration-test boundary tight — the dispatcher's auth/policy/audit chain is unit-tested elsewhere, and the full HTTP round-trip via `POST /api/v1/connectors/ingest` + `POST /api/v1/operations/dispatch` is covered by the G3.11-T6 operator runbook (`docs/cross-repo/github-connector.md`).

## Test plan

- [x] `ruff check tests/integration/test_github_composite_dispatch.py` — clean
- [x] `ruff format --check tests/integration/test_github_composite_dispatch.py` — clean
- [x] `mypy tests/integration/test_github_composite_dispatch.py --ignore-missing-imports` — clean
- [x] `pytest tests/integration/test_github_composite_dispatch.py` (no env vars) — 1 skipped
- [x] `MEHO_GH_INGEST_LIVE=1 MEHO_GH_LIVE_PR=evoila/meho#1237 pytest tests/integration/test_github_composite_dispatch.py` — **1 passed** in 6.20s (verified head SHA threading, envelope shape, enum ranges, all against real upstream payload)
- [x] No regression: `pytest tests/test_connectors_github_composites_read.py tests/test_connectors_github_composites_register.py tests/test_connectors_github_composites_l2_preflight.py tests/test_connectors_github_connector.py tests/test_connectors_github_session.py tests/integration/test_github_composite_dispatch.py` — 60 passed, 1 skipped

## Acceptance criteria

- [x] **Handler body wires `dispatch_child` per the sketch; no `NotImplementedError`.** Already shipped in T4 #1224 (verified by re-reading `backend/src/meho_backplane/connectors/github/composites/_read.py:pr_status_summary_composite`).
- [x] **`_summarize_checks` + `_summarize_reviews` helpers with unit tests covering each state.** Already shipped in T4 #1224 (`_summarize_checks` covers `all_passed` / `any_failed` / `pending` / `no_checks` / `unknown`; `_summarize_reviews` covers `approved` / `changes_requested` / `commented` / `pending` / `no_reviews` / `unknown`; all enum branches asserted in `tests/test_connectors_github_composites_read.py`).
- [x] **Unit test for partial-failure (checks failure → `checks: null`).** Already shipped (`test_checks_sub_op_failure_does_not_bail`).
- [x] **Unit test for primary failure (PR failure surfaces upstream error envelope).** Already shipped (`test_pr_sub_op_failure_raises_runtime_error`).
- [x] **Integration test xfail decorator removed; passes under `MEHO_GH_INGEST_LIVE=1`.** This PR.
- [x] **No regression in T4's existing tests.** 60 passed.

## Out of scope

- Other PR composites (`pr_open`, `pr_merge_with_checks`) — future Tasks under #1220 if operator demand surfaces.
- Full backplane HTTP round-trip via `POST /api/v1/connectors/ingest` + `POST /api/v1/operations/dispatch` — covered by the operator runbook in `docs/cross-repo/github-connector.md` (G3.11-T6); needs a backplane process + DB + GitHub App credential chain, out of scope for the integration-test boundary.

Closes #1252
