### PR TITLE
refactor(cli-targets): G0.12-T14 migrate list/describe/probe/discover to the generated typed client (#1272)

### DIFF
--- a/cli/internal/cmd/targets/describe.go
+++ b/cli/internal/cmd/targets/describe.go
@@ -8,48 +8,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
-
-// Target mirrors the backend Target Pydantic model
-// (backend/src/meho_backplane/targets/schemas.py L75-112). The
-// shape includes the G0.3-T1.5 additions:
-//
-//   - Fingerprint — cached FingerprintResult from the last successful
-//     probe. Server-managed; only the probe handler writes it.
-//   - PreferredImplId — operator override for the G0.6 resolver's
-//     tie-break ladder.
-//
-// Fingerprint is typed as map[string]any rather than the concrete
-// FingerprintResult struct so the CLI surfaces every key the backend
-// persists without needing a Go regen each time
-// FingerprintResult's optional field set grows; --json round-trips
-// the wire shape verbatim.
-type Target struct {
-	ID              string         `json:"id"`
-	TenantID        string         `json:"tenant_id"`
-	Name            string         `json:"name"`
-	Aliases         []string       `json:"aliases"`
-	Product         string         `json:"product"`
-	Host            string         `json:"host"`
-	Port            *int           `json:"port"`
-	Fqdn            *string        `json:"fqdn"`
-	SecretRef       *string        `json:"secret_ref"`
-	AuthModel       string         `json:"auth_model"`
-	VpnRequired     bool           `json:"vpn_required"`
-	Extras          map[string]any `json:"extras"`
-	Notes           *string        `json:"notes"`
-	Fingerprint     map[string]any `json:"fingerprint"`
-	PreferredImplID *string        `json:"preferred_impl_id"`
-	CreatedAt       string         `json:"created_at"`
-	UpdatedAt       string         `json:"updated_at"`
-}
 
 // newDescribeCmd returns the `meho targets describe` command.
 //
@@ -120,10 +88,14 @@ func runDescribe(cmd *cobra.Command, opts describeOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	t, err := getTarget(cmd.Context(), backplaneURL, opts.Query)
+	resp, err := getTarget(cmd.Context(), backplaneURL, opts.Query)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
+	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	t := resp.JSON200
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), t)
 	}
@@ -131,26 +103,23 @@ func runDescribe(cmd *cobra.Command, opts describeOptions) error {
 	return nil
 }
 
-// buildDescribePath assembles the GET path. Exposed for unit tests
-// so the URL encoding of names with special characters stays
-// covered.
-func buildDescribePath(query string) string {
-	// PathEscape escapes path-segment-unsafe characters (spaces,
-	// slashes, ?, #). Operators routinely pick names with hyphens
-	// and dots; the unsafe set is rare but worth protecting.
-	return "/api/v1/targets/" + pathEscape(query)
-}
-
-func getTarget(ctx context.Context, backplaneURL, query string) (*Target, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildDescribePath(query), nil)
+func getTarget(
+	ctx context.Context,
+	backplaneURL, query string,
+) (*api.DescribeTargetApiV1TargetsNameGetResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out Target
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode target response: %w", err)
-	}
-	return &out, nil
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.DescribeTargetApiV1TargetsNameGetResponse, error) {
+			// The typed client path-escapes `query` internally
+			// (matching url.PathEscape) before substituting into
+			// /api/v1/targets/{name}.
+			return authed.DescribeTargetApiV1TargetsNameGetWithResponse(ctx, query, nil)
+		},
+		func(r *api.DescribeTargetApiV1TargetsNameGetResponse) int { return r.StatusCode() },
+	)
 }
 
 // printTargetSummary renders the full Target as a stable, scannable
@@ -158,10 +127,10 @@ func getTarget(ctx context.Context, backplaneURL, query string) (*Target, error)
 // padded to a fixed width for vertical alignment. Fingerprint is
 // rendered as a compact one-liner with the high-signal fields; the
 // full structure is in --json.
-func printTargetSummary(w io.Writer, t *Target) {
+func printTargetSummary(w io.Writer, t *api.Target) {
 	fmt.Fprintf(w, "%-18s %s\n", "name:", t.Name)
-	fmt.Fprintf(w, "%-18s %s\n", "id:", t.ID)
-	fmt.Fprintf(w, "%-18s %s\n", "tenant_id:", t.TenantID)
+	fmt.Fprintf(w, "%-18s %s\n", "id:", t.Id.String())
+	fmt.Fprintf(w, "%-18s %s\n", "tenant_id:", t.TenantId.String())
 	if len(t.Aliases) > 0 {
 		fmt.Fprintf(w, "%-18s %s\n", "aliases:", strings.Join(t.Aliases, ", "))
 	} else {
@@ -175,13 +144,13 @@ func printTargetSummary(w io.Writer, t *Target) {
 	if t.Fqdn != nil && *t.Fqdn != "" {
 		fmt.Fprintf(w, "%-18s %s\n", "fqdn:", *t.Fqdn)
 	}
-	fmt.Fprintf(w, "%-18s %s\n", "auth_model:", t.AuthModel)
+	fmt.Fprintf(w, "%-18s %s\n", "auth_model:", string(t.AuthModel))
 	fmt.Fprintf(w, "%-18s %t\n", "vpn_required:", t.VpnRequired)
 	if t.SecretRef != nil && *t.SecretRef != "" {
 		fmt.Fprintf(w, "%-18s %s\n", "secret_ref:", *t.SecretRef)
 	}
-	if t.PreferredImplID != nil && *t.PreferredImplID != "" {
-		fmt.Fprintf(w, "%-18s %s\n", "preferred_impl_id:", *t.PreferredImplID)
+	if t.PreferredImplId != nil && *t.PreferredImplId != "" {
+		fmt.Fprintf(w, "%-18s %s\n", "preferred_impl_id:", *t.PreferredImplId)
 	} else {
 		fmt.Fprintf(w, "%-18s -\n", "preferred_impl_id:")
 	}
@@ -192,8 +161,11 @@ func printTargetSummary(w io.Writer, t *Target) {
 	if len(t.Extras) > 0 {
 		fmt.Fprintf(w, "%-18s %s\n", "extras:", formatExtras(t.Extras))
 	}
-	fmt.Fprintf(w, "%-18s %s\n", "created_at:", t.CreatedAt)
-	fmt.Fprintf(w, "%-18s %s\n", "updated_at:", t.UpdatedAt)
+	// Render timestamps in the same RFC3339Z shape the backend's
+	// model_dump(mode="json") emits, so --json output and the human
+	// view show byte-identical strings.
+	fmt.Fprintf(w, "%-18s %s\n", "created_at:", t.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"))
+	fmt.Fprintf(w, "%-18s %s\n", "updated_at:", t.UpdatedAt.UTC().Format("2006-01-02T15:04:05Z"))
 }
 
 // formatFingerprint renders the cached fingerprint as a one-line
@@ -201,16 +173,17 @@ func printTargetSummary(w io.Writer, t *Target) {
 // reachable=<bool>)" when set; "(none — never probed)" otherwise.
 // Full key set is in --json. Keep the high-signal fields visible
 // without overflowing the line width.
-func formatFingerprint(fp map[string]any) string {
-	if len(fp) == 0 {
+func formatFingerprint(fp *map[string]interface{}) string {
+	if fp == nil || len(*fp) == 0 {
 		return "(none — never probed)"
 	}
-	vendor, _ := fp["vendor"].(string)
-	product, _ := fp["product"].(string)
-	version, _ := fp["version"].(string)
-	probedAt, _ := fp["probed_at"].(string)
-	method, _ := fp["probe_method"].(string)
-	reachable, _ := fp["reachable"].(bool)
+	m := *fp
+	vendor, _ := m["vendor"].(string)
+	product, _ := m["product"].(string)
+	version, _ := m["version"].(string)
+	probedAt, _ := m["probed_at"].(string)
+	method, _ := m["probe_method"].(string)
+	reachable, _ := m["reachable"].(bool)
 	head := strings.TrimSpace(vendor + "/" + product)
 	if version != "" {
 		head = head + " " + version
@@ -222,7 +195,7 @@ func formatFingerprint(fp map[string]any) string {
 // formatExtras renders the extras map as a `key=value, key=value`
 // list with keys sorted for deterministic output (tests + diffs).
 // Non-scalar values land as their JSON representation.
-func formatExtras(extras map[string]any) string {
+func formatExtras(extras map[string]interface{}) string {
 	if len(extras) == 0 {
 		return "-"
 	}

--- a/cli/internal/cmd/targets/describe_test.go
+++ b/cli/internal/cmd/targets/describe_test.go
@@ -11,23 +11,10 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/evoila/meho/cli/internal/api"
 )
-
-// TestBuildDescribePathSimpleName — operator-typical names produce
-// a clean GET path without spurious encoding.
-func TestBuildDescribePathSimpleName(t *testing.T) {
-	if got := buildDescribePath("rdc-vcenter"); got != "/api/v1/targets/rdc-vcenter" {
-		t.Fatalf("describe path: got %q", got)
-	}
-}
-
-// TestBuildDescribePathEscapesSpecial — slash, hash, space all get
-// URL-encoded so the backplane sees a single path segment.
-func TestBuildDescribePathEscapesSpecial(t *testing.T) {
-	if got := buildDescribePath("name with/slash"); got != "/api/v1/targets/name%20with%2Fslash" {
-		t.Fatalf("describe path with special chars: got %q", got)
-	}
-}
 
 // TestRunDescribeRejectsEmptyQuery — cobra's ExactArgs(1) blocks the
 // command-line zero-arg case; the runner still must reject empty
@@ -51,9 +38,17 @@ func TestPrintTargetSummaryHappyPath(t *testing.T) {
 	secret := "vault://vsphere/rdc"
 	notes := "primary"
 	preferred := "vsphere-rest-9.0"
-	tgt := &Target{
-		ID:              "abc-id",
-		TenantID:        "tnt-id",
+	fingerprint := map[string]interface{}{
+		"vendor":       "vmware",
+		"product":      "vcenter",
+		"version":      "9.0.0",
+		"reachable":    true,
+		"probed_at":    "2026-05-15T08:00:00Z",
+		"probe_method": "rest",
+	}
+	tgt := &api.Target{
+		Id:              mustUUID(t, "11111111-1111-1111-1111-111111111111"),
+		TenantId:        mustUUID(t, "22222222-2222-2222-2222-222222222222"),
 		Name:            "rdc-vcenter",
 		Aliases:         []string{"vc-prod"},
 		Product:         "vcenter",
@@ -64,21 +59,14 @@ func TestPrintTargetSummaryHappyPath(t *testing.T) {
 		AuthModel:       "shared_service_account",
 		VpnRequired:     true,
 		Notes:           &notes,
-		PreferredImplID: &preferred,
-		Fingerprint: map[string]any{
-			"vendor":       "vmware",
-			"product":      "vcenter",
-			"version":      "9.0.0",
-			"reachable":    true,
-			"probed_at":    "2026-05-15T08:00:00Z",
-			"probe_method": "rest",
-		},
-		Extras: map[string]any{
+		PreferredImplId: &preferred,
+		Fingerprint:     &fingerprint,
+		Extras: map[string]interface{}{
 			"region":   "eu-central",
 			"replicas": float64(3),
 		},
-		CreatedAt: "2026-05-01T00:00:00Z",
-		UpdatedAt: "2026-05-15T08:00:00Z",
+		CreatedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 5, 15, 8, 0, 0, 0, time.UTC),
 	}
 	var buf bytes.Buffer
 	printTargetSummary(&buf, tgt)
@@ -109,7 +97,7 @@ func TestPrintTargetSummaryHappyPath(t *testing.T) {
 // dashed placeholder for preferred_impl_id, so operators see the
 // difference between "field absent" and "field empty".
 func TestPrintTargetSummaryNoFingerprint(t *testing.T) {
-	tgt := &Target{
+	tgt := &api.Target{
 		Name:        "fresh-target",
 		Aliases:     nil,
 		AuthModel:   "shared_service_account",
@@ -138,7 +126,8 @@ func TestFormatFingerprintNilEmpty(t *testing.T) {
 	if got := formatFingerprint(nil); !strings.Contains(got, "never probed") {
 		t.Errorf("nil fp: got %q", got)
 	}
-	if got := formatFingerprint(map[string]any{}); !strings.Contains(got, "never probed") {
+	empty := map[string]interface{}{}
+	if got := formatFingerprint(&empty); !strings.Contains(got, "never probed") {
 		t.Errorf("empty fp: got %q", got)
 	}
 }
@@ -147,7 +136,7 @@ func TestFormatFingerprintNilEmpty(t *testing.T) {
 // the same string for the same input map across runs (no map
 // iteration order leak).
 func TestFormatExtrasSortedDeterministic(t *testing.T) {
-	m := map[string]any{"b": 2, "a": 1, "c": "x"}
+	m := map[string]interface{}{"b": 2, "a": 1, "c": "x"}
 	got := formatExtras(m)
 	if got != "a=1, b=2, c=x" {
 		t.Errorf("non-deterministic extras render: got %q", got)
@@ -173,7 +162,8 @@ func TestFormatScalarFloatVsInt(t *testing.T) {
 
 // TestRunDescribeHappyPath — describe drives end-to-end through the
 // auth stack; backend returns a Target shape with fingerprint +
-// preferred_impl_id set.
+// preferred_impl_id set. Confirms the typed-client path round-trips
+// the api.Target envelope.
 func TestRunDescribeHappyPath(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/targets/rdc-vcenter", func(w http.ResponseWriter, r *http.Request) {
@@ -182,10 +172,18 @@ func TestRunDescribeHappyPath(t *testing.T) {
 		}
 		port := 443
 		preferred := "vsphere-rest-9.0"
+		fp := map[string]interface{}{
+			"vendor":       "vmware",
+			"product":      "vcenter",
+			"version":      "9.0.0",
+			"reachable":    true,
+			"probed_at":    "2026-05-15T08:00:00Z",
+			"probe_method": "rest",
+		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(Target{
-			ID:              "abc",
-			TenantID:        "tnt",
+		_ = json.NewEncoder(w).Encode(api.Target{
+			Id:              mustUUID(t, "11111111-1111-1111-1111-111111111111"),
+			TenantId:        mustUUID(t, "22222222-2222-2222-2222-222222222222"),
 			Name:            "rdc-vcenter",
 			Aliases:         []string{"vc-prod"},
 			Product:         "vcenter",
@@ -193,17 +191,11 @@ func TestRunDescribeHappyPath(t *testing.T) {
 			Port:            &port,
 			AuthModel:       "shared_service_account",
 			VpnRequired:     false,
-			PreferredImplID: &preferred,
-			Fingerprint: map[string]any{
-				"vendor":       "vmware",
-				"product":      "vcenter",
-				"version":      "9.0.0",
-				"reachable":    true,
-				"probed_at":    "2026-05-15T08:00:00Z",
-				"probe_method": "rest",
-			},
-			CreatedAt: "2026-05-01T00:00:00Z",
-			UpdatedAt: "2026-05-15T08:00:00Z",
+			PreferredImplId: &preferred,
+			Fingerprint:     &fp,
+			Extras:          map[string]interface{}{},
+			CreatedAt:       time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+			UpdatedAt:       time.Date(2026, 5, 15, 8, 0, 0, 0, time.UTC),
 		})
 	})
 	srv := httptest.NewServer(mux)
@@ -235,12 +227,17 @@ func TestRunDescribeAlias(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/targets/vc-prod", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(Target{
+		_ = json.NewEncoder(w).Encode(api.Target{
+			Id:        mustUUID(t, "11111111-1111-1111-1111-111111111111"),
+			TenantId:  mustUUID(t, "22222222-2222-2222-2222-222222222222"),
 			Name:      "rdc-vcenter",
 			Aliases:   []string{"vc-prod"},
 			Product:   "vcenter",
 			Host:      "vc.example",
 			AuthModel: "shared_service_account",
+			Extras:    map[string]interface{}{},
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
 		})
 	})
 	srv := httptest.NewServer(mux)
@@ -258,10 +255,11 @@ func TestRunDescribeAlias(t *testing.T) {
 
 // TestRunDescribe404RendersNearMisses — 404 with structured detail
 // must surface the candidate names so the operator fixes a typo on
-// the next try.
+// the next try. Pinned via a literal path so we don't depend on the
+// typed-client's path-escape behaviour for the test name.
 func TestRunDescribe404RendersNearMisses(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/targets/", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/api/v1/targets/rdc-vc", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 		fmt.Fprint(w, `{"detail":{"error":"no_target","query":"rdc-vc","matches":[
             {"id":"id1","name":"rdc-vcenter","aliases":["vc-prod"],"product":"vcenter","host":"vc.example"},

--- a/cli/internal/cmd/targets/discover.go
+++ b/cli/internal/cmd/targets/discover.go
@@ -5,58 +5,17 @@ package targets
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
+	"net/http"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
-
-// CandidateHint mirrors the backend CandidateHint Pydantic model
-// (backend/src/meho_backplane/connectors/schemas.py L274). One
-// potentially-reachable target a connector inferred from a seed
-// (a vCenter exposing its managed ESXi hosts, a kubeconfig listing
-// peer cluster contexts, …). `Evidence` is the connector's debugging
-// payload — whatever made it think the candidate exists; `Confidence`
-// is its probe-vs-curation self-assessment. Hand-written rather than
-// aliased to a generated type for the same decoupling reason the
-// other target shapes (TargetSummary etc.) document.
-type CandidateHint struct {
-	Name       string         `json:"name"`
-	Host       string         `json:"host"`
-	Port       *int           `json:"port"`
-	Evidence   map[string]any `json:"evidence"`
-	Confidence string         `json:"confidence"`
-}
-
-// SkippedConnector mirrors the backend SkippedConnector Pydantic
-// model (backend/src/meho_backplane/api/v1/targets.py). One connector
-// that contributed nothing for the product — clean-but-empty
-// ("no candidates") or errored (exception class + message). One bad
-// connector never fails the sweep server-side; the CLI surfaces the
-// skip list so the operator sees why a candidate they expected is
-// missing.
-type SkippedConnector struct {
-	Name   string `json:"name"`
-	Reason string `json:"reason"`
-}
-
-// DiscoverResult mirrors the backend aggregate
-// (backend/src/meho_backplane/api/v1/targets.py): merged candidate
-// list across every connector registered for the product, plus the
-// connectors that contributed nothing. The verb never auto-creates
-// `targets` rows — the operator reviews `discovered` and runs
-// `meho targets create` (Initiative #363: auto-registration is
-// v0.2.next).
-type DiscoverResult struct {
-	Discovered []CandidateHint    `json:"discovered"`
-	Skipped    []SkippedConnector `json:"skipped"`
-}
 
 // newDiscoverCmd returns the `meho targets discover <product>` command.
 //
@@ -134,10 +93,14 @@ func runDiscover(cmd *cobra.Command, opts discoverOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	result, err := getDiscover(cmd.Context(), backplaneURL, opts)
+	resp, err := getDiscover(cmd.Context(), backplaneURL, opts)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
+	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	result := resp.JSON200
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), result)
 	}
@@ -145,30 +108,39 @@ func runDiscover(cmd *cobra.Command, opts discoverOptions) error {
 	return nil
 }
 
-// buildDiscoverPath assembles the GET /api/v1/targets/discover query
-// string. `product` is required (the cobra ExactArgs(1) guarantees a
-// value); `seed_target` is omitted when unset. The path-segment
-// `/discover` is matched as the dedicated route ahead of the
-// parametrised describe route server-side. Exposed for unit tests.
-func buildDiscoverPath(opts discoverOptions) string {
-	q := url.Values{}
-	q.Set("product", opts.Product)
-	if opts.SeedTarget != "" {
-		q.Set("seed_target", opts.SeedTarget)
+// buildDiscoverParams assembles the typed query-parameter struct for
+// GET /api/v1/targets/discover. `product` is required (the cobra
+// ExactArgs(1) guarantees a value); `seed_target` is omitted when
+// unset. The path-segment `/discover` is matched as the dedicated
+// route ahead of the parametrised describe route server-side.
+// Exposed for unit tests.
+func buildDiscoverParams(opts discoverOptions) *api.DiscoverTargetsApiV1TargetsDiscoverGetParams {
+	params := &api.DiscoverTargetsApiV1TargetsDiscoverGetParams{
+		Product: opts.Product,
 	}
-	return "/api/v1/targets/discover?" + q.Encode()
+	if opts.SeedTarget != "" {
+		s := opts.SeedTarget
+		params.SeedTarget = &s
+	}
+	return params
 }
 
-func getDiscover(ctx context.Context, backplaneURL string, opts discoverOptions) (*DiscoverResult, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildDiscoverPath(opts), nil)
+func getDiscover(
+	ctx context.Context,
+	backplaneURL string,
+	opts discoverOptions,
+) (*api.DiscoverTargetsApiV1TargetsDiscoverGetResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out DiscoverResult
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode discover response: %w", err)
-	}
-	return &out, nil
+	params := buildDiscoverParams(opts)
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.DiscoverTargetsApiV1TargetsDiscoverGetResponse, error) {
+			return authed.DiscoverTargetsApiV1TargetsDiscoverGetWithResponse(ctx, params)
+		},
+		func(r *api.DiscoverTargetsApiV1TargetsDiscoverGetResponse) int { return r.StatusCode() },
+	)
 }
 
 // printDiscoverTables renders the discovered candidates as a
@@ -177,7 +149,7 @@ func getDiscover(ctx context.Context, backplaneURL string, opts discoverOptions)
 // why an expected candidate is absent. Zero candidates renders the
 // no-candidates line (operationally meaningful — an empty lab) rather
 // than a bare header.
-func printDiscoverTables(w io.Writer, r *DiscoverResult) {
+func printDiscoverTables(w io.Writer, r *api.TargetsDiscoverResult) {
 	if len(r.Discovered) == 0 {
 		fmt.Fprintln(w, "no candidate targets discovered for this product")
 	} else {
@@ -191,7 +163,7 @@ func printDiscoverTables(w io.Writer, r *DiscoverResult) {
 				truncate(c.Name, 30),
 				truncate(c.Host, 30),
 				port,
-				truncate(c.Confidence, 10),
+				truncate(string(c.Confidence), 10),
 			)
 		}
 	}

--- a/cli/internal/cmd/targets/discover_test.go
+++ b/cli/internal/cmd/targets/discover_test.go
@@ -11,24 +11,30 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/evoila/meho/cli/internal/api"
 )
 
-// TestBuildDiscoverPathRequiresProduct — product always rides the
-// query string; seed_target is omitted when unset.
-func TestBuildDiscoverPathRequiresProduct(t *testing.T) {
-	got := buildDiscoverPath(discoverOptions{Product: "vmware"})
-	if got != "/api/v1/targets/discover?product=vmware" {
-		t.Fatalf("default path: got %q", got)
+// TestBuildDiscoverParamsRequiresProduct — product always lands in
+// the typed params struct; seed_target is omitted (nil) when unset.
+func TestBuildDiscoverParamsRequiresProduct(t *testing.T) {
+	p := buildDiscoverParams(discoverOptions{Product: "vmware"})
+	if p.Product != "vmware" {
+		t.Fatalf("Product: got %q; want %q", p.Product, "vmware")
+	}
+	if p.SeedTarget != nil {
+		t.Errorf("unset SeedTarget should marshal as nil pointer; got %q", *p.SeedTarget)
 	}
 }
 
-// TestBuildDiscoverPathSetsSeed — --seed-target lands as seed_target.
-func TestBuildDiscoverPathSetsSeed(t *testing.T) {
-	got := buildDiscoverPath(discoverOptions{Product: "k8s", SeedTarget: "rke2-meho"})
-	for _, want := range []string{"product=k8s", "seed_target=rke2-meho"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("buildDiscoverPath missing %q in %q", want, got)
-		}
+// TestBuildDiscoverParamsSetsSeed — --seed-target lands as *SeedTarget.
+func TestBuildDiscoverParamsSetsSeed(t *testing.T) {
+	p := buildDiscoverParams(discoverOptions{Product: "k8s", SeedTarget: "rke2-meho"})
+	if p.Product != "k8s" {
+		t.Errorf("Product: got %q", p.Product)
+	}
+	if p.SeedTarget == nil || *p.SeedTarget != "rke2-meho" {
+		t.Errorf("SeedTarget: got %+v; want pointer to %q", p.SeedTarget, "rke2-meho")
 	}
 }
 
@@ -36,7 +42,7 @@ func TestBuildDiscoverPathSetsSeed(t *testing.T) {
 // no-candidates line (operationally meaningful) without a header.
 func TestPrintDiscoverTablesEmpty(t *testing.T) {
 	var buf bytes.Buffer
-	printDiscoverTables(&buf, &DiscoverResult{})
+	printDiscoverTables(&buf, &api.TargetsDiscoverResult{})
 	out := buf.String()
 	if !strings.Contains(out, "no candidate targets discovered") {
 		t.Errorf("empty render missing no-candidates hint; got %q", out)
@@ -50,11 +56,11 @@ func TestPrintDiscoverTablesEmpty(t *testing.T) {
 // table both render.
 func TestPrintDiscoverTablesRendersBoth(t *testing.T) {
 	port := 443
-	r := &DiscoverResult{
-		Discovered: []CandidateHint{
-			{Name: "esxi-2", Host: "esxi-2.lab", Port: &port, Confidence: "high"},
+	r := &api.TargetsDiscoverResult{
+		Discovered: []api.CandidateHint{
+			{Name: "esxi-2", Host: "esxi-2.lab", Port: &port, Confidence: api.CandidateHintConfidence("high")},
 		},
-		Skipped: []SkippedConnector{
+		Skipped: []api.SkippedConnector{
 			{Name: "vmware-pyvmomi-7.0", Reason: "no candidates"},
 		},
 	}
@@ -74,7 +80,8 @@ func TestPrintDiscoverTablesRendersBoth(t *testing.T) {
 
 // TestRunDiscoverHappyPath — `targets discover --product vmware`
 // lists candidate targets from the registered vmware connectors
-// (acceptance criterion 4).
+// (acceptance criterion 4). Asserts the typed `product` query param
+// round-trips on the wire.
 func TestRunDiscoverHappyPath(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/targets/discover", func(w http.ResponseWriter, r *http.Request) {
@@ -86,11 +93,11 @@ func TestRunDiscoverHappyPath(t *testing.T) {
 		}
 		port := 443
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(DiscoverResult{
-			Discovered: []CandidateHint{
-				{Name: "esxi-2", Host: "esxi-2.lab", Port: &port, Confidence: "high"},
+		_ = json.NewEncoder(w).Encode(api.TargetsDiscoverResult{
+			Discovered: []api.CandidateHint{
+				{Name: "esxi-2", Host: "esxi-2.lab", Port: &port, Confidence: api.CandidateHintConfidence("high")},
 			},
-			Skipped: []SkippedConnector{},
+			Skipped: []api.SkippedConnector{},
 		})
 	})
 	srv := httptest.NewServer(mux)
@@ -114,9 +121,11 @@ func TestRunDiscoverJSON(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/targets/discover", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(DiscoverResult{
-			Discovered: []CandidateHint{{Name: "c1", Host: "h1", Confidence: "low"}},
-			Skipped:    []SkippedConnector{},
+		_ = json.NewEncoder(w).Encode(api.TargetsDiscoverResult{
+			Discovered: []api.CandidateHint{
+				{Name: "c1", Host: "h1", Confidence: api.CandidateHintConfidence("low")},
+			},
+			Skipped: []api.SkippedConnector{},
 		})
 	})
 	srv := httptest.NewServer(mux)
@@ -128,7 +137,7 @@ func TestRunDiscoverJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runDiscover --json: %v; stderr=%s", err, stderr.String())
 	}
-	var decoded DiscoverResult
+	var decoded api.TargetsDiscoverResult
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout.String())
 	}

--- a/cli/internal/cmd/targets/import.go
+++ b/cli/internal/cmd/targets/import.go
@@ -4,10 +4,12 @@
 package targets
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -17,6 +19,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -245,7 +248,7 @@ func runImport(cmd *cobra.Command, opts importOptions) error {
 
 	p, err := buildLivePlan(cmd.Context(), doer, entries, opts.Update)
 	if err != nil {
-		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+		return renderImportRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
 
 	// Default mode: duplicates abort the whole import.
@@ -265,7 +268,7 @@ func runImport(cmd *cobra.Command, opts importOptions) error {
 	}
 
 	if err := executePlan(cmd.Context(), doer, p); err != nil {
-		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+		return renderImportRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
 	return renderApplyResult(cmd, p, opts.JSONOut)
 }
@@ -423,7 +426,32 @@ func buildOfflinePlan(entries []map[string]any, _ bool) *plan {
 // tests pass a closure that drives an httptest.Server, sidestepping
 // the auth/token-store machinery (which would otherwise require
 // staging a fake $XDG_CONFIG_HOME with a stub credentials file).
+//
+// `import.go` keeps its own untyped HTTP plumbing (rather than the
+// generated typed client every sibling verb now uses) because the
+// YAML-to-API mapping in entryToCreateBody / entryToUpdateBody emits
+// a sparse `map[string]any` body to preserve the partial-PATCH /
+// extras-spill semantics — coercing through `api.TargetCreate` /
+// `api.TargetUpdate` would either send unspecified fields as
+// pydantic defaults (overwriting rich existing state on a partial
+// patch — the PR #362 regression that motivated the sparse-body
+// fix) or require per-field option plumbing for every patchable
+// column. The untyped path is the smaller blast radius for v0.2.
 type httpDoer func(ctx context.Context, method, path string, body []byte) ([]byte, error)
+
+// httpError carries a non-2xx response from the import-path HTTP
+// plumbing so renderRequestError can map it to the right exit-code
+// class. Not exported and not shared with the verb-side typed-client
+// renderHTTPStatus, which acts on the typed response envelope's
+// (statusCode, body) pair directly.
+type httpError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
 
 // authedDoer adapts doAuthedRequest to the httpDoer shape with the
 // backplane URL pre-bound.
@@ -431,6 +459,111 @@ func authedDoer(backplaneURL string) httpDoer {
 	return func(ctx context.Context, method, path string, body []byte) ([]byte, error) {
 		return doAuthedRequest(ctx, backplaneURL, method, path, body)
 	}
+}
+
+// doAuthedRequest issues a single HTTP request against the backplane
+// with bearer injection + one-shot 401-refresh-retry. Returns the
+// response body bytes (already drained) on a 2xx outcome, or an
+// *httpError when the backplane returned a non-2xx, or an error
+// categorised by api.IsTokenNotFound / api.IsNoRefreshToken / generic
+// transport so renderRequestError can pick the right StructuredError
+// category.
+//
+// Mirrors cli/internal/cmd/operation/operation.go::doAuthedRequest.
+// Kept independent of the operation package for the import-cycle
+// reason called out on resolveBackplane.
+func doAuthedRequest(
+	ctx context.Context,
+	backplaneURL, method, path string,
+	body []byte,
+) ([]byte, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	httpClient := authed.HTTPClient()
+	bearer := authed.AccessToken()
+	if bearer == "" {
+		return nil, errMissingAccessToken
+	}
+
+	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		// One-shot refresh + retry, mirroring api.AuthedClient.GetHealth
+		// and operation/operation.go doAuthedRequest.
+		if rerr := authed.Refresh(ctx); rerr != nil {
+			resp.Body.Close() //nolint:errcheck
+			return nil, rerr
+		}
+		resp.Body.Close() //nolint:errcheck
+		bearer = authed.AccessToken()
+		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	defer resp.Body.Close() //nolint:errcheck
+
+	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MiB cap
+	if readErr != nil {
+		return nil, fmt.Errorf("read response: %w", readErr)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
+	}
+	return raw, nil
+}
+
+// sendRequest is the bottom of the stack: build the http.Request,
+// stamp bearer + content headers, fire it. Split out so the
+// 401-refresh-retry path in doAuthedRequest can reuse the same body
+// bytes without re-marshalling.
+func sendRequest(
+	ctx context.Context,
+	client *http.Client,
+	backplaneURL, method, path, bearer string,
+	body []byte,
+) (*http.Response, error) {
+	fullURL := backplaneURL + path
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return client.Do(req)
+}
+
+// renderImportRequestError translates an error from one of the
+// import-path HTTP helpers (`doAuthedRequest`, `buildLivePlan`,
+// `executePlan`) into the right output.StructuredError category. The
+// HTTP-failure case routes through the same renderHTTPStatus the
+// verb-side helpers use (same 401/403/404/409/501 ladder); the
+// transport / auth-state cases delegate to the shared
+// renderRequestError. Errors from `listExistingNames` /
+// `executePlan` arrive wrapped in `fmt.Errorf(... "%w", ...)`; we
+// use `errors.As` to unwrap to the underlying *httpError.
+func renderImportRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	var he *httpError
+	if errors.As(err, &he) {
+		return renderHTTPStatus(cmd, backplaneURL, he.StatusCode, []byte(he.Body), jsonOut)
+	}
+	return renderRequestError(cmd, backplaneURL, err, jsonOut)
 }
 
 // buildLivePlan partitions entries against the live backplane:

--- a/cli/internal/cmd/targets/list.go
+++ b/cli/internal/cmd/targets/list.go
@@ -5,33 +5,17 @@ package targets
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
-	"strconv"
+	"net/http"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
-
-// TargetSummary mirrors the backend TargetSummary Pydantic model
-// (backend/src/meho_backplane/targets/schemas.py L57-72). Hand-
-// written rather than aliased to the generated api.TargetSummary so
-// the targets package stays decoupled from the generated client's
-// type surface — the operation/retrieval packages take the same
-// stance for the same reason (generated types churn on every spec
-// re-snapshot).
-type TargetSummary struct {
-	ID      string   `json:"id"`
-	Name    string   `json:"name"`
-	Aliases []string `json:"aliases"`
-	Product string   `json:"product"`
-	Host    string   `json:"host"`
-}
 
 // newListCmd returns the `meho targets list` command.
 //
@@ -117,10 +101,14 @@ func runList(cmd *cobra.Command, opts listOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	summaries, err := getTargets(cmd.Context(), backplaneURL, opts)
+	resp, err := getTargets(cmd.Context(), backplaneURL, opts)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
+	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	summaries := *resp.JSON200
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), summaries)
 	}
@@ -128,44 +116,51 @@ func runList(cmd *cobra.Command, opts listOptions) error {
 	return nil
 }
 
-// buildListPath assembles the GET /api/v1/targets query string from
-// the per-call options. Exposed for tests so the URL construction
-// stays unit-checkable without standing up an httptest.Server.
-func buildListPath(opts listOptions) string {
-	q := url.Values{}
+// buildListParams assembles the typed query-parameter struct from the
+// per-call options. Exposed for tests so the param wiring stays
+// unit-checkable without standing up an httptest.Server. The typed
+// client (`oapi-codegen`-generated) handles URL encoding internally,
+// so the previous `buildListPath` string-concat helper retired.
+func buildListParams(opts listOptions) *api.ListTargetsApiV1TargetsGetParams {
+	params := &api.ListTargetsApiV1TargetsGetParams{}
 	if opts.Product != "" {
-		q.Set("product", opts.Product)
+		p := opts.Product
+		params.Product = &p
 	}
 	if opts.Limit > 0 {
-		q.Set("limit", strconv.Itoa(opts.Limit))
+		l := opts.Limit
+		params.Limit = &l
 	}
 	if opts.Cursor != "" {
-		q.Set("cursor", opts.Cursor)
+		c := opts.Cursor
+		params.Cursor = &c
 	}
-	path := "/api/v1/targets"
-	if encoded := q.Encode(); encoded != "" {
-		path = path + "?" + encoded
-	}
-	return path
+	return params
 }
 
-func getTargets(ctx context.Context, backplaneURL string, opts listOptions) ([]TargetSummary, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildListPath(opts), nil)
+func getTargets(
+	ctx context.Context,
+	backplaneURL string,
+	opts listOptions,
+) (*api.ListTargetsApiV1TargetsGetResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out []TargetSummary
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode targets response: %w", err)
-	}
-	return out, nil
+	params := buildListParams(opts)
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.ListTargetsApiV1TargetsGetResponse, error) {
+			return authed.ListTargetsApiV1TargetsGetWithResponse(ctx, params)
+		},
+		func(r *api.ListTargetsApiV1TargetsGetResponse) int { return r.StatusCode() },
+	)
 }
 
 // printTargetsTable renders the list as a compact, scannable table.
 // Columns: NAME, ALIASES, PRODUCT, HOST per the issue's acceptance
 // criterion 1. ID is omitted from the human view (operators rarely
 // need the UUID; --json surfaces it).
-func printTargetsTable(w io.Writer, summaries []TargetSummary) {
+func printTargetsTable(w io.Writer, summaries []api.TargetSummary) {
 	if len(summaries) == 0 {
 		fmt.Fprintln(w, "no targets registered in this tenant")
 		return

--- a/cli/internal/cmd/targets/list_test.go
+++ b/cli/internal/cmd/targets/list_test.go
@@ -15,44 +15,52 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/auth"
 )
 
-// TestBuildListPathOmitsEmptyFilters — the empty options shape sends
-// no query string so the backplane sees a clean
-// /api/v1/targets.
-func TestBuildListPathOmitsEmptyFilters(t *testing.T) {
-	if got := buildListPath(listOptions{}); got != "/api/v1/targets" {
-		t.Fatalf("empty opts path: got %q; want %q", got, "/api/v1/targets")
+// TestBuildListParamsOmitsEmptyFilters — the empty options shape sends
+// no query string so the backplane sees a clean /api/v1/targets.
+func TestBuildListParamsOmitsEmptyFilters(t *testing.T) {
+	p := buildListParams(listOptions{})
+	if p.Product != nil {
+		t.Errorf("empty Product should marshal as nil pointer; got %q", *p.Product)
+	}
+	if p.Limit != nil {
+		t.Errorf("empty Limit should marshal as nil pointer; got %d", *p.Limit)
+	}
+	if p.Cursor != nil {
+		t.Errorf("empty Cursor should marshal as nil pointer; got %q", *p.Cursor)
 	}
 }
 
-// TestBuildListPathSetsProduct — --product P appends ?product=P.
-func TestBuildListPathSetsProduct(t *testing.T) {
-	got := buildListPath(listOptions{Product: "vcenter"})
-	if got != "/api/v1/targets?product=vcenter" {
-		t.Fatalf("product opt: got %q", got)
+// TestBuildListParamsSetsProduct — --product P populates *Product
+// without leaking the value into other fields.
+func TestBuildListParamsSetsProduct(t *testing.T) {
+	p := buildListParams(listOptions{Product: "vcenter"})
+	if p.Product == nil || *p.Product != "vcenter" {
+		t.Fatalf("Product: got %+v; want pointer to %q", p.Product, "vcenter")
+	}
+	if p.Limit != nil || p.Cursor != nil {
+		t.Errorf("non-Product fields should stay nil; got Limit=%+v Cursor=%+v", p.Limit, p.Cursor)
 	}
 }
 
-// TestBuildListPathSetsAllFilters — every option lands on the wire.
-func TestBuildListPathSetsAllFilters(t *testing.T) {
-	got := buildListPath(listOptions{Product: "k8s", Limit: 25, Cursor: "rke2-meho"})
-	for _, want := range []string{"product=k8s", "limit=25", "cursor=rke2-meho"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("buildListPath missing %q in %q", want, got)
-		}
+// TestBuildListParamsSetsAllFilters — every option lands on the
+// typed params struct.
+func TestBuildListParamsSetsAllFilters(t *testing.T) {
+	p := buildListParams(listOptions{Product: "k8s", Limit: 25, Cursor: "rke2-meho"})
+	if p.Product == nil || *p.Product != "k8s" {
+		t.Errorf("Product: got %+v", p.Product)
 	}
-}
-
-// TestBuildListPathEncodesSpecialChars — operator-typical names with
-// hyphens stay alone; a cursor with a space gets URL-encoded.
-func TestBuildListPathEncodesSpecialChars(t *testing.T) {
-	got := buildListPath(listOptions{Cursor: "weird name"})
-	if !strings.Contains(got, "cursor=weird+name") {
-		t.Errorf("buildListPath did not URL-encode space; got %q", got)
+	if p.Limit == nil || *p.Limit != 25 {
+		t.Errorf("Limit: got %+v", p.Limit)
+	}
+	if p.Cursor == nil || *p.Cursor != "rke2-meho" {
+		t.Errorf("Cursor: got %+v", p.Cursor)
 	}
 }
 
@@ -73,9 +81,9 @@ func TestPrintTargetsTableEmpty(t *testing.T) {
 // TestPrintTargetsTableRendersColumns — happy-path render with two
 // rows: header line + each target's name / aliases / product / host.
 func TestPrintTargetsTableRendersColumns(t *testing.T) {
-	rows := []TargetSummary{
-		{ID: "1", Name: "rdc-vcenter", Aliases: []string{"vc-prod"}, Product: "vcenter", Host: "vc.example"},
-		{ID: "2", Name: "rke2-meho", Aliases: nil, Product: "k8s", Host: "k.example"},
+	rows := []api.TargetSummary{
+		{Id: mustUUID(t, "11111111-1111-1111-1111-111111111111"), Name: "rdc-vcenter", Aliases: []string{"vc-prod"}, Product: "vcenter", Host: "vc.example"},
+		{Id: mustUUID(t, "22222222-2222-2222-2222-222222222222"), Name: "rke2-meho", Aliases: nil, Product: "k8s", Host: "k.example"},
 	}
 	var buf bytes.Buffer
 	printTargetsTable(&buf, rows)
@@ -115,9 +123,8 @@ func TestRunListRejectsNegativeLimit(t *testing.T) {
 }
 
 // TestRunListHappyPath drives runList end-to-end through the auth
-// + transport stack against an httptest server. Mirrors the
-// retrieval / status sibling tests' file-fallback approach to
-// credential injection.
+// + transport stack against an httptest server. Asserts the typed
+// `product` query param round-trips on the wire.
 func TestRunListHappyPath(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/targets", func(w http.ResponseWriter, r *http.Request) {
@@ -128,8 +135,8 @@ func TestRunListHappyPath(t *testing.T) {
 			t.Errorf("missing Authorization header")
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]TargetSummary{
-			{ID: "1", Name: "rdc-vcenter", Aliases: []string{"vc-prod"}, Product: "vcenter", Host: "vc.example"},
+		_ = json.NewEncoder(w).Encode([]api.TargetSummary{
+			{Id: mustUUID(t, "11111111-1111-1111-1111-111111111111"), Name: "rdc-vcenter", Aliases: []string{"vc-prod"}, Product: "vcenter", Host: "vc.example"},
 		})
 	})
 	srv := httptest.NewServer(mux)
@@ -155,8 +162,8 @@ func TestRunListJSONHappyPath(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/targets", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]TargetSummary{
-			{ID: "deadbeef", Name: "rdc-vcenter", Aliases: []string{"vc-prod"}, Product: "vcenter", Host: "vc.example"},
+		_ = json.NewEncoder(w).Encode([]api.TargetSummary{
+			{Id: mustUUID(t, "11111111-1111-1111-1111-111111111111"), Name: "rdc-vcenter", Aliases: []string{"vc-prod"}, Product: "vcenter", Host: "vc.example"},
 		})
 	})
 	srv := httptest.NewServer(mux)
@@ -170,7 +177,7 @@ func TestRunListJSONHappyPath(t *testing.T) {
 	}
 	// Parse stdout as JSON to confirm the operator sees a structured
 	// envelope, not the table.
-	var decoded []TargetSummary
+	var decoded []api.TargetSummary
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout is not valid JSON: %v\n%s", err, stdout.String())
 	}
@@ -281,4 +288,17 @@ func newRunCmd(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
 	t.Cleanup(cancel)
 	cmd.SetContext(ctx)
 	return cmd, &stdout, &stderr
+}
+
+// mustUUID parses a UUID string in a test; fatal on failure. Used to
+// build `api.TargetSummary` / `api.Target` fixtures whose Id /
+// TenantId fields are `openapi_types.UUID` (a type alias for
+// `uuid.UUID`).
+func mustUUID(t *testing.T, s string) uuid.UUID {
+	t.Helper()
+	u, err := uuid.Parse(s)
+	if err != nil {
+		t.Fatalf("uuid.Parse(%q): %v", s, err)
+	}
+	return u
 }

--- a/cli/internal/cmd/targets/probe.go
+++ b/cli/internal/cmd/targets/probe.go
@@ -5,41 +5,18 @@ package targets
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
-
-// FingerprintResult mirrors the backend FingerprintResult Pydantic
-// model (backend/src/meho_backplane/connectors/schemas.py L96-118).
-// The shape matches the response of
-// POST /api/v1/targets/{name}/probe. Per the 2026-05-14 amendment to
-// Initiative #224 (G0.3-T1.5 / Task #477) the backend now returns
-// FingerprintResult (not ProbeResult) and persists it to
-// targets.fingerprint so the G0.6 resolver can read it without
-// re-probing.
-//
-// Optional fields (version / build / edition) are `*string` so the
-// CLI can distinguish "connector explicitly omitted the field" from
-// "connector reported an empty string".
-type FingerprintResult struct {
-	Vendor      string         `json:"vendor"`
-	Product     string         `json:"product"`
-	Version     *string        `json:"version"`
-	Build       *string        `json:"build"`
-	Edition     *string        `json:"edition"`
-	Reachable   bool           `json:"reachable"`
-	ProbedAt    string         `json:"probed_at"`
-	ProbeMethod string         `json:"probe_method"`
-	Extras      map[string]any `json:"extras,omitempty"`
-}
 
 // newProbeCmd returns the `meho targets probe` command.
 //
@@ -120,10 +97,14 @@ func runProbe(cmd *cobra.Command, opts probeOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	fp, err := postProbe(cmd.Context(), backplaneURL, opts.Query)
+	resp, err := postProbe(cmd.Context(), backplaneURL, opts.Query)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
+	if resp.StatusCode() != http.StatusOK || resp.JSON200 == nil {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	fp := resp.JSON200
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), fp)
 	}
@@ -131,26 +112,23 @@ func runProbe(cmd *cobra.Command, opts probeOptions) error {
 	return nil
 }
 
-// buildProbePath assembles the POST path. Exposed for unit tests so
-// the URL encoding of names with special characters stays covered.
-func buildProbePath(query string) string {
-	return "/api/v1/targets/" + pathEscape(query) + "/probe"
-}
-
-func postProbe(ctx context.Context, backplaneURL, query string) (*FingerprintResult, error) {
-	// Empty body — the route reads only the path-param name + the
-	// authed operator. Pass nil so doAuthedRequest skips the
-	// Content-Type/Content-Length stamp and lets the server route
-	// see an actual zero-length body.
-	raw, err := doAuthedRequest(ctx, backplaneURL, "POST", buildProbePath(query), nil)
+func postProbe(
+	ctx context.Context,
+	backplaneURL, query string,
+) (*api.ProbeTargetApiV1TargetsNameProbePostResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out FingerprintResult
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode fingerprint response: %w", err)
-	}
-	return &out, nil
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.ProbeTargetApiV1TargetsNameProbePostResponse, error) {
+			// Empty body — the route reads only the path-param name +
+			// the authed operator. The typed client path-escapes
+			// `query` before substituting into /api/v1/targets/{name}.
+			return authed.ProbeTargetApiV1TargetsNameProbePostWithResponse(ctx, query, nil)
+		},
+		func(r *api.ProbeTargetApiV1TargetsNameProbePostResponse) int { return r.StatusCode() },
+	)
 }
 
 // printFingerprint renders a FingerprintResult as a key-value
@@ -158,7 +136,7 @@ func postProbe(ctx context.Context, backplaneURL, query string) (*FingerprintRes
 // but with full multi-line breakdown — operators run `probe` for
 // the explicit "what did this connector report just now?" answer
 // and want every field visible.
-func printFingerprint(w io.Writer, fp *FingerprintResult) {
+func printFingerprint(w io.Writer, fp *api.FingerprintResult) {
 	fmt.Fprintf(w, "%-14s %s\n", "vendor:", fp.Vendor)
 	fmt.Fprintf(w, "%-14s %s\n", "product:", fp.Product)
 	if v := strDeref(fp.Version); v != "" {
@@ -171,17 +149,19 @@ func printFingerprint(w io.Writer, fp *FingerprintResult) {
 		fmt.Fprintf(w, "%-14s %s\n", "edition:", e)
 	}
 	fmt.Fprintf(w, "%-14s %t\n", "reachable:", fp.Reachable)
-	fmt.Fprintf(w, "%-14s %s\n", "probed_at:", fp.ProbedAt)
+	// Render in the same RFC3339Z shape the backend's
+	// model_dump(mode="json") emits.
+	fmt.Fprintf(w, "%-14s %s\n", "probed_at:", fp.ProbedAt.UTC().Format("2006-01-02T15:04:05Z"))
 	fmt.Fprintf(w, "%-14s %s\n", "probe_method:", fp.ProbeMethod)
-	if len(fp.Extras) > 0 {
-		fmt.Fprintf(w, "%-14s %s\n", "extras:", formatProbeExtras(fp.Extras))
+	if fp.Extras != nil && len(*fp.Extras) > 0 {
+		fmt.Fprintf(w, "%-14s %s\n", "extras:", formatProbeExtras(*fp.Extras))
 	}
 }
 
 // formatProbeExtras renders the extras map deterministically. Same
 // shape as describe.go::formatExtras; duplicated here to avoid an
 // implicit coupling between the two verbs' rendering rules.
-func formatProbeExtras(extras map[string]any) string {
+func formatProbeExtras(extras map[string]interface{}) string {
 	if len(extras) == 0 {
 		return "-"
 	}

--- a/cli/internal/cmd/targets/probe_test.go
+++ b/cli/internal/cmd/targets/probe_test.go
@@ -11,23 +11,10 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/evoila/meho/cli/internal/api"
 )
-
-// TestBuildProbePathSimpleName — operator-typical names produce a
-// clean POST path.
-func TestBuildProbePathSimpleName(t *testing.T) {
-	if got := buildProbePath("rdc-vcenter"); got != "/api/v1/targets/rdc-vcenter/probe" {
-		t.Fatalf("probe path: got %q", got)
-	}
-}
-
-// TestBuildProbePathEscapesSpecial — names with slashes / spaces are
-// path-escaped so the URL stays a single segment.
-func TestBuildProbePathEscapesSpecial(t *testing.T) {
-	if got := buildProbePath("a/b c"); got != "/api/v1/targets/a%2Fb%20c/probe" {
-		t.Fatalf("escape: got %q", got)
-	}
-}
 
 // TestRunProbeRejectsEmptyQuery — defensive guard against the
 // argv-empty case that ExactArgs(1) lets through.
@@ -49,16 +36,17 @@ func TestPrintFingerprintRendersAllFields(t *testing.T) {
 	ver := "9.0.0"
 	build := "12345"
 	edition := "enterprise"
-	fp := &FingerprintResult{
+	extras := map[string]interface{}{"datacenter_count": float64(2)}
+	fp := &api.FingerprintResult{
 		Vendor:      "vmware",
 		Product:     "vcenter",
 		Version:     &ver,
 		Build:       &build,
 		Edition:     &edition,
 		Reachable:   true,
-		ProbedAt:    "2026-05-15T08:00:00Z",
+		ProbedAt:    time.Date(2026, 5, 15, 8, 0, 0, 0, time.UTC),
 		ProbeMethod: "rest",
-		Extras:      map[string]any{"datacenter_count": float64(2)},
+		Extras:      &extras,
 	}
 	var buf bytes.Buffer
 	printFingerprint(&buf, fp)
@@ -84,11 +72,11 @@ func TestPrintFingerprintRendersAllFields(t *testing.T) {
 // edition lines should not appear so operators don't see a wall of
 // empty fields when the connector reported only the required set.
 func TestPrintFingerprintOmitsNilOptionals(t *testing.T) {
-	fp := &FingerprintResult{
+	fp := &api.FingerprintResult{
 		Vendor:      "vmware",
 		Product:     "vcenter",
 		Reachable:   true,
-		ProbedAt:    "2026-05-15T08:00:00Z",
+		ProbedAt:    time.Date(2026, 5, 15, 8, 0, 0, 0, time.UTC),
 		ProbeMethod: "rest",
 	}
 	var buf bytes.Buffer
@@ -115,12 +103,12 @@ func TestRunProbeHappyPath(t *testing.T) {
 		}
 		ver := "9.0.0"
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(FingerprintResult{
+		_ = json.NewEncoder(w).Encode(api.FingerprintResult{
 			Vendor:      "vmware",
 			Product:     "vcenter",
 			Version:     &ver,
 			Reachable:   true,
-			ProbedAt:    "2026-05-15T08:00:00Z",
+			ProbedAt:    time.Date(2026, 5, 15, 8, 0, 0, 0, time.UTC),
 			ProbeMethod: "rest",
 		})
 	})
@@ -147,12 +135,12 @@ func TestRunProbeJSONRoundTrip(t *testing.T) {
 	mux.HandleFunc("/api/v1/targets/rdc-vcenter/probe", func(w http.ResponseWriter, _ *http.Request) {
 		ver := "9.0.0"
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(FingerprintResult{
+		_ = json.NewEncoder(w).Encode(api.FingerprintResult{
 			Vendor:      "vmware",
 			Product:     "vcenter",
 			Version:     &ver,
 			Reachable:   true,
-			ProbedAt:    "2026-05-15T08:00:00Z",
+			ProbedAt:    time.Date(2026, 5, 15, 8, 0, 0, 0, time.UTC),
 			ProbeMethod: "rest",
 		})
 	})
@@ -165,7 +153,7 @@ func TestRunProbeJSONRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runProbe --json: %v", err)
 	}
-	var decoded FingerprintResult
+	var decoded api.FingerprintResult
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout.String())
 	}

--- a/cli/internal/cmd/targets/targets.go
+++ b/cli/internal/cmd/targets/targets.go
@@ -36,10 +36,22 @@
 //     every connector registered for `<product>` can reach but that
 //     are not yet registered; never auto-creates rows.
 //
-// Each verb wraps one or more backplane routes and renders the
-// response in either a human-readable form or `--json` mode.
-// Authentication piggybacks on the token meho login wrote — same
-// pattern as `meho operation` and `meho retrieval eval`.
+// G0.12-T14 #1272 migrated `list` / `describe` / `probe` / `discover`
+// off hand-rolled HTTP onto the generated `api.ClientWithResponses`
+// surface — verbs now consume `api.TargetSummary`, `api.Target`,
+// `api.FingerprintResult`, `api.CandidateHint`, `api.SkippedConnector`,
+// and `api.TargetsDiscoverResult` directly, kept in lock-step with the
+// FastAPI Pydantic models by the `cli-api-snapshot-freshness` CI gate
+// (Initiative #1118). `import` still owns local `httpDoer` /
+// `doAuthedRequest` plumbing because its sparse-PATCH + extras-spill
+// mapping reads YAML into untyped `map[string]any` bodies (see
+// `import.go`'s `entryToCreateBody` / `entryToUpdateBody`), which the
+// untyped POST/PATCH path serves more cleanly than coercing through
+// `api.TargetCreate` / `api.TargetUpdate`. Each verb wraps one or
+// more backplane routes and renders the response in either a human-
+// readable form or `--json` mode. Authentication piggybacks on the
+// token meho login wrote — same pattern as `meho operation` and
+// `meho retrieval eval`.
 //
 // Write verbs (`create` / `update` / `delete`) are out of scope for
 // v0.2 per the issue body — operators use `import --update` for
@@ -47,12 +59,10 @@
 package targets
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -83,32 +93,86 @@ func NewRootCmd() *cobra.Command {
 	return cmd
 }
 
+// errMissingAccessToken is the sentinel newAuthedClient returns when
+// the stored token row exists but its access_token is empty — a
+// credential-state failure that renderRequestError maps to
+// auth_expired with a `meho login` hint. Mirrors the agent / approvals
+// siblings' shape.
+var errMissingAccessToken = errors.New("meho: stored token has no access_token")
+
+// newAuthedClient builds an api.AuthedClient for the supplied backplane
+// URL and verifies a non-empty bearer is loaded. Centralised so every
+// verb's typed-call path goes through the same "stored-token-loaded +
+// non-empty bearer" gate; the caller forwards any returned error to
+// renderRequestError for category mapping.
+func newAuthedClient(ctx context.Context, backplaneURL string) (*api.AuthedClient, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if authed.AccessToken() == "" {
+		return nil, errMissingAccessToken
+	}
+	return authed, nil
+}
+
+// retryOn401 invokes call once, and if the typed response carries a
+// 401, runs a one-shot bearer refresh and re-issues call. Mirrors the
+// behaviour `api.AuthedClient.GetHealth` implements for the
+// /api/v1/health endpoint, generalised so every targets verb runs the
+// same transparent-retry contract.
+//
+// statusOf reads the StatusCode off the typed response envelope (the
+// generated *Response types expose StatusCode() through their embedded
+// *http.Response). A nil response counts as "no retry" — the transport
+// already failed and the caller surfaces err directly.
+func retryOn401[R any](
+	ctx context.Context,
+	authed *api.AuthedClient,
+	call func(ctx context.Context) (*R, error),
+	statusOf func(*R) int,
+) (*R, error) {
+	resp, err := call(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || statusOf(resp) != http.StatusUnauthorized {
+		return resp, nil
+	}
+	if rerr := authed.Refresh(ctx); rerr != nil {
+		return resp, rerr
+	}
+	return call(ctx)
+}
+
 // renderRequestError translates an error from one of the per-verb
 // request helpers into the right output.StructuredError category.
-// Same classification ladder as operation/operation.go but with
-// extra dispatch for the target-specific 4xx envelopes:
+// Same classification ladder as the pre-G0.12 shape but acting on
+// transport-layer errors only — non-2xx HTTP responses now arrive on
+// the typed response envelope and route through renderHTTPStatus
+// instead.
 //
-//   - 401 (refresh failed / no_refresh_token / token_not_found) →
-//     auth_expired with a `meho login <url>` hint.
-//   - 403 (RBAC denial) → insufficient_role; the backend's 403
-//     detail string names the required role.
-//   - 404 with detail.error == "no_target" → unexpected_response,
-//     with the target query and any near-miss names surfaced in
-//     the detail for operator scannability.
-//   - 409 with detail.error == "ambiguous_target" → unexpected,
-//     listing the colliding names so the operator can disambiguate.
-//   - 501 → unexpected with the "no connector registered for
-//     product=X yet" string the operator needs to resolve the gap
-//     (file a Goal G3 connector task).
-//   - Any other 4xx/5xx → unexpected with the raw body.
-//   - Pure transport errors (timeouts, DNS, connection refused) →
-//     unreachable.
+//   - empty stored bearer → auth_expired with a `meho login` hint.
+//   - token never stored (auth.ErrTokenNotFound wrapper) → auth_expired
+//     with a `meho login` hint.
+//   - refresh impossible (errNoRefreshToken) → auth_expired.
+//   - any other error → unreachable (network / transport failure
+//     before the backplane responded).
 func renderRequestError(
 	cmd *cobra.Command,
 	backplaneURL string,
 	err error,
 	jsonOut bool,
 ) error {
+	if errors.Is(err, errMissingAccessToken) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored credentials for %s are incomplete; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
 	if api.IsTokenNotFound(err) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.AuthExpired(fmt.Sprintf(
@@ -127,30 +191,33 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
-		return renderHTTPError(cmd, backplaneURL, he, jsonOut)
-	}
 	return output.RenderError(cmd.ErrOrStderr(),
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
 }
 
-// renderHTTPError classifies a non-2xx response into the right
+// renderHTTPStatus classifies a non-2xx response into the right
 // StructuredError category. Lifted into its own helper so per-verb
 // shims (probe wants the 501 message to point at G3) can wrap it.
-func renderHTTPError(
+// Acts on the (statusCode, body) pair the typed-client response
+// envelope already buffered.
+//
+// The 401 case fires when the one-shot refresh inside retryOn401 ran
+// and the re-issued call also came back 401 — the stored credentials
+// are dead and the operator must rerun `meho login`.
+func renderHTTPStatus(
 	cmd *cobra.Command,
 	backplaneURL string,
-	he *httpError,
+	statusCode int,
+	body []byte,
 	jsonOut bool,
 ) error {
-	switch he.StatusCode {
+	bodyStr := strings.TrimSpace(string(body))
+	switch statusCode {
 	case http.StatusUnauthorized:
-		// The 401-refresh-retry path in doAuthedRequest already
-		// exhausted the refresh budget. The token is dead; the
-		// operator must rerun `meho login`.
+		// The retryOn401 path already exhausted the refresh budget.
+		// The token is dead; the operator must rerun `meho login`.
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.AuthExpired(fmt.Sprintf(
 				"backplane rejected the stored token; run `meho login %s`",
@@ -164,7 +231,7 @@ func renderHTTPError(
 		// writes the required role into the detail string; pass it
 		// through verbatim so the operator sees what role they need.
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.InsufficientRole(decodeDetailString(he.Body)),
+			output.InsufficientRole(decodeDetailString(bodyStr)),
 			jsonOut,
 		)
 	case http.StatusNotFound:
@@ -174,7 +241,7 @@ func renderHTTPError(
 		// near-miss suggestions when the structured form lands so the
 		// operator sees "did you mean rdc-vcenter? rdc-vsphere?".
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(formatNotFound(he.Body)),
+			output.Unexpected(formatNotFound(bodyStr)),
 			jsonOut,
 		)
 	case http.StatusConflict:
@@ -182,7 +249,7 @@ func renderHTTPError(
 		// colliding names so the operator can re-issue with the
 		// disambiguated name.
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(formatAmbiguous(he.Body)),
+			output.Unexpected(formatAmbiguous(bodyStr)),
 			jsonOut,
 		)
 	case http.StatusNotImplemented:
@@ -190,13 +257,13 @@ func renderHTTPError(
 		// product=<X>". Pointer to G3 connector goals so operators
 		// know where to look for the work.
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(formatNoConnector(he.Body)),
+			output.Unexpected(formatNoConnector(bodyStr)),
 			jsonOut,
 		)
 	default:
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, statusCode, bodyStr)),
 			jsonOut,
 		)
 	}
@@ -297,102 +364,6 @@ func parseResolverDetail(body string) ([]resolverMatchOnTheWire, string, bool) {
 		return nil, "", false
 	}
 	return detail.Matches, detail.Query, true
-}
-
-// doAuthedRequest issues a single HTTP request against the backplane
-// with bearer injection + one-shot 401-refresh-retry. Returns the
-// response body bytes (already drained) on a 2xx outcome, or an
-// *httpError when the backplane returned a non-2xx, or an error
-// categorised by api.IsTokenNotFound / api.IsNoRefreshToken / generic
-// transport so renderRequestError can pick the right StructuredError
-// category.
-//
-// Mirrors cli/internal/cmd/operation/operation.go::doAuthedRequest.
-// Kept independent of the operation package for the import-cycle
-// reason called out on resolveBackplane.
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
-	}
-
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		// One-shot refresh + retry, mirroring api.AuthedClient.GetHealth
-		// and operation/operation.go doAuthedRequest.
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MiB cap
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-// httpError carries a non-2xx response so per-verb runners can
-// render the right category (404 → not-found with near-misses, 501 →
-// no-connector pointer, etc.). Not an output.StructuredError directly
-// — renderHTTPError decides exit-code class based on status.
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-// sendRequest is the bottom of the stack: build the http.Request,
-// stamp bearer + content headers, fire it. Split out so the
-// 401-refresh-retry path in doAuthedRequest can reuse the same body
-// bytes without re-marshalling.
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
 }
 
 // pathEscape escapes a single path segment for use inside a backend

--- a/cli/internal/cmd/targets/targets_test.go
+++ b/cli/internal/cmd/targets/targets_test.go
@@ -117,7 +117,9 @@ func TestStrDerefNilEmpty(t *testing.T) {
 
 // TestPathEscapeRoundTrip — the helper must escape the FastAPI-
 // unsafe characters but leave the operator-typical characters
-// (hyphens, dots, alphanumerics) alone.
+// (hyphens, dots, alphanumerics) alone. The import-side YAML loader
+// is the lone caller now that the verb files delegate path-segment
+// encoding to the generated typed client.
 func TestPathEscapeRoundTrip(t *testing.T) {
 	cases := []struct {
 		in   string
@@ -223,9 +225,11 @@ func TestFormatNoConnectorAppendsG3Pointer(t *testing.T) {
 	}
 }
 
-// TestRenderHTTPErrorRoutesByStatus — each HTTP status the targets
+// TestRenderHTTPStatusRoutesByStatus — each HTTP status the targets
 // surface produces lands in the right StructuredError category.
-func TestRenderHTTPErrorRoutesByStatus(t *testing.T) {
+// Pins the (statusCode, body) renderer the typed-client verbs feed
+// directly off the generated response envelope.
+func TestRenderHTTPStatusRoutesByStatus(t *testing.T) {
 	cases := []struct {
 		name     string
 		status   int
@@ -281,8 +285,7 @@ func TestRenderHTTPErrorRoutesByStatus(t *testing.T) {
 			cmd := &cobra.Command{}
 			var stderr strings.Builder
 			cmd.SetErr(&stderr)
-			he := &httpError{StatusCode: c.status, Body: c.body}
-			err := renderHTTPError(cmd, "https://meho.test", he, false)
+			err := renderHTTPStatus(cmd, "https://meho.test", c.status, []byte(c.body), false)
 			if err == nil {
 				t.Fatalf("expected non-nil error")
 			}
@@ -306,7 +309,10 @@ func TestRenderHTTPErrorRoutesByStatus(t *testing.T) {
 }
 
 // TestHTTPErrorErrorString — the *httpError formatter must not lose
-// the underlying status / body so wrapping errors stays useful.
+// the underlying status / body so wrapping errors stays useful. The
+// type now lives in import.go (the lone remaining caller); the test
+// stays in package_test so it runs against the same in-tree
+// definition.
 func TestHTTPErrorErrorString(t *testing.T) {
 	he := &httpError{StatusCode: 418, Body: "i am a teapot"}
 	got := he.Error()

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -941,17 +941,24 @@ under G0.3-T6 (#257).
 
 ### HTTP shape + error envelopes
 
-All three verbs route through `api.NewAuthedClient(...)` for bearer
-injection + one-shot 401-refresh-retry, mirroring the
-`meho operation` sibling. The shared `doAuthedRequest` helper in
-`targets.go` builds the request manually (rather than using the
-generated `ClientWithResponses`) because the target verbs need
-fine-grained 4xx classification: 404 carries the resolver's
+`list` / `describe` / `probe` / `discover` route through the
+generated `api.ClientWithResponses` typed client (G0.12-T14 #1272),
+wrapped by `api.AuthedClient` for the bearer + one-shot
+401-refresh-retry. Each verb's runner reads the typed response
+envelope's `JSON200`/`StatusCode()`/`Body` fields directly — no
+hand-written `json.Unmarshal` step — so consumer-side struct drift
+(the G0.12 root cause documented on Initiative #1118) can't recur.
+The targets-specific error-classification ladder lives in
+`renderHTTPStatus` (in `targets.go`): 404 carries the resolver's
 structured `{"error": "no_target", "query": "...", "matches": [...]}`
 envelope, 409 carries `ambiguous_target` with colliding names, and
-501 carries the "no connector registered" detail. The hand-written
-`renderHTTPError` ladder classifies each status into the right
-`output.StructuredError` category.
+501 carries the "no connector registered" detail.
+
+`import` keeps its own untyped HTTP plumbing
+(`doAuthedRequest` / `httpDoer` / local `httpError`) in `import.go`
+because the YAML-to-API mapping emits a sparse `map[string]any`
+body to preserve the partial-PATCH + extras-spill semantics — see
+the comment block on `httpDoer` for the rationale.
 
 ### Exit codes
 


### PR DESCRIPTION
## Summary

- `meho targets` read verbs (`list` / `describe` / `probe` / `discover`) move off hand-rolled HTTP + duplicated `Target` / `TargetSummary` / `FingerprintResult` / `CandidateHint` / `SkippedConnector` / `DiscoverResult` shapes onto `api.ClientWithResponses` — consumer-side struct drift (Initiative #1118's root cause) can't recur because each verb now consumes `api.TargetSummary` / `api.Target` / `api.FingerprintResult` / `api.CandidateHint` / `api.SkippedConnector` / `api.TargetsDiscoverResult` directly.
- `import.go` keeps its untyped `doAuthedRequest` / `httpDoer` plumbing (the helpers move out of `targets.go` into `import.go`, the lone remaining caller) because its sparse-PATCH + extras-spill YAML mapping emits `map[string]any` bodies that the typed `api.TargetCreate` / `api.TargetUpdate` shapes would force into per-field option plumbing for every patchable column — see the `httpDoer` doc comment for the rationale.
- The targets-specific 4xx classification ladder (404 → no-target-with-near-misses, 409 → ambiguous_target, 501 → no-connector-pointer-to-G3) survives as `renderHTTPStatus`, acting on the `(statusCode, body)` pair lifted off the typed response envelope. Transparent 401-refresh-retry generalises as the `retryOn401` generic helper — same shape sibling `cmd/agent/` (PR #1277) introduced.

## Test plan

- [x] `go build ./cli/...` — clean
- [x] `go vet ./cli/...` — clean
- [x] `go test ./cli/internal/cmd/targets/...` — passes; rewrites every verb's fixtures around `api.*` types and replaces path-string assertions (`buildListPath`) with typed params-struct assertions (`buildListParams` / `buildDiscoverParams`)
- [x] `go test ./cli/...` — all packages pass
- [x] `cd cli && make snapshot-openapi && make generate` — no-op (no OpenAPI / generated-client drift)
- [x] Acceptance grep AC1 — `grep -rn "http.NewRequest\|doAuthedRequest" cli/internal/cmd/targets/` returns matches only in `import.go` (its remaining untyped path) and doc-comment mentions in `targets.go`
- [x] Acceptance grep AC2 — `grep -rn "^type Target \|^type CandidateHint \|^type SkippedConnector \|^type DiscoverResult \|^type FingerprintResult \|^type TargetSummary " cli/internal/cmd/targets/` returns no matches
- [x] Acceptance grep AC3 — `ListTargetsApiV1TargetsGetWithResponse`, `DescribeTargetApiV1TargetsNameGetWithResponse`, `ProbeTargetApiV1TargetsNameProbePostWithResponse`, `DiscoverTargetsApiV1TargetsDiscoverGetWithResponse` all land in their respective verb files
- [x] Backend untouched — `git diff --stat -- backend/` is empty
- [x] `docs/codebase/cli.md` updated to record the migration + rationale for keeping `import.go` on the untyped path

## Out of scope

- Re-touching `import.go`'s YAML-to-API mapping. Migrating its `entryToCreateBody` / `entryToUpdateBody` onto `api.TargetCreate` / `api.TargetUpdate` would require per-field option plumbing for every patchable column and re-implementing the partial-spill contract on top of pointer-shaped option types. The untyped path is the smaller v0.2 blast radius and is documented at the source. A future task can revisit when the typed-client generator gains better support for sparse-PATCH bodies.
- Write verbs (`create` / `update` / `delete`) — still deferred per the v0.2 contract; operators reach for `import --update`.
- Adjacent CLI verb directories — covered by sibling Initiative #1118 tasks.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1272


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated target commands (`list`, `describe`, `probe`, `discover`, `import`) to use generated API client for improved consistency and reliability in request/response handling.

* **Tests**
  * Aligned test fixtures and validation with updated API client types and models.

* **Documentation**
  * Updated target command documentation to reflect API client-based request/response workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->