### PR TITLE
feat(cli): G0.12-T2 operation verbs use generated typed client

### DIFF
--- a/cli/internal/cmd/operation/call.go
+++ b/cli/internal/cmd/operation/call.go
@@ -9,9 +9,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -22,6 +24,15 @@ import (
 // cleanest renderer until callers grow a need for per-shape
 // specialisation. Same approach `retrieval.EvalResult` takes for
 // `Thresholds`.
+//
+// Kept hand-written rather than generator-backed because the FastAPI
+// surface types this route's response as `dict[str, Any]` and the
+// oapi-codegen generator therefore emits the response as a
+// `*map[string]interface{}` (see PostCallApiV1OperationsCallPostResponse
+// .JSON200 in client.gen.go) — no typed model worth using. Promoting
+// the FastAPI response to a typed model so the generator picks it up
+// is a separate backend Task explicitly out of scope for G0.12-T2
+// #1260 (Initiative #1118 is consumer-side only).
 type CallResult struct {
 	Status     string          `json:"status"`
 	OpID       string          `json:"op_id"`
@@ -29,19 +40,6 @@ type CallResult struct {
 	Error      *string         `json:"error"`
 	Extras     json.RawMessage `json:"extras,omitempty"`
 	DurationMs float64         `json:"duration_ms"`
-}
-
-// callRequestBody mirrors the backend CallOperationBody Pydantic
-// model. Target uses a map[string]any so the empty case (typed
-// handlers that don't need a target) can serialise as `null` rather
-// than an empty struct; the route layer's resolver short-circuits
-// on the missing-name case (raising 400) for the few ops that do
-// need a target.
-type callRequestBody struct {
-	ConnectorID string         `json:"connector_id"`
-	OpID        string         `json:"op_id"`
-	Target      map[string]any `json:"target"`
-	Params      map[string]any `json:"params,omitempty"`
 }
 
 // newCallCmd returns the `meho operation call` command.
@@ -133,7 +131,11 @@ func runCall(cmd *cobra.Command, opts callOptions) error {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(err.Error()), opts.JSONOut)
 	}
-	result, err := postCall(cmd.Context(), backplaneURL, opts, params)
+	client, err := newAuthedClient(cmd.Context(), backplaneURL)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	result, err := postCall(cmd.Context(), client, opts, params)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
@@ -183,33 +185,53 @@ func runCall(cmd *cobra.Command, opts callOptions) error {
 // errEvalGate.
 var errOpError = errors.New("operation status not ok")
 
+// postCall constructs the typed CallOperationBody, picks the bare-
+// string target shape via FromCallOperationBodyTarget0 when --target
+// is supplied (the canonical write surface per G0.13-T2 #1132; the
+// CLI never needed the dict-shape fqdn override — that's an MCP-
+// handler use case), and issues the POST through the generated
+// *WithResponse helper. The 401-refresh dance mirrors GetHealth on
+// *api.AuthedClient.
 func postCall(
 	ctx context.Context,
-	backplaneURL string,
+	client operationsAPI,
 	opts callOptions,
 	params map[string]any,
 ) (*CallResult, error) {
-	body := callRequestBody{
-		ConnectorID: opts.ConnectorID,
-		OpID:        opts.OpID,
-		Target:      nil,
+	body := api.CallOperationBody{
+		ConnectorId: opts.ConnectorID,
+		OpId:        opts.OpID,
 	}
 	if opts.TargetName != "" {
-		body.Target = map[string]any{"name": opts.TargetName}
+		var target api.CallOperationBody_Target
+		if err := target.FromCallOperationBodyTarget0(opts.TargetName); err != nil {
+			return nil, fmt.Errorf("encode target: %w", err)
+		}
+		body.Target = &target
 	}
 	if params != nil {
-		body.Params = params
+		p := params
+		body.Params = &p
 	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal call request: %w", err)
-	}
-	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
+	apiParams := &api.PostCallApiV1OperationsCallPostParams{}
+	resp, err := client.PostCallApiV1OperationsCallPostWithResponse(ctx, apiParams, body)
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode() == http.StatusUnauthorized {
+		if rerr := client.Refresh(ctx); rerr != nil {
+			return nil, rerr
+		}
+		resp, err = client.PostCallApiV1OperationsCallPostWithResponse(ctx, apiParams, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, classifyNon2xx(resp.HTTPResponse, resp.Body)
+	}
 	var out CallResult
-	if err := json.Unmarshal(respBody, &out); err != nil {
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		return nil, fmt.Errorf("decode call response: %w", err)
 	}
 	return &out, nil

--- a/cli/internal/cmd/operation/client_test.go
+++ b/cli/internal/cmd/operation/client_test.go
@@ -1,0 +1,491 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package operation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/api"
+)
+
+// fakeOperationsClient is a per-package test double satisfying the
+// operationsAPI interface. Each verb's WithResponse method records
+// the typed params struct it was called with and returns a canned
+// *Response; the per-test setup wires the canned response (status,
+// body, refresh-counter, error) for the scenario under exercise.
+//
+// Compared to mocking the full generated ClientWithResponsesInterface
+// (~140 methods), the per-package interface keeps this fake tiny:
+// three call recorders + one refresh counter + per-call canned
+// responses. New G0.12 hygiene Tasks (#1261, #1262, …) get their
+// own per-package interface + fake the same shape.
+type fakeOperationsClient struct {
+	// Recorded params from the most recent call to each verb. Tests
+	// inspect these to verify that typed params are passed (not
+	// raw-string URL concatenation).
+	lastCallParams   *api.PostCallApiV1OperationsCallPostParams
+	lastCallBody     *api.CallOperationBody
+	lastGroupsParams *api.GetGroupsApiV1OperationsGroupsGetParams
+	lastSearchParams *api.GetSearchApiV1OperationsSearchGetParams
+
+	// Sequenced canned responses — pop one per call (per verb). Tests
+	// register two responses on the auth-refresh scenarios (first a
+	// 401, then the post-refresh outcome) and one on every other
+	// path.
+	callResponses   []*api.PostCallApiV1OperationsCallPostResponse
+	groupsResponses []*api.GetGroupsApiV1OperationsGroupsGetResponse
+	searchResponses []*api.GetSearchApiV1OperationsSearchGetResponse
+
+	// Per-verb transport-error queues. Drain in the same order as
+	// the response queues so a refresh-then-transport-failure scenario
+	// can be authored.
+	callErrors   []error
+	groupsErrors []error
+	searchErrors []error
+
+	// refreshCount tracks how many times Refresh was invoked across
+	// the whole client's lifetime. The 401 dance asserts this hits
+	// exactly 1.
+	refreshCount int
+	// refreshErr is returned from Refresh; tests that want to model
+	// a no-refresh-token / IdP-rejected refresh set this.
+	refreshErr error
+}
+
+func (f *fakeOperationsClient) PostCallApiV1OperationsCallPostWithResponse(
+	_ context.Context,
+	params *api.PostCallApiV1OperationsCallPostParams,
+	body api.PostCallApiV1OperationsCallPostJSONRequestBody,
+	_ ...api.RequestEditorFn,
+) (*api.PostCallApiV1OperationsCallPostResponse, error) {
+	f.lastCallParams = params
+	bodyCopy := body
+	f.lastCallBody = &bodyCopy
+	return popCallResp(&f.callResponses), popErr(&f.callErrors)
+}
+
+func (f *fakeOperationsClient) GetGroupsApiV1OperationsGroupsGetWithResponse(
+	_ context.Context,
+	params *api.GetGroupsApiV1OperationsGroupsGetParams,
+	_ ...api.RequestEditorFn,
+) (*api.GetGroupsApiV1OperationsGroupsGetResponse, error) {
+	f.lastGroupsParams = params
+	return popGroupsResp(&f.groupsResponses), popErr(&f.groupsErrors)
+}
+
+func (f *fakeOperationsClient) GetSearchApiV1OperationsSearchGetWithResponse(
+	_ context.Context,
+	params *api.GetSearchApiV1OperationsSearchGetParams,
+	_ ...api.RequestEditorFn,
+) (*api.GetSearchApiV1OperationsSearchGetResponse, error) {
+	f.lastSearchParams = params
+	return popSearchResp(&f.searchResponses), popErr(&f.searchErrors)
+}
+
+func (f *fakeOperationsClient) Refresh(_ context.Context) error {
+	f.refreshCount++
+	return f.refreshErr
+}
+
+func popCallResp(q *[]*api.PostCallApiV1OperationsCallPostResponse) *api.PostCallApiV1OperationsCallPostResponse {
+	if len(*q) == 0 {
+		return nil
+	}
+	r := (*q)[0]
+	*q = (*q)[1:]
+	return r
+}
+
+func popGroupsResp(q *[]*api.GetGroupsApiV1OperationsGroupsGetResponse) *api.GetGroupsApiV1OperationsGroupsGetResponse {
+	if len(*q) == 0 {
+		return nil
+	}
+	r := (*q)[0]
+	*q = (*q)[1:]
+	return r
+}
+
+func popSearchResp(q *[]*api.GetSearchApiV1OperationsSearchGetResponse) *api.GetSearchApiV1OperationsSearchGetResponse {
+	if len(*q) == 0 {
+		return nil
+	}
+	r := (*q)[0]
+	*q = (*q)[1:]
+	return r
+}
+
+func popErr(q *[]error) error {
+	if len(*q) == 0 {
+		return nil
+	}
+	e := (*q)[0]
+	*q = (*q)[1:]
+	return e
+}
+
+func makeHTTPResp(status int) *http.Response {
+	return &http.Response{StatusCode: status}
+}
+
+// ---- getGroups ----
+
+// TestGetGroupsPassesTypedConnectorIdParam — happy path asserts the
+// typed ConnectorId field is populated (no raw `?connector_id=`
+// URL-concat anywhere).
+func TestGetGroupsPassesTypedConnectorIdParam(t *testing.T) {
+	body, _ := json.Marshal(GroupsResponse{
+		ConnectorID: "vault-1.x",
+		Groups:      []GroupSummary{{GroupKey: "kv", Name: "KV", WhenToUse: "secrets", OperationCount: 3}},
+	})
+	f := &fakeOperationsClient{
+		groupsResponses: []*api.GetGroupsApiV1OperationsGroupsGetResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: body},
+		},
+	}
+	got, err := getGroups(context.Background(), f, "vault-1.x")
+	if err != nil {
+		t.Fatalf("getGroups: %v", err)
+	}
+	if f.lastGroupsParams == nil || f.lastGroupsParams.ConnectorId != "vault-1.x" {
+		t.Fatalf("getGroups should pass typed ConnectorId=%q; got %+v",
+			"vault-1.x", f.lastGroupsParams)
+	}
+	if got.ConnectorID != "vault-1.x" || len(got.Groups) != 1 || got.Groups[0].GroupKey != "kv" {
+		t.Fatalf("getGroups returned wrong shape: %+v", got)
+	}
+}
+
+// TestGetGroupsRefreshesOn401AndRetries — the per-verb 401 dance
+// mirrors api.AuthedClient.GetHealth: first call returns 401, Refresh
+// runs once, second call returns 200.
+func TestGetGroupsRefreshesOn401AndRetries(t *testing.T) {
+	body, _ := json.Marshal(GroupsResponse{ConnectorID: "vault-1.x"})
+	f := &fakeOperationsClient{
+		groupsResponses: []*api.GetGroupsApiV1OperationsGroupsGetResponse{
+			{HTTPResponse: makeHTTPResp(401), Body: []byte(`{"detail":"token expired"}`)},
+			{HTTPResponse: makeHTTPResp(200), Body: body},
+		},
+	}
+	if _, err := getGroups(context.Background(), f, "vault-1.x"); err != nil {
+		t.Fatalf("getGroups after refresh: %v", err)
+	}
+	if f.refreshCount != 1 {
+		t.Fatalf("expected exactly one Refresh; got %d", f.refreshCount)
+	}
+}
+
+// TestGetGroupsClassifies403AsApiResponseError — non-401 4xx wraps
+// as *apiResponseError; renderRequestError later maps it to
+// unexpected_response.
+func TestGetGroupsClassifies403AsApiResponseError(t *testing.T) {
+	f := &fakeOperationsClient{
+		groupsResponses: []*api.GetGroupsApiV1OperationsGroupsGetResponse{
+			{HTTPResponse: makeHTTPResp(403), Body: []byte(`{"detail":"forbidden"}`)},
+		},
+	}
+	_, err := getGroups(context.Background(), f, "vault-1.x")
+	if err == nil {
+		t.Fatalf("expected non-2xx error; got nil")
+	}
+	var apiErr *apiResponseError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != 403 {
+		t.Fatalf("expected *apiResponseError{StatusCode:403}; got %+v", err)
+	}
+	if apiErr.Body != `{"detail":"forbidden"}` {
+		t.Fatalf("apiResponseError.Body should preserve the response body; got %q", apiErr.Body)
+	}
+}
+
+// TestGetGroupsTransportErrorPropagates — pure transport failure
+// (DNS / connection-refused etc.) returns directly so
+// renderRequestError can classify as unreachable.
+func TestGetGroupsTransportErrorPropagates(t *testing.T) {
+	transportErr := errors.New("dial tcp: lookup meho.test on 8.8.8.8: no such host")
+	f := &fakeOperationsClient{
+		groupsErrors: []error{transportErr},
+	}
+	_, err := getGroups(context.Background(), f, "vault-1.x")
+	if !errors.Is(err, transportErr) {
+		t.Fatalf("expected transport error to propagate verbatim; got %v", err)
+	}
+	var apiErr *apiResponseError
+	if errors.As(err, &apiErr) {
+		t.Fatalf("transport error should not wrap as *apiResponseError")
+	}
+}
+
+// ---- getSearch ----
+
+// TestGetSearchPassesTypedParams — all four params (ConnectorId,
+// Query, Group, Limit) land on the typed struct; Group + Limit are
+// pointer-typed so the test asserts they're set (not nil).
+func TestGetSearchPassesTypedParams(t *testing.T) {
+	body, _ := json.Marshal(SearchResponse{
+		Hits:            []SearchHit{{OpID: "vault.kv.read", FusedScore: 0.9}},
+		QueryDurationMs: 12.0,
+	})
+	f := &fakeOperationsClient{
+		searchResponses: []*api.GetSearchApiV1OperationsSearchGetResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: body},
+		},
+	}
+	opts := searchOptions{
+		ConnectorID: "vault-1.x",
+		Query:       "secret",
+		GroupKey:    "kv",
+		Limit:       7,
+	}
+	if _, err := getSearch(context.Background(), f, opts); err != nil {
+		t.Fatalf("getSearch: %v", err)
+	}
+	p := f.lastSearchParams
+	if p == nil || p.ConnectorId != "vault-1.x" || p.Query != "secret" {
+		t.Fatalf("getSearch should pass typed ConnectorId+Query; got %+v", p)
+	}
+	if p.Group == nil || *p.Group != "kv" {
+		t.Fatalf("getSearch should pass typed Group=%q; got %+v", "kv", p.Group)
+	}
+	if p.Limit == nil || *p.Limit != 7 {
+		t.Fatalf("getSearch should pass typed Limit=%d; got %+v", 7, p.Limit)
+	}
+}
+
+// TestGetSearchOmitsOptionalParamsWhenEmpty — Group + Limit are
+// nil-pointer when the operator didn't supply them, so the generator's
+// omitempty form keeps them out of the URL.
+func TestGetSearchOmitsOptionalParamsWhenEmpty(t *testing.T) {
+	body, _ := json.Marshal(SearchResponse{Hits: nil, QueryDurationMs: 0})
+	f := &fakeOperationsClient{
+		searchResponses: []*api.GetSearchApiV1OperationsSearchGetResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: body},
+		},
+	}
+	opts := searchOptions{
+		ConnectorID: "vault-1.x",
+		Query:       "secret",
+		GroupKey:    "", // omitted
+		Limit:       0,  // omitted
+	}
+	if _, err := getSearch(context.Background(), f, opts); err != nil {
+		t.Fatalf("getSearch: %v", err)
+	}
+	p := f.lastSearchParams
+	if p == nil {
+		t.Fatalf("getSearch should populate params struct")
+	}
+	if p.Group != nil {
+		t.Fatalf("empty --group should leave Group=nil; got %v", *p.Group)
+	}
+	if p.Limit != nil {
+		t.Fatalf("zero --limit should leave Limit=nil; got %v", *p.Limit)
+	}
+}
+
+// ---- postCall ----
+
+// TestPostCallTargetBareString — --target <slug> uses the bare-string
+// shape (FromCallOperationBodyTarget0), not the dict shape. Verifies
+// the union marshals as `"slug"`, not `{"name":"slug"}`.
+func TestPostCallTargetBareString(t *testing.T) {
+	cr, _ := json.Marshal(CallResult{
+		Status: "ok", OpID: "vault.kv.read",
+		Result:     json.RawMessage(`{"value":"secret"}`),
+		DurationMs: 23,
+	})
+	f := &fakeOperationsClient{
+		callResponses: []*api.PostCallApiV1OperationsCallPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: cr},
+		},
+	}
+	opts := callOptions{
+		ConnectorID: "vault-1.x",
+		OpID:        "vault.kv.read",
+		TargetName:  "rdc-vault",
+	}
+	if _, err := postCall(context.Background(), f, opts, nil); err != nil {
+		t.Fatalf("postCall: %v", err)
+	}
+	b := f.lastCallBody
+	if b == nil {
+		t.Fatalf("postCall should populate body")
+	}
+	if b.ConnectorId != "vault-1.x" || b.OpId != "vault.kv.read" {
+		t.Fatalf("body should carry typed connector_id + op_id; got %+v", b)
+	}
+	if b.Target == nil {
+		t.Fatalf("body.Target should be non-nil when --target is set")
+	}
+	// Round-trip the union via its MarshalJSON to verify the bare-string
+	// shape — the union's internal json.RawMessage is set by
+	// FromCallOperationBodyTarget0 so MarshalJSON should emit `"rdc-vault"`.
+	raw, err := b.Target.MarshalJSON()
+	if err != nil {
+		t.Fatalf("target.MarshalJSON: %v", err)
+	}
+	want := `"rdc-vault"`
+	if string(raw) != want {
+		t.Fatalf("--target should marshal as bare string %q; got %q", want, string(raw))
+	}
+	// AsCallOperationBodyTarget0 should round-trip the same value.
+	bare, err := b.Target.AsCallOperationBodyTarget0()
+	if err != nil {
+		t.Fatalf("AsCallOperationBodyTarget0: %v", err)
+	}
+	if bare != "rdc-vault" {
+		t.Fatalf("round-tripped bare-string target: got %q; want %q", bare, "rdc-vault")
+	}
+}
+
+// TestPostCallTargetNilWhenOmitted — --target omitted leaves the
+// generated body's Target pointer nil, so the JSON serialiser emits
+// `"target": null` (the generator's CallOperationBody.Target carries
+// a `json:"target"` tag without omitempty; the route accepts null).
+func TestPostCallTargetNilWhenOmitted(t *testing.T) {
+	cr, _ := json.Marshal(CallResult{Status: "ok", OpID: "k8s.about", DurationMs: 1})
+	f := &fakeOperationsClient{
+		callResponses: []*api.PostCallApiV1OperationsCallPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: cr},
+		},
+	}
+	opts := callOptions{
+		ConnectorID: "k8s-1.x",
+		OpID:        "k8s.about",
+		TargetName:  "",
+	}
+	if _, err := postCall(context.Background(), f, opts, nil); err != nil {
+		t.Fatalf("postCall: %v", err)
+	}
+	if f.lastCallBody.Target != nil {
+		t.Fatalf("--target omitted should leave body.Target=nil; got %+v", f.lastCallBody.Target)
+	}
+	// Marshal the whole body and verify "target":null is on the wire.
+	raw, err := json.Marshal(f.lastCallBody)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	if !bytes.Contains(raw, []byte(`"target":null`)) {
+		t.Fatalf("expected `\"target\":null` on the wire; got %s", string(raw))
+	}
+}
+
+// TestPostCallParamsSetWhenSupplied — non-nil params land on the
+// body.Params pointer; nil params leave it nil so the wire omits
+// the key (the generator's CallOperationBody.Params carries
+// `json:"params,omitempty"`).
+func TestPostCallParamsSetWhenSupplied(t *testing.T) {
+	cr, _ := json.Marshal(CallResult{Status: "ok", OpID: "vault.kv.read", DurationMs: 1})
+	f := &fakeOperationsClient{
+		callResponses: []*api.PostCallApiV1OperationsCallPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: cr},
+		},
+	}
+	opts := callOptions{
+		ConnectorID: "vault-1.x",
+		OpID:        "vault.kv.read",
+		TargetName:  "rdc-vault",
+	}
+	params := map[string]any{"path": "secret/foo"}
+	if _, err := postCall(context.Background(), f, opts, params); err != nil {
+		t.Fatalf("postCall: %v", err)
+	}
+	if f.lastCallBody.Params == nil {
+		t.Fatalf("params should be set on body.Params; got nil")
+	}
+	got := *f.lastCallBody.Params
+	if got["path"] != "secret/foo" {
+		t.Fatalf("params not threaded through; got %v", got)
+	}
+}
+
+// TestPostCallParamsNilWhenOmitted — empty --params leaves the
+// body.Params pointer nil so the wire omits the key entirely.
+func TestPostCallParamsNilWhenOmitted(t *testing.T) {
+	cr, _ := json.Marshal(CallResult{Status: "ok", OpID: "k8s.about", DurationMs: 1})
+	f := &fakeOperationsClient{
+		callResponses: []*api.PostCallApiV1OperationsCallPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: cr},
+		},
+	}
+	opts := callOptions{
+		ConnectorID: "k8s-1.x",
+		OpID:        "k8s.about",
+	}
+	if _, err := postCall(context.Background(), f, opts, nil); err != nil {
+		t.Fatalf("postCall: %v", err)
+	}
+	if f.lastCallBody.Params != nil {
+		t.Fatalf("nil params should leave body.Params=nil; got %+v", f.lastCallBody.Params)
+	}
+	raw, err := json.Marshal(f.lastCallBody)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	if bytes.Contains(raw, []byte(`"params"`)) {
+		t.Fatalf("omitted params should not appear on the wire; got %s", string(raw))
+	}
+}
+
+// TestPostCallRefreshOn401 — same one-shot refresh dance as
+// TestGetGroupsRefreshesOn401AndRetries, exercised through postCall.
+func TestPostCallRefreshOn401(t *testing.T) {
+	cr, _ := json.Marshal(CallResult{Status: "ok", OpID: "vault.kv.read", DurationMs: 1})
+	f := &fakeOperationsClient{
+		callResponses: []*api.PostCallApiV1OperationsCallPostResponse{
+			{HTTPResponse: makeHTTPResp(401), Body: []byte(`{"detail":"token expired"}`)},
+			{HTTPResponse: makeHTTPResp(200), Body: cr},
+		},
+	}
+	opts := callOptions{ConnectorID: "vault-1.x", OpID: "vault.kv.read", TargetName: "rdc-vault"}
+	if _, err := postCall(context.Background(), f, opts, nil); err != nil {
+		t.Fatalf("postCall after refresh: %v", err)
+	}
+	if f.refreshCount != 1 {
+		t.Fatalf("expected exactly one Refresh; got %d", f.refreshCount)
+	}
+}
+
+// TestPostCallRefreshFailurePropagates — Refresh returning a
+// no-refresh-token error propagates so the verb's renderer can map
+// it to auth_expired.
+func TestPostCallRefreshFailurePropagates(t *testing.T) {
+	refreshErr := errors.New("meho: stored token has no refresh_token")
+	f := &fakeOperationsClient{
+		callResponses: []*api.PostCallApiV1OperationsCallPostResponse{
+			{HTTPResponse: makeHTTPResp(401), Body: []byte(`{"detail":"token expired"}`)},
+		},
+		refreshErr: refreshErr,
+	}
+	opts := callOptions{ConnectorID: "vault-1.x", OpID: "vault.kv.read"}
+	_, err := postCall(context.Background(), f, opts, nil)
+	if !errors.Is(err, refreshErr) {
+		t.Fatalf("expected refreshErr to propagate; got %v", err)
+	}
+}
+
+// TestPostCallNon2xxAfterRefreshClassifiesAsApiResponseError —
+// 401 → Refresh succeeds → second call returns 500 → wrapped as
+// *apiResponseError so renderRequestError maps to
+// unexpected_response.
+func TestPostCallNon2xxAfterRefreshClassifiesAsApiResponseError(t *testing.T) {
+	f := &fakeOperationsClient{
+		callResponses: []*api.PostCallApiV1OperationsCallPostResponse{
+			{HTTPResponse: makeHTTPResp(401), Body: []byte(`{"detail":"token expired"}`)},
+			{HTTPResponse: makeHTTPResp(500), Body: []byte(`{"detail":"backplane unavailable"}`)},
+		},
+	}
+	opts := callOptions{ConnectorID: "vault-1.x", OpID: "vault.kv.read"}
+	_, err := postCall(context.Background(), f, opts, nil)
+	if err == nil {
+		t.Fatalf("expected error; got nil")
+	}
+	var apiErr *apiResponseError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != 500 {
+		t.Fatalf("expected *apiResponseError{StatusCode:500}; got %+v", err)
+	}
+}

--- a/cli/internal/cmd/operation/groups.go
+++ b/cli/internal/cmd/operation/groups.go
@@ -8,20 +8,24 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
 // GroupSummary mirrors the backend OperationGroupSummary Pydantic
 // model. Kept hand-written (rather than oapi-codegen-generated)
-// because the openapi spec types these routes' responses as
-// dict[str, Any] — the typed shape is locked by the backend test
-// suite, and a minor drift on either side surfaces on the matching
-// CI gate.
+// because the FastAPI surface types this route's response as
+// `dict[str, Any]` — the generator therefore emits no
+// `OperationGroupSummary` model worth using, and the typed shape is
+// locked by the backend test suite. Promoting the response to a
+// typed FastAPI return so the generator picks it up is a separate
+// backend Task explicitly out of scope for G0.12-T2 #1260 (the CLI
+// hygiene Initiative #1118 is consumer-side only).
 type GroupSummary struct {
 	GroupKey       string `json:"group_key"`
 	Name           string `json:"name"`
@@ -30,7 +34,8 @@ type GroupSummary struct {
 }
 
 // GroupsResponse is the JSON envelope returned by
-// GET /api/v1/operations/groups.
+// GET /api/v1/operations/groups. Hand-typed for the same reason as
+// GroupSummary above.
 type GroupsResponse struct {
 	ConnectorID string         `json:"connector_id"`
 	Groups      []GroupSummary `json:"groups"`
@@ -82,7 +87,11 @@ func runGroups(cmd *cobra.Command, connectorID string, jsonOut bool, backplaneOv
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
-	result, err := getGroups(cmd.Context(), backplaneURL, connectorID)
+	client, err := newAuthedClient(cmd.Context(), backplaneURL)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	result, err := getGroups(cmd.Context(), client, connectorID)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
@@ -93,16 +102,33 @@ func runGroups(cmd *cobra.Command, connectorID string, jsonOut bool, backplaneOv
 	return nil
 }
 
-func getGroups(ctx context.Context, backplaneURL, connectorID string) (*GroupsResponse, error) {
-	q := url.Values{}
-	q.Set("connector_id", connectorID)
-	path := "/api/v1/operations/groups?" + q.Encode()
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
+// getGroups issues the typed GET via the generated client, runs the
+// one-shot 401-refresh dance via the AuthedClient's Refresh hook
+// (mirroring api.AuthedClient.GetHealth), and unmarshals the 200
+// body into the hand-typed GroupsResponse. Non-2xx outcomes wrap as
+// *apiResponseError for renderRequestError to classify.
+func getGroups(ctx context.Context, client operationsAPI, connectorID string) (*GroupsResponse, error) {
+	params := &api.GetGroupsApiV1OperationsGroupsGetParams{
+		ConnectorId: connectorID,
+	}
+	resp, err := client.GetGroupsApiV1OperationsGroupsGetWithResponse(ctx, params)
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode() == http.StatusUnauthorized {
+		if rerr := client.Refresh(ctx); rerr != nil {
+			return nil, rerr
+		}
+		resp, err = client.GetGroupsApiV1OperationsGroupsGetWithResponse(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, classifyNon2xx(resp.HTTPResponse, resp.Body)
+	}
 	var out GroupsResponse
-	if err := json.Unmarshal(raw, &out); err != nil {
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		return nil, fmt.Errorf("decode groups response: %w", err)
 	}
 	return &out, nil

--- a/cli/internal/cmd/operation/operation.go
+++ b/cli/internal/cmd/operation/operation.go
@@ -16,8 +16,9 @@
 // Each verb wraps one backplane route and renders the response in
 // either a human-readable table or `--json` mode. Authentication
 // piggybacks on the token meho login wrote — api.NewAuthedClient
-// handles the bearer injection + 401 refresh dance, same as
-// `meho retrieval eval` and `meho status`.
+// handles the bearer injection + 401 refresh dance via the generated
+// typed client, same as `meho status` and the rest of the G0.12 CLI
+// hygiene migration (Initiative #1118).
 //
 // The fourth route `GET /api/v1/operations/{descriptor_id}` (tenant-
 // admin diagnostic) is deferred — the DoD line for G0.6-T13 #481 was
@@ -25,12 +26,10 @@
 package operation
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -58,11 +57,62 @@ func NewRootCmd() *cobra.Command {
 	return cmd
 }
 
+// operationsAPI is the minimal slice of api.ClientWithResponsesInterface
+// the three operation verbs consume, plus the Refresh hook the
+// per-verb 401-retry path invokes. Defined as a per-package interface
+// so the test suite can substitute a tiny fake without reaching for
+// the full ~140-method generated surface. *api.AuthedClient satisfies
+// this directly: it embeds *ClientWithResponses (which provides the
+// three *WithResponse calls) and defines Refresh of its own.
+type operationsAPI interface {
+	PostCallApiV1OperationsCallPostWithResponse(
+		ctx context.Context,
+		params *api.PostCallApiV1OperationsCallPostParams,
+		body api.PostCallApiV1OperationsCallPostJSONRequestBody,
+		reqEditors ...api.RequestEditorFn,
+	) (*api.PostCallApiV1OperationsCallPostResponse, error)
+	GetGroupsApiV1OperationsGroupsGetWithResponse(
+		ctx context.Context,
+		params *api.GetGroupsApiV1OperationsGroupsGetParams,
+		reqEditors ...api.RequestEditorFn,
+	) (*api.GetGroupsApiV1OperationsGroupsGetResponse, error)
+	GetSearchApiV1OperationsSearchGetWithResponse(
+		ctx context.Context,
+		params *api.GetSearchApiV1OperationsSearchGetParams,
+		reqEditors ...api.RequestEditorFn,
+	) (*api.GetSearchApiV1OperationsSearchGetResponse, error)
+	Refresh(ctx context.Context) error
+}
+
+// newAuthedClient is the production-mode factory the verbs default to
+// — overridden in tests via newAuthedClientForTest. Returning the
+// operationsAPI interface (not *api.AuthedClient) keeps the call
+// sites typed against the per-package seam, not the generated client.
+var newAuthedClient = func(ctx context.Context, backplaneURL string) (operationsAPI, error) {
+	return api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+}
+
+// apiResponseError carries a non-2xx response so renderRequestError
+// can pick the right output category (401 → auth_expired, other
+// non-2xx → unexpected_response). Constructed from the generated
+// *Response.HTTPResponse.StatusCode + Body fields after the per-verb
+// 401-retry path has exhausted its refresh shot.
+type apiResponseError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *apiResponseError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
 // renderRequestError translates an error from one of the per-verb
-// request helpers into the right output.RenderError category.
-// Same classification ladder as retrieval/eval.go: token-not-found
-// and no-refresh-token surface as auth_expired with `meho login`
-// hints; everything else is unreachable.
+// request helpers into the right output.RenderError category. Same
+// classification ladder as retrieval/eval.go: token-not-found and
+// no-refresh-token surface as auth_expired with `meho login` hints;
+// a non-2xx response from the backplane after auth refresh wraps as
+// *apiResponseError so the renderer can split 401 from the rest;
+// everything else (transport / DNS / TLS) falls through to unreachable.
 func renderRequestError(
 	cmd *cobra.Command,
 	backplaneURL string,
@@ -87,18 +137,31 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	// HTTP-level errors from the backplane (4xx/5xx with a body) come
-	// back wrapped in *httpError. Those are structured responses, not
-	// transport failures — classify as unexpected_response (exit 4) so
-	// the operator sees the right "this is a backend disagreement" hint
-	// rather than the "your network is down" one. Pure transport errors
-	// (timeouts, DNS, connection refused) still fall through to
-	// unreachable (exit 3).
-	var he *httpError
-	if errors.As(err, &he) {
+	// HTTP-level errors from the backplane (a non-2xx response with a
+	// body) come back wrapped in *apiResponseError. 401 here means the
+	// one-shot refresh either was not attempted (Refresh failure was
+	// already surfaced upstream) or returned a fresh token that the
+	// backplane still rejected — either way the operator needs to
+	// re-login, so surface as auth_expired (exit 2). Every other non-2xx
+	// is a structured backplane disagreement, not a transport failure
+	// — classify as unexpected_response (exit 4) so the operator sees
+	// the "this is a backend disagreement" hint rather than the "your
+	// network is down" one. Pure transport errors (timeouts, DNS,
+	// connection refused) still fall through to unreachable (exit 3).
+	var apiErr *apiResponseError
+	if errors.As(err, &apiErr) {
+		if apiErr.StatusCode == http.StatusUnauthorized {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.AuthExpired(fmt.Sprintf(
+					"backplane rejected the refreshed token; run `meho login %s`",
+					backplaneURL,
+				)),
+				jsonOut,
+			)
+		}
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, apiErr.StatusCode, apiErr.Body)),
 			jsonOut,
 		)
 	}
@@ -108,110 +171,22 @@ func renderRequestError(
 	)
 }
 
-// doAuthedRequest issues a single HTTP request against the backplane
-// with bearer injection + one-shot 401-refresh-retry. Returns the
-// response body bytes (already drained) on a 2xx outcome, or an
-// error categorised by api.IsTokenNotFound / api.IsNoRefreshToken /
-// generic transport so renderRequestError can pick the right
-// StructuredError category.
-//
-// Centralised here (rather than duplicated per verb) because all
-// three operation verbs share the same auth + refresh pattern. The
-// retrieval/eval.go sibling inlines an equivalent helper as
-// postEval; this package factors it out so the three verbs stay
-// small.
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
+// classifyNon2xx wraps the generated *Response fields into the local
+// apiResponseError sentinel renderRequestError extracts via
+// errors.As. Pulled out so the three verbs share one body-truncation
+// pass — the backplane error responses are JSON envelopes well under
+// the 1 MiB ceiling, but the cap matches the previous pre-migration
+// transport's response read.
+func classifyNon2xx(resp *http.Response, body []byte) *apiResponseError {
+	const cap = 1 << 20 // 1 MiB
+	b := body
+	if len(b) > cap {
+		b = b[:cap]
 	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
+	return &apiResponseError{
+		StatusCode: resp.StatusCode,
+		Body:       strings.TrimSpace(string(b)),
 	}
-
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		// One-shot refresh + retry, mirroring api.AuthedClient.GetHealth
-		// and retrieval.postEval.
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MiB cap
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-// httpError carries a non-2xx response so per-verb runners can
-// render the right category (4xx → unexpected with body, 5xx →
-// unreachable, etc.). Not an output.StructuredError directly — the
-// renderer decides exit-code class based on status.
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-// sendRequest is the bottom of the stack: build the http.Request,
-// stamp bearer + content headers, fire it. Split out so the
-// 401-refresh-retry path in doAuthedRequest can reuse the same
-// body bytes without re-marshalling.
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = newBodyReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
-}
-
-// newBodyReader wraps a fresh io.Reader around the request body
-// bytes for each attempt (the 401-retry path needs a fresh reader,
-// can't rewind the previous one). bytes.NewReader matches the
-// retrieval/eval.go sibling's choice and avoids the string<->bytes
-// round-trip strings.NewReader would impose.
-func newBodyReader(body []byte) io.Reader {
-	return bytes.NewReader(body)
 }
 
 // loadParamsFlag parses the --params flag value. Prefixing with '@'

--- a/cli/internal/cmd/operation/operation.go
+++ b/cli/internal/cmd/operation/operation.go
@@ -175,13 +175,15 @@ func renderRequestError(
 // apiResponseError sentinel renderRequestError extracts via
 // errors.As. Pulled out so the three verbs share one body-truncation
 // pass — the backplane error responses are JSON envelopes well under
-// the 1 MiB ceiling, but the cap matches the previous pre-migration
-// transport's response read.
+// the 1 MiB ceiling, but maxBodyBytes matches the previous
+// pre-migration transport's response read. Name is deliberately not
+// `cap` because the revive `redefines-builtin-id` rule (enabled in
+// cli/.golangci.yml) treats shadowing the `cap` builtin as a lint error.
 func classifyNon2xx(resp *http.Response, body []byte) *apiResponseError {
-	const cap = 1 << 20 // 1 MiB
+	const maxBodyBytes = 1 << 20 // 1 MiB
 	b := body
-	if len(b) > cap {
-		b = b[:cap]
+	if len(b) > maxBodyBytes {
+		b = b[:maxBodyBytes]
 	}
 	return &apiResponseError{
 		StatusCode: resp.StatusCode,

--- a/cli/internal/cmd/operation/search.go
+++ b/cli/internal/cmd/operation/search.go
@@ -8,11 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
-	"strconv"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -22,6 +22,13 @@ import (
 // nullable per the backend's frozen pydantic model — pointer-typed
 // here so the JSON unmarshal preserves the null vs. zero-value
 // distinction.
+//
+// Kept hand-written for the same reason as GroupSummary (see
+// groups.go): the FastAPI route types its response as
+// `dict[str, Any]`, so the oapi-codegen generator emits no
+// `OperationSearchHit` model worth using. Promoting the FastAPI
+// response to a typed model so the generator picks it up is a
+// separate backend Task explicitly out of scope for G0.12-T2 #1260.
 type SearchHit struct {
 	OpID             string   `json:"op_id"`
 	Summary          *string  `json:"summary"`
@@ -35,7 +42,8 @@ type SearchHit struct {
 }
 
 // SearchResponse is the JSON envelope returned by
-// GET /api/v1/operations/search.
+// GET /api/v1/operations/search. Hand-typed for the same reason as
+// SearchHit above.
 type SearchResponse struct {
 	Hits            []SearchHit `json:"hits"`
 	QueryDurationMs float64     `json:"query_duration_ms"`
@@ -119,7 +127,11 @@ func runSearch(cmd *cobra.Command, opts searchOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	result, err := getSearch(cmd.Context(), backplaneURL, opts)
+	client, err := newAuthedClient(cmd.Context(), backplaneURL)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	result, err := getSearch(cmd.Context(), client, opts)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
@@ -130,23 +142,43 @@ func runSearch(cmd *cobra.Command, opts searchOptions) error {
 	return nil
 }
 
-func getSearch(ctx context.Context, backplaneURL string, opts searchOptions) (*SearchResponse, error) {
-	q := url.Values{}
-	q.Set("connector_id", opts.ConnectorID)
-	q.Set("query", opts.Query)
+// getSearch issues the typed GET via the generated client. The
+// generated GetSearchApiV1OperationsSearchGetParams carries typed
+// pointer fields for the optional query params (Group, Limit) — the
+// generator emits them as *string / *int so a nil value omits the
+// param from the URL. ConnectorId and Query are required and stay
+// plain string.
+func getSearch(ctx context.Context, client operationsAPI, opts searchOptions) (*SearchResponse, error) {
+	params := &api.GetSearchApiV1OperationsSearchGetParams{
+		ConnectorId: opts.ConnectorID,
+		Query:       opts.Query,
+	}
 	if opts.GroupKey != "" {
-		q.Set("group", opts.GroupKey)
+		gk := opts.GroupKey
+		params.Group = &gk
 	}
 	if opts.Limit > 0 {
-		q.Set("limit", strconv.Itoa(opts.Limit))
+		l := opts.Limit
+		params.Limit = &l
 	}
-	path := "/api/v1/operations/search?" + q.Encode()
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
+	resp, err := client.GetSearchApiV1OperationsSearchGetWithResponse(ctx, params)
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode() == http.StatusUnauthorized {
+		if rerr := client.Refresh(ctx); rerr != nil {
+			return nil, rerr
+		}
+		resp, err = client.GetSearchApiV1OperationsSearchGetWithResponse(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, classifyNon2xx(resp.HTTPResponse, resp.Body)
+	}
 	var out SearchResponse
-	if err := json.Unmarshal(raw, &out); err != nil {
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		return nil, fmt.Errorf("decode search response: %w", err)
 	}
 	return &out, nil

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -176,11 +176,12 @@ cli/
     │   │   ├── disable.go        # `meho connector disable <id>` (constructor only; logic in enable.go).
     │   │   └── connector_test.go # pure-function + httptest-mocked HTTP contract tests.
     │   ├── operation/         # G0.6-T13 #481 — `meho operation …` meta-tool surface.
-    │   │   ├── operation.go      # NewRootCmd + shared HTTP/auth helpers.
-    │   │   ├── groups.go         # `meho operation groups` (GET /api/v1/operations/groups).
-    │   │   ├── search.go         # `meho operation search` (GET /api/v1/operations/search).
-    │   │   ├── call.go           # `meho operation call`   (POST /api/v1/operations/call).
-    │   │   └── operation_test.go # render + helper + sentinel tests.
+    │   │   ├── operation.go      # NewRootCmd + operationsAPI seam + apiResponseError sentinel + loadParamsFlag (G0.12-T2 #1260).
+    │   │   ├── groups.go         # `meho operation groups` (GET /api/v1/operations/groups) — typed via api.GetGroupsApiV1OperationsGroupsGetParams.
+    │   │   ├── search.go         # `meho operation search` (GET /api/v1/operations/search) — typed via api.GetSearchApiV1OperationsSearchGetParams.
+    │   │   ├── call.go           # `meho operation call`   (POST /api/v1/operations/call) — typed via api.CallOperationBody + FromCallOperationBodyTarget0.
+    │   │   ├── operation_test.go # render + helper + sentinel tests.
+    │   │   └── client_test.go    # G0.12-T2 #1260 — fakeOperationsClient mocks the operationsAPI seam; asserts typed request params + 401 refresh dance + error classification.
     │   ├── retrieval/         # G4.3-T2 #441 — retrieval-quality tooling.
     │   │   ├── retrieval.go            # NewRootCmd.
     │   │   ├── eval.go                 # `meho retrieval eval` (POST /api/v1/retrieve/eval).
@@ -840,17 +841,53 @@ narrow-waist contract.
 
 ### HTTP shape
 
-All three verbs route through `api.NewAuthedClient(...)` for bearer
-injection + 401-refresh-retry. The shared `doAuthedRequest` helper in
-`operation.go` builds the request manually (rather than using the
-generated `ClientWithResponses`) because the openapi spec types the
-three routes' responses as `dict[str, Any]`; the generated `JSON200`
-is `*map[string]interface{}` which doesn't expose the typed
+All three verbs route through `api.NewAuthedClient(...)` and call the
+generated typed client directly (G0.12-T2 #1260 — Initiative #1118
+CLI hygiene migration). Per-verb request helpers (`getGroups`,
+`getSearch`, `postCall`) build the typed params/body structs
+(`api.GetGroupsApiV1OperationsGroupsGetParams`,
+`api.GetSearchApiV1OperationsSearchGetParams`,
+`api.CallOperationBody`), invoke the `*WithResponse` methods on the
+embedded `*api.ClientWithResponses`, run a one-shot 401-refresh dance
+on the `*api.AuthedClient.Refresh` hook (mirroring
+`AuthedClient.GetHealth`), and parse the 200 body into the
+hand-written response struct. Non-2xx outcomes wrap as the local
+`*apiResponseError` sentinel that `renderRequestError` extracts
+(`errors.As`) to pick the right `output.RenderError` category
+(401→`auth_expired`, other non-2xx→`unexpected_response`, transport
+failures→`unreachable`).
+
+Response models stay hand-typed (`GroupSummary` + `GroupsResponse`,
+`SearchHit` + `SearchResponse`, `CallResult`) because the FastAPI
+surface types these routes' responses as `dict[str, Any]`; the
+generator therefore emits the response as
+`*map[string]interface{}`, which doesn't expose the typed
 `OperationGroupSummary` / `OperationSearchHit` / `OperationResult`
-shapes the renderer needs. Hand-written structs (`GroupSummary`,
-`SearchHit`, `CallResult`) mirror the backend Pydantic models
-one-for-one; backend tests + CLI tests lock the contract on both
-sides.
+shapes the renderer needs. Promoting the FastAPI return to a typed
+model so the generator picks it up is a separate backend Task
+explicitly out of scope for the consumer-side Initiative #1118.
+
+For `call`, the `target` field uses the bare-string oneOf shape
+via `api.CallOperationBody_Target.FromCallOperationBodyTarget0`
+(G0.13-T2 #1132 — the forward-preferred form that round-trips
+through the `query_topology` / `query_audit` read surfaces). The
+CLI never emits the dict shape — the `fqdn` override is an MCP-
+handler use case, not an operator-CLI use case. When `--target` is
+omitted, `body.Target = nil` so the wire emits `"target": null`,
+which the dispatcher accepts for typed handlers that resolve their
+own context.
+
+The package-local `operationsAPI` interface in `operation.go`
+defines the minimal slice of `api.ClientWithResponsesInterface` the
+three verbs consume (three `*WithResponse` methods + `Refresh`) so
+`client_test.go` can substitute a tiny `fakeOperationsClient`
+without reaching for the full ~140-method generated interface.
+`*api.AuthedClient` satisfies the seam directly: it embeds
+`*ClientWithResponses` (which provides the three `*WithResponse`
+calls) and defines `Refresh` of its own. The test fake records the
+typed params/body each verb passes and pops canned responses from
+per-verb queues to drive the 401-dance and error-classification
+scenarios.
 
 ### Exit codes
 


### PR DESCRIPTION
## Summary

- Migrates `cli/internal/cmd/operation/` (3 verbs: `groups` / `search` / `call`) from the hand-rolled `doAuthedRequest`/`sendRequest`/`httpError` transport to the generated typed client (`cli/internal/api/client.gen.go`). First in-Initiative cut for `operation/`; `approvals/` (sibling Task G0.12-T1 #1251) is in flight in parallel.
- Verbs now pass typed params/body structs (`api.GetGroupsApiV1OperationsGroupsGetParams`, `api.GetSearchApiV1OperationsSearchGetParams`, `api.CallOperationBody`) into the `*WithResponse` helpers, run a one-shot 401-refresh dance via `*api.AuthedClient.Refresh` (mirroring `AuthedClient.GetHealth`), and parse the 200 body into the deliberately hand-typed response structs (per Initiative #1118's "OpenAPI surface stays unchanged" scope rule).
- `call`'s `--target <slug>` is wired through `FromCallOperationBodyTarget0` (bare-string shape, the forward-preferred form per G0.13-T2 #1132); empty case sends `Target=nil`. CLI never emits the dict shape — the `fqdn` override is an MCP-handler use case.
- New `client_test.go` (~490 LOC) introduces a per-package `operationsAPI` interface seam + `fakeOperationsClient` test double that asserts typed params reach the generator (no URL-concat), 401 dance hits `Refresh` exactly once, and non-2xx outcomes wrap as `*apiResponseError` for `renderRequestError` to classify.
- `docs/codebase/cli.md` updated to reflect the typed-client adoption + the `operationsAPI` seam.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — every package passes
- [x] `go vet ./...` — clean
- [x] `gofmt -l ./internal/cmd/operation/` — empty
- [x] `grep -rn "http.NewRequest\|doAuthedRequest\|sendRequest\|callRequestBody\|httpError\b" cli/internal/cmd/operation/` — no matches (AC1)
- [x] `grep -rn "api.CallOperationBody\|api.GetSearchApiV1OperationsSearchGetParams\|api.GetGroupsApiV1OperationsGroupsGetParams\|PostCallApiV1OperationsCallPostWithResponse" cli/internal/cmd/operation/` — matches in `call.go`, `search.go`, `groups.go`, `operation.go` (AC2)
- [x] `CallResult`, `SearchHit`, `SearchResponse`, `GroupSummary`, `GroupsResponse` still exist; each carries an updated comment pointing at G0.12-T2 #1260 explaining the deliberate hand-typing (AC3)
- [x] `cd cli && make snapshot-openapi && make generate` is a no-op (`git status` clean) (AC7)
- [x] `client_test.go` covers `--target` bare-string + nil cases, `--params` set vs. omitted, the 401 refresh dance per verb, refresh-failure propagation, and non-2xx-after-refresh classification (AC5)
- [ ] Manual smoke against a running backplane (deferred to reviewer / pre-merge — no backplane available in this worktree sandbox)

## Out of scope

- Typing the three FastAPI response models so `OperationResult` / `OperationGroupSummary` / `OperationSearchHit` land in `client.gen.go` — separate backend Task, explicitly excluded by Initiative #1118.
- Other CLI verb directories (sibling Tasks G0.12-T1 #1251 `approvals/` and onward).
- Promoting `api.AuthedClient` to a shared `ClientWithResponses` factory beyond the three operation verbs.
- Adding the dict-shape `target` path back to the CLI — bare-string is the canonical write surface per #1132.

## Adjacent findings (out of scope, recorded for follow-up)

- The issue body claims the existing `operation_test.go` (333 lines) uses `httptest.Server` to stub the backplane; in fact the existing tests are pure UI tests (truncate / printers / loadParamsFlag) with zero transport mocking. The new mock-based tests landed in a separate `client_test.go` so the existing tests stay focused on renderers; AC5 ("reworked test suite asserts typed request params") is satisfied by the new file.

<!-- auto-implement-issue: fresh, iteration 1 -->

---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-28)

Addressed review findings from [pr-1275-iter-1](../../.claude/auto/review-results/pr-1275-iter-1.json):

- **B1** `ba6be91` — rename `const cap = 1 << 20` -> `const maxBodyBytes = 1 << 20` in `classifyNon2xx` to clear the revive `redefines-builtin-id` lint failure (CI run 26562510880). Mechanical rename, zero behaviour change; updated the inline comment to spell out why the name is not `cap` so a future contributor doesn't reintroduce the shadow.

Disputed: none.

Deferred (recorded as adjacent findings; orchestrator may file follow-up issues):

- Project-19 board hygiene (Issue #1260 / PR #1275 not registered on the MEHO board) and the pre-existing `tests/test_budget_enforcement.py::test_per_identity_kill_switch_via_zero_request_limit` failure on `main` — both surfaced by the reviewer, neither in scope of this PR's blast radius.

<!-- auto-implement-issue: continue, iteration 2 -->

Closes #1260


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Operation commands (groups, search, call) automatically refresh authentication and retry once when sessions expire, eliminating spurious failures during normal usage

* **Documentation**
  * Updated CLI operations documentation with current implementation details, error classification, and behavior of optional parameters

* **Tests**
  * Added comprehensive test suite covering operation command functionality, parameter passing, optional field handling, transport errors, and authorization refresh scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->