### PR TITLE
feat(audit): G12.1-T2 run_id_var + step_id_var contextvar plumbing for runbook correlation

### DIFF
--- a/backend/src/meho_backplane/operations/__init__.py
+++ b/backend/src/meho_backplane/operations/__init__.py
@@ -60,6 +60,8 @@ from meho_backplane.operations._audit import (
     AgentRunAuditMeta,
     agent_run_audit_meta_var,
     agent_session_id_var,
+    run_id_var,
+    step_id_var,
 )
 from meho_backplane.operations.composite import (
     CompositeL2DependencyMissing,
@@ -116,6 +118,8 @@ __all__ = [
     "register_typed_op_registrar",
     "register_typed_operation",
     "reset_dispatcher_caches",
+    "run_id_var",
     "run_typed_op_registrars",
     "set_default_reducer",
+    "step_id_var",
 ]

--- a/backend/src/meho_backplane/operations/_audit.py
+++ b/backend/src/meho_backplane/operations/_audit.py
@@ -52,6 +52,8 @@ __all__ = [
     "audit_and_broadcast_safe",
     "parent_audit_id_var",
     "publish_broadcast",
+    "run_id_var",
+    "step_id_var",
     "write_audit_row",
 ]
 
@@ -96,6 +98,42 @@ parent_audit_id_var: ContextVar[uuid.UUID | None] = ContextVar(
 #: agent's full session graph.
 agent_session_id_var: ContextVar[uuid.UUID | None] = ContextVar(
     "agent_session_id",
+    default=None,
+)
+
+
+#: ContextVar carrying the active runbook run's id while a step's
+#: ``operation_call`` (step body OR verify dispatch) fires from the
+#: G12.3 step-execution engine. The engine binds this contextvar
+#: around every ``call_operation(...)`` invocation produced by step
+#: execution; :func:`write_audit_row` reads it into the real
+#: ``audit_log.run_id`` column added by migration ``0034`` (#1292 /
+#: G12.1-T1). Defaulting to ``None`` is correct -- a non-runbook
+#: dispatch (chassis HTTP, MCP tool, agent loop outside a runbook)
+#: has no run.
+#:
+#: Same mechanism as :data:`parent_audit_id_var` and
+#: :data:`agent_session_id_var`: one source-of-truth contextvar
+#: bound at a boundary, read at every audit-write call site that
+#: lives inside the same async task. ``asyncio.create_task``
+#: snapshots the contextvars, so the engine can spawn helpers that
+#: inherit the binding for their whole life.
+run_id_var: ContextVar[uuid.UUID | None] = ContextVar(
+    "run_id",
+    default=None,
+)
+
+
+#: ContextVar carrying the active runbook step's id (the ``id`` field
+#: inside ``runbook_templates.steps[]``) while a step's
+#: ``operation_call`` fires. Bound by the G12.3 engine alongside
+#: :data:`run_id_var`; read by :func:`write_audit_row` into
+#: ``audit_log.step_id``. ``str`` (not UUID) because step ids are
+#: template-author-defined slugs (``revoke-old-cert``,
+#: ``rotate-credentials``), not generated UUIDs. ``None`` outside a
+#: runbook step execution.
+step_id_var: ContextVar[str | None] = ContextVar(
+    "step_id",
     default=None,
 )
 
@@ -275,6 +313,17 @@ def _build_audit_payload(
             # example) through verbatim. JSON-incompatible shapes are
             # the meta producer's responsibility, not this layer's.
             payload["agent_cost"] = str(meta.cost) if isinstance(meta.cost, Decimal) else meta.cost
+    # G12.1-T2 #1294 -- runbook correlation. The run_id / step_id mirrors in
+    # the JSON payload serve the broadcast-event surface (consumers parse
+    # ``payload``); the canonical columns live on ``audit_log.run_id`` /
+    # ``audit_log.step_id`` (migration ``0034`` / G12.1-T1 #1292), written
+    # by :func:`write_audit_row`. ``None`` outside a runbook step execution.
+    run_id = run_id_var.get()
+    if run_id is not None:
+        payload["run_id"] = str(run_id)
+    step_id = step_id_var.get()
+    if step_id is not None:
+        payload["step_id"] = step_id
     # Handler-bound extras last so a handler can intentionally override
     # a default (e.g. a future per-op result_status override); the
     # default keys are documented + load-bearing for audit consumers,
@@ -340,6 +389,18 @@ async def write_audit_row(
     # an agent run (the chassis HTTP / MCP dispatch path), which is
     # the correct value for the nullable column.
     agent_session_id = agent_session_id_var.get()
+    # G12.1-T2 #1294 -- read the runbook correlation contextvars. The
+    # columns (``run_id`` / ``step_id``) are added by migration ``0034``
+    # (G12.1-T1 #1292). We pass them only when the model carries the
+    # columns so this module stays forward-compatible while #1292 is
+    # not yet merged into the base branch.
+    run_id = run_id_var.get()
+    step_id = step_id_var.get()
+    runbook_kwargs: dict[str, Any] = {}
+    if hasattr(AuditLog, "run_id"):
+        runbook_kwargs["run_id"] = run_id
+    if hasattr(AuditLog, "step_id"):
+        runbook_kwargs["step_id"] = step_id
     async with sessionmaker() as session:
         row = AuditLog(
             id=audit_id,
@@ -358,6 +419,7 @@ async def write_audit_row(
             payload=payload,
             raw_payload=raw_payload,
             redaction_manifest=redaction_manifest,
+            **runbook_kwargs,
         )
         session.add(row)
         await session.commit()

--- a/backend/tests/test_audit_runbook_correlation.py
+++ b/backend/tests/test_audit_runbook_correlation.py
@@ -57,8 +57,6 @@ from meho_backplane.operations._audit import run_id_var, step_id_var
 from meho_backplane.retrieval.embedding import EMBEDDING_DIMENSION
 from meho_backplane.settings import get_settings
 
-pytestmark = pytest.mark.asyncio
-
 _TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
 
 # Guard: skip DB-column assertions when the schema predates migration 0034.

--- a/backend/tests/test_audit_runbook_correlation.py
+++ b/backend/tests/test_audit_runbook_correlation.py
@@ -1,0 +1,340 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the runbook contextvar plumbing (G12.1-T2 #1294).
+
+Acceptance criteria covered:
+
+* ``test_audit_row_carries_run_step_when_contextvars_set`` -- bind
+  ``run_id_var`` + ``step_id_var``, dispatch a safe op, fetch the
+  resulting ``audit_log`` row, assert ``row.run_id == <uuid>`` and
+  ``row.step_id == "rotate-creds"``. Skipped when the DB schema
+  predates migration ``0034`` (G12.1-T1 #1292) -- the columns are
+  wired by this module but only present after T1 merges.
+* ``test_audit_row_null_when_contextvars_unset`` -- dispatch with no
+  contextvar binding, assert ``row.run_id is None`` and
+  ``row.step_id is None``. Same skip guard as the prior test.
+* ``test_audit_payload_mirrors_run_step`` -- bind contextvars,
+  dispatch, assert ``row.payload["run_id"] == str(<uuid>)`` and
+  ``row.payload["step_id"] == "rotate-creds"``. No DB column
+  required -- always runs.
+* ``test_audit_payload_omits_run_step_when_unset`` -- dispatch with
+  no contextvars, assert ``"run_id" not in row.payload`` and
+  ``"step_id" not in row.payload``. Always runs.
+* ``test_contextvar_resets_cleanly`` -- pure unit test: ``set`` →
+  assert non-None → ``reset`` → assert ``.get() is None``. No
+  dispatch, no DB. Always runs.
+
+The tests exercise the dispatcher's audit-write path directly by
+binding the new contextvars (the same shape the G12.3 step-execution
+engine will use) and seeding a typed operation; this isolates the
+propagation contract from the runbook engine's implementation.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import clear_registry, register_connector_v2
+from meho_backplane.connectors.schemas import FingerprintResult, OperationResult, ProbeResult
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog
+from meho_backplane.operations import (
+    dispatch,
+    register_typed_operation,
+    reset_dispatcher_caches,
+)
+from meho_backplane.operations._audit import run_id_var, step_id_var
+from meho_backplane.retrieval.embedding import EMBEDDING_DIMENSION
+from meho_backplane.settings import get_settings
+
+pytestmark = pytest.mark.asyncio
+
+_TENANT_A = uuid.UUID("11111111-1111-1111-1111-111111111111")
+
+# Guard: skip DB-column assertions when the schema predates migration 0034.
+# Once G12.1-T1 (#1292) merges and the column exists on AuditLog, the
+# skip guard becomes False and both tests run.
+_COLUMNS_PRESENT = hasattr(AuditLog, "run_id") and hasattr(AuditLog, "step_id")
+_skip_if_no_columns = pytest.mark.skipif(
+    not _COLUMNS_PRESENT,
+    reason="audit_log.run_id / .step_id columns added by migration 0034 (G12.1-T1 #1292); "
+    "skip until that PR merges into main.",
+)
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin the env vars :class:`Settings` requires."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> Iterator[None]:
+    """Clear connector + dispatcher caches around each test."""
+    clear_registry()
+    reset_dispatcher_caches()
+    yield
+    clear_registry()
+    reset_dispatcher_caches()
+
+
+@pytest.fixture
+async def db_session() -> AsyncIterator[AsyncSession]:
+    """One :class:`AsyncSession` per test for direct row inspection."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as s:
+        yield s
+
+
+@pytest.fixture
+def stub_embedding_service() -> AsyncMock:
+    """Embedding stub for the typed-op descriptor's embedding column."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.0] * EMBEDDING_DIMENSION
+    service.encode.return_value = [[0.0] * EMBEDDING_DIMENSION]
+    service.dimension = EMBEDDING_DIMENSION
+    return service
+
+
+def _operator() -> Operator:
+    """Test operator in tenant A."""
+    return Operator(
+        sub="alice@example.com",
+        name="Alice",
+        email=None,
+        raw_jwt="<test-raw-jwt>",
+        tenant_id=_TENANT_A,
+        tenant_role=TenantRole.OPERATOR,
+    )
+
+
+class _StubConnector(Connector):
+    """Minimal connector so dispatcher resolver finds a class for the triple."""
+
+    product = "stub"
+    version = "1.x"
+    impl_id = "stub"
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(  # type: ignore[override]
+        self,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        raise NotImplementedError
+
+
+async def _echo_handler(
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Typed handler: return params verbatim."""
+    return {"ok": True}
+
+
+async def _seed_typed_op(stub_embedding_service: AsyncMock) -> None:
+    """Register the stub connector + typed op the dispatcher can find."""
+    register_connector_v2(product="stub", version="", impl_id="", cls=_StubConnector)
+    await register_typed_operation(
+        product="stub",
+        version="1.x",
+        impl_id="stub",
+        op_id="stub.op_call",
+        handler=_echo_handler,
+        summary="Stub op for runbook-correlation tests.",
+        description="Echo params; used to assert the audit row's run_id / step_id.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+
+# ---------------------------------------------------------------------------
+# DB column assertions (skipped until migration 0034 lands)
+# ---------------------------------------------------------------------------
+
+
+@_skip_if_no_columns
+async def test_audit_row_carries_run_step_when_contextvars_set(
+    db_session: AsyncSession,
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A dispatch inside a runbook step carries the run_id + step_id on the row.
+
+    Mirrors the agent_session_id propagation test: bind the contextvars,
+    dispatch, assert the real DB columns. The G12.3 engine will bind these
+    contextvars around every ``call_operation(...)`` invocation; this test
+    validates the plumbing without the engine present.
+    """
+    await _seed_typed_op(stub_embedding_service)
+    operator = _operator()
+    run_id = uuid.uuid4()
+
+    run_id_token = run_id_var.set(run_id)
+    step_id_token = step_id_var.set("rotate-creds")
+    try:
+        await dispatch(
+            operator=operator,
+            connector_id="stub-1.x",
+            op_id="stub.op_call",
+            target=None,
+            params={},
+        )
+    finally:
+        run_id_var.reset(run_id_token)
+        step_id_var.reset(step_id_token)
+
+    rows = (await db_session.scalars(select(AuditLog))).all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.run_id == run_id  # type: ignore[attr-defined]
+    assert row.step_id == "rotate-creds"  # type: ignore[attr-defined]
+
+
+@_skip_if_no_columns
+async def test_audit_row_null_when_contextvars_unset(
+    db_session: AsyncSession,
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """A top-level dispatch (no runbook in scope) leaves run_id/step_id NULL.
+
+    Regression guard: chassis HTTP, MCP tool, and agent-loop dispatches
+    that fire outside a runbook step must not gain spurious correlation.
+    """
+    await _seed_typed_op(stub_embedding_service)
+    operator = _operator()
+
+    # No contextvar binding.
+    await dispatch(
+        operator=operator,
+        connector_id="stub-1.x",
+        op_id="stub.op_call",
+        target=None,
+        params={},
+    )
+
+    rows = (await db_session.scalars(select(AuditLog))).all()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.run_id is None  # type: ignore[attr-defined]
+    assert row.step_id is None  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Payload mirror assertions (always run -- no DB column dependency)
+# ---------------------------------------------------------------------------
+
+
+async def test_audit_payload_mirrors_run_step(
+    db_session: AsyncSession,
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """The run_id + step_id appear in the JSON payload when contextvars are set.
+
+    Broadcast consumers parse ``payload`` (not the dedicated columns), so
+    the mirror is the load-bearing surface for G12.3 audit subscribers.
+    """
+    await _seed_typed_op(stub_embedding_service)
+    operator = _operator()
+    run_id = uuid.uuid4()
+
+    run_id_token = run_id_var.set(run_id)
+    step_id_token = step_id_var.set("rotate-creds")
+    try:
+        await dispatch(
+            operator=operator,
+            connector_id="stub-1.x",
+            op_id="stub.op_call",
+            target=None,
+            params={},
+        )
+    finally:
+        run_id_var.reset(run_id_token)
+        step_id_var.reset(step_id_token)
+
+    rows = (await db_session.scalars(select(AuditLog))).all()
+    assert len(rows) == 1
+    payload = rows[0].payload
+    assert isinstance(payload, dict)
+    assert payload["run_id"] == str(run_id)
+    assert payload["step_id"] == "rotate-creds"
+
+
+async def test_audit_payload_omits_run_step_when_unset(
+    db_session: AsyncSession,
+    stub_embedding_service: AsyncMock,
+) -> None:
+    """Payload carries no run_id / step_id keys when contextvars are unset.
+
+    The mirror uses ``if value is not None:`` guards (consistent with the
+    parent_audit_id / agent_session_id mirrors); this test confirms the
+    guard fires correctly so non-runbook rows stay clean.
+    """
+    await _seed_typed_op(stub_embedding_service)
+    operator = _operator()
+
+    # No contextvar binding.
+    await dispatch(
+        operator=operator,
+        connector_id="stub-1.x",
+        op_id="stub.op_call",
+        target=None,
+        params={},
+    )
+
+    rows = (await db_session.scalars(select(AuditLog))).all()
+    assert len(rows) == 1
+    payload = rows[0].payload
+    assert isinstance(payload, dict)
+    assert "run_id" not in payload
+    assert "step_id" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Pure unit test -- no dispatch, no DB
+# ---------------------------------------------------------------------------
+
+
+def test_contextvar_resets_cleanly() -> None:
+    """set → non-None → reset → None; no dispatch, no DB.
+
+    Validates that the contextvar tokens work correctly so the G12.3
+    engine's set/reset pattern around step execution is sound.
+    """
+    assert run_id_var.get() is None
+    assert step_id_var.get() is None
+
+    run_id = uuid.uuid4()
+    run_token = run_id_var.set(run_id)
+    step_token = step_id_var.set("rotate-creds")
+
+    assert run_id_var.get() == run_id
+    assert step_id_var.get() == "rotate-creds"
+
+    run_id_var.reset(run_token)
+    step_id_var.reset(step_token)
+
+    assert run_id_var.get() is None
+    assert step_id_var.get() is None


### PR DESCRIPTION
## Summary

- Adds `run_id_var: ContextVar[uuid.UUID | None]` and `step_id_var: ContextVar[str | None]` to `_audit.py`, immediately after `agent_session_id_var`, following the same one-source-of-truth contextvar pattern used by `parent_audit_id_var` (composite recursion) and `agent_session_id_var` (agent loop).
- `write_audit_row()` reads both new contextvars and passes them into the `AuditLog` constructor via `hasattr`-guarded kwargs — forward-compatible with the `main` branch that predates migration `0034` (G12.1-T1 #1292); the guard activates automatically once T1 merges.
- `_build_audit_payload()` mirrors `run_id` + `step_id` into the JSON payload using the same `if value is not None:` guard as `parent_audit_id` / `agent_session_id`, keeping the broadcast-event surface attribution-complete.
- Both names exported on `__all__` in `_audit.py` and re-exported from `operations/__init__.py` (alphabetical order).

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy` — clean (2 source files)
- [x] `pytest tests/test_audit_runbook_correlation.py -v` — 3 passed, 2 skipped (DB-column tests skip until migration 0034 lands with T1)
- [x] `pytest tests/test_operations_composite.py tests/test_agent_audit_invocation.py tests/test_audit_middleware.py` — 26 passed (no regression)
- [x] `pytest tests/test_operations_dispatcher.py` — 30 passed (no regression)

### Acceptance criteria

- [x] `run_id_var` and `step_id_var` defined in `_audit.py` immediately after `agent_session_id_var`, with exact `ContextVar[...]` types.
- [x] `__all__` in `_audit.py` includes both new names (alphabetical).
- [x] `write_audit_row()` reads both contextvars and passes them into the `AuditLog(...)` constructor (guarded by `hasattr` for forward-compat with pre-0034 schema).
- [x] `_build_audit_payload()` mirrors both into the JSON payload using the `if value is not None:` guard.
- [x] Five tests in `test_audit_runbook_correlation.py`; 3 always run (payload + reset), 2 skipif-guarded on column presence (activate post T1 merge).
- [x] Composite, agent-audit, middleware, and dispatcher regressions all green.

## Out of scope

- Schema / migration — G12.1-T1 #1292 ships the `audit_log.run_id` / `step_id` columns.
- The G12.3 step-execution engine that binds these contextvars — that's G12.3 (Run lifecycle Initiative #1198).
- MCP / REST / CLI surfaces — later Initiatives.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1294


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audit logging system enhanced to support runbook-step correlation, enabling improved tracking of audit records across runbook executions and individual processing steps.

* **Tests**
  * Added comprehensive test coverage for audit record correlation, validating payload tracking and context variable behavior across various operational scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->