### PR TITLE
refactor(cli): G0.12-T16 promote dispatch.Connector to own typed transport (#1274)

### DIFF
--- a/cli/internal/cmd/bind9/bind9.go
+++ b/cli/internal/cmd/bind9/bind9.go
@@ -38,19 +38,15 @@
 package bind9
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -108,11 +104,15 @@ func NewRootCmd() *cobra.Command {
 	return cmd
 }
 
-// renderRequestError translates an error from doAuthedRequest into
-// the right output.RenderError category. Same classification ladder
-// as the vmware sibling: token-not-found / no-refresh-token →
-// auth_expired with `meho login` hints; HTTP-error → unexpected;
-// everything else (transport) → unreachable.
+// renderRequestError translates an error from conn.Call into the
+// right output.RenderError category. Same classification ladder as
+// the vmware sibling: token-not-found / no-refresh-token →
+// auth_expired with `meho login` hints; non-2xx HTTP →
+// unexpected_response; everything else (transport) → unreachable.
+//
+// Matches *dispatch.APIResponseError instead of a local httpError
+// sentinel after G0.12-T16 #1274 promoted the authed transport into
+// the shared dispatch package.
 func renderRequestError(
 	cmd *cobra.Command,
 	backplaneURL string,
@@ -137,11 +137,11 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
+	var apiErr *dispatch.APIResponseError
+	if errors.As(err, &apiErr) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, apiErr.StatusCode, apiErr.Body)),
 			jsonOut,
 		)
 	}
@@ -149,96 +149,6 @@ func renderRequestError(
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
-}
-
-// httpError carries a non-2xx response so renderRequestError can
-// pick the right StructuredError category. Same shape as the
-// vmware / vault siblings.
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-// doAuthedRequest issues a single HTTP request against the backplane
-// with bearer injection + one-shot 401-refresh-retry. Mirrors the
-// vmware / vault siblings verbatim (duplicated to avoid an import
-// cycle — cmd/root.go grafts each onto the tree). Centralised
-// per-package so the per-verb runners stay small.
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
-	}
-
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-
-	// 1 MiB cap matches the vmware sibling. bind9 `zone.read` on a
-	// production zone with thousands of records can be hundreds of
-	// KiB; the cap leaves headroom while bounding pathological
-	// payloads.
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-// sendRequest builds + fires the HTTP request. Mirrors the vmware
-// sibling; split out so the 401-refresh-retry path can reuse the
-// same body bytes without re-marshalling.
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
 }
 
 // readLocalFile loads a local file path as UTF-8 bytes. Used by the

--- a/cli/internal/cmd/bind9/dispatch.go
+++ b/cli/internal/cmd/bind9/dispatch.go
@@ -25,9 +25,11 @@ type (
 // errOpError is the structured-failure sentinel (status error/denied).
 var errOpError = dispatch.ErrOpError
 
-// conn binds this package's pre-baked connector_id + authed transport
-// (doAuthedRequest) to the shared dispatch core.
-var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}
+// conn binds this package's pre-baked connector_id to the shared
+// dispatch core. The authed transport (lazy *api.AuthedClient over the
+// generated typed surface) lives inside dispatch.Connector after
+// G0.12-T16 #1274 promoted the per-vendor doAuthedRequest copies.
+var conn = dispatch.New(ConnectorID)
 
 // printErrorTrailer renders the connector error + extras tail shared by
 // the bind9 per-verb pretty-printers (the success body is verb-specific).

--- a/cli/internal/cmd/gcloud/dispatch.go
+++ b/cli/internal/cmd/gcloud/dispatch.go
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package gcloud
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/dispatch"
+)
+
+// Aliases + binding to the shared dispatch core (cli/internal/dispatch).
+// gcloud was the deviation pre-#1274: it carried its own dispatchOp /
+// renderCallResult / printGenericResult trio with no dispatch.go file,
+// while every other vendor dir bound to the shared dispatch.Connector
+// (with the per-dir doAuthedRequest still injected). G0.12-T16 #1274
+// promoted the authed transport into the shared dispatch.Connector and
+// folded gcloud onto the same pattern at the same time.
+type (
+	// CallResult is the decoded OperationResult envelope.
+	CallResult = dispatch.CallResult
+	// callRequestBody is the on-the-wire OperationCall body (asserted by tests).
+	callRequestBody = dispatch.CallRequestBody
+)
+
+// errOpError is the structured-failure sentinel (status error/denied).
+var errOpError = dispatch.ErrOpError
+
+// conn binds this package's pre-baked connector_id to the shared
+// dispatch core. The authed transport (lazy *api.AuthedClient over the
+// generated typed surface) lives inside dispatch.Connector after
+// G0.12-T16 #1274 promoted the per-vendor doAuthedRequest copies.
+var conn = dispatch.New(ConnectorID)
+
+// dispatchOp is a thin wrapper around conn.Call kept so the per-verb
+// files (about.go / project.go / services.go / iam.go / compute.go)
+// continue calling the unqualified name they were authored against.
+func dispatchOp(
+	ctx context.Context,
+	backplaneURL, opID, targetSlug string,
+	params map[string]any,
+) (*CallResult, error) {
+	return conn.Call(ctx, backplaneURL, opID, targetSlug, params)
+}
+
+// renderCallResult is a thin wrapper around conn.Render for the same
+// reason as dispatchOp above.
+func renderCallResult(
+	cmd *cobra.Command,
+	opID string,
+	r *CallResult,
+	jsonOut bool,
+	prettyPrinter func(w io.Writer, r *CallResult),
+) error {
+	return conn.Render(cmd, opID, r, jsonOut, prettyPrinter)
+}
+
+// printGenericResult renders a CallResult in the generic envelope
+// shape. Retained as a free function (instead of always routing via
+// conn.PrintGeneric) so the per-verb pretty-printers continue
+// referencing the unqualified name.
+func printGenericResult(w io.Writer, opID string, r *CallResult) {
+	conn.PrintGeneric(w, opID, r)
+}
+
+// errRowsKeyAbsent is returned by decodeRowsResult when the result
+// envelope is a well-formed JSON object that carries no `rows` key at
+// all. This is distinct from an empty list (`{"rows": []}`): an absent
+// key signals a malformed or unexpected envelope, so callers route it
+// to fallbackResultRender (dump the raw shape) rather than rendering a
+// misleading "(0 rows)" line. A sentinel so callers can branch on it
+// via errors.Is if they ever need to.
+var errRowsKeyAbsent = errors.New("rows key absent from result envelope")
+
+// decodeRowsResult decodes the canonical `{"rows": [...], "total": N}`
+// envelope that every set-shaped gcloud read op returns. Returns the
+// row list, or an error when the shape doesn't match.
+//
+// An absent `rows` key is treated as a malformed envelope and reported
+// as errRowsKeyAbsent — distinct from a legitimately-empty list
+// (`{"rows": []}`), which returns an empty slice and a nil error. A
+// JSON null result (or no result at all) is the operation's "nothing to
+// render" case and returns (nil, nil), unchanged from before.
+func decodeRowsResult(raw json.RawMessage) ([]map[string]any, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return nil, fmt.Errorf("decode rows envelope: %w", err)
+	}
+	rowsRaw, ok := envelope["rows"]
+	if !ok {
+		return nil, errRowsKeyAbsent
+	}
+	var rows []map[string]any
+	if err := json.Unmarshal(rowsRaw, &rows); err != nil {
+		return nil, fmt.Errorf("decode rows: %w", err)
+	}
+	return rows, nil
+}
+
+// decodeFlatResult decodes a flat-dict result (gcloud.about,
+// gcloud.project.describe, gcloud.iam.policy.read). Returns the
+// decoded map or an error.
+func decodeFlatResult(raw json.RawMessage) (map[string]any, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("decode flat: %w", err)
+	}
+	return m, nil
+}
+
+// stringField pulls a string field from a result entry, returning empty
+// string when the field is missing or wrong type. Mirrors the bind9 /
+// k8s siblings.
+func stringField(e map[string]any, key string) string {
+	v, ok := e[key]
+	if !ok {
+		return ""
+	}
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// boolField pulls a boolean field from a result entry, returning false
+// when the field is missing or wrong type.
+func boolField(e map[string]any, key string) bool {
+	v, ok := e[key]
+	if !ok {
+		return false
+	}
+	if b, ok := v.(bool); ok {
+		return b
+	}
+	return false
+}
+
+// fallbackResultRender dumps the result envelope verbatim when the
+// typed per-verb decode fails. Used by every verb's pretty-printer
+// so contract drift surfaces with the same affordance.
+func fallbackResultRender(w io.Writer, r *CallResult) {
+	if len(r.Result) == 0 || string(r.Result) == "null" {
+		return
+	}
+	pretty, err := dispatch.PrettyJSON(r.Result)
+	if err == nil {
+		fmt.Fprintln(w, pretty)
+		return
+	}
+	fmt.Fprintln(w, string(r.Result))
+}
+
+// printErrorTrailer surfaces the dispatcher error / extras envelope.
+// Mirrors the bind9 / k8s siblings.
+func printErrorTrailer(w io.Writer, r *CallResult) {
+	if r.Error != nil && *r.Error != "" {
+		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
+	} else {
+		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
+	}
+	if len(r.Extras) > 0 && string(r.Extras) != "null" {
+		fmt.Fprintln(w, "extras:")
+		pretty, err := dispatch.PrettyJSON(r.Extras)
+		if err == nil {
+			fmt.Fprintln(w, pretty)
+		} else {
+			fmt.Fprintln(w, string(r.Extras))
+		}
+	}
+}

--- a/cli/internal/cmd/gcloud/dispatch.go
+++ b/cli/internal/cmd/gcloud/dispatch.go
@@ -61,14 +61,6 @@ func renderCallResult(
 	return conn.Render(cmd, opID, r, jsonOut, prettyPrinter)
 }
 
-// printGenericResult renders a CallResult in the generic envelope
-// shape. Retained as a free function (instead of always routing via
-// conn.PrintGeneric) so the per-verb pretty-printers continue
-// referencing the unqualified name.
-func printGenericResult(w io.Writer, opID string, r *CallResult) {
-	conn.PrintGeneric(w, opID, r)
-}
-
 // errRowsKeyAbsent is returned by decodeRowsResult when the result
 // envelope is a well-formed JSON object that carries no `rows` key at
 // all. This is distinct from an empty list (`{"rows": []}`): an absent

--- a/cli/internal/cmd/gcloud/gcloud.go
+++ b/cli/internal/cmd/gcloud/gcloud.go
@@ -35,13 +35,8 @@
 package gcloud
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"net/url"
 	"strings"
 
@@ -49,6 +44,7 @@ import (
 
 	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -184,11 +180,11 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
+	var apiErr *dispatch.APIResponseError
+	if errors.As(err, &apiErr) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, apiErr.StatusCode, apiErr.Body)),
 			jsonOut,
 		)
 	}
@@ -196,92 +192,6 @@ func renderRequestError(
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
-}
-
-// httpError carries a non-2xx response. Same shape as the bind9 / k8s
-// siblings.
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-// doAuthedRequest issues a single HTTP request against the backplane
-// with bearer injection + one-shot 401-refresh-retry. Mirrors the
-// bind9 / k8s siblings verbatim (duplicated to avoid an import cycle).
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
-	}
-
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-
-	// 1 MiB cap — gcloud aggregated instance/subnet lists can be
-	// large on projects with many zones/regions; the cap bounds
-	// pathological payloads.
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-// sendRequest builds + fires the HTTP request. Mirrors the bind9 / k8s
-// siblings; split out so the 401-refresh-retry path can reuse the
-// same body bytes without re-marshalling.
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
 }
 
 // truncate cuts s to maxLen runes, appending an ellipsis when
@@ -297,248 +207,4 @@ func truncate(s string, maxLen int) string {
 		return s
 	}
 	return string(runes[:maxLen-1]) + "…"
-}
-
-// CallResult mirrors the backend OperationResult Pydantic model. Same
-// shape as the bind9 / k8s siblings; duplicated to avoid an import
-// cycle.
-type CallResult struct {
-	Status     string          `json:"status"`
-	OpID       string          `json:"op_id"`
-	Result     json.RawMessage `json:"result"`
-	Error      *string         `json:"error"`
-	Extras     json.RawMessage `json:"extras,omitempty"`
-	DurationMs float64         `json:"duration_ms"`
-}
-
-// callRequestBody mirrors the backend CallOperationBody Pydantic
-// model. Target uses a map[string]any so the empty case serialises
-// as `null`; the route layer's resolver short-circuits on missing-name
-// for ops that need a target.
-type callRequestBody struct {
-	ConnectorID string         `json:"connector_id"`
-	OpID        string         `json:"op_id"`
-	Target      map[string]any `json:"target"`
-	Params      map[string]any `json:"params,omitempty"`
-}
-
-// errOpError is the sentinel returned when the dispatcher reported a
-// structured-failure result (status == "error" or status == "denied").
-var errOpError = errors.New("operation status not ok")
-
-// dispatchOp POSTs an OperationCall to the backplane and returns the
-// decoded CallResult. The pre-baked connector_id ("gcloud-rest-1.0")
-// is baked in; callers pass op_id, an optional target slug (empty
-// string → no target field on the wire), and an optional params map.
-func dispatchOp(
-	ctx context.Context,
-	backplaneURL, opID, targetSlug string,
-	params map[string]any,
-) (*CallResult, error) {
-	body := callRequestBody{
-		ConnectorID: ConnectorID,
-		OpID:        opID,
-		Target:      nil,
-	}
-	if targetSlug != "" {
-		body.Target = map[string]any{"name": targetSlug}
-	}
-	if params != nil {
-		body.Params = params
-	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal call request: %w", err)
-	}
-	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
-	if err != nil {
-		return nil, err
-	}
-	var out CallResult
-	if err := json.Unmarshal(respBody, &out); err != nil {
-		return nil, fmt.Errorf("decode call response: %w", err)
-	}
-	return &out, nil
-}
-
-// renderCallResult handles the unified post-dispatch path every verb
-// uses: validate status enum, render the envelope (JSON or human),
-// then translate "error" / "denied" into errOpError.
-func renderCallResult(
-	cmd *cobra.Command,
-	opID string,
-	r *CallResult,
-	jsonOut bool,
-	prettyPrinter func(w io.Writer, r *CallResult),
-) error {
-	switch r.Status {
-	case "ok", "error", "denied":
-		// expected statuses — fall through
-	default:
-		return output.RenderError(
-			cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf(
-				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
-				r.Status,
-			)),
-			jsonOut,
-		)
-	}
-	if jsonOut {
-		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
-			return err
-		}
-	} else if prettyPrinter != nil {
-		prettyPrinter(cmd.OutOrStdout(), r)
-	} else {
-		printGenericResult(cmd.OutOrStdout(), opID, r)
-	}
-	if r.Status == "ok" {
-		return nil
-	}
-	return errOpError
-}
-
-// printGenericResult renders a CallResult in the generic envelope
-// shape. Used as the fallback pretty-printer for verbs that don't
-// define their own table layout.
-func printGenericResult(w io.Writer, opID string, r *CallResult) {
-	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
-	if r.Status == "ok" {
-		if len(r.Result) > 0 && string(r.Result) != "null" {
-			pretty, err := prettyJSON(r.Result)
-			if err == nil {
-				fmt.Fprintln(w, pretty)
-				return
-			}
-			fmt.Fprintln(w, string(r.Result))
-		}
-		return
-	}
-	printErrorTrailer(w, r)
-}
-
-// printErrorTrailer surfaces the dispatcher error / extras envelope.
-// Mirrors the bind9 / k8s siblings.
-func printErrorTrailer(w io.Writer, r *CallResult) {
-	if r.Error != nil && *r.Error != "" {
-		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
-	} else {
-		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
-	}
-	if len(r.Extras) > 0 && string(r.Extras) != "null" {
-		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
-		if err == nil {
-			fmt.Fprintln(w, pretty)
-		} else {
-			fmt.Fprintln(w, string(r.Extras))
-		}
-	}
-}
-
-// prettyJSON pretty-prints a json.RawMessage with 2-space indent.
-func prettyJSON(raw json.RawMessage) (string, error) {
-	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return "", err
-	}
-	out, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
-}
-
-// errRowsKeyAbsent is returned by decodeRowsResult when the result
-// envelope is a well-formed JSON object that carries no `rows` key at
-// all. This is distinct from an empty list (`{"rows": []}`): an absent
-// key signals a malformed or unexpected envelope, so callers route it
-// to fallbackResultRender (dump the raw shape) rather than rendering a
-// misleading "(0 rows)" line. A sentinel so callers can branch on it
-// via errors.Is if they ever need to.
-var errRowsKeyAbsent = errors.New("rows key absent from result envelope")
-
-// decodeRowsResult decodes the canonical `{"rows": [...], "total": N}`
-// envelope that every set-shaped gcloud read op returns. Returns the
-// row list, or an error when the shape doesn't match.
-//
-// An absent `rows` key is treated as a malformed envelope and reported
-// as errRowsKeyAbsent — distinct from a legitimately-empty list
-// (`{"rows": []}`), which returns an empty slice and a nil error. A
-// JSON null result (or no result at all) is the operation's "nothing to
-// render" case and returns (nil, nil), unchanged from before.
-func decodeRowsResult(raw json.RawMessage) ([]map[string]any, error) {
-	if len(raw) == 0 || string(raw) == "null" {
-		return nil, nil
-	}
-	var envelope map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &envelope); err != nil {
-		return nil, fmt.Errorf("decode rows envelope: %w", err)
-	}
-	rowsRaw, ok := envelope["rows"]
-	if !ok {
-		return nil, errRowsKeyAbsent
-	}
-	var rows []map[string]any
-	if err := json.Unmarshal(rowsRaw, &rows); err != nil {
-		return nil, fmt.Errorf("decode rows: %w", err)
-	}
-	return rows, nil
-}
-
-// decodeFlatResult decodes a flat-dict result (gcloud.about,
-// gcloud.project.describe, gcloud.iam.policy.read). Returns the
-// decoded map or an error.
-func decodeFlatResult(raw json.RawMessage) (map[string]any, error) {
-	if len(raw) == 0 || string(raw) == "null" {
-		return nil, nil
-	}
-	var m map[string]any
-	if err := json.Unmarshal(raw, &m); err != nil {
-		return nil, fmt.Errorf("decode flat: %w", err)
-	}
-	return m, nil
-}
-
-// stringField pulls a string field from a result entry, returning empty
-// string when the field is missing or wrong type. Mirrors the bind9 /
-// k8s siblings.
-func stringField(e map[string]any, key string) string {
-	v, ok := e[key]
-	if !ok {
-		return ""
-	}
-	if s, ok := v.(string); ok {
-		return s
-	}
-	return ""
-}
-
-// boolField pulls a boolean field from a result entry, returning false
-// when the field is missing or wrong type.
-func boolField(e map[string]any, key string) bool {
-	v, ok := e[key]
-	if !ok {
-		return false
-	}
-	if b, ok := v.(bool); ok {
-		return b
-	}
-	return false
-}
-
-// fallbackResultRender dumps the result envelope verbatim when the
-// typed per-verb decode fails. Used by every verb's pretty-printer
-// so contract drift surfaces with the same affordance.
-func fallbackResultRender(w io.Writer, r *CallResult) {
-	if len(r.Result) == 0 || string(r.Result) == "null" {
-		return
-	}
-	pretty, err := prettyJSON(r.Result)
-	if err == nil {
-		fmt.Fprintln(w, pretty)
-		return
-	}
-	fmt.Fprintln(w, string(r.Result))
 }

--- a/cli/internal/cmd/harbor/dispatch.go
+++ b/cli/internal/cmd/harbor/dispatch.go
@@ -23,9 +23,11 @@ type (
 // errOpError is the structured-failure sentinel (status error/denied).
 var errOpError = dispatch.ErrOpError
 
-// conn binds this package's pre-baked connector_id + authed transport
-// (doAuthedRequest) to the shared dispatch core.
-var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}
+// conn binds this package's pre-baked connector_id to the shared
+// dispatch core. The authed transport (lazy *api.AuthedClient over the
+// generated typed surface) lives inside dispatch.Connector after
+// G0.12-T16 #1274 promoted the per-vendor doAuthedRequest copies.
+var conn = dispatch.New(ConnectorID)
 
 // decodeHarborList decodes the result of a Harbor list op. Harbor
 // list endpoints return a bare JSON array (no "results" wrapper).

--- a/cli/internal/cmd/harbor/harbor.go
+++ b/cli/internal/cmd/harbor/harbor.go
@@ -28,13 +28,10 @@
 package harbor
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"strings"
 
@@ -98,11 +95,11 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
+	var apiErr *dispatch.APIResponseError
+	if errors.As(err, &apiErr) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, apiErr.StatusCode, apiErr.Body)),
 			jsonOut,
 		)
 	}
@@ -110,83 +107,6 @@ func renderRequestError(
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
-}
-
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
-	}
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-	const maxBody = int64(1 << 20)
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if int64(len(raw)) > maxBody {
-		return nil, fmt.Errorf("backplane response body exceeds %d bytes", maxBody)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
 }
 
 func loadParamsFlag(val string) (map[string]any, error) {

--- a/cli/internal/cmd/harbor/operation.go
+++ b/cli/internal/cmd/harbor/operation.go
@@ -4,16 +4,13 @@
 package harbor
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
-	"strconv"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -30,23 +27,14 @@ func newOperationCmd() *cobra.Command {
 	return cmd
 }
 
-// searchHit mirrors the backend OperationSearchHit Pydantic model.
-type searchHit struct {
-	OpID             string   `json:"op_id"`
-	Summary          *string  `json:"summary"`
-	Description      *string  `json:"description"`
-	GroupKey         *string  `json:"group_key"`
-	SafetyLevel      string   `json:"safety_level"`
-	RequiresApproval bool     `json:"requires_approval"`
-	FusedScore       float64  `json:"fused_score"`
-	Bm25Score        *float64 `json:"bm25_score"`
-	CosineScore      *float64 `json:"cosine_score"`
-}
-
-type searchResponse struct {
-	Hits            []searchHit `json:"hits"`
-	QueryDurationMs float64     `json:"query_duration_ms"`
-}
+// searchHit + searchResponse alias the dispatch-package types
+// promoted from this dir's pre-#1274 copies. The verb file references
+// the unqualified names so the per-verb pretty-printers + tests stay
+// readable; the underlying types live once in dispatch.
+type (
+	searchHit      = dispatch.SearchHit
+	searchResponse = dispatch.SearchResponse
+)
 
 func newOperationSearchCmd() *cobra.Command {
 	var (
@@ -88,7 +76,7 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
-	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
+	result, err := conn.Search(cmd.Context(), backplaneURL, query, groupKey, limit)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
@@ -97,28 +85,6 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 	}
 	printSearchTable(cmd.OutOrStdout(), query, result)
 	return nil
-}
-
-func getSearch(ctx context.Context, backplaneURL, query, groupKey string, limit int) (*searchResponse, error) {
-	q := url.Values{}
-	q.Set("connector_id", ConnectorID)
-	q.Set("query", query)
-	if groupKey != "" {
-		q.Set("group", groupKey)
-	}
-	if limit > 0 {
-		q.Set("limit", strconv.Itoa(limit))
-	}
-	path := "/api/v1/operations/search?" + q.Encode()
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
-	if err != nil {
-		return nil, err
-	}
-	var out searchResponse
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode search response: %w", err)
-	}
-	return &out, nil
 }
 
 func printSearchTable(w io.Writer, query string, r *searchResponse) {

--- a/cli/internal/cmd/hetzner-robot/dispatch.go
+++ b/cli/internal/cmd/hetzner-robot/dispatch.go
@@ -6,72 +6,50 @@ package hetznerrobot
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
 
-	"github.com/evoila/meho/cli/internal/output"
+	"github.com/evoila/meho/cli/internal/dispatch"
 )
 
-// CallResult mirrors the backend OperationResult Pydantic model.
-type CallResult struct {
-	Status     string          `json:"status"`
-	OpID       string          `json:"op_id"`
-	Result     json.RawMessage `json:"result"`
-	Error      *string         `json:"error"`
-	Extras     json.RawMessage `json:"extras,omitempty"`
-	DurationMs float64         `json:"duration_ms"`
-}
+// Aliases + binding to the shared dispatch core (cli/internal/dispatch).
+// Pre-#1274 hetzner-robot carried its own dispatchOp / renderCallResult /
+// printGenericResult trio because the shared dispatch.Connector hadn't
+// owned the authed transport yet — the local copies threaded the per-
+// dir doAuthedRequest into the request loop. G0.12-T16 #1274 promoted
+// the transport into dispatch.Connector itself; hetzner-robot now folds
+// onto the shared pattern (matching bind9 / k8s / vault / etc.).
+type (
+	// CallResult is the decoded OperationResult envelope.
+	CallResult = dispatch.CallResult
+	// callRequestBody is the on-the-wire OperationCall body (asserted by tests).
+	callRequestBody = dispatch.CallRequestBody
+)
 
-// callRequestBody mirrors the backend CallOperationBody Pydantic model.
-type callRequestBody struct {
-	ConnectorID string         `json:"connector_id"`
-	OpID        string         `json:"op_id"`
-	Target      map[string]any `json:"target"`
-	Params      map[string]any `json:"params,omitempty"`
-}
+// errOpError is the structured-failure sentinel (status error/denied).
+var errOpError = dispatch.ErrOpError
 
-var errOpError = errors.New("operation status not ok")
+// conn binds this package's pre-baked connector_id to the shared
+// dispatch core. The authed transport (lazy *api.AuthedClient over the
+// generated typed surface) lives inside dispatch.Connector after
+// G0.12-T16 #1274 promoted the per-vendor doAuthedRequest copies.
+var conn = dispatch.New(ConnectorID)
 
-// dispatchOp POSTs an OperationCall to the backplane and returns the
-// decoded CallResult with connector_id="hetzner-rest-2026.04" pre-baked.
-//
-// When targetSlug is empty, the body's target field is encoded as JSON
-// null — matches the backend contract for ops that don't act on a target.
+// dispatchOp is a thin wrapper around conn.Call kept so the per-verb
+// files continue calling the unqualified name they were authored
+// against.
 func dispatchOp(
 	ctx context.Context,
 	backplaneURL, opID, targetSlug string,
 	params map[string]any,
 ) (*CallResult, error) {
-	body := callRequestBody{
-		ConnectorID: ConnectorID,
-		OpID:        opID,
-		Target:      nil,
-	}
-	if targetSlug != "" {
-		body.Target = map[string]any{"name": targetSlug}
-	}
-	if params != nil {
-		body.Params = params
-	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal call request: %w", err)
-	}
-	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
-	if err != nil {
-		return nil, err
-	}
-	var out CallResult
-	if err := json.Unmarshal(respBody, &out); err != nil {
-		return nil, fmt.Errorf("decode call response: %w", err)
-	}
-	return &out, nil
+	return conn.Call(ctx, backplaneURL, opID, targetSlug, params)
 }
 
-// renderCallResult handles the unified post-dispatch rendering path.
+// renderCallResult is a thin wrapper around conn.Render for the same
+// reason as dispatchOp above.
 func renderCallResult(
 	cmd *cobra.Command,
 	opID string,
@@ -79,61 +57,7 @@ func renderCallResult(
 	jsonOut bool,
 	prettyPrinter func(w io.Writer, r *CallResult),
 ) error {
-	switch r.Status {
-	case "ok", "error", "denied":
-	default:
-		return output.RenderError(
-			cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf(
-				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
-				r.Status,
-			)),
-			jsonOut,
-		)
-	}
-	if jsonOut {
-		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
-			return err
-		}
-	} else if prettyPrinter != nil {
-		prettyPrinter(cmd.OutOrStdout(), r)
-	} else {
-		printGenericResult(cmd.OutOrStdout(), opID, r)
-	}
-	if r.Status == "ok" {
-		return nil
-	}
-	return errOpError
-}
-
-// printGenericResult renders a CallResult in the generic envelope shape.
-func printGenericResult(w io.Writer, opID string, r *CallResult) {
-	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
-	if r.Status == "ok" {
-		if len(r.Result) > 0 && string(r.Result) != "null" {
-			pretty, err := prettyJSON(r.Result)
-			if err == nil {
-				fmt.Fprintln(w, pretty)
-				return
-			}
-			fmt.Fprintln(w, string(r.Result))
-		}
-		return
-	}
-	if r.Error != nil && *r.Error != "" {
-		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
-	} else {
-		fmt.Fprintf(w, "meho: connector status=%s\n", r.Status)
-	}
-	if len(r.Extras) > 0 && string(r.Extras) != "null" {
-		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
-		if err == nil {
-			fmt.Fprintln(w, pretty)
-		} else {
-			fmt.Fprintln(w, string(r.Extras))
-		}
-	}
+	return conn.Render(cmd, opID, r, jsonOut, prettyPrinter)
 }
 
 // decodeRobotList decodes the result of a Robot list op. Hetzner Robot
@@ -160,16 +84,4 @@ func decodeRobotList(raw json.RawMessage) ([]map[string]any, error) {
 		}
 	}
 	return nil, fmt.Errorf("decode robot list: no array found in object")
-}
-
-func prettyJSON(raw json.RawMessage) (string, error) {
-	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return "", err
-	}
-	out, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
 }

--- a/cli/internal/cmd/hetzner-robot/hetzner_robot.go
+++ b/cli/internal/cmd/hetzner-robot/hetzner_robot.go
@@ -35,13 +35,10 @@
 package hetznerrobot
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -50,6 +47,7 @@ import (
 
 	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -163,11 +161,11 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
+	var apiErr *dispatch.APIResponseError
+	if errors.As(err, &apiErr) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, apiErr.StatusCode, apiErr.Body)),
 			jsonOut,
 		)
 	}
@@ -175,83 +173,6 @@ func renderRequestError(
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
-}
-
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
-	}
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-	const maxBody = int64(1 << 20)
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if int64(len(raw)) > maxBody {
-		return nil, fmt.Errorf("backplane response body exceeds %d bytes", maxBody)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
 }
 
 func loadParamsFlag(val string) (map[string]any, error) {
@@ -300,7 +221,7 @@ func printErrorTrailer(w io.Writer, r *CallResult) {
 	}
 	if len(r.Extras) > 0 && string(r.Extras) != "null" {
 		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
+		pretty, err := dispatch.PrettyJSON(r.Extras)
 		if err == nil {
 			fmt.Fprintln(w, pretty)
 		} else {
@@ -315,7 +236,7 @@ func fallbackResultRender(w io.Writer, r *CallResult) {
 	if len(r.Result) == 0 || string(r.Result) == "null" {
 		return
 	}
-	pretty, err := prettyJSON(r.Result)
+	pretty, err := dispatch.PrettyJSON(r.Result)
 	if err == nil {
 		fmt.Fprintln(w, pretty)
 		return

--- a/cli/internal/cmd/hetzner-robot/operation.go
+++ b/cli/internal/cmd/hetzner-robot/operation.go
@@ -4,15 +4,12 @@
 package hetznerrobot
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
-	"strconv"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -31,23 +28,14 @@ func newOperationCmd() *cobra.Command {
 	return cmd
 }
 
-// searchHit mirrors the backend OperationSearchHit Pydantic model.
-type searchHit struct {
-	OpID             string   `json:"op_id"`
-	Summary          *string  `json:"summary"`
-	Description      *string  `json:"description"`
-	GroupKey         *string  `json:"group_key"`
-	SafetyLevel      string   `json:"safety_level"`
-	RequiresApproval bool     `json:"requires_approval"`
-	FusedScore       float64  `json:"fused_score"`
-	Bm25Score        *float64 `json:"bm25_score"`
-	CosineScore      *float64 `json:"cosine_score"`
-}
-
-type searchResponse struct {
-	Hits            []searchHit `json:"hits"`
-	QueryDurationMs float64     `json:"query_duration_ms"`
-}
+// searchHit + searchResponse alias the dispatch-package types
+// promoted from this dir's pre-#1274 copies. The verb file references
+// the unqualified names so the per-verb pretty-printers + tests stay
+// readable; the underlying types live once in dispatch.
+type (
+	searchHit      = dispatch.SearchHit
+	searchResponse = dispatch.SearchResponse
+)
 
 func newOperationSearchCmd() *cobra.Command {
 	var (
@@ -90,7 +78,7 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), classifyBackplaneError(err), jsonOut)
 	}
-	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
+	result, err := conn.Search(cmd.Context(), backplaneURL, query, groupKey, limit)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
@@ -99,28 +87,6 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 	}
 	printSearchTable(cmd.OutOrStdout(), query, result)
 	return nil
-}
-
-func getSearch(ctx context.Context, backplaneURL, query, groupKey string, limit int) (*searchResponse, error) {
-	q := url.Values{}
-	q.Set("connector_id", ConnectorID)
-	q.Set("query", query)
-	if groupKey != "" {
-		q.Set("group", groupKey)
-	}
-	if limit > 0 {
-		q.Set("limit", strconv.Itoa(limit))
-	}
-	path := "/api/v1/operations/search?" + q.Encode()
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
-	if err != nil {
-		return nil, err
-	}
-	var out searchResponse
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode search response: %w", err)
-	}
-	return &out, nil
 }
 
 func printSearchTable(w io.Writer, query string, r *searchResponse) {

--- a/cli/internal/cmd/holodeck/dispatch.go
+++ b/cli/internal/cmd/holodeck/dispatch.go
@@ -6,50 +6,24 @@ package holodeck
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
 
-	"github.com/evoila/meho/cli/internal/output"
+	"github.com/evoila/meho/cli/internal/dispatch"
 )
 
-// CallResult mirrors the backend OperationResult Pydantic model.
-// Same shape as cmd/pfsense/CallResult; duplicated here because
-// cmd/holodeck can't import cmd/pfsense without an import cycle
-// (cmd/root.go grafts both onto the tree).
-type CallResult struct {
-	Status     string          `json:"status"`
-	OpID       string          `json:"op_id"`
-	Result     json.RawMessage `json:"result"`
-	Error      *string         `json:"error"`
-	Extras     json.RawMessage `json:"extras,omitempty"`
-	DurationMs float64         `json:"duration_ms"`
-}
-
-// callRequestBody mirrors the backend CallOperationBody Pydantic
-// model. Target uses a map[string]any so the empty case serialises
-// as `null` rather than an empty struct.
-type callRequestBody struct {
-	ConnectorID string         `json:"connector_id"`
-	OpID        string         `json:"op_id"`
-	Target      map[string]any `json:"target"`
-	Params      map[string]any `json:"params,omitempty"`
-}
-
-// errOpError is the sentinel returned when the dispatcher reported a
-// structured-failure result (status == "error" or status == "denied").
-var errOpError = errors.New("operation status not ok")
-
-// dispatchOp POSTs an OperationCall to the backplane and returns the
-// decoded CallResult. The pre-baked connector_id ("holodeck-ssh-9.0")
-// is baked in; callers pass op_id, an optional target slug (empty
-// string → no target field on the wire), and an optional params map.
+// Aliases + binding to the shared dispatch core (cli/internal/dispatch).
+// The verb files in this package keep referring to the unqualified names;
+// the operation-call logic lives once in the dispatch package.
 //
-// Centralised here so every verb in the package shares one
-// dispatcher implementation. A grep for `dispatchOp` finds every
-// alias-verb dispatch in the holodeck package.
+// Pre-#1274 holodeck carried its own dispatchOp / renderCallResult /
+// printGenericResult trio because the shared dispatch.Connector hadn't
+// owned the authed transport yet — the local copies threaded the per-
+// dir doAuthedRequest into the request loop. G0.12-T16 #1274 promoted
+// the transport into dispatch.Connector itself; holodeck now folds onto
+// the shared pattern (matching bind9 / k8s / vault / etc.).
 //
 // NOTE: holodeck.k8s.exec passes the operator's `kubectl` command
 // verbatim in `params["command"]`. The CLI does not pre-parse or
@@ -58,41 +32,35 @@ var errOpError = errors.New("operation status not ok")
 // invocation containing `;` / `&&` / `|` / `$(...)` / backticks /
 // `>` / `<` / newline is refused with `result_connector_error` and
 // surfaces as a non-ok status on the CLI side.
+type (
+	// CallResult is the decoded OperationResult envelope.
+	CallResult = dispatch.CallResult
+	// callRequestBody is the on-the-wire OperationCall body (asserted by tests).
+	callRequestBody = dispatch.CallRequestBody
+)
+
+// errOpError is the structured-failure sentinel (status error/denied).
+var errOpError = dispatch.ErrOpError
+
+// conn binds this package's pre-baked connector_id to the shared
+// dispatch core. The authed transport (lazy *api.AuthedClient over the
+// generated typed surface) lives inside dispatch.Connector after
+// G0.12-T16 #1274 promoted the per-vendor doAuthedRequest copies.
+var conn = dispatch.New(ConnectorID)
+
+// dispatchOp is a thin wrapper around conn.Call kept so the per-verb
+// files (about.go / pod.go / service.go / ...) continue calling the
+// unqualified name they were authored against.
 func dispatchOp(
 	ctx context.Context,
 	backplaneURL, opID, targetSlug string,
 	params map[string]any,
 ) (*CallResult, error) {
-	body := callRequestBody{
-		ConnectorID: ConnectorID,
-		OpID:        opID,
-		Target:      nil,
-	}
-	if targetSlug != "" {
-		body.Target = map[string]any{"name": targetSlug}
-	}
-	if params != nil {
-		body.Params = params
-	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal call request: %w", err)
-	}
-	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
-	if err != nil {
-		return nil, err
-	}
-	var out CallResult
-	if err := json.Unmarshal(respBody, &out); err != nil {
-		return nil, fmt.Errorf("decode call response: %w", err)
-	}
-	return &out, nil
+	return conn.Call(ctx, backplaneURL, opID, targetSlug, params)
 }
 
-// renderCallResult handles the unified post-dispatch path every verb
-// uses: validate status enum, render the envelope (JSON or human),
-// then translate "error" / "denied" into the errOpError sentinel so
-// main propagates the right non-zero exit.
+// renderCallResult is a thin wrapper around conn.Render for the same
+// reason as dispatchOp above.
 func renderCallResult(
 	cmd *cobra.Command,
 	opID string,
@@ -100,52 +68,11 @@ func renderCallResult(
 	jsonOut bool,
 	prettyPrinter func(w io.Writer, r *CallResult),
 ) error {
-	switch r.Status {
-	case "ok", "error", "denied":
-		// fall through.
-	default:
-		return output.RenderError(
-			cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf(
-				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
-				r.Status,
-			)),
-			jsonOut,
-		)
-	}
-	if jsonOut {
-		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
-			return err
-		}
-	} else if prettyPrinter != nil {
-		prettyPrinter(cmd.OutOrStdout(), r)
-	} else {
-		printGenericResult(cmd.OutOrStdout(), opID, r)
-	}
-	if r.Status == "ok" {
-		return nil
-	}
-	return errOpError
+	return conn.Render(cmd, opID, r, jsonOut, prettyPrinter)
 }
 
-// printGenericResult renders a CallResult in a generic envelope shape.
-func printGenericResult(w io.Writer, opID string, r *CallResult) {
-	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
-	if r.Status == "ok" {
-		if len(r.Result) > 0 && string(r.Result) != "null" {
-			pretty, err := prettyJSON(r.Result)
-			if err == nil {
-				fmt.Fprintln(w, pretty)
-				return
-			}
-			fmt.Fprintln(w, string(r.Result))
-		}
-		return
-	}
-	printErrorTrailer(w, r)
-}
-
-// printErrorTrailer surfaces the dispatcher error / extras envelope.
+// printErrorTrailer surfaces the dispatcher error + extras envelope.
+// Used by the per-verb pretty-printers' non-ok branch.
 func printErrorTrailer(w io.Writer, r *CallResult) {
 	if r.Error != nil && *r.Error != "" {
 		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
@@ -154,7 +81,7 @@ func printErrorTrailer(w io.Writer, r *CallResult) {
 	}
 	if len(r.Extras) > 0 && string(r.Extras) != "null" {
 		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
+		pretty, err := dispatch.PrettyJSON(r.Extras)
 		if err == nil {
 			fmt.Fprintln(w, pretty)
 		} else {

--- a/cli/internal/cmd/holodeck/dispatch.go
+++ b/cli/internal/cmd/holodeck/dispatch.go
@@ -39,9 +39,6 @@ type (
 	callRequestBody = dispatch.CallRequestBody
 )
 
-// errOpError is the structured-failure sentinel (status error/denied).
-var errOpError = dispatch.ErrOpError
-
 // conn binds this package's pre-baked connector_id to the shared
 // dispatch core. The authed transport (lazy *api.AuthedClient over the
 // generated typed surface) lives inside dispatch.Connector after

--- a/cli/internal/cmd/holodeck/holodeck.go
+++ b/cli/internal/cmd/holodeck/holodeck.go
@@ -53,13 +53,9 @@
 package holodeck
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"strings"
 
@@ -67,6 +63,7 @@ import (
 
 	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -227,11 +224,11 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
+	var apiErr *dispatch.APIResponseError
+	if errors.As(err, &apiErr) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, apiErr.StatusCode, apiErr.Body)),
 			jsonOut,
 		)
 	}
@@ -239,93 +236,6 @@ func renderRequestError(
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
-}
-
-// httpError carries a non-2xx response so renderRequestError can
-// pick the right StructuredError category.
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-// doAuthedRequest issues a single HTTP request against the backplane
-// with bearer injection + one-shot 401-refresh-retry. Mirrors the
-// pfsense / bind9 siblings verbatim (duplicated to avoid import
-// cycle — cmd/root.go grafts each onto the tree).
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
-	}
-
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-
-	// 2 MiB cap — holodeck.config.show can return a large appliance
-	// config and holodeck.logs.tail can return up to 5000 lines per
-	// log file (with multi-file glob). The cap leaves headroom while
-	// bounding pathological payloads.
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-// sendRequest builds + fires the HTTP request. Mirrors the pfsense
-// sibling.
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
 }
 
 // truncate cuts s to maxLen runes, appending an ellipsis when
@@ -344,26 +254,13 @@ func truncate(s string, maxLen int) string {
 	return string(runes[:maxLen-1]) + "…"
 }
 
-// prettyJSON pretty-prints a json.RawMessage with 2-space indent.
-func prettyJSON(raw json.RawMessage) (string, error) {
-	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return "", err
-	}
-	out, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
-}
-
 // fallbackResultRender dumps the result envelope verbatim when the
 // typed per-verb decode fails.
 func fallbackResultRender(w io.Writer, r *CallResult) {
 	if len(r.Result) == 0 || string(r.Result) == "null" {
 		return
 	}
-	pretty, err := prettyJSON(r.Result)
+	pretty, err := dispatch.PrettyJSON(r.Result)
 	if err == nil {
 		fmt.Fprintln(w, pretty)
 		return

--- a/cli/internal/cmd/k8s/dispatch.go
+++ b/cli/internal/cmd/k8s/dispatch.go
@@ -25,9 +25,11 @@ type (
 // errOpError is the structured-failure sentinel (status error/denied).
 var errOpError = dispatch.ErrOpError
 
-// conn binds this package's pre-baked connector_id + authed transport
-// (doAuthedRequest) to the shared dispatch core.
-var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}
+// conn binds this package's pre-baked connector_id to the shared
+// dispatch core. The authed transport (lazy *api.AuthedClient over the
+// generated typed surface) lives inside dispatch.Connector after
+// G0.12-T16 #1274 promoted the per-vendor doAuthedRequest copies.
+var conn = dispatch.New(ConnectorID)
 
 type k8sAddrFlags struct {
 	targetName        string

--- a/cli/internal/cmd/k8s/k8s.go
+++ b/cli/internal/cmd/k8s/k8s.go
@@ -45,19 +45,16 @@
 package k8s
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -150,11 +147,11 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
+	var apiErr *dispatch.APIResponseError
+	if errors.As(err, &apiErr) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, apiErr.StatusCode, apiErr.Body)),
 			jsonOut,
 		)
 	}
@@ -162,92 +159,6 @@ func renderRequestError(
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
-}
-
-// httpError carries a non-2xx response so renderRequestError can pick
-// the right StructuredError category. Same shape as the vault sibling.
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-// doAuthedRequest issues a single HTTP request against the backplane
-// with bearer injection + one-shot 401-refresh-retry. Mirrors the
-// vault sibling verbatim (duplicated to avoid an import cycle).
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
-	}
-
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-
-	// 1 MiB cap matches the vault sibling. K8s op results (rows, pod
-	// info, logs) fit comfortably; the cap bounds pathological
-	// payloads (e.g. a logs response not yet truncated server-side).
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-// sendRequest builds + fires the HTTP request. Mirrors the vault
-// sibling; split out so the 401-refresh-retry path can reuse the same
-// body bytes without re-marshalling.
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
 }
 
 // loadJSONFlag parses a flag value that is either inline JSON or an

--- a/cli/internal/cmd/nsx/dispatch.go
+++ b/cli/internal/cmd/nsx/dispatch.go
@@ -18,6 +18,8 @@ type (
 // errOpError is the structured-failure sentinel (status error/denied).
 var errOpError = dispatch.ErrOpError
 
-// conn binds this package's pre-baked connector_id + authed transport
-// (doAuthedRequest) to the shared dispatch core.
-var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}
+// conn binds this package's pre-baked connector_id to the shared
+// dispatch core. The authed transport (lazy *api.AuthedClient over the
+// generated typed surface) lives inside dispatch.Connector after
+// G0.12-T16 #1274 promoted the per-vendor doAuthedRequest copies.
+var conn = dispatch.New(ConnectorID)

--- a/cli/internal/cmd/nsx/nsx.go
+++ b/cli/internal/cmd/nsx/nsx.go
@@ -25,13 +25,10 @@
 package nsx
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"strings"
 
@@ -164,11 +161,11 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
+	var apiErr *dispatch.APIResponseError
+	if errors.As(err, &apiErr) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, apiErr.StatusCode, apiErr.Body)),
 			jsonOut,
 		)
 	}
@@ -176,83 +173,6 @@ func renderRequestError(
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
-}
-
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
-	}
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-	const maxBody = int64(1 << 20) // 1 MiB
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if int64(len(raw)) > maxBody {
-		return nil, fmt.Errorf("backplane response body exceeds %d bytes", maxBody)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
 }
 
 func loadParamsFlag(val string) (map[string]any, error) {

--- a/cli/internal/cmd/nsx/operation.go
+++ b/cli/internal/cmd/nsx/operation.go
@@ -4,16 +4,13 @@
 package nsx
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
-	"strconv"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -30,23 +27,14 @@ func newOperationCmd() *cobra.Command {
 	return cmd
 }
 
-// searchHit mirrors the backend OperationSearchHit Pydantic model.
-type searchHit struct {
-	OpID             string   `json:"op_id"`
-	Summary          *string  `json:"summary"`
-	Description      *string  `json:"description"`
-	GroupKey         *string  `json:"group_key"`
-	SafetyLevel      string   `json:"safety_level"`
-	RequiresApproval bool     `json:"requires_approval"`
-	FusedScore       float64  `json:"fused_score"`
-	Bm25Score        *float64 `json:"bm25_score"`
-	CosineScore      *float64 `json:"cosine_score"`
-}
-
-type searchResponse struct {
-	Hits            []searchHit `json:"hits"`
-	QueryDurationMs float64     `json:"query_duration_ms"`
-}
+// searchHit + searchResponse alias the dispatch-package types
+// promoted from this dir's pre-#1274 copies. The verb file references
+// the unqualified names so the per-verb pretty-printers + tests stay
+// readable; the underlying types live once in dispatch.
+type (
+	searchHit      = dispatch.SearchHit
+	searchResponse = dispatch.SearchResponse
+)
 
 func newOperationSearchCmd() *cobra.Command {
 	var (
@@ -88,7 +76,7 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
-	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
+	result, err := conn.Search(cmd.Context(), backplaneURL, query, groupKey, limit)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
@@ -97,28 +85,6 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 	}
 	printSearchTable(cmd.OutOrStdout(), query, result)
 	return nil
-}
-
-func getSearch(ctx context.Context, backplaneURL, query, groupKey string, limit int) (*searchResponse, error) {
-	q := url.Values{}
-	q.Set("connector_id", ConnectorID)
-	q.Set("query", query)
-	if groupKey != "" {
-		q.Set("group", groupKey)
-	}
-	if limit > 0 {
-		q.Set("limit", strconv.Itoa(limit))
-	}
-	path := "/api/v1/operations/search?" + q.Encode()
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
-	if err != nil {
-		return nil, err
-	}
-	var out searchResponse
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode search response: %w", err)
-	}
-	return &out, nil
 }
 
 func printSearchTable(w io.Writer, query string, r *searchResponse) {

--- a/cli/internal/cmd/pfsense/dispatch.go
+++ b/cli/internal/cmd/pfsense/dispatch.go
@@ -28,9 +28,6 @@ type (
 	callRequestBody = dispatch.CallRequestBody
 )
 
-// errOpError is the structured-failure sentinel (status error/denied).
-var errOpError = dispatch.ErrOpError
-
 // conn binds this package's pre-baked connector_id to the shared
 // dispatch core. The authed transport (lazy *api.AuthedClient over the
 // generated typed surface) lives inside dispatch.Connector after

--- a/cli/internal/cmd/pfsense/dispatch.go
+++ b/cli/internal/cmd/pfsense/dispatch.go
@@ -6,85 +6,50 @@ package pfsense
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
 
-	"github.com/evoila/meho/cli/internal/output"
+	"github.com/evoila/meho/cli/internal/dispatch"
 )
 
-// CallResult mirrors the backend OperationResult Pydantic model.
-// Same shape as cmd/bind9/CallResult; duplicated here because
-// cmd/pfsense can't import cmd/bind9 without an import cycle
-// (cmd/root.go grafts both onto the tree).
-type CallResult struct {
-	Status     string          `json:"status"`
-	OpID       string          `json:"op_id"`
-	Result     json.RawMessage `json:"result"`
-	Error      *string         `json:"error"`
-	Extras     json.RawMessage `json:"extras,omitempty"`
-	DurationMs float64         `json:"duration_ms"`
-}
+// Aliases + binding to the shared dispatch core (cli/internal/dispatch).
+// Pre-#1274 pfsense carried its own dispatchOp / renderCallResult /
+// printGenericResult trio because the shared dispatch.Connector hadn't
+// owned the authed transport yet — the local copies threaded the per-
+// dir doAuthedRequest into the request loop. G0.12-T16 #1274 promoted
+// the transport into dispatch.Connector itself; pfsense now folds onto
+// the shared pattern (matching bind9 / k8s / vault / etc.).
+type (
+	// CallResult is the decoded OperationResult envelope.
+	CallResult = dispatch.CallResult
+	// callRequestBody is the on-the-wire OperationCall body (asserted by tests).
+	callRequestBody = dispatch.CallRequestBody
+)
 
-// callRequestBody mirrors the backend CallOperationBody Pydantic
-// model. Target uses a map[string]any so the empty case serialises
-// as `null` rather than an empty struct.
-type callRequestBody struct {
-	ConnectorID string         `json:"connector_id"`
-	OpID        string         `json:"op_id"`
-	Target      map[string]any `json:"target"`
-	Params      map[string]any `json:"params,omitempty"`
-}
+// errOpError is the structured-failure sentinel (status error/denied).
+var errOpError = dispatch.ErrOpError
 
-// errOpError is the sentinel returned when the dispatcher reported a
-// structured-failure result (status == "error" or status == "denied").
-var errOpError = errors.New("operation status not ok")
+// conn binds this package's pre-baked connector_id to the shared
+// dispatch core. The authed transport (lazy *api.AuthedClient over the
+// generated typed surface) lives inside dispatch.Connector after
+// G0.12-T16 #1274 promoted the per-vendor doAuthedRequest copies.
+var conn = dispatch.New(ConnectorID)
 
-// dispatchOp POSTs an OperationCall to the backplane and returns the
-// decoded CallResult. The pre-baked connector_id ("pfsense-ssh-2.7")
-// is baked in; callers pass op_id, an optional target slug (empty
-// string → no target field on the wire), and an optional params map.
-//
-// Centralised here so every verb in the package shares one
-// dispatcher implementation. A grep for `dispatchOp` finds every
-// alias-verb dispatch in the pfsense package.
+// dispatchOp is a thin wrapper around conn.Call kept so the per-verb
+// files continue calling the unqualified name they were authored
+// against.
 func dispatchOp(
 	ctx context.Context,
 	backplaneURL, opID, targetSlug string,
 	params map[string]any,
 ) (*CallResult, error) {
-	body := callRequestBody{
-		ConnectorID: ConnectorID,
-		OpID:        opID,
-		Target:      nil,
-	}
-	if targetSlug != "" {
-		body.Target = map[string]any{"name": targetSlug}
-	}
-	if params != nil {
-		body.Params = params
-	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal call request: %w", err)
-	}
-	respBody, err := doAuthedRequest(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
-	if err != nil {
-		return nil, err
-	}
-	var out CallResult
-	if err := json.Unmarshal(respBody, &out); err != nil {
-		return nil, fmt.Errorf("decode call response: %w", err)
-	}
-	return &out, nil
+	return conn.Call(ctx, backplaneURL, opID, targetSlug, params)
 }
 
-// renderCallResult handles the unified post-dispatch path every verb
-// uses: validate status enum, render the envelope (JSON or human),
-// then translate "error" / "denied" into the errOpError sentinel so
-// main propagates the right non-zero exit.
+// renderCallResult is a thin wrapper around conn.Render for the same
+// reason as dispatchOp above.
 func renderCallResult(
 	cmd *cobra.Command,
 	opID string,
@@ -92,52 +57,11 @@ func renderCallResult(
 	jsonOut bool,
 	prettyPrinter func(w io.Writer, r *CallResult),
 ) error {
-	switch r.Status {
-	case "ok", "error", "denied":
-		// fall through.
-	default:
-		return output.RenderError(
-			cmd.ErrOrStderr(),
-			output.Unexpected(fmt.Sprintf(
-				"backplane returned invalid OperationResult.status %q (expected one of: ok / error / denied)",
-				r.Status,
-			)),
-			jsonOut,
-		)
-	}
-	if jsonOut {
-		if err := output.PrintJSON(cmd.OutOrStdout(), r); err != nil {
-			return err
-		}
-	} else if prettyPrinter != nil {
-		prettyPrinter(cmd.OutOrStdout(), r)
-	} else {
-		printGenericResult(cmd.OutOrStdout(), opID, r)
-	}
-	if r.Status == "ok" {
-		return nil
-	}
-	return errOpError
+	return conn.Render(cmd, opID, r, jsonOut, prettyPrinter)
 }
 
-// printGenericResult renders a CallResult in a generic envelope shape.
-func printGenericResult(w io.Writer, opID string, r *CallResult) {
-	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", ConnectorID, opID, r.Status, r.DurationMs)
-	if r.Status == "ok" {
-		if len(r.Result) > 0 && string(r.Result) != "null" {
-			pretty, err := prettyJSON(r.Result)
-			if err == nil {
-				fmt.Fprintln(w, pretty)
-				return
-			}
-			fmt.Fprintln(w, string(r.Result))
-		}
-		return
-	}
-	printErrorTrailer(w, r)
-}
-
-// printErrorTrailer surfaces the dispatcher error / extras envelope.
+// printErrorTrailer surfaces the dispatcher error + extras envelope.
+// Used by the per-verb pretty-printers' non-ok branch.
 func printErrorTrailer(w io.Writer, r *CallResult) {
 	if r.Error != nil && *r.Error != "" {
 		fmt.Fprintf(w, "meho: connector error: %s\n", *r.Error)
@@ -146,7 +70,7 @@ func printErrorTrailer(w io.Writer, r *CallResult) {
 	}
 	if len(r.Extras) > 0 && string(r.Extras) != "null" {
 		fmt.Fprintln(w, "extras:")
-		pretty, err := prettyJSON(r.Extras)
+		pretty, err := dispatch.PrettyJSON(r.Extras)
 		if err == nil {
 			fmt.Fprintln(w, pretty)
 		} else {

--- a/cli/internal/cmd/pfsense/pfsense.go
+++ b/cli/internal/cmd/pfsense/pfsense.go
@@ -32,13 +32,9 @@
 package pfsense
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"strings"
 
@@ -46,6 +42,7 @@ import (
 
 	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -193,11 +190,11 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
+	var apiErr *dispatch.APIResponseError
+	if errors.As(err, &apiErr) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, apiErr.StatusCode, apiErr.Body)),
 			jsonOut,
 		)
 	}
@@ -205,91 +202,6 @@ func renderRequestError(
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
-}
-
-// httpError carries a non-2xx response so renderRequestError can
-// pick the right StructuredError category.
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-// doAuthedRequest issues a single HTTP request against the backplane
-// with bearer injection + one-shot 401-refresh-retry. Mirrors the
-// bind9 sibling verbatim (duplicated to avoid import cycle — cmd/root.go
-// grafts each onto the tree).
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
-	}
-
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-
-	// 2 MiB cap — pfsense.config.show can return a large config.xml
-	// and pfsense.firewall.state can return thousands of state rows;
-	// the cap leaves headroom while bounding pathological payloads.
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-// sendRequest builds + fires the HTTP request. Mirrors the bind9 sibling.
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
 }
 
 // truncate cuts s to maxLen runes, appending an ellipsis when
@@ -307,26 +219,13 @@ func truncate(s string, maxLen int) string {
 	return string(runes[:maxLen-1]) + "…"
 }
 
-// prettyJSON pretty-prints a json.RawMessage with 2-space indent.
-func prettyJSON(raw json.RawMessage) (string, error) {
-	var v any
-	if err := json.Unmarshal(raw, &v); err != nil {
-		return "", err
-	}
-	out, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
-}
-
 // fallbackResultRender dumps the result envelope verbatim when the
 // typed per-verb decode fails.
 func fallbackResultRender(w io.Writer, r *CallResult) {
 	if len(r.Result) == 0 || string(r.Result) == "null" {
 		return
 	}
-	pretty, err := prettyJSON(r.Result)
+	pretty, err := dispatch.PrettyJSON(r.Result)
 	if err == nil {
 		fmt.Fprintln(w, pretty)
 		return

--- a/cli/internal/cmd/sddc-manager/dispatch.go
+++ b/cli/internal/cmd/sddc-manager/dispatch.go
@@ -18,6 +18,8 @@ type (
 // errOpError is the structured-failure sentinel (status error/denied).
 var errOpError = dispatch.ErrOpError
 
-// conn binds this package's pre-baked connector_id + authed transport
-// (doAuthedRequest) to the shared dispatch core.
-var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}
+// conn binds this package's pre-baked connector_id to the shared
+// dispatch core. The authed transport (lazy *api.AuthedClient over the
+// generated typed surface) lives inside dispatch.Connector after
+// G0.12-T16 #1274 promoted the per-vendor doAuthedRequest copies.
+var conn = dispatch.New(ConnectorID)

--- a/cli/internal/cmd/sddc-manager/operation.go
+++ b/cli/internal/cmd/sddc-manager/operation.go
@@ -4,16 +4,13 @@
 package sddcmanager
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
-	"strconv"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -30,22 +27,14 @@ func newOperationCmd() *cobra.Command {
 	return cmd
 }
 
-type searchHit struct {
-	OpID             string   `json:"op_id"`
-	Summary          *string  `json:"summary"`
-	Description      *string  `json:"description"`
-	GroupKey         *string  `json:"group_key"`
-	SafetyLevel      string   `json:"safety_level"`
-	RequiresApproval bool     `json:"requires_approval"`
-	FusedScore       float64  `json:"fused_score"`
-	Bm25Score        *float64 `json:"bm25_score"`
-	CosineScore      *float64 `json:"cosine_score"`
-}
-
-type searchResponse struct {
-	Hits            []searchHit `json:"hits"`
-	QueryDurationMs float64     `json:"query_duration_ms"`
-}
+// searchHit + searchResponse alias the dispatch-package types
+// promoted from this dir's pre-#1274 copies. The verb file references
+// the unqualified names so the per-verb pretty-printers + tests stay
+// readable; the underlying types live once in dispatch.
+type (
+	searchHit      = dispatch.SearchHit
+	searchResponse = dispatch.SearchResponse
+)
 
 func newOperationSearchCmd() *cobra.Command {
 	var (
@@ -87,7 +76,7 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
-	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
+	result, err := conn.Search(cmd.Context(), backplaneURL, query, groupKey, limit)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
@@ -96,28 +85,6 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 	}
 	printSearchTable(cmd.OutOrStdout(), query, result)
 	return nil
-}
-
-func getSearch(ctx context.Context, backplaneURL, query, groupKey string, limit int) (*searchResponse, error) {
-	q := url.Values{}
-	q.Set("connector_id", ConnectorID)
-	q.Set("query", query)
-	if groupKey != "" {
-		q.Set("group", groupKey)
-	}
-	if limit > 0 {
-		q.Set("limit", strconv.Itoa(limit))
-	}
-	path := "/api/v1/operations/search?" + q.Encode()
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
-	if err != nil {
-		return nil, err
-	}
-	var out searchResponse
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode search response: %w", err)
-	}
-	return &out, nil
 }
 
 func printSearchTable(w io.Writer, query string, r *searchResponse) {

--- a/cli/internal/cmd/sddc-manager/sddc_manager.go
+++ b/cli/internal/cmd/sddc-manager/sddc_manager.go
@@ -25,13 +25,10 @@
 package sddcmanager
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"strings"
 
@@ -161,11 +158,11 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
+	var apiErr *dispatch.APIResponseError
+	if errors.As(err, &apiErr) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, apiErr.StatusCode, apiErr.Body)),
 			jsonOut,
 		)
 	}
@@ -173,83 +170,6 @@ func renderRequestError(
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
-}
-
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
-	}
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-	const maxBody = int64(1 << 20)
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if int64(len(raw)) > maxBody {
-		return nil, fmt.Errorf("backplane response body exceeds %d bytes", maxBody)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
 }
 
 func loadParamsFlag(val string) (map[string]any, error) {

--- a/cli/internal/cmd/sddc-manager/sddc_manager_test.go
+++ b/cli/internal/cmd/sddc-manager/sddc_manager_test.go
@@ -563,9 +563,9 @@ func TestSearchSendsConnectorIDPreBaked(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	r, err := getSearch(context.Background(), srv.URL, "list domains", "", 10)
+	r, err := conn.Search(context.Background(), srv.URL, "list domains", "", 10)
 	if err != nil {
-		t.Fatalf("getSearch: %v", err)
+		t.Fatalf("Search: %v", err)
 	}
 	if len(r.Hits) != 1 || r.Hits[0].OpID != "GET:/v1/domains" {
 		t.Fatalf("unexpected search response: %+v", r)

--- a/cli/internal/cmd/vault/dispatch.go
+++ b/cli/internal/cmd/vault/dispatch.go
@@ -18,6 +18,8 @@ type (
 // errOpError is the structured-failure sentinel (status error/denied).
 var errOpError = dispatch.ErrOpError
 
-// conn binds this package's pre-baked connector_id + authed transport
-// (doAuthedRequest) to the shared dispatch core.
-var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}
+// conn binds this package's pre-baked connector_id to the shared
+// dispatch core. The authed transport (lazy *api.AuthedClient over the
+// generated typed surface) lives inside dispatch.Connector after
+// G0.12-T16 #1274 promoted the per-vendor doAuthedRequest copies.
+var conn = dispatch.New(ConnectorID)

--- a/cli/internal/cmd/vault/vault.go
+++ b/cli/internal/cmd/vault/vault.go
@@ -36,19 +36,16 @@
 package vault
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -97,11 +94,15 @@ func NewRootCmd() *cobra.Command {
 	return cmd
 }
 
-// renderRequestError translates an error from doAuthedRequest into the
-// right output.RenderError category. Same classification ladder as the
-// vmware sibling: token-not-found / no-refresh-token → auth_expired
-// with `meho login` hints; HTTP-error → unexpected; everything else
-// (transport) → unreachable.
+// renderRequestError translates an error from conn.Call into the
+// right output.RenderError category. Same classification ladder as
+// the vmware sibling: token-not-found / no-refresh-token →
+// auth_expired with `meho login` hints; non-2xx HTTP →
+// unexpected_response; everything else (transport) → unreachable.
+//
+// Matches *dispatch.APIResponseError instead of a local httpError
+// sentinel after G0.12-T16 #1274 promoted the authed transport into
+// the shared dispatch package.
 func renderRequestError(
 	cmd *cobra.Command,
 	backplaneURL string,
@@ -126,11 +127,11 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
+	var apiErr *dispatch.APIResponseError
+	if errors.As(err, &apiErr) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, apiErr.StatusCode, apiErr.Body)),
 			jsonOut,
 		)
 	}
@@ -138,94 +139,6 @@ func renderRequestError(
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
-}
-
-// httpError carries a non-2xx response so renderRequestError can pick
-// the right StructuredError category. Same shape as the vmware sibling.
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-// doAuthedRequest issues a single HTTP request against the backplane
-// with bearer injection + one-shot 401-refresh-retry. Mirrors the
-// vmware sibling verbatim (duplicated to avoid an import cycle —
-// cmd/root.go grafts each onto the tree). Centralised per-package so
-// the per-verb runners stay small.
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
-	}
-
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-
-	// 1 MiB cap matches the vmware sibling. Vault secret payloads are
-	// small; the cap leaves headroom while still bounding pathological
-	// payloads.
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-// sendRequest builds + fires the HTTP request. Mirrors the vmware
-// sibling; split out so the 401-refresh-retry path can reuse the same
-// body bytes without re-marshalling.
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
 }
 
 // loadJSONFlag parses a flag value that is either inline JSON or an

--- a/cli/internal/cmd/vcf-automation/dispatch.go
+++ b/cli/internal/cmd/vcf-automation/dispatch.go
@@ -24,9 +24,11 @@ type (
 // errOpError is the structured-failure sentinel (status error/denied).
 var errOpError = dispatch.ErrOpError
 
-// conn binds this package's pre-baked connector_id + authed transport
-// (doAuthedRequest) to the shared dispatch core.
-var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}
+// conn binds this package's pre-baked connector_id to the shared
+// dispatch core. The authed transport (lazy *api.AuthedClient over the
+// generated typed surface) lives inside dispatch.Connector after
+// G0.12-T16 #1274 promoted the per-vendor doAuthedRequest copies.
+var conn = dispatch.New(ConnectorID)
 
 // dispatchOp POSTs an OperationCall with connector_id="vcfa-rest-9.0"
 // pre-baked. The optional fqdn is threaded into the request body's

--- a/cli/internal/cmd/vcf-automation/operation.go
+++ b/cli/internal/cmd/vcf-automation/operation.go
@@ -4,16 +4,13 @@
 package vcfautomation
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
-	"strconv"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -33,23 +30,14 @@ func newOperationCmd() *cobra.Command {
 	return cmd
 }
 
-// searchHit mirrors the backend OperationSearchHit Pydantic model.
-type searchHit struct {
-	OpID             string   `json:"op_id"`
-	Summary          *string  `json:"summary"`
-	Description      *string  `json:"description"`
-	GroupKey         *string  `json:"group_key"`
-	SafetyLevel      string   `json:"safety_level"`
-	RequiresApproval bool     `json:"requires_approval"`
-	FusedScore       float64  `json:"fused_score"`
-	Bm25Score        *float64 `json:"bm25_score"`
-	CosineScore      *float64 `json:"cosine_score"`
-}
-
-type searchResponse struct {
-	Hits            []searchHit `json:"hits"`
-	QueryDurationMs float64     `json:"query_duration_ms"`
-}
+// searchHit + searchResponse alias the dispatch-package types
+// promoted from this dir's pre-#1274 copies. The verb file references
+// the unqualified names so the per-verb pretty-printers + tests stay
+// readable; the underlying types live once in dispatch.
+type (
+	searchHit      = dispatch.SearchHit
+	searchResponse = dispatch.SearchResponse
+)
 
 func newOperationSearchCmd() *cobra.Command {
 	var (
@@ -93,7 +81,7 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
-	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
+	result, err := conn.Search(cmd.Context(), backplaneURL, query, groupKey, limit)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
@@ -102,28 +90,6 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 	}
 	printSearchTable(cmd.OutOrStdout(), query, result)
 	return nil
-}
-
-func getSearch(ctx context.Context, backplaneURL, query, groupKey string, limit int) (*searchResponse, error) {
-	q := url.Values{}
-	q.Set("connector_id", ConnectorID)
-	q.Set("query", query)
-	if groupKey != "" {
-		q.Set("group", groupKey)
-	}
-	if limit > 0 {
-		q.Set("limit", strconv.Itoa(limit))
-	}
-	path := "/api/v1/operations/search?" + q.Encode()
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
-	if err != nil {
-		return nil, err
-	}
-	var out searchResponse
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode search response: %w", err)
-	}
-	return &out, nil
 }
 
 func printSearchTable(w io.Writer, query string, r *searchResponse) {

--- a/cli/internal/cmd/vcf-automation/vcfa.go
+++ b/cli/internal/cmd/vcf-automation/vcfa.go
@@ -43,13 +43,10 @@
 package vcfautomation
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"strings"
 
@@ -297,11 +294,11 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
+	var apiErr *dispatch.APIResponseError
+	if errors.As(err, &apiErr) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, apiErr.StatusCode, apiErr.Body)),
 			jsonOut,
 		)
 	}
@@ -309,83 +306,6 @@ func renderRequestError(
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
-}
-
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
-	}
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-	const maxBody = int64(1 << 20) // 1 MiB
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if int64(len(raw)) > maxBody {
-		return nil, fmt.Errorf("backplane response body exceeds %d bytes", maxBody)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
 }
 
 func loadParamsFlag(val string) (map[string]any, error) {

--- a/cli/internal/cmd/vcf-fleet/dispatch.go
+++ b/cli/internal/cmd/vcf-fleet/dispatch.go
@@ -18,6 +18,8 @@ type (
 // errOpError is the structured-failure sentinel (status error/denied).
 var errOpError = dispatch.ErrOpError
 
-// conn binds this package's pre-baked connector_id + authed transport
-// (doAuthedRequest) to the shared dispatch core.
-var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}
+// conn binds this package's pre-baked connector_id to the shared
+// dispatch core. The authed transport (lazy *api.AuthedClient over the
+// generated typed surface) lives inside dispatch.Connector after
+// G0.12-T16 #1274 promoted the per-vendor doAuthedRequest copies.
+var conn = dispatch.New(ConnectorID)

--- a/cli/internal/cmd/vcf-fleet/operation.go
+++ b/cli/internal/cmd/vcf-fleet/operation.go
@@ -4,16 +4,13 @@
 package vcffleet
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
-	"strconv"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -30,22 +27,14 @@ func newOperationCmd() *cobra.Command {
 	return cmd
 }
 
-type searchHit struct {
-	OpID             string   `json:"op_id"`
-	Summary          *string  `json:"summary"`
-	Description      *string  `json:"description"`
-	GroupKey         *string  `json:"group_key"`
-	SafetyLevel      string   `json:"safety_level"`
-	RequiresApproval bool     `json:"requires_approval"`
-	FusedScore       float64  `json:"fused_score"`
-	Bm25Score        *float64 `json:"bm25_score"`
-	CosineScore      *float64 `json:"cosine_score"`
-}
-
-type searchResponse struct {
-	Hits            []searchHit `json:"hits"`
-	QueryDurationMs float64     `json:"query_duration_ms"`
-}
+// searchHit + searchResponse alias the dispatch-package types
+// promoted from this dir's pre-#1274 copies. The verb file references
+// the unqualified names so the per-verb pretty-printers + tests stay
+// readable; the underlying types live once in dispatch.
+type (
+	searchHit      = dispatch.SearchHit
+	searchResponse = dispatch.SearchResponse
+)
 
 func newOperationSearchCmd() *cobra.Command {
 	var (
@@ -87,7 +76,7 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
-	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
+	result, err := conn.Search(cmd.Context(), backplaneURL, query, groupKey, limit)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
@@ -96,28 +85,6 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 	}
 	printSearchTable(cmd.OutOrStdout(), query, result)
 	return nil
-}
-
-func getSearch(ctx context.Context, backplaneURL, query, groupKey string, limit int) (*searchResponse, error) {
-	q := url.Values{}
-	q.Set("connector_id", ConnectorID)
-	q.Set("query", query)
-	if groupKey != "" {
-		q.Set("group", groupKey)
-	}
-	if limit > 0 {
-		q.Set("limit", strconv.Itoa(limit))
-	}
-	path := "/api/v1/operations/search?" + q.Encode()
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
-	if err != nil {
-		return nil, err
-	}
-	var out searchResponse
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode search response: %w", err)
-	}
-	return &out, nil
 }
 
 func printSearchTable(w io.Writer, query string, r *searchResponse) {

--- a/cli/internal/cmd/vcf-fleet/vcf_fleet.go
+++ b/cli/internal/cmd/vcf-fleet/vcf_fleet.go
@@ -29,13 +29,10 @@
 package vcffleet
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"strings"
 
@@ -165,11 +162,11 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
+	var apiErr *dispatch.APIResponseError
+	if errors.As(err, &apiErr) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, apiErr.StatusCode, apiErr.Body)),
 			jsonOut,
 		)
 	}
@@ -177,83 +174,6 @@ func renderRequestError(
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
-}
-
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
-	}
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-	const maxBody = int64(1 << 20) // 1 MiB
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if int64(len(raw)) > maxBody {
-		return nil, fmt.Errorf("backplane response body exceeds %d bytes", maxBody)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
 }
 
 func loadParamsFlag(val string) (map[string]any, error) {

--- a/cli/internal/cmd/vcf-fleet/vcf_fleet_test.go
+++ b/cli/internal/cmd/vcf-fleet/vcf_fleet_test.go
@@ -565,9 +565,9 @@ func TestSearchSendsConnectorIDPreBaked(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	r, err := getSearch(context.Background(), srv.URL, "list environments", "", 10)
+	r, err := conn.Search(context.Background(), srv.URL, "list environments", "", 10)
 	if err != nil {
-		t.Fatalf("getSearch: %v", err)
+		t.Fatalf("Search: %v", err)
 	}
 	if len(r.Hits) != 1 || r.Hits[0].OpID != environmentListOpID {
 		t.Fatalf("unexpected search response: %+v", r)

--- a/cli/internal/cmd/vcf-logs/dispatch.go
+++ b/cli/internal/cmd/vcf-logs/dispatch.go
@@ -18,6 +18,8 @@ type (
 // errOpError is the structured-failure sentinel (status error/denied).
 var errOpError = dispatch.ErrOpError
 
-// conn binds this package's pre-baked connector_id + authed transport
-// (doAuthedRequest) to the shared dispatch core.
-var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}
+// conn binds this package's pre-baked connector_id to the shared
+// dispatch core. The authed transport (lazy *api.AuthedClient over the
+// generated typed surface) lives inside dispatch.Connector after
+// G0.12-T16 #1274 promoted the per-vendor doAuthedRequest copies.
+var conn = dispatch.New(ConnectorID)

--- a/cli/internal/cmd/vcf-logs/operation.go
+++ b/cli/internal/cmd/vcf-logs/operation.go
@@ -4,16 +4,13 @@
 package vcflogs
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
-	"strconv"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -30,23 +27,14 @@ func newOperationCmd() *cobra.Command {
 	return cmd
 }
 
-// searchHit mirrors the backend OperationSearchHit Pydantic model.
-type searchHit struct {
-	OpID             string   `json:"op_id"`
-	Summary          *string  `json:"summary"`
-	Description      *string  `json:"description"`
-	GroupKey         *string  `json:"group_key"`
-	SafetyLevel      string   `json:"safety_level"`
-	RequiresApproval bool     `json:"requires_approval"`
-	FusedScore       float64  `json:"fused_score"`
-	Bm25Score        *float64 `json:"bm25_score"`
-	CosineScore      *float64 `json:"cosine_score"`
-}
-
-type searchResponse struct {
-	Hits            []searchHit `json:"hits"`
-	QueryDurationMs float64     `json:"query_duration_ms"`
-}
+// searchHit + searchResponse alias the dispatch-package types
+// promoted from this dir's pre-#1274 copies. The verb file references
+// the unqualified names so the per-verb pretty-printers + tests stay
+// readable; the underlying types live once in dispatch.
+type (
+	searchHit      = dispatch.SearchHit
+	searchResponse = dispatch.SearchResponse
+)
 
 func newOperationSearchCmd() *cobra.Command {
 	var (
@@ -88,7 +76,7 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
-	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
+	result, err := conn.Search(cmd.Context(), backplaneURL, query, groupKey, limit)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
@@ -97,28 +85,6 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 	}
 	printSearchTable(cmd.OutOrStdout(), query, result)
 	return nil
-}
-
-func getSearch(ctx context.Context, backplaneURL, query, groupKey string, limit int) (*searchResponse, error) {
-	q := url.Values{}
-	q.Set("connector_id", ConnectorID)
-	q.Set("query", query)
-	if groupKey != "" {
-		q.Set("group", groupKey)
-	}
-	if limit > 0 {
-		q.Set("limit", strconv.Itoa(limit))
-	}
-	path := "/api/v1/operations/search?" + q.Encode()
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
-	if err != nil {
-		return nil, err
-	}
-	var out searchResponse
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode search response: %w", err)
-	}
-	return &out, nil
 }
 
 func printSearchTable(w io.Writer, query string, r *searchResponse) {

--- a/cli/internal/cmd/vcf-logs/vcf_logs.go
+++ b/cli/internal/cmd/vcf-logs/vcf_logs.go
@@ -30,13 +30,10 @@
 package vcflogs
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"strings"
 
@@ -188,11 +185,11 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
+	var apiErr *dispatch.APIResponseError
+	if errors.As(err, &apiErr) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, apiErr.StatusCode, apiErr.Body)),
 			jsonOut,
 		)
 	}
@@ -200,83 +197,6 @@ func renderRequestError(
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
-}
-
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
-	}
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-	const maxBody = int64(1 << 20) // 1 MiB
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if int64(len(raw)) > maxBody {
-		return nil, fmt.Errorf("backplane response body exceeds %d bytes", maxBody)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
 }
 
 func loadParamsFlag(val string) (map[string]any, error) {

--- a/cli/internal/cmd/vcf-operations/dispatch.go
+++ b/cli/internal/cmd/vcf-operations/dispatch.go
@@ -18,6 +18,8 @@ type (
 // errOpError is the structured-failure sentinel (status error/denied).
 var errOpError = dispatch.ErrOpError
 
-// conn binds this package's pre-baked connector_id + authed transport
-// (doAuthedRequest) to the shared dispatch core.
-var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}
+// conn binds this package's pre-baked connector_id to the shared
+// dispatch core. The authed transport (lazy *api.AuthedClient over the
+// generated typed surface) lives inside dispatch.Connector after
+// G0.12-T16 #1274 promoted the per-vendor doAuthedRequest copies.
+var conn = dispatch.New(ConnectorID)

--- a/cli/internal/cmd/vcf-operations/operation.go
+++ b/cli/internal/cmd/vcf-operations/operation.go
@@ -4,16 +4,13 @@
 package vcfoperations
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
-	"strconv"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -30,23 +27,14 @@ func newOperationCmd() *cobra.Command {
 	return cmd
 }
 
-// searchHit mirrors the backend OperationSearchHit Pydantic model.
-type searchHit struct {
-	OpID             string   `json:"op_id"`
-	Summary          *string  `json:"summary"`
-	Description      *string  `json:"description"`
-	GroupKey         *string  `json:"group_key"`
-	SafetyLevel      string   `json:"safety_level"`
-	RequiresApproval bool     `json:"requires_approval"`
-	FusedScore       float64  `json:"fused_score"`
-	Bm25Score        *float64 `json:"bm25_score"`
-	CosineScore      *float64 `json:"cosine_score"`
-}
-
-type searchResponse struct {
-	Hits            []searchHit `json:"hits"`
-	QueryDurationMs float64     `json:"query_duration_ms"`
-}
+// searchHit + searchResponse alias the dispatch-package types
+// promoted from this dir's pre-#1274 copies. The verb file references
+// the unqualified names so the per-verb pretty-printers + tests stay
+// readable; the underlying types live once in dispatch.
+type (
+	searchHit      = dispatch.SearchHit
+	searchResponse = dispatch.SearchResponse
+)
 
 func newOperationSearchCmd() *cobra.Command {
 	var (
@@ -88,7 +76,7 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
-	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
+	result, err := conn.Search(cmd.Context(), backplaneURL, query, groupKey, limit)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
@@ -97,28 +85,6 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 	}
 	printSearchTable(cmd.OutOrStdout(), query, result)
 	return nil
-}
-
-func getSearch(ctx context.Context, backplaneURL, query, groupKey string, limit int) (*searchResponse, error) {
-	q := url.Values{}
-	q.Set("connector_id", ConnectorID)
-	q.Set("query", query)
-	if groupKey != "" {
-		q.Set("group", groupKey)
-	}
-	if limit > 0 {
-		q.Set("limit", strconv.Itoa(limit))
-	}
-	path := "/api/v1/operations/search?" + q.Encode()
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
-	if err != nil {
-		return nil, err
-	}
-	var out searchResponse
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode search response: %w", err)
-	}
-	return &out, nil
 }
 
 func printSearchTable(w io.Writer, query string, r *searchResponse) {

--- a/cli/internal/cmd/vcf-operations/vcf_operations.go
+++ b/cli/internal/cmd/vcf-operations/vcf_operations.go
@@ -34,13 +34,10 @@
 package vcfoperations
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"strings"
 
@@ -233,11 +230,11 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
+	var apiErr *dispatch.APIResponseError
+	if errors.As(err, &apiErr) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, apiErr.StatusCode, apiErr.Body)),
 			jsonOut,
 		)
 	}
@@ -245,86 +242,6 @@ func renderRequestError(
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
-}
-
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
-	}
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-	// 1 MiB cap matches the NSX sibling. vROps list payloads on a
-	// large fleet can run into the hundreds of KiB; the cap leaves
-	// headroom while still bounding pathological payloads.
-	const maxBody = int64(1 << 20)
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if int64(len(raw)) > maxBody {
-		return nil, fmt.Errorf("backplane response body exceeds %d bytes", maxBody)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
 }
 
 // loadParamsFlag parses the --params flag value. Prefixing with '@'

--- a/cli/internal/cmd/vcf-operations/vcf_operations_test.go
+++ b/cli/internal/cmd/vcf-operations/vcf_operations_test.go
@@ -644,9 +644,9 @@ func TestSearchSendsConnectorIDPreBaked(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	r, err := getSearch(context.Background(), srv.URL, "list resources", "", 10)
+	r, err := conn.Search(context.Background(), srv.URL, "list resources", "", 10)
 	if err != nil {
-		t.Fatalf("getSearch: %v", err)
+		t.Fatalf("Search: %v", err)
 	}
 	if len(r.Hits) != 1 || r.Hits[0].OpID != "GET:/suite-api/api/resources" {
 		t.Fatalf("unexpected search response: %+v", r)

--- a/cli/internal/cmd/vmware/dispatch.go
+++ b/cli/internal/cmd/vmware/dispatch.go
@@ -18,6 +18,8 @@ type (
 // errOpError is the structured-failure sentinel (status error/denied).
 var errOpError = dispatch.ErrOpError
 
-// conn binds this package's pre-baked connector_id + authed transport
-// (doAuthedRequest) to the shared dispatch core.
-var conn = dispatch.Connector{ID: ConnectorID, Request: doAuthedRequest}
+// conn binds this package's pre-baked connector_id to the shared
+// dispatch core. The authed transport (lazy *api.AuthedClient over the
+// generated typed surface) lives inside dispatch.Connector after
+// G0.12-T16 #1274 promoted the per-vendor doAuthedRequest copies.
+var conn = dispatch.New(ConnectorID)

--- a/cli/internal/cmd/vmware/operation.go
+++ b/cli/internal/cmd/vmware/operation.go
@@ -4,16 +4,13 @@
 package vmware
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
 	"io"
-	"net/url"
-	"strconv"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -34,26 +31,14 @@ func newOperationCmd() *cobra.Command {
 	return cmd
 }
 
-// searchHit mirrors the backend OperationSearchHit Pydantic model.
-// Same shape as cmd/operation's SearchHit — duplicated to avoid an
-// import cycle; the wire shape is canonical and stable.
-type searchHit struct {
-	OpID             string   `json:"op_id"`
-	Summary          *string  `json:"summary"`
-	Description      *string  `json:"description"`
-	GroupKey         *string  `json:"group_key"`
-	SafetyLevel      string   `json:"safety_level"`
-	RequiresApproval bool     `json:"requires_approval"`
-	FusedScore       float64  `json:"fused_score"`
-	Bm25Score        *float64 `json:"bm25_score"`
-	CosineScore      *float64 `json:"cosine_score"`
-}
-
-// searchResponse mirrors the backend OperationSearchResponse model.
-type searchResponse struct {
-	Hits            []searchHit `json:"hits"`
-	QueryDurationMs float64     `json:"query_duration_ms"`
-}
+// searchHit + searchResponse alias the dispatch-package types
+// promoted from this dir's pre-#1274 copies. The verb file references
+// the unqualified names so the per-verb pretty-printers + tests stay
+// readable; the underlying types live once in dispatch.
+type (
+	searchHit      = dispatch.SearchHit
+	searchResponse = dispatch.SearchResponse
+)
 
 // newOperationSearchCmd returns `meho vmware operation search`.
 //
@@ -115,7 +100,7 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 	if err != nil {
 		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), jsonOut)
 	}
-	result, err := getSearch(cmd.Context(), backplaneURL, query, groupKey, limit)
+	result, err := conn.Search(cmd.Context(), backplaneURL, query, groupKey, limit)
 	if err != nil {
 		return renderRequestError(cmd, backplaneURL, err, jsonOut)
 	}
@@ -124,28 +109,6 @@ func runOperationSearch(cmd *cobra.Command, query, groupKey string, limit int, j
 	}
 	printSearchTable(cmd.OutOrStdout(), query, result)
 	return nil
-}
-
-func getSearch(ctx context.Context, backplaneURL, query, groupKey string, limit int) (*searchResponse, error) {
-	q := url.Values{}
-	q.Set("connector_id", ConnectorID)
-	q.Set("query", query)
-	if groupKey != "" {
-		q.Set("group", groupKey)
-	}
-	if limit > 0 {
-		q.Set("limit", strconv.Itoa(limit))
-	}
-	path := "/api/v1/operations/search?" + q.Encode()
-	raw, err := doAuthedRequest(ctx, backplaneURL, "GET", path, nil)
-	if err != nil {
-		return nil, err
-	}
-	var out searchResponse
-	if err := json.Unmarshal(raw, &out); err != nil {
-		return nil, fmt.Errorf("decode search response: %w", err)
-	}
-	return &out, nil
 }
 
 func printSearchTable(w io.Writer, query string, r *searchResponse) {

--- a/cli/internal/cmd/vmware/vmware.go
+++ b/cli/internal/cmd/vmware/vmware.go
@@ -40,19 +40,16 @@
 package vmware
 
 import (
-	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/dispatch"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
@@ -139,11 +136,11 @@ func renderRequestError(
 			jsonOut,
 		)
 	}
-	var he *httpError
-	if errors.As(err, &he) {
+	var apiErr *dispatch.APIResponseError
+	if errors.As(err, &apiErr) {
 		return output.RenderError(cmd.ErrOrStderr(),
 			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
-				backplaneURL, he.StatusCode, he.Body)),
+				backplaneURL, apiErr.StatusCode, apiErr.Body)),
 			jsonOut,
 		)
 	}
@@ -151,95 +148,6 @@ func renderRequestError(
 		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
 		jsonOut,
 	)
-}
-
-// httpError carries a non-2xx response so renderRequestError can
-// pick the right StructuredError category. Same shape as the
-// operation / connector siblings.
-type httpError struct {
-	StatusCode int
-	Body       string
-}
-
-func (e *httpError) Error() string {
-	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
-}
-
-// doAuthedRequest issues a single HTTP request against the backplane
-// with bearer injection + one-shot 401-refresh-retry. Mirrors the
-// operation / connector siblings verbatim (duplicated to avoid an
-// import cycle — cmd/root.go grafts each onto the tree). Centralised
-// per-package so the per-verb runners stay small.
-func doAuthedRequest(
-	ctx context.Context,
-	backplaneURL, method, path string,
-	body []byte,
-) ([]byte, error) {
-	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
-	if err != nil {
-		return nil, err
-	}
-	httpClient := authed.HTTPClient()
-	bearer := authed.AccessToken()
-	if bearer == "" {
-		return nil, errors.New("meho: stored token has no access_token")
-	}
-
-	resp, err := sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		if rerr := authed.Refresh(ctx); rerr != nil {
-			resp.Body.Close()
-			return nil, rerr
-		}
-		resp.Body.Close()
-		bearer = authed.AccessToken()
-		resp, err = sendRequest(ctx, httpClient, backplaneURL, method, path, bearer, body)
-		if err != nil {
-			return nil, err
-		}
-	}
-	defer resp.Body.Close()
-
-	// 1 MiB cap matches the operation sibling. Vendor responses (vm
-	// lists on busy targets) can be hundreds of KiB; the cap leaves
-	// headroom while still bounding pathological payloads.
-	raw, readErr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	if readErr != nil {
-		return nil, fmt.Errorf("read response: %w", readErr)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, &httpError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(raw))}
-	}
-	return raw, nil
-}
-
-// sendRequest builds + fires the HTTP request. Mirrors the operation
-// sibling; split out so the 401-refresh-retry path can reuse the
-// same body bytes without re-marshalling.
-func sendRequest(
-	ctx context.Context,
-	client *http.Client,
-	backplaneURL, method, path, bearer string,
-	body []byte,
-) (*http.Response, error) {
-	fullURL := backplaneURL + path
-	var bodyReader io.Reader
-	if body != nil {
-		bodyReader = bytes.NewReader(body)
-	}
-	req, err := http.NewRequestWithContext(ctx, method, fullURL, bodyReader)
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+bearer)
-	req.Header.Set("Accept", "application/json")
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	return client.Do(req)
 }
 
 // loadParamsFlag parses the --params flag value. Prefixing with '@'

--- a/cli/internal/cmd/vmware/vmware_test.go
+++ b/cli/internal/cmd/vmware/vmware_test.go
@@ -659,9 +659,9 @@ func TestSearchSendsConnectorIDPreBaked(t *testing.T) {
 	defer srv.Close()
 	primeToken(t, srv.URL)
 
-	r, err := getSearch(context.Background(), srv.URL, "list VMs", "", 10)
+	r, err := conn.Search(context.Background(), srv.URL, "list VMs", "", 10)
 	if err != nil {
-		t.Fatalf("getSearch: %v", err)
+		t.Fatalf("Search: %v", err)
 	}
 	if len(r.Hits) != 1 || r.Hits[0].OpID != "GET:/vcenter/vm" {
 		t.Fatalf("unexpected search response: %+v", r)

--- a/cli/internal/dispatch/dispatch.go
+++ b/cli/internal/dispatch/dispatch.go
@@ -2,17 +2,21 @@
 // Copyright (c) 2026 evoila Group
 
 // Package dispatch is the shared operation-call core for the per-vendor
-// CLI command packages (cmd/vault, cmd/harbor, cmd/nsx, ...). Before it,
-// every vendor package carried a byte-identical dispatch.go — CallResult,
-// dispatchOp, renderCallResult, printGenericResult, prettyJSON —
-// duplicated only because sibling cmd/* packages can't import one another
-// without an import cycle (cmd/root.go grafts each onto the tree). This
-// leaf package breaks that cycle: each vendor package binds one
-// Connector{ID, Request} and calls its methods.
+// CLI command packages (cmd/vault, cmd/harbor, cmd/nsx, ...). Before
+// it, every vendor package carried a byte-identical dispatch.go —
+// CallResult, dispatchOp, renderCallResult, printGenericResult,
+// prettyJSON — duplicated only because sibling cmd/* packages can't
+// import one another without an import cycle (cmd/root.go grafts
+// each onto the tree). This leaf package breaks that cycle: each
+// vendor package binds one Connector and calls its methods.
 //
-// The authed transport is *injected* (Request) rather than imported here,
-// so the per-package doAuthedRequest helper stays where it is for now;
-// deduplicating that transport cluster is a separate change.
+// G0.12-T16 (#1274) promoted Connector to own the authed transport
+// — it now lazily builds an *api.AuthedClient per call and issues
+// every request through the generated typed surface (oapi-codegen
+// *WithResponse helpers). The per-vendor doAuthedRequest / sendRequest /
+// httpError trio is gone; per-vendor renderRequestError now matches
+// *APIResponseError from this package instead of a local sentinel.
+// The one-shot 401-refresh dance mirrors api.AuthedClient.GetHealth.
 package dispatch
 
 import (
@@ -21,18 +25,30 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 
 	"github.com/spf13/cobra"
 
+	"github.com/evoila/meho/cli/internal/api"
 	"github.com/evoila/meho/cli/internal/output"
 )
 
-// CallResult mirrors the backend OperationResult Pydantic model. Result
-// and Extras stay json.RawMessage because the backend types Result as a
-// oneOf(dict, list) union — pretty-printing the raw bytes is the cleanest
-// renderer. Set-shaped responses arrive already reduced to a JSONFlux
-// handle envelope + sample by the dispatcher, so they render verbatim
-// here with the handle hint intact.
+// CallResult mirrors the backend OperationResult Pydantic model.
+// Result and Extras stay json.RawMessage because the backend types
+// Result as a oneOf(dict, list) union — pretty-printing the raw bytes
+// is the cleanest renderer. Set-shaped responses arrive already
+// reduced to a JSONFlux handle envelope + sample by the dispatcher,
+// so they render verbatim here with the handle hint intact.
+//
+// Kept hand-typed rather than generator-backed because the FastAPI
+// surface types `/api/v1/operations/call`'s response as
+// `dict[str, Any]`, so the oapi-codegen generator emits the response
+// as `*map[string]interface{}` (see
+// PostCallApiV1OperationsCallPostResponse.JSON200 in client.gen.go) —
+// no typed model worth using. Promoting the FastAPI response to a
+// typed model so the generator picks it up is a separate backend
+// Task explicitly out of scope for G0.12-T16 #1274 (the CLI hygiene
+// Initiative #1118 is consumer-side only).
 type CallResult struct {
 	Status     string          `json:"status"`
 	OpID       string          `json:"op_id"`
@@ -46,6 +62,12 @@ type CallResult struct {
 // Target is a map so the empty case serialises as null rather than an
 // empty struct; the route layer's resolver short-circuits the missing-
 // name case for ops that need a target.
+//
+// Retained even though Connector.Call no longer marshals this struct
+// directly (it builds api.CallOperationBody from the generated client
+// instead) — per-vendor tests assert on-the-wire shape by decoding
+// the request body into this struct via httptest, and the type
+// continues to mirror the wire format exactly.
 type CallRequestBody struct {
 	ConnectorID string         `json:"connector_id"`
 	OpID        string         `json:"op_id"`
@@ -53,29 +75,125 @@ type CallRequestBody struct {
 	Params      map[string]any `json:"params,omitempty"`
 }
 
+// SearchHit mirrors the backend OperationSearchHit Pydantic model.
+// Pointer fields are nullable per the backend's frozen pydantic
+// model — preserved so JSON unmarshal keeps the null vs zero-value
+// distinction.
+//
+// Promoted from the 9 per-vendor copies (harbor / hetzner-robot /
+// nsx / sddc-manager / vcf-automation / vcf-fleet / vcf-logs /
+// vcf-operations / vmware) in G0.12-T16 #1274. Hand-typed for the
+// same reason as CallResult: the FastAPI surface types
+// `/api/v1/operations/search`'s response as `dict[str, Any]`.
+type SearchHit struct {
+	OpID             string   `json:"op_id"`
+	Summary          *string  `json:"summary"`
+	Description      *string  `json:"description"`
+	GroupKey         *string  `json:"group_key"`
+	SafetyLevel      string   `json:"safety_level"`
+	RequiresApproval bool     `json:"requires_approval"`
+	FusedScore       float64  `json:"fused_score"`
+	Bm25Score        *float64 `json:"bm25_score"`
+	CosineScore      *float64 `json:"cosine_score"`
+}
+
+// SearchResponse is the JSON envelope returned by
+// GET /api/v1/operations/search. Hand-typed for the same reason as
+// SearchHit above.
+type SearchResponse struct {
+	Hits            []SearchHit `json:"hits"`
+	QueryDurationMs float64     `json:"query_duration_ms"`
+}
+
 // ErrOpError is the sentinel returned when the dispatcher reported a
-// structured failure (status == "error" or "denied"). main translates a
-// non-nil RunE error into a non-zero exit; SilenceErrors=true on each
-// command keeps cobra from double-printing the error string.
+// structured failure (status == "error" or "denied"). main translates
+// a non-nil RunE error into a non-zero exit; SilenceErrors=true on
+// each command keeps cobra from double-printing the error string.
 var ErrOpError = errors.New("operation status not ok")
 
-// RequestFunc issues a single authed HTTP request against the backplane
-// and returns the response body. It matches each vendor package's
-// doAuthedRequest verbatim and is injected into a Connector so this
-// package stays transport-agnostic.
-type RequestFunc func(ctx context.Context, backplaneURL, method, path string, body []byte) ([]byte, error)
+// APIResponseError wraps a non-2xx response from the backplane so
+// per-vendor renderRequestError can pick the right output category
+// (401 → AuthExpired, 403 → InsufficientRole, other non-2xx →
+// Unexpected). Constructed by Connector.Call / CallWithTarget /
+// Search after the one-shot 401-refresh path has been exhausted.
+//
+// Replaces the per-vendor *httpError sentinel that the G0.12-T16
+// #1274 consolidation deleted. Each vendor package's
+// renderRequestError matches via errors.As against this type.
+type APIResponseError struct {
+	StatusCode int
+	Body       string
+}
 
-// Connector binds a pre-baked connector_id and an authed transport so
-// every alias verb in a vendor package shares one dispatch + render
-// implementation.
+func (e *APIResponseError) Error() string {
+	return fmt.Sprintf("HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// operationsAPI is the minimal slice of api.ClientWithResponsesInterface
+// the dispatch package consumes, plus the Refresh hook the one-shot
+// 401-retry path invokes. Defined as a package-private interface so
+// the dispatch test suite can substitute a tiny fake without reaching
+// for the full ~140-method generated surface. *api.AuthedClient
+// satisfies this directly: it embeds *ClientWithResponses (which
+// provides the two *WithResponse calls) and defines Refresh of its
+// own.
+type operationsAPI interface {
+	PostCallApiV1OperationsCallPostWithResponse(
+		ctx context.Context,
+		params *api.PostCallApiV1OperationsCallPostParams,
+		body api.PostCallApiV1OperationsCallPostJSONRequestBody,
+		reqEditors ...api.RequestEditorFn,
+	) (*api.PostCallApiV1OperationsCallPostResponse, error)
+	GetSearchApiV1OperationsSearchGetWithResponse(
+		ctx context.Context,
+		params *api.GetSearchApiV1OperationsSearchGetParams,
+		reqEditors ...api.RequestEditorFn,
+	) (*api.GetSearchApiV1OperationsSearchGetResponse, error)
+	Refresh(ctx context.Context) error
+}
+
+// newAuthedClient is the production-mode factory Connector defaults to
+// for building the authed transport per call. Returning the per-package
+// operationsAPI interface (not *api.AuthedClient) keeps the call sites
+// typed against the dispatch seam, not the generated client; tests
+// override this var with a fake. Variable rather than method so the
+// override stays scoped to the test file.
+var newAuthedClient = func(ctx context.Context, backplaneURL string) (operationsAPI, error) {
+	return api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{})
+}
+
+// Connector binds a pre-baked connector_id and owns the authed
+// transport so every alias verb in a vendor package shares one
+// dispatch + render implementation. The transport is built lazily
+// per Call/Search invocation (mirroring the pre-#1274 doAuthedRequest
+// lifecycle) so refreshed tokens land back in the store between
+// invocations without per-Connector caching.
 type Connector struct {
-	ID      string
-	Request RequestFunc
+	ID string
+}
+
+// New constructs a Connector with the supplied pre-baked connector_id.
+// Vendor packages bind one package-level `var conn = dispatch.New(...)`
+// per dir.
+func New(connectorID string) Connector {
+	return Connector{ID: connectorID}
 }
 
 // Call POSTs an OperationCall to the backplane and returns the decoded
-// CallResult. An empty targetSlug omits the target field on the wire; a
-// nil params omits params.
+// CallResult. An empty targetSlug omits the target field on the wire
+// (JSON null) for ops that don't act on a target; nil params omits
+// params.
+//
+// targetSlug serializes as the dict shape `{"name": "<slug>"}` via
+// FromCallOperationBodyTarget1 — the wire shape every pre-#1274
+// per-vendor verb has been sending. The bare-string target shape
+// (FromCallOperationBodyTarget0) is the forward-preferred form per
+// G0.13-T2 #1132 but operationally identical (the backend normalises
+// both to the same dict before dispatch); keeping the dict shape
+// preserves byte-identical wire output for the existing per-vendor
+// test suites that assert on body.Target["name"]. CallWithTarget
+// below is the explicit entry point for callers (vcf-automation)
+// that thread additional dict keys.
 func (c Connector) Call(
 	ctx context.Context,
 	backplaneURL, opID, targetSlug string,
@@ -90,37 +208,167 @@ func (c Connector) Call(
 
 // CallWithTarget is Call for connectors that need extra target keys
 // beyond "name" (e.g. cmd/vcf-automation threads a per-call "fqdn"
-// vhost override). target is encoded verbatim — pass nil to omit the
-// target field (JSON null) for ops that don't act on a target.
+// vhost override). target is encoded verbatim — pass nil to omit
+// the target field (JSON null) for ops that don't act on a target.
+//
+// Uses the dict-shape target form (FromCallOperationBodyTarget1)
+// because the bare-string form can't carry extra keys.
 func (c Connector) CallWithTarget(
 	ctx context.Context,
 	backplaneURL, opID string,
 	target map[string]any,
 	params map[string]any,
 ) (*CallResult, error) {
-	body := CallRequestBody{ConnectorID: c.ID, OpID: opID, Target: target}
+	body := api.CallOperationBody{
+		ConnectorId: c.ID,
+		OpId:        opID,
+	}
+	if target != nil {
+		var t api.CallOperationBody_Target
+		if err := t.FromCallOperationBodyTarget1(target); err != nil {
+			return nil, fmt.Errorf("encode target: %w", err)
+		}
+		body.Target = &t
+	}
 	if params != nil {
-		body.Params = params
+		p := params
+		body.Params = &p
 	}
-	raw, err := json.Marshal(body)
-	if err != nil {
-		return nil, fmt.Errorf("marshal call request: %w", err)
-	}
-	respBody, err := c.Request(ctx, backplaneURL, "POST", "/api/v1/operations/call", raw)
+	return c.postCall(ctx, backplaneURL, body)
+}
+
+// postCall issues the typed POST through the generated *WithResponse
+// helper and runs the one-shot 401-refresh dance, mirroring
+// api.AuthedClient.GetHealth. Non-2xx outcomes wrap as
+// *APIResponseError for renderRequestError to classify.
+func (c Connector) postCall(
+	ctx context.Context,
+	backplaneURL string,
+	body api.CallOperationBody,
+) (*CallResult, error) {
+	client, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
 		return nil, err
 	}
+	apiParams := &api.PostCallApiV1OperationsCallPostParams{}
+	resp, err := client.PostCallApiV1OperationsCallPostWithResponse(ctx, apiParams, body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode() == http.StatusUnauthorized {
+		if rerr := client.Refresh(ctx); rerr != nil {
+			return nil, rerr
+		}
+		resp, err = client.PostCallApiV1OperationsCallPostWithResponse(ctx, apiParams, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, classifyNon2xx(resp.HTTPResponse, resp.Body)
+	}
 	var out CallResult
-	if err := json.Unmarshal(respBody, &out); err != nil {
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		return nil, fmt.Errorf("decode call response: %w", err)
 	}
 	return &out, nil
 }
 
+// Search GETs the operations-search route and returns the decoded
+// envelope. groupKey == "" omits the optional `group` filter; limit
+// <= 0 omits the optional `limit` cap (the backend applies its own
+// default).
+//
+// The typed GetSearchApiV1OperationsSearchGetParams carries pointer
+// fields for the optional query params — nil leaves them off the
+// URL via the generator's omitempty form.
+func (c Connector) Search(
+	ctx context.Context,
+	backplaneURL, query, groupKey string,
+	limit int,
+) (*SearchResponse, error) {
+	client, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	params := &api.GetSearchApiV1OperationsSearchGetParams{
+		ConnectorId: c.ID,
+		Query:       query,
+	}
+	if groupKey != "" {
+		g := groupKey
+		params.Group = &g
+	}
+	if limit > 0 {
+		l := limit
+		params.Limit = &l
+	}
+	resp, err := client.GetSearchApiV1OperationsSearchGetWithResponse(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode() == http.StatusUnauthorized {
+		if rerr := client.Refresh(ctx); rerr != nil {
+			return nil, rerr
+		}
+		resp, err = client.GetSearchApiV1OperationsSearchGetWithResponse(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return nil, classifyNon2xx(resp.HTTPResponse, resp.Body)
+	}
+	var out SearchResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		return nil, fmt.Errorf("decode search response: %w", err)
+	}
+	return &out, nil
+}
+
+// classifyNon2xx wraps the generated *Response fields into the local
+// APIResponseError sentinel renderRequestError extracts via
+// errors.As. Truncates the body at 1 MiB to match the pre-#1274
+// transport's response read cap.
+func classifyNon2xx(resp *http.Response, body []byte) *APIResponseError {
+	const maxBodyBytes = 1 << 20 // 1 MiB
+	b := body
+	if len(b) > maxBodyBytes {
+		b = b[:maxBodyBytes]
+	}
+	return &APIResponseError{
+		StatusCode: resp.StatusCode,
+		Body:       trimSpace(string(b)),
+	}
+}
+
+// trimSpace mirrors strings.TrimSpace but as a local helper so the
+// dispatch package keeps its import surface compact (strings would
+// otherwise enter just for one call).
+func trimSpace(s string) string {
+	start := 0
+	end := len(s)
+	for start < end && isSpace(s[start]) {
+		start++
+	}
+	for end > start && isSpace(s[end-1]) {
+		end--
+	}
+	return s[start:end]
+}
+
+func isSpace(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\r', '\v', '\f':
+		return true
+	}
+	return false
+}
+
 // Render runs the unified post-dispatch path every verb uses: validate
 // the status enum, render the envelope (JSON or human), then map
-// "error" / "denied" to ErrOpError. When prettyPrinter is nil the generic
-// envelope is used.
+// "error" / "denied" to ErrOpError. When prettyPrinter is nil the
+// generic envelope is used.
 func (c Connector) Render(
 	cmd *cobra.Command,
 	opID string,
@@ -157,9 +405,9 @@ func (c Connector) Render(
 }
 
 // PrintGeneric renders a CallResult in the generic envelope shape: a
-// status line, then the pretty-printed Result on success or the connector
-// error + extras on failure. Used as the default pretty-printer when a
-// verb passes none.
+// status line, then the pretty-printed Result on success or the
+// connector error + extras on failure. Used as the default
+// pretty-printer when a verb passes none.
 func (c Connector) PrintGeneric(w io.Writer, opID string, r *CallResult) {
 	fmt.Fprintf(w, "%s %s — status=%s (%.0fms)\n", c.ID, opID, r.Status, r.DurationMs)
 	if r.Status == "ok" {

--- a/cli/internal/dispatch/dispatch_test.go
+++ b/cli/internal/dispatch/dispatch_test.go
@@ -8,71 +8,409 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
 )
 
-// capturingConn returns a Connector whose Request records the last
-// marshalled body and replies with a fixed response.
-func capturingConn(id string, reply []byte, replyErr error) (*Connector, *[]byte) {
-	var last []byte
-	c := Connector{
-		ID: id,
-		Request: func(_ context.Context, _, _, _ string, body []byte) ([]byte, error) {
-			last = body
-			return reply, replyErr
-		},
-	}
-	return &c, &last
+// fakeOperationsClient is the dispatch-test double satisfying the
+// package-private operationsAPI interface. Per-test setup wires
+// canned responses (status, body, error) for each verb; the fake
+// records the typed params + body so wire-shape assertions don't
+// have to go through httptest.
+type fakeOperationsClient struct {
+	lastCallParams   *api.PostCallApiV1OperationsCallPostParams
+	lastCallBody     *api.CallOperationBody
+	lastSearchParams *api.GetSearchApiV1OperationsSearchGetParams
+
+	// Sequenced canned responses — pop one per call. Tests register
+	// two responses on the auth-refresh scenarios (first a 401, then
+	// the post-refresh outcome) and one on every other path.
+	callResponses   []*api.PostCallApiV1OperationsCallPostResponse
+	searchResponses []*api.GetSearchApiV1OperationsSearchGetResponse
+
+	// Per-verb transport-error queues. Drained in lockstep with the
+	// response queues so a refresh-then-transport-failure scenario
+	// can be authored.
+	callErrors   []error
+	searchErrors []error
+
+	// refreshCount tracks how many times Refresh was invoked across
+	// the fake's lifetime. The 401 dance asserts this hits exactly 1.
+	refreshCount int
+	// refreshErr is returned from Refresh; tests that want to model a
+	// no-refresh-token / IdP-rejected refresh set this.
+	refreshErr error
 }
 
-func TestCallBakesConnectorIDAndTarget(t *testing.T) {
-	c, last := capturingConn("vault-1.x", []byte(`{"status":"ok","op_id":"x","duration_ms":1}`), nil)
+func (f *fakeOperationsClient) PostCallApiV1OperationsCallPostWithResponse(
+	_ context.Context,
+	params *api.PostCallApiV1OperationsCallPostParams,
+	body api.PostCallApiV1OperationsCallPostJSONRequestBody,
+	_ ...api.RequestEditorFn,
+) (*api.PostCallApiV1OperationsCallPostResponse, error) {
+	f.lastCallParams = params
+	bodyCopy := body
+	f.lastCallBody = &bodyCopy
+	return popCallResp(&f.callResponses), popErr(&f.callErrors)
+}
+
+func (f *fakeOperationsClient) GetSearchApiV1OperationsSearchGetWithResponse(
+	_ context.Context,
+	params *api.GetSearchApiV1OperationsSearchGetParams,
+	_ ...api.RequestEditorFn,
+) (*api.GetSearchApiV1OperationsSearchGetResponse, error) {
+	f.lastSearchParams = params
+	return popSearchResp(&f.searchResponses), popErr(&f.searchErrors)
+}
+
+func (f *fakeOperationsClient) Refresh(_ context.Context) error {
+	f.refreshCount++
+	return f.refreshErr
+}
+
+func popCallResp(q *[]*api.PostCallApiV1OperationsCallPostResponse) *api.PostCallApiV1OperationsCallPostResponse {
+	if len(*q) == 0 {
+		return nil
+	}
+	r := (*q)[0]
+	*q = (*q)[1:]
+	return r
+}
+
+func popSearchResp(q *[]*api.GetSearchApiV1OperationsSearchGetResponse) *api.GetSearchApiV1OperationsSearchGetResponse {
+	if len(*q) == 0 {
+		return nil
+	}
+	r := (*q)[0]
+	*q = (*q)[1:]
+	return r
+}
+
+func popErr(q *[]error) error {
+	if len(*q) == 0 {
+		return nil
+	}
+	e := (*q)[0]
+	*q = (*q)[1:]
+	return e
+}
+
+func makeHTTPResp(status int) *http.Response {
+	return &http.Response{StatusCode: status}
+}
+
+// withFake swaps the package-level newAuthedClient factory for the
+// supplied fake for the duration of one test, then restores the
+// production factory via t.Cleanup. Returns the fake so the test
+// body can inspect recorded params + tweak canned responses.
+func withFake(t *testing.T, fake *fakeOperationsClient) *fakeOperationsClient {
+	t.Helper()
+	prev := newAuthedClient
+	newAuthedClient = func(_ context.Context, _ string) (operationsAPI, error) {
+		return fake, nil
+	}
+	t.Cleanup(func() { newAuthedClient = prev })
+	return fake
+}
+
+// ---- Call / CallWithTarget ----
+
+// TestCallBakesConnectorIDAndDictTarget — happy path asserts the
+// typed body carries the pre-baked connector_id and the dict-shape
+// target form (FromCallOperationBodyTarget1) — the wire shape every
+// pre-#1274 per-vendor verb has been sending. The bare-string shape
+// (FromCallOperationBodyTarget0) is operationally identical (the
+// backend normalises both); keeping the dict shape preserves byte-
+// identical wire output for the existing per-vendor test suites
+// that assert on body.Target["name"].
+func TestCallBakesConnectorIDAndDictTarget(t *testing.T) {
+	cr, _ := json.Marshal(CallResult{
+		Status: "ok", OpID: "vault.kv.read", DurationMs: 1,
+	})
+	f := withFake(t, &fakeOperationsClient{
+		callResponses: []*api.PostCallApiV1OperationsCallPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: cr},
+		},
+	})
+	c := New("vault-1.x")
 	if _, err := c.Call(context.Background(), "https://bp", "vault.kv.read", "rdc-vault", map[string]any{"path": "p"}); err != nil {
 		t.Fatalf("Call: %v", err)
 	}
-	var body CallRequestBody
-	if err := json.Unmarshal(*last, &body); err != nil {
-		t.Fatalf("decode body: %v", err)
+	if f.lastCallBody == nil {
+		t.Fatalf("Call should populate body")
 	}
-	if body.ConnectorID != "vault-1.x" || body.OpID != "vault.kv.read" {
-		t.Fatalf("connector/op not baked: %+v", body)
+	if f.lastCallBody.ConnectorId != "vault-1.x" || f.lastCallBody.OpId != "vault.kv.read" {
+		t.Fatalf("body should carry typed connector_id + op_id; got %+v", f.lastCallBody)
 	}
-	if body.Target["name"] != "rdc-vault" {
-		t.Fatalf("target name = %v, want rdc-vault", body.Target["name"])
+	if f.lastCallBody.Target == nil {
+		t.Fatalf("body.Target should be non-nil when --target is set")
 	}
-	if body.Params["path"] != "p" {
-		t.Fatalf("params not threaded: %+v", body.Params)
+	got, err := f.lastCallBody.Target.AsCallOperationBodyTarget1()
+	if err != nil {
+		t.Fatalf("AsCallOperationBodyTarget1: %v", err)
+	}
+	if got["name"] != "rdc-vault" {
+		t.Fatalf("Call should encode target as dict {\"name\": \"rdc-vault\"}; got %+v", got)
+	}
+	if f.lastCallBody.Params == nil || (*f.lastCallBody.Params)["path"] != "p" {
+		t.Fatalf("params not threaded: %+v", f.lastCallBody.Params)
 	}
 }
 
+// TestCallEmptyTargetSerialisesNull — empty targetSlug leaves the
+// body.Target pointer nil so the JSON serialiser emits `"target":null`
+// (the generator's CallOperationBody.Target carries `json:"target"`
+// without omitempty; the route accepts null).
 func TestCallEmptyTargetSerialisesNull(t *testing.T) {
-	c, last := capturingConn("c", []byte(`{"status":"ok"}`), nil)
+	cr, _ := json.Marshal(CallResult{Status: "ok"})
+	f := withFake(t, &fakeOperationsClient{
+		callResponses: []*api.PostCallApiV1OperationsCallPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: cr},
+		},
+	})
+	c := New("c")
 	if _, err := c.Call(context.Background(), "https://bp", "op", "", nil); err != nil {
 		t.Fatalf("Call: %v", err)
 	}
-	if got := string(*last); !strings.Contains(got, `"target":null`) {
-		t.Fatalf("empty target should serialise null, got %s", got)
+	if f.lastCallBody.Target != nil {
+		t.Fatalf("empty target should leave body.Target=nil; got %+v", f.lastCallBody.Target)
+	}
+	raw, err := json.Marshal(f.lastCallBody)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	if !bytes.Contains(raw, []byte(`"target":null`)) {
+		t.Fatalf("expected `\"target\":null` on the wire; got %s", string(raw))
 	}
 }
 
-func TestCallWithTargetThreadsExtraKeys(t *testing.T) {
-	c, last := capturingConn("vcfa-rest-9.0", []byte(`{"status":"ok"}`), nil)
+// TestCallWithTargetThreadsExtraKeysAsDict — CallWithTarget uses the
+// dict-shape target form (FromCallOperationBodyTarget1) so callers
+// can thread extra keys like "fqdn" alongside "name".
+func TestCallWithTargetThreadsExtraKeysAsDict(t *testing.T) {
+	cr, _ := json.Marshal(CallResult{Status: "ok"})
+	f := withFake(t, &fakeOperationsClient{
+		callResponses: []*api.PostCallApiV1OperationsCallPostResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: cr},
+		},
+	})
+	c := New("vcfa-rest-9.0")
 	target := map[string]any{"name": "vcfa", "fqdn": "vra.lab"}
 	if _, err := c.CallWithTarget(context.Background(), "https://bp", "op", target, nil); err != nil {
 		t.Fatalf("CallWithTarget: %v", err)
 	}
-	var body CallRequestBody
-	_ = json.Unmarshal(*last, &body)
-	if body.Target["fqdn"] != "vra.lab" {
-		t.Fatalf("fqdn not threaded into target: %+v", body.Target)
+	if f.lastCallBody.Target == nil {
+		t.Fatalf("body.Target should be set")
+	}
+	got, err := f.lastCallBody.Target.AsCallOperationBodyTarget1()
+	if err != nil {
+		t.Fatalf("AsCallOperationBodyTarget1: %v", err)
+	}
+	if got["fqdn"] != "vra.lab" || got["name"] != "vcfa" {
+		t.Fatalf("fqdn/name not threaded into dict target: %+v", got)
 	}
 }
 
+// TestCallRefreshesOn401AndRetries — the 401 dance mirrors
+// api.AuthedClient.GetHealth: first call returns 401, Refresh runs
+// once, second call returns 200.
+func TestCallRefreshesOn401AndRetries(t *testing.T) {
+	cr, _ := json.Marshal(CallResult{Status: "ok"})
+	f := withFake(t, &fakeOperationsClient{
+		callResponses: []*api.PostCallApiV1OperationsCallPostResponse{
+			{HTTPResponse: makeHTTPResp(401), Body: []byte(`{"detail":"token expired"}`)},
+			{HTTPResponse: makeHTTPResp(200), Body: cr},
+		},
+	})
+	c := New("c")
+	if _, err := c.Call(context.Background(), "https://bp", "op", "t", nil); err != nil {
+		t.Fatalf("Call after refresh: %v", err)
+	}
+	if f.refreshCount != 1 {
+		t.Fatalf("expected exactly one Refresh; got %d", f.refreshCount)
+	}
+}
+
+// TestCallClassifies403AsAPIResponseError — non-401 4xx wraps as
+// *APIResponseError; renderRequestError later maps it to unexpected.
+func TestCallClassifies403AsAPIResponseError(t *testing.T) {
+	withFake(t, &fakeOperationsClient{
+		callResponses: []*api.PostCallApiV1OperationsCallPostResponse{
+			{HTTPResponse: makeHTTPResp(403), Body: []byte(`{"detail":"forbidden"}`)},
+		},
+	})
+	c := New("c")
+	_, err := c.Call(context.Background(), "https://bp", "op", "t", nil)
+	if err == nil {
+		t.Fatalf("expected non-2xx error; got nil")
+	}
+	var apiErr *APIResponseError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != 403 {
+		t.Fatalf("expected *APIResponseError{StatusCode:403}; got %+v", err)
+	}
+	if apiErr.Body != `{"detail":"forbidden"}` {
+		t.Fatalf("APIResponseError.Body should preserve the response body; got %q", apiErr.Body)
+	}
+}
+
+// TestCallTransportErrorPropagates — pure transport failure (DNS /
+// connection-refused etc.) returns directly so renderRequestError can
+// classify as unreachable.
+func TestCallTransportErrorPropagates(t *testing.T) {
+	transportErr := errors.New("dial tcp: lookup meho.test on 8.8.8.8: no such host")
+	withFake(t, &fakeOperationsClient{callErrors: []error{transportErr}})
+	c := New("c")
+	_, err := c.Call(context.Background(), "https://bp", "op", "t", nil)
+	if !errors.Is(err, transportErr) {
+		t.Fatalf("expected transport error to propagate verbatim; got %v", err)
+	}
+	var apiErr *APIResponseError
+	if errors.As(err, &apiErr) {
+		t.Fatalf("transport error should not wrap as *APIResponseError")
+	}
+}
+
+// TestCallRefreshFailurePropagates — Refresh returning a no-refresh-
+// token error propagates so the verb's renderer can map it to
+// auth_expired.
+func TestCallRefreshFailurePropagates(t *testing.T) {
+	refreshErr := errors.New("meho: stored token has no refresh_token")
+	withFake(t, &fakeOperationsClient{
+		callResponses: []*api.PostCallApiV1OperationsCallPostResponse{
+			{HTTPResponse: makeHTTPResp(401), Body: []byte(`{"detail":"token expired"}`)},
+		},
+		refreshErr: refreshErr,
+	})
+	c := New("c")
+	_, err := c.Call(context.Background(), "https://bp", "op", "t", nil)
+	if !errors.Is(err, refreshErr) {
+		t.Fatalf("expected refreshErr to propagate; got %v", err)
+	}
+}
+
+// ---- Search ----
+
+// TestSearchPassesTypedParams — all four params (ConnectorId, Query,
+// Group, Limit) land on the typed struct; Group + Limit are pointer-
+// typed so the test asserts they're set (not nil).
+func TestSearchPassesTypedParams(t *testing.T) {
+	body, _ := json.Marshal(SearchResponse{
+		Hits:            []SearchHit{{OpID: "vault.kv.read", FusedScore: 0.9}},
+		QueryDurationMs: 12.0,
+	})
+	f := withFake(t, &fakeOperationsClient{
+		searchResponses: []*api.GetSearchApiV1OperationsSearchGetResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: body},
+		},
+	})
+	c := New("vault-1.x")
+	if _, err := c.Search(context.Background(), "https://bp", "secret", "kv", 7); err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	p := f.lastSearchParams
+	if p == nil || p.ConnectorId != "vault-1.x" || p.Query != "secret" {
+		t.Fatalf("Search should pass typed ConnectorId+Query; got %+v", p)
+	}
+	if p.Group == nil || *p.Group != "kv" {
+		t.Fatalf("Search should pass typed Group=%q; got %+v", "kv", p.Group)
+	}
+	if p.Limit == nil || *p.Limit != 7 {
+		t.Fatalf("Search should pass typed Limit=%d; got %+v", 7, p.Limit)
+	}
+}
+
+// TestSearchOmitsOptionalParamsWhenEmpty — Group + Limit are nil-
+// pointer when the caller didn't supply them, so the generator's
+// omitempty form keeps them out of the URL.
+func TestSearchOmitsOptionalParamsWhenEmpty(t *testing.T) {
+	body, _ := json.Marshal(SearchResponse{Hits: nil, QueryDurationMs: 0})
+	f := withFake(t, &fakeOperationsClient{
+		searchResponses: []*api.GetSearchApiV1OperationsSearchGetResponse{
+			{HTTPResponse: makeHTTPResp(200), Body: body},
+		},
+	})
+	c := New("vault-1.x")
+	if _, err := c.Search(context.Background(), "https://bp", "secret", "", 0); err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	p := f.lastSearchParams
+	if p == nil {
+		t.Fatalf("Search should populate params struct")
+	}
+	if p.Group != nil {
+		t.Fatalf("empty groupKey should leave Group=nil; got %v", *p.Group)
+	}
+	if p.Limit != nil {
+		t.Fatalf("zero limit should leave Limit=nil; got %v", *p.Limit)
+	}
+}
+
+// TestSearchRefreshesOn401AndRetries — 401 dance for Search.
+func TestSearchRefreshesOn401AndRetries(t *testing.T) {
+	body, _ := json.Marshal(SearchResponse{})
+	f := withFake(t, &fakeOperationsClient{
+		searchResponses: []*api.GetSearchApiV1OperationsSearchGetResponse{
+			{HTTPResponse: makeHTTPResp(401), Body: []byte(`{"detail":"token expired"}`)},
+			{HTTPResponse: makeHTTPResp(200), Body: body},
+		},
+	})
+	c := New("c")
+	if _, err := c.Search(context.Background(), "https://bp", "q", "", 0); err != nil {
+		t.Fatalf("Search after refresh: %v", err)
+	}
+	if f.refreshCount != 1 {
+		t.Fatalf("expected exactly one Refresh; got %d", f.refreshCount)
+	}
+}
+
+// TestSearchClassifies5xxAsAPIResponseError — 5xx wraps as
+// *APIResponseError, body preserved.
+func TestSearchClassifies5xxAsAPIResponseError(t *testing.T) {
+	withFake(t, &fakeOperationsClient{
+		searchResponses: []*api.GetSearchApiV1OperationsSearchGetResponse{
+			{HTTPResponse: makeHTTPResp(500), Body: []byte(`{"detail":"backplane unavailable"}`)},
+		},
+	})
+	c := New("c")
+	_, err := c.Search(context.Background(), "https://bp", "q", "", 0)
+	var apiErr *APIResponseError
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != 500 {
+		t.Fatalf("expected *APIResponseError{StatusCode:500}; got %+v", err)
+	}
+}
+
+// TestClassifyNon2xxTrimsBodyWhitespace — Server-Sent envelopes
+// often carry trailing newlines; the trim keeps the rendered error
+// compact.
+func TestClassifyNon2xxTrimsBodyWhitespace(t *testing.T) {
+	httpResp := &http.Response{StatusCode: 422}
+	apiErr := classifyNon2xx(httpResp, []byte("  {\"detail\":\"bad\"}\n\n  "))
+	if apiErr.Body != `{"detail":"bad"}` {
+		t.Fatalf("classifyNon2xx should trim whitespace; got %q", apiErr.Body)
+	}
+}
+
+// TestClassifyNon2xxCapsBodyAtOneMiB — payloads larger than 1 MiB
+// are truncated so the rendered error doesn't bloat operator output.
+func TestClassifyNon2xxCapsBodyAtOneMiB(t *testing.T) {
+	const sizeOverCap = (1 << 20) + 100
+	body := bytes.Repeat([]byte("x"), sizeOverCap)
+	httpResp := &http.Response{StatusCode: 500}
+	apiErr := classifyNon2xx(httpResp, body)
+	if len(apiErr.Body) > (1 << 20) {
+		t.Fatalf("classifyNon2xx should cap at 1 MiB; got %d bytes", len(apiErr.Body))
+	}
+}
+
+// ---- Render / PrintGeneric / PrettyJSON ----
+
 func TestRenderStatusMapping(t *testing.T) {
-	c := Connector{ID: "c"}
+	c := New("c")
 	cases := []struct {
 		status  string
 		wantErr error
@@ -94,7 +432,7 @@ func TestRenderStatusMapping(t *testing.T) {
 }
 
 func TestRenderInvalidStatusReturnsRenderError(t *testing.T) {
-	c := Connector{ID: "c"}
+	c := New("c")
 	cmd := &cobra.Command{}
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
@@ -105,7 +443,7 @@ func TestRenderInvalidStatusReturnsRenderError(t *testing.T) {
 }
 
 func TestPrintGenericSuccessRendersResult(t *testing.T) {
-	c := Connector{ID: "vault-1.x"}
+	c := New("vault-1.x")
 	var buf bytes.Buffer
 	c.PrintGeneric(&buf, "vault.kv.read", &CallResult{
 		Status: "ok", Result: json.RawMessage(`{"k":"v"}`), DurationMs: 12,

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -199,8 +199,8 @@ cli/
     │   ├── vault/             # G3.3-T6 #550 — `meho vault …` alias verb tree (connector_id="vault-1.x" pre-baked).
     │   └── topology/          # G9.1-T6 #454 + G9.2-T6 #599 — `meho topology refresh/dependents/dependencies/path/annotate/unannotate/list-edges` over the T5 REST surface (#453, #597).
     │                          #   (the 5th G9.1-T6 verb, `meho targets discover`, lives in targets/discover.go.)
-    │       ├── vault.go          # NewRootCmd + shared HTTP/auth/render helpers + ConnectorID const.
-    │       ├── dispatch.go       # CallResult/callRequestBody + dispatchOp + renderCallResult + generic renderer.
+    │       ├── vault.go          # NewRootCmd + ConnectorID const + per-package renderRequestError (auth-ladder + *dispatch.APIResponseError); transport now lives in `cli/internal/dispatch` (G0.12-T16 #1274).
+    │       ├── dispatch.go       # Alias CallResult/callRequestBody to dispatch types + `var conn = dispatch.New(ConnectorID)` (transport owned by dispatch.Connector after G0.12-T16 #1274).
     │       ├── kv.go             # `meho vault kv read|list|put|versions|delete` (vault.kv.* ops, #545).
     │       ├── sys.go            # `meho vault sys health|seal-status|mounts-list|auth-list` (vault.sys.* ops, #546).
     │       ├── auth.go           # `meho vault auth userpass/approle list+read` (vault.auth.* ops, #547).
@@ -1042,13 +1042,21 @@ prints that verbatim with the handle hint intact, consistent with the
 ### HTTP shape + exit codes
 
 Identical to the `meho operation` surface (the verbs are pre-scoped
-wrappers over the same route): bearer injection + one-shot
-401-refresh-retry via `api.NewAuthedClient`, hand-written
-`CallResult` / `callRequestBody` structs mirroring the backend
-Pydantic models (duplicated per package to avoid the cmd/* import
-cycle cmd/root.go's graft would otherwise create). Exit codes: `0`
-status=ok, `1` status=error/denied (via the `errOpError` sentinel),
-`2` auth_expired, `3` unreachable, `4` unexpected_response.
+wrappers over the same route): the shared `cli/internal/dispatch`
+package owns the authed transport (lazy `*api.AuthedClient` over the
+generated typed `*WithResponse` helpers) including the one-shot
+401-refresh-retry; `CallResult` / `CallRequestBody` are exported
+from the dispatch package and aliased verbatim in each vendor's
+`dispatch.go` so the per-verb pretty-printers continue referencing the
+unqualified names. After G0.12-T16 #1274 the 15 vendor dirs (`vault`,
+`vmware`, `harbor`, `nsx`, `hetzner-robot`, `holodeck`, `pfsense`,
+`gcloud`, `bind9`, `k8s`, `sddc-manager`, `vcf-automation`, `vcf-fleet`,
+`vcf-logs`, `vcf-operations`) share **one** transport implementation
+instead of byte-near-identical `doAuthedRequest` / `sendRequest` /
+`httpError` trios. Exit codes: `0` status=ok, `1` status=error/denied
+(via the `errOpError` sentinel re-exported from
+`dispatch.ErrOpError`), `2` auth_expired, `3` unreachable,
+`4` unexpected_response.
 
 ## Topology verbs (`meho topology`, G9.1-T6 #454 + G9.2-T6 #599)
 

--- a/docs/codebase/connectors-gcloud.md
+++ b/docs/codebase/connectors-gcloud.md
@@ -215,7 +215,8 @@ All 8 ops are reachable via `meho gcloud …`. Source:
 
 | File | Commands |
 |---|---|
-| `gcloud.go` | `NewRootCmd()`, helper types (`CallResult`, `dispatchOp`, decoders) |
+| `gcloud.go` | `NewRootCmd()`, `renderRequestError`, `resolveBackplane`, helpers |
+| `dispatch.go` | Aliases `CallResult` / `callRequestBody` to `dispatch` package types + `var conn = dispatch.New(ConnectorID)` (shared transport); `dispatchOp` / `renderCallResult` thin wrappers; `decodeFlatResult` / `decodeRowsResult` decoders |
 | `about.go` | `meho gcloud about` |
 | `project.go` | `meho gcloud project describe` |
 | `services.go` | `meho gcloud services list [--all]` |


### PR DESCRIPTION
## Summary

- Promote `cli/internal/dispatch.Connector` to own the authed backplane transport via the oapi-codegen-generated typed client (`PostCallApiV1OperationsCallPostWithResponse` / `GetSearchApiV1OperationsSearchGetWithResponse` + one-shot 401-refresh dance mirroring `api.AuthedClient.GetHealth`).
- Eliminate the 15 per-vendor `doAuthedRequest` / `sendRequest` / `httpError` copies and the 9 `getSearch` / `searchHit` / `searchResponse` copies across the connector verb dirs. Each `dispatch.go` now binds `var conn = dispatch.New(ConnectorID)` and `<vendor>.go`'s `renderRequestError` matches `*dispatch.APIResponseError` instead of the local `*httpError` sentinel.
- Fold gcloud (the pre-#1274 deviation — no `dispatch.go`, local `dispatchOp`/`renderCallResult`/`printGenericResult` trio) onto the shared pattern by adding `cli/internal/cmd/gcloud/dispatch.go`. Wire-shape and verb signatures preserved for every dir.

Net diff: **~1,500 LOC deleted, ~340 added** (47 files touched: shared `dispatch` package + 15 vendor dirs + 2 docs).

## Test plan

- [x] `go test ./cli/...` — all packages pass (dispatch + all 15 vendor dirs + every unaffected sibling).
- [x] `go vet ./cli/...` — clean.
- [x] `cd cli && make snapshot-openapi && make generate` — no drift against `openapi.json` or `client.gen.go`; the `cli-api-snapshot-freshness` required CI gate stays green.
- [x] `grep -rn "func doAuthedRequest|func sendRequest|type httpError" cli/internal/cmd/{bind9,gcloud,harbor,hetzner-robot,holodeck,k8s,nsx,pfsense,sddc-manager,vault,vcf-automation,vcf-fleet,vcf-logs,vcf-operations,vmware}/` returns no matches.
- [x] `grep -rn "func getSearch|type searchHit|type searchResponse" cli/internal/cmd/{harbor,hetzner-robot,nsx,sddc-manager,vcf-automation,vcf-fleet,vcf-logs,vcf-operations,vmware}/` returns no matches.
- [x] `grep -rn "Request: doAuthedRequest|RequestFunc" cli/internal/dispatch/ cli/internal/cmd/` returns no matches (the injection seam is gone).
- [x] `cli/internal/cmd/gcloud/dispatch.go` exists and binds `var conn = dispatch.New(...)`; all gcloud verbs route through `conn.Call` (via the thin `dispatchOp` wrapper kept for call-site compatibility).
- [x] `grep -rn "dispatch.Connector|dispatch.New\b" cli/internal/cmd/` returns matches in all 15 dirs.
- [x] `dispatch.Connector.Search`, `dispatch.SearchHit`, `dispatch.SearchResponse` exist (promoted from per-dir copies).
- [x] Consolidated `cli/internal/dispatch/dispatch_test.go` covers Call / CallWithTarget / Search / 401-refresh-once / 4xx → APIResponseError / transport-error propagation / refresh-failure propagation / typed-param shape / body trim+cap.
- [ ] **Manual smoke** for one alias verb per dir (15 invocations: `meho harbor about --target prod-harbor`, `meho vcf-fleet datacenter list --target rdc-fleet`, `meho k8s about --target prod-k8s`, etc.) — pending operator-side validation against a real backplane; out of sandbox scope.
- [ ] **Manual smoke** for `meho harbor operation search "<q>"` + `meho harbor operation call <op_id> --target T` — same.

## Out of scope

- Backend OpenAPI surface changes — `/api/v1/operations/call` + `/api/v1/operations/search` response types stay `dict[str, Any]` in the FastAPI surface; `dispatch.CallResult` + `dispatch.SearchResponse` stay hand-typed for the same reason G0.12-T2 #1260 documents.
- Changing CLI verb names, flag names, exit codes, or output formatting for any of the 15 connector verbs. Migration is implementation-only.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1274


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated HTTP request and authentication logic across vendor integrations into a shared dispatch layer, reducing code duplication and improving maintainability.

* **Documentation**
  * Updated codebase documentation to reflect refactored internal architecture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->