### PR TITLE
feat(runbooks): G12.1-T1 migration 0034 + SQLAlchemy models + audit_log run_id/step_id columns

### DIFF
--- a/backend/alembic/versions/0034_runbook_tables_and_audit_correlation.py
+++ b/backend/alembic/versions/0034_runbook_tables_and_audit_correlation.py
@@ -1,0 +1,327 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Runbook schema tables + ``audit_log`` run/step correlation columns.
+
+Revision ID: 0034
+Revises: 0033
+Create Date: 2026-05-29
+
+Storage substrate for Task #1292 (G12.1-T1) under Initiative #1196
+(G12.1 Runbook schema + dispatcher correlation). Pure DDL work: three
+new tables and two additive nullable columns on ``audit_log``. No
+business logic is wired here; that belongs to sibling Tasks T2 (dispatcher
+contextvar plumbing) and T3 (tool / MCP / REST surface).
+
+What this migration adds
+------------------------
+
+Three new tables
+~~~~~~~~~~~~~~~~
+
+**``runbook_templates``** — immutable versioned recipes. A template is
+the static definition of a multi-step procedure (e.g. "drain a K8s node
+safely"). Each ``(tenant_id, slug, version)`` triple is unique; once a
+template row reaches ``status='published'`` the G12.2 write layer rejects
+further edits (a new version must be created). The ``steps`` column is a
+JSONB array of step descriptors; shape validation (discriminated
+``type: operation_call`` / ``type: manual`` unions) lives in the Pydantic
+layer (G12.2). Portable ``sa.JSON`` in the migration; JSONB on PG via
+the model's ``_PORTABLE_JSON.with_variant`` (same pattern as every
+JSON column since migration ``0003``).
+
+**``runbook_runs``** — execution state machine. One row per template
+invocation. ``template_slug`` + ``template_version`` are pinned at run
+start so later template edits cannot alter an in-flight run's step list.
+``params`` carries the substitution context for ``${run.params.X}``
+expressions (G12.3); defaults to ``{}`` so a params-less run remains
+insertable without ambiguity. The ``state`` column drives the three-state
+machine (``in_progress`` → ``completed`` | ``abandoned``). No ``params``
+server-default on SQLite — dialect detection at upgrade time follows
+the ``0027`` pattern.
+
+**``runbook_run_step_states``** — per-(run, step) state machine. Child
+of ``runbook_runs`` via a real ``ForeignKey("runbook_runs.run_id",
+ondelete="CASCADE")`` so deleting a run row cascades cleanly. The
+composite PK ``(run_id, step_id)`` covers the per-run advance query
+without an additional index. ``verify_response`` is nullable JSONB — it
+captures the operator's confirmation (``yes`` / ``no`` / ``escalate`` for
+``confirm`` steps) or the dispatched-call result (for ``operation_call``
+steps).
+
+Two additive columns on ``audit_log``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**``audit_log.run_id``** — nullable UUID soft-FK to
+``runbook_runs.run_id``. The G12.1-T2 dispatcher contextvar populates it
+for every operation issued inside a runbook run. NULL for all pre-G12.1
+rows and for operations issued outside a run context. Same soft-FK
+discipline as ``parent_audit_id`` / ``target_id`` / ``agent_session_id``
+(documented in the module docstring of ``db/models.py``).
+
+**``audit_log.step_id``** — nullable Text. Set alongside ``run_id``;
+identifies the specific step within the template that triggered the
+operation. Both columns together form the join key between an audit row
+and a ``runbook_run_step_states`` row.
+
+One new index on ``audit_log``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**``audit_log_run_id_idx``** — b-tree on ``run_id``. Drives the
+"show all audit rows for this run" query path used by the G12.3 senior
+review and G8.x audit-query surfaces.
+
+Why additive (not amend ``0030``)
+----------------------------------
+
+Same reversible-additive discipline established by ``0006``+. Migration
+``0033`` is merged to ``main`` and applied in CI/dev DBs. New requirement =
+new migration head. This migration is purely additive in ``upgrade()``
+and reversible in ``downgrade()`` — the ``check_migration_compat.py``
+guard in CI will confirm no destructive pattern exists in ``upgrade()``.
+
+Dialect-portability decisions
+------------------------------
+
+* JSON columns use generic ``sa.JSON`` in the migration; the model pins
+  ``JSONB`` on PostgreSQL via ``_PORTABLE_JSON.with_variant``. Same
+  pattern as every JSON column since ``0003``.
+* ``nullable=True`` on the two new ``audit_log`` columns. Additive
+  column on a populated table without a server default; existing rows
+  carry NULL. Helm-rollback compatible (Goal #11 DoD §3).
+* The ``params`` column on ``runbook_runs`` is NOT NULL with ``'{}'`` as
+  the PG server default; on SQLite the server default is omitted and
+  the ORM's ``default=dict`` provides the Python-side value for dev/test
+  inserts (same pattern as ``event_outbox.payload`` in ``0027``).
+* The ``runbook_run_step_states.verify_response`` column is nullable
+  JSON — NULL while the step is pending/in-progress, populated on
+  completion.
+* Composite PK ``(run_id, step_id)`` on ``runbook_run_step_states`` is
+  declared via ``primary_key=True`` on both columns in ``op.create_table``
+  (no separate ``PrimaryKeyConstraint`` needed — Alembic infers it from
+  the pair of ``primary_key=True`` column declarations).
+
+Creation order
+--------------
+
+``runbook_templates`` first (no FKs), then ``runbook_runs`` (no FKs to
+the other two new tables), then ``runbook_run_step_states`` (real FK to
+``runbook_runs.run_id``). ``downgrade()`` drops in reverse.
+
+Reversibility contract
+-----------------------
+
+``downgrade()`` drops the audit index, then the two audit columns
+(in reverse add order), then the child-to-parent tables in reverse
+creation order, then the parent tables. ``op.drop_index`` with
+``table_name`` is supplied for every index so Alembic's dialect router
+can emit the correct dialect-specific SQL without a table scan.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0034"
+down_revision: str | None = "0033"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create three runbook tables + two audit_log columns + one audit index."""
+    bind = op.get_bind()
+    is_postgres = bind.dialect.name == "postgresql"
+
+    # ------------------------------------------------------------------
+    # 1. runbook_templates — versioned recipe definitions.
+    # ------------------------------------------------------------------
+    op.create_table(
+        "runbook_templates",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("tenant_id", sa.Uuid(), nullable=False),
+        sa.Column("slug", sa.Text(), nullable=False),
+        sa.Column("version", sa.Integer(), nullable=False),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False),
+        # JSONB on PG (via model _PORTABLE_JSON.with_variant); generic JSON
+        # in the migration for dialect portability (0030 precedent).
+        sa.Column("steps", sa.JSON(), nullable=False),
+        sa.Column("target_kind", sa.Text(), nullable=True),
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'draft'"),
+        ),
+        sa.Column("created_by", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("edited_by", sa.Text(), nullable=False),
+        sa.Column("edited_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "status IN ('draft', 'published', 'deprecated')",
+            name="ck_runbook_templates_status",
+        ),
+    )
+
+    # UNIQUE b-tree on (tenant_id, slug, version) — runbook templates are
+    # always tenant-scoped, so a single full unique index suffices (no
+    # partial-index split like operation_group_global_idx / _tenant_idx).
+    op.create_index(
+        "runbook_templates_tenant_slug_version_idx",
+        "runbook_templates",
+        ["tenant_id", "slug", "version"],
+        unique=True,
+        postgresql_using="btree",
+    )
+
+    # b-tree on (tenant_id, status) — drives the runbook_list_templates
+    # query path (G12.2: "list templates for tenant, optionally filtered
+    # by status").
+    op.create_index(
+        "runbook_templates_tenant_status_idx",
+        "runbook_templates",
+        ["tenant_id", "status"],
+        postgresql_using="btree",
+    )
+
+    # ------------------------------------------------------------------
+    # 2. runbook_runs — execution state machine.
+    # ------------------------------------------------------------------
+    # ``params`` server default: PG only — ``'{}'`` is the empty-JSON-object
+    # literal; SQLite omits the server default and relies on the ORM-side
+    # ``default=dict`` (same pattern as event_outbox.payload in 0027).
+    params_server_default = sa.text("'{}'") if is_postgres else None
+
+    op.create_table(
+        "runbook_runs",
+        sa.Column("run_id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("tenant_id", sa.Uuid(), nullable=False),
+        sa.Column("template_slug", sa.Text(), nullable=False),
+        sa.Column("template_version", sa.Integer(), nullable=False),
+        sa.Column("assigned_to", sa.Text(), nullable=False),
+        sa.Column("target", sa.Text(), nullable=False),
+        sa.Column(
+            "params",
+            sa.JSON(),
+            nullable=False,
+            server_default=params_server_default,
+        ),
+        sa.Column(
+            "state",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'in_progress'"),
+        ),
+        sa.Column("started_by", sa.Text(), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("abandoned_at", sa.DateTime(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "state IN ('in_progress', 'completed', 'abandoned')",
+            name="ck_runbook_runs_state",
+        ),
+    )
+
+    # b-tree on (tenant_id, assigned_to, state) — drives the priming query
+    # (G12.4: "in-progress runs assigned to this operator") and
+    # runbook_list_runs (G12.3).
+    op.create_index(
+        "runbook_runs_tenant_assigned_state_idx",
+        "runbook_runs",
+        ["tenant_id", "assigned_to", "state"],
+        postgresql_using="btree",
+    )
+
+    # b-tree on (tenant_id, template_slug, template_version) — drives the
+    # post-completion read-allowance lookup (G12.3: "did this operator run
+    # this template?").
+    op.create_index(
+        "runbook_runs_tenant_template_idx",
+        "runbook_runs",
+        ["tenant_id", "template_slug", "template_version"],
+        postgresql_using="btree",
+    )
+
+    # ------------------------------------------------------------------
+    # 3. runbook_run_step_states — per-(run, step) state.
+    # ------------------------------------------------------------------
+    # Real FK to runbook_runs.run_id with CASCADE delete — this is a new-
+    # table child relationship (same pattern as GraphEdge → GraphNode in
+    # db/models.py). The composite PK (run_id, step_id) is inferred by
+    # Alembic from the two primary_key=True column declarations.
+    op.create_table(
+        "runbook_run_step_states",
+        sa.Column(
+            "run_id",
+            sa.Uuid(),
+            sa.ForeignKey("runbook_runs.run_id", ondelete="CASCADE"),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column("step_id", sa.Text(), primary_key=True, nullable=False),
+        sa.Column(
+            "state",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("verified_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("verify_response", sa.JSON(), nullable=True),
+        sa.CheckConstraint(
+            "state IN ('pending', 'in_progress', 'verified', 'failed')",
+            name="ck_runbook_run_step_states_state",
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # 4. audit_log — two new nullable correlation columns.
+    # ------------------------------------------------------------------
+    # Soft-FK to runbook_runs.run_id — same discipline as parent_audit_id /
+    # target_id / agent_session_id (nullable, no DB-level FK constraint).
+    # Populated by the G12.1-T2 dispatcher contextvar; pre-G12.1 rows and
+    # non-run operations leave both columns NULL.
+    op.add_column(
+        "audit_log",
+        sa.Column("run_id", sa.Uuid(), nullable=True),
+    )
+    op.add_column(
+        "audit_log",
+        sa.Column("step_id", sa.Text(), nullable=True),
+    )
+
+    # ------------------------------------------------------------------
+    # 5. audit_log — index on run_id.
+    # ------------------------------------------------------------------
+    # Drives the "show all audit rows for this run" query (G12.3 / G8.x
+    # senior-review surface).
+    op.create_index(
+        "audit_log_run_id_idx",
+        "audit_log",
+        ["run_id"],
+        postgresql_using="btree",
+    )
+
+
+def downgrade() -> None:
+    """Reverse the upgrade — drop indexes, columns, and tables in reverse order."""
+    # Drop the audit_log index and new columns first.
+    op.drop_index("audit_log_run_id_idx", table_name="audit_log")
+    op.drop_column("audit_log", "step_id")
+    op.drop_column("audit_log", "run_id")
+
+    # Drop child table before parents (FK dependency).
+    op.drop_table("runbook_run_step_states")
+
+    # Drop runbook_runs indexes before the table.
+    op.drop_index("runbook_runs_tenant_template_idx", table_name="runbook_runs")
+    op.drop_index("runbook_runs_tenant_assigned_state_idx", table_name="runbook_runs")
+    op.drop_table("runbook_runs")
+
+    # Drop runbook_templates indexes before the table.
+    op.drop_index("runbook_templates_tenant_status_idx", table_name="runbook_templates")
+    op.drop_index("runbook_templates_tenant_slug_version_idx", table_name="runbook_templates")
+    op.drop_table("runbook_templates")

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -251,6 +251,9 @@ __all__ = [
     "GraphNodeHistory",
     "IdentityBudget",
     "OperationGroup",
+    "RunbookRun",
+    "RunbookRunStepState",
+    "RunbookTemplate",
     "Target",
     "Tenant",
     "TenantConvention",
@@ -482,6 +485,23 @@ class AuditLog(Base):
         nullable=True,
         default=None,
     )
+    # Runbook correlation (G12.1-T2 #1292). The dispatcher contextvar
+    # populates ``run_id`` + ``step_id`` for every operation issued inside
+    # a runbook run; pre-G12.1 rows and operations outside a run context
+    # carry NULL on both columns. Soft-FK discipline — no DB-level FK
+    # constraint to ``runbook_runs.run_id`` in v0.2, same as
+    # ``parent_audit_id`` / ``target_id`` / ``agent_session_id``. Added by
+    # migration ``0034``.
+    run_id: Mapped[uuid.UUID | None] = mapped_column(
+        Uuid(),
+        nullable=True,
+        default=None,
+    )
+    step_id: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        default=None,
+    )
 
     __table_args__ = (
         Index(
@@ -517,6 +537,11 @@ class AuditLog(Base):
         Index(
             "audit_log_actor_sub_idx",
             "actor_sub",
+            postgresql_using="btree",
+        ),
+        Index(
+            "audit_log_run_id_idx",
+            "run_id",
             postgresql_using="btree",
         ),
     )
@@ -4265,5 +4290,283 @@ class IdentityBudget(Base):
             "tenant_id",
             "principal_sub",
             postgresql_using="btree",
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Runbook schema (G12.1-T1 / #1292)
+# ---------------------------------------------------------------------------
+
+
+class RunbookTemplate(Base):
+    """A versioned runbook recipe (immutable on publish).
+
+    One row per ``(tenant_id, slug, version)`` triple. The ``slug`` is
+    the operator-facing stable identifier for the procedure (e.g.
+    ``drain-k8s-node``); ``version`` is a monotonically increasing
+    integer per ``(tenant_id, slug)`` — first draft starts at 1, each
+    edit that bumps the draft creates a new version row. The G12.2
+    write layer rejects edits to published templates (a new version must
+    be created).
+
+    Schema decisions
+    ----------------
+
+    * ``id`` — UUID primary key; ``default=uuid.uuid4`` for the SQLite
+      dev/test path (no ``gen_random_uuid()`` server default in v0.2).
+    * ``tenant_id`` — UUID NOT NULL. Soft-FK per existing discipline
+      (no DB-level FK to ``tenant.id`` in v0.2 — same as every other
+      per-tenant table that predates the FK-tightening pass).
+    * ``slug`` — Text NOT NULL. Validated against
+      :data:`meho_backplane.kb.schemas.SLUG_PATTERN` at the schema
+      layer (G12.2); the DB only stores the pre-validated string.
+    * ``version`` — Integer NOT NULL. Uniqueness enforced by
+      ``runbook_templates_tenant_slug_version_idx`` (unique b-tree on
+      ``(tenant_id, slug, version)``).
+    * ``steps`` — ``_PORTABLE_JSON`` NOT NULL. Ordered list of step
+      descriptors; shape validation (discriminated
+      ``type: operation_call`` / ``type: manual`` unions) lives in the
+      Pydantic layer (G12.2).
+    * ``status`` — Text NOT NULL DEFAULT ``'draft'``. Drives the
+      lifecycle machine ``draft → published → deprecated``.
+      ``CheckConstraint`` enforces the closed vocabulary.
+    * ``created_by`` / ``edited_by`` — operator sub (JWT ``sub`` claim).
+      ``edited_by`` mirrors ``created_by`` on first creation; updated by
+      the G12.2 edit surface on each subsequent write.
+    * ``created_at`` / ``edited_at`` — ``timestamptz`` NOT NULL.
+      ``default=lambda: datetime.now(UTC)`` so SQLite dev/test paths
+      populate the column without relying on a dialect server default.
+
+    Indexes
+    -------
+
+    * ``runbook_templates_tenant_slug_version_idx`` — unique b-tree on
+      ``(tenant_id, slug, version)``.  Templates are always
+      tenant-scoped so a single full unique index suffices (no partial-
+      index split like ``operation_group_global_idx`` /
+      ``operation_group_tenant_idx``).
+    * ``runbook_templates_tenant_status_idx`` — b-tree on
+      ``(tenant_id, status)`` for the ``runbook_list_templates`` query
+      path (G12.2).
+    """
+
+    __tablename__ = "runbook_templates"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    # Soft-FK — no DB-level FK to tenant.id in v0.2 (same discipline
+    # as every other per-tenant table in this module).
+    tenant_id: Mapped[uuid.UUID] = mapped_column(Uuid(), nullable=False)
+    slug: Mapped[str] = mapped_column(Text, nullable=False)
+    version: Mapped[int] = mapped_column(Integer, nullable=False)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    steps: Mapped[dict[str, object]] = mapped_column(
+        _PORTABLE_JSON,
+        nullable=False,
+        default=list,
+    )
+    target_kind: Mapped[str | None] = mapped_column(Text, nullable=True, default=None)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="draft")
+    created_by: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    edited_by: Mapped[str] = mapped_column(Text, nullable=False)
+    edited_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+
+    __table_args__ = (
+        Index(
+            "runbook_templates_tenant_slug_version_idx",
+            "tenant_id",
+            "slug",
+            "version",
+            unique=True,
+            postgresql_using="btree",
+        ),
+        Index(
+            "runbook_templates_tenant_status_idx",
+            "tenant_id",
+            "status",
+            postgresql_using="btree",
+        ),
+        sa.CheckConstraint(
+            "status IN ('draft', 'published', 'deprecated')",
+            name="ck_runbook_templates_status",
+        ),
+    )
+
+
+class RunbookRun(Base):
+    """An execution of a :class:`RunbookTemplate` — one row per invocation.
+
+    The state machine drives ``in_progress → completed | abandoned``.
+    ``template_slug`` and ``template_version`` are pinned at run start so
+    later template edits cannot alter an in-flight run's step list. The
+    ``params`` column carries the ``${run.params.X}`` substitution context
+    (G12.3); it defaults to an empty dict so a params-less run is
+    insertable without ambiguity.
+
+    Schema decisions
+    ----------------
+
+    * ``run_id`` — UUID primary key; ``default=uuid.uuid4`` for dev/test.
+    * ``tenant_id`` — UUID NOT NULL. Soft-FK (no DB-level FK in v0.2).
+    * ``template_slug`` / ``template_version`` — pinned at start. Composite
+      soft-reference to ``(tenant_id, slug, version)`` in
+      ``runbook_templates`` — no DB-level multi-column FK in v0.2 by the
+      existing discipline.
+    * ``params`` — ``_PORTABLE_JSON`` NOT NULL. ``default=dict`` for the
+      SQLite path; PG gets ``'{}'`` as the server default in the migration
+      (same pattern as ``event_outbox.payload`` in migration ``0027``).
+    * ``state`` — Text NOT NULL DEFAULT ``'in_progress'``.
+      ``CheckConstraint`` enforces the closed vocabulary.
+    * ``completed_at`` / ``abandoned_at`` — NULL until the respective
+      terminal transition.
+
+    Indexes
+    -------
+
+    * ``runbook_runs_tenant_assigned_state_idx`` — b-tree on
+      ``(tenant_id, assigned_to, state)`` — drives the G12.4 priming
+      query ("in-progress runs assigned to this operator") and
+      ``runbook_list_runs`` (G12.3).
+    * ``runbook_runs_tenant_template_idx`` — b-tree on
+      ``(tenant_id, template_slug, template_version)`` — drives the
+      G12.3 post-completion read-allowance lookup ("did this operator
+      run this template?").
+    """
+
+    __tablename__ = "runbook_runs"
+
+    run_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    # Soft-FK (same discipline as tenant_id on other tables).
+    tenant_id: Mapped[uuid.UUID] = mapped_column(Uuid(), nullable=False)
+    # Pinned at start; composite soft-reference to runbook_templates.
+    template_slug: Mapped[str] = mapped_column(Text, nullable=False)
+    template_version: Mapped[int] = mapped_column(Integer, nullable=False)
+    assigned_to: Mapped[str] = mapped_column(Text, nullable=False)
+    target: Mapped[str] = mapped_column(Text, nullable=False)
+    params: Mapped[dict[str, object]] = mapped_column(
+        _PORTABLE_JSON,
+        nullable=False,
+        default=dict,
+    )
+    state: Mapped[str] = mapped_column(Text, nullable=False, default="in_progress")
+    started_by: Mapped[str] = mapped_column(Text, nullable=False)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+    abandoned_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+
+    __table_args__ = (
+        Index(
+            "runbook_runs_tenant_assigned_state_idx",
+            "tenant_id",
+            "assigned_to",
+            "state",
+            postgresql_using="btree",
+        ),
+        Index(
+            "runbook_runs_tenant_template_idx",
+            "tenant_id",
+            "template_slug",
+            "template_version",
+            postgresql_using="btree",
+        ),
+        sa.CheckConstraint(
+            "state IN ('in_progress', 'completed', 'abandoned')",
+            name="ck_runbook_runs_state",
+        ),
+    )
+
+
+class RunbookRunStepState(Base):
+    """Per-(run, step) state for a :class:`RunbookRun`.
+
+    One row per step per run; created in bulk when a run is started
+    (G12.3), all rows initially in ``state='pending'``. The composite PK
+    ``(run_id, step_id)`` is the natural join key; no additional index is
+    needed because the PK covers the per-run advance query path (G12.3:
+    "advance run X to step Y").
+
+    Schema decisions
+    ----------------
+
+    * ``run_id`` — part of the composite PK. Real
+      ``ForeignKey("runbook_runs.run_id", ondelete="CASCADE")`` — this
+      is a new-table child relationship, so a DB-level FK is
+      appropriate (same pattern as :class:`GraphEdge` → :class:`GraphNode`
+      with ``ondelete="CASCADE"``). Cascade-delete so dropping a run row
+      also removes its step states.
+    * ``step_id`` — part of the composite PK. Matches the ``id`` field
+      inside ``runbook_templates.steps[]``; validated by the G12.3 layer
+      at write time.
+    * ``state`` — Text NOT NULL DEFAULT ``'pending'``. Drives the per-step
+      state machine. ``CheckConstraint`` enforces the closed vocabulary.
+    * ``started_at`` — NULL while ``state='pending'``; stamped when the
+      step transitions to ``in_progress``.
+    * ``verified_at`` — NULL until the step reaches ``verified``.
+    * ``verify_response`` — nullable JSONB. Captures the operator's
+      confirmation result (``yes`` / ``no`` / ``escalate`` for ``confirm``
+      steps) or the dispatched-call result (for ``operation_call`` steps).
+      NULL while the step is in-progress or pending.
+    """
+
+    __tablename__ = "runbook_run_step_states"
+
+    run_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(),
+        ForeignKey("runbook_runs.run_id", ondelete="CASCADE"),
+        primary_key=True,
+        nullable=False,
+    )
+    step_id: Mapped[str] = mapped_column(Text, primary_key=True, nullable=False)
+    state: Mapped[str] = mapped_column(Text, nullable=False, default="pending")
+    started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+    verified_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        default=None,
+    )
+    verify_response: Mapped[object] = mapped_column(
+        _PORTABLE_JSON,
+        nullable=True,
+        default=None,
+    )
+
+    __table_args__ = (
+        sa.CheckConstraint(
+            "state IN ('pending', 'in_progress', 'verified', 'failed')",
+            name="ck_runbook_run_step_states_state",
         ),
     )

--- a/backend/src/meho_backplane/db/models.py
+++ b/backend/src/meho_backplane/db/models.py
@@ -4365,7 +4365,7 @@ class RunbookTemplate(Base):
     version: Mapped[int] = mapped_column(Integer, nullable=False)
     title: Mapped[str] = mapped_column(Text, nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=False)
-    steps: Mapped[dict[str, object]] = mapped_column(
+    steps: Mapped[list[dict[str, object]]] = mapped_column(
         _PORTABLE_JSON,
         nullable=False,
         default=list,

--- a/backend/tests/test_migration_0034_runbook_tables.py
+++ b/backend/tests/test_migration_0034_runbook_tables.py
@@ -1,0 +1,327 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for Alembic migration ``0034_runbook_tables_and_audit_correlation``.
+
+Task #1292 (G12.1-T1) under Initiative #1196. Adds three new tables
+(``runbook_templates``, ``runbook_runs``, ``runbook_run_step_states``)
+and two additive nullable columns on ``audit_log``
+(``run_id``, ``step_id``) plus one new index
+(``audit_log_run_id_idx``). Reversible; soft-column discipline mirrors
+``0014`` / ``0021`` / ``0030`` for the audit columns; new-table
+discipline mirrors ``0027`` for the three runbook tables.
+
+Test matrix
+-----------
+
+1. Upgrade succeeds; all three new tables present; ``audit_log.run_id``
+   + ``audit_log.step_id`` present and nullable; all four new indexes
+   present.
+2. Upgrade → downgrade ``0033`` → upgrade round-trip: tables dropped on
+   downgrade, columns removed, all four indexes gone; upgrade restores
+   them.
+3. Inserting an ``audit_log`` row without ``run_id`` / ``step_id`` works;
+   both columns are NULL on that row (no regression on pre-G12.1 rows).
+4. Inserting a ``runbook_run_step_states`` row referencing a nonexistent
+   ``run_id`` raises ``IntegrityError`` (the FK is a real constraint).
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine as sa_create_engine
+from sqlalchemy import event, text
+from sqlalchemy.exc import IntegrityError
+
+from meho_backplane.db.engine import reset_engine_for_testing
+from meho_backplane.db.migrations import alembic_config
+from meho_backplane.settings import get_settings
+
+
+@pytest.fixture
+def alembic_cfg(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[Config, str]]:
+    """Pin env, reset caches, return an Alembic config + sync URL."""
+    db_path = tmp_path / "migration_0034.db"
+    async_url = f"sqlite+aiosqlite:///{db_path}"
+    sync_url = f"sqlite:///{db_path}"
+    monkeypatch.setenv("DATABASE_URL", async_url)
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    reset_engine_for_testing()
+
+    cfg = alembic_config()
+    cfg.set_main_option("sqlalchemy.url", async_url)
+    try:
+        yield cfg, sync_url
+    finally:
+        get_settings.cache_clear()
+        reset_engine_for_testing()
+
+
+def _table_names(sync_url: str) -> set[str]:
+    """Return all table names present in the database."""
+    eng = sa_create_engine(sync_url)
+    try:
+        with eng.connect() as conn:
+            rows = conn.execute(text("SELECT name FROM sqlite_master WHERE type='table'")).all()
+    finally:
+        eng.dispose()
+    return {str(row[0]) for row in rows}
+
+
+def _table_columns(sync_url: str, table: str) -> set[str]:
+    """Return column names for *table* via SQLite PRAGMA."""
+    eng = sa_create_engine(sync_url)
+    try:
+        with eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    finally:
+        eng.dispose()
+    return {str(row[1]) for row in rows}
+
+
+def _column_is_nullable(sync_url: str, table: str, column: str) -> bool:
+    """Return True if *column* on *table* allows NULL values."""
+    eng = sa_create_engine(sync_url)
+    try:
+        with eng.connect() as conn:
+            rows = conn.execute(text(f"PRAGMA table_info({table})")).all()
+    finally:
+        eng.dispose()
+    for row in rows:
+        if str(row[1]) == column:
+            # PRAGMA table_info column 3: notnull (1 = NOT NULL).
+            return int(row[3]) == 0
+    raise AssertionError(f"column {column!r} not found on table {table!r}")
+
+
+def _index_names(sync_url: str) -> set[str]:
+    """Return all index names in the database."""
+    eng = sa_create_engine(sync_url)
+    try:
+        with eng.connect() as conn:
+            rows = conn.execute(text("SELECT name FROM sqlite_master WHERE type='index'")).all()
+    finally:
+        eng.dispose()
+    return {str(row[0]) for row in rows}
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — upgrade lands all tables, columns, and indexes.
+# ---------------------------------------------------------------------------
+
+
+def test_upgrade_lands_tables_columns_and_indexes(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """``upgrade head`` creates all three runbook tables, both audit columns,
+    and all four new indexes."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    tables = _table_names(sync_url)
+    assert "runbook_templates" in tables
+    assert "runbook_runs" in tables
+    assert "runbook_run_step_states" in tables
+
+    # audit_log columns present and nullable.
+    audit_cols = _table_columns(sync_url, "audit_log")
+    assert "run_id" in audit_cols
+    assert "step_id" in audit_cols
+    assert _column_is_nullable(sync_url, "audit_log", "run_id")
+    assert _column_is_nullable(sync_url, "audit_log", "step_id")
+
+    # Four new indexes present.
+    indexes = _index_names(sync_url)
+    assert "runbook_templates_tenant_slug_version_idx" in indexes
+    assert "runbook_templates_tenant_status_idx" in indexes
+    assert "runbook_runs_tenant_assigned_state_idx" in indexes
+    assert "runbook_runs_tenant_template_idx" in indexes
+    assert "audit_log_run_id_idx" in indexes
+
+    # Spot-check columns on runbook_templates.
+    rt_cols = _table_columns(sync_url, "runbook_templates")
+    for col in (
+        "id",
+        "tenant_id",
+        "slug",
+        "version",
+        "title",
+        "description",
+        "steps",
+        "target_kind",
+        "status",
+        "created_by",
+        "created_at",
+        "edited_by",
+        "edited_at",
+    ):
+        assert col in rt_cols, f"runbook_templates.{col} missing after upgrade"
+
+    # Spot-check columns on runbook_runs.
+    rr_cols = _table_columns(sync_url, "runbook_runs")
+    for col in (
+        "run_id",
+        "tenant_id",
+        "template_slug",
+        "template_version",
+        "assigned_to",
+        "target",
+        "params",
+        "state",
+        "started_by",
+        "started_at",
+        "completed_at",
+        "abandoned_at",
+    ):
+        assert col in rr_cols, f"runbook_runs.{col} missing after upgrade"
+
+    # Spot-check columns on runbook_run_step_states.
+    ss_cols = _table_columns(sync_url, "runbook_run_step_states")
+    for col in ("run_id", "step_id", "state", "started_at", "verified_at", "verify_response"):
+        assert col in ss_cols, f"runbook_run_step_states.{col} missing after upgrade"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — downgrade → upgrade round-trip.
+# ---------------------------------------------------------------------------
+
+
+def test_downgrade_to_0033_then_upgrade_round_trips(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """Downgrade to ``0033`` drops tables / columns / indexes;
+    upgrade head restores them all."""
+    cfg, sync_url = alembic_cfg
+
+    command.upgrade(cfg, "head")
+    assert "runbook_templates" in _table_names(sync_url)
+
+    command.downgrade(cfg, "0033")
+
+    # Tables dropped.
+    tables = _table_names(sync_url)
+    assert "runbook_templates" not in tables
+    assert "runbook_runs" not in tables
+    assert "runbook_run_step_states" not in tables
+
+    # Audit columns dropped.
+    audit_cols = _table_columns(sync_url, "audit_log")
+    assert "run_id" not in audit_cols
+    assert "step_id" not in audit_cols
+
+    # Indexes dropped.
+    indexes = _index_names(sync_url)
+    assert "runbook_templates_tenant_slug_version_idx" not in indexes
+    assert "runbook_templates_tenant_status_idx" not in indexes
+    assert "runbook_runs_tenant_assigned_state_idx" not in indexes
+    assert "runbook_runs_tenant_template_idx" not in indexes
+    assert "audit_log_run_id_idx" not in indexes
+
+    # Re-upgrade — everything restored.
+    command.upgrade(cfg, "head")
+
+    assert "runbook_templates" in _table_names(sync_url)
+    assert "runbook_runs" in _table_names(sync_url)
+    assert "runbook_run_step_states" in _table_names(sync_url)
+
+    audit_cols = _table_columns(sync_url, "audit_log")
+    assert "run_id" in audit_cols
+    assert "step_id" in audit_cols
+
+    indexes = _index_names(sync_url)
+    assert "audit_log_run_id_idx" in indexes
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — pre-existing audit_log rows (NULL run_id / step_id).
+# ---------------------------------------------------------------------------
+
+
+def test_audit_log_insert_without_run_id_step_id(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """An ``audit_log`` row inserted without ``run_id`` / ``step_id``
+    succeeds and carries NULL on both columns (no regression)."""
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    row_id = str(uuid.uuid4()).replace("-", "")
+    eng = sa_create_engine(sync_url)
+    try:
+        with eng.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO audit_log "
+                    "(id, occurred_at, operator_sub, method, path, status_code, payload) "
+                    "VALUES (:id, datetime('now'), 'op-test', 'DISPATCH', 'some.op', 200, '{}')"
+                ),
+                {"id": row_id},
+            )
+        with eng.connect() as conn:
+            row = conn.execute(
+                text("SELECT run_id, step_id FROM audit_log WHERE id = :id"),
+                {"id": row_id},
+            ).one()
+    finally:
+        eng.dispose()
+
+    assert row[0] is None, "run_id should be NULL for a pre-G12.1 audit row"
+    assert row[1] is None, "step_id should be NULL for a pre-G12.1 audit row"
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — FK integrity on runbook_run_step_states.
+# ---------------------------------------------------------------------------
+
+
+def test_runbook_run_step_states_fk_rejects_orphan_run_id(
+    alembic_cfg: tuple[Config, str],
+) -> None:
+    """Inserting a ``runbook_run_step_states`` row referencing a
+    nonexistent ``run_id`` raises :exc:`IntegrityError` — the FK is real.
+
+    SQLite enforces FK constraints only when ``PRAGMA foreign_keys=ON``
+    is issued on every connection (the default is OFF). The test engine
+    registers an event listener to enable FK enforcement so the
+    integrity constraint is exercised on the dev/test driver, mirroring
+    what PostgreSQL production always enforces unconditionally.
+    """
+    cfg, sync_url = alembic_cfg
+    command.upgrade(cfg, "head")
+
+    nonexistent_run_id = str(uuid.uuid4()).replace("-", "")
+    eng = sa_create_engine(sync_url)
+
+    @event.listens_for(eng, "connect")
+    def _enable_foreign_keys(dbapi_connection: Any, _connection_record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute("PRAGMA foreign_keys=ON")
+        finally:
+            cursor.close()
+
+    try:
+        with pytest.raises(IntegrityError), eng.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO runbook_run_step_states "
+                    "(run_id, step_id, state) "
+                    "VALUES (:run_id, 'step-1', 'pending')"
+                ),
+                {"run_id": nonexistent_run_id},
+            )
+    finally:
+        eng.dispose()


### PR DESCRIPTION
## Summary

- Adds Alembic migration `0034_runbook_tables_and_audit_correlation.py` with three new tables (`runbook_templates`, `runbook_runs`, `runbook_run_step_states`), two additive nullable columns on `audit_log` (`run_id`, `step_id`), and one new index (`audit_log_run_id_idx`)
- Adds matching SQLAlchemy 2.x typed-mapped model classes to `db/models.py`; `__all__` updated alphabetically
- Adds migration test suite `test_migration_0034_runbook_tables.py` (4 tests: upgrade, round-trip downgrade/upgrade, NULL audit regression, FK enforcement)

## Notes

- Migration `0031`–`0033` are already merged; this uses `0034` (correcting the stale reference in Initiative #1196 body — flagged as out-of-scope follow-up)
- Pre-existing `ruff RUF034` in `0023_create_approval_request.py` and `mypy import-untyped` for `pgvector` are baseline issues in `main`, not introduced here
- No dispatcher contextvar plumbing in this PR — that's G12.1-T2 (#1294), which depends on this

## Test plan

- [x] `pytest backend/tests/test_migration_0034_runbook_tables.py` — 4/4 passed (requires `ALEMBIC_CONFIG` pointed at worktree `alembic.ini`)
- [x] `pytest backend/tests/test_migration_compat.py` — 19/19 passed
- [x] `ruff check` clean on all changed files
- [x] `mypy` clean on all changed files (pre-existing pgvector error excluded)

Closes #1292

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced runbook template system for creating and managing reusable standardized operational procedures.
  * Added support for executing runbook instances with configurable parameters and execution state management.
  * Enhanced audit logging to track and correlate audit events with specific runbook executions for improved operational traceability.

* **Chores**
  * Updated database schema to support the new runbook management capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->