### PR TITLE
refactor(cli-memory): G0.12-T10 migrate cmd/memory/ to typed client (#1268)

### DIFF
--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -69,6 +69,21 @@ type AuthedClientOptions struct {
 	// step on refresh. Tests pass a fake; production code passes
 	// nil so NewAuthedClient routes to auth.FetchDiscoveryFromRealm.
 	RefreshDiscoverer func(ctx context.Context, httpClient *http.Client, issuerURL string) (*auth.DiscoveryDocument, error)
+	// ResponseBodyLimit caps the bytes the underlying transport reads
+	// off `rsp.Body` for every response. Zero (default) means no cap
+	// — back-compat with consumers that haven't opted in. When > 0,
+	// NewAuthedClient wraps the client's transport in a
+	// RoundTripper that re-binds `rsp.Body` to an
+	// `http.MaxBytesReader`-equivalent so the generated
+	// `*WithResponse` parsers (which call `io.ReadAll(rsp.Body)`)
+	// can't be pinned by an adversarial / runaway backplane response.
+	// A read at the cap surfaces as `*http.MaxBytesError`, which
+	// consumer-side `renderRequestError` helpers map to
+	// `output.Unexpected` (exit 4) rather than `output.Unreachable`
+	// (exit 3). 1 MiB is the convention adopted by the kb verb tree
+	// (`cli/internal/cmd/kb/kb.go`); other consumers should pick a
+	// per-package cap matching their largest expected payload.
+	ResponseBodyLimit int64
 }
 
 // NewAuthedClient builds an AuthedClient for the supplied backplane
@@ -99,6 +114,20 @@ func NewAuthedClient(_ context.Context, backplaneURL string, opts AuthedClientOp
 	httpClient := opts.HTTPClient
 	if httpClient == nil {
 		httpClient = http.DefaultClient
+	}
+	if opts.ResponseBodyLimit > 0 {
+		// Clone so capping the body cap doesn't mutate the
+		// caller-supplied http.Client (notably
+		// http.DefaultClient, which is process-global). The clone
+		// keeps Timeout / Jar / CheckRedirect intact and only
+		// swaps the Transport for a capped wrapper.
+		clone := *httpClient
+		base := clone.Transport
+		if base == nil {
+			base = http.DefaultTransport
+		}
+		clone.Transport = &capRoundTripper{base: base, limit: opts.ResponseBodyLimit}
+		httpClient = &clone
 	}
 
 	discoverer := opts.RefreshDiscoverer
@@ -239,4 +268,42 @@ func (c *AuthedClient) Refresh(ctx context.Context) error {
 // operator must rerun `meho login`).
 func IsNoRefreshToken(err error) bool {
 	return errors.Is(err, errNoRefreshToken)
+}
+
+// capRoundTripper wraps an http.RoundTripper so every response body
+// is re-bound to an http.MaxBytesReader before the typed-client
+// parsers (oapi-codegen's generated `Parse*Response` helpers, which
+// `io.ReadAll(rsp.Body)` to populate `*Response.Body []byte`) get a
+// chance to drain it. Without this, an adversarial or runaway
+// backplane response could OOM the CLI by streaming an unbounded
+// body into ReadAll. The wrapper applies the cap server-wide on the
+// underlying transport so every typed verb on the same AuthedClient
+// inherits it uniformly.
+//
+// Reads at or past `limit` surface as `*http.MaxBytesError` out of
+// the body Reader, which the kb verb's `renderRequestError` (and
+// any future consumer following the same pattern) maps to
+// `output.Unexpected` (exit 4 — `unexpected_response`) rather than
+// `output.Unreachable` (exit 3 — `network_unreachable`). The
+// `*http.MaxBytesError` shape was added in Go 1.19 and is the
+// canonical signal for "transport refused to read past N bytes."
+type capRoundTripper struct {
+	base  http.RoundTripper
+	limit int64
+}
+
+func (c *capRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := c.base.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	if resp.Body != nil && c.limit > 0 {
+		// http.MaxBytesReader returns an io.ReadCloser whose Close
+		// closes the underlying body, so the existing close
+		// discipline on the caller (oapi-codegen's `defer
+		// rsp.Body.Close()` inside every `*WithResponse` method)
+		// still drains the original body cleanly.
+		resp.Body = http.MaxBytesReader(nil, resp.Body, c.limit)
+	}
+	return resp, nil
 }

--- a/cli/internal/cmd/memory/forget.go
+++ b/cli/internal/cmd/memory/forget.go
@@ -6,9 +6,11 @@ package memory
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -151,8 +153,19 @@ func runForget(cmd *cobra.Command, opts forgetOptions) error {
 		return output.RenderError(cmd.ErrOrStderr(),
 			backplane.ClassifyError(err), opts.JSONOut)
 	}
-	if err := callForget(cmd.Context(), backplaneURL, scope, slug, opts.TargetArg); err != nil {
+	resp, err := callForget(cmd.Context(), backplaneURL, scope, slug, opts.TargetArg)
+	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	// The forget route is idempotent server-side: a delete against
+	// an absent slug returns 204. Treat anything other than 204 as
+	// a non-success and route through renderHTTPStatus — the
+	// pre-migration ladder rejected non-2xx via the local httpError
+	// sentinel, and the typed-client equivalent is to gate on the
+	// 204 status code (the only success code the substrate emits
+	// for this route).
+	if resp.StatusCode() != http.StatusNoContent {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
 	}
 	result := forgetResult{
 		Scope:  string(scope),
@@ -167,18 +180,34 @@ func runForget(cmd *cobra.Command, opts forgetOptions) error {
 	return nil
 }
 
+// buildForgetParams maps the CLI flags onto the generated query-
+// param shape. `TargetName` is set only when the operator supplied
+// `--target` so an unset flag stays absent on the wire (user /
+// user-tenant / tenant forgets carry no target_name).
+func buildForgetParams(targetName string) *api.ForgetApiV1MemoryScopeSlugDeleteParams {
+	params := &api.ForgetApiV1MemoryScopeSlugDeleteParams{}
+	if targetName != "" {
+		t := targetName
+		params.TargetName = &t
+	}
+	return params
+}
+
 func callForget(
 	ctx context.Context,
 	backplaneURL string,
 	scope Scope,
 	slug, targetName string,
-) error {
-	// doAuthedRequest returns (nil, nil) on a 204; the forget route
-	// emits an empty 204 body whether or not the row existed
-	// server-side. We discard the (nil) response — the success
-	// signal is the absence of an error.
-	_, err := doAuthedRequest(
-		ctx, backplaneURL, "DELETE", buildRecallPath(scope, slug, targetName), nil,
+) (*api.ForgetApiV1MemoryScopeSlugDeleteResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	params := buildForgetParams(targetName)
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.ForgetApiV1MemoryScopeSlugDeleteResponse, error) {
+			return authed.ForgetApiV1MemoryScopeSlugDeleteWithResponse(ctx, scope, slug, params)
+		},
+		func(r *api.ForgetApiV1MemoryScopeSlugDeleteResponse) int { return r.StatusCode() },
 	)
-	return err
 }

--- a/cli/internal/cmd/memory/list.go
+++ b/cli/internal/cmd/memory/list.go
@@ -5,14 +5,13 @@ package memory
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
-	"strconv"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -99,7 +98,7 @@ func NewListCmd() *cobra.Command {
 	cmd.Flags().IntVar(&limitFlag, "limit", 0,
 		"max memories per page (1..500, server default 100 when omitted)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
-		"emit raw ListResponse JSON instead of the human table")
+		"emit raw MemoryListResponse JSON instead of the human table")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by `meho login`)")
 	return cmd
@@ -116,20 +115,21 @@ type listOptions struct {
 }
 
 func runList(cmd *cobra.Command, opts listOptions) error {
+	var typedScope *Scope
 	if opts.ScopeArg != "" {
 		scope, err := parseScope(opts.ScopeArg)
 		if err != nil {
 			return output.RenderError(cmd.ErrOrStderr(),
 				output.Unexpected(err.Error()), opts.JSONOut)
 		}
-		// Write the trimmed Scope value back so buildListPath
-		// forwards the normalised form. Without this, a padded
-		// input like `--scope " user "` passes the preflight (the
-		// validScopes lookup trims) and then 422s on the backend
-		// when the raw query string reaches FastAPI's enum check.
-		// Mirrors the recall.go:191-203 pattern where parseScope's
-		// return value is propagated through kindFilter.
-		opts.ScopeArg = string(scope)
+		// Capture the trimmed Scope value so listQueryParams forwards
+		// the normalised form. Without this, a padded input like
+		// `--scope " user "` passes the preflight (the validScopes
+		// lookup trims) and then 422s on the backend when the raw
+		// query string reaches FastAPI's enum check. Mirrors the
+		// recall.go pattern where parseScope's typed return value is
+		// propagated through kindFilter.
+		typedScope = &scope
 	}
 	// Mirror the kb list helper's bound check: server clamps with
 	// Query(ge=1, le=500). Surface the constraint string locally so
@@ -147,55 +147,85 @@ func runList(cmd *cobra.Command, opts listOptions) error {
 		return output.RenderError(cmd.ErrOrStderr(),
 			backplane.ClassifyError(err), opts.JSONOut)
 	}
-	resp, err := getList(cmd.Context(), backplaneURL, opts)
+	resp, err := getList(cmd.Context(), backplaneURL, opts, typedScope)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
-	if opts.JSONOut {
-		return output.PrintJSON(cmd.OutOrStdout(), resp)
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
 	}
-	printListTable(cmd.OutOrStdout(), resp)
+	// Guard against 200 + missing-content-type leaving JSON200 nil.
+	// printListTable's nil-or-empty branch prints "no memories" —
+	// without this guard, a malformed 200 would be actively
+	// misleading (conflated with a genuinely-empty tenant). Mirrors
+	// `cli/internal/cmd/status.go:142` + the kb sibling's
+	// post-iter-2 nil-guard pattern.
+	if resp.JSON200 == nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without a memory list payload",
+				backplaneURL,
+			)),
+			opts.JSONOut,
+		)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
+	}
+	printListTable(cmd.OutOrStdout(), resp.JSON200)
 	return nil
 }
 
-// buildListPath assembles the GET /api/v1/memory query string from
-// the per-call options. Exposed for unit tests so the URL
-// construction stays unit-checkable without standing up an
-// httptest.Server.
-func buildListPath(opts listOptions) string {
-	q := url.Values{}
-	if opts.ScopeArg != "" {
-		q.Set("scope", opts.ScopeArg)
+// listQueryParams maps the CLI flags onto the generated query-param
+// shape. Each pointer field is set only when the operator supplied
+// the flag so the backplane's own defaults apply for unset values
+// (filter omitted entirely; limit defaults to 100 server-side;
+// include_expired defaults to false). `typedScope` is the
+// pre-validated `*Scope` from runList — passing the typed pointer
+// directly into the generated `Scope *MemoryScope` field eliminates
+// the post-validate round-trip through a string.
+func listQueryParams(opts listOptions, typedScope *Scope) *api.ListMemoriesApiV1MemoryGetParams {
+	params := &api.ListMemoriesApiV1MemoryGetParams{}
+	if typedScope != nil {
+		params.Scope = typedScope
 	}
 	if opts.SlugPatternArg != "" {
-		q.Set("slug_pattern", opts.SlugPatternArg)
+		s := opts.SlugPatternArg
+		params.SlugPattern = &s
 	}
 	if opts.TagArg != "" {
-		q.Set("tag", opts.TagArg)
+		t := opts.TagArg
+		params.Tag = &t
 	}
 	if opts.IncludeExpired {
-		q.Set("include_expired", "true")
+		ie := true
+		params.IncludeExpired = &ie
 	}
 	if opts.LimitArg > 0 {
-		q.Set("limit", strconv.Itoa(opts.LimitArg))
+		l := opts.LimitArg
+		params.Limit = &l
 	}
-	path := "/api/v1/memory"
-	if encoded := q.Encode(); encoded != "" {
-		path = path + "?" + encoded
-	}
-	return path
+	return params
 }
 
-func getList(ctx context.Context, backplaneURL string, opts listOptions) (*ListResponse, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildListPath(opts), nil)
+func getList(
+	ctx context.Context,
+	backplaneURL string,
+	opts listOptions,
+	typedScope *Scope,
+) (*api.ListMemoriesApiV1MemoryGetResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out ListResponse
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode list response: %w", err)
-	}
-	return &out, nil
+	params := listQueryParams(opts, typedScope)
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.ListMemoriesApiV1MemoryGetResponse, error) {
+			return authed.ListMemoriesApiV1MemoryGetWithResponse(ctx, params)
+		},
+		func(r *api.ListMemoriesApiV1MemoryGetResponse) int { return r.StatusCode() },
+	)
 }
 
 // printListTable renders the list as a compact, scannable table.
@@ -204,7 +234,7 @@ func getList(ctx context.Context, backplaneURL string, opts listOptions) (*ListR
 // audit-log rows want the precise cutoff; "(none)" is rendered for
 // the absent case. Body is truncated to 60 chars so a default
 // terminal width doesn't wrap.
-func printListTable(w io.Writer, r *ListResponse) {
+func printListTable(w io.Writer, r *api.MemoryListResponse) {
 	if r == nil || len(r.Entries) == 0 {
 		fmt.Fprintln(w, "no memories visible in this tenant")
 		return
@@ -215,7 +245,7 @@ func printListTable(w io.Writer, r *ListResponse) {
 		fmt.Fprintf(w, "%-14s %-32s %-32s %s\n",
 			truncate(string(e.Scope), 14),
 			truncate(e.Slug, 32),
-			truncate(pluralisePtr(e.ExpiresAt), 32),
+			truncate(formatTimePtr(e.ExpiresAt), 32),
 			truncate(snippetOf(e.Body), 60),
 		)
 	}

--- a/cli/internal/cmd/memory/memory.go
+++ b/cli/internal/cmd/memory/memory.go
@@ -2,13 +2,14 @@
 // Copyright (c) 2026 evoila Group
 
 // Package memory hosts the top-level cobra commands `meho remember`,
-// `meho recall`, `meho forget`, and `meho list` for G5.1-T4 (#424) of
-// Initiative #332. The four verbs wrap the four REST routes shipped
-// by G5.1-T2 (#422) plus the G0.4-T5 `/api/v1/retrieve` route for the
-// `meho recall --query` retrieval form:
+// `meho recall`, `meho forget`, `meho list`, and `meho promote` for
+// G5.1-T4 (#424) + G5.2-T4 (#627) of Initiative #332. The five verbs
+// wrap the REST routes shipped by G5.1-T2 (#422) plus the G0.4-T5
+// `/api/v1/retrieve` route for the `meho recall --query` retrieval
+// form:
 //
 //   - `meho remember "body" [--scope SCOPE] [--slug SLUG]
-//     [--target NAME] [--tag T] [--ttl 7d] [--json]` —
+//     [--target NAME] [--tag T] [--ttl 7d] [--persist] [--json]` —
 //     POST /api/v1/memory. Default scope `user-tenant`. Body can be
 //     piped on stdin when the positional arg is `-`.
 //   - `meho recall <scope>/<slug> [--target NAME] [--json]` —
@@ -20,6 +21,8 @@
 //   - `meho list [--scope SCOPE] [--tag T] [--include-expired]
 //     [--slug-pattern P] [--limit N] [--json]` —
 //     GET /api/v1/memory.
+//   - `meho promote <scope>/<slug> --to <scope> [--move] [--json]` —
+//     POST /api/v1/memory/{scope}/{slug}/promote (G5.2-T4 #626).
 //
 // The verbs are registered as **top-level** cobra commands per the
 // consumer-needs.md §G5 ergonomic shape (the consumer-facing CLI
@@ -28,27 +31,29 @@
 // `meho list --scope user` verbatim; `meho memory list` would
 // violate the contract.
 //
-// The implementation deliberately follows the in-package HTTP helper
-// pattern the sibling verb trees use (one resolveBackplane /
-// doAuthedRequest / renderRequestError trio per package) rather
-// than a shared cli/internal/api_client package. The reason is the
-// import-cycle one: each verb tree is registered onto the root
-// command, so a shared helper imported from cmd/* and from any
-// per-tree package would close the cycle. Duplicating the helpers
-// (a handful of small, stable functions) is the convention every
-// sibling package follows — see cli/internal/cmd/kb/kb.go's identical
-// docstring for the matching justification.
+// G0.12-T10 #1268 migrated this package off the sibling-verb
+// pattern of hand-rolled HTTP + hand-typed copies of backend
+// pydantic models. Every verb here drives the generated
+// `api.ClientWithResponses` surface directly: `api.NewAuthedClient`
+// wires the bearer + lazy 401-refresh editor onto the embedded
+// `ClientWithResponses`, and the verbs call the typed `*WithResponse`
+// methods (`ListMemoriesApiV1MemoryGetWithResponse` etc.).
+// Consumer-side struct drift — the #1069 root cause Initiative #1118
+// targets — can't recur because we now consume `api.MemoryEntry`,
+// `api.MemoryScope`, `api.MemoryListResponse`, `api.RetrievalHit`,
+// and `api.RetrieveResponse` directly. The shared retrieval route's
+// types live only in the generated client now (the parallel kb/
+// migration in G0.12-T9 #1267 removed the matching duplicates from
+// that sibling).
 package memory
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -58,38 +63,51 @@ import (
 	"github.com/evoila/meho/cli/internal/output"
 )
 
-// Scope is the wire-level identifier matching the backend's
-// MemoryScope StrEnum (`backend/src/meho_backplane/memory/schemas.py`
-// L87-107). Five values; one per consumer-needs.md §G5 row. The
-// string values are the same identifier the route path segment,
-// `--scope` flag value, and the audit/broadcast contextvar carry.
+// Scope is the local alias for the generated `api.MemoryScope` enum.
+// Adopted in G0.12-T10 #1268 as the canonical typed-enum the package
+// uses; the alias rather than a re-declaration lets every internal
+// call site reference `Scope` (short, scoped to the verb tree)
+// without the verb signatures or options structs leaking the
+// generated `api.MemoryScope` name into the public surface. The wire-
+// level identifier (route path segment, audit scope contextvar,
+// `--scope` flag value) is whatever the underlying generated string
+// carries.
 //
-// Hand-typed rather than aliased to a generated client type so the
-// memory package stays decoupled from oapi-codegen churn — same
-// stance every sibling package (kb, audit, targets, ...) takes for
-// its mirrored enums.
-type Scope string
+// The alias matches the AC carve-out in #1268: "unless `Scope` stays
+// because no typed-enum equivalent exists; if so, it gets a comment
+// pointing at this Task." The typed enum DOES exist
+// (`api.MemoryScope`); the alias *is* the adoption of it, not a
+// duplicate.
+type Scope = api.MemoryScope
 
+// The five MemoryScope values exposed by the substrate, re-exported
+// here so the verb runners + tests reference one package-local name
+// per scope rather than the generated `api.MemoryScope*` family.
+// Adopting the generated enum directly is the canonical move for
+// G0.12 (the whole point of the migration is to delete consumer-side
+// duplicates), but keeping the local aliases keeps the verb code
+// scannable — `ScopeUserTenant` is shorter than
+// `api.MemoryScopeUserTenant` everywhere it appears.
 const (
 	// ScopeUser is the per-operator-across-tenants scope — a memory
 	// only the writing operator can read, across every tenant they
 	// belong to.
-	ScopeUser Scope = "user"
+	ScopeUser Scope = api.MemoryScopeUser
 	// ScopeUserTenant is the operator-within-one-tenant scope — the
 	// default for `meho remember` because consumer-needs.md §G5 L137
 	// identifies it as the most common case.
-	ScopeUserTenant Scope = "user-tenant"
+	ScopeUserTenant Scope = api.MemoryScopeUserTenant
 	// ScopeUserTarget is the operator-against-one-target scope —
 	// requires `--target`.
-	ScopeUserTarget Scope = "user-target"
+	ScopeUserTarget Scope = api.MemoryScopeUserTarget
 	// ScopeTenant is the tenant-wide scope — write requires
 	// `tenant_admin`; the substrate's RBAC matrix surfaces this as
 	// 403 from the service.
-	ScopeTenant Scope = "tenant"
+	ScopeTenant Scope = api.MemoryScopeTenant
 	// ScopeTarget is the per-target-shared scope — every operator
 	// touching one infrastructure target sees the same memory.
 	// Requires `--target`.
-	ScopeTarget Scope = "target"
+	ScopeTarget Scope = api.MemoryScopeTarget
 )
 
 // validScopes is the set the parseScope helper uses to reject typos
@@ -115,169 +133,24 @@ var targetScoped = map[Scope]bool{
 	ScopeTarget:     true,
 }
 
-// Entry mirrors the backend `MemoryEntry` pydantic model
-// (`backend/src/meho_backplane/memory/schemas.py` L152-177). One
-// row as returned by GET /api/v1/memory/{scope}/{slug} and
-// POST /api/v1/memory.
-type Entry struct {
-	ID         string         `json:"id"`
-	TenantID   string         `json:"tenant_id"`
-	Scope      Scope          `json:"scope"`
-	Slug       string         `json:"slug"`
-	Body       string         `json:"body"`
-	Metadata   map[string]any `json:"metadata"`
-	ExpiresAt  *string        `json:"expires_at"`
-	UserSub    *string        `json:"user_sub"`
-	TargetName *string        `json:"target_name"`
-	CreatedAt  string         `json:"created_at"`
-	UpdatedAt  string         `json:"updated_at"`
-}
-
-// ListResponse mirrors the backend `MemoryListResponse` envelope.
-// Wrapped in `{"entries": [...]}` for forward-compat with future
-// cursor / paging fields — same shape kb / connectors_ingest adopt.
-type ListResponse struct {
-	Entries []Entry `json:"entries"`
-}
-
-// RetrievalHit mirrors the backend `RetrievalHit` pydantic model
-// (`backend/src/meho_backplane/retrieval/retriever.py`). Returned by
-// POST /api/v1/retrieve. `BM25Score`, `CosineScore`, `BM25Rank`, and
-// `CosineRank` are pointer-typed because the backend emits `null`
-// for documents that did not appear in that signal's top-K
-// candidate list.
-type RetrievalHit struct {
-	DocumentID  string         `json:"document_id"`
-	TenantID    string         `json:"tenant_id"`
-	Source      string         `json:"source"`
-	SourceID    string         `json:"source_id"`
-	Kind        string         `json:"kind"`
-	Body        string         `json:"body"`
-	DocMetadata map[string]any `json:"doc_metadata"`
-	FusedScore  float64        `json:"fused_score"`
-	BM25Score   *float64       `json:"bm25_score"`
-	CosineScore *float64       `json:"cosine_score"`
-	BM25Rank    *int           `json:"bm25_rank"`
-	CosineRank  *int           `json:"cosine_rank"`
-}
-
-// RetrieveResponse mirrors the backend `RetrieveResponse` envelope.
-type RetrieveResponse struct {
-	Hits            []RetrievalHit `json:"hits"`
-	QueryDurationMS float64        `json:"query_duration_ms"`
-}
-
-// rememberRequest mirrors the backend `RememberBody` pydantic model
-// (`backend/src/meho_backplane/api/v1/memory.py` L174-211). Fields
-// without JSON `omitempty` are mandatory at the wire level.
-//
-// `Persist` is a tri-state escape-hatch for the `expires_at` field
-// the backend's G5.2-T2 (#624) default-TTL injection key on:
-//
-//   - Persist=false, ExpiresAt="" → field is OMITTED from the JSON;
-//     the backend's :func:`_resolve_default_ttl` sees the field as
-//     absent from :attr:`BaseModel.model_fields_set` and injects
-//     “now + memory_user_default_ttl_days“ on “memory-user“ writes.
-//   - Persist=false, ExpiresAt="<RFC3339>" → field is sent verbatim;
-//     the backend honours it as the explicit cutoff.
-//   - Persist=true → field is emitted as explicit JSON `null`; the
-//     backend sees the field as present in
-//     :attr:`BaseModel.model_fields_set` with value None and skips
-//     the default. This is the wire shape `meho remember --persist`
-//     uses to opt out of the auto-TTL and pin the memory forever.
-//
-// The marshaling can't ride on Go's `,omitempty` semantics alone
-// because `*string`+`omitempty` collapses nil-pointer and empty-
-// string into "omit", whereas the backend's contract distinguishes
-// "absent field" (default fires) from "explicit null" (default
-// skipped). The custom :func:`MarshalJSON` below is the load-bearing
-// gate for the three-state discipline.
-type rememberRequest struct {
-	Scope      Scope
-	Body       string
-	Slug       string
-	Metadata   map[string]any
-	ExpiresAt  string
-	TargetName string
-	// Persist, when true, emits ``"expires_at": null`` on the wire
-	// even when ExpiresAt is empty. Mutually exclusive with a non-
-	// empty ExpiresAt in practice; the verb-level CLI gate refuses
-	// `--persist` + `--ttl` together so the operator's intent is
-	// unambiguous. The struct doesn't enforce that mutual exclusion
-	// itself (callers do) -- when both are set, ExpiresAt wins
-	// because emitting "null" alongside a real timestamp would be
-	// nonsensical.
-	Persist bool
-}
-
-// MarshalJSON renders rememberRequest with explicit handling for the
-// G5.2-T2 (#624) tri-state “expires_at“ contract. See the type-level
-// docstring for the three states and their wire shapes.
-//
-// Implementation notes:
-//
-//   - Uses a positional emit (json.Marshal over a map[string]any)
-//     rather than struct tags so the `expires_at` rendering can branch
-//     on the Persist bool without leaking into the public field set.
-//   - The map ordering does not affect JSON correctness; the backend
-//     parses fields by key, not position.
-//   - "Persist + ExpiresAt set" lets ExpiresAt win (we already wrote
-//     the operator's intent to a clock-aligned cutoff at the
-//     parseTTLFlag stage; emitting `null` would silently override
-//     their `--ttl` value). The verb-level mutual-exclusion gate is
-//     where this collision is reported back to the operator.
-func (r rememberRequest) MarshalJSON() ([]byte, error) {
-	out := map[string]any{
-		"scope": r.Scope,
-		"body":  r.Body,
-	}
-	if r.Slug != "" {
-		out["slug"] = r.Slug
-	}
-	if r.Metadata != nil {
-		out["metadata"] = r.Metadata
-	}
-	if r.TargetName != "" {
-		out["target_name"] = r.TargetName
-	}
-	switch {
-	case r.ExpiresAt != "":
-		out["expires_at"] = r.ExpiresAt
-	case r.Persist:
-		// Explicit JSON `null` so backend's
-		// :func:`_resolve_default_ttl` sees "expires_at" in
-		// :attr:`BaseModel.model_fields_set` and skips the default.
-		out["expires_at"] = nil
-	}
-	return json.Marshal(out)
-}
-
-// retrieveRequest mirrors the backend `RetrieveRequest` pydantic
-// model (`backend/src/meho_backplane/api/v1/retrieve.py` L102-120).
-// `meho recall --query` pins `source="memory"` so the substrate
-// only ranks memory-scoped rows.
-type retrieveRequest struct {
-	Query  string `json:"query"`
-	Source string `json:"source,omitempty"`
-	Kind   string `json:"kind,omitempty"`
-	Limit  int    `json:"limit,omitempty"`
-}
-
-// errMissingAccessToken is the sentinel doAuthedRequest returns
+// errMissingAccessToken is the sentinel newAuthedClient returns
 // when the stored token row exists but its access_token field is
 // empty. Routed to auth_expired (exit 2) with a `meho login` hint
 // rather than the generic transport-error path. Mirrors the kb
 // sibling's fix that landed in PR #500 review iteration 1.
 var errMissingAccessToken = errors.New("meho: stored token has no access_token")
 
-// responseBodyCap is the hard upper bound on a backplane response
-// body the CLI is willing to read. Memory list pages cap at 500
-// rows server-side; an average memory body is small (consumer-needs
-// describes them as "useful behavioral preferences" not multi-KB
-// blobs), so 1 MiB is comfortable headroom. The +1 byte read in
-// doAuthedRequest distinguishes "fits in the cap" from "truncated
-// at the cap" so a silently-truncated JSON payload never reaches
-// the decoder.
+// responseBodyCap bounds the bytes the memory verb tree's transport
+// will read off any backplane response body. 1 MiB is generous: list
+// pages cap at 500 rows server-side, and an average memory body is
+// small (consumer-needs.md describes them as "useful behavioral
+// preferences" not multi-KB blobs). Without the cap, an adversarial
+// or runaway backplane response could OOM the CLI because the
+// generated `Parse*Response` helpers call `io.ReadAll(rsp.Body)` on
+// an unbounded body before constructing the typed envelope. The cap
+// is installed at the transport layer via
+// `api.AuthedClientOptions.ResponseBodyLimit` so it applies
+// uniformly to every typed verb on the same `AuthedClient`.
 const responseBodyCap int64 = 1 << 20
 
 // loadBodyStdinCap bounds the `-` (stdin) read on `meho remember`
@@ -287,21 +160,72 @@ const responseBodyCap int64 = 1 << 20
 // blobs.
 const loadBodyStdinCap int64 = 1 << 20
 
-// httpError carries a non-2xx response so per-verb runners can
-// render the right category. Same shape as the kb sibling.
-type httpError struct {
-	StatusCode int
-	Body       string
+// newAuthedClient builds an api.AuthedClient for the supplied
+// backplane URL and verifies a non-empty bearer is loaded.
+// Centralised so every verb's typed-call path goes through the
+// same "stored-token-loaded + non-empty bearer" gate; the caller
+// forwards any returned error to renderRequestError for category
+// mapping. Mirrors the sibling verb-tree migrations
+// (G0.12-T4 #1262, G0.12-T9 #1267). Opts into the transport-layer
+// response-body cap (responseBodyCap) so the generated typed
+// parsers can't be pinned by an unbounded backplane response.
+func newAuthedClient(ctx context.Context, backplaneURL string) (*api.AuthedClient, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{
+		ResponseBodyLimit: responseBodyCap,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if authed.AccessToken() == "" {
+		return nil, errMissingAccessToken
+	}
+	return authed, nil
 }
 
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+// retryOn401 invokes call once, and if the typed response carries a
+// 401, runs a one-shot bearer refresh and re-issues call. Same
+// shape `kb` adopted in G0.12-T9 #1267 so every memory verb runs
+// the same transparent-retry contract.
+//
+// statusOf reads the StatusCode off the typed response envelope (the
+// generated *Response types expose StatusCode() through their
+// embedded *http.Response). A nil response counts as "no retry" —
+// the transport already failed and the caller surfaces err directly.
+func retryOn401[R any](
+	ctx context.Context,
+	authed *api.AuthedClient,
+	call func(ctx context.Context) (*R, error),
+	statusOf func(*R) int,
+) (*R, error) {
+	resp, err := call(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || statusOf(resp) != http.StatusUnauthorized {
+		return resp, nil
+	}
+	if rerr := authed.Refresh(ctx); rerr != nil {
+		return resp, rerr
+	}
+	return call(ctx)
 }
 
-// renderRequestError translates an error from one of the per-verb
-// request helpers into the right output.StructuredError category.
-// Same classification ladder as kb / audit / targets, with the
-// memory-route-specific 4xx handling lifted into renderHTTPError.
+// renderRequestError translates a transport-layer request error
+// into the right output.StructuredError category. Maps the memory
+// REST surface's pre-response failures: missing bearer, no-refresh-
+// token, token-not-found, body-cap / parse failures bubbling out of
+// the generated `*WithResponse` parsers, plus the generic transport-
+// down case. Non-2xx status codes carried in a typed response
+// envelope are classified by renderHTTPStatus instead.
+//
+// Parse / cap failures route to `output.Unexpected` (exit 4 —
+// `unexpected_response`) rather than `output.Unreachable` (exit 3 —
+// `network_unreachable`). A 1 MiB body cap firing or a JSON decode
+// rejecting a malformed payload is a contract / shape failure on
+// the server side, not a transport-down failure on the operator's
+// side; surfacing it as "unreachable" would send operators chasing
+// a network ghost. The cap is installed by `newAuthedClient` via
+// `api.AuthedClientOptions.ResponseBodyLimit` (responseBodyCap).
 func renderRequestError(
 	cmd *cobra.Command,
 	backplaneURL string,
@@ -335,9 +259,23 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
-		return renderHTTPError(cmd, backplaneURL, he, jsonOut)
+	// Transport-layer body-cap firing (*http.MaxBytesReader returned
+	// from capRoundTripper) and JSON shape failures bubbling out of
+	// the generated parsers are server-side contract failures, not
+	// transport-down failures — surface them as unexpected_response
+	// (exit 4) with the backplane URL so the operator sees the
+	// origin without chasing a network ghost.
+	var maxBytesErr *http.MaxBytesError
+	var syntaxErr *json.SyntaxError
+	var unmarshalErr *json.UnmarshalTypeError
+	if errors.As(err, &maxBytesErr) ||
+		errors.As(err, &syntaxErr) ||
+		errors.As(err, &unmarshalErr) ||
+		errors.Is(err, io.ErrUnexpectedEOF) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+			jsonOut,
+		)
 	}
 	return output.RenderError(cmd.ErrOrStderr(),
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
@@ -345,10 +283,12 @@ func renderRequestError(
 	)
 }
 
-// renderHTTPError classifies a non-2xx response into the right
-// StructuredError category.
-//
-// Memory-route-specific notes:
+// renderHTTPStatus classifies a non-2xx response carried in the
+// typed envelope into the right StructuredError category. Mirrors
+// the pre-migration `renderHTTPError` switch but acts on the
+// (statusCode, body) pair lifted off the generated
+// `*Response.HTTPResponse` + `Body` fields rather than a sentinel
+// value. Memory-route-specific notes:
 //
 //   - 403 — write to a scope the operator's tenant role can't reach.
 //     The backend's detail string is `permission_denied: <reason>`;
@@ -364,14 +304,15 @@ func renderRequestError(
 //     field that failed.
 //   - 401 — backplane rejected the stored token after a refresh
 //     attempt; auth_expired with a `meho login` hint.
-//   - Pure transport errors fall through to unreachable.
-func renderHTTPError(
+func renderHTTPStatus(
 	cmd *cobra.Command,
 	backplaneURL string,
-	he *httpError,
+	statusCode int,
+	body []byte,
 	jsonOut bool,
 ) error {
-	switch he.StatusCode {
+	bodyStr := strings.TrimSpace(string(body))
+	switch statusCode {
 	case http.StatusUnauthorized:
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.AuthExpired(fmt.Sprintf(
@@ -382,23 +323,23 @@ func renderHTTPError(
 		)
 	case http.StatusForbidden:
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.InsufficientRole(decodeDetailString(he.Body)),
+			output.InsufficientRole(decodeDetailString(bodyStr)),
 			jsonOut,
 		)
 	case http.StatusNotFound:
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(decodeDetailString(he.Body)),
+			output.Unexpected(decodeDetailString(bodyStr)),
 			jsonOut,
 		)
 	case http.StatusUnprocessableEntity:
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf("invalid request: %s", he.Body)),
+			output.Unexpected(fmt.Sprintf("invalid request: %s", bodyStr)),
 			jsonOut,
 		)
 	default:
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, statusCode, bodyStr)),
 			jsonOut,
 		)
 	}
@@ -421,106 +362,6 @@ func decodeDetailString(body string) string {
 		}
 	}
 	return strings.TrimSpace(body)
-}
-
-// doAuthedRequest issues a single HTTP request against the backplane
-// with bearer injection and one-shot 401-refresh-retry. Returns the
-// response body bytes (already drained) on 2xx, or an *httpError on
-// non-2xx, or an error categorised by api.IsTokenNotFound /
-// api.IsNoRefreshToken / generic transport.
-//
-// Mirrors cli/internal/cmd/kb/kb.go::doAuthedRequest and its
-// targets / operation / audit / connector siblings.
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errMissingAccessToken
-	}
-
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-
-	// Read with a 1-MiB cap and the +1 byte truncation-detection
-	// trick — same shape as the kb sibling. A response that fills
-	// the cap is treated as oversized rather than fed to the JSON
-	// decoder where it would surface as "unexpected end of JSON
-	// input" without naming the real cause.
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, responseBodyCap+1))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if int64(len(raw)) > responseBodyCap {
-		return nil, fmt.Errorf(
-			"response body exceeds %d-byte cap; refusing to decode possibly-truncated JSON",
-			responseBodyCap,
-		)
-	}
-	// DELETE /api/v1/memory/{scope}/{slug} returns 204 with no body
-	// whether or not the row existed (idempotent contract — same
-	// shape kb adopted; the conflation prevents tenant-probe by
-	// status-code differential).
-	if resp.StatusCode == http.StatusNoContent {
-		return nil, nil
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-// sendRequest is the bottom of the stack: build the http.Request,
-// stamp bearer + content headers, fire it. Mirrors the kb sibling.
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
-}
-
-// pathEscape escapes a single path segment for use inside a backend
-// URL. Mirrors the kb sibling.
-func pathEscape(segment string) string {
-	return url.PathEscape(segment)
 }
 
 // truncate cuts s to maxLen runes, appending an ellipsis when
@@ -615,63 +456,6 @@ func parseTagsFlag(tags []string) []string {
 		return nil
 	}
 	return out
-}
-
-// parseTTLFlag parses the `--ttl 7d` flag value into an ISO-8601
-// timestamp suitable for the wire-level `expires_at` field. The
-// helper accepts shorthand units (`s`/`m`/`h`/`d`) plus the
-// `time.ParseDuration` set (`s`/`m`/`h`); pure-Go ParseDuration
-// doesn't accept `d`, so the day suffix is handled explicitly.
-// Returns the ISO-8601 expires_at as `time.Now().UTC()` plus the
-// parsed duration so the backend sees a clock-aligned cutoff.
-//
-// Empty input returns ("", nil) so the caller can omit the field
-// and let the substrate apply its own default (no automatic TTL in
-// G5.1; G5.2 #374 ships the default-7-day injection on
-// `memory-user` writes).
-//
-// The `now` parameter is injectable so tests can pin the reference
-// time. Production callers pass `time.Now`.
-func parseTTLFlag(raw string, now func() time.Time) (string, error) {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return "", nil
-	}
-	d, err := parseDurationShorthand(raw)
-	if err != nil {
-		return "", err
-	}
-	if d <= 0 {
-		return "", fmt.Errorf("--ttl %q must be positive", raw)
-	}
-	expires := now().UTC().Add(d)
-	return expires.Format(time.RFC3339), nil
-}
-
-// parseDurationShorthand extends time.ParseDuration with a `d`
-// (days) suffix. The shape `7d` is the canonical TTL UX from the
-// issue body's `--ttl 7d` example; ParseDuration only accepts
-// h/m/s/ms/us/ns so days must be handled here.
-//
-// Accepts the same h/m/s units ParseDuration handles, so an
-// operator who wants `--ttl 36h` doesn't need to think about
-// whether the CLI rolled its own parser.
-func parseDurationShorthand(raw string) (time.Duration, error) {
-	if strings.HasSuffix(raw, "d") {
-		var days int
-		if _, err := fmt.Sscanf(raw, "%dd", &days); err != nil {
-			return 0, fmt.Errorf("--ttl %q: %w", raw, err)
-		}
-		if days <= 0 {
-			return 0, fmt.Errorf("--ttl %q: days must be positive", raw)
-		}
-		return time.Duration(days) * 24 * time.Hour, nil
-	}
-	d, err := time.ParseDuration(raw)
-	if err != nil {
-		return 0, fmt.Errorf("--ttl %q: %w (expected e.g. 30m, 24h, 7d)", raw, err)
-	}
-	return d, nil
 }
 
 // requireTargetForScope enforces the AC "scope=target/user-target
@@ -777,4 +561,61 @@ func pluralisePtr(p *string) string {
 // produce two newlines when Fprintln adds its own.
 func writeBodyToStdout(w io.Writer, body string) {
 	fmt.Fprintln(w, strings.TrimRight(body, "\r\n"))
+}
+
+// parseTTLFlag parses the `--ttl 7d` flag value into an ISO-8601
+// timestamp suitable for the wire-level `expires_at` field. The
+// helper accepts shorthand units (`s`/`m`/`h`/`d`) plus the
+// `time.ParseDuration` set (`s`/`m`/`h`); pure-Go ParseDuration
+// doesn't accept `d`, so the day suffix is handled explicitly.
+// Returns the ISO-8601 expires_at as `time.Now().UTC()` plus the
+// parsed duration so the backend sees a clock-aligned cutoff.
+//
+// Empty input returns ("", nil) so the caller can omit the field
+// and let the substrate apply its own default (no automatic TTL in
+// G5.1; G5.2 #374 ships the default-7-day injection on
+// `memory-user` writes).
+//
+// The `now` parameter is injectable so tests can pin the reference
+// time. Production callers pass `time.Now`.
+func parseTTLFlag(raw string, now func() time.Time) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", nil
+	}
+	d, err := parseDurationShorthand(raw)
+	if err != nil {
+		return "", err
+	}
+	if d <= 0 {
+		return "", fmt.Errorf("--ttl %q must be positive", raw)
+	}
+	expires := now().UTC().Add(d)
+	return expires.Format(time.RFC3339), nil
+}
+
+// parseDurationShorthand extends time.ParseDuration with a `d`
+// (days) suffix. The shape `7d` is the canonical TTL UX from the
+// issue body's `--ttl 7d` example; ParseDuration only accepts
+// h/m/s/ms/us/ns so days must be handled here.
+//
+// Accepts the same h/m/s units ParseDuration handles, so an
+// operator who wants `--ttl 36h` doesn't need to think about
+// whether the CLI rolled its own parser.
+func parseDurationShorthand(raw string) (time.Duration, error) {
+	if strings.HasSuffix(raw, "d") {
+		var days int
+		if _, err := fmt.Sscanf(raw, "%dd", &days); err != nil {
+			return 0, fmt.Errorf("--ttl %q: %w", raw, err)
+		}
+		if days <= 0 {
+			return 0, fmt.Errorf("--ttl %q: days must be positive", raw)
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("--ttl %q: %w (expected e.g. 30m, 24h, 7d)", raw, err)
+	}
+	return d, nil
 }

--- a/cli/internal/cmd/memory/memory_test.go
+++ b/cli/internal/cmd/memory/memory_test.go
@@ -17,8 +17,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/auth"
 	"github.com/evoila/meho/cli/internal/backplane"
 )
@@ -72,6 +75,24 @@ func newRunCmd(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
 func fixedNow() time.Time {
 	return time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
 }
+
+// uuidFromString converts a hex UUID string to the generated
+// openapi_types.UUID (= google/uuid.UUID). Helper exists so test
+// fixtures stay readable rather than carrying a parse+abort line
+// per row.
+func uuidFromString(t *testing.T, hex string) openapi_types.UUID {
+	t.Helper()
+	id, err := uuid.Parse(hex)
+	if err != nil {
+		t.Fatalf("uuidFromString %q: %v", hex, err)
+	}
+	return id
+}
+
+// timePtr returns a pointer to a time literal, used to build
+// fixture rows for the generated `api.MemoryEntry.ExpiresAt`
+// (`*time.Time`).
+func timePtr(t time.Time) *time.Time { return &t }
 
 // ---------------------------------------------------------------
 // Helpers — pure functions exercised first because the verbs build
@@ -313,12 +334,6 @@ func TestTruncateRuneAware(t *testing.T) {
 	}
 }
 
-func TestPathEscapePreservesSlugChars(t *testing.T) {
-	if got := pathEscape("k8s.rollout-note"); got != "k8s.rollout-note" {
-		t.Errorf("PathEscape stripped legal slug chars; got %q", got)
-	}
-}
-
 func TestLoadBodyInline(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetIn(bytes.NewBufferString(""))
@@ -391,61 +406,6 @@ func TestConfirmPromptYesNo(t *testing.T) {
 	}
 }
 
-func TestBuildRecallPathBasic(t *testing.T) {
-	got := buildRecallPath(ScopeUserTenant, "wine-preference", "")
-	want := "/api/v1/memory/user-tenant/wine-preference"
-	if got != want {
-		t.Errorf("buildRecallPath: got %q; want %q", got, want)
-	}
-}
-
-func TestBuildRecallPathWithTarget(t *testing.T) {
-	got := buildRecallPath(ScopeTarget, "rollout", "rke2-meho")
-	want := "/api/v1/memory/target/rollout?target_name=rke2-meho"
-	if got != want {
-		t.Errorf("buildRecallPath with target: got %q; want %q", got, want)
-	}
-}
-
-func TestBuildRecallPathEscapesSlug(t *testing.T) {
-	// SLUG_PATTERN admits letters/digits/hyphen/underscore/dot, all
-	// of which url.PathEscape passes through. A space (which would
-	// fail server-side validation but should still escape cleanly)
-	// proves the encoding seam.
-	got := buildRecallPath(ScopeUser, "weird slug", "")
-	if !strings.Contains(got, "weird%20slug") {
-		t.Errorf("expected escaped slug; got %q", got)
-	}
-}
-
-func TestBuildListPathOmitsEmptyFilters(t *testing.T) {
-	got := buildListPath(listOptions{})
-	if got != "/api/v1/memory" {
-		t.Errorf("expected bare path; got %q", got)
-	}
-}
-
-func TestBuildListPathIncludesProvidedFilters(t *testing.T) {
-	got := buildListPath(listOptions{
-		ScopeArg:       "user-tenant",
-		TagArg:         "rollout",
-		SlugPatternArg: "wine",
-		IncludeExpired: true,
-		LimitArg:       50,
-	})
-	for _, want := range []string{
-		"scope=user-tenant",
-		"tag=rollout",
-		"slug_pattern=wine",
-		"include_expired=true",
-		"limit=50",
-	} {
-		if !strings.Contains(got, want) {
-			t.Errorf("buildListPath missing %q; got %q", want, got)
-		}
-	}
-}
-
 func TestScopeFromKindStripsPrefix(t *testing.T) {
 	if got := scopeFromKind("memory-user-tenant"); got != "user-tenant" {
 		t.Errorf("scopeFromKind: got %q", got)
@@ -485,9 +445,123 @@ func TestPluralisePtrRendersNone(t *testing.T) {
 	}
 }
 
+func TestFormatTimePtrNilRendersNone(t *testing.T) {
+	if got := formatTimePtr(nil); got != "(none)" {
+		t.Errorf("nil *time.Time should render '(none)'; got %q", got)
+	}
+}
+
+func TestFormatTimePtrUTC(t *testing.T) {
+	when := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	if got := formatTimePtr(&when); got != "2026-05-26T12:00:00Z" {
+		t.Errorf("expected UTC ISO format; got %q", got)
+	}
+}
+
+func TestListQueryParamsOmitsEmptyFilters(t *testing.T) {
+	got := listQueryParams(listOptions{}, nil)
+	if got.Scope != nil {
+		t.Errorf("expected nil Scope; got %+v", got.Scope)
+	}
+	if got.Tag != nil || got.SlugPattern != nil || got.IncludeExpired != nil || got.Limit != nil {
+		t.Errorf("expected all filters nil; got %+v", got)
+	}
+}
+
+func TestListQueryParamsForwardsFilters(t *testing.T) {
+	scope := ScopeUserTenant
+	got := listQueryParams(listOptions{
+		TagArg:         "rollout",
+		SlugPatternArg: "wine",
+		IncludeExpired: true,
+		LimitArg:       50,
+	}, &scope)
+	if got.Scope == nil || *got.Scope != ScopeUserTenant {
+		t.Errorf("expected scope forwarded; got %+v", got.Scope)
+	}
+	if got.Tag == nil || *got.Tag != "rollout" {
+		t.Errorf("expected tag forwarded; got %+v", got.Tag)
+	}
+	if got.SlugPattern == nil || *got.SlugPattern != "wine" {
+		t.Errorf("expected slug_pattern forwarded; got %+v", got.SlugPattern)
+	}
+	if got.IncludeExpired == nil || !*got.IncludeExpired {
+		t.Errorf("expected include_expired=true; got %+v", got.IncludeExpired)
+	}
+	if got.Limit == nil || *got.Limit != 50 {
+		t.Errorf("expected limit=50; got %+v", got.Limit)
+	}
+}
+
+func TestBuildRecallParamsOmitsEmptyTarget(t *testing.T) {
+	got := buildRecallParams("")
+	if got.TargetName != nil {
+		t.Errorf("expected nil TargetName when empty; got %+v", got.TargetName)
+	}
+}
+
+func TestBuildRecallParamsForwardsTarget(t *testing.T) {
+	got := buildRecallParams("rke2-meho")
+	if got.TargetName == nil || *got.TargetName != "rke2-meho" {
+		t.Errorf("expected target forwarded; got %+v", got.TargetName)
+	}
+}
+
+func TestBuildForgetParamsOmitsEmptyTarget(t *testing.T) {
+	got := buildForgetParams("")
+	if got.TargetName != nil {
+		t.Errorf("expected nil TargetName when empty; got %+v", got.TargetName)
+	}
+}
+
+func TestBuildForgetParamsForwardsTarget(t *testing.T) {
+	got := buildForgetParams("rke2-meho")
+	if got.TargetName == nil || *got.TargetName != "rke2-meho" {
+		t.Errorf("expected target forwarded; got %+v", got.TargetName)
+	}
+}
+
+func TestBuildRecallQueryBodyPinsMemorySource(t *testing.T) {
+	got := buildRecallQueryBody(recallOptions{QueryArg: "wine"}, "")
+	if got.Source == nil || *got.Source != "memory" {
+		t.Errorf("expected source=memory pinned; got %+v", got.Source)
+	}
+	if got.Kind != nil {
+		t.Errorf("expected nil Kind when no kindFilter; got %+v", got.Kind)
+	}
+	if got.Limit != nil {
+		t.Errorf("expected nil Limit when LimitArg=0; got %+v", got.Limit)
+	}
+}
+
+func TestBuildRecallQueryBodyForwardsKindAndLimit(t *testing.T) {
+	got := buildRecallQueryBody(recallOptions{QueryArg: "wine", LimitArg: 25}, "memory-user-tenant")
+	if got.Kind == nil || *got.Kind != "memory-user-tenant" {
+		t.Errorf("expected kind forwarded; got %+v", got.Kind)
+	}
+	if got.Limit == nil || *got.Limit != 25 {
+		t.Errorf("expected limit=25; got %+v", got.Limit)
+	}
+}
+
 // ---------------------------------------------------------------
 // remember
 // ---------------------------------------------------------------
+
+// fakeMemoryEntry builds a typed MemoryEntry fixture used in
+// httptest handlers. Encodes via encoding/json so the wire shape
+// the typed parsers see matches what a real backend would produce.
+func fakeMemoryEntry(scope Scope, slug, body string) api.MemoryEntry {
+	now := time.Now().UTC()
+	return api.MemoryEntry{
+		Scope:     scope,
+		Slug:      slug,
+		Body:      body,
+		Metadata:  map[string]interface{}{},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
 
 func TestRunRememberHappyPath(t *testing.T) {
 	var bodyJSON map[string]any
@@ -502,18 +576,18 @@ func TestRunRememberHappyPath(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		expiresStr := "2026-05-26T12:00:00Z"
-		_ = json.NewEncoder(w).Encode(Entry{
-			ID:        "00000000-0000-0000-0000-000000000001",
-			TenantID:  "00000000-0000-0000-0000-000000000002",
+		entry := api.MemoryEntry{
+			Id:        uuidFromString(t, "00000000-0000-0000-0000-000000000001"),
+			TenantId:  uuidFromString(t, "00000000-0000-0000-0000-000000000002"),
 			Scope:     ScopeUserTenant,
 			Slug:      "wine-preference",
 			Body:      "I prefer dry red wines.",
-			Metadata:  map[string]any{"tags": []string{"food", "pref"}},
-			ExpiresAt: &expiresStr,
-			CreatedAt: "2026-05-19T12:00:00Z",
-			UpdatedAt: "2026-05-19T12:00:00Z",
-		})
+			Metadata:  map[string]interface{}{"tags": []string{"food", "pref"}},
+			ExpiresAt: timePtr(time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)),
+			CreatedAt: time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC),
+			UpdatedAt: time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC),
+		}
+		_ = json.NewEncoder(w).Encode(entry)
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -561,8 +635,9 @@ func TestRunRememberOmitsSlugWhenAbsent(t *testing.T) {
 		if err := json.Unmarshal(body, &bodyJSON); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(Entry{Scope: ScopeUser, Slug: "auto-gen"})
+		_ = json.NewEncoder(w).Encode(fakeMemoryEntry(ScopeUser, "auto-gen", ""))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -586,10 +661,11 @@ func TestRunRememberOmitsSlugWhenAbsent(t *testing.T) {
 func TestRunRememberJSONOutEmitsEntry(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(Entry{
-			Scope: ScopeUserTenant, Slug: "x", Body: "y",
-		})
+		entry := fakeMemoryEntry(ScopeUserTenant, "x", "y")
+		entry.Id = uuidFromString(t, "00000000-0000-0000-0000-000000000010")
+		_ = json.NewEncoder(w).Encode(entry)
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -602,7 +678,7 @@ func TestRunRememberJSONOutEmitsEntry(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("runRemember --json: %v", err)
 	}
-	var decoded Entry
+	var decoded api.MemoryEntry
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
 	}
@@ -619,8 +695,9 @@ func TestRunRememberSendsExpiresAtFromTTL(t *testing.T) {
 		if err := json.Unmarshal(body, &bodyJSON); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(Entry{Scope: ScopeUser, Slug: "x"})
+		_ = json.NewEncoder(w).Encode(fakeMemoryEntry(ScopeUser, "x", ""))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -662,6 +739,11 @@ func TestRunRememberSendsExpiresAtFromTTL(t *testing.T) {
 // The "explicit null vs absent" assertion uses json.RawMessage so the
 // test sees the literal wire bytes, not the decoded map (which would
 // collapse both shapes to a Go nil interface).
+//
+// The tri-state is the load-bearing reason we kept the
+// `rememberRequest` struct + custom MarshalJSON despite the typed
+// migration — the generated `api.RememberBody` can only express two
+// states (value vs null).
 
 func TestRunRememberPersistEmitsExplicitNullExpiresAt(t *testing.T) {
 	var rawBody json.RawMessage
@@ -669,8 +751,9 @@ func TestRunRememberPersistEmitsExplicitNullExpiresAt(t *testing.T) {
 	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, r *http.Request) {
 		b, _ := io.ReadAll(r.Body)
 		rawBody = json.RawMessage(b)
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(Entry{Scope: ScopeUser, Slug: "persisted"})
+		_ = json.NewEncoder(w).Encode(fakeMemoryEntry(ScopeUser, "persisted", ""))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -706,8 +789,9 @@ func TestRunRememberOmitsExpiresAtWhenNoPersistAndNoTTL(t *testing.T) {
 	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, r *http.Request) {
 		b, _ := io.ReadAll(r.Body)
 		rawBody = json.RawMessage(b)
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(Entry{Scope: ScopeUser, Slug: "auto"})
+		_ = json.NewEncoder(w).Encode(fakeMemoryEntry(ScopeUser, "auto", ""))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -903,8 +987,9 @@ func TestRunRememberReadsBodyFromStdin(t *testing.T) {
 		if err := json.Unmarshal(body, &bodyJSON); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(Entry{Scope: ScopeUser, Slug: "x", Body: "piped"})
+		_ = json.NewEncoder(w).Encode(fakeMemoryEntry(ScopeUser, "x", "piped"))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -922,6 +1007,39 @@ func TestRunRememberReadsBodyFromStdin(t *testing.T) {
 	}
 }
 
+// TestRunRemember201WithoutPayloadSurfacesUnexpected pins the nil-
+// guard added in the typed migration. A backplane / proxy that
+// returns 201 without the `application/json` Content-Type leaves
+// the generated `JSON201` nil; the verb routes the malformed
+// response through `output.Unexpected` (exit 4) rather than silently
+// emitting `null` or a phantom summary. Mirrors the sibling kb
+// migration's post-iter-2 nil-guard tests.
+func TestRunRemember201WithoutPayloadSurfacesUnexpected(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, _ *http.Request) {
+		// Deliberately no Content-Type — the generated parser keys
+		// JSON201 off the json content-type AND a 201 status; both
+		// must hold for JSON201 to populate.
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"00000000-0000-0000-0000-000000000099"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runRemember(cmd, rememberOptions{
+		BodyArg: "y", ScopeArg: "user", BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected nil-guard error on missing payload")
+	}
+	if !strings.Contains(stderr.String(), "HTTP 201 without a memory entry payload") {
+		t.Errorf("expected nil-guard message; got %q", stderr.String())
+	}
+}
+
 // ---------------------------------------------------------------
 // recall
 // ---------------------------------------------------------------
@@ -934,11 +1052,7 @@ func TestRunRecallByKeyPrintsBody(t *testing.T) {
 				t.Errorf("expected GET; got %s", r.Method)
 			}
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(Entry{
-				Scope: ScopeUserTenant,
-				Slug:  "wine-preference",
-				Body:  "Prefers dry red.",
-			})
+			_ = json.NewEncoder(w).Encode(fakeMemoryEntry(ScopeUserTenant, "wine-preference", "Prefers dry red."))
 		},
 	)
 	srv := httptest.NewServer(mux)
@@ -987,7 +1101,8 @@ func TestRunRecallByKeyJSONOutEmitsEntry(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/memory/user/wine",
 		func(w http.ResponseWriter, _ *http.Request) {
-			_ = json.NewEncoder(w).Encode(Entry{Scope: ScopeUser, Slug: "wine", Body: "y"})
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(fakeMemoryEntry(ScopeUser, "wine", "y"))
 		},
 	)
 	srv := httptest.NewServer(mux)
@@ -1001,7 +1116,7 @@ func TestRunRecallByKeyJSONOutEmitsEntry(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("runRecall --json: %v", err)
 	}
-	var got Entry
+	var got api.MemoryEntry
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
 	}
@@ -1057,18 +1172,22 @@ func TestRunRecallByQueryHappyPath(t *testing.T) {
 		if err := json.Unmarshal(body, &bodyJSON); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		_ = json.NewEncoder(w).Encode(RetrieveResponse{
-			Hits: []RetrievalHit{
-				{
-					DocumentID: "1",
-					Source:     "memory",
-					SourceID:   "user-tenant:abc:wine",
-					Kind:       "memory-user-tenant",
-					Body:       "I prefer dry red wines.",
-					FusedScore: 0.9,
-				},
-			},
-			QueryDurationMS: 12.5,
+		w.Header().Set("Content-Type", "application/json")
+		hit := api.RetrievalHit{
+			DocumentId:  uuidFromString(t, "00000000-0000-0000-0000-0000000000aa"),
+			TenantId:    uuidFromString(t, "00000000-0000-0000-0000-0000000000bb"),
+			Source:      "memory",
+			SourceId:    "user-tenant:abc:wine",
+			Kind:        "memory-user-tenant",
+			Body:        "I prefer dry red wines.",
+			DocMetadata: map[string]interface{}{},
+			FusedScore:  0.9,
+			CreatedAt:   time.Now().UTC(),
+			UpdatedAt:   time.Now().UTC(),
+		}
+		_ = json.NewEncoder(w).Encode(api.RetrieveResponse{
+			Hits:            []api.RetrievalHit{hit},
+			QueryDurationMs: 12.5,
 		})
 	})
 	srv := httptest.NewServer(mux)
@@ -1110,6 +1229,58 @@ func TestRunRecallQueryRejectsBadLimit(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "between 1 and 50") {
 		t.Errorf("expected limit-range message; got %q", stderr.String())
+	}
+}
+
+// TestRunRecallByKey200WithoutPayloadSurfacesUnexpected pins the
+// nil-guard added in the typed migration. Mirrors the kb sibling's
+// post-iter-2 pattern.
+func TestRunRecallByKey200WithoutPayloadSurfacesUnexpected(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory/user/wine",
+		func(w http.ResponseWriter, _ *http.Request) {
+			// No Content-Type → JSON200 stays nil.
+			_, _ = w.Write([]byte(`{"id":"00000000-0000-0000-0000-000000000099"}`))
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runRecall(cmd, recallOptions{
+		ScopeSlugArg: "user/wine", BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected nil-guard error on missing payload")
+	}
+	if !strings.Contains(stderr.String(), "HTTP 200 without a memory entry payload") {
+		t.Errorf("expected nil-guard message; got %q", stderr.String())
+	}
+}
+
+// TestRunRecallByQuery200WithoutPayloadSurfacesUnexpected pins the
+// nil-guard on the retrieve path.
+func TestRunRecallByQuery200WithoutPayloadSurfacesUnexpected(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/retrieve", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"hits":[]}`)) // no content-type → JSON200 nil
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runRecall(cmd, recallOptions{
+		QueryArg: "wine", BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected nil-guard error on missing payload")
+	}
+	if !strings.Contains(stderr.String(), "HTTP 200 without a retrieve response payload") {
+		t.Errorf("expected nil-guard message; got %q", stderr.String())
 	}
 }
 
@@ -1263,6 +1434,32 @@ func TestRunForget403SurfacesInsufficientRole(t *testing.T) {
 	}
 }
 
+func TestRunForgetForwardsTargetQueryParam(t *testing.T) {
+	var captured string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory/target/rollout",
+		func(w http.ResponseWriter, r *http.Request) {
+			captured = r.URL.RawQuery
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	if err := runForget(cmd, forgetOptions{
+		ScopeSlugArg: "target/rollout", TargetArg: "rke2-meho",
+		Confirm: true, BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runForget: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(captured, "target_name=rke2-meho") {
+		t.Errorf("expected target_name in query; got %q", captured)
+	}
+}
+
 // ---------------------------------------------------------------
 // list
 // ---------------------------------------------------------------
@@ -1274,10 +1471,10 @@ func TestRunListHappyPath(t *testing.T) {
 			t.Errorf("expected GET; got %s", r.Method)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(ListResponse{
-			Entries: []Entry{
-				{Scope: ScopeUser, Slug: "wine", Body: "dry red"},
-				{Scope: ScopeUserTenant, Slug: "k8s.note", Body: "rollout"},
+		_ = json.NewEncoder(w).Encode(api.MemoryListResponse{
+			Entries: []api.MemoryEntry{
+				fakeMemoryEntry(ScopeUser, "wine", "dry red"),
+				fakeMemoryEntry(ScopeUserTenant, "k8s.note", "rollout"),
 			},
 		})
 	})
@@ -1301,8 +1498,9 @@ func TestRunListHappyPath(t *testing.T) {
 func TestRunListJSONHappyPath(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(ListResponse{
-			Entries: []Entry{{Scope: ScopeUser, Slug: "x", Body: "y"}},
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.MemoryListResponse{
+			Entries: []api.MemoryEntry{fakeMemoryEntry(ScopeUser, "x", "y")},
 		})
 	})
 	srv := httptest.NewServer(mux)
@@ -1316,7 +1514,7 @@ func TestRunListJSONHappyPath(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("runList --json: %v", err)
 	}
-	var resp ListResponse
+	var resp api.MemoryListResponse
 	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
 		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
 	}
@@ -1328,7 +1526,8 @@ func TestRunListJSONHappyPath(t *testing.T) {
 func TestRunListEmptyResponse(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(ListResponse{Entries: nil})
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.MemoryListResponse{Entries: nil})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -1349,7 +1548,8 @@ func TestRunListForwardsFilters(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, r *http.Request) {
 		capturedQuery = r.URL.RawQuery
-		_ = json.NewEncoder(w).Encode(ListResponse{})
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.MemoryListResponse{})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -1379,13 +1579,16 @@ func TestRunListNormalisesScopeWhitespace(t *testing.T) {
 	// Without normalisation runList passed parseScope's preflight
 	// (validScopes lookup trims internally) and then forwarded the
 	// raw " user " back into the query string, producing a 422 on
-	// the FastAPI enum check. Mirrors the recall.go fix shape that
-	// already propagates parseScope's typed return value.
+	// the FastAPI enum check. Mirrors the pre-migration fix shape:
+	// the typed-client path now threads the validated `*Scope` into
+	// `listQueryParams`, so the same regression is structurally
+	// impossible.
 	var capturedQuery string
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, r *http.Request) {
 		capturedQuery = r.URL.RawQuery
-		_ = json.NewEncoder(w).Encode(ListResponse{})
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.MemoryListResponse{})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -1433,6 +1636,28 @@ func TestRunListInvalidScopeFailsFast(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "invalid --scope") {
 		t.Errorf("expected invalid-scope message; got %q", stderr.String())
+	}
+}
+
+// TestRunList200WithoutPayloadSurfacesUnexpected pins the nil-guard
+// on the list path.
+func TestRunList200WithoutPayloadSurfacesUnexpected(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"entries":[]}`)) // no content-type → JSON200 nil
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runList(cmd, listOptions{BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected nil-guard error on missing payload")
+	}
+	if !strings.Contains(stderr.String(), "HTTP 200 without a memory list payload") {
+		t.Errorf("expected nil-guard message; got %q", stderr.String())
 	}
 }
 

--- a/cli/internal/cmd/memory/promote.go
+++ b/cli/internal/cmd/memory/promote.go
@@ -5,8 +5,6 @@ package memory
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -114,7 +113,7 @@ func NewPromoteCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&moveFlag, "move", false,
 		"delete the source row in the same transaction (broadens-and-leaves vs. broadens-and-rewires)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
-		"emit raw Entry JSON instead of the human summary")
+		"emit raw MemoryEntry JSON instead of the human summary")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by `meho login`)")
 	// --to is required at the CLI layer; failing to flag it raises a
@@ -141,17 +140,6 @@ type promoteOptions struct {
 	Now func() time.Time
 }
 
-// promoteRequest mirrors the backend “PromoteBody“ pydantic model
-// (`backend/src/meho_backplane/api/v1/memory.py`). “move“ is sent
-// regardless of value (the route's pydantic v2 “BaseModel“ accepts
-// the default “false“ explicitly — same shape “forget“ /
-// “remember“ use).
-type promoteRequest struct {
-	To         Scope  `json:"to"`
-	Move       bool   `json:"move"`
-	TargetName string `json:"target_name,omitempty"`
-}
-
 func runPromote(cmd *cobra.Command, opts promoteOptions) error {
 	if opts.Now == nil {
 		opts.Now = time.Now
@@ -171,9 +159,9 @@ func runPromote(cmd *cobra.Command, opts promoteOptions) error {
 		return output.RenderError(cmd.ErrOrStderr(),
 			backplane.ClassifyError(err), opts.JSONOut)
 	}
-	req := promoteRequest{
+	reqBody := api.PromoteBody{
 		To:   targetScope,
-		Move: opts.Move,
+		Move: &opts.Move,
 	}
 	// Capture the pre-POST wall clock so a successful response can be
 	// classified as fresh (entry.CreatedAt >= preCallAt) vs.
@@ -186,9 +174,28 @@ func runPromote(cmd *cobra.Command, opts promoteOptions) error {
 	// from a previous wall-clock, which is on the seconds-or-more
 	// timescale.
 	preCallAt := opts.Now().UTC()
-	entry, err := postPromote(cmd.Context(), backplaneURL, sourceScope, sourceSlug, req)
+	resp, err := postPromote(cmd.Context(), backplaneURL, sourceScope, sourceSlug, reqBody)
 	if err != nil {
 		return renderPromoteRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return renderPromoteHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	// Guard against 200 + missing-content-type leaving JSON200 nil
+	// (printPromoteSummary nil-guards, but the operator would see an
+	// empty line with exit 0 — phantom success). Mirrors
+	// `cli/internal/cmd/status.go:142` + the kb sibling's
+	// post-iter-2 nil-guard pattern.
+	entry := resp.JSON200
+	if entry == nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without a memory entry payload",
+				backplaneURL,
+			)),
+			opts.JSONOut,
+		)
 	}
 	idempotent := isIdempotentRerun(entry, preCallAt)
 	if opts.JSONOut {
@@ -233,29 +240,20 @@ func (*idempotentPromoteError) ExitCode() int { return exitIdempotentPromote }
 //
 // Robustness notes:
 //
-//   - Empty / unparseable “created_at“ → treated as fresh (false).
+//   - Zero / unset “CreatedAt“ → treated as fresh (false).
 //     Misclassifying a re-run as fresh degrades the UX (operator sees
 //     exit 0 + "promoted" wording) but never returns the wrong row;
-//     the alternative — treating a parse failure as idempotent —
+//     the alternative — treating a missing timestamp as idempotent —
 //     would block a successful first promotion behind a false-positive
 //     warning.
 //   - Sub-second skew between client and server clocks is tolerable
 //     because a re-run carries the “created_at“ from a previous
 //     promotion, which is seconds-or-more in the past.
-func isIdempotentRerun(entry *Entry, preCallAt time.Time) bool {
-	if entry == nil || entry.CreatedAt == "" {
+func isIdempotentRerun(entry *api.MemoryEntry, preCallAt time.Time) bool {
+	if entry == nil || entry.CreatedAt.IsZero() {
 		return false
 	}
-	createdAt, err := time.Parse(time.RFC3339Nano, entry.CreatedAt)
-	if err != nil {
-		// Fall back to RFC3339 for backends that strip sub-second
-		// precision in serialisation.
-		createdAt, err = time.Parse(time.RFC3339, entry.CreatedAt)
-		if err != nil {
-			return false
-		}
-	}
-	return createdAt.UTC().Before(preCallAt)
+	return entry.CreatedAt.UTC().Before(preCallAt)
 }
 
 func postPromote(
@@ -263,51 +261,56 @@ func postPromote(
 	backplaneURL string,
 	sourceScope Scope,
 	sourceSlug string,
-	req promoteRequest,
-) (*Entry, error) {
-	raw, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("marshal promote request: %w", err)
-	}
-	path := fmt.Sprintf("/api/v1/memory/%s/%s/promote",
-		pathEscape(string(sourceScope)), pathEscape(sourceSlug))
-	resp, err := doAuthedRequest(ctx, backplaneURL, "POST", path, raw)
+	req api.PromoteBody,
+) (*api.PromoteApiV1MemoryScopeSlugPromotePostResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out Entry
-	if err := json.Unmarshal(resp, &out); err != nil {
-		return nil, fmt.Errorf("decode promote response: %w", err)
-	}
-	return &out, nil
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.PromoteApiV1MemoryScopeSlugPromotePostResponse, error) {
+			return authed.PromoteApiV1MemoryScopeSlugPromotePostWithResponse(
+				ctx,
+				sourceScope,
+				sourceSlug,
+				&api.PromoteApiV1MemoryScopeSlugPromotePostParams{},
+				req,
+			)
+		},
+		func(r *api.PromoteApiV1MemoryScopeSlugPromotePostResponse) int { return r.StatusCode() },
+	)
 }
 
-// renderPromoteRequestError translates an error from postPromote into
-// the right “output.StructuredError“ category. Specialises the
-// shared :func:`renderRequestError` to surface the promote route's
-// 403 canonical detail (“insufficient_promotion_authority“) under
-// the explicit “insufficient_promotion_authority“ exit code 5 from
-// the issue #627 mapping, and to keep the 400 cross-ladder /
-// 404 source-not-visible branches uniformly under
-// “unexpected_response“ (exit 4).
+// renderPromoteRequestError translates a transport-layer error from
+// postPromote into the right “output.StructuredError“ category.
+// The transport surface is identical to the shared
+// :func:`renderRequestError`; specialisation is at the HTTP-status
+// layer (:func:`renderPromoteHTTPStatus`).
 func renderPromoteRequestError(
 	cmd *cobra.Command,
 	backplaneURL string,
 	err error,
 	jsonOut bool,
 ) error {
-	// Sentinel-error paths (errMissingAccessToken / token-not-found /
-	// no-refresh-token / transport) flow through the shared helper
-	// unchanged — only the http-status branch needs verb-specific
-	// shaping.
-	var he *httpError
-	if !errors.As(err, &he) {
-		return renderRequestError(cmd, backplaneURL, err, jsonOut)
-	}
-	switch he.StatusCode {
+	return renderRequestError(cmd, backplaneURL, err, jsonOut)
+}
+
+// renderPromoteHTTPStatus classifies a non-2xx promote response.
+// Specialises the shared :func:`renderHTTPStatus` for the promote
+// route's distinct 403 mapping (`insufficient_promotion_authority`)
+// and the 400 cross-ladder / 404 source-not-visible / 409 / 422 /
+// 501 spread that all collapse to `unexpected_response` (exit 4).
+func renderPromoteHTTPStatus(
+	cmd *cobra.Command,
+	backplaneURL string,
+	statusCode int,
+	body []byte,
+	jsonOut bool,
+) error {
+	switch statusCode {
 	case http.StatusUnauthorized:
-		// Mirrors the shared helper; pinned here so the per-verb error
-		// table is one read.
+		// Mirrors the shared helper; pinned here so the per-verb
+		// error table is one read.
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.AuthExpired(fmt.Sprintf(
 				"backplane rejected the stored token; run `meho login %s`",
@@ -323,7 +326,7 @@ func renderPromoteRequestError(
 		// :func:`api.v1.memory.promote`); decodeDetailString unwraps
 		// it.
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.InsufficientRole(decodeDetailString(he.Body)),
+			output.InsufficientRole(decodeDetailString(string(body))),
 			jsonOut,
 		)
 	default:
@@ -335,7 +338,7 @@ func renderPromoteRequestError(
 		// detail prose.
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, decodeDetailString(he.Body))),
+				backplaneURL, statusCode, decodeDetailString(string(body)))),
 			jsonOut,
 		)
 	}
@@ -347,7 +350,7 @@ func renderPromoteRequestError(
 // On an idempotent re-run the wording flips to "already promoted" so
 // the operator sees the no-op explicitly; the human-mode exit-6 code
 // is what scripts read.
-func printPromoteSummary(w io.Writer, e *Entry, idempotent bool, move bool) {
+func printPromoteSummary(w io.Writer, e *api.MemoryEntry, idempotent bool, move bool) {
 	if e == nil {
 		return
 	}
@@ -364,13 +367,13 @@ func printPromoteSummary(w io.Writer, e *Entry, idempotent bool, move bool) {
 		suffix = " (source row removed)"
 	}
 	fmt.Fprintf(w, "%s %s/%s%s\n", verb, e.Scope, e.Slug, suffix)
-	fmt.Fprintf(w, "%-14s %s\n", "id:", e.ID)
+	fmt.Fprintf(w, "%-14s %s\n", "id:", e.Id.String())
 	fmt.Fprintf(w, "%-14s %s\n", "scope:", e.Scope)
 	fmt.Fprintf(w, "%-14s %s\n", "slug:", e.Slug)
-	fmt.Fprintf(w, "%-14s %s\n", "expires_at:", pluralisePtr(e.ExpiresAt))
+	fmt.Fprintf(w, "%-14s %s\n", "expires_at:", formatTimePtr(e.ExpiresAt))
 	fmt.Fprintf(w, "%-14s %s\n", "user_sub:", pluralisePtr(e.UserSub))
 	fmt.Fprintf(w, "%-14s %s\n", "target_name:", pluralisePtr(e.TargetName))
-	fmt.Fprintf(w, "%-14s %s\n", "created_at:", e.CreatedAt)
+	fmt.Fprintf(w, "%-14s %s\n", "created_at:", e.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"))
 	if promotedFrom := metadataStringField(e.Metadata, "promoted_from"); promotedFrom != "" {
 		fmt.Fprintf(w, "%-14s %s\n", "promoted_from:", promotedFrom)
 	}

--- a/cli/internal/cmd/memory/promote_e2e_test.go
+++ b/cli/internal/cmd/memory/promote_e2e_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/auth"
 )
 
@@ -76,8 +77,9 @@ func requireLiveBackplane(t *testing.T) string {
 // debugging a failed CI job.
 //
 // `seedXDGAndToken` writes a placeholder StoredToken; we overwrite
-// it with the operator's real bearer here so `doAuthedRequest`
-// sends production credentials to the live backplane.
+// it with the operator's real bearer here so the typed-client's
+// bearer-injecting editor sends production credentials to the live
+// backplane.
 func seedLiveTokenStore(t *testing.T, backplaneURL, accessToken string) {
 	t.Helper()
 	seedXDGAndToken(t, backplaneURL)
@@ -265,7 +267,7 @@ func TestE2EPromoteIdempotentRerun(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("E2E idempotent --json: %v", err)
 	}
-	var decoded Entry
+	var decoded api.MemoryEntry
 	if err := json.Unmarshal(stdoutJSON.Bytes(), &decoded); err != nil {
 		t.Fatalf("E2E idempotent --json: stdout not JSON: %v\n%s", err, stdoutJSON.String())
 	}

--- a/cli/internal/cmd/memory/promote_test.go
+++ b/cli/internal/cmd/memory/promote_test.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/evoila/meho/cli/internal/api"
 )
 
 // TestRunPromoteHappyPath exercises the fresh-promotion branch end-to-
@@ -37,14 +39,14 @@ func TestRunPromoteHappyPath(t *testing.T) {
 			// CreatedAt slightly in the future ensures
 			// isIdempotentRerun returns false even if the test
 			// runner's clock skews backward by milliseconds.
-			created := time.Now().UTC().Add(50 * time.Millisecond).Format(time.RFC3339Nano)
-			_ = json.NewEncoder(w).Encode(Entry{
-				ID:        "00000000-0000-0000-0000-000000000001",
-				TenantID:  "00000000-0000-0000-0000-000000000002",
+			created := time.Now().UTC().Add(50 * time.Millisecond)
+			_ = json.NewEncoder(w).Encode(api.MemoryEntry{
+				Id:        uuidFromString(t, "00000000-0000-0000-0000-000000000001"),
+				TenantId:  uuidFromString(t, "00000000-0000-0000-0000-000000000002"),
 				Scope:     ScopeUserTenant,
 				Slug:      "wine-preference",
 				Body:      "Prefers dry red.",
-				Metadata:  map[string]any{"promoted_from": "user/wine-preference"},
+				Metadata:  map[string]interface{}{"promoted_from": "user/wine-preference"},
 				CreatedAt: created,
 				UpdatedAt: created,
 			})
@@ -92,11 +94,12 @@ func TestRunPromoteMoveHappyPath(t *testing.T) {
 			if err := json.Unmarshal(body, &bodyJSON); err != nil {
 				t.Fatalf("decode: %v", err)
 			}
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			created := time.Now().UTC().Add(50 * time.Millisecond).Format(time.RFC3339Nano)
-			_ = json.NewEncoder(w).Encode(Entry{
+			created := time.Now().UTC().Add(50 * time.Millisecond)
+			_ = json.NewEncoder(w).Encode(api.MemoryEntry{
 				Scope: ScopeUserTenant, Slug: "note", Body: "z",
-				Metadata:  map[string]any{"promoted_from": "user/note"},
+				Metadata:  map[string]interface{}{"promoted_from": "user/note"},
 				CreatedAt: created, UpdatedAt: created,
 			})
 		})
@@ -130,15 +133,16 @@ func TestRunPromoteIdempotentRerunHumanExit6(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/memory/user/wine/promote",
 		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			// Created an hour ago — well before any pre-POST clock.
-			ancient := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339Nano)
-			_ = json.NewEncoder(w).Encode(Entry{
-				ID:        "11111111-1111-1111-1111-111111111111",
+			ancient := time.Now().UTC().Add(-1 * time.Hour)
+			_ = json.NewEncoder(w).Encode(api.MemoryEntry{
+				Id:        uuidFromString(t, "11111111-1111-1111-1111-111111111111"),
 				Scope:     ScopeUserTenant,
 				Slug:      "wine",
 				Body:      "prefers dry red",
-				Metadata:  map[string]any{"promoted_from": "user/wine"},
+				Metadata:  map[string]interface{}{"promoted_from": "user/wine"},
 				CreatedAt: ancient,
 				UpdatedAt: ancient,
 			})
@@ -180,14 +184,15 @@ func TestRunPromoteIdempotentRerunJSONExit0(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/memory/user/wine/promote",
 		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			ancient := time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339Nano)
-			_ = json.NewEncoder(w).Encode(Entry{
-				ID:        "22222222-2222-2222-2222-222222222222",
+			ancient := time.Now().UTC().Add(-1 * time.Hour)
+			_ = json.NewEncoder(w).Encode(api.MemoryEntry{
+				Id:        uuidFromString(t, "22222222-2222-2222-2222-222222222222"),
 				Scope:     ScopeUserTenant,
 				Slug:      "wine",
 				Body:      "prefers dry red",
-				Metadata:  map[string]any{"promoted_from": "user/wine"},
+				Metadata:  map[string]interface{}{"promoted_from": "user/wine"},
 				CreatedAt: ancient,
 				UpdatedAt: ancient,
 			})
@@ -207,11 +212,11 @@ func TestRunPromoteIdempotentRerunJSONExit0(t *testing.T) {
 	if err != nil {
 		t.Fatalf("--json idempotent should be exit 0; got %v; stderr=%s", err, stderr.String())
 	}
-	var decoded Entry
+	var decoded api.MemoryEntry
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
 	}
-	if decoded.ID != "22222222-2222-2222-2222-222222222222" {
+	if decoded.Id.String() != "22222222-2222-2222-2222-222222222222" {
 		t.Errorf("expected target row id round-trip; got %+v", decoded)
 	}
 	// The promoted_from marker must survive the JSON round-trip so a
@@ -403,19 +408,20 @@ func TestRunPromote401AuthExpiredSurfacesExit2(t *testing.T) {
 }
 
 // TestRunPromoteJSONHappyPathEmitsEntry — “--json“ on the fresh-
-// promotion branch emits the raw Entry envelope; exit 0.
+// promotion branch emits the raw MemoryEntry envelope; exit 0.
 func TestRunPromoteJSONHappyPathEmitsEntry(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/memory/user/wine/promote",
 		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			created := time.Now().UTC().Add(50 * time.Millisecond).Format(time.RFC3339Nano)
-			_ = json.NewEncoder(w).Encode(Entry{
-				ID:        "33333333-3333-3333-3333-333333333333",
+			created := time.Now().UTC().Add(50 * time.Millisecond)
+			_ = json.NewEncoder(w).Encode(api.MemoryEntry{
+				Id:        uuidFromString(t, "33333333-3333-3333-3333-333333333333"),
 				Scope:     ScopeUserTenant,
 				Slug:      "wine",
 				Body:      "prefers dry red",
-				Metadata:  map[string]any{"promoted_from": "user/wine"},
+				Metadata:  map[string]interface{}{"promoted_from": "user/wine"},
 				CreatedAt: created,
 				UpdatedAt: created,
 			})
@@ -435,11 +441,11 @@ func TestRunPromoteJSONHappyPathEmitsEntry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runPromote --json: %v; stderr=%s", err, stderr.String())
 	}
-	var decoded Entry
+	var decoded api.MemoryEntry
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
 	}
-	if decoded.ID != "33333333-3333-3333-3333-333333333333" {
+	if decoded.Id.String() != "33333333-3333-3333-3333-333333333333" {
 		t.Errorf("expected target row id round-trip; got %+v", decoded)
 	}
 	got, _ := decoded.Metadata["promoted_from"].(string)
@@ -526,7 +532,7 @@ func TestIsIdempotentRerunVariousTimestamps(t *testing.T) {
 	preCall := time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)
 	cases := []struct {
 		name  string
-		entry *Entry
+		entry *api.MemoryEntry
 		want  bool
 	}{
 		{
@@ -535,34 +541,24 @@ func TestIsIdempotentRerunVariousTimestamps(t *testing.T) {
 			want:  false,
 		},
 		{
-			name:  "empty created_at returns false",
-			entry: &Entry{CreatedAt: ""},
-			want:  false,
-		},
-		{
-			name:  "unparseable created_at returns false",
-			entry: &Entry{CreatedAt: "not-a-timestamp"},
+			name:  "zero created_at returns false",
+			entry: &api.MemoryEntry{},
 			want:  false,
 		},
 		{
 			name:  "created_at strictly before pre-call wall clock is idempotent",
-			entry: &Entry{CreatedAt: "2026-05-21T11:00:00Z"},
+			entry: &api.MemoryEntry{CreatedAt: time.Date(2026, 5, 21, 11, 0, 0, 0, time.UTC)},
 			want:  true,
 		},
 		{
 			name:  "created_at after pre-call wall clock is fresh",
-			entry: &Entry{CreatedAt: "2026-05-21T13:00:00Z"},
+			entry: &api.MemoryEntry{CreatedAt: time.Date(2026, 5, 21, 13, 0, 0, 0, time.UTC)},
 			want:  false,
 		},
 		{
 			name:  "created_at equal to pre-call wall clock is fresh",
-			entry: &Entry{CreatedAt: "2026-05-21T12:00:00Z"},
+			entry: &api.MemoryEntry{CreatedAt: time.Date(2026, 5, 21, 12, 0, 0, 0, time.UTC)},
 			want:  false,
-		},
-		{
-			name:  "RFC3339 without sub-second precision parses cleanly",
-			entry: &Entry{CreatedAt: "2026-05-21T11:00:00Z"},
-			want:  true,
 		},
 	}
 	for _, tc := range cases {
@@ -590,5 +586,34 @@ func TestMetadataStringFieldEdgeCases(t *testing.T) {
 	}
 	if got := metadataStringField(map[string]any{"promoted_from": "user/x"}, "promoted_from"); got != "user/x" {
 		t.Errorf("string field: got %q", got)
+	}
+}
+
+// TestRunPromote200WithoutPayloadSurfacesUnexpected pins the
+// nil-guard on the promote path. Mirrors the kb sibling's
+// post-iter-2 nil-guard pattern.
+func TestRunPromote200WithoutPayloadSurfacesUnexpected(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/memory/user/wine/promote",
+		func(w http.ResponseWriter, _ *http.Request) {
+			// No Content-Type → JSON200 stays nil.
+			_, _ = w.Write([]byte(`{"id":"00000000-0000-0000-0000-000000000099"}`))
+		})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	cmd.SetIn(bytes.NewBufferString(""))
+	err := runPromote(cmd, promoteOptions{
+		ScopeSlugArg:      "user/wine",
+		ToArg:             "user-tenant",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected nil-guard error on missing payload")
+	}
+	if !strings.Contains(stderr.String(), "HTTP 200 without a memory entry payload") {
+		t.Errorf("expected nil-guard message; got %q", stderr.String())
 	}
 }

--- a/cli/internal/cmd/memory/recall.go
+++ b/cli/internal/cmd/memory/recall.go
@@ -5,13 +5,13 @@ package memory
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -97,6 +97,7 @@ func NewRecallCmd() *cobra.Command {
 				QueryArg:          queryFlag,
 				ScopeFilterArg:    scopeFlag,
 				LimitArg:          limitFlag,
+				LimitChanged:      cmd.Flags().Changed("limit"),
 				TargetArg:         targetFlag,
 				JSONOut:           jsonOut,
 				BackplaneOverride: backplaneOverride,
@@ -113,17 +114,25 @@ func NewRecallCmd() *cobra.Command {
 	cmd.Flags().StringVar(&targetFlag, "target", "",
 		"target name for user-target / target scopes (positional mode only)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
-		"emit raw Entry / RetrieveResponse JSON instead of human output")
+		"emit raw MemoryEntry / RetrieveResponse JSON instead of human output")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by `meho login`)")
 	return cmd
 }
 
 type recallOptions struct {
-	ScopeSlugArg      string
-	QueryArg          string
-	ScopeFilterArg    string
-	LimitArg          int
+	ScopeSlugArg   string
+	QueryArg       string
+	ScopeFilterArg string
+	LimitArg       int
+	// LimitChanged mirrors `cmd.Flags().Changed("limit")` for
+	// runRecallByQuery's "operator-supplied 0 is an error;
+	// default-0 means 'use the server default'" gate. Threaded as
+	// a field rather than re-reading off cmd so tests that drive
+	// runRecall directly (bypassing the cobra flag-parse path) can
+	// opt in / out of the gate explicitly. Mirrors the kb sibling's
+	// searchOptions.Changed shape.
+	LimitChanged      bool
 	TargetArg         string
 	JSONOut           bool
 	BackplaneOverride string
@@ -165,14 +174,32 @@ func runRecallByKey(cmd *cobra.Command, backplaneURL string, opts recallOptions)
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(err.Error()), opts.JSONOut)
 	}
-	entry, err := getRecall(cmd.Context(), backplaneURL, scope, slug, opts.TargetArg)
+	resp, err := getRecall(cmd.Context(), backplaneURL, scope, slug, opts.TargetArg)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
-	if opts.JSONOut {
-		return output.PrintJSON(cmd.OutOrStdout(), entry)
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
 	}
-	writeBodyToStdout(cmd.OutOrStdout(), entry.Body)
+	// Guard against 200 + missing-content-type leaving JSON200 nil
+	// (writeBodyToStdout silently writes one newline, so the operator
+	// would see an empty stdout with exit 0 — phantom success).
+	// Mirrors `cli/internal/cmd/status.go:142` + the kb sibling's
+	// post-iter-2 nil-guard pattern.
+	if resp.JSON200 == nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without a memory entry payload",
+				backplaneURL,
+			)),
+			opts.JSONOut,
+		)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
+	}
+	writeBodyToStdout(cmd.OutOrStdout(), resp.JSON200.Body)
 	return nil
 }
 
@@ -180,8 +207,7 @@ func runRecallByQuery(cmd *cobra.Command, backplaneURL string, opts recallOption
 	// Mirror the --limit clamp from `meho kb search`: backend
 	// rejects with 422 outside 1..50; surface the constraint string
 	// locally so operators see the bound without a round-trip.
-	limitProvided := cmd.Flags().Changed("limit")
-	if opts.LimitArg < 0 || opts.LimitArg > 50 || (limitProvided && opts.LimitArg == 0) {
+	if opts.LimitArg < 0 || opts.LimitArg > 50 || (opts.LimitChanged && opts.LimitArg == 0) {
 		return output.RenderError(
 			cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf(
@@ -207,27 +233,42 @@ func runRecallByQuery(cmd *cobra.Command, backplaneURL string, opts recallOption
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
-	if opts.JSONOut {
-		return output.PrintJSON(cmd.OutOrStdout(), resp)
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
 	}
-	printRecallTable(cmd.OutOrStdout(), resp)
+	// Guard against 200 + missing-content-type leaving JSON200 nil
+	// (printRecallTable's nil-or-empty branch would print "no hits"
+	// — actively misleading on a malformed 200). Mirrors the kb
+	// sibling's post-iter-2 nil-guard pattern.
+	if resp.JSON200 == nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without a retrieve response payload",
+				backplaneURL,
+			)),
+			opts.JSONOut,
+		)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
+	}
+	printRecallTable(cmd.OutOrStdout(), resp.JSON200)
 	return nil
 }
 
-// buildRecallPath assembles the GET path. Exposed for unit tests so
-// URL encoding of slugs (which admit hyphen / underscore / dot per
-// SLUG_PATTERN) stays covered. The optional `target_name` query
-// param is appended only when set — `user` / `user-tenant` /
-// `tenant` recalls have no target_name semantics.
-func buildRecallPath(scope Scope, slug, targetName string) string {
-	path := fmt.Sprintf("/api/v1/memory/%s/%s",
-		pathEscape(string(scope)), pathEscape(slug))
+// buildRecallParams maps the positional-mode CLI flags onto the
+// generated query-param shape. `TargetName` is set only when the
+// operator supplied `--target` so an unset flag stays absent on the
+// wire (user / user-tenant / tenant recalls have no target_name
+// semantics).
+func buildRecallParams(targetName string) *api.RecallApiV1MemoryScopeSlugGetParams {
+	params := &api.RecallApiV1MemoryScopeSlugGetParams{}
 	if targetName != "" {
-		q := url.Values{}
-		q.Set("target_name", targetName)
-		path = path + "?" + q.Encode()
+		t := targetName
+		params.TargetName = &t
 	}
-	return path
+	return params
 }
 
 func getRecall(
@@ -235,18 +276,43 @@ func getRecall(
 	backplaneURL string,
 	scope Scope,
 	slug, targetName string,
-) (*Entry, error) {
-	raw, err := doAuthedRequest(
-		ctx, backplaneURL, "GET", buildRecallPath(scope, slug, targetName), nil,
-	)
+) (*api.RecallApiV1MemoryScopeSlugGetResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out Entry
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode recall response: %w", err)
+	params := buildRecallParams(targetName)
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.RecallApiV1MemoryScopeSlugGetResponse, error) {
+			return authed.RecallApiV1MemoryScopeSlugGetWithResponse(ctx, scope, slug, params)
+		},
+		func(r *api.RecallApiV1MemoryScopeSlugGetResponse) int { return r.StatusCode() },
+	)
+}
+
+// buildRecallQueryBody assembles the typed POST body for
+// /api/v1/retrieve. `Source` is pinned to "memory" so the substrate
+// scopes hits to memory-entry rows. `Kind` is set only when the
+// operator narrowed via --scope (translated to `memory-<scope>`).
+// `Limit` flows onto the wire only when the operator passed a
+// positive value; the generated field tag is `omitempty`, so a nil
+// pointer keeps the JSON key absent and the backend's
+// `Field(ge=1, le=50, default=10)` applies.
+func buildRecallQueryBody(opts recallOptions, kindFilter string) api.RetrieveRequest {
+	src := "memory"
+	body := api.RetrieveRequest{
+		Query:  opts.QueryArg,
+		Source: &src,
 	}
-	return &out, nil
+	if kindFilter != "" {
+		k := kindFilter
+		body.Kind = &k
+	}
+	if opts.LimitArg > 0 {
+		limit := opts.LimitArg
+		body.Limit = &limit
+	}
+	return body
 }
 
 func postRecallQuery(
@@ -254,28 +320,22 @@ func postRecallQuery(
 	backplaneURL string,
 	opts recallOptions,
 	kindFilter string,
-) (*RetrieveResponse, error) {
-	req := retrieveRequest{
-		Query:  opts.QueryArg,
-		Source: "memory",
-		Kind:   kindFilter,
-	}
-	if opts.LimitArg > 0 {
-		req.Limit = opts.LimitArg
-	}
-	raw, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("marshal recall query: %w", err)
-	}
-	resp, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/retrieve", raw)
+) (*api.RetrieveEndpointApiV1RetrievePostResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out RetrieveResponse
-	if err := json.Unmarshal(resp, &out); err != nil {
-		return nil, fmt.Errorf("decode recall query response: %w", err)
-	}
-	return &out, nil
+	reqBody := buildRecallQueryBody(opts, kindFilter)
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.RetrieveEndpointApiV1RetrievePostResponse, error) {
+			return authed.RetrieveEndpointApiV1RetrievePostWithResponse(
+				ctx,
+				&api.RetrieveEndpointApiV1RetrievePostParams{},
+				reqBody,
+			)
+		},
+		func(r *api.RetrieveEndpointApiV1RetrievePostResponse) int { return r.StatusCode() },
+	)
 }
 
 // printRecallTable renders the ranked hits from --query mode as a
@@ -284,7 +344,7 @@ func postRecallQuery(
 // SLUG (the substrate's `source_id`), SNIPPET (200-char excerpt).
 // The fused / per-signal scores are visible in --json output for
 // retrieval-tuning sessions.
-func printRecallTable(w io.Writer, r *RetrieveResponse) {
+func printRecallTable(w io.Writer, r *api.RetrieveResponse) {
 	if r == nil || len(r.Hits) == 0 {
 		fmt.Fprintln(w, "no memory hits for this query")
 		return
@@ -296,12 +356,12 @@ func printRecallTable(w io.Writer, r *RetrieveResponse) {
 			i+1,
 			hit.FusedScore,
 			scopeFromKind(hit.Kind),
-			truncate(slugFromSourceID(hit.SourceID), 40),
+			truncate(slugFromSourceID(hit.SourceId), 40),
 			truncate(snippetOf(hit.Body), 80),
 		)
 	}
-	if r.QueryDurationMS > 0 {
-		fmt.Fprintf(w, "queried in %.2f ms\n", r.QueryDurationMS)
+	if r.QueryDurationMs > 0 {
+		fmt.Fprintf(w, "queried in %.2f ms\n", r.QueryDurationMs)
 	}
 }
 

--- a/cli/internal/cmd/memory/remember.go
+++ b/cli/internal/cmd/memory/remember.go
@@ -4,15 +4,18 @@
 package memory
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -128,7 +131,7 @@ func NewRememberCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&persistFlag, "persist", false,
 		"persist forever — opt out of the backend's default-7-day TTL on memory-user writes (sends expires_at=null)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
-		"emit raw Entry JSON instead of the human summary")
+		"emit raw MemoryEntry JSON instead of the human summary")
 	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
 		"backplane URL to query (defaults to the URL recorded by `meho login`)")
 	return cmd
@@ -148,6 +151,86 @@ type rememberOptions struct {
 	Persist           bool
 	JSONOut           bool
 	BackplaneOverride string
+}
+
+// rememberRequest captures the inputs to the POST /api/v1/memory
+// request the verb sends. The struct exists alongside the generated
+// `api.RememberBody` because the wire contract requires a tri-state
+// for `expires_at` (absent → backend default fires; null → opt-out;
+// value → explicit cutoff) that the generated type can't express:
+// `api.RememberBody.ExpiresAt` is `*time.Time` *without* `omitempty`,
+// so encoding/json would always emit either a value or `null` and
+// the "absent → default fires" branch would be unreachable.
+//
+// The custom :func:`MarshalJSON` below handles the tri-state by
+// emitting via a `map[string]any`, branching on Persist + ExpiresAt:
+//
+//   - Persist=false, ExpiresAt="" → field OMITTED; backend default
+//     fires on user-scope writes.
+//   - Persist=false, ExpiresAt="<RFC3339>" → field sent verbatim;
+//     backend honours it as the explicit cutoff.
+//   - Persist=true → field emitted as JSON `null`; backend sees the
+//     field as present in :attr:`BaseModel.model_fields_set` with
+//     value None and skips the default. Wire shape for
+//     `meho remember --persist`.
+type rememberRequest struct {
+	Scope      Scope
+	Body       string
+	Slug       string
+	Metadata   map[string]any
+	ExpiresAt  string
+	TargetName string
+	// Persist, when true, emits ``"expires_at": null`` on the wire
+	// even when ExpiresAt is empty. Mutually exclusive with a non-
+	// empty ExpiresAt in practice; the verb-level CLI gate refuses
+	// `--persist` + `--ttl` together so the operator's intent is
+	// unambiguous. The struct doesn't enforce that mutual exclusion
+	// itself (callers do) -- when both are set, ExpiresAt wins
+	// because emitting "null" alongside a real timestamp would be
+	// nonsensical.
+	Persist bool
+}
+
+// MarshalJSON renders rememberRequest with explicit handling for the
+// G5.2-T2 (#624) tri-state “expires_at“ contract. See the type-level
+// docstring for the three states and their wire shapes.
+//
+// Implementation notes:
+//
+//   - Uses a positional emit (json.Marshal over a map[string]any)
+//     rather than struct tags so the `expires_at` rendering can branch
+//     on the Persist bool without leaking into the public field set.
+//   - The map ordering does not affect JSON correctness; the backend
+//     parses fields by key, not position.
+//   - "Persist + ExpiresAt set" lets ExpiresAt win (we already wrote
+//     the operator's intent to a clock-aligned cutoff at the
+//     parseTTLFlag stage; emitting `null` would silently override
+//     their `--ttl` value). The verb-level mutual-exclusion gate is
+//     where this collision is reported back to the operator.
+func (r rememberRequest) MarshalJSON() ([]byte, error) {
+	out := map[string]any{
+		"scope": r.Scope,
+		"body":  r.Body,
+	}
+	if r.Slug != "" {
+		out["slug"] = r.Slug
+	}
+	if r.Metadata != nil {
+		out["metadata"] = r.Metadata
+	}
+	if r.TargetName != "" {
+		out["target_name"] = r.TargetName
+	}
+	switch {
+	case r.ExpiresAt != "":
+		out["expires_at"] = r.ExpiresAt
+	case r.Persist:
+		// Explicit JSON `null` so backend's
+		// :func:`_resolve_default_ttl` sees "expires_at" in
+		// :attr:`BaseModel.model_fields_set` and skips the default.
+		out["expires_at"] = nil
+	}
+	return json.Marshal(out)
 }
 
 func runRemember(cmd *cobra.Command, opts rememberOptions) error {
@@ -201,9 +284,32 @@ func runRemember(cmd *cobra.Command, opts rememberOptions) error {
 		// the convention.
 		req.Metadata = map[string]any{"tags": tags}
 	}
-	entry, err := postRemember(cmd.Context(), backplaneURL, req)
+	resp, err := postRemember(cmd.Context(), backplaneURL, req)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode() != http.StatusCreated {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	// Generated `ParseRememberApiV1MemoryPostResponse` populates
+	// JSON201 only when the response has Content-Type containing
+	// json AND status 201 (`cli/internal/api/client.gen.go`). A
+	// backplane / proxy that returns 201 with a missing or mistyped
+	// content-type leaves JSON201 nil; without this guard the verb
+	// would emit `null` in `--json` mode and silently no-op in
+	// summary mode. Mirrors the convention in
+	// `cli/internal/cmd/status.go:142` and the kb sibling's
+	// post-iter-2 nil-guard pattern (PR #1282).
+	entry := resp.JSON201
+	if entry == nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 201 without a memory entry payload",
+				backplaneURL,
+			)),
+			opts.JSONOut,
+		)
 	}
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), entry)
@@ -212,37 +318,69 @@ func runRemember(cmd *cobra.Command, opts rememberOptions) error {
 	return nil
 }
 
-func postRemember(ctx context.Context, backplaneURL string, req rememberRequest) (*Entry, error) {
+func postRemember(
+	ctx context.Context,
+	backplaneURL string,
+	req rememberRequest,
+) (*api.RememberApiV1MemoryPostResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	// rememberRequest's custom MarshalJSON owns the tri-state
+	// expires_at contract that the generated `api.RememberBody`
+	// struct can't express (the generated `ExpiresAt *time.Time`
+	// has no `omitempty` tag, so encoding/json would always emit
+	// either a value or `null` and never omit the field). We send
+	// the hand-marshaled body through the `*WithBodyWithResponse`
+	// shape that accepts an `io.Reader`; the typed `*WithResponse`
+	// variant takes a generated `RememberBody` and would break the
+	// tri-state.
 	raw, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("marshal remember request: %w", err)
 	}
-	resp, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/memory", raw)
-	if err != nil {
-		return nil, err
-	}
-	var out Entry
-	if err := json.Unmarshal(resp, &out); err != nil {
-		return nil, fmt.Errorf("decode remember response: %w", err)
-	}
-	return &out, nil
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.RememberApiV1MemoryPostResponse, error) {
+			return authed.RememberApiV1MemoryPostWithBodyWithResponse(
+				ctx,
+				&api.RememberApiV1MemoryPostParams{},
+				"application/json",
+				bytes.NewReader(raw),
+			)
+		},
+		func(r *api.RememberApiV1MemoryPostResponse) int { return r.StatusCode() },
+	)
 }
 
 // printRememberSummary renders the created entry as a compact
 // confirmation line plus the natural-key coordinates the operator
 // will use for a subsequent `meho recall` / `meho forget`. Body is
 // not echoed back — the operator just typed it.
-func printRememberSummary(w io.Writer, e *Entry) {
+func printRememberSummary(w io.Writer, e *api.MemoryEntry) {
 	if e == nil {
 		return
 	}
 	fmt.Fprintf(w, "remembered %s/%s\n", e.Scope, e.Slug)
-	fmt.Fprintf(w, "%-14s %s\n", "id:", e.ID)
+	fmt.Fprintf(w, "%-14s %s\n", "id:", e.Id.String())
 	fmt.Fprintf(w, "%-14s %s\n", "scope:", e.Scope)
 	fmt.Fprintf(w, "%-14s %s\n", "slug:", e.Slug)
-	fmt.Fprintf(w, "%-14s %s\n", "expires_at:", pluralisePtr(e.ExpiresAt))
+	fmt.Fprintf(w, "%-14s %s\n", "expires_at:", formatTimePtr(e.ExpiresAt))
 	fmt.Fprintf(w, "%-14s %s\n", "user_sub:", pluralisePtr(e.UserSub))
 	fmt.Fprintf(w, "%-14s %s\n", "target_name:", pluralisePtr(e.TargetName))
-	fmt.Fprintf(w, "%-14s %s\n", "created_at:", e.CreatedAt)
+	fmt.Fprintf(w, "%-14s %s\n", "created_at:", e.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"))
 	fmt.Fprintf(w, "%-14s %d bytes\n", "body:", len(e.Body))
+}
+
+// formatTimePtr renders a *time.Time as a UTC-ISO8601 string when
+// set, or "(none)" when nil. The generated `api.MemoryEntry`
+// surfaces optional timestamps as `*time.Time`; this helper keeps
+// the summary printers' time-rendering identical to the
+// `pluralisePtr(*string)` shape they already use for other optional
+// fields.
+func formatTimePtr(t *time.Time) string {
+	if t == nil {
+		return "(none)"
+	}
+	return t.UTC().Format("2006-01-02T15:04:05Z")
 }

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -158,8 +158,8 @@ cli/
     │   │   ├── history.go        # `meho conventions history <slug> [--limit N]` (GET /api/v1/conventions/{slug}/history); unified-diff per row.
     │   │   ├── conventions_test.go # helpers + register-all-six-verbs + body/confirm/path-escape contract tests.
     │   │   └── crud_test.go      # per-verb HTTP-server tests: list table + JSON, show 404, create 409/422-over-budget, edit flag/$EDITOR modes + 422 inline surface, delete confirm/decline/404, history diffs + --limit + --json.
-    │   ├── memory/           # G5.1-T4 #424 — top-level `meho remember/recall/forget/list` (no parent).
-    │   │   ├── memory.go         # Scope enum + Entry/ListResponse/RetrievalHit + shared HTTP/auth helpers + parseScope/parseTTL/parseTags/parseScopeSlugArg/loadBody/confirmPrompt.
+    │   ├── memory/           # G5.1-T4 #424 — top-level `meho remember/recall/forget/list/promote` (no parent).
+    │   │   ├── memory.go         # Scope alias for api.MemoryScope + newAuthedClient/retryOn401/renderHTTPStatus typed-client helpers (G0.12-T10 #1268) + parseScope/parseTTL/parseTags/parseScopeSlugArg/loadBody/confirmPrompt.
     │   │   ├── remember.go       # `meho remember <body> [--scope --slug --target --tag --ttl --persist --json]` (POST /api/v1/memory). `--persist` (G5.2-T2 #624) sends explicit `expires_at: null` to opt out of the backend's default-7-day TTL on `memory-user` writes.
     │   │   ├── recall.go         # `meho recall <scope>/<slug>` or `meho recall --query` (GET /api/v1/memory/{scope}/{slug} or POST /api/v1/retrieve, source="memory").
     │   │   ├── forget.go         # `meho forget <scope>/<slug> [--confirm --target --json]` (DELETE /api/v1/memory/{scope}/{slug}).


### PR DESCRIPTION
## Summary

- Migrates `cli/internal/cmd/memory/` (the `meho remember/recall/list/forget/promote` verbs) off the per-package hand-rolled `doAuthedRequest` + consumer-side `Entry` / `ListResponse` / `Scope` / `RetrievalHit` / `RetrieveResponse` duplicates onto the generated typed client (`api.ClientWithResponses` via `api.AuthedClient`). Closes the #1069-class schema-drift hole the freshness gate is designed to catch.
- Same shape as the sibling migrations on Initiative #1118: T1 #1251 approvals/, T4 #1262 agent-principal/, T9 #1267 kb/. Reuses the `retryOn401[R]` generic helper pattern so every verb runs the same one-shot bearer-refresh contract, and opts into the `AuthedClientOptions.ResponseBodyLimit` transport cap (1 MiB) — same `capRoundTripper` shape kb #1282 added (this PR re-introduces it so the work doesn't depend on #1282 landing first; either merge order resolves with a trivial conflict).
- `Scope` stays as a `type Scope = api.MemoryScope` alias per the AC carve-out — the typed enum DOES exist in the generator, so the alias *is* its adoption (not a duplicate); local `Scope`/`ScopeUser`/etc. keep the verb code scannable.
- The remember verb keeps a small `rememberRequest` struct with custom `MarshalJSON` because the wire contract for `expires_at` is tri-state (absent → backend default fires; null → opt-out via `--persist`; value → explicit cutoff) which the generated `api.RememberBody` struct can't express (its `ExpiresAt *time.Time` has no `omitempty`). The verb sends the hand-marshaled body through `RememberApiV1MemoryPostWithBodyWithResponse` to preserve the tri-state.
- Every typed verb has a `resp.JSON200`/`JSON201` nil-guard up front (routes to `output.Unexpected` exit 4) — applied from the start, mirroring the kb sibling's post-iter-2 pattern (PR #1282).
- Per-verb tests reworked against the typed surface: handlers decode the wire body into typed shapes so the "no consumer-side duplicates" claim is the load-bearing assertion under test. Added per-verb nil-guard regression tests pinning the 200/201-without-payload path.
- Doc note added to `docs/codebase/cli.md` (memory.go tree-line); backend memory.py untouched.

## Test plan

- [x] `go vet ./...` — clean
- [x] `go test ./...` — every package passes (full CLI suite)
- [x] `go test ./internal/cmd/memory/...` — all memory tests pass (incl. the existing promote_test + e2e env-gated tests)
- [x] `gofmt -l cli/internal/cmd/memory/ cli/internal/api/client.go` — clean
- [x] `python3 .claude/hooks/code-quality.py --diff` — clean
- [x] `grep -rnE "http\.NewRequest|doAuthedRequest|^type Scope |^type Entry |^type ListResponse |^type RetrievalHit |^type RetrieveResponse " cli/internal/cmd/memory/` — only the documented `type Scope = api.MemoryScope` alias remains (per AC carve-out; comment points at #1268).
- [x] `grep -rn "api.ClientWithResponses|api.MemoryEntry" cli/internal/cmd/memory/` — present across all verb files (10 matches across remember.go, promote.go, memory.go, recall.go, list.go, forget.go).
- [x] No change to `backend/src/meho_backplane/api/v1/memory.py` — server stays unchanged
- [x] Manual byte-identical-output check: verb signatures, flag names, and output formatters (`printRememberSummary`, `printPromoteSummary`, `printListTable`, `printRecallTable`, `writeBodyToStdout`, `forgetResult`) preserved.
- [x] Error category mapping preserved: 401 → `auth_expired`, 403 → `insufficient_role`, 404 → `unexpected_response(memory_not_found)`, 422 → `unexpected_response(invalid request)`. Promote-verb 403 → `insufficient_promotion_authority` exit 5; 400/404/409/422/501 → `unexpected_response` exit 4 per #627.
- [x] Tri-state `expires_at` contract regression pinned: `TestRunRememberPersistEmitsExplicitNullExpiresAt`, `TestRunRememberOmitsExpiresAtWhenNoPersistAndNoTTL`, `TestRememberRequestMarshalPersistTriState`.
- [x] Promote-verb idempotency contract pinned (exit 6 human / exit 0 `--json`).

## Out of scope

- Sibling typed-client migrations on Initiative #1118 (covered by their own tasks).
- FastAPI memory / retrieve route shapes (server side untouched).
- Renaming verbs, flags, or output formatting.

Closes #1268
