### PR TITLE
feat(runbooks): G12.2-T1 runbook template Pydantic schemas + step-shape validation

### DIFF
--- a/backend/src/meho_backplane/runbooks/__init__.py
+++ b/backend/src/meho_backplane/runbooks/__init__.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Runbooks package -- versioned procedure templates + guided execution.
+
+Initiative #1197 (G12.2 Template lifecycle), under Goal #1195 (G12
+Runbooks). A runbook template is an ordered list of steps an operator
+walks through during a procedure; each step gates advance on a
+``verify`` outcome. Templates version on edit and lock on publish.
+
+This package's first file is :mod:`meho_backplane.runbooks.schemas` --
+the Pydantic shape contract (discriminated step / verify unions,
+substitution allowlist) every downstream surface (G12.2 service,
+routes, MCP tools; G12.3 execution engine) validates against. The
+storage-level shapes live as SQLAlchemy models in
+:mod:`meho_backplane.db.models` (G12.1-T1, #1292).
+"""

--- a/backend/src/meho_backplane/runbooks/schemas.py
+++ b/backend/src/meho_backplane/runbooks/schemas.py
@@ -1,0 +1,449 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Pydantic v2 shape contract for the G12.2 runbook template lifecycle (#1295).
+
+Pure types -- no service logic, no routes, no tools. Every downstream
+G12.2 surface (service, REST routes, MCP tools) and the G12.3 execution
+engine validate against these models. The storage-level shapes are the
+SQLAlchemy models in :mod:`meho_backplane.db.models` (G12.1-T1, #1292);
+this module is the validation layer that sits between operator input and
+the ``runbook_templates.steps`` JSONB column.
+
+The load-bearing data structure is the **step shape**. Each step is a
+discriminated union on ``type``:
+
+* :class:`OperationCallStep` (``type="operation_call"``) -- the agent
+  dispatches the step via the operation registry.
+* :class:`ManualStep` (``type="manual"``) -- the operator performs the
+  step off-MEHO (SSH, web UI) and reports back.
+
+Each step's ``verify`` field is itself a discriminated union on ``type``:
+
+* :class:`ConfirmVerify` (``type="confirm"``) -- operator answers the
+  prompt; only an affirmative advances.
+* :class:`OperationCallVerify` (``type="operation_call"``) -- MEHO
+  dispatches the verify call and matches the result against ``expect``
+  by structural-equality + presence (no operators, no JSONPath, no
+  boolean composition -- substrate minimalism, same call as #1177).
+
+The discriminated-union + model-validator posture mirrors
+:class:`meho_backplane.scheduler.schemas.ScheduledTriggerCreate`: a
+malformed body surfaces as a clean 422 at the HTTP boundary (Pydantic
+renders ``ValueError`` as a validation error) rather than as a flush-time
+failure deeper in the stack.
+
+The ``${...}`` substitution allowlist (:func:`validate_substitutions`)
+is defense in depth: at **publish** time the template body is walked
+recursively and every substitution pattern except ``${run.target}`` and
+``${run.params.X}`` is rejected. G12.3 re-checks at advance time using
+the same exported helper, so a template that somehow reached storage with
+a disallowed pattern still cannot expand it at runtime.
+
+The ``slug`` identifier reuses :data:`meho_backplane.kb.schemas.SLUG_PATTERN`
+verbatim (per #1292 / G12.1-T1) -- it is imported, never redefined.
+Step ids use the tighter :data:`STEP_ID_PATTERN`.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Annotated, Final, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from meho_backplane.kb.schemas import SLUG_PATTERN
+
+__all__ = [
+    "SLUG_PATTERN",
+    "STEP_ID_PATTERN",
+    "ConfirmVerify",
+    "DeprecateTemplateRequest",
+    "DeprecateTemplateResponse",
+    "DraftTemplateRequest",
+    "DraftTemplateResponse",
+    "EditTemplateRequest",
+    "EditTemplateResponse",
+    "ForkInfo",
+    "ListTemplatesFilter",
+    "ManualStep",
+    "OperationCallStep",
+    "OperationCallVerify",
+    "PublishTemplateRequest",
+    "PublishTemplateResponse",
+    "RunbookTemplateBody",
+    "ShowTemplateResponse",
+    "Step",
+    "TemplateSummary",
+    "Verify",
+    "validate_substitutions",
+]
+
+
+#: Step id pattern. Same lowercase-anchored shape as the kb slug pattern
+#: but capped tighter (no dots) because step ids are short procedure
+#: handles authors type by hand (``revoke-old-cert``,
+#: ``verify-cluster-quorum``), not version-numbered filenames. Anchored
+#: start + end: a lowercase letter leads, the remainder is lowercase
+#: letters / digits / hyphens, total length <= 64.
+STEP_ID_PATTERN: Final[re.Pattern[str]] = re.compile(r"^[a-z][a-z0-9\-]{0,63}$")
+
+#: Every ``${...}`` occurrence. The inner group is captured non-greedily
+#: so adjacent substitutions in one string are matched independently. The
+#: capture excludes the braces, so the captured text is the bare path
+#: (``run.target``, ``run.params.foo``).
+_SUBSTITUTION_PATTERN: Final[re.Pattern[str]] = re.compile(r"\$\{([^}]*)\}")
+
+#: The parameter-name grammar inside ``${run.params.X}``. Lowercase
+#: letter or underscore leads; remainder is lowercase letters / digits /
+#: underscores. No dots, so a nested path (``${run.params.X.Y}``) is
+#: rejected -- only one flat param level is allowed.
+_PARAM_NAME_PATTERN: Final[re.Pattern[str]] = re.compile(r"^run\.params\.[a-z_][a-z0-9_]*$")
+
+
+def validate_substitutions(value: object) -> None:
+    """Reject every ``${...}`` pattern except the two allowlisted forms.
+
+    Walks *value* recursively (``str`` / ``dict`` / ``list``) and inspects
+    every ``${...}`` occurrence found in any string. The only accepted
+    patterns are:
+
+    * ``${run.target}`` -- the run's target host / resource.
+    * ``${run.params.X}`` -- a run parameter, where ``X`` matches
+      ``[a-z_][a-z0-9_]*`` (one flat level; no nested ``X.Y``).
+
+    Any other pattern raises :class:`ValueError`. Dict keys are walked as
+    well as values: a substitution smuggled into a key
+    (``{"${evil}": 1}``) is just as dangerous as one in a value.
+
+    The function returns ``None`` on success and is the single sink both
+    this module's template validator (publish time) and G12.3's execution
+    engine (advance time) call -- centralising the allowlist so a future
+    contract change ships in one place.
+    """
+    if isinstance(value, str):
+        for match in _SUBSTITUTION_PATTERN.finditer(value):
+            inner = match.group(1)
+            if inner == "run.target":
+                continue
+            if _PARAM_NAME_PATTERN.match(inner):
+                continue
+            raise ValueError(f"disallowed substitution pattern: {match.group(0)}")
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            validate_substitutions(key)
+            validate_substitutions(item)
+    elif isinstance(value, list):
+        for item in value:
+            validate_substitutions(item)
+    # Scalars other than str (int / float / bool / None) carry no
+    # substitution surface; nothing to walk.
+
+
+class ConfirmVerify(BaseModel):
+    """Operator answers a yes/no prompt; only an affirmative advances.
+
+    The minimal verify shape: MEHO shows :attr:`prompt` to the operator
+    and gates the step on their answer. No structured result, no
+    comparison -- the human is the oracle.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    type: Literal["confirm"]
+    prompt: str
+
+
+class OperationCallVerify(BaseModel):
+    """MEHO dispatches the verify call and matches the result against ``expect``.
+
+    The match is structural-equality + presence only: every key/value in
+    :attr:`expect` must be present and equal in the call result. There are
+    deliberately no operators, no JSONPath, and no boolean composition --
+    substrate minimalism (same call as #1177): determinism over
+    expressivity. :attr:`params` may carry ``${...}`` substitutions
+    (allowlisted at publish time); :attr:`expect` may too.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    type: Literal["operation_call"]
+    op_id: str
+    params: dict[str, object]
+    expect: dict[str, object]
+
+
+#: A step's verify gate -- discriminated on ``type``. Pydantic routes a
+#: payload to :class:`ConfirmVerify` or :class:`OperationCallVerify` by
+#: the ``type`` tag and surfaces an unknown tag as a clean validation
+#: error (no silent fall-through to the first union member).
+Verify = Annotated[
+    ConfirmVerify | OperationCallVerify,
+    Field(discriminator="type"),
+]
+
+
+class OperationCallStep(BaseModel):
+    """A step the agent dispatches via the operation registry.
+
+    :attr:`op_id` is the registry operation id (e.g.
+    ``vmware.composite.vm.create``); :attr:`params` is the call payload,
+    which may contain ``${...}`` substitutions resolved at advance time.
+    :attr:`body` is operator-readable Markdown context (may also contain
+    substitutions). :attr:`verify` gates advance to the next step.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: Annotated[str, Field(pattern=STEP_ID_PATTERN.pattern)]
+    title: str
+    body: str
+    type: Literal["operation_call"]
+    op_id: str
+    params: dict[str, object]
+    verify: Verify
+
+
+class ManualStep(BaseModel):
+    """A step the operator performs off-MEHO (SSH, web UI, console).
+
+    Carries no operation call -- :attr:`body` is the operator-readable
+    instruction (Markdown; may contain ``${...}`` substitutions) and
+    :attr:`verify` gates advance once the operator reports the step done.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: Annotated[str, Field(pattern=STEP_ID_PATTERN.pattern)]
+    title: str
+    body: str
+    type: Literal["manual"]
+    verify: Verify
+
+
+#: One ordered step in a runbook -- discriminated on ``type``. The
+#: ``type`` tag routes a payload to :class:`OperationCallStep` or
+#: :class:`ManualStep`; an unknown tag is a validation error.
+Step = Annotated[
+    OperationCallStep | ManualStep,
+    Field(discriminator="type"),
+]
+
+
+class RunbookTemplateBody(BaseModel):
+    """The author-facing template shape stored in ``runbook_templates.steps``.
+
+    This is what a template author writes and what the G12.2 service
+    layer (T2) serialises into the ``steps`` JSONB column (alongside the
+    ``title`` / ``description`` / ``target_kind`` columns it lifts out).
+    :attr:`steps` is ordered; each step's verify gates advance to the
+    next at run time.
+
+    The :meth:`_validate_step_ids_unique_and_substitutions_allowlisted`
+    validator enforces the two template-level invariants the per-step
+    models cannot see on their own: step-id uniqueness across the
+    template, and the ``${...}`` substitution allowlist over every
+    string the template carries.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    title: str
+    description: str
+    target_kind: str | None = None
+    steps: list[Step]
+
+    @model_validator(mode="after")
+    def _validate_step_ids_unique_and_substitutions_allowlisted(
+        self,
+    ) -> RunbookTemplateBody:
+        """Enforce unique step ids + allowlisted substitutions across the body.
+
+        Raised as :class:`ValueError` so Pydantic renders it as a 422 at
+        the HTTP boundary (matching the
+        :class:`~meho_backplane.scheduler.schemas.ScheduledTriggerCreate`
+        posture). Two invariants:
+
+        1. **Step ids are unique** within the template -- a duplicate id
+           would make run-time step addressing (G12.3) ambiguous.
+        2. **Substitutions are allowlisted** -- every step body, op-call
+           params, verify params, and verify expect is walked recursively
+           and any ``${...}`` pattern other than ``${run.target}`` /
+           ``${run.params.X}`` is rejected (defense in depth; G12.3
+           re-checks at advance time via :func:`validate_substitutions`).
+        """
+        seen: set[str] = set()
+        for step in self.steps:
+            if step.id in seen:
+                raise ValueError(f"duplicate step id: {step.id!r}")
+            seen.add(step.id)
+
+            validate_substitutions(step.body)
+            verify = step.verify
+            if isinstance(step, OperationCallStep):
+                validate_substitutions(step.params)
+            if isinstance(verify, OperationCallVerify):
+                validate_substitutions(verify.params)
+                validate_substitutions(verify.expect)
+        return self
+
+
+class ForkInfo(BaseModel):
+    """Surfaced by ``runbook_edit_template`` when editing a published template forks.
+
+    Editing a *published* template cannot mutate it in place (published
+    templates are immutable); the edit forks a new draft instead. This
+    shape tells the senior what they are forking from -- the source
+    version and how many runs are still pinned to it -- so they can decide
+    whether the fork is the right move.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    slug: str
+    version: int
+    in_flight_run_count: int
+
+
+class DraftTemplateRequest(BaseModel):
+    """Request body for ``runbook_draft_template`` -- create a new draft.
+
+    :attr:`slug` is validated against :data:`SLUG_PATTERN` (the kb slug
+    contract, reused verbatim).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    slug: Annotated[str, Field(pattern=SLUG_PATTERN.pattern)]
+    body: RunbookTemplateBody
+
+
+class DraftTemplateResponse(BaseModel):
+    """Response for ``runbook_draft_template`` -- the created draft's coordinates."""
+
+    model_config = ConfigDict(frozen=True)
+
+    slug: str
+    version: int
+    status: Literal["draft"]
+
+
+class EditTemplateRequest(BaseModel):
+    """Request body for ``runbook_edit_template`` -- edit a draft or fork a publish."""
+
+    model_config = ConfigDict(frozen=True)
+
+    slug: Annotated[str, Field(pattern=SLUG_PATTERN.pattern)]
+    body: RunbookTemplateBody
+
+
+class EditTemplateResponse(BaseModel):
+    """Response for ``runbook_edit_template``.
+
+    :attr:`version` equals the input version when editing a draft in
+    place; it is a new version when forking from a published template, in
+    which case :attr:`forked_from` is populated with the source's
+    :class:`ForkInfo`. On the draft-edit path :attr:`forked_from` is
+    ``None``.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    slug: str
+    version: int
+    status: Literal["draft"]
+    forked_from: ForkInfo | None = None
+
+
+class PublishTemplateRequest(BaseModel):
+    """Request body for ``runbook_publish_template`` -- promote a draft to published."""
+
+    model_config = ConfigDict(frozen=True)
+
+    slug: Annotated[str, Field(pattern=SLUG_PATTERN.pattern)]
+    version: int
+
+
+class PublishTemplateResponse(BaseModel):
+    """Response for ``runbook_publish_template`` -- the now-published coordinates."""
+
+    model_config = ConfigDict(frozen=True)
+
+    slug: str
+    version: int
+    status: Literal["published"]
+
+
+class DeprecateTemplateRequest(BaseModel):
+    """Request body for ``runbook_deprecate_template`` -- retire a published version."""
+
+    model_config = ConfigDict(frozen=True)
+
+    slug: Annotated[str, Field(pattern=SLUG_PATTERN.pattern)]
+    version: int
+
+
+class DeprecateTemplateResponse(BaseModel):
+    """Response for ``runbook_deprecate_template`` -- the now-deprecated coordinates."""
+
+    model_config = ConfigDict(frozen=True)
+
+    slug: str
+    version: int
+    status: Literal["deprecated"]
+
+
+class ListTemplatesFilter(BaseModel):
+    """Optional filters for ``runbook_list_templates``.
+
+    Both fields default to ``None`` (no filter). A bare
+    :class:`ListTemplatesFilter` lists every template the caller can see.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    status: Literal["draft", "published", "deprecated"] | None = None
+    target_kind: str | None = None
+
+
+class TemplateSummary(BaseModel):
+    """Operator-readable summary row surfaced by ``runbook_list_templates``.
+
+    The list-view projection -- enough to identify a template and its
+    lifecycle state without loading the full step list (which
+    :class:`ShowTemplateResponse` carries).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    slug: str
+    version: int
+    title: str
+    status: Literal["draft", "published", "deprecated"]
+    target_kind: str | None
+    edited_at: datetime
+
+
+class ShowTemplateResponse(BaseModel):
+    """Full template surface returned by ``runbook_show_template``.
+
+    The complete template including the ordered :attr:`steps` and the
+    authorship / timestamp provenance. Mirrors the
+    :class:`~meho_backplane.db.models.RunbookTemplate` column set projected
+    to wire types.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    slug: str
+    version: int
+    title: str
+    description: str
+    target_kind: str | None
+    status: Literal["draft", "published", "deprecated"]
+    steps: list[Step]
+    created_by: str
+    created_at: datetime
+    edited_by: str
+    edited_at: datetime

--- a/backend/tests/test_runbooks_schemas.py
+++ b/backend/tests/test_runbooks_schemas.py
@@ -1,0 +1,337 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.runbooks.schemas` (G12.2-T1, #1295).
+
+Coverage matrix:
+
+* Step discriminated union -- both step types parse; an unknown ``type``
+  tag, a missing ``id``, and an id violating :data:`STEP_ID_PATTERN` all
+  reject.
+* Verify discriminated union -- both verify types parse; an unknown
+  ``type`` tag rejects.
+* :func:`validate_substitutions` -- ``${run.target}`` and
+  ``${run.params.X}`` are accepted everywhere a template carries a
+  string (body, op params, verify params, verify expect); every other
+  pattern (``${run.bad}``, nested ``${run.params.X.Y}``, capitalised
+  ``${run.params.WithCaps}``, arbitrary ``${anything_else}``) is rejected
+  with the documented message.
+* :meth:`RunbookTemplateBody._validate_step_ids_unique_and_substitutions_allowlisted`
+  -- duplicate step ids reject.
+* Tool request/response shapes -- the fork-info path on
+  :class:`EditTemplateResponse`, optional filter fields, and a template
+  body round-trip through ``model_dump`` / re-parse with no information
+  loss.
+* The :func:`validate_substitutions` helper is importable for G12.3 reuse.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from meho_backplane.runbooks.schemas import (
+    ConfirmVerify,
+    EditTemplateResponse,
+    ForkInfo,
+    ListTemplatesFilter,
+    ManualStep,
+    OperationCallStep,
+    OperationCallVerify,
+    RunbookTemplateBody,
+    Step,
+    Verify,
+    validate_substitutions,
+)
+
+# A reusable TypeAdapter so the discriminated-union aliases can be
+# exercised standalone (they are type aliases, not BaseModel subclasses).
+_STEP_ADAPTER = TypeAdapter(Step)
+_VERIFY_ADAPTER = TypeAdapter(Verify)
+
+_CONFIRM_VERIFY: dict[str, object] = {"type": "confirm", "prompt": "Did it work?"}
+
+
+# ---------------------------------------------------------------------------
+# Step shape
+# ---------------------------------------------------------------------------
+
+
+def test_operation_call_step_valid() -> None:
+    step = _STEP_ADAPTER.validate_python(
+        {
+            "id": "create-vm",
+            "title": "Create the VM",
+            "body": "Provision the guest.",
+            "type": "operation_call",
+            "op_id": "vmware.composite.vm.create",
+            "params": {"name": "web-01"},
+            "verify": _CONFIRM_VERIFY,
+        }
+    )
+    assert isinstance(step, OperationCallStep)
+    assert step.op_id == "vmware.composite.vm.create"
+    assert isinstance(step.verify, ConfirmVerify)
+
+
+def test_manual_step_valid() -> None:
+    step = _STEP_ADAPTER.validate_python(
+        {
+            "id": "drain-node",
+            "title": "Drain the node",
+            "body": "SSH in and cordon the node.",
+            "type": "manual",
+            "verify": _CONFIRM_VERIFY,
+        }
+    )
+    assert isinstance(step, ManualStep)
+    assert step.id == "drain-node"
+
+
+def test_step_unknown_type_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _STEP_ADAPTER.validate_python(
+            {
+                "id": "x",
+                "title": "t",
+                "body": "b",
+                "type": "magic",
+                "verify": _CONFIRM_VERIFY,
+            }
+        )
+
+
+def test_step_missing_id_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _STEP_ADAPTER.validate_python(
+            {
+                "title": "t",
+                "body": "b",
+                "type": "manual",
+                "verify": _CONFIRM_VERIFY,
+            }
+        )
+
+
+def test_step_id_pattern_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _STEP_ADAPTER.validate_python(
+            {
+                "id": "Has-Caps",
+                "title": "t",
+                "body": "b",
+                "type": "manual",
+                "verify": _CONFIRM_VERIFY,
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# Verify shape
+# ---------------------------------------------------------------------------
+
+
+def test_confirm_verify_valid() -> None:
+    verify = _VERIFY_ADAPTER.validate_python(_CONFIRM_VERIFY)
+    assert isinstance(verify, ConfirmVerify)
+    assert verify.prompt == "Did it work?"
+
+
+def test_operation_call_verify_valid() -> None:
+    verify = _VERIFY_ADAPTER.validate_python(
+        {
+            "type": "operation_call",
+            "op_id": "vmware.vm.power_state",
+            "params": {"vm": "web-01"},
+            "expect": {"power_state": "poweredOn"},
+        }
+    )
+    assert isinstance(verify, OperationCallVerify)
+    assert verify.expect == {"power_state": "poweredOn"}
+
+
+def test_verify_unknown_type_rejected() -> None:
+    with pytest.raises(ValidationError):
+        _VERIFY_ADAPTER.validate_python({"type": "magic", "prompt": "?"})
+
+
+# ---------------------------------------------------------------------------
+# Substitution allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_substitution_allowed() -> None:
+    # ``${run.target}`` and ``${run.params.X}`` surface in every place a
+    # template carries a string: step body, op-call params, verify params,
+    # and verify expect. The model validator must accept all of them.
+    body = RunbookTemplateBody(
+        title="Rotate creds on ${run.target}",
+        description="d",
+        steps=[
+            OperationCallStep(
+                id="rotate",
+                title="Rotate",
+                body="Rotate on ${run.target} for ${run.params.account}",
+                type="operation_call",
+                op_id="vault.kv.rotate",
+                params={"path": "${run.params.secret_path}", "host": "${run.target}"},
+                verify=OperationCallVerify(
+                    type="operation_call",
+                    op_id="vault.kv.read",
+                    params={"path": "${run.params.secret_path}"},
+                    expect={"target": "${run.target}"},
+                ),
+            ),
+        ],
+    )
+    assert body.steps[0].id == "rotate"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "${anything_else}",
+        "${run.bad}",
+        "${run.params.X.Y}",  # nested path -- only one flat level allowed
+        "${run.params.WithCaps}",  # capital letters rejected
+    ],
+)
+def test_substitution_rejected(bad: str) -> None:
+    with pytest.raises(ValueError, match="disallowed substitution pattern"):
+        validate_substitutions(bad)
+
+    # And the same pattern is rejected when reached through a template
+    # body (the publish-time defense-in-depth path).
+    with pytest.raises(ValidationError, match="disallowed substitution pattern"):
+        RunbookTemplateBody(
+            title="t",
+            description="d",
+            steps=[
+                ManualStep(
+                    id="s1",
+                    title="t",
+                    body=f"do {bad}",
+                    type="manual",
+                    verify=ConfirmVerify(type="confirm", prompt="ok?"),
+                ),
+            ],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Template-body invariants
+# ---------------------------------------------------------------------------
+
+
+def test_step_ids_must_be_unique() -> None:
+    with pytest.raises(ValidationError, match="duplicate step id"):
+        RunbookTemplateBody(
+            title="t",
+            description="d",
+            steps=[
+                ManualStep(
+                    id="dup",
+                    title="a",
+                    body="b",
+                    type="manual",
+                    verify=ConfirmVerify(type="confirm", prompt="?"),
+                ),
+                ManualStep(
+                    id="dup",
+                    title="c",
+                    body="d",
+                    type="manual",
+                    verify=ConfirmVerify(type="confirm", prompt="?"),
+                ),
+            ],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tool request / response shapes
+# ---------------------------------------------------------------------------
+
+
+def test_fork_info_response_shape() -> None:
+    forked = EditTemplateResponse(
+        slug="drain-node",
+        version=2,
+        status="draft",
+        forked_from=ForkInfo(slug="drain-node", version=1, in_flight_run_count=3),
+    )
+    assert forked.forked_from is not None
+    assert forked.forked_from.in_flight_run_count == 3
+
+    draft_edit = EditTemplateResponse(slug="drain-node", version=1, status="draft")
+    assert draft_edit.forked_from is None
+
+
+def test_list_templates_filter_optional_fields() -> None:
+    assert ListTemplatesFilter().status is None
+    assert ListTemplatesFilter().target_kind is None
+
+    filtered = ListTemplatesFilter(status="published", target_kind="k8s")
+    assert filtered.status == "published"
+    assert filtered.target_kind == "k8s"
+
+
+def test_template_body_roundtrip() -> None:
+    body = RunbookTemplateBody(
+        title="Drain a node",
+        description="Cordon, drain, verify empty.",
+        target_kind="k8s",
+        steps=[
+            ManualStep(
+                id="cordon",
+                title="Cordon",
+                body="kubectl cordon ${run.target}",
+                type="manual",
+                verify=ConfirmVerify(type="confirm", prompt="Cordoned?"),
+            ),
+            OperationCallStep(
+                id="verify-empty",
+                title="Verify empty",
+                body="Check no pods remain.",
+                type="operation_call",
+                op_id="k8s.node.pod_count",
+                params={"node": "${run.target}"},
+                verify=OperationCallVerify(
+                    type="operation_call",
+                    op_id="k8s.node.pod_count",
+                    params={"node": "${run.target}"},
+                    expect={"count": 0},
+                ),
+            ),
+        ],
+    )
+
+    dumped = body.model_dump()
+    reparsed = RunbookTemplateBody.model_validate(dumped)
+    assert reparsed == body
+
+
+def test_validate_substitutions_helper_exported() -> None:
+    # G12.3 reuses this helper at advance time -- the import must work and
+    # the function must accept the allowlisted forms without raising.
+    from meho_backplane.runbooks.schemas import validate_substitutions as imported
+
+    imported("${run.target}")
+    imported({"k": ["${run.params.foo}", 1, None]})
+
+
+def test_datetime_carrying_response_parses() -> None:
+    # Sanity: the datetime-bearing summary/show shapes parse a tz-aware
+    # value (the column type the G12.2 service lifts from the model).
+    from meho_backplane.runbooks.schemas import TemplateSummary
+
+    summary = TemplateSummary(
+        slug="drain-node",
+        version=1,
+        title="Drain a node",
+        status="published",
+        target_kind=None,
+        edited_at=datetime.now(UTC),
+    )
+    assert summary.target_kind is None


### PR DESCRIPTION
## Summary
- Lands `backend/src/meho_backplane/runbooks/schemas.py` — the Pydantic v2 shape contract for the G12.2 template lifecycle. Pure types: no service logic, no routes, no tools.
- Step shape is a discriminated union on `type` (`operation_call` | `manual`), each step carrying a `verify` discriminated union on `type` (`confirm` | `operation_call`). The discriminated-union + `model_validator(mode="after")` posture mirrors `ScheduledTriggerCreate` so a malformed body surfaces as a clean 422 at the HTTP boundary.
- `validate_substitutions()` is module-level and exported: it walks a value recursively and rejects every `${...}` pattern except `${run.target}` and `${run.params.X}` (X matching `[a-z_][a-z0-9_]*`). G12.3 reuses it at advance time (defense in depth). The template validator also enforces step-id uniqueness.
- `slug` validation imports `SLUG_PATTERN` from `kb.schemas` verbatim (no redefinition); step ids use the tighter `STEP_ID_PATTERN`. Every model is `ConfigDict(frozen=True)`; `__all__` is alphabetical and complete.

## Test plan
- [x] `ruff check src/meho_backplane/runbooks/ tests/test_runbooks_schemas.py` — clean
- [x] `ruff format --check` — clean (3 files already formatted)
- [x] `mypy src/meho_backplane/runbooks/schemas.py` — clean
- [x] `pytest tests/test_runbooks_schemas.py -v` — 19 passed (covers all 14 specified cases + datetime-bearing summary)
- [x] code-quality hook (`--diff`) — 0 blockers, 1 warning (schemas.py 450 lines, under 600 block threshold)
- [x] Both step types + both verify types parse; unknown `type` tags, missing `id`, bad-pattern `id` all reject
- [x] `${run.target}` / `${run.params.X}` accepted in body / op params / verify params / verify expect; `${run.bad}`, nested `${run.params.X.Y}`, capitalised, and arbitrary patterns rejected
- [x] Duplicate step ids reject; fork-info path + optional filter fields + template-body round-trip verified; `validate_substitutions` importable for G12.3

## Out of scope
- Service layer (T2), REST routes (T3), MCP tools (T4), multi-session drafting docs (T5).
- Substitution at advance time (G12.3 reuses the helper; engine out of scope here).
- Run-side schemas (`StartRunRequest`, etc.) — G12.3 ships its own module.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1295


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced runbook templates with versioned procedures and step-based execution.
  * Added support for multiple step types with configurable verification gates.
  * Enabled template lifecycle management (draft, publish, deprecate) and editing capabilities.
  * Implemented validation for template structure and parameter substitutions.

* **Tests**
  * Added comprehensive test coverage for runbook schema validation and template operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->