### PR TITLE
refactor(cli-topology): G0.12-T15 migrate cmd/topology/ to typed client (#1273)

### DIFF
--- a/cli/internal/cmd/topology/annotate.go
+++ b/cli/internal/cmd/topology/annotate.go
@@ -5,13 +5,14 @@ package topology
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -138,24 +139,39 @@ type annotateOptions struct {
 	BackplaneOverride string
 }
 
-// annotateRequestBody is the wire shape for POST /api/v1/topology/edges
-// — the issue body specifies `{from, kind, to, note?, evidence_url?}`.
-// `evidence_url` is snake_case on the wire (the JSON tag) even though
-// the CLI flag is kebab-case `--evidence-url` (Cobra convention).
-// Endpoints are nested objects carrying `name` + optional `kind` — the
-// route binds them via the `_EdgeEndpoint` Pydantic model and the
-// `_AnnotateEdgeRequest`'s `from` / `to` aliases.
-type annotateRequestBody struct {
-	From        annotateRequestEndpoint `json:"from"`
-	Kind        string                  `json:"kind"`
-	To          annotateRequestEndpoint `json:"to"`
-	Note        string                  `json:"note,omitempty"`
-	EvidenceURL string                  `json:"evidence_url,omitempty"`
-}
-
-type annotateRequestEndpoint struct {
-	Name string `json:"name"`
-	Kind string `json:"kind,omitempty"`
+// buildAnnotateBody wraps the operator-typed annotate inputs into the
+// generated `UnderscoreAnnotateEdgeRequest` body. `Kind` is forwarded
+// as a plain string and validated server-side against the closed
+// 10-kind GraphEdgeKind vocabulary (a 422 with the per-row message is
+// the failure surface the operator sees if they typo the kind, same
+// shape as the pre-migration contract). Endpoint kinds are passed as
+// nil pointers when the operator didn't supply --from-kind / --to-kind
+// so the wire shape sees an absent field rather than an empty string
+// (the backend's _EdgeEndpoint model treats absent and empty kind
+// differently — absent means "no pin", empty would fail validation).
+func buildAnnotateBody(opts annotateOptions) api.UnderscoreAnnotateEdgeRequest {
+	body := api.UnderscoreAnnotateEdgeRequest{
+		From: api.UnderscoreEdgeEndpoint{Name: opts.From},
+		Kind: api.GraphEdgeKind(opts.Kind),
+		To:   api.UnderscoreEdgeEndpoint{Name: opts.To},
+	}
+	if opts.FromKind != "" {
+		fk := opts.FromKind
+		body.From.Kind = &fk
+	}
+	if opts.ToKind != "" {
+		tk := opts.ToKind
+		body.To.Kind = &tk
+	}
+	if opts.Note != "" {
+		n := opts.Note
+		body.Note = &n
+	}
+	if opts.EvidenceURL != "" {
+		u := opts.EvidenceURL
+		body.EvidenceUrl = &u
+	}
+	return body
 }
 
 func runAnnotate(cmd *cobra.Command, opts annotateOptions) error {
@@ -163,22 +179,21 @@ func runAnnotate(cmd *cobra.Command, opts annotateOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	body := annotateRequestBody{
-		From:        annotateRequestEndpoint{Name: opts.From, Kind: opts.FromKind},
-		Kind:        opts.Kind,
-		To:          annotateRequestEndpoint{Name: opts.To, Kind: opts.ToKind},
-		Note:        opts.Note,
-		EvidenceURL: opts.EvidenceURL,
-	}
-	encoded, err := json.Marshal(body)
-	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf("encode annotate body: %v", err)),
-			opts.JSONOut)
-	}
-	edge, err := postAnnotate(cmd.Context(), backplaneURL, encoded)
+	edge, statusCode, body, err := postAnnotate(cmd.Context(), backplaneURL, opts)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if statusCode != http.StatusCreated {
+		return renderHTTPStatus(cmd, backplaneURL, statusCode, body, opts.JSONOut)
+	}
+	if edge == nil {
+		// Guard the 201-without-payload case so the renderer below
+		// doesn't dereference nil. Mirrors the kb / memory iter-2
+		// nil-guard pattern.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 201 without an annotate payload", backplaneURL)),
+			opts.JSONOut)
 	}
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), edge)
@@ -187,25 +202,35 @@ func runAnnotate(cmd *cobra.Command, opts annotateOptions) error {
 	return nil
 }
 
-func postAnnotate(ctx context.Context, backplaneURL string, body []byte) (*Edge, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/topology/edges", body)
+func postAnnotate(
+	ctx context.Context,
+	backplaneURL string,
+	opts annotateOptions,
+) (*api.TopologyEdge, int, []byte, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
-		return nil, err
+		return nil, 0, nil, err
 	}
-	var out Edge
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode annotate response: %w", err)
+	body := buildAnnotateBody(opts)
+	resp, err := retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.AnnotateEdgeRouteApiV1TopologyEdgesPostResponse, error) {
+			return authed.AnnotateEdgeRouteApiV1TopologyEdgesPostWithResponse(ctx, nil, body)
+		},
+		func(r *api.AnnotateEdgeRouteApiV1TopologyEdgesPostResponse) int { return r.StatusCode() },
+	)
+	if err != nil {
+		return nil, 0, nil, err
 	}
-	return &out, nil
+	return resp.JSON201, resp.StatusCode(), resp.Body, nil
 }
 
 // printAnnotateSummary renders the resulting edge as a compact two-
 // line block: the relationship in `kind/from -> kind/to` form (the
 // same arrow notation the `path` verb uses) plus the edge id so the
 // operator can pipe it into a follow-up `unannotate <id>`.
-func printAnnotateSummary(w io.Writer, e *Edge) {
+func printAnnotateSummary(w io.Writer, e *api.TopologyEdge) {
 	fmt.Fprintf(w, "annotated edge: %s/%s --[%s]--> %s/%s\n",
 		e.From.Kind, e.From.Name, e.Kind, e.To.Kind, e.To.Name)
-	fmt.Fprintf(w, "  edge_id: %s\n", e.ID)
+	fmt.Fprintf(w, "  edge_id: %s\n", e.Id)
 	fmt.Fprintf(w, "  source:  %s\n", e.Source)
 }

--- a/cli/internal/cmd/topology/bulk_import.go
+++ b/cli/internal/cmd/topology/bulk_import.go
@@ -6,26 +6,29 @@ package topology
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
-// bulkImportDoc is the on-disk root: a single `edges:` list. Decode
-// into a typed struct rather than a generic map because every supported
-// field maps 1:1 to the wire shape — there is no extras-spill contract
-// for bulk-import the way targets/import.go has. yaml.v3's strict mode
-// (KnownFields) would reject typo'd field names; we leave that off so
-// the server-side validation surfaces every problem in one round trip
-// rather than the CLI failing fast on the first typo.
+// bulkImportDoc is the on-disk root: a single `edges:` list. Decoded
+// from YAML (or JSON, since yaml.v3 is a JSON superset for the input
+// shape we accept). Each row carries the YAML tag set the operator
+// types in the file; the wire shape is later projected onto the
+// generated `api.UnderscoreBulkImportEdge` struct (which only has JSON
+// tags) inside `buildBulkImportBody`. Keeping the file shape distinct
+// from the wire shape lets the YAML decoder accept the bare-scalar
+// shorthand for endpoints (`from: svc-x`) — a vocabulary the generated
+// struct can't express directly.
 type bulkImportDoc struct {
 	Edges []bulkImportEdgeYAML `yaml:"edges" json:"edges"`
 }
@@ -44,9 +47,10 @@ type bulkImportEdgeYAML struct {
 	EvidenceURL string             `yaml:"evidence_url,omitempty" json:"evidence_url,omitempty"`
 }
 
-// bulkImportEndpoint is the wire shape for one annotate endpoint.
-// `Name` is required; `Kind` is the optional disambiguator for an
-// ambiguous bare name. The YAML can spell each endpoint two ways:
+// bulkImportEndpoint is the wire shape for one annotate endpoint as
+// read off the file. `Name` is required; `Kind` is the optional
+// disambiguator for an ambiguous bare name. The YAML can spell each
+// endpoint two ways:
 //
 //	from: svc-orders                 # bare string -> Name="svc-orders"
 //	from: { name: svc-orders, kind: service }
@@ -85,38 +89,7 @@ func (e *bulkImportEndpoint) UnmarshalYAML(node *yaml.Node) error {
 	}
 }
 
-// bulkImportRequest is the wire shape for
-// POST /api/v1/topology/edges/bulk: `{edges: [...], dry_run: bool}`.
-// The route accepts both “dry_run=true/false“ in the body and a
-// canonical 200 response.
-type bulkImportRequest struct {
-	Edges  []bulkImportEdgeYAML `json:"edges"`
-	DryRun bool                 `json:"dry_run,omitempty"`
-}
-
-// bulkImportResponseRow mirrors the per-row outcome from the service.
-type bulkImportResponseRow struct {
-	Index      int      `json:"index"`
-	Action     string   `json:"action"`
-	EdgeID     *string  `json:"edge_id"`
-	FromName   string   `json:"from_name"`
-	FromKind   string   `json:"from_kind"`
-	ToName     string   `json:"to_name"`
-	ToKind     string   `json:"to_kind"`
-	Kind       string   `json:"kind"`
-	Superseded []string `json:"superseded"`
-	Conflicts  []string `json:"conflicts"`
-}
-
-type bulkImportResponse struct {
-	DryRun    bool                    `json:"dry_run"`
-	Created   int                     `json:"created"`
-	Updated   int                     `json:"updated"`
-	Conflicts int                     `json:"conflicts"`
-	Rows      []bulkImportResponseRow `json:"rows"`
-}
-
-// bulkImportError mirrors the 422 invalid_bulk envelope.
+// bulkImportErrorEnvelope mirrors the 422 invalid_bulk envelope.
 type bulkImportErrorEnvelope struct {
 	Error  string                 `json:"error"`
 	Errors []bulkImportRowErrJSON `json:"errors"`
@@ -228,18 +201,26 @@ func runBulkImport(cmd *cobra.Command, opts bulkImportOptions) error {
 		return output.RenderError(cmd.ErrOrStderr(),
 			backplane.ClassifyError(err), opts.JSONOut)
 	}
-	body, err := json.Marshal(bulkImportRequest{
-		Edges:  doc.Edges,
-		DryRun: opts.DryRun,
-	})
+	resp, statusCode, body, err := postBulkImport(cmd.Context(), backplaneURL, doc, opts.DryRun)
 	if err != nil {
-		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf("encode bulk-import body: %v", err)),
-			opts.JSONOut)
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
-	resp, err := postBulkImport(cmd.Context(), backplaneURL, body)
-	if err != nil {
-		return renderBulkImportError(cmd, backplaneURL, err, opts.JSONOut)
+	if statusCode != http.StatusOK {
+		// Special-case 422 invalid_bulk: surface the structured per-
+		// row error list before falling back to the generic renderer.
+		if statusCode == http.StatusUnprocessableEntity {
+			if msg := formatInvalidBulkEnvelope(string(body)); msg != "" {
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unexpected(msg), opts.JSONOut)
+			}
+		}
+		return renderHTTPStatus(cmd, backplaneURL, statusCode, body, opts.JSONOut)
+	}
+	if resp == nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without a bulk-import payload", backplaneURL)),
+			opts.JSONOut)
 	}
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), resp)
@@ -275,37 +256,67 @@ func parseBulkImportDoc(data []byte) (*bulkImportDoc, error) {
 	return &doc, nil
 }
 
-func postBulkImport(ctx context.Context, backplaneURL string, body []byte) (*bulkImportResponse, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "POST",
-		"/api/v1/topology/edges/bulk", body)
-	if err != nil {
-		return nil, err
+// buildBulkImportBody projects the YAML-decoded `bulkImportDoc` onto
+// the generated `api.UnderscoreBulkImportRequest` body. The kind
+// rides as a typed `api.GraphEdgeKind` so the generated parser's
+// closed-vocabulary contract is the wire-level check (operators see
+// the substrate's per-row 422 message on a bad kind, same shape as
+// the pre-migration `httpError` ladder).
+func buildBulkImportBody(doc *bulkImportDoc, dryRun bool) api.UnderscoreBulkImportRequest {
+	edges := make([]api.UnderscoreBulkImportEdge, 0, len(doc.Edges))
+	for _, e := range doc.Edges {
+		edge := api.UnderscoreBulkImportEdge{
+			From: api.UnderscoreEdgeEndpoint{Name: e.From.Name},
+			Kind: api.GraphEdgeKind(e.Kind),
+			To:   api.UnderscoreEdgeEndpoint{Name: e.To.Name},
+		}
+		if e.From.Kind != "" {
+			fk := e.From.Kind
+			edge.From.Kind = &fk
+		}
+		if e.To.Kind != "" {
+			tk := e.To.Kind
+			edge.To.Kind = &tk
+		}
+		if e.Note != "" {
+			n := e.Note
+			edge.Note = &n
+		}
+		if e.EvidenceURL != "" {
+			u := e.EvidenceURL
+			edge.EvidenceUrl = &u
+		}
+		edges = append(edges, edge)
 	}
-	var out bulkImportResponse
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode bulk-import response: %w", err)
+	body := api.UnderscoreBulkImportRequest{Edges: edges}
+	if dryRun {
+		dr := true
+		body.DryRun = &dr
 	}
-	return &out, nil
+	return body
 }
 
-// renderBulkImportError intercepts the 422 `invalid_bulk` envelope so
-// the per-row error list is rendered as a structured operator-readable
-// block — one line per bad row pointing at the file index. Other
-// errors fall back to the generic renderer.
-func renderBulkImportError(
-	cmd *cobra.Command,
+func postBulkImport(
+	ctx context.Context,
 	backplaneURL string,
-	err error,
-	jsonOut bool,
-) error {
-	var he *httpError
-	if errors.As(err, &he) && he.StatusCode == 422 {
-		if msg := formatInvalidBulkEnvelope(he.Body); msg != "" {
-			return output.RenderError(cmd.ErrOrStderr(),
-				output.Unexpected(msg), jsonOut)
-		}
+	doc *bulkImportDoc,
+	dryRun bool,
+) (*api.UnderscoreBulkImportResponse, int, []byte, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, 0, nil, err
 	}
-	return renderRequestError(cmd, backplaneURL, err, jsonOut)
+	body := buildBulkImportBody(doc, dryRun)
+	resp, err := retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.BulkImportEdgesRouteApiV1TopologyEdgesBulkPostResponse, error) {
+			return authed.BulkImportEdgesRouteApiV1TopologyEdgesBulkPostWithResponse(ctx, nil, body)
+		},
+		func(r *api.BulkImportEdgesRouteApiV1TopologyEdgesBulkPostResponse) int { return r.StatusCode() },
+	)
+	if err != nil {
+		return nil, 0, nil, err
+	}
+	return resp.JSON200, resp.StatusCode(), resp.Body, nil
 }
 
 // formatInvalidBulkEnvelope renders the 422 `invalid_bulk` body into
@@ -337,7 +348,12 @@ func formatInvalidBulkEnvelope(body string) string {
 // summary header names the action counts; the per-row block surfaces
 // the §6 conflict classifications + the edge ids so the operator can
 // pipe a follow-up unannotate by id.
-func printBulkImportSummary(w io.Writer, resp *bulkImportResponse) {
+//
+// `r.EdgeId` is `*openapi_types.UUID` in the generated client; the
+// dry-run shape leaves it nil, the apply shape populates it. The
+// renderer accesses it only through the existing supersede / conflict
+// lists which carry edge-id strings independently.
+func printBulkImportSummary(w io.Writer, resp *api.UnderscoreBulkImportResponse) {
 	mode := "applied"
 	if resp.DryRun {
 		mode = "planned (dry-run)"

--- a/cli/internal/cmd/topology/bulk_import_test.go
+++ b/cli/internal/cmd/topology/bulk_import_test.go
@@ -13,6 +13,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/evoila/meho/cli/internal/api"
 )
 
 // --- parseBulkImportDoc ----------------------------------------------------
@@ -139,12 +141,12 @@ func TestFormatInvalidBulkEnvelopeReturnsEmptyForGenericBody(t *testing.T) {
 // --- printBulkImportSummary ------------------------------------------------
 
 func TestPrintBulkImportSummaryDryRun(t *testing.T) {
-	resp := &bulkImportResponse{
+	resp := &api.UnderscoreBulkImportResponse{
 		DryRun:    true,
 		Created:   1,
 		Updated:   0,
 		Conflicts: 1,
-		Rows: []bulkImportResponseRow{
+		Rows: []api.UnderscoreBulkImportRowResponse{
 			{Index: 0, Action: "create", Kind: "depends-on",
 				FromKind: "service", FromName: "svc-A",
 				ToKind: "service", ToName: "db-1"},
@@ -169,7 +171,7 @@ func TestPrintBulkImportSummaryDryRun(t *testing.T) {
 }
 
 func TestPrintBulkImportSummaryApply(t *testing.T) {
-	resp := &bulkImportResponse{Created: 3, Updated: 0, Conflicts: 0, Rows: []bulkImportResponseRow{}}
+	resp := &api.UnderscoreBulkImportResponse{Created: 3, Updated: 0, Conflicts: 0, Rows: []api.UnderscoreBulkImportRowResponse{}}
 	var buf bytes.Buffer
 	printBulkImportSummary(&buf, resp)
 	out := buf.String()
@@ -194,7 +196,7 @@ func TestRunBulkImportPostsBatchAndRendersSummary(t *testing.T) {
 		t.Fatalf("write file: %v", err)
 	}
 
-	var receivedBody bulkImportRequest
+	var receivedBody api.UnderscoreBulkImportRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/v1/topology/edges/bulk" {
 			http.Error(w, "wrong path", http.StatusNotFound)
@@ -210,10 +212,10 @@ func TestRunBulkImportPostsBatchAndRendersSummary(t *testing.T) {
 			return
 		}
 		edgeID := "11111111-2222-3333-4444-555555555555"
-		resp := bulkImportResponse{
+		resp := api.UnderscoreBulkImportResponse{
 			DryRun: false, Created: 1, Updated: 0, Conflicts: 0,
-			Rows: []bulkImportResponseRow{{
-				Index: 0, Action: "create", EdgeID: &edgeID,
+			Rows: []api.UnderscoreBulkImportRowResponse{{
+				Index: 0, Action: "create", EdgeId: &edgeID,
 				FromName: "sa-a", FromKind: "principal",
 				ToName: "vr-a", ToKind: "vault-role",
 				Kind: "authenticates-via",
@@ -238,8 +240,10 @@ func TestRunBulkImportPostsBatchAndRendersSummary(t *testing.T) {
 	if len(receivedBody.Edges) != 1 || receivedBody.Edges[0].From.Name != "sa-a" {
 		t.Errorf("wrong body posted: %+v", receivedBody)
 	}
-	if receivedBody.DryRun {
-		t.Errorf("dry-run should default to false")
+	// dry_run should default to false / absent on the wire — the
+	// CLI omits it from the body unless --dry-run is set.
+	if receivedBody.DryRun != nil && *receivedBody.DryRun {
+		t.Errorf("dry-run should default to false; got %v", *receivedBody.DryRun)
 	}
 	if !strings.Contains(stdout.String(), "Bulk-import applied: 1 to create") {
 		t.Errorf("missing summary in stdout: %q", stdout.String())
@@ -257,27 +261,28 @@ func TestRunBulkImportDryRunForwardsFlag(t *testing.T) {
 		t.Fatalf("write file: %v", err)
 	}
 
-	var receivedBody bulkImportRequest
+	var receivedBody api.UnderscoreBulkImportRequest
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		raw, _ := io.ReadAll(r.Body)
 		_ = json.Unmarshal(raw, &receivedBody)
-		resp := bulkImportResponse{DryRun: true, Created: 1}
+		resp := api.UnderscoreBulkImportResponse{DryRun: true, Created: 1}
 		body, _ := json.Marshal(resp)
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(body)
 	}))
 	defer srv.Close()
 
 	seedXDGAndToken(t, srv.URL)
-	cmd, _, _ := newRunCmd(t)
+	cmd, _, stderr := newRunCmd(t)
 	if err := runBulkImport(cmd, bulkImportOptions{
 		File:              file,
 		DryRun:            true,
 		BackplaneOverride: srv.URL,
 	}); err != nil {
-		t.Fatalf("runBulkImport: %v", err)
+		t.Fatalf("runBulkImport: %v; stderr=%s", err, stderr.String())
 	}
-	if !receivedBody.DryRun {
+	if receivedBody.DryRun == nil || !*receivedBody.DryRun {
 		t.Errorf("dry_run not forwarded; got body %+v", receivedBody)
 	}
 }

--- a/cli/internal/cmd/topology/closure.go
+++ b/cli/internal/cmd/topology/closure.go
@@ -5,25 +5,24 @@ package topology
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/url"
-	"strconv"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
 // closureOptions is shared by the `dependents` and `dependencies`
 // verbs — the two are mirror traversals over the identical REST
-// query-param contract, so the option bag, path builder, request
-// helper, and renderer are factored here and the per-verb files only
-// differ in the route segment ("dependents" vs "dependencies") and
-// the help prose.
+// query-param contract, so the option bag, request helper, and
+// renderer are factored here and the per-verb files only differ in
+// the `Verb` discriminator ("dependents" vs "dependencies") and the
+// help prose.
 type closureOptions struct {
-	// Verb is the route segment: "dependents" or "dependencies".
+	// Verb is the route discriminator: "dependents" or "dependencies".
 	Verb string
 	// Name is the anchor node name (or alias — alias→name resolution
 	// is the backend's job; this is passed through verbatim).
@@ -41,7 +40,7 @@ type closureOptions struct {
 	// param). Empty → unpinned; an ambiguous name then returns 409
 	// ambiguous_node and the renderer points the operator back here.
 	NodeKind string
-	// JSONOut emits the raw []Node envelope.
+	// JSONOut emits the raw []TopologyNode envelope.
 	JSONOut bool
 	// BackplaneOverride overrides the configured backplane URL.
 	BackplaneOverride string
@@ -67,9 +66,23 @@ func runClosure(cmd *cobra.Command, opts closureOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	nodes, err := getClosure(cmd.Context(), backplaneURL, opts)
+	nodes, statusCode, body, err := getClosure(cmd.Context(), backplaneURL, opts)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if statusCode != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, statusCode, body, opts.JSONOut)
+	}
+	if nodes == nil {
+		// 200 OK without a typed payload (e.g. content-type drift) —
+		// fail loud rather than rendering "node not found" for what
+		// is actually a contract mismatch. The kb / memory siblings
+		// adopted the same JSON200-nil guard in their post-iter-2
+		// fix loop.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without a closure payload", backplaneURL)),
+			opts.JSONOut)
 	}
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), nodes)
@@ -78,40 +91,84 @@ func runClosure(cmd *cobra.Command, opts closureOptions) error {
 	return nil
 }
 
-// buildClosurePath assembles the GET path + query string for a
-// dependents/dependencies call. The name is a path segment
-// (pathEscape keeps a slash/space in an operator-typed name from
-// corrupting the URL); depth / kind_filter / kind ride the query
-// string and are omitted when unset so the server applies its
-// defaults. Exposed for unit tests.
-func buildClosurePath(opts closureOptions) string {
-	q := url.Values{}
-	if opts.Depth > 0 {
-		q.Set("depth", strconv.Itoa(opts.Depth))
-	}
-	if opts.EdgeKind != "" {
-		q.Set("kind_filter", opts.EdgeKind)
-	}
-	if opts.NodeKind != "" {
-		q.Set("kind", opts.NodeKind)
-	}
-	path := "/api/v1/topology/" + opts.Verb + "/" + pathEscape(opts.Name)
-	if encoded := q.Encode(); encoded != "" {
-		path = path + "?" + encoded
-	}
-	return path
-}
-
-func getClosure(ctx context.Context, backplaneURL string, opts closureOptions) ([]Node, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildClosurePath(opts), nil)
+// getClosure invokes the dependents-or-dependencies typed call against
+// the supplied backplane URL and returns (parsed nodes, status code,
+// raw body, transport-error). The (nodes, statusCode, body) triple is
+// the same shape the kb / memory siblings settled on after their
+// iter-2 fixes: callers branch on statusCode (200 → render `nodes`;
+// non-200 → renderHTTPStatus with the raw body) without re-parsing
+// the envelope.
+func getClosure(
+	ctx context.Context,
+	backplaneURL string,
+	opts closureOptions,
+) ([]api.TopologyNode, int, []byte, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
-		return nil, err
+		return nil, 0, nil, err
 	}
-	var out []Node
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode %s response: %w", opts.Verb, err)
+	// Build the typed param once; both branches feed it to the
+	// matching `*WithResponse` method.
+	var depthPtr *int
+	if opts.Depth > 0 {
+		d := opts.Depth
+		depthPtr = &d
 	}
-	return out, nil
+	var kindFilterPtr *string
+	if opts.EdgeKind != "" {
+		k := opts.EdgeKind
+		kindFilterPtr = &k
+	}
+	var anchorKindPtr *string
+	if opts.NodeKind != "" {
+		k := opts.NodeKind
+		anchorKindPtr = &k
+	}
+
+	switch opts.Verb {
+	case "dependents":
+		params := &api.DependentsApiV1TopologyDependentsNameGetParams{
+			Depth:      depthPtr,
+			KindFilter: kindFilterPtr,
+			Kind:       anchorKindPtr,
+		}
+		resp, err := retryOn401(ctx, authed,
+			func(ctx context.Context) (*api.DependentsApiV1TopologyDependentsNameGetResponse, error) {
+				return authed.DependentsApiV1TopologyDependentsNameGetWithResponse(ctx, opts.Name, params)
+			},
+			func(r *api.DependentsApiV1TopologyDependentsNameGetResponse) int { return r.StatusCode() },
+		)
+		if err != nil {
+			return nil, 0, nil, err
+		}
+		if resp.JSON200 != nil {
+			return *resp.JSON200, resp.StatusCode(), resp.Body, nil
+		}
+		return nil, resp.StatusCode(), resp.Body, nil
+	case "dependencies":
+		params := &api.DependenciesApiV1TopologyDependenciesNameGetParams{
+			Depth:      depthPtr,
+			KindFilter: kindFilterPtr,
+			Kind:       anchorKindPtr,
+		}
+		resp, err := retryOn401(ctx, authed,
+			func(ctx context.Context) (*api.DependenciesApiV1TopologyDependenciesNameGetResponse, error) {
+				return authed.DependenciesApiV1TopologyDependenciesNameGetWithResponse(ctx, opts.Name, params)
+			},
+			func(r *api.DependenciesApiV1TopologyDependenciesNameGetResponse) int { return r.StatusCode() },
+		)
+		if err != nil {
+			return nil, 0, nil, err
+		}
+		if resp.JSON200 != nil {
+			return *resp.JSON200, resp.StatusCode(), resp.Body, nil
+		}
+		return nil, resp.StatusCode(), resp.Body, nil
+	default:
+		// Belt-and-braces: callers (newDependents/Dependencies) hard-
+		// code the verb string, so a mismatch is a programmer error.
+		return nil, 0, nil, fmt.Errorf("internal: unknown closure verb %q", opts.Verb)
+	}
 }
 
 // addClosureFlags wires the shared flag set onto a dependents/

--- a/cli/internal/cmd/topology/diff.go
+++ b/cli/internal/cmd/topology/diff.go
@@ -5,15 +5,14 @@ package topology
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
-	"strconv"
+	"net/http"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -109,9 +108,18 @@ func runDiff(cmd *cobra.Command, opts diffOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	result, err := getDiff(cmd.Context(), backplaneURL, opts)
+	result, statusCode, body, err := getDiff(cmd.Context(), backplaneURL, opts)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if statusCode != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, statusCode, body, opts.JSONOut)
+	}
+	if result == nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without a diff payload", backplaneURL)),
+			opts.JSONOut)
 	}
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), result)
@@ -120,74 +128,69 @@ func runDiff(cmd *cobra.Command, opts diffOptions) error {
 	return nil
 }
 
-// buildDiffPath assembles the GET path + query string for a diff call.
-// ts1 / ts2 are both resolved client-side from duration shorthand to
-// absolute ISO-8601 to match the REST router's absolute-only contract
-// (mirrors the timeline verb).
-func buildDiffPath(opts diffOptions, now time.Time) (string, error) {
-	q := url.Values{}
-	ts1ISO, err := resolveDurationOrISO(opts.TS1, now)
+// buildDiffParams assembles the generated query-param shape for a
+// diff call. ts1 / ts2 are required and resolved client-side from
+// duration shorthand to absolute time.Time (mirrors the timeline
+// contract). The optional --kind / --changed-only filters land as
+// pointer fields only when set.
+func buildDiffParams(opts diffOptions, now time.Time) (*api.DiffRouteApiV1TopologyDiffGetParams, error) {
+	params := &api.DiffRouteApiV1TopologyDiffGetParams{}
+	ts1, err := resolveDurationOrISO(opts.TS1, now)
 	if err != nil {
-		return "", fmt.Errorf("ts1 %q: %w", opts.TS1, err)
+		return nil, fmt.Errorf("ts1 %q: %w", opts.TS1, err)
 	}
-	q.Set("ts1", ts1ISO)
-	ts2ISO, err := resolveDurationOrISO(opts.TS2, now)
+	params.Ts1 = ts1
+	ts2, err := resolveDurationOrISO(opts.TS2, now)
 	if err != nil {
-		return "", fmt.Errorf("ts2 %q: %w", opts.TS2, err)
+		return nil, fmt.Errorf("ts2 %q: %w", opts.TS2, err)
 	}
-	q.Set("ts2", ts2ISO)
+	params.Ts2 = ts2
 	if opts.Kind != "" {
-		q.Set("kind", opts.Kind)
+		k := opts.Kind
+		params.Kind = &k
 	}
 	if opts.ChangedOnly {
-		q.Set("changed_only", strconv.FormatBool(true))
+		co := true
+		params.ChangedOnly = &co
 	}
-	return "/api/v1/topology/diff?" + q.Encode(), nil
+	return params, nil
 }
 
-func getDiff(ctx context.Context, backplaneURL string, opts diffOptions) (*DiffResult, error) {
-	path, err := buildDiffPath(opts, time.Now().UTC())
+func getDiff(
+	ctx context.Context,
+	backplaneURL string,
+	opts diffOptions,
+) (*api.TopologyDiffResult, int, []byte, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
-		return nil, err
+		return nil, 0, nil, err
 	}
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
+	params, err := buildDiffParams(opts, time.Now().UTC())
 	if err != nil {
-		return nil, err
+		return nil, 0, nil, err
 	}
-	var out DiffResult
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode diff response: %w", err)
+	resp, err := retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.DiffRouteApiV1TopologyDiffGetResponse, error) {
+			return authed.DiffRouteApiV1TopologyDiffGetWithResponse(ctx, params)
+		},
+		func(r *api.DiffRouteApiV1TopologyDiffGetResponse) int { return r.StatusCode() },
+	)
+	if err != nil {
+		return nil, 0, nil, err
 	}
-	return &out, nil
-}
-
-// DiffEntry mirrors the backend `TopologyDiffEntry` Pydantic model
-// (`backend/src/meho_backplane/topology/schemas.py`). Hand-written for
-// the same reason `TimelineEntry` is: keep the topology package
-// decoupled from oapi-codegen churn.
-type DiffEntry struct {
-	ChangeKind string  `json:"change_kind"`
-	Source     string  `json:"source"`
-	ResourceID *string `json:"resource_id"`
-	Kind       string  `json:"kind"`
-	Name       *string `json:"name"`
-	Summary    string  `json:"summary"`
-}
-
-// DiffResult mirrors the backend `TopologyDiffResult`. `TruncationHint`
-// keeps the JSON key as `null` (no `omitempty`) so a re-marshal
-// preserves the Pydantic wire shape.
-type DiffResult struct {
-	Entries        []DiffEntry `json:"entries"`
-	Truncated      bool        `json:"truncated"`
-	TruncationHint *string     `json:"truncation_hint"`
+	return resp.JSON200, resp.StatusCode(), resp.Body, nil
 }
 
 // printDiffSummary renders the diff result as a structured summary:
 // counts by (source, change_kind) plus a truncation banner when the
 // server cap fired. The JSON path carries the same data with per-entry
 // detail for callers who want the full list.
-func printDiffSummary(w io.Writer, r *DiffResult) {
+//
+// `e.Source` and `e.ChangeKind` are typed enum aliases in the
+// generated client (`TopologyDiffEntrySource`, `TopologyDiffEntryChangeKind`);
+// the map-key shape converts back to the underlying string so the
+// per-quadrant lookup line below stays scannable.
+func printDiffSummary(w io.Writer, r *api.TopologyDiffResult) {
 	if r == nil {
 		fmt.Fprintln(w, "no diff result")
 		return
@@ -205,7 +208,7 @@ func printDiffSummary(w io.Writer, r *DiffResult) {
 	type key struct{ source, kind string }
 	counts := map[key]int{}
 	for _, e := range r.Entries {
-		counts[key{e.Source, e.ChangeKind}]++
+		counts[key{string(e.Source), string(e.ChangeKind)}]++
 	}
 	render := func(src string) {
 		created := counts[key{src, "created"}]

--- a/cli/internal/cmd/topology/e2e_test.go
+++ b/cli/internal/cmd/topology/e2e_test.go
@@ -10,7 +10,27 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	openapi_types "github.com/oapi-codegen/runtime/types"
+
+	"github.com/evoila/meho/cli/internal/api"
 )
+
+// fakeTargetUUID is a stable canonical UUID used as the typed
+// `target_id` field on the substrate's RefreshResult contract. The
+// pre-migration shape carried this as a free-form string ("abc", "z");
+// the typed `api.RefreshResult.TargetId` is `openapi_types.UUID` so
+// the test fixture must round-trip a real UUID through the wire.
+const fakeTargetUUID = "11111111-2222-3333-4444-555555555555"
+
+func mustUUID(t *testing.T, s string) openapi_types.UUID {
+	t.Helper()
+	parsed := openapi_types.UUID{}
+	if err := parsed.UnmarshalText([]byte(s)); err != nil {
+		t.Fatalf("UnmarshalText(%q): %v", s, err)
+	}
+	return parsed
+}
 
 // TestRefreshHappyPath drives runRefresh end-to-end through the auth
 // + transport stack against an httptest server, asserting the POST
@@ -25,8 +45,9 @@ func TestRefreshHappyPath(t *testing.T) {
 			t.Errorf("missing Authorization header")
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(RefreshResult{
-			TargetID: "abc", AddedNodes: 3, RemovedNodes: 1, UpdatedNodes: 2,
+		_ = json.NewEncoder(w).Encode(api.RefreshResult{
+			TargetId:   mustUUID(t, fakeTargetUUID),
+			AddedNodes: 3, RemovedNodes: 1, UpdatedNodes: 2,
 			AddedEdges: 4, RemovedEdges: 0, UpdatedEdges: 1,
 		})
 	})
@@ -48,10 +69,13 @@ func TestRefreshHappyPath(t *testing.T) {
 
 // TestRefreshJSON — --json round-trips the raw RefreshResult shape.
 func TestRefreshJSON(t *testing.T) {
+	const altUUID = "22222222-3333-4444-5555-666666666666"
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/topology/refresh/t", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(RefreshResult{TargetID: "z", AddedNodes: 1, DurationMs: 42.5})
+		_ = json.NewEncoder(w).Encode(api.RefreshResult{
+			TargetId: mustUUID(t, altUUID), AddedNodes: 1, DurationMs: 42.5,
+		})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -61,11 +85,11 @@ func TestRefreshJSON(t *testing.T) {
 	if err := runRefresh(cmd, refreshOptions{Target: "t", JSONOut: true, BackplaneOverride: srv.URL}); err != nil {
 		t.Fatalf("runRefresh --json: %v; stderr=%s", err, stderr.String())
 	}
-	var decoded RefreshResult
+	var decoded api.RefreshResult
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout.String())
 	}
-	if decoded.TargetID != "z" || decoded.AddedNodes != 1 {
+	if decoded.TargetId.String() != altUUID || decoded.AddedNodes != 1 {
 		t.Errorf("--json decode produced %+v", decoded)
 	}
 	// duration_ms is part of the T5 RefreshResult contract; --json
@@ -115,9 +139,9 @@ func TestDependentsHappyPathFlagsPassThrough(t *testing.T) {
 		}
 		via := "routes-through"
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]Node{
-			{ID: "1", Kind: "service", Name: "customer-a-prod-foo", Depth: 0},
-			{ID: "2", Kind: "ingress", Name: "ing-1", Depth: 1, ViaEdgeKind: &via},
+		_ = json.NewEncoder(w).Encode([]api.TopologyNode{
+			{Id: mustUUID(t, "10000000-0000-0000-0000-000000000001"), Kind: "service", Name: "customer-a-prod-foo", Depth: 0},
+			{Id: mustUUID(t, "10000000-0000-0000-0000-000000000002"), Kind: "ingress", Name: "ing-1", Depth: 1, ViaEdgeKind: &via},
 		})
 	})
 	srv := httptest.NewServer(mux)
@@ -139,12 +163,15 @@ func TestDependentsHappyPathFlagsPassThrough(t *testing.T) {
 	}
 }
 
-// TestDependenciesJSON — --json round-trips the []Node shape.
+// TestDependenciesJSON — --json round-trips the []api.TopologyNode shape.
 func TestDependenciesJSON(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/topology/dependencies/web", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]Node{{ID: "1", Kind: "vm", Name: "web", Depth: 0}})
+		_ = json.NewEncoder(w).Encode([]api.TopologyNode{{
+			Id:   mustUUID(t, "10000000-0000-0000-0000-000000000003"),
+			Kind: "vm", Name: "web", Depth: 0,
+		}})
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -157,7 +184,7 @@ func TestDependenciesJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runClosure --json: %v; stderr=%s", err, stderr.String())
 	}
-	var decoded []Node
+	var decoded []api.TopologyNode
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout not valid JSON: %v\n%s", err, stdout.String())
 	}
@@ -241,10 +268,10 @@ func TestPathReachable(t *testing.T) {
 			t.Errorf("max_hops param: got %q; want 5", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(Path{
-			Nodes: []Node{
-				{Kind: "vm", Name: "web"},
-				{Kind: "datastore", Name: "ds"},
+		_ = json.NewEncoder(w).Encode(api.TopologyPath{
+			Nodes: []api.TopologyNode{
+				{Id: mustUUID(t, "10000000-0000-0000-0000-000000000004"), Kind: "vm", Name: "web"},
+				{Id: mustUUID(t, "10000000-0000-0000-0000-000000000005"), Kind: "datastore", Name: "ds"},
 			},
 			TotalHops: 1,
 		})
@@ -344,24 +371,24 @@ func TestAnnotateRoundTripVisibleViaListEdgesThenUnannotate(t *testing.T) {
 	mux.HandleFunc("/api/v1/topology/edges", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodPost:
-			var body annotateRequestBody
+			var body api.UnderscoreAnnotateEdgeRequest
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Errorf("decode POST body: %v", err)
 			}
-			if body.From.Name != "service-x" || body.Kind != "depends-on" || body.To.Name != "database-y" {
+			if body.From.Name != "service-x" || string(body.Kind) != "depends-on" || body.To.Name != "database-y" {
 				t.Errorf("POST body mismatch: %+v", body)
 			}
-			if body.EvidenceURL != "https://docs/example" {
-				t.Errorf("evidence_url not propagated: %q", body.EvidenceURL)
+			if body.EvidenceUrl == nil || *body.EvidenceUrl != "https://docs/example" {
+				t.Errorf("evidence_url not propagated: %v", body.EvidenceUrl)
 			}
 			annotated = true
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusCreated)
-			_ = json.NewEncoder(w).Encode(Edge{
-				ID:     edgeID,
-				From:   EdgeEndpoint{ID: "a", Kind: "service", Name: "service-x"},
-				To:     EdgeEndpoint{ID: "b", Kind: "database", Name: "database-y"},
-				Kind:   "depends-on",
-				Source: "curated",
+			_ = json.NewEncoder(w).Encode(api.TopologyEdge{
+				Id:   mustUUID(t, edgeID),
+				From: api.TopologyEdgeEndpoint{Id: mustUUID(t, "20000000-0000-0000-0000-000000000001"), Kind: "service", Name: "service-x"},
+				To:   api.TopologyEdgeEndpoint{Id: mustUUID(t, "20000000-0000-0000-0000-000000000002"), Kind: "database", Name: "database-y"},
+				Kind: "depends-on", Source: "curated",
 			})
 		case http.MethodGet:
 			// Honour the source filter — annotate test issues
@@ -374,12 +401,11 @@ func TestAnnotateRoundTripVisibleViaListEdgesThenUnannotate(t *testing.T) {
 				_, _ = w.Write([]byte(`[]`))
 				return
 			}
-			_ = json.NewEncoder(w).Encode([]Edge{{
-				ID:     edgeID,
-				From:   EdgeEndpoint{ID: "a", Kind: "service", Name: "service-x"},
-				To:     EdgeEndpoint{ID: "b", Kind: "database", Name: "database-y"},
-				Kind:   "depends-on",
-				Source: "curated",
+			_ = json.NewEncoder(w).Encode([]api.TopologyEdge{{
+				Id:   mustUUID(t, edgeID),
+				From: api.TopologyEdgeEndpoint{Id: mustUUID(t, "20000000-0000-0000-0000-000000000001"), Kind: "service", Name: "service-x"},
+				To:   api.TopologyEdgeEndpoint{Id: mustUUID(t, "20000000-0000-0000-0000-000000000002"), Kind: "database", Name: "database-y"},
+				Kind: "depends-on", Source: "curated",
 			}})
 		default:
 			t.Errorf("unexpected method on /edges: %s", r.Method)
@@ -452,13 +478,15 @@ func TestAnnotateRoundTripVisibleViaListEdgesThenUnannotate(t *testing.T) {
 // TopologyEdge envelope unchanged so a consumer (jq, MCP shim, etc.)
 // can pipe the response into a follow-up call.
 func TestAnnotateJSONPassesThroughRawEdge(t *testing.T) {
+	const edgeID = "33333333-4444-5555-6666-777777777777"
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/topology/edges", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(Edge{
-			ID:   "edge-abc",
-			From: EdgeEndpoint{ID: "1", Kind: "vm", Name: "a"},
-			To:   EdgeEndpoint{ID: "2", Kind: "vm", Name: "b"},
+		_ = json.NewEncoder(w).Encode(api.TopologyEdge{
+			Id:   mustUUID(t, edgeID),
+			From: api.TopologyEdgeEndpoint{Id: mustUUID(t, "20000000-0000-0000-0000-000000000003"), Kind: "vm", Name: "a"},
+			To:   api.TopologyEdgeEndpoint{Id: mustUUID(t, "20000000-0000-0000-0000-000000000004"), Kind: "vm", Name: "b"},
 			Kind: "depends-on", Source: "curated",
 		})
 	})
@@ -474,11 +502,11 @@ func TestAnnotateJSONPassesThroughRawEdge(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runAnnotate --json: %v; stderr=%s", err, stderr.String())
 	}
-	var decoded Edge
+	var decoded api.TopologyEdge
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout not JSON: %v\n%s", err, stdout.String())
 	}
-	if decoded.ID != "edge-abc" || decoded.Kind != "depends-on" {
+	if decoded.Id.String() != edgeID || decoded.Kind != "depends-on" {
 		t.Errorf("--json decode produced %+v", decoded)
 	}
 }
@@ -613,9 +641,9 @@ func TestUnannotateTupleAmbiguous(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/topology/edges", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]Edge{
-			{ID: "id-1", From: EdgeEndpoint{Kind: "vm", Name: "a"}, To: EdgeEndpoint{Kind: "host", Name: "b"}, Kind: "runs-on"},
-			{ID: "id-2", From: EdgeEndpoint{Kind: "vm", Name: "a"}, To: EdgeEndpoint{Kind: "host", Name: "b"}, Kind: "runs-on"},
+		_ = json.NewEncoder(w).Encode([]api.TopologyEdge{
+			{Id: mustUUID(t, "40000000-0000-0000-0000-000000000001"), From: api.TopologyEdgeEndpoint{Kind: "vm", Name: "a"}, To: api.TopologyEdgeEndpoint{Kind: "host", Name: "b"}, Kind: "runs-on"},
+			{Id: mustUUID(t, "40000000-0000-0000-0000-000000000002"), From: api.TopologyEdgeEndpoint{Kind: "vm", Name: "a"}, To: api.TopologyEdgeEndpoint{Kind: "host", Name: "b"}, Kind: "runs-on"},
 		})
 	})
 	mux.HandleFunc("/api/v1/topology/edges/", func(_ http.ResponseWriter, _ *http.Request) {
@@ -632,7 +660,7 @@ func TestUnannotateTupleAmbiguous(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error for ambiguous tuple")
 	}
-	for _, want := range []string{"matches 2 curated edges", "id-1", "id-2"} {
+	for _, want := range []string{"matches 2 curated edges", "40000000-0000-0000-0000-000000000001", "40000000-0000-0000-0000-000000000002"} {
 		if !strings.Contains(stderr.String(), want) {
 			t.Errorf("ambiguous render missing %q in %q", want, stderr.String())
 		}
@@ -664,16 +692,16 @@ func TestUnannotateTupleNotFound(t *testing.T) {
 	}
 }
 
-// TestListEdgesJSONRoundTrip — --json emits the raw []Edge envelope so
+// TestListEdgesJSONRoundTrip — --json emits the raw []TopologyEdge envelope so
 // a consumer can pipe the response into the unannotate id form.
 func TestListEdgesJSONRoundTrip(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/topology/edges", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]Edge{{
-			ID:   "edge-1",
-			From: EdgeEndpoint{ID: "n1", Kind: "vm", Name: "web"},
-			To:   EdgeEndpoint{ID: "n2", Kind: "host", Name: "esxi-1"},
+		_ = json.NewEncoder(w).Encode([]api.TopologyEdge{{
+			Id:   mustUUID(t, "50000000-0000-0000-0000-000000000001"),
+			From: api.TopologyEdgeEndpoint{Id: mustUUID(t, "20000000-0000-0000-0000-000000000005"), Kind: "vm", Name: "web"},
+			To:   api.TopologyEdgeEndpoint{Id: mustUUID(t, "20000000-0000-0000-0000-000000000006"), Kind: "host", Name: "esxi-1"},
 			Kind: "runs-on", Source: "auto",
 		}})
 	})
@@ -686,11 +714,11 @@ func TestListEdgesJSONRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("runListEdges --json: %v; stderr=%s", err, stderr.String())
 	}
-	var decoded []Edge
+	var decoded []api.TopologyEdge
 	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
 		t.Fatalf("stdout not JSON: %v\n%s", err, stdout.String())
 	}
-	if len(decoded) != 1 || decoded[0].ID != "edge-1" {
+	if len(decoded) != 1 || decoded[0].Id.String() != "50000000-0000-0000-0000-000000000001" {
 		t.Errorf("--json decode produced %+v", decoded)
 	}
 }

--- a/cli/internal/cmd/topology/history.go
+++ b/cli/internal/cmd/topology/history.go
@@ -5,15 +5,14 @@ package topology
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
-	"strconv"
+	"net/http"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -38,7 +37,7 @@ import (
 // forensic reconstruction.
 //
 // Exit codes (shared with the sibling topology verbs via
-// renderRequestError / renderHTTPError):
+// renderRequestError / renderHTTPStatus):
 //   - 0   query returned cleanly (incl. zero-row result).
 //   - 2   auth_expired
 //   - 3   unreachable
@@ -139,9 +138,18 @@ func runHistory(cmd *cobra.Command, opts historyOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	result, err := getHistory(cmd.Context(), backplaneURL, opts)
+	result, statusCode, body, err := getHistory(cmd.Context(), backplaneURL, opts)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if statusCode != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, statusCode, body, opts.JSONOut)
+	}
+	if result == nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without a history payload", backplaneURL)),
+			opts.JSONOut)
 	}
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), result)
@@ -150,90 +158,67 @@ func runHistory(cmd *cobra.Command, opts historyOptions) error {
 	return nil
 }
 
-// buildHistoryPath assembles the GET path + query string for a
-// history call. The anchor name is a path segment (pathEscape keeps
-// a slash/space in an operator-typed name from corrupting the URL);
-// optional filters land as query params only when set so the server
-// applies its defaults for the rest. Duration shorthand (e.g. "24h")
-// is resolved client-side to an absolute ISO-8601 (same parser
-// `timeline.go` uses via resolveDurationOrISO) so the backend's
-// REST router accepts absolute timestamps only -- one parser in one
-// place.
-func buildHistoryPath(opts historyOptions, now time.Time) (string, error) {
-	q := url.Values{}
+// buildHistoryParams assembles the generated query-param shape. The
+// anchor name is a path segment carried by the typed call's second
+// arg, not a param. Optional filters land as pointer fields only when
+// set so the server applies its defaults for the rest. Duration
+// shorthand (e.g. "24h") is resolved client-side to an absolute
+// time.Time the typed param then carries — one parser in one place
+// (the CLI), matching the timeline contract.
+func buildHistoryParams(opts historyOptions, now time.Time) (*api.HistoryRouteApiV1TopologyHistoryNameGetParams, error) {
+	params := &api.HistoryRouteApiV1TopologyHistoryNameGetParams{}
 	if opts.NodeKind != "" {
-		q.Set("kind", opts.NodeKind)
+		k := opts.NodeKind
+		params.Kind = &k
 	}
 	if opts.Since != "" {
-		iso, err := resolveDurationOrISO(opts.Since, now)
+		ts, err := resolveDurationOrISO(opts.Since, now)
 		if err != nil {
-			return "", fmt.Errorf("--since %q: %w", opts.Since, err)
+			return nil, fmt.Errorf("--since %q: %w", opts.Since, err)
 		}
-		q.Set("since", iso)
+		params.Since = &ts
 	}
 	if opts.Until != "" {
-		iso, err := resolveDurationOrISO(opts.Until, now)
+		ts, err := resolveDurationOrISO(opts.Until, now)
 		if err != nil {
-			return "", fmt.Errorf("--until %q: %w", opts.Until, err)
+			return nil, fmt.Errorf("--until %q: %w", opts.Until, err)
 		}
-		q.Set("until", iso)
+		params.Until = &ts
 	}
 	if opts.IncludeEdges {
-		q.Set("include_edges", "true")
+		ie := true
+		params.IncludeEdges = &ie
 	}
 	if opts.Limit > 0 {
-		q.Set("limit", strconv.Itoa(opts.Limit))
+		l := opts.Limit
+		params.Limit = &l
 	}
-	path := "/api/v1/topology/history/" + pathEscape(opts.Name)
-	if encoded := q.Encode(); encoded != "" {
-		path = path + "?" + encoded
-	}
-	return path, nil
+	return params, nil
 }
 
-func getHistory(ctx context.Context, backplaneURL string, opts historyOptions) (*HistoryResult, error) {
-	path, err := buildHistoryPath(opts, time.Now().UTC())
+func getHistory(
+	ctx context.Context,
+	backplaneURL string,
+	opts historyOptions,
+) (*api.TopologyHistoryResult, int, []byte, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
-		return nil, err
+		return nil, 0, nil, err
 	}
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
+	params, err := buildHistoryParams(opts, time.Now().UTC())
 	if err != nil {
-		return nil, err
+		return nil, 0, nil, err
 	}
-	var out HistoryResult
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode history response: %w", err)
+	resp, err := retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.HistoryRouteApiV1TopologyHistoryNameGetResponse, error) {
+			return authed.HistoryRouteApiV1TopologyHistoryNameGetWithResponse(ctx, opts.Name, params)
+		},
+		func(r *api.HistoryRouteApiV1TopologyHistoryNameGetResponse) int { return r.StatusCode() },
+	)
+	if err != nil {
+		return nil, 0, nil, err
 	}
-	return &out, nil
-}
-
-// HistoryEntry mirrors the backend `TopologyHistoryEntry` Pydantic
-// model (`backend/src/meho_backplane/topology/schemas.py`). Fields
-// are hand-written rather than oapi-codegen-generated for the same
-// reason the audit `Entry` shape is — the topology package stays
-// decoupled from oapi churn, matching the sibling-package convention.
-// `Snapshot` keeps the JSON shape verbatim so `--json` round-trips
-// the backend's payload without CLI loss-of-fidelity (the table
-// view extracts a 1-line summary; the JSON path is what an operator
-// uses for forensic reconstruction).
-type HistoryEntry struct {
-	ValidFrom  string         `json:"valid_from"`
-	HistoryID  int64          `json:"history_id"`
-	Source     string         `json:"source"`
-	ChangeKind string         `json:"change_kind"`
-	ResourceID *string        `json:"resource_id"`
-	Snapshot   map[string]any `json:"snapshot"`
-	AuditID    *string        `json:"audit_id"`
-}
-
-// HistoryResult mirrors the backend `TopologyHistoryResult`.
-// `AnchorNodeID` is the resolved `graph_node.id` and `IncludeEdges`
-// echoes the call-site flag so a re-marshal preserves the Pydantic
-// wire shape.
-type HistoryResult struct {
-	AnchorNodeID string         `json:"anchor_node_id"`
-	IncludeEdges bool           `json:"include_edges"`
-	Rows         []HistoryEntry `json:"rows"`
+	return resp.JSON200, resp.StatusCode(), resp.Body, nil
 }
 
 // printHistoryTable renders the per-resource history page as a
@@ -243,7 +228,7 @@ type HistoryResult struct {
 // the full snapshot (that is the `--json` mode's job, the forensic
 // payload an operator pipes into `jq`). An empty result renders the
 // "no changes" line.
-func printHistoryTable(w io.Writer, root string, r *HistoryResult) {
+func printHistoryTable(w io.Writer, root string, r *api.TopologyHistoryResult) {
 	if r == nil || len(r.Rows) == 0 {
 		fmt.Fprintf(w, "no history rows for %q in this tenant (or window is empty)\n", root)
 		return
@@ -252,15 +237,15 @@ func printHistoryTable(w io.Writer, root string, r *HistoryResult) {
 		"VALID_FROM", "SRC", "CHANGE", "SUMMARY", "AUDIT_ID")
 	for _, row := range r.Rows {
 		fmt.Fprintf(w, "%-22s %-5s %-8s %-38s %s\n",
-			truncate(row.ValidFrom, 22),
+			truncate(row.ValidFrom.UTC().Format(time.RFC3339), 22),
 			row.Source,
 			truncate(row.ChangeKind, 8),
 			truncate(historyRowSummary(row), 38),
-			truncate(strDeref(row.AuditID), 36),
+			truncate(uuidPtrToString(row.AuditId), 36),
 		)
 	}
 	fmt.Fprintf(w, "anchor: %s; include_edges: %t; rows: %d\n",
-		r.AnchorNodeID, r.IncludeEdges, len(r.Rows))
+		r.AnchorNodeId, r.IncludeEdges, len(r.Rows))
 }
 
 // historyRowSummary renders a 1-line description of a history row
@@ -269,15 +254,21 @@ func printHistoryTable(w io.Writer, root string, r *HistoryResult) {
 // "what's new" surveys) and the pre-state for removed (the row that
 // just went away). Falls back to "<change_kind> <source>" when the
 // snapshot is malformed or missing.
-func historyRowSummary(row HistoryEntry) string {
+//
+// `row.Snapshot` is `*map[string]interface{}` in the generated
+// client (Pydantic JSONB rendered as a pointer to a map so absence
+// is representable). Dereference once before the switch / lookup
+// below to keep the field access cheap and readable.
+func historyRowSummary(row api.TopologyHistoryEntry) string {
 	if row.Snapshot == nil {
 		return fmt.Sprintf("%s %s", row.ChangeKind, row.Source)
 	}
+	snap := *row.Snapshot
 	var side any
 	if row.ChangeKind == "removed" {
-		side = row.Snapshot["before"]
+		side = snap["before"]
 	} else {
-		side = row.Snapshot["after"]
+		side = snap["after"]
 	}
 	m, ok := side.(map[string]any)
 	if !ok {

--- a/cli/internal/cmd/topology/list_edges.go
+++ b/cli/internal/cmd/topology/list_edges.go
@@ -5,46 +5,16 @@ package topology
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
-	"strconv"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
-
-// Edge mirrors the backend TopologyEdge Pydantic model
-// (backend/src/meho_backplane/topology/schemas.py). The wire shape uses
-// `from` / `to` keys (`serialization_alias` on the Python side); the
-// Go struct names the fields `From` / `To` and uses the same JSON tag
-// so the response decodes cleanly. `Properties` is a free-form bag the
-// service writes (conflict markers, supersede UUIDs, operator notes);
-// rendered only in --json mode to keep the table view scannable.
-// Hand-written rather than aliased to a generated client type for the
-// same generated-client-decoupling reason the other verb trees document.
-type Edge struct {
-	ID         string         `json:"id"`
-	From       EdgeEndpoint   `json:"from"`
-	To         EdgeEndpoint   `json:"to"`
-	Kind       string         `json:"kind"`
-	Source     string         `json:"source"`
-	Properties map[string]any `json:"properties"`
-	LastSeen   *string        `json:"last_seen"`
-}
-
-// EdgeEndpoint mirrors backend TopologyEdgeEndpoint. Carries the three
-// fields a human-readable edge summary needs: the node id, the kind,
-// and the name. The full node properties bag is not included — an
-// edge listing is a survey of relationships, not a node dump.
-type EdgeEndpoint struct {
-	ID   string `json:"id"`
-	Kind string `json:"kind"`
-	Name string `json:"name"`
-}
 
 // newListEdgesCmd returns the `meho topology list-edges` command.
 //
@@ -157,9 +127,21 @@ func runListEdges(cmd *cobra.Command, opts listEdgesOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	edges, err := getEdges(cmd.Context(), backplaneURL, opts)
+	edges, statusCode, body, err := getEdges(cmd.Context(), backplaneURL, opts)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if statusCode != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, statusCode, body, opts.JSONOut)
+	}
+	if edges == nil {
+		// 200 OK with a missing payload — fail loud rather than
+		// silently rendering "no edges matched". Mirrors the kb /
+		// memory iter-2 nil-guard pattern.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without a list-edges payload", backplaneURL)),
+			opts.JSONOut)
 	}
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), edges)
@@ -168,53 +150,76 @@ func runListEdges(cmd *cobra.Command, opts listEdgesOptions) error {
 	return nil
 }
 
-// buildListEdgesPath assembles the GET path + query string. Every
-// filter is omitted from the wire when unset so the server applies
-// its defaults (no kind / source filter, limit=200, offset=0). The
-// `--source` flag maps directly to the `?source=` query param (the
-// `graph_edge.source` column literal — `auto` or `curated`); the
-// route's regex pattern enforces the same closed pair. Exposed for
-// unit tests.
-func buildListEdgesPath(opts listEdgesOptions) string {
-	q := url.Values{}
+// buildListEdgesParams maps the CLI flags onto the generated query-
+// param shape. Every filter is omitted from the wire when unset so
+// the server applies its defaults (no kind / source filter,
+// limit=200, offset=0). The `--source` flag maps directly to the
+// `?source=` query param (the `graph_edge.source` column literal —
+// `auto` or `curated`); the route's regex pattern enforces the same
+// closed pair.
+//
+// `Kind` rides as the typed `*GraphEdgeKind` enum because the
+// generator narrowed the wire pattern to the closed vocabulary; we
+// reuse the operator-typed string verbatim — invalid kinds round-
+// trip to a 422 with the per-row message rather than failing
+// client-side, matching the pre-migration contract where the CLI
+// didn't second-guess the substrate's vocabulary check.
+func buildListEdgesParams(opts listEdgesOptions) *api.ListEdgesRouteApiV1TopologyEdgesGetParams {
+	params := &api.ListEdgesRouteApiV1TopologyEdgesGetParams{}
 	if opts.Kind != "" {
-		q.Set("kind", opts.Kind)
+		k := api.GraphEdgeKind(opts.Kind)
+		params.Kind = &k
 	}
 	if opts.Source != "" {
-		q.Set("source", opts.Source)
+		s := opts.Source
+		params.Source = &s
 	}
 	if opts.From != "" {
-		q.Set("from", opts.From)
+		f := opts.From
+		params.From = &f
 	}
 	if opts.To != "" {
-		q.Set("to", opts.To)
+		t := opts.To
+		params.To = &t
 	}
 	if opts.Conflicts {
-		q.Set("conflicts", "true")
+		c := true
+		params.Conflicts = &c
 	}
 	if opts.Limit > 0 {
-		q.Set("limit", strconv.Itoa(opts.Limit))
+		l := opts.Limit
+		params.Limit = &l
 	}
 	if opts.Offset > 0 {
-		q.Set("offset", strconv.Itoa(opts.Offset))
+		o := opts.Offset
+		params.Offset = &o
 	}
-	path := "/api/v1/topology/edges"
-	if encoded := q.Encode(); encoded != "" {
-		path = path + "?" + encoded
-	}
-	return path
+	return params
 }
 
-func getEdges(ctx context.Context, backplaneURL string, opts listEdgesOptions) ([]Edge, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildListEdgesPath(opts), nil)
+func getEdges(
+	ctx context.Context,
+	backplaneURL string,
+	opts listEdgesOptions,
+) ([]api.TopologyEdge, int, []byte, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
-		return nil, err
+		return nil, 0, nil, err
 	}
-	var out []Edge
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode list-edges response: %w", err)
+	params := buildListEdgesParams(opts)
+	resp, err := retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.ListEdgesRouteApiV1TopologyEdgesGetResponse, error) {
+			return authed.ListEdgesRouteApiV1TopologyEdgesGetWithResponse(ctx, params)
+		},
+		func(r *api.ListEdgesRouteApiV1TopologyEdgesGetResponse) int { return r.StatusCode() },
+	)
+	if err != nil {
+		return nil, 0, nil, err
 	}
-	return out, nil
+	if resp.JSON200 != nil {
+		return *resp.JSON200, resp.StatusCode(), resp.Body, nil
+	}
+	return nil, resp.StatusCode(), resp.Body, nil
 }
 
 // printEdgeListing renders edges as an aligned table. Columns: KIND,
@@ -223,7 +228,11 @@ func getEdges(ctx context.Context, backplaneURL string, opts listEdgesOptions) (
 // emits the full envelope including ids for piping into `unannotate
 // <edge-id>`. Empty listing → an explanatory line so an operator can
 // tell "tenant has no curated edges yet" from "filter matched nothing".
-func printEdgeListing(w io.Writer, edges []Edge) {
+//
+// `e.LastSeen` is a `*time.Time` in the generated client; the table
+// renders the RFC3339 form to preserve operator-readable timestamps
+// for audit correlation.
+func printEdgeListing(w io.Writer, edges []api.TopologyEdge) {
 	if len(edges) == 0 {
 		fmt.Fprintln(w, "no edges matched")
 		return
@@ -232,8 +241,8 @@ func printEdgeListing(w io.Writer, edges []Edge) {
 		"KIND", "SOURCE", "FROM", "TO", "LAST_SEEN")
 	for _, e := range edges {
 		lastSeen := "-"
-		if e.LastSeen != nil && *e.LastSeen != "" {
-			lastSeen = *e.LastSeen
+		if e.LastSeen != nil && !e.LastSeen.IsZero() {
+			lastSeen = e.LastSeen.UTC().Format("2006-01-02T15:04:05Z")
 		}
 		from := fmt.Sprintf("%s/%s", e.From.Kind, e.From.Name)
 		to := fmt.Sprintf("%s/%s", e.To.Kind, e.To.Name)

--- a/cli/internal/cmd/topology/nodes.go
+++ b/cli/internal/cmd/topology/nodes.go
@@ -6,24 +6,9 @@ package topology
 import (
 	"fmt"
 	"io"
-)
 
-// Node mirrors the backend TopologyNode Pydantic model
-// (backend/src/meho_backplane/topology/schemas.py). `Properties` is a
-// free-form JSON object the connector populated; the CLI renders it
-// only in --json mode (the table view stays scannable). `ViaEdgeKind`
-// is the graph_edge.kind of the edge used to reach this node, or nil
-// for the query root (depth 0, reached by no edge). Hand-written for
-// the same generated-client-decoupling reason the other verb trees
-// document.
-type Node struct {
-	ID          string         `json:"id"`
-	Kind        string         `json:"kind"`
-	Name        string         `json:"name"`
-	Properties  map[string]any `json:"properties"`
-	Depth       int            `json:"depth"`
-	ViaEdgeKind *string        `json:"via_edge_kind"`
-}
+	"github.com/evoila/meho/cli/internal/api"
+)
 
 // printNodeClosure renders a dependents/dependencies closure as a
 // depth-ordered table. Columns: DEPTH, KIND, NAME, VIA (the edge kind
@@ -34,7 +19,11 @@ type Node struct {
 // backend's one-element-vs-empty contract makes, and the surface
 // where a cross-tenant query reads as "not found" rather than leaking
 // another tenant's node.
-func printNodeClosure(w io.Writer, root string, nodes []Node) {
+//
+// Consumes the generated `api.TopologyNode` type directly per
+// G0.12-T15 #1273 — the previously-duplicated local `Node` struct was
+// removed in the same change.
+func printNodeClosure(w io.Writer, root string, nodes []api.TopologyNode) {
 	if len(nodes) == 0 {
 		fmt.Fprintf(w, "no node named %q in this tenant (or no matching closure)\n", root)
 		return

--- a/cli/internal/cmd/topology/path.go
+++ b/cli/internal/cmd/topology/path.go
@@ -5,29 +5,17 @@ package topology
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
-	"strconv"
+	"net/http"
+	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
-
-// Path mirrors the backend TopologyPath Pydantic model
-// (backend/src/meho_backplane/topology/schemas.py). `Nodes` runs from
-// the `from` node (depth 0) to the `to` node (depth == TotalHops)
-// inclusive; `TotalHops == len(Nodes) - 1`. The route returns JSON
-// `null` (HTTP 200) when `to` is unreachable from `from` within
-// max_hops, or either endpoint does not exist in the tenant —
-// unreachability is a valid answer, not an error.
-type Path struct {
-	Nodes     []Node `json:"nodes"`
-	TotalHops int    `json:"total_hops"`
-}
 
 // _maxHopsMax mirrors the API's Query(le=32) ceiling
 // (backend/src/meho_backplane/api/v1/topology.py `_MAX_HOPS_MAX`).
@@ -115,59 +103,98 @@ func runPath(cmd *cobra.Command, opts pathOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	path, err := getPath(cmd.Context(), backplaneURL, opts)
+	path, statusCode, body, err := getPath(cmd.Context(), backplaneURL, opts)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
+	if statusCode != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, statusCode, body, opts.JSONOut)
+	}
+	// 200 + nil result legitimately means "unreachable" (see getPath
+	// docstring re: literal JSON `null` body). The JSON path emits
+	// `null` so jq consumers see one stable contract; the table path
+	// renders the no-path line via printPath's nil branch.
 	if opts.JSONOut {
-		// `path` is nil on the unreachable / missing-endpoint case;
-		// PrintJSON emits literal `null`, the same shape the API
-		// returns, so a jq consumer sees one stable contract.
 		return output.PrintJSON(cmd.OutOrStdout(), path)
 	}
 	printPath(cmd.OutOrStdout(), opts.From, opts.To, path)
 	return nil
 }
 
-// buildPathQuery assembles the GET /api/v1/topology/path query
-// string. `from` / `to` match the route spec (`?from=A&to=B`); the
-// optional kind pins and max_hops are omitted when unset so the
-// server applies its default. Exposed for unit tests.
-func buildPathQuery(opts pathOptions) string {
-	q := url.Values{}
-	q.Set("from", opts.From)
-	q.Set("to", opts.To)
+// buildPathParams maps the CLI flags onto the generated query-param
+// shape. `From` / `To` are required (the path verb's two positional
+// args); the optional kind pins and max_hops are omitted when unset
+// so the server applies its default.
+func buildPathParams(opts pathOptions) *api.PathApiV1TopologyPathGetParams {
+	params := &api.PathApiV1TopologyPathGetParams{
+		From: opts.From,
+		To:   opts.To,
+	}
 	if opts.MaxHops > 0 {
-		q.Set("max_hops", strconv.Itoa(opts.MaxHops))
+		mh := opts.MaxHops
+		params.MaxHops = &mh
 	}
 	if opts.FromKind != "" {
-		q.Set("from_kind", opts.FromKind)
+		fk := opts.FromKind
+		params.FromKind = &fk
 	}
 	if opts.ToKind != "" {
-		q.Set("to_kind", opts.ToKind)
+		tk := opts.ToKind
+		params.ToKind = &tk
 	}
-	return "/api/v1/topology/path?" + q.Encode()
+	return params
 }
 
-func getPath(ctx context.Context, backplaneURL string, opts pathOptions) (*Path, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildPathQuery(opts), nil)
+// getPath invokes the path typed call. The route's response_model is
+// `TopologyPath | None`: a literal JSON `null` body is the unreachable
+// answer (the route returns 200 with body `null` rather than 404).
+// oapi-codegen's generated parser populates `JSON200` to a zero-value
+// `*TopologyPath` even for `null` bodies (`json.Unmarshal("null",
+// &dest)` succeeds without touching dest); we explicitly detect the
+// "null" body byte sequence and surface it as a nil result so the
+// caller (printPath / the --json path) sees the unreachable shape
+// unchanged from the pre-migration contract.
+func getPath(
+	ctx context.Context,
+	backplaneURL string,
+	opts pathOptions,
+) (*api.TopologyPath, int, []byte, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
-		return nil, err
+		return nil, 0, nil, err
 	}
-	// The route's response_model is `TopologyPath | None`: a literal
-	// JSON `null` is the unreachable answer, decoded here as a nil
-	// *Path (distinct from a decode error).
-	var out *Path
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode path response: %w", err)
+	params := buildPathParams(opts)
+	resp, err := retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.PathApiV1TopologyPathGetResponse, error) {
+			return authed.PathApiV1TopologyPathGetWithResponse(ctx, params)
+		},
+		func(r *api.PathApiV1TopologyPathGetResponse) int { return r.StatusCode() },
+	)
+	if err != nil {
+		return nil, 0, nil, err
 	}
-	return out, nil
+	if resp.StatusCode() == http.StatusOK && isJSONNull(resp.Body) {
+		return nil, resp.StatusCode(), resp.Body, nil
+	}
+	return resp.JSON200, resp.StatusCode(), resp.Body, nil
+}
+
+// isJSONNull reports whether the body is the literal JSON `null`
+// token, ignoring leading/trailing whitespace. The path route uses
+// this shape to signal unreachability; distinguishing it from a
+// populated TopologyPath envelope cannot be done from the typed
+// `*TopologyPath` alone because `json.Unmarshal("null", &dest)`
+// leaves `dest` as the zero value, and the parser then stamps a
+// non-nil `JSON200` pointing at it.
+func isJSONNull(body []byte) bool {
+	trimmed := strings.TrimSpace(string(body))
+	return trimmed == "null"
 }
 
 // printPath renders the hop chain as `a -> b -> c (N hops)`, or the
 // no-path line when the backend returned null (unreachable, missing
 // endpoint, or cross-tenant — all the same answer).
-func printPath(w io.Writer, from, to string, p *Path) {
+func printPath(w io.Writer, from, to string, p *api.TopologyPath) {
 	if p == nil || len(p.Nodes) == 0 {
 		fmt.Fprintf(w, "no path from %q to %q within the hop budget\n", from, to)
 		return

--- a/cli/internal/cmd/topology/refresh.go
+++ b/cli/internal/cmd/topology/refresh.go
@@ -5,36 +5,16 @@ package topology
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
-
-// RefreshResult mirrors the backend RefreshResult Pydantic model
-// (backend/src/meho_backplane/topology/refresh.py). Hand-written
-// rather than aliased to a generated client type so the topology
-// package stays decoupled from the generated client's surface — the
-// targets/operation/kb packages take the same stance for the same
-// reason (generated types churn on every spec re-snapshot).
-type RefreshResult struct {
-	TargetID     string `json:"target_id"`
-	AddedNodes   int    `json:"added_nodes"`
-	RemovedNodes int    `json:"removed_nodes"`
-	UpdatedNodes int    `json:"updated_nodes"`
-	AddedEdges   int    `json:"added_edges"`
-	RemovedEdges int    `json:"removed_edges"`
-	UpdatedEdges int    `json:"updated_edges"`
-	// DurationMs is wall-clock for the whole resolve + discover +
-	// reconcile + commit cycle. float64 mirrors the backend
-	// RefreshResult.duration_ms (a Python float), so --json round-trips
-	// the full T5 contract rather than silently dropping the field.
-	DurationMs float64 `json:"duration_ms"`
-}
 
 // newRefreshCmd returns the `meho topology refresh <target>` command.
 //
@@ -93,9 +73,21 @@ func runRefresh(cmd *cobra.Command, opts refreshOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	result, err := postRefresh(cmd.Context(), backplaneURL, opts.Target)
+	result, statusCode, body, err := postRefresh(cmd.Context(), backplaneURL, opts.Target)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if statusCode != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, statusCode, body, opts.JSONOut)
+	}
+	if result == nil {
+		// Guard 200 + missing-content-type leaving JSON200 nil — without
+		// this, printRefreshSummary would dereference nil. Mirrors the
+		// kb / memory iter-2 nil-guard pattern.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without a refresh-result payload", backplaneURL)),
+			opts.JSONOut)
 	}
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), result)
@@ -106,28 +98,44 @@ func runRefresh(cmd *cobra.Command, opts refreshOptions) error {
 
 // buildRefreshPath assembles the POST path. The target is a single
 // path segment; pathEscape keeps an operator-typed name with spaces
-// or slashes from corrupting the URL. Exposed for unit tests.
+// or slashes from corrupting the URL. The generated client also uses
+// the target name as a path segment internally; this helper stays
+// exposed for the unit test that asserts the wire-level path shape.
 func buildRefreshPath(target string) string {
 	return "/api/v1/topology/refresh/" + pathEscape(target)
 }
 
-func postRefresh(ctx context.Context, backplaneURL, target string) (*RefreshResult, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "POST", buildRefreshPath(target), nil)
+func postRefresh(
+	ctx context.Context,
+	backplaneURL, target string,
+) (*api.RefreshResult, int, []byte, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
-		return nil, err
+		return nil, 0, nil, err
 	}
-	var out RefreshResult
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode refresh response: %w", err)
+	resp, err := retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.RefreshApiV1TopologyRefreshTargetNamePostResponse, error) {
+			return authed.RefreshApiV1TopologyRefreshTargetNamePostWithResponse(ctx, target, nil)
+		},
+		func(r *api.RefreshApiV1TopologyRefreshTargetNamePostResponse) int { return r.StatusCode() },
+	)
+	if err != nil {
+		return nil, 0, nil, err
 	}
-	return &out, nil
+	return resp.JSON200, resp.StatusCode(), resp.Body, nil
 }
 
 // printRefreshSummary renders the reconcile counts as a compact
 // two-column summary. The shape mirrors the kb/vault sibling
 // convention of a stable key-value block rather than a one-row table.
-func printRefreshSummary(w io.Writer, target string, r *RefreshResult) {
-	fmt.Fprintf(w, "refreshed topology for %q (target_id=%s)\n", target, r.TargetID)
+//
+// `r.DurationMs` is a float32 in the generated client (the wire
+// contract is a Pydantic float); Printf's `%.0f` accepts both.
+// `r.TargetId` is a UUID (`openapi_types.UUID` ≡ `uuid.UUID`); its
+// `String()` method renders the canonical 8-4-4-4-12 form for the
+// audit-correlation line.
+func printRefreshSummary(w io.Writer, target string, r *api.RefreshResult) {
+	fmt.Fprintf(w, "refreshed topology for %q (target_id=%s)\n", target, r.TargetId)
 	fmt.Fprintf(w, "  nodes:  +%d  -%d  ~%d\n", r.AddedNodes, r.RemovedNodes, r.UpdatedNodes)
 	fmt.Fprintf(w, "  edges:  +%d  -%d  ~%d\n", r.AddedEdges, r.RemovedEdges, r.UpdatedEdges)
 	fmt.Fprintf(w, "  took:   %.0f ms\n", r.DurationMs)

--- a/cli/internal/cmd/topology/timeline.go
+++ b/cli/internal/cmd/topology/timeline.go
@@ -5,15 +5,16 @@ package topology
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
+	"net/http"
 	"strconv"
 	"time"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -37,7 +38,7 @@ import (
 // keyset compare and never duplicates or skips a returned row.
 //
 // Exit codes (shared with the sibling topology verbs via
-// renderRequestError / renderHTTPError):
+// renderRequestError / renderHTTPStatus):
 //   - 0   query returned cleanly (incl. zero-row result).
 //   - 2   auth_expired
 //   - 3   unreachable
@@ -137,9 +138,18 @@ func runTimeline(cmd *cobra.Command, opts timelineOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	result, err := getTimeline(cmd.Context(), backplaneURL, opts)
+	result, statusCode, body, err := getTimeline(cmd.Context(), backplaneURL, opts)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if statusCode != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, statusCode, body, opts.JSONOut)
+	}
+	if result == nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without a timeline payload", backplaneURL)),
+			opts.JSONOut)
 	}
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), result)
@@ -148,93 +158,77 @@ func runTimeline(cmd *cobra.Command, opts timelineOptions) error {
 	return nil
 }
 
-// buildTimelinePath assembles the GET path + query string for a
-// timeline call. Optional filters land as query params only when set
-// so the server applies its defaults for the rest. Duration shorthand
-// (e.g. "24h") is resolved client-side to an absolute ISO-8601 to
-// match the REST router's absolute-only contract — the audit-query
-// router parses shorthand server-side but the topology timeline route
-// (a fresh G9.3 surface) keeps shorthand on the CLI to minimise the
-// backend's parsing surface (one parser, in one place: the CLI). The
-// raw input falls through as-is if it doesn't parse as shorthand —
-// the operator may already have pasted an ISO-8601.
-func buildTimelinePath(opts timelineOptions, now time.Time) (string, error) {
-	q := url.Values{}
+// buildTimelineParams assembles the generated query-param shape for a
+// timeline call. Optional filters land as pointer fields only when
+// set so the server applies its defaults for the rest. Duration
+// shorthand (e.g. "24h") is resolved client-side to an absolute
+// time.Time the typed param then carries — keeps the shorthand vocab
+// out of the backend's parser surface (one parser, in one place: the
+// CLI).
+func buildTimelineParams(opts timelineOptions, now time.Time) (*api.TimelineRouteApiV1TopologyTimelineGetParams, error) {
+	params := &api.TimelineRouteApiV1TopologyTimelineGetParams{}
 	if opts.Target != "" {
-		q.Set("target", opts.Target)
+		t := opts.Target
+		params.Target = &t
 	}
 	if opts.Since != "" {
-		iso, err := resolveDurationOrISO(opts.Since, now)
+		ts, err := resolveDurationOrISO(opts.Since, now)
 		if err != nil {
-			return "", fmt.Errorf("--since %q: %w", opts.Since, err)
+			return nil, fmt.Errorf("--since %q: %w", opts.Since, err)
 		}
-		q.Set("since", iso)
+		params.Since = &ts
 	}
 	if opts.Until != "" {
-		iso, err := resolveDurationOrISO(opts.Until, now)
+		ts, err := resolveDurationOrISO(opts.Until, now)
 		if err != nil {
-			return "", fmt.Errorf("--until %q: %w", opts.Until, err)
+			return nil, fmt.Errorf("--until %q: %w", opts.Until, err)
 		}
-		q.Set("until", iso)
+		params.Until = &ts
 	}
 	if opts.Limit > 0 {
-		q.Set("limit", strconv.Itoa(opts.Limit))
+		l := opts.Limit
+		params.Limit = &l
 	}
 	if opts.Cursor != "" {
-		q.Set("cursor", opts.Cursor)
+		c := opts.Cursor
+		params.Cursor = &c
 	}
-	path := "/api/v1/topology/timeline"
-	if encoded := q.Encode(); encoded != "" {
-		path = path + "?" + encoded
-	}
-	return path, nil
+	return params, nil
 }
 
-func getTimeline(ctx context.Context, backplaneURL string, opts timelineOptions) (*TimelineResult, error) {
-	path, err := buildTimelinePath(opts, time.Now().UTC())
+func getTimeline(
+	ctx context.Context,
+	backplaneURL string,
+	opts timelineOptions,
+) (*api.TopologyTimelineResult, int, []byte, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
-		return nil, err
+		return nil, 0, nil, err
 	}
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
+	params, err := buildTimelineParams(opts, time.Now().UTC())
 	if err != nil {
-		return nil, err
+		return nil, 0, nil, err
 	}
-	var out TimelineResult
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode timeline response: %w", err)
+	resp, err := retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.TimelineRouteApiV1TopologyTimelineGetResponse, error) {
+			return authed.TimelineRouteApiV1TopologyTimelineGetWithResponse(ctx, params)
+		},
+		func(r *api.TimelineRouteApiV1TopologyTimelineGetResponse) int { return r.StatusCode() },
+	)
+	if err != nil {
+		return nil, 0, nil, err
 	}
-	return &out, nil
-}
-
-// TimelineEntry mirrors the backend `TopologyTimelineEntry` Pydantic
-// model (`backend/src/meho_backplane/topology/schemas.py`). Fields are
-// hand-written rather than oapi-codegen-generated for the same reason
-// the audit `Entry` shape is — the topology package stays decoupled
-// from oapi churn, matching the sibling-package convention.
-type TimelineEntry struct {
-	ValidFrom  string  `json:"valid_from"`
-	HistoryID  int64   `json:"history_id"`
-	Source     string  `json:"source"`
-	ChangeKind string  `json:"change_kind"`
-	ResourceID *string `json:"resource_id"`
-	Summary    string  `json:"summary"`
-	AuditID    *string `json:"audit_id"`
-}
-
-// TimelineResult mirrors the backend `TopologyTimelineResult`.
-// `NextCursor` keeps the JSON key as `null` (no `omitempty`) so a
-// re-marshal preserves the Pydantic wire shape — the audit
-// QueryResult does the same.
-type TimelineResult struct {
-	Rows       []TimelineEntry `json:"rows"`
-	NextCursor *string         `json:"next_cursor"`
+	return resp.JSON200, resp.StatusCode(), resp.Body, nil
 }
 
 // printTimelineTable renders the timeline page as a compact,
 // scannable table. Columns: VALID_FROM, SRC, CHANGE, SUMMARY,
 // AUDIT_ID. When `next_cursor` is set, a final NEXT line tells the
 // operator how to paste-paginate.
-func printTimelineTable(w io.Writer, r *TimelineResult) {
+//
+// `row.ValidFrom` is `time.Time` in the generated client; the table
+// renders the RFC3339 form (matching the pre-migration string column).
+func printTimelineTable(w io.Writer, r *api.TopologyTimelineResult) {
 	if r == nil || len(r.Rows) == 0 {
 		fmt.Fprintln(w, "no graph changes in the requested window")
 		return
@@ -243,11 +237,11 @@ func printTimelineTable(w io.Writer, r *TimelineResult) {
 		"VALID_FROM", "SRC", "CHANGE", "SUMMARY", "AUDIT_ID")
 	for _, row := range r.Rows {
 		fmt.Fprintf(w, "%-22s %-5s %-8s %-38s %s\n",
-			truncate(row.ValidFrom, 22),
+			truncate(row.ValidFrom.UTC().Format(time.RFC3339), 22),
 			row.Source,
 			truncate(row.ChangeKind, 8),
 			truncate(row.Summary, 38),
-			truncate(strDeref(row.AuditID), 36),
+			truncate(uuidPtrToString(row.AuditId), 36),
 		)
 	}
 	if r.NextCursor != nil && *r.NextCursor != "" {
@@ -255,18 +249,19 @@ func printTimelineTable(w io.Writer, r *TimelineResult) {
 	}
 }
 
-// strDeref returns *s or empty string when s is nil. Mirrors the
-// audit-package helper of the same name; duplicated to avoid the
-// import-cycle the cmd/audit → cmd/topology → cmd path would create.
-func strDeref(s *string) string {
-	if s == nil {
+// uuidPtrToString returns the canonical 8-4-4-4-12 form of a UUID
+// pointer or the empty string when nil. Replaces the pre-migration
+// strDeref helper (which worked on `*string`) for the generated
+// client's `*openapi_types.UUID` audit / resource id fields.
+func uuidPtrToString(u *openapi_types.UUID) string {
+	if u == nil {
 		return ""
 	}
-	return *s
+	return u.String()
 }
 
 // resolveDurationOrISO converts an operator-typed --since/--until
-// value into an absolute RFC3339 timestamp. Accepts:
+// value into an absolute time.Time. Accepts:
 //
 //   - duration shorthand: <N><unit> where unit ∈ {s,m,h,d,w}. Result
 //     is `now - duration`.
@@ -279,41 +274,40 @@ func strDeref(s *string) string {
 // surfaces accept the same vocabulary. Audit forensics often wants
 // sub-minute resolution (`30s`) and multi-week windows (`2w`), so
 // the timeline parser ships the wider grammar.
-func resolveDurationOrISO(raw string, now time.Time) (string, error) {
-	if iso, ok := tryParseDuration(raw, now); ok {
-		return iso, nil
+func resolveDurationOrISO(raw string, now time.Time) (time.Time, error) {
+	if ts, ok := tryParseDuration(raw, now); ok {
+		return ts, nil
 	}
 	parsed, err := time.Parse(time.RFC3339, raw)
 	if err == nil {
-		return parsed.UTC().Format(time.RFC3339), nil
+		return parsed.UTC(), nil
 	}
 	// One more shape: bare ISO-8601 date (no time component). Promote
-	// to RFC3339 midnight UTC so the server's `valid_from >= :since`
-	// compare lands somewhere meaningful for an operator typing a
-	// date.
+	// to midnight UTC so the server's `valid_from >= :since` compare
+	// lands somewhere meaningful for an operator typing a date.
 	parsed, err = time.Parse("2006-01-02", raw)
 	if err == nil {
-		return parsed.UTC().Format(time.RFC3339), nil
+		return parsed.UTC(), nil
 	}
-	return "", fmt.Errorf(
+	return time.Time{}, fmt.Errorf(
 		"not a duration shorthand (e.g. 24h) or ISO-8601 timestamp",
 	)
 }
 
 // tryParseDuration recognises <N><unit> shorthand. unit ∈ {s,m,h,d,w};
 // N is an unsigned integer ≤ 9999.
-func tryParseDuration(raw string, now time.Time) (string, bool) {
+func tryParseDuration(raw string, now time.Time) (time.Time, bool) {
 	if len(raw) < 2 {
-		return "", false
+		return time.Time{}, false
 	}
 	unit := raw[len(raw)-1]
 	digits := raw[:len(raw)-1]
 	if len(digits) == 0 || len(digits) > 4 {
-		return "", false
+		return time.Time{}, false
 	}
 	n, err := strconv.Atoi(digits)
 	if err != nil || n < 0 {
-		return "", false
+		return time.Time{}, false
 	}
 	var dur time.Duration
 	switch unit {
@@ -328,7 +322,7 @@ func tryParseDuration(raw string, now time.Time) (string, bool) {
 	case 'w':
 		dur = time.Duration(n) * 7 * 24 * time.Hour
 	default:
-		return "", false
+		return time.Time{}, false
 	}
-	return now.Add(-dur).UTC().Format(time.RFC3339), true
+	return now.Add(-dur).UTC(), true
 }

--- a/cli/internal/cmd/topology/topology.go
+++ b/cli/internal/cmd/topology/topology.go
@@ -45,6 +45,8 @@
 //     row aborts the entire batch (no partial apply). Re-running
 //     the same file is a per-row no-op. Role: tenant_admin.
 //
+// G9.3 timeline / diff / history verbs round out the topology surface.
+//
 // The fifth G9.1-T6 verb, `meho targets discover <product>`, lives
 // under `cli/internal/cmd/targets/discover.go` because it sits under
 // the canonical `/api/v1/targets` prefix next to the other target-
@@ -57,18 +59,20 @@
 // `meho login` wrote — same pattern as `meho audit`, `meho targets`,
 // and `meho kb`.
 //
-// The implementation deliberately follows the in-package HTTP helper
-// pattern the sibling verb trees use (one resolveBackplane /
-// doAuthedRequest / renderRequestError trio per package) rather than
-// a shared `cli/internal/api_client` package. The reason is the
-// import-cycle one the `kb` and `targets` packages already document:
-// each verb tree is registered onto the root command, so a shared
-// helper imported from cmd/* and from any per-tree package would
-// close the cycle. Duplicating the small, stable helpers is the
-// convention every sibling package follows. (Initiative #363 names a
-// `cli/internal/api_client/topology.go`; the codebase convention
-// supersedes that path — the intent, "a Go client for the T5
-// routes," is satisfied in-package.)
+// G0.12-T15 #1273 migrated this package off the sibling-verb pattern
+// of hand-rolled HTTP + hand-typed copies of the backend pydantic
+// models. Every verb here drives the generated
+// `api.ClientWithResponses` surface directly: `api.NewAuthedClient`
+// wires the bearer + lazy 401-refresh editor onto the embedded
+// `ClientWithResponses`, and the verbs call the typed `*WithResponse`
+// methods (`PathApiV1TopologyPathGetWithResponse` etc.). Consumer-side
+// struct drift — the #1069 root cause Initiative #1118 targets —
+// can't recur because we now consume `api.TopologyNode`,
+// `api.TopologyEdge`, `api.TopologyPath`, `api.TopologyHistoryResult`,
+// `api.TopologyTimelineResult`, `api.TopologyDiffResult`, and
+// `api.RefreshResult` directly. Opts into the T10 #1268
+// transport-layer response-body cap (1 MiB) so the generated parsers
+// can't be pinned by an unbounded backplane response.
 //
 // Per [CLAUDE.md](../../CLAUDE.md) postulate 5 these verbs are
 // operator-facing ergonomics; the agent surface for the same data is
@@ -76,7 +80,6 @@
 package topology
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -133,33 +136,169 @@ func NewRootCmd() *cobra.Command {
 	return cmd
 }
 
-// renderRequestError translates an error from one of the per-verb
-// request helpers into the right output.StructuredError category.
-// Same classification ladder as targets/targets.go but with the
-// topology-specific 4xx envelopes:
+// errMissingAccessToken is the sentinel newAuthedClient returns
+// when the stored token row exists but its access_token field is
+// empty. Routed to auth_expired (exit 2) with a `meho login` hint
+// rather than the generic transport-error path. Mirrors the kb /
+// memory siblings.
+var errMissingAccessToken = errors.New("meho: stored token has no access_token")
+
+// responseBodyCap bounds the bytes the topology verb tree's transport
+// will read off any backplane response body. 1 MiB matches the
+// per-call ceiling the substrate enforces server-side on the listing /
+// diff / history routes (timeline cursor pages, history rows capped at
+// 5000, diff entries at 1000) — generous headroom for a JSON payload
+// whose contract caps the row count well below the byte cap. Without
+// the cap, an adversarial or runaway backplane response could OOM the
+// CLI because the generated `Parse*Response` helpers call
+// `io.ReadAll(rsp.Body)` on an unbounded body before constructing the
+// typed envelope. The cap is installed at the transport layer via
+// `capRoundTripper` below so it applies uniformly to every typed verb
+// on the same `AuthedClient`. The sibling G0.12-T9 #1267 / G0.12-T10
+// #1268 / G0.12-T12 #1270 verb trees all install the same wrapper
+// locally rather than reach into `cli/internal/api/client.go` — the
+// shared `ResponseBodyLimit` option in that file is destined to
+// supersede every per-tree copy in a follow-on refactor; until then,
+// the inline wrapper keeps this migration's blast radius inside the
+// topology verb tree.
+const responseBodyCap int64 = 1 << 20
+
+// capRoundTripper wraps an http.RoundTripper so every response body
+// is re-bound to an http.MaxBytesReader before the typed-client
+// parsers (oapi-codegen's generated `Parse*Response` helpers, which
+// `io.ReadAll(rsp.Body)` to populate `*Response.Body []byte`) get a
+// chance to drain it. A read at or past `limit` surfaces as
+// `*http.MaxBytesError`, which `renderRequestError` maps to
+// `output.Unexpected` (exit 4 — `unexpected_response`) rather than
+// `output.Unreachable` (exit 3 — `network_unreachable`).
 //
-//   - 401 → auth_expired with a `meho login <url>` hint.
-//   - 403 (RBAC denial) → insufficient_role; the backend's 403 detail
-//     string names the required role (operator).
-//   - 404 → unexpected_response. `refresh` resolves the target via
-//     resolve_target, so its 404 carries the structured
-//     `{"error":"no_target","query":...,"matches":[...]}` envelope
-//     (near-misses surfaced); the read verbs never 404 (a missing
-//     node is an empty list / null path, 200), so a 404 there is a
-//     routing surprise surfaced verbatim.
-//   - 409 with detail.error == "ambiguous_node" → unexpected, listing
-//     the colliding kinds so the operator can re-issue with
-//     --node-kind (the anchor `kind` pin; --kind is the edge filter
-//     and does not clear this 409).
-//   - Any other 4xx/5xx → unexpected with the raw body.
-//   - Pure transport errors (timeouts, DNS, connection refused) →
-//     unreachable.
+// The `*http.MaxBytesError` shape was added in Go 1.19 and is the
+// canonical signal for "transport refused to read past N bytes."
+// The wrapper applies the cap server-wide on the underlying
+// transport so every typed verb on the same AuthedClient inherits
+// it uniformly.
+type capRoundTripper struct {
+	base  http.RoundTripper
+	limit int64
+}
+
+func (c *capRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := c.base.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	if resp.Body != nil && c.limit > 0 {
+		// http.MaxBytesReader returns an io.ReadCloser whose Close
+		// closes the underlying body, so the existing close
+		// discipline on the caller (oapi-codegen's `defer
+		// rsp.Body.Close()` inside every `*WithResponse` method)
+		// still drains the original body cleanly.
+		resp.Body = http.MaxBytesReader(nil, resp.Body, c.limit)
+	}
+	return resp, nil
+}
+
+// cappedHTTPClient returns an http.Client whose Transport caps every
+// response body at responseBodyCap. The clone keeps Timeout / Jar /
+// CheckRedirect intact and only swaps the Transport for the capped
+// wrapper so callers don't mutate http.DefaultClient (which is
+// process-global). Passing the returned client to
+// `api.AuthedClientOptions.HTTPClient` threads the cap through both
+// the bearer-injecting editor and the oauth2 refresh exchange.
+func cappedHTTPClient(base *http.Client) *http.Client {
+	if base == nil {
+		base = http.DefaultClient
+	}
+	clone := *base
+	transport := clone.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	clone.Transport = &capRoundTripper{base: transport, limit: responseBodyCap}
+	return &clone
+}
+
+// newAuthedClient builds an api.AuthedClient for the supplied
+// backplane URL with the 1 MiB response-body cap installed at the
+// transport layer, and verifies a non-empty bearer is loaded.
+// Centralised so every verb's typed-call path goes through the same
+// "stored-token-loaded + non-empty bearer" gate; the caller forwards
+// any returned error to renderRequestError for category mapping.
+// Mirrors the sibling verb-tree migrations (G0.12-T9 #1267 kb,
+// G0.12-T10 #1268 memory, G0.12-T12 #1270 retrieval).
+func newAuthedClient(ctx context.Context, backplaneURL string) (*api.AuthedClient, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{
+		HTTPClient: cappedHTTPClient(nil),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if authed.AccessToken() == "" {
+		return nil, errMissingAccessToken
+	}
+	return authed, nil
+}
+
+// retryOn401 invokes call once, and if the typed response carries a
+// 401, runs a one-shot bearer refresh and re-issues call. Same
+// shape `kb` adopted in G0.12-T9 #1267 and `memory` re-used in
+// G0.12-T10 #1268 so every topology verb runs the same
+// transparent-retry contract.
+//
+// statusOf reads the StatusCode off the typed response envelope (the
+// generated *Response types expose StatusCode() through their
+// embedded *http.Response). A nil response counts as "no retry" —
+// the transport already failed and the caller surfaces err directly.
+func retryOn401[R any](
+	ctx context.Context,
+	authed *api.AuthedClient,
+	call func(ctx context.Context) (*R, error),
+	statusOf func(*R) int,
+) (*R, error) {
+	resp, err := call(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || statusOf(resp) != http.StatusUnauthorized {
+		return resp, nil
+	}
+	if rerr := authed.Refresh(ctx); rerr != nil {
+		return resp, rerr
+	}
+	return call(ctx)
+}
+
+// renderRequestError translates a transport-layer request error
+// into the right output.StructuredError category. Maps the topology
+// REST surface's pre-response failures: missing bearer, no-refresh-
+// token, token-not-found, body-cap / parse failures bubbling out of
+// the generated `*WithResponse` parsers, plus the generic transport-
+// down case. Non-2xx status codes carried in a typed response
+// envelope are classified by renderHTTPStatus instead.
+//
+// Parse / cap failures route to `output.Unexpected` (exit 4 —
+// `unexpected_response`) rather than `output.Unreachable` (exit 3 —
+// `network_unreachable`). A 1 MiB body cap firing or a JSON decode
+// rejecting a malformed payload is a contract / shape failure on
+// the server side, not a transport-down failure on the operator's
+// side; surfacing it as "unreachable" would send operators chasing
+// a network ghost. The cap is installed by `newAuthedClient` via
+// `api.AuthedClientOptions.ResponseBodyLimit` (responseBodyCap).
 func renderRequestError(
 	cmd *cobra.Command,
 	backplaneURL string,
 	err error,
 	jsonOut bool,
 ) error {
+	if errors.Is(err, errMissingAccessToken) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored credentials for %s are incomplete; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
 	if api.IsTokenNotFound(err) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.AuthExpired(fmt.Sprintf(
@@ -178,9 +317,23 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
-		return renderHTTPError(cmd, backplaneURL, he, jsonOut)
+	// Transport-layer body-cap firing (*http.MaxBytesReader returned
+	// from capRoundTripper) and JSON shape failures bubbling out of
+	// the generated parsers are server-side contract failures, not
+	// transport-down failures — surface them as unexpected_response
+	// (exit 4) with the backplane URL so the operator sees the
+	// origin without chasing a network ghost.
+	var maxBytesErr *http.MaxBytesError
+	var syntaxErr *json.SyntaxError
+	var unmarshalErr *json.UnmarshalTypeError
+	if errors.As(err, &maxBytesErr) ||
+		errors.As(err, &syntaxErr) ||
+		errors.As(err, &unmarshalErr) ||
+		errors.Is(err, io.ErrUnexpectedEOF) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+			jsonOut,
+		)
 	}
 	return output.RenderError(cmd.ErrOrStderr(),
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
@@ -188,15 +341,36 @@ func renderRequestError(
 	)
 }
 
-// renderHTTPError classifies a non-2xx response into the right
-// StructuredError category.
-func renderHTTPError(
+// renderHTTPStatus classifies a non-2xx response carried in the
+// typed envelope into the right StructuredError category. Same
+// classification ladder as the pre-migration `renderHTTPError` switch
+// but acts on the (statusCode, body) pair lifted off the generated
+// `*Response.HTTPResponse` + `Body` fields rather than a sentinel
+// `httpError` value:
+//
+//   - 401 → auth_expired with a `meho login <url>` hint.
+//   - 403 (RBAC denial) → insufficient_role; the backend's 403 detail
+//     string names the required role (operator).
+//   - 404 → unexpected_response. `refresh` resolves the target via
+//     resolve_target, so its 404 carries the structured
+//     `{"error":"no_target","query":...,"matches":[...]}` envelope
+//     (near-misses surfaced); the read verbs never 404 (a missing
+//     node is an empty list / null path, 200), so a 404 there is a
+//     routing surprise surfaced verbatim.
+//   - 409 with detail.error == "ambiguous_node" → unexpected, listing
+//     the colliding kinds so the operator can re-issue with
+//     --node-kind (the anchor `kind` pin; --kind is the edge filter
+//     and does not clear this 409).
+//   - Any other 4xx/5xx → unexpected with the raw body.
+func renderHTTPStatus(
 	cmd *cobra.Command,
 	backplaneURL string,
-	he *httpError,
+	statusCode int,
+	body []byte,
 	jsonOut bool,
 ) error {
-	switch he.StatusCode {
+	bodyStr := strings.TrimSpace(string(body))
+	switch statusCode {
 	case http.StatusUnauthorized:
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.AuthExpired(fmt.Sprintf(
@@ -210,7 +384,7 @@ func renderHTTPError(
 		// ({"detail": "<string>"}). require_role writes the required
 		// role into the detail string; pass it through verbatim.
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.InsufficientRole(decodeDetailString(he.Body)),
+			output.InsufficientRole(decodeDetailString(bodyStr)),
 			jsonOut,
 		)
 	case http.StatusNotFound:
@@ -221,7 +395,7 @@ func renderHTTPError(
 		// cross-tenant boundary surface for refresh: a target in
 		// another tenant resolves to no_target, identical to a typo.
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(formatNotFound(he.Body)),
+			output.Unexpected(formatNotFound(bodyStr)),
 			jsonOut,
 		)
 	case http.StatusConflict:
@@ -231,13 +405,13 @@ func renderHTTPError(
 		// (the anchor `kind` pin — not --kind, which is the edge
 		// filter `kind_filter` and cannot clear the ambiguity).
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(formatAmbiguousNode(he.Body)),
+			output.Unexpected(formatAmbiguousNode(bodyStr)),
 			jsonOut,
 		)
 	default:
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, statusCode, bodyStr)),
 			jsonOut,
 		)
 	}
@@ -328,101 +502,14 @@ func formatAmbiguousNode(body string) string {
 	return "ambiguous node: " + decodeDetailString(body)
 }
 
-// doAuthedRequest issues a single HTTP request against the backplane
-// with bearer injection + one-shot 401-refresh-retry. Returns the
-// response body bytes (already drained) on a 2xx outcome, or an
-// *httpError when the backplane returned a non-2xx, or an error
-// categorised by api.IsTokenNotFound / api.IsNoRefreshToken / generic
-// transport so renderRequestError can pick the right category.
-//
-// Mirrors cli/internal/cmd/targets/targets.go::doAuthedRequest. Kept
-// independent of the targets package for the import-cycle reason
-// called out on resolveBackplane.
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
-	}
-
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		// One-shot refresh + retry, mirroring the targets sibling.
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MiB cap
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-// httpError carries a non-2xx response so per-verb runners can render
-// the right category. Not an output.StructuredError directly —
-// renderHTTPError decides exit-code class based on status.
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-// sendRequest is the bottom of the stack: build the http.Request,
-// stamp bearer + content headers, fire it. Split out so the
-// 401-refresh-retry path can reuse the same body bytes.
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
-}
-
 // pathEscape escapes a single path segment for use inside a backend
 // URL. url.PathEscape escapes path-segment-unsafe characters without
 // touching the unreserved set.
+//
+// Still useful for the small handful of CLI-side paths that the
+// G0.12-T15 migration kept hand-rolled (refresh's path-shape test
+// fixture, plus the test plumbing that pre-dates the typed-client
+// transport).
 func pathEscape(segment string) string {
 	return url.PathEscape(segment)
 }

--- a/cli/internal/cmd/topology/topology_test.go
+++ b/cli/internal/cmd/topology/topology_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/auth"
 )
 
@@ -91,7 +92,11 @@ func TestNewRootCmdWiresAllVerbs(t *testing.T) {
 }
 
 // TestBuildRefreshPathEscapes — an operator-typed target with a slash
-// must not split the URL path.
+// must not split the URL path. The generated client's path-shape
+// machinery uses url.PathEscape on each path-param; this test
+// re-asserts the contract against the package-local pathEscape helper
+// so a future refactor that delegates to a different escape routine
+// surfaces immediately.
 func TestBuildRefreshPathEscapes(t *testing.T) {
 	got := buildRefreshPath("a/b")
 	if got != "/api/v1/topology/refresh/a%2Fb" {
@@ -100,11 +105,22 @@ func TestBuildRefreshPathEscapes(t *testing.T) {
 }
 
 // TestBuildClosurePathOmitsDefaults — the empty-options shape sends
-// no query string so the server applies its defaults.
+// no query string so the server applies its defaults. With the typed
+// client the path is implicit (the generated `NewDependents…Request`
+// builds it from `name + params`); the contract here is that no
+// param fields are populated when the options are empty.
 func TestBuildClosurePathOmitsDefaults(t *testing.T) {
-	got := buildClosurePath(closureOptions{Verb: "dependents", Name: "foo"})
-	if got != "/api/v1/topology/dependents/foo" {
-		t.Fatalf("default path: got %q", got)
+	opts := closureOptions{Verb: "dependents", Name: "foo"}
+	// Mirror the closureQueryParam build that getClosure runs:
+	// every pointer field must be nil.
+	if depth := buildClosureParamsForTest(opts).Depth; depth != nil {
+		t.Errorf("Depth should be nil; got %v", depth)
+	}
+	if kf := buildClosureParamsForTest(opts).KindFilter; kf != nil {
+		t.Errorf("KindFilter should be nil; got %v", kf)
+	}
+	if k := buildClosureParamsForTest(opts).Kind; k != nil {
+		t.Errorf("Kind should be nil; got %v", k)
 	}
 }
 
@@ -113,37 +129,67 @@ func TestBuildClosurePathOmitsDefaults(t *testing.T) {
 // param contract; --kind is the edge filter, --node-kind disambiguates
 // the anchor).
 func TestBuildClosurePathMapsFlags(t *testing.T) {
-	got := buildClosurePath(closureOptions{
+	opts := closureOptions{
 		Verb: "dependencies", Name: "db", Depth: 4,
 		EdgeKind: "mounts", NodeKind: "datastore",
-	})
-	if !strings.HasPrefix(got, "/api/v1/topology/dependencies/db?") {
-		t.Fatalf("path prefix wrong: %q", got)
 	}
-	for _, want := range []string{"depth=4", "kind_filter=mounts", "kind=datastore"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("buildClosurePath missing %q in %q", want, got)
-		}
+	params := buildClosureParamsForTest(opts)
+	if params.Depth == nil || *params.Depth != 4 {
+		t.Errorf("Depth: got %v; want 4", params.Depth)
+	}
+	if params.KindFilter == nil || *params.KindFilter != "mounts" {
+		t.Errorf("KindFilter: got %v; want mounts", params.KindFilter)
+	}
+	if params.Kind == nil || *params.Kind != "datastore" {
+		t.Errorf("Kind: got %v; want datastore", params.Kind)
 	}
 }
 
+// buildClosureParamsForTest mirrors the per-verb branch inside
+// getClosure so the unit tests can assert the typed-param shape
+// without standing up an httptest.Server. Returns the
+// dependencies-flavoured params struct because both branches share
+// the same field set; the test's assertions don't read the type-
+// discriminator.
+func buildClosureParamsForTest(opts closureOptions) *api.DependenciesApiV1TopologyDependenciesNameGetParams {
+	params := &api.DependenciesApiV1TopologyDependenciesNameGetParams{}
+	if opts.Depth > 0 {
+		d := opts.Depth
+		params.Depth = &d
+	}
+	if opts.EdgeKind != "" {
+		k := opts.EdgeKind
+		params.KindFilter = &k
+	}
+	if opts.NodeKind != "" {
+		k := opts.NodeKind
+		params.Kind = &k
+	}
+	return params
+}
+
 // TestBuildPathQuerySetsFromTo — from/to are always present; the
-// optional pins/hop cap ride along only when set.
+// optional pins/hop cap ride along only when set. Replaces the
+// pre-migration buildPathQuery unit-shape assertion with a typed-
+// param check against the generator's `PathApiV1TopologyPathGetParams`
+// shape.
 func TestBuildPathQuerySetsFromTo(t *testing.T) {
-	got := buildPathQuery(pathOptions{From: "a", To: "b"})
-	for _, want := range []string{"from=a", "to=b"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("buildPathQuery missing %q in %q", want, got)
-		}
+	got := buildPathParams(pathOptions{From: "a", To: "b"})
+	if got.From != "a" || got.To != "b" {
+		t.Errorf("from/to: got from=%q to=%q", got.From, got.To)
 	}
-	if strings.Contains(got, "max_hops") {
-		t.Errorf("buildPathQuery should omit max_hops when unset: %q", got)
+	if got.MaxHops != nil {
+		t.Errorf("buildPathParams should omit MaxHops when unset: %v", got.MaxHops)
 	}
-	got = buildPathQuery(pathOptions{From: "a", To: "b", MaxHops: 3, FromKind: "vm", ToKind: "host"})
-	for _, want := range []string{"max_hops=3", "from_kind=vm", "to_kind=host"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("buildPathQuery missing %q in %q", want, got)
-		}
+	got = buildPathParams(pathOptions{From: "a", To: "b", MaxHops: 3, FromKind: "vm", ToKind: "host"})
+	if got.MaxHops == nil || *got.MaxHops != 3 {
+		t.Errorf("MaxHops: got %v; want 3", got.MaxHops)
+	}
+	if got.FromKind == nil || *got.FromKind != "vm" {
+		t.Errorf("FromKind: got %v; want vm", got.FromKind)
+	}
+	if got.ToKind == nil || *got.ToKind != "host" {
+		t.Errorf("ToKind: got %v; want host", got.ToKind)
 	}
 }
 
@@ -165,9 +211,9 @@ func TestPrintNodeClosureEmpty(t *testing.T) {
 // dependent with its via-edge kind.
 func TestPrintNodeClosureRendersRows(t *testing.T) {
 	via := "runs-on"
-	rows := []Node{
-		{ID: "1", Kind: "host", Name: "esxi-1", Depth: 0, ViaEdgeKind: nil},
-		{ID: "2", Kind: "vm", Name: "web-1", Depth: 1, ViaEdgeKind: &via},
+	rows := []api.TopologyNode{
+		{Kind: "host", Name: "esxi-1", Depth: 0, ViaEdgeKind: nil},
+		{Kind: "vm", Name: "web-1", Depth: 1, ViaEdgeKind: &via},
 	}
 	var buf bytes.Buffer
 	printNodeClosure(&buf, "esxi-1", rows)
@@ -192,8 +238,8 @@ func TestPrintPathNil(t *testing.T) {
 // TestPrintPathChain — a two-hop chain renders kind/name arrows and a
 // pluralised hop count.
 func TestPrintPathChain(t *testing.T) {
-	p := &Path{
-		Nodes: []Node{
+	p := &api.TopologyPath{
+		Nodes: []api.TopologyNode{
 			{Kind: "vm", Name: "web-1"},
 			{Kind: "host", Name: "esxi-1"},
 			{Kind: "datastore", Name: "ds-1"},
@@ -213,8 +259,8 @@ func TestPrintPathChain(t *testing.T) {
 
 // TestPrintPathSingleHopSingular — one hop is rendered "1 hop".
 func TestPrintPathSingleHopSingular(t *testing.T) {
-	p := &Path{
-		Nodes:     []Node{{Kind: "vm", Name: "a"}, {Kind: "host", Name: "b"}},
+	p := &api.TopologyPath{
+		Nodes:     []api.TopologyNode{{Kind: "vm", Name: "a"}, {Kind: "host", Name: "b"}},
 		TotalHops: 1,
 	}
 	var buf bytes.Buffer
@@ -288,29 +334,50 @@ func TestEdgeKindVocabularyMatchesEnum(t *testing.T) {
 }
 
 // TestBuildListEdgesPathOmitsDefaults — empty options send no query
-// string so the server applies its defaults.
+// string so the server applies its defaults. Asserts the typed-param
+// shape (every pointer field nil; Conflicts off) since the wire-level
+// query string is now assembled by the generated client.
 func TestBuildListEdgesPathOmitsDefaults(t *testing.T) {
-	got := buildListEdgesPath(listEdgesOptions{})
-	if got != "/api/v1/topology/edges" {
-		t.Fatalf("default path: got %q", got)
+	got := buildListEdgesParams(listEdgesOptions{})
+	if got.Kind != nil || got.Source != nil || got.From != nil || got.To != nil {
+		t.Fatalf("default params should leave filters nil; got %+v", got)
+	}
+	if got.Conflicts != nil {
+		t.Fatalf("Conflicts should default to nil (omit); got %v", got.Conflicts)
+	}
+	if got.Limit != nil || got.Offset != nil {
+		t.Fatalf("Limit/Offset should default to nil (omit); got limit=%v offset=%v", got.Limit, got.Offset)
 	}
 }
 
 // TestBuildListEdgesPathMapsFilters — every flag maps to the route's
 // documented query-param name; --conflicts only rides when true.
 func TestBuildListEdgesPathMapsFilters(t *testing.T) {
-	got := buildListEdgesPath(listEdgesOptions{
+	got := buildListEdgesParams(listEdgesOptions{
 		Kind: "depends-on", Source: "curated",
 		From: "svc", To: "db",
 		Conflicts: true, Limit: 25, Offset: 5,
 	})
-	if !strings.HasPrefix(got, "/api/v1/topology/edges?") {
-		t.Fatalf("prefix wrong: %q", got)
+	if got.Kind == nil || string(*got.Kind) != "depends-on" {
+		t.Errorf("Kind: got %v; want depends-on", got.Kind)
 	}
-	for _, want := range []string{"kind=depends-on", "source=curated", "from=svc", "to=db", "conflicts=true", "limit=25", "offset=5"} {
-		if !strings.Contains(got, want) {
-			t.Errorf("buildListEdgesPath missing %q in %q", want, got)
-		}
+	if got.Source == nil || *got.Source != "curated" {
+		t.Errorf("Source: got %v; want curated", got.Source)
+	}
+	if got.From == nil || *got.From != "svc" {
+		t.Errorf("From: got %v; want svc", got.From)
+	}
+	if got.To == nil || *got.To != "db" {
+		t.Errorf("To: got %v; want db", got.To)
+	}
+	if got.Conflicts == nil || !*got.Conflicts {
+		t.Errorf("Conflicts: got %v; want true", got.Conflicts)
+	}
+	if got.Limit == nil || *got.Limit != 25 {
+		t.Errorf("Limit: got %v; want 25", got.Limit)
+	}
+	if got.Offset == nil || *got.Offset != 5 {
+		t.Errorf("Offset: got %v; want 5", got.Offset)
 	}
 }
 

--- a/cli/internal/cmd/topology/unannotate.go
+++ b/cli/internal/cmd/topology/unannotate.go
@@ -8,11 +8,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -121,8 +123,8 @@ func runUnannotate(cmd *cobra.Command, opts unannotateOptions) error {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 
-	edgeID := opts.EdgeID
-	if edgeID == "" {
+	edgeIDStr := opts.EdgeID
+	if edgeIDStr == "" {
 		// Tuple form — resolve client-side. The list helper applies the
 		// tenant scope server-side, so a cross-tenant tuple returns an
 		// empty list (rendered as "not found"), never another tenant's
@@ -134,24 +136,24 @@ func runUnannotate(cmd *cobra.Command, opts unannotateOptions) error {
 		if err != nil {
 			return renderUnannotateResolveError(cmd, backplaneURL, err, opts)
 		}
-		edgeID = resolved
-	} else {
-		if _, perr := uuid.Parse(edgeID); perr != nil {
-			return output.RenderError(cmd.ErrOrStderr(),
-				output.Unexpected(fmt.Sprintf(
-					"invalid <edge-id> %q: not a UUID (%v)", edgeID, perr)),
-				opts.JSONOut)
-		}
+		edgeIDStr = resolved
+	}
+	edgeUUID, perr := uuid.Parse(edgeIDStr)
+	if perr != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"invalid <edge-id> %q: not a UUID (%v)", edgeIDStr, perr)),
+			opts.JSONOut)
 	}
 
-	if err := deleteEdge(cmd.Context(), backplaneURL, edgeID); err != nil {
+	if err := deleteEdge(cmd.Context(), backplaneURL, edgeUUID); err != nil {
 		return renderUnannotateDeleteError(cmd, backplaneURL, err, opts.JSONOut)
 	}
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(),
-			map[string]string{"deleted": edgeID})
+			map[string]string{"deleted": edgeUUID.String()})
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "deleted edge %s\n", edgeID)
+	fmt.Fprintf(cmd.OutOrStdout(), "deleted edge %s\n", edgeUUID)
 	return nil
 }
 
@@ -174,9 +176,14 @@ func resolveCuratedEdgeID(
 		To:     opts.To,
 		Limit:  2, // 2 is enough to detect ambiguity without dragging back the world.
 	}
-	edges, err := getEdges(ctx, backplaneURL, listOpts)
+	edges, statusCode, body, err := getEdges(ctx, backplaneURL, listOpts)
 	if err != nil {
 		return "", err
+	}
+	if statusCode != http.StatusOK {
+		// Surface a synthetic httpStatusError so the caller can route
+		// to the same renderHTTPStatus path the deleted-edge call uses.
+		return "", &httpStatusError{StatusCode: statusCode, Body: body}
 	}
 	// Filter client-side by endpoint kind when the operator pinned one
 	// — the list route filters by name only.
@@ -197,13 +204,13 @@ func resolveCuratedEdgeID(
 	case 0:
 		return "", &unannotateResolveError{kind: "not_found"}
 	case 1:
-		return edges[0].ID, nil
+		return edges[0].Id.String(), nil
 	default:
 		ids := make([]string, 0, len(edges))
 		for _, e := range edges {
 			ids = append(ids, fmt.Sprintf(
 				"%s (%s/%s --[%s]--> %s/%s)",
-				e.ID, e.From.Kind, e.From.Name, e.Kind, e.To.Kind, e.To.Name))
+				e.Id, e.From.Kind, e.From.Name, e.Kind, e.To.Kind, e.To.Name))
 		}
 		return "", &unannotateResolveError{
 			kind:    "ambiguous",
@@ -226,6 +233,20 @@ func (e *unannotateResolveError) Error() string {
 		return "ambiguous tuple matches multiple edges"
 	}
 	return "no matching curated edge"
+}
+
+// httpStatusError is the bridge for non-2xx responses surfaced from a
+// helper that has no direct cobra context (e.g. resolveCuratedEdgeID).
+// Carries (statusCode, body) so the caller's renderUnannotate* helper
+// can route through the shared renderHTTPStatus / renderUnannotateDeleteError
+// ladder.
+type httpStatusError struct {
+	StatusCode int
+	Body       []byte
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, strings.TrimSpace(string(e.Body)))
 }
 
 func renderUnannotateResolveError(
@@ -252,25 +273,33 @@ func renderUnannotateResolveError(
 				opts.From, opts.Kind, opts.To)),
 			opts.JSONOut)
 	}
+	var he *httpStatusError
+	if errors.As(err, &he) {
+		return renderHTTPStatus(cmd, backplaneURL, he.StatusCode, he.Body, opts.JSONOut)
+	}
 	return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 }
 
 // renderUnannotateDeleteError intercepts the route's 409 auto-edge
 // envelope so the operator sees the server's `detail.message`
 // verbatim — the annotate-over-auto remediation guidance — instead of
-// the raw 409 body the generic renderHTTPError would surface.
+// the raw 409 body the generic renderHTTPStatus would surface.
 func renderUnannotateDeleteError(
 	cmd *cobra.Command,
 	backplaneURL string,
 	err error,
 	jsonOut bool,
 ) error {
-	var he *httpError
-	if errors.As(err, &he) && he.StatusCode == 409 {
-		if msg := formatAutoEdgeConflict(he.Body); msg != "" {
+	var he *httpStatusError
+	if errors.As(err, &he) && he.StatusCode == http.StatusConflict {
+		if msg := formatAutoEdgeConflict(string(he.Body)); msg != "" {
 			return output.RenderError(cmd.ErrOrStderr(),
 				output.Unexpected(msg), jsonOut)
 		}
+		return renderHTTPStatus(cmd, backplaneURL, he.StatusCode, he.Body, jsonOut)
+	}
+	if errors.As(err, &he) {
+		return renderHTTPStatus(cmd, backplaneURL, he.StatusCode, he.Body, jsonOut)
 	}
 	return renderRequestError(cmd, backplaneURL, err, jsonOut)
 }
@@ -306,9 +335,27 @@ func formatAutoEdgeConflict(body string) string {
 	return fmt.Sprintf("cannot delete edge %s: %s", detail.EdgeID, detail.Message)
 }
 
-func deleteEdge(ctx context.Context, backplaneURL, edgeID string) error {
-	// edgeID is UUID-validated above; pathEscape is belt-and-braces.
-	_, err := doAuthedRequest(ctx, backplaneURL,
-		"DELETE", "/api/v1/topology/edges/"+pathEscape(edgeID), nil)
-	return err
+// deleteEdge issues the DELETE call against the generated typed
+// client. The route returns 204 No Content on success (whether the
+// row existed or not — idempotent contract) and 409 + structured
+// detail for an auto-row delete attempt. The caller forwards the
+// returned error to renderUnannotateDeleteError for category mapping.
+func deleteEdge(ctx context.Context, backplaneURL string, edgeID uuid.UUID) error {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return err
+	}
+	resp, err := retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.UnannotateEdgeRouteApiV1TopologyEdgesEdgeIdDeleteResponse, error) {
+			return authed.UnannotateEdgeRouteApiV1TopologyEdgesEdgeIdDeleteWithResponse(ctx, edgeID, nil)
+		},
+		func(r *api.UnannotateEdgeRouteApiV1TopologyEdgesEdgeIdDeleteResponse) int { return r.StatusCode() },
+	)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode() == http.StatusNoContent {
+		return nil
+	}
+	return &httpStatusError{StatusCode: resp.StatusCode(), Body: resp.Body}
 }

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -1133,30 +1133,47 @@ discipline `meho targets list --limit` applies.
 ### Reserved flags (every verb)
 
 - `--json` — emit the raw envelope to stdout instead of the human
-  render. Stable schemas: `refresh` → `RefreshResult`;
-  `dependents`/`dependencies` → `[]Node`; `path` →
-  `Path` or literal `null` (the unreachable answer, emitted
-  verbatim so jq consumers see one contract); `annotate` →
-  `TopologyEdge` (the 201 response shape); `unannotate` →
+  render. Stable schemas (all are now the generated typed shapes
+  per G0.12-T15 #1273): `refresh` → `api.RefreshResult`;
+  `dependents`/`dependencies` → `[]api.TopologyNode`; `path` →
+  `api.TopologyPath` or literal `null` (the unreachable answer,
+  emitted verbatim so jq consumers see one contract); `annotate` →
+  `api.TopologyEdge` (the 201 response shape); `unannotate` →
   `{"deleted": "<edge_id>"}` on success; `list-edges` →
-  `[]TopologyEdge`.
+  `[]api.TopologyEdge`.
 - `--backplane <url>` — override the backplane URL (defaults to the
   URL `meho login` recorded).
 
 ### HTTP shape + exit codes
 
-Same in-package `resolveBackplane` / `doAuthedRequest` /
-`renderRequestError` trio every sibling verb tree carries (the
-shared-helper-vs-import-cycle reason `kb.go` documents — Initiative
-#363 names a `cli/internal/api_client/topology.go`, but the codebase
-convention supersedes that path; the intent is satisfied in-package).
-`renderHTTPError` adds the topology-specific 409 `ambiguous_node`
-classifier (names the colliding kinds + the `--node-kind` remedy) and
-reuses the resolver's structured 404 near-miss formatter for
-`refresh`. Exit codes: `0` ok (including empty closure / no drift /
-no path — all operationally meaningful, never 404), `2` auth_expired,
-`3` unreachable, `4` unexpected_response (404 / 409 / malformed),
-`5` insufficient_role (403; backend names the required role).
+G0.12-T15 #1273 migrated the verb tree off the hand-rolled
+`doAuthedRequest` + duplicated-struct pattern to the generated
+`api.ClientWithResponses` typed surface. Every verb's request helper
+now goes through the package-local `newAuthedClient` (which installs
+the 1 MiB transport-layer response-body cap via a `capRoundTripper`
+HTTP-client wrapper — the T12 #1270 inline-cap pattern, kept local
+to this verb tree until the cap settles into
+`api.AuthedClientOptions`) and the generic `retryOn401[R]` helper
+(one-shot bearer refresh on 401, transparent to the caller). The
+response is the generated `*WithResponse` envelope; the verb branches
+on `resp.StatusCode()`, forwards 4xx/5xx bodies to
+`renderHTTPStatus`, and consumes `resp.JSON200` / `resp.JSON201`
+directly.
+
+`renderHTTPStatus` carries the topology-specific 409
+`ambiguous_node` classifier (names the colliding kinds + the
+`--node-kind` remedy) and reuses the resolver's structured 404
+near-miss formatter for `refresh`. The 409 auto-row-deletion 409 on
+`unannotate` is intercepted by `renderUnannotateDeleteError` so the
+operator sees the server's `detail.message` verbatim (the
+annotate-over-auto remediation guidance) rather than a raw HTTP
+dump.
+
+Exit codes: `0` ok (including empty closure / no drift / no path —
+all operationally meaningful, never 404), `2` auth_expired, `3`
+unreachable, `4` unexpected_response (404 / 409 / malformed body /
+cap-fired transport), `5` insufficient_role (403; backend names the
+required role).
 
 ## Server-driven discovery (`internal/discovery/`)
 


### PR DESCRIPTION
## Summary

- Migrates `cli/internal/cmd/topology/` (the 11 `meho topology *` verbs across 15 source files) off hand-rolled `doAuthedRequest` + duplicated consumer-side structs (`Node`, `Edge`, `EdgeEndpoint`, `Path`, `HistoryEntry/Result`, `TimelineEntry/Result`, `DiffEntry`, `RefreshResult`) onto the generated `api.ClientWithResponses` typed surface.
- Reuses the canonical Initiative #1118 pattern: `newAuthedClient` + `retryOn401[R]` + typed `*WithResponse` methods. Installs the 1 MiB response-body cap inline via the T12 #1270 `capRoundTripper` wrapper (no `cli/internal/api/client.go` modifications).
- `path` verb's literal-JSON-`null` unreachable contract preserved via explicit `isJSONNull` byte check; oapi-codegen otherwise populates a non-nil zero-value envelope for `null` bodies.
- Tests reworked against typed shapes — real UUIDs for `RefreshResult.TargetId`, `Content-Type: application/json` set before `WriteHeader` so the generated parser populates `JSON200/JSON201`.
- `docs/codebase/cli.md` topology section refreshed for the typed contracts.

## Test plan

- [x] `go vet ./cli/...` — clean
- [x] `go test ./cli/...` — pass (including `topology` package + the multi-verb composition `e2e_test.go`)
- [x] `gofmt -l cli/internal/cmd/topology/` — clean
- [x] **AC1**: `grep -rn "http.NewRequest\|doAuthedRequest\|^type Node \|^type Edge \|^type EdgeEndpoint \|^type Path \|^type HistoryEntry \|^type HistoryResult \|^type TimelineEntry \|^type TimelineResult \|^type DiffEntry \|^type RefreshResult " cli/internal/cmd/topology/` returns 0 matches
- [x] **AC2**: `grep -rn "api.ClientWithResponses\|api.TopologyNode\|api.TopologyEdge" cli/internal/cmd/topology/` returns matches across the verb files (annotate / closure / list_edges / nodes / topology + tests + docstring)
- [x] **AC4**: error category mapping preserved — 401 → `AuthExpired`, 403 → `InsufficientRole`, 404 → `Unexpected(topology_node_not_found)`, 422 → `Unexpected(body)`; 409 `auto_edge_deletion` still renders the server's verbatim message, 409 `ambiguous_node` still renders the `--node-kind` remedy
- [x] **AC7**: no change to `backend/src/meho_backplane/api/v1/topology.py` (no backend files touched)
- [ ] **AC5**: `cd cli && make snapshot-openapi && make generate` no-op — locally not runnable (requires backend `uv` environment); the snapshot freshness gate in CI (`.github/workflows/cli-api-snapshot.yml`) validates this on every PR
- [ ] Manual smoke for representative verbs against a live backplane (deferred — orchestrator validates byte-identity on merge)

## Out of scope

- Other CLI verb directories (Initiative #1118's per-verb-tree sweep continues in T13/T14/etc.).
- Adding `ResponseBodyLimit` to `api.AuthedClientOptions` — the inline `capRoundTripper` keeps this PR's blast radius inside the topology verb tree (the shared option lands separately when the sibling initiative settles).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1273
