### PR TITLE
feat(connectors): G3.11-T10 validator asserts (product, version, impl_id) triple registration

### DIFF
--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -116,7 +116,7 @@ from meho_backplane.memory import (
 from meho_backplane.metrics import render_metrics
 from meho_backplane.middleware import BroadcastDetailMiddleware, RequestContextMiddleware
 from meho_backplane.operations import run_typed_op_registrars, set_default_reducer
-from meho_backplane.operations.ingest import load_catalog
+from meho_backplane.operations.ingest import load_catalog, validate_catalog_registry_coverage
 from meho_backplane.operations.jsonflux_reducer import JsonFluxReducer
 from meho_backplane.retrieval.embedding import get_embedding_service
 from meho_backplane.scheduler import start_scheduler, stop_scheduler
@@ -255,11 +255,20 @@ async def _run_lifespan_startup() -> None:
     # field, non-PEP-440 spec_info_version, duplicate (product, version))
     # raises here and crashes the lifespan, so CI's app-boot smoke fails
     # instead of the bad catalog surfacing as a 500 on first
-    # GET /api/v1/connectors/catalog. Registry-coverage of each entry's
-    # requires_connector_class is a CI regression test, not a startup
-    # guard (the registry's populated-ness is import-order-dependent
-    # under pytest-xdist; see catalog.py).
+    # GET /api/v1/connectors/catalog.
     load_catalog()
+    # Catalog ↔ registry triple coverage (G3.11-T10 #1253). At chassis
+    # boot the registry is fully populated (_eager_import_connectors
+    # above ran every connectors/<product>/__init__.py registration),
+    # so the validator can assert both the class-presence check
+    # (#743 crit. b) and the (product, version, impl_id) triple-
+    # registration check (T10) without the pytest-xdist import-order
+    # hazard the test suite hits. A mismatch fails-fast here rather
+    # than surfacing as ``no_connector`` on the first dispatch — the
+    # T8 #1242 class of bug (catalog ``version: v3`` vs registry
+    # ``version: "3"``) would have crashed the lifespan instead of
+    # shipping silently.
+    validate_catalog_registry_coverage()
     # Typed-op registration (G0.6-T-Refactor-Vault #390). See the
     # docstring for the contract; runs registrars connectors appended
     # to during the import pass above so descriptor rows are populated

--- a/backend/src/meho_backplane/operations/ingest/catalog.py
+++ b/backend/src/meho_backplane/operations/ingest/catalog.py
@@ -30,16 +30,34 @@ connector-catalog.md`` is the operator-facing pointer.
   YAML crash startup (and therefore CI's app-boot smoke). It does not
   touch the connector registry, so it is safe to run inside the lifespan
   regardless of import-cache state.
-* :func:`validate_catalog_registry_coverage` cross-checks every entry's
-  ``requires_connector_class`` against
-  :func:`~meho_backplane.connectors.registry.all_connectors_v2`. That is
-  the #743 criterion-(b) guard; it runs as a CI regression test (where
-  the full connector set is registered) rather than at startup, where the
-  registry's populated-ness is import-order-dependent under pytest-xdist.
+* :func:`validate_catalog_registry_coverage` cross-checks every entry
+  against :func:`~meho_backplane.connectors.registry.all_connectors_v2`
+  on two axes:
+
+  - **Class presence** (#743 criterion (b)) — the
+    ``requires_connector_class`` resolves to a registered connector class.
+  - **Triple registration** (G3.11-T10 #1253) — the ``(product, version,
+    impl_id)`` triple itself has an entry in the v2 registry table.
+    T8 #1242 surfaced this gap: T1 #1221 registered ``("gh", "3",
+    "gh-rest")`` while T3 #1223 wrote the catalog row as ``version: v3``;
+    the class-presence check passed because ``GitHubRestConnector`` was
+    registered (under a different version key), and the drift only
+    surfaced at first dispatch. The triple check catches the class of
+    bug at boot / CI time.
+
+  Failure raises :class:`CatalogError` with a ``catalog_registry_triple
+  _mismatch:`` (or ``unregistered connector class``) code prefix per
+  the G0.14-T11 #1141 error-message-shape convention. At chassis
+  startup the lifespan calls this after :func:`_eager_import_connectors`
+  has populated the registry, so any mismatch fails the boot rather
+  than the first ``POST /api/v1/operations/call``. The same call from
+  the test suite exercises the synthetic-drift unit test and the
+  shipped-catalog self-test.
 """
 
 from __future__ import annotations
 
+import difflib
 import functools
 import re
 from importlib import resources
@@ -197,27 +215,158 @@ def load_catalog() -> ConnectorSpecCatalog:
     return parse_catalog(raw)
 
 
-def validate_catalog_registry_coverage(catalog: ConnectorSpecCatalog | None = None) -> None:
-    """Assert every ``requires_connector_class`` is registered (#743 crit. b).
+def _format_triple(product: str, version: str, impl_id: str) -> str:
+    """Render a ``(product, version, impl_id)`` triple for error messages.
 
-    Cross-checks against
-    :func:`~meho_backplane.connectors.registry.all_connectors_v2`. Raises
-    :class:`CatalogError` listing the offenders. Imported lazily so this
-    module stays import-light for the startup parse path.
+    A standalone helper so the unit test, the failure message, and the
+    closest-match hint all render the same shape — drift between the
+    three is itself a class of bug we're guarding against here.
+    """
+    return f"(product={product!r}, version={version!r}, impl_id={impl_id!r})"
+
+
+def _closest_registered_triple(
+    target_product: str,
+    target_version: str,
+    target_impl_id: str,
+    registered_triples: list[tuple[str, str, str]],
+) -> tuple[str, str, str] | None:
+    """Return the closest registered triple to ``target`` (or ``None``).
+
+    Used to populate the closest-match hint in the
+    ``catalog_registry_triple_mismatch`` envelope so the operator can
+    see *which field drifted*. The matching strategy is two-pass:
+
+    1. **Prefer same product.** When the registry has at least one
+       triple sharing the catalog row's ``product`` slug, return the
+       closest among them (matched on the concatenated
+       ``version|impl_id`` string). This is the T8 #1242 motivating
+       case: catalog says ``("gh", "v3", "gh-rest")`` and registry has
+       ``("gh", "3", "gh-rest")`` — same product, the version drifted.
+
+    2. **Fall back to global closest.** No same-product match (e.g.
+       the operator typo'd the product slug itself) → match against
+       every registered triple's joined ``product|version|impl_id``
+       string. Returns ``None`` only when the registry is empty.
+
+    Why a hint rather than a fuzzy-resolution: detection only. The
+    operator fixes the source of truth (catalog YAML or the
+    ``register_connector_v2`` call); the validator never auto-patches.
+    """
+    if not registered_triples:
+        return None
+
+    same_product = [t for t in registered_triples if t[0] == target_product]
+    if same_product:
+        # Match on version|impl_id when the product agrees — this is the
+        # T8 #1242 shape (version-string drift on the same product).
+        target_tail = f"{target_version}|{target_impl_id}"
+        candidates = {f"{v}|{i}": (p, v, i) for (p, v, i) in same_product}
+        match = difflib.get_close_matches(target_tail, list(candidates), n=1, cutoff=0.0)
+        if match:
+            return candidates[match[0]]
+        # `get_close_matches` returned nothing (very rare with cutoff=0.0;
+        # only when `candidates` is empty, which `same_product` truthiness
+        # already excluded). Fall through to global match.
+
+    # No same-product entry, or no candidate beat the cutoff — match on
+    # the full triple string against every registered entry.
+    target_joined = f"{target_product}|{target_version}|{target_impl_id}"
+    joined_to_triple = {f"{p}|{v}|{i}": (p, v, i) for (p, v, i) in registered_triples}
+    match = difflib.get_close_matches(target_joined, list(joined_to_triple), n=1, cutoff=0.0)
+    if match:
+        return joined_to_triple[match[0]]
+    return None
+
+
+def validate_catalog_registry_coverage(catalog: ConnectorSpecCatalog | None = None) -> None:
+    """Assert every catalog entry resolves cleanly against the v2 registry.
+
+    Two axes are checked per the G3.11-T10 #1253 extension:
+
+    * **Class presence** (#743 criterion (b)) —
+      ``requires_connector_class`` resolves to a class in
+      :func:`~meho_backplane.connectors.registry.all_connectors_v2`.
+    * **Triple registration** (T10 #1253) — the row's ``(product,
+      version, impl_id)`` triple is itself a key in
+      :func:`all_connectors_v2`. This catches the T8 #1242 class of
+      bug: a catalog/registry version-string drift that the
+      class-only check missed (the class was registered, just under a
+      different version key).
+
+    Failure raises :class:`CatalogError`. For the triple-mismatch
+    branch, the message carries a ``catalog_registry_triple_mismatch:``
+    code prefix and names the catalog triple plus the closest
+    registered triple for the same product so the operator can see
+    which field drifted, per the
+    ``docs/codebase/error-message-shape.md`` convention.
+
+    Imported lazily so this module stays import-light for the startup
+    parse path.
     """
     from meho_backplane.connectors.registry import all_connectors_v2
 
     cat = catalog if catalog is not None else load_catalog()
-    registered = {cls.__name__ for cls in all_connectors_v2().values()}
-    missing = sorted(
+    registry_v2 = all_connectors_v2()
+    registered_class_names = {cls.__name__ for cls in registry_v2.values()}
+
+    # Axis 1: class presence (existing #743 criterion (b) check).
+    missing_classes = sorted(
         {
             e.requires_connector_class
             for e in cat.entries
-            if e.requires_connector_class not in registered
+            if e.requires_connector_class not in registered_class_names
         }
     )
-    if missing:
+    if missing_classes:
         raise CatalogError(
             "connector-spec catalog references unregistered connector class(es): "
-            f"{missing}; registered classes: {sorted(registered)}"
+            f"{missing_classes}; registered classes: {sorted(registered_class_names)}"
+        )
+
+    # Axis 2: triple registration (T10 #1253). Walk catalog rows; flag
+    # any whose (product, version, impl_id) triple isn't in the v2
+    # registry table. The two checks are layered (class first, then
+    # triple) so a totally-missing class surfaces its specific code
+    # rather than a triple miss that points at the wrong thing.
+    registered_triples = sorted(registry_v2.keys())
+    triple_mismatches: list[tuple[ConnectorSpecEntry, tuple[str, str, str] | None]] = []
+    for entry in cat.entries:
+        triple = (entry.product, entry.version, entry.impl_id)
+        if triple not in registry_v2:
+            hint = _closest_registered_triple(
+                entry.product, entry.version, entry.impl_id, registered_triples
+            )
+            triple_mismatches.append((entry, hint))
+
+    if triple_mismatches:
+        # Build the message in three clauses per the T11 convention:
+        # (a) the offending values, (b) the closest-registered hint,
+        # (c) the doc reference + remediation imperative.
+        catalog_path = "backend/src/meho_backplane/operations/ingest/catalog.yaml"
+        register_path = "connectors/<product>/__init__.py"
+        details: list[str] = []
+        for entry, hint in triple_mismatches:
+            catalog_triple = _format_triple(entry.product, entry.version, entry.impl_id)
+            if hint is not None:
+                hint_str = _format_triple(*hint)
+                details.append(
+                    f"catalog row {catalog_triple}; closest registered triple: {hint_str}"
+                )
+            else:
+                # Registry empty (rare; mostly test scaffolding) or no
+                # close match found — still surface the catalog triple
+                # and the full registered list so the operator has the
+                # raw data to debug from.
+                details.append(
+                    f"catalog row {catalog_triple}; no close registered triple "
+                    f"(registered triples: {registered_triples})"
+                )
+        joined = "; ".join(details)
+        raise CatalogError(
+            "catalog_registry_triple_mismatch: connector-spec catalog row(s) name a "
+            f"(product, version, impl_id) triple not present in the v2 connector registry: "
+            f"{joined}. Reconcile {catalog_path} with the matching "
+            f"register_connector_v2(...) call in {register_path}. See "
+            f"docs/codebase/error-message-shape.md for the envelope convention."
         )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -596,6 +596,39 @@ def _force_import_mcp_modules() -> None:
     eager_import_mcp_modules()
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _force_import_connector_modules() -> None:
+    """Import every ``connectors/<product>/`` subpackage ONCE per worker.
+
+    Same hazard as :func:`_force_import_mcp_modules` above, but for the
+    connector registry: ``register_connector`` / ``register_connector_v2``
+    fire as module-import side effects, so the first
+    :func:`_eager_import_connectors` call populates the v1+v2 tables;
+    every subsequent call is a cached no-op (Python caches imports).
+    The per-test :func:`_isolate_global_registries` snapshot/restore then
+    pins the registry to whatever was registered *before* the snapshot
+    was first taken — empty if no prior test triggered a lifespan,
+    populated otherwise. That coupling bit G3.11-T10 #1253 when the
+    chassis lifespan started calling
+    :func:`validate_catalog_registry_coverage` post-:func:`load_catalog`:
+    a test exercising the lifespan after a registry-clearing test (or
+    in isolation, before any other test had triggered an import) saw an
+    empty registry and the validator raised
+    ``catalog_registry_triple_mismatch``.
+
+    Forcing the imports once at session start makes the registrations
+    land before any test runs; the snapshot then captures the populated
+    baseline; every subsequent lifespan ``_eager_import_connectors``
+    call (any worker, any order) is a cached no-op against an
+    already-populated registry. The triple-check validator finds every
+    catalog row's triple in the v2 table and lifespan startup tests
+    boot cleanly.
+    """
+    from meho_backplane.connectors.registry import _eager_import_connectors
+
+    _eager_import_connectors()
+
+
 @pytest.fixture(autouse=True)
 def _isolate_global_registries() -> Iterator[None]:
     """Snapshot/restore every process-global registry around each test.

--- a/backend/tests/test_connectors_registry.py
+++ b/backend/tests/test_connectors_registry.py
@@ -354,6 +354,12 @@ def test_lifespan_calls_eager_import_connectors() -> None:
             # ``patch.multiple`` to stay under CPython's "too many
             # statically nested blocks" limit (20) the parenthesised
             # ``with`` form imposes.
+            # G3.11-T10 #1253 added validate_catalog_registry_coverage
+            # to the lifespan after load_catalog. With _eager_import_connectors
+            # mocked out the registry is empty by construction, so patch
+            # load_catalog + the validator into the same patch.multiple
+            # block (avoids tripping CPython's 20-statically-nested-block
+            # limit the parenthesised ``with`` form imposes).
             patch.multiple(
                 "meho_backplane.main",
                 start_scheduler=MagicMock(),
@@ -362,6 +368,8 @@ def test_lifespan_calls_eager_import_connectors() -> None:
                 stop_agent_run_reaper=AsyncMock(),
                 start_event_drain=MagicMock(),
                 stop_event_drain=AsyncMock(),
+                load_catalog=MagicMock(),
+                validate_catalog_registry_coverage=MagicMock(),
             ),
         ):
             # Manually step through the lifespan async generator.
@@ -436,6 +444,10 @@ def test_lifespan_runs_broadcast_dispose_even_when_engine_dispose_fails() -> Non
             # ``patch.multiple`` to stay under CPython's "too many
             # statically nested blocks" limit (20) the parenthesised
             # ``with`` form imposes.
+            # Same G3.11-T10 #1253 shape as the sibling lifespan test —
+            # registry is empty under the mocks, so skip the catalog
+            # coverage validator. Folded into patch.multiple to fit
+            # under CPython's 20-statically-nested-block limit.
             patch.multiple(
                 "meho_backplane.main",
                 start_scheduler=MagicMock(),
@@ -444,6 +456,8 @@ def test_lifespan_runs_broadcast_dispose_even_when_engine_dispose_fails() -> Non
                 stop_agent_run_reaper=AsyncMock(),
                 start_event_drain=MagicMock(),
                 stop_event_drain=AsyncMock(),
+                load_catalog=MagicMock(),
+                validate_catalog_registry_coverage=MagicMock(),
             ),
         ):
             gen = lifespan(None)  # type: ignore[arg-type]

--- a/backend/tests/test_operations_ingest_catalog.py
+++ b/backend/tests/test_operations_ingest_catalog.py
@@ -196,6 +196,93 @@ def test_validate_catalog_registry_coverage_raises_on_unknown_class() -> None:
 
 
 # ---------------------------------------------------------------------------
+# (b') Triple registration — G3.11-T10 #1253 extension
+#
+# The class-presence check above catches the case where the connector
+# class isn't registered at all. The triple-registration check below
+# catches the T8 #1242 class of bug: the class IS registered, but under
+# a different (product, version, impl_id) key than the catalog row
+# names. The shipped catalog is exercised by
+# test_validate_catalog_registry_coverage_passes_for_shipped_catalog
+# (same fixture covers both axes); the dedicated tests below focus on
+# the synthetic-drift envelope shape per the G0.14-T11 #1141 convention.
+# ---------------------------------------------------------------------------
+
+
+def test_validate_catalog_registry_coverage_raises_on_triple_drift(
+    _registered_connectors: set[str],
+) -> None:
+    """The exact T8 #1242 shape: catalog ``v3`` vs registry ``3``.
+
+    ``GitHubRestConnector`` is registered (by ``_registered_connectors``)
+    under the triple ``("gh", "3", "gh-rest")`` — the class-presence
+    check passes — but the synthetic catalog row names the pre-T8
+    drifted ``("gh", "v3", "gh-rest")`` triple, which is NOT in the
+    registry. The validator must raise ``CatalogError`` with the
+    ``catalog_registry_triple_mismatch:`` code prefix and the
+    closest-same-product hint.
+    """
+    drifted = ConnectorSpecCatalog(
+        entries=(
+            _entry(
+                product="gh",
+                version="v3",  # drifted from registry's "3"
+                impl_id="gh-rest",
+                requires_connector_class="GitHubRestConnector",
+            ),
+        ),
+    )
+    with pytest.raises(CatalogError) as exc_info:
+        validate_catalog_registry_coverage(drifted)
+    msg = str(exc_info.value)
+    assert msg.startswith("catalog_registry_triple_mismatch:"), msg
+    # (a) The catalog triple is named verbatim.
+    assert "product='gh'" in msg and "version='v3'" in msg and "impl_id='gh-rest'" in msg
+    # (b) The closest registered triple for the same product is the
+    # canonical post-T8 form — `version='3'` (no leading 'v').
+    assert "closest registered triple" in msg
+    assert "version='3'" in msg
+    # (c) The remediation imperative names both source-of-truth files
+    # and points at the error-message-shape doc.
+    assert "catalog.yaml" in msg
+    assert "register_connector_v2" in msg
+    assert "error-message-shape.md" in msg
+
+
+def test_validate_catalog_registry_coverage_drift_hint_falls_back_to_global(
+    _registered_connectors: set[str],
+) -> None:
+    """Product slug typo'd → hint falls back to the closest GLOBAL triple.
+
+    When the catalog row's ``product`` doesn't match ANY registered
+    triple, the same-product hint logic has nothing to compare against;
+    the validator should still produce a useful hint by matching the
+    full ``product|version|impl_id`` string against every registered
+    triple. The shipped catalog has ``("k8s", "1.x", "k8s")`` registered,
+    so a row claiming ``("k8z", "1.x", "k8s")`` (one-character product
+    typo) should surface ``k8s`` as the closest hint.
+    """
+    typo = ConnectorSpecCatalog(
+        entries=(
+            _entry(
+                product="k8z",
+                version="1.x",
+                impl_id="k8s",
+                requires_connector_class="KubernetesConnector",
+            ),
+        ),
+    )
+    with pytest.raises(CatalogError) as exc_info:
+        validate_catalog_registry_coverage(typo)
+    msg = str(exc_info.value)
+    assert "catalog_registry_triple_mismatch:" in msg
+    assert "product='k8z'" in msg
+    # Hint resolves to the closest globally — k8s with version 1.x.
+    assert "product='k8s'" in msg
+    assert "version='1.x'" in msg
+
+
+# ---------------------------------------------------------------------------
 # (c) spec_info_version is PEP 440
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Extend `validate_catalog_registry_coverage` to assert each catalog row's `(product, version, impl_id)` triple is a key in the v2 connector registry (G3.11-T10 #1253). Closes the gap that let T8 #1242's catalog-`v3`-vs-registry-`3` drift ship — the class-presence-only check passed because `GitHubRestConnector` was registered, just under a different version key.
- T11-compliant envelope: `catalog_registry_triple_mismatch:` code prefix, message names the offending catalog triple, the closest registered triple for the same product (with global fallback when the product slug itself is typo'd), the source-of-truth files to reconcile, and the convention doc.
- Validator now also runs at chassis startup after `_eager_import_connectors` + `load_catalog`, so a triple drift fails-fast at boot instead of surfacing as `no_connector` on the first dispatch.
- New session-scoped `_force_import_connector_modules` conftest fixture mirrors the existing `_force_import_mcp_modules` pattern (#585) — guarantees connector registrations land before the per-test `_isolate_global_registries` snapshot, so lifespan-driving tests see a populated registry and the new boot-time validator passes under pytest-xdist.

## Self-test against the shipped catalog
Verified that the extended validator passes for ALL 8 currently-shipped catalog rows against the live registry:

```
vmware/9.0/vmware-rest         sddc-manager/9.0/sddc-rest    harbor/2.x/harbor-rest
nsx/4.2/nsx-rest               gh/3/gh-rest (post T8 #1242)  vault/1.x/vault
k8s/1.x/k8s                    bind9/9.x/bind9-ssh
```

No drift on any non-gh connector — no pushback to the issue needed.

## Test plan
- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/operations/ingest/catalog.py src/meho_backplane/main.py` — clean
- [x] `pytest tests/test_operations_ingest_catalog.py` — 23 passed (existing 20 + 2 new T10 drift envelope tests + 1 unchanged passing under the extended check)
- [x] `pytest tests/test_mcp_startup_guard.py tests/test_connectors_registry.py` — startup-guard `test_lifespan_boots_when_backplane_url_resolves` boots cleanly under the new validator after the conftest fixture lands; both `test_lifespan_*` tests updated to mock `load_catalog` + `validate_catalog_registry_coverage` for the mocked-registry path
- [x] Live shipped-catalog self-test — validator passes for every existing connector row (above)
- [x] Synthetic drift unit test — `("gh", "v3", "gh-rest")` catalog row + `("gh", "3", "gh-rest")` registry triple raises `CatalogError` with the exact `catalog_registry_triple_mismatch:` envelope shape, names both triples, references `catalog.yaml` + `register_connector_v2` + `error-message-shape.md`
- [x] Global-fallback hint test — typo'd product (`k8z` vs `k8s`) still produces a useful closest-triple hint

## Out of scope
- Auto-fixing catalog↔registry drift at boot (detection only — operators reconcile the source of truth).
- Validator coverage for connectors with no catalog row (some still use exclusively code-side typed-op declaration).
- Mechanizing the T11 envelope assertion across other startup-time errors (stretch goal listed in `docs/codebase/error-message-shape.md`).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1253
