### PR TITLE
refactor(cli-approvals): G0.12-T1 migrate to generated typed client (#1251)

### DIFF
--- a/cli/internal/cmd/approvals/approvals.go
+++ b/cli/internal/cmd/approvals/approvals.go
@@ -12,36 +12,73 @@
 //     GET /api/v1/approvals/{id}. Role: operator. Renders proposed_effect
 //     and elicitation_url; --json for the raw envelope.
 //   - `meho approvals approve <id> [--reason TEXT] [--json]` — approve via
-//     POST /api/v1/approvals/{id}/approve. Role: operator. Resumes the
+//     POST /api/v1/approvals/{id}/decide. Role: operator. Resumes the
 //     paused agent run via the T4 path.
 //   - `meho approvals reject <id> [--reason TEXT] [--json]` — reject via
-//     POST /api/v1/approvals/{id}/reject. Role: operator. Aborts the
+//     POST /api/v1/approvals/{id}/decide. Role: operator. Aborts the
 //     paused agent run.
 //
 // Authentication piggybacks on the token meho login wrote — same pattern
 // as `meho agent`, `meho audit`, `meho conventions`.
 //
-// The implementation follows the in-package HTTP helper pattern the sibling
-// verb trees use (a local doAuthedRequest / renderRequestError pair) rather
-// than a shared client package, for the import-cycle reason every sibling
-// cites: each verb tree is grafted onto the root command, so a shared helper
-// imported from cmd/* and from a per-tree package would close the cycle.
+// G0.12-T1 #1251 migrated this package off the sibling-verb pattern of
+// hand-rolled HTTP + hand-typed copies of backend pydantic models.
+// Every verb here drives the generated `api.ClientWithResponses`
+// surface directly: `api.NewAuthedClient` wires the bearer + lazy
+// 401-refresh editor onto the embedded `ClientWithResponses`, and
+// the verbs call the typed `*WithResponse` methods
+// (`ListApprovalsApiV1ApprovalsGetWithResponse` etc.). Consumer-side
+// struct drift — the #1069 root cause — can't recur because we now
+// consume `api.ApprovalRequestView` directly.
 package approvals
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
-	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/output"
 )
+
+// httpResponseError carries a non-2xx status from a typed-client
+// `*WithResponse` call up to the verb's renderer. The typed-client
+// surface returns non-2xx responses in-band on the `(*Response, nil)`
+// tuple (transport-layer failures come back on the `(nil, err)`
+// tuple instead) — we lift the HTTP-failure case to an error type so
+// the call sites can use a single `if err != nil` branch and
+// `errors.As` routes the right way (HTTP status → `renderHTTPStatus`,
+// everything else → `renderTransportError`). See `routeRequestError`.
+type httpResponseError struct {
+	statusCode int
+	body       []byte
+}
+
+func (e *httpResponseError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.statusCode, trimmedBody(e.body))
+}
+
+// routeRequestError is the single dispatcher every verb feeds an
+// error from `fetchList` / `fetchDetail` / `postDecision` into. The
+// error is either an `*httpResponseError` (the backplane responded
+// with a non-2xx status) or a transport-layer failure (network,
+// refresh-impossible, etc.); we route the former through
+// `renderHTTPStatus` and the latter through `renderTransportError`.
+func routeRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	var he *httpResponseError
+	if errors.As(err, &he) {
+		return renderHTTPStatus(cmd, backplaneURL, he.statusCode, he.body, jsonOut)
+	}
+	return renderTransportError(cmd, backplaneURL, err, jsonOut)
+}
 
 // NewRootCmd returns the `meho approvals` parent command. Grafted onto
 // the top-level meho tree by cmd/root.go alongside `meho agent`,
@@ -68,156 +105,36 @@ func NewRootCmd() *cobra.Command {
 	return cmd
 }
 
-// ApprovalSummary mirrors backend ApprovalRequestView for list rendering.
-// (Backend returns the same view shape for list and show; the CLI keeps a
-// trimmed alias for the table view.)
-type ApprovalSummary struct {
-	ID           string  `json:"id"`
-	TenantID     string  `json:"tenant_id"`
-	Status       string  `json:"status"`
-	ConnectorID  string  `json:"connector_id"`
-	OpID         string  `json:"op_id"`
-	PrincipalSub string  `json:"principal_sub"`
-	PrincipalAct *string `json:"principal_act"`
-	CreatedAt    string  `json:"created_at"`
-	ExpiresAt    *string `json:"expires_at"`
-}
-
-// ApprovalDetail mirrors the backend ApprovalRequestView pydantic model
-// returned by GET /api/v1/approvals and GET /api/v1/approvals/{id}.
-type ApprovalDetail struct {
-	ID             string                  `json:"id"`
-	TenantID       string                  `json:"tenant_id"`
-	Status         string                  `json:"status"`
-	RunID          *string                 `json:"run_id"`
-	ConnectorID    string                  `json:"connector_id"`
-	OpID           string                  `json:"op_id"`
-	TargetID       *string                 `json:"target_id"`
-	ParamsHash     string                  `json:"params_hash"`
-	ProposedEffect *map[string]interface{} `json:"proposed_effect"`
-	PrincipalSub   string                  `json:"principal_sub"`
-	PrincipalAct   *string                 `json:"principal_act"`
-	ReviewedBy     *string                 `json:"reviewed_by"`
-	DecidedAt      *string                 `json:"decided_at"`
-	ExpiresAt      *string                 `json:"expires_at"`
-	CreatedAt      string                  `json:"created_at"`
-}
-
-// (ListResponse envelope removed — backend GET /api/v1/approvals returns
-// a plain JSON array of ApprovalSummary, mirroring T4's merged surface.)
-
-// decisionBody is the JSON body for the POST /api/v1/approvals/{id}/decide
-// route (G11.2-T5 operator-decision path; the agent-side /approve route
-// with params + hash-check stays available for the agent's REST resume).
-type decisionBody struct {
-	Decision string `json:"decision"`
-	Reason   string `json:"reason,omitempty"`
-}
-
-// errMissingAccessToken is the sentinel doAuthedRequest returns when the
-// stored token row exists but access_token is empty.
-var errMissingAccessToken = errors.New("meho: stored token has no access_token")
-
-// responseBodyCap bounds the response body the CLI will read.
-const responseBodyCap int64 = 1 << 20 // 1 MiB
-
-// httpError carries a non-2xx response.
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-// doAuthedRequest issues an authenticated HTTP request with one-shot
-// 401-refresh-retry. Mirrors the pattern agent / conventions use.
-func doAuthedRequest(
+// newAuthedClient builds an `api.AuthedClient` and surfaces its
+// construction-time errors as the right `output.StructuredError`
+// category (auth_expired when no token was ever stored, else
+// unexpected_response with the underlying error wrapped). Splits the
+// boilerplate every verb here used to duplicate inline.
+func newAuthedClient(
 	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	cmd *cobra.Command,
+	backplaneURL string,
+	jsonOut bool,
+) (*api.AuthedClient, error) {
+	client, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
 	if err != nil {
-		return nil, err
+		return nil, renderClientError(cmd, backplaneURL, err, jsonOut)
 	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errMissingAccessToken
-	}
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close() //nolint:errcheck
-			return nil, rerr
-		}
-		resp.Body.Close() //nolint:errcheck
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close() //nolint:errcheck
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, responseBodyCap+1))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if int64(len(raw)) > responseBodyCap {
-		return nil, fmt.Errorf("response body exceeds %d-byte cap", responseBodyCap)
-	}
-	if resp.StatusCode == http.StatusNoContent {
-		return nil, nil
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
+	return client, nil
 }
 
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	base, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	var reqBody io.Reader
-	if len(body) > 0 {
-		reqBody = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, base+path, reqBody)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	if len(body) > 0 {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
-}
-
-// renderRequestError translates a request error into the right
-// output.StructuredError category. Mirrors conventions / agent shape.
-func renderRequestError(
+// renderClientError maps `api.NewAuthedClient` failures onto the
+// structured-error envelope. `IsTokenNotFound` is the "operator
+// never ran meho login" sentinel and surfaces as auth_expired with a
+// `meho login` hint; anything else is a build-time failure of the
+// authed transport itself (token store unreadable, etc.) and
+// surfaces as unexpected_response so the operator sees the cause.
+func renderClientError(
 	cmd *cobra.Command,
 	backplaneURL string,
 	err error,
 	jsonOut bool,
 ) error {
-	if errors.Is(err, errMissingAccessToken) {
-		return output.RenderError(cmd.ErrOrStderr(),
-			output.AuthExpired(fmt.Sprintf(
-				"stored credentials for %s are incomplete; run `meho login %s`",
-				backplaneURL, backplaneURL,
-			)),
-			jsonOut,
-		)
-	}
 	if api.IsTokenNotFound(err) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.AuthExpired(fmt.Sprintf(
@@ -227,6 +144,23 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unexpected(fmt.Sprintf("build authed client for %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+// renderTransportError maps a generated-client call's transport-layer
+// error (network failure, refresh-impossible after a 401) onto the
+// right structured-error category. The typed-client surface returns
+// `(nil, err)` for these; non-2xx HTTP responses arrive as
+// `(*Response, nil)` and are routed through `renderHTTPStatus` instead.
+func renderTransportError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
 	if api.IsNoRefreshToken(err) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.AuthExpired(fmt.Sprintf(
@@ -236,23 +170,29 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
-		return renderHTTPError(cmd, backplaneURL, he, jsonOut)
-	}
 	return output.RenderError(cmd.ErrOrStderr(),
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
 }
 
-func renderHTTPError(
+// renderHTTPStatus maps a non-2xx HTTP status from the typed-client
+// response onto the right structured-error category. Mirrors the
+// pre-migration `renderHTTPError` shape (401→AuthExpired,
+// 403→InsufficientRole, 404→approval_request_not_found, 409/422→
+// Unexpected(body), other non-2xx→Unexpected(HTTP N: body)) but acts
+// on the (StatusCode, Body) pair lifted off the generated
+// `*Response.HTTPResponse` + `Body` fields rather than a sentinel
+// `httpError` value.
+func renderHTTPStatus(
 	cmd *cobra.Command,
 	backplaneURL string,
-	he *httpError,
+	statusCode int,
+	body []byte,
 	jsonOut bool,
 ) error {
-	switch he.StatusCode {
+	bodyStr := trimmedBody(body)
+	switch statusCode {
 	case http.StatusUnauthorized:
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.AuthExpired(fmt.Sprintf(
@@ -263,7 +203,7 @@ func renderHTTPError(
 		)
 	case http.StatusForbidden:
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.InsufficientRole(he.Body),
+			output.InsufficientRole(bodyStr),
 			jsonOut,
 		)
 	case http.StatusNotFound:
@@ -271,20 +211,38 @@ func renderHTTPError(
 			output.Unexpected("approval_request_not_found"),
 			jsonOut,
 		)
-	case http.StatusConflict:
+	case http.StatusConflict, http.StatusUnprocessableEntity:
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(he.Body),
-			jsonOut,
-		)
-	case http.StatusUnprocessableEntity:
-		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(he.Body),
+			output.Unexpected(bodyStr),
 			jsonOut,
 		)
 	default:
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf("HTTP %d: %s", he.StatusCode, he.Body)),
+			output.Unexpected(fmt.Sprintf("HTTP %d: %s", statusCode, bodyStr)),
 			jsonOut,
 		)
 	}
+}
+
+// trimmedBody renders a response body for inclusion in an error
+// envelope: trims trailing whitespace, surfaces a placeholder when
+// the backend returned an empty body so the operator-facing string
+// is never just "HTTP 500:".
+func trimmedBody(body []byte) string {
+	s := string(body)
+	// Strip trailing whitespace only — leading whitespace inside a
+	// JSON envelope is legitimate. Same shape as
+	// strings.TrimRightFunc(s, unicode.IsSpace) but no extra import.
+	for len(s) > 0 {
+		last := s[len(s)-1]
+		if last == ' ' || last == '\n' || last == '\r' || last == '\t' {
+			s = s[:len(s)-1]
+			continue
+		}
+		break
+	}
+	if s == "" {
+		return "(empty body)"
+	}
+	return s
 }

--- a/cli/internal/cmd/approvals/approvals_test.go
+++ b/cli/internal/cmd/approvals/approvals_test.go
@@ -1,0 +1,766 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package approvals
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// ---------- helpers ----------
+
+// inMemoryStore satisfies auth.TokenStore without touching the OS
+// keyring or the filesystem. Mirrors the shape of the helper in
+// cli/internal/api/client_test.go (which is unexported, so cannot
+// be imported across packages).
+type inMemoryStore struct {
+	entries map[string]auth.StoredToken
+}
+
+func (s *inMemoryStore) key(service, user string) string {
+	return service + "\x00" + user
+}
+
+func (s *inMemoryStore) Save(service, user string, tok auth.StoredToken) error {
+	if s.entries == nil {
+		s.entries = map[string]auth.StoredToken{}
+	}
+	s.entries[s.key(service, user)] = tok
+	return nil
+}
+
+func (s *inMemoryStore) Load(service, user string) (auth.StoredToken, error) {
+	tok, ok := s.entries[s.key(service, user)]
+	if !ok {
+		return auth.StoredToken{}, auth.ErrTokenNotFound
+	}
+	return tok, nil
+}
+
+func (s *inMemoryStore) Delete(service, user string) error {
+	delete(s.entries, s.key(service, user))
+	return nil
+}
+
+func (inMemoryStore) Describe() string { return "in-memory test store" }
+
+// newTestClient builds an AuthedClient backed by an in-memory store
+// pre-loaded with a bearer for the supplied test server. Bypasses
+// the production keychain / config-file path. Mirrors the test
+// substrate used by client_test.go.
+func newTestClient(t *testing.T, srv *httptest.Server) *api.AuthedClient {
+	t.Helper()
+	store := &inMemoryStore{}
+	service, user := auth.KeyForBackplane(srv.URL)
+	_ = store.Save(service, user, auth.StoredToken{
+		BackplaneURL: srv.URL,
+		AccessToken:  "test-bearer",
+		Expiry:       time.Now().Add(time.Hour),
+	})
+	client, err := api.NewAuthedClient(context.Background(), srv.URL,
+		api.AuthedClientOptions{Store: store, HTTPClient: srv.Client()})
+	if err != nil {
+		t.Fatalf("NewAuthedClient: %v", err)
+	}
+	return client
+}
+
+// stubID is a fixed UUID used in every approval-API fixture. Reading
+// the literal "11111111-..." in a request URL or response body in a
+// test failure makes the assertion easier to chase than a random
+// uuid.New() that changes per test run.
+const stubID = "11111111-1111-1111-1111-111111111111"
+
+func newApprovalView(t *testing.T, status, reason string) api.ApprovalRequestView {
+	t.Helper()
+	id, err := uuid.Parse(stubID)
+	if err != nil {
+		t.Fatalf("uuid.Parse(stubID): %v", err)
+	}
+	tenant, err := uuid.Parse("22222222-2222-2222-2222-222222222222")
+	if err != nil {
+		t.Fatalf("uuid.Parse(tenant): %v", err)
+	}
+	reviewed := "alice@example.com"
+	var reviewedBy *string
+	if reason != "" {
+		reviewedBy = &reviewed
+	}
+	return api.ApprovalRequestView{
+		Id:           id,
+		TenantId:     tenant,
+		Status:       api.ApprovalRequestStatus(status),
+		ConnectorId:  "vmware-rest-9.0",
+		OpId:         "GET:/api/vcenter/cluster",
+		ParamsHash:   "deadbeef",
+		PrincipalSub: "user-abc",
+		CreatedAt:    "2026-05-28T12:00:00Z",
+		ReviewedBy:   reviewedBy,
+	}
+}
+
+// mockHandler is the HandlerFunc alias mockBackplane keys its
+// routing table on. Same shape as connector_test.go's helper.
+type mockHandler = http.HandlerFunc
+
+// mockBackplane stands up an httptest.Server that routes by
+// `<METHOD> <path>`. The empty key acts as a catch-all so tests can
+// validate URL escaping or other path-derived behaviour without
+// over-specifying. Mirrors connector_test.go's helper to keep the
+// in-package test surface uniform across verb trees.
+func mockBackplane(t *testing.T, routes map[string]mockHandler) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.Method + " " + r.URL.Path
+		if h, ok := routes[key]; ok {
+			h(w, r)
+			return
+		}
+		if h, ok := routes[""]; ok {
+			h(w, r)
+			return
+		}
+		t.Errorf("mockBackplane: unhandled route %s", key)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, body any) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Errorf("writeJSON marshal: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, err := w.Write(raw); err != nil {
+		t.Errorf("writeJSON write: %v", err)
+	}
+}
+
+// readJSONBody decodes the request body into a fresh value of v's
+// type. Used by handlers that want to assert on the wire shape they
+// received (typically against a generated `api.*RequestBody` type,
+// not a consumer-side duplicate).
+func readJSONBody[T any](t *testing.T, r *http.Request) T {
+	t.Helper()
+	var v T
+	if err := json.NewDecoder(r.Body).Decode(&v); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	return v
+}
+
+// ---------- helper-function tests ----------
+
+// TestTrimmedBodyDropsTrailingWhitespace pins the small renderer
+// helper. Backplane responses often arrive with a trailing newline;
+// dropping it keeps the error envelope's `HTTP 500: foo` shape
+// stable in the operator-visible output.
+func TestTrimmedBodyDropsTrailingWhitespace(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"plain", "plain"},
+		{"trail\n", "trail"},
+		{"trail \r\n", "trail"},
+		{"trail\t  ", "trail"},
+		{"", "(empty body)"},
+		{"   \n", "(empty body)"},
+		{"   leading kept", "   leading kept"},
+	}
+	for _, tc := range cases {
+		if got := trimmedBody([]byte(tc.in)); got != tc.want {
+			t.Errorf("trimmedBody(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestParseRequestIDRejectsGarbage pins the UUID-at-the-edge
+// behaviour the show / approve / reject verbs share. Garbage input
+// surfaces a clean output.Unexpected (no panic, no `fmt.Errorf`
+// blob halfway through a request).
+func TestParseRequestIDRejectsGarbage(t *testing.T) {
+	cases := []string{
+		"not-a-uuid",
+		"",
+		"11111111-1111-1111-1111-1111111111", // one char short
+	}
+	for _, in := range cases {
+		_, err := parseRequestID(in)
+		if err == nil {
+			t.Errorf("parseRequestID(%q): expected rejection, got nil err", in)
+			continue
+		}
+		if !strings.Contains(err.Error(), "approval-id is not a valid UUID") {
+			t.Errorf("parseRequestID(%q): unexpected error %q", in, err)
+		}
+	}
+}
+
+// TestParseRequestIDAcceptsValid pins the happy path so a regression
+// to strict v4-only parsing (uuid.MustParse rejects v1/v3/v5) would
+// surface here.
+func TestParseRequestIDAcceptsValid(t *testing.T) {
+	got, err := parseRequestID(stubID)
+	if err != nil {
+		t.Fatalf("parseRequestID(%q): %v", stubID, err)
+	}
+	if got.String() != stubID {
+		t.Errorf("round-trip: got %q want %q", got.String(), stubID)
+	}
+}
+
+// ---------- list verb ----------
+
+// TestListPassesTypedStatusParam pins the load-bearing G0.12-T1
+// migration claim: list passes the typed `status` param through the
+// generated client, no string-concat. The mock asserts on the
+// decoded query param shape.
+func TestListPassesTypedStatusParam(t *testing.T) {
+	var seenStatus string
+	srv := mockBackplane(t, map[string]mockHandler{
+		"GET /api/v1/approvals": func(w http.ResponseWriter, r *http.Request) {
+			seenStatus = r.URL.Query().Get("status")
+			writeJSON(t, w, http.StatusOK, []api.ApprovalRequestView{
+				newApprovalView(t, "pending", ""),
+			})
+		},
+	})
+	defer srv.Close()
+	client := newTestClient(t, srv)
+
+	items, err := fetchList(context.Background(), client, listOpts{StatusFilter: "pending"})
+	if err != nil {
+		t.Fatalf("fetchList: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(items))
+	}
+	if seenStatus != "pending" {
+		t.Errorf("expected status=pending on the wire, got %q", seenStatus)
+	}
+	if items[0].Id.String() != stubID {
+		t.Errorf("decoded ApprovalRequestView.Id: got %q want %q", items[0].Id.String(), stubID)
+	}
+}
+
+// TestListOmitsStatusWhenUnset confirms an empty StatusFilter sends
+// no `status` query param (the backend then applies its own default
+// of `pending`).
+func TestListOmitsStatusWhenUnset(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"GET /api/v1/approvals": func(w http.ResponseWriter, r *http.Request) {
+			if got := r.URL.Query().Get("status"); got != "" {
+				t.Errorf("unset StatusFilter should omit query param; got status=%q", got)
+			}
+			// Confirm we don't accidentally send limit/offset either —
+			// the generated client's params struct doesn't expose them,
+			// so they should never reach the wire even though the CLI
+			// flags accept them.
+			if got := r.URL.Query().Get("limit"); got != "" {
+				t.Errorf("limit should not reach wire (generator omits it); got limit=%q", got)
+			}
+			if got := r.URL.Query().Get("offset"); got != "" {
+				t.Errorf("offset should not reach wire (generator omits it); got offset=%q", got)
+			}
+			writeJSON(t, w, http.StatusOK, []api.ApprovalRequestView{})
+		},
+	})
+	defer srv.Close()
+	client := newTestClient(t, srv)
+
+	// Even when --limit and --offset are set, they're a no-op at the
+	// typed-client layer (the backend doesn't accept them and the
+	// generator agrees).
+	if _, err := fetchList(context.Background(), client, listOpts{Limit: 10, Offset: 5}); err != nil {
+		t.Fatalf("fetchList: %v", err)
+	}
+}
+
+// TestListMaps403ToInsufficientRole confirms the 403 → insufficient_role
+// mapping survives the migration off the pre-G0.12 local httpError
+// sentinel. Same shape as the pre-migration test would have looked,
+// just driving the typed client through the verb's RunE.
+func TestListMaps403ToInsufficientRole(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"GET /api/v1/approvals": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte("operator role required"))
+		},
+	})
+	defer srv.Close()
+
+	stderr, exitErr := runListWithMock(t, srv, listOpts{StatusFilter: "pending", JSONOut: true})
+	assertRenderedErrorCode(t, stderr, exitErr, output.ErrCodeInsufficientRole, "operator role required")
+}
+
+// TestListMaps422ToUnexpected pins 422 (the FastAPI validation error
+// route) → unexpected_response. Same gate the pre-migration
+// renderHTTPError used.
+func TestListMaps422ToUnexpected(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"GET /api/v1/approvals": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = w.Write([]byte(`{"detail":"validation"}`))
+		},
+	})
+	defer srv.Close()
+
+	stderr, exitErr := runListWithMock(t, srv, listOpts{StatusFilter: "pending", JSONOut: true})
+	assertRenderedErrorCode(t, stderr, exitErr, output.ErrCodeUnexpected, "validation")
+}
+
+// TestListMaps404ToApprovalRequestNotFound — the list route never
+// returns 404 in practice (it's a tenant-scoped list), but the
+// renderer's switch covers it for the show / decide siblings and
+// the gate must survive uniformly across verbs. Pinned here so a
+// rewrite of `renderHTTPStatus` can't lose the case silently.
+func TestListMaps404ToApprovalRequestNotFound(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"GET /api/v1/approvals": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("missing"))
+		},
+	})
+	defer srv.Close()
+
+	stderr, exitErr := runListWithMock(t, srv, listOpts{StatusFilter: "pending", JSONOut: true})
+	assertRenderedErrorCode(t, stderr, exitErr, output.ErrCodeUnexpected, "approval_request_not_found")
+}
+
+// ---------- show verb ----------
+
+// TestShowPathParamCarriesUUID pins the typed UUID path-param
+// behaviour: the operator's string `<id>` round-trips through the
+// generated client into the URL path as the canonical UUID form,
+// not concatenated, not escaped twice.
+func TestShowPathParamCarriesUUID(t *testing.T) {
+	var seenPath string
+	srv := mockBackplane(t, map[string]mockHandler{
+		"GET /api/v1/approvals/" + stubID: func(w http.ResponseWriter, r *http.Request) {
+			seenPath = r.URL.Path
+			writeJSON(t, w, http.StatusOK, newApprovalView(t, "pending", ""))
+		},
+	})
+	defer srv.Close()
+	client := newTestClient(t, srv)
+
+	id, err := parseRequestID(stubID)
+	if err != nil {
+		t.Fatalf("parseRequestID: %v", err)
+	}
+	detail, err := fetchDetail(context.Background(), client, id)
+	if err != nil {
+		t.Fatalf("fetchDetail: %v", err)
+	}
+	if seenPath != "/api/v1/approvals/"+stubID {
+		t.Errorf("path: got %q want %q", seenPath, "/api/v1/approvals/"+stubID)
+	}
+	if detail == nil || detail.Id.String() != stubID {
+		t.Fatalf("decoded ApprovalRequestView.Id: got %+v want id=%q", detail, stubID)
+	}
+}
+
+// TestShowRejectsGarbageIDCleanly drives the verb's RunE with a
+// non-UUID arg and asserts the renderer fires output.Unexpected
+// with the operator-visible hint — no panic, no fmt-into-the-URL.
+func TestShowRejectsGarbageID(t *testing.T) {
+	cmd, _, stderr := newCapturingCmd(t)
+	err := runShow(cmd, "not-a-uuid", true, "https://meho.example")
+	assertRenderedErrorCode(t, stderr, err, output.ErrCodeUnexpected, "approval-id is not a valid UUID")
+}
+
+// ---------- approve / reject verbs ----------
+
+// TestApproveDispatchesDecideAndShow pins the two-call shape:
+// /decide POST with decision=approved + the supplied reason, then
+// GET on the same id to re-render the view. Mirrors the same shape
+// reject uses; documented here once on the approve verb.
+func TestApproveDispatchesDecideAndShow(t *testing.T) {
+	type call struct {
+		method string
+		path   string
+		body   *api.DecideRequestBody
+	}
+	var calls []call
+
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/approvals/" + stubID + "/decide": func(w http.ResponseWriter, r *http.Request) {
+			b := readJSONBody[api.DecideRequestBody](t, r)
+			calls = append(calls, call{r.Method, r.URL.Path, &b})
+			writeJSON(t, w, http.StatusOK, api.DecideResponseBody{
+				ApprovalRequestId: mustUUID(t, stubID),
+				Decision:          "approved",
+				Reason:            "T-test",
+			})
+		},
+		"GET /api/v1/approvals/" + stubID: func(w http.ResponseWriter, r *http.Request) {
+			calls = append(calls, call{r.Method, r.URL.Path, nil})
+			writeJSON(t, w, http.StatusOK, newApprovalView(t, "approved", "T-test"))
+		},
+	})
+	defer srv.Close()
+	client := newTestClient(t, srv)
+
+	id := mustUUID(t, stubID)
+	detail, err := postDecision(context.Background(), client, id, "approve", "T-test")
+	if err != nil {
+		t.Fatalf("postDecision: %v", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls (decide + show); got %d: %+v", len(calls), calls)
+	}
+	if calls[0].method != "POST" || calls[0].path != "/api/v1/approvals/"+stubID+"/decide" {
+		t.Errorf("first call: got %s %s", calls[0].method, calls[0].path)
+	}
+	if calls[0].body == nil || calls[0].body.Decision != "approved" {
+		t.Errorf("decide body: got %+v want decision=approved", calls[0].body)
+	}
+	if calls[0].body.Reason == nil || *calls[0].body.Reason != "T-test" {
+		t.Errorf("decide body reason: got %+v want pointer to %q", calls[0].body.Reason, "T-test")
+	}
+	if calls[1].method != "GET" || calls[1].path != "/api/v1/approvals/"+stubID {
+		t.Errorf("second call: got %s %s", calls[1].method, calls[1].path)
+	}
+	if detail == nil || string(detail.Status) != "approved" {
+		t.Fatalf("decoded view: got %+v want status=approved", detail)
+	}
+}
+
+// TestRejectDispatchesDecideWithRejectedDecision confirms the verb
+// shape mirrors approve but with `decision=rejected`. Asserts the
+// past-tense translation (verb "reject" → decision "rejected").
+func TestRejectDispatchesDecideWithRejectedDecision(t *testing.T) {
+	var seenDecision string
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/approvals/" + stubID + "/decide": func(w http.ResponseWriter, r *http.Request) {
+			b := readJSONBody[api.DecideRequestBody](t, r)
+			seenDecision = b.Decision
+			writeJSON(t, w, http.StatusOK, api.DecideResponseBody{
+				ApprovalRequestId: mustUUID(t, stubID),
+				Decision:          "rejected",
+				Reason:            "",
+			})
+		},
+		"GET /api/v1/approvals/" + stubID: func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, http.StatusOK, newApprovalView(t, "rejected", ""))
+		},
+	})
+	defer srv.Close()
+	client := newTestClient(t, srv)
+
+	id := mustUUID(t, stubID)
+	if _, err := postDecision(context.Background(), client, id, "reject", ""); err != nil {
+		t.Fatalf("postDecision: %v", err)
+	}
+	if seenDecision != "rejected" {
+		t.Errorf("verb=reject should send decision=rejected; got %q", seenDecision)
+	}
+}
+
+// TestApproveOmitsReasonWhenEmpty pins the wire-shape semantics: an
+// unset --reason marshals to a body with no `reason` key (the
+// generated DecideRequestBody.Reason is *string with `omitempty`),
+// not an explicit `"reason": ""` that would land in the decision
+// audit row as a blank string.
+func TestApproveOmitsReasonWhenEmpty(t *testing.T) {
+	var rawBody []byte
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/approvals/" + stubID + "/decide": func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			rawBody = body
+			writeJSON(t, w, http.StatusOK, api.DecideResponseBody{
+				ApprovalRequestId: mustUUID(t, stubID),
+				Decision:          "approved",
+			})
+		},
+		"GET /api/v1/approvals/" + stubID: func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, http.StatusOK, newApprovalView(t, "approved", ""))
+		},
+	})
+	defer srv.Close()
+	client := newTestClient(t, srv)
+
+	id := mustUUID(t, stubID)
+	if _, err := postDecision(context.Background(), client, id, "approve", ""); err != nil {
+		t.Fatalf("postDecision: %v", err)
+	}
+	if strings.Contains(string(rawBody), `"reason"`) {
+		t.Errorf("empty reason should not marshal a `reason` key; got body=%s", rawBody)
+	}
+}
+
+// TestApproveSurfacesDecide409 confirms a 409 on /decide (e.g.
+// "approval_request_already_approved") propagates as
+// `unexpected_response` with the backplane's body — the operator
+// sees the real reason.
+func TestApproveSurfacesDecide409(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"POST /api/v1/approvals/" + stubID + "/decide": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte("approval_request_already_approved"))
+		},
+		// The GET shouldn't fire — postDecision short-circuits on
+		// the non-2xx decide response. mockBackplane's t.Errorf
+		// catch-all would flag any stray call.
+	})
+	defer srv.Close()
+	client := newTestClient(t, srv)
+
+	id := mustUUID(t, stubID)
+	_, err := postDecision(context.Background(), client, id, "approve", "")
+	if err == nil {
+		t.Fatalf("expected error from 409; got nil")
+	}
+	var he *httpResponseError
+	if !errors.As(err, &he) || he.statusCode != http.StatusConflict {
+		t.Fatalf("expected *httpResponseError 409; got %T %v", err, err)
+	}
+}
+
+// ---------- 401 refresh retry ----------
+
+// TestFetchList401RefreshFailureSurfacesAuthExpired pins the
+// 401-retry shape end-to-end through the typed client + AuthedClient
+// (RefreshDiscovery never configured, no refresh_token persisted →
+// IsNoRefreshToken sentinel surfaces). Mirrors AuthedClient.GetHealth's
+// 401 path the typed-client migration has to preserve. The renderer
+// maps the sentinel onto auth_expired.
+func TestFetchList401RefreshFailureSurfacesAuthExpired(t *testing.T) {
+	srv := mockBackplane(t, map[string]mockHandler{
+		"GET /api/v1/approvals": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		},
+	})
+	defer srv.Close()
+	client := newTestClient(t, srv) // bearer has no refresh_token
+
+	_, err := fetchList(context.Background(), client, listOpts{StatusFilter: "pending"})
+	if err == nil {
+		t.Fatal("expected error from 401 + no-refresh-token; got nil")
+	}
+	if !api.IsNoRefreshToken(err) {
+		t.Fatalf("expected IsNoRefreshToken sentinel; got %T %v", err, err)
+	}
+
+	// Confirm the verb's renderer maps the sentinel onto
+	// `auth_expired` with the `meho login` hint.
+	cmd, _, stderr := newCapturingCmd(t)
+	rerr := routeRequestError(cmd, srv.URL, err, true)
+	assertRenderedErrorCode(t, stderr, rerr, output.ErrCodeAuthExpired, "no refresh_token")
+}
+
+// ---------- printDetail / printListTable renderers ----------
+
+// TestPrintDetailRendersOptionalFields confirms the renderer omits
+// optional fields when nil (target_id, run_id, reviewed_by,
+// decided_at, expires_at, proposed_effect) and includes them when
+// present. Asserts against the generated api.ApprovalRequestView
+// directly — there is no consumer-side duplicate by design.
+func TestPrintDetailRendersOptionalFields(t *testing.T) {
+	d := newApprovalView(t, "approved", "T-test")
+	target := mustUUID(t, "33333333-3333-3333-3333-333333333333")
+	decidedAt := "2026-05-28T12:05:00Z"
+	d.TargetId = &target
+	d.DecidedAt = &decidedAt
+	d.ProposedEffect = map[string]interface{}{"action": "create"}
+
+	cmd, stdout, _ := newCapturingCmd(t)
+	printDetail(cmd, &d)
+	out := stdout.String()
+	for _, want := range []string{
+		"ID:           " + stubID,
+		"Status:       approved",
+		"Connector:    vmware-rest-9.0",
+		"Operation:    GET:/api/vcenter/cluster",
+		"Target:       33333333-3333-3333-3333-333333333333",
+		"Principal:    user-abc",
+		"Params hash:  deadbeef",
+		"Created:      2026-05-28T12:00:00Z",
+		"Reviewed by:  alice@example.com",
+		"Decided at:   2026-05-28T12:05:00Z",
+		"Effect:",
+		"\"action\": \"create\"",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printDetail render missing %q in:\n%s", want, out)
+		}
+	}
+	for _, banned := range []string{"Acting as:", "Agent run:", "Expires:"} {
+		if strings.Contains(out, banned) {
+			t.Errorf("printDetail render included %q for nil field in:\n%s", banned, out)
+		}
+	}
+}
+
+// TestPrintListTableEmpty — zero items renders the empty-tenant line.
+func TestPrintListTableEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	printListTable(&buf, nil)
+	if !strings.Contains(buf.String(), "no approval requests in this tenant") {
+		t.Errorf("empty list: missing empty-line; got:\n%s", buf.String())
+	}
+}
+
+// TestPrintListTableHappyPath — happy-path render emits the header,
+// the row's coordinates, and the "Showing N." footer.
+func TestPrintListTableHappyPath(t *testing.T) {
+	items := []api.ApprovalRequestView{newApprovalView(t, "pending", "")}
+	var buf bytes.Buffer
+	printListTable(&buf, items)
+	out := buf.String()
+	for _, want := range []string{
+		"ID", "STATUS", "CONNECTOR", "OP", "PRINCIPAL", "CREATED",
+		stubID, "pending", "vmware-rest-9.0", "user-abc",
+		"Showing 1.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("printListTable render missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestTruncatePassthroughAndCut covers the rune-aware truncate
+// helper. Same shape as the connector sibling's test — duplicated
+// in-package because cmd/approvals can't import cmd/connector
+// without an import cycle.
+func TestTruncatePassthroughAndCut(t *testing.T) {
+	cases := []struct {
+		in     string
+		maxLen int
+		want   string
+	}{
+		{"abc", 5, "abc"},
+		{"abcdef", 4, "abc…"},
+		{"café world", 5, "café…"},
+		{"x", 0, ""},
+	}
+	for _, tc := range cases {
+		if got := truncate(tc.in, tc.maxLen); got != tc.want {
+			t.Errorf("truncate(%q, %d) = %q; want %q", tc.in, tc.maxLen, got, tc.want)
+		}
+	}
+}
+
+// ---------- small helpers ----------
+
+// mustUUID parses s as a UUID, failing the test on error. Strict
+// helper used by handlers that need a canonical UUID for fixture
+// data.
+func mustUUID(t *testing.T, s string) uuid.UUID {
+	t.Helper()
+	id, err := uuid.Parse(s)
+	if err != nil {
+		t.Fatalf("mustUUID(%q): %v", s, err)
+	}
+	return id
+}
+
+// newCapturingCmd builds a cobra.Command with in-memory stdout and
+// stderr buffers wired up. Returns the command, the stdout buffer
+// (for renderers that write to cmd.OutOrStdout()), and the stderr
+// buffer (for error-envelope assertions that route through
+// cmd.ErrOrStderr()).
+func newCapturingCmd(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	cmd := &cobra.Command{Use: "x"}
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetContext(context.Background())
+	return cmd, stdout, stderr
+}
+
+// runListWithMock runs runList against a mocked backplane, with a
+// pre-populated in-memory token store so newAuthedClient succeeds.
+// Returns the captured stderr buffer + the RunE error. The
+// runList path resolves the backplane URL via `backplane.Resolve`
+// which reads $XDG_CONFIG_HOME; we point it at a tempdir holding a
+// config.json that names the test server.
+func runListWithMock(t *testing.T, srv *httptest.Server, opts listOpts) (*bytes.Buffer, error) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	cfgDir := filepath.Join(dir, "meho")
+	if err := os.MkdirAll(cfgDir, 0o700); err != nil {
+		t.Fatalf("mkdir config: %v", err)
+	}
+	cfgBlob, _ := json.Marshal(map[string]string{"backplane_url": srv.URL})
+	if err := os.WriteFile(filepath.Join(cfgDir, "config.json"), cfgBlob, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	// Prime the on-disk file-backed token store (matches
+	// auth.fileTokenStore shape).
+	service, user := auth.KeyForBackplane(srv.URL)
+	store, err := auth.NewTokenStore()
+	if err != nil {
+		t.Fatalf("NewTokenStore: %v", err)
+	}
+	if err := store.Save(service, user, auth.StoredToken{
+		AccessToken:  "test-bearer",
+		BackplaneURL: srv.URL,
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+
+	cmd := &cobra.Command{Use: "list"}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetContext(context.Background())
+
+	// Drive runList with the override pointing at the test server.
+	opts.BackplaneOverride = srv.URL
+	err = runList(cmd, opts)
+	return &stderr, err
+}
+
+// assertRenderedErrorCode parses the JSON error envelope from stderr
+// and asserts the StructuredError code + a substring in the detail.
+// Also confirms `exitErr` is non-nil (RunE returned an error so the
+// cobra dispatcher exits non-zero) and carries the expected exit
+// code so the operator's shell-script `$?` sees the right value.
+func assertRenderedErrorCode(t *testing.T, stderr *bytes.Buffer, exitErr error, wantCode, wantDetailSubstr string) {
+	t.Helper()
+	if exitErr == nil {
+		t.Fatalf("expected RunE to return non-nil error; got nil. stderr=%q", stderr.String())
+	}
+	var envelope map[string]interface{}
+	if err := json.NewDecoder(stderr).Decode(&envelope); err != nil {
+		t.Fatalf("decode error envelope %q: %v", stderr.String(), err)
+	}
+	gotCode, _ := envelope["error"].(string)
+	if gotCode != wantCode {
+		t.Errorf("error: got %q want %q (envelope=%+v)", gotCode, wantCode, envelope)
+	}
+	detail, _ := envelope["detail"].(string)
+	if wantDetailSubstr != "" && !strings.Contains(detail, wantDetailSubstr) {
+		t.Errorf("detail %q missing substring %q (envelope=%+v)", detail, wantDetailSubstr, envelope)
+	}
+}

--- a/cli/internal/cmd/approvals/approve.go
+++ b/cli/internal/cmd/approvals/approve.go
@@ -5,11 +5,12 @@ package approvals
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -19,8 +20,9 @@ import (
 //	meho approvals approve <id> [--reason TEXT] [--json] [--backplane <url>]
 //
 // Role: operator. Approves a pending approval request via
-// POST /api/v1/approvals/{id}/approve. The backplane resumes the
-// paused agent run and records the decision as an audit row.
+// POST /api/v1/approvals/{id}/decide. The backplane records the
+// decision durably and broadcasts approval_decided; the paused agent
+// run resumes off the broadcast (#1117 path).
 func newApproveCmd() *cobra.Command {
 	var (
 		reason            string
@@ -30,11 +32,12 @@ func newApproveCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "approve <id>",
 		Short: "Approve a pending approval request",
-		Long: "approve calls POST /api/v1/approvals/{id}/approve to " +
-			"flip the request status to approved, resume the paused " +
-			"agent run (T4 path), and record the decision as an audit " +
-			"row. Only pending requests can be approved; any other " +
-			"status returns 409. --reason attaches a human-readable " +
+		Long: "approve calls POST /api/v1/approvals/{id}/decide with " +
+			"decision=approved to flip the request status, write the " +
+			"decision audit row, and broadcast approval_decided. The " +
+			"paused agent run resumes off the broadcast (T9 #1117). " +
+			"Only pending requests can be approved; any other status " +
+			"returns 409. --reason attaches a human-readable " +
 			"rationale to the decision row.",
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
@@ -55,8 +58,9 @@ func newApproveCmd() *cobra.Command {
 //	meho approvals reject <id> [--reason TEXT] [--json] [--backplane <url>]
 //
 // Role: operator. Rejects a pending approval request via
-// POST /api/v1/approvals/{id}/reject. The backplane aborts the paused
-// agent run and records the decision as an audit row.
+// POST /api/v1/approvals/{id}/decide. The backplane records the
+// decision durably and broadcasts approval_decided; the paused agent
+// run aborts off the broadcast (#1117 path).
 func newRejectCmd() *cobra.Command {
 	var (
 		reason            string
@@ -66,11 +70,12 @@ func newRejectCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "reject <id>",
 		Short: "Reject a pending approval request",
-		Long: "reject calls POST /api/v1/approvals/{id}/reject to " +
-			"flip the request status to rejected, abort the paused " +
-			"agent run (T4 path), and record the decision as an audit " +
-			"row. Only pending requests can be rejected; any other " +
-			"status returns 409. --reason attaches a human-readable " +
+		Long: "reject calls POST /api/v1/approvals/{id}/decide with " +
+			"decision=rejected to flip the request status, write the " +
+			"decision audit row, and broadcast approval_decided. The " +
+			"paused agent run aborts off the broadcast (T9 #1117). " +
+			"Only pending requests can be rejected; any other status " +
+			"returns 409. --reason attaches a human-readable " +
 			"rationale to the rejection.",
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
@@ -87,25 +92,46 @@ func newRejectCmd() *cobra.Command {
 }
 
 // runDecision is the shared implementation for approve and reject.
+// It parses the operator's `<id>` arg as a UUID, dispatches the
+// /decide POST through the typed client, then re-fetches the
+// ApprovalRequestView so the renderer has the full post-decision
+// shape (status, reviewed_by, decided_at).
 func runDecision(
 	cmd *cobra.Command,
-	id, verb, reason string,
+	idArg, verb, reason string,
 	jsonOut bool,
 	backplaneOverride string,
 ) error {
+	requestID, err := parseRequestID(idArg)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()),
+			jsonOut,
+		)
+	}
 	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
-	detail, err := postDecision(cmd.Context(), backplaneURL, id, verb, reason)
+	client, cerr := newAuthedClient(cmd.Context(), cmd, backplaneURL, jsonOut)
+	if cerr != nil {
+		return cerr
+	}
+	detail, err := postDecision(cmd.Context(), client, requestID, verb, reason)
 	if err != nil {
-		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+		return routeRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	if detail == nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("backplane returned 200 OK but no JSON body decoded against ApprovalRequestView after decide"),
+			jsonOut,
+		)
 	}
 	if jsonOut {
 		return output.PrintJSON(cmd.OutOrStdout(), detail)
 	}
 	w := cmd.OutOrStdout()
-	fmt.Fprintf(w, "approval_request %s → %s\n", id, detail.Status)
+	fmt.Fprintf(w, "approval_request %s → %s\n", idArg, string(detail.Status))
 	if detail.ReviewedBy != nil {
 		fmt.Fprintf(w, "reviewed by: %s\n", *detail.ReviewedBy)
 	}
@@ -115,39 +141,50 @@ func runDecision(
 	return nil
 }
 
-// postDecision calls POST /api/v1/approvals/{id}/decide (G11.2-T5
-// operator-decision path: no params required; the backend flips the
-// status, writes the decision audit row, and broadcasts the
-// approval_decided event). After the decision commits, the function
-// fetches GET /api/v1/approvals/{id} so the caller can render the
-// full ApprovalRequestView (status, reviewed_by, decided_at).
+// postDecision calls POST /api/v1/approvals/{id}/decide via the
+// generated client (G11.2-T5 operator-decision path: no params
+// required; the backend flips the status, writes the decision audit
+// row, and broadcasts the approval_decided event), then re-fetches
+// the ApprovalRequestView via GET /api/v1/approvals/{id} so the
+// caller can render the full post-decision shape. Returns a
+// non-2xx response on the decide POST as an `*httpResponseError`
+// without making the follow-up GET — there's no shape to render
+// when the decision was rejected.
 func postDecision(
 	ctx context.Context,
-	backplaneURL, id, verb, reason string,
-) (*ApprovalDetail, error) {
+	client *api.AuthedClient,
+	requestID uuid.UUID,
+	verb, reason string,
+) (*api.ApprovalRequestView, error) {
 	// verb is "approve" or "reject"; backend wants the past-tense form.
 	decision := "approved"
 	if verb == "reject" {
 		decision = "rejected"
 	}
-	body := decisionBody{Decision: decision, Reason: reason}
-	bodyJSON, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal decision body: %w", err)
+	body := api.DecideRequestBody{Decision: decision}
+	if reason != "" {
+		r := reason
+		body.Reason = &r
 	}
-	decidePath := fmt.Sprintf("/api/v1/approvals/%s/decide", id)
-	if _, err := doAuthedRequest(ctx, backplaneURL, "POST", decidePath, bodyJSON); err != nil {
-		return nil, err
-	}
-	// Fetch the full view for rendering.
-	showPath := fmt.Sprintf("/api/v1/approvals/%s", id)
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", showPath, nil)
+	resp, err := client.DecideApprovalRequestApiV1ApprovalsRequestIdDecidePostWithResponse(ctx, requestID, nil, body)
 	if err != nil {
 		return nil, err
 	}
-	var out ApprovalDetail
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode show response after decide: %w", err)
+	if resp.StatusCode() == 401 {
+		if rerr := client.Refresh(ctx); rerr != nil {
+			return nil, rerr
+		}
+		resp, err = client.DecideApprovalRequestApiV1ApprovalsRequestIdDecidePostWithResponse(ctx, requestID, nil, body)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return &out, nil
+	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
+		return nil, &httpResponseError{statusCode: resp.StatusCode(), body: resp.Body}
+	}
+	// Decision committed; fetch the full ApprovalRequestView for
+	// rendering. fetchDetail already retries on 401 (rare here since
+	// the decide call just succeeded, but defensive against a
+	// token-rotation window between the two calls).
+	return fetchDetail(ctx, client, requestID)
 }

--- a/cli/internal/cmd/approvals/list.go
+++ b/cli/internal/cmd/approvals/list.go
@@ -5,14 +5,12 @@ package approvals
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
-	"strconv"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -56,6 +54,14 @@ func newListCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&statusFilter, "status", "",
 		"filter by status: pending, approved, rejected, expired (default: all)")
+	// --limit and --offset are preserved for CLI-signature compatibility
+	// (operator scripts may pass them). The backend's
+	// /api/v1/approvals route doesn't accept either parameter today
+	// (see backend/src/meho_backplane/api/v1/approvals.py:list_approvals),
+	// and the generated client's ListApprovalsApiV1ApprovalsGetParams
+	// therefore exposes only `status`. We still client-side-validate
+	// the flag ranges so operators get a clear error on bad input;
+	// adding paging on the server is its own (out-of-scope) Task.
 	cmd.Flags().IntVar(&limit, "limit", 0,
 		"max requests per page (1..500, server default 50 when omitted)")
 	cmd.Flags().IntVar(&offset, "offset", 0,
@@ -107,51 +113,73 @@ func runList(cmd *cobra.Command, opts listOpts) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	resp, err := fetchList(cmd.Context(), backplaneURL, opts)
+	client, cerr := newAuthedClient(cmd.Context(), cmd, backplaneURL, opts.JSONOut)
+	if cerr != nil {
+		return cerr
+	}
+	items, err := fetchList(cmd.Context(), client, opts)
 	if err != nil {
-		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+		return routeRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if items == nil {
+		// Defensive: a 2xx with a missing JSON200 means the server's
+		// response didn't decode against ApprovalRequestView (schema
+		// drift). The OpenAPI freshness gate catches new fields; a
+		// `nil` JSON200 here would mean the FastAPI side returned
+		// 200 with a body that doesn't match the spec — unexpected.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("backplane returned 200 OK but no JSON body decoded against ApprovalRequestView"),
+			opts.JSONOut,
+		)
 	}
 	if opts.JSONOut {
-		return output.PrintJSON(cmd.OutOrStdout(), resp)
+		return output.PrintJSON(cmd.OutOrStdout(), items)
 	}
-	printListTable(cmd.OutOrStdout(), resp)
+	printListTable(cmd.OutOrStdout(), items)
 	return nil
 }
 
-// buildListPath assembles the GET /api/v1/approvals query string.
-func buildListPath(opts listOpts) string {
-	q := url.Values{}
+// fetchList drives the typed-client `ListApprovalsApiV1ApprovalsGet`
+// endpoint with a one-shot 401-retry around the underlying
+// AuthedClient's refresh path (mirrors `AuthedClient.GetHealth`'s
+// pattern in client.go). Non-2xx responses are returned as
+// `*httpResponseError` so the caller can route them through
+// `renderHTTPStatus`; transport-layer errors return verbatim.
+func fetchList(
+	ctx context.Context,
+	client *api.AuthedClient,
+	opts listOpts,
+) ([]api.ApprovalRequestView, error) {
+	params := &api.ListApprovalsApiV1ApprovalsGetParams{}
 	if opts.StatusFilter != "" {
-		q.Set("status", opts.StatusFilter)
+		s := opts.StatusFilter
+		params.Status = &s
 	}
-	if opts.Limit > 0 {
-		q.Set("limit", strconv.Itoa(opts.Limit))
-	}
-	if opts.Offset > 0 {
-		q.Set("offset", strconv.Itoa(opts.Offset))
-	}
-	path := "/api/v1/approvals"
-	if encoded := q.Encode(); encoded != "" {
-		path = path + "?" + encoded
-	}
-	return path
-}
-
-func fetchList(ctx context.Context, backplaneURL string, opts listOpts) ([]ApprovalSummary, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildListPath(opts), nil)
+	resp, err := client.ListApprovalsApiV1ApprovalsGetWithResponse(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	var out []ApprovalSummary
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode approvals list response: %w", err)
+	if resp.StatusCode() == 401 {
+		if rerr := client.Refresh(ctx); rerr != nil {
+			return nil, rerr
+		}
+		resp, err = client.ListApprovalsApiV1ApprovalsGetWithResponse(ctx, params)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return out, nil
+	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
+		return nil, &httpResponseError{statusCode: resp.StatusCode(), body: resp.Body}
+	}
+	if resp.JSON200 == nil {
+		return nil, nil
+	}
+	return *resp.JSON200, nil
 }
 
 // printListTable renders the list as a compact table.
 // Columns: ID (truncated), STATUS, CONNECTOR, OP, PRINCIPAL, CREATED.
-func printListTable(w io.Writer, items []ApprovalSummary) {
+func printListTable(w io.Writer, items []api.ApprovalRequestView) {
 	if len(items) == 0 {
 		fmt.Fprintln(w, "no approval requests in this tenant")
 		return
@@ -160,10 +188,10 @@ func printListTable(w io.Writer, items []ApprovalSummary) {
 		"ID", "STATUS", "CONNECTOR", "OP", "PRINCIPAL", "CREATED")
 	for _, e := range items {
 		fmt.Fprintf(w, "%-36s %-9s %-24s %-32s %-20s %s\n",
-			e.ID,
-			e.Status,
-			truncate(e.ConnectorID, 24),
-			truncate(e.OpID, 32),
+			e.Id.String(),
+			string(e.Status),
+			truncate(e.ConnectorId, 24),
+			truncate(e.OpId, 32),
 			truncate(e.PrincipalSub, 20),
 			e.CreatedAt,
 		)

--- a/cli/internal/cmd/approvals/show.go
+++ b/cli/internal/cmd/approvals/show.go
@@ -8,8 +8,10 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -49,14 +51,31 @@ func newShowCmd() *cobra.Command {
 	return cmd
 }
 
-func runShow(cmd *cobra.Command, id string, jsonOut bool, backplaneOverride string) error {
+func runShow(cmd *cobra.Command, idArg string, jsonOut bool, backplaneOverride string) error {
+	requestID, err := parseRequestID(idArg)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()),
+			jsonOut,
+		)
+	}
 	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
-	detail, err := fetchDetail(cmd.Context(), backplaneURL, id)
+	client, cerr := newAuthedClient(cmd.Context(), cmd, backplaneURL, jsonOut)
+	if cerr != nil {
+		return cerr
+	}
+	detail, err := fetchDetail(cmd.Context(), client, requestID)
 	if err != nil {
-		return renderRequestError(cmd, backplaneURL, err, jsonOut)
+		return routeRequestError(cmd, backplaneURL, err, jsonOut)
+	}
+	if detail == nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("backplane returned 200 OK but no JSON body decoded against ApprovalRequestView"),
+			jsonOut,
+		)
 	}
 	if jsonOut {
 		return output.PrintJSON(cmd.OutOrStdout(), detail)
@@ -65,33 +84,68 @@ func runShow(cmd *cobra.Command, id string, jsonOut bool, backplaneOverride stri
 	return nil
 }
 
-func fetchDetail(ctx context.Context, backplaneURL, id string) (*ApprovalDetail, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", "/api/v1/approvals/"+id, nil)
+// parseRequestID validates the operator's `<id>` arg as a UUID at
+// the verb edge. The typed-client's path parameter is
+// `openapi_types.UUID` (an alias for `uuid.UUID`); parsing here
+// keeps the bad-input error a clean output.Unexpected instead of a
+// `fmt.Errorf("invalid UUID: %s")` mid-request or a server-side 422
+// after the round-trip. Returns a `uuid.UUID` (assignable to
+// `openapi_types.UUID` since the alias resolves to the same type).
+func parseRequestID(idArg string) (uuid.UUID, error) {
+	id, err := uuid.Parse(idArg)
+	if err != nil {
+		return uuid.UUID{}, fmt.Errorf("approval-id is not a valid UUID: %s", idArg)
+	}
+	return id, nil
+}
+
+// fetchDetail drives the typed-client `GetApprovalRequestApiV1ApprovalsRequestIdGet`
+// endpoint with the same one-shot 401-retry shape `fetchList` uses
+// (see comments there for the rationale). Returns `*ApprovalRequestView`
+// on success, `*httpResponseError` for a non-2xx response, the
+// underlying error for transport-layer failures, and `(nil, nil)`
+// if the backplane returned 200 with a body that didn't decode
+// against `ApprovalRequestView` (the defensive-nil branch the
+// caller surfaces as `output.Unexpected`).
+func fetchDetail(
+	ctx context.Context,
+	client *api.AuthedClient,
+	requestID uuid.UUID,
+) (*api.ApprovalRequestView, error) {
+	resp, err := client.GetApprovalRequestApiV1ApprovalsRequestIdGetWithResponse(ctx, requestID, nil)
 	if err != nil {
 		return nil, err
 	}
-	var out ApprovalDetail
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode approval detail response: %w", err)
+	if resp.StatusCode() == 401 {
+		if rerr := client.Refresh(ctx); rerr != nil {
+			return nil, rerr
+		}
+		resp, err = client.GetApprovalRequestApiV1ApprovalsRequestIdGetWithResponse(ctx, requestID, nil)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return &out, nil
+	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
+		return nil, &httpResponseError{statusCode: resp.StatusCode(), body: resp.Body}
+	}
+	return resp.JSON200, nil
 }
 
-func printDetail(cmd *cobra.Command, d *ApprovalDetail) {
+func printDetail(cmd *cobra.Command, d *api.ApprovalRequestView) {
 	w := cmd.OutOrStdout()
-	fmt.Fprintf(w, "ID:           %s\n", d.ID)
-	fmt.Fprintf(w, "Status:       %s\n", d.Status)
-	fmt.Fprintf(w, "Connector:    %s\n", d.ConnectorID)
-	fmt.Fprintf(w, "Operation:    %s\n", d.OpID)
-	if d.TargetID != nil {
-		fmt.Fprintf(w, "Target:       %s\n", *d.TargetID)
+	fmt.Fprintf(w, "ID:           %s\n", d.Id.String())
+	fmt.Fprintf(w, "Status:       %s\n", string(d.Status))
+	fmt.Fprintf(w, "Connector:    %s\n", d.ConnectorId)
+	fmt.Fprintf(w, "Operation:    %s\n", d.OpId)
+	if d.TargetId != nil {
+		fmt.Fprintf(w, "Target:       %s\n", d.TargetId.String())
 	}
 	fmt.Fprintf(w, "Principal:    %s\n", d.PrincipalSub)
 	if d.PrincipalAct != nil {
 		fmt.Fprintf(w, "Acting as:    %s\n", *d.PrincipalAct)
 	}
-	if d.RunID != nil {
-		fmt.Fprintf(w, "Agent run:    %s\n", *d.RunID)
+	if d.RunId != nil {
+		fmt.Fprintf(w, "Agent run:    %s\n", d.RunId.String())
 	}
 	fmt.Fprintf(w, "Params hash:  %s\n", d.ParamsHash)
 	fmt.Fprintf(w, "Created:      %s\n", d.CreatedAt)


### PR DESCRIPTION
## Summary

- First migration under Initiative #1118 (G0.12 CLI hygiene). Drops the `meho approvals ...` package off hand-rolled HTTP + consumer-side struct duplicates and onto the generated typed client (`api.ClientWithResponses` via the embedded `api.AuthedClient`).
- Deletes `ApprovalSummary`, `ApprovalDetail`, `decisionBody`, the local `doAuthedRequest` / `sendRequest` / `httpError` triple (484 LOC of pre-existing duplicate machinery), and the inline JSON-decode helpers. The renderers (`printListTable`, `printDetail`, the inline decision summary) consume `api.ApprovalRequestView` directly; the `cli-api-snapshot-freshness` gate now covers them.
- Hoists `<id>` arg validation to the verb edge via `uuid.Parse` (`openapi_types.UUID = uuid.UUID`), surfacing garbage cleanly as `output.Unexpected("approval-id is not a valid UUID: …")` instead of a panic, an `fmt.Errorf` mid-request, or a server-side 422 after the round-trip.
- Adds `cli/internal/cmd/approvals/approvals_test.go` (760 lines, no prior tests in the package) covering all four verbs + the four error categories via an `httptest.Server` + in-memory `auth.TokenStore` fixture (mirrors `cli/internal/cmd/connector/connector_test.go`).
- Preserves operator-visible behaviour byte-for-byte: same flag names, same output format, same error categories, same `/decide` route semantics (the direct `/approve` and `/reject` typed-client methods are deliberately out of scope for this hygiene Initiative).

The `--limit` and `--offset` flags on `meho approvals list` are preserved for CLI-signature compatibility but become no-ops at the typed-client layer — the backend's `/api/v1/approvals` route never accepted either parameter, and the generated `ListApprovalsApiV1ApprovalsGetParams` accordingly exposes only `status`. Adding paging server-side is a separate Task. The issue body's claim that the generator already exposes typed `limit` / `offset` params was factually incorrect; reality wins. Operator-visible behaviour stays byte-identical (the backend ignored both params before; ignores them now).

## Test plan

- [x] `cd cli && go build ./...` — clean
- [x] `cd cli && go vet ./...` — clean
- [x] `cd cli && go test ./internal/cmd/approvals/...` — pass (18 tests)
- [x] `cd cli && go test ./...` — pass (every package in the CLI module)
- [x] `cd cli && grep -rn "http.NewRequest\|json.Unmarshal\|doAuthedRequest\|ApprovalSummary\|ApprovalDetail\|decisionBody" internal/cmd/approvals/` — zero matches (acceptance criterion 1)
- [x] `cd cli && grep -rn "api.ClientWithResponses\|ApprovalRequestView" internal/cmd/approvals/` — matches in `approvals.go` / `list.go` / `show.go` / `approve.go` / `approvals_test.go` (acceptance criterion 2)
- [x] No backend changes; `git status` clean outside `cli/internal/cmd/approvals/` (acceptance criterion 5 + 6)
- [ ] Manual smoke against a running backplane (`meho approvals list / show / approve / reject`) — deferred to CI / a follow-up smoke pass; the httptest-mocked unit tests cover the wire shape + error mapping the acceptance criterion 6 asks for, and CI's contract gates cover the rest.

## Out of scope

- The FastAPI approvals surface — server stays exactly as it is.
- Switching from `/decide` to the direct `/approve` and `/reject` routes (the typed client exposes them; a route-semantics change is its own ticket).
- The other CLI verb directories listed under Initiative #1118 — each is its own G0.12-T<N> Task.
- Promoting `api.AuthedClient` to a shared `ClientWithResponses` factory beyond the four approvals verbs; the broader factory pattern is deferred to G0.12-T2 (`operation/`) where it gets exercised harder.

Closes #1251
