### PR TITLE
refactor(cli): G0.12-T8 migrate cmd/conventions/ to typed client (#1266)

### DIFF
--- a/cli/internal/cmd/conventions/conventions.go
+++ b/cli/internal/cmd/conventions/conventions.go
@@ -32,16 +32,33 @@
 // `meho audit`. The backend writes the audit_log row keyed by op_id
 // (`conventions.<verb>`); the CLI just calls the route.
 //
-// The implementation deliberately follows the in-package HTTP helper
-// pattern the sibling verb trees use (a local doAuthedRequest /
-// renderRequestError pair) rather than a shared client package, for the
-// import-cycle reason every sibling cites: each verb tree is grafted
-// onto the root command, so a shared helper imported from cmd/* and
-// from a per-tree package would close the cycle.
+// G0.12-T8 #1266 migrated this package off the sibling-verb pattern of
+// hand-rolled HTTP + hand-typed copies of backend pydantic models.
+// Every verb here drives the generated `api.ClientWithResponses`
+// surface directly: `api.NewAuthedClient` wires the bearer + lazy
+// 401-refresh editor onto the embedded `ClientWithResponses`, and
+// the verbs call the typed client methods (`ListConventionsApiV1ConventionsGet`
+// etc.) that own URL building, header injection, and request body
+// encoding from the generated query-param / body types
+// (`api.ConventionCreate`, `api.ConventionUpdate`,
+// `api.ListConventionsApiV1ConventionsGetParams`). Consumer-side
+// struct drift — the #1069 root cause Initiative #1118 targets —
+// can't recur because we now consume `api.Convention`,
+// `api.ConventionSummary`, `api.ConventionListResponse`,
+// `api.ConventionHistoryEntry`, `api.BudgetStatus` directly.
+//
+// We deliberately bind to the lower-level non-`*WithResponse` methods
+// (each returns `*http.Response`, not the typed `*<Op>Response`
+// envelope) so the generated parser's HTTPValidationError-only 422
+// unmarshal doesn't swallow the over-budget string-detail 422 the
+// conventions surface emits (G7.1-T7 #1094). The shared `doRequest`
+// helper reads the body once into a `rawResponse` (status + bytes)
+// and the verbs unmarshal 2xx payloads themselves; non-2xx flows
+// through `renderHTTPStatus` uniformly regardless of whether the body
+// matches the OpenAPI spec's declared error shape.
 package conventions
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -86,121 +103,133 @@ func NewRootCmd() *cobra.Command {
 	return cmd
 }
 
-// Convention mirrors the backend Convention pydantic model
-// (`backend/src/meho_backplane/api/v1/conventions.py`). Hand-written
-// rather than aliased to the generated oapi-codegen client type so the
-// conventions package stays decoupled from generator churn — the kb /
-// agent / audit packages take the same stance. `CreatedBySub` is a
-// pointer because the seed migration (T5) inserts rows with no
-// authenticated principal (the seed pre-dates any HTTP request).
-type Convention struct {
-	ID           string  `json:"id"`
-	TenantID     string  `json:"tenant_id"`
-	Slug         string  `json:"slug"`
-	Title        string  `json:"title"`
-	Body         string  `json:"body"`
-	Kind         string  `json:"kind"`
-	Priority     int     `json:"priority"`
-	CreatedBySub *string `json:"created_by_sub"`
-	CreatedAt    string  `json:"created_at"`
-	UpdatedAt    string  `json:"updated_at"`
-}
-
-// Summary mirrors the backend ConventionSummary pydantic model — the
-// lighter list-row shape returned by GET /api/v1/conventions. Omits the
-// full `body` so a list of 20 conventions doesn't materialise 20 KB of
-// rule text on every list call.
-type Summary struct {
-	ID           string  `json:"id"`
-	TenantID     string  `json:"tenant_id"`
-	Slug         string  `json:"slug"`
-	Title        string  `json:"title"`
-	Kind         string  `json:"kind"`
-	Priority     int     `json:"priority"`
-	CreatedBySub *string `json:"created_by_sub"`
-	CreatedAt    string  `json:"created_at"`
-	UpdatedAt    string  `json:"updated_at"`
-}
-
-// BudgetStatus mirrors the backend BudgetStatus pydantic model — the
-// preamble budget arithmetic the GET /api/v1/conventions list response
-// surfaces on every call (T7 #1094). MaxTokens is the budget the
-// preamble assembler enforces; EstimatedTokens is the actual weight of
-// the assembled preamble text; OverBudget is True iff DroppedSlugs is
-// non-empty; DroppedSlugs lists the slugs the packer omitted, in
-// lowest-priority-first drop order.
-//
-// The list verb consults DroppedSlugs: when non-empty (and not in --json
-// mode), it prints a stderr warning naming the dropped slugs and exits
-// with code 5 (insufficient_budget). --json mode emits the full envelope
-// and exits 0 — JSON consumers parse the field themselves.
-type BudgetStatus struct {
-	MaxTokens       int      `json:"max_tokens"`
-	EstimatedTokens int      `json:"estimated_tokens"`
-	OverBudget      bool     `json:"over_budget"`
-	DroppedSlugs    []string `json:"dropped_slugs"`
-}
-
-// ListResponse mirrors the backend ConventionListResponse envelope —
-// wrapped in `{"entries": [...]}` for forward-compat with future paging
-// fields. Same shape kb / agent adopted.
-//
-// BudgetStatus (T7 #1094) is always populated; the backend computes it
-// from the tenant's full operational-conventions set on every list
-// call. The --kind query filter narrows Entries only; BudgetStatus
-// always reflects the full operational set so an operator scoping
-// the list by kind cannot mask an over-budget tenant.
-type ListResponse struct {
-	Entries      []Summary    `json:"entries"`
-	BudgetStatus BudgetStatus `json:"budget_status"`
-}
-
-// HistoryEntry mirrors the backend ConventionHistoryEntry pydantic
-// model. `BodyBefore` is a pointer because the first history row (the
-// CREATE event) has no prior state; `AuditID` is a pointer because the
-// T5 seed migration inserts history rows with no audit_log row.
-type HistoryEntry struct {
-	ID           string  `json:"id"`
-	ConventionID string  `json:"convention_id"`
-	BodyBefore   *string `json:"body_before"`
-	BodyAfter    string  `json:"body_after"`
-	ActorSub     string  `json:"actor_sub"`
-	AuditID      *string `json:"audit_id"`
-	Ts           string  `json:"ts"`
-}
-
 // validKinds mirrors the backend ConventionKind enum. CLI-side
 // validation gives the operator an immediate rejection rather than a
 // remote 422.
 var validKinds = map[string]bool{"operational": true, "workflow": true, "reference": true}
 
-// errMissingAccessToken is the sentinel doAuthedRequest returns when
+// errMissingAccessToken is the sentinel newAuthedClient returns when
 // the stored token row exists but its access_token is empty — a
-// credential-state failure that renderRequestError maps to
-// auth_expired with a `meho login` hint. Mirrors the kb / agent shape.
+// credential-state failure renderRequestError maps to auth_expired
+// with a `meho login` hint. Mirrors the agent-principal / approvals
+// packages' shape so an operator sees the same hint across every verb
+// tree.
 var errMissingAccessToken = errors.New("meho: stored token has no access_token")
 
-// renderRequestError translates a request error into the right
-// output.StructuredError category. Maps the conventions REST surface's
-// status codes:
+// newAuthedClient builds an api.AuthedClient for the supplied
+// backplane URL and verifies a non-empty bearer is loaded. Centralised
+// so every verb's typed-call path goes through the same
+// "stored-token-loaded + non-empty bearer" gate; the caller forwards
+// any returned error to renderRequestError for category mapping.
+func newAuthedClient(ctx context.Context, backplaneURL string) (*api.AuthedClient, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if authed.AccessToken() == "" {
+		return nil, errMissingAccessToken
+	}
+	return authed, nil
+}
+
+// rawResponse is the (status, body) pair the verbs operate on after a
+// successful HTTP round-trip. We bind to `*http.Response` rather than
+// the generated `*WithResponse` envelope because the conventions
+// surface emits two distinct 422 shapes (string detail for the
+// over-budget gate; list detail for pydantic validation), only one of
+// which matches the OpenAPI spec's HTTPValidationError. The generated
+// parser surfaces a json.Unmarshal error on the unspec'd shape and
+// drops the response on the floor — costing us the status + body
+// we need to render the right error category. Reading the body
+// ourselves bypasses that limitation while keeping every URL / query
+// / body shape in lock-step with the generated client (the typed
+// non-WithResponse methods own URL building, header injection, and
+// request encoding).
+type rawResponse struct {
+	StatusCode int
+	Body       []byte
+}
+
+// readAllBody drains rsp.Body up to the responseBodyCap, closing the
+// body before returning. Splitting this out keeps each verb's call
+// site to a single line and makes the cap auditable in one place.
+func readAllBody(rsp *http.Response) ([]byte, error) {
+	defer rsp.Body.Close() //nolint:errcheck
+	raw, err := io.ReadAll(io.LimitReader(rsp.Body, responseBodyCap+1))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+	if int64(len(raw)) > responseBodyCap {
+		return nil, fmt.Errorf(
+			"response body exceeds %d-byte cap; refusing to decode possibly-truncated JSON",
+			responseBodyCap,
+		)
+	}
+	return raw, nil
+}
+
+// responseBodyCap bounds the response body the CLI will read. A
+// convention body is a Markdown rule (the operational kind is hard-
+// capped at the preamble token budget, ~3 KB; workflow / reference can
+// be larger but ~50 KB is realistic). 1 MiB is comfortable headroom
+// and protects against an adversarial / misconfigured backplane sending
+// an unbounded response.
+const responseBodyCap int64 = 1 << 20
+
+// doRequest invokes call once and, if the resulting response status
+// is 401, runs a one-shot bearer refresh + re-issues call. Mirrors
+// the behaviour `api.AuthedClient.GetHealth` implements for
+// /api/v1/health, generalised so every conventions verb runs the same
+// transparent-retry contract. Returns the drained (status, body) pair
+// on the final response.
+//
+// The conventions package binds to the lower-level non-WithResponse
+// client methods (each returns *http.Response, not the
+// `*<Op>Response` envelope) so the generated parser's
+// HTTPValidationError-only 422 unmarshal doesn't swallow the
+// over-budget string-detail 422 the conventions surface emits.
+// Reading the body via readAllBody lets renderHTTPStatus classify
+// every non-2xx uniformly off the (status, body) pair, regardless of
+// whether the body matches the OpenAPI spec's 422 shape.
+func doRequest(
+	ctx context.Context,
+	authed *api.AuthedClient,
+	call func(ctx context.Context) (*http.Response, error),
+) (*rawResponse, error) {
+	rsp, err := call(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if rsp.StatusCode == http.StatusUnauthorized {
+		// Drain + close before re-issuing so the underlying transport
+		// can reuse the connection.
+		_, _ = io.Copy(io.Discard, rsp.Body)
+		rsp.Body.Close() //nolint:errcheck
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			return nil, rerr
+		}
+		rsp, err = call(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+	raw, err := readAllBody(rsp)
+	if err != nil {
+		return nil, err
+	}
+	return &rawResponse{StatusCode: rsp.StatusCode, Body: raw}, nil
+}
+
+// renderRequestError translates a transport-layer request error into
+// the right output.StructuredError category. Maps the conventions REST
+// surface's pre-response failures: missing bearer, no-refresh-token,
+// token-not-found, plus the generic transport-down case. Non-2xx
+// status codes carried in a typed response envelope are classified by
+// renderHTTPStatus instead.
 //
 //   - empty stored bearer → auth_expired.
-//   - 401 (refresh failed) → auth_expired with a `meho login` hint.
-//   - 403 → insufficient_role (the backend's detail names the required
-//     role, typically "tenant_admin required" on write verbs).
-//   - 404 → unexpected with the backend's detail (`convention_not_found`;
-//     cross-tenant probes land here per the no-existence-leak posture).
-//   - 409 → unexpected with the duplicate detail
-//     (`convention_already_exists` on create with a slug that already
-//     exists in the same tenant).
-//   - 422 → unexpected with the validation envelope. The conventions
-//     route has a domain-specific 422 the others don't: the over-budget
-//     gate, raised when an `operational` body exceeds the preamble
-//     token budget. The detail string is human-friendly verbatim
-//     ("convention body exceeds preamble budget (estimated=X,
-//     budget=Y)"); surface it as-is so the operator sees exactly how
-//     many tokens over they are.
-//   - Other 4xx/5xx → unexpected with the raw body.
+//   - `meho login` not yet run → auth_expired with the file-store hint.
+//   - 401 after a failed refresh (no refresh_token) → auth_expired.
 //   - Pure transport errors → unreachable.
 func renderRequestError(
 	cmd *cobra.Command,
@@ -235,25 +264,48 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
-		return renderHTTPError(cmd, backplaneURL, he, jsonOut)
-	}
 	return output.RenderError(cmd.ErrOrStderr(),
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
 }
 
-// renderHTTPError classifies a non-2xx response into the right
-// StructuredError category.
-func renderHTTPError(
+// renderHTTPStatus classifies a non-2xx response (or 401 after a
+// failed refresh) carried in the typed envelope into the right
+// StructuredError category. Mirrors the pre-migration `httpError`
+// switch but acts on the (statusCode, body) pair lifted off the
+// generated `*Response.HTTPResponse` + `Body` fields rather than a
+// sentinel value.
+//
+// The mapping preserved across the migration:
+//
+//   - 401 → auth_expired (refresh impossible / token rejected).
+//   - 403 → insufficient_role with the backend's detail string.
+//   - 404 → unexpected with the backend's detail
+//     (convention_not_found; cross-tenant probes land here per the
+//     no-existence-leak posture).
+//   - 409 → unexpected with the backend's detail
+//     (convention_already_exists on create with a slug that already
+//     exists in the same tenant).
+//   - 422 → unexpected, prefixed with "invalid request: ". The
+//     conventions surface emits two distinct 422s: pydantic
+//     validation envelopes (`{"detail":[{...}]}`) on malformed
+//     input, and the over-budget gate string detail when an
+//     `operational` body exceeds DEFAULT_MAX_PREAMBLE_TOKENS.
+//     decodeDetailString returns the string detail verbatim for
+//     the budget gate; the validation envelope falls through to
+//     the raw body. Both surface as unexpected so callers can branch
+//     on exit code 4.
+//   - Other non-2xx → unexpected with the raw body.
+func renderHTTPStatus(
 	cmd *cobra.Command,
 	backplaneURL string,
-	he *httpError,
+	statusCode int,
+	body []byte,
 	jsonOut bool,
 ) error {
-	switch he.StatusCode {
+	bodyStr := strings.TrimSpace(string(body))
+	switch statusCode {
 	case http.StatusUnauthorized:
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.AuthExpired(fmt.Sprintf(
@@ -264,7 +316,7 @@ func renderHTTPError(
 		)
 	case http.StatusForbidden:
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.InsufficientRole(decodeDetailString(he.Body)),
+			output.InsufficientRole(decodeDetailString(bodyStr)),
 			jsonOut,
 		)
 	case http.StatusNotFound:
@@ -276,53 +328,45 @@ func renderHTTPError(
 		// doesn't exist on this backplane — typically an older deploy
 		// without T2.
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(decodeDetailString(he.Body)),
+			output.Unexpected(decodeDetailString(bodyStr)),
 			jsonOut,
 		)
 	case http.StatusConflict:
 		// `create` with a slug that already exists in the same tenant
 		// surfaces here (`convention_already_exists`).
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(decodeDetailString(he.Body)),
+			output.Unexpected(decodeDetailString(bodyStr)),
 			jsonOut,
 		)
 	case http.StatusUnprocessableEntity:
-		// The conventions surface emits two distinct 422s:
-		//   1. Pydantic validation envelope (`{"detail":[{...}]}`) on
-		//      malformed input (invalid slug shape, missing field, bad
-		//      kind value).
-		//   2. The over-budget gate detail string when an `operational`
-		//      body exceeds DEFAULT_MAX_PREAMBLE_TOKENS. Backend emits a
-		//      string detail with the estimated and budget token counts
-		//      so the operator can re-size the body precisely.
-		//
-		// decodeDetailString returns the string detail verbatim when the
-		// JSON shape matches `{"detail": "..."}`; on the pydantic
-		// envelope shape (`{"detail": [...]}`) it falls through to the
-		// raw body. Both surface as unexpected so callers can branch
-		// on exit code 4.
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf("invalid request: %s", decodeDetailString(he.Body))),
+			output.Unexpected(fmt.Sprintf("invalid request: %s", decodeDetailString(bodyStr))),
 			jsonOut,
 		)
 	default:
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, statusCode, bodyStr)),
 			jsonOut,
 		)
 	}
 }
 
-// detailEnvelope models FastAPI's HTTPException JSON shape.
+// detailEnvelope models FastAPI's HTTPException JSON shape. `detail`
+// is a `json.RawMessage` so both shapes the conventions route emits
+// round-trip cleanly: the plain `{"detail":"..."}` string the
+// HTTPException branch emits, and the `{"detail":[...]}` list shape
+// pydantic's validation envelope produces. decodeDetailString below
+// only surfaces the string form; the list form falls back to the raw
+// body so the operator sees the validation context.
 type detailEnvelope struct {
 	Detail json.RawMessage `json:"detail"`
 }
 
 // decodeDetailString pulls the `detail` field out of a FastAPI error
 // body when it's a plain string. Falls back to the raw body when the
-// JSON shape doesn't match (the pydantic validation envelope's `detail`
-// is a list, not a string).
+// JSON shape doesn't match (the pydantic validation envelope's
+// `detail` is a list, not a string).
 func decodeDetailString(body string) string {
 	var env detailEnvelope
 	if err := json.Unmarshal([]byte(body), &env); err == nil {
@@ -332,114 +376,6 @@ func decodeDetailString(body string) string {
 		}
 	}
 	return strings.TrimSpace(body)
-}
-
-// doAuthedRequest issues a single HTTP request against the backplane
-// with bearer injection and one-shot 401-refresh-retry. Returns the
-// response body bytes (already drained) on 2xx, or an *httpError on
-// non-2xx, or an error categorised by api.IsTokenNotFound /
-// api.IsNoRefreshToken / generic transport. A 204 yields a nil body
-// without error (the DELETE verb hits this path).
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errMissingAccessToken
-	}
-
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, responseBodyCap+1))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if int64(len(raw)) > responseBodyCap {
-		return nil, fmt.Errorf(
-			"response body exceeds %d-byte cap; refusing to decode possibly-truncated JSON",
-			responseBodyCap,
-		)
-	}
-	if resp.StatusCode == http.StatusNoContent {
-		return nil, nil
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-// responseBodyCap bounds the response body the CLI will read. A
-// convention body is a Markdown rule (the operational kind is hard-
-// capped at the preamble token budget, ~3 KB; workflow / reference can
-// be larger but ~50 KB is realistic). 1 MiB is comfortable headroom
-// and protects against an adversarial / misconfigured backplane sending
-// an unbounded response.
-const responseBodyCap int64 = 1 << 20
-
-// httpError carries a non-2xx response so per-verb runners render the
-// right category.
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
-}
-
-// pathEscape escapes a single path segment.
-func pathEscape(segment string) string {
-	// url.PathEscape is the right call but we shouldn't import net/url
-	// just for this; mirror the kb package's helper signature so the
-	// per-verb buildShowPath / buildHistoryPath stays unit-testable.
-	return urlPathEscape(segment)
 }
 
 // loadBodyFlag reads the --body flag value supporting inline text,
@@ -529,34 +465,6 @@ func confirmPrompt(cmd *cobra.Command, prompt string) bool {
 	}
 	answer = strings.ToLower(strings.TrimSpace(answer))
 	return answer == "y" || answer == "yes"
-}
-
-// urlPathEscape escapes a path segment. Pulled out for a per-package
-// seam — agents have a richer pathEscape with multi-segment handling;
-// conventions doesn't need that level today.
-func urlPathEscape(s string) string {
-	// Per RFC 3986, a path segment may contain unreserved (ALPHA / DIGIT /
-	// `-._~`), `pct-encoded`, sub-delims (`!$&'()*+,;=`), and `:@`.
-	// Conventions slugs are constrained server-side to lowercase ASCII +
-	// digits + hyphen (the V_SLUG pattern), so the escape is a no-op in
-	// the realistic case — but we still escape defensively so an
-	// adversarial slug (e.g., from a buggy script) can't smuggle a path
-	// separator. Using net/url here directly to keep the implementation
-	// stdlib-only and the code path obvious.
-	var b strings.Builder
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		switch {
-		case 'a' <= c && c <= 'z',
-			'A' <= c && c <= 'Z',
-			'0' <= c && c <= '9',
-			c == '-', c == '.', c == '_', c == '~':
-			b.WriteByte(c)
-		default:
-			fmt.Fprintf(&b, "%%%02X", c)
-		}
-	}
-	return b.String()
 }
 
 // runEditor lives in editor.go alongside the other editor-related

--- a/cli/internal/cmd/conventions/conventions_test.go
+++ b/cli/internal/cmd/conventions/conventions_test.go
@@ -17,8 +17,10 @@ import (
 )
 
 // seedXDGAndToken seeds a per-test config dir + token store that
-// backplane.Resolve / doAuthedRequest read. Mirrors the same helper in
-// cli/internal/cmd/agent/agent_test.go.
+// backplane.Resolve / newAuthedClient read. Mirrors the same helper
+// in cli/internal/cmd/agent/agent_test.go and the sibling typed-
+// client migrations (T1 #1251, T3 #1261, T4 #1262) so a single test
+// substrate covers every verb tree.
 func seedXDGAndToken(t *testing.T, backplaneURL string) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -189,26 +191,6 @@ func TestDecodeDetailStringFallsThroughOnListDetail(t *testing.T) {
 	got := decodeDetailString(raw)
 	if !strings.Contains(got, "string too short") {
 		t.Errorf("list-detail fall-through lost content: %q", got)
-	}
-}
-
-// TestURLPathEscapePreservesUnreserved — slug-shaped strings (the
-// V_SLUG pattern) round-trip without escaping.
-func TestURLPathEscapePreservesUnreserved(t *testing.T) {
-	for _, slug := range []string{"vault-canonical", "rbac.canonical", "secret-handling_v2"} {
-		if urlPathEscape(slug) != slug {
-			t.Errorf("urlPathEscape mutated unreserved slug %q -> %q", slug, urlPathEscape(slug))
-		}
-	}
-}
-
-// TestURLPathEscapeEscapesPathSeparator — defensive escape of an
-// adversarial slug containing `/` so it can't smuggle a path
-// boundary.
-func TestURLPathEscapeEscapesPathSeparator(t *testing.T) {
-	got := urlPathEscape("not/a/slug")
-	if strings.Contains(got, "/") {
-		t.Errorf("urlPathEscape failed to escape `/`: %q", got)
 	}
 }
 

--- a/cli/internal/cmd/conventions/create.go
+++ b/cli/internal/cmd/conventions/create.go
@@ -8,25 +8,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
-
-// createRequest mirrors the backend ConventionCreate pydantic model.
-// `Priority` is a pointer so the field is omitted from the JSON body
-// when the operator doesn't pass --priority (backend defaults to 0,
-// matching the SmallInteger column's server_default; round-trips
-// identically through create + show).
-type createRequest struct {
-	Slug     string `json:"slug"`
-	Title    string `json:"title"`
-	Body     string `json:"body"`
-	Kind     string `json:"kind"`
-	Priority *int   `json:"priority,omitempty"`
-}
 
 // newCreateCmd returns the `meho conventions create` command.
 //
@@ -163,58 +152,90 @@ func runCreate(cmd *cobra.Command, opts createOptions) error {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 
-	req := createRequest{
+	resp, err := postCreate(cmd.Context(), backplaneURL, opts, body)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode != http.StatusCreated {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode, resp.Body, opts.JSONOut)
+	}
+	var conv api.Convention
+	if err := json.Unmarshal(resp.Body, &conv); err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("decode conventions create response: %v", err)),
+			opts.JSONOut)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), conv)
+	}
+	printCreateSummary(cmd.OutOrStdout(), &conv)
+	return nil
+}
+
+// buildCreateBody maps the verb's validated options + loaded body onto
+// the generated ConventionCreate body. Priority is a *int in the
+// generated type (the backend's pydantic model treats null/omitted as
+// "use the column's server_default of 0"); we send the pointer only
+// when the operator passed --priority so an unset flag leaves the
+// field absent on the wire instead of stamping an explicit 0 the
+// backend would treat as "operator pinned to 0" vs "operator didn't
+// say" — the latter being important if the column default ever moves.
+func buildCreateBody(opts createOptions, body string) api.ConventionCreate {
+	out := api.ConventionCreate{
 		Slug:  opts.Slug,
-		Kind:  opts.Kind,
+		Kind:  api.ConventionKind(opts.Kind),
 		Title: opts.Title,
 		Body:  body,
 	}
 	if opts.prioritySet {
 		p := opts.Priority
-		req.Priority = &p
+		out.Priority = &p
 	}
-	conv, err := postCreate(cmd.Context(), backplaneURL, req)
-	if err != nil {
-		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
-	}
-	if opts.JSONOut {
-		return output.PrintJSON(cmd.OutOrStdout(), conv)
-	}
-	printCreateSummary(cmd.OutOrStdout(), conv)
-	return nil
+	return out
 }
 
-func postCreate(ctx context.Context, backplaneURL string, req createRequest) (*Convention, error) {
-	body, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("marshal conventions create request: %w", err)
-	}
-	raw, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/conventions", body)
+func postCreate(
+	ctx context.Context,
+	backplaneURL string,
+	opts createOptions,
+	body string,
+) (*rawResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out Convention
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode conventions create response: %w", err)
-	}
-	return &out, nil
+	reqBody := buildCreateBody(opts, body)
+	return doRequest(ctx, authed,
+		func(ctx context.Context) (*http.Response, error) {
+			return authed.CreateConventionApiV1ConventionsPost(
+				ctx,
+				&api.CreateConventionApiV1ConventionsPostParams{},
+				reqBody,
+			)
+		},
+	)
 }
 
 // printCreateSummary renders the created convention as a compact
 // one-line confirmation plus the round-tripped slug / timestamps /
 // body length. Operators who want the full body should chase with
 // `meho conventions show <slug>`.
-func printCreateSummary(w io.Writer, c *Convention) {
+//
+// CreatedAt / UpdatedAt arrive as typed time.Time off the generated
+// Convention type (were strings on the pre-migration consumer-side
+// duplicate); we format them back to the RFC 3339 shape the
+// operator-facing summary contract has always used.
+func printCreateSummary(w io.Writer, c *api.Convention) {
 	if c == nil {
 		return
 	}
 	fmt.Fprintf(w, "created convention %q\n", c.Slug)
-	fmt.Fprintf(w, "%-14s %s\n", "id:", c.ID)
-	fmt.Fprintf(w, "%-14s %s\n", "tenant_id:", c.TenantID)
+	fmt.Fprintf(w, "%-14s %s\n", "id:", c.Id.String())
+	fmt.Fprintf(w, "%-14s %s\n", "tenant_id:", c.TenantId.String())
 	fmt.Fprintf(w, "%-14s %s\n", "kind:", c.Kind)
 	fmt.Fprintf(w, "%-14s %d\n", "priority:", c.Priority)
 	fmt.Fprintf(w, "%-14s %s\n", "title:", c.Title)
-	fmt.Fprintf(w, "%-14s %s\n", "created_at:", c.CreatedAt)
-	fmt.Fprintf(w, "%-14s %s\n", "updated_at:", c.UpdatedAt)
+	fmt.Fprintf(w, "%-14s %s\n", "created_at:", c.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"))
+	fmt.Fprintf(w, "%-14s %s\n", "updated_at:", c.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z"))
 	fmt.Fprintf(w, "%-14s %d bytes\n", "body:", len(c.Body))
 }

--- a/cli/internal/cmd/conventions/crud_test.go
+++ b/cli/internal/cmd/conventions/crud_test.go
@@ -4,6 +4,7 @@
 package conventions
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -11,46 +12,117 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
 )
 
-func sampleConvention() Convention {
-	return Convention{
-		ID:        "11111111-1111-1111-1111-111111111111",
-		TenantID:  "22222222-2222-2222-2222-222222222222",
+// stubID / stubTenantID are the fixed UUIDs every fixture uses so a
+// test failure reads "11111111-..." in the request URL or response
+// body — easier to chase than a uuid.New() that rotates per run.
+// Mirrors the same const pair in cli/internal/cmd/agent-principal/
+// agent_principal_test.go (T4 #1262).
+const (
+	stubID       = "11111111-1111-1111-1111-111111111111"
+	stubTenantID = "22222222-2222-2222-2222-222222222222"
+)
+
+func mustUUID(t *testing.T, s string) uuid.UUID {
+	t.Helper()
+	id, err := uuid.Parse(s)
+	if err != nil {
+		t.Fatalf("mustUUID(%q): %v", s, err)
+	}
+	return id
+}
+
+// writeJSON wraps the common httptest.Server handler pattern so every
+// mock response sets `Content-Type: application/json` before writing.
+// The generated client's Parse* helpers only populate JSON200 / JSON201
+// when the response Content-Type contains "json"; a bare Encode against
+// http.ResponseWriter omits the header and the response body bytes
+// land in `.Body` but the typed `JSONxxx` pointer stays nil. Centralise
+// the header-then-encode so a test failure can't be a misset header.
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, body any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		t.Errorf("writeJSON encode: %v", err)
+	}
+}
+
+// writeJSONErr is the equivalent of writeJSON for error bodies — the
+// status code is the *first* arg (mirrors writeJSON's signature)
+// and the body is the raw JSON envelope the FastAPI route would emit
+// for that status. Returns a (status, body) shape into the typed
+// response's `.Body` field so renderHTTPStatus can pick up the
+// backend's `detail` field.
+func writeJSONErr(t *testing.T, w http.ResponseWriter, status int, body string) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, err := w.Write([]byte(body)); err != nil {
+		t.Errorf("writeJSONErr write: %v", err)
+	}
+}
+
+// sampleConvention returns a fully-populated api.Convention (the
+// generated type) for happy-path round-trips. Same field semantics
+// as the pre-migration consumer-side duplicate; only the type moved.
+func sampleConvention(t *testing.T) api.Convention {
+	t.Helper()
+	ts := time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC)
+	return api.Convention{
+		Id:        mustUUID(t, stubID),
+		TenantId:  mustUUID(t, stubTenantID),
 		Slug:      "vault-canonical",
 		Title:     "Vault is canonical",
 		Body:      "Vault is the canonical secret store.\nNever paste secrets into chat.",
 		Kind:      "operational",
 		Priority:  10,
-		CreatedAt: "2026-05-24T00:00:00Z",
-		UpdatedAt: "2026-05-24T00:00:00Z",
+		CreatedAt: ts,
+		UpdatedAt: ts,
 	}
 }
 
-func sampleSummary() Summary {
-	return Summary{
-		ID:        "11111111-1111-1111-1111-111111111111",
-		TenantID:  "22222222-2222-2222-2222-222222222222",
+func sampleSummary(t *testing.T) api.ConventionSummary {
+	t.Helper()
+	ts := time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC)
+	return api.ConventionSummary{
+		Id:        mustUUID(t, stubID),
+		TenantId:  mustUUID(t, stubTenantID),
 		Slug:      "vault-canonical",
 		Title:     "Vault is canonical",
 		Kind:      "operational",
 		Priority:  10,
-		CreatedAt: "2026-05-24T00:00:00Z",
-		UpdatedAt: "2026-05-24T00:00:00Z",
+		CreatedAt: ts,
+		UpdatedAt: ts,
 	}
 }
 
 // --- list ---
 
-func TestBuildListPath(t *testing.T) {
-	if got := buildListPath(listOptions{}); got != "/api/v1/conventions" {
-		t.Fatalf("empty opts: got %q", got)
+// TestListQueryParamsOmitsKindWhenUnset confirms the default flag
+// state sends no `kind` query param. The backplane's own default
+// (returning all kinds) then applies; sending an explicit empty
+// `kind` would trip pydantic's enum validation.
+func TestListQueryParamsOmitsKindWhenUnset(t *testing.T) {
+	params := listQueryParams(listOptions{})
+	if params.Kind != nil {
+		t.Errorf("unset --kind should leave params.Kind nil; got %+v", params.Kind)
 	}
-	got := buildListPath(listOptions{Kind: "operational"})
-	if !strings.Contains(got, "kind=operational") {
-		t.Errorf("buildListPath kind: got %q", got)
+}
+
+// TestListQueryParamsPassesKindWhenSet pins that the validated
+// string is forwarded as the generated typed enum.
+func TestListQueryParamsPassesKindWhenSet(t *testing.T) {
+	params := listQueryParams(listOptions{Kind: "operational"})
+	if params.Kind == nil || *params.Kind != api.ConventionKind("operational") {
+		t.Errorf("expected params.Kind == operational; got %+v", params.Kind)
 	}
 }
 
@@ -71,7 +143,9 @@ func TestRunListHappyPath(t *testing.T) {
 		if r.Header.Get("Authorization") == "" {
 			t.Errorf("missing Authorization header")
 		}
-		_ = json.NewEncoder(w).Encode(ListResponse{Entries: []Summary{sampleSummary()}})
+		writeJSON(t, w, http.StatusOK, api.ConventionListResponse{
+			Entries: []api.ConventionSummary{sampleSummary(t)},
+		})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -91,7 +165,9 @@ func TestRunListHappyPath(t *testing.T) {
 func TestRunListJSONPath(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(ListResponse{Entries: []Summary{sampleSummary()}})
+		writeJSON(t, w, http.StatusOK, api.ConventionListResponse{
+			Entries: []api.ConventionSummary{sampleSummary(t)},
+		})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -101,7 +177,7 @@ func TestRunListJSONPath(t *testing.T) {
 	if err := runList(cmd, listOptions{BackplaneOverride: srv.URL, JSONOut: true}); err != nil {
 		t.Fatalf("runList --json: %v", err)
 	}
-	var got ListResponse
+	var got api.ConventionListResponse
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("decode stdout JSON: %v; raw=%s", err, stdout.String())
 	}
@@ -112,7 +188,7 @@ func TestRunListJSONPath(t *testing.T) {
 
 func TestPrintListTableEmpty(t *testing.T) {
 	var sb strings.Builder
-	printListTable(&sb, &ListResponse{})
+	printListTable(&sb, &api.ConventionListResponse{})
 	if !strings.Contains(sb.String(), "no conventions registered") {
 		t.Errorf("empty render missing hint; got %q", sb.String())
 	}
@@ -126,9 +202,9 @@ func TestPrintListTableEmpty(t *testing.T) {
 func TestRunListOverBudgetExitsFive(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(ListResponse{
-			Entries: []Summary{sampleSummary()},
-			BudgetStatus: BudgetStatus{
+		writeJSON(t, w, http.StatusOK, api.ConventionListResponse{
+			Entries: []api.ConventionSummary{sampleSummary(t)},
+			BudgetStatus: api.BudgetStatus{
 				MaxTokens:       600,
 				EstimatedTokens: 920,
 				OverBudget:      true,
@@ -182,9 +258,9 @@ func TestRunListOverBudgetExitsFive(t *testing.T) {
 func TestRunListOverBudgetJSONExitsZero(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(ListResponse{
-			Entries: []Summary{sampleSummary()},
-			BudgetStatus: BudgetStatus{
+		writeJSON(t, w, http.StatusOK, api.ConventionListResponse{
+			Entries: []api.ConventionSummary{sampleSummary(t)},
+			BudgetStatus: api.BudgetStatus{
 				MaxTokens:       600,
 				EstimatedTokens: 920,
 				OverBudget:      true,
@@ -205,7 +281,7 @@ func TestRunListOverBudgetJSONExitsZero(t *testing.T) {
 		t.Errorf("expected clean stderr under --json; got %q", stderr.String())
 	}
 	// stdout carries the full envelope including budget_status.
-	var got ListResponse
+	var got api.ConventionListResponse
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("decode stdout JSON: %v; raw=%s", err, stdout.String())
 	}
@@ -223,9 +299,9 @@ func TestRunListOverBudgetJSONExitsZero(t *testing.T) {
 func TestRunListFittingTenantExitsZero(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(ListResponse{
-			Entries: []Summary{sampleSummary()},
-			BudgetStatus: BudgetStatus{
+		writeJSON(t, w, http.StatusOK, api.ConventionListResponse{
+			Entries: []api.ConventionSummary{sampleSummary(t)},
+			BudgetStatus: api.BudgetStatus{
 				MaxTokens:       600,
 				EstimatedTokens: 120,
 				OverBudget:      false,
@@ -249,18 +325,36 @@ func TestRunListFittingTenantExitsZero(t *testing.T) {
 	}
 }
 
-// --- show ---
+// TestRunListPassesKindOnWire confirms the typed query-param shape
+// surfaces on the wire as `kind=operational`. The generated client
+// handles the URL building; this test pins that we feed it the
+// right value, not just that the func runs.
+func TestRunListPassesKindOnWire(t *testing.T) {
+	var seenKind string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, r *http.Request) {
+		seenKind = r.URL.Query().Get("kind")
+		writeJSON(t, w, http.StatusOK, api.ConventionListResponse{})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
 
-func TestBuildShowPath(t *testing.T) {
-	if got := buildShowPath("vault-canonical"); got != "/api/v1/conventions/vault-canonical" {
-		t.Fatalf("buildShowPath: got %q", got)
+	cmd, _, stderr := newRunCmd(t)
+	if err := runList(cmd, listOptions{Kind: "workflow", BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runList --kind: %v; stderr=%s", err, stderr.String())
+	}
+	if seenKind != "workflow" {
+		t.Errorf("--kind=workflow should send kind=workflow on wire; got %q", seenKind)
 	}
 }
+
+// --- show ---
 
 func TestRunShowHappyPath(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/conventions/vault-canonical", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(sampleConvention())
+		writeJSON(t, w, http.StatusOK, sampleConvention(t))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -279,8 +373,7 @@ func TestRunShowHappyPath(t *testing.T) {
 func TestRunShow404SurfacesNotFound(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/conventions/nope", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprint(w, `{"detail":"convention_not_found"}`)
+		writeJSONErr(t, w, http.StatusNotFound, `{"detail":"convention_not_found"}`)
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -315,16 +408,21 @@ func TestRunCreateHappyPath(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("method: got %s; want POST", r.Method)
 		}
-		var body createRequest
-		_ = json.NewDecoder(r.Body).Decode(&body)
-		if body.Slug != "vault-canonical" || body.Kind != "operational" || body.Title != "Vault is canonical" {
+		// Decode against the generated request body type so a
+		// schema-drift between the CLI's send and the backend's
+		// expected shape would fail at unmarshal time.
+		var body api.ConventionCreate
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		if body.Slug != "vault-canonical" || body.Kind != api.ConventionKind("operational") ||
+			body.Title != "Vault is canonical" {
 			t.Errorf("unexpected request body: %+v", body)
 		}
 		if body.Body == "" {
 			t.Errorf("body missing")
 		}
-		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(sampleConvention())
+		writeJSON(t, w, http.StatusCreated, sampleConvention(t))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -389,8 +487,7 @@ func TestRunCreateRejectsEmptyTitle(t *testing.T) {
 func TestRunCreate409SurfacesDuplicate(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusConflict)
-		fmt.Fprint(w, `{"detail":"convention_already_exists"}`)
+		writeJSONErr(t, w, http.StatusConflict, `{"detail":"convention_already_exists"}`)
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -412,8 +509,7 @@ func TestRunCreate409SurfacesDuplicate(t *testing.T) {
 func TestRunCreate403SurfacesInsufficientRole(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusForbidden)
-		fmt.Fprint(w, `{"detail":"Insufficient role: tenant_admin required"}`)
+		writeJSONErr(t, w, http.StatusForbidden, `{"detail":"Insufficient role: tenant_admin required"}`)
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -435,8 +531,8 @@ func TestRunCreate403SurfacesInsufficientRole(t *testing.T) {
 func TestRunCreate422SurfacesOverBudget(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusUnprocessableEntity)
-		fmt.Fprint(w, `{"detail":"convention body exceeds preamble budget (estimated=1200, budget=800)"}`)
+		writeJSONErr(t, w, http.StatusUnprocessableEntity,
+			`{"detail":"convention body exceeds preamble budget (estimated=1200, budget=800)"}`)
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -458,18 +554,20 @@ func TestRunCreate422SurfacesOverBudget(t *testing.T) {
 	}
 }
 
+// TestRunCreatePriorityOmittedWhenNotSet — load-bearing wire-format
+// guarantee: an unset --priority flag must NOT marshal as
+// `"priority":0` (which the backend would treat as "operator pinned
+// to 0" if the column default ever moves). It also must NOT marshal
+// as `"priority":null` (the generated `Priority *int` field has
+// `omitempty`, so a nil pointer drops the key entirely).
 func TestRunCreatePriorityOmittedWhenNotSet(t *testing.T) {
-	var got createRequest
+	var rawBody bytes.Buffer
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, r *http.Request) {
-		raw, _ := io.ReadAll(r.Body)
-		// Confirm "priority" key is not in the JSON when not set.
-		if strings.Contains(string(raw), `"priority"`) {
-			t.Errorf("priority key present when --priority not set: %s", raw)
+		if _, err := rawBody.ReadFrom(r.Body); err != nil {
+			t.Fatalf("read body: %v", err)
 		}
-		_ = json.Unmarshal(raw, &got)
-		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(sampleConvention())
+		writeJSON(t, w, http.StatusCreated, sampleConvention(t))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -482,6 +580,39 @@ func TestRunCreatePriorityOmittedWhenNotSet(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("runCreate: %v; stderr=%s", err, stderr.String())
+	}
+	body := rawBody.String()
+	if strings.Contains(body, `"priority"`) {
+		t.Errorf("priority key present when --priority not set: %s", body)
+	}
+}
+
+// TestRunCreatePrioritySentOnWireWhenSet pins the inverse: when the
+// operator did pass --priority, the value must reach the wire.
+func TestRunCreatePrioritySentOnWireWhenSet(t *testing.T) {
+	var seen api.ConventionCreate
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/conventions", func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&seen); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		writeJSON(t, w, http.StatusCreated, sampleConvention(t))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, _ := newRunCmd(t)
+	err := runCreate(cmd, createOptions{
+		Slug: "x", Kind: "operational", Title: "t", BodyArg: "b",
+		Priority: 42, prioritySet: true,
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runCreate: %v", err)
+	}
+	if seen.Priority == nil || *seen.Priority != 42 {
+		t.Errorf("body Priority: got %+v want pointer to 42", seen.Priority)
 	}
 }
 
@@ -527,9 +658,9 @@ func TestRunEditFlagDrivenHappyPath(t *testing.T) {
 		if !strings.Contains(string(raw), "priority") {
 			t.Errorf("PATCH body missing priority: %s", raw)
 		}
-		conv := sampleConvention()
+		conv := sampleConvention(t)
 		conv.Priority = 20
-		_ = json.NewEncoder(w).Encode(conv)
+		writeJSON(t, w, http.StatusOK, conv)
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -563,10 +694,10 @@ func TestRunEditEditorModeHappyPath(t *testing.T) {
 	mux.HandleFunc("/api/v1/conventions/vault-canonical", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			_ = json.NewEncoder(w).Encode(sampleConvention())
+			writeJSON(t, w, http.StatusOK, sampleConvention(t))
 		case http.MethodPatch:
 			raw, _ := io.ReadAll(r.Body)
-			var body updateRequest
+			var body api.ConventionUpdate
 			_ = json.Unmarshal(raw, &body)
 			if body.Body == nil {
 				t.Errorf("PATCH body missing body field: %s", raw)
@@ -576,9 +707,9 @@ func TestRunEditEditorModeHappyPath(t *testing.T) {
 			if body.Title != nil || body.Priority != nil {
 				t.Errorf("PATCH body should only have body field: %+v", body)
 			}
-			conv := sampleConvention()
+			conv := sampleConvention(t)
 			conv.Body = *body.Body
-			_ = json.NewEncoder(w).Encode(conv)
+			writeJSON(t, w, http.StatusOK, conv)
 		default:
 			t.Errorf("unexpected method %s", r.Method)
 		}
@@ -613,7 +744,7 @@ func TestRunEditEditorModeAbortsOnEmptyBody(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/conventions/vault-canonical", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
-			_ = json.NewEncoder(w).Encode(sampleConvention())
+			writeJSON(t, w, http.StatusOK, sampleConvention(t))
 			return
 		}
 		if r.Method == http.MethodPatch {
@@ -653,7 +784,7 @@ func TestRunEditEditorModeAbortsOnUnchangedBody(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/conventions/vault-canonical", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
-			_ = json.NewEncoder(w).Encode(sampleConvention())
+			writeJSON(t, w, http.StatusOK, sampleConvention(t))
 			return
 		}
 		if r.Method == http.MethodPatch {
@@ -692,7 +823,7 @@ func TestRunEditEditorModeAbortsOnEditorFailure(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/conventions/vault-canonical", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
-			_ = json.NewEncoder(w).Encode(sampleConvention())
+			writeJSON(t, w, http.StatusOK, sampleConvention(t))
 			return
 		}
 		if r.Method == http.MethodPatch {
@@ -722,8 +853,7 @@ func TestRunEditEditorModeAbortsOnEditorFailure(t *testing.T) {
 func TestRunEditEditorMode404SurfacesNotFoundFromShowFetch(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/conventions/nope", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprint(w, `{"detail":"convention_not_found"}`)
+		writeJSONErr(t, w, http.StatusNotFound, `{"detail":"convention_not_found"}`)
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -753,10 +883,10 @@ func TestRunEdit422OverBudgetSurfacedInline(t *testing.T) {
 	mux.HandleFunc("/api/v1/conventions/vault-canonical", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
-			_ = json.NewEncoder(w).Encode(sampleConvention())
+			writeJSON(t, w, http.StatusOK, sampleConvention(t))
 		case http.MethodPatch:
-			w.WriteHeader(http.StatusUnprocessableEntity)
-			fmt.Fprint(w, `{"detail":"convention body exceeds preamble budget (estimated=900, budget=800)"}`)
+			writeJSONErr(t, w, http.StatusUnprocessableEntity,
+				`{"detail":"convention body exceeds preamble budget (estimated=900, budget=800)"}`)
 		}
 	})
 	srv := httptest.NewServer(mux)
@@ -820,8 +950,7 @@ func TestRunDeleteDeclinedExitsZero(t *testing.T) {
 func TestRunDelete404SurfacesNotFound(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/conventions/nope", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprint(w, `{"detail":"convention_not_found"}`)
+		writeJSONErr(t, w, http.StatusNotFound, `{"detail":"convention_not_found"}`)
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -839,35 +968,29 @@ func TestRunDelete404SurfacesNotFound(t *testing.T) {
 
 // --- history ---
 
-func TestBuildHistoryPath(t *testing.T) {
-	if got := buildHistoryPath("vault-canonical"); got != "/api/v1/conventions/vault-canonical/history" {
-		t.Fatalf("buildHistoryPath: got %q", got)
-	}
-}
-
 func TestRunHistoryHappyPathRendersDiffs(t *testing.T) {
 	bodyBefore := "Vault is canonical."
-	entries := []HistoryEntry{
+	entries := []api.ConventionHistoryEntry{
 		{
-			ID:           "h2",
-			ConventionID: "11111111-1111-1111-1111-111111111111",
+			Id:           mustUUID(t, "33333333-3333-3333-3333-333333333333"),
+			ConventionId: mustUUID(t, stubID),
 			BodyBefore:   &bodyBefore,
 			BodyAfter:    "Vault is canonical.\nAdded rule.",
 			ActorSub:     "ops-admin",
-			Ts:           "2026-05-25T00:00:00Z",
+			Ts:           time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC),
 		},
 		{
-			ID:           "h1",
-			ConventionID: "11111111-1111-1111-1111-111111111111",
+			Id:           mustUUID(t, "44444444-4444-4444-4444-444444444444"),
+			ConventionId: mustUUID(t, stubID),
 			BodyBefore:   nil,
 			BodyAfter:    "Vault is canonical.",
 			ActorSub:     "ops-admin",
-			Ts:           "2026-05-24T00:00:00Z",
+			Ts:           time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC),
 		},
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/conventions/vault-canonical/history", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(entries)
+		writeJSON(t, w, http.StatusOK, entries)
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -892,19 +1015,26 @@ func TestRunHistoryHappyPathRendersDiffs(t *testing.T) {
 
 func TestRunHistoryLimit(t *testing.T) {
 	bodyBefore := "x"
-	mkEntry := func(id string, ts string) HistoryEntry {
-		return HistoryEntry{
-			ID: id, BodyBefore: &bodyBefore, BodyAfter: "y", Ts: ts, ActorSub: "ops",
+	idFor := func(i int) uuid.UUID {
+		return mustUUID(t, fmt.Sprintf("%08x-0000-0000-0000-000000000000", i))
+	}
+	mkEntry := func(id uuid.UUID, day int) api.ConventionHistoryEntry {
+		return api.ConventionHistoryEntry{
+			Id:         id,
+			BodyBefore: &bodyBefore,
+			BodyAfter:  "y",
+			Ts:         time.Date(2026, 5, day, 0, 0, 0, 0, time.UTC),
+			ActorSub:   "ops",
 		}
 	}
-	entries := []HistoryEntry{
-		mkEntry("h3", "2026-05-26T00:00:00Z"),
-		mkEntry("h2", "2026-05-25T00:00:00Z"),
-		mkEntry("h1", "2026-05-24T00:00:00Z"),
+	entries := []api.ConventionHistoryEntry{
+		mkEntry(idFor(3), 26),
+		mkEntry(idFor(2), 25),
+		mkEntry(idFor(1), 24),
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/conventions/x/history", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(entries)
+		writeJSON(t, w, http.StatusOK, entries)
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -915,10 +1045,10 @@ func TestRunHistoryLimit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runHistory --limit: %v; stderr=%s", err, stderr.String())
 	}
-	if strings.Contains(stdout.String(), "h1") {
+	if strings.Contains(stdout.String(), idFor(1).String()) {
 		t.Errorf("--limit 2 included beyond-limit row: %q", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "h2") {
+	if !strings.Contains(stdout.String(), idFor(2).String()) {
 		t.Errorf("--limit 2 dropped on-limit row: %q", stdout.String())
 	}
 }
@@ -926,7 +1056,7 @@ func TestRunHistoryLimit(t *testing.T) {
 func TestRunHistoryEmpty(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/conventions/x/history", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode([]HistoryEntry{})
+		writeJSON(t, w, http.StatusOK, []api.ConventionHistoryEntry{})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -955,12 +1085,18 @@ func TestRunHistoryRejectsNegativeLimit(t *testing.T) {
 
 func TestRunHistoryJSON(t *testing.T) {
 	bodyBefore := "x"
-	entries := []HistoryEntry{
-		{ID: "h1", BodyBefore: &bodyBefore, BodyAfter: "y", Ts: "2026-05-24T00:00:00Z", ActorSub: "ops"},
+	entries := []api.ConventionHistoryEntry{
+		{
+			Id:         mustUUID(t, stubID),
+			BodyBefore: &bodyBefore,
+			BodyAfter:  "y",
+			Ts:         time.Date(2026, 5, 24, 0, 0, 0, 0, time.UTC),
+			ActorSub:   "ops",
+		},
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/conventions/x/history", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(entries)
+		writeJSON(t, w, http.StatusOK, entries)
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -971,11 +1107,11 @@ func TestRunHistoryJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runHistory --json: %v", err)
 	}
-	var got []HistoryEntry
+	var got []api.ConventionHistoryEntry
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("decode stdout JSON: %v; raw=%s", err, stdout.String())
 	}
-	if len(got) != 1 || got[0].ID != "h1" {
+	if len(got) != 1 || got[0].Id != mustUUID(t, stubID) {
 		t.Errorf("decoded JSON unexpected: %+v", got)
 	}
 }

--- a/cli/internal/cmd/conventions/delete.go
+++ b/cli/internal/cmd/conventions/delete.go
@@ -6,9 +6,11 @@ package conventions
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -106,8 +108,14 @@ func runDelete(cmd *cobra.Command, opts deleteOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	if err := callDelete(cmd.Context(), backplaneURL, opts.Slug); err != nil {
+	resp, err := callDelete(cmd.Context(), backplaneURL, opts.Slug)
+	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	// Backend returns 204 No Content on success; anything else is an
+	// error category routed through the standard renderer.
+	if resp.StatusCode != http.StatusNoContent {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode, resp.Body, opts.JSONOut)
 	}
 	result := deleteResult{Slug: opts.Slug, Status: "deleted"}
 	if opts.JSONOut {
@@ -117,9 +125,19 @@ func runDelete(cmd *cobra.Command, opts deleteOptions) error {
 	return nil
 }
 
-func callDelete(ctx context.Context, backplaneURL, slug string) error {
-	// doAuthedRequest returns (nil, nil) on a 204; the success signal
-	// is the absence of an error.
-	_, err := doAuthedRequest(ctx, backplaneURL, "DELETE", buildShowPath(slug), nil)
-	return err
+func callDelete(
+	ctx context.Context,
+	backplaneURL, slug string,
+) (*rawResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	return doRequest(ctx, authed,
+		func(ctx context.Context) (*http.Response, error) {
+			return authed.DeleteConventionApiV1ConventionsSlugDelete(
+				ctx, slug, &api.DeleteConventionApiV1ConventionsSlugDeleteParams{},
+			)
+		},
+	)
 }

--- a/cli/internal/cmd/conventions/edit.go
+++ b/cli/internal/cmd/conventions/edit.go
@@ -8,33 +8,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
-
-// updateRequest mirrors the backend ConventionUpdate pydantic model
-// (PATCH /api/v1/conventions/{slug}). Pydantic v2's
-// `model_fields_set` distinguishes "field absent from JSON" from "field
-// present with null", and the route handler applies only the
-// explicitly-set keys to the ORM row. Each field is a pointer so an
-// omitted CLI flag is left out of the JSON body via omitempty.
-//
-// `slug` and `kind` are absent from this struct by design — they're
-// not in the PATCH surface. Renaming a convention is delete + recreate
-// (the audit log and history rows reference the old slug); changing a
-// convention's kind in-place would silently change its preamble-
-// inclusion behaviour (operational → reference would disappear from
-// every future preamble without an audit signal), so the substrate
-// rejects it.
-type updateRequest struct {
-	Title    *string `json:"title,omitempty"`
-	Body     *string `json:"body,omitempty"`
-	Priority *int    `json:"priority,omitempty"`
-}
 
 // newEditCmd returns the `meho conventions edit` command.
 //
@@ -154,8 +136,9 @@ func runEdit(cmd *cobra.Command, opts editOptions) error {
 	if err != nil {
 		// buildEditRequest may surface either a CLI-level validation
 		// error (unexpected category) or an upstream HTTP error
-		// (rendered via renderRequestError already in $EDITOR mode).
-		// Distinguish by checking for our editorAbortError sentinel.
+		// (rendered via renderRequestError / renderHTTPStatus in
+		// $EDITOR mode). Distinguish by checking for our sentinel
+		// wrappers.
 		var abort *editorAbortError
 		if errors.As(err, &abort) {
 			// Editor mode aborted (editor failure or empty buffer).
@@ -168,7 +151,12 @@ func runEdit(cmd *cobra.Command, opts editOptions) error {
 		if errors.As(err, &preflight) {
 			// Show-side fetch failed (404 / 401 / transport); render
 			// using the standard ladder so 404 carries the backend's
-			// convention_not_found detail.
+			// convention_not_found detail. A non-2xx HTTP response on
+			// the show fetch surfaces as a showHTTPError wrapped here.
+			var he *showHTTPError
+			if errors.As(preflight.cause, &he) {
+				return renderHTTPStatus(cmd, backplaneURL, he.StatusCode, he.Body, opts.JSONOut)
+			}
 			return renderRequestError(cmd, backplaneURL, preflight.cause, opts.JSONOut)
 		}
 		return output.RenderError(cmd.ErrOrStderr(),
@@ -183,9 +171,18 @@ func runEdit(cmd *cobra.Command, opts editOptions) error {
 			output.Unexpected("edit produced an empty PATCH body"), opts.JSONOut)
 	}
 
-	conv, err := patchEdit(cmd.Context(), backplaneURL, opts.Slug, *req)
+	resp, err := patchEdit(cmd.Context(), backplaneURL, opts.Slug, *req)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode, resp.Body, opts.JSONOut)
+	}
+	var conv api.Convention
+	if err := json.Unmarshal(resp.Body, &conv); err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("decode conventions edit response: %v", err)),
+			opts.JSONOut)
 	}
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), conv)
@@ -194,7 +191,8 @@ func runEdit(cmd *cobra.Command, opts editOptions) error {
 	fmt.Fprintf(cmd.OutOrStdout(), "%-14s %s\n", "kind:", conv.Kind)
 	fmt.Fprintf(cmd.OutOrStdout(), "%-14s %d\n", "priority:", conv.Priority)
 	fmt.Fprintf(cmd.OutOrStdout(), "%-14s %s\n", "title:", conv.Title)
-	fmt.Fprintf(cmd.OutOrStdout(), "%-14s %s\n", "updated_at:", conv.UpdatedAt)
+	fmt.Fprintf(cmd.OutOrStdout(), "%-14s %s\n", "updated_at:",
+		conv.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z"))
 	fmt.Fprintf(cmd.OutOrStdout(), "%-14s %d bytes\n", "body:", len(conv.Body))
 	return nil
 }
@@ -222,15 +220,15 @@ func (e *editFetchError) Unwrap() error { return e.cause }
 
 // buildEditRequest assembles the PATCH body from the flag set or from
 // $EDITOR depending on which mode the operator invoked. Returns the
-// populated updateRequest or an error.
+// populated ConventionUpdate body or an error.
 //
 // Split from runEdit so the field-selection logic stays unit-testable
 // without standing up an httptest.Server in every test.
-func buildEditRequest(cmd *cobra.Command, backplaneURL string, opts editOptions) (*updateRequest, error) {
+func buildEditRequest(cmd *cobra.Command, backplaneURL string, opts editOptions) (*api.ConventionUpdate, error) {
 	anyFlagSet := opts.titleSet || opts.bodySet || opts.prioritySet
 
 	if anyFlagSet {
-		req := &updateRequest{}
+		req := &api.ConventionUpdate{}
 		if opts.titleSet {
 			t := opts.Title
 			req.Title = &t
@@ -269,26 +267,27 @@ func buildEditRequest(cmd *cobra.Command, backplaneURL string, opts editOptions)
 	if trimmed == strings.TrimRight(current.Body, "\r\n") {
 		return nil, &editorAbortError{reason: "edited body is unchanged; aborting without API call"}
 	}
-	req := &updateRequest{Body: &trimmed}
+	req := &api.ConventionUpdate{Body: &trimmed}
 	return req, nil
 }
 
 func patchEdit(
 	ctx context.Context,
 	backplaneURL, slug string,
-	body updateRequest,
-) (*Convention, error) {
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal conventions edit request: %w", err)
-	}
-	resp, err := doAuthedRequest(ctx, backplaneURL, "PATCH", buildShowPath(slug), raw)
+	body api.ConventionUpdate,
+) (*rawResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out Convention
-	if err := json.Unmarshal(resp, &out); err != nil {
-		return nil, fmt.Errorf("decode conventions edit response: %w", err)
-	}
-	return &out, nil
+	return doRequest(ctx, authed,
+		func(ctx context.Context) (*http.Response, error) {
+			return authed.UpdateConventionApiV1ConventionsSlugPatch(
+				ctx,
+				slug,
+				&api.UpdateConventionApiV1ConventionsSlugPatchParams{},
+				body,
+			)
+		},
+	)
 }

--- a/cli/internal/cmd/conventions/history.go
+++ b/cli/internal/cmd/conventions/history.go
@@ -8,10 +8,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -105,9 +107,18 @@ func runHistory(cmd *cobra.Command, opts historyOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	entries, err := getHistory(cmd.Context(), backplaneURL, opts.Slug)
+	resp, err := getHistory(cmd.Context(), backplaneURL, opts.Slug)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode, resp.Body, opts.JSONOut)
+	}
+	var entries []api.ConventionHistoryEntry
+	if err := json.Unmarshal(resp.Body, &entries); err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("decode conventions history response: %v", err)),
+			opts.JSONOut)
 	}
 	if opts.Limit > 0 && len(entries) > opts.Limit {
 		entries = entries[:opts.Limit]
@@ -119,21 +130,21 @@ func runHistory(cmd *cobra.Command, opts historyOptions) error {
 	return nil
 }
 
-// buildHistoryPath assembles the GET path. Exposed for unit tests.
-func buildHistoryPath(slug string) string {
-	return "/api/v1/conventions/" + pathEscape(slug) + "/history"
-}
-
-func getHistory(ctx context.Context, backplaneURL, slug string) ([]HistoryEntry, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildHistoryPath(slug), nil)
+func getHistory(
+	ctx context.Context,
+	backplaneURL, slug string,
+) (*rawResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out []HistoryEntry
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode conventions history response: %w", err)
-	}
-	return out, nil
+	return doRequest(ctx, authed,
+		func(ctx context.Context) (*http.Response, error) {
+			return authed.ListHistoryApiV1ConventionsSlugHistoryGet(
+				ctx, slug, &api.ListHistoryApiV1ConventionsSlugHistoryGetParams{},
+			)
+		},
+	)
 }
 
 // printHistoryDiffs renders each history row as a header + a unified
@@ -150,7 +161,12 @@ func getHistory(ctx context.Context, backplaneURL, slug string) ([]HistoryEntry,
 // transaction boundary. The substrate writes one history row per
 // transaction, so the row-local before/after pair is already the right
 // granularity.
-func printHistoryDiffs(w io.Writer, slug string, entries []HistoryEntry) {
+//
+// Ts is a typed time.Time off the generated ConventionHistoryEntry
+// (was a string on the pre-migration consumer-side duplicate); we
+// format it back to the RFC 3339 / ISO 8601 shape the operator-facing
+// history contract has always used.
+func printHistoryDiffs(w io.Writer, slug string, entries []api.ConventionHistoryEntry) {
 	if len(entries) == 0 {
 		fmt.Fprintf(w, "no history for convention %q\n", slug)
 		return
@@ -159,9 +175,10 @@ func printHistoryDiffs(w io.Writer, slug string, entries []HistoryEntry) {
 		if i > 0 {
 			fmt.Fprintln(w)
 		}
-		fmt.Fprintf(w, "=== %s  actor=%s  history_id=%s\n", e.Ts, e.ActorSub, e.ID)
-		if e.AuditID != nil {
-			fmt.Fprintf(w, "    audit_id=%s\n", *e.AuditID)
+		tsStr := e.Ts.UTC().Format("2006-01-02T15:04:05Z")
+		fmt.Fprintf(w, "=== %s  actor=%s  history_id=%s\n", tsStr, e.ActorSub, e.Id.String())
+		if e.AuditId != nil {
+			fmt.Fprintf(w, "    audit_id=%s\n", e.AuditId.String())
 		} else {
 			fmt.Fprintln(w, "    audit_id=<seed>")
 		}
@@ -171,7 +188,7 @@ func printHistoryDiffs(w io.Writer, slug string, entries []HistoryEntry) {
 			// the initial body as a + block so the trail visibly
 			// distinguishes the create from a body-replacing edit.
 			fmt.Fprintln(w, "--- /dev/null")
-			fmt.Fprintf(w, "+++ %s @ %s\n", slug, e.Ts)
+			fmt.Fprintf(w, "+++ %s @ %s\n", slug, tsStr)
 			for _, line := range strings.Split(strings.TrimRight(e.BodyAfter, "\r\n"), "\n") {
 				fmt.Fprintf(w, "+ %s\n", line)
 			}
@@ -190,7 +207,7 @@ func printHistoryDiffs(w io.Writer, slug string, entries []HistoryEntry) {
 			continue
 		}
 		fmt.Fprintf(w, "--- %s @ <prev>\n", slug)
-		fmt.Fprintf(w, "+++ %s @ %s\n", slug, e.Ts)
+		fmt.Fprintf(w, "+++ %s @ %s\n", slug, tsStr)
 		writeUnifiedDiff(w, before, after)
 	}
 }

--- a/cli/internal/cmd/conventions/list.go
+++ b/cli/internal/cmd/conventions/list.go
@@ -8,10 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -65,8 +66,8 @@ func newListCmd() *cobra.Command {
 			"conventions registered in the operator's tenant, sorted " +
 			"priority DESC, created_at ASC — the same order T4's preamble " +
 			"assembler uses. --kind filters by operational | workflow | " +
-			"reference. --json emits the raw ListResponse envelope for jq " +
-			"pipelines.",
+			"reference. --json emits the raw ConventionListResponse envelope " +
+			"for jq pipelines.",
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -81,7 +82,7 @@ func newListCmd() *cobra.Command {
 	cmd.Flags().StringVar(&kind, "kind", "",
 		"narrow entries by kind: operational | workflow | reference")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
-		"emit raw ListResponse JSON instead of the human table")
+		"emit raw ConventionListResponse JSON instead of the human table")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
 	return cmd
@@ -114,15 +115,24 @@ func runList(cmd *cobra.Command, opts listOptions) error {
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
+	if resp.StatusCode != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode, resp.Body, opts.JSONOut)
+	}
+	var payload api.ConventionListResponse
+	if err := json.Unmarshal(resp.Body, &payload); err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("decode conventions list response: %v", err)),
+			opts.JSONOut)
+	}
 	if opts.JSONOut {
 		// --json mode is the agent / scripting surface: emit the full
 		// envelope (entries + budget_status) and exit 0 regardless of
 		// over-budget state. JSON consumers parse budget_status
 		// themselves; the human warning + exit-code-5 branch is for
 		// the table mode below.
-		return output.PrintJSON(cmd.OutOrStdout(), resp)
+		return output.PrintJSON(cmd.OutOrStdout(), payload)
 	}
-	printListTable(cmd.OutOrStdout(), resp)
+	printListTable(cmd.OutOrStdout(), &payload)
 	// G7.1-T7 (#1094): when the tenant is over budget, the table is
 	// still useful (it shows what's there), so we always print it.
 	// But we also need to alert the operator that some conventions
@@ -132,11 +142,11 @@ func runList(cmd *cobra.Command, opts listOptions) error {
 	// makes the failure machine-detectable. T3 #315 deferred this AC
 	// because the list endpoint had no dropped_slugs surface; T7 is
 	// the plumbing that finally satisfies it.
-	if resp != nil && resp.BudgetStatus.OverBudget {
-		printOverBudgetWarning(cmd.ErrOrStderr(), &resp.BudgetStatus)
+	if payload.BudgetStatus.OverBudget {
+		printOverBudgetWarning(cmd.ErrOrStderr(), &payload.BudgetStatus)
 		return output.RenderError(
 			cmd.ErrOrStderr(),
-			output.InsufficientBudget(formatBudgetDetail(&resp.BudgetStatus)),
+			output.InsufficientBudget(formatBudgetDetail(&payload.BudgetStatus)),
 			false, // JSON mode exited earlier; this path is human-only
 		)
 	}
@@ -161,7 +171,7 @@ func runList(cmd *cobra.Command, opts listOptions) error {
 // The remediation hint is concrete — operators routinely run `meho
 // conventions edit <slug>` after seeing this, so the message points
 // them at the right next action.
-func printOverBudgetWarning(stderrW io.Writer, bs *BudgetStatus) {
+func printOverBudgetWarning(stderrW io.Writer, bs *api.BudgetStatus) {
 	fmt.Fprintf(stderrW,
 		"WARNING: tenant operational conventions exceed preamble budget "+
 			"(max_tokens=%d; estimated=%d).\n",
@@ -183,7 +193,7 @@ func printOverBudgetWarning(stderrW io.Writer, bs *BudgetStatus) {
 // is the structured detail jq-style consumers see in the JSON
 // envelope's "detail" field. Compact + machine-friendly: names the
 // slug count and the overflow magnitude.
-func formatBudgetDetail(bs *BudgetStatus) string {
+func formatBudgetDetail(bs *api.BudgetStatus) string {
 	return fmt.Sprintf(
 		"%d operational convention(s) will be dropped from the agent preamble "+
 			"(estimated=%d, max_tokens=%d): %v",
@@ -191,38 +201,47 @@ func formatBudgetDetail(bs *BudgetStatus) string {
 	)
 }
 
-// buildListPath assembles the GET /api/v1/conventions query string from
-// the per-call options. Exposed for unit tests so the URL construction
-// stays unit-checkable without standing up an httptest.Server.
-func buildListPath(opts listOptions) string {
-	q := url.Values{}
+// listQueryParams maps the CLI flags onto the generated query-param
+// shape. The `kind` query param is omitted from the wire when the
+// operator didn't pass --kind so the backend's "return all kinds"
+// default applies cleanly; sending an explicit empty kind would be
+// rejected by pydantic's enum validation.
+func listQueryParams(opts listOptions) *api.ListConventionsApiV1ConventionsGetParams {
+	params := &api.ListConventionsApiV1ConventionsGetParams{}
 	if opts.Kind != "" {
-		q.Set("kind", opts.Kind)
+		kind := api.ConventionKind(opts.Kind)
+		params.Kind = &kind
 	}
-	path := "/api/v1/conventions"
-	if encoded := q.Encode(); encoded != "" {
-		path = path + "?" + encoded
-	}
-	return path
+	return params
 }
 
-func getList(ctx context.Context, backplaneURL string, opts listOptions) (*ListResponse, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildListPath(opts), nil)
+func getList(
+	ctx context.Context,
+	backplaneURL string,
+	opts listOptions,
+) (*rawResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out ListResponse
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode conventions list response: %w", err)
-	}
-	return &out, nil
+	params := listQueryParams(opts)
+	return doRequest(ctx, authed,
+		func(ctx context.Context) (*http.Response, error) {
+			return authed.ListConventionsApiV1ConventionsGet(ctx, params)
+		},
+	)
 }
 
 // printListTable renders the list as a compact, scannable table.
 // Columns: SLUG, KIND, PRIORITY, UPDATED, TITLE. The full ISO-8601
 // timestamp is kept verbatim (not truncated) because operators
 // correlating with audit-log rows want the precise updated_at.
-func printListTable(w io.Writer, r *ListResponse) {
+//
+// UpdatedAt is now a typed time.Time off the generated
+// ConventionSummary (was a string on the pre-migration consumer-side
+// Summary duplicate); we format it back to the RFC 3339 / ISO 8601
+// shape the operator-facing table contract has always used.
+func printListTable(w io.Writer, r *api.ConventionListResponse) {
 	if r == nil || len(r.Entries) == 0 {
 		fmt.Fprintln(w, "no conventions registered in this tenant")
 		return
@@ -233,7 +252,7 @@ func printListTable(w io.Writer, r *ListResponse) {
 			truncate(e.Slug, 32),
 			e.Kind,
 			e.Priority,
-			e.UpdatedAt,
+			e.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z"),
 			truncate(e.Title, 60),
 		)
 	}

--- a/cli/internal/cmd/conventions/show.go
+++ b/cli/internal/cmd/conventions/show.go
@@ -8,10 +8,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -87,34 +89,84 @@ func runShow(cmd *cobra.Command, opts showOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	conv, err := getConvention(cmd.Context(), backplaneURL, opts.Slug)
+	resp, err := getShow(cmd.Context(), backplaneURL, opts.Slug)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode, resp.Body, opts.JSONOut)
+	}
+	var conv api.Convention
+	if err := json.Unmarshal(resp.Body, &conv); err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("decode conventions show response: %v", err)),
+			opts.JSONOut)
 	}
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), conv)
 	}
-	printConventionBody(cmd.OutOrStdout(), conv)
+	printConventionBody(cmd.OutOrStdout(), &conv)
 	return nil
 }
 
-// buildShowPath assembles the GET path. Exposed for unit tests so URL
-// encoding of slugs stays covered (slugs are constrained to lowercase
-// ASCII + digits + hyphen server-side, but the escape is defensive).
-func buildShowPath(slug string) string {
-	return "/api/v1/conventions/" + pathEscape(slug)
-}
-
-func getConvention(ctx context.Context, backplaneURL, slug string) (*Convention, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildShowPath(slug), nil)
+// getShow runs the typed Show call against the generated client with
+// the standard 401-refresh retry around it.
+func getShow(
+	ctx context.Context,
+	backplaneURL, slug string,
+) (*rawResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out Convention
-	if err := json.Unmarshal(raw, &out); err != nil {
+	return doRequest(ctx, authed,
+		func(ctx context.Context) (*http.Response, error) {
+			return authed.ShowConventionApiV1ConventionsSlugGet(
+				ctx, slug, &api.ShowConventionApiV1ConventionsSlugGetParams{},
+			)
+		},
+	)
+}
+
+// getConvention is the success-path convenience wrapper for callers
+// that just want the decoded Convention (or an error categorised by
+// the standard ladder). Used by the edit verb's $EDITOR-mode
+// pre-fetch; the verb separately classifies non-2xx via
+// renderHTTPStatus on the wrapping run handler so a 404 surfaces with
+// the backend's `convention_not_found` detail.
+func getConvention(
+	ctx context.Context,
+	backplaneURL, slug string,
+) (*api.Convention, error) {
+	resp, err := getShow(ctx, backplaneURL, slug)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, &showHTTPError{
+			StatusCode: resp.StatusCode,
+			Body:       resp.Body,
+		}
+	}
+	var conv api.Convention
+	if err := json.Unmarshal(resp.Body, &conv); err != nil {
 		return nil, fmt.Errorf("decode conventions show response: %w", err)
 	}
-	return &out, nil
+	return &conv, nil
+}
+
+// showHTTPError wraps a non-2xx response from the show endpoint so
+// the edit verb's pre-fetch can route it back through renderHTTPStatus
+// once it reaches the runEdit caller (the categorisation matches
+// pre-migration behaviour: 404 on the show fetch surfaces as
+// convention_not_found, not as a generic "couldn't fetch" message).
+type showHTTPError struct {
+	StatusCode int
+	Body       []byte
+}
+
+func (e *showHTTPError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, strings.TrimSpace(string(e.Body)))
 }
 
 // printConventionBody writes the convention's Markdown body to stdout
@@ -125,7 +177,7 @@ func getConvention(ctx context.Context, backplaneURL, slug string) (*Convention,
 // Trimming `\r` + `\n` from the right keeps the single-trailing-
 // newline contract regardless of whether the operator stored their
 // body with or without a trailing LF/CRLF.
-func printConventionBody(w io.Writer, c *Convention) {
+func printConventionBody(w io.Writer, c *api.Convention) {
 	if c == nil {
 		return
 	}

--- a/docs/codebase/tenant_conventions.md
+++ b/docs/codebase/tenant_conventions.md
@@ -318,7 +318,15 @@ T3 (#315) ships the `meho conventions ...` cobra subcommand tree
 Each verb wraps exactly one T2 route; the audit log row + history
 row are written server-side, so the CLI is a thin HTTP client over
 the same JWT auth + bearer-refresh path the sibling `meho kb` /
-`meho agent` trees use.
+`meho agent` trees use. G0.12-T8 (#1266, Initiative #1118) migrated
+the package off the per-package hand-rolled `doAuthedRequest` +
+consumer-side `Convention` / `Summary` / `BudgetStatus` /
+`ListResponse` / `HistoryEntry` duplicates onto the generated typed
+client (`api.ClientWithResponses` via `api.AuthedClient`);
+`api.Convention`, `api.ConventionSummary`, `api.ConventionListResponse`,
+`api.ConventionHistoryEntry`, and `api.BudgetStatus` are now the
+single source of truth on the CLI side, kept in lock-step with the
+FastAPI Pydantic models by the `cli-api-snapshot-freshness` CI gate.
 
 Six verbs:
 


### PR DESCRIPTION
## Summary

- Migrates `cli/internal/cmd/conventions/` (the `meho conventions {list, show, create, edit, delete, history}` verbs) off the per-package hand-rolled `doAuthedRequest` + consumer-side `Convention` / `Summary` / `BudgetStatus` / `ListResponse` / `HistoryEntry` duplicates onto the generated typed client (`api.ClientWithResponses` via `api.AuthedClient`). Closes the #1069-class schema-drift hole the freshness gate is designed to catch — second-discovered drift symptom of Initiative #1118 (G7.1-T3 #1046 shipped these verbs hand-rolled).
- Reworks `conventions_test.go` and `crud_test.go` against `api.Convention*` types with a `writeJSON` / `writeJSONErr` helper that pins the `Content-Type: application/json` header (the generated parser only populates JSON200/JSON201 when present). Same shape as the sibling migrations on the same Initiative: T1 (#1251) `approvals/`, T3 (#1261) `agent/`, T4 (#1262) `agent-principal/`.
- Binds to the lower-level non-`*WithResponse` client methods so the over-budget string-detail 422 (G7.1-T7 #1094 `{"detail":"convention body exceeds preamble budget ..."}`) doesn't trip the generated parser's `HTTPValidationError`-only unmarshal. The shared `doRequest` helper reads body bytes once into a `rawResponse` so verbs unmarshal 2xx via their own typed pointer and route non-2xx through `renderHTTPStatus` uniformly.
- One-line doc note added to `docs/codebase/tenant_conventions.md` on the existing CLI-surface section recording the substrate's typed-client migration.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./...` — every CLI package passes
- [x] `go test -v -count=1 ./internal/cmd/conventions/...` — 39 tests, all pass
- [x] `gofmt -l ./internal/cmd/conventions/` — clean
- [x] `grep -rnE "http.NewRequest|doAuthedRequest|^type Convention |^type Summary |^type BudgetStatus |^type ListResponse |^type HistoryEntry " cli/internal/cmd/conventions/` — returns no matches
- [x] `grep -rn "api.AuthedClient|api.Convention\b|ListConventionsApiV1ConventionsGet" cli/internal/cmd/conventions/` — present across the six verb files + the shared `conventions.go`
- [x] `api/openapi.json` + `cli/internal/api/client.gen.go` unchanged — freshness gate green
- [x] No change to `backend/src/meho_backplane/api/v1/conventions.py` — server stays unchanged
- [x] `.claude/hooks/code-quality.py --diff` — clean

## Out of scope

- Other CLI verb directories under `cli/internal/cmd/` (covered by sibling tasks on Initiative #1118).
- FastAPI conventions route shapes (server side untouched).
- The `editor.go` `$EDITOR` integration (UX-only, no transport).
- Renaming verbs, flags, or output formatting.

Closes #1266
