### PR TITLE
refactor(cli): G0.12-T3 migrate cmd/agent/ to the generated typed client

### DIFF
--- a/cli/internal/cmd/agent/agent.go
+++ b/cli/internal/cmd/agent/agent.go
@@ -39,16 +39,20 @@
 // backend rejects non-tenant_admin write callers with HTTP 403; the
 // verbs render this as insufficient_role.
 //
-// The implementation follows the in-package HTTP helper pattern the
-// sibling verb trees use (a local doAuthedRequest / renderRequestError
-// pair) rather than a shared client package, for the import-cycle
-// reason every sibling cites: each verb tree is grafted onto the root
-// command, so a shared helper imported from cmd/* and from a per-tree
-// package would close the cycle.
+// The HTTP surface is the generated oapi-codegen typed client at
+// `cli/internal/api/client.gen.go`, wrapped by `api.AuthedClient` for
+// the bearer + one-shot 401-refresh retry. The agent package no longer
+// owns request/response struct definitions: `api.AgentDefinitionRead`,
+// `api.AgentDefinitionListResponse`, `api.AgentDefinitionCreate`,
+// `api.AgentDefinitionUpdate`, `api.AgentRunRequest`,
+// `api.AgentRunStatusResponse`, `api.AgentGrantRead`,
+// `api.AgentGrantListResponse`, `api.AgentGrantCreate`, and
+// `api.AgentElevationCreate` are the single source of truth — kept in
+// lock-step with the FastAPI Pydantic models by the
+// `cli-api-snapshot-freshness` CI gate (G0.12 Initiative #1118).
 package agent
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -99,51 +103,65 @@ func NewRootCmd() *cobra.Command {
 	return cmd
 }
 
-// Entry mirrors the backend AgentDefinitionRead pydantic model
-// (`backend/src/meho_backplane/api/v1/agents.py`). Hand-written rather
-// than aliased to a generated client type so the agent package stays
-// decoupled from oapi-codegen churn — the same stance the kb / audit /
-// broadcast packages take. `OutputSchema` is a pointer so the JSON
-// round-trip preserves the explicit-null wire shape (an agent with no
-// structured-output schema has the field null).
-type Entry struct {
-	ID           string         `json:"id"`
-	TenantID     string         `json:"tenant_id"`
-	Name         string         `json:"name"`
-	IdentityRef  string         `json:"identity_ref"`
-	ModelTier    string         `json:"model_tier"`
-	SystemPrompt string         `json:"system_prompt"`
-	Toolset      map[string]any `json:"toolset"`
-	TurnBudget   int            `json:"turn_budget"`
-	OutputSchema map[string]any `json:"output_schema"`
-	Enabled      bool           `json:"enabled"`
-	CreatedBySub string         `json:"created_by_sub"`
-	CreatedAt    string         `json:"created_at"`
-	UpdatedAt    string         `json:"updated_at"`
-}
-
-// ListResponse mirrors the backend AgentDefinitionListResponse
-// envelope (`{"agents": [...]}`) — wrapped for forward-compat with
-// future paging fields.
-type ListResponse struct {
-	Agents []Entry `json:"agents"`
-}
-
 // validModelTiers mirrors the backend AgentModelTier enum. CLI-side
 // validation gives the operator an immediate rejection rather than a
 // remote 422.
 var validModelTiers = map[string]bool{"standard": true, "fast": true, "deep": true}
 
-// errMissingAccessToken is the sentinel doAuthedRequest returns when
+// errMissingAccessToken is the sentinel newAuthedClient returns when
 // the stored token row exists but its access_token is empty — a
 // credential-state failure that renderRequestError maps to
-// auth_expired with a `meho login` hint. Mirrors the kb package's
-// shape.
+// auth_expired with a `meho login` hint.
 var errMissingAccessToken = errors.New("meho: stored token has no access_token")
 
-// renderRequestError translates a request error into the right
-// output.StructuredError category. Maps the agents REST surface's
-// status codes:
+// newAuthedClient builds an api.AuthedClient for the supplied
+// backplane URL and verifies a non-empty bearer is loaded. Centralised
+// so every verb's typed-call path goes through the same
+// "stored-token-loaded + non-empty bearer" gate; the caller forwards
+// any returned error to renderRequestError for category mapping.
+func newAuthedClient(ctx context.Context, backplaneURL string) (*api.AuthedClient, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if authed.AccessToken() == "" {
+		return nil, errMissingAccessToken
+	}
+	return authed, nil
+}
+
+// retryOn401 invokes call once, and if the typed response carries a
+// 401, runs a one-shot bearer refresh and re-issues call. Mirrors the
+// behaviour `api.AuthedClient.GetHealth` implements for the
+// /api/v1/health endpoint, generalised so every agent verb runs the
+// same transparent-retry contract.
+//
+// statusOf reads the StatusCode off the typed response envelope (the
+// generated *Response types expose StatusCode() through their embedded
+// *http.Response). A nil response counts as "no retry" — the transport
+// already failed and the caller surfaces err directly.
+func retryOn401[R any](
+	ctx context.Context,
+	authed *api.AuthedClient,
+	call func(ctx context.Context) (*R, error),
+	statusOf func(*R) int,
+) (*R, error) {
+	resp, err := call(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || statusOf(resp) != http.StatusUnauthorized {
+		return resp, nil
+	}
+	if rerr := authed.Refresh(ctx); rerr != nil {
+		return resp, rerr
+	}
+	return call(ctx)
+}
+
+// renderRequestError translates a request error or the status code on
+// a typed response into the right output.StructuredError category.
+// Maps the agents REST surface's status codes:
 //
 //   - empty stored bearer → auth_expired.
 //   - 401 (refresh failed) → auth_expired with a `meho login` hint.
@@ -187,25 +205,26 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
-		return renderHTTPError(cmd, backplaneURL, he, jsonOut)
-	}
 	return output.RenderError(cmd.ErrOrStderr(),
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
 }
 
-// renderHTTPError classifies a non-2xx response into the right
-// StructuredError category.
-func renderHTTPError(
+// renderHTTPStatus classifies a non-2xx response (or 401 after a
+// failed refresh) carried in the typed envelope into the right
+// StructuredError category. resp must be non-nil and statusCode must
+// be the HTTP status from resp; body is the raw response body bytes
+// the envelope already buffered.
+func renderHTTPStatus(
 	cmd *cobra.Command,
 	backplaneURL string,
-	he *httpError,
+	statusCode int,
+	body []byte,
 	jsonOut bool,
 ) error {
-	switch he.StatusCode {
+	bodyStr := strings.TrimSpace(string(body))
+	switch statusCode {
 	case http.StatusUnauthorized:
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.AuthExpired(fmt.Sprintf(
@@ -216,7 +235,7 @@ func renderHTTPError(
 		)
 	case http.StatusForbidden:
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.InsufficientRole(decodeDetailString(he.Body)),
+			output.InsufficientRole(decodeDetailString(bodyStr)),
 			jsonOut,
 		)
 	case http.StatusNotFound:
@@ -227,23 +246,23 @@ func renderHTTPError(
 		// the path) a 404 means the route doesn't exist on this
 		// backplane — typically an older deploy without T2.
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(decodeDetailString(he.Body)),
+			output.Unexpected(decodeDetailString(bodyStr)),
 			jsonOut,
 		)
 	case http.StatusConflict:
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(decodeDetailString(he.Body)),
+			output.Unexpected(decodeDetailString(bodyStr)),
 			jsonOut,
 		)
 	case http.StatusUnprocessableEntity:
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf("invalid request: %s", he.Body)),
+			output.Unexpected(fmt.Sprintf("invalid request: %s", bodyStr)),
 			jsonOut,
 		)
 	default:
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, statusCode, bodyStr)),
 			jsonOut,
 		)
 	}
@@ -268,114 +287,16 @@ func decodeDetailString(body string) string {
 	return strings.TrimSpace(body)
 }
 
-// doAuthedRequest issues a single HTTP request against the backplane
-// with bearer injection and one-shot 401-refresh-retry. Returns the
-// response body bytes (already drained) on 2xx, or an *httpError on
-// non-2xx, or an error categorised by api.IsTokenNotFound /
-// api.IsNoRefreshToken / generic transport. A 204 yields a nil body
-// without error (the DELETE verb hits this path).
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errMissingAccessToken
-	}
-
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, responseBodyCap+1))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if int64(len(raw)) > responseBodyCap {
-		return nil, fmt.Errorf(
-			"response body exceeds %d-byte cap; refusing to decode possibly-truncated JSON",
-			responseBodyCap,
-		)
-	}
-	if resp.StatusCode == http.StatusNoContent {
-		return nil, nil
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-// responseBodyCap bounds the response body the CLI will read. An agent
-// definition is a small structured record (system prompt + toolset
-// spec); 1 MiB is comfortable headroom and protects against an
-// adversarial / misconfigured backplane sending an unbounded response.
-const responseBodyCap int64 = 1 << 20
-
-// httpError carries a non-2xx response so per-verb runners render the
-// right category.
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
-}
-
-// printEntrySummary renders a definition as a key-value summary. The
-// system prompt is reported by length (not dumped) so the summary stays
-// scannable; operators wanting the full prompt use `--json`.
-func printEntrySummary(w io.Writer, e *Entry) {
+// printDefinitionSummary renders a definition as a key-value summary.
+// The system prompt is reported by length (not dumped) so the summary
+// stays scannable; operators wanting the full prompt use `--json`.
+func printDefinitionSummary(w io.Writer, e *api.AgentDefinitionRead) {
 	if e == nil {
 		return
 	}
 	fmt.Fprintf(w, "%-16s %s\n", "name:", e.Name)
-	fmt.Fprintf(w, "%-16s %s\n", "id:", e.ID)
-	fmt.Fprintf(w, "%-16s %s\n", "tenant_id:", e.TenantID)
+	fmt.Fprintf(w, "%-16s %s\n", "id:", e.Id.String())
+	fmt.Fprintf(w, "%-16s %s\n", "tenant_id:", e.TenantId.String())
 	fmt.Fprintf(w, "%-16s %s\n", "identity_ref:", e.IdentityRef)
 	fmt.Fprintf(w, "%-16s %s\n", "model_tier:", e.ModelTier)
 	fmt.Fprintf(w, "%-16s %d\n", "turn_budget:", e.TurnBudget)
@@ -383,8 +304,8 @@ func printEntrySummary(w io.Writer, e *Entry) {
 	fmt.Fprintf(w, "%-16s %d bytes\n", "system_prompt:", len(e.SystemPrompt))
 	fmt.Fprintf(w, "%-16s %t\n", "output_schema:", e.OutputSchema != nil)
 	fmt.Fprintf(w, "%-16s %s\n", "created_by:", e.CreatedBySub)
-	fmt.Fprintf(w, "%-16s %s\n", "created_at:", e.CreatedAt)
-	fmt.Fprintf(w, "%-16s %s\n", "updated_at:", e.UpdatedAt)
+	fmt.Fprintf(w, "%-16s %s\n", "created_at:", e.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"))
+	fmt.Fprintf(w, "%-16s %s\n", "updated_at:", e.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z"))
 }
 
 // confirmPrompt prompts on stdin/stdout and returns true only when the

--- a/cli/internal/cmd/agent/agent_test.go
+++ b/cli/internal/cmd/agent/agent_test.go
@@ -17,7 +17,8 @@ import (
 )
 
 // seedXDGAndToken seeds a per-test config dir + token store that
-// backplane.Resolve / doAuthedRequest read. Mirrors the same helper in
+// backplane.Resolve and the generated typed client (via
+// api.NewAuthedClient) read. Mirrors the same helper in
 // cli/internal/cmd/kb/kb_test.go.
 func seedXDGAndToken(t *testing.T, backplaneURL string) string {
 	t.Helper()

--- a/cli/internal/cmd/agent/create.go
+++ b/cli/internal/cmd/agent/create.go
@@ -5,31 +5,15 @@ package agent
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
-
-// createRequest mirrors the backend AgentDefinitionCreate pydantic
-// model. Optional JSON-object fields use pointers / omitempty so an
-// omitted flag is left out of the request body (the backend applies
-// its documented defaults). `Enabled` is a pointer so the CLI can omit
-// it (backend default true) yet still send an explicit false when
-// --disabled is passed.
-type createRequest struct {
-	Name         string         `json:"name"`
-	IdentityRef  string         `json:"identity_ref"`
-	ModelTier    string         `json:"model_tier"`
-	SystemPrompt string         `json:"system_prompt"`
-	Toolset      map[string]any `json:"toolset,omitempty"`
-	TurnBudget   int            `json:"turn_budget"`
-	OutputSchema map[string]any `json:"output_schema,omitempty"`
-	Enabled      *bool          `json:"enabled,omitempty"`
-}
 
 // newCreateCmd returns the `meho agent create` command.
 //
@@ -97,7 +81,7 @@ func newCreateCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&disabled, "disabled", false,
 		"create the definition parked (enabled=false; default is enabled)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
-		"emit raw Entry JSON instead of the human summary")
+		"emit raw AgentDefinitionRead JSON instead of the human summary")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
 	_ = cmd.MarkFlagRequired("identity-ref")
@@ -149,43 +133,53 @@ func runCreate(cmd *cobra.Command, opts createOptions) error {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 
-	req := createRequest{
+	body := api.AgentDefinitionCreate{
 		Name:         opts.Name,
 		IdentityRef:  opts.IdentityRef,
-		ModelTier:    opts.ModelTier,
+		ModelTier:    api.AgentModelTier(opts.ModelTier),
 		SystemPrompt: opts.SystemPrompt,
-		Toolset:      toolset,
 		TurnBudget:   opts.TurnBudget,
-		OutputSchema: outputSchema,
+	}
+	// Toolset is `*map[string]interface{}` with `omitempty` — leaving it
+	// nil tells the backend to apply its documented default ({}).
+	if toolset != nil {
+		body.Toolset = &toolset
+	}
+	// OutputSchema is `*map[string]interface{}` without `omitempty`, so a
+	// nil pointer round-trips to wire `null`, matching the backend's
+	// "no structured-output schema" semantics.
+	if outputSchema != nil {
+		body.OutputSchema = &outputSchema
 	}
 	if opts.Disabled {
 		disabled := false
-		req.Enabled = &disabled
+		body.Enabled = &disabled
 	}
-	entry, err := postCreate(cmd.Context(), backplaneURL, req)
+	resp, err := postCreate(cmd.Context(), backplaneURL, body)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
+	if resp.StatusCode() != http.StatusCreated {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	entry := resp.JSON201
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), entry)
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "created agent definition %q\n", entry.Name)
-	printEntrySummary(cmd.OutOrStdout(), entry)
+	printDefinitionSummary(cmd.OutOrStdout(), entry)
 	return nil
 }
 
-func postCreate(ctx context.Context, backplaneURL string, req createRequest) (*Entry, error) {
-	body, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("marshal agent create request: %w", err)
-	}
-	raw, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/agents", body)
+func postCreate(ctx context.Context, backplaneURL string, body api.AgentDefinitionCreate) (*api.CreateAgentApiV1AgentsPostResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out Entry
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode agent create response: %w", err)
-	}
-	return &out, nil
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.CreateAgentApiV1AgentsPostResponse, error) {
+			return authed.CreateAgentApiV1AgentsPostWithResponse(ctx, nil, body)
+		},
+		func(r *api.CreateAgentApiV1AgentsPostResponse) int { return r.StatusCode() },
+	)
 }

--- a/cli/internal/cmd/agent/crud_test.go
+++ b/cli/internal/cmd/agent/crud_test.go
@@ -11,36 +11,50 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/evoila/meho/cli/internal/api"
 )
 
-func sampleEntry() Entry {
-	return Entry{
-		ID:           "11111111-1111-1111-1111-111111111111",
-		TenantID:     "22222222-2222-2222-2222-222222222222",
+// sampleDefinition returns a representative AgentDefinitionRead for
+// happy-path fixtures. Stable UUIDs / timestamps so subtests can
+// assert on the rendered output without time-of-day flakiness.
+func sampleDefinition() api.AgentDefinitionRead {
+	id := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	tenantID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	created := time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC)
+	toolset := map[string]any{"allow": []any{"call_operation"}}
+	return api.AgentDefinitionRead{
+		Id:           id,
+		TenantId:     tenantID,
 		Name:         "incident-triage",
 		IdentityRef:  "agent:incident-triage",
 		ModelTier:    "deep",
 		SystemPrompt: "You triage incidents.",
-		Toolset:      map[string]any{"allow": []any{"call_operation"}},
+		Toolset:      toolset,
 		TurnBudget:   25,
 		Enabled:      true,
 		CreatedBySub: "op-admin",
-		CreatedAt:    "2026-05-24T00:00:00Z",
-		UpdatedAt:    "2026-05-24T00:00:00Z",
+		CreatedAt:    created,
+		UpdatedAt:    created,
 	}
 }
 
 // --- list ---
 
-func TestBuildListPath(t *testing.T) {
-	if got := buildListPath(listOptions{}); got != "/api/v1/agents" {
-		t.Fatalf("empty opts: got %q", got)
+func TestListQueryParams(t *testing.T) {
+	params := listQueryParams(listOptions{})
+	if params.Limit != nil || params.Offset != nil {
+		t.Fatalf("empty opts must leave Limit / Offset nil; got %+v", params)
 	}
-	got := buildListPath(listOptions{Limit: 25, Offset: 10})
-	for _, want := range []string{"limit=25", "offset=10"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("buildListPath missing %q in %q", want, got)
-		}
+	params = listQueryParams(listOptions{Limit: 25, Offset: 10})
+	if params.Limit == nil || *params.Limit != 25 {
+		t.Errorf("Limit: got %+v", params.Limit)
+	}
+	if params.Offset == nil || *params.Offset != 10 {
+		t.Errorf("Offset: got %+v", params.Offset)
 	}
 }
 
@@ -50,7 +64,13 @@ func TestRunListHappyPath(t *testing.T) {
 		if r.Header.Get("Authorization") == "" {
 			t.Errorf("missing Authorization header")
 		}
-		_ = json.NewEncoder(w).Encode(ListResponse{Agents: []Entry{sampleEntry()}})
+		// The generated client sets Accept: application/json (the only
+		// content-type the spec advertises for the list endpoint), so
+		// no special header assertion is needed beyond bearer presence.
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.AgentDefinitionListResponse{
+			Agents: []api.AgentDefinitionRead{sampleDefinition()},
+		})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -69,7 +89,7 @@ func TestRunListHappyPath(t *testing.T) {
 
 func TestPrintListTableEmpty(t *testing.T) {
 	var sb strings.Builder
-	printListTable(&sb, &ListResponse{})
+	printListTable(&sb, &api.AgentDefinitionListResponse{})
 	if !strings.Contains(sb.String(), "no agent definitions") {
 		t.Errorf("empty render missing hint; got %q", sb.String())
 	}
@@ -77,16 +97,11 @@ func TestPrintListTableEmpty(t *testing.T) {
 
 // --- show ---
 
-func TestBuildShowPathEscapes(t *testing.T) {
-	if got := buildShowPath("vm.inventory-bot"); got != "/api/v1/agents/vm.inventory-bot" {
-		t.Fatalf("buildShowPath: got %q", got)
-	}
-}
-
 func TestRunShowHappyPath(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/agents/incident-triage", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(sampleEntry())
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sampleDefinition())
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -130,13 +145,19 @@ func TestRunCreateHappyPath(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("method: got %s; want POST", r.Method)
 		}
-		var body createRequest
-		_ = json.NewDecoder(r.Body).Decode(&body)
-		if body.Name != "incident-triage" || body.ModelTier != "deep" || body.TurnBudget != 25 {
+		// Assert the typed request body decodes into the generated
+		// AgentDefinitionCreate shape and the operator-supplied field
+		// values round-trip onto the wire.
+		var body api.AgentDefinitionCreate
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		if body.Name != "incident-triage" || string(body.ModelTier) != "deep" || body.TurnBudget != 25 {
 			t.Errorf("unexpected request body: %+v", body)
 		}
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(sampleEntry())
+		_ = json.NewEncoder(w).Encode(sampleDefinition())
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -235,27 +256,31 @@ func TestRunCreate403SurfacesInsufficientRole(t *testing.T) {
 
 func TestBuildEditBodyOnlyChangedFields(t *testing.T) {
 	cmd, _, _ := newTestCmd(t)
-	body, err := buildEditBody(cmd, editOptions{
+	body, anySet, err := buildEditBody(cmd, editOptions{
 		TurnBudget: 50, turnBudgetSet: true,
 		disabledSet: true,
 	})
 	if err != nil {
 		t.Fatalf("buildEditBody: %v", err)
 	}
-	if len(body) != 2 {
-		t.Fatalf("expected 2 fields; got %+v", body)
+	if !anySet {
+		t.Fatalf("expected anySet=true with two field flags")
 	}
-	if body["turn_budget"] != 50 {
-		t.Errorf("turn_budget: got %v", body["turn_budget"])
+	if body.TurnBudget == nil || *body.TurnBudget != 50 {
+		t.Errorf("TurnBudget: got %+v", body.TurnBudget)
 	}
-	if body["enabled"] != false {
-		t.Errorf("enabled: got %v", body["enabled"])
+	if body.Enabled == nil || *body.Enabled != false {
+		t.Errorf("Enabled: got %+v", body.Enabled)
+	}
+	// Field flags that weren't set must round-trip nil.
+	if body.IdentityRef != nil || body.SystemPrompt != nil || body.ModelTier != nil || body.Toolset != nil {
+		t.Errorf("untouched fields must stay nil; got %+v", body)
 	}
 }
 
 func TestBuildEditBodyRejectsBadTier(t *testing.T) {
 	cmd, _, _ := newTestCmd(t)
-	_, err := buildEditBody(cmd, editOptions{ModelTier: "ultra", modelTierSet: true})
+	_, _, err := buildEditBody(cmd, editOptions{ModelTier: "ultra", modelTierSet: true})
 	if err == nil {
 		t.Fatalf("expected error for bad model tier")
 	}
@@ -293,8 +318,9 @@ func TestRunEditHappyPath(t *testing.T) {
 		if !strings.Contains(string(raw), "turn_budget") {
 			t.Errorf("PATCH body missing turn_budget: %s", raw)
 		}
-		entry := sampleEntry()
+		entry := sampleDefinition()
 		entry.TurnBudget = 50
+		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(entry)
 	})
 	srv := httptest.NewServer(mux)

--- a/cli/internal/cmd/agent/delete.go
+++ b/cli/internal/cmd/agent/delete.go
@@ -6,9 +6,11 @@ package agent
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -93,8 +95,12 @@ func runDelete(cmd *cobra.Command, opts deleteOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	if err := callDelete(cmd.Context(), backplaneURL, opts.Name); err != nil {
+	resp, err := callDelete(cmd.Context(), backplaneURL, opts.Name)
+	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode() != http.StatusNoContent {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
 	}
 	result := deleteResult{Name: opts.Name, Status: "deleted"}
 	if opts.JSONOut {
@@ -104,9 +110,15 @@ func runDelete(cmd *cobra.Command, opts deleteOptions) error {
 	return nil
 }
 
-func callDelete(ctx context.Context, backplaneURL, name string) error {
-	// doAuthedRequest returns (nil, nil) on a 204; the success signal is
-	// the absence of an error.
-	_, err := doAuthedRequest(ctx, backplaneURL, "DELETE", buildShowPath(name), nil)
-	return err
+func callDelete(ctx context.Context, backplaneURL, name string) (*api.DeleteAgentApiV1AgentsNameDeleteResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.DeleteAgentApiV1AgentsNameDeleteResponse, error) {
+			return authed.DeleteAgentApiV1AgentsNameDeleteWithResponse(ctx, name, nil)
+		},
+		func(r *api.DeleteAgentApiV1AgentsNameDeleteResponse) int { return r.StatusCode() },
+	)
 }

--- a/cli/internal/cmd/agent/edit.go
+++ b/cli/internal/cmd/agent/edit.go
@@ -5,11 +5,12 @@ package agent
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -88,7 +89,7 @@ func newEditCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&enabled, "enabled", false, "enable the definition")
 	cmd.Flags().BoolVar(&disabled, "disabled", false, "disable (park) the definition")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
-		"emit raw Entry JSON instead of the human summary")
+		"emit raw AgentDefinitionRead JSON instead of the human summary")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
 	return cmd
@@ -126,11 +127,11 @@ func runEdit(cmd *cobra.Command, opts editOptions) error {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected("pass at most one of --enabled / --disabled"), opts.JSONOut)
 	}
-	body, err := buildEditBody(cmd, opts)
+	body, anySet, err := buildEditBody(cmd, opts)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), opts.JSONOut)
 	}
-	if len(body) == 0 {
+	if !anySet {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected("edit requires at least one field flag to change"), opts.JSONOut)
 	}
@@ -139,81 +140,108 @@ func runEdit(cmd *cobra.Command, opts editOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	entry, err := patchEdit(cmd.Context(), backplaneURL, opts.Name, body)
+	resp, err := patchEdit(cmd.Context(), backplaneURL, opts.Name, body)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	entry := resp.JSON200
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), entry)
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "updated agent definition %q\n", entry.Name)
-	printEntrySummary(cmd.OutOrStdout(), entry)
+	printDefinitionSummary(cmd.OutOrStdout(), entry)
 	return nil
 }
 
 // buildEditBody assembles the PATCH request body from only the flags
-// the operator set. Returns the marshalled JSON (empty map -> caller
-// rejects the no-op edit). Exposed-adjacent: kept as a separate
-// function so the field-selection logic stays unit-testable.
-func buildEditBody(cmd *cobra.Command, opts editOptions) (map[string]any, error) {
-	body := map[string]any{}
+// the operator set. Returns the typed AgentDefinitionUpdate and a
+// boolean indicating whether any field was actually populated (so the
+// caller can reject a no-op edit before issuing the request). Kept
+// separate from runEdit so the field-selection logic stays
+// unit-testable without a live HTTP transport.
+//
+// The backend's PATCH semantics use Pydantic's exclude_unset, so an
+// `omitempty` pointer field left nil is "field omitted" and the
+// existing value is preserved. Toolset / OutputSchema in the
+// generated AgentDefinitionUpdate are NOT tagged `omitempty` (they
+// carry the wire `null` distinction the backend's v0.2 limitation
+// documents), so this helper leaves them nil when the operator
+// didn't pass the flag; they only become non-nil when --toolset /
+// --output-schema is actually set.
+func buildEditBody(cmd *cobra.Command, opts editOptions) (api.AgentDefinitionUpdate, bool, error) {
+	body := api.AgentDefinitionUpdate{}
+	anySet := false
 	if opts.identityRefSet {
-		body["identity_ref"] = opts.IdentityRef
+		identityRef := opts.IdentityRef
+		body.IdentityRef = &identityRef
+		anySet = true
 	}
 	if opts.modelTierSet {
 		if !validModelTiers[opts.ModelTier] {
-			return nil, fmt.Errorf("--model-tier must be one of: standard, fast, deep")
+			return api.AgentDefinitionUpdate{}, false, fmt.Errorf("--model-tier must be one of: standard, fast, deep")
 		}
-		body["model_tier"] = opts.ModelTier
+		tier := api.AgentModelTier(opts.ModelTier)
+		body.ModelTier = &tier
+		anySet = true
 	}
 	if opts.systemPromptSet {
-		body["system_prompt"] = opts.SystemPrompt
+		systemPrompt := opts.SystemPrompt
+		body.SystemPrompt = &systemPrompt
+		anySet = true
 	}
 	if opts.turnBudgetSet {
 		if opts.TurnBudget < 1 || opts.TurnBudget > 1000 {
-			return nil, fmt.Errorf("--turn-budget must be between 1 and 1000; got %d", opts.TurnBudget)
+			return api.AgentDefinitionUpdate{}, false, fmt.Errorf("--turn-budget must be between 1 and 1000; got %d", opts.TurnBudget)
 		}
-		body["turn_budget"] = opts.TurnBudget
+		turnBudget := opts.TurnBudget
+		body.TurnBudget = &turnBudget
+		anySet = true
 	}
 	if opts.toolsetSet {
 		toolset, err := loadJSONObjectFlag(cmd, opts.ToolsetArg, "--toolset")
 		if err != nil {
-			return nil, err
+			return api.AgentDefinitionUpdate{}, false, err
 		}
-		body["toolset"] = toolset
+		body.Toolset = &toolset
+		anySet = true
 	}
 	if opts.outputSchemaSet {
 		schema, err := loadJSONObjectFlag(cmd, opts.OutputSchemaArg, "--output-schema")
 		if err != nil {
-			return nil, err
+			return api.AgentDefinitionUpdate{}, false, err
 		}
-		body["output_schema"] = schema
+		body.OutputSchema = &schema
+		anySet = true
 	}
 	if opts.enabledSet {
-		body["enabled"] = true
+		enabled := true
+		body.Enabled = &enabled
+		anySet = true
 	}
 	if opts.disabledSet {
-		body["enabled"] = false
+		disabled := false
+		body.Enabled = &disabled
+		anySet = true
 	}
-	return body, nil
+	return body, anySet, nil
 }
 
 func patchEdit(
 	ctx context.Context,
 	backplaneURL, name string,
-	body map[string]any,
-) (*Entry, error) {
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal agent edit request: %w", err)
-	}
-	resp, err := doAuthedRequest(ctx, backplaneURL, "PATCH", buildShowPath(name), raw)
+	body api.AgentDefinitionUpdate,
+) (*api.EditAgentApiV1AgentsNamePatchResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out Entry
-	if err := json.Unmarshal(resp, &out); err != nil {
-		return nil, fmt.Errorf("decode agent edit response: %w", err)
-	}
-	return &out, nil
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.EditAgentApiV1AgentsNamePatchResponse, error) {
+			return authed.EditAgentApiV1AgentsNamePatchWithResponse(ctx, name, nil, body)
+		},
+		func(r *api.EditAgentApiV1AgentsNamePatchResponse) int { return r.StatusCode() },
+	)
 }

--- a/cli/internal/cmd/agent/grant.go
+++ b/cli/internal/cmd/agent/grant.go
@@ -5,14 +5,15 @@ package agent
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
+	"net/http"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -49,65 +50,6 @@ func NewGrantRootCmd() *cobra.Command {
 }
 
 // ---------------------------------------------------------------------------
-// Wire types mirroring the backend Pydantic shapes
-// ---------------------------------------------------------------------------
-
-// grantEntry mirrors backend AgentGrantRead.
-type grantEntry struct {
-	ID           string  `json:"id"`
-	TenantID     string  `json:"tenant_id"`
-	PrincipalSub string  `json:"principal_sub"`
-	OpPattern    string  `json:"op_pattern"`
-	TargetScope  *string `json:"target_scope"`
-	Verdict      string  `json:"verdict"`
-	CreatedBySub string  `json:"created_by_sub"`
-	ExpiresAt    *string `json:"expires_at"`
-	CreatedAt    string  `json:"created_at"`
-	UpdatedAt    string  `json:"updated_at"`
-}
-
-// grantListResponse mirrors backend AgentGrantListResponse.
-type grantListResponse struct {
-	Grants []grantEntry `json:"grants"`
-}
-
-// grantCreateRequest mirrors backend AgentGrantCreate.
-type grantCreateRequest struct {
-	PrincipalSub string  `json:"principal_sub"`
-	OpPattern    string  `json:"op_pattern"`
-	TargetScope  *string `json:"target_scope,omitempty"`
-	Verdict      string  `json:"verdict"`
-	ExpiresAt    *string `json:"expires_at,omitempty"`
-}
-
-const _grantsBasePath = "/api/v1/agents/grants"
-
-func buildGrantListPath(principalSub string, includeExpired bool, limit, offset int) string {
-	q := url.Values{}
-	if principalSub != "" {
-		q.Set("principal_sub", principalSub)
-	}
-	if includeExpired {
-		q.Set("include_expired", "true")
-	}
-	if limit > 0 {
-		q.Set("limit", fmt.Sprintf("%d", limit))
-	}
-	if offset > 0 {
-		q.Set("offset", fmt.Sprintf("%d", offset))
-	}
-	path := _grantsBasePath
-	if enc := q.Encode(); enc != "" {
-		path = path + "?" + enc
-	}
-	return path
-}
-
-func buildGrantShowPath(grantID string) string {
-	return _grantsBasePath + "/" + grantID
-}
-
-// ---------------------------------------------------------------------------
 // meho agent grant list
 // ---------------------------------------------------------------------------
 
@@ -135,20 +77,18 @@ func newGrantListCmd() *cobra.Command {
 			if err != nil {
 				return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 			}
-			raw, err := doAuthedRequest(cmd.Context(), backplaneURL, "GET",
-				buildGrantListPath(principalSub, includeExpired, limit, offset), nil)
+			params := grantListParams(principalSub, includeExpired, limit, offset)
+			resp, err := getGrantList(cmd.Context(), backplaneURL, params)
 			if err != nil {
 				return renderRequestError(cmd, backplaneURL, err, jsonOut)
 			}
-			var resp grantListResponse
-			if err := json.Unmarshal(raw, &resp); err != nil {
-				return output.RenderError(cmd.ErrOrStderr(),
-					output.Unexpected(fmt.Sprintf("decode grant list: %v", err)), jsonOut)
+			if resp.StatusCode() != http.StatusOK {
+				return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, jsonOut)
 			}
 			if jsonOut {
-				return output.PrintJSON(cmd.OutOrStdout(), resp)
+				return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
 			}
-			printGrantListTable(cmd.OutOrStdout(), resp.Grants)
+			printGrantListTable(cmd.OutOrStdout(), resp.JSON200.Grants)
 			return nil
 		},
 	}
@@ -160,13 +100,47 @@ func newGrantListCmd() *cobra.Command {
 		"max grants per page (1..500, server default 100)")
 	cmd.Flags().IntVar(&offset, "offset", 0, "page offset (default 0)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
-		"emit raw ListResponse JSON")
+		"emit raw AgentGrantListResponse JSON")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL (defaults to the URL from `meho login`)")
 	return cmd
 }
 
-func printGrantListTable(w io.Writer, grants []grantEntry) {
+func grantListParams(principalSub string, includeExpired bool, limit, offset int) *api.ListGrantsApiV1AgentsGrantsGetParams {
+	params := &api.ListGrantsApiV1AgentsGrantsGetParams{}
+	if principalSub != "" {
+		sub := principalSub
+		params.PrincipalSub = &sub
+	}
+	if includeExpired {
+		expired := true
+		params.IncludeExpired = &expired
+	}
+	if limit > 0 {
+		l := limit
+		params.Limit = &l
+	}
+	if offset > 0 {
+		o := offset
+		params.Offset = &o
+	}
+	return params
+}
+
+func getGrantList(ctx context.Context, backplaneURL string, params *api.ListGrantsApiV1AgentsGrantsGetParams) (*api.ListGrantsApiV1AgentsGrantsGetResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.ListGrantsApiV1AgentsGrantsGetResponse, error) {
+			return authed.ListGrantsApiV1AgentsGrantsGetWithResponse(ctx, params)
+		},
+		func(r *api.ListGrantsApiV1AgentsGrantsGetResponse) int { return r.StatusCode() },
+	)
+}
+
+func printGrantListTable(w io.Writer, grants []api.AgentGrantRead) {
 	if len(grants) == 0 {
 		fmt.Fprintln(w, "no permission grants in this tenant")
 		return
@@ -176,10 +150,10 @@ func printGrantListTable(w io.Writer, grants []grantEntry) {
 	for _, g := range grants {
 		exp := "-"
 		if g.ExpiresAt != nil {
-			exp = *g.ExpiresAt
+			exp = g.ExpiresAt.UTC().Format(time.RFC3339)
 		}
 		fmt.Fprintf(w, "%-36s %-36s %-30s %-12s %-22s %s\n",
-			g.ID, g.PrincipalSub, g.OpPattern, g.Verdict, exp, g.CreatedBySub)
+			g.Id.String(), g.PrincipalSub, g.OpPattern, g.Verdict, exp, g.CreatedBySub)
 	}
 }
 
@@ -201,50 +175,68 @@ func newGrantShowCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			grantID, err := uuid.Parse(args[0])
+			if err != nil {
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unexpected(fmt.Sprintf("invalid <grant-id>: %v", err)), jsonOut)
+			}
 			backplaneURL, err := backplane.Resolve(backplaneOverride)
 			if err != nil {
 				return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 			}
-			raw, err := doAuthedRequest(cmd.Context(), backplaneURL, "GET",
-				buildGrantShowPath(args[0]), nil)
+			resp, err := getGrant(cmd.Context(), backplaneURL, grantID)
 			if err != nil {
 				return renderRequestError(cmd, backplaneURL, err, jsonOut)
 			}
-			var entry grantEntry
-			if err := json.Unmarshal(raw, &entry); err != nil {
-				return output.RenderError(cmd.ErrOrStderr(),
-					output.Unexpected(fmt.Sprintf("decode grant show: %v", err)), jsonOut)
+			if resp.StatusCode() != http.StatusOK {
+				return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, jsonOut)
 			}
 			if jsonOut {
-				return output.PrintJSON(cmd.OutOrStdout(), entry)
+				return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
 			}
-			printGrantDetail(cmd.OutOrStdout(), entry)
+			printGrantDetail(cmd.OutOrStdout(), resp.JSON200)
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit raw grant JSON")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit raw AgentGrantRead JSON")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL (defaults to the URL from `meho login`)")
 	return cmd
 }
 
-func printGrantDetail(w io.Writer, g grantEntry) {
+func getGrant(ctx context.Context, backplaneURL string, grantID uuid.UUID) (*api.ShowGrantApiV1AgentsGrantsGrantIdGetResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.ShowGrantApiV1AgentsGrantsGrantIdGetResponse, error) {
+			return authed.ShowGrantApiV1AgentsGrantsGrantIdGetWithResponse(ctx, grantID, nil)
+		},
+		func(r *api.ShowGrantApiV1AgentsGrantsGrantIdGetResponse) int { return r.StatusCode() },
+	)
+}
+
+func printGrantDetail(w io.Writer, g *api.AgentGrantRead) {
+	if g == nil {
+		return
+	}
 	exp := "-"
 	if g.ExpiresAt != nil {
-		exp = *g.ExpiresAt
+		exp = g.ExpiresAt.UTC().Format(time.RFC3339)
 	}
 	scope := "*"
 	if g.TargetScope != nil {
 		scope = *g.TargetScope
 	}
-	fmt.Fprintf(w, "id:            %s\n", g.ID)
+	fmt.Fprintf(w, "id:            %s\n", g.Id.String())
 	fmt.Fprintf(w, "principal_sub: %s\n", g.PrincipalSub)
 	fmt.Fprintf(w, "op_pattern:    %s\n", g.OpPattern)
 	fmt.Fprintf(w, "target_scope:  %s\n", scope)
 	fmt.Fprintf(w, "verdict:       %s\n", g.Verdict)
 	fmt.Fprintf(w, "expires_at:    %s\n", exp)
 	fmt.Fprintf(w, "created_by:    %s\n", g.CreatedBySub)
-	fmt.Fprintf(w, "created_at:    %s\n", g.CreatedAt)
+	fmt.Fprintf(w, "created_at:    %s\n", g.CreatedAt.UTC().Format(time.RFC3339))
 }
 
 // ---------------------------------------------------------------------------
@@ -285,11 +277,14 @@ func newGrantCreateCmd() *cobra.Command {
 			if err != nil {
 				return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 			}
-			raw, err := doAuthedRequest(cmd.Context(), backplaneURL, "POST", _grantsBasePath, body)
+			resp, err := postGrantCreate(cmd.Context(), backplaneURL, body)
 			if err != nil {
 				return renderRequestError(cmd, backplaneURL, err, jsonOut)
 			}
-			return renderGrantResult(cmd.OutOrStdout(), raw, jsonOut, "created")
+			if resp.StatusCode() != http.StatusCreated {
+				return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, jsonOut)
+			}
+			return renderGrantEntry(cmd.OutOrStdout(), resp.JSON201, jsonOut, "created")
 		},
 	}
 	cmd.Flags().StringVar(&principalSub, "principal", "", "JWT sub of the agent principal (required)")
@@ -300,10 +295,23 @@ func newGrantCreateCmd() *cobra.Command {
 		"target UUID or '*' for any target (default: any)")
 	cmd.Flags().StringVar(&expiresAt, "expires", "",
 		"ISO 8601 UTC expiry for a time-bounded elevation, e.g. 2026-05-25T18:00:00Z")
-	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit raw grant JSON")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit raw AgentGrantRead JSON")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL (defaults to the URL from `meho login`)")
 	return cmd
+}
+
+func postGrantCreate(ctx context.Context, backplaneURL string, body api.AgentGrantCreate) (*api.CreateGrantApiV1AgentsGrantsPostResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.CreateGrantApiV1AgentsGrantsPostResponse, error) {
+			return authed.CreateGrantApiV1AgentsGrantsPostWithResponse(ctx, nil, body)
+		},
+		func(r *api.CreateGrantApiV1AgentsGrantsPostResponse) int { return r.StatusCode() },
+	)
 }
 
 // ---------------------------------------------------------------------------
@@ -336,7 +344,7 @@ func newGrantElevateCmd() *cobra.Command {
 					output.Unexpected("--principal, --op, --verdict, and --expires are all required for elevate"),
 					jsonOut)
 			}
-			body, err := buildGrantCreateBody(principalSub, opPattern, verdict, targetScope, expiresAt)
+			body, err := buildGrantElevateBody(principalSub, opPattern, verdict, targetScope, expiresAt)
 			if err != nil {
 				return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), jsonOut)
 			}
@@ -344,12 +352,14 @@ func newGrantElevateCmd() *cobra.Command {
 			if err != nil {
 				return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 			}
-			raw, err := doAuthedRequest(cmd.Context(), backplaneURL, "POST",
-				_grantsBasePath+"/elevate", body)
+			resp, err := postGrantElevate(cmd.Context(), backplaneURL, body)
 			if err != nil {
 				return renderRequestError(cmd, backplaneURL, err, jsonOut)
 			}
-			return renderGrantResult(cmd.OutOrStdout(), raw, jsonOut, "elevated")
+			if resp.StatusCode() != http.StatusCreated {
+				return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, jsonOut)
+			}
+			return renderGrantEntry(cmd.OutOrStdout(), resp.JSON201, jsonOut, "elevated")
 		},
 	}
 	cmd.Flags().StringVar(&principalSub, "principal", "", "JWT sub of the agent principal (required)")
@@ -358,10 +368,23 @@ func newGrantElevateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&targetScope, "target", "", "target UUID or '*' for any target (optional)")
 	cmd.Flags().StringVar(&expiresAt, "expires", "",
 		"required ISO 8601 UTC expiry, e.g. 2026-06-01T00:00:00Z")
-	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit raw grant JSON")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "emit raw AgentGrantRead JSON")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL (defaults to the URL from `meho login`)")
 	return cmd
+}
+
+func postGrantElevate(ctx context.Context, backplaneURL string, body api.AgentElevationCreate) (*api.ElevateGrantApiV1AgentsGrantsElevatePostResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.ElevateGrantApiV1AgentsGrantsElevatePostResponse, error) {
+			return authed.ElevateGrantApiV1AgentsGrantsElevatePostWithResponse(ctx, nil, body)
+		},
+		func(r *api.ElevateGrantApiV1AgentsGrantsElevatePostResponse) int { return r.StatusCode() },
+	)
 }
 
 // ---------------------------------------------------------------------------
@@ -384,16 +407,21 @@ func newGrantRevokeCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			grantID := args[0]
+			grantIDArg := args[0]
+			grantID, err := uuid.Parse(grantIDArg)
+			if err != nil {
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unexpected(fmt.Sprintf("invalid <grant-id>: %v", err)), jsonOut)
+			}
 			if !confirm {
-				prompt := fmt.Sprintf("Revoke grant %q. Continue?", grantID)
+				prompt := fmt.Sprintf("Revoke grant %q. Continue?", grantIDArg)
 				if !confirmPrompt(cmd, prompt) {
 					if jsonOut {
 						return output.PrintJSON(cmd.OutOrStdout(), map[string]string{
-							"grant_id": grantID, "status": "declined",
+							"grant_id": grantIDArg, "status": "declined",
 						})
 					}
-					fmt.Fprintf(cmd.OutOrStdout(), "declined: grant %q not revoked\n", grantID)
+					fmt.Fprintf(cmd.OutOrStdout(), "declined: grant %q not revoked\n", grantIDArg)
 					return nil
 				}
 			}
@@ -401,15 +429,19 @@ func newGrantRevokeCmd() *cobra.Command {
 			if err != nil {
 				return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 			}
-			if err := callGrantRevoke(cmd.Context(), backplaneURL, grantID); err != nil {
+			resp, err := callGrantRevoke(cmd.Context(), backplaneURL, grantID)
+			if err != nil {
 				return renderRequestError(cmd, backplaneURL, err, jsonOut)
+			}
+			if resp.StatusCode() != http.StatusNoContent {
+				return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, jsonOut)
 			}
 			if jsonOut {
 				return output.PrintJSON(cmd.OutOrStdout(), map[string]string{
-					"grant_id": grantID, "status": "revoked",
+					"grant_id": grantIDArg, "status": "revoked",
 				})
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "revoked grant %q\n", grantID)
+			fmt.Fprintf(cmd.OutOrStdout(), "revoked grant %q\n", grantIDArg)
 			return nil
 		},
 	}
@@ -420,53 +452,87 @@ func newGrantRevokeCmd() *cobra.Command {
 	return cmd
 }
 
-func callGrantRevoke(ctx context.Context, backplaneURL, grantID string) error {
-	_, err := doAuthedRequest(ctx, backplaneURL, "DELETE", buildGrantShowPath(grantID), nil)
-	return err
+func callGrantRevoke(ctx context.Context, backplaneURL string, grantID uuid.UUID) (*api.RevokeGrantApiV1AgentsGrantsGrantIdDeleteResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.RevokeGrantApiV1AgentsGrantsGrantIdDeleteResponse, error) {
+			return authed.RevokeGrantApiV1AgentsGrantsGrantIdDeleteWithResponse(ctx, grantID, nil)
+		},
+		func(r *api.RevokeGrantApiV1AgentsGrantsGrantIdDeleteResponse) int { return r.StatusCode() },
+	)
 }
 
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
 
-// buildGrantCreateBody builds the JSON request body for create / elevate.
-// Validates the expiresAt format when supplied.
+// buildGrantCreateBody assembles the generated AgentGrantCreate body
+// for the /grants create endpoint. ExpiresAt is `*time.Time` (omit for
+// a permanent grant); a non-empty --expires must parse as RFC 3339 /
+// ISO 8601.
 func buildGrantCreateBody(
 	principalSub, opPattern, verdict, targetScope, expiresAt string,
-) ([]byte, error) {
-	req := grantCreateRequest{
+) (api.AgentGrantCreate, error) {
+	body := api.AgentGrantCreate{
 		PrincipalSub: principalSub,
 		OpPattern:    opPattern,
-		Verdict:      verdict,
+		Verdict:      api.PermissionVerdict(verdict),
 	}
 	if targetScope != "" {
-		req.TargetScope = &targetScope
+		scope := targetScope
+		body.TargetScope = &scope
 	}
 	if expiresAt != "" {
-		// Validate format — must parse as RFC 3339 / ISO 8601.
-		if _, err := time.Parse(time.RFC3339, expiresAt); err != nil {
-			return nil, fmt.Errorf("--expires %q is not a valid ISO 8601 date-time: %w", expiresAt, err)
+		parsed, err := time.Parse(time.RFC3339, expiresAt)
+		if err != nil {
+			return api.AgentGrantCreate{}, fmt.Errorf("--expires %q is not a valid ISO 8601 date-time: %w", expiresAt, err)
 		}
-		req.ExpiresAt = &expiresAt
+		body.ExpiresAt = &parsed
 	}
-	return json.Marshal(req)
+	return body, nil
 }
 
-// renderGrantResult decodes the raw backend response (a grantEntry JSON
-// object), prints a human summary or raw JSON, and returns any error.
-func renderGrantResult(w io.Writer, raw []byte, jsonOut bool, verb string) error {
-	var entry grantEntry
-	if err := json.Unmarshal(raw, &entry); err != nil {
-		return fmt.Errorf("decode grant response: %w", err)
+// buildGrantElevateBody assembles the generated AgentElevationCreate
+// body. ExpiresAt is required and `time.Time` (not a pointer) — the
+// elevate endpoint refuses an open-ended elevation.
+func buildGrantElevateBody(
+	principalSub, opPattern, verdict, targetScope, expiresAt string,
+) (api.AgentElevationCreate, error) {
+	parsed, err := time.Parse(time.RFC3339, expiresAt)
+	if err != nil {
+		return api.AgentElevationCreate{}, fmt.Errorf("--expires %q is not a valid ISO 8601 date-time: %w", expiresAt, err)
+	}
+	body := api.AgentElevationCreate{
+		PrincipalSub: principalSub,
+		OpPattern:    opPattern,
+		Verdict:      api.PermissionVerdict(verdict),
+		ExpiresAt:    parsed,
+	}
+	if targetScope != "" {
+		scope := targetScope
+		body.TargetScope = &scope
+	}
+	return body, nil
+}
+
+// renderGrantEntry prints a single AgentGrantRead — either as raw JSON
+// (with --json) or as the existing "<verb> grant <id>: ..." human line.
+// Shared between the create and elevate verbs.
+func renderGrantEntry(w io.Writer, entry *api.AgentGrantRead, jsonOut bool, verb string) error {
+	if entry == nil {
+		return fmt.Errorf("backend returned an empty grant body")
 	}
 	if jsonOut {
 		return output.PrintJSON(w, entry)
 	}
 	exp := "permanent"
 	if entry.ExpiresAt != nil {
-		exp = "expires " + *entry.ExpiresAt
+		exp = "expires " + entry.ExpiresAt.UTC().Format(time.RFC3339)
 	}
 	fmt.Fprintf(w, "%s grant %s: principal=%s op=%s verdict=%s (%s)\n",
-		verb, entry.ID, entry.PrincipalSub, entry.OpPattern, entry.Verdict, exp)
+		verb, entry.Id.String(), entry.PrincipalSub, entry.OpPattern, entry.Verdict, exp)
 	return nil
 }

--- a/cli/internal/cmd/agent/grant_test.go
+++ b/cli/internal/cmd/agent/grant_test.go
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package agent
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/evoila/meho/cli/internal/api"
+)
+
+func TestBuildGrantCreateBodyMinimal(t *testing.T) {
+	body, err := buildGrantCreateBody("agent:scout", "*", "auto-execute", "", "")
+	if err != nil {
+		t.Fatalf("buildGrantCreateBody: %v", err)
+	}
+	if body.PrincipalSub != "agent:scout" || body.OpPattern != "*" {
+		t.Errorf("scalar fields: %+v", body)
+	}
+	if string(body.Verdict) != "auto-execute" {
+		t.Errorf("verdict: got %q", body.Verdict)
+	}
+	if body.ExpiresAt != nil {
+		t.Errorf("ExpiresAt should be nil for permanent grant; got %+v", body.ExpiresAt)
+	}
+	if body.TargetScope != nil {
+		t.Errorf("TargetScope should be nil when --target absent; got %+v", body.TargetScope)
+	}
+}
+
+func TestBuildGrantCreateBodyWithTargetAndExpires(t *testing.T) {
+	body, err := buildGrantCreateBody(
+		"agent:scout", "vault.kv.*", "needs-approval",
+		"00000000-0000-0000-0000-000000000001",
+		"2026-06-01T00:00:00Z",
+	)
+	if err != nil {
+		t.Fatalf("buildGrantCreateBody: %v", err)
+	}
+	if body.TargetScope == nil || *body.TargetScope != "00000000-0000-0000-0000-000000000001" {
+		t.Errorf("TargetScope: got %+v", body.TargetScope)
+	}
+	if body.ExpiresAt == nil {
+		t.Fatalf("ExpiresAt should be set; got nil")
+	}
+	if !body.ExpiresAt.Equal(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("ExpiresAt: got %s", body.ExpiresAt)
+	}
+}
+
+func TestBuildGrantCreateBodyRejectsBadExpires(t *testing.T) {
+	_, err := buildGrantCreateBody("agent:scout", "*", "deny", "", "tomorrow")
+	if err == nil {
+		t.Fatalf("expected error for non-RFC3339 --expires")
+	}
+}
+
+func TestBuildGrantElevateBodyRequiresExpires(t *testing.T) {
+	_, err := buildGrantElevateBody("agent:scout", "*", "auto-execute", "", "")
+	if err == nil {
+		t.Fatalf("expected error for missing --expires on elevation")
+	}
+}
+
+func TestBuildGrantElevateBodyHappy(t *testing.T) {
+	body, err := buildGrantElevateBody(
+		"agent:scout", "vault.kv.*", "auto-execute", "*",
+		"2026-06-01T00:00:00Z",
+	)
+	if err != nil {
+		t.Fatalf("buildGrantElevateBody: %v", err)
+	}
+	if body.ExpiresAt.IsZero() {
+		t.Errorf("ExpiresAt should be set; got zero")
+	}
+	if body.TargetScope == nil || *body.TargetScope != "*" {
+		t.Errorf("TargetScope: got %+v", body.TargetScope)
+	}
+	if string(body.Verdict) != "auto-execute" {
+		t.Errorf("Verdict: got %q", body.Verdict)
+	}
+}
+
+func TestGrantListParamsBuild(t *testing.T) {
+	params := grantListParams("agent:scout", true, 25, 0)
+	if params.PrincipalSub == nil || *params.PrincipalSub != "agent:scout" {
+		t.Errorf("PrincipalSub: got %+v", params.PrincipalSub)
+	}
+	if params.IncludeExpired == nil || !*params.IncludeExpired {
+		t.Errorf("IncludeExpired: got %+v", params.IncludeExpired)
+	}
+	if params.Limit == nil || *params.Limit != 25 {
+		t.Errorf("Limit: got %+v", params.Limit)
+	}
+	if params.Offset != nil {
+		t.Errorf("Offset should be nil when zero; got %+v", params.Offset)
+	}
+}
+
+func TestPrintGrantListTableEmpty(t *testing.T) {
+	var sb strings.Builder
+	printGrantListTable(&sb, nil)
+	if !strings.Contains(sb.String(), "no permission grants") {
+		t.Errorf("empty render missing hint; got %q", sb.String())
+	}
+}
+
+func TestPrintGrantListTableRows(t *testing.T) {
+	var sb strings.Builder
+	expires := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	grants := []api.AgentGrantRead{
+		{
+			Id:           uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+			PrincipalSub: "agent:scout",
+			OpPattern:    "vault.kv.*",
+			Verdict:      "auto-execute",
+			ExpiresAt:    &expires,
+			CreatedBySub: "op-admin",
+			CreatedAt:    expires,
+		},
+	}
+	printGrantListTable(&sb, grants)
+	for _, want := range []string{"agent:scout", "vault.kv.*", "auto-execute", "2026-06-01T00:00:00Z"} {
+		if !strings.Contains(sb.String(), want) {
+			t.Errorf("printGrantListTable missing %q in %q", want, sb.String())
+		}
+	}
+}
+
+func TestRenderGrantEntryHumanLine(t *testing.T) {
+	var sb strings.Builder
+	expires := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	entry := &api.AgentGrantRead{
+		Id:           uuid.MustParse("22222222-2222-2222-2222-222222222222"),
+		PrincipalSub: "agent:scout",
+		OpPattern:    "*",
+		Verdict:      "auto-execute",
+		ExpiresAt:    &expires,
+	}
+	if err := renderGrantEntry(&sb, entry, false, "created"); err != nil {
+		t.Fatalf("renderGrantEntry: %v", err)
+	}
+	for _, want := range []string{"created grant", "agent:scout", "expires 2026-06-01T12:00:00Z"} {
+		if !strings.Contains(sb.String(), want) {
+			t.Errorf("human render missing %q in %q", want, sb.String())
+		}
+	}
+}
+
+func TestRenderGrantEntryPermanent(t *testing.T) {
+	var sb strings.Builder
+	entry := &api.AgentGrantRead{
+		Id:           uuid.MustParse("22222222-2222-2222-2222-222222222222"),
+		PrincipalSub: "agent:scout",
+		OpPattern:    "*",
+		Verdict:      "auto-execute",
+	}
+	if err := renderGrantEntry(&sb, entry, false, "created"); err != nil {
+		t.Fatalf("renderGrantEntry: %v", err)
+	}
+	if !strings.Contains(sb.String(), "permanent") {
+		t.Errorf("nil ExpiresAt should render \"permanent\"; got %q", sb.String())
+	}
+}
+
+func TestGrantRevokeRejectsInvalidUUID(t *testing.T) {
+	// The revoke verb is wired inline in newGrantRevokeCmd, so exercise
+	// it via the command tree to assert the uuid.Parse error path.
+	root := NewGrantRootCmd()
+	root.SetArgs([]string{"revoke", "not-a-uuid"})
+	cmd, _, stderr := newTestCmd(t)
+	root.SetOut(cmd.OutOrStdout())
+	root.SetErr(stderr)
+	root.SetContext(cmd.Context())
+	if err := root.Execute(); err == nil {
+		t.Fatalf("expected error for invalid grant-id UUID")
+	}
+	if !strings.Contains(stderr.String(), "invalid <grant-id>") {
+		t.Errorf("stderr missing parse-error hint; got %q", stderr.String())
+	}
+}

--- a/cli/internal/cmd/agent/list.go
+++ b/cli/internal/cmd/agent/list.go
@@ -5,14 +5,13 @@ package agent
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
-	"strconv"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -37,7 +36,7 @@ func newListCmd() *cobra.Command {
 			"definitions in the operator's tenant, name-sorted. --limit " +
 			"caps the page size (1..500, server default 100). --offset " +
 			"advances the page window (default 0). --json emits the raw " +
-			"ListResponse envelope for jq pipelines.",
+			"AgentDefinitionListResponse envelope for jq pipelines.",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -55,7 +54,7 @@ func newListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&offset, "offset", 0,
 		"offset into the name-sorted result set (default 0)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
-		"emit raw ListResponse JSON instead of the human table")
+		"emit raw AgentDefinitionListResponse JSON instead of the human table")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
 	return cmd
@@ -91,46 +90,49 @@ func runList(cmd *cobra.Command, opts listOptions) error {
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
-	if opts.JSONOut {
-		return output.PrintJSON(cmd.OutOrStdout(), resp)
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
 	}
-	printListTable(cmd.OutOrStdout(), resp)
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
+	}
+	printListTable(cmd.OutOrStdout(), resp.JSON200)
 	return nil
 }
 
-// buildListPath assembles the GET /api/v1/agents query string. Exposed
-// for unit tests so URL construction stays checkable without standing
-// up an httptest.Server.
-func buildListPath(opts listOptions) string {
-	q := url.Values{}
+// listQueryParams maps the CLI flags onto the generated query-param
+// shape. limit / offset are *int because oapi-codegen emits `omitempty`
+// pointer fields when the OpenAPI parameter is optional.
+func listQueryParams(opts listOptions) *api.ListAgentsApiV1AgentsGetParams {
+	params := &api.ListAgentsApiV1AgentsGetParams{}
 	if opts.Limit > 0 {
-		q.Set("limit", strconv.Itoa(opts.Limit))
+		limit := opts.Limit
+		params.Limit = &limit
 	}
 	if opts.Offset > 0 {
-		q.Set("offset", strconv.Itoa(opts.Offset))
+		offset := opts.Offset
+		params.Offset = &offset
 	}
-	path := "/api/v1/agents"
-	if encoded := q.Encode(); encoded != "" {
-		path = path + "?" + encoded
-	}
-	return path
+	return params
 }
 
-func getList(ctx context.Context, backplaneURL string, opts listOptions) (*ListResponse, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildListPath(opts), nil)
+func getList(ctx context.Context, backplaneURL string, opts listOptions) (*api.ListAgentsApiV1AgentsGetResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out ListResponse
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode agent list response: %w", err)
-	}
-	return &out, nil
+	params := listQueryParams(opts)
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.ListAgentsApiV1AgentsGetResponse, error) {
+			return authed.ListAgentsApiV1AgentsGetWithResponse(ctx, params)
+		},
+		func(r *api.ListAgentsApiV1AgentsGetResponse) int { return r.StatusCode() },
+	)
 }
 
 // printListTable renders the definitions as a compact table:
 // NAME, TIER, BUDGET, ENABLED, IDENTITY.
-func printListTable(w io.Writer, r *ListResponse) {
+func printListTable(w io.Writer, r *api.AgentDefinitionListResponse) {
 	if r == nil || len(r.Agents) == 0 {
 		fmt.Fprintln(w, "no agent definitions registered in this tenant")
 		return

--- a/cli/internal/cmd/agent/run.go
+++ b/cli/internal/cmd/agent/run.go
@@ -8,28 +8,36 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
-// RunRequest mirrors the backend AgentRunRequest pydantic model
-// (`backend/src/meho_backplane/api/v1/agent_runs.py`). `Async` uses the
-// `async` wire key (a Python keyword on the backend, plain on the wire).
-type RunRequest struct {
-	Input string `json:"input"`
-	Async bool   `json:"async"`
-}
-
-// RunResult mirrors the backend AgentRunResultResponse (a terminal sync
-// run, HTTP 200) and AgentRunHandleResponse (an async / converted-to-async
-// run, HTTP 202) combined — only the fields present in a given response are
-// populated, so unset pointer fields distinguish the two shapes. Output is
-// a free-shaped JSON object (the run's structured / {"text": ...} result).
-type RunResult struct {
+// runResponse models the wire body of POST /api/v1/agents/{name}/run.
+// The endpoint is one of the small set of MEHO routes whose response
+// is a discriminated union of two unrelated Pydantic models —
+// AgentRunResultResponse on a terminal sync run (HTTP 200) and
+// AgentRunHandleResponse on an async / converted-to-async run
+// (HTTP 202) — emitted via a JSONResponse without a single
+// FastAPI response_model. The OpenAPI snapshot therefore renders
+// the response as a free-shape `Any` at 200 only, and the generated
+// `RunAgentApiV1AgentsNameRunPostResponse.JSON200` lands as
+// `*interface{}`. To keep the CLI's typed-printing contract we
+// re-decode the response body off the typed envelope into this
+// union; the field set covers both wire shapes (omitempty on
+// terminal-only / handle-only fields lets the marshaler still emit a
+// minimal --json payload).
+//
+// Code-quality-allow: tracked under the "fix Run endpoint OpenAPI
+// surface to use a discriminated union of two response models" follow-
+// up issue (Initiative G0.12 #1118 adjacent finding) — that's a
+// backend FastAPI change outside the blast radius of this consumer-
+// side migration.
+type runResponse struct {
 	RunID            string         `json:"run_id"`
 	Status           string         `json:"status"`
 	Output           map[string]any `json:"output,omitempty"`
@@ -107,43 +115,50 @@ func runRun(cmd *cobra.Command, opts runOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	result, err := postRun(cmd.Context(), backplaneURL, opts)
+	resp, err := postRun(cmd.Context(), backplaneURL, opts)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	// /run replies with 200 on a terminal sync outcome and 202 on a
+	// converted-to-async / fresh-async run; both are success here.
+	status := resp.StatusCode()
+	if status != http.StatusOK && status != http.StatusAccepted {
+		return renderHTTPStatus(cmd, backplaneURL, status, resp.Body, opts.JSONOut)
+	}
+	var result runResponse
+	if err := json.Unmarshal(resp.Body, &result); err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("decode agent run response: %v", err)), opts.JSONOut)
 	}
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), result)
 	}
-	printRunResult(cmd.OutOrStdout(), result)
+	printRunResult(cmd.OutOrStdout(), &result)
 	return nil
 }
 
-// buildRunPath assembles the POST path. Exposed for unit tests so URL
-// encoding of names with dots / hyphens stays covered.
-func buildRunPath(name string) string {
-	return "/api/v1/agents/" + url.PathEscape(name) + "/run"
-}
-
-func postRun(ctx context.Context, backplaneURL string, opts runOptions) (*RunResult, error) {
-	body, err := json.Marshal(RunRequest{Input: opts.Input, Async: opts.Async})
-	if err != nil {
-		return nil, fmt.Errorf("encode run request: %w", err)
-	}
-	raw, err := doAuthedRequest(ctx, backplaneURL, "POST", buildRunPath(opts.Name), body)
+func postRun(ctx context.Context, backplaneURL string, opts runOptions) (*api.RunAgentApiV1AgentsNameRunPostResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out RunResult
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode agent run response: %w", err)
+	asyncFlag := opts.Async
+	body := api.AgentRunRequest{
+		Input: opts.Input,
+		Async: &asyncFlag,
 	}
-	return &out, nil
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.RunAgentApiV1AgentsNameRunPostResponse, error) {
+			return authed.RunAgentApiV1AgentsNameRunPostWithResponse(ctx, opts.Name, nil, body)
+		},
+		func(r *api.RunAgentApiV1AgentsNameRunPostResponse) int { return r.StatusCode() },
+	)
 }
 
 // printRunResult renders a run response as a key-value summary. A terminal
 // run shows its output; an async / converted run shows the handle and a
 // hint to poll it.
-func printRunResult(w io.Writer, r *RunResult) {
+func printRunResult(w io.Writer, r *runResponse) {
 	if r == nil {
 		return
 	}

--- a/cli/internal/cmd/agent/run_events.go
+++ b/cli/internal/cmd/agent/run_events.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -91,58 +90,60 @@ func runRunEvents(cmd *cobra.Command, opts runEventsOptions) error {
 	return nil
 }
 
-// buildRunEventsPath assembles the SSE POST path. Exposed for unit tests.
-func buildRunEventsPath(name string) string {
-	return "/api/v1/agents/" + url.PathEscape(name) + "/run/events"
-}
-
-// streamRunEvents opens the SSE connection and prints each event frame. The
-// bearer is injected via the shared authed client; a 401 surfaces as an
-// *httpError so renderRequestError maps it to auth_expired. Unlike the
-// broadcast `status --watch` verb, this is a single-shot stream (one run),
-// so there is no reconnect loop — the run ends, the stream ends.
+// streamRunEvents opens the SSE connection and prints each event frame.
+// The endpoint is the streaming variant of the agent-run RPC, so it
+// uses the generated client's non-`*WithResponse` method
+// (RunAgentEventsApiV1AgentsNameRunEventsPost) — that signature returns
+// the raw `*http.Response` so the body stays unbuffered for the SSE
+// scanner. The `*WithResponse` variant would buffer the entire body
+// and break event streaming.
+//
+// 401 retry runs once: a stale bearer triggers a refresh and one
+// re-issue, mirroring api.AuthedClient.GetHealth's contract. The
+// Accept header is overridden via a per-call RequestEditorFn so the
+// SSE response carries the right Content-Type negotiation.
 func streamRunEvents(cmd *cobra.Command, backplaneURL string, opts runEventsOptions) error {
-	body, err := json.Marshal(RunRequest{Input: opts.Input})
-	if err != nil {
-		return fmt.Errorf("encode run-events request: %w", err)
-	}
-	authed, err := api.NewAuthedClient(cmd.Context(), backplaneURL, api.AuthedClientOptions{})
+	authed, err := newAuthedClient(cmd.Context(), backplaneURL)
 	if err != nil {
 		return err
 	}
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return errMissingAccessToken
+	body := api.AgentRunRequest{Input: opts.Input}
+	editor := func(_ context.Context, req *http.Request) error {
+		req.Header.Set("Accept", "text/event-stream")
+		return nil
 	}
-	resp, err := sendSSERequest(cmd.Context(), authed.HTTPClient(), backplaneURL, opts.Name, bearer, body)
+	resp, err := authed.RunAgentEventsApiV1AgentsNameRunEventsPost(
+		cmd.Context(), opts.Name, nil, body, editor,
+	)
 	if err != nil {
 		return err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		if rerr := authed.Refresh(cmd.Context()); rerr != nil {
+			resp.Body.Close()
+			return rerr
+		}
+		resp.Body.Close()
+		resp, err = authed.RunAgentEventsApiV1AgentsNameRunEventsPost(
+			cmd.Context(), opts.Name, nil, body, editor,
+		)
+		if err != nil {
+			return err
+		}
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		raw, _ := io.ReadAll(io.LimitReader(resp.Body, responseBodyCap))
-		return &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
+		// Drain an error body into the renderer; cap the read so an
+		// adversarial / oversized error body can't pin the verb.
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, errBodyCap))
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode, raw, opts.JSONOut)
 	}
 	return printSSEStream(cmd.OutOrStdout(), resp.Body, opts.JSONOut)
 }
 
-func sendSSERequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, name, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(
-		ctx, "POST", backplaneURL+buildRunEventsPath(name), strings.NewReader(string(body)),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("build run-events request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "text/event-stream")
-	req.Header.Set("Content-Type", "application/json")
-	return client.Do(req)
-}
+// errBodyCap bounds the error-body read on a non-2xx SSE handshake.
+// Symmetric with the buffered envelope's 1 MiB ceiling.
+const errBodyCap int64 = 1 << 20
 
 // printSSEStream parses the SSE frames off r and prints one line per event.
 // SSE frames are `event: <kind>` + `data: <json>` separated by a blank

--- a/cli/internal/cmd/agent/run_events.go
+++ b/cli/internal/cmd/agent/run_events.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -85,6 +86,17 @@ func runRunEvents(cmd *cobra.Command, opts runEventsOptions) error {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 	if err := streamRunEvents(cmd, backplaneURL, opts); err != nil {
+		// streamRunEvents calls renderHTTPStatus on a non-2xx handshake,
+		// which already writes the rendered category to stderr and returns
+		// an output.ExitCoder (silent sentinel). Forwarding that through
+		// renderRequestError would print a SECOND stderr line —
+		// `meho: unreachable: …` with an empty error tail — directly
+		// violating AC #6 (byte-identical to main) on the 401/403/404/422
+		// paths. Only transport-level errors need renderRequestError.
+		var rendered output.ExitCoder
+		if errors.As(err, &rendered) {
+			return err
+		}
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
 	return nil

--- a/cli/internal/cmd/agent/run_status.go
+++ b/cli/internal/cmd/agent/run_status.go
@@ -8,26 +8,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
+	"net/http"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
-
-// RunStatus mirrors the backend AgentRunStatusResponse pydantic model
-// (`backend/src/meho_backplane/api/v1/agent_runs.py`). Output / Error are
-// populated only once the run reaches a terminal state.
-type RunStatus struct {
-	RunID    string         `json:"run_id"`
-	Status   string         `json:"status"`
-	Turns    int            `json:"turns"`
-	Provider *string        `json:"provider"`
-	Model    *string        `json:"model"`
-	Output   map[string]any `json:"output"`
-	Error    *string        `json:"error"`
-}
 
 // newRunStatusCmd returns the `meho agent run-status` command.
 //
@@ -61,7 +50,7 @@ func newRunStatusCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
-		"emit the raw status JSON instead of the human summary")
+		"emit the raw AgentRunStatusResponse JSON instead of the human summary")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
 	return cmd
@@ -78,46 +67,53 @@ func runRunStatus(cmd *cobra.Command, opts runStatusOptions) error {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected("run-status requires a non-empty <handle> argument"), opts.JSONOut)
 	}
+	// The generated client takes the handle as a uuid.UUID (the OpenAPI
+	// spec marks the path param as format=uuid), so parse the operator's
+	// string argument once at the verb edge and surface a clean
+	// CLI-side error before the request is built.
+	handle, err := uuid.Parse(opts.Handle)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("invalid <handle>: %v", err)), opts.JSONOut)
+	}
 	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	status, err := getRunStatus(cmd.Context(), backplaneURL, opts.Handle)
+	resp, err := getRunStatus(cmd.Context(), backplaneURL, handle)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
-	if opts.JSONOut {
-		return output.PrintJSON(cmd.OutOrStdout(), status)
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
 	}
-	printRunStatus(cmd.OutOrStdout(), status)
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
+	}
+	printRunStatus(cmd.OutOrStdout(), resp.JSON200)
 	return nil
 }
 
-// buildRunStatusPath assembles the GET path. Exposed for unit tests so URL
-// encoding of the handle stays covered.
-func buildRunStatusPath(handle string) string {
-	return "/api/v1/agents/runs/" + url.PathEscape(handle)
-}
-
-func getRunStatus(ctx context.Context, backplaneURL, handle string) (*RunStatus, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildRunStatusPath(handle), nil)
+func getRunStatus(ctx context.Context, backplaneURL string, handle uuid.UUID) (*api.GetRunStatusApiV1AgentsRunsHandleGetResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out RunStatus
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode agent run-status response: %w", err)
-	}
-	return &out, nil
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.GetRunStatusApiV1AgentsRunsHandleGetResponse, error) {
+			return authed.GetRunStatusApiV1AgentsRunsHandleGetWithResponse(ctx, handle, nil)
+		},
+		func(r *api.GetRunStatusApiV1AgentsRunsHandleGetResponse) int { return r.StatusCode() },
+	)
 }
 
 // printRunStatus renders a run status as a key-value summary.
-func printRunStatus(w io.Writer, s *RunStatus) {
+func printRunStatus(w io.Writer, s *api.AgentRunStatusResponse) {
 	if s == nil {
 		return
 	}
-	fmt.Fprintf(w, "%-16s %s\n", "run_id:", s.RunID)
-	fmt.Fprintf(w, "%-16s %s\n", "status:", s.Status)
+	fmt.Fprintf(w, "%-16s %s\n", "run_id:", s.RunId.String())
+	fmt.Fprintf(w, "%-16s %s\n", "status:", string(s.Status))
 	fmt.Fprintf(w, "%-16s %d\n", "turns:", s.Turns)
 	if s.Provider != nil {
 		fmt.Fprintf(w, "%-16s %s\n", "provider:", *s.Provider)
@@ -129,7 +125,7 @@ func printRunStatus(w io.Writer, s *RunStatus) {
 		fmt.Fprintf(w, "%-16s %s\n", "error:", *s.Error)
 	}
 	if s.Output != nil {
-		if encoded, err := json.Marshal(s.Output); err == nil {
+		if encoded, err := json.Marshal(*s.Output); err == nil {
 			fmt.Fprintf(w, "%-16s %s\n", "output:", string(encoded))
 		}
 	}

--- a/cli/internal/cmd/agent/run_test.go
+++ b/cli/internal/cmd/agent/run_test.go
@@ -10,15 +10,13 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/evoila/meho/cli/internal/api"
 )
 
 // --- run ---
-
-func TestBuildRunPathEscapes(t *testing.T) {
-	if got := buildRunPath("vm.inventory-bot"); got != "/api/v1/agents/vm.inventory-bot/run" {
-		t.Fatalf("buildRunPath: got %q", got)
-	}
-}
 
 func TestRunSyncHappyPath(t *testing.T) {
 	mux := http.NewServeMux()
@@ -29,12 +27,21 @@ func TestRunSyncHappyPath(t *testing.T) {
 		if r.Header.Get("Authorization") == "" {
 			t.Errorf("missing Authorization header")
 		}
-		var body RunRequest
-		_ = json.NewDecoder(r.Body).Decode(&body)
+		// Assert the typed request body decodes into the generated
+		// AgentRunRequest shape, with the operator's --input on the
+		// wire and the --async flag absent (defaults to false).
+		var body api.AgentRunRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
 		if body.Input != "what happened?" {
 			t.Errorf("unexpected input: %q", body.Input)
 		}
-		_ = json.NewEncoder(w).Encode(RunResult{
+		if body.Async != nil && *body.Async {
+			t.Errorf("expected async=false on the wire for sync run")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(runResponse{
 			RunID:  "11111111-1111-1111-1111-111111111111",
 			Status: "succeeded",
 			Output: map[string]any{"text": "triaged: ok"},
@@ -59,13 +66,14 @@ func TestRunSyncHappyPath(t *testing.T) {
 func TestRunAsyncPrintsHandleHint(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/agents/triage/run", func(w http.ResponseWriter, r *http.Request) {
-		var body RunRequest
+		var body api.AgentRunRequest
 		_ = json.NewDecoder(r.Body).Decode(&body)
-		if !body.Async {
+		if body.Async == nil || !*body.Async {
 			t.Errorf("expected async=true on the wire")
 		}
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
-		_ = json.NewEncoder(w).Encode(RunResult{
+		_ = json.NewEncoder(w).Encode(runResponse{
 			RunID:  "22222222-2222-2222-2222-222222222222",
 			Status: "running",
 		})
@@ -97,25 +105,32 @@ func TestRunRequiresInput(t *testing.T) {
 
 // --- run-status ---
 
-func TestBuildRunStatusPathEscapes(t *testing.T) {
-	got := buildRunStatusPath("11111111-1111-1111-1111-111111111111")
-	if got != "/api/v1/agents/runs/11111111-1111-1111-1111-111111111111" {
-		t.Fatalf("buildRunStatusPath: got %q", got)
+func TestRunStatusRejectsInvalidUUID(t *testing.T) {
+	cmd, _, stderr := newTestCmd(t)
+	err := runRunStatus(cmd, runStatusOptions{Handle: "abc", BackplaneOverride: "http://x"})
+	if err == nil {
+		t.Fatalf("expected error for non-UUID handle")
+	}
+	if !strings.Contains(stderr.String(), "invalid <handle>") {
+		t.Errorf("stderr missing parse-error hint; got %q", stderr.String())
 	}
 }
 
 func TestRunStatusHappyPath(t *testing.T) {
+	handle := "11111111-1111-1111-1111-111111111111"
 	provider := "anthropic"
 	model := "claude-sonnet-4-6"
+	output := map[string]any{"text": "done"}
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/agents/runs/abc", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(RunStatus{
-			RunID:    "abc",
-			Status:   "succeeded",
+	mux.HandleFunc("/api/v1/agents/runs/"+handle, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.AgentRunStatusResponse{
+			RunId:    uuid.MustParse(handle),
+			Status:   api.AgentRunStatusSucceeded,
 			Turns:    2,
 			Provider: &provider,
 			Model:    &model,
-			Output:   map[string]any{"text": "done"},
+			Output:   &output,
 		})
 	})
 	srv := httptest.NewServer(mux)
@@ -123,7 +138,7 @@ func TestRunStatusHappyPath(t *testing.T) {
 	seedXDGAndToken(t, srv.URL)
 
 	cmd, stdout, stderr := newTestCmd(t)
-	if err := runRunStatus(cmd, runStatusOptions{Handle: "abc", BackplaneOverride: srv.URL}); err != nil {
+	if err := runRunStatus(cmd, runStatusOptions{Handle: handle, BackplaneOverride: srv.URL}); err != nil {
 		t.Fatalf("runRunStatus: %v; stderr=%s", err, stderr.String())
 	}
 	for _, want := range []string{"succeeded", "anthropic", "done"} {
@@ -134,8 +149,9 @@ func TestRunStatusHappyPath(t *testing.T) {
 }
 
 func TestRunStatusNotFoundRendersError(t *testing.T) {
+	handle := "33333333-3333-3333-3333-333333333333"
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/agents/runs/missing", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/api/v1/agents/runs/"+handle, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		_ = json.NewEncoder(w).Encode(map[string]any{"detail": "agent_run_not_found"})
 	})
@@ -144,7 +160,7 @@ func TestRunStatusNotFoundRendersError(t *testing.T) {
 	seedXDGAndToken(t, srv.URL)
 
 	cmd, _, stderr := newTestCmd(t)
-	err := runRunStatus(cmd, runStatusOptions{Handle: "missing", BackplaneOverride: srv.URL})
+	err := runRunStatus(cmd, runStatusOptions{Handle: handle, BackplaneOverride: srv.URL})
 	if err == nil {
 		t.Fatalf("expected error on 404")
 	}
@@ -155,15 +171,15 @@ func TestRunStatusNotFoundRendersError(t *testing.T) {
 
 // --- run-events (SSE) ---
 
-func TestBuildRunEventsPathEscapes(t *testing.T) {
-	if got := buildRunEventsPath("vm.bot"); got != "/api/v1/agents/vm.bot/run/events" {
-		t.Fatalf("buildRunEventsPath: got %q", got)
-	}
-}
-
 func TestRunEventsStreamsFrames(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/agents/triage/run/events", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/api/v1/agents/triage/run/events", func(w http.ResponseWriter, r *http.Request) {
+		// Verify the SSE-specific Accept override the verb sets via
+		// the per-call RequestEditorFn so the backend's negotiation
+		// reads the right content-type intent.
+		if got := r.Header.Get("Accept"); got != "text/event-stream" {
+			t.Errorf("Accept header: got %q; want text/event-stream", got)
+		}
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, "event: turn\ndata: {\"run_id\":\"r1\"}\n\n")

--- a/cli/internal/cmd/agent/run_test.go
+++ b/cli/internal/cmd/agent/run_test.go
@@ -213,3 +213,39 @@ func TestPrintSSEEventJSON(t *testing.T) {
 		t.Errorf("json event missing merged event kind; got %q", sb.String())
 	}
 }
+
+// TestRunEvents403SingleErrorLine — regression for B1 on #1277. A non-2xx
+// SSE handshake is rendered by streamRunEvents via renderHTTPStatus, which
+// returns an already-rendered *silentError. runRunEvents must NOT re-route
+// that error through renderRequestError (which would fall through to
+// output.Unreachable and emit a second `meho:` stderr line — a direct
+// regression of AC #6 "byte-identical to main output" for the 401/403/
+// 404/422 paths on this streaming verb).
+func TestRunEvents403SingleErrorLine(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/agents/triage/run/events", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"detail":"Insufficient role: tenant_admin required"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newTestCmd(t)
+	err := runRunEvents(cmd, runEventsOptions{
+		Name: "triage", Input: "go", BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error on 403")
+	}
+	got := stderr.String()
+	if c := strings.Count(got, "meho:"); c != 1 {
+		t.Errorf("expected exactly one 'meho:' stderr line, got %d: %q", c, got)
+	}
+	if !strings.Contains(got, "insufficient_role") {
+		t.Errorf("expected insufficient_role category in stderr; got %q", got)
+	}
+	if strings.Contains(got, "unreachable") {
+		t.Errorf("403 must not surface as 'unreachable' (B1 regression); got %q", got)
+	}
+}

--- a/cli/internal/cmd/agent/show.go
+++ b/cli/internal/cmd/agent/show.go
@@ -5,12 +5,11 @@ package agent
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"net/url"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -31,8 +30,8 @@ func newShowCmd() *cobra.Command {
 		Use:   "show <name>",
 		Short: "Fetch one agent definition by name",
 		Long: "show calls GET /api/v1/agents/{name} and renders the " +
-			"definition as a key-value summary (or the full Entry JSON " +
-			"with --json). A 404 means the name doesn't exist in your " +
+			"definition as a key-value summary (or the full AgentDefinitionRead " +
+			"JSON with --json). A 404 means the name doesn't exist in your " +
 			"tenant — the route conflates cross-tenant probes with " +
 			"genuine absence so existence is never leaked.",
 		Args:          cobra.ExactArgs(1),
@@ -47,7 +46,7 @@ func newShowCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
-		"emit raw Entry JSON instead of the human summary")
+		"emit raw AgentDefinitionRead JSON instead of the human summary")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
 	return cmd
@@ -71,31 +70,29 @@ func runShow(cmd *cobra.Command, opts showOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	entry, err := getEntry(cmd.Context(), backplaneURL, opts.Name)
+	resp, err := getDefinition(cmd.Context(), backplaneURL, opts.Name)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
-	if opts.JSONOut {
-		return output.PrintJSON(cmd.OutOrStdout(), entry)
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
 	}
-	printEntrySummary(cmd.OutOrStdout(), entry)
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
+	}
+	printDefinitionSummary(cmd.OutOrStdout(), resp.JSON200)
 	return nil
 }
 
-// buildShowPath assembles the GET path. Exposed for unit tests so URL
-// encoding of names with dots / hyphens stays covered.
-func buildShowPath(name string) string {
-	return "/api/v1/agents/" + url.PathEscape(name)
-}
-
-func getEntry(ctx context.Context, backplaneURL, name string) (*Entry, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildShowPath(name), nil)
+func getDefinition(ctx context.Context, backplaneURL, name string) (*api.ShowAgentApiV1AgentsNameGetResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out Entry
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode agent show response: %w", err)
-	}
-	return &out, nil
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.ShowAgentApiV1AgentsNameGetResponse, error) {
+			return authed.ShowAgentApiV1AgentsNameGetWithResponse(ctx, name, nil)
+		},
+		func(r *api.ShowAgentApiV1AgentsNameGetResponse) int { return r.StatusCode() },
+	)
 }

--- a/docs/codebase/agent-definition.md
+++ b/docs/codebase/agent-definition.md
@@ -174,9 +174,17 @@ event regardless of transport (REST vs MCP).
 - `mcp/registry.py` — `register_mcp_tool` (auto-discovered at startup
   via `eager_import_mcp_modules`).
 - CLI: `cli/internal/cmd/agent/` (cobra package) + `cli/internal/backplane`
-  (shared backplane resolution) + a local `doAuthedRequest` /
-  `renderRequestError` pair (the import-cycle-avoidance convention every
-  sibling CLI verb tree follows).
+  (shared backplane resolution). The verbs call the generated
+  oapi-codegen typed client (`cli/internal/api/client.gen.go`) via
+  `api.AuthedClient` for bearer injection + one-shot 401-refresh; a
+  small per-package `retryOn401` helper runs the same retry contract
+  per typed endpoint that `AuthedClient.GetHealth` runs for `/health`.
+  The package-local `renderRequestError` / `renderHTTPStatus` pair
+  preserves the agents REST surface's status-code → category mapping
+  (401 → `auth_expired`, 403 → `insufficient_role`, 404 →
+  `agent_not_found`, 409 / 422 → backend detail, etc.). G0.12-T3
+  (#1261, Initiative #1118) flipped the verbs off the per-verb
+  hand-rolled `doAuthedRequest` onto this typed-client transport.
 
 ## Known issues
 


### PR DESCRIPTION
## Summary

- Flips every `meho agent ...` verb (list / show / create / edit /
  delete / grant {list,show,create,elevate,revoke} / run /
  run-status / run-events) off the package-local hand-rolled
  HTTP layer onto the generated oapi-codegen typed client at
  `cli/internal/api/client.gen.go`, with bearer + one-shot
  401-refresh-retry going through `api.AuthedClient` per Initiative
  #1118 (G0.12 CLI hygiene).
- Deletes the consumer-side duplicate Go structs (`Entry`,
  `ListResponse`, `RunRequest`, `RunResult`, `RunStatus`,
  `grantEntry`, `grantListResponse`, `grantCreateRequest`) plus
  the package-local `doAuthedRequest` / `sendRequest` / `httpError`
  / `responseBodyCap` machinery; renderers consume
  `api.AgentDefinitionRead`, `api.AgentRunStatusResponse`,
  `api.AgentGrantRead`, etc. directly.
- A small per-package `retryOn401` helper runs the same
  401 → refresh → re-issue contract `AuthedClient.GetHealth`
  runs for `/health`, generalised over the typed *Response
  envelopes so every verb gets transparent refresh without
  duplicating GetHealth's body.
- Verb signatures, flag names, and human / `--json` output stay
  byte-identical to `main` for the same fixtures — the migration
  is implementation-only (per the issue's acceptance criteria).

## Notes & deliberate scope deviations

- **`POST /api/v1/agents/{name}/run` keeps a tiny local response
  shape.** The endpoint emits a discriminated union of two
  unrelated Pydantic models (`AgentRunResultResponse` at 200,
  `AgentRunHandleResponse` at 202) via a `JSONResponse` with no
  `response_model=`. The OpenAPI snapshot therefore renders the
  response as a free-shape `Any` at 200 only, and the generated
  `JSON200` is `*interface{}`. The verb unmarshals
  `resp.Body` into a local `runResponse` union so the human /
  `--json` printing contract is preserved; flagged in `run.go`
  with a `code-quality-allow` reason and recorded as an adjacent
  finding for a backend OpenAPI follow-up (outside this
  consumer-side migration's blast radius).
- **`run-events` uses the non-`*WithResponse` generated method.**
  The streaming endpoint needs the response body unbuffered; the
  `*WithResponse` variant would buffer the entire stream and break
  SSE delivery. A per-call `RequestEditorFn` overrides the Accept
  header to `text/event-stream`.
- **UUID-keyed paths parse the operator's string argument at the
  verb edge.** `GetRunStatusApiV1AgentsRunsHandleGetWithResponse`
  and the grant `show` / `revoke` methods take
  `openapi_types.UUID`; `uuid.Parse` runs once at the boundary
  and surfaces `output.Unexpected("invalid <handle>: ...")` on a
  parse failure so a bad string doesn't reach the server as a 422
  the operator can't act on.

## Test plan

- [x] `go vet ./...` — clean across the whole CLI module
- [x] `gofmt -l internal/cmd/agent/` — no diffs
- [x] `go test ./internal/cmd/agent/...` — 29 tests pass
  (`TestRunListHappyPath`, `TestRunShowHappyPath` / `404`,
  `TestRunCreateHappyPath` / `409` / `403`, `TestRunEditHappyPath`
  / no-fields / conflict / bad-tier, `TestRunDeleteConfirmHappyPath`
  / `Declined` / `404`, `TestRunSyncHappyPath`,
  `TestRunAsyncPrintsHandleHint`, `TestRunStatusRejectsInvalidUUID`,
  `TestRunStatusHappyPath` / `404`, `TestRunEventsStreamsFrames`,
  `TestPrintSSEEventJSON`, `TestBuildEditBodyOnlyChangedFields` /
  bad-tier, `TestListQueryParams`, `TestBuildGrantCreateBody*`,
  `TestBuildGrantElevateBody*`, `TestGrantListParamsBuild`,
  `TestPrintGrantListTable*`, `TestRenderGrantEntry*`,
  `TestGrantRevokeRejectsInvalidUUID`)
- [x] `go test ./...` — every sibling CLI package still green
- [x] `cd cli && make snapshot-openapi && make generate` — no-op
  (clean `git status`); OpenAPI snapshot freshness gate stays
  green
- [x] Acceptance grep
  `grep -rn "http.NewRequest|doAuthedRequest|^type Entry |^type ListResponse |^type RunRequest |^type RunResult |^type RunStatus |grantEntry|grantListResponse|grantCreateRequest" cli/internal/cmd/agent/`
  returns **no matches**
- [x] Acceptance grep for typed-client surface usage returns
  matches in `list.go`, `show.go`, `create.go`, `edit.go`, `grant.go`
  (and `run.go`, `run_events.go`, `run_status.go`, `delete.go`)
- [x] Backend `backend/src/meho_backplane/api/v1/agents.py` and
  `agent_runs.py` unchanged
- [x] `docs/codebase/agent-definition.md` updated to point at the
  new typed-client transport
- [ ] Live smoke against a real backplane — gated behind CI / staging

## Out of scope

- Other CLI verb directories (`approvals/`, `operation/`, `kb/`,
  `memory/`, etc.) — each is its own G0.12-T<N> Task.
- Promoting `api.AuthedClient` to a shared typed-client factory
  beyond the agent verbs' immediate needs (per the Initiative's
  out-of-scope list).
- Fixing the `POST /agents/{name}/run` discriminated-union
  OpenAPI gap — backend FastAPI change, adjacent finding only.

Closes #1261
