### PR TITLE
refactor(cli-audit): G0.12-T5 migrate to generated typed client (#1263)

### DIFF
--- a/cli/internal/cmd/audit/audit.go
+++ b/cli/internal/cmd/audit/audit.go
@@ -2,7 +2,7 @@
 // Copyright (c) 2026 evoila Group
 
 // Package audit hosts the cobra commands under `meho audit ...` for
-// G8.1-T3 (#467) of Initiative #334. v0.2 ships five operator-facing
+// G8.1-T3 (#467) of Initiative #334. v0.2 ships six operator-facing
 // verbs that wrap the T2 REST surface (#466) shipped by
 // `backend/src/meho_backplane/api/v1/audit.py`:
 //
@@ -24,24 +24,40 @@
 //   - `meho audit my-recent [--since DUR] [--limit N] [--json]` —
 //     pre-canned shortcut filtered to the operator's own JWT subject
 //     via GET /api/v1/audit/my-recent.
+//   - `meho audit replay <session-id> [--json] [--max-depth N]` —
+//     parent/child audit tree via
+//     GET /api/v1/audit/sessions/{session_id}/replay.
 //
 // Each verb wraps one backplane route, renders the response either
 // as a human-readable table / key-value summary or as raw JSON when
 // `--json` is set. Authentication piggybacks on the token meho login
 // wrote — same pattern as `meho targets` and `meho retrieval`.
+//
+// G0.12-T5 #1263 migrated this package off the sibling-verb pattern
+// of hand-rolled HTTP + hand-typed copies of backend pydantic models.
+// Every verb here drives the generated `api.ClientWithResponses`
+// surface directly: `api.NewAuthedClient` wires the bearer + lazy
+// 401-refresh editor onto the embedded `ClientWithResponses`, and
+// the verbs call the typed `*WithResponse` methods
+// (`QueryApiV1AuditQueryPostWithResponse`,
+// `ShowApiV1AuditShowAuditIdGetWithResponse`,
+// `ReplayApiV1AuditSessionsSessionIdReplayGetWithResponse`,
+// `MyRecentApiV1AuditMyRecentGetWithResponse`,
+// `WhoTouchedApiV1AuditWhoTouchedTargetGetWithResponse`).
+// Consumer-side struct drift can't recur because we now consume
+// `api.AuditEntry` / `api.AuditQueryResult` / `api.AuditReplayResult`
+// / `api.ReplayNode` directly.
 package audit
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
-	"net/url"
-	"strings"
+	"time"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
@@ -73,69 +89,48 @@ func NewRootCmd() *cobra.Command {
 	return cmd
 }
 
-// Entry mirrors the backend `AuditEntry` Pydantic model
-// (`backend/src/meho_backplane/audit_query/schemas.py`). Fields are
-// hand-written rather than aliased to a generated client type so the
-// audit package stays decoupled from oapi-codegen churn — the
-// targets / retrieval / operation packages take the same stance.
-//
-// Optional Pydantic fields land as `*string` so the JSON round-trip
-// preserves the explicit-null wire shape. `DurationMS` is a string
-// because Pydantic v2 serialises `Decimal` as a quoted decimal string
-// by default.
-type Entry struct {
-	ID               string         `json:"id"`
-	TS               string         `json:"ts"`
-	TenantID         *string        `json:"tenant_id"`
-	PrincipalSub     string         `json:"principal_sub"`
-	PrincipalName    *string        `json:"principal_name"`
-	TargetID         *string        `json:"target_id"`
-	TargetName       *string        `json:"target_name"`
-	Method           string         `json:"method"`
-	Path             string         `json:"path"`
-	StatusCode       int            `json:"status_code"`
-	RequestID        *string        `json:"request_id"`
-	DurationMS       *string        `json:"duration_ms"`
-	Payload          map[string]any `json:"payload"`
-	OpID             string         `json:"op_id"`
-	OpClass          string         `json:"op_class"`
-	ResultStatus     string         `json:"result_status"`
-	ParentAuditID    *string        `json:"parent_audit_id"`
-	AgentSessionID   *string        `json:"agent_session_id"`
-	BroadcastEventID *string        `json:"broadcast_event_id"`
+// httpResponseError carries a non-2xx status from a typed-client
+// `*WithResponse` call up to the verb's renderer. The typed-client
+// surface returns non-2xx responses in-band on the `(*Response, nil)`
+// tuple (transport-layer failures come back on the `(nil, err)`
+// tuple instead) — we lift the HTTP-failure case to an error type so
+// the call sites can use a single `if err != nil` branch and
+// `errors.As` routes the right way (HTTP status → `renderHTTPStatus`,
+// everything else → `renderTransportError`). See `routeRequestError`.
+type httpResponseError struct {
+	statusCode int
+	body       []byte
 }
 
-// QueryResult mirrors the backend `AuditQueryResult` Pydantic model
-// — a page of audit rows plus the opaque forward-only cursor.
-// `NextCursor` keeps the JSON key on null (no omitempty) so the wire
-// shape matches the Pydantic side, where the field is always emitted
-// as `null` when there is no further page. The retire-checklist PR
-// (#497) tripped on the same omitempty / schema-stability gotcha and
-// the fix is to never drop the key on Go re-marshal.
-type QueryResult struct {
-	Rows       []Entry `json:"rows"`
-	NextCursor *string `json:"next_cursor"`
+func (e *httpResponseError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.statusCode, trimmedBody(e.body))
 }
 
-// renderRequestError translates an error from one of the per-verb
-// request helpers into the right output.StructuredError category.
-// Same classification ladder as targets / operation packages with
-// audit-specific 400 handling:
-//
-//   - 401 (refresh failed) → auth_expired with a `meho login` hint.
-//   - 403 (RBAC denial) → insufficient_role; the backend's 403 detail
-//     names the required role.
-//   - 400 → unexpected with the parser / substrate error message —
-//     `DurationParseError`, `InvalidCursorError`, and
-//     `UnsupportedFilterError` (v0.2's `parent_audit_id` /
-//     `agent_session_id` gap) all surface as 400 from the backend.
-//   - 404 → unexpected with "audit row not found" (only the
-//     show endpoint emits this; cross-tenant probes also surface
-//     here per the substrate's tenant-scoping discipline).
-//   - 422 → unexpected with the FastAPI validation envelope.
-//   - Any other 4xx/5xx → unexpected with the raw body.
-//   - Pure transport errors → unreachable.
-func renderRequestError(
+// newAuthedClient builds an `api.AuthedClient` and surfaces its
+// construction-time errors as the right `output.StructuredError`
+// category (auth_expired when no token was ever stored, else
+// unexpected_response with the underlying error wrapped). Splits the
+// boilerplate every verb here used to duplicate inline.
+func newAuthedClient(
+	ctx context.Context,
+	cmd *cobra.Command,
+	backplaneURL string,
+	jsonOut bool,
+) (*api.AuthedClient, error) {
+	client, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, renderClientError(cmd, backplaneURL, err, jsonOut)
+	}
+	return client, nil
+}
+
+// renderClientError maps `api.NewAuthedClient` failures onto the
+// structured-error envelope. `IsTokenNotFound` is the "operator
+// never ran meho login" sentinel and surfaces as auth_expired with a
+// `meho login` hint; anything else is a build-time failure of the
+// authed transport itself (token store unreadable, etc.) and
+// surfaces as unexpected_response so the operator sees the cause.
+func renderClientError(
 	cmd *cobra.Command,
 	backplaneURL string,
 	err error,
@@ -150,6 +145,43 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unexpected(fmt.Sprintf("build authed client for %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+// routeRequestError is the single dispatcher every verb feeds an
+// error from `postQuery` / `getEntry` / `getMyRecent` /
+// `getWhoTouched` / `fetchReplay` into. The error is either an
+// `*httpResponseError` (the backplane responded with a non-2xx
+// status) or a transport-layer failure (network, refresh-impossible,
+// etc.); we route the former through `renderHTTPStatus` and the
+// latter through `renderTransportError`.
+func routeRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	var he *httpResponseError
+	if errors.As(err, &he) {
+		return renderHTTPStatus(cmd, backplaneURL, he.statusCode, he.body, jsonOut)
+	}
+	return renderTransportError(cmd, backplaneURL, err, jsonOut)
+}
+
+// renderTransportError maps a generated-client call's transport-layer
+// error (network failure, refresh-impossible after a 401) onto the
+// right structured-error category. The typed-client surface returns
+// `(nil, err)` for these; non-2xx HTTP responses arrive as
+// `(*Response, nil)` and are routed through `renderHTTPStatus` instead.
+func renderTransportError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
 	if api.IsNoRefreshToken(err) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.AuthExpired(fmt.Sprintf(
@@ -159,25 +191,41 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
-		return renderHTTPError(cmd, backplaneURL, he, jsonOut)
-	}
 	return output.RenderError(cmd.ErrOrStderr(),
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
 }
 
-// renderHTTPError classifies a non-2xx response into the right
-// StructuredError category.
-func renderHTTPError(
+// renderHTTPStatus classifies a non-2xx HTTP status (lifted off the
+// generated `*Response.HTTPResponse.StatusCode` + `.Body` fields)
+// into the right StructuredError category. Mirrors the audit-specific
+// ladder the pre-G0.12-T5 `renderHTTPError` enforced:
+//
+//   - 401 (refresh failed) → auth_expired with a `meho login` hint.
+//   - 403 (RBAC denial) → insufficient_role; the backend's 403 detail
+//     names the required role.
+//   - 400 → unexpected with the parser / substrate error message —
+//     `DurationParseError`, `InvalidCursorError`, and
+//     `UnsupportedFilterError` (v0.2's `parent_audit_id` /
+//     `agent_session_id` gap) all surface as 400 from the backend.
+//   - 404 → unexpected with "audit row not found" (only the
+//     show endpoint emits this; cross-tenant probes also surface
+//     here per the substrate's tenant-scoping discipline).
+//   - 413 → defensive fallback to a session-too-large hint; the
+//     replay verb intercepts 413 before reaching here so it can
+//     append the session id to the `meho audit query` redirect.
+//   - 422 → unexpected with the FastAPI validation envelope.
+//   - Any other 4xx/5xx → unexpected with the raw body.
+func renderHTTPStatus(
 	cmd *cobra.Command,
 	backplaneURL string,
-	he *httpError,
+	statusCode int,
+	body []byte,
 	jsonOut bool,
 ) error {
-	switch he.StatusCode {
+	bodyStr := trimmedBody(body)
+	switch statusCode {
 	case http.StatusUnauthorized:
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.AuthExpired(fmt.Sprintf(
@@ -188,7 +236,7 @@ func renderHTTPError(
 		)
 	case http.StatusForbidden:
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.InsufficientRole(decodeDetailString(he.Body)),
+			output.InsufficientRole(decodeDetailString(bodyStr)),
 			jsonOut,
 		)
 	case http.StatusBadRequest:
@@ -197,7 +245,7 @@ func renderHTTPError(
 		// (substrate). The backend's HTTPException detail is the
 		// parser's own message; surface it verbatim.
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(decodeDetailString(he.Body)),
+			output.Unexpected(decodeDetailString(bodyStr)),
 			jsonOut,
 		)
 	case http.StatusNotFound:
@@ -209,32 +257,50 @@ func renderHTTPError(
 			jsonOut,
 		)
 	case http.StatusRequestEntityTooLarge:
-		// Only the replay endpoint emits 413 (session_too_large): a
-		// session above the server's replayRowCap anchor rows. The
-		// replay verb intercepts this status before reaching here so it
-		// can append the `meho audit query --session-id <id>` redirect
-		// (it knows the session id; this shared renderer does not). This
-		// arm is the defensive fallback for any other caller — surface
-		// the cardinality and the same query-verb pointer.
+		// Defensive fallback for any caller that didn't intercept
+		// the replay-specific 413 before reaching here. The replay
+		// verb's `renderReplayRequestError` shadows this arm so it
+		// can append the session id to the `meho audit query
+		// --session-id <id>` redirect.
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf(
 				"session too large to replay (%s rows, cap %d); "+
 					"use `meho audit query --session-id <id>` to page the flat rows",
-				decodeSessionTooLargeRowCount(he.Body), replayRowCap)),
+				decodeSessionTooLargeRowCount(bodyStr), replayRowCap)),
 			jsonOut,
 		)
 	case http.StatusUnprocessableEntity:
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf("invalid request: %s", he.Body)),
+			output.Unexpected(fmt.Sprintf("invalid request: %s", bodyStr)),
 			jsonOut,
 		)
 	default:
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, statusCode, bodyStr)),
 			jsonOut,
 		)
 	}
+}
+
+// trimmedBody renders a response body for inclusion in an error
+// envelope: trims trailing whitespace, surfaces a placeholder when
+// the backend returned an empty body so the operator-facing string
+// is never just "HTTP 500:".
+func trimmedBody(body []byte) string {
+	s := string(body)
+	for len(s) > 0 {
+		last := s[len(s)-1]
+		if last == ' ' || last == '\n' || last == '\r' || last == '\t' {
+			s = s[:len(s)-1]
+			continue
+		}
+		break
+	}
+	if s == "" {
+		return "(empty body)"
+	}
+	return s
 }
 
 // replayRowCap mirrors the backend `_REPLAY_ROW_CAP`
@@ -289,126 +355,14 @@ func decodeDetailString(body string) string {
 			return s
 		}
 	}
-	return strings.TrimSpace(body)
-}
-
-// doAuthedRequest issues a single HTTP request against the backplane
-// with bearer injection and one-shot 401-refresh-retry. Returns the
-// response body bytes (already drained) on 2xx, or an *httpError on
-// non-2xx, or an error categorised by api.IsTokenNotFound /
-// api.IsNoRefreshToken / generic transport.
-//
-// Mirrors cli/internal/cmd/targets/targets.go::doAuthedRequest and
-// operation/operation.go's namesake — kept independent for the
-// import-cycle reason called out on resolveBackplane.
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
+	// Trim trailing whitespace defensively when falling back to the
+	// raw body — keeps the operator-visible message stable when the
+	// backend appends a newline.
+	for len(body) > 0 && (body[len(body)-1] == ' ' || body[len(body)-1] == '\n' ||
+		body[len(body)-1] == '\r' || body[len(body)-1] == '\t') {
+		body = body[:len(body)-1]
 	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
-	}
-
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-
-	// Read with a 1-MiB cap. The +1 byte over the cap is the
-	// truncation-detection trick: if ReadAll returns more than
-	// ``responseBodyCap`` bytes, the response was at least cap+1 bytes
-	// long and the decoder would otherwise consume a silently-truncated
-	// JSON payload. Fail loud instead — a truncated audit response
-	// surfaces as "decode error: unexpected end of JSON input" without
-	// this guard, which buries the real cause (response too large for
-	// the chassis CLI's safety cap).
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, responseBodyCap+1))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if int64(len(raw)) > responseBodyCap {
-		return nil, fmt.Errorf(
-			"response body exceeds %d-byte cap; refusing to decode possibly-truncated JSON",
-			responseBodyCap,
-		)
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-// responseBodyCap is the hard upper bound on a backplane response
-// body the CLI is willing to read. Audit pages cap at 1000 rows
-// server-side; a typical row at ~500 B yields ~500 KiB, so 1 MiB
-// is comfortable headroom. The cap protects against an
-// adversarial / misconfigured backplane sending an unbounded
-// response — the alternative is OOM. The +1-byte read pattern in
-// “doAuthedRequest“ distinguishes "fits in the cap" from
-// "truncated at the cap" so the decoder doesn't silently consume
-// a half-JSON.
-const responseBodyCap int64 = 1 << 20
-
-// httpError carries a non-2xx response so per-verb runners can
-// render the right category.
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-// sendRequest is the bottom of the stack: build the http.Request,
-// stamp bearer + content headers, fire it.
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
-}
-
-// pathEscape escapes a single path segment for use inside a backend
-// URL.
-func pathEscape(segment string) string {
-	return url.PathEscape(segment)
+	return body
 }
 
 // truncate cuts s to maxLen runes, appending an ellipsis when
@@ -435,21 +389,24 @@ func strDeref(s *string) string {
 	return *s
 }
 
-// decodeAuditResponse JSON-decodes *raw* into *out* via a
-// “json.Decoder“ configured with “UseNumber()“ so payload numbers
-// survive as “json.Number“ rather than collapsing to “float64“.
-// Audit payloads carry integer-valued fields (“hit_count“,
-// “query_count“, timestamps stored as Unix seconds, etc.) that
-// silently lose precision when decoded as IEEE-754 doubles past
-// 2^53. The exact-integer-preserving path lets jq pipelines and the
-// human-readable summary render the value the backend actually wrote
-// instead of a rounded float. Used by every audit verb that decodes
-// an “Entry“ or “QueryResult“.
-func decodeAuditResponse(raw []byte, out any) error {
-	dec := json.NewDecoder(bytes.NewReader(raw))
-	dec.UseNumber()
-	if err := dec.Decode(out); err != nil {
-		return fmt.Errorf("decode audit response: %w", err)
+// uuidDeref returns u.String() or empty string when u is nil. The
+// generated client surfaces nullable UUID fields as `*openapi_types.UUID`
+// (= `*uuid.UUID`); the renderers consume them via this helper so the
+// "-" placeholder rendering stays in one place.
+func uuidDeref(u *openapi_types.UUID) string {
+	if u == nil {
+		return ""
 	}
-	return nil
+	return u.String()
+}
+
+// formatTS renders an `api.AuditEntry.Ts` (`time.Time`) as the
+// RFC3339-with-nanos string the pre-migration `Entry.TS` string
+// field carried verbatim. The backend emits the column as an
+// ISO-8601 string; the generated client decodes it into `time.Time`
+// via the JSON unmarshal default; the renderer re-serialises with
+// the same precision so the operator-visible column matches the
+// pre-migration shape. UTC is the substrate-canonical zone.
+func formatTS(ts time.Time) string {
+	return ts.UTC().Format(time.RFC3339Nano)
 }

--- a/cli/internal/cmd/audit/audit_test.go
+++ b/cli/internal/cmd/audit/audit_test.go
@@ -6,6 +6,7 @@ package audit
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -13,17 +14,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/backplane"
 )
 
 // seedXDGAndToken seeds a per-test config dir + token store that
-// resolveBackplane / doAuthedRequest will read. Mirrors the same
-// helper in cli/internal/cmd/targets/list_test.go — the auth
-// package's keyring backend defaults are disabled for tests so the
-// file-store path is exercised deterministically.
+// the typed client's `api.NewAuthedClient` will read via the default
+// `auth.NewTokenStore` path. Mirrors the same helper in
+// cli/internal/cmd/targets/list_test.go.
 func seedXDGAndToken(t *testing.T, backplaneURL string) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -154,6 +157,31 @@ func TestDecodeDetailStringFallsBackOnNonJSON(t *testing.T) {
 	}
 }
 
+// TestTrimmedBodyDropsTrailingWhitespace pins the small renderer
+// helper. Backplane responses often arrive with a trailing newline;
+// dropping it keeps the error envelope's `HTTP 500: foo` shape
+// stable in the operator-visible output. Mirrors the approvals
+// migration's namesake helper (G0.12-T1 #1276).
+func TestTrimmedBodyDropsTrailingWhitespace(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"plain", "plain"},
+		{"trail\n", "trail"},
+		{"trail \r\n", "trail"},
+		{"trail\t  ", "trail"},
+		{"", "(empty body)"},
+		{"   \n", "(empty body)"},
+		{"   leading kept", "   leading kept"},
+	}
+	for _, tc := range cases {
+		if got := trimmedBody([]byte(tc.in)); got != tc.want {
+			t.Errorf("trimmedBody(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 // TestTruncateRuneAware — multi-byte UTF-8 stays valid when the
 // table renderer truncates a long target name.
 func TestTruncateRuneAware(t *testing.T) {
@@ -175,117 +203,250 @@ func TestStrDerefHandlesNil(t *testing.T) {
 	}
 }
 
-// TestDoAuthedRequestRejectsOversizedResponse — the 1 MiB cap on
-// “io.LimitReader“ is paired with a +1-byte read so a response
-// that fills the cap surfaces as a clear error rather than feeding
-// a silently-truncated JSON body into the decoder. Without this
-// guard, an oversized audit page would surface as
-// "unexpected end of JSON input" — confusing to operators and
-// indistinguishable from a malformed backend response.
-func TestDoAuthedRequestRejectsOversizedResponse(t *testing.T) {
-	// Emit 1 MiB + 1 byte of payload — exactly at the threshold the
-	// truncation guard fires. Anything strictly above the cap must
-	// fail loud rather than silently decode.
-	oversized := strings.Repeat("a", int(responseBodyCap)+1)
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/audit/test", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(oversized))
-	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
-	seedXDGAndToken(t, srv.URL)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	_, err := doAuthedRequest(ctx, srv.URL, "GET", "/api/v1/audit/test", nil)
-	if err == nil {
-		t.Fatalf("expected error on oversized response")
-	}
-	if !strings.Contains(err.Error(), "exceeds") {
-		t.Errorf("error message does not mention size cap: %v", err)
+// TestUUIDDerefHandlesNil pins the renderer's nil-UUID rendering.
+// The generated client surfaces nullable UUIDs as
+// `*openapi_types.UUID`; the summary's "-" rendering depends on
+// the nil-safe deref.
+func TestUUIDDerefHandlesNil(t *testing.T) {
+	if got := uuidDeref(nil); got != "" {
+		t.Errorf("uuidDeref(nil): got %q", got)
 	}
 }
 
-// TestDoAuthedRequestAcceptsResponseExactlyAtCap — the threshold
-// itself is allowed through. The +1-byte read distinguishes
-// "fits in the cap" from "spilled past the cap"; exactly-at-cap
-// must still decode.
-func TestDoAuthedRequestAcceptsResponseExactlyAtCap(t *testing.T) {
-	exact := strings.Repeat("a", int(responseBodyCap))
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/audit/test", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(exact))
-	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
-	seedXDGAndToken(t, srv.URL)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	raw, err := doAuthedRequest(ctx, srv.URL, "GET", "/api/v1/audit/test", nil)
+// TestFormatTSRendersUTCRFC3339 — the generated client decodes the
+// backend's ISO-8601 `ts` string into `time.Time`; the renderer
+// re-serialises in UTC RFC3339 so the operator-visible column
+// matches the pre-migration `Entry.TS` string field shape.
+func TestFormatTSRendersUTCRFC3339(t *testing.T) {
+	ts, err := time.Parse(time.RFC3339, "2026-05-13T15:42:11Z")
 	if err != nil {
-		t.Fatalf("exact-cap response should not error: %v", err)
+		t.Fatalf("parse fixture: %v", err)
 	}
-	if int64(len(raw)) != responseBodyCap {
-		t.Errorf("expected %d bytes; got %d", responseBodyCap, len(raw))
+	got := formatTS(ts)
+	if got != "2026-05-13T15:42:11Z" {
+		t.Errorf("formatTS round-trip: got %q", got)
 	}
 }
 
-// TestDecodeAuditResponsePreservesLargeIntegers — Unix-millis
-// timestamps and other 64-bit integers in audit payloads must
-// survive the JSON round-trip without losing precision. Without
-// “UseNumber()“ they collapse to “float64“ and any integer above
-// 2^53 rounds — silently mangling forensic data.
-func TestDecodeAuditResponsePreservesLargeIntegers(t *testing.T) {
-	// 1745923128091 is a real Unix-millis timestamp shape; well
-	// below 2^53 so the failure mode for ``float64`` would be a
-	// trailing-decimal render rather than a precision loss, but the
-	// principle covers the larger range too.
-	raw := []byte(`{
-		"id": "00000000-0000-0000-0000-000000000001",
-		"ts": "2026-05-13T00:00:00Z",
-		"tenant_id": null,
-		"principal_sub": "damir",
-		"principal_name": null,
-		"target_id": null,
-		"target_name": null,
-		"method": "GET",
-		"path": "/x",
-		"status_code": 200,
-		"request_id": null,
-		"duration_ms": null,
-		"payload": {"hit_count": 1745923128091, "ratio": 0.5},
-		"op_id": "x.y",
-		"op_class": "read",
-		"result_status": "ok",
-		"parent_audit_id": null,
-		"agent_session_id": null,
-		"broadcast_event_id": null
-	}`)
-	var entry Entry
-	if err := decodeAuditResponse(raw, &entry); err != nil {
-		t.Fatalf("decodeAuditResponse: %v", err)
+// TestRenderHTTPStatusMaps401ToAuthExpired pins the 401 arm of the
+// shared HTTP-status switch. The backend 401 surface lands here when
+// a refresh failed mid-call; the operator sees a `meho login` hint.
+func TestRenderHTTPStatusMaps401ToAuthExpired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("unauthorised"))
+	}))
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runMyRecent(cmd, myRecentOptions{
+		JSONOut:           true,
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected error on 401")
 	}
-	// The payload's integer must render exactly — no scientific
-	// notation, no trailing ``.0``. With ``UseNumber()`` it lands
-	// as ``json.Number("1745923128091")`` and formatPayloadScalar
-	// emits the bare digits.
-	hit, ok := entry.Payload["hit_count"]
-	if !ok {
-		t.Fatalf("payload missing hit_count: %+v", entry.Payload)
-	}
-	got := formatPayloadScalar(hit)
-	if got != "1745923128091" {
-		t.Errorf("integer precision lost: got %q; want %q", got, "1745923128091")
-	}
-	// And the float case still renders compactly.
-	ratio, ok := entry.Payload["ratio"]
-	if !ok {
-		t.Fatalf("payload missing ratio: %+v", entry.Payload)
-	}
-	if got := formatPayloadScalar(ratio); got != "0.5" {
-		t.Errorf("float render: got %q; want %q", got, "0.5")
+	if !strings.Contains(stderr.String(), "meho login") {
+		t.Errorf("stderr missing login hint: %s", stderr.String())
 	}
 }
+
+// TestRouteRequestErrorRoutesHTTPStatus — the dispatcher correctly
+// routes an `*httpResponseError` through `renderHTTPStatus` rather
+// than the transport ladder.
+func TestRouteRequestErrorRoutesHTTPStatus(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	he := &httpResponseError{statusCode: http.StatusForbidden, body: []byte(`{"detail":"operator required"}`)}
+	if err := routeRequestError(cmd, "https://meho.example", he, true); err == nil {
+		t.Fatalf("expected error returned from routeRequestError")
+	}
+	if !strings.Contains(stderr.String(), "operator required") {
+		t.Errorf("stderr missing 403 detail: %s", stderr.String())
+	}
+}
+
+// TestRouteRequestErrorRoutesTransport — a non-HTTP error path takes
+// the transport ladder (Unreachable) rather than the HTTP-status
+// switch.
+func TestRouteRequestErrorRoutesTransport(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	if err := routeRequestError(cmd, "https://meho.example", context.Canceled, true); err == nil {
+		t.Fatalf("expected error returned from routeRequestError")
+	}
+	if !strings.Contains(stderr.String(), "call ") {
+		t.Errorf("stderr does not look like Unreachable: %s", stderr.String())
+	}
+}
+
+// TestNewAuthedClientNoStoredTokenSurfacesAuthExpired pins the
+// `renderClientError` `IsTokenNotFound` arm — invoking any verb
+// against a backplane that has no stored token surfaces an
+// auth_expired envelope with a `meho login` hint, before any
+// network round-trip.
+func TestNewAuthedClientNoStoredTokenSurfacesAuthExpired(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("MEHO_KEYRING_DISABLE", "1")
+	if err := auth.SaveConfigAt(
+		filepath.Join(dir, "meho", "config.json"),
+		auth.Config{BackplaneURL: "https://meho.example"},
+	); err != nil {
+		t.Fatalf("SaveConfigAt: %v", err)
+	}
+
+	cmd, _, stderr := newRunCmd(t)
+	_, err := newAuthedClient(cmd.Context(), cmd, "https://meho.example", true)
+	if err == nil {
+		t.Fatalf("expected error from newAuthedClient with no stored token")
+	}
+	if !strings.Contains(stderr.String(), "meho login") {
+		t.Errorf("stderr missing login hint: %s", stderr.String())
+	}
+}
+
+// TestPostQueryReturnsHTTPErrorOnNon2xx pins the `postQuery` helper
+// behaviour: a non-2xx response lands as an `*httpResponseError`
+// (not a transport error), so `routeRequestError` can classify it.
+func TestPostQueryReturnsHTTPErrorOnNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("forbidden"))
+	}))
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+	client, err := api.NewAuthedClient(context.Background(), srv.URL, api.AuthedClientOptions{})
+	if err != nil {
+		t.Fatalf("NewAuthedClient: %v", err)
+	}
+	_, _, err = postQuery(context.Background(), client, api.AuditQueryRequest{})
+	if err == nil {
+		t.Fatalf("expected error on 403")
+	}
+	var he *httpResponseError
+	if !asHTTPResponseError(err, &he) {
+		t.Errorf("expected *httpResponseError; got %T: %v", err, err)
+	} else if he.statusCode != http.StatusForbidden {
+		t.Errorf("statusCode: got %d; want 403", he.statusCode)
+	}
+}
+
+// asHTTPResponseError is a tiny test helper that wraps errors.As so
+// the cast above stays readable without dragging the std-lib import
+// into the assertion site.
+func asHTTPResponseError(err error, target **httpResponseError) bool {
+	for cause := err; cause != nil; {
+		if h, ok := cause.(*httpResponseError); ok {
+			*target = h
+			return true
+		}
+		// Stop at the first non-wrap; this skill's errors don't
+		// nest under wrap helpers.
+		break
+	}
+	return false
+}
+
+// TestRenderHTTPStatus404SurfacesAuditRowNotFound pins the audit-
+// specific 404 arm. The cross-tenant probe always reads as 404 —
+// the substrate's tenant WHERE clause yields zero rows and the
+// route returns 404 rather than 403 so existence never leaks.
+func TestRenderHTTPStatus404SurfacesAuditRowNotFound(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	if err := renderHTTPStatus(cmd, "https://meho.example", http.StatusNotFound,
+		[]byte(`{"detail":"audit row not found"}`), true); err == nil {
+		t.Fatalf("expected error returned for 404")
+	}
+	if !strings.Contains(stderr.String(), "audit row not found") {
+		t.Errorf("stderr missing not-found hint: %s", stderr.String())
+	}
+}
+
+// TestRenderHTTPStatus400SurfacesParserDetail — 400 from the audit
+// API is DurationParseError / InvalidCursorError /
+// UnsupportedFilterError; the operator sees the parser's own message.
+func TestRenderHTTPStatus400SurfacesParserDetail(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	if err := renderHTTPStatus(cmd, "https://meho.example", http.StatusBadRequest,
+		[]byte(`{"detail":"unrecognised duration 'foo'"}`), true); err == nil {
+		t.Fatalf("expected error returned for 400")
+	}
+	if !strings.Contains(stderr.String(), "unrecognised duration") {
+		t.Errorf("stderr missing parser detail: %s", stderr.String())
+	}
+}
+
+// TestRenderHTTPStatus413DefensiveFallback — the replay verb shadows
+// this arm with its own session-id-aware redirect, but a non-replay
+// caller hitting 413 still gets the cap + redirect hint.
+func TestRenderHTTPStatus413DefensiveFallback(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	if err := renderHTTPStatus(cmd, "https://meho.example", http.StatusRequestEntityTooLarge,
+		[]byte(`{"detail":{"detail":"session_too_large","row_count":12345}}`), true); err == nil {
+		t.Fatalf("expected error returned for 413")
+	}
+	if !strings.Contains(stderr.String(), "12345 rows") {
+		t.Errorf("stderr missing row count: %s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "meho audit query") {
+		t.Errorf("stderr missing redirect hint: %s", stderr.String())
+	}
+}
+
+// TestRenderHTTPStatus422SurfacesValidation — FastAPI's validation
+// envelope passes through with the "invalid request" prefix.
+func TestRenderHTTPStatus422SurfacesValidation(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	body := []byte(`{"detail":[{"loc":["path","audit_id"],"msg":"value is not a valid uuid"}]}`)
+	if err := renderHTTPStatus(cmd, "https://meho.example", http.StatusUnprocessableEntity,
+		body, true); err == nil {
+		t.Fatalf("expected error returned for 422")
+	}
+	if !strings.Contains(stderr.String(), "invalid request") {
+		t.Errorf("stderr missing validation hint: %s", stderr.String())
+	}
+}
+
+// TestRenderHTTPStatusDefaultArm — anything else surfaces as
+// unexpected with the raw body for the operator.
+func TestRenderHTTPStatusDefaultArm(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	if err := renderHTTPStatus(cmd, "https://meho.example", http.StatusServiceUnavailable,
+		[]byte("maintenance"), true); err == nil {
+		t.Fatalf("expected error returned for 503")
+	}
+	if !strings.Contains(stderr.String(), "HTTP 503") {
+		t.Errorf("stderr missing HTTP code: %s", stderr.String())
+	}
+}
+
+// mustUUID parses s as a UUID and casts to the openapi_types alias,
+// failing the test on error. Used by fixtures that need a canonical
+// UUID for typed `api.AuditEntry.Id` / `.TenantId` / etc. fields.
+func mustUUID(t *testing.T, s string) openapi_types.UUID {
+	t.Helper()
+	parsed, err := uuid.Parse(s)
+	if err != nil {
+		t.Fatalf("mustUUID(%q): %v", s, err)
+	}
+	return openapi_types.UUID(parsed)
+}
+
+// mustUUIDPtr is the pointer companion to mustUUID for the
+// nullable-UUID fields on `api.AuditEntry` (TenantId, TargetId,
+// RequestId, ParentAuditId, AgentSessionId, BroadcastEventId).
+func mustUUIDPtr(t *testing.T, s string) *openapi_types.UUID {
+	t.Helper()
+	u := mustUUID(t, s)
+	return &u
+}
+
+// Sentinel: package-level helpers compile against the typed client's
+// public surface. A regression that drops one of the imports surfaces
+// as a build failure pinning the helper-shape contract.
+var (
+	_ = json.NewDecoder
+	_ = newAuthedClient
+	_ = mustUUIDPtr
+	_ api.AuditEntry
+)

--- a/cli/internal/cmd/audit/audit_test.go
+++ b/cli/internal/cmd/audit/audit_test.go
@@ -335,14 +335,14 @@ func TestPostQueryReturnsHTTPErrorOnNon2xx(t *testing.T) {
 // the cast above stays readable without dragging the std-lib import
 // into the assertion site.
 func asHTTPResponseError(err error, target **httpResponseError) bool {
-	for cause := err; cause != nil; {
-		if h, ok := cause.(*httpResponseError); ok {
-			*target = h
-			return true
-		}
-		// Stop at the first non-wrap; this skill's errors don't
-		// nest under wrap helpers.
-		break
+	// Stop at the first non-wrap; this skill's errors don't nest
+	// under wrap helpers, so a single type assertion is sufficient.
+	if err == nil {
+		return false
+	}
+	if h, ok := err.(*httpResponseError); ok {
+		*target = h
+		return true
 	}
 	return false
 }

--- a/cli/internal/cmd/audit/my_recent.go
+++ b/cli/internal/cmd/audit/my_recent.go
@@ -6,11 +6,10 @@ package audit
 import (
 	"context"
 	"fmt"
-	"net/url"
-	"strconv"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -44,7 +43,7 @@ func newMyRecentCmd() *cobra.Command {
 			"--since defaults to 24h server-side; pass a different " +
 			"shorthand (7d / 30m / 2w) or an ISO-8601 datetime to widen " +
 			"the window. --limit caps the page size (1..1000, server " +
-			"default 100). --json emits the raw QueryResult.",
+			"default 100). --json emits the raw AuditQueryResult.",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -62,7 +61,7 @@ func newMyRecentCmd() *cobra.Command {
 	cmd.Flags().IntVar(&limit, "limit", 0,
 		"max rows (1..1000, server default 100 when omitted)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
-		"emit raw QueryResult JSON instead of the human table")
+		"emit raw AuditQueryResult JSON instead of the human table")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
 	return cmd
@@ -87,45 +86,69 @@ func runMyRecent(cmd *cobra.Command, opts myRecentOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	result, err := getMyRecent(cmd.Context(), backplaneURL, opts)
+	client, cerr := newAuthedClient(cmd.Context(), cmd, backplaneURL, opts.JSONOut)
+	if cerr != nil {
+		return cerr
+	}
+	rawBody, result, err := getMyRecent(cmd.Context(), client, opts)
 	if err != nil {
-		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+		return routeRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
 	if opts.JSONOut {
-		return output.PrintJSON(cmd.OutOrStdout(), result)
+		_, werr := cmd.OutOrStdout().Write(append(rawBody, '\n'))
+		return werr
+	}
+	if result == nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("backplane returned 200 OK but no JSON body decoded against AuditQueryResult"),
+			opts.JSONOut,
+		)
 	}
 	printQueryTable(cmd.OutOrStdout(), result)
 	return nil
 }
 
-// buildMyRecentPath assembles the GET path with optional --since /
-// --limit query params. Exposed for unit tests.
-func buildMyRecentPath(since string, limit int) string {
-	q := url.Values{}
-	if since != "" {
-		q.Set("since", since)
+// buildMyRecentParams assembles the typed-client params struct from
+// the per-call options. The query-param fields are pointer-typed so
+// nil means "don't emit on the wire" — the backend then applies its
+// own defaults (since=24h, server-side limit).
+func buildMyRecentParams(opts myRecentOptions) *api.MyRecentApiV1AuditMyRecentGetParams {
+	params := &api.MyRecentApiV1AuditMyRecentGetParams{}
+	if opts.Since != "" {
+		v := opts.Since
+		params.Since = &v
 	}
-	if limit > 0 {
-		q.Set("limit", strconv.Itoa(limit))
+	if opts.Limit > 0 {
+		l := opts.Limit
+		params.Limit = &l
 	}
-	path := "/api/v1/audit/my-recent"
-	if encoded := q.Encode(); encoded != "" {
-		path = path + "?" + encoded
-	}
-	return path
+	return params
 }
 
-func getMyRecent(ctx context.Context, backplaneURL string, opts myRecentOptions) (*QueryResult, error) {
-	raw, err := doAuthedRequest(
-		ctx, backplaneURL, "GET",
-		buildMyRecentPath(opts.Since, opts.Limit), nil,
-	)
+// getMyRecent drives the typed-client
+// `MyRecentApiV1AuditMyRecentGet` endpoint with the same one-shot
+// 401-retry shape `postQuery` uses.
+func getMyRecent(
+	ctx context.Context,
+	client *api.AuthedClient,
+	opts myRecentOptions,
+) ([]byte, *api.AuditQueryResult, error) {
+	params := buildMyRecentParams(opts)
+	resp, err := client.MyRecentApiV1AuditMyRecentGetWithResponse(ctx, params)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	var out QueryResult
-	if err := decodeAuditResponse(raw, &out); err != nil {
-		return nil, err
+	if resp.StatusCode() == 401 {
+		if rerr := client.Refresh(ctx); rerr != nil {
+			return nil, nil, rerr
+		}
+		resp, err = client.MyRecentApiV1AuditMyRecentGetWithResponse(ctx, params)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
-	return &out, nil
+	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
+		return nil, nil, &httpResponseError{statusCode: resp.StatusCode(), body: resp.Body}
+	}
+	return resp.Body, resp.JSON200, nil
 }

--- a/cli/internal/cmd/audit/my_recent_test.go
+++ b/cli/internal/cmd/audit/my_recent_test.go
@@ -9,54 +9,67 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/evoila/meho/cli/internal/api"
 )
 
-// TestBuildMyRecentPathOmitsEmptyParams — the no-flag form sends a
-// bare path so the backend's defaults take over.
-func TestBuildMyRecentPathOmitsEmptyParams(t *testing.T) {
-	got := buildMyRecentPath("", 0)
-	if got != "/api/v1/audit/my-recent" {
-		t.Errorf("buildMyRecentPath empty: got %q", got)
+// TestBuildMyRecentParamsOmitsEmptyParams — the no-flag form leaves
+// every pointer field on the generated params struct nil, so the
+// query-string builder emits no `since` / `limit` keys and the
+// backend's own defaults take over.
+func TestBuildMyRecentParamsOmitsEmptyParams(t *testing.T) {
+	p := buildMyRecentParams(myRecentOptions{})
+	if p.Since != nil {
+		t.Errorf("Since should be nil; got %v", *p.Since)
+	}
+	if p.Limit != nil {
+		t.Errorf("Limit should be nil; got %v", *p.Limit)
 	}
 }
 
-// TestBuildMyRecentPathEmitsParams — every set flag lands on the
-// query string.
-func TestBuildMyRecentPathEmitsParams(t *testing.T) {
-	got := buildMyRecentPath("2w", 25)
-	if !strings.Contains(got, "since=2w") {
-		t.Errorf("missing since: %q", got)
+// TestBuildMyRecentParamsEmitsParams — every set flag lands on the
+// params struct with the correct value.
+func TestBuildMyRecentParamsEmitsParams(t *testing.T) {
+	p := buildMyRecentParams(myRecentOptions{Since: "2w", Limit: 25})
+	if p.Since == nil || *p.Since != "2w" {
+		t.Errorf("Since: got %v; want 2w", p.Since)
 	}
-	if !strings.Contains(got, "limit=25") {
-		t.Errorf("missing limit: %q", got)
+	if p.Limit == nil || *p.Limit != 25 {
+		t.Errorf("Limit: got %v; want 25", p.Limit)
 	}
 }
 
-// TestRunMyRecentHappyPath — the verb hits GET /api/v1/audit/my-
-// recent. The backend's `principal` filter is derived from the JWT
-// sub claim server-side; the CLI never supplies it.
-func TestRunMyRecentHappyPath(t *testing.T) {
+// TestRunMyRecentSendsParamsToWire — round-trip: a set --since /
+// --limit pair lands on the wire as query-string params, and the
+// CLI does NOT supply a `principal` param (the backend reads it from
+// the JWT server-side).
+func TestRunMyRecentSendsParamsToWire(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/audit/my-recent", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			t.Errorf("method: got %s; want GET", r.Method)
 		}
-		// The route reads the principal filter from the JWT
-		// server-side; no client-supplied principal flag.
+		if got := r.URL.Query().Get("since"); got != "2w" {
+			t.Errorf("since: got %q; want 2w", got)
+		}
+		if got := r.URL.Query().Get("limit"); got != "25" {
+			t.Errorf("limit: got %q; want 25", got)
+		}
+		// Server-side `principal` filter — never client-supplied.
 		if r.URL.Query().Get("principal") != "" {
 			t.Errorf("CLI should not supply principal query param: got %q",
 				r.URL.Query().Get("principal"))
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(QueryResult{
-			Rows: []Entry{{
-				ID:           "00000000-0000-0000-0000-000000000001",
-				TS:           "2026-05-15T09:00:00Z",
+		_ = json.NewEncoder(w).Encode(api.AuditQueryResult{
+			Rows: []api.AuditEntry{{
+				Id:           mustUUID(t, "00000000-0000-0000-0000-000000000001"),
+				Ts:           mustTS(t, "2026-05-15T09:00:00Z"),
 				PrincipalSub: "damir",
 				Method:       "POST",
 				Path:         "/api/v1/retrieve",
 				StatusCode:   200,
-				OpID:         "meho.retrieval.query",
+				OpId:         "meho.retrieval.query",
 				OpClass:      "audit_query",
 				ResultStatus: "ok",
 				Payload:      map[string]any{},
@@ -68,7 +81,11 @@ func TestRunMyRecentHappyPath(t *testing.T) {
 	seedXDGAndToken(t, srv.URL)
 
 	cmd, stdout, stderr := newRunCmd(t)
-	err := runMyRecent(cmd, myRecentOptions{BackplaneOverride: srv.URL})
+	err := runMyRecent(cmd, myRecentOptions{
+		Since:             "2w",
+		Limit:             25,
+		BackplaneOverride: srv.URL,
+	})
 	if err != nil {
 		t.Fatalf("runMyRecent: %v; stderr=%s", err, stderr.String())
 	}
@@ -77,6 +94,27 @@ func TestRunMyRecentHappyPath(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("stdout missing %q in %s", want, out)
 		}
+	}
+}
+
+// TestRunMyRecentOmitsEmptyParamsOnWire — the no-flag form sends a
+// bare GET so the backend's defaults take over.
+func TestRunMyRecentOmitsEmptyParamsOnWire(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/my-recent", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.RawQuery; got != "" {
+			t.Errorf("no-flag form should send empty query; got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"rows":[],"next_cursor":null}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	if err := runMyRecent(cmd, myRecentOptions{BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runMyRecent: %v; stderr=%s", err, stderr.String())
 	}
 }
 
@@ -89,7 +127,8 @@ func TestRunMyRecentRejectsOutOfRangeLimit(t *testing.T) {
 	}
 }
 
-// TestRunMyRecentJSONRoundTrips — --json emits the structured shape.
+// TestRunMyRecentJSONRoundTrips — --json emits the raw server bytes
+// verbatim; the typed-AuditQueryResult shape parses back cleanly.
 func TestRunMyRecentJSONRoundTrips(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/audit/my-recent", func(w http.ResponseWriter, _ *http.Request) {
@@ -105,7 +144,7 @@ func TestRunMyRecentJSONRoundTrips(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runMyRecent --json: %v", err)
 	}
-	var decoded QueryResult
+	var decoded api.AuditQueryResult
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout.String())
 	}

--- a/cli/internal/cmd/audit/query.go
+++ b/cli/internal/cmd/audit/query.go
@@ -5,39 +5,18 @@ package audit
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
 
 	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
-
-// auditQueryRequest mirrors the backend `AuditQueryRequest` Pydantic
-// model (`backend/src/meho_backplane/api/v1/audit_models.py`). Every
-// filter field is a pointer (or `omitempty`-tagged primitive) so the
-// CLI emits only the keys the operator actually set — the backend
-// treats absent keys as "no narrowing on this column". `Limit=0`
-// special-cases the unset state because Go's zero-value int collides
-// with the backend's `ge=1` validation otherwise.
-type auditQueryRequest struct {
-	Target         *string `json:"target,omitempty"`
-	Principal      *string `json:"principal,omitempty"`
-	OpID           *string `json:"op_id,omitempty"`
-	OpClass        *string `json:"op_class,omitempty"`
-	ResultStatus   *string `json:"result_status,omitempty"`
-	Since          *string `json:"since,omitempty"`
-	Until          *string `json:"until,omitempty"`
-	AuditID        *string `json:"audit_id,omitempty"`
-	ParentAuditID  *string `json:"parent_audit_id,omitempty"`
-	AgentSessionID *string `json:"agent_session_id,omitempty"`
-	Limit          int     `json:"limit,omitempty"`
-	Cursor         *string `json:"cursor,omitempty"`
-}
 
 // newQueryCmd returns the `meho audit query` command.
 //
@@ -56,7 +35,7 @@ type auditQueryRequest struct {
 //	  [--audit-id ID]              # exact-id lookup
 //	  [--parent-audit-id ID]       # v0.2 substrate rejects (400)
 //	  [--session-id ID]            # narrow to one agent session (UUID)
-//	  [--json]                     # raw RetireChecklistReport JSON
+//	  [--json]                     # raw AuditQueryResult JSON
 //	  [--backplane <url>]          # override the configured backplane
 //
 // Exit codes:
@@ -92,7 +71,7 @@ func newQueryCmd() *cobra.Command {
 			"that accepts a tenant id. --since/--until accept either a " +
 			"duration shorthand (24h / 7d / 30m / 2w) or an ISO-8601 " +
 			"datetime. --cursor pastes the opaque next_cursor from a " +
-			"prior page. --json emits the raw QueryResult so " +
+			"prior page. --json emits the raw AuditQueryResult so " +
 			"operators can pipe into jq.",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
@@ -142,7 +121,7 @@ func newQueryCmd() *cobra.Command {
 	cmd.Flags().StringVar(&sessionID, "session-id", "",
 		"narrow to one agent session (UUID); the flat companion to `meho audit replay`")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
-		"emit raw QueryResult JSON instead of the human table")
+		"emit raw AuditQueryResult JSON instead of the human table")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
 	return cmd
@@ -173,104 +152,163 @@ func runQuery(cmd *cobra.Command, opts queryOptions) error {
 			opts.JSONOut,
 		)
 	}
-	if opts.SessionID != "" {
-		// The backend declares agent_session_id as a UUID and rejects a
-		// malformed value with 422. Catch it client-side so the operator
-		// sees a clear "not a UUID" message instead of a FastAPI
-		// validation envelope after a round-trip.
-		if _, err := uuid.Parse(strings.TrimSpace(opts.SessionID)); err != nil {
-			return output.RenderError(
-				cmd.ErrOrStderr(),
-				output.Unexpected(fmt.Sprintf(
-					"--session-id must be a valid UUID; %q is not a UUID", opts.SessionID)),
-				opts.JSONOut,
-			)
-		}
+	// UUIDs live in the generated request body as
+	// `*openapi_types.UUID`; parse the operator strings at the verb
+	// edge so the bad-input case is a clean output.Unexpected rather
+	// than a server-side 422 after a round-trip. Empty string means
+	// "filter not set" and stays nil on the wire.
+	body, err := buildAuditQueryRequest(opts)
+	if err != nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()),
+			opts.JSONOut,
+		)
 	}
 	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	result, err := postQuery(cmd.Context(), backplaneURL, opts)
+	client, cerr := newAuthedClient(cmd.Context(), cmd, backplaneURL, opts.JSONOut)
+	if cerr != nil {
+		return cerr
+	}
+	rawBody, result, err := postQuery(cmd.Context(), client, body)
 	if err != nil {
-		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+		return routeRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
 	if opts.JSONOut {
-		return output.PrintJSON(cmd.OutOrStdout(), result)
+		// Emit the server bytes verbatim so payload integers above
+		// 2^53 survive without rounding through the generated
+		// `map[string]interface{}` decoder. The human-rendered
+		// summary lossily accepts the float64 conversion for the
+		// table/summary view; the --json path is the precision-
+		// preserving contract callers pipe through jq.
+		_, werr := cmd.OutOrStdout().Write(append(rawBody, '\n'))
+		return werr
+	}
+	if result == nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("backplane returned 200 OK but no JSON body decoded against AuditQueryResult"),
+			opts.JSONOut,
+		)
 	}
 	printQueryTable(cmd.OutOrStdout(), result)
 	return nil
 }
 
-// buildQueryRequest assembles the JSON body from the per-call
-// options. Each filter field lands on the wire only when the operator
-// set it. Empty strings stay empty (Pydantic's `extra="ignore"`
-// silently drops fields not on the model; the explicit Go-side
-// omission keeps the wire compact and matches the existing CLI
-// pattern in `cli/internal/cmd/retrieval/eval.go`).
-func buildQueryRequest(opts queryOptions) auditQueryRequest {
-	body := auditQueryRequest{}
+// buildAuditQueryRequest assembles the typed `api.AuditQueryRequest`
+// from per-call options. Filter fields land on the wire as nil
+// (omitted-or-null per the field's JSON tag) when the operator
+// didn't set them — the backend's Pydantic model treats absent /
+// null filters as "no narrowing on this column". UUIDs are parsed
+// at the edge so an obviously-malformed value short-circuits before
+// a network round-trip.
+func buildAuditQueryRequest(opts queryOptions) (api.AuditQueryRequest, error) {
+	body := api.AuditQueryRequest{}
 	if opts.Target != "" {
-		body.Target = &opts.Target
+		v := opts.Target
+		body.Target = &v
 	}
 	if opts.Principal != "" {
-		body.Principal = &opts.Principal
+		v := opts.Principal
+		body.Principal = &v
 	}
 	if opts.OpID != "" {
-		body.OpID = &opts.OpID
+		v := opts.OpID
+		body.OpId = &v
 	}
 	if opts.OpClass != "" {
-		body.OpClass = &opts.OpClass
+		v := opts.OpClass
+		body.OpClass = &v
 	}
 	if opts.ResultStatus != "" {
-		body.ResultStatus = &opts.ResultStatus
+		v := opts.ResultStatus
+		body.ResultStatus = &v
 	}
 	if opts.Since != "" {
-		body.Since = &opts.Since
+		v := opts.Since
+		body.Since = &v
 	}
 	if opts.Until != "" {
-		body.Until = &opts.Until
-	}
-	if opts.AuditID != "" {
-		body.AuditID = &opts.AuditID
-	}
-	if opts.ParentAuditID != "" {
-		body.ParentAuditID = &opts.ParentAuditID
-	}
-	if opts.SessionID != "" {
-		body.AgentSessionID = &opts.SessionID
+		v := opts.Until
+		body.Until = &v
 	}
 	if opts.Cursor != "" {
-		body.Cursor = &opts.Cursor
+		v := opts.Cursor
+		body.Cursor = &v
+	}
+	if opts.AuditID != "" {
+		u, perr := uuid.Parse(strings.TrimSpace(opts.AuditID))
+		if perr != nil {
+			return body, fmt.Errorf(
+				"--audit-id must be a valid UUID; %q is not a UUID", opts.AuditID)
+		}
+		uu := openapi_types.UUID(u)
+		body.AuditId = &uu
+	}
+	if opts.ParentAuditID != "" {
+		u, perr := uuid.Parse(strings.TrimSpace(opts.ParentAuditID))
+		if perr != nil {
+			return body, fmt.Errorf(
+				"--parent-audit-id must be a valid UUID; %q is not a UUID", opts.ParentAuditID)
+		}
+		uu := openapi_types.UUID(u)
+		body.ParentAuditId = &uu
+	}
+	if opts.SessionID != "" {
+		u, perr := uuid.Parse(strings.TrimSpace(opts.SessionID))
+		if perr != nil {
+			return body, fmt.Errorf(
+				"--session-id must be a valid UUID; %q is not a UUID", opts.SessionID)
+		}
+		uu := openapi_types.UUID(u)
+		body.AgentSessionId = &uu
 	}
 	if opts.Limit > 0 {
-		body.Limit = opts.Limit
+		l := opts.Limit
+		body.Limit = &l
 	}
-	return body
+	return body, nil
 }
 
-func postQuery(ctx context.Context, backplaneURL string, opts queryOptions) (*QueryResult, error) {
-	body := buildQueryRequest(opts)
-	raw, err := json.Marshal(body)
+// postQuery drives the typed-client `QueryApiV1AuditQueryPost`
+// endpoint with a one-shot 401-retry around the underlying
+// AuthedClient's refresh path (mirrors `AuthedClient.GetHealth`'s
+// pattern in client.go). Non-2xx responses are returned as
+// `*httpResponseError` so the caller can route them through
+// `renderHTTPStatus`; transport-layer errors return verbatim.
+// Returns both the raw response body bytes (for --json verbatim
+// passthrough) and the decoded typed envelope (for the table render).
+func postQuery(
+	ctx context.Context,
+	client *api.AuthedClient,
+	body api.AuditQueryRequest,
+) ([]byte, *api.AuditQueryResult, error) {
+	resp, err := client.QueryApiV1AuditQueryPostWithResponse(ctx, nil, body)
 	if err != nil {
-		return nil, fmt.Errorf("marshal audit query: %w", err)
+		return nil, nil, err
 	}
-	resp, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/audit/query", raw)
-	if err != nil {
-		return nil, err
+	if resp.StatusCode() == 401 {
+		if rerr := client.Refresh(ctx); rerr != nil {
+			return nil, nil, rerr
+		}
+		resp, err = client.QueryApiV1AuditQueryPostWithResponse(ctx, nil, body)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
-	var out QueryResult
-	if err := decodeAuditResponse(resp, &out); err != nil {
-		return nil, err
+	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
+		return nil, nil, &httpResponseError{statusCode: resp.StatusCode(), body: resp.Body}
 	}
-	return &out, nil
+	return resp.Body, resp.JSON200, nil
 }
 
 // printQueryTable renders the audit page as a compact, scannable
 // table. Columns: TIME, PRINCIPAL, TARGET, OP_ID, CLASS, STATUS per
 // the issue body's spec. When `next_cursor` is set, a final NEXT
 // line tells the operator how to paste-paginate.
-func printQueryTable(w io.Writer, r *QueryResult) {
+func printQueryTable(w io.Writer, r *api.AuditQueryResult) {
 	if r == nil || len(r.Rows) == 0 {
 		fmt.Fprintln(w, "no audit rows matched the filter")
 		return
@@ -283,10 +321,10 @@ func printQueryTable(w io.Writer, r *QueryResult) {
 			target = "-"
 		}
 		fmt.Fprintf(w, "%-22s %-12s %-18s %-26s %-16s %s\n",
-			truncate(row.TS, 22),
+			truncate(formatTS(row.Ts), 22),
 			truncate(row.PrincipalSub, 12),
 			truncate(target, 18),
-			truncate(row.OpID, 26),
+			truncate(row.OpId, 26),
 			truncate(row.OpClass, 16),
 			truncate(row.ResultStatus, 8),
 		)

--- a/cli/internal/cmd/audit/query_test.go
+++ b/cli/internal/cmd/audit/query_test.go
@@ -11,31 +11,94 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/evoila/meho/cli/internal/api"
 )
 
-// TestBuildQueryRequestEmptyOptsOmitsEveryFilter — the no-flag form
-// sends a minimal `{}` body, letting the backend defaults take over
-// (server-side limit=100, no narrowing filters). Mirrors the
-// retire-checklist learning that empty Go pointers must drop on the
-// wire — otherwise the backend reads "set to empty string" as a
-// match condition.
-func TestBuildQueryRequestEmptyOptsOmitsEveryFilter(t *testing.T) {
-	body := buildQueryRequest(queryOptions{})
+// TestBuildAuditQueryRequestEmptyOptsHasZeroNonNilFilters — the
+// no-flag form leaves every pointer-typed filter nil. The generated
+// `api.AuditQueryRequest` JSON marshalling will emit each nullable
+// key as `null` on the wire (the backend's Pydantic model accepts
+// `Optional[...] = None`), and the `omitempty`-tagged `limit` is
+// dropped because it's a `*int` left nil. The exact wire-shape
+// assertion is on `TestBuildAuditQueryRequestEmptyOptsWireShape`.
+func TestBuildAuditQueryRequestEmptyOptsHasZeroNonNilFilters(t *testing.T) {
+	body, err := buildAuditQueryRequest(queryOptions{})
+	if err != nil {
+		t.Fatalf("buildAuditQueryRequest: %v", err)
+	}
+	if body.Target != nil {
+		t.Errorf("Target should be nil; got %v", *body.Target)
+	}
+	if body.Principal != nil {
+		t.Errorf("Principal should be nil; got %v", *body.Principal)
+	}
+	if body.OpId != nil {
+		t.Errorf("OpId should be nil; got %v", *body.OpId)
+	}
+	if body.OpClass != nil {
+		t.Errorf("OpClass should be nil; got %v", *body.OpClass)
+	}
+	if body.ResultStatus != nil {
+		t.Errorf("ResultStatus should be nil; got %v", *body.ResultStatus)
+	}
+	if body.Since != nil {
+		t.Errorf("Since should be nil; got %v", *body.Since)
+	}
+	if body.Until != nil {
+		t.Errorf("Until should be nil; got %v", *body.Until)
+	}
+	if body.Cursor != nil {
+		t.Errorf("Cursor should be nil; got %v", *body.Cursor)
+	}
+	if body.AuditId != nil {
+		t.Errorf("AuditId should be nil; got %v", *body.AuditId)
+	}
+	if body.ParentAuditId != nil {
+		t.Errorf("ParentAuditId should be nil; got %v", *body.ParentAuditId)
+	}
+	if body.AgentSessionId != nil {
+		t.Errorf("AgentSessionId should be nil; got %v", *body.AgentSessionId)
+	}
+	if body.Limit != nil {
+		t.Errorf("Limit should be nil; got %v", *body.Limit)
+	}
+}
+
+// TestBuildAuditQueryRequestEmptyOptsWireShape — pin the wire-shape
+// of the no-flag body so a regression away from null-permitted
+// filters (e.g. someone re-adding `omitempty` to half the fields
+// inconsistently) surfaces at unit-time. Every nullable filter
+// renders as `"key":null`; `limit` is omitted entirely (the only
+// field carrying `omitempty` on the generated struct).
+func TestBuildAuditQueryRequestEmptyOptsWireShape(t *testing.T) {
+	body, _ := buildAuditQueryRequest(queryOptions{})
 	raw, err := json.Marshal(body)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
 	got := string(raw)
-	if got != "{}" {
-		t.Errorf("empty opts marshalled non-empty: %s", got)
+	for _, want := range []string{
+		`"target":null`, `"principal":null`, `"op_id":null`, `"op_class":null`,
+		`"result_status":null`, `"since":null`, `"until":null`, `"cursor":null`,
+		`"audit_id":null`, `"parent_audit_id":null`, `"agent_session_id":null`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("wire shape missing %q in %s", want, got)
+		}
+	}
+	if strings.Contains(got, `"limit"`) {
+		t.Errorf("limit should be omitted when nil; got %s", got)
 	}
 }
 
-// TestBuildQueryRequestEveryFlagLandsOnWire — every operator-set
-// flag round-trips into the JSON body with the backend-expected
-// key. The AuditQueryRequest Pydantic model is `extra="ignore"` so
-// a typo'd key would silently drop; the test pins each key by name.
-func TestBuildQueryRequestEveryFlagLandsOnWire(t *testing.T) {
+// TestBuildAuditQueryRequestEveryFlagLandsOnWire — every operator-
+// set flag round-trips into the JSON body with the backend-expected
+// key. The `extra="forbid"` Pydantic model rejects unknown fields
+// with 422, so a typo'd key would fail the contract; the test pins
+// each key by name.
+func TestBuildAuditQueryRequestEveryFlagLandsOnWire(t *testing.T) {
 	opts := queryOptions{
 		Target:        "rdc-vcenter",
 		Principal:     "damir",
@@ -50,7 +113,10 @@ func TestBuildQueryRequestEveryFlagLandsOnWire(t *testing.T) {
 		Limit:         50,
 		Cursor:        "opaque-cursor-bytes",
 	}
-	body := buildQueryRequest(opts)
+	body, err := buildAuditQueryRequest(opts)
+	if err != nil {
+		t.Fatalf("buildAuditQueryRequest: %v", err)
+	}
 	raw, err := json.Marshal(body)
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
@@ -71,19 +137,51 @@ func TestBuildQueryRequestEveryFlagLandsOnWire(t *testing.T) {
 		`"cursor":"opaque-cursor-bytes"`,
 	} {
 		if !strings.Contains(wire, want) {
-			t.Errorf("buildQueryRequest missing %q in %s", want, wire)
+			t.Errorf("buildAuditQueryRequest missing %q in %s", want, wire)
 		}
 	}
 }
 
-// TestBuildQueryRequestLimitZeroDoesNotMarshal — Limit=0 means "use
-// server default 100"; the wire must not carry `"limit":0` because
-// Pydantic's `ge=1` validation rejects it.
-func TestBuildQueryRequestLimitZeroDoesNotMarshal(t *testing.T) {
-	body := buildQueryRequest(queryOptions{Limit: 0})
+// TestBuildAuditQueryRequestLimitZeroDoesNotMarshal — Limit=0 means
+// "use server default 100"; the wire must not carry `"limit":0`
+// because Pydantic's `ge=1` validation rejects it.
+func TestBuildAuditQueryRequestLimitZeroDoesNotMarshal(t *testing.T) {
+	body, _ := buildAuditQueryRequest(queryOptions{Limit: 0})
 	raw, _ := json.Marshal(body)
-	if strings.Contains(string(raw), "limit") {
+	if strings.Contains(string(raw), `"limit"`) {
 		t.Errorf("limit=0 should be omitted; got %s", string(raw))
+	}
+}
+
+// TestBuildAuditQueryRequestRejectsBadAuditID — UUID-at-the-edge:
+// a non-UUID `--audit-id` is rejected client-side before any
+// network round-trip.
+func TestBuildAuditQueryRequestRejectsBadAuditID(t *testing.T) {
+	_, err := buildAuditQueryRequest(queryOptions{AuditID: "not-a-uuid"})
+	if err == nil {
+		t.Fatalf("expected error for non-UUID --audit-id")
+	}
+	if !strings.Contains(err.Error(), "must be a valid UUID") {
+		t.Errorf("error missing UUID hint: %v", err)
+	}
+}
+
+// TestBuildAuditQueryRequestRejectsBadParentAuditID — same gate on
+// --parent-audit-id.
+func TestBuildAuditQueryRequestRejectsBadParentAuditID(t *testing.T) {
+	_, err := buildAuditQueryRequest(queryOptions{ParentAuditID: "not-a-uuid"})
+	if err == nil {
+		t.Fatalf("expected error for non-UUID --parent-audit-id")
+	}
+}
+
+// TestBuildAuditQueryRequestRejectsBadSessionID — same gate on
+// --session-id (mirrors the dedicated test below, kept here so the
+// builder's contract is one-stop).
+func TestBuildAuditQueryRequestRejectsBadSessionID(t *testing.T) {
+	_, err := buildAuditQueryRequest(queryOptions{SessionID: "not-a-uuid"})
+	if err == nil {
+		t.Fatalf("expected error for non-UUID --session-id")
 	}
 }
 
@@ -120,16 +218,16 @@ func TestRunQueryHappyPathTable(t *testing.T) {
 		tname := "rdc-vcenter"
 		next := "opaque-next-cursor"
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(QueryResult{
-			Rows: []Entry{{
-				ID:           "00000000-0000-0000-0000-000000000001",
-				TS:           "2026-05-13T15:42:11Z",
+		_ = json.NewEncoder(w).Encode(api.AuditQueryResult{
+			Rows: []api.AuditEntry{{
+				Id:           mustUUID(t, "00000000-0000-0000-0000-000000000001"),
+				Ts:           mustTS(t, "2026-05-13T15:42:11Z"),
 				PrincipalSub: "damir",
 				TargetName:   &tname,
 				Method:       "GET",
 				Path:         "/api/v1/vsphere/vm/list",
 				StatusCode:   200,
-				OpID:         "vsphere.vm.list",
+				OpId:         "vsphere.vm.list",
 				OpClass:      "read",
 				ResultStatus: "ok",
 				Payload:      map[string]any{},
@@ -159,11 +257,11 @@ func TestRunQueryHappyPathTable(t *testing.T) {
 }
 
 // TestRunQueryJSONPassthroughRoundTrips — --json emits the raw
-// QueryResult shape so jq pipelines see a stable contract.
+// server bytes verbatim so jq pipelines see a stable contract.
 // The backend always emits `next_cursor` as a JSON key (Pydantic
-// v2 default for `str | None`); the CLI must preserve the key when
-// re-marshalling so consumers can `jq .next_cursor` without an
-// optional-presence dance.
+// v2 default for `str | None`); the CLI's verbatim passthrough
+// preserves the key when re-emitting so consumers can `jq
+// .next_cursor` without an optional-presence dance.
 func TestRunQueryJSONPassthroughRoundTrips(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/audit/query", func(w http.ResponseWriter, _ *http.Request) {
@@ -184,13 +282,69 @@ func TestRunQueryJSONPassthroughRoundTrips(t *testing.T) {
 	if !strings.Contains(stdout.String(), `"next_cursor"`) {
 		t.Errorf("--json dropped next_cursor key: %s", stdout.String())
 	}
-	var decoded QueryResult
+	var decoded api.AuditQueryResult
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout.String())
 	}
 	if decoded.NextCursor != nil {
 		t.Errorf("expected nil NextCursor; got %v", decoded.NextCursor)
 	}
+}
+
+// TestRunQueryJSONPreservesPayloadIntegerPrecision pins the
+// precision-preservation contract --json carries: an integer above
+// 2^53 in an audit row's payload survives the round-trip exactly,
+// because the verb writes the server bytes verbatim rather than
+// round-tripping through the generated client's
+// `map[string]interface{}` (float64-conversion) decoder.
+func TestRunQueryJSONPreservesPayloadIntegerPrecision(t *testing.T) {
+	bigInt := int64(9007199254740993) // 2^53 + 1; rounds under float64
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/query", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Hand-encode so the integer literal isn't normalised
+		// through json.Marshal's float path; the operator-side
+		// guarantee is "the bytes the backend wrote, unchanged".
+		_, _ = w.Write([]byte(`{"rows":[{"id":"00000000-0000-0000-0000-000000000001",` +
+			`"ts":"2026-05-13T15:42:11Z","tenant_id":null,"principal_sub":"damir",` +
+			`"principal_name":null,"target_id":null,"target_name":null,` +
+			`"method":"GET","path":"/x","status_code":200,"request_id":null,` +
+			`"duration_ms":null,"payload":{"hit_count":9007199254740993},` +
+			`"op_id":"x.y","op_class":"read","result_status":"ok",` +
+			`"parent_audit_id":null,"agent_session_id":null,` +
+			`"broadcast_event_id":null}],"next_cursor":null}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	err := runQuery(cmd, queryOptions{JSONOut: true, BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runQuery --json: %v", err)
+	}
+	// The exact integer survives in the emitted bytes.
+	if !strings.Contains(stdout.String(), `"hit_count":9007199254740993`) {
+		t.Errorf("integer precision lost in --json passthrough: %s", stdout.String())
+	}
+	// And the decoded shape (with UseNumber) preserves it too.
+	dec := json.NewDecoder(bytes.NewReader(stdout.Bytes()))
+	dec.UseNumber()
+	var roundtrip map[string]any
+	if err := dec.Decode(&roundtrip); err != nil {
+		t.Fatalf("decode --json output: %v", err)
+	}
+	rows, _ := roundtrip["rows"].([]any)
+	if len(rows) != 1 {
+		t.Fatalf("rows: got %d; want 1", len(rows))
+	}
+	row, _ := rows[0].(map[string]any)
+	payload, _ := row["payload"].(map[string]any)
+	got, _ := payload["hit_count"].(json.Number)
+	if got.String() != "9007199254740993" {
+		t.Errorf("precision lost on decode: got %s; want 9007199254740993", got)
+	}
+	_ = bigInt // pin the literal to its semantic value in the assertion
 }
 
 // TestRunQuery400SurfacesParserError — DurationParseError /
@@ -236,8 +390,6 @@ func TestRunQueryUnreachableSurfacesAsTransport(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected unreachable error")
 	}
-	// Two acceptable readings: connection refused (Darwin) or the
-	// generic call-error wrapper. Both go through Unreachable.
 	if !strings.Contains(stderr.String(), "call ") {
 		t.Errorf("stderr does not look like Unreachable: %s", stderr.String())
 	}
@@ -246,8 +398,9 @@ func TestRunQueryUnreachableSurfacesAsTransport(t *testing.T) {
 // TestRunQuerySessionIDRejectsNonUUID — AC: a non-UUID --session-id
 // is rejected client-side with a clear message, before any network
 // round-trip (the backend would otherwise emit a 422 validation
-// envelope). The check runs in runQuery so the empty-flag case stays
-// unaffected.
+// envelope). The check now runs inside `buildAuditQueryRequest`
+// since the generated client requires a parsed UUID on the typed
+// param; the rejection still surfaces via the same render path.
 func TestRunQuerySessionIDRejectsNonUUID(t *testing.T) {
 	cmd, _, stderr := newRunCmd(t)
 	err := runQuery(cmd, queryOptions{SessionID: "not-a-uuid"})
@@ -289,7 +442,7 @@ func TestRunQuerySessionIDLandsInBody(t *testing.T) {
 // header but missing body".
 func TestPrintQueryTableEmpty(t *testing.T) {
 	var buf bytes.Buffer
-	printQueryTable(&buf, &QueryResult{Rows: []Entry{}})
+	printQueryTable(&buf, &api.AuditQueryResult{Rows: []api.AuditEntry{}})
 	out := buf.String()
 	if !strings.Contains(out, "no audit rows matched the filter") {
 		t.Errorf("empty table missing helper line: %s", out)
@@ -297,4 +450,16 @@ func TestPrintQueryTableEmpty(t *testing.T) {
 	if strings.Contains(out, "TIME") {
 		t.Errorf("empty table should not print header: %s", out)
 	}
+}
+
+// mustTS parses s as RFC3339, failing the test on error. The
+// generated client's `Ts` field is `time.Time`; fixtures use the
+// helper so callers don't repeat the parse-or-fatal pattern.
+func mustTS(t *testing.T, s string) time.Time {
+	t.Helper()
+	ts, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("mustTS(%q): %v", s, err)
+	}
+	return ts
 }

--- a/cli/internal/cmd/audit/recent_test.go
+++ b/cli/internal/cmd/audit/recent_test.go
@@ -10,6 +10,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/evoila/meho/cli/internal/api"
 )
 
 // TestRunRecentBindsSince24h — `meho audit recent` is the shortcut
@@ -68,7 +70,7 @@ func TestRunRecentJSONRoundTrips(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runQuery via recent --json: %v", err)
 	}
-	var decoded QueryResult
+	var decoded api.AuditQueryResult
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout.String())
 	}

--- a/cli/internal/cmd/audit/replay.go
+++ b/cli/internal/cmd/audit/replay.go
@@ -4,6 +4,7 @@
 package audit
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -11,8 +12,10 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -24,38 +27,6 @@ import (
 // limit are folded into a single "… N more level(s) (use --max-depth
 // to expand)" marker. 20 matches the issue's spec.
 const defaultReplayMaxDepth = 20
-
-// ReplayNode mirrors the backend `ReplayNode` Pydantic model
-// (`backend/src/meho_backplane/audit_query/schemas.py`), which
-// subclasses `AuditEntry` and adds `depth` + `children`. Like `Entry`
-// the fields are hand-written rather than aliased to the generated
-// `api.ReplayNode` so the audit package stays decoupled from
-// oapi-codegen churn — the same stance the rest of this package takes.
-//
-// Only the rendering-relevant fields are pulled out as named members;
-// every other audit column survives the --json round-trip because the
-// verb re-marshals the raw server bytes verbatim rather than this
-// struct (see runReplay's --json branch). `DurationMS` is a `*string`
-// because Pydantic v2 serialises `Decimal` as a quoted decimal string
-// (or null).
-type ReplayNode struct {
-	TS           string       `json:"ts"`
-	OpID         string       `json:"op_id"`
-	ResultStatus string       `json:"result_status"`
-	DurationMS   *string      `json:"duration_ms"`
-	Depth        int          `json:"depth"`
-	Children     []ReplayNode `json:"children"`
-}
-
-// ReplayResult mirrors the backend `AuditReplayResult` envelope — a
-// `ReplayNode` forest plus the echoed session/tenant identity and the
-// session's anchor-row count.
-type ReplayResult struct {
-	Root      []ReplayNode `json:"root"`
-	SessionID string       `json:"session_id"`
-	TenantID  string       `json:"tenant_id"`
-	RowCount  int          `json:"row_count"`
-}
 
 // newReplayCmd returns the `meho audit replay` command.
 //
@@ -71,7 +42,7 @@ type ReplayResult struct {
 // A 413 from the backend means the session exceeds the server's
 // 10 000-anchor-row replay cap. The verb surfaces a friendly redirect
 // to `meho audit query --session-id <id>` (which paginates the flat
-// rows) and exits non-zero — see renderHTTPError's 413 arm in audit.go.
+// rows) and exits non-zero — see renderReplayRequestError.
 //
 // Exit codes:
 //   - 0   tree rendered cleanly (incl. an empty / unknown session)
@@ -129,7 +100,12 @@ type replayOptions struct {
 }
 
 func runReplay(cmd *cobra.Command, opts replayOptions) error {
-	if _, err := uuid.Parse(strings.TrimSpace(opts.SessionID)); err != nil {
+	// The typed-client's `sessionId` path parameter is
+	// `openapi_types.UUID`. Parse the operator string at the verb
+	// edge so a non-UUID argument surfaces as a clean
+	// output.Unexpected before any network round-trip.
+	parsed, err := uuid.Parse(strings.TrimSpace(opts.SessionID))
+	if err != nil {
 		return output.RenderError(
 			cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf(
@@ -137,6 +113,7 @@ func runReplay(cmd *cobra.Command, opts replayOptions) error {
 			opts.JSONOut,
 		)
 	}
+	sessionID := openapi_types.UUID(parsed)
 	if opts.MaxDepth < 0 {
 		return output.RenderError(
 			cmd.ErrOrStderr(),
@@ -148,30 +125,59 @@ func runReplay(cmd *cobra.Command, opts replayOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	raw, err := doAuthedRequest(
-		cmd.Context(), backplaneURL, "GET", buildReplayPath(opts.SessionID), nil)
+	client, cerr := newAuthedClient(cmd.Context(), cmd, backplaneURL, opts.JSONOut)
+	if cerr != nil {
+		return cerr
+	}
+	rawBody, result, err := fetchReplay(cmd.Context(), client, sessionID)
 	if err != nil {
 		return renderReplayRequestError(cmd, backplaneURL, opts.SessionID, err, opts.JSONOut)
 	}
 	if opts.JSONOut {
 		// Emit the server bytes verbatim so every audit column on each
 		// node survives the round-trip — the compliance-export contract
-		// must not be lossy through the CLI's render-only struct.
-		_, werr := cmd.OutOrStdout().Write(append(raw, '\n'))
+		// must not be lossy through the CLI's typed-decode pass.
+		_, werr := cmd.OutOrStdout().Write(append(rawBody, '\n'))
 		return werr
 	}
-	var result ReplayResult
-	if derr := decodeAuditResponse(raw, &result); derr != nil {
-		return renderRequestError(cmd, backplaneURL, derr, opts.JSONOut)
+	if result == nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("backplane returned 200 OK but no JSON body decoded against AuditReplayResult"),
+			opts.JSONOut,
+		)
 	}
-	printReplayTree(cmd.OutOrStdout(), &result, opts.MaxDepth)
+	printReplayTree(cmd.OutOrStdout(), result, opts.MaxDepth)
 	return nil
 }
 
-// buildReplayPath assembles the GET path. Exposed for unit tests so the
-// URL encoding of the session id stays covered.
-func buildReplayPath(sessionID string) string {
-	return "/api/v1/audit/sessions/" + pathEscape(sessionID) + "/replay"
+// fetchReplay drives the typed-client
+// `ReplayApiV1AuditSessionsSessionIdReplayGet` endpoint with the
+// same one-shot 401-retry shape `postQuery` uses. Returns the raw
+// body bytes (for --json verbatim), the decoded result (for the
+// tree render), and an `*httpResponseError` carrying the non-2xx
+// status code + body for the renderer to classify.
+func fetchReplay(
+	ctx context.Context,
+	client *api.AuthedClient,
+	sessionID openapi_types.UUID,
+) ([]byte, *api.AuditReplayResult, error) {
+	resp, err := client.ReplayApiV1AuditSessionsSessionIdReplayGetWithResponse(ctx, sessionID, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode() == 401 {
+		if rerr := client.Refresh(ctx); rerr != nil {
+			return nil, nil, rerr
+		}
+		resp, err = client.ReplayApiV1AuditSessionsSessionIdReplayGetWithResponse(ctx, sessionID, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
+		return nil, nil, &httpResponseError{statusCode: resp.StatusCode(), body: resp.Body}
+	}
+	return resp.Body, resp.JSON200, nil
 }
 
 // renderReplayRequestError adds the 413 session-too-large redirect on
@@ -180,22 +186,22 @@ func buildReplayPath(sessionID string) string {
 // the verb turns it into an actionable `meho audit query --session-id`
 // pointer (the query verb paginates the flat rows the over-cap tree
 // can't render). Every other status falls through to the shared
-// renderRequestError ladder used by the sibling verbs.
+// `routeRequestError` ladder used by the sibling verbs.
 func renderReplayRequestError(
 	cmd *cobra.Command,
 	backplaneURL, sessionID string,
 	err error,
 	jsonOut bool,
 ) error {
-	var he *httpError
-	if errors.As(err, &he) && he.StatusCode == http.StatusRequestEntityTooLarge {
-		rows := decodeSessionTooLargeRowCount(he.Body)
+	var he *httpResponseError
+	if errors.As(err, &he) && he.statusCode == http.StatusRequestEntityTooLarge {
+		rows := decodeSessionTooLargeRowCount(trimmedBody(he.body))
 		msg := fmt.Sprintf(
 			"session %s has %s rows (cap %d); use: meho audit query --session-id %s",
 			sessionID, rows, replayRowCap, sessionID)
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(msg), jsonOut)
 	}
-	return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	return routeRequestError(cmd, backplaneURL, err, jsonOut)
 }
 
 // printReplayTree renders the replay forest as an ASCII tree. Roots are
@@ -204,7 +210,7 @@ func renderReplayRequestError(
 // parent with the standard `├──`/`└──` connectors and `│  `/`   `
 // continuation prefixes. Nodes deeper than maxDepth are folded into a
 // single marker so a pathological session can't flood the terminal.
-func printReplayTree(w io.Writer, r *ReplayResult, maxDepth int) {
+func printReplayTree(w io.Writer, r *api.AuditReplayResult, maxDepth int) {
 	if r == nil || len(r.Root) == 0 {
 		fmt.Fprintln(w, "no audit rows in this session")
 		return
@@ -219,7 +225,7 @@ func printReplayTree(w io.Writer, r *ReplayResult, maxDepth int) {
 // continuation lines; `isLast` selects the connector for this node.
 func printReplayNode(
 	w io.Writer,
-	node *ReplayNode,
+	node *api.ReplayNode,
 	prefix string,
 	isLast bool,
 	depth, maxDepth int,
@@ -239,9 +245,13 @@ func printReplayNode(
 		}
 		return
 	}
-	for i := range node.Children {
+	if node.Children == nil {
+		return
+	}
+	kids := *node.Children
+	for i := range kids {
 		printReplayNode(
-			w, &node.Children[i], childPrefix, i == len(node.Children)-1, depth+1, maxDepth)
+			w, &kids[i], childPrefix, i == len(kids)-1, depth+1, maxDepth)
 	}
 }
 
@@ -252,21 +262,25 @@ func printReplayNode(
 // `occurred_at` is the node's `ts` field (the audit row's
 // `occurred_at`). A null duration renders as `(-ms)` so the column
 // stays present and grep-friendly across nodes.
-func formatReplayNode(node *ReplayNode) string {
-	dur := strDeref(node.DurationMS)
+func formatReplayNode(node *api.ReplayNode) string {
+	dur := strDeref(node.DurationMs)
 	if dur == "" {
 		dur = "-"
 	}
-	return fmt.Sprintf("%s %s [%s] (%sms)", node.TS, node.OpID, node.ResultStatus, dur)
+	return fmt.Sprintf("%s %s [%s] (%sms)", formatTS(node.Ts), node.OpId, node.ResultStatus, dur)
 }
 
 // countDescendants counts every node strictly below `node` (its whole
 // subtree minus itself). Used to summarise how many nodes the
 // --max-depth fold hid.
-func countDescendants(node *ReplayNode) int {
+func countDescendants(node *api.ReplayNode) int {
+	if node.Children == nil {
+		return 0
+	}
+	kids := *node.Children
 	total := 0
-	for i := range node.Children {
-		total += 1 + countDescendants(&node.Children[i])
+	for i := range kids {
+		total += 1 + countDescendants(&kids[i])
 	}
 	return total
 }

--- a/cli/internal/cmd/audit/replay_test.go
+++ b/cli/internal/cmd/audit/replay_test.go
@@ -10,68 +10,89 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/evoila/meho/cli/internal/api"
 )
 
-// twoLevelReplay returns a small `ReplayResult` with two chronological
-// roots; the first carries one child that itself carries a grandchild.
-// Used by the tree-render and max-depth tests so they share one fixture
-// and the expected line shapes stay in one place.
-func twoLevelReplay() ReplayResult {
-	dur := func(s string) *string { return &s }
-	return ReplayResult{
-		SessionID: "11111111-1111-1111-1111-111111111111",
-		TenantID:  "22222222-2222-2222-2222-222222222222",
-		RowCount:  4,
-		Root: []ReplayNode{
-			{
-				TS:           "2026-05-13T10:00:00Z",
-				OpID:         "vsphere.vm.migrate",
-				ResultStatus: "ok",
-				DurationMS:   dur("120.5"),
-				Depth:        0,
-				Children: []ReplayNode{
-					{
-						TS:           "2026-05-13T10:00:01Z",
-						OpID:         "vsphere.vm.power_off",
-						ResultStatus: "ok",
-						DurationMS:   dur("40"),
-						Depth:        1,
-						Children: []ReplayNode{
-							{
-								TS:           "2026-05-13T10:00:02Z",
-								OpID:         "vsphere.task.wait",
-								ResultStatus: "error",
-								DurationMS:   nil,
-								Depth:        2,
-							},
-						},
-					},
-				},
-			},
-			{
-				TS:           "2026-05-13T10:05:00Z",
-				OpID:         "vsphere.vm.list",
-				ResultStatus: "ok",
-				DurationMS:   dur("8"),
-				Depth:        0,
-			},
-		},
+// twoLevelReplay returns a small `api.AuditReplayResult` with two
+// chronological roots; the first carries one child that itself
+// carries a grandchild. Used by the tree-render and max-depth tests
+// so they share one fixture and the expected line shapes stay in
+// one place.
+func twoLevelReplay(t *testing.T) api.AuditReplayResult {
+	t.Helper()
+	dur120 := "120.5"
+	dur40 := "40"
+	dur8 := "8"
+	grandchild := api.ReplayNode{
+		Id:           mustUUID(t, "44444444-4444-4444-4444-444444444444"),
+		Ts:           mustTS(t, "2026-05-13T10:00:02Z"),
+		PrincipalSub: "damir",
+		Method:       "GET",
+		Path:         "/x/task",
+		StatusCode:   500,
+		OpId:         "vsphere.task.wait",
+		OpClass:      "read",
+		ResultStatus: "error",
+		DurationMs:   nil,
+		Depth:        2,
 	}
-}
-
-// TestBuildReplayPathEscapesSessionID — UUIDs are URL-safe, but the
-// segment is escaped defensively so a typo'd argument can't collapse
-// the path.
-func TestBuildReplayPathEscapesSessionID(t *testing.T) {
-	got := buildReplayPath("11111111-1111-1111-1111-111111111111")
-	want := "/api/v1/audit/sessions/11111111-1111-1111-1111-111111111111/replay"
-	if got != want {
-		t.Errorf("buildReplayPath: got %q; want %q", got, want)
+	grandKids := []api.ReplayNode{grandchild}
+	child := api.ReplayNode{
+		Id:           mustUUID(t, "33333333-3333-3333-3333-333333333333"),
+		Ts:           mustTS(t, "2026-05-13T10:00:01Z"),
+		PrincipalSub: "damir",
+		Method:       "POST",
+		Path:         "/x/power",
+		StatusCode:   200,
+		OpId:         "vsphere.vm.power_off",
+		OpClass:      "write",
+		ResultStatus: "ok",
+		DurationMs:   &dur40,
+		Depth:        1,
+		Children:     &grandKids,
+	}
+	childKids := []api.ReplayNode{child}
+	root1 := api.ReplayNode{
+		Id:           mustUUID(t, "11111111-1111-1111-1111-111111111111"),
+		Ts:           mustTS(t, "2026-05-13T10:00:00Z"),
+		PrincipalSub: "damir",
+		Method:       "POST",
+		Path:         "/x/migrate",
+		StatusCode:   200,
+		OpId:         "vsphere.vm.migrate",
+		OpClass:      "write",
+		ResultStatus: "ok",
+		DurationMs:   &dur120,
+		Depth:        0,
+		Children:     &childKids,
+	}
+	root2 := api.ReplayNode{
+		Id:           mustUUID(t, "22222222-2222-2222-2222-222222222222"),
+		Ts:           mustTS(t, "2026-05-13T10:05:00Z"),
+		PrincipalSub: "damir",
+		Method:       "GET",
+		Path:         "/x/list",
+		StatusCode:   200,
+		OpId:         "vsphere.vm.list",
+		OpClass:      "read",
+		ResultStatus: "ok",
+		DurationMs:   &dur8,
+		Depth:        0,
+	}
+	return api.AuditReplayResult{
+		SessionId: mustUUID(t, "55555555-5555-5555-5555-555555555555"),
+		TenantId:  mustUUID(t, "66666666-6666-6666-6666-666666666666"),
+		RowCount:  4,
+		Root:      []api.ReplayNode{root1, root2},
 	}
 }
 
 // TestRunReplayRejectsNonUUID — AC: a non-UUID <session-id> is
-// rejected client-side with a clear message, before any network call.
+// rejected client-side with a clear message, before any network
+// round-trip. The typed-client path parameter is
+// `openapi_types.UUID`; parsing at the verb edge keeps the bad-
+// input error a clean output.Unexpected.
 func TestRunReplayRejectsNonUUID(t *testing.T) {
 	cmd, _, stderr := newRunCmd(t)
 	err := runReplay(cmd, replayOptions{SessionID: "not-a-uuid"})
@@ -103,7 +124,7 @@ func TestRunReplayRejectsNegativeMaxDepth(t *testing.T) {
 // ASCII tree with chronological roots, indented children, and the
 // documented per-line shape `<ts> <op_id> [<status>] (<ms>ms)`.
 func TestRunReplayHappyPathTree(t *testing.T) {
-	fixture := twoLevelReplay()
+	fixture := twoLevelReplay(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/audit/sessions/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -167,7 +188,7 @@ func TestRunReplayHappyPathTree(t *testing.T) {
 // TestRunReplayJSONVerbatim — AC2: --json emits the raw
 // AuditReplayResult JSON; nesting is parseable and matches the tree.
 func TestRunReplayJSONVerbatim(t *testing.T) {
-	fixture := twoLevelReplay()
+	fixture := twoLevelReplay(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/audit/sessions/", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -187,7 +208,7 @@ func TestRunReplayJSONVerbatim(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runReplay --json: %v; stderr=%s", err, stderr.String())
 	}
-	var decoded ReplayResult
+	var decoded api.AuditReplayResult
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("--json output not parseable: %v\n%s", err, stdout.String())
 	}
@@ -195,12 +216,15 @@ func TestRunReplayJSONVerbatim(t *testing.T) {
 		t.Fatalf("--json root count: got %d; want 2", len(decoded.Root))
 	}
 	// Nesting survives: root[0] → child → grandchild.
-	if len(decoded.Root[0].Children) != 1 ||
-		len(decoded.Root[0].Children[0].Children) != 1 {
+	if decoded.Root[0].Children == nil ||
+		len(*decoded.Root[0].Children) != 1 ||
+		(*decoded.Root[0].Children)[0].Children == nil ||
+		len(*(*decoded.Root[0].Children)[0].Children) != 1 {
 		t.Errorf("--json nesting lost: %+v", decoded.Root[0])
 	}
-	if decoded.Root[0].Children[0].Children[0].OpID != "vsphere.task.wait" {
-		t.Errorf("--json grandchild op_id wrong: %+v", decoded.Root[0].Children[0].Children[0])
+	if (*(*decoded.Root[0].Children)[0].Children)[0].OpId != "vsphere.task.wait" {
+		t.Errorf("--json grandchild op_id wrong: %+v",
+			(*(*decoded.Root[0].Children)[0].Children)[0])
 	}
 	// row_count echoed verbatim.
 	if decoded.RowCount != 4 {
@@ -212,7 +236,7 @@ func TestRunReplayJSONVerbatim(t *testing.T) {
 // rendering below depth 1. The grandchild (depth 2) must be folded
 // into a "more node(s)" marker, not printed as its own line.
 func TestRunReplayMaxDepthTruncates(t *testing.T) {
-	fixture := twoLevelReplay()
+	fixture := twoLevelReplay(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/audit/sessions/", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -347,7 +371,7 @@ func TestRunReplay403SurfacesInsufficientRole(t *testing.T) {
 // (covered indirectly above, pinned here directly for the renderer).
 func TestPrintReplayTreeEmpty(t *testing.T) {
 	var buf bytes.Buffer
-	printReplayTree(&buf, &ReplayResult{Root: []ReplayNode{}}, defaultReplayMaxDepth)
+	printReplayTree(&buf, &api.AuditReplayResult{Root: []api.ReplayNode{}}, defaultReplayMaxDepth)
 	if !strings.Contains(buf.String(), "no audit rows in this session") {
 		t.Errorf("empty tree missing helper line: %s", buf.String())
 	}
@@ -356,14 +380,32 @@ func TestPrintReplayTreeEmpty(t *testing.T) {
 // TestFormatReplayNodeNullDuration — a node with a null duration_ms
 // renders `(-ms)` so the column stays present and grep-friendly.
 func TestFormatReplayNodeNullDuration(t *testing.T) {
-	got := formatReplayNode(&ReplayNode{
-		TS:           "2026-05-13T10:00:00Z",
-		OpID:         "x.y",
+	got := formatReplayNode(&api.ReplayNode{
+		Id:           mustUUID(t, "11111111-1111-1111-1111-111111111111"),
+		Ts:           mustTS(t, "2026-05-13T10:00:00Z"),
+		PrincipalSub: "damir",
+		Method:       "GET",
+		Path:         "/x",
+		StatusCode:   200,
+		OpId:         "x.y",
+		OpClass:      "read",
 		ResultStatus: "ok",
-		DurationMS:   nil,
+		DurationMs:   nil,
 	})
 	if !strings.Contains(got, "(-ms)") {
 		t.Errorf("null duration not rendered as dash: %q", got)
+	}
+}
+
+// TestCountDescendantsNilChildren pins the helper's nil-children
+// arm. The generated `ReplayNode.Children` is `*[]ReplayNode`; a
+// nil pointer must round-trip as zero descendants.
+func TestCountDescendantsNilChildren(t *testing.T) {
+	node := &api.ReplayNode{
+		Id: mustUUID(t, "11111111-1111-1111-1111-111111111111"),
+	}
+	if got := countDescendants(node); got != 0 {
+		t.Errorf("nil-children descendants: got %d; want 0", got)
 	}
 }
 

--- a/cli/internal/cmd/audit/show.go
+++ b/cli/internal/cmd/audit/show.go
@@ -11,8 +11,11 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -83,61 +86,105 @@ func runShow(cmd *cobra.Command, opts showOptions) error {
 			opts.JSONOut,
 		)
 	}
+	// The typed-client's `auditId` path parameter is
+	// `openapi_types.UUID`. Parse the operator string at the verb
+	// edge so a malformed argument surfaces as a clean
+	// output.Unexpected instead of either a server-side 422 after
+	// the round-trip or a panic on assignment to the typed param.
+	parsed, err := uuid.Parse(strings.TrimSpace(opts.AuditID))
+	if err != nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"audit-id is not a valid UUID: %s", opts.AuditID)),
+			opts.JSONOut,
+		)
+	}
+	auditID := openapi_types.UUID(parsed)
 	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	entry, err := getEntry(cmd.Context(), backplaneURL, opts.AuditID)
+	client, cerr := newAuthedClient(cmd.Context(), cmd, backplaneURL, opts.JSONOut)
+	if cerr != nil {
+		return cerr
+	}
+	rawBody, entry, err := getEntry(cmd.Context(), client, auditID)
 	if err != nil {
-		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+		return routeRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
 	if opts.JSONOut {
-		return output.PrintJSON(cmd.OutOrStdout(), entry)
+		// Emit server bytes verbatim so a payload integer above
+		// 2^53 survives without rounding through the generated
+		// `map[string]interface{}` decoder. The human summary path
+		// accepts the float64 conversion for the table view (a
+		// rounding loss only matters in the extreme-int edge case,
+		// and the --json contract is the precision-preserving one
+		// jq pipelines consume).
+		_, werr := cmd.OutOrStdout().Write(append(rawBody, '\n'))
+		return werr
+	}
+	if entry == nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("backplane returned 200 OK but no JSON body decoded against AuditEntry"),
+			opts.JSONOut,
+		)
 	}
 	printEntrySummary(cmd.OutOrStdout(), entry)
 	return nil
 }
 
-// buildShowPath assembles the GET path. Exposed for unit tests so
-// URL encoding of UUIDs with unusual rendering stays covered.
-func buildShowPath(auditID string) string {
-	return "/api/v1/audit/show/" + pathEscape(auditID)
-}
-
-func getEntry(ctx context.Context, backplaneURL, auditID string) (*Entry, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildShowPath(auditID), nil)
+// getEntry drives the typed-client `ShowApiV1AuditShowAuditIdGet`
+// endpoint with a one-shot 401-retry (mirrors `postQuery`). Returns
+// the raw body bytes (for --json verbatim passthrough) plus the
+// decoded `*api.AuditEntry` (for the key-value summary), or an
+// `*httpResponseError` for a non-2xx status.
+func getEntry(
+	ctx context.Context,
+	client *api.AuthedClient,
+	auditID openapi_types.UUID,
+) ([]byte, *api.AuditEntry, error) {
+	resp, err := client.ShowApiV1AuditShowAuditIdGetWithResponse(ctx, auditID, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	var out Entry
-	if err := decodeAuditResponse(raw, &out); err != nil {
-		return nil, err
+	if resp.StatusCode() == 401 {
+		if rerr := client.Refresh(ctx); rerr != nil {
+			return nil, nil, rerr
+		}
+		resp, err = client.ShowApiV1AuditShowAuditIdGetWithResponse(ctx, auditID, nil)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
-	return &out, nil
+	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
+		return nil, nil, &httpResponseError{statusCode: resp.StatusCode(), body: resp.Body}
+	}
+	return resp.Body, resp.JSON200, nil
 }
 
 // printEntrySummary renders the full audit row as a stable
 // key-value summary. Optional fields are shown as "-" when null so
 // the layout stays grep-able and predictable across rows.
-func printEntrySummary(w io.Writer, e *Entry) {
-	fmt.Fprintf(w, "%-18s %s\n", "id:", e.ID)
-	fmt.Fprintf(w, "%-18s %s\n", "ts:", e.TS)
-	fmt.Fprintf(w, "%-18s %s\n", "tenant_id:", strDerefOrDash(e.TenantID))
+func printEntrySummary(w io.Writer, e *api.AuditEntry) {
+	fmt.Fprintf(w, "%-18s %s\n", "id:", e.Id.String())
+	fmt.Fprintf(w, "%-18s %s\n", "ts:", formatTS(e.Ts))
+	fmt.Fprintf(w, "%-18s %s\n", "tenant_id:", strOrDash(uuidDeref(e.TenantId)))
 	fmt.Fprintf(w, "%-18s %s\n", "principal_sub:", e.PrincipalSub)
-	fmt.Fprintf(w, "%-18s %s\n", "principal_name:", strDerefOrDash(e.PrincipalName))
-	fmt.Fprintf(w, "%-18s %s\n", "target_id:", strDerefOrDash(e.TargetID))
-	fmt.Fprintf(w, "%-18s %s\n", "target_name:", strDerefOrDash(e.TargetName))
+	fmt.Fprintf(w, "%-18s %s\n", "principal_name:", strOrDash(strDeref(e.PrincipalName)))
+	fmt.Fprintf(w, "%-18s %s\n", "target_id:", strOrDash(uuidDeref(e.TargetId)))
+	fmt.Fprintf(w, "%-18s %s\n", "target_name:", strOrDash(strDeref(e.TargetName)))
 	fmt.Fprintf(w, "%-18s %s\n", "method:", e.Method)
 	fmt.Fprintf(w, "%-18s %s\n", "path:", e.Path)
 	fmt.Fprintf(w, "%-18s %d\n", "status_code:", e.StatusCode)
-	fmt.Fprintf(w, "%-18s %s\n", "request_id:", strDerefOrDash(e.RequestID))
-	fmt.Fprintf(w, "%-18s %s\n", "duration_ms:", strDerefOrDash(e.DurationMS))
-	fmt.Fprintf(w, "%-18s %s\n", "op_id:", e.OpID)
+	fmt.Fprintf(w, "%-18s %s\n", "request_id:", strOrDash(uuidDeref(e.RequestId)))
+	fmt.Fprintf(w, "%-18s %s\n", "duration_ms:", strOrDash(strDeref(e.DurationMs)))
+	fmt.Fprintf(w, "%-18s %s\n", "op_id:", e.OpId)
 	fmt.Fprintf(w, "%-18s %s\n", "op_class:", e.OpClass)
 	fmt.Fprintf(w, "%-18s %s\n", "result_status:", e.ResultStatus)
-	fmt.Fprintf(w, "%-18s %s\n", "parent_audit_id:", strDerefOrDash(e.ParentAuditID))
-	fmt.Fprintf(w, "%-18s %s\n", "agent_session_id:", strDerefOrDash(e.AgentSessionID))
-	fmt.Fprintf(w, "%-18s %s\n", "broadcast_event_id:", strDerefOrDash(e.BroadcastEventID))
+	fmt.Fprintf(w, "%-18s %s\n", "parent_audit_id:", strOrDash(uuidDeref(e.ParentAuditId)))
+	fmt.Fprintf(w, "%-18s %s\n", "agent_session_id:", strOrDash(uuidDeref(e.AgentSessionId)))
+	fmt.Fprintf(w, "%-18s %s\n", "broadcast_event_id:", strOrDash(uuidDeref(e.BroadcastEventId)))
 	if len(e.Payload) > 0 {
 		fmt.Fprintf(w, "%-18s %s\n", "payload:", formatPayload(e.Payload))
 	} else {
@@ -145,15 +192,14 @@ func printEntrySummary(w io.Writer, e *Entry) {
 	}
 }
 
-// strDerefOrDash returns *s, or "-" when s is nil / empty. Used by
-// the audit-row summary so absent optional fields stay grep-friendly
+// strOrDash returns "-" when s is empty, otherwise s. Used by the
+// audit-row summary so absent optional fields stay grep-friendly
 // rather than rendering as a blank cell.
-func strDerefOrDash(s *string) string {
-	v := strDeref(s)
-	if v == "" {
+func strOrDash(s string) string {
+	if s == "" {
 		return "-"
 	}
-	return v
+	return s
 }
 
 // formatPayload renders the audit payload as a sorted-key
@@ -176,12 +222,14 @@ func formatPayload(payload map[string]any) string {
 // print directly; objects/lists round-trip through json.Marshal so
 // at least the JSON form is readable on a single line.
 //
-// “json.Number“ is the load-bearing case: the package's decoder
-// uses “UseNumber()“ (see “decodeAuditResponse“) so payload
-// numbers survive as their exact decimal string rather than rounding
-// through float64. A 64-bit “hit_count“ like “1745923128091“ (a
-// Unix-millis timestamp) prints back identical to what the backend
-// wrote, where “float64(1745923128091)“ would round-trip lossily.
+// The generated client decodes payload fields as `interface{}` via
+// `json.Unmarshal`, which lands integer values as `float64`. The
+// helper folds the integer case (a float64 whose fractional part is
+// zero) back to a bare integer render so `hit_count=7` doesn't
+// surface as `hit_count=7.000000`. For the rare ≥2^53 integer the
+// rounding-through-float64 loss is real; operators who need
+// exact-precision payload bytes pipe through `--json`, which writes
+// the server bytes verbatim.
 func formatPayloadScalar(v any) string {
 	switch v := v.(type) {
 	case string:
@@ -189,10 +237,11 @@ func formatPayloadScalar(v any) string {
 	case bool:
 		return fmt.Sprintf("%t", v)
 	case json.Number:
+		// Test fixtures that explicitly construct entries with
+		// json.Number values exercise this arm; production calls
+		// land as float64 via the generated decoder.
 		return v.String()
 	case float64:
-		// Defensive fallback for code paths that bypass the
-		// UseNumber decoder (e.g. payloads constructed by tests).
 		if v == float64(int64(v)) {
 			return fmt.Sprintf("%d", int64(v))
 		}

--- a/cli/internal/cmd/audit/show_test.go
+++ b/cli/internal/cmd/audit/show_test.go
@@ -10,32 +10,31 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/evoila/meho/cli/internal/api"
 )
 
-// TestBuildShowPathEscapesUUID — UUIDs are URL-safe by spec, but
-// pathEscape is the cheap defence against a typo'd argument with a
-// slash / space leaking into the URL.
-func TestBuildShowPathEscapesUUID(t *testing.T) {
-	got := buildShowPath("00000000-0000-0000-0000-000000000001")
-	want := "/api/v1/audit/show/00000000-0000-0000-0000-000000000001"
-	if got != want {
-		t.Errorf("buildShowPath: got %q; want %q", got, want)
+// TestRunShowRejectsNonUUIDArg — UUID-at-the-edge: a non-UUID
+// argument is rejected client-side with a clear message, before any
+// network round-trip. The typed-client path parameter is
+// `openapi_types.UUID`; parsing here keeps the bad-input error a
+// clean output.Unexpected instead of a panic.
+func TestRunShowRejectsNonUUIDArg(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runShow(cmd, showOptions{AuditID: "not-a-uuid"})
+	if err == nil {
+		t.Fatalf("expected error for non-UUID audit-id")
 	}
-}
-
-// TestBuildShowPathHandlesSpecialChars — a typo'd argument with a
-// slash gets percent-encoded so the URL doesn't collapse the path
-// segment.
-func TestBuildShowPathHandlesSpecialChars(t *testing.T) {
-	got := buildShowPath("weird/value")
-	if !strings.Contains(got, "weird%2Fvalue") {
-		t.Errorf("buildShowPath did not URL-encode slash: %q", got)
+	if !strings.Contains(stderr.String(), "audit-id is not a valid UUID") {
+		t.Errorf("stderr missing UUID-rejection hint: %s", stderr.String())
 	}
 }
 
 // TestRunShowRequiresAuditIDArg — the empty-argument path goes
 // through the same renderError surface as a backplane refusal, so
-// operators see one consistent error class.
+// operators see one consistent error class. (Cobra's ExactArgs(1)
+// gate also catches this at parse time; this exercises the defence-
+// in-depth check inside runShow.)
 func TestRunShowRequiresAuditIDArg(t *testing.T) {
 	cmd, _, stderr := newRunCmd(t)
 	err := runShow(cmd, showOptions{AuditID: ""})
@@ -62,15 +61,15 @@ func TestRunShowHappyPath(t *testing.T) {
 		}
 		tname := "rdc-vcenter"
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(Entry{
-			ID:           "11111111-1111-1111-1111-111111111111",
-			TS:           "2026-05-13T15:42:11Z",
+		_ = json.NewEncoder(w).Encode(api.AuditEntry{
+			Id:           mustUUID(t, "11111111-1111-1111-1111-111111111111"),
+			Ts:           mustTS(t, "2026-05-13T15:42:11Z"),
 			PrincipalSub: "damir",
 			TargetName:   &tname,
 			Method:       "GET",
 			Path:         "/api/v1/vsphere/vm/list",
 			StatusCode:   200,
-			OpID:         "vsphere.vm.list",
+			OpId:         "vsphere.vm.list",
 			OpClass:      "read",
 			ResultStatus: "ok",
 			Payload:      map[string]any{"hit_count": float64(7)},
@@ -131,16 +130,18 @@ func TestRunShow404SurfacesNotFound(t *testing.T) {
 	}
 }
 
-// TestRunShow422SurfacesValidationDetail — a malformed UUID
-// argument is rejected by FastAPI's validation before reaching the
-// handler. The CLI passes the validation envelope through so the
-// operator sees what was malformed.
+// TestRunShow422SurfacesValidationDetail — a 422 from the server
+// (e.g. the route's downstream validator rejecting the body shape)
+// passes through with the "invalid request" prefix. (Note: a
+// malformed-UUID `<audit-id>` arg is now caught at the verb edge by
+// `uuid.Parse` so it never reaches the network; this test covers
+// the residual server-side 422 path.)
 func TestRunShow422SurfacesValidationDetail(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/audit/show/", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnprocessableEntity)
-		_, _ = w.Write([]byte(`{"detail":[{"loc":["path","audit_id"],"msg":"value is not a valid uuid"}]}`))
+		_, _ = w.Write([]byte(`{"detail":[{"loc":["body"],"msg":"value error"}]}`))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -148,7 +149,7 @@ func TestRunShow422SurfacesValidationDetail(t *testing.T) {
 
 	cmd, _, stderr := newRunCmd(t)
 	err := runShow(cmd, showOptions{
-		AuditID:           "not-a-uuid",
+		AuditID:           "11111111-1111-1111-1111-111111111111",
 		BackplaneOverride: srv.URL,
 	})
 	if err == nil {
@@ -159,19 +160,56 @@ func TestRunShow422SurfacesValidationDetail(t *testing.T) {
 	}
 }
 
-// TestPrintEntrySummaryShowsDashForNullFields — optional
-// fields render as "-" so the summary stays grep-friendly across
-// rows with different optional-field populations.
+// TestRunShowJSONVerbatim — --json emits the raw server bytes so a
+// payload integer above 2^53 (Unix-millis timestamps, hash blobs)
+// survives without rounding through the generated client's
+// `map[string]interface{}` decoder.
+func TestRunShowJSONVerbatim(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/audit/show/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Hand-encode so the integer isn't normalised through
+		// json.Marshal's float path.
+		_, _ = w.Write([]byte(`{"id":"11111111-1111-1111-1111-111111111111",` +
+			`"ts":"2026-05-13T15:42:11Z","tenant_id":null,"principal_sub":"damir",` +
+			`"principal_name":null,"target_id":null,"target_name":null,` +
+			`"method":"GET","path":"/x","status_code":200,"request_id":null,` +
+			`"duration_ms":null,"payload":{"hit_count":9007199254740993},` +
+			`"op_id":"x.y","op_class":"read","result_status":"ok",` +
+			`"parent_audit_id":null,"agent_session_id":null,` +
+			`"broadcast_event_id":null}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	err := runShow(cmd, showOptions{
+		AuditID:           "11111111-1111-1111-1111-111111111111",
+		JSONOut:           true,
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runShow --json: %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"hit_count":9007199254740993`) {
+		t.Errorf("integer precision lost in --json: %s", stdout.String())
+	}
+}
+
+// TestPrintEntrySummaryShowsDashForNullFields — optional fields
+// render as "-" so the summary stays grep-friendly across rows
+// with different optional-field populations.
 func TestPrintEntrySummaryShowsDashForNullFields(t *testing.T) {
 	var buf bytes.Buffer
-	printEntrySummary(&buf, &Entry{
-		ID:           "abc",
-		TS:           "2026-05-13T00:00:00Z",
+	printEntrySummary(&buf, &api.AuditEntry{
+		Id:           mustUUID(t, "11111111-1111-1111-1111-111111111111"),
+		Ts:           mustTS(t, "2026-05-13T00:00:00Z"),
 		PrincipalSub: "damir",
 		Method:       "GET",
 		Path:         "/x",
 		StatusCode:   200,
-		OpID:         "x.y",
+		OpId:         "x.y",
 		OpClass:      "read",
 		ResultStatus: "ok",
 		Payload:      map[string]any{},
@@ -195,6 +233,54 @@ func TestPrintEntrySummaryShowsDashForNullFields(t *testing.T) {
 	}
 }
 
+// TestPrintEntrySummaryRendersUUIDsAndOptionals — the populated-
+// field render path. UUIDs come back as canonical
+// lowercase-hyphenated strings; optional strings render verbatim.
+func TestPrintEntrySummaryRendersUUIDsAndOptionals(t *testing.T) {
+	var buf bytes.Buffer
+	pname := "Damir"
+	tname := "rdc-vcenter"
+	dur := "12.3"
+	printEntrySummary(&buf, &api.AuditEntry{
+		Id:               mustUUID(t, "11111111-1111-1111-1111-111111111111"),
+		Ts:               mustTS(t, "2026-05-13T00:00:00Z"),
+		TenantId:         mustUUIDPtr(t, "22222222-2222-2222-2222-222222222222"),
+		PrincipalSub:     "damir",
+		PrincipalName:    &pname,
+		TargetId:         mustUUIDPtr(t, "33333333-3333-3333-3333-333333333333"),
+		TargetName:       &tname,
+		Method:           "GET",
+		Path:             "/x",
+		StatusCode:       200,
+		RequestId:        mustUUIDPtr(t, "44444444-4444-4444-4444-444444444444"),
+		DurationMs:       &dur,
+		OpId:             "x.y",
+		OpClass:          "read",
+		ResultStatus:     "ok",
+		ParentAuditId:    mustUUIDPtr(t, "55555555-5555-5555-5555-555555555555"),
+		AgentSessionId:   mustUUIDPtr(t, "66666666-6666-6666-6666-666666666666"),
+		BroadcastEventId: mustUUIDPtr(t, "77777777-7777-7777-7777-777777777777"),
+		Payload:          map[string]any{"k": "v"},
+	})
+	out := buf.String()
+	for _, want := range []string{
+		"tenant_id:         22222222-2222-2222-2222-222222222222",
+		"principal_name:    Damir",
+		"target_id:         33333333-3333-3333-3333-333333333333",
+		"target_name:       rdc-vcenter",
+		"request_id:        44444444-4444-4444-4444-444444444444",
+		"duration_ms:       12.3",
+		"parent_audit_id:   55555555-5555-5555-5555-555555555555",
+		"agent_session_id:  66666666-6666-6666-6666-666666666666",
+		"broadcast_event_id: 77777777-7777-7777-7777-777777777777",
+		"payload:           k=v",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("summary missing %q in %s", want, out)
+		}
+	}
+}
+
 // TestFormatPayloadSortedKeys — payload renderer keys are sorted so
 // snapshot tests stay deterministic and operator diffs across runs
 // don't churn on map-iteration order.
@@ -210,5 +296,30 @@ func TestFormatPayloadSortedKeys(t *testing.T) {
 	}
 	if !strings.Contains(got, "midpoint=x") {
 		t.Errorf("formatPayload missing middle key: %s", got)
+	}
+}
+
+// TestFormatPayloadScalarFloat64IntegerRendersBare pins the
+// summary's payload-render contract: a float64 whose fractional
+// part is zero (the common shape audit payloads land as via the
+// generated client's `map[string]interface{}` decoder) renders as
+// a bare integer rather than `7.000000`. Exact-precision payload
+// bytes are preserved via `--json` (see show_test/query_test).
+func TestFormatPayloadScalarFloat64IntegerRendersBare(t *testing.T) {
+	if got := formatPayloadScalar(float64(7)); got != "7" {
+		t.Errorf("integer-valued float should render bare; got %q", got)
+	}
+	if got := formatPayloadScalar(0.5); got != "0.5" {
+		t.Errorf("fractional float: got %q", got)
+	}
+}
+
+// TestFormatPayloadScalarJSONNumberRendersExact — `json.Number`
+// values (from test fixtures that explicitly use UseNumber()) keep
+// their exact decimal representation.
+func TestFormatPayloadScalarJSONNumberRendersExact(t *testing.T) {
+	n := json.Number("9007199254740993")
+	if got := formatPayloadScalar(n); got != "9007199254740993" {
+		t.Errorf("json.Number precision lost; got %q", got)
 	}
 }

--- a/cli/internal/cmd/audit/who_touched.go
+++ b/cli/internal/cmd/audit/who_touched.go
@@ -6,11 +6,10 @@ package audit
 import (
 	"context"
 	"fmt"
-	"net/url"
-	"strconv"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -47,7 +46,7 @@ func newWhoTouchedCmd() *cobra.Command {
 			"24h; pass a different shorthand (7d / 30m / 2w) or an " +
 			"ISO-8601 datetime to widen the window. --limit caps the " +
 			"page size (1..1000, server default 100). --json emits the " +
-			"raw QueryResult.",
+			"raw AuditQueryResult.",
 		Args:          cobra.ExactArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -66,7 +65,7 @@ func newWhoTouchedCmd() *cobra.Command {
 	cmd.Flags().IntVar(&limit, "limit", 0,
 		"max rows (1..1000, server default 100 when omitted)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
-		"emit raw QueryResult JSON instead of the human table")
+		"emit raw AuditQueryResult JSON instead of the human table")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
 	return cmd
@@ -99,48 +98,71 @@ func runWhoTouched(cmd *cobra.Command, opts whoTouchedOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	result, err := getWhoTouched(cmd.Context(), backplaneURL, opts)
+	client, cerr := newAuthedClient(cmd.Context(), cmd, backplaneURL, opts.JSONOut)
+	if cerr != nil {
+		return cerr
+	}
+	rawBody, result, err := getWhoTouched(cmd.Context(), client, opts)
 	if err != nil {
-		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+		return routeRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
 	if opts.JSONOut {
-		return output.PrintJSON(cmd.OutOrStdout(), result)
+		_, werr := cmd.OutOrStdout().Write(append(rawBody, '\n'))
+		return werr
+	}
+	if result == nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected("backplane returned 200 OK but no JSON body decoded against AuditQueryResult"),
+			opts.JSONOut,
+		)
 	}
 	printQueryTable(cmd.OutOrStdout(), result)
 	return nil
 }
 
-// buildWhoTouchedPath assembles the GET path with query params. Only
-// emits the query params the operator set so the backend's own
-// defaults (since=24h, limit=100) take over otherwise. Exposed for
-// unit tests so the URL encoding of names with special characters
-// stays covered.
-func buildWhoTouchedPath(target string, since string, limit int) string {
-	q := url.Values{}
-	if since != "" {
-		q.Set("since", since)
+// buildWhoTouchedParams assembles the typed-client params struct
+// from the per-call options. The target name passes as the typed
+// path parameter on the call site; only the query-string params
+// `since` / `limit` land on this struct.
+func buildWhoTouchedParams(opts whoTouchedOptions) *api.WhoTouchedApiV1AuditWhoTouchedTargetGetParams {
+	params := &api.WhoTouchedApiV1AuditWhoTouchedTargetGetParams{}
+	if opts.Since != "" {
+		v := opts.Since
+		params.Since = &v
 	}
-	if limit > 0 {
-		q.Set("limit", strconv.Itoa(limit))
+	if opts.Limit > 0 {
+		l := opts.Limit
+		params.Limit = &l
 	}
-	path := "/api/v1/audit/who-touched/" + pathEscape(target)
-	if encoded := q.Encode(); encoded != "" {
-		path = path + "?" + encoded
-	}
-	return path
+	return params
 }
 
-func getWhoTouched(ctx context.Context, backplaneURL string, opts whoTouchedOptions) (*QueryResult, error) {
-	raw, err := doAuthedRequest(
-		ctx, backplaneURL, "GET",
-		buildWhoTouchedPath(opts.Target, opts.Since, opts.Limit), nil,
-	)
+// getWhoTouched drives the typed-client
+// `WhoTouchedApiV1AuditWhoTouchedTargetGet` endpoint with the same
+// one-shot 401-retry shape `postQuery` uses. The `target` argument
+// passes as the typed path parameter — the generated request
+// builder URL-encodes the segment.
+func getWhoTouched(
+	ctx context.Context,
+	client *api.AuthedClient,
+	opts whoTouchedOptions,
+) ([]byte, *api.AuditQueryResult, error) {
+	params := buildWhoTouchedParams(opts)
+	resp, err := client.WhoTouchedApiV1AuditWhoTouchedTargetGetWithResponse(ctx, opts.Target, params)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	var out QueryResult
-	if err := decodeAuditResponse(raw, &out); err != nil {
-		return nil, err
+	if resp.StatusCode() == 401 {
+		if rerr := client.Refresh(ctx); rerr != nil {
+			return nil, nil, rerr
+		}
+		resp, err = client.WhoTouchedApiV1AuditWhoTouchedTargetGetWithResponse(ctx, opts.Target, params)
+		if err != nil {
+			return nil, nil, err
+		}
 	}
-	return &out, nil
+	if resp.StatusCode() < 200 || resp.StatusCode() >= 300 {
+		return nil, nil, &httpResponseError{statusCode: resp.StatusCode(), body: resp.Body}
+	}
+	return resp.Body, resp.JSON200, nil
 }

--- a/cli/internal/cmd/audit/who_touched_test.go
+++ b/cli/internal/cmd/audit/who_touched_test.go
@@ -9,56 +9,39 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/evoila/meho/cli/internal/api"
 )
 
-// TestBuildWhoTouchedPathOmitsEmptyParams — the no-flag form sends a
-// bare path so the backend's defaults (since=24h, limit=100) take
-// over.
-func TestBuildWhoTouchedPathOmitsEmptyParams(t *testing.T) {
-	got := buildWhoTouchedPath("rdc-vcenter", "", 0)
-	if got != "/api/v1/audit/who-touched/rdc-vcenter" {
-		t.Errorf("buildWhoTouchedPath empty: got %q", got)
+// TestBuildWhoTouchedParamsOmitsEmptyParams — the no-flag form
+// leaves every pointer field nil so the query-string builder emits
+// no `since` / `limit` keys and the backend's defaults take over.
+func TestBuildWhoTouchedParamsOmitsEmptyParams(t *testing.T) {
+	p := buildWhoTouchedParams(whoTouchedOptions{})
+	if p.Since != nil {
+		t.Errorf("Since should be nil; got %v", *p.Since)
+	}
+	if p.Limit != nil {
+		t.Errorf("Limit should be nil; got %v", *p.Limit)
 	}
 }
 
-// TestBuildWhoTouchedPathEmitsParams — every set flag lands on the
-// wire as a query string param.
-func TestBuildWhoTouchedPathEmitsParams(t *testing.T) {
-	got := buildWhoTouchedPath("rdc-vcenter", "7d", 50)
-	if !strings.Contains(got, "since=7d") {
-		t.Errorf("missing since: %q", got)
+// TestBuildWhoTouchedParamsEmitsParams — every set flag lands on the
+// params struct with the correct value.
+func TestBuildWhoTouchedParamsEmitsParams(t *testing.T) {
+	p := buildWhoTouchedParams(whoTouchedOptions{Since: "7d", Limit: 50})
+	if p.Since == nil || *p.Since != "7d" {
+		t.Errorf("Since: got %v; want 7d", p.Since)
 	}
-	if !strings.Contains(got, "limit=50") {
-		t.Errorf("missing limit: %q", got)
-	}
-}
-
-// TestBuildWhoTouchedPathEscapesTarget — a target name with a slash
-// (operator typo) doesn't collapse the URL path.
-func TestBuildWhoTouchedPathEscapesTarget(t *testing.T) {
-	got := buildWhoTouchedPath("foo/bar", "", 0)
-	if !strings.Contains(got, "foo%2Fbar") {
-		t.Errorf("buildWhoTouchedPath did not URL-encode slash: %q", got)
-	}
-}
-
-// TestRunWhoTouchedRequiresTarget — the cobra `ExactArgs(1)` gate
-// already catches missing args at the parser level; this exercises
-// the defence-in-depth path inside runWhoTouched.
-func TestRunWhoTouchedRequiresTarget(t *testing.T) {
-	cmd, _, stderr := newRunCmd(t)
-	err := runWhoTouched(cmd, whoTouchedOptions{Target: ""})
-	if err == nil {
-		t.Fatalf("expected error for empty target")
-	}
-	if !strings.Contains(stderr.String(), "non-empty <target>") {
-		t.Errorf("stderr missing target-required hint: %s", stderr.String())
+	if p.Limit == nil || *p.Limit != 50 {
+		t.Errorf("Limit: got %v; want 50", p.Limit)
 	}
 }
 
 // TestRunWhoTouchedHappyPath — the verb hits GET /api/v1/audit/who-
-// touched/{target} and renders the rows using the same table the
-// query verb emits.
+// touched/{target} with the typed path parameter, sends the query-
+// string params on the wire, and renders the response with the same
+// table the query verb emits.
 func TestRunWhoTouchedHappyPath(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/audit/who-touched/rdc-vcenter", func(w http.ResponseWriter, r *http.Request) {
@@ -70,16 +53,16 @@ func TestRunWhoTouchedHappyPath(t *testing.T) {
 		}
 		tname := "rdc-vcenter"
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(QueryResult{
-			Rows: []Entry{{
-				ID:           "00000000-0000-0000-0000-000000000001",
-				TS:           "2026-05-12T12:00:00Z",
+		_ = json.NewEncoder(w).Encode(api.AuditQueryResult{
+			Rows: []api.AuditEntry{{
+				Id:           mustUUID(t, "00000000-0000-0000-0000-000000000001"),
+				Ts:           mustTS(t, "2026-05-12T12:00:00Z"),
 				PrincipalSub: "tarik",
 				TargetName:   &tname,
 				Method:       "POST",
 				Path:         "/api/v1/vsphere/nsx/firewall/update",
 				StatusCode:   200,
-				OpID:         "nsx.firewall.update",
+				OpId:         "nsx.firewall.update",
 				OpClass:      "write",
 				ResultStatus: "ok",
 				Payload:      map[string]any{},
@@ -107,9 +90,50 @@ func TestRunWhoTouchedHappyPath(t *testing.T) {
 	}
 }
 
-// TestRunWhoTouchedJSONRoundTrips — --json emits the same wire shape
-// the substrate returns; pinning the key set keeps jq pipelines
-// stable.
+// TestRunWhoTouchedEscapesTargetInPath — a target name with a slash
+// is URL-encoded by the generated request builder so the path
+// doesn't collapse.
+func TestRunWhoTouchedEscapesTargetInPath(t *testing.T) {
+	var seenPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.EscapedPath()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"rows":[],"next_cursor":null}`))
+	}))
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runWhoTouched(cmd, whoTouchedOptions{
+		Target:            "foo/bar",
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runWhoTouched: %v; stderr=%s", err, stderr.String())
+	}
+	// The slash must appear as %2F in the wire path; otherwise the
+	// HTTP router would split it into a different sub-path.
+	if !strings.Contains(seenPath, "foo%2Fbar") {
+		t.Errorf("target slash not percent-encoded in wire path: %q", seenPath)
+	}
+}
+
+// TestRunWhoTouchedRequiresTarget — the cobra `ExactArgs(1)` gate
+// already catches missing args at the parser level; this exercises
+// the defence-in-depth path inside runWhoTouched.
+func TestRunWhoTouchedRequiresTarget(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runWhoTouched(cmd, whoTouchedOptions{Target: ""})
+	if err == nil {
+		t.Fatalf("expected error for empty target")
+	}
+	if !strings.Contains(stderr.String(), "non-empty <target>") {
+		t.Errorf("stderr missing target-required hint: %s", stderr.String())
+	}
+}
+
+// TestRunWhoTouchedJSONRoundTrips — --json emits the raw server
+// bytes; pinning the key set keeps jq pipelines stable.
 func TestRunWhoTouchedJSONRoundTrips(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/audit/who-touched/rdc-vcenter", func(w http.ResponseWriter, _ *http.Request) {
@@ -129,7 +153,7 @@ func TestRunWhoTouchedJSONRoundTrips(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runWhoTouched --json: %v", err)
 	}
-	var decoded QueryResult
+	var decoded api.AuditQueryResult
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout.String())
 	}

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -119,7 +119,7 @@ cli/
     │   ├── status.go          # `meho status` subcommand + --json + URL resolver.
     │   ├── status_test.go     # happy/JSON/no-creds/unreachable/401/redaction tests.
     │   ├── audit/            # G8.1-T3 #467 — `meho audit …` verb tree.
-    │   │   ├── audit.go          # NewRootCmd + shared HTTP/auth helpers.
+    │   │   ├── audit.go          # NewRootCmd + shared typed-client helpers (G0.12-T5 #1263).
     │   │   ├── query.go          # `meho audit query` (POST /api/v1/audit/query).
     │   │   ├── recent.go         # `meho audit recent` — shortcut for `query --since 24h`.
     │   │   ├── show.go           # `meho audit show <audit-id>` (GET /api/v1/audit/show/{id}).


### PR DESCRIPTION
## Summary

- Fifth migration under Initiative #1118 (G0.12 CLI hygiene). Drops the `meho audit ...` package off hand-rolled HTTP + consumer-side struct duplicates and onto the generated typed client (`api.ClientWithResponses` via the embedded `api.AuthedClient`) — mirrors the canonical pattern G0.12-T1 #1276 set.
- Deletes `Entry`, `QueryResult`, `ReplayNode`, `ReplayResult`, `auditQueryRequest`, and the local `doAuthedRequest` / `sendRequest` / `httpError` / `responseBodyCap` machinery (786 LOC of pre-existing duplicate transport + types). Renderers consume `api.AuditEntry` / `api.AuditQueryResult` / `api.AuditReplayResult` / `api.ReplayNode` directly; the `cli-api-snapshot-freshness` gate now covers them, so the silent-drift class Initiative #1118 cites (e.g. PR #1069) can't recur here.
- Every verb (`query`, `recent`, `show`, `who-touched`, `my-recent`, `replay`) now drives the typed `*WithResponse` methods with a one-shot 401-retry around `api.AuthedClient.Refresh` — same shape as the approvals migration.
- Hoists `<audit-id>` / `<session-id>` / `--audit-id` / `--parent-audit-id` / `--session-id` UUID validation to the verb edge via `uuid.Parse`. Bad input surfaces a clean `output.Unexpected("...is not a valid UUID")` instead of a server-side 422 after the round-trip.
- Preserves audit-specific error mapping byte-for-byte: 400 → parser-error detail (DurationParseError, InvalidCursorError, UnsupportedFilterError), 404 → "audit row not found" (cross-tenant probe stays indistinguishable from a real miss), 413 → session-too-large redirect with row count + `meho audit query --session-id <id>` pointer (replay verb only; defensive fallback elsewhere), 422 → "invalid request" prefix, plus the 401/403 categories.
- `--json` mode for every verb writes the server bytes verbatim (mirrors `replay.go`'s existing pattern). Preserves exact integer precision for payload integers above 2^53 (Unix-millis, large-cardinality counts) that a typed-decode pass would round through `float64` — the precision-preservation contract the operator-side `jq` pipelines depend on.
- Reworks the seven `_test.go` files (audit / query / show / replay / recent / who-touched / my-recent) to drive the typed-client surface via `httptest.Server`. Fixtures construct `api.AuditEntry` / `api.AuditQueryResult` / `api.ReplayNode` directly so an OpenAPI rename is caught at unit-time. Adds precision-preservation tests on the `--json` passthrough for both `query` and `show`.

## Test plan

- [x] `cd cli && go build ./...` — clean
- [x] `cd cli && go vet ./...` — clean
- [x] `cd cli && go test ./internal/cmd/audit/...` — pass (56+ tests, 0.03s)
- [x] `cd cli && go test ./...` — every package in the CLI module passes
- [x] `cd cli && grep -rn "http.NewRequest\|doAuthedRequest\|^type Entry \|^type QueryResult \|^type ReplayNode \|^type ReplayResult " internal/cmd/audit/` — zero matches (acceptance criterion 1)
- [x] `cd cli && grep -rn "api.ClientWithResponses\|api.AuditEntry\|WhoTouchedApiV1AuditWhoTouchedTargetGetWithResponse" internal/cmd/audit/` — matches in audit.go / query.go / show.go / replay.go / my_recent.go / who_touched.go / the seven test files (acceptance criterion 2)
- [x] `cd cli && make generate` — no-op (`git diff cli/internal/api/` is empty after re-running the generator)
- [x] No backend changes; `git status` outside `cli/internal/cmd/audit/` is the single in-scope `docs/codebase/cli.md` line update (acceptance criteria 5 + 7)
- [ ] Manual smoke against a running backplane (`meho audit query / show / replay / recent / my-recent / who-touched`) — deferred to CI / the post-merge smoke pass. The httptest-mocked unit tests cover the wire shape + error mapping the acceptance criterion 6 asks for; the freshness gate covers the schema contract.

## Out of scope

- The FastAPI audit surface — server stays exactly as it is (acceptance criterion 7).
- CLI verb signature changes (flag rename, output reformat, exit-code reshuffle). The migration is implementation-only.
- The other CLI verb directories listed under Initiative #1118 — each is its own G0.12-T<N> Task.
- Promoting a shared transport helper across the verb trees — G0.12-T16 #1274 territory.

## Adjacent findings (recorded; no follow-up filed by this PR)

- The pre-migration `audit.go` carried a defensive 1 MiB `responseBodyCap` on the local `doAuthedRequest` helper, paired with a `+1`-byte read to distinguish "fits cap" from "spilled past cap". The generated client uses unbounded `io.ReadAll(rsp.Body)`. Audit pages cap server-side at 1000 rows so the practical bound is unchanged; this matches the cap-removal trade-off the approvals (#1276) / operation (#1275) / agent (#1277) migrations already made. Worth a one-shot audit if any of the typed routes turn out to emit unbounded response bodies under degraded conditions.
- The human-rendered key-value summary (`show`) and table (`query` / `recent` / `who-touched` / `my-recent`) lose exact precision on payload integers ≥ 2^53 because the generated decoder lands `interface{}` values as `float64`. Operators who need exact-precision payload bytes pipe through `--json` (which writes the server bytes verbatim). The pre-migration `decodeAuditResponse` used `UseNumber()` and preserved precision in both render paths; this PR drops the human-render precision in exchange for the typed-decode benefit. Acceptable per Initiative #1118 (single-direction migration; the precision contract operator pipelines rely on stays exact via `--json`).

Closes #1263
