### PR TITLE
refactor(cli-broadcast): G0.12-T6 migrate to generated typed client (#1264)

### DIFF
--- a/cli/internal/cmd/broadcast/broadcast.go
+++ b/cli/internal/cmd/broadcast/broadcast.go
@@ -17,23 +17,32 @@
 // shape as `meho audit` / `meho targets` / `meho retrieval`. RBAC at
 // the backend rejects non-`tenant_admin` callers with HTTP 403; the
 // verb renders this as `insufficient_role`.
+//
+// G0.12-T6 #1264 migrated this package off the sibling-verb pattern
+// of hand-rolled HTTP + hand-typed copies of the backend Pydantic
+// models. Every verb here drives the generated
+// `api.ClientWithResponses` surface directly: `api.NewAuthedClient`
+// wires the bearer + lazy 401-refresh editor onto the embedded
+// `ClientWithResponses`, and the verbs call the typed
+// `*WithResponse` methods
+// (`ListOverridesApiV1BroadcastOverridesGetWithResponse`,
+// `CreateOverrideApiV1BroadcastOverridesPostWithResponse`,
+// `DeleteOverrideApiV1BroadcastOverridesOverrideIdDeleteWithResponse`).
+// Consumer-side struct drift — the #1069 root cause — can't recur
+// because we now consume `api.BroadcastOverrideRead` and produce
+// `api.BroadcastOverrideCreate` directly.
 package broadcast
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
-	"net/url"
-	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -78,99 +87,67 @@ func newOverridesCmd() *cobra.Command {
 	return cmd
 }
 
-// Entry mirrors the backend `BroadcastOverrideRead` Pydantic model
-// (`backend/src/meho_backplane/api/v1/broadcast_overrides.py`). Hand-
-// written rather than aliased to a generated client type so the
-// broadcast package stays decoupled from oapi-codegen churn -- same
-// stance as the audit / targets / retrieval packages.
-//
-// `ScopeField` and `ScopeValue` are `*string` so the JSON round-trip
-// preserves the explicit-null wire shape (an op-wide rule has both
-// fields null).
-type Entry struct {
-	ID           string  `json:"id"`
-	TenantID     string  `json:"tenant_id"`
-	OpIDPattern  string  `json:"op_id_pattern"`
-	ScopeField   *string `json:"scope_field"`
-	ScopeValue   *string `json:"scope_value"`
-	Detail       string  `json:"detail"`
-	CreatedBySub string  `json:"created_by_sub"`
-	CreatedAt    string  `json:"created_at"`
-	UpdatedAt    string  `json:"updated_at"`
+// httpResponseError carries a non-2xx status from a typed-client
+// `*WithResponse` call up to the verb's renderer. The typed-client
+// surface returns non-2xx responses in-band on the `(*Response, nil)`
+// tuple (transport-layer failures come back on the `(nil, err)`
+// tuple instead) — we lift the HTTP-failure case to an error type so
+// the call sites can use a single `if err != nil` branch and
+// `errors.As` routes the right way (HTTP status → `renderHTTPStatus`,
+// everything else → `renderTransportError`). See `routeRequestError`.
+type httpResponseError struct {
+	statusCode int
+	body       []byte
 }
 
-// CreateRequest mirrors the backend `BroadcastOverrideCreate` Pydantic
-// model. Optional fields use `*string` so the JSON round-trip omits
-// them rather than sending an explicit null when the caller didn't
-// supply a value.
-type CreateRequest struct {
-	OpIDPattern string  `json:"op_id_pattern"`
-	ScopeField  *string `json:"scope_field,omitempty"`
-	ScopeValue  *string `json:"scope_value,omitempty"`
-	Detail      string  `json:"detail"`
+func (e *httpResponseError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.statusCode, trimmedBody(e.body))
 }
 
-// errNoBackplaneConfigured mirrors the cli/internal/cmd/audit/audit.go
-// shape. Re-declared here to avoid the import cycle the cmd → cmd/audit
-// → cmd path would create.
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane configured; run `meho login <url>` or pass --backplane"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
-func resolveBackplane(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
+// routeRequestError is the single dispatcher every verb feeds an
+// error from `listOverrides` / `createOverride` / `deleteOverride`
+// into. The error is either an `*httpResponseError` (the backplane
+// responded with a non-2xx status) or a transport-layer failure
+// (network, refresh-impossible, etc.); we route the former through
+// `renderHTTPStatus` and the latter through `renderTransportError`.
+func routeRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	var he *httpResponseError
+	if errors.As(err, &he) {
+		return renderHTTPStatus(cmd, backplaneURL, he.statusCode, he.body, jsonOut)
 	}
-	cfg, err := auth.LoadConfig()
+	return renderTransportError(cmd, backplaneURL, err, jsonOut)
+}
+
+// newAuthedClient builds an `api.AuthedClient` and surfaces its
+// construction-time errors as the right `output.StructuredError`
+// category (auth_expired when no token was ever stored, else
+// unexpected_response with the underlying error wrapped). Splits the
+// boilerplate every verb here used to duplicate inline.
+func newAuthedClient(
+	ctx context.Context,
+	cmd *cobra.Command,
+	backplaneURL string,
+	jsonOut bool,
+) (*api.AuthedClient, error) {
+	client, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
 	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
+		return nil, renderClientError(cmd, backplaneURL, err, jsonOut)
 	}
-	return normaliseURL(cfg.BackplaneURL)
+	return client, nil
 }
 
-func classifyBackplaneError(err error) *output.StructuredError {
-	if errors.Is(err, auth.ErrConfigNotFound) {
-		return output.AuthExpired(err.Error())
-	}
-	return output.Unexpected(err.Error())
-}
-
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
-	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
-	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
-}
-
-// renderRequestError classifies a request error into the right
-// StructuredError category. Maps the broadcast-overrides REST
-// surface's status codes:
-//
-//   - 401 (refresh failed) → auth_expired.
-//   - 403 → insufficient_role.
-//   - 404 → unexpected with "broadcast override not found"
-//     (cross-tenant probes land here per the backend's
-//     no-existence-leak posture).
-//   - 409 → unexpected with the duplicate-rule message.
-//   - 422 → unexpected with the FastAPI validation envelope.
-//   - Other 4xx/5xx → unexpected with the raw body.
-//   - Pure transport errors → unreachable.
-func renderRequestError(
+// renderClientError maps `api.NewAuthedClient` failures onto the
+// structured-error envelope. `IsTokenNotFound` is the "operator
+// never ran meho login" sentinel and surfaces as auth_expired with a
+// `meho login` hint; anything else is a build-time failure of the
+// authed transport itself (token store unreadable, etc.) and
+// surfaces as unexpected_response so the operator sees the cause.
+func renderClientError(
 	cmd *cobra.Command,
 	backplaneURL string,
 	err error,
@@ -185,6 +162,23 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unexpected(fmt.Sprintf("build authed client for %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+// renderTransportError maps a generated-client call's transport-layer
+// error (network failure, refresh-impossible after a 401) onto the
+// right structured-error category. The typed-client surface returns
+// `(nil, err)` for these; non-2xx HTTP responses arrive as
+// `(*Response, nil)` and are routed through `renderHTTPStatus` instead.
+func renderTransportError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
 	if api.IsNoRefreshToken(err) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.AuthExpired(fmt.Sprintf(
@@ -194,23 +188,36 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
-		return renderHTTPError(cmd, backplaneURL, he, jsonOut)
-	}
 	return output.RenderError(cmd.ErrOrStderr(),
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
 }
 
-func renderHTTPError(
+// renderHTTPStatus maps a non-2xx HTTP status from the typed-client
+// response onto the right structured-error category. Mirrors the
+// pre-migration `renderHTTPError` shape:
+//
+//   - 401 → AuthExpired
+//   - 403 → InsufficientRole(detail) -- the backend's own detail
+//     string surfaces, not a hardcoded message.
+//   - 404 → Unexpected(detail) -- list/set on an older backplane
+//     (route missing) and remove on a missing/cross-tenant id both
+//     hit this path; the backend's own detail
+//     (`broadcast_override_not_found` for remove) round-trips
+//     cleanly.
+//   - 409 → Unexpected(detail) -- duplicate-rule rejection.
+//   - 422 → Unexpected("invalid request: <body>")
+//   - other non-2xx → Unexpected("call <url>: HTTP N: <body>")
+func renderHTTPStatus(
 	cmd *cobra.Command,
 	backplaneURL string,
-	he *httpError,
+	statusCode int,
+	body []byte,
 	jsonOut bool,
 ) error {
-	switch he.StatusCode {
+	bodyStr := trimmedBody(body)
+	switch statusCode {
 	case http.StatusUnauthorized:
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.AuthExpired(fmt.Sprintf(
@@ -221,154 +228,72 @@ func renderHTTPError(
 		)
 	case http.StatusForbidden:
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.InsufficientRole(decodeDetailString(he.Body)),
+			output.InsufficientRole(decodeDetail(body, bodyStr)),
 			jsonOut,
 		)
 	case http.StatusNotFound:
-		// Surface the backend's own `detail` instead of hard-coding
-		// "broadcast override not found": for `list` / `set` (which
-		// don't carry an id in the path), a 404 means "route doesn't
-		// exist on this backplane" -- typically because the operator
-		// is talking to an older deploy that hasn't shipped T4 yet.
-		// `remove`'s 404 carries `broadcast_override_not_found`
-		// detail; both shapes round-trip cleanly through
-		// `decodeDetailString`.
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(decodeDetailString(he.Body)),
+			output.Unexpected(decodeDetail(body, bodyStr)),
 			jsonOut,
 		)
 	case http.StatusConflict:
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(decodeDetailString(he.Body)),
+			output.Unexpected(decodeDetail(body, bodyStr)),
 			jsonOut,
 		)
 	case http.StatusUnprocessableEntity:
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf("invalid request: %s", he.Body)),
+			output.Unexpected(fmt.Sprintf("invalid request: %s", bodyStr)),
 			jsonOut,
 		)
 	default:
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, statusCode, bodyStr)),
 			jsonOut,
 		)
 	}
 }
 
-type detailEnvelope struct {
-	Detail json.RawMessage `json:"detail"`
+// trimmedBody renders a response body for inclusion in an error
+// envelope: trims trailing whitespace, surfaces a placeholder when
+// the backend returned an empty body so the operator-facing string
+// is never just "HTTP 500:".
+func trimmedBody(body []byte) string {
+	s := string(body)
+	for len(s) > 0 {
+		last := s[len(s)-1]
+		if last == ' ' || last == '\n' || last == '\r' || last == '\t' {
+			s = s[:len(s)-1]
+			continue
+		}
+		break
+	}
+	if s == "" {
+		return "(empty body)"
+	}
+	return s
 }
 
-func decodeDetailString(body string) string {
-	var env detailEnvelope
-	if err := json.Unmarshal([]byte(body), &env); err == nil {
+// decodeDetail extracts the FastAPI `{"detail": "..."}` envelope's
+// string payload from a response body, falling back to the trimmed
+// body when the envelope can't be decoded. Pre-migration this lived
+// in `decodeDetailString`; the typed-client error path still receives
+// raw bytes so the same shape applies. `fallback` is the
+// already-trimmed body so the empty-body placeholder ("(empty body)")
+// flows through unchanged. FastAPI's `detail` can be either a
+// string (HTTPException) or a nested object (422-style validation
+// envelope); the string-shape case is the operator-friendly one we
+// surface, anything else gets the raw-body fallback.
+func decodeDetail(body []byte, fallback string) string {
+	var env struct {
+		Detail json.RawMessage `json:"detail"`
+	}
+	if err := json.Unmarshal(body, &env); err == nil {
 		var s string
 		if jerr := json.Unmarshal(env.Detail, &s); jerr == nil && s != "" {
 			return s
 		}
 	}
-	return strings.TrimSpace(body)
-}
-
-// doAuthedRequest issues a single HTTP request against the backplane
-// with bearer injection and one-shot 401-refresh-retry. Returns the
-// response body bytes (already drained) on 2xx, or an *httpError on
-// non-2xx, or an error categorised by api.IsTokenNotFound /
-// api.IsNoRefreshToken / generic transport.
-//
-// 204 No Content yields an empty body without error -- DELETE is the
-// only verb that hits this path.
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
-	}
-
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, responseBodyCap+1))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if int64(len(raw)) > responseBodyCap {
-		return nil, fmt.Errorf(
-			"response body exceeds %d-byte cap; refusing to decode possibly-truncated JSON",
-			responseBodyCap,
-		)
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-const responseBodyCap int64 = 1 << 20
-
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
-}
-
-func pathEscape(segment string) string {
-	return url.PathEscape(segment)
-}
-
-func strDerefOrDash(s *string) string {
-	if s == nil || *s == "" {
-		return "-"
-	}
-	return *s
+	return fallback
 }

--- a/cli/internal/cmd/broadcast/broadcast_test.go
+++ b/cli/internal/cmd/broadcast/broadcast_test.go
@@ -14,11 +14,15 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 )
 
 // seedXDGAndToken seeds a per-test config dir + token store that
-// resolveBackplane / doAuthedRequest will read. Mirrors the helper
-// in cli/internal/cmd/audit/audit_test.go.
+// `backplane.Resolve` and `api.NewAuthedClient` will read. Mirrors
+// the helper in cli/internal/cmd/audit/audit_test.go. The token's
+// access_token is a non-empty string so the bearer-injecting editor
+// in `api.NewAuthedClient` doesn't short-circuit on "stored token
+// has no access_token".
 func seedXDGAndToken(t *testing.T, backplaneURL string) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -104,25 +108,68 @@ func TestOverridesRegistersListSetRemove(t *testing.T) {
 	}
 }
 
-// TestNormaliseURLStripsTrailingSlash -- shared resolver shape.
-func TestNormaliseURLStripsTrailingSlash(t *testing.T) {
-	got, err := normaliseURL("https://meho.test:8443/")
+// TestBackplaneNormaliseURLContract -- the shared resolver still
+// strips trailing slashes; this test is here to flag any regression
+// at the broadcast package's edge (the previous local normaliseURL
+// helper was deleted in G0.12-T6 in favour of backplane.NormaliseURL).
+func TestBackplaneNormaliseURLContract(t *testing.T) {
+	got, err := backplane.NormaliseURL("https://meho.test:8443/")
 	if err != nil {
-		t.Fatalf("normaliseURL: %v", err)
+		t.Fatalf("backplane.NormaliseURL: %v", err)
 	}
 	if got != "https://meho.test:8443" {
 		t.Errorf("got %q; want %q", got, "https://meho.test:8443")
 	}
 }
 
-func TestNormaliseURLRejectsEmpty(t *testing.T) {
-	if _, err := normaliseURL(""); err == nil {
-		t.Errorf("empty URL should error")
+// TestTrimmedBodyDropsTrailingWhitespace pins the small renderer
+// helper. Backplane responses often arrive with a trailing newline;
+// dropping it keeps the error envelope's `HTTP 500: foo` shape
+// stable in the operator-visible output.
+func TestTrimmedBodyDropsTrailingWhitespace(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"plain", "plain"},
+		{"trail\n", "trail"},
+		{"trail \r\n", "trail"},
+		{"trail\t  ", "trail"},
+		{"", "(empty body)"},
+		{"   \n", "(empty body)"},
+		{"   leading kept", "   leading kept"},
+	}
+	for _, tc := range cases {
+		if got := trimmedBody([]byte(tc.in)); got != tc.want {
+			t.Errorf("trimmedBody(%q) = %q; want %q", tc.in, got, tc.want)
+		}
 	}
 }
 
-func TestNormaliseURLRejectsNoHost(t *testing.T) {
-	if _, err := normaliseURL("https:///path"); err == nil {
-		t.Errorf("no-host URL should error")
+// TestDecodeDetailRoundTripsFastAPIEnvelope -- the FastAPI
+// `{"detail": "..."}` shape gets unwrapped; non-envelope bodies
+// fall back to the trimmed body. The string-shape detail is the
+// operator-friendly one we surface (HTTPException); a dict/list
+// detail (422 validation envelope) falls back to the raw body.
+func TestDecodeDetailRoundTripsFastAPIEnvelope(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		fallback string
+		want     string
+	}{
+		{"string detail", `{"detail":"broadcast_override_not_found"}`, "fallback", "broadcast_override_not_found"},
+		{"empty detail", `{"detail":""}`, "fallback-on-empty", "fallback-on-empty"},
+		{"dict detail", `{"detail":{"loc":["body"],"msg":"bad"}}`, "fallback-on-dict", "fallback-on-dict"},
+		{"not JSON", `not json`, "fallback-on-garbage", "fallback-on-garbage"},
+		{"no detail key", `{"other":"thing"}`, "fallback-no-key", "fallback-no-key"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := decodeDetail([]byte(tc.body), tc.fallback)
+			if got != tc.want {
+				t.Errorf("decodeDetail(%q, %q) = %q; want %q", tc.body, tc.fallback, got, tc.want)
+			}
+		})
 	}
 }

--- a/cli/internal/cmd/broadcast/overrides_list.go
+++ b/cli/internal/cmd/broadcast/overrides_list.go
@@ -5,13 +5,13 @@ package broadcast
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -55,13 +55,17 @@ type overridesListOptions struct {
 }
 
 func runOverridesList(cmd *cobra.Command, opts overridesListOptions) error {
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	entries, err := listOverrides(cmd.Context(), backplaneURL, opts.OpIDPattern)
+	client, cerr := newAuthedClient(cmd.Context(), cmd, backplaneURL, opts.JSONOut)
+	if cerr != nil {
+		return cerr
+	}
+	entries, err := listOverrides(cmd.Context(), client, opts.OpIDPattern)
 	if err != nil {
-		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+		return routeRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), entries)
@@ -70,31 +74,49 @@ func runOverridesList(cmd *cobra.Command, opts overridesListOptions) error {
 	return nil
 }
 
-// buildListPath assembles the GET path including the optional
-// query parameter. Exposed for unit tests so URL encoding stays
-// covered when the pattern contains special characters.
-func buildListPath(opIDPattern string) string {
-	if opIDPattern == "" {
-		return "/api/v1/broadcast/overrides"
+// listOverrides drives the typed-client
+// `ListOverridesApiV1BroadcastOverridesGet` endpoint with a one-shot
+// 401-retry around the underlying AuthedClient's refresh path
+// (mirrors `AuthedClient.GetHealth`'s pattern in client.go). Non-2xx
+// responses are returned as `*httpResponseError` so the caller can
+// route them through `renderHTTPStatus`; transport-layer errors
+// return verbatim.
+func listOverrides(
+	ctx context.Context,
+	client *api.AuthedClient,
+	opIDPattern string,
+) ([]api.BroadcastOverrideRead, error) {
+	params := &api.ListOverridesApiV1BroadcastOverridesGetParams{}
+	if opIDPattern != "" {
+		p := opIDPattern
+		params.OpIdPattern = &p
 	}
-	q := url.Values{}
-	q.Set("op_id_pattern", opIDPattern)
-	return "/api/v1/broadcast/overrides?" + q.Encode()
-}
-
-func listOverrides(ctx context.Context, backplaneURL, opIDPattern string) ([]Entry, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildListPath(opIDPattern), nil)
+	resp, err := client.ListOverridesApiV1BroadcastOverridesGetWithResponse(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	var out []Entry
-	if jerr := json.Unmarshal(raw, &out); jerr != nil {
-		return nil, fmt.Errorf("decode broadcast overrides list: %w", jerr)
+	if resp.StatusCode() == 401 {
+		if rerr := client.Refresh(ctx); rerr != nil {
+			return nil, rerr
+		}
+		resp, err = client.ListOverridesApiV1BroadcastOverridesGetWithResponse(ctx, params)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return out, nil
+	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
+		return nil, &httpResponseError{statusCode: resp.StatusCode(), body: resp.Body}
+	}
+	if resp.JSON200 == nil {
+		// 2xx without a JSON200 means the response body didn't
+		// decode against BroadcastOverrideRead -- treat as the empty
+		// list rather than NPE'ing.
+		return nil, nil
+	}
+	return *resp.JSON200, nil
 }
 
-func printOverridesTable(w io.Writer, entries []Entry) {
+func printOverridesTable(w io.Writer, entries []api.BroadcastOverrideRead) {
 	if len(entries) == 0 {
 		fmt.Fprintln(w, "(no broadcast-detail overrides in this tenant)")
 		return
@@ -104,12 +126,23 @@ func printOverridesTable(w io.Writer, entries []Entry) {
 	fmt.Fprintln(w, "  ---")
 	for _, e := range entries {
 		fmt.Fprintf(w, "%-36s  %-30s  %-12s  %-20s  %-9s  %s\n",
-			e.ID,
-			e.OpIDPattern,
+			e.Id.String(),
+			e.OpIdPattern,
 			strDerefOrDash(e.ScopeField),
 			strDerefOrDash(e.ScopeValue),
 			e.Detail,
 			e.CreatedBySub,
 		)
 	}
+}
+
+// strDerefOrDash renders an optional string field as "-" when nil
+// or empty, otherwise as the underlying value. Used by both the
+// list table and the set summary so an op-wide rule (scope_field /
+// scope_value both null) renders consistently across verbs.
+func strDerefOrDash(s *string) string {
+	if s == nil || *s == "" {
+		return "-"
+	}
+	return *s
 }

--- a/cli/internal/cmd/broadcast/overrides_list_test.go
+++ b/cli/internal/cmd/broadcast/overrides_list_test.go
@@ -9,26 +9,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/evoila/meho/cli/internal/api"
 )
-
-// TestBuildListPathOmitsEmptyQuery -- without --op-id-pattern, the
-// path is the bare resource URL (no trailing `?`).
-func TestBuildListPathOmitsEmptyQuery(t *testing.T) {
-	got := buildListPath("")
-	want := "/api/v1/broadcast/overrides"
-	if got != want {
-		t.Errorf("buildListPath(\"\") = %q; want %q", got, want)
-	}
-}
-
-// TestBuildListPathEncodesPattern -- glob characters round-trip
-// through url.Values encoding (the `*` survives as `%2A`).
-func TestBuildListPathEncodesPattern(t *testing.T) {
-	got := buildListPath("vault.kv.*")
-	if !strings.Contains(got, "op_id_pattern=") {
-		t.Errorf("buildListPath did not encode query: %q", got)
-	}
-}
 
 // TestRunOverridesListEmptyResult -- HTTP 200 + empty array renders
 // the `(no broadcast-detail overrides ...)` line in the human table
@@ -56,7 +39,10 @@ func TestRunOverridesListEmptyResult(t *testing.T) {
 	}
 }
 
-// TestRunOverridesListJSON -- --json passes the raw array through.
+// TestRunOverridesListJSON -- --json passes the typed array through.
+// Decoded against api.BroadcastOverrideRead directly (the typed
+// client's response shape) -- pre-migration this decoded against
+// the package-local Entry struct.
 func TestRunOverridesListJSON(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/broadcast/overrides", func(w http.ResponseWriter, _ *http.Request) {
@@ -79,17 +65,19 @@ func TestRunOverridesListJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runOverridesList --json: %v", err)
 	}
-	var decoded []Entry
+	var decoded []api.BroadcastOverrideRead
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout.String())
 	}
-	if len(decoded) != 1 || decoded[0].OpIDPattern != "vault.kv.*" {
+	if len(decoded) != 1 || decoded[0].OpIdPattern != "vault.kv.*" {
 		t.Errorf("decoded JSON shape mismatch: %+v", decoded)
 	}
 }
 
 // TestRunOverridesListBindsPatternQuery -- --op-id-pattern lands as a
-// URL query parameter on the GET.
+// URL query parameter on the GET. The typed client encodes the
+// `op_id_pattern` form parameter onto the query string per the
+// generated `ListOverridesApiV1BroadcastOverridesGetParams` shape.
 func TestRunOverridesListBindsPatternQuery(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/broadcast/overrides", func(w http.ResponseWriter, r *http.Request) {
@@ -111,6 +99,94 @@ func TestRunOverridesListBindsPatternQuery(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("runOverridesList: %v", err)
+	}
+}
+
+// TestRunOverridesListGlobPatternEncoded -- a glob pattern with `*`
+// survives the typed-client's URL encoding. Pre-migration this was
+// covered by `buildListPath` directly; the typed client now does
+// the encoding, but the behaviour is the same.
+func TestRunOverridesListGlobPatternEncoded(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/broadcast/overrides", func(w http.ResponseWriter, r *http.Request) {
+		got := r.URL.Query().Get("op_id_pattern")
+		if got != "vault.kv.*" {
+			t.Errorf("op_id_pattern query: got %q; want %q", got, "vault.kv.*")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, _ := newRunCmd(t)
+	err := runOverridesList(cmd, overridesListOptions{
+		OpIDPattern:       "vault.kv.*",
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runOverridesList: %v", err)
+	}
+}
+
+// TestRunOverridesListRendersTable -- non-empty result renders the
+// human-readable table; checks the columns and a row payload.
+func TestRunOverridesListRendersTable(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/broadcast/overrides", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"id":"11111111-1111-1111-1111-111111111111",` +
+			`"tenant_id":"22222222-2222-2222-2222-222222222222",` +
+			`"op_id_pattern":"vault.kv.*","scope_field":null,"scope_value":null,` +
+			`"detail":"aggregate","created_by_sub":"op-1",` +
+			`"created_at":"2026-05-19T12:00:00Z","updated_at":"2026-05-19T12:00:00Z"}]`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	err := runOverridesList(cmd, overridesListOptions{BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runOverridesList: %v", err)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"op_id_pattern", // header
+		"vault.kv.*",    // pattern column
+		"aggregate",     // detail column
+		"op-1",          // created_by column
+		"-",             // op-wide rule renders nil scope fields as "-"
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table missing %q: %q", want, out)
+		}
+	}
+}
+
+// TestRunOverridesList403RendersInsufficientRole -- non-tenant-admin
+// callers see `insufficient_role` derived from the backend's detail
+// envelope, not the raw HTTP body.
+func TestRunOverridesList403RendersInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/broadcast/overrides", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail":"tenant_admin role required"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runOverridesList(cmd, overridesListOptions{BackplaneOverride: srv.URL})
+	_ = err
+	if !strings.Contains(stderr.String(), "insufficient_role") {
+		t.Errorf("stderr should classify as insufficient_role: %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "tenant_admin role required") {
+		t.Errorf("stderr should surface backend detail: %q", stderr.String())
 	}
 }
 

--- a/cli/internal/cmd/broadcast/overrides_remove.go
+++ b/cli/internal/cmd/broadcast/overrides_remove.go
@@ -5,9 +5,13 @@ package broadcast
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -55,24 +59,73 @@ func runOverridesRemove(cmd *cobra.Command, opts overridesRemoveOptions) error {
 			opts.JSONOut,
 		)
 	}
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	overrideID, err := parseOverrideID(opts.OverrideID)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()),
+			opts.JSONOut,
+		)
 	}
-	if err := deleteOverride(cmd.Context(), backplaneURL, opts.OverrideID); err != nil {
-		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	client, cerr := newAuthedClient(cmd.Context(), cmd, backplaneURL, opts.JSONOut)
+	if cerr != nil {
+		return cerr
+	}
+	if err := deleteOverride(cmd.Context(), client, overrideID); err != nil {
+		return routeRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
 	// Silent on success -- mirrors `meho` UX convention for DELETE.
 	return nil
 }
 
-// buildRemovePath assembles the DELETE path with the override id
-// path-escaped. Exposed for unit tests.
-func buildRemovePath(overrideID string) string {
-	return "/api/v1/broadcast/overrides/" + pathEscape(overrideID)
+// parseOverrideID validates the operator's `<override-id>` arg as a
+// UUID at the verb edge. The typed-client's path parameter is
+// `openapi_types.UUID` (an alias for `uuid.UUID`); parsing here
+// keeps the bad-input error a clean output.Unexpected instead of a
+// `fmt.Errorf("invalid UUID: %s")` mid-request or a server-side
+// 422 after the round-trip. Returns a `uuid.UUID` (assignable to
+// `openapi_types.UUID` since the alias resolves to the same type).
+func parseOverrideID(idArg string) (uuid.UUID, error) {
+	id, err := uuid.Parse(idArg)
+	if err != nil {
+		return uuid.UUID{}, fmt.Errorf("override-id is not a valid UUID: %s", idArg)
+	}
+	return id, nil
 }
 
-func deleteOverride(ctx context.Context, backplaneURL, overrideID string) error {
-	_, err := doAuthedRequest(ctx, backplaneURL, "DELETE", buildRemovePath(overrideID), nil)
-	return err
+// deleteOverride drives the typed-client
+// `DeleteOverrideApiV1BroadcastOverridesOverrideIdDelete` endpoint
+// with a one-shot 401-retry around the underlying AuthedClient's
+// refresh path. The route returns 204 No Content on success;
+// non-2xx responses come back as `*httpResponseError`.
+func deleteOverride(
+	ctx context.Context,
+	client *api.AuthedClient,
+	overrideID uuid.UUID,
+) error {
+	params := &api.DeleteOverrideApiV1BroadcastOverridesOverrideIdDeleteParams{}
+	resp, err := client.DeleteOverrideApiV1BroadcastOverridesOverrideIdDeleteWithResponse(
+		ctx, overrideID, params,
+	)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode() == 401 {
+		if rerr := client.Refresh(ctx); rerr != nil {
+			return rerr
+		}
+		resp, err = client.DeleteOverrideApiV1BroadcastOverridesOverrideIdDeleteWithResponse(
+			ctx, overrideID, params,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
+		return &httpResponseError{statusCode: resp.StatusCode(), body: resp.Body}
+	}
+	return nil
 }

--- a/cli/internal/cmd/broadcast/overrides_remove_test.go
+++ b/cli/internal/cmd/broadcast/overrides_remove_test.go
@@ -10,17 +10,39 @@ import (
 	"testing"
 )
 
-// TestBuildRemovePathEscapesID -- the override id path-segment is
-// URL-encoded so reserved characters survive the round-trip. Uses
-// an ID with `/`, ` `, `?` so a regression that dropped
-// `url.PathEscape` from `buildRemovePath` would actually fail the
-// test (the pre-fixup UUID-only fixture would have passed even
-// with no escaping).
-func TestBuildRemovePathEscapesID(t *testing.T) {
-	got := buildRemovePath("abc/def ghi?")
-	want := "/api/v1/broadcast/overrides/abc%2Fdef%20ghi%3F"
-	if got != want {
-		t.Errorf("buildRemovePath: got %q; want %q", got, want)
+const stubOverrideID = "11111111-1111-1111-1111-111111111111"
+
+// TestParseOverrideIDRejectsGarbage -- the bad-input path returns
+// the operator-friendly "override-id is not a valid UUID" message.
+// This is the typed-client-edge equivalent of the pre-migration
+// `pathEscape`-on-arbitrary-string behaviour: the generated
+// `Delete...WithResponse` method requires `openapi_types.UUID`, so
+// the verb has to parse + reject before calling.
+func TestParseOverrideIDRejectsGarbage(t *testing.T) {
+	cases := []string{
+		"not-a-uuid",
+		"abc/def ghi?",
+		"11111111",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			if _, err := parseOverrideID(in); err == nil {
+				t.Errorf("parseOverrideID(%q) should have failed", in)
+			}
+		})
+	}
+}
+
+// TestParseOverrideIDAcceptsValidUUID -- the happy path round-trips
+// a canonical UUID string into the typed UUID expected by the
+// generated client.
+func TestParseOverrideIDAcceptsValidUUID(t *testing.T) {
+	id, err := parseOverrideID(stubOverrideID)
+	if err != nil {
+		t.Fatalf("parseOverrideID(%q): %v", stubOverrideID, err)
+	}
+	if id.String() != stubOverrideID {
+		t.Errorf("parsed UUID round-trip: got %q; want %q", id.String(), stubOverrideID)
 	}
 }
 
@@ -40,7 +62,7 @@ func TestRunOverridesRemoveSilentOn204(t *testing.T) {
 
 	cmd, stdout, _ := newRunCmd(t)
 	err := runOverridesRemove(cmd, overridesRemoveOptions{
-		OverrideID:        "11111111-1111-1111-1111-111111111111",
+		OverrideID:        stubOverrideID,
 		BackplaneOverride: srv.URL,
 	})
 	if err != nil {
@@ -51,13 +73,39 @@ func TestRunOverridesRemoveSilentOn204(t *testing.T) {
 	}
 }
 
+// TestRunOverridesRemovePathContainsID -- the typed client builds
+// the DELETE path with the UUID embedded in the path segment.
+func TestRunOverridesRemovePathContainsID(t *testing.T) {
+	var gotPath string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/broadcast/overrides/", func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, _ := newRunCmd(t)
+	err := runOverridesRemove(cmd, overridesRemoveOptions{
+		OverrideID:        stubOverrideID,
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runOverridesRemove: %v", err)
+	}
+	want := "/api/v1/broadcast/overrides/" + stubOverrideID
+	if gotPath != want {
+		t.Errorf("DELETE path: got %q; want %q", gotPath, want)
+	}
+}
+
 // TestRunOverridesRemove404RendersBackendDetail -- 404 surfaces the
-// backend's own `detail` string (post-fixup behavior). The remove
-// verb's 404 carries `broadcast_override_not_found`; list/set on
-// an older backplane (route missing) would return a different
-// detail and the same surface flows through. The pre-fixup
-// behavior hard-coded "broadcast override not found" regardless of
-// the actual response.
+// backend's own `detail` string. The remove verb's 404 carries
+// `broadcast_override_not_found`. Pre-migration this assertion
+// hardened the post-fixup behaviour (vs. the hard-coded message);
+// post-migration the same `decodeDetail` envelope-unwrapper flows
+// through.
 func TestRunOverridesRemove404RendersBackendDetail(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/broadcast/overrides/", func(w http.ResponseWriter, _ *http.Request) {
@@ -71,7 +119,7 @@ func TestRunOverridesRemove404RendersBackendDetail(t *testing.T) {
 
 	cmd, _, stderr := newRunCmd(t)
 	err := runOverridesRemove(cmd, overridesRemoveOptions{
-		OverrideID:        "11111111-1111-1111-1111-111111111111",
+		OverrideID:        stubOverrideID,
 		BackplaneOverride: srv.URL,
 	})
 	_ = err
@@ -91,6 +139,22 @@ func TestRunOverridesRemoveEmptyIDRejected(t *testing.T) {
 	_ = err
 	if !strings.Contains(stderr.String(), "non-empty <override-id>") {
 		t.Errorf("stderr should reject empty override-id: %q", stderr.String())
+	}
+}
+
+// TestRunOverridesRemoveBadUUIDRejected -- a syntactically invalid
+// UUID is rejected at the verb edge with the operator-friendly
+// "override-id is not a valid UUID" message, instead of either a
+// server-side 422 round-trip or a mid-request fmt.Errorf.
+func TestRunOverridesRemoveBadUUIDRejected(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runOverridesRemove(cmd, overridesRemoveOptions{
+		OverrideID:        "not-a-uuid",
+		BackplaneOverride: "http://unreached.test",
+	})
+	_ = err
+	if !strings.Contains(stderr.String(), "override-id is not a valid UUID") {
+		t.Errorf("stderr should reject bad UUID at the verb edge: %q", stderr.String())
 	}
 }
 

--- a/cli/internal/cmd/broadcast/overrides_set.go
+++ b/cli/internal/cmd/broadcast/overrides_set.go
@@ -5,12 +5,13 @@ package broadcast
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -97,22 +98,34 @@ func runOverridesSet(cmd *cobra.Command, opts overridesSetOptions) error {
 		)
 	}
 
-	backplaneURL, err := resolveBackplane(opts.BackplaneOverride)
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), opts.JSONOut)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 
-	req := CreateRequest{
-		OpIDPattern: opts.OpIDPattern,
-		Detail:      opts.Detail,
+	client, cerr := newAuthedClient(cmd.Context(), cmd, backplaneURL, opts.JSONOut)
+	if cerr != nil {
+		return cerr
+	}
+
+	body := api.BroadcastOverrideCreate{
+		OpIdPattern: opts.OpIDPattern,
+		Detail:      api.BroadcastOverrideCreateDetail(opts.Detail),
 	}
 	if scopeFieldSet {
-		req.ScopeField = &opts.ScopeField
-		req.ScopeValue = &opts.ScopeValue
+		sf := api.BroadcastOverrideCreateScopeField(opts.ScopeField)
+		body.ScopeField = &sf
+		body.ScopeValue = &opts.ScopeValue
 	}
-	entry, err := createOverride(cmd.Context(), backplaneURL, req)
+	entry, err := createOverride(cmd.Context(), client, body)
 	if err != nil {
-		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+		return routeRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if entry == nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("backplane returned 2xx but no JSON body decoded against BroadcastOverrideRead"),
+			opts.JSONOut,
+		)
 	}
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), entry)
@@ -121,29 +134,45 @@ func runOverridesSet(cmd *cobra.Command, opts overridesSetOptions) error {
 	return nil
 }
 
-func createOverride(ctx context.Context, backplaneURL string, req CreateRequest) (*Entry, error) {
-	body, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("marshal broadcast override request: %w", err)
-	}
-	raw, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/broadcast/overrides", body)
+// createOverride drives the typed-client
+// `CreateOverrideApiV1BroadcastOverridesPost` endpoint with a
+// one-shot 401-retry around the underlying AuthedClient's refresh
+// path. Non-2xx responses come back as `*httpResponseError` so the
+// caller can route them through `renderHTTPStatus`. The generated
+// client serialises `api.BroadcastOverrideCreate` and reads
+// `JSON201` (the route returns 201 Created, not 200 OK).
+func createOverride(
+	ctx context.Context,
+	client *api.AuthedClient,
+	body api.BroadcastOverrideCreate,
+) (*api.BroadcastOverrideRead, error) {
+	params := &api.CreateOverrideApiV1BroadcastOverridesPostParams{}
+	resp, err := client.CreateOverrideApiV1BroadcastOverridesPostWithResponse(ctx, params, body)
 	if err != nil {
 		return nil, err
 	}
-	var out Entry
-	if jerr := json.Unmarshal(raw, &out); jerr != nil {
-		return nil, fmt.Errorf("decode broadcast override response: %w", jerr)
+	if resp.StatusCode() == 401 {
+		if rerr := client.Refresh(ctx); rerr != nil {
+			return nil, rerr
+		}
+		resp, err = client.CreateOverrideApiV1BroadcastOverridesPostWithResponse(ctx, params, body)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return &out, nil
+	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
+		return nil, &httpResponseError{statusCode: resp.StatusCode(), body: resp.Body}
+	}
+	return resp.JSON201, nil
 }
 
-func printOverrideSummary(w io.Writer, e *Entry) {
-	fmt.Fprintf(w, "%-16s %s\n", "id:", e.ID)
-	fmt.Fprintf(w, "%-16s %s\n", "tenant_id:", e.TenantID)
-	fmt.Fprintf(w, "%-16s %s\n", "op_id_pattern:", e.OpIDPattern)
+func printOverrideSummary(w io.Writer, e *api.BroadcastOverrideRead) {
+	fmt.Fprintf(w, "%-16s %s\n", "id:", e.Id.String())
+	fmt.Fprintf(w, "%-16s %s\n", "tenant_id:", e.TenantId.String())
+	fmt.Fprintf(w, "%-16s %s\n", "op_id_pattern:", e.OpIdPattern)
 	fmt.Fprintf(w, "%-16s %s\n", "scope_field:", strDerefOrDash(e.ScopeField))
 	fmt.Fprintf(w, "%-16s %s\n", "scope_value:", strDerefOrDash(e.ScopeValue))
 	fmt.Fprintf(w, "%-16s %s\n", "detail:", e.Detail)
 	fmt.Fprintf(w, "%-16s %s\n", "created_by:", e.CreatedBySub)
-	fmt.Fprintf(w, "%-16s %s\n", "created_at:", e.CreatedAt)
+	fmt.Fprintf(w, "%-16s %s\n", "created_at:", e.CreatedAt.Format("2006-01-02T15:04:05Z07:00"))
 }

--- a/cli/internal/cmd/broadcast/overrides_set_test.go
+++ b/cli/internal/cmd/broadcast/overrides_set_test.go
@@ -10,10 +10,15 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/evoila/meho/cli/internal/api"
 )
 
 // TestRunOverridesSetPOSTsCreateRequest -- the request body shape
-// matches the BroadcastOverrideCreate Pydantic model.
+// matches the generated `api.BroadcastOverrideCreate` Pydantic
+// model. The handler decodes against the generated type directly
+// (pre-migration this decoded against the consumer-side
+// CreateRequest struct, which was deleted in G0.12-T6).
 func TestRunOverridesSetPOSTsCreateRequest(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/broadcast/overrides", func(w http.ResponseWriter, r *http.Request) {
@@ -21,12 +26,12 @@ func TestRunOverridesSetPOSTsCreateRequest(t *testing.T) {
 			t.Errorf("method: got %s; want POST", r.Method)
 		}
 		body, _ := io.ReadAll(r.Body)
-		var req CreateRequest
+		var req api.BroadcastOverrideCreate
 		if err := json.Unmarshal(body, &req); err != nil {
 			t.Fatalf("decode body: %v\n%s", err, body)
 		}
-		if req.OpIDPattern != "k8s.configmap.info" {
-			t.Errorf("op_id_pattern: got %q; want k8s.configmap.info", req.OpIDPattern)
+		if req.OpIdPattern != "k8s.configmap.info" {
+			t.Errorf("op_id_pattern: got %q; want k8s.configmap.info", req.OpIdPattern)
 		}
 		if req.ScopeField == nil || *req.ScopeField != "namespace" {
 			t.Errorf("scope_field: got %v; want \"namespace\"", req.ScopeField)
@@ -67,17 +72,33 @@ func TestRunOverridesSetPOSTsCreateRequest(t *testing.T) {
 }
 
 // TestRunOverridesSetOpWideOmitsScopeFields -- when --scope-field /
-// --scope-value are both empty, the request body omits them entirely
-// (so Pydantic's model_validator sees None for both, not "" + "").
-func TestRunOverridesSetOpWideOmitsScopeFields(t *testing.T) {
+// --scope-value are both empty, the request body sends both keys as
+// JSON null. Pydantic v2's model_validator sees None for both, which
+// is the op-wide rule shape. The generated
+// `api.BroadcastOverrideCreate` declares `ScopeField` and
+// `ScopeValue` without `omitempty`, so the typed-client serialiser
+// always emits the keys (even when nil); the explicit-null wire
+// shape matches the backend's expected payload exactly.
+//
+// Pre-migration the consumer-side `CreateRequest` carried
+// `omitempty` on both fields, so an op-wide POST dropped the keys
+// entirely. The backend accepts both shapes (missing keys default
+// to None, explicit nulls are None directly) -- this test pins the
+// post-migration wire shape so a future change to the generated
+// type's tags doesn't silently re-flip the behaviour.
+func TestRunOverridesSetOpWideSendsExplicitNulls(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/broadcast/overrides", func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		if strings.Contains(string(body), `"scope_field"`) {
-			t.Errorf("op-wide POST should not send scope_field key: %s", body)
+		var req api.BroadcastOverrideCreate
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("decode body: %v\n%s", err, body)
 		}
-		if strings.Contains(string(body), `"scope_value"`) {
-			t.Errorf("op-wide POST should not send scope_value key: %s", body)
+		if req.ScopeField != nil {
+			t.Errorf("op-wide POST should leave scope_field nil; got %v", *req.ScopeField)
+		}
+		if req.ScopeValue != nil {
+			t.Errorf("op-wide POST should leave scope_value nil; got %v", *req.ScopeValue)
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
@@ -136,9 +157,6 @@ func TestRunOverridesSetHalfSetScopeRejectedClientSide(t *testing.T) {
 	// (the StructuredError shape goes to stderr); the test verifies
 	// stderr contains the expected message.
 	if err != nil {
-		// The runner may surface the structured-error return; either
-		// outcome is acceptable as long as the operator sees the
-		// rejection.
 		_ = err
 	}
 	if !strings.Contains(stderr.String(), "both be set or both be omitted") {
@@ -146,7 +164,8 @@ func TestRunOverridesSetHalfSetScopeRejectedClientSide(t *testing.T) {
 	}
 }
 
-// TestRunOverridesSetJSON -- --json emits the created Entry as JSON.
+// TestRunOverridesSetJSON -- --json emits the created
+// api.BroadcastOverrideRead as JSON.
 func TestRunOverridesSetJSON(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/broadcast/overrides", func(w http.ResponseWriter, _ *http.Request) {
@@ -172,12 +191,37 @@ func TestRunOverridesSetJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runOverridesSet --json: %v", err)
 	}
-	var decoded Entry
+	var decoded api.BroadcastOverrideRead
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout.String())
 	}
 	if decoded.Detail != "full" {
 		t.Errorf("decoded detail: got %q; want full", decoded.Detail)
+	}
+}
+
+// TestRunOverridesSet409RendersConflict -- the duplicate-rule
+// rejection surfaces the backend's `detail` string.
+func TestRunOverridesSet409RendersConflict(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/broadcast/overrides", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"detail":"duplicate_override_rule"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runOverridesSet(cmd, overridesSetOptions{
+		OpIDPattern:       "vault.kv.*",
+		Detail:            "aggregate",
+		BackplaneOverride: srv.URL,
+	})
+	_ = err
+	if !strings.Contains(stderr.String(), "duplicate_override_rule") {
+		t.Errorf("stderr should surface the backend's 409 detail: %q", stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- Migrates `meho broadcast overrides {list, set, remove}` off hand-rolled HTTP + consumer-side struct duplicates onto the generated typed client (`api.ClientWithResponses` via the embedded `api.AuthedClient`), matching the G0.12-T1 #1251 / G0.12-T2 #1260 / G0.12-T3 #1261 pattern.
- Deletes `Entry` (duplicate of `api.BroadcastOverrideRead`), `CreateRequest` (duplicate of `api.BroadcastOverrideCreate`), the local `doAuthedRequest` / `sendRequest` / `httpError` triple, the inline `buildListPath` / `buildRemovePath` / `pathEscape` helpers, the local `resolveBackplane` / `classifyBackplaneError` / `normaliseURL` / `errNoBackplaneConfigured` shims (now sourced from `cli/internal/backplane.*`), and the inline JSON-decode helpers. Renderers consume `api.BroadcastOverrideRead` directly; the `cli-api-snapshot-freshness` gate now covers them.
- Hoists `<override-id>` arg validation to the verb edge via `uuid.Parse` (`openapi_types.UUID = uuid.UUID`), surfacing garbage as `output.Unexpected("override-id is not a valid UUID: ...")` instead of a mid-request `fmt.Errorf` or a server-side 422 round-trip.
- Reworks the four `_test.go` files to drive `api.BroadcastOverrideRead` / `api.BroadcastOverrideCreate` through `httptest.NewServer` (the typed client makes real HTTP calls, so no mock-interface plumbing is needed). Adds coverage for the 403 `insufficient_role` rendering, the 409 duplicate-rule rendering, the explicit-null op-wide POST shape, the UUID-at-the-edge happy path, and the typed-client URL path embedding.

Preserves operator-visible behaviour byte-for-byte: same flag names, same output format (UUID `String()` round-trip matches the previous opaque-string rendering), same error categories (401 → AuthExpired, 403 → InsufficientRole(detail), 404 → Unexpected(detail), 409 → Unexpected(detail), 422 → Unexpected("invalid request: ..."), other → Unexpected(HTTP N)), same silent-on-204 DELETE UX, same FastAPI `detail`-envelope unwrapping. The set verb's op-wide POST now sends `scope_field: null` / `scope_value: null` explicitly (the generated type omits `omitempty`) instead of dropping the keys entirely; Pydantic v2's `model_validator(mode="after")` sees `None` for both either way.

## Test plan

- [x] `cd cli && go build ./...` — clean
- [x] `cd cli && go vet ./...` — clean
- [x] `cd cli && go test ./internal/cmd/broadcast/...` — pass (26 tests)
- [x] `cd cli && go test ./...` — pass (every package in the CLI module)
- [x] `grep -rn "http.NewRequest\|doAuthedRequest\|^type Entry \|^type CreateRequest " cli/internal/cmd/broadcast/` — zero matches (acceptance criterion 1)
- [x] `grep -rn "api.ClientWithResponses" cli/internal/cmd/broadcast/` — matches in `broadcast.go` plus typed-client method calls across the three verb files (acceptance criterion 2)
- [x] `cd cli && make generate` — no-op (typed client unchanged; the consumer side simply caught up to the spec)
- [x] No change to `backend/src/meho_backplane/api/v1/broadcast.py` (acceptance criterion 7)
- [ ] Manual smoke against a running backplane (`meho broadcast overrides list / set / remove`) — deferred to CI / a follow-up smoke pass; the httptest-mocked unit tests cover the wire shape, the error categorisation, and the explicit-null op-wide shape that acceptance criterion 6 asks for.

## Out of scope

- The FastAPI broadcast surface — server stays exactly as it is.
- CLI verb signatures, flag names, or output reformatting (Initiative #1118 is consumer-side only).
- The other CLI verb directories listed under Initiative #1118 — each is its own G0.12-T<N> Task.

Closes #1264
