### PR TITLE
fix(tests): G3.11-T11 swap capture_logs for monkeypatched LogCapture in orphan-class test

### DIFF
--- a/backend/tests/test_operations_register_ingested.py
+++ b/backend/tests/test_operations_register_ingested.py
@@ -846,17 +846,48 @@ def test_check_version_covered_raises_when_label_outside_range() -> None:
     assert "_FakeRangedConnector" in detail
 
 
-def test_check_version_covered_logs_orphan_when_no_class_registered() -> None:
-    """No class for ``(product, impl_id)`` → log ``connector_ingest_orphaned_class``; no raise."""
+def test_check_version_covered_logs_orphan_when_no_class_registered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No class for ``(product, impl_id)`` → log ``connector_ingest_orphaned_class``; no raise.
+
+    Capture surface (#1254): the test does NOT use
+    :func:`structlog.testing.capture_logs` — under pytest-xdist with
+    other tests on the same worker mutating
+    :func:`structlog.configure` (lifespan boot, observability fixtures),
+    ``capture_logs`` has been observed to miss the event even when the
+    event was emitted to fd-level stdout (CI iter-1 of T7 #1241/PR
+    #1248, xdist ``gw4``). The flake is in the global
+    processor-list-swap pattern ``capture_logs`` uses, not in the
+    subject code.
+
+    Instead we bind a private :class:`structlog.testing.LogCapture`
+    onto a freshly-wrapped logger and monkeypatch the subject
+    module's module-level ``_log`` for the test's duration. This is
+    process-local, contextvar-free, and immune to any concurrent
+    :func:`structlog.configure` call. The original ``_log`` is
+    restored automatically by ``monkeypatch`` on test teardown.
+    """
     # Registry is empty (autouse fixture cleared it).
-    with structlog.testing.capture_logs() as captured:
-        check_version_covered_by_registered_class(
-            product="brand-new-vendor",
-            version="1.0",
-            impl_id="brand-new-impl",
-        )
+    from meho_backplane.operations.ingest import connector_registration
+
+    capture = structlog.testing.LogCapture()
+    private_log = structlog.wrap_logger(
+        structlog.PrintLogger(),
+        processors=[capture],
+    )
+    monkeypatch.setattr(connector_registration, "_log", private_log)
+
+    check_version_covered_by_registered_class(
+        product="brand-new-vendor",
+        version="1.0",
+        impl_id="brand-new-impl",
+    )
+
     events = [
-        entry for entry in captured if entry.get("event") == "connector_ingest_orphaned_class"
+        entry
+        for entry in capture.entries
+        if entry.get("event") == "connector_ingest_orphaned_class"
     ]
     assert len(events) == 1
     assert events[0]["product"] == "brand-new-vendor"


### PR DESCRIPTION
## Summary

T7 #1241's PR #1248 CI iter-1 hit a flake on xdist worker `gw4` in `test_check_version_covered_logs_orphan_when_no_class_registered`: the structlog event WAS emitted (captured stdout proved it) but `structlog.testing.capture_logs()` returned an empty list. Flake mechanism is `capture_logs`'s global-processor-list-swap pattern interacting with pytest-xdist + concurrent `structlog.configure(...)` calls from observability fixtures + lifespan boot.

**Resolution A** per the issue body — sink-based, contextvar-free, auto-restoring:
- Bind a private `structlog.testing.LogCapture` onto a freshly-wrapped logger (`structlog.wrap_logger(PrintLogger(), processors=[capture])`)
- Monkeypatch the subject module's `_log` for the test's duration. `monkeypatch` auto-restores on teardown.

## Test plan

- [x] Single-run sanity: `pytest tests/test_operations_register_ingested.py::test_check_version_covered_logs_orphan_when_no_class_registered` → passed
- [x] 5 consecutive `pytest -n auto --dist loadscope tests/test_operations_register_ingested.py` iterations all passed 21/21
- [x] Ruff clean on the changed file
- [x] Subject behavior preserved — `orphaned_endpoint_descriptor` event still emitted with `product` + `impl_id` fields

## Out of scope

- Project-wide migration off `capture_logs()` (other call sites of `capture_logs` in `backend/tests/`)
- New fixture wrapping the sink pattern in an xdist-safe way

Mypy errors on lines 146 + 781 are pre-existing on `origin/main`, not introduced by this diff.

Closes #1254

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of test for orphaned class logging validation by refactoring log capture mechanism.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->