### PR TITLE
refactor(cli): G0.12-T11 migrate cmd/migrate/ to typed client (#1269)

### DIFF
--- a/cli/internal/cmd/migrate/memory.go
+++ b/cli/internal/cmd/migrate/memory.go
@@ -19,16 +19,6 @@ import (
 // the real doSubmit wired in newMemoryCmd.
 type SubmitFn func(plans []migrate.SubmitPlan) error
 
-// dryRunEnvelope is the machine-readable shape emitted by --dry-run
-// (one JSON object per line). Matches the T5 POST body exactly.
-type dryRunEnvelope struct {
-	Scope    string         `json:"scope"`
-	Slug     string         `json:"slug"`
-	Body     string         `json:"body"`
-	Metadata map[string]any `json:"metadata"`
-	SourceID string         `json:"source_id"`
-}
-
 func newMemoryCmd() *cobra.Command {
 	// Real submit fn is wired inside RunE via newMemoryCmdWithSubmit(nil):
 	// a nil submitFn causes RunE to call doSubmit (the real HTTP POST path).
@@ -156,7 +146,20 @@ func newMemoryCmdWithSubmit(submitFn SubmitFn) *cobra.Command {
 }
 
 // runDryRun prints one JSON envelope per migrate-selected file (default
-// plan, no form) and makes no network call.
+// plan, no form) and makes no network call. The envelope is the typed
+// api.RememberBody — same shape postOne sends on the wire after the
+// G0.12-T11 migration to the generated client. Operators reading the
+// dry-run output get an honest preview of the actual request body.
+//
+// Pre-migration the dry-run envelope included a `source_id` field that
+// the legacy hand-rolled body also sent; the backend's frozen
+// `extra="forbid"` RememberBody schema rejects `source_id` (the server
+// computes it from `(scope, user_sub, target_name, slug)`), so the
+// legacy preview was misleading. The migration drops `source_id` from
+// both the wire body and the dry-run envelope. Deduplication semantics
+// are unchanged — the server still computes the same source_id from
+// the same (scope, slug, target_name) triple — the field just never
+// belonged in the operator-supplied body.
 func runDryRun(cmd *cobra.Command, files []migrate.MemoryFile, opts migrate.BuildFormOpts) error {
 	enc := json.NewEncoder(cmd.OutOrStdout())
 	enc.SetEscapeHTML(false)
@@ -165,17 +168,7 @@ func runDryRun(cmd *cobra.Command, files []migrate.MemoryFile, opts migrate.Buil
 		if plan.Skip {
 			continue
 		}
-		md := plan.File.Metadata
-		if md == nil {
-			md = map[string]any{}
-		}
-		env := dryRunEnvelope{
-			Scope:    plan.Scope,
-			Slug:     plan.Slug,
-			Body:     plan.Body,
-			Metadata: md,
-			SourceID: sourceID(plan),
-		}
+		env := buildRememberBody(plan)
 		if err := enc.Encode(env); err != nil {
 			return err
 		}
@@ -215,13 +208,4 @@ func filterMigrate(plans []migrate.SubmitPlan) []migrate.SubmitPlan {
 		}
 	}
 	return out
-}
-
-// sourceID builds the stable source_id string from a plan's BodySHA256.
-func sourceID(plan migrate.SubmitPlan) string {
-	prefix := plan.File.BodySHA256
-	if len(prefix) > migrate.SourceIDPrefix {
-		prefix = prefix[:migrate.SourceIDPrefix]
-	}
-	return "laptop-migration/" + prefix
 }

--- a/cli/internal/cmd/migrate/memory_test.go
+++ b/cli/internal/cmd/migrate/memory_test.go
@@ -88,19 +88,22 @@ func TestDryRun_EmitsJSONEnvelopes(t *testing.T) {
 		if err := json.Unmarshal([]byte(line), &env); err != nil {
 			t.Errorf("line is not valid JSON: %q — %v", line, err)
 		}
-		for _, field := range []string{"scope", "slug", "body", "metadata", "source_id"} {
+		// G0.12-T11 migrated the dry-run envelope onto api.RememberBody
+		// (the typed POST body). The required fields match the FastAPI
+		// schema: scope / body / slug / metadata. expires_at and
+		// target_name are present-with-null per the typed JSON encoder
+		// (pointer types with no `omitempty` tag).
+		for _, field := range []string{"scope", "body", "slug", "metadata"} {
 			if _, ok := env[field]; !ok {
 				t.Errorf("dry-run envelope missing field %q", field)
 			}
 		}
-		sid, _ := env["source_id"].(string)
-		if !strings.HasPrefix(sid, "laptop-migration/") {
-			t.Errorf("source_id = %q; want prefix laptop-migration/", sid)
-		}
-		// prefix length check: 17 ("laptop-migration/") + SourceIDPrefix hex chars
-		wantLen := 17 + migrate.SourceIDPrefix
-		if len(sid) != wantLen {
-			t.Errorf("source_id len = %d; want %d", len(sid), wantLen)
+		// source_id is NOT in the wire body — the server computes it
+		// from `(scope, user_sub, target_name, slug)`. The pre-T11 CLI
+		// was sending source_id and being silently rejected by the
+		// backend's frozen extra="forbid" RememberBody schema.
+		if _, ok := env["source_id"]; ok {
+			t.Errorf("dry-run envelope MUST NOT contain source_id; got: %s", line)
 		}
 	}
 }
@@ -200,9 +203,15 @@ func TestNonInteractive_MachineLocalSkipped(t *testing.T) {
 	}
 }
 
-// ── source_id stability ───────────────────────────────────────────────────────
+// ── Wire-body stability ───────────────────────────────────────────────────────
 
-func TestDryRun_SourceIDStable(t *testing.T) {
+// Two dry-runs of the same fixture must emit byte-identical
+// envelopes. The server-side dedup contract (G5.1 upsert by
+// `(tenant_id, source, source_id)` where source_id is server-computed
+// from `(scope, user_sub, target_name, slug)`) is preserved iff the
+// CLI sends the same `(scope, slug, target_name)` triple on every
+// re-run — exactly what equal-bytes on the dry-run envelope asserts.
+func TestDryRun_WireBodyStable(t *testing.T) {
 	dir := t.TempDir()
 	writeFixture(t, dir, "user.md", userFixture)
 
@@ -212,16 +221,12 @@ func TestDryRun_SourceIDStable(t *testing.T) {
 		if err != nil {
 			t.Fatalf("dry-run error: %v", err)
 		}
-		var env map[string]any
-		if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &env); err != nil {
-			t.Fatalf("unmarshal: %v", err)
-		}
-		return env["source_id"].(string)
+		return strings.TrimSpace(out)
 	}
 
-	id1, id2 := run(), run()
-	if id1 != id2 {
-		t.Errorf("source_id is not stable: %q != %q", id1, id2)
+	b1, b2 := run(), run()
+	if b1 != b2 {
+		t.Errorf("dry-run wire body is not stable across reruns:\n  first:  %s\n  second: %s", b1, b2)
 	}
 }
 

--- a/cli/internal/cmd/migrate/submit.go
+++ b/cli/internal/cmd/migrate/submit.go
@@ -267,6 +267,18 @@ func buildRememberBody(plan migrate.SubmitPlan) api.RememberBody {
 // 504 from the backplane. 201-without-body (transientStatusError with
 // status 201) is NOT transient — the server confirmed the row exists,
 // the contract failure is on the response shape.
+//
+// Credential-state failures returned by newAuthedClient
+// (errMissingAccessToken, api.IsTokenNotFound, api.IsNoRefreshToken)
+// short-circuit BEFORE any HTTP call leaves the process — retrying
+// cannot resolve them. The pre-T11 code resolved the auth token outside
+// the retry loop, so these errors never reached isTransient; the
+// migration moved the call site into the loop, which would otherwise
+// classify them as transient and burn three retries (non-interactive)
+// or three Retry/Skip/Abort prompts (interactive) before
+// renderSubmitError finally rendered the correct auth_expired hint.
+// Short-circuit here so postWithRetry sees a single non-transient
+// failure and routes straight to renderSubmitError.
 func isTransient(err error) bool {
 	var tse *transientStatusError
 	if errors.As(err, &tse) {
@@ -277,6 +289,16 @@ func isTransient(err error) bool {
 			http.StatusGatewayTimeout:
 			return true
 		}
+		return false
+	}
+	// Credential failures from newAuthedClient surface before the HTTP
+	// call; no amount of retrying gets the operator a token. Match the
+	// three sentinels renderSubmitError already maps to auth_expired so
+	// the retry-vs-permanent decision and the exit-code classification
+	// agree on what "credential failure" means.
+	if errors.Is(err, errMissingAccessToken) ||
+		api.IsTokenNotFound(err) ||
+		api.IsNoRefreshToken(err) {
 		return false
 	}
 	// Transport / parse errors (connection refused, timeout, MaxBytesError,

--- a/cli/internal/cmd/migrate/submit.go
+++ b/cli/internal/cmd/migrate/submit.go
@@ -4,14 +4,12 @@
 package migrate
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 
 	"charm.land/huh/v2"
@@ -19,25 +17,10 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
-	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/migrate"
 	"github.com/evoila/meho/cli/internal/output"
 )
-
-// memoryPostBody is the request body POSTed to POST /api/v1/memory.
-// source_id is the deduplication key on the server side — the G5.1
-// upsert-by-source_id contract means that re-running with the same
-// body is a no-op (updated_at unchanged) and with a changed body is
-// an update (updated_at bumped). expires_at is deliberately omitted:
-// the G5.2 server-side default-TTL injection owns it for user-scoped
-// entries (#374).
-type memoryPostBody struct {
-	Scope    string         `json:"scope"`
-	Slug     string         `json:"slug"`
-	Body     string         `json:"body"`
-	Metadata map[string]any `json:"metadata"`
-	SourceID string         `json:"source_id"`
-}
 
 // submitResult tallies the outcome of a submitPlans call.
 type submitResult struct {
@@ -61,9 +44,9 @@ var runSpinnerFn = func(sp *spinner.Spinner) error { return sp.Run() }
 // doSubmit orchestrates per-entry submission. The interactive error prompt runs
 // outside the spinner to avoid concurrent tea programs sharing the same TTY.
 func doSubmit(cmd *cobra.Command, backplaneOverride string, plans []migrate.SubmitPlan) error {
-	backplaneURL, err := resolveBackplaneURL(backplaneOverride)
+	backplaneURL, err := backplane.Resolve(backplaneOverride)
 	if err != nil {
-		return renderSubmitError(cmd, "", err)
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), false)
 	}
 
 	nonInteractive, _ := cmd.Flags().GetBool("non-interactive")
@@ -79,10 +62,11 @@ func doSubmit(cmd *cobra.Command, backplaneOverride string, plans []migrate.Subm
 			// Route the permanent error through renderSubmitError so the
 			// exit code reflects the failure class (auth_expired=2 for
 			// expired/missing/refresh-rejected tokens, unexpected=4 for
-			// other non-2xx, unreachable=3 for transport errors). Without
-			// this, every permanent error would exit 1 — same code as a
-			// generic CLI error — and `meho migrate memory` in a cron job
-			// would be indistinguishable from an unrelated CLI flag bug.
+			// non-2xx and parse failures, unreachable=3 for transport
+			// errors). Without this, every permanent error would exit 1 —
+			// same code as a generic CLI error — and `meho migrate memory`
+			// in a cron job would be indistinguishable from an unrelated
+			// CLI flag bug.
 			return renderSubmitError(cmd, backplaneURL, err)
 		}
 	}
@@ -100,6 +84,21 @@ func doSubmit(cmd *cobra.Command, backplaneOverride string, plans []migrate.Subm
 
 var errAborted = errors.New("migration aborted by user")
 
+// transientStatusError carries a non-2xx server response back from
+// postOne so postWithRetry's transient-vs-permanent switch can act on
+// the status code. Lifts the status off the typed response envelope
+// after the verb's own JSON201 nil-guard runs; we need the numeric
+// code (not a rendered output.StructuredError) for the retry-vs-abort
+// decision.
+type transientStatusError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *transientStatusError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
 // postWithRetry submits one plan entry. In non-interactive mode it auto-retries
 // on transient errors (up to maxAutoRetry attempts). In interactive mode, each
 // attempt runs inside its own spinner; the Retry/Skip/Abort prompt is presented
@@ -111,19 +110,6 @@ func postWithRetry(
 	nonInteractive bool,
 	res *submitResult,
 ) error {
-	body := memoryPostBody{
-		Scope:    plan.Scope,
-		Slug:     plan.Slug,
-		Body:     plan.Body,
-		Metadata: map[string]any{"tags": []string{}},
-		SourceID: buildSourceID(plan),
-	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		res.Errored++
-		return nil // marshal failure is a local bug, skip gracefully
-	}
-
 	attempt := 0
 	for {
 		attempt++
@@ -131,7 +117,7 @@ func postWithRetry(
 		sp := spinner.New().
 			Title(fmt.Sprintf("Migrating %q…", plan.Slug)).
 			ActionWithErr(func(ctx context.Context) error {
-				_, postErr = doAuthedRequest(ctx, backplaneURL, http.MethodPost, "/api/v1/memory", raw)
+				postErr = postOne(ctx, backplaneURL, plan)
 				return nil
 			})
 		if err := runSpinnerFn(sp); err != nil {
@@ -147,8 +133,8 @@ func postWithRetry(
 			res.Errored++
 			// Bubble the raw error up — doSubmit routes it through
 			// renderSubmitError for proper exit-code classification.
-			// fmt.Errorf with %w preserves errors.As(_, *httpError) so
-			// renderSubmitError can pick the right exit class.
+			// fmt.Errorf with %w preserves errors.As against the
+			// status / typed-parse error categories below.
 			return fmt.Errorf("entry %s: %w", plan.Slug, postErr)
 		}
 
@@ -191,23 +177,100 @@ func postWithRetry(
 	}
 }
 
-// buildSourceID constructs the stable source_id for a plan's body hash.
-// Matches the dry-run output from the sourceID function in memory.go.
-func buildSourceID(plan migrate.SubmitPlan) string {
-	prefix := plan.File.BodySHA256
-	n := migrate.SourceIDPrefix
-	if len(prefix) > n {
-		prefix = prefix[:n]
+// postOne drives one POST /api/v1/memory through the generated typed
+// client. Errors:
+//
+//   - transport / parse failures bubble up verbatim (renderSubmitError
+//     classifies them into output.Unreachable or output.Unexpected).
+//   - non-2xx responses return a *transientStatusError carrying the
+//     status code + body so postWithRetry can decide retry-vs-abort and
+//     renderSubmitError can map the code to a category.
+//   - a 201 without a decoded JSON201 payload (Content-Type drift
+//     between backplane and parser) surfaces as *transientStatusError
+//     too, marked unexpected — mirrors the convention in
+//     cli/internal/cmd/status.go:142 and the kb iter-2 nil-guard
+//     pattern.
+//
+// The buildRememberBody seam keeps the wire shape isolated so a
+// regenerated client (oapi-codegen renames a field, the FastAPI route
+// adds a required field) surfaces as a compile error here rather than
+// at every call site.
+func postOne(ctx context.Context, backplaneURL string, plan migrate.SubmitPlan) error {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return err
 	}
-	return "laptop-migration/" + prefix
+	body := buildRememberBody(plan)
+	resp, err := retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.RememberApiV1MemoryPostResponse, error) {
+			return authed.RememberApiV1MemoryPostWithResponse(
+				ctx,
+				&api.RememberApiV1MemoryPostParams{},
+				body,
+			)
+		},
+		func(r *api.RememberApiV1MemoryPostResponse) int { return r.StatusCode() },
+	)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode() != http.StatusCreated {
+		return &transientStatusError{
+			StatusCode: resp.StatusCode(),
+			Body:       strings.TrimSpace(string(resp.Body)),
+		}
+	}
+	// Generated ParseRememberApiV1MemoryPostResponse only populates
+	// JSON201 when the response has Content-Type containing "json" AND
+	// status 201. A backplane / proxy that returns 201 with a missing
+	// or mistyped content-type leaves JSON201 nil; without this guard
+	// res.Migrated would tick up but the operator never gets a chance
+	// to notice the contract drift. Mirrors the convention in
+	// cli/internal/cmd/status.go:142 and the kb iter-2 nil-guard
+	// pattern.
+	if resp.JSON201 == nil {
+		return &transientStatusError{
+			StatusCode: resp.StatusCode(),
+			Body:       fmt.Sprintf("HTTP 201 without a memory entry payload (body=%dB)", len(resp.Body)),
+		}
+	}
+	return nil
+}
+
+// buildRememberBody maps a SubmitPlan onto the generated POST body.
+// The scope MUST round-trip through api.MemoryScope so any backend
+// rename of a scope constant surfaces as a compile error here rather
+// than as a 422 on the wire. The metadata payload ("tags=[]") matches
+// the legacy hand-typed body shape so cron jobs running this CLI on
+// upgrade see byte-identical wire payloads — modulo the source_id
+// field, which the legacy hand-typed body sent but the backend's
+// frozen extra="forbid" RememberBody schema rejects (the server
+// computes source_id itself from `(scope, user_sub, target_name,
+// slug)` in `memory/_internal.py::encode_source_id`). Tests masked
+// the latent 422 because the httptest mock accepted any JSON; the
+// migration to the typed client both modernises the transport and
+// closes the #1069-class drift this Initiative #1118 targets.
+func buildRememberBody(plan migrate.SubmitPlan) api.RememberBody {
+	scope := api.MemoryScope(plan.Scope)
+	slug := plan.Slug
+	md := map[string]interface{}{"tags": []string{}}
+	return api.RememberBody{
+		Scope:    scope,
+		Slug:     &slug,
+		Body:     plan.Body,
+		Metadata: &md,
+	}
 }
 
 // isTransient returns true for errors that are worth retrying: network
-// timeouts, 500/502/503/504 from the backplane.
+// timeouts (any non-status error returned by postOne) and 500/502/503/
+// 504 from the backplane. 201-without-body (transientStatusError with
+// status 201) is NOT transient — the server confirmed the row exists,
+// the contract failure is on the response shape.
 func isTransient(err error) bool {
-	var he *httpError
-	if errors.As(err, &he) {
-		switch he.StatusCode {
+	var tse *transientStatusError
+	if errors.As(err, &tse) {
+		switch tse.StatusCode {
 		case http.StatusInternalServerError,
 			http.StatusBadGateway,
 			http.StatusServiceUnavailable,
@@ -216,55 +279,73 @@ func isTransient(err error) bool {
 		}
 		return false
 	}
-	// Transport errors (connection refused, timeout) are transient.
+	// Transport / parse errors (connection refused, timeout, MaxBytesError,
+	// JSON unmarshal) are transient.
 	return true
 }
 
-// ── In-package HTTP helper trio (copied from cli/internal/cmd/kb/kb.go) ──────
-// This duplication is intentional: a shared helper would close an import
-// cycle via cmd/root.go. Each cmd/* verb tree carries its own copy per
-// the established convention (audit/, kb/, targets/, operation/ all do the
-// same).
-
+// errMissingAccessToken is the sentinel newAuthedClient returns when
+// the stored token row exists but its access_token is empty — a
+// credential-state failure renderSubmitError maps to auth_expired
+// with a `meho login` hint. Mirrors the agent-principal / kb / agent
+// package shapes so an operator sees the same hint across every
+// verb tree.
 var errMissingAccessToken = errors.New("meho: stored token has no access_token")
 
-type errNoBackplaneConfigured struct{ inner error }
-
-func (e *errNoBackplaneConfigured) Error() string {
-	return "no backplane URL configured; run `meho login <url>` first or pass --backplane <url>"
-}
-func (e *errNoBackplaneConfigured) Unwrap() error { return e.inner }
-
-func resolveBackplaneURL(override string) (string, error) {
-	if override != "" {
-		return normaliseURL(override)
-	}
-	cfg, err := auth.LoadConfig()
+// newAuthedClient builds an api.AuthedClient for the supplied
+// backplane URL and verifies a non-empty bearer is loaded. Centralised
+// so the typed-call path goes through the same "stored-token-loaded +
+// non-empty bearer" gate; the caller forwards any returned error to
+// renderSubmitError for category mapping.
+func newAuthedClient(ctx context.Context, backplaneURL string) (*api.AuthedClient, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
 	if err != nil {
-		if errors.Is(err, auth.ErrConfigNotFound) {
-			return "", &errNoBackplaneConfigured{inner: err}
-		}
-		return "", err
+		return nil, err
 	}
-	return normaliseURL(cfg.BackplaneURL)
+	if authed.AccessToken() == "" {
+		return nil, errMissingAccessToken
+	}
+	return authed, nil
 }
 
-func normaliseURL(s string) (string, error) {
-	trimmed := strings.TrimRight(strings.TrimSpace(s), "/")
-	if trimmed == "" {
-		return "", errors.New("backplane URL is empty")
-	}
-	u, err := url.ParseRequestURI(trimmed)
+// retryOn401 invokes call once, and if the typed response carries a
+// 401, runs a one-shot bearer refresh and re-issues call. Mirrors the
+// behaviour api.AuthedClient.GetHealth implements for /api/v1/health,
+// generalised so the migrate verb runs the same transparent-retry
+// contract as the agent-principal / kb / agent siblings.
+//
+// statusOf reads the StatusCode off the typed response envelope. A
+// nil response counts as "no retry" — the transport already failed
+// and the caller surfaces err directly.
+func retryOn401[R any](
+	ctx context.Context,
+	authed *api.AuthedClient,
+	call func(ctx context.Context) (*R, error),
+	statusOf func(*R) int,
+) (*R, error) {
+	resp, err := call(ctx)
 	if err != nil {
-		return "", fmt.Errorf("invalid backplane URL %q: %w", s, err)
+		return nil, err
 	}
-	if u.Host == "" {
-		return "", fmt.Errorf("backplane URL %q has no host", s)
+	if resp == nil || statusOf(resp) != http.StatusUnauthorized {
+		return resp, nil
 	}
-	u.Path = strings.TrimRight(u.Path, "/")
-	return u.String(), nil
+	if rerr := authed.Refresh(ctx); rerr != nil {
+		return resp, rerr
+	}
+	return call(ctx)
 }
 
+// renderSubmitError translates a postOne error into the right
+// output.StructuredError category.
+//
+// Parse / cap failures route to output.Unexpected (exit 4 —
+// unexpected_response) rather than output.Unreachable (exit 3 —
+// network_unreachable). A JSON decode rejecting a malformed payload
+// or a body-cap firing is a contract / shape failure on the server
+// side, not a transport-down failure on the operator's side;
+// surfacing it as "unreachable" would send operators chasing a
+// network ghost. Mirrors the kb iter-2 classification.
 func renderSubmitError(cmd *cobra.Command, backplaneURL string, err error) error {
 	if errors.Is(err, errMissingAccessToken) {
 		return output.RenderError(cmd.ErrOrStderr(),
@@ -293,18 +374,25 @@ func renderSubmitError(cmd *cobra.Command, backplaneURL string, err error) error
 			false,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
-		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
-			false,
-		)
+	var tse *transientStatusError
+	if errors.As(err, &tse) {
+		return renderHTTPStatus(cmd, backplaneURL, tse.StatusCode, []byte(tse.Body))
 	}
-	var nbc *errNoBackplaneConfigured
-	if errors.As(err, &nbc) {
+	// Transport-layer body-cap firing and JSON shape failures bubbling
+	// out of the generated parsers are server-side contract failures,
+	// not transport-down failures — surface them as unexpected_response
+	// (exit 4) with the backplane URL so the operator sees the origin
+	// without chasing a network ghost. Mirrors the kb iter-2
+	// classification.
+	var maxBytesErr *http.MaxBytesError
+	var syntaxErr *json.SyntaxError
+	var unmarshalErr *json.UnmarshalTypeError
+	if errors.As(err, &maxBytesErr) ||
+		errors.As(err, &syntaxErr) ||
+		errors.As(err, &unmarshalErr) ||
+		errors.Is(err, io.ErrUnexpectedEOF) {
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.AuthExpired(nbc.Error()),
+			output.Unexpected(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 			false,
 		)
 	}
@@ -314,88 +402,56 @@ func renderSubmitError(cmd *cobra.Command, backplaneURL string, err error) error
 	)
 }
 
-const responseBodyCap int64 = 1 << 20
-
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
+// renderHTTPStatus classifies a non-2xx response (or 201 without a
+// decoded payload, treated as an unexpected contract failure) into
+// the right StructuredError category. Preserves the pre-migration
+// mapping:
+//
+//   - 401 → auth_expired (refresh impossible / token rejected).
+//   - 403 → insufficient_role with the backend's detail string.
+//   - Other non-2xx → unexpected with the raw body.
+func renderHTTPStatus(
+	cmd *cobra.Command,
+	backplaneURL string,
+	statusCode int,
 	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errMissingAccessToken
-	}
-
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, responseBodyCap+1))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if int64(len(raw)) > responseBodyCap {
-		return nil, fmt.Errorf(
-			"response body exceeds %d-byte cap; refusing to decode possibly-truncated response",
-			responseBodyCap,
+) error {
+	bodyStr := strings.TrimSpace(string(body))
+	switch statusCode {
+	case http.StatusUnauthorized:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"backplane rejected the stored token; run `meho login %s`",
+				backplaneURL,
+			)),
+			false,
+		)
+	case http.StatusForbidden:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.InsufficientRole(decodeDetailString(bodyStr)),
+			false,
+		)
+	default:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, statusCode, bodyStr)),
+			false,
 		)
 	}
-	if resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusCreated {
-		return raw, nil
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
 }
 
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
+// detailEnvelope models FastAPI's HTTPException JSON shape.
+type detailEnvelope struct {
+	Detail string `json:"detail"`
+}
+
+// decodeDetailString pulls the `detail` field out of a FastAPI error
+// body. Returns the raw body string if the body is not valid JSON or
+// the `detail` field is missing / empty.
+func decodeDetailString(body string) string {
+	var env detailEnvelope
+	if err := json.Unmarshal([]byte(body), &env); err == nil && env.Detail != "" {
+		return env.Detail
 	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
+	return body
 }

--- a/cli/internal/cmd/migrate/submit_test.go
+++ b/cli/internal/cmd/migrate/submit_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -348,6 +349,90 @@ func TestIsTransient_ClientErrors(t *testing.T) {
 func TestIsTransient_TransportError(t *testing.T) {
 	if !isTransient(errors.New("connection refused")) {
 		t.Error("expected isTransient(transport error)=true")
+	}
+}
+
+// TestIsTransient_CredentialFailuresAreNonTransient is the unit-level
+// guard for the B1 regression on PR #1285. Before the fix, the migration
+// moved the auth-token resolution inside the retry loop; isTransient's
+// generic "transport error → retry" fallthrough then classified
+// errMissingAccessToken / auth.ErrTokenNotFound / errNoRefreshToken as
+// transient, triggering up-to-3 wasted retries (non-interactive) or 3
+// spurious Retry/Skip/Abort prompts (interactive) for an error that
+// retrying CANNOT resolve — the operator must run `meho login`.
+//
+// Pin each of the three credential sentinels renderSubmitError already
+// maps to auth_expired so the retry-vs-permanent decision agrees with
+// the exit-code classification.
+func TestIsTransient_CredentialFailuresAreNonTransient(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+	}{
+		{"errMissingAccessToken", errMissingAccessToken},
+		{"errMissingAccessToken wrapped", fmt.Errorf("postOne: %w", errMissingAccessToken)},
+		{"auth.ErrTokenNotFound", auth.ErrTokenNotFound},
+		{"auth.ErrTokenNotFound wrapped", fmt.Errorf("api.NewAuthedClient: %w", auth.ErrTokenNotFound)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if isTransient(tc.err) {
+				t.Errorf("expected isTransient(%v)=false (credential failures are not retryable)", tc.err)
+			}
+		})
+	}
+}
+
+// TestSubmit_MissingTokenExitsOnceNoRetries is the end-to-end guard
+// for the B1 regression on PR #1285. With XDG_CONFIG_HOME pointing at
+// an empty dir, api.NewAuthedClient surfaces auth.ErrTokenNotFound;
+// the fix routes that straight to renderSubmitError, so the operator
+// sees a single auth_expired hint with zero HTTP calls and zero
+// retries. Before the fix, isTransient classified it as transient and
+// postWithRetry burned three retries (non-interactive) before giving
+// up.
+func TestSubmit_MissingTokenExitsOnceNoRetries(t *testing.T) {
+	var serverCalls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, _ *http.Request) {
+		serverCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write(stubMemoryEntry(t, "user", "foo"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// Empty XDG dir + keyring disabled → auth.ErrTokenNotFound from
+	// api.NewAuthedClient. Mirrors the same env shape the production
+	// "operator never ran `meho login`" path produces.
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("MEHO_KEYRING_DISABLE", "1")
+
+	plan := makePlan("foo", "user", "body", "aabbccdd1122")
+	cmd, stdout, stderr := newTestCmd(t)
+	if err := cmd.Flags().Set("non-interactive", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := doSubmit(cmd, srv.URL, []migrate.SubmitPlan{plan})
+	if err == nil {
+		t.Fatalf("expected error when token store is empty; got nil. stdout=%q stderr=%q",
+			stdout.String(), stderr.String())
+	}
+	if got := serverCalls.Load(); got != 0 {
+		t.Errorf("expected zero HTTP calls (credential failure short-circuits before POST); got %d", got)
+	}
+	if !strings.Contains(stderr.String(), "auth_expired") &&
+		!strings.Contains(stderr.String(), "meho login") {
+		t.Errorf("expected auth_expired classification or `meho login` hint; got stderr=%q", stderr.String())
+	}
+	// The summary line is printed by doSubmit before renderSubmitError
+	// fires; it MUST show zero retries because credential failures are
+	// non-transient and postWithRetry must NOT enter the retry path.
+	if !strings.Contains(stdout.String(), "retried 0") {
+		t.Errorf("expected 'retried 0' in summary (no retry attempts on credential failure); got stdout=%q", stdout.String())
 	}
 }
 

--- a/cli/internal/cmd/migrate/submit_test.go
+++ b/cli/internal/cmd/migrate/submit_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -17,8 +18,10 @@ import (
 	"time"
 
 	"charm.land/huh/v2/spinner"
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/migrate"
 )
@@ -33,8 +36,8 @@ func TestMain(m *testing.M) {
 }
 
 // seedXDGAndToken seeds a per-test XDG config dir + file-based token store
-// that resolveBackplaneURL / doAuthedRequest will read. Mirrors the same
-// helper in cli/internal/cmd/kb/kb_test.go.
+// that backplane.Resolve / postOne will read. Mirrors the same helper in
+// cli/internal/cmd/kb/kb_test.go.
 func seedXDGAndToken(t *testing.T, backplaneURL string) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -88,21 +91,47 @@ func makePlan(slug, scope, body, sha string) migrate.SubmitPlan {
 	}
 }
 
+// stubMemoryEntry returns a JSON body matching the api.MemoryEntry
+// shape (the 201 response payload). Used by httptest handlers so the
+// generated ParseRememberApiV1MemoryPostResponse populates JSON201
+// and postOne's nil-guard passes.
+func stubMemoryEntry(t *testing.T, scope, slug string) []byte {
+	t.Helper()
+	now := time.Now().UTC()
+	entry := api.MemoryEntry{
+		Id:        uuid.New(),
+		TenantId:  uuid.New(),
+		Scope:     api.MemoryScope(scope),
+		Slug:      slug,
+		Body:      "stub",
+		Metadata:  map[string]any{"tags": []string{}},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	raw, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal stub entry: %v", err)
+	}
+	return raw
+}
+
 // ── POST body shape ───────────────────────────────────────────────────────────
 
 func TestSubmit_PostsCorrectBody(t *testing.T) {
-	var received []memoryPostBody
+	var received []api.RememberBody
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		var b memoryPostBody
+		var b api.RememberBody
 		if err := json.NewDecoder(r.Body).Decode(&b); err != nil {
 			t.Errorf("decode body: %v", err)
 		}
 		received = append(received, b)
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write(stubMemoryEntry(t, string(b.Scope), *b.Slug))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -123,18 +152,14 @@ func TestSubmit_PostsCorrectBody(t *testing.T) {
 	}
 	for i, got := range received {
 		want := plans[i]
-		if got.Scope != want.Scope {
-			t.Errorf("[%d] scope = %q; want %q", i, got.Scope, want.Scope)
+		if string(got.Scope) != want.Scope {
+			t.Errorf("[%d] scope = %q; want %q", i, string(got.Scope), want.Scope)
 		}
-		if got.Slug != want.Slug {
-			t.Errorf("[%d] slug = %q; want %q", i, got.Slug, want.Slug)
+		if got.Slug == nil || *got.Slug != want.Slug {
+			t.Errorf("[%d] slug = %v; want %q", i, got.Slug, want.Slug)
 		}
 		if got.Body != want.Body {
 			t.Errorf("[%d] body = %q; want %q", i, got.Body, want.Body)
-		}
-		wantSourceID := "laptop-migration/" + want.File.BodySHA256[:migrate.SourceIDPrefix]
-		if got.SourceID != wantSourceID {
-			t.Errorf("[%d] source_id = %q; want %q", i, got.SourceID, wantSourceID)
 		}
 		if got.Metadata == nil {
 			t.Errorf("[%d] metadata should not be nil", i)
@@ -142,37 +167,32 @@ func TestSubmit_PostsCorrectBody(t *testing.T) {
 	}
 }
 
-// ── source_id stability / upsert contract ─────────────────────────────────────
+// ── source_id stability (now a server-side property) ─────────────────────────
 
-func TestSubmit_SourceIDStable(t *testing.T) {
-	p1 := makePlan("foo", "user", "same body", "aabbccdd1122")
-	p2 := makePlan("foo", "user", "same body", "aabbccdd1122")
-	id1 := buildSourceID(p1)
-	id2 := buildSourceID(p2)
-	if id1 != id2 {
-		t.Errorf("source_id not stable: %q != %q", id1, id2)
-	}
-	if id1 != "laptop-migration/aabbccdd1122" {
-		t.Errorf("source_id = %q; want laptop-migration/aabbccdd1122", id1)
-	}
-}
+// The pre-G0.12-T11 CLI sent a `source_id` field in the body that the
+// backend's frozen extra="forbid" RememberBody rejected with 422. The
+// migration drops the field from the wire body — the backend computes
+// source_id itself from `(scope, user_sub, target_name, slug)`
+// (`backend/src/meho_backplane/memory/_internal.py::encode_source_id`)
+// so the (scope, slug) pair is the deduplication key from the
+// operator's perspective. Test that re-submitting an unchanged
+// (scope, slug) entry hits the route twice without changing the body
+// shape — the server-side upsert (G5.1) is what carries the
+// "idempotent re-run" property the legacy CLI tried to express via
+// source_id.
 
-func TestSubmit_ChangedBody_DifferentSourceID(t *testing.T) {
-	p1 := makePlan("foo", "user", "body v1", "aabbccdd1122")
-	p2 := makePlan("foo", "user", "body v2", "112233aabbcc")
-	if buildSourceID(p1) == buildSourceID(p2) {
-		t.Error("expected different source_id for different BodySHA256")
-	}
-}
-
-// TestSubmit_SameBodyRerun simulates the server-side upsert: two POSTs
-// with the same source_id both succeed (server returns 200/201 either way).
-func TestSubmit_SameBodyRerun(t *testing.T) {
-	var callCount atomic.Int32
+func TestSubmit_SameSlugRerunSendsSameBody(t *testing.T) {
+	var received []api.RememberBody
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, r *http.Request) {
-		callCount.Add(1)
+		var b api.RememberBody
+		if err := json.NewDecoder(r.Body).Decode(&b); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		received = append(received, b)
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write(stubMemoryEntry(t, string(b.Scope), *b.Slug))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -181,17 +201,53 @@ func TestSubmit_SameBodyRerun(t *testing.T) {
 	plan := makePlan("foo", "user", "same body", "aabbccdd1122")
 	cmd, stdout, _ := newTestCmd(t)
 
-	// First run.
 	if err := doSubmit(cmd, srv.URL, []migrate.SubmitPlan{plan}); err != nil {
 		t.Fatalf("first run: %v", err)
 	}
-	// Second run with identical body.
 	stdout.Reset()
 	if err := doSubmit(cmd, srv.URL, []migrate.SubmitPlan{plan}); err != nil {
 		t.Fatalf("second run: %v", err)
 	}
-	if callCount.Load() != 2 {
-		t.Errorf("expected exactly 2 POST calls (one per run); got %d", callCount.Load())
+	if len(received) != 2 {
+		t.Fatalf("expected exactly 2 POST calls (one per run); got %d", len(received))
+	}
+	if string(received[0].Scope) != string(received[1].Scope) ||
+		*received[0].Slug != *received[1].Slug ||
+		received[0].Body != received[1].Body {
+		t.Errorf("body shape drifted between identical reruns: %+v vs %+v", received[0], received[1])
+	}
+}
+
+// ── No source_id on the wire ─────────────────────────────────────────────────
+
+// Belt-and-suspenders: assert the typed body the CLI sends doesn't
+// carry a `source_id` field. The generated RememberBody type has no
+// such field, so this can only fail if a future regression adds one.
+
+func TestSubmit_BodyOmitsSourceID(t *testing.T) {
+	var rawBody []byte
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, r *http.Request) {
+		rawBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write(stubMemoryEntry(t, "user", "foo"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	plan := makePlan("foo", "user", "body", "aabbccdd1122")
+	cmd, _, _ := newTestCmd(t)
+	if err := doSubmit(cmd, srv.URL, []migrate.SubmitPlan{plan}); err != nil {
+		t.Fatalf("doSubmit: %v", err)
+	}
+	var anyMap map[string]any
+	if err := json.Unmarshal(rawBody, &anyMap); err != nil {
+		t.Fatalf("decode raw body: %v", err)
+	}
+	if _, ok := anyMap["source_id"]; ok {
+		t.Errorf("wire body must NOT contain source_id (the backend computes it); got: %s", rawBody)
 	}
 }
 
@@ -206,7 +262,9 @@ func TestSubmit_TransientRetryThenSuccess(t *testing.T) {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write(stubMemoryEntry(t, "user", "retry-me"))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -233,8 +291,16 @@ func TestSubmit_TransientRetryThenSuccess(t *testing.T) {
 
 func TestSubmit_SummaryLine(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, r *http.Request) {
+		var b api.RememberBody
+		_ = json.NewDecoder(r.Body).Decode(&b)
+		slug := "a"
+		if b.Slug != nil {
+			slug = *b.Slug
+		}
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write(stubMemoryEntry(t, string(b.Scope), slug))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -265,7 +331,7 @@ func TestSubmit_SummaryLine(t *testing.T) {
 
 func TestIsTransient_ServerErrors(t *testing.T) {
 	for _, code := range []int{500, 502, 503, 504} {
-		if !isTransient(&httpError{StatusCode: code}) {
+		if !isTransient(&transientStatusError{StatusCode: code}) {
 			t.Errorf("expected isTransient(%d)=true", code)
 		}
 	}
@@ -273,40 +339,162 @@ func TestIsTransient_ServerErrors(t *testing.T) {
 
 func TestIsTransient_ClientErrors(t *testing.T) {
 	for _, code := range []int{400, 401, 403, 404, 422} {
-		if isTransient(&httpError{StatusCode: code}) {
+		if isTransient(&transientStatusError{StatusCode: code}) {
 			t.Errorf("expected isTransient(%d)=false", code)
 		}
 	}
 }
 
-// ── normaliseURL ──────────────────────────────────────────────────────────────
-
-func TestNormaliseURL(t *testing.T) {
-	cases := []struct {
-		input   string
-		want    string
-		wantErr bool
-	}{
-		{"https://meho.example.com/", "https://meho.example.com", false},
-		{"https://meho.example.com/api", "https://meho.example.com/api", false},
-		{"", "", true},
-		{"not-a-url", "", true},
-		{"/just/a/path", "", true},
+func TestIsTransient_TransportError(t *testing.T) {
+	if !isTransient(errors.New("connection refused")) {
+		t.Error("expected isTransient(transport error)=true")
 	}
-	for _, tc := range cases {
-		got, err := normaliseURL(tc.input)
-		if tc.wantErr {
-			if err == nil {
-				t.Errorf("normaliseURL(%q): expected error, got nil", tc.input)
-			}
-		} else {
-			if err != nil {
-				t.Errorf("normaliseURL(%q): unexpected error %v", tc.input, err)
-			}
-			if got != tc.want {
-				t.Errorf("normaliseURL(%q) = %q; want %q", tc.input, got, tc.want)
-			}
-		}
+}
+
+// ── 201 without JSON payload (Content-Type drift / nil-guard) ────────────────
+
+// Belt-and-suspenders for the M2/M3-class punch-list finding from
+// sibling T9 (#1282): the generated parser only populates JSON201 when
+// the response has Content-Type containing "json" AND status 201. A
+// 201 without that Content-Type leaves JSON201 nil; postOne MUST
+// surface the contract failure rather than count it as a successful
+// migration.
+func TestSubmit_Rejects201WithoutJSONPayload(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, _ *http.Request) {
+		// 201 + non-JSON Content-Type → parser leaves JSON201 nil.
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte("OK"))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	plan := makePlan("foo", "user", "body", "aabbccdd1122")
+	cmd, stdout, stderr := newTestCmd(t)
+	if err := cmd.Flags().Set("non-interactive", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := doSubmit(cmd, srv.URL, []migrate.SubmitPlan{plan})
+	if err == nil {
+		t.Fatalf("expected error on 201 without JSON payload; got nil. stdout=%q stderr=%q",
+			stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "HTTP 201 without a memory entry payload") &&
+		!strings.Contains(stderr.String(), "unexpected_response") {
+		t.Errorf("expected unexpected_response classification mentioning the 201-without-payload origin; got stderr=%q", stderr.String())
+	}
+}
+
+// ── 401 surfaces as auth_expired ──────────────────────────────────────────────
+
+func TestSubmit_401SurfacesAsAuthExpired(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail":"token expired"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	plan := makePlan("foo", "user", "body", "aabbccdd1122")
+	cmd, _, stderr := newTestCmd(t)
+	if err := cmd.Flags().Set("non-interactive", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := doSubmit(cmd, srv.URL, []migrate.SubmitPlan{plan})
+	if err == nil {
+		t.Fatal("expected error on 401; got nil")
+	}
+	if !strings.Contains(stderr.String(), "auth_expired") &&
+		!strings.Contains(stderr.String(), "meho login") {
+		t.Errorf("expected auth_expired classification or `meho login` hint; got stderr=%q", stderr.String())
+	}
+}
+
+// ── 403 surfaces as insufficient_role ─────────────────────────────────────────
+
+func TestSubmit_403SurfacesAsInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail":"tenant_admin required to write tenant scope"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	plan := makePlan("foo", "tenant", "body", "aabbccdd1122")
+	cmd, _, stderr := newTestCmd(t)
+	if err := cmd.Flags().Set("non-interactive", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := doSubmit(cmd, srv.URL, []migrate.SubmitPlan{plan})
+	if err == nil {
+		t.Fatal("expected error on 403; got nil")
+	}
+	if !strings.Contains(stderr.String(), "insufficient_role") &&
+		!strings.Contains(stderr.String(), "tenant_admin required") {
+		t.Errorf("expected insufficient_role classification surfacing backend detail; got stderr=%q", stderr.String())
+	}
+}
+
+// ── 422 surfaces as unexpected_response (non-transient) ──────────────────────
+
+func TestSubmit_422SurfacesAsUnexpectedNonTransient(t *testing.T) {
+	var calls atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"detail":"unknown field 'source_id'"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	plan := makePlan("foo", "user", "body", "aabbccdd1122")
+	cmd, _, stderr := newTestCmd(t)
+	if err := cmd.Flags().Set("non-interactive", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	err := doSubmit(cmd, srv.URL, []migrate.SubmitPlan{plan})
+	if err == nil {
+		t.Fatal("expected error on 422; got nil")
+	}
+	if calls.Load() != 1 {
+		t.Errorf("expected exactly 1 call (422 is non-transient, no retries); got %d", calls.Load())
+	}
+	if !strings.Contains(stderr.String(), "unexpected_response") &&
+		!strings.Contains(stderr.String(), "HTTP 422") {
+		t.Errorf("expected unexpected_response with HTTP 422; got stderr=%q", stderr.String())
+	}
+}
+
+// ── No backplane configured surfaces as auth_expired ─────────────────────────
+
+func TestSubmit_NoBackplaneConfiguredSurfacesAsAuthExpired(t *testing.T) {
+	// Empty XDG_CONFIG_HOME with no override means backplane.Resolve
+	// returns *NotConfiguredError → ClassifyError → AuthExpired.
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	plan := makePlan("foo", "user", "body", "aabbccdd1122")
+	cmd, _, stderr := newTestCmd(t)
+
+	err := doSubmit(cmd, "", []migrate.SubmitPlan{plan})
+	if err == nil {
+		t.Fatal("expected error when no backplane is configured; got nil")
+	}
+	if !strings.Contains(stderr.String(), "auth_expired") &&
+		!strings.Contains(stderr.String(), "meho login") {
+		t.Errorf("expected auth_expired / `meho login` hint; got stderr=%q", stderr.String())
 	}
 }
 
@@ -336,5 +524,38 @@ func TestMarkMigrated_WritesMarker(t *testing.T) {
 	}
 	if !exists {
 		t.Error("marker should exist after --mark-migrated")
+	}
+}
+
+// ── buildRememberBody ────────────────────────────────────────────────────────
+
+// Belt-and-suspenders: the typed body the CLI builds carries the
+// operator's chosen scope verbatim through api.MemoryScope (no
+// silent coercion to a different enum constant on a backend rename),
+// stamps a non-nil pointer-slug so the FastAPI route's
+// `slug: str | None` arm accepts the value, and writes a non-nil
+// metadata pointer so the empty `tags` array reaches the wire.
+
+func TestBuildRememberBody_ShapePreserved(t *testing.T) {
+	plan := makePlan("daily-routine", "user", "I start my day by checking email.", "abc123")
+	body := buildRememberBody(plan)
+	if string(body.Scope) != "user" {
+		t.Errorf("scope = %q; want %q", string(body.Scope), "user")
+	}
+	if body.Slug == nil || *body.Slug != "daily-routine" {
+		t.Errorf("slug = %v; want %q", body.Slug, "daily-routine")
+	}
+	if body.Body != "I start my day by checking email." {
+		t.Errorf("body = %q; want %q", body.Body, "I start my day by checking email.")
+	}
+	if body.Metadata == nil {
+		t.Fatal("metadata pointer should not be nil")
+	}
+	tags, ok := (*body.Metadata)["tags"]
+	if !ok {
+		t.Fatal("metadata should carry 'tags' key")
+	}
+	if tagsSlice, ok := tags.([]string); !ok || len(tagsSlice) != 0 {
+		t.Errorf("expected empty []string tags, got %T(%v)", tags, tags)
 	}
 }

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -189,12 +189,12 @@ cli/
     │   │   ├── usage_test.go           # query-param + wire-shape + 403/400 routing tests.
     │   │   ├── retire_checklist.go     # `meho retrieval retire-checklist` (POST /api/v1/retrieve/retire-checklist) — G4.3-T6 #445.
     │   │   └── retire_checklist_test.go # surface-bucket + table-render + marshal tests.
-    │   ├── migrate/           # G5.3 #608–#612 — `meho migrate …` laptop-local migration verb tree (Initiative #375).
+    │   ├── migrate/           # G5.3 #608–#612 — `meho migrate …` laptop-local migration verb tree (Initiative #375). G0.12-T11 #1269 migrated to typed client.
     │   │   ├── migrate.go        # NewRootCmd + _ import charm.land/huh/v2.
-    │   │   ├── memory.go         # `meho migrate memory` RunE — interactive picker / --dry-run / --non-interactive; real submitFn wired in T5 (#612).
-    │   │   ├── memory_test.go    # --dry-run envelope + source_id, --non-interactive filter, machine-local skip, empty-dir guard.
-    │   │   ├── submit.go         # G5.3-T5 #612 — doSubmit (spinner + POST /api/v1/memory), in-package HTTP helper trio, isTransient retry logic.
-    │   │   └── submit_test.go    # POST body shape, source_id stability, upsert rerun, transient retry, summary line, --mark-migrated.
+    │   │   ├── memory.go         # `meho migrate memory` RunE — interactive picker / --dry-run / --non-interactive. Dry-run envelope is `api.RememberBody` directly (post-T11 #1269; no consumer-side dryRunEnvelope shadow).
+    │   │   ├── memory_test.go    # --dry-run envelope, --non-interactive filter, machine-local skip, empty-dir guard, wire-body stability.
+    │   │   ├── submit.go         # doSubmit + spinner + RememberApiV1MemoryPostWithResponse via api.AuthedClient + retryOn401 generic. G0.12-T11 #1269 dropped the in-package HTTP helper trio (doAuthedRequest/sendRequest/httpError) + the local `source_id`-in-body bug the typed RememberBody schema's `extra="forbid"` would have rejected on a real backend (httptest mock masked it). isTransient retry logic preserved.
+    │   │   └── submit_test.go    # typed RememberBody body shape, same-slug rerun stable, no-source_id-on-wire, transient retry, summary line, --mark-migrated, 201-without-payload nil-guard, 401/403/422 classification, no-backplane → auth_expired.
     │   ├── vmware/            # G3.1-T7 #511 — `meho vmware …` alias verb tree (connector_id="vmware-rest-9.0" pre-baked).
     │   ├── vault/             # G3.3-T6 #550 — `meho vault …` alias verb tree (connector_id="vault-1.x" pre-baked).
     │   └── topology/          # G9.1-T6 #454 + G9.2-T6 #599 — `meho topology refresh/dependents/dependencies/path/annotate/unannotate/list-edges` over the T5 REST surface (#453, #597).


### PR DESCRIPTION
## Summary

- Migrates `cli/internal/cmd/migrate/` (the `meho migrate memory` verb) off the per-package hand-rolled `doAuthedRequest` + `memoryPostBody` consumer-side duplicates onto the generated typed client (`api.ClientWithResponses` via `api.AuthedClient`). Closes the #1069-class schema-drift hole the freshness gate is designed to catch.
- Same shape as the sibling migrations on Initiative #1118: T1 (#1251) `approvals/`, T4 (#1262) `agent-principal/`, T9 (#1267) `kb/`. Reuses the `retryOn401[R]` generic helper pattern so every verb runs the same one-shot bearer-refresh contract.
- **Bonus: fixes a latent `source_id`-in-body bug.** The pre-T11 hand-typed body included a `source_id` field that the backend's frozen `extra="forbid"` `RememberBody` schema rejects with 422 — the server computes `source_id` itself from `(scope, user_sub, target_name, slug)` in `memory/_internal.py::encode_source_id`. Tests masked it because the httptest mock accepted any JSON. The migration both modernises the transport and closes the latent drift.
- Pre-empts the T9 #1282 iter-2 punch list: `JSON201 == nil` guards on every typed envelope decode (mirroring `cli/internal/cmd/status.go:142` + the post-iter-2 kb pattern); transport-layer JSON-shape / cap failures (`*http.MaxBytesError`, `*json.SyntaxError`, `*json.UnmarshalTypeError`, `io.ErrUnexpectedEOF`) routed to `output.Unexpected` (exit 4) rather than `output.Unreachable` (exit 3).
- Test suite rebuilt: typed RememberBody body-shape assertions, same-slug rerun stability (replaces the now-obsolete `source_id` stability test), no-`source_id`-on-wire belt-and-suspenders, 201-without-JSON-payload contract failure, 401/403/422 classification, no-backplane-configured → `auth_expired`, `TestBuildRememberBody_ShapePreserved` against future typed-shape drift.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./...` — every package passes (full CLI suite)
- [x] `go test ./internal/cmd/migrate/...` — 23 tests pass (8 dry-run/non-interactive + 15 submit/build path)
- [x] `gofmt -l ./internal/cmd/migrate/` — clean
- [x] `make snapshot-openapi && make generate` — no-op on `cli/api/openapi.json` + `cli/internal/api/client.gen.go` (freshness gate green)
- [x] `grep -rnE 'http\.NewRequest|doAuthedRequest|^type memoryPostBody |^type httpError ' cli/internal/cmd/migrate/` — returns **no** matches
- [x] `grep -rnE 'api\.ClientWithResponses|api\.RememberBody|RememberApiV1MemoryPostWithResponse' cli/internal/cmd/migrate/` — present across `submit.go` + tests
- [x] No change to `backend/src/meho_backplane/api/v1/memory.py` — server stays unchanged
- [x] DCO sign-off on the commit
- [x] `docs/codebase/cli.md` line 192 updated to reflect the migration

## Out of scope

- Other CLI verb directories under `cli/internal/cmd/` (covered by sibling tasks on Initiative #1118 — T10 #1268 for `memory/` is the in-flight sibling that also writes through `POST /api/v1/memory`).
- FastAPI memory route shape (server side untouched).
- Renaming verbs, flags, or output formatting.
- Migration source-format parsing logic in `migrate.go` / `memory.go` (that's pre-transport).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1269


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed migration dry-run format to align with backend API requirements
  * Improved error handling for submissions with clearer classification of authentication, permission, validation, and server response failures
  * Enhanced stability validation for repeated migrations with identical configurations

* **Documentation**
  * Updated migration command documentation to reflect current implementation details

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->