### PR TITLE
refactor(cli-scheduler): G0.12-T13 migrate cmd/scheduler/ to typed client (#1271)

### DIFF
--- a/cli/internal/cmd/scheduler/cancel.go
+++ b/cli/internal/cmd/scheduler/cancel.go
@@ -6,10 +6,11 @@ package scheduler
 import (
 	"context"
 	"fmt"
-	"net/url"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -70,29 +71,45 @@ type cancelOptions struct {
 	BackplaneOverride string
 }
 
-// buildCancelPath assembles the DELETE /api/v1/scheduler/triggers/{id}
-// path with the optional tenant_filter query.
-func buildCancelPath(opts cancelOptions) string {
-	path := "/api/v1/scheduler/triggers/" + url.PathEscape(opts.TriggerID)
-	if opts.Tenant != "" {
-		q := url.Values{}
-		q.Set("tenant_filter", opts.Tenant)
-		path = path + "?" + q.Encode()
-	}
-	return path
-}
-
 func runCancel(cmd *cobra.Command, opts cancelOptions) error {
 	if opts.TriggerID == "" {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected("cancel requires a non-empty <trigger_id> argument"), opts.JSONOut)
 	}
+	// Parse the path-arg UUID CLI-side so a malformed value surfaces
+	// locally rather than as a 422 round-trip; the generated DELETE
+	// signature requires `openapi_types.UUID`.
+	var triggerID openapi_types.UUID
+	if err := triggerID.UnmarshalText([]byte(opts.TriggerID)); err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("trigger-id is not a valid UUID: %v", err)),
+			opts.JSONOut)
+	}
+	var tenantFilter *openapi_types.UUID
+	if opts.Tenant != "" {
+		var parsed openapi_types.UUID
+		if err := parsed.UnmarshalText([]byte(opts.Tenant)); err != nil {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.Unexpected(fmt.Sprintf("--tenant is not a valid UUID: %v", err)),
+				opts.JSONOut)
+		}
+		tenantFilter = &parsed
+	}
 	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	if err := deleteCancel(cmd.Context(), backplaneURL, opts); err != nil {
+	resp, err := deleteCancel(cmd.Context(), backplaneURL, triggerID, tenantFilter)
+	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	// Cancel returns 204 No Content on success (the generated
+	// envelope has no JSON200/JSON204 typed field — only `Body`
+	// and `HTTPResponse`). Treat any 2xx as success; everything
+	// else routes through renderHTTPStatus.
+	status := resp.StatusCode()
+	if status < 200 || status >= 300 {
+		return renderHTTPStatus(cmd, backplaneURL, status, resp.Body, opts.JSONOut)
 	}
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(),
@@ -102,7 +119,34 @@ func runCancel(cmd *cobra.Command, opts cancelOptions) error {
 	return nil
 }
 
-func deleteCancel(ctx context.Context, backplaneURL string, opts cancelOptions) error {
-	_, err := doAuthedRequest(ctx, backplaneURL, "DELETE", buildCancelPath(opts), nil)
-	return err
+// deleteCancel calls DELETE /api/v1/scheduler/triggers/{id} via the
+// generated typed client. The 401-refresh-retry loop runs through
+// retryOn401. The authed-client construction is hoisted out of the
+// retry loop so a credential failure routes directly to
+// renderRequestError rather than getting swallowed by the retry
+// shape (per the T11 #1285 iter-2 lesson).
+func deleteCancel(
+	ctx context.Context,
+	backplaneURL string,
+	triggerID openapi_types.UUID,
+	tenantFilter *openapi_types.UUID,
+) (*api.CancelTriggerApiV1SchedulerTriggersTriggerIdDeleteResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	params := &api.CancelTriggerApiV1SchedulerTriggersTriggerIdDeleteParams{}
+	if tenantFilter != nil {
+		params.TenantFilter = tenantFilter
+	}
+	return retryOn401(
+		ctx,
+		authed,
+		func(ctx context.Context) (*api.CancelTriggerApiV1SchedulerTriggersTriggerIdDeleteResponse, error) {
+			return authed.CancelTriggerApiV1SchedulerTriggersTriggerIdDeleteWithResponse(ctx, triggerID, params)
+		},
+		func(r *api.CancelTriggerApiV1SchedulerTriggersTriggerIdDeleteResponse) int {
+			return r.StatusCode()
+		},
+	)
 }

--- a/cli/internal/cmd/scheduler/create.go
+++ b/cli/internal/cmd/scheduler/create.go
@@ -5,33 +5,18 @@ package scheduler
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
+	"time"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
-
-// createRequest mirrors the backend ScheduledTriggerCreate pydantic
-// model. The discriminated-union invariant (exactly one of
-// cron_expr / fire_at / event_filter populated) is checked CLI-side
-// before the request lands; the backend's model validator is the
-// ultimate gate.
-type createRequest struct {
-	Kind              string         `json:"kind"`
-	AgentDefinitionID string         `json:"agent_definition_id"`
-	CronExpr          *string        `json:"cron_expr,omitempty"`
-	FireAt            *string        `json:"fire_at,omitempty"`
-	EventFilter       map[string]any `json:"event_filter,omitempty"`
-	Timezone          string         `json:"timezone,omitempty"`
-	Inputs            map[string]any `json:"inputs,omitempty"`
-	IdentitySub       string         `json:"identity_sub,omitempty"`
-	InFlightPolicy    string         `json:"in_flight_policy,omitempty"`
-	TenantID          *string        `json:"tenant_id,omitempty"`
-}
 
 // newCreateCmd returns the `meho scheduler create` command.
 //
@@ -194,60 +179,166 @@ func runCreate(cmd *cobra.Command, opts createOptions) error {
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(err.Error()), opts.JSONOut)
 	}
+	// Parse --agent-definition and --tenant CLI-side so malformed
+	// UUIDs surface locally as a clear error rather than after the
+	// server's 422 round-trip. The generated `ScheduledTriggerCreate`
+	// requires `openapi_types.UUID` for both fields.
+	var agentDefID openapi_types.UUID
+	if err := agentDefID.UnmarshalText([]byte(opts.AgentDefinition)); err != nil {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--agent-definition is not a valid UUID: %v", err)),
+			opts.JSONOut)
+	}
+	var tenantID *openapi_types.UUID
+	if opts.Tenant != "" {
+		var parsed openapi_types.UUID
+		if err := parsed.UnmarshalText([]byte(opts.Tenant)); err != nil {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.Unexpected(fmt.Sprintf("--tenant is not a valid UUID: %v", err)),
+				opts.JSONOut)
+		}
+		tenantID = &parsed
+	}
+	// Parse --fire-at CLI-side. The generated `ScheduledTriggerCreate.FireAt`
+	// is `*time.Time`; the typed client serialises that as the wire
+	// shape the backend's pydantic `datetime` validator expects (ISO
+	// 8601). Accept either RFC3339 (with timezone) or the
+	// timezone-less form the consumer doc mentions; the backend
+	// rejects naive datetimes with 422 invalid_arguments.
+	var fireAtTime *time.Time
+	if opts.FireAt != "" {
+		parsed, perr := time.Parse(time.RFC3339Nano, opts.FireAt)
+		if perr != nil {
+			// Fall back to the simpler RFC3339 (no nanoseconds) form.
+			parsed2, perr2 := time.Parse(time.RFC3339, opts.FireAt)
+			if perr2 != nil {
+				return output.RenderError(cmd.ErrOrStderr(),
+					output.Unexpected(fmt.Sprintf(
+						"--fire-at must be RFC 3339 (e.g. 2026-01-15T12:00:00Z): %v", perr)),
+					opts.JSONOut)
+			}
+			parsed = parsed2
+		}
+		fireAtTime = &parsed
+	}
 	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
 
-	req := createRequest{
-		Kind:              opts.Kind,
-		AgentDefinitionID: opts.AgentDefinition,
-		Timezone:          opts.Timezone,
-		Inputs:            inputs,
-		IdentitySub:       opts.IdentitySub,
-		InFlightPolicy:    opts.InFlightPolicy,
-	}
-	if opts.CronExpr != "" {
-		cronCopy := opts.CronExpr
-		req.CronExpr = &cronCopy
-	}
-	if opts.FireAt != "" {
-		fireAtCopy := opts.FireAt
-		req.FireAt = &fireAtCopy
-	}
-	if eventFilter != nil {
-		req.EventFilter = eventFilter
-	}
-	if opts.Tenant != "" {
-		tenantCopy := opts.Tenant
-		req.TenantID = &tenantCopy
-	}
-
-	entry, err := postCreate(cmd.Context(), backplaneURL, req)
+	body := buildCreateBody(opts, agentDefID, tenantID, fireAtTime, eventFilter, inputs)
+	resp, err := postCreate(cmd.Context(), backplaneURL, body)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
+	if resp.StatusCode() != http.StatusCreated {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	// Guard against 201 + missing-content-type leaving JSON201 nil
+	// (oapi-codegen only populates the typed field when the
+	// response advertises `application/json`). Without this guard
+	// a malformed 201 would pass `entry` as nil into
+	// `printTriggerSummary`, which short-circuits — operator sees
+	// the "created" prose with no follow-up summary as if every
+	// field were empty.
+	if resp.JSON201 == nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 201 without a created-trigger payload",
+				backplaneURL,
+			)),
+			opts.JSONOut,
+		)
+	}
+	entry := resp.JSON201
 	if opts.JSONOut {
 		return output.PrintJSON(cmd.OutOrStdout(), entry)
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "created %s trigger %s\n", entry.Kind, entry.ID)
+	fmt.Fprintf(cmd.OutOrStdout(), "created %s trigger %s\n", string(entry.Kind), entry.Id.String())
 	printTriggerSummary(cmd.OutOrStdout(), entry)
 	return nil
 }
 
-func postCreate(ctx context.Context, backplaneURL string, req createRequest) (*Trigger, error) {
-	body, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("marshal scheduler create request: %w", err)
+// buildCreateBody assembles the typed POST body. Pulled out so the
+// wire-shape rendering (kind enum, pointer-or-omit semantics on
+// nullable fields, conditional `tenant_id` for cross-tenant admin)
+// stays unit-testable without spinning up an httptest.Server.
+//
+// Wire-shape note: the generated `api.ScheduledTriggerCreate` types
+// `CronExpr`, `FireAt`, `EventFilter`, `Inputs`, `TenantId` as
+// nullable pointers (no `omitempty` on their JSON tags); the
+// pre-migration `createRequest` carried `,omitempty` and dropped the
+// keys for the nil case. The backend's pydantic validator treats
+// `null` and absent identically for these fields (its model marks
+// them `Optional[X] = None`), so the wire-level switch from "drop"
+// to "explicit null" is behaviour-preserving on the server. The
+// pre-condition pre-check in `runCreate` still rejects forbidden-
+// for-this-kind fields locally so the wire never sends a
+// `cron_expr=null` + `fire_at=<value>` combination the backend's
+// discriminated-union validator would reject as 422.
+func buildCreateBody(
+	opts createOptions,
+	agentDefID openapi_types.UUID,
+	tenantID *openapi_types.UUID,
+	fireAtTime *time.Time,
+	eventFilter map[string]any,
+	inputs map[string]any,
+) api.ScheduledTriggerCreate {
+	body := api.ScheduledTriggerCreate{
+		AgentDefinitionId: agentDefID,
+		Kind:              api.ScheduledTriggerKind(opts.Kind),
 	}
-	raw, err := doAuthedRequest(ctx, backplaneURL, "POST",
-		"/api/v1/scheduler/triggers", body)
+	if opts.CronExpr != "" {
+		cronCopy := opts.CronExpr
+		body.CronExpr = &cronCopy
+	}
+	if fireAtTime != nil {
+		body.FireAt = fireAtTime
+	}
+	if eventFilter != nil {
+		ef := map[string]interface{}(eventFilter)
+		body.EventFilter = &ef
+	}
+	if opts.Timezone != "" {
+		tz := opts.Timezone
+		body.Timezone = &tz
+	}
+	if inputs != nil {
+		in := map[string]interface{}(inputs)
+		body.Inputs = &in
+	}
+	if opts.IdentitySub != "" {
+		sub := opts.IdentitySub
+		body.IdentitySub = &sub
+	}
+	if opts.InFlightPolicy != "" {
+		policy := api.ScheduledTriggerInFlightPolicy(opts.InFlightPolicy)
+		body.InFlightPolicy = &policy
+	}
+	if tenantID != nil {
+		body.TenantId = tenantID
+	}
+	return body
+}
+
+// postCreate calls POST /api/v1/scheduler/triggers via the generated
+// typed client. The 401-refresh-retry loop runs through retryOn401.
+func postCreate(
+	ctx context.Context,
+	backplaneURL string,
+	body api.ScheduledTriggerCreate,
+) (*api.CreateTriggerApiV1SchedulerTriggersPostResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out Trigger
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode scheduler create response: %w", err)
-	}
-	return &out, nil
+	return retryOn401(
+		ctx,
+		authed,
+		func(ctx context.Context) (*api.CreateTriggerApiV1SchedulerTriggersPostResponse, error) {
+			return authed.CreateTriggerApiV1SchedulerTriggersPostWithResponse(ctx, nil, body)
+		},
+		func(r *api.CreateTriggerApiV1SchedulerTriggersPostResponse) int { return r.StatusCode() },
+	)
 }

--- a/cli/internal/cmd/scheduler/list.go
+++ b/cli/internal/cmd/scheduler/list.go
@@ -5,14 +5,14 @@ package scheduler
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
-	"strconv"
+	"net/http"
 
+	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/backplane"
 	"github.com/evoila/meho/cli/internal/output"
 )
@@ -109,62 +109,122 @@ func runList(cmd *cobra.Command, opts listOptions) error {
 			output.Unexpected(fmt.Sprintf("--offset must be non-negative; got %d", opts.Offset)),
 			opts.JSONOut)
 	}
+	// Parse --tenant CLI-side so a malformed UUID surfaces locally
+	// as a clear error rather than after the server's 422 round-trip.
+	// The generated `TenantFilter` is `*openapi_types.UUID`; sending
+	// raw strings is not an option on the typed client.
+	var tenantFilter *openapi_types.UUID
+	if opts.Tenant != "" {
+		var parsed openapi_types.UUID
+		if err := parsed.UnmarshalText([]byte(opts.Tenant)); err != nil {
+			return output.RenderError(cmd.ErrOrStderr(),
+				output.Unexpected(fmt.Sprintf("--tenant is not a valid UUID: %v", err)),
+				opts.JSONOut)
+		}
+		tenantFilter = &parsed
+	}
 	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
 	}
-	resp, err := getList(cmd.Context(), backplaneURL, opts)
+	resp, err := getList(cmd.Context(), backplaneURL, opts, tenantFilter)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
 	}
-	if opts.JSONOut {
-		return output.PrintJSON(cmd.OutOrStdout(), resp)
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
 	}
-	printListTable(cmd.OutOrStdout(), resp)
+	// Guard against 200 + missing-content-type leaving JSON200 nil
+	// (oapi-codegen's `ParseListTriggers...` only populates the
+	// typed field when Content-Type contains `application/json`).
+	// Without this guard, a malformed 200 would print "no scheduled
+	// triggers in this tenant" as if the tenant genuinely had zero
+	// — actively misleading. Mirrors the convention in
+	// `cli/internal/cmd/status.go:142` and the post-iter-2 fix the
+	// kb sibling adopted on PR #1282.
+	if resp.JSON200 == nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without a scheduler list payload",
+				backplaneURL,
+			)),
+			opts.JSONOut,
+		)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
+	}
+	printListTable(cmd.OutOrStdout(), resp.JSON200)
 	return nil
 }
 
-// buildListPath assembles the GET /api/v1/scheduler/triggers query
-// string. Exposed for unit tests so URL construction stays checkable.
-func buildListPath(opts listOptions) string {
-	q := url.Values{}
+// listQueryParams maps the CLI flags onto the generated query-param
+// shape. Mirrors the pre-migration `buildListPath` query-string
+// composition exactly: --kind / --status are typed enum pointers;
+// --tenant is a UUID pointer; --limit / --offset only send when
+// non-zero so the backend's default-100 page-size kicks in when the
+// operator omits the flag. The bearer header is injected by the
+// `api.AuthedClient` request editor; the `Authorization` form param
+// the generated `Params` struct exposes is left nil so we don't
+// double-emit it.
+func listQueryParams(opts listOptions, tenantFilter *openapi_types.UUID) *api.ListTriggersApiV1SchedulerTriggersGetParams {
+	params := &api.ListTriggersApiV1SchedulerTriggersGetParams{}
 	if opts.Kind != "" {
-		q.Set("kind", opts.Kind)
+		k := api.ListTriggersApiV1SchedulerTriggersGetParamsKind(opts.Kind)
+		params.Kind = &k
 	}
 	if opts.Status != "" {
-		q.Set("status", opts.Status)
+		s := api.ListTriggersApiV1SchedulerTriggersGetParamsStatus(opts.Status)
+		params.Status = &s
 	}
-	if opts.Tenant != "" {
-		q.Set("tenant_filter", opts.Tenant)
+	if tenantFilter != nil {
+		params.TenantFilter = tenantFilter
 	}
 	if opts.Limit > 0 {
-		q.Set("limit", strconv.Itoa(opts.Limit))
+		l := opts.Limit
+		params.Limit = &l
 	}
 	if opts.Offset > 0 {
-		q.Set("offset", strconv.Itoa(opts.Offset))
+		o := opts.Offset
+		params.Offset = &o
 	}
-	path := "/api/v1/scheduler/triggers"
-	if encoded := q.Encode(); encoded != "" {
-		path = path + "?" + encoded
-	}
-	return path
+	return params
 }
 
-func getList(ctx context.Context, backplaneURL string, opts listOptions) (*ListResponse, error) {
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", buildListPath(opts), nil)
+// getList calls GET /api/v1/scheduler/triggers via the generated
+// typed client. The 401-refresh-retry loop runs through retryOn401.
+// The authed-client construction is hoisted out of the retry loop
+// so a credential failure routes directly to renderRequestError
+// rather than getting swallowed by the retry shape (per the T11
+// #1285 iter-2 lesson).
+func getList(
+	ctx context.Context,
+	backplaneURL string,
+	opts listOptions,
+	tenantFilter *openapi_types.UUID,
+) (*api.ListTriggersApiV1SchedulerTriggersGetResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
-	var out ListResponse
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode scheduler list response: %w", err)
-	}
-	return &out, nil
+	params := listQueryParams(opts, tenantFilter)
+	return retryOn401(
+		ctx,
+		authed,
+		func(ctx context.Context) (*api.ListTriggersApiV1SchedulerTriggersGetResponse, error) {
+			return authed.ListTriggersApiV1SchedulerTriggersGetWithResponse(ctx, params)
+		},
+		func(r *api.ListTriggersApiV1SchedulerTriggersGetResponse) int { return r.StatusCode() },
+	)
 }
 
 // printListTable renders the triggers as a compact table:
 // ID, KIND, STATUS, SCHEDULE (cron_expr or fire_at), NEXT_FIRE_AT.
-func printListTable(w io.Writer, r *ListResponse) {
+// Consumes `api.ScheduledTriggerListResponse` directly so the
+// generated typed envelope is the single source of truth for the
+// on-screen shape.
+func printListTable(w io.Writer, r *api.ScheduledTriggerListResponse) {
 	if r == nil || len(r.Triggers) == 0 {
 		fmt.Fprintln(w, "no scheduled triggers in this tenant")
 		return
@@ -173,7 +233,7 @@ func printListTable(w io.Writer, r *ListResponse) {
 		"ID", "KIND", "STATUS", "SCHEDULE", "NEXT_FIRE_AT")
 	for _, t := range r.Triggers {
 		schedule := ""
-		switch t.Kind {
+		switch string(t.Kind) {
 		case "cron":
 			if t.CronExpr != nil {
 				schedule = *t.CronExpr
@@ -183,16 +243,16 @@ func printListTable(w io.Writer, r *ListResponse) {
 			}
 		case "one_off":
 			if t.FireAt != nil {
-				schedule = *t.FireAt
+				schedule = formatTime(t.FireAt)
 			}
 		case "event":
 			schedule = "event-filter"
 		}
 		next := "-"
 		if t.NextFireAt != nil {
-			next = *t.NextFireAt
+			next = formatTime(t.NextFireAt)
 		}
 		fmt.Fprintf(w, "%-36s %-8s %-10s %-30s %s\n",
-			t.ID, t.Kind, t.Status, schedule, next)
+			t.Id.String(), string(t.Kind), string(t.Status), schedule, next)
 	}
 }

--- a/cli/internal/cmd/scheduler/scheduler.go
+++ b/cli/internal/cmd/scheduler/scheduler.go
@@ -24,14 +24,20 @@
 // non-tenant_admin write callers with HTTP 403; the verbs render this
 // as insufficient_role.
 //
-// The implementation follows the in-package HTTP helper pattern the
-// sibling verb trees use (a local doAuthedRequest / renderRequestError
-// pair) rather than a shared client package, for the import-cycle
-// reason every sibling cites.
+// G0.12-T13 #1271 migrated this package off the sibling-verb pattern
+// of hand-rolled HTTP + hand-typed copies of backend pydantic models.
+// Every verb here drives the generated `api.ClientWithResponses`
+// surface directly: `api.NewAuthedClient` wires the bearer + lazy
+// 401-refresh editor onto the embedded `ClientWithResponses`, and
+// the verbs call the typed `*WithResponse` methods
+// (`ListTriggersApiV1SchedulerTriggersGetWithResponse` etc.).
+// Consumer-side struct drift — the #1069 root cause Initiative
+// #1118 targets — can't recur because we now consume
+// `api.ScheduledTriggerRead`, `api.ScheduledTriggerListResponse`,
+// and `api.ScheduledTriggerCreate` directly.
 package scheduler
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -40,6 +46,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -145,38 +152,11 @@ func NewRootCmd() *cobra.Command {
 	return cmd
 }
 
-// Trigger mirrors the backend ScheduledTriggerRead pydantic model
-// (`backend/src/meho_backplane/scheduler/schemas.py`). Hand-written
-// rather than aliased to a generated client type so the scheduler
-// package stays decoupled from oapi-codegen churn — the stance the
-// agent / kb / audit / broadcast packages take.
-type Trigger struct {
-	ID                string         `json:"id"`
-	TenantID          string         `json:"tenant_id"`
-	AgentDefinitionID string         `json:"agent_definition_id"`
-	Kind              string         `json:"kind"`
-	CronExpr          *string        `json:"cron_expr"`
-	Timezone          string         `json:"timezone"`
-	FireAt            *string        `json:"fire_at"`
-	EventFilter       map[string]any `json:"event_filter"`
-	Status            string         `json:"status"`
-	InFlightPolicy    string         `json:"in_flight_policy"`
-	NextFireAt        *string        `json:"next_fire_at"`
-	LastFiredAt       *string        `json:"last_fired_at"`
-	Inputs            map[string]any `json:"inputs"`
-	IdentitySub       string         `json:"identity_sub"`
-	CreatedBySub      string         `json:"created_by_sub"`
-	CreatedAt         string         `json:"created_at"`
-	UpdatedAt         string         `json:"updated_at"`
-}
-
-// ListResponse mirrors the backend ScheduledTriggerListResponse
-// envelope (`{"triggers": [...]}`).
-type ListResponse struct {
-	Triggers []Trigger `json:"triggers"`
-}
-
-// validKinds mirrors the backend ScheduledTriggerKind enum.
+// validKinds mirrors the backend ScheduledTriggerKind enum. Kept as a
+// plain-string set so the per-verb pre-check (rejects unknown --kind
+// before the round-trip) can be exercised in tests without parsing the
+// generated `api.ScheduledTriggerKind` constants — the wire-level
+// values are the canonical truth.
 var validKinds = map[string]bool{"cron": true, "one_off": true, "event": true}
 
 // validStatuses mirrors the backend ScheduledTriggerStatus enum.
@@ -193,12 +173,155 @@ var validInFlightPolicies = map[string]bool{
 	"resume":          true,
 }
 
-// errMissingAccessToken is the sentinel doAuthedRequest returns when
-// the stored token row exists but its access_token is empty.
+// errMissingAccessToken is the sentinel newAuthedClient returns when
+// the stored token row exists but its `access_token` field is empty.
+// It's a credential-state failure rather than a transport failure, so
+// renderRequestError maps it to auth_expired (exit 2) with a `meho
+// login` hint — not unreachable (exit 3). Mirrors the shape adopted
+// by the sibling typed-client migrations on Initiative #1118 (T1
+// #1251 approvals, T4 #1262 agent-principal, T9 #1267 kb, T12 #1270
+// retrieval).
 var errMissingAccessToken = errors.New("meho: stored token has no access_token")
 
-// renderRequestError translates a request error into the right
-// output.StructuredError category, mirroring the agent package shape.
+// responseBodyCap bounds the bytes the scheduler verb tree's
+// transport will read off any backplane response body before
+// surfacing `*http.MaxBytesError`. 1 MiB is generous for a paginated
+// trigger list (limit 500 with full row payloads stays well under
+// even with verbose `event_filter` JSON / `inputs` maps).
+//
+// Without the cap, an adversarial or runaway backplane response
+// could OOM the CLI because the generated `Parse*Response` helpers
+// call `io.ReadAll(rsp.Body)` on an unbounded body before
+// constructing the typed envelope. The cap is installed at the
+// transport layer via an inline `capRoundTripper` so it applies
+// uniformly to every typed verb on the same `AuthedClient`. The kb
+// / memory siblings install the same cap via
+// `api.AuthedClientOptions.ResponseBodyLimit`; we duplicate the
+// wrapper locally rather than reach into `cli/internal/api/client.go`
+// to keep this PR's blast radius inside the scheduler verb tree
+// (per Initiative #1118's "blast radius = touched files" discipline
+// — the shared options struct will land separately when the sibling
+// PRs settle).
+const responseBodyCap int64 = 1 << 20
+
+// capRoundTripper wraps an http.RoundTripper so every response body
+// is re-bound to an http.MaxBytesReader before the typed-client
+// parsers (oapi-codegen's generated `Parse*Response` helpers, which
+// `io.ReadAll(rsp.Body)` to populate `*Response.Body []byte`) get a
+// chance to drain it. A read at or past `limit` surfaces as
+// `*http.MaxBytesError`, which `renderRequestError` maps to
+// `output.Unexpected` (exit 4 — `unexpected_response`) rather than
+// `output.Unreachable` (exit 3 — `network_unreachable`).
+//
+// The `*http.MaxBytesError` shape was added in Go 1.19 and is the
+// canonical signal for "transport refused to read past N bytes."
+// The wrapper applies the cap server-wide on the underlying
+// transport so every typed verb on the same AuthedClient inherits
+// it uniformly.
+type capRoundTripper struct {
+	base  http.RoundTripper
+	limit int64
+}
+
+func (c *capRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := c.base.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+	if resp.Body != nil && c.limit > 0 {
+		// http.MaxBytesReader returns an io.ReadCloser whose Close
+		// closes the underlying body, so the existing close
+		// discipline on the caller (oapi-codegen's `defer
+		// rsp.Body.Close()` inside every `*WithResponse` method)
+		// still drains the original body cleanly.
+		resp.Body = http.MaxBytesReader(nil, resp.Body, c.limit)
+	}
+	return resp, nil
+}
+
+// cappedHTTPClient returns an http.Client whose Transport caps every
+// response body at responseBodyCap. The clone keeps Timeout / Jar /
+// CheckRedirect intact and only swaps the Transport for the capped
+// wrapper so callers don't mutate http.DefaultClient (which is
+// process-global). Passing the returned client to
+// `api.AuthedClientOptions.HTTPClient` threads the cap through both
+// the bearer-injecting editor and the oauth2 refresh exchange.
+func cappedHTTPClient(base *http.Client) *http.Client {
+	if base == nil {
+		base = http.DefaultClient
+	}
+	clone := *base
+	transport := clone.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	clone.Transport = &capRoundTripper{base: transport, limit: responseBodyCap}
+	return &clone
+}
+
+// newAuthedClient builds an api.AuthedClient for the supplied
+// backplane URL with the 1 MiB response-body cap installed at the
+// transport layer, and verifies a non-empty bearer is loaded. The
+// caller forwards any returned error to renderRequestError for
+// category mapping. Mirrors the sibling verb-tree migrations
+// (G0.12-T4 #1262, G0.12-T9 #1267, G0.12-T12 #1270).
+func newAuthedClient(ctx context.Context, backplaneURL string) (*api.AuthedClient, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{
+		HTTPClient: cappedHTTPClient(nil),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if authed.AccessToken() == "" {
+		return nil, errMissingAccessToken
+	}
+	return authed, nil
+}
+
+// retryOn401 invokes call once, and if the typed response carries a
+// 401, runs a one-shot bearer refresh and re-issues call. Mirrors
+// the behaviour `api.AuthedClient.GetHealth` implements for the
+// /api/v1/health endpoint, generalised so every scheduler verb runs
+// the same transparent-retry contract.
+//
+// statusOf reads the StatusCode off the typed response envelope (the
+// generated *Response types expose StatusCode() through their
+// embedded *http.Response). A nil response counts as "no retry" —
+// the transport already failed and the caller surfaces err directly.
+func retryOn401[R any](
+	ctx context.Context,
+	authed *api.AuthedClient,
+	call func(ctx context.Context) (*R, error),
+	statusOf func(*R) int,
+) (*R, error) {
+	resp, err := call(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || statusOf(resp) != http.StatusUnauthorized {
+		return resp, nil
+	}
+	if rerr := authed.Refresh(ctx); rerr != nil {
+		return resp, rerr
+	}
+	return call(ctx)
+}
+
+// renderRequestError translates a transport-layer request error into
+// the right output.StructuredError category. Maps the scheduler REST
+// surface's pre-response failures: missing bearer, no-refresh-token,
+// token-not-found, body-cap / parse failures bubbling out of the
+// generated `*WithResponse` parsers, plus the generic transport-down
+// case. Non-2xx status codes carried in a typed response envelope
+// are classified by renderHTTPStatus instead.
+//
+// Parse / cap failures route to `output.Unexpected` (exit 4 —
+// `unexpected_response`) rather than `output.Unreachable` (exit 3 —
+// `network_unreachable`). A 1 MiB body cap firing or a JSON decode
+// rejecting a malformed payload is a contract / shape failure on
+// the server side, not a transport-down failure on the operator's
+// side; surfacing it as "unreachable" would send operators chasing
+// a network ghost.
 func renderRequestError(
 	cmd *cobra.Command,
 	backplaneURL string,
@@ -232,9 +355,23 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
-		return renderHTTPError(cmd, backplaneURL, he, jsonOut)
+	// Transport-layer body-cap firing (*http.MaxBytesError out of
+	// the capRoundTripper) and JSON shape failures bubbling out of
+	// the generated parsers are server-side contract failures, not
+	// transport-down failures — surface them as unexpected_response
+	// (exit 4) with the backplane URL so the operator sees the
+	// origin without chasing a network ghost.
+	var maxBytesErr *http.MaxBytesError
+	var syntaxErr *json.SyntaxError
+	var unmarshalErr *json.UnmarshalTypeError
+	if errors.As(err, &maxBytesErr) ||
+		errors.As(err, &syntaxErr) ||
+		errors.As(err, &unmarshalErr) ||
+		errors.Is(err, io.ErrUnexpectedEOF) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+			jsonOut,
+		)
 	}
 	return output.RenderError(cmd.ErrOrStderr(),
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
@@ -242,14 +379,38 @@ func renderRequestError(
 	)
 }
 
-// renderHTTPError classifies a non-2xx response.
-func renderHTTPError(
+// renderHTTPStatus classifies a non-2xx response carried in the
+// typed envelope into the right StructuredError category. Mirrors
+// the pre-migration `renderHTTPError` switch but acts on the
+// (statusCode, body) pair lifted off the generated
+// `*Response.HTTPResponse` + `Body` fields rather than a sentinel
+// value. Scheduler-route-specific notes:
+//
+//   - 403 — write to a trigger the operator's role can't reach (the
+//     operator-role caller using --tenant lands here too).
+//   - 404 — `trigger_not_found` covers both genuine absence and
+//     cross-tenant probes; the existence of a trigger is **not**
+//     leaked across tenants via a 403/404 differential.
+//   - 409 — `trigger_already_fired` on a cancel against a terminal
+//     one-off trigger (lifecycle is `fired → end`, not
+//     `fired → cancelled`).
+//   - 422 — FastAPI validation envelope (invalid cron, unknown
+//     `agent_definition_id`, malformed body); the verb surfaces
+//     the backend's detail so the operator sees the field that
+//     failed.
+//   - 401 — backplane rejected the stored token after a refresh
+//     attempt; auth_expired with a `meho login` hint.
+//   - Other non-2xx — `Unexpected` carrying the raw body so the
+//     operator sees an actionable signal.
+func renderHTTPStatus(
 	cmd *cobra.Command,
 	backplaneURL string,
-	he *httpError,
+	statusCode int,
+	body []byte,
 	jsonOut bool,
 ) error {
-	switch he.StatusCode {
+	bodyStr := strings.TrimSpace(string(body))
+	switch statusCode {
 	case http.StatusUnauthorized:
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.AuthExpired(fmt.Sprintf(
@@ -260,7 +421,7 @@ func renderHTTPError(
 		)
 	case http.StatusForbidden:
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.InsufficientRole(decodeDetailString(he.Body)),
+			output.InsufficientRole(decodeDetailString(bodyStr)),
 			jsonOut,
 		)
 	case http.StatusNotFound:
@@ -268,24 +429,24 @@ func renderHTTPError(
 		// `trigger_not_found` covers both genuine absence and
 		// cross-tenant probes (no existence leak across tenants).
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(decodeDetailString(he.Body)),
+			output.Unexpected(decodeDetailString(bodyStr)),
 			jsonOut,
 		)
 	case http.StatusConflict:
 		// `trigger_already_fired` on a cancel against a terminal one-off.
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(decodeDetailString(he.Body)),
+			output.Unexpected(decodeDetailString(bodyStr)),
 			jsonOut,
 		)
 	case http.StatusUnprocessableEntity:
 		return output.RenderError(cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf("invalid request: %s", he.Body)),
+			output.Unexpected(fmt.Sprintf("invalid request: %s", bodyStr)),
 			jsonOut,
 		)
 	default:
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, statusCode, bodyStr)),
 			jsonOut,
 		)
 	}
@@ -308,123 +469,50 @@ func decodeDetailString(body string) string {
 	return strings.TrimSpace(body)
 }
 
-// doAuthedRequest issues a single HTTP request against the backplane
-// with bearer injection and one-shot 401-refresh-retry.
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errMissingAccessToken
-	}
-
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, responseBodyCap+1))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if int64(len(raw)) > responseBodyCap {
-		return nil, fmt.Errorf(
-			"response body exceeds %d-byte cap; refusing to decode possibly-truncated JSON",
-			responseBodyCap,
-		)
-	}
-	if resp.StatusCode == http.StatusNoContent {
-		return nil, nil
-	}
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-// responseBodyCap bounds the response body the CLI will read. 1 MiB
-// is comfortable for a paginated trigger list (limit 500 with full row
-// payloads stays well under).
-const responseBodyCap int64 = 1 << 20
-
-// httpError carries a non-2xx response.
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
-}
-
 // printTriggerSummary renders one trigger as a key-value summary.
-func printTriggerSummary(w io.Writer, t *Trigger) {
+// Consumes `api.ScheduledTriggerRead` directly so the generated
+// typed envelope is the single source of truth for the on-screen
+// shape; drift in the backend pydantic model now surfaces here at
+// `go build` time rather than at runtime via the freshness gate.
+func printTriggerSummary(w io.Writer, t *api.ScheduledTriggerRead) {
 	if t == nil {
 		return
 	}
-	fmt.Fprintf(w, "%-22s %s\n", "id:", t.ID)
-	fmt.Fprintf(w, "%-22s %s\n", "tenant_id:", t.TenantID)
-	fmt.Fprintf(w, "%-22s %s\n", "agent_definition_id:", t.AgentDefinitionID)
-	fmt.Fprintf(w, "%-22s %s\n", "kind:", t.Kind)
-	fmt.Fprintf(w, "%-22s %s\n", "status:", t.Status)
-	fmt.Fprintf(w, "%-22s %s\n", "in_flight_policy:", t.InFlightPolicy)
+	fmt.Fprintf(w, "%-22s %s\n", "id:", t.Id.String())
+	fmt.Fprintf(w, "%-22s %s\n", "tenant_id:", t.TenantId.String())
+	fmt.Fprintf(w, "%-22s %s\n", "agent_definition_id:", t.AgentDefinitionId.String())
+	fmt.Fprintf(w, "%-22s %s\n", "kind:", string(t.Kind))
+	fmt.Fprintf(w, "%-22s %s\n", "status:", string(t.Status))
+	fmt.Fprintf(w, "%-22s %s\n", "in_flight_policy:", string(t.InFlightPolicy))
 	if t.CronExpr != nil {
 		fmt.Fprintf(w, "%-22s %s\n", "cron_expr:", *t.CronExpr)
 		fmt.Fprintf(w, "%-22s %s\n", "timezone:", t.Timezone)
 	}
 	if t.FireAt != nil {
-		fmt.Fprintf(w, "%-22s %s\n", "fire_at:", *t.FireAt)
+		fmt.Fprintf(w, "%-22s %s\n", "fire_at:", formatTime(t.FireAt))
 	}
 	if t.NextFireAt != nil {
-		fmt.Fprintf(w, "%-22s %s\n", "next_fire_at:", *t.NextFireAt)
+		fmt.Fprintf(w, "%-22s %s\n", "next_fire_at:", formatTime(t.NextFireAt))
 	}
 	if t.LastFiredAt != nil {
-		fmt.Fprintf(w, "%-22s %s\n", "last_fired_at:", *t.LastFiredAt)
+		fmt.Fprintf(w, "%-22s %s\n", "last_fired_at:", formatTime(t.LastFiredAt))
 	}
 	fmt.Fprintf(w, "%-22s %s\n", "identity_sub:", t.IdentitySub)
 	fmt.Fprintf(w, "%-22s %s\n", "created_by:", t.CreatedBySub)
-	fmt.Fprintf(w, "%-22s %s\n", "created_at:", t.CreatedAt)
+	fmt.Fprintf(w, "%-22s %s\n", "created_at:", formatTime(&t.CreatedAt))
+}
+
+// formatTime renders a *time.Time the way the backend ships it on
+// the wire: ISO 8601 with sub-second precision when present. Go's
+// stdlib `time.RFC3339Nano` layout matches what FastAPI emits for a
+// `datetime` field (which uses Python's `isoformat()` and preserves
+// microsecond precision). Rendering it here keeps the human-readable
+// summary's wall-clock strings byte-for-byte aligned with the
+// pre-migration output (which passed the JSON string through
+// untouched).
+func formatTime(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.Format(time.RFC3339Nano)
 }

--- a/cli/internal/cmd/scheduler/scheduler_test.go
+++ b/cli/internal/cmd/scheduler/scheduler_test.go
@@ -5,11 +5,113 @@ package scheduler
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/auth"
 )
+
+// seedXDGAndToken seeds a per-test config dir + token store the way
+// the sibling test files do (mirrors `cli/internal/cmd/memory/memory_test.go`).
+// `MEHO_KEYRING_DISABLE=1` forces the file-backed token store path so
+// the test never touches the OS keyring.
+func seedXDGAndToken(t *testing.T, backplaneURL string) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("MEHO_KEYRING_DISABLE", "1")
+	store, err := auth.NewFileStore()
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	if err := store.Save(service, user, auth.StoredToken{
+		BackplaneURL: backplaneURL,
+		AccessToken:  "eyJ.test.token",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(1 * time.Hour),
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+	if err := auth.SaveConfigAt(
+		filepath.Join(dir, "meho", "config.json"),
+		auth.Config{BackplaneURL: backplaneURL},
+	); err != nil {
+		t.Fatalf("SaveConfigAt: %v", err)
+	}
+	return dir
+}
+
+// newRunCmd builds a fresh cobra.Command with stdout/stderr buffers.
+// The runXxx helpers consume cmd.OutOrStdout / cmd.ErrOrStderr;
+// tests inspect the buffers afterwards.
+func newRunCmd(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	cmd.SetContext(ctx)
+	return cmd, &stdout, &stderr
+}
+
+// stubTriggerID is the fixed trigger UUID used in every test
+// fixture. Reading the literal "11111111-..." in a failing
+// assertion makes the failure easier to chase than a random
+// uuid.New() that changes per test run.
+const (
+	stubTriggerID   = "11111111-1111-1111-1111-111111111111"
+	stubTenantID    = "22222222-2222-2222-2222-222222222222"
+	stubAgentDefID  = "33333333-3333-3333-3333-333333333333"
+	stubOtherTenant = "44444444-4444-4444-4444-444444444444"
+)
+
+func parseStubUUID(t *testing.T, s string) openapi_types.UUID {
+	t.Helper()
+	id, err := uuid.Parse(s)
+	if err != nil {
+		t.Fatalf("uuid.Parse(%q): %v", s, err)
+	}
+	return id
+}
+
+// fakeTrigger builds a minimal `api.ScheduledTriggerRead` fixture
+// keyed off the package's stub UUIDs. Callers override fields per
+// test (e.g. setting CronExpr for a cron-trigger row).
+func fakeTrigger(t *testing.T, kind string) api.ScheduledTriggerRead {
+	t.Helper()
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	return api.ScheduledTriggerRead{
+		Id:                parseStubUUID(t, stubTriggerID),
+		TenantId:          parseStubUUID(t, stubTenantID),
+		AgentDefinitionId: parseStubUUID(t, stubAgentDefID),
+		Kind:              api.ScheduledTriggerKind(kind),
+		Status:            api.ScheduledTriggerStatus("active"),
+		InFlightPolicy:    api.ScheduledTriggerInFlightPolicy("fail_into_audit"),
+		Timezone:          "UTC",
+		IdentitySub:       "__scheduler__",
+		CreatedBySub:      "alice@example.com",
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+}
+
+// ---------------------------------------------------------------
+// Subcommand wiring
+// ---------------------------------------------------------------
 
 func TestNewRootCmd_Subcommands(t *testing.T) {
 	cmd := NewRootCmd()
@@ -28,82 +130,9 @@ func TestNewRootCmd_Subcommands(t *testing.T) {
 	}
 }
 
-func TestBuildListPath(t *testing.T) {
-	tests := []struct {
-		name string
-		opts listOptions
-		// substrings the path should contain (order-independent)
-		contains []string
-		// substrings the path must NOT contain
-		notContains []string
-	}{
-		{
-			name:        "no_filters",
-			opts:        listOptions{},
-			contains:    []string{"/api/v1/scheduler/triggers"},
-			notContains: []string{"?"},
-		},
-		{
-			name:     "kind_and_status",
-			opts:     listOptions{Kind: "cron", Status: "active"},
-			contains: []string{"kind=cron", "status=active"},
-		},
-		{
-			name:     "tenant_filter",
-			opts:     listOptions{Tenant: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"},
-			contains: []string{"tenant_filter=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"},
-		},
-		{
-			name:     "limit_and_offset",
-			opts:     listOptions{Limit: 25, Offset: 50},
-			contains: []string{"limit=25", "offset=50"},
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := buildListPath(tc.opts)
-			for _, sub := range tc.contains {
-				if !strings.Contains(got, sub) {
-					t.Errorf("expected %q to contain %q", got, sub)
-				}
-			}
-			for _, sub := range tc.notContains {
-				if strings.Contains(got, sub) {
-					t.Errorf("expected %q NOT to contain %q", got, sub)
-				}
-			}
-		})
-	}
-}
-
-func TestBuildCancelPath(t *testing.T) {
-	tests := []struct {
-		name string
-		opts cancelOptions
-		want string
-	}{
-		{
-			name: "no_tenant",
-			opts: cancelOptions{TriggerID: "abc-123"},
-			want: "/api/v1/scheduler/triggers/abc-123",
-		},
-		{
-			name: "with_tenant",
-			opts: cancelOptions{
-				TriggerID: "abc-123",
-				Tenant:    "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-			},
-			want: "/api/v1/scheduler/triggers/abc-123?tenant_filter=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := buildCancelPath(tc.opts); got != tc.want {
-				t.Errorf("got %q want %q", got, tc.want)
-			}
-		})
-	}
-}
+// ---------------------------------------------------------------
+// Enum guards
+// ---------------------------------------------------------------
 
 func TestValidKinds(t *testing.T) {
 	for _, k := range []string{"cron", "one_off", "event"} {
@@ -132,11 +161,12 @@ func TestValidInFlightPolicies(t *testing.T) {
 	}
 }
 
-// TestLoadJSONObjectFlag_RejectsJSONNull covers review M3 on PR #1128:
-// json.Unmarshal of `null` into map[string]any sets the map to nil
-// without error; the helper must catch this so a `--event-filter null`
-// invocation surfaces a clear error rather than silently forwarding
-// an empty field.
+// ---------------------------------------------------------------
+// JSON-object flag loader (review M3 / M4 on PR #1128 — unchanged
+// by the G0.12-T13 typed-client migration).
+// ---------------------------------------------------------------
+
+// TestLoadJSONObjectFlag_RejectsJSONNull covers review M3 on PR #1128.
 func TestLoadJSONObjectFlag_RejectsJSONNull(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetIn(strings.NewReader(""))
@@ -160,8 +190,6 @@ func TestLoadJSONObjectFlag_RejectsJSONNull(t *testing.T) {
 	}
 }
 
-// TestLoadJSONObjectFlag_RejectsJSONNullViaStdin checks that the stdin
-// branch also rejects JSON `null`, not just the inline branch.
 func TestLoadJSONObjectFlag_RejectsJSONNullViaStdin(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.SetIn(strings.NewReader("null\n"))
@@ -174,20 +202,12 @@ func TestLoadJSONObjectFlag_RejectsJSONNullViaStdin(t *testing.T) {
 	}
 }
 
-// TestReadJSONFile_RejectsOverCapFile covers review M4 on PR #1128:
-// readJSONFile must enforce jsonObjectCap so a multi-GiB JSON file
-// cannot OOM the CLI. We stub the file-read seam with a hand-rolled
-// stub that returns over-cap bytes via the limit-reader path.
+// TestLoadJSONObjectFlag_RejectsOverCapFile covers review M4 on PR #1128.
 func TestLoadJSONObjectFlag_RejectsOverCapFile(t *testing.T) {
 	original := readJSONFile
 	t.Cleanup(func() { readJSONFile = original })
 
-	// Stub the seam to mirror what the real implementation does: read
-	// up to jsonObjectCap+1 bytes and reject when the payload is over
-	// the cap. The test passes bytes that are deliberately over.
 	readJSONFile = func(_ string) ([]byte, error) {
-		// Match the implementation's error shape exactly so the
-		// caller's wrapping error chain is testable.
 		return nil, &capExceededError{}
 	}
 
@@ -206,4 +226,610 @@ type capExceededError struct{}
 
 func (capExceededError) Error() string {
 	return "file \"/tmp/huge.json\" exceeds 262144-byte cap"
+}
+
+// ---------------------------------------------------------------
+// listQueryParams — wire-shape pin
+// ---------------------------------------------------------------
+
+func TestListQueryParamsOmitsEmptyFilters(t *testing.T) {
+	got := listQueryParams(listOptions{}, nil)
+	if got.Kind != nil || got.Status != nil || got.TenantFilter != nil ||
+		got.Limit != nil || got.Offset != nil {
+		t.Errorf("expected all filters nil; got %+v", got)
+	}
+}
+
+func TestListQueryParamsForwardsFilters(t *testing.T) {
+	tenantID := parseStubUUID(t, stubOtherTenant)
+	got := listQueryParams(listOptions{
+		Kind:   "cron",
+		Status: "active",
+		Limit:  25,
+		Offset: 50,
+	}, &tenantID)
+	if got.Kind == nil || string(*got.Kind) != "cron" {
+		t.Errorf("expected kind=cron forwarded; got %+v", got.Kind)
+	}
+	if got.Status == nil || string(*got.Status) != "active" {
+		t.Errorf("expected status=active forwarded; got %+v", got.Status)
+	}
+	if got.TenantFilter == nil || got.TenantFilter.String() != stubOtherTenant {
+		t.Errorf("expected tenant_filter forwarded; got %+v", got.TenantFilter)
+	}
+	if got.Limit == nil || *got.Limit != 25 {
+		t.Errorf("expected limit=25; got %+v", got.Limit)
+	}
+	if got.Offset == nil || *got.Offset != 50 {
+		t.Errorf("expected offset=50; got %+v", got.Offset)
+	}
+}
+
+// ---------------------------------------------------------------
+// buildCreateBody — wire-shape pin
+// ---------------------------------------------------------------
+
+func TestBuildCreateBodyCron(t *testing.T) {
+	agentID := parseStubUUID(t, stubAgentDefID)
+	body := buildCreateBody(
+		createOptions{
+			Kind:           "cron",
+			CronExpr:       "* * * * *",
+			Timezone:       "UTC",
+			InFlightPolicy: "resume",
+			IdentitySub:    "alice",
+		},
+		agentID, nil, nil, nil, nil,
+	)
+	if body.Kind != api.ScheduledTriggerKind("cron") {
+		t.Errorf("kind: got %q want cron", body.Kind)
+	}
+	if body.AgentDefinitionId != agentID {
+		t.Errorf("agent_definition_id not forwarded; got %v", body.AgentDefinitionId)
+	}
+	if body.CronExpr == nil || *body.CronExpr != "* * * * *" {
+		t.Errorf("cron_expr not forwarded; got %+v", body.CronExpr)
+	}
+	if body.Timezone == nil || *body.Timezone != "UTC" {
+		t.Errorf("timezone not forwarded; got %+v", body.Timezone)
+	}
+	if body.InFlightPolicy == nil || string(*body.InFlightPolicy) != "resume" {
+		t.Errorf("in_flight_policy not forwarded; got %+v", body.InFlightPolicy)
+	}
+	if body.IdentitySub == nil || *body.IdentitySub != "alice" {
+		t.Errorf("identity_sub not forwarded; got %+v", body.IdentitySub)
+	}
+	if body.FireAt != nil || body.EventFilter != nil || body.Inputs != nil || body.TenantId != nil {
+		t.Errorf("non-cron fields should stay nil; got %+v", body)
+	}
+}
+
+func TestBuildCreateBodyOneOff(t *testing.T) {
+	agentID := parseStubUUID(t, stubAgentDefID)
+	when := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	body := buildCreateBody(
+		createOptions{Kind: "one_off"},
+		agentID, nil, &when, nil, nil,
+	)
+	if body.FireAt == nil || !body.FireAt.Equal(when) {
+		t.Errorf("fire_at not forwarded; got %+v", body.FireAt)
+	}
+	if body.CronExpr != nil || body.EventFilter != nil {
+		t.Errorf("non-one_off fields should stay nil; got %+v", body)
+	}
+}
+
+func TestBuildCreateBodyEvent(t *testing.T) {
+	agentID := parseStubUUID(t, stubAgentDefID)
+	filter := map[string]any{"kind": "agent_run.finished"}
+	inputs := map[string]any{"target": "rke2"}
+	tenantID := parseStubUUID(t, stubOtherTenant)
+	body := buildCreateBody(
+		createOptions{Kind: "event"},
+		agentID, &tenantID, nil, filter, inputs,
+	)
+	if body.EventFilter == nil {
+		t.Fatalf("event_filter not forwarded; got nil")
+	}
+	if (*body.EventFilter)["kind"] != "agent_run.finished" {
+		t.Errorf("event_filter content wrong: got %+v", *body.EventFilter)
+	}
+	if body.Inputs == nil || (*body.Inputs)["target"] != "rke2" {
+		t.Errorf("inputs not forwarded; got %+v", body.Inputs)
+	}
+	if body.TenantId == nil || body.TenantId.String() != stubOtherTenant {
+		t.Errorf("tenant_id not forwarded; got %+v", body.TenantId)
+	}
+}
+
+// ---------------------------------------------------------------
+// list verb — end-to-end via httptest.Server
+// ---------------------------------------------------------------
+
+func TestRunListHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/scheduler/triggers", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET; got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ScheduledTriggerListResponse{
+			Triggers: []api.ScheduledTriggerRead{fakeTrigger(t, "cron")},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	if err := runList(cmd, listOptions{BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runList: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), stubTriggerID) {
+		t.Errorf("expected trigger id in stdout; got %q", stdout.String())
+	}
+}
+
+func TestRunListJSONHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/scheduler/triggers", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ScheduledTriggerListResponse{
+			Triggers: []api.ScheduledTriggerRead{fakeTrigger(t, "cron")},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	if err := runList(cmd, listOptions{
+		JSONOut:           true,
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runList --json: %v; stderr=%s", err, stderr.String())
+	}
+	var resp api.ScheduledTriggerListResponse
+	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
+		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
+	}
+	if len(resp.Triggers) != 1 {
+		t.Errorf("expected 1 trigger in JSON; got %d", len(resp.Triggers))
+	}
+}
+
+func TestRunListEmptyResponse(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/scheduler/triggers", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ScheduledTriggerListResponse{Triggers: nil})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	if err := runList(cmd, listOptions{BackplaneOverride: srv.URL}); err != nil {
+		t.Fatalf("runList: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "no scheduled triggers") {
+		t.Errorf("expected empty-list message; got %q", stdout.String())
+	}
+}
+
+func TestRunListForwardsFilters(t *testing.T) {
+	var capturedQuery string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/scheduler/triggers", func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ScheduledTriggerListResponse{})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	if err := runList(cmd, listOptions{
+		Kind:              "cron",
+		Status:            "active",
+		Tenant:            stubOtherTenant,
+		Limit:             25,
+		Offset:            50,
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runList: %v; stderr=%s", err, stderr.String())
+	}
+	for _, want := range []string{
+		"kind=cron",
+		"status=active",
+		"tenant_filter=" + stubOtherTenant,
+		"limit=25",
+		"offset=50",
+	} {
+		if !strings.Contains(capturedQuery, want) {
+			t.Errorf("expected query %q to contain %q", capturedQuery, want)
+		}
+	}
+}
+
+func TestRunListInvalidKindFailsFast(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	if err := runList(cmd, listOptions{Kind: "bogus"}); err == nil {
+		t.Fatalf("expected validation error")
+	}
+	if !strings.Contains(stderr.String(), "--kind must be one of") {
+		t.Errorf("expected validation message; got %q", stderr.String())
+	}
+}
+
+func TestRunListInvalidTenantUUIDFailsFast(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	if err := runList(cmd, listOptions{Tenant: "not-a-uuid"}); err == nil {
+		t.Fatalf("expected UUID validation error")
+	}
+	if !strings.Contains(stderr.String(), "--tenant is not a valid UUID") {
+		t.Errorf("expected UUID message; got %q", stderr.String())
+	}
+}
+
+// TestRunList200WithoutPayloadSurfacesUnexpected pins the JSON200
+// nil-guard. A 200 without an `application/json` Content-Type
+// leaves `resp.JSON200` nil; without the guard the verb would
+// print "no scheduled triggers in this tenant" as if the tenant
+// genuinely had zero — actively misleading.
+func TestRunList200WithoutPayloadSurfacesUnexpected(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/scheduler/triggers", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"triggers":[]}`)) // no Content-Type → JSON200 nil
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runList(cmd, listOptions{BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected nil-guard error on missing payload")
+	}
+	if !strings.Contains(stderr.String(), "HTTP 200 without a scheduler list payload") {
+		t.Errorf("expected nil-guard message; got %q", stderr.String())
+	}
+}
+
+func TestRunList403SurfacesInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/scheduler/triggers", func(w http.ResponseWriter, _ *http.Request) {
+		// No Content-Type — the parser exits cleanly with raw Body
+		// bytes and StatusCode=403, the verb routes through
+		// renderHTTPStatus → InsufficientRole.
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"detail":"tenant_filter_requires_tenant_admin"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runList(cmd, listOptions{Tenant: stubOtherTenant, BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatalf("expected 403 to surface as error")
+	}
+	if !strings.Contains(stderr.String(), "tenant_filter_requires_tenant_admin") {
+		t.Errorf("expected backend detail; got %q", stderr.String())
+	}
+}
+
+// ---------------------------------------------------------------
+// create verb
+// ---------------------------------------------------------------
+
+func TestRunCreateCronHappyPath(t *testing.T) {
+	var capturedBody api.ScheduledTriggerCreate
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/scheduler/triggers", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST; got %s", r.Method)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&capturedBody); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		trigger := fakeTrigger(t, "cron")
+		cronExpr := "* * * * *"
+		trigger.CronExpr = &cronExpr
+		_ = json.NewEncoder(w).Encode(trigger)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	if err := runCreate(cmd, createOptions{
+		Kind:              "cron",
+		AgentDefinition:   stubAgentDefID,
+		CronExpr:          "* * * * *",
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runCreate: %v; stderr=%s", err, stderr.String())
+	}
+	if string(capturedBody.Kind) != "cron" {
+		t.Errorf("expected wire kind=cron; got %q", capturedBody.Kind)
+	}
+	if capturedBody.CronExpr == nil || *capturedBody.CronExpr != "* * * * *" {
+		t.Errorf("expected cron_expr on wire; got %+v", capturedBody.CronExpr)
+	}
+	if !strings.Contains(stdout.String(), "created cron trigger") {
+		t.Errorf("expected created-prose in stdout; got %q", stdout.String())
+	}
+}
+
+func TestRunCreateRejectsUnknownKind(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	if err := runCreate(cmd, createOptions{Kind: "bogus"}); err == nil {
+		t.Fatalf("expected validation error")
+	}
+	if !strings.Contains(stderr.String(), "--kind must be one of") {
+		t.Errorf("expected validation message; got %q", stderr.String())
+	}
+}
+
+func TestRunCreateRejectsCronWithoutExpr(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runCreate(cmd, createOptions{
+		Kind: "cron", AgentDefinition: stubAgentDefID,
+	})
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+	if !strings.Contains(stderr.String(), "--kind=cron requires --cron-expr") {
+		t.Errorf("expected validation message; got %q", stderr.String())
+	}
+}
+
+func TestRunCreateRejectsInvalidAgentDefUUID(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runCreate(cmd, createOptions{
+		Kind:            "cron",
+		AgentDefinition: "not-a-uuid",
+		CronExpr:        "* * * * *",
+	})
+	if err == nil {
+		t.Fatalf("expected UUID validation error")
+	}
+	if !strings.Contains(stderr.String(), "--agent-definition is not a valid UUID") {
+		t.Errorf("expected UUID message; got %q", stderr.String())
+	}
+}
+
+func TestRunCreateRejectsInvalidFireAt(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runCreate(cmd, createOptions{
+		Kind:            "one_off",
+		AgentDefinition: stubAgentDefID,
+		FireAt:          "not-a-timestamp",
+	})
+	if err == nil {
+		t.Fatalf("expected fire-at validation error")
+	}
+	if !strings.Contains(stderr.String(), "--fire-at must be RFC 3339") {
+		t.Errorf("expected fire-at message; got %q", stderr.String())
+	}
+}
+
+// TestRunCreate201WithoutPayloadSurfacesUnexpected pins the JSON201
+// nil-guard.
+func TestRunCreate201WithoutPayloadSurfacesUnexpected(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/scheduler/triggers", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{}`)) // no Content-Type → JSON201 nil
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runCreate(cmd, createOptions{
+		Kind: "cron", AgentDefinition: stubAgentDefID, CronExpr: "* * * * *",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected nil-guard error on missing payload")
+	}
+	if !strings.Contains(stderr.String(), "HTTP 201 without a created-trigger payload") {
+		t.Errorf("expected nil-guard message; got %q", stderr.String())
+	}
+}
+
+func TestRunCreate422SurfacesUnexpected(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/scheduler/triggers", func(w http.ResponseWriter, _ *http.Request) {
+		// Deliberately no Content-Type header — the backend's
+		// HTTPException(detail="string") path lands without the
+		// `application/json` content type, so the oapi-codegen parser
+		// leaves `JSON422` nil but still populates `Body` with the
+		// raw bytes. The verb then routes through `renderHTTPStatus`
+		// which extracts the detail string via `decodeDetailString`.
+		// Mirrors the approach the approvals sibling adopted on PR
+		// #1276.
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"detail":"agent_definition_not_found"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runCreate(cmd, createOptions{
+		Kind: "cron", AgentDefinition: stubAgentDefID, CronExpr: "* * * * *",
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected 422 error")
+	}
+	if !strings.Contains(stderr.String(), "agent_definition_not_found") {
+		t.Errorf("expected backend detail; got %q", stderr.String())
+	}
+}
+
+// ---------------------------------------------------------------
+// cancel verb
+// ---------------------------------------------------------------
+
+func TestRunCancelHappyPath(t *testing.T) {
+	var capturedPath, capturedQuery string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/scheduler/triggers/"+stubTriggerID,
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodDelete {
+				t.Errorf("expected DELETE; got %s", r.Method)
+			}
+			capturedPath = r.URL.Path
+			capturedQuery = r.URL.RawQuery
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	if err := runCancel(cmd, cancelOptions{
+		TriggerID:         stubTriggerID,
+		Tenant:            stubOtherTenant,
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runCancel: %v; stderr=%s", err, stderr.String())
+	}
+	if capturedPath != "/api/v1/scheduler/triggers/"+stubTriggerID {
+		t.Errorf("unexpected path: %q", capturedPath)
+	}
+	if !strings.Contains(capturedQuery, "tenant_filter="+stubOtherTenant) {
+		t.Errorf("expected tenant_filter; got %q", capturedQuery)
+	}
+	if !strings.Contains(stdout.String(), "cancelled trigger "+stubTriggerID) {
+		t.Errorf("expected cancelled-prose; got %q", stdout.String())
+	}
+}
+
+func TestRunCancelJSONOutput(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/scheduler/triggers/"+stubTriggerID,
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	if err := runCancel(cmd, cancelOptions{
+		TriggerID:         stubTriggerID,
+		JSONOut:           true,
+		BackplaneOverride: srv.URL,
+	}); err != nil {
+		t.Fatalf("runCancel: %v; stderr=%s", err, stderr.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
+	}
+	if got["cancelled"] != true {
+		t.Errorf("expected cancelled=true; got %+v", got)
+	}
+	if got["trigger_id"] != stubTriggerID {
+		t.Errorf("expected trigger_id echoed; got %+v", got)
+	}
+}
+
+func TestRunCancel404SurfacesUnexpected(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/scheduler/triggers/"+stubTriggerID,
+		func(w http.ResponseWriter, _ *http.Request) {
+			// No Content-Type — mirrors the FastAPI HTTPException
+			// wire shape and the approvals-sibling test pattern.
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"detail":"trigger_not_found"}`))
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runCancel(cmd, cancelOptions{
+		TriggerID:         stubTriggerID,
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected 404 error")
+	}
+	if !strings.Contains(stderr.String(), "trigger_not_found") {
+		t.Errorf("expected backend detail; got %q", stderr.String())
+	}
+}
+
+func TestRunCancel409SurfacesUnexpected(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/scheduler/triggers/"+stubTriggerID,
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusConflict)
+			_, _ = w.Write([]byte(`{"detail":"trigger_already_fired"}`))
+		},
+	)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runCancel(cmd, cancelOptions{
+		TriggerID:         stubTriggerID,
+		BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatalf("expected 409 error")
+	}
+	if !strings.Contains(stderr.String(), "trigger_already_fired") {
+		t.Errorf("expected backend detail; got %q", stderr.String())
+	}
+}
+
+func TestRunCancelRejectsInvalidTriggerUUID(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runCancel(cmd, cancelOptions{TriggerID: "not-a-uuid"})
+	if err == nil {
+		t.Fatalf("expected UUID validation error")
+	}
+	if !strings.Contains(stderr.String(), "trigger-id is not a valid UUID") {
+		t.Errorf("expected UUID message; got %q", stderr.String())
+	}
+}
+
+// ---------------------------------------------------------------
+// printTriggerSummary
+// ---------------------------------------------------------------
+
+func TestPrintTriggerSummaryNilNoop(t *testing.T) {
+	var buf bytes.Buffer
+	printTriggerSummary(&buf, nil)
+	if buf.Len() != 0 {
+		t.Errorf("expected nil trigger to render nothing; got %q", buf.String())
+	}
+}
+
+func TestPrintTriggerSummaryHasAllKeys(t *testing.T) {
+	trigger := fakeTrigger(t, "cron")
+	cron := "0 12 * * *"
+	trigger.CronExpr = &cron
+	var buf bytes.Buffer
+	printTriggerSummary(&buf, &trigger)
+	out := buf.String()
+	for _, want := range []string{"id:", "tenant_id:", "kind:", "status:", "cron_expr:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in summary; got %q", want, out)
+		}
+	}
 }

--- a/docs/codebase/scheduler.md
+++ b/docs/codebase/scheduler.md
@@ -337,6 +337,32 @@ of `null` into `map[string]any` sets the map to nil without error,
 which would silently forward an empty body field that the backend
 cannot distinguish from "omitted").
 
+### CLI transport (G0.12-T13 #1271)
+
+`cli/internal/cmd/scheduler/` drives the generated
+`api.ClientWithResponses` surface directly: `api.NewAuthedClient`
+wires the bearer + lazy 401-refresh editor onto the embedded
+`ClientWithResponses`, and the verbs call the typed `*WithResponse`
+methods (`ListTriggersApiV1SchedulerTriggersGetWithResponse`,
+`CreateTriggerApiV1SchedulerTriggersPostWithResponse`,
+`CancelTriggerApiV1SchedulerTriggersTriggerIdDeleteWithResponse`).
+Consumer-side struct duplicates of the backend pydantic models
+(previously `Trigger`, `ListResponse`) are gone — every wire shape
+is now sourced from `cli/internal/api/client.gen.go`
+(`api.ScheduledTriggerRead`, `api.ScheduledTriggerListResponse`,
+`api.ScheduledTriggerCreate`) so a schema drift between the backend
+and the CLI surfaces at `go build` time rather than as the kind of
+#1069-class silent loss the freshness gate at
+`.github/workflows/cli-api-snapshot.yml` is designed to catch.
+
+A 1 MiB response-body cap is installed at the transport layer via
+an inline `capRoundTripper` threaded through
+`api.AuthedClientOptions.HTTPClient` (mirroring the T12 retrieval
+sibling on PR #1286). The wrapper re-binds every response body to
+`http.MaxBytesReader` so the generated `Parse*Response` helpers
+(which `io.ReadAll(rsp.Body)` into the typed envelope) can't be
+pinned by an adversarial / runaway backplane response.
+
 ## References
 
 - Issue #823 (G11.3-T2 cron + one-off triggers)


### PR DESCRIPTION
## Summary
- Migrates `cli/internal/cmd/scheduler/` (the `meho scheduler {list, create, cancel}` verbs) off hand-rolled HTTP onto the generated `api.ClientWithResponses` typed surface, closing the #1069-class schema-drift hole.
- Deletes consumer-side `Trigger` / `ListResponse` duplicates + the package-local `doAuthedRequest` machinery; every wire type now sources from `api.ScheduledTriggerRead` / `api.ScheduledTriggerListResponse` / `api.ScheduledTriggerCreate`.
- Same shape as the sibling migrations on Initiative #1118 (T1 approvals, T4 agent-principal, T9 kb, T10 memory, T12 retrieval): canonical `newAuthedClient` + `retryOn401[R]` + `renderRequestError` + `renderHTTPStatus` triad; auth hoisted out of retry loop (T11 lesson); JSON200/JSON201 nil-guards up front (pre-empts T9 iter-2 punch list); 1 MiB body cap via inline `capRoundTripper` threaded through `api.AuthedClientOptions.HTTPClient` (T12 pattern, scoped to the package).
- UUID arg validation hoisted to verb edges; `--fire-at` parsed CLI-side.

## Test plan
- [x] `go vet ./...` — clean.
- [x] `go test ./...` — every CLI package passes.
- [x] `go test ./internal/cmd/scheduler/...` — 28 tests pass.
- [x] `make snapshot-openapi` + `make generate` — no-op (freshness gate green).
- [x] AC #1 grep — no banned symbols (`http.NewRequest|doAuthedRequest|type Trigger|type ListResponse`) remain in `cli/internal/cmd/scheduler/`.
- [x] AC #2 grep — every verb file calls the typed `*WithResponse` method.
- [x] AC #3 — verb signatures / flags / output formatting preserved.
- [x] AC #4 — error-category mapping preserved (401→AuthExpired, 403→InsufficientRole, 404/409/422→Unexpected with backend detail).
- [x] AC #5 — `make snapshot-openapi && make generate` no-op (verified).
- [x] AC #7 — backend `scheduler.py` untouched.

## Out of scope
- Migrating other CLI verb directories (sibling tasks under Initiative #1118 own those).
- Adding `ResponseBodyLimit` to `cli/internal/api/client.go` (sibling T9/T10/T12 PRs add it byte-identically; per orchestrator note, scoping locally).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1271
