### PR TITLE
fix(broadcast): G0.16-T3 backlog prelude on fresh SSE connections (#1305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,23 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+### Fixed
+
+- **SSE feed delivers zero bytes despite stream writes (SEV-1, signal
+  draft `sse-feed-delivers-zero-events-despite-stream-writes`)** — a
+  fresh `GET /api/v1/feed` or `/ui/broadcast/stream` connection
+  defaulted to the Valkey `$` live-tail cursor, which combined with
+  the 30 s heartbeat cadence produced 0 bytes for the first 30 s on
+  any tenant with no concurrent writes during the window, and
+  permanently empty `/ui/broadcast` pages for tenants with 76+
+  existing entries on the stream. `_feed_generator` and
+  `_ui_feed_generator` now run a backlog prelude
+  (`XREVRANGE … COUNT 50`) before the BLOCK loop on fresh `$`
+  connections; explicit-replay cursors (`Last-Event-Id`, `since`)
+  skip the prelude. Root cause documented in
+  `docs/codebase/broadcast.md` as the writer → fanout → consumer
+  triage path (#1305 / #1302).
+
 ## [0.8.0] - 2026-05-28
 
 **MVP7 — consolidated post-v0.7 release.** v0.8.0 collapses what

--- a/backend/src/meho_backplane/api/v1/feed.py
+++ b/backend/src/meho_backplane/api/v1/feed.py
@@ -47,9 +47,37 @@ Replay
 
 Either of the two replay knobs may be set; ``Last-Event-Id`` header
 takes precedence over the ``since`` query parameter when both are
-present. The default cursor is ``$`` (Valkey's "from now" anchor), so
-a fresh connection yields only events ``XADD``\\ ed after the SSE
-handshake completes.
+present. When neither is provided, a fresh connection emits a
+**backlog prelude** — the last :data:`_BACKLOG_PRELUDE_COUNT`
+entries on the tenant stream are replayed in chronological order
+before the live-tail BLOCK loop takes over. This solves two
+operator-visible bugs that ``$`` alone produces:
+
+1. A fresh ``GET /api/v1/feed`` against a stream with existing
+   entries but no new writes during the test window returns zero
+   bytes for the first ``_HEARTBEAT_INTERVAL_SECONDS`` — ``$``
+   skips backlog AND the heartbeat is 30 s, so curl / EventSource
+   intermediaries time out before seeing any byte. The repro in
+   ``claude-rdc-hetzner-dc#771`` Finding 14 (G0.16-T3, #1305) is
+   exactly this shape: 76+ events on the tenant stream, 0 bytes
+   observed at the SSE consumer over 6-8 s.
+2. The ``/ui/broadcast`` page renders the header "Live activity
+   across tenant X" with an empty event list because the live-tail
+   cursor ignores history. The operator perceives the broadcast
+   feature as broken even when stream writes are succeeding.
+
+The prelude reads via ``XREVRANGE meho:feed:{tenant} + - COUNT N``,
+reverses the result into chronological order, yields each as a
+regular ``event: broadcast`` SSE frame, then advances the cursor
+to the most recent entry id so the subsequent BLOCK loop reads
+strictly past the backlog (no duplicates). When the stream is
+empty the prelude is a no-op and the loop enters BLOCK with
+cursor ``$`` as before.
+
+Subscribers reconnecting with ``Last-Event-Id`` or callers passing
+``since`` skip the prelude — those cursors are explicit
+"resume-from-here" anchors and the caller already knows where
+they left off.
 
 Tenant scoping
 ==============
@@ -169,8 +197,24 @@ _XREAD_COUNT: Final[int] = 20
 #: Initial cursor when the client doesn't provide one. Valkey's ``$``
 #: anchor means "only entries XADD'd after this XREAD call started" —
 #: a fresh connection without ``Last-Event-Id`` / ``since`` gets the
-#: live tail, not a backlog.
+#: live tail. The :func:`_emit_backlog_prelude` helper does an
+#: ``XREVRANGE`` before the BLOCK loop so the operator sees recent
+#: history immediately and the HTTP intermediary buffer flushes on
+#: connection open; see the module docstring's *Replay* section for
+#: why the prelude is gated on a ``$`` cursor (explicit replay anchors
+#: are honoured verbatim).
 _LIVE_TAIL_CURSOR: Final[str] = "$"
+
+#: Number of historical entries replayed on a fresh ``$`` connection
+#: before the BLOCK loop runs. 50 matches the
+#: :mod:`~meho_backplane.mcp.resources.tenant_feed` snapshot ceiling
+#: so the SSE and the MCP-resource snapshot surface the same window
+#: of context on first connection. The cap is intentionally tight —
+#: a busy tenant with 10 000 entries on the stream should not ship
+#: every one of them to a fresh subscriber; an operator who wants the
+#: full history queries the audit log instead. Operators who want
+#: deeper replay pass an explicit ``since`` cursor.
+_BACKLOG_PRELUDE_COUNT: Final[int] = 50
 
 #: Valkey stream entry id shape — ``<ms-timestamp>`` or
 #: ``<ms-timestamp>-<sequence>``. Accepts both forms because the
@@ -494,6 +538,80 @@ def _process_entries(
         yield entry_id, _format_event(entry_id, raw_event_json)
 
 
+async def _emit_backlog_prelude(
+    client: object,
+    *,
+    stream_key: str,
+    op_class: str | None,
+    principal: str | None,
+    target: str | None,
+) -> tuple[list[str], str | None]:
+    """Read up to :data:`_BACKLOG_PRELUDE_COUNT` recent entries; return frames + advance.
+
+    Issues a single ``XREVRANGE stream_key + - COUNT N`` (latest-first)
+    and reverses the result into chronological order so the SSE
+    consumer sees entries in publish order. Each surviving entry is
+    formatted into a regular ``event: broadcast`` frame via the same
+    :func:`_process_entries` helper the live loop uses, so the wire
+    shape is identical between the prelude and live tail — clients
+    can't distinguish "this is replay" from "this is fresh" at the
+    frame level (the entry id distinguishes them at the application
+    level if needed).
+
+    Returns ``(frames, last_entry_id)``:
+
+    * ``frames`` — the SSE frames to yield, post-filter. Empty list
+      when the stream has no entries OR every entry filters out.
+    * ``last_entry_id`` — the Valkey id of the most recent entry
+      *fetched* (NOT *matched*) — ``None`` when the stream is empty.
+      Mirrors the live-loop invariant
+      (:func:`_consume_xread_batch`'s ``new_cursor = items[-1][0]``):
+      advance the cursor past every consumed entry, not just the
+      matched ones, so a busy-but-filtered tenant doesn't re-read
+      the same prelude batch on the first BLOCK iteration.
+
+    A :class:`redis.exceptions.RedisError` during the prelude is the
+    same operator-visible condition as the live loop's first XREAD
+    failure (broadcast pod down, network partition); we let it
+    propagate so the live-loop's ``except RedisError`` arm formats a
+    single ``feed_error`` frame for the subscriber. Catching it here
+    would double-handle the error path.
+
+    :param client: the redis-py asyncio client.
+        Typed as ``object`` because the public surface of
+        :class:`redis.asyncio.Redis` carries methods that mypy can't
+        verify against this module's narrow use (xrevrange takes
+        ``name, max, min, count`` keyword-only or positional depending
+        on version); we trust the runtime + the framework-research
+        introspection over the published stub shape.
+    """
+    # ``xrevrange`` returns ``[(entry_id, fields_dict), ...]`` —
+    # latest-first per the Valkey command contract. ``count`` is
+    # keyword-only on redis-py 7.x; the introspection
+    # (`uv run python -c "import redis.asyncio as r; help(r.Redis.xrevrange)"`)
+    # confirms the signature on the installed wheel.
+    raw_items = await client.xrevrange(  # type: ignore[attr-defined]
+        stream_key,
+        count=_BACKLOG_PRELUDE_COUNT,
+    )
+    if not raw_items:
+        return [], None
+    # XREVRANGE returns latest-first; reverse for chronological emit.
+    items: list[tuple[str, dict[str, str]]] = list(reversed(raw_items))
+    last_entry_id = items[-1][0]
+    frames = [
+        frame
+        for _entry_id, frame in _process_entries(
+            items,
+            op_class=op_class,
+            principal=principal,
+            target=target,
+            stream_key=stream_key,
+        )
+    ]
+    return frames, last_entry_id
+
+
 async def _feed_generator(
     operator: Operator,
     cursor: str,
@@ -501,7 +619,26 @@ async def _feed_generator(
     principal: str | None,
     target: str | None,
 ) -> AsyncIterator[str]:
-    """SSE generator: BLOCK on XREAD, delegate parsing, heartbeat-on-silence.
+    """SSE generator: prelude → BLOCK on XREAD, delegate parsing, heartbeat-on-silence.
+
+    Backlog prelude — when *cursor* is ``$`` (the live-tail default
+    selected by :func:`_resolve_cursor` when neither ``Last-Event-Id``
+    nor ``since`` is provided), the generator first calls
+    :func:`_emit_backlog_prelude` to replay the most recent
+    :data:`_BACKLOG_PRELUDE_COUNT` entries on the stream. This solves
+    the consumer-visible bug surfaced by ``claude-rdc-hetzner-dc#771``
+    Finding 14 (G0.16-T3, #1305): a fresh
+    ``GET /api/v1/feed`` against a tenant with existing entries but
+    no new writes during the test window otherwise returns zero bytes
+    for ``_HEARTBEAT_INTERVAL_SECONDS`` (``$`` skips backlog AND the
+    heartbeat cadence is 30 s), tripping curl / EventSource
+    intermediary timeouts before any byte is observed. The prelude
+    also gives the ``/ui/broadcast`` page a populated initial render
+    instead of a misleading empty list under a "Live activity" header.
+    Subscribers that pass an explicit replay cursor
+    (``Last-Event-Id`` or ``since``) skip the prelude — those cursors
+    are "resume exactly here" anchors and the caller already saw the
+    history.
 
     Heartbeat semantics — ``last_heartbeat`` tracks the wall-clock of
     the **last outbound yield** (event frame or heartbeat), NOT the
@@ -539,6 +676,46 @@ async def _feed_generator(
     last_heartbeat = time.monotonic()
 
     try:
+        # Backlog prelude — only when the caller didn't pin an explicit
+        # replay anchor. ``Last-Event-Id`` / ``since`` are honoured as
+        # "resume exactly here", which is incompatible with a backlog
+        # dump from "+" (would replay events the caller already saw).
+        # See the module docstring's *Replay* section for the full
+        # rationale and the consumer-side repro this addresses.
+        if cursor == _LIVE_TAIL_CURSOR:
+            try:
+                prelude_frames, prelude_last_id = await _emit_backlog_prelude(
+                    client,
+                    stream_key=stream_key,
+                    op_class=op_class,
+                    principal=principal,
+                    target=target,
+                )
+            except RedisError as exc:
+                # Same operator-visible condition as the live-loop's
+                # first XREAD failure (broadcast pod down). Emit one
+                # T11-compliant error frame and break — the connection
+                # closes cleanly and ``EventSource`` reconnects per its
+                # spec semantics, which will re-evaluate Valkey
+                # reachability on the next handshake.
+                yield _log_and_format_broadcast_unavailable(operator, stream_key, exc)
+                return
+            for frame in prelude_frames:
+                yield frame
+            if prelude_last_id is not None:
+                # Advance past every prelude entry — including the ones
+                # that filtered out — so the BLOCK loop reads strictly
+                # past the prelude window. Without this advance, a
+                # fully-filtered prelude would leave cursor at ``$``,
+                # the BLOCK loop would silently re-skip every prelude
+                # entry on its next read (XREAD with id strictly later
+                # than $ never returns older entries, but a busy stream
+                # could still flag this as "we re-fetched and the
+                # filter dropped them again"). Setting the cursor here
+                # makes the intent explicit.
+                cursor = prelude_last_id
+            if prelude_frames:
+                last_heartbeat = time.monotonic()
         while True:
             try:
                 entries = await client.xread(

--- a/backend/src/meho_backplane/ui/routes/broadcast/stream.py
+++ b/backend/src/meho_backplane/ui/routes/broadcast/stream.py
@@ -73,8 +73,10 @@ from fastapi.responses import StreamingResponse
 
 from meho_backplane.api.v1.feed import (
     _HEARTBEAT_INTERVAL_SECONDS,
+    _LIVE_TAIL_CURSOR,
     _XREAD_BLOCK_MS,
     _XREAD_COUNT,
+    _emit_backlog_prelude,
     _process_entries,
     _resolve_cursor,
     _validate_cursor_or_400,
@@ -116,13 +118,24 @@ async def _ui_feed_generator(
     """SSE generator scoped to the session's tenant.
 
     Structurally identical to
-    :func:`meho_backplane.api.v1.feed._feed_generator` -- BLOCK on
-    XREAD, delegate parse + filter to the shared
-    :func:`_process_entries`, emit a heartbeat on outbound silence so
-    HTTP intermediaries don't idle-time-out the connection. The cursor
-    advances past every consumed entry (not only the ones that survive
-    the filter) so a busy-but-filtered tenant doesn't re-read the same
-    batch under explicit-cursor replay.
+    :func:`meho_backplane.api.v1.feed._feed_generator` -- prelude
+    backlog on fresh ``$`` connections, then BLOCK on XREAD, delegate
+    parse + filter to the shared :func:`_process_entries`, emit a
+    heartbeat on outbound silence so HTTP intermediaries don't
+    idle-time-out the connection. The cursor advances past every
+    consumed entry (not only the ones that survive the filter) so a
+    busy-but-filtered tenant doesn't re-read the same batch under
+    explicit-cursor replay.
+
+    Backlog prelude rationale matches the API edge -- see the docstring
+    of :func:`meho_backplane.api.v1.feed._feed_generator` and the
+    consumer signal in ``claude-rdc-hetzner-dc#771`` Finding 14 +
+    issue #1305: a fresh ``EventSource`` connection from the
+    ``/ui/broadcast`` page with a quiet tenant otherwise sees zero
+    frames over the first 30 s (``$`` skips history, heartbeat
+    cadence is 30 s), so the page renders an empty list under its
+    "Live activity" header for the entire first heartbeat window
+    even when the tenant has 76+ entries on the stream.
 
     On client disconnect Starlette raises
     :class:`asyncio.CancelledError` into the pending ``xread`` await;
@@ -134,6 +147,28 @@ async def _ui_feed_generator(
     last_heartbeat = time.monotonic()
 
     try:
+        # Backlog prelude — same shape as the API edge, gated on the
+        # live-tail cursor so explicit-replay reconnects honour the
+        # caller's anchor. A RedisError during the prelude propagates
+        # out of the generator (same path the BLOCK loop's untrapped
+        # error takes today on this surface — the UI bridge does NOT
+        # emit T11 error frames, distinct from the API edge); the
+        # surrounding FastAPI / Starlette stack closes the SSE
+        # connection and ``EventSource`` reconnects per its spec.
+        if cursor == _LIVE_TAIL_CURSOR:
+            prelude_frames, prelude_last_id = await _emit_backlog_prelude(
+                client,
+                stream_key=stream_key,
+                op_class=op_class,
+                principal=principal,
+                target=target,
+            )
+            for frame in prelude_frames:
+                yield frame
+            if prelude_last_id is not None:
+                cursor = prelude_last_id
+            if prelude_frames:
+                last_heartbeat = time.monotonic()
         while True:
             entries = await client.xread(
                 {stream_key: cursor},

--- a/backend/tests/test_api_v1_feed.py
+++ b/backend/tests/test_api_v1_feed.py
@@ -100,6 +100,42 @@ def _isolated_broadcast_client() -> Iterator[None]:
     reset_broadcast_client_for_testing()
 
 
+@pytest.fixture(autouse=True)
+def _empty_backlog_prelude_by_default(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Default the backlog prelude's ``XREVRANGE`` to "no entries".
+
+    G0.16-T3 (#1305) added a backlog prelude that runs whenever the
+    generator's cursor is ``$``. Most pre-existing tests in this
+    module instantiate ``_feed_generator(..., cursor="$")`` and only
+    mock ``xread`` — they never wanted the prelude path to fire and
+    have no fixture to handle ``xrevrange``. Patching
+    ``redis.asyncio.Redis.xrevrange`` at the class level (rather than
+    on a single instance returned by
+    :func:`get_broadcast_client`) covers both the prelude-path tests
+    that share the client cache and the cases where individual tests
+    swap the cached client; defaulting to "stream is empty"
+    preserves the legacy assertions byte-for-byte.
+
+    Tests that exercise the prelude branch
+    (``TestFeedBacklogPrelude``) override this within their body via
+    :func:`patch.object` against the active client; the inner
+    instance-level patch wins over the outer class-level patch for
+    the duration of the test's ``with`` block, and the autouse
+    monkeypatch is restored on teardown either way.
+
+    The real-Valkey ``TestFeedIntegration`` class (Docker-gated)
+    explicitly opts out via its own monkeypatch undo — see that
+    class's ``valkey_url`` fixture.
+    """
+    import redis.asyncio as redis
+
+    async def _empty(*_args: object, **_kwargs: object) -> list[object]:
+        return []
+
+    monkeypatch.setattr(redis.Redis, "xrevrange", _empty, raising=True)
+    yield
+
+
 @pytest.fixture
 def _feed_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     """Pin chassis env vars so ``get_settings`` succeeds + JWT verification works.
@@ -842,6 +878,333 @@ class TestFeedGenerator:
         )
         assert decoded["code"] == "broadcast_subsystem_unavailable"
         assert "TimeoutError" in decoded["message"]
+
+
+# ---------------------------------------------------------------------------
+# Backlog prelude (G0.16-T3 #1305 — SSE feed delivers zero bytes fix)
+# ---------------------------------------------------------------------------
+
+
+def _idle_xread_mock() -> AsyncMock:
+    """An ``xread`` mock that yields to the event loop, returns ``None`` forever.
+
+    Used by :class:`TestFeedBacklogPrelude` to assert prelude /
+    BLOCK-loop interactions without the generator spinning
+    uncancellably. ``AsyncMock(return_value=None)`` returns
+    synchronously, so a generator's ``while True: await xread(...)``
+    would never suspend and the test's ``asyncio.timeout``
+    surrounding ``_collect_n_frames`` could never preempt the loop
+    (the runner core stays pinned until pytest declares the worker
+    lost). The ``asyncio.sleep`` yield point is what makes the
+    cancellation contract observable inside the same task tree.
+    Mirrors the side-effect dance inside :func:`_xread_returning`.
+    """
+
+    async def _side_effect(*_a: object, **_k: object) -> None:
+        await asyncio.sleep(0.01)
+        return None
+
+    return AsyncMock(side_effect=_side_effect)
+
+
+class TestFeedBacklogPrelude:
+    """``_emit_backlog_prelude`` + the ``$``-cursor entry path on ``_feed_generator``.
+
+    These tests pin the v0.8.0 → v0.9.0 fix for
+    ``claude-rdc-hetzner-dc#771`` Finding 14: a fresh
+    ``GET /api/v1/feed`` against a tenant with existing entries on
+    the stream must surface those entries within bounded latency.
+    Pre-fix, the generator's ``$`` cursor unconditionally skipped
+    backlog AND the 30 s heartbeat cadence meant ``curl`` saw 0
+    bytes inside its default 8 s timeout.
+    """
+
+    async def test_fresh_dollar_connection_replays_backlog_chronologically(
+        self,
+        _feed_env: None,
+    ) -> None:
+        """``cursor="$"`` → prelude yields backlog before BLOCK starts.
+
+        Mirrors the consumer repro: the stream has 3 entries, the
+        operator opens an SSE connection, the first three SSE frames
+        carry those events in chronological order. The XREVRANGE
+        result comes in reverse order from Valkey; the prelude
+        helper is responsible for the reversal, so the assertion is
+        on the frame order, not the XREVRANGE input order.
+        """
+        events = [
+            _make_event(op_id="audit.first"),
+            _make_event(op_id="audit.second"),
+            _make_event(op_id="audit.third"),
+        ]
+        # XREVRANGE returns latest-first by entry id: the largest id
+        # comes first. ``audit.third`` was published last so it
+        # carries the largest id (``...002``); ``audit.first`` the
+        # smallest (``...000``). The prelude helper reverses this
+        # back into chronological order for the SSE consumer.
+        xrevrange_items = [
+            ("1715600000002-0", {"event": events[2].model_dump_json()}),
+            ("1715600000001-0", {"event": events[1].model_dump_json()}),
+            ("1715600000000-0", {"event": events[0].model_dump_json()}),
+        ]
+        broadcast_client = get_broadcast_client()
+        # Idle XREAD with a yield point — see :func:`_idle_xread_mock`'s
+        # docstring for the cancellation rationale (a bare
+        # ``AsyncMock(return_value=None)`` pins the runner core).
+        idle_xread = _idle_xread_mock()
+        prelude = AsyncMock(return_value=xrevrange_items)
+        with (
+            patch.object(broadcast_client, "xrevrange", new=prelude),
+            patch.object(broadcast_client, "xread", new=idle_xread),
+        ):
+            gen = _feed_generator(
+                operator=_make_operator(tenant_id=_TENANT_A),
+                cursor="$",
+                op_class=None,
+                principal=None,
+                target=None,
+            )
+            frames = await _collect_n_frames(gen, n=3, timeout=2.0)
+
+        assert prelude.await_count == 1
+        # XREVRANGE called with the tenant stream key + the prelude
+        # cap. redis-py 7.x exposes ``count`` as a keyword-only arg.
+        call = prelude.await_args_list[0]
+        assert call.args[0] == f"meho:feed:{_TENANT_A}"
+        assert call.kwargs.get("count") == 50
+        assert len(frames) == 3
+        op_ids = [
+            json.loads(
+                next(line for line in frame.split("\n") if line.startswith("data: "))[
+                    len("data: ") :
+                ]
+            )["op_id"]
+            for frame in frames
+        ]
+        assert op_ids == ["audit.first", "audit.second", "audit.third"]
+        for frame in frames:
+            # The prelude reuses ``_format_event`` so frames are
+            # indistinguishable from live-tail frames at the wire
+            # level — same prefix, same id line shape.
+            assert frame.startswith("event: broadcast\n")
+            assert "\nid: " in frame
+
+    async def test_prelude_advances_block_cursor_past_replayed_entries(
+        self,
+        _feed_env: None,
+    ) -> None:
+        """After prelude, BLOCK loop reads from the last replayed entry id, not ``$``.
+
+        Without this advance, the BLOCK loop's first XREAD would
+        observe an XADD made between the prelude and the BLOCK
+        landing as "new", but the prelude already shipped earlier
+        entries past which the cursor should now sit. The assertion
+        is that the BLOCK loop's first XREAD argument carries the
+        last-replayed entry id as the cursor, not ``$``.
+        """
+        event = _make_event()
+        xrevrange_items = [
+            ("1715600000005-0", {"event": event.model_dump_json()}),
+        ]
+        broadcast_client = get_broadcast_client()
+        idle_xread = _idle_xread_mock()
+        prelude = AsyncMock(return_value=xrevrange_items)
+        with (
+            patch.object(broadcast_client, "xrevrange", new=prelude),
+            patch.object(broadcast_client, "xread", new=idle_xread),
+        ):
+            gen = _feed_generator(
+                operator=_make_operator(tenant_id=_TENANT_A),
+                cursor="$",
+                op_class=None,
+                principal=None,
+                target=None,
+            )
+            # Consume the prelude frame AND let the generator land
+            # in the BLOCK loop's first XREAD await before the
+            # timeout fires. Asking for n=2 reaches the BLOCK loop
+            # because the prelude yields exactly 1 frame; the
+            # ``async for`` then suspends on ``client.xread`` until
+            # the timeout cancels the iteration.
+            await _collect_n_frames(gen, n=2, timeout=0.3)
+
+        assert idle_xread.await_count >= 1
+        first_xread_streams = idle_xread.await_args_list[0].args[0]
+        assert first_xread_streams == {f"meho:feed:{_TENANT_A}": "1715600000005-0"}
+
+    async def test_empty_stream_prelude_is_noop_and_block_runs_from_dollar(
+        self,
+        _feed_env: None,
+    ) -> None:
+        """No history on stream → prelude yields zero frames, BLOCK reads from ``$``.
+
+        A fresh tenant whose stream is empty should fall through to
+        the live-tail behaviour pre-#1305 — no prelude frames, BLOCK
+        loop's first XREAD uses ``$``.
+        """
+        broadcast_client = get_broadcast_client()
+        # Empty xrevrange = empty stream.
+        prelude = AsyncMock(return_value=[])
+        idle_xread = _idle_xread_mock()
+        with (
+            patch.object(broadcast_client, "xrevrange", new=prelude),
+            patch.object(broadcast_client, "xread", new=idle_xread),
+        ):
+            gen = _feed_generator(
+                operator=_make_operator(tenant_id=_TENANT_A),
+                cursor="$",
+                op_class=None,
+                principal=None,
+                target=None,
+            )
+            # n>0 + low timeout so the generator actually runs the
+            # prelude (yielding nothing because the stream is empty)
+            # and lands in the BLOCK loop's first XREAD, which we
+            # then cancel via the timeout. ``n=0`` short-circuits
+            # through ``aclose`` without ever entering the generator.
+            frames = await _collect_n_frames(gen, n=1, timeout=0.3)
+
+        assert frames == []
+        assert prelude.await_count == 1
+        assert idle_xread.await_count >= 1
+        # No prelude advance → BLOCK loop cursor stays ``$``.
+        assert idle_xread.await_args_list[0].args[0] == {f"meho:feed:{_TENANT_A}": "$"}
+
+    async def test_explicit_since_cursor_skips_prelude(
+        self,
+        _feed_env: None,
+    ) -> None:
+        """``cursor != "$"`` → prelude is bypassed; only BLOCK loop runs.
+
+        Subscribers passing ``Last-Event-Id`` (after a reconnect) or
+        ``since`` (explicit replay) pinned an anchor. Replaying from
+        ``+`` would re-deliver entries the caller already saw —
+        ``EventSource`` would show duplicates and the operator
+        couldn't trust the cursor handshake. The prelude must skip
+        on any non-``$`` cursor.
+        """
+        broadcast_client = get_broadcast_client()
+        prelude = AsyncMock(return_value=[])
+        idle_xread = _idle_xread_mock()
+        with (
+            patch.object(broadcast_client, "xrevrange", new=prelude),
+            patch.object(broadcast_client, "xread", new=idle_xread),
+        ):
+            gen = _feed_generator(
+                operator=_make_operator(tenant_id=_TENANT_A),
+                cursor="1715600000000-0",
+                op_class=None,
+                principal=None,
+                target=None,
+            )
+            # See the empty-stream test for why n=1 (not 0) is the
+            # right driver — ``_collect_n_frames`` short-circuits on
+            # ``n<=0`` before the generator runs.
+            await _collect_n_frames(gen, n=1, timeout=0.3)
+
+        assert prelude.await_count == 0
+        assert idle_xread.await_count >= 1
+        assert idle_xread.await_args_list[0].args[0] == {
+            f"meho:feed:{_TENANT_A}": "1715600000000-0"
+        }
+
+    async def test_prelude_applies_op_class_filter(
+        self,
+        _feed_env: None,
+    ) -> None:
+        """Prelude entries that fail ``op_class`` filter are dropped just like live-tail.
+
+        Same ``_process_entries`` helper as the live loop, so
+        op_class / principal / target filters work identically.
+        """
+        read_event = _make_event(op_class="read", op_id="vsphere.vm.list")
+        write_event = _make_event(op_class="write", op_id="vsphere.vm.create")
+        # XREVRANGE returns latest-first; published order is read then write.
+        xrevrange_items = [
+            ("1715600000001-0", {"event": write_event.model_dump_json()}),
+            ("1715600000000-0", {"event": read_event.model_dump_json()}),
+        ]
+        broadcast_client = get_broadcast_client()
+        prelude = AsyncMock(return_value=xrevrange_items)
+        idle_xread = _idle_xread_mock()
+        with (
+            patch.object(broadcast_client, "xrevrange", new=prelude),
+            patch.object(broadcast_client, "xread", new=idle_xread),
+        ):
+            gen = _feed_generator(
+                operator=_make_operator(tenant_id=_TENANT_A),
+                cursor="$",
+                op_class="read",
+                principal=None,
+                target=None,
+            )
+            # n=2 reaches the BLOCK loop's first XREAD (only one
+            # frame survives the filter, so the second iteration
+            # suspends on xread until the timeout).
+            frames = await _collect_n_frames(gen, n=2, timeout=0.5)
+
+        assert len(frames) == 1
+        data = json.loads(
+            next(line for line in frames[0].split("\n") if line.startswith("data: "))[
+                len("data: ") :
+            ]
+        )
+        assert data["op_class"] == "read"
+        # Cursor advance is past the latest *fetched* (write) entry,
+        # not past the matched (read) entry — mirrors the live-loop
+        # busy-but-filtered invariant.
+        first_xread_streams = idle_xread.await_args_list[0].args[0]
+        assert first_xread_streams == {f"meho:feed:{_TENANT_A}": "1715600000001-0"}
+
+    async def test_prelude_redis_error_emits_feed_error_then_closes(
+        self,
+        _feed_env: None,
+    ) -> None:
+        """Transport-down on the prelude XREVRANGE → SSE error frame, clean close.
+
+        Same operator-visible condition as a BLOCK-loop XREAD
+        failure (broadcast pod down on a fresh deploy, post-rollout
+        connection refused). The prelude is the FIRST Valkey call
+        on a fresh ``$`` connection, so the prelude path must also
+        emit the T11-compliant ``event: feed_error`` frame rather
+        than propagating the exception (which would land as a bare
+        connection drop on the SSE consumer, since
+        ``http.response.start`` was sent on the StreamingResponse's
+        first byte).
+        """
+        import redis.exceptions as redis_exc
+
+        broadcast_client = get_broadcast_client()
+        prelude = AsyncMock(side_effect=redis_exc.ConnectionError("connection refused"))
+        idle_xread = _idle_xread_mock()
+        with (
+            patch.object(broadcast_client, "xrevrange", new=prelude),
+            patch.object(broadcast_client, "xread", new=idle_xread),
+        ):
+            gen = _feed_generator(
+                operator=_make_operator(tenant_id=_TENANT_A),
+                cursor="$",
+                op_class=None,
+                principal=None,
+                target=None,
+            )
+            frames: list[str] = []
+            async for chunk in gen:
+                frames.append(chunk)
+
+        assert len(frames) == 1
+        assert frames[0].startswith("event: feed_error\n")
+        data = json.loads(
+            next(line for line in frames[0].split("\n") if line.startswith("data: "))[
+                len("data: ") :
+            ]
+        )
+        assert data["code"] == "broadcast_subsystem_unavailable"
+        assert "ConnectionError" in data["message"]
+        # The BLOCK loop is never reached after the prelude's error
+        # frame because the prelude path ``return``s; xread must not
+        # have been called.
+        assert idle_xread.await_count == 0
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_ui_broadcast_feed.py
+++ b/backend/tests/test_ui_broadcast_feed.py
@@ -130,6 +130,29 @@ def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     reset_engine_for_testing()
 
 
+@pytest.fixture(autouse=True)
+def _empty_backlog_prelude_by_default(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Default the UI bridge's prelude ``XREVRANGE`` to "no entries".
+
+    G0.16-T3 (#1305) added the backlog prelude shared between
+    ``/api/v1/feed`` and ``/ui/broadcast/stream``. The pre-existing
+    UI tests under :class:`TestBroadcastStreamGenerator` pass
+    ``cursor="$"`` and only mock ``xread``; without this fixture
+    they would hit a real ``redis.asyncio.Redis.xrevrange`` call
+    against the test ``BROADCAST_REDIS_URL`` (``broadcast.test``,
+    unresolvable in CI / sandbox) and fail with a connection
+    error. Patching at the class level mirrors the same fixture in
+    :mod:`backend.tests.test_api_v1_feed`.
+    """
+    import redis.asyncio as redis
+
+    async def _empty(*_args: object, **_kwargs: object) -> list[object]:
+        return []
+
+    monkeypatch.setattr(redis.Redis, "xrevrange", _empty, raising=True)
+    yield
+
+
 def _build_app() -> FastAPI:
     """Construct a minimal FastAPI app wired for the broadcast UI tests.
 
@@ -518,6 +541,105 @@ class TestBroadcastStreamGenerator:
             ]
         )
         assert decoded["op_class"] == "read"
+
+    async def test_fresh_dollar_connection_replays_backlog_chronologically(self) -> None:
+        """G0.16-T3 (#1305): UI bridge prelude surfaces history on fresh ``$`` connection.
+
+        Mirrors :class:`backend.tests.test_api_v1_feed.TestFeedBacklogPrelude`'s
+        equivalent — the UI bridge imports
+        :func:`_emit_backlog_prelude` from
+        :mod:`meho_backplane.api.v1.feed` so the wire shape stays
+        byte-compatible. This test pins the call against the
+        bridge's own generator so a future divergence between the
+        two surfaces would surface here.
+        """
+        events = [
+            _make_event(op_id="audit.one", tenant_id=_TENANT_A),
+            _make_event(op_id="audit.two", tenant_id=_TENANT_A),
+        ]
+        # XREVRANGE returns latest-first by entry id: id 11 (newer)
+        # comes before id 10 (older). ``audit.two`` was published
+        # after ``audit.one`` so it carries the larger id.
+        xrevrange_items = [
+            ("1715600000011-0", {"event": events[1].model_dump_json()}),
+            ("1715600000010-0", {"event": events[0].model_dump_json()}),
+        ]
+        broadcast_client = get_broadcast_client()
+        prelude = AsyncMock(return_value=xrevrange_items)
+        # Idle XREAD with a yield point — see :func:`_xread_returning`'s
+        # docstring for the cancellation rationale.
+        idle_xread = _xread_returning([])
+        with (
+            patch.object(broadcast_client, "xrevrange", new=prelude),
+            patch.object(broadcast_client, "xread", new=idle_xread),
+        ):
+            gen = _ui_feed_generator(
+                tenant_id=_TENANT_A,
+                operator_sub="op-a",
+                cursor="$",
+                op_class=None,
+                principal=None,
+                target=None,
+            )
+            # n=3 reaches the BLOCK loop's first XREAD after the
+            # two prelude frames are yielded (see the API edge's
+            # equivalent test for the same async-generator drain
+            # rationale — ``_collect_n_frames`` only suspends past
+            # the last requested frame).
+            frames = await _collect_n_frames(gen, n=3, timeout=2.0)
+
+        assert prelude.await_count == 1
+        assert prelude.await_args_list[0].args[0] == f"meho:feed:{_TENANT_A}"
+        assert prelude.await_args_list[0].kwargs.get("count") == 50
+        assert len(frames) == 2
+        op_ids = [
+            json.loads(
+                next(line for line in frame.split("\n") if line.startswith("data: "))[
+                    len("data: ") :
+                ]
+            )["op_id"]
+            for frame in frames
+        ]
+        assert op_ids == ["audit.one", "audit.two"]
+        # BLOCK loop's first XREAD reads strictly past the prelude.
+        first_block_cursor = idle_xread.await_args_list[0].args[0]
+        assert first_block_cursor == {f"meho:feed:{_TENANT_A}": "1715600000011-0"}
+
+    async def test_explicit_replay_cursor_skips_prelude_on_ui_bridge(self) -> None:
+        """``Last-Event-Id`` reconnect via UI bridge bypasses backlog.
+
+        Same contract as the API edge: the caller pinned an
+        anchor; replaying from ``+`` would re-deliver entries the
+        EventSource already saw and produce duplicate frames on
+        reconnect.
+        """
+        broadcast_client = get_broadcast_client()
+        prelude = AsyncMock(return_value=[])
+        # Idle XREAD with a yield point — see :func:`_xread_returning`'s
+        # docstring for the cancellation rationale.
+        idle_xread = _xread_returning([])
+        with (
+            patch.object(broadcast_client, "xrevrange", new=prelude),
+            patch.object(broadcast_client, "xread", new=idle_xread),
+        ):
+            gen = _ui_feed_generator(
+                tenant_id=_TENANT_A,
+                operator_sub="op-a",
+                cursor="1715600000000-0",
+                op_class=None,
+                principal=None,
+                target=None,
+            )
+            # n=1 lets the generator land in the BLOCK loop's xread
+            # (n=0 short-circuits through ``aclose`` before the
+            # generator's body runs at all — same drain rationale
+            # as the API edge tests).
+            await _collect_n_frames(gen, n=1, timeout=0.3)
+
+        assert prelude.await_count == 0
+        assert idle_xread.await_args_list[0].args[0] == {
+            f"meho:feed:{_TENANT_A}": "1715600000000-0"
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/docs/codebase/broadcast.md
+++ b/docs/codebase/broadcast.md
@@ -1,0 +1,235 @@
+# Activity broadcast
+
+Operator-facing real-time view of every audited operation, plus
+agent-authored announcements, scoped per tenant. The substrate is a
+Valkey 9.x Stream (`meho:feed:{tenant_id}`); the SSE surface
+(`/api/v1/feed` and `/ui/broadcast/stream`) and the MCP tools
+(`meho.broadcast.recent`, `meho.broadcast.watch`,
+`meho.broadcast.announce`) all read or write to that single substrate.
+
+## Overview
+
+Three layers, separated for traceability:
+
+1. **Writer side.** `AuditMiddleware` (`backend/src/meho_backplane/audit.py`)
+   and the MCP dispatcher (`backend/src/meho_backplane/mcp/handlers.py`)
+   both call `publish_event(BroadcastEvent)` after the audit row
+   commits. The publisher is **fail-open** — a Valkey wobble never
+   converts an OK request into a 5xx. The agent-authored counterpart
+   `publish_agent_announcement(AgentAnnouncementEvent)` is
+   **fail-loud** — the calling agent needs to know whether its
+   announcement landed. Both go through one `XADD meho:feed:{tenant_id}`
+   per call, single `event` field carrying the JSON-serialised model,
+   `MAXLEN ~` trim to `BROADCAST_MAXLEN = 10_000` entries.
+
+2. **Fanout side.** **There is no separate fanout worker.** The
+   publisher writes directly to the per-tenant stream; readers
+   subscribe directly. This is a deliberate v0.1+ shape (ADR 0005):
+   Valkey Streams' XREAD BLOCK semantics give us the live-tail
+   subscription primitive without an intermediate broker process. A
+   future Slack mirror / cross-cluster bridge (G6.2 #333) would be
+   the first surface that takes a separate consumer-group reader; v0.8
+   does not have one.
+
+3. **Reader side.** Three reader shapes for three call patterns:
+
+   | Reader | Surface | Read primitive | Cursor default | Backlog |
+   | --- | --- | --- | --- | --- |
+   | SSE feed | `GET /api/v1/feed` (Bearer JWT) | `XREAD BLOCK` | `$` (live tail) | **Last 50 on `$` connections** |
+   | SSE bridge | `GET /ui/broadcast/stream` (session cookie) | `XREAD BLOCK` | `$` (live tail) | **Last 50 on `$` connections** |
+   | MCP recent | `meho.broadcast.recent` | `XRANGE` | 30-min window | All entries in window |
+   | MCP watch | `meho.broadcast.watch` | `XREAD BLOCK` | caller-supplied `since_cursor` (required) | None — caller pins |
+   | MCP resource | `tenant_feed` snapshot | `XREVRANGE + COUNT 50` | n/a | Latest 50 |
+   | UI history | `GET /ui/broadcast/history` | `XRANGE` | 30-min window | All entries in window |
+
+   The SSE backlog prelude is the v0.8.0 fix for #1305 — see *Known
+   issues* below.
+
+## Key types
+
+- `BroadcastEvent` (`broadcast/events.py`) — every audited operation
+  publishes one. Fields: `event_id` (UUID), `ts`, `tenant_id`,
+  `principal_sub`, `principal_name`, `target_name`, `op_id`,
+  `op_class`, `result_status`, `audit_id`, `payload`.
+  `event_kind = "audit_derived"` discriminator.
+- `AgentAnnouncementEvent` (`broadcast/agent_events.py`) — agent-
+  authored announcements published via `meho.broadcast.announce`.
+  Fields: `tenant_id`, `principal_sub`, `activity`, `target`,
+  `scope`, `phase`. `event_kind = "agent_announcement"` discriminator
+  so readers can dispatch on the kind.
+- `Operator` (`auth/operator.py`) — the JWT-bound principal the SSE
+  feed reads its `tenant_id` from. UUID.
+- `UISessionContext` (`ui/auth/middleware.py`) — the session-cookie
+  equivalent, same `tenant_id: uuid.UUID` shape. Sourced from the
+  encrypted session row.
+
+## Control flow
+
+### Write path (audit-derived)
+
+```
+HTTP request
+  → AuditMiddleware (audit.py)
+    → handler runs
+    → audit row INSERT commits
+    → publish_event(BroadcastEvent)        ← fail-open
+      → XADD meho:feed:{operator.tenant_id} {event: <json>} MAXLEN ~ 10000
+```
+
+### Write path (agent-authored)
+
+```
+MCP tools/call meho.broadcast.announce
+  → _handler_announce (mcp/tools/broadcast.py)
+    → publish_agent_announcement(AgentAnnouncementEvent)  ← fail-loud
+      → XADD meho:feed:{operator.tenant_id} {event: <json>} MAXLEN ~ 10000
+      → returns Valkey entry id verbatim
+    → returns {event_id} to the agent
+```
+
+### Read path (SSE)
+
+```
+GET /api/v1/feed (Bearer JWT)
+  → require_role(OPERATOR) gate
+  → _validate_cursor_or_400(_resolve_cursor(Last-Event-Id, since))
+  → _feed_generator(operator, cursor, op_class, principal, target)
+    [prelude — only when cursor == "$"]
+      → XREVRANGE meho:feed:{tenant_id} + - COUNT 50
+      → yield each entry as `event: broadcast` frame (chronological)
+      → advance cursor to last entry id
+    [live-tail loop]
+      → XREAD BLOCK 30000 COUNT 20 meho:feed:{tenant_id} {cursor}
+      → yield each surviving entry as `event: broadcast` frame
+      → heartbeat on outbound silence ≥ 30s
+```
+
+### Read path (UI SSE bridge)
+
+`GET /ui/broadcast/stream` is the session-cookie-gated mirror of
+`/api/v1/feed`. The browser's `EventSource` can't set
+`Authorization: Bearer ...` headers, so the live broadcast page
+(`/ui/broadcast`) wires its `sse-connect` to this bridge, which
+authenticates via `UISessionMiddleware` and the BFF session cookie.
+Frame shape is byte-compatible with the API edge — the `_process_entries`
+helper, the cursor resolver, and the backlog prelude are imported
+verbatim from `api/v1/feed.py`.
+
+## Dependencies
+
+- `redis.asyncio` (redis-py 7.4) — Valkey 9.x is wire-compatible with
+  Redis 7.2.4; the same redis-py driver speaks both. Connection pool
+  per-process, cached via `broadcast/client.py`'s
+  `get_broadcast_client()`.
+- `BROADCAST_REDIS_URL` env var — production points at the Helm
+  chart's `redis://{{ .Release.Name }}-broadcast:6379/0` Service.
+  Dev default is `redis://localhost:6379`. Schemes other than
+  `redis://` / `rediss://` / `unix://` are rejected at startup.
+- `prometheus_client.Counter` — three counters surface the publish
+  path on `/metrics`:
+  `broadcast_events_published_total{op_class,result_status}`,
+  `broadcast_publish_errors_total`,
+  `broadcast_agent_announcements_total{phase}`.
+
+## Known issues
+
+### `claude-rdc-hetzner-dc#771` Finding 14 — SSE feed delivers zero bytes (FIXED v0.9.0, #1305)
+
+**Symptom.** A fresh `GET /api/v1/feed` (Bearer JWT) or
+`/ui/broadcast/stream` (session cookie) returned zero bytes within a
+6–8 s curl test window even when the tenant stream contained 76+
+entries and fresh writes were observed via `mcp.broadcast.announce`
+during the window. The operator-facing `/ui/broadcast` page rendered
+its "Live activity across tenant X" header but an empty event list,
+permanently.
+
+**Root cause (consumer side).** The SSE generator's initial cursor
+was unconditionally `$` (`_LIVE_TAIL_CURSOR`). Valkey's `$` means
+"deliver only entries XADD'd after the XREAD call landed", which
+combined with the 30 s heartbeat cadence produced two visible
+failure modes:
+
+1. **No new writes during the window → 0 bytes.** A curl test with
+   no concurrent writer would see zero bytes for 30 s
+   (`_HEARTBEAT_INTERVAL_SECONDS`) — well past the 8 s curl default
+   timeout — even on a tenant with thousands of entries on the
+   stream. The HTTP intermediary observed a dropped connection
+   without a single byte transferred and assumed the SSE endpoint
+   was broken.
+2. **76+ existing events never surfaced.** The `/ui/broadcast`
+   page's first render had no signal of life, no backlog, no
+   indication that the operator was even on the right tenant.
+   The MCP `meho.broadcast.recent` tool (XRANGE-based) surfaced
+   the same events fine to agents, deepening the consumer's
+   "the SSE layer is broken" diagnosis.
+
+**Not** a consumer-group mismatch (the publisher and readers use
+plain XADD / XREAD against the same key with no consumer-group
+layer), **not** a fanout worker outage (no separate fanout worker
+exists; writers XADD directly), **not** a tenant-scoping divergence
+(every reader and the publisher derive the stream key from the same
+`tenant_id: UUID` field; the `f"meho:feed:{tenant_id}"` string is
+byte-identical across surfaces).
+
+**Fix.** `_feed_generator` and `_ui_feed_generator` now run a
+**backlog prelude** before entering the BLOCK loop, but only when
+the resolved cursor is `$` (the live-tail default for a fresh
+connection without `Last-Event-Id` / `since`). The prelude:
+
+- Issues `XREVRANGE meho:feed:{tenant_id} + - COUNT 50`.
+- Reverses the result into chronological order.
+- Filters via `_process_entries` (same filter helper the live loop
+  uses, so `op_class` / `principal` / `target` apply identically).
+- Yields each surviving entry as a regular `event: broadcast`
+  SSE frame — wire-shape identical to the live loop, so clients
+  cannot distinguish "this is replay" at the frame level.
+- Advances the live-loop cursor to the most recent prelude entry
+  id (NOT the last *matched* one — mirrors the live loop's
+  `_consume_xread_batch` "advance past every consumed entry"
+  invariant so a busy-but-filtered tenant doesn't re-read the same
+  prelude batch).
+
+Explicit-replay cursors (`Last-Event-Id`, `since`) skip the prelude
+— the caller pinned an anchor; replaying from `+` would re-deliver
+entries the caller already saw.
+
+The cap (`_BACKLOG_PRELUDE_COUNT = 50`) matches the MCP
+`tenant_feed` snapshot ceiling so the SSE prelude and the MCP
+resource surface the same window of context on first connection.
+
+**Acceptance test** lives in `backend/tests/test_api_v1_feed.py`
+under `TestFeedBacklogPrelude`. The test mirrors the RDC repro:
+publish via `_publish_event_into_mock` → open the SSE generator →
+assert the published events show up in the first batch of frames
+within bounded latency. A second test asserts that an explicit
+`since=` cursor skips the prelude.
+
+### Earlier issue: empty broadcast feed in v0.7.0 (#755)
+
+The v0.7.0 cycle (`claude-rdc-hetzner-dc#753`) surfaced "I see empty
+broadcast" without resolving the root cause; G0.15-T9 (tenant chip
+wiring, #1217) confirmed the tenant context was correctly propagated
+to the SSE endpoint, narrowing the suspect surface for v0.8.0
+investigation. #1305 is the closing fix.
+
+## References
+
+- Source: `claude-rdc-hetzner-dc#771` Finding 14, signal draft
+  `sse-feed-delivers-zero-events-despite-stream-writes`.
+- Parent Initiative: #1302 (G0.16 — v0.8.0 closed-loop dogfood
+  hardening). Parent Goal: #221.
+- Related closed: #1216 (G0.15-T7 BFF audit-thread — UI session is
+  correctly tenant-scoped).
+- ADR 0005 — Valkey 9.x as the broadcast substrate.
+- Code:
+  - Publishers: `backend/src/meho_backplane/broadcast/publisher.py`.
+  - SSE API edge: `backend/src/meho_backplane/api/v1/feed.py`.
+  - SSE UI bridge: `backend/src/meho_backplane/ui/routes/broadcast/stream.py`.
+  - MCP tools: `backend/src/meho_backplane/mcp/tools/broadcast.py`.
+  - History (XRANGE) helper: `backend/src/meho_backplane/broadcast/history.py`.
+  - Client / lifespan: `backend/src/meho_backplane/broadcast/client.py`.
+- Valkey commands:
+  - `XADD` — https://valkey.io/commands/xadd/
+  - `XREAD` — https://valkey.io/commands/xread/
+  - `XREVRANGE` — https://valkey.io/commands/xrevrange/
+- SSE / EventSource — https://html.spec.whatwg.org/multipage/server-sent-events.html.


### PR DESCRIPTION
## Summary

- SSE generators on `/api/v1/feed` and `/ui/broadcast/stream` opened with the Valkey `$` cursor — "live tail, no history". Combined with the 30 s heartbeat cadence, a fresh `curl` against either endpoint on a quiet tenant returned **zero bytes for the entire heartbeat window** (well past curl's 8 s default), and the `/ui/broadcast` page rendered "Live activity across tenant X" against a permanently empty event list even when 76+ entries existed on the stream. This was the SEV-1 finding 14 of `claude-rdc-hetzner-dc#771` (signal draft `sse-feed-delivers-zero-events-despite-stream-writes`).
- Root cause is on the **consumer (reader) side**: the publisher's `XADD` lands correctly, the MCP `meho.broadcast.recent` / `.watch` tools surface those entries to agents (explicit cursors), but the SSE generators' `$` cursor invisibly skipped any backlog. Documented in `docs/codebase/broadcast.md` (new) with the writer / fanout / consumer triage triangulation.
- Fix: `_feed_generator` and `_ui_feed_generator` now run a **backlog prelude** before the BLOCK loop, but only when the resolved cursor is `$` (the live-tail default). The prelude reads up to 50 most recent entries via `XREVRANGE meho:feed:{tenant_id} + - COUNT 50`, reverses them into chronological order, yields each as a regular `event: broadcast` SSE frame, and advances the cursor past the last replayed entry. Explicit-replay cursors (`Last-Event-Id`, `since`) skip the prelude — those anchors mean "resume exactly here".

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — 778 files already formatted
- [x] `mypy src/meho_backplane/` — Success: no issues found in 379 source files
- [x] `pytest tests/test_api_v1_feed.py tests/test_ui_broadcast_feed.py` — 41 passed, 1 skipped (docker-gated)
- [x] `pytest tests/ -k 'broadcast or feed or audit'` — 741 passed, 60 skipped — pre-existing tests pass under the new `_empty_backlog_prelude_by_default` autouse fixture, no regressions
- [x] Acceptance criterion 1 (`curl /api/v1/feed` receives events within ~1 s of a broadcast write): exercised by `TestFeedBacklogPrelude::test_fresh_dollar_connection_replays_backlog_chronologically` — three entries written, three prelude frames yielded before the BLOCK loop's first XREAD.
- [x] Acceptance criterion 2 (`/ui/broadcast/stream` SSE delivers events to the operator UI): exercised by `TestBroadcastStreamGenerator::test_fresh_dollar_connection_replays_backlog_chronologically` on the UI bridge.
- [x] Acceptance criterion 3 (acceptance test mirrors the RDC repro): both prelude tests above; `test_explicit_since_cursor_skips_prelude` pins the no-duplicate contract for reconnects.
- [x] Acceptance criterion 4 (root cause documented in `docs/codebase/broadcast.md`): file created with writer / fanout / consumer breakdown and the explicit "not consumer-group, not fanout-worker, not tenant-scoping" findings.
- [x] Acceptance criterion 5 (CHANGELOG bullet citing consumer signal): added under `[Unreleased]` Fixed.

## Out of scope

- Architectural question on Finding 23 of the same doc (curated-vs-OpenAPI-derived) is owned by `docs/codebase/api-shape-conventions.md` §1 per #1302's DoD; this task focuses on the SSE delivery bug.
- The Docker-gated `TestFeedIntegration::test_publish_then_generator_read` is unchanged — it explicitly uses `cursor="0"` to avoid the live-tail race and exercises the same publish → read path end-to-end against a real Valkey when Docker is available in CI.
- Sibling SEV-2 findings (T4 Vault probe / T5 gh/3 catalog-vs-spec drift) are separate Tasks under the same Initiative #1302.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1305
