### PR TITLE
fix(connectors): G0.17-T1 k8s list-op request-shape parity — converge event/service/ingress/configmap onto pod.list shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,23 @@ connector-related release-notes line.
 
 ### Changed
 
+- **K8s connector list-op request-shape parity — `event` / `service` /
+  `ingress` / `configmap` `.list` adopt the `pod.list` input shape
+  (G0.17-T1 #1330, RDC #771 Finding 24).** Every namespaced list op
+  on the K8s connector now accepts `namespace` XOR `all_namespaces`
+  plus `label_selector`, so the operator's "show me all Warning
+  events cluster-wide" / "what argocd-labeled services exist across
+  the cluster?" question maps to a single
+  `{all_namespaces: true, ...}` call instead of an N-namespace
+  client-side loop. The `all_namespaces=true` path routes through
+  `CoreV1Api.list_X_for_all_namespaces` /
+  `NetworkingV1Api.list_ingress_for_all_namespaces`. Backward-compatible:
+  existing `{namespace: <X>}` calls keep working unchanged. Anchors
+  the new §10 in
+  [`docs/codebase/api-shape-conventions.md`](docs/codebase/api-shape-conventions.md)
+  (intra-connector list-op request-shape parity). Server-side `limit`
+  + `continue_token` paging on service / ingress / configmap deferred
+  as a follow-up.
 - `POST /api/v1/connectors/ingest` defaults to `async=true` and returns
   `202 Accepted` + a job handle on the non-dry-run path; operators poll
   `GET /api/v1/connectors/ingest/jobs/{job_id}` for completion.

--- a/backend/src/meho_backplane/connectors/kubernetes/connector.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/connector.py
@@ -548,23 +548,36 @@ class KubernetesConnector(Connector):
         target: KubernetesTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
-        """List services in a namespace -- name / type / cluster_ip / ports / selector.
+        """List services per-namespace or cluster-wide.
 
-        Op-id: ``k8s.service.list``. Wraps
-        ``CoreV1Api.list_namespaced_service(namespace)`` and projects
-        each :class:`V1Service` through
+        Op-id: ``k8s.service.list``. Branches on ``all_namespaces``
+        between ``CoreV1Api.list_namespaced_service(namespace, ...)``
+        and ``CoreV1Api.list_service_for_all_namespaces(...)``
+        (G0.17-T1 #1330) and projects each :class:`V1Service` through
         :func:`~meho_backplane.connectors.kubernetes.ops_network.service_row`.
-        The helper is pure so the unit suite pins the wire shape against
-        synthetic fixtures without booting an event loop.
+        The helper is pure so the unit suite pins the wire shape
+        against synthetic fixtures without booting an event loop.
+        Forwards ``label_selector`` verbatim to the API.
 
         ``operator`` is forwarded to :meth:`_get_api_client`; see
         :meth:`about` for the threading rationale.
         """
         from meho_backplane.connectors.kubernetes.ops_network import service_row
 
+        namespace: str | None = params.get("namespace")
+        all_namespaces = bool(params.get("all_namespaces", False))
+        label_selector = params.get("label_selector")
         api_client = await self._get_api_client(target, operator)
         core_v1 = client.CoreV1Api(api_client)
-        resp = await core_v1.list_namespaced_service(namespace=params["namespace"])
+        kwargs: dict[str, Any] = {}
+        if label_selector:
+            kwargs["label_selector"] = label_selector
+        if all_namespaces:
+            resp = await core_v1.list_service_for_all_namespaces(**kwargs)
+        else:
+            # Schema enforces XOR; ``or ""`` is defensive against a
+            # future schema relaxation.
+            resp = await core_v1.list_namespaced_service(namespace=namespace or "", **kwargs)
         rows = [service_row(s) for s in resp.items]
         return {"rows": rows, "total": len(rows)}
 
@@ -574,21 +587,33 @@ class KubernetesConnector(Connector):
         target: KubernetesTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
-        """List ingresses in a namespace -- class / hosts / TLS hosts / rules.
+        """List ingresses per-namespace or cluster-wide.
 
-        Op-id: ``k8s.ingress.list``. Wraps
-        ``NetworkingV1Api.list_namespaced_ingress(namespace)`` and
-        projects each :class:`V1Ingress` through
+        Op-id: ``k8s.ingress.list``. Branches on ``all_namespaces``
+        between
+        ``NetworkingV1Api.list_namespaced_ingress(namespace, ...)``
+        and ``NetworkingV1Api.list_ingress_for_all_namespaces(...)``
+        (G0.17-T1 #1330) and projects each :class:`V1Ingress` through
         :func:`~meho_backplane.connectors.kubernetes.ops_network.ingress_row`.
+        Forwards ``label_selector`` verbatim to the API.
 
         ``operator`` is forwarded to :meth:`_get_api_client`; see
         :meth:`about` for the threading rationale.
         """
         from meho_backplane.connectors.kubernetes.ops_network import ingress_row
 
+        namespace: str | None = params.get("namespace")
+        all_namespaces = bool(params.get("all_namespaces", False))
+        label_selector = params.get("label_selector")
         api_client = await self._get_api_client(target, operator)
         networking_v1 = client.NetworkingV1Api(api_client)
-        resp = await networking_v1.list_namespaced_ingress(namespace=params["namespace"])
+        kwargs: dict[str, Any] = {}
+        if label_selector:
+            kwargs["label_selector"] = label_selector
+        if all_namespaces:
+            resp = await networking_v1.list_ingress_for_all_namespaces(**kwargs)
+        else:
+            resp = await networking_v1.list_namespaced_ingress(namespace=namespace or "", **kwargs)
         rows = [ingress_row(i) for i in resp.items]
         return {"rows": rows, "total": len(rows)}
 
@@ -598,24 +623,38 @@ class KubernetesConnector(Connector):
         target: KubernetesTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
-        """List configmaps in a namespace -- **keys only, no values**.
+        """List configmaps per-namespace or cluster-wide -- **keys only, no values**.
 
-        Op-id: ``k8s.configmap.list``. Wraps
-        ``CoreV1Api.list_namespaced_config_map(namespace)`` and projects
-        each :class:`V1ConfigMap` through
+        Op-id: ``k8s.configmap.list``. Branches on ``all_namespaces``
+        between
+        ``CoreV1Api.list_namespaced_config_map(namespace, ...)`` and
+        ``CoreV1Api.list_config_map_for_all_namespaces(...)``
+        (G0.17-T1 #1330) and projects each :class:`V1ConfigMap`
+        through
         :func:`~meho_backplane.connectors.kubernetes.ops_config.configmap_list_row`,
         which deliberately omits ``data`` / ``binary_data`` values.
+        The privacy contract holds identically across both paths.
         Operators wanting values call ``k8s.configmap.info`` per
         configmap so the audit row records the targeted read.
+        Forwards ``label_selector`` verbatim to the API.
 
         ``operator`` is forwarded to :meth:`_get_api_client`; see
         :meth:`about` for the threading rationale.
         """
         from meho_backplane.connectors.kubernetes.ops_config import configmap_list_row
 
+        namespace: str | None = params.get("namespace")
+        all_namespaces = bool(params.get("all_namespaces", False))
+        label_selector = params.get("label_selector")
         api_client = await self._get_api_client(target, operator)
         core_v1 = client.CoreV1Api(api_client)
-        resp = await core_v1.list_namespaced_config_map(namespace=params["namespace"])
+        kwargs: dict[str, Any] = {}
+        if label_selector:
+            kwargs["label_selector"] = label_selector
+        if all_namespaces:
+            resp = await core_v1.list_config_map_for_all_namespaces(**kwargs)
+        else:
+            resp = await core_v1.list_namespaced_config_map(namespace=namespace or "", **kwargs)
         rows = [configmap_list_row(cm) for cm in resp.items]
         return {"rows": rows, "total": len(rows)}
 
@@ -652,12 +691,17 @@ class KubernetesConnector(Connector):
         target: KubernetesTargetLike,
         params: dict[str, Any],
     ) -> dict[str, Any]:
-        """List events in a namespace, sorted most-recent-first, truncated to ``limit``.
+        """List events most-recent-first, truncated to ``limit``; per-namespace or cluster-wide.
 
-        Op-id: ``k8s.event.list``. Wraps
-        ``CoreV1Api.list_namespaced_event(namespace, field_selector=..., limit=...)``
-        and projects each :class:`CoreV1Event` through
+        Op-id: ``k8s.event.list``. Branches on ``all_namespaces``
+        between ``CoreV1Api.list_namespaced_event(namespace, ...)``
+        (default) and ``CoreV1Api.list_event_for_all_namespaces(...)``
+        (G0.17-T1 #1330 -- the cluster-wide
+        ``kubectl get events -A`` operator question) and projects each
+        :class:`CoreV1Event` through
         :func:`~meho_backplane.connectors.kubernetes.ops_events.event_row`.
+        Per-row ``namespace`` already flows through ``event_row`` so
+        cross-namespace results stay distinguishable.
 
         The K8s API server returns events in resource-version order
         (creation order), **not** last-seen order, and offers no
@@ -678,9 +722,10 @@ class KubernetesConnector(Connector):
         client-side to the caller's ``limit``. The cap is set in
         :mod:`ops_events` (currently 500) at the same operator-ergonomic
         ceiling the schema's ``maximum`` enforces; above that the
-        operator is better served by a ``field_selector`` than by a
-        bigger result set (the K8s API itself paginates above ~1k
-        items per response in most deployments).
+        operator is better served by a ``field_selector`` /
+        ``label_selector`` than by a bigger result set (the K8s API
+        itself paginates above ~1k items per response in most
+        deployments).
         """
         from meho_backplane.connectors.kubernetes.ops_events import (
             DEFAULT_EVENT_LIMIT,
@@ -689,7 +734,8 @@ class KubernetesConnector(Connector):
             sort_event_rows_recent_first,
         )
 
-        namespace = params["namespace"]
+        namespace: str | None = params.get("namespace")
+        all_namespaces = bool(params.get("all_namespaces", False))
         limit = int(params.get("limit", DEFAULT_EVENT_LIMIT))
         # Defence in depth: the schema's ``maximum`` already enforces
         # the cap. Keep the explicit clamp so a future schema relaxation
@@ -698,6 +744,7 @@ class KubernetesConnector(Connector):
         if limit > MAX_EVENT_LIMIT:
             limit = MAX_EVENT_LIMIT
         field_selector = params.get("field_selector")
+        label_selector = params.get("label_selector")
 
         api_client = await self._get_api_client(target, operator)
         core_v1 = client.CoreV1Api(api_client)
@@ -705,10 +752,19 @@ class KubernetesConnector(Connector):
         # sort sees the full recency-relevant superset; the caller's
         # ``limit`` truncates after the sort. See the docstring above
         # for the ordering rationale.
-        kwargs: dict[str, Any] = {"namespace": namespace, "limit": MAX_EVENT_LIMIT}
+        kwargs: dict[str, Any] = {"limit": MAX_EVENT_LIMIT}
         if field_selector:
             kwargs["field_selector"] = field_selector
-        resp = await core_v1.list_namespaced_event(**kwargs)
+        if label_selector:
+            kwargs["label_selector"] = label_selector
+        if all_namespaces:
+            resp = await core_v1.list_event_for_all_namespaces(**kwargs)
+        else:
+            # Schema enforces exactly-one-of (namespace, all_namespaces);
+            # the ``or ""`` cast is defensive against a future schema
+            # relaxation that would otherwise crash with a TypeError
+            # from kubernetes_asyncio.
+            resp = await core_v1.list_namespaced_event(namespace=namespace or "", **kwargs)
         rows = [event_row(e) for e in resp.items]
         sorted_rows = sort_event_rows_recent_first(rows)
         truncated = sorted_rows[:limit]

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_config.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_config.py
@@ -4,24 +4,40 @@
 """Config ops -- ``k8s.configmap.list/info``.
 
 G3.2-T4 (#324) of Initiative #320. Two read-only "what's configured?"
-ops layered on top of the T1 / T2 / T5 base substrate:
+ops layered on top of the T1 / T2 / T5 base substrate. G0.17-T1
+(#1330) converged ``k8s.configmap.list``'s request shape onto the
+workload list ops' base (``namespace`` XOR ``all_namespaces`` +
+``label_selector``); ``.info`` stays per-configmap because the
+targeted-read audit semantics are unchanged.
 
-* ``k8s.configmap.list [--namespace X]`` -- ``CoreV1Api.list_namespaced_config_map``.
+* ``k8s.configmap.list [--namespace X | --all-namespaces]
+  [--label-selector ...]`` --
+  ``CoreV1Api.list_namespaced_config_map`` (per-namespace) /
+  ``CoreV1Api.list_config_map_for_all_namespaces`` (cluster-wide).
   Per-row shape carries ``keys`` (the configmap's data keys) **but
-  never the values**. The split is privacy-relevant: configmaps in the
-  wild often blur into sensitive territory (registry credentials in
-  ``imagePullSecrets``-adjacent maps, OIDC client secrets in
+  never the values**. The split is privacy-relevant: configmaps in
+  the wild often blur into sensitive territory (registry credentials
+  in ``imagePullSecrets``-adjacent maps, OIDC client secrets in
   ``argocd-cm``, vendor licence keys), and the operator's list view
   should not bulk-broadcast the bytes through the SSE feed during a
-  routine "what's configured here?" scan. Operators wanting values
-  call ``.info`` per configmap so the audit row records the targeted
-  read instead of the bulk dump.
+  routine "what's configured here?" scan. The privacy contract holds
+  identically across the namespace and all_namespaces paths --
+  values are emitted by neither. Operators wanting values call
+  ``.info`` per configmap so the audit row records the targeted read
+  instead of the bulk dump.
 
 * ``k8s.configmap.info <name> --namespace X`` -- ``CoreV1Api.read_namespaced_config_map``.
   Returns the full configmap, including ``data`` and ``binary_data``.
   Carries ``op_class=read`` for v0.2; G6.3 may upgrade specific
   configmap patterns (managed-by ``secret-translator``, names matching
-  ``*-secret-config``) to a ``sensitive-read`` audit classifier.
+  ``*-secret-config``) to a ``sensitive-read`` audit classifier. The
+  info op is intentionally not cross-namespace -- the audit row
+  needs a single (name, namespace) tuple to record.
+
+Server-side ``limit`` / ``_continue`` paging is **deliberately not
+exposed** on ``configmap.list`` in G0.17-T1 -- configmap populations
+are typically O(10) per namespace and the issue's acceptance section
+calls out the paging widening as a follow-up candidate.
 
 Row-shape helpers (:func:`configmap_list_row`, :func:`configmap_info`)
 are pure functions over :mod:`kubernetes_asyncio.client.models`
@@ -34,8 +50,10 @@ under the 600-line code-quality cap.
 
 References
 ----------
-* Parent task: G3.2-T4 (#324).
+* Parent task: G3.2-T4 (#324); request-shape parity: G0.17-T1 (#1330).
 * Parent Initiative: G3.2 (#320), kubernetes-asyncio typed connector.
+* Conventions doc: ``docs/codebase/api-shape-conventions.md`` §10
+  (intra-connector list-op request-shape parity).
 * k8s ConfigMap API: https://kubernetes.io/docs/reference/kubernetes-api/config-and-storage-resources/config-map-v1/
 * ``kubernetes_asyncio.CoreV1Api``:
   https://github.com/tomplus/kubernetes_asyncio/blob/master/kubernetes_asyncio/docs/CoreV1Api.md
@@ -48,6 +66,12 @@ from typing import TYPE_CHECKING, Any
 
 from meho_backplane.connectors.kubernetes.ops import KubernetesOp
 from meho_backplane.connectors.kubernetes.ops_core import age_seconds
+from meho_backplane.connectors.kubernetes.ops_listparams import (
+    ALL_NAMESPACES_PARAM,
+    LABEL_SELECTOR_PARAM,
+    NAMESPACE_PARAM,
+    NAMESPACE_XOR_ALL_NAMESPACES,
+)
 
 if TYPE_CHECKING:
     from kubernetes_asyncio.client.models import V1ConfigMap
@@ -154,20 +178,29 @@ def configmap_info(
 # ---------------------------------------------------------------------------
 
 
-_NAMESPACE_PARAM_SCHEMA: dict[str, Any] = {
+#: Tighter ``namespace`` shape for the per-resource ``.info`` op:
+#: still single-namespace + non-empty + non-whitespace. The
+#: ``oneOf`` machinery applies only to the list op.
+_INFO_NAMESPACE_PARAM_SCHEMA: dict[str, Any] = {
     "type": "string",
     "minLength": 1,
     "pattern": r"\S",
-    "description": "Namespace to list within.",
+    "description": "Namespace to read within.",
 }
 
 
+#: ``k8s.configmap.list`` parameter schema. Adopts the shared
+#: ``namespace`` XOR ``all_namespaces`` selector + ``label_selector``
+#: (G0.17-T1 #1330). The privacy contract (no values emitted) holds
+#: across both the namespace and the all_namespaces paths.
 K8S_CONFIGMAP_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
-        "namespace": _NAMESPACE_PARAM_SCHEMA,
+        "namespace": NAMESPACE_PARAM,
+        "all_namespaces": ALL_NAMESPACES_PARAM,
+        "label_selector": LABEL_SELECTOR_PARAM,
     },
-    "required": ["namespace"],
+    "oneOf": NAMESPACE_XOR_ALL_NAMESPACES,
     "additionalProperties": False,
 }
 
@@ -198,20 +231,31 @@ K8S_CONFIGMAP_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
 
 K8S_CONFIGMAP_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
     "when_to_use": (
-        "Call when the operator asks 'what configmaps are in <namespace>?' "
-        "or needs to discover configmap names + the set of keys each one "
-        "exposes -- WITHOUT exposing values to the audit/broadcast feed. "
-        "For full data, follow up with k8s.configmap.info per "
-        "configmap (the targeted read records a per-configmap audit row)."
+        "Call when the operator asks 'what configmaps are in "
+        "<namespace>?' or needs to discover configmap names + the set "
+        "of keys each one exposes -- WITHOUT exposing values to the "
+        "audit/broadcast feed. Use ``all_namespaces=true`` for the "
+        "cluster-wide variant. For full data, follow up with "
+        "k8s.configmap.info per configmap (the targeted read records "
+        "a per-configmap audit row)."
     ),
     "parameter_hints": {
-        "namespace": ("Required. The Kubernetes namespace whose configmaps to list."),
+        "namespace": "Required unless ``all_namespaces`` is true.",
+        "all_namespaces": (
+            "Pass true for cluster-wide listings; mutually exclusive with ``namespace``."
+        ),
+        "label_selector": (
+            "Optional. k8s label-selector syntax (e.g. "
+            "``managed-by=helm``, ``app in (argocd,traefik)``)."
+        ),
     },
     "output_shape": (
         "{'rows': [{name, namespace, keys, age_seconds}], 'total': <int>}. "
         "``keys`` is the sorted union of ``data`` + ``binary_data`` keys. "
         "Values are NEVER included in this op; call k8s.configmap.info "
-        "to read them."
+        "to read them. Each row carries its own ``namespace`` so "
+        "cross-namespace rows under ``all_namespaces=true`` stay "
+        "distinguishable."
     ),
 }
 
@@ -225,7 +269,7 @@ K8S_CONFIGMAP_INFO_PARAMETER_SCHEMA: dict[str, Any] = {
             "pattern": r"\S",
             "description": "Configmap name (exact match; no prefix resolution).",
         },
-        "namespace": _NAMESPACE_PARAM_SCHEMA,
+        "namespace": _INFO_NAMESPACE_PARAM_SCHEMA,
     },
     "required": ["name", "namespace"],
     "additionalProperties": False,
@@ -283,16 +327,20 @@ CONFIG_OPS: tuple[KubernetesOp, ...] = (
     KubernetesOp(
         op_id="k8s.configmap.list",
         handler_attr="k8s_configmap_list",
-        summary="List configmaps in a namespace -- keys only, NO values.",
+        summary=("List configmaps per-namespace or cluster-wide -- keys only, NO values."),
         description=(
-            "Calls ``CoreV1Api.list_namespaced_config_map(namespace)`` "
-            "and projects each ConfigMap into {name, namespace, keys, "
-            "age_seconds}. ``keys`` is the sorted union of ``data`` "
-            "and ``binary_data`` keys. Values are **never** included -- "
-            "the list op is the privacy-safe entry point; operators "
-            "that need values call ``k8s.configmap.info`` per "
-            "configmap so the audit row records the targeted read "
-            "instead of the bulk dump. Read-only."
+            "Calls "
+            "``CoreV1Api.list_namespaced_config_map(namespace, ...)`` "
+            "(per-namespace) or "
+            "``CoreV1Api.list_config_map_for_all_namespaces(...)`` "
+            "(``all_namespaces=true``) and projects each ConfigMap "
+            "into {name, namespace, keys, age_seconds}. ``keys`` is "
+            "the sorted union of ``data`` and ``binary_data`` keys. "
+            "Values are **never** included -- the list op is the "
+            "privacy-safe entry point; operators that need values "
+            "call ``k8s.configmap.info`` per configmap so the audit "
+            "row records the targeted read instead of the bulk dump. "
+            "``label_selector`` is forwarded server-side. Read-only."
         ),
         parameter_schema=K8S_CONFIGMAP_LIST_PARAMETER_SCHEMA,
         response_schema=K8S_CONFIGMAP_LIST_RESPONSE_SCHEMA,

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_events.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_events.py
@@ -4,15 +4,27 @@
 """Observability ops -- ``k8s.event.list``.
 
 G3.2-T4 (#324) of Initiative #320. The "what's recently happened?"
-read-only op layered on top of the T1 / T2 / T5 base substrate:
+read-only op layered on top of the T1 / T2 / T5 base substrate.
+G0.17-T1 (#1330) converged the request shape onto the workload list
+ops' base (``namespace`` XOR ``all_namespaces`` + ``label_selector``)
+so the operator's "show me all Warning events cluster-wide" question
+maps to a single ``{all_namespaces: true, field_selector: 'type=Warning'}``
+call instead of an N-namespace client-side loop.
 
-* ``k8s.event.list [--namespace X] [--field-selector ...] [--limit N]`` --
-  ``CoreV1Api.list_namespaced_event``. Returns recent events ordered
-  most-recent-first (descending ``last_seen``). Default ``limit=50``;
-  ``--field-selector`` is forwarded verbatim to the K8s API so the
-  operator can apply server-side filters like
-  ``type=Warning,involvedObject.kind=Pod`` without the connector
-  re-encoding the syntax.
+* ``k8s.event.list [--namespace X | --all-namespaces]
+  [--label-selector ...] [--field-selector ...] [--limit N]`` --
+  ``CoreV1Api.list_namespaced_event`` (per-namespace) /
+  ``CoreV1Api.list_event_for_all_namespaces`` (cluster-wide). Returns
+  recent events ordered most-recent-first (descending ``last_seen``).
+  Default ``limit=50``; ``--field-selector`` and ``--label-selector``
+  are forwarded verbatim to the K8s API so the operator can apply
+  server-side filters like ``type=Warning,involvedObject.kind=Pod``
+  without the connector re-encoding the syntax.
+
+The op deliberately omits ``continue_token`` -- unlike pod / deployment
+list, the most-recent-first contract means paging is expressed as
+"narrow the ``field_selector``", not "walk a cursor". The omission is
+documented on :data:`K8S_EVENT_LIST_PAGINATION_HINT`.
 
 The event surface lives in its own module (rather than alongside the
 configmap ops in :mod:`ops_config`) for two reasons:
@@ -35,8 +47,10 @@ fixtures without booting an event loop.
 
 References
 ----------
-* Parent task: G3.2-T4 (#324).
+* Parent task: G3.2-T4 (#324); request-shape parity: G0.17-T1 (#1330).
 * Parent Initiative: G3.2 (#320), kubernetes-asyncio typed connector.
+* Conventions doc: ``docs/codebase/api-shape-conventions.md`` §10
+  (intra-connector list-op request-shape parity).
 * k8s Event API: https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/
 * ``kubernetes_asyncio.CoreV1Api``:
   https://github.com/tomplus/kubernetes_asyncio/blob/master/kubernetes_asyncio/docs/CoreV1Api.md
@@ -49,6 +63,13 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from meho_backplane.connectors.kubernetes.ops import KubernetesOp
+from meho_backplane.connectors.kubernetes.ops_listparams import (
+    ALL_NAMESPACES_PARAM,
+    FIELD_SELECTOR_PARAM,
+    LABEL_SELECTOR_PARAM,
+    NAMESPACE_PARAM,
+    NAMESPACE_XOR_ALL_NAMESPACES,
+)
 
 if TYPE_CHECKING:
     from kubernetes_asyncio.client.models import CoreV1Event
@@ -241,22 +262,23 @@ def sort_event_rows_recent_first(
 # ---------------------------------------------------------------------------
 
 
-_NAMESPACE_PARAM_SCHEMA: dict[str, Any] = {
-    "type": "string",
-    "minLength": 1,
-    "pattern": r"\S",
-    "description": "Namespace to list within.",
-}
-
-
+#: ``k8s.event.list`` parameter schema. Adopts the shared
+#: ``namespace`` XOR ``all_namespaces`` namespace selector (G0.17-T1
+#: #1330) and the ``label_selector`` forwarding knob. Keeps the
+#: event-specific ``field_selector`` example wording and the bounded
+#: ``limit`` with its event-tuned ``default`` + ``maximum``. The
+#: ``continue_token`` knob is **deliberately omitted** -- the
+#: handler's client-side recency-sort + truncation contract
+#: supersedes server-side paging here; see
+#: :data:`K8S_EVENT_LIST_PAGINATION_HINT`.
 K8S_EVENT_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
-        "namespace": _NAMESPACE_PARAM_SCHEMA,
+        "namespace": NAMESPACE_PARAM,
+        "all_namespaces": ALL_NAMESPACES_PARAM,
+        "label_selector": LABEL_SELECTOR_PARAM,
         "field_selector": {
-            "type": "string",
-            "minLength": 1,
-            "pattern": r"\S",
+            **FIELD_SELECTOR_PARAM,
             "description": (
                 "K8s field selector forwarded server-side. "
                 "Examples: 'type=Warning', "
@@ -277,7 +299,7 @@ K8S_EVENT_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
             ),
         },
     },
-    "required": ["namespace"],
+    "oneOf": NAMESPACE_XOR_ALL_NAMESPACES,
     "additionalProperties": False,
 }
 
@@ -334,10 +356,14 @@ K8S_EVENT_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
 #: ``k8s.event.list`` does not surface a server-side ``_continue``
 #: token through this connector -- ``limit`` truncates the
 #: most-recent-first sort, so paging across older events is done by
-#: narrowing ``field_selector`` (event type / involved object / source
-#: component) rather than walking a cursor. G0.15-T8 (#1219). The hint
-#: documents that contract so consumers don't reach for
-#: ``continue_token`` here as they would on pod / deployment lists.
+#: narrowing ``field_selector`` / ``label_selector`` (event type /
+#: involved object / source component / labels on the involved object)
+#: rather than walking a cursor. G0.15-T8 (#1219). The hint documents
+#: that contract so consumers don't reach for ``continue_token`` here
+#: as they would on pod / deployment lists; the curated
+#: ``example_next_call`` is a cluster-wide warning sweep (G0.17-T1
+#: #1330) -- the canonical motivating operator question for the
+#: ``all_namespaces`` knob.
 K8S_EVENT_LIST_PAGINATION_HINT: dict[str, Any] = {
     "params": {
         "field_selector": (
@@ -347,7 +373,16 @@ K8S_EVENT_LIST_PAGINATION_HINT: dict[str, Any] = {
             "'source.component=<controller>'. Multiple filters "
             "comma-separated."
         ),
+        "label_selector": (
+            "K8s label-selector string applied to the event's own "
+            "metadata.labels (events typically inherit labels from "
+            "the involved object). Forwarded server-side."
+        ),
         "namespace": "Switch to a different namespace's event feed.",
+        "all_namespaces": (
+            "List events across every namespace the kubeconfig can "
+            "read; mutually exclusive with ``namespace``."
+        ),
         "limit": (
             f"Cap rows per response (default {DEFAULT_EVENT_LIMIT}, "
             f"capped at {MAX_EVENT_LIMIT}). Sort + truncate keeps the "
@@ -359,7 +394,7 @@ K8S_EVENT_LIST_PAGINATION_HINT: dict[str, Any] = {
         "args": {
             "op_id": "k8s.event.list",
             "params": {
-                "namespace": "kube-system",
+                "all_namespaces": True,
                 "field_selector": "type=Warning",
                 "limit": 50,
             },
@@ -370,14 +405,26 @@ K8S_EVENT_LIST_PAGINATION_HINT: dict[str, Any] = {
 
 K8S_EVENT_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
     "when_to_use": (
-        "Call when the operator asks 'what's recently happened in "
-        "<namespace>?', 'why did this pod restart?', or 'are there "
-        "any warnings?'. Rows are sorted most-recent-first; pair with "
-        "``field_selector='type=Warning'`` to scope the answer to "
-        "operator-actionable signals."
+        "Call when the operator asks 'what's recently happened?', "
+        "'why did this pod restart?', or 'are there any warnings?'. "
+        "Rows are sorted most-recent-first; pair with "
+        "``field_selector='type=Warning'`` to scope to operator-"
+        "actionable signals. Use ``all_namespaces=true`` for the "
+        "cluster-wide 'kubectl get events -A' question; use "
+        "``namespace=<X>`` to scope to one namespace."
     ),
     "parameter_hints": {
-        "namespace": ("Required. The Kubernetes namespace whose events to list."),
+        "namespace": "Required unless ``all_namespaces`` is true.",
+        "all_namespaces": (
+            "Pass true for cluster-wide event listings (the "
+            "'kubectl get events -A' question); mutually exclusive "
+            "with ``namespace``."
+        ),
+        "label_selector": (
+            "Optional. K8s label-selector syntax (e.g. "
+            "``app=argocd-server``, ``app in (frontend,backend)``); "
+            "forwarded server-side."
+        ),
         "field_selector": (
             "Optional. K8s field-selector string forwarded server-side "
             "(e.g. 'type=Warning', 'involvedObject.kind=Pod'). Multiple "
@@ -395,7 +442,9 @@ K8S_EVENT_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
         "first_seen_seconds, last_seen_seconds}], 'total': <int>}. "
         "``type`` is 'Normal' or 'Warning'; ``count`` is how many "
         "times the event has fired; ``last_seen_seconds`` is how "
-        "long ago the event was last observed."
+        "long ago the event was last observed. Each row carries "
+        "its own ``namespace`` so cross-namespace rows under "
+        "``all_namespaces=true`` stay distinguishable."
     ),
     "pagination_hint": K8S_EVENT_LIST_PAGINATION_HINT,
 }
@@ -405,18 +454,21 @@ EVENT_OPS: tuple[KubernetesOp, ...] = (
     KubernetesOp(
         op_id="k8s.event.list",
         handler_attr="k8s_event_list",
-        summary="List recent Kubernetes events in a namespace, most-recent-first.",
+        summary="List recent Kubernetes events most-recent-first; per-namespace or cluster-wide.",
         description=(
-            "Calls ``CoreV1Api.list_namespaced_event(namespace, "
-            "field_selector=..., limit=...)`` and projects each Event "
-            "into {name, namespace, type, reason, message, "
-            "involved_object: {kind, name, namespace}, source, count, "
+            "Calls ``CoreV1Api.list_namespaced_event(namespace, ...)`` "
+            "(per-namespace) or "
+            "``CoreV1Api.list_event_for_all_namespaces(...)`` "
+            "(``all_namespaces=true``) and projects each Event into "
+            "{name, namespace, type, reason, message, involved_object: "
+            "{kind, name, namespace}, source, count, "
             "first_seen_seconds, last_seen_seconds}. Rows are sorted "
             "most-recent-first by ``last_seen_seconds`` before "
             "``limit`` truncates the tail, so the kept rows are "
             "deterministically the N most-recent events. "
-            "``field_selector`` is forwarded verbatim to the K8s API "
-            "(e.g. 'type=Warning', 'involvedObject.kind=Pod'). "
+            "``field_selector`` (e.g. 'type=Warning', "
+            "'involvedObject.kind=Pod') and ``label_selector`` are "
+            "forwarded verbatim to the K8s API. "
             f"Default limit {DEFAULT_EVENT_LIMIT}, capped at "
             f"{MAX_EVENT_LIMIT}. Read-only."
         ),

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_listparams.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_listparams.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Shared request-shape building blocks for K8s list ops.
+
+G0.17-T1 (#1330) factored the workload list ops'
+``_LIST_BASE_PROPERTIES`` + ``_NAMESPACE_XOR_ALL_NAMESPACES`` out of
+:mod:`ops_workload` so every namespaced list op in the connector
+(`k8s.pod.list`, `k8s.deployment.list`, `k8s.event.list`,
+`k8s.service.list`, `k8s.ingress.list`, `k8s.configmap.list`) shares
+one canonical request shape.
+
+See ``docs/codebase/api-shape-conventions.md`` §10 (intra-connector
+list-op request-shape parity) for the convention this module anchors:
+sibling list operations over the same kind of scoped resource on one
+connector share one input-parameter shape, the shared shape lives in
+one place, and individual ops document deliberate omissions
+(e.g. ``k8s.event.list`` omits ``continue_token`` because its
+client-side recency-sort + truncation contract supersedes server-side
+paging -- documented in
+:data:`~meho_backplane.connectors.kubernetes.ops_events.K8S_EVENT_LIST_PAGINATION_HINT`).
+
+Three building blocks live here:
+
+* :data:`NAMESPACE_PARAM` / :data:`ALL_NAMESPACES_PARAM` --
+  the two namespace selectors as standalone property schemas. An op
+  that needs only a subset of the full base (e.g. ``k8s.event.list``
+  intentionally omits ``continue_token``) imports the individual
+  blocks and assembles its own ``properties`` dict.
+* :data:`LABEL_SELECTOR_PARAM` / :data:`FIELD_SELECTOR_PARAM` /
+  :data:`LIMIT_PARAM` / :data:`CONTINUE_TOKEN_PARAM` -- the standard
+  k8s filter / paging knobs as standalone property schemas. Same
+  cherry-pick pattern as above.
+* :data:`LIST_BASE_PROPERTIES` -- the full six-key properties dict
+  that ``k8s.pod.list`` / ``k8s.deployment.list`` use as-is. Ops that
+  want the full shape import this directly.
+* :data:`NAMESPACE_XOR_ALL_NAMESPACES` -- the ``oneOf`` clause that
+  enforces "exactly one of ``{namespace, all_namespaces=true}``".
+  Imported verbatim by every list op (the XOR semantics are uniform
+  across the family).
+
+Authoring contract for a new k8s list op:
+
+1. **Has a per-namespace API + a `for_all_namespaces` API in
+   ``kubernetes_asyncio``** -> compose its parameter schema by spread-
+   importing :data:`LIST_BASE_PROPERTIES` (or by cherry-picking the
+   subset that applies) and the :data:`NAMESPACE_XOR_ALL_NAMESPACES`
+   ``oneOf``. Never copy-paste the property dicts.
+2. **Has only a per-namespace API** -> omit ``all_namespaces`` and
+   document the omission in the op's docstring (no upstream support
+   = a vendor constraint, which §10's parity rule explicitly
+   acknowledges).
+3. **Is genuinely cluster-scoped** (`k8s.namespace.list`,
+   ``k8s.node.list``) -> no ``namespace`` / ``all_namespaces`` axis;
+   neither block applies.
+
+Mutability note: every constant in this module is a dict / list and
+Python does not freeze them, but the wider connector relies on the
+treat-as-immutable convention (compare to ``KUBERNETES_OPS`` -- a
+``tuple`` precisely because the operator descriptor list is shared
+across many readers). Treat these constants the same way; do not
+mutate them in tests or callers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "ALL_NAMESPACES_PARAM",
+    "CONTINUE_TOKEN_PARAM",
+    "FIELD_SELECTOR_PARAM",
+    "LABEL_SELECTOR_PARAM",
+    "LIMIT_PARAM",
+    "LIST_BASE_PROPERTIES",
+    "NAMESPACE_PARAM",
+    "NAMESPACE_XOR_ALL_NAMESPACES",
+]
+
+
+#: Per-namespace selector. Required unless ``all_namespaces`` is true;
+#: the XOR clause in :data:`NAMESPACE_XOR_ALL_NAMESPACES` enforces
+#: exactly-one-of {namespace, all_namespaces=true}.
+NAMESPACE_PARAM: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "description": "Namespace to list in. Required unless ``all_namespaces`` is true.",
+}
+
+
+#: Cluster-wide flag. ``true`` routes the handler to the
+#: ``list_X_for_all_namespaces`` API. Mutually exclusive with
+#: ``namespace`` via :data:`NAMESPACE_XOR_ALL_NAMESPACES`.
+ALL_NAMESPACES_PARAM: dict[str, Any] = {
+    "type": "boolean",
+    "default": False,
+    "description": (
+        "List across every namespace the kubeconfig's service "
+        "account can read. Mutually exclusive with ``namespace``."
+    ),
+}
+
+
+#: Standard k8s label-selector string, forwarded verbatim to the API.
+#: The K8s server applies it before paging; combine with
+#: ``all_namespaces=true`` for cluster-wide narrowed listings.
+LABEL_SELECTOR_PARAM: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "description": (
+        "Standard k8s label selector (e.g. ``app=argocd-server``, "
+        "``app in (frontend,backend)``). Forwarded server-side."
+    ),
+}
+
+
+#: Standard k8s field-selector string, forwarded verbatim.
+FIELD_SELECTOR_PARAM: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "description": (
+        "Standard k8s field selector (e.g. ``status.phase=Running``, "
+        "``spec.nodeName=node-1``). Forwarded server-side."
+    ),
+}
+
+
+#: Server-side page size. Capped at 1000 to bound per-call payload --
+#: above that the operator is better served by a tighter selector than
+#: by a bigger result set.
+LIMIT_PARAM: dict[str, Any] = {
+    "type": "integer",
+    "minimum": 1,
+    "maximum": 1000,
+    "description": (
+        "Server-side ``?limit=`` for paginated reads. Combine with "
+        "``continue_token`` from a prior response's ``next_continue`` "
+        "field to walk pages. Capped at 1000 to bound per-call "
+        "payload."
+    ),
+}
+
+
+#: Server-emitted pagination cursor. The connector renames the K8s
+#: ``_continue`` cursor to ``continue_token`` on the way out so the
+#: operator-facing surface stays kubectl-shaped; the handler renames
+#: it back when forwarding to the API.
+CONTINUE_TOKEN_PARAM: dict[str, Any] = {
+    "type": "string",
+    "minLength": 1,
+    "description": (
+        "Server-emitted pagination cursor from a prior list call's "
+        "``next_continue`` field. Pass it back unchanged to fetch the "
+        "next page; passing a stale token (>5..15 min old) returns a "
+        "410 ResourceExpired -- restart the list without it."
+    ),
+}
+
+
+#: Full canonical ``properties`` dict for a list-op schema. Used as-is
+#: by ops that adopt the entire shape (``k8s.pod.list``,
+#: ``k8s.deployment.list``). Ops that deliberately omit a knob compose
+#: the dict from the individual building blocks above and document the
+#: omission in their docstring + pagination-hint.
+LIST_BASE_PROPERTIES: dict[str, Any] = {
+    "namespace": NAMESPACE_PARAM,
+    "all_namespaces": ALL_NAMESPACES_PARAM,
+    "label_selector": LABEL_SELECTOR_PARAM,
+    "field_selector": FIELD_SELECTOR_PARAM,
+    "limit": LIMIT_PARAM,
+    "continue_token": CONTINUE_TOKEN_PARAM,
+}
+
+
+#: ``oneOf`` clause: exactly one of {namespace, all_namespaces=true}.
+#:
+#: The ``not`` branches encode "the other selector is absent" for the
+#: namespace branch and "all_namespaces is false-or-absent" for the
+#: missing-both branch. Draft 2020-12 evaluates each branch
+#: independently; the combined effect is the operator must supply
+#: exactly one selector. A schema using this clause MUST also include
+#: both ``namespace`` and ``all_namespaces`` in its ``properties`` --
+#: the clause references the names but does not declare them.
+NAMESPACE_XOR_ALL_NAMESPACES: list[dict[str, Any]] = [
+    {
+        "required": ["namespace"],
+        "not": {"required": ["all_namespaces"]},
+    },
+    {
+        "required": ["namespace", "all_namespaces"],
+        "properties": {"all_namespaces": {"const": False}},
+    },
+    {
+        "required": ["all_namespaces"],
+        "properties": {"all_namespaces": {"const": True}},
+        "not": {"required": ["namespace"]},
+    },
+]

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_network.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_network.py
@@ -4,20 +4,39 @@
 """Network ops -- ``k8s.service.list`` / ``k8s.ingress.list``.
 
 G3.2-T4 (#324) of Initiative #320. Adds the two "what's exposed?"
-read-only ops on top of the T1 / T2 / T5 base substrate:
+read-only ops on top of the T1 / T2 / T5 base substrate. G0.17-T1
+(#1330) converged the request shape onto the workload list ops' base
+(``namespace`` XOR ``all_namespaces`` + ``label_selector``) so the
+operator's "what argocd-labeled services exist cluster-wide?" question
+maps to a single ``{all_namespaces: true, label_selector: '...'}``
+call instead of an N-namespace client-side loop.
 
-* ``k8s.service.list [--namespace X]`` -- ``CoreV1Api.list_namespaced_service``.
-  Returns one row per Service with name / namespace / type / cluster_ip /
-  external_ips / ports / selector. The ``ports`` projection flattens
-  :class:`V1ServicePort` to the operator-visible four-tuple
-  (``name`` / ``port`` / ``target_port`` / ``protocol``).
-* ``k8s.ingress.list [--namespace X]`` -- ``NetworkingV1Api.list_namespaced_ingress``.
-  Returns one row per Ingress with name / namespace / class / hosts /
-  tls_hosts / rules. The ``hosts`` list deduplicates entries across
-  rules (the spec allows the same host on multiple rules with different
-  path sets); ``tls_hosts`` is the union of every ``V1IngressTLS.hosts``
+* ``k8s.service.list [--namespace X | --all-namespaces]
+  [--label-selector ...]`` -- ``CoreV1Api.list_namespaced_service``
+  (per-namespace) / ``CoreV1Api.list_service_for_all_namespaces``
+  (cluster-wide). Returns one row per Service with name / namespace /
+  type / cluster_ip / external_ips / ports / selector. The ``ports``
+  projection flattens :class:`V1ServicePort` to the operator-visible
+  four-tuple (``name`` / ``port`` / ``target_port`` / ``protocol``).
+* ``k8s.ingress.list [--namespace X | --all-namespaces]
+  [--label-selector ...]`` --
+  ``NetworkingV1Api.list_namespaced_ingress`` /
+  ``NetworkingV1Api.list_ingress_for_all_namespaces``. Returns one row
+  per Ingress with name / namespace / class / hosts / tls_hosts /
+  rules. The ``hosts`` list deduplicates entries across rules (the
+  spec allows the same host on multiple rules with different path
+  sets); ``tls_hosts`` is the union of every ``V1IngressTLS.hosts``
   entry so the operator can spot whether the ingress carries a TLS
   certificate without walking the full rule tree.
+
+Server-side ``limit`` / ``_continue`` paging is **deliberately not
+exposed** for these two ops in G0.17-T1 -- service / ingress
+populations are typically O(10) per namespace and the issue's
+acceptance section calls out the paging widening as a follow-up
+candidate. The schema's XOR + label_selector knob is the cross-namespace
+fix Finding 24 motivates; the paging widening is mechanical and can
+land as a sibling task if a future deployment hits a heavy-tenancy
+namespace.
 
 Row-shape helpers (:func:`service_row`, :func:`service_port_row`,
 :func:`ingress_row`, :func:`ingress_rule_row`) are pure functions over
@@ -32,8 +51,10 @@ row projection to the helpers here.
 
 References
 ----------
-* Parent task: G3.2-T4 (#324).
+* Parent task: G3.2-T4 (#324); request-shape parity: G0.17-T1 (#1330).
 * Parent Initiative: G3.2 (#320), kubernetes-asyncio typed connector.
+* Conventions doc: ``docs/codebase/api-shape-conventions.md`` §10
+  (intra-connector list-op request-shape parity).
 * k8s Service API: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/
 * k8s Ingress API: https://kubernetes.io/docs/reference/kubernetes-api/service-resources/ingress-v1/
 * ``kubernetes_asyncio.CoreV1Api``:
@@ -47,6 +68,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from meho_backplane.connectors.kubernetes.ops import KubernetesOp
+from meho_backplane.connectors.kubernetes.ops_listparams import (
+    ALL_NAMESPACES_PARAM,
+    LABEL_SELECTOR_PARAM,
+    NAMESPACE_PARAM,
+    NAMESPACE_XOR_ALL_NAMESPACES,
+)
 
 if TYPE_CHECKING:
     from kubernetes_asyncio.client.models import (
@@ -208,25 +235,18 @@ def ingress_row(ingress: V1Ingress) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-#: Both list ops accept an optional ``namespace`` (when omitted, the
-#: handler errors -- v0.2 scopes network ops to a single namespace per
-#: call; the parent Initiative's cross-namespace aggregation is a
-#: higher-level concern). The schema's ``minLength``/``pattern`` reject
-#: whitespace-only inputs so the handler doesn't have to.
-_NAMESPACE_PARAM_SCHEMA: dict[str, Any] = {
-    "type": "string",
-    "minLength": 1,
-    "pattern": r"\S",
-    "description": "Namespace to list within.",
-}
-
-
+#: ``k8s.service.list`` parameter schema. Adopts the shared
+#: ``namespace`` XOR ``all_namespaces`` selector + ``label_selector``
+#: (G0.17-T1 #1330). Server-side paging (``limit``/``continue_token``)
+#: is deliberately omitted -- see the module docstring.
 K8S_SERVICE_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
-        "namespace": _NAMESPACE_PARAM_SCHEMA,
+        "namespace": NAMESPACE_PARAM,
+        "all_namespaces": ALL_NAMESPACES_PARAM,
+        "label_selector": LABEL_SELECTOR_PARAM,
     },
-    "required": ["namespace"],
+    "oneOf": NAMESPACE_XOR_ALL_NAMESPACES,
     "additionalProperties": False,
 }
 
@@ -280,19 +300,31 @@ K8S_SERVICE_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
 
 K8S_SERVICE_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
     "when_to_use": (
-        "Call when the operator asks 'what services are in <namespace>?', "
-        "'what's exposing the argocd UI?', or needs the cluster-internal "
-        "addresses (ClusterIP + port) for a service. Read-only; safe."
+        "Call when the operator asks 'what services are in "
+        "<namespace>?', 'what's exposing the argocd UI?', or needs the "
+        "cluster-internal addresses (ClusterIP + port) for a service. "
+        "Use ``all_namespaces=true`` for cluster-wide listings (e.g. "
+        "'what argocd-labeled services exist across the cluster?'). "
+        "Read-only; safe."
     ),
     "parameter_hints": {
-        "namespace": ("Required. The Kubernetes namespace whose services to list."),
+        "namespace": "Required unless ``all_namespaces`` is true.",
+        "all_namespaces": (
+            "Pass true for cluster-wide listings; mutually exclusive with ``namespace``."
+        ),
+        "label_selector": (
+            "Optional. k8s label-selector syntax (e.g. "
+            "``app=argocd-server``, ``role in (cp,etcd)``)."
+        ),
     },
     "output_shape": (
         "{'rows': [{name, namespace, type, cluster_ip, external_ips, "
         "ports: [{name, port, target_port, protocol}], selector}], "
         "'total': <int>}. ``type`` is the Service type "
         "('ClusterIP' / 'NodePort' / 'LoadBalancer' / 'ExternalName'); "
-        "``cluster_ip`` is the stable in-cluster VIP."
+        "``cluster_ip`` is the stable in-cluster VIP. Each row "
+        "carries its own ``namespace`` so cross-namespace rows under "
+        "``all_namespaces=true`` stay distinguishable."
     ),
 }
 
@@ -300,9 +332,11 @@ K8S_SERVICE_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
 K8S_INGRESS_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
     "type": "object",
     "properties": {
-        "namespace": _NAMESPACE_PARAM_SCHEMA,
+        "namespace": NAMESPACE_PARAM,
+        "all_namespaces": ALL_NAMESPACES_PARAM,
+        "label_selector": LABEL_SELECTOR_PARAM,
     },
-    "required": ["namespace"],
+    "oneOf": NAMESPACE_XOR_ALL_NAMESPACES,
     "additionalProperties": False,
 }
 
@@ -364,18 +398,26 @@ K8S_INGRESS_LIST_RESPONSE_SCHEMA: dict[str, Any] = {
 
 K8S_INGRESS_LIST_LLM_INSTRUCTIONS: dict[str, Any] = {
     "when_to_use": (
-        "Call when the operator asks 'what URLs route into <namespace>?', "
-        "'is there a TLS cert on the argocd ingress?', or needs the "
-        "host->service routing table. Read-only; safe."
+        "Call when the operator asks 'what URLs route into "
+        "<namespace>?', 'is there a TLS cert on the argocd ingress?', "
+        "or needs the host->service routing table. Use "
+        "``all_namespaces=true`` for cluster-wide listings (e.g. "
+        "'what hostnames does the cluster serve?'). Read-only; safe."
     ),
     "parameter_hints": {
-        "namespace": ("Required. The Kubernetes namespace whose ingresses to list."),
+        "namespace": "Required unless ``all_namespaces`` is true.",
+        "all_namespaces": (
+            "Pass true for cluster-wide listings; mutually exclusive with ``namespace``."
+        ),
+        "label_selector": ("Optional. k8s label-selector syntax (e.g. ``app=argocd-server``)."),
     },
     "output_shape": (
         "{'rows': [{name, namespace, class, hosts, tls_hosts, "
         "rules: [{host, paths: [{path, path_type, service, port}]}]}], "
         "'total': <int>}. ``hosts`` and ``tls_hosts`` are sorted "
-        "deduplicated lists across the rule set."
+        "deduplicated lists across the rule set. Each row carries "
+        "its own ``namespace`` so cross-namespace rows under "
+        "``all_namespaces=true`` stay distinguishable."
     ),
 }
 
@@ -384,19 +426,25 @@ NETWORK_OPS: tuple[KubernetesOp, ...] = (
     KubernetesOp(
         op_id="k8s.service.list",
         handler_attr="k8s_service_list",
-        summary="List Kubernetes services in a namespace -- type / cluster_ip / ports / selector.",
+        summary=(
+            "List Kubernetes services per-namespace or cluster-wide "
+            "-- type / cluster_ip / ports / selector."
+        ),
         description=(
-            "Calls ``CoreV1Api.list_namespaced_service(namespace)`` and "
-            "projects each Service into {name, namespace, type, "
-            "cluster_ip, external_ips, ports, selector}. ``type`` is the "
-            "Service type ('ClusterIP' / 'NodePort' / 'LoadBalancer' / "
-            "'ExternalName'); ``cluster_ip`` is the stable in-cluster VIP "
-            "(may be 'None' for ExternalName services or headless "
-            "services with selector). ``ports`` flattens each "
-            "``V1ServicePort`` to {name, port, target_port, protocol}; "
-            "``target_port`` may be either an integer or a named-port "
-            "string. ``selector`` is the label map the service uses to "
-            "pick pods. Read-only."
+            "Calls ``CoreV1Api.list_namespaced_service(namespace, ...)`` "
+            "(per-namespace) or "
+            "``CoreV1Api.list_service_for_all_namespaces(...)`` "
+            "(``all_namespaces=true``) and projects each Service into "
+            "{name, namespace, type, cluster_ip, external_ips, ports, "
+            "selector}. ``type`` is the Service type ('ClusterIP' / "
+            "'NodePort' / 'LoadBalancer' / 'ExternalName'); "
+            "``cluster_ip`` is the stable in-cluster VIP (may be 'None' "
+            "for ExternalName services or headless services with "
+            "selector). ``ports`` flattens each ``V1ServicePort`` to "
+            "{name, port, target_port, protocol}; ``target_port`` may "
+            "be either an integer or a named-port string. ``selector`` "
+            "is the label map the service uses to pick pods. "
+            "``label_selector`` is forwarded server-side. Read-only."
         ),
         parameter_schema=K8S_SERVICE_LIST_PARAMETER_SCHEMA,
         response_schema=K8S_SERVICE_LIST_RESPONSE_SCHEMA,
@@ -409,21 +457,28 @@ NETWORK_OPS: tuple[KubernetesOp, ...] = (
     KubernetesOp(
         op_id="k8s.ingress.list",
         handler_attr="k8s_ingress_list",
-        summary="List Kubernetes ingresses in a namespace -- hosts / TLS hosts / routing rules.",
+        summary=(
+            "List Kubernetes ingresses per-namespace or cluster-wide "
+            "-- hosts / TLS hosts / routing rules."
+        ),
         description=(
-            "Calls ``NetworkingV1Api.list_namespaced_ingress(namespace)`` "
-            "and projects each Ingress into {name, namespace, class, "
-            "hosts, tls_hosts, rules}. ``class`` is the "
-            "``ingressClassName`` (e.g. 'nginx', 'traefik'); ``hosts`` "
-            "is the deduplicated sorted union of every rule's host; "
-            "``tls_hosts`` is the union of every TLS entry's hosts list "
-            "(operators use it to spot whether the ingress has TLS "
-            "configured without walking the rule tree). ``rules`` "
-            "flattens each ``V1IngressRule`` to "
+            "Calls "
+            "``NetworkingV1Api.list_namespaced_ingress(namespace, ...)`` "
+            "(per-namespace) or "
+            "``NetworkingV1Api.list_ingress_for_all_namespaces(...)`` "
+            "(``all_namespaces=true``) and projects each Ingress into "
+            "{name, namespace, class, hosts, tls_hosts, rules}. "
+            "``class`` is the ``ingressClassName`` (e.g. 'nginx', "
+            "'traefik'); ``hosts`` is the deduplicated sorted union of "
+            "every rule's host; ``tls_hosts`` is the union of every "
+            "TLS entry's hosts list (operators use it to spot whether "
+            "the ingress has TLS configured without walking the rule "
+            "tree). ``rules`` flattens each ``V1IngressRule`` to "
             "{host, paths: [{path, path_type, service, port}]}; the "
             "backend's IngressServiceBackend wrapper is collapsed to "
             "the flat service+port fields for the operator-facing wire "
-            "shape. Read-only."
+            "shape. ``label_selector`` is forwarded server-side. "
+            "Read-only."
         ),
         parameter_schema=K8S_INGRESS_LIST_PARAMETER_SCHEMA,
         response_schema=K8S_INGRESS_LIST_RESPONSE_SCHEMA,

--- a/backend/src/meho_backplane/connectors/kubernetes/ops_workload.py
+++ b/backend/src/meho_backplane/connectors/kubernetes/ops_workload.py
@@ -94,6 +94,10 @@ from kubernetes_asyncio import client
 
 from meho_backplane.connectors.kubernetes.ops import KubernetesOp
 from meho_backplane.connectors.kubernetes.ops_core import age_seconds
+from meho_backplane.connectors.kubernetes.ops_listparams import (
+    LIST_BASE_PROPERTIES,
+    NAMESPACE_XOR_ALL_NAMESPACES,
+)
 
 if TYPE_CHECKING:
     from kubernetes_asyncio.client.models import (
@@ -786,94 +790,20 @@ async def k8s_deployment_info(
 # ---------------------------------------------------------------------------
 
 
-#: Shared by both list ops: namespace XOR all_namespaces, plus the
-#: standard k8s ``label_selector`` / ``field_selector`` / ``limit`` /
-#: ``continue_token`` filter knobs. The ``oneOf`` clause enforces
-#: exactly-one of the namespace selectors so the operator can't
-#: accidentally pass both (which would be ambiguous about whether
-#: ``all_namespaces`` overrides ``namespace`` or vice-versa).
-_LIST_BASE_PROPERTIES: dict[str, Any] = {
-    "namespace": {
-        "type": "string",
-        "minLength": 1,
-        "description": "Namespace to list in. Required unless ``all_namespaces`` is true.",
-    },
-    "all_namespaces": {
-        "type": "boolean",
-        "default": False,
-        "description": (
-            "List across every namespace the kubeconfig's service "
-            "account can read. Mutually exclusive with ``namespace``."
-        ),
-    },
-    "label_selector": {
-        "type": "string",
-        "minLength": 1,
-        "description": (
-            "Standard k8s label selector (e.g. ``app=argocd-server``, "
-            "``app in (frontend,backend)``). Forwarded server-side."
-        ),
-    },
-    "field_selector": {
-        "type": "string",
-        "minLength": 1,
-        "description": (
-            "Standard k8s field selector (e.g. ``status.phase=Running``, "
-            "``spec.nodeName=node-1``). Forwarded server-side."
-        ),
-    },
-    "limit": {
-        "type": "integer",
-        "minimum": 1,
-        "maximum": 1000,
-        "description": (
-            "Server-side ``?limit=`` for paginated reads. Combine with "
-            "``continue_token`` from a prior response's ``next_continue`` "
-            "field to walk pages. Capped at 1000 to bound per-call "
-            "payload."
-        ),
-    },
-    "continue_token": {
-        "type": "string",
-        "minLength": 1,
-        "description": (
-            "Server-emitted pagination cursor from a prior list call's "
-            "``next_continue`` field. Pass it back unchanged to fetch the "
-            "next page; passing a stale token (>5..15 min old) returns a "
-            "410 ResourceExpired -- restart the list without it."
-        ),
-    },
-}
-
-
-#: ``oneOf`` clause: exactly one of {namespace, all_namespaces=true}.
-#:
-#: The ``not`` branches encode "the other selector is absent" for the
-#: namespace branch and "all_namespaces is false-or-absent" for the
-#: missing-both branch. Draft 2020-12 evaluates each branch
-#: independently; the combined effect is the operator must supply
-#: exactly one selector.
-_NAMESPACE_XOR_ALL_NAMESPACES: list[dict[str, Any]] = [
-    {
-        "required": ["namespace"],
-        "not": {"required": ["all_namespaces"]},
-    },
-    {
-        "required": ["namespace", "all_namespaces"],
-        "properties": {"all_namespaces": {"const": False}},
-    },
-    {
-        "required": ["all_namespaces"],
-        "properties": {"all_namespaces": {"const": True}},
-        "not": {"required": ["namespace"]},
-    },
-]
-
-
+#: ``k8s.pod.list`` parameter schema. The shared
+#: :data:`~meho_backplane.connectors.kubernetes.ops_listparams.LIST_BASE_PROPERTIES`
+#: + :data:`~meho_backplane.connectors.kubernetes.ops_listparams.NAMESPACE_XOR_ALL_NAMESPACES`
+#: are the reference shape for every list op in this connector
+#: (`docs/codebase/api-shape-conventions.md` §10). Pod / deployment
+#: list adopt the full base; event / service / ingress / configmap
+#: list adopt the subset that maps to their server-side API surface
+#: (e.g. ``k8s.event.list`` keeps the namespace XOR + ``label_selector``
+#: but omits ``continue_token`` -- the omission is documented in
+#: :data:`~meho_backplane.connectors.kubernetes.ops_events.K8S_EVENT_LIST_PAGINATION_HINT`).
 K8S_POD_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
     "type": "object",
-    "properties": _LIST_BASE_PROPERTIES,
-    "oneOf": _NAMESPACE_XOR_ALL_NAMESPACES,
+    "properties": LIST_BASE_PROPERTIES,
+    "oneOf": NAMESPACE_XOR_ALL_NAMESPACES,
     "additionalProperties": False,
 }
 
@@ -903,8 +833,8 @@ K8S_POD_INFO_PARAMETER_SCHEMA: dict[str, Any] = {
 
 K8S_DEPLOYMENT_LIST_PARAMETER_SCHEMA: dict[str, Any] = {
     "type": "object",
-    "properties": _LIST_BASE_PROPERTIES,
-    "oneOf": _NAMESPACE_XOR_ALL_NAMESPACES,
+    "properties": LIST_BASE_PROPERTIES,
+    "oneOf": NAMESPACE_XOR_ALL_NAMESPACES,
     "additionalProperties": False,
 }
 

--- a/backend/tests/test_connectors_k8s_network_config.py
+++ b/backend/tests/test_connectors_k8s_network_config.py
@@ -1164,3 +1164,312 @@ async def test_k8s_event_list_limit_clamps_at_max() -> None:
         # of how the caller's ``limit`` was clamped -- the clamp
         # affects the post-sort truncation, not the wire request.
         assert kwargs["limit"] == MAX_EVENT_LIMIT
+
+
+# ---------------------------------------------------------------------------
+# G0.17-T1 (#1330): request-shape parity sweep
+#
+# The pod / deployment list ops use a shared ``namespace`` XOR
+# ``all_namespaces`` clause + ``label_selector`` forwarding (covered by
+# ``test_list_schemas_enforce_namespace_xor_all_namespaces`` in
+# ``test_connectors_k8s_workload.py``). G0.17-T1 (#1330) converged the
+# event / service / ingress / configmap list ops onto the same shape;
+# the tests below pin that contract.
+# ---------------------------------------------------------------------------
+
+
+#: The four ops G0.17-T1 (#1330) widened to the shared request shape.
+#: ``test_list_schemas_enforce_namespace_xor_all_namespaces`` in
+#: ``test_connectors_k8s_workload.py`` covers ``k8s.pod.list`` and
+#: ``k8s.deployment.list``; this parametrization extends the parity
+#: contract to the rest of the namespaced list-op family on this
+#: connector.
+_G0_17_T1_LIST_OP_IDS: tuple[str, ...] = (
+    "k8s.event.list",
+    "k8s.service.list",
+    "k8s.ingress.list",
+    "k8s.configmap.list",
+)
+
+
+@pytest.mark.parametrize("op_id", _G0_17_T1_LIST_OP_IDS)
+def test_list_schemas_enforce_namespace_xor_all_namespaces(op_id: str) -> None:
+    """Every G0.17-T1 list op enforces ``namespace`` XOR ``all_namespaces``.
+
+    Mirrors the workload-list test (``test_connectors_k8s_workload.py:
+    test_list_schemas_enforce_namespace_xor_all_namespaces``) but
+    extended to the event / service / ingress / configmap list ops
+    via the shared schema building blocks in :mod:`ops_listparams`.
+    See ``docs/codebase/api-shape-conventions.md`` §10 for the
+    convention.
+    """
+    from jsonschema import Draft202012Validator
+
+    op = next(op for op in KUBERNETES_OPS if op.op_id == op_id)
+    validator = Draft202012Validator(op.parameter_schema)
+    # Valid: namespace alone.
+    assert validator.is_valid({"namespace": "argocd"})
+    # Valid: all_namespaces=true alone.
+    assert validator.is_valid({"all_namespaces": True})
+    # Invalid: neither.
+    assert not validator.is_valid({})
+    # Invalid: both, with all_namespaces=true (conflict).
+    assert not validator.is_valid({"namespace": "argocd", "all_namespaces": True})
+    # Valid: both, with all_namespaces=false (effectively just namespace).
+    assert validator.is_valid({"namespace": "argocd", "all_namespaces": False})
+    # Valid: label_selector forwarded alongside namespace.
+    assert validator.is_valid({"namespace": "argocd", "label_selector": "app=argocd-server"})
+    # Valid: label_selector forwarded alongside all_namespaces.
+    assert validator.is_valid({"all_namespaces": True, "label_selector": "app in (a,b)"})
+
+
+# ---------------------------------------------------------------------------
+# Per-op all_namespaces dispatch tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_k8s_event_list_all_namespaces_uses_for_all_namespaces() -> None:
+    """``all_namespaces=true`` routes through ``list_event_for_all_namespaces``.
+
+    Mirrors ``test_k8s_pod_list_all_namespaces_uses_for_all_namespaces``
+    in ``test_connectors_k8s_workload.py`` for the event op (G0.17-T1
+    #1330).
+    """
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = []
+        core_v1_cls.return_value.list_event_for_all_namespaces = AsyncMock(return_value=list_resp)
+        core_v1_cls.return_value.list_namespaced_event = AsyncMock(return_value=list_resp)
+        await connector.k8s_event_list(_make_operator(), _TARGET, {"all_namespaces": True})
+
+    core_v1_cls.return_value.list_event_for_all_namespaces.assert_awaited_once()
+    core_v1_cls.return_value.list_namespaced_event.assert_not_awaited()
+    # Wire still asks for MAX_EVENT_LIMIT on the all-namespaces path.
+    kwargs = core_v1_cls.return_value.list_event_for_all_namespaces.call_args.kwargs
+    assert kwargs["limit"] == MAX_EVENT_LIMIT
+    # No namespace passed on the cluster-wide call.
+    assert "namespace" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_k8s_event_list_label_selector_flows_through() -> None:
+    """``label_selector`` forwards to the API as ``label_selector=...``."""
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = []
+        core_v1_cls.return_value.list_namespaced_event = AsyncMock(return_value=list_resp)
+        await connector.k8s_event_list(
+            _make_operator(),
+            _TARGET,
+            {"namespace": "argocd", "label_selector": "app=argocd-server"},
+        )
+    kwargs = core_v1_cls.return_value.list_namespaced_event.call_args.kwargs
+    assert kwargs["label_selector"] == "app=argocd-server"
+
+
+@pytest.mark.asyncio
+async def test_k8s_service_list_all_namespaces_uses_for_all_namespaces() -> None:
+    """``all_namespaces=true`` routes through ``list_service_for_all_namespaces``."""
+    services = [
+        _make_service(name="svc-1", namespace="argocd"),
+        _make_service(name="svc-2", namespace="kube-system"),
+    ]
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = services
+        list_resp.metadata = V1ListMeta()
+        core_v1_cls.return_value.list_service_for_all_namespaces = AsyncMock(return_value=list_resp)
+        core_v1_cls.return_value.list_namespaced_service = AsyncMock()
+        result = await connector.k8s_service_list(
+            _make_operator(), _TARGET, {"all_namespaces": True}
+        )
+
+    assert result["total"] == 2
+    core_v1_cls.return_value.list_service_for_all_namespaces.assert_awaited_once()
+    core_v1_cls.return_value.list_namespaced_service.assert_not_awaited()
+    # No namespace kwarg on the cluster-wide call.
+    kwargs = core_v1_cls.return_value.list_service_for_all_namespaces.call_args.kwargs
+    assert "namespace" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_k8s_service_list_label_selector_flows_through() -> None:
+    """``label_selector`` forwards to the API on the per-namespace path."""
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = []
+        core_v1_cls.return_value.list_namespaced_service = AsyncMock(return_value=list_resp)
+        await connector.k8s_service_list(
+            _make_operator(),
+            _TARGET,
+            {"namespace": "argocd", "label_selector": "app=argocd-server"},
+        )
+    kwargs = core_v1_cls.return_value.list_namespaced_service.call_args.kwargs
+    assert kwargs["label_selector"] == "app=argocd-server"
+    assert kwargs["namespace"] == "argocd"
+
+
+@pytest.mark.asyncio
+async def test_k8s_ingress_list_all_namespaces_uses_for_all_namespaces() -> None:
+    """``all_namespaces=true`` routes through ``list_ingress_for_all_namespaces``."""
+    ingress = _make_ingress(
+        name="ing-1",
+        rules=[
+            V1IngressRule(
+                host="argocd.evba.lab",
+                http=V1HTTPIngressRuleValue(paths=[_http_path()]),
+            )
+        ],
+    )
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.client.NetworkingV1Api"
+        ) as networking_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = [ingress]
+        networking_cls.return_value.list_ingress_for_all_namespaces = AsyncMock(
+            return_value=list_resp
+        )
+        networking_cls.return_value.list_namespaced_ingress = AsyncMock()
+        result = await connector.k8s_ingress_list(
+            _make_operator(), _TARGET, {"all_namespaces": True}
+        )
+
+    assert result["total"] == 1
+    networking_cls.return_value.list_ingress_for_all_namespaces.assert_awaited_once()
+    networking_cls.return_value.list_namespaced_ingress.assert_not_awaited()
+    kwargs = networking_cls.return_value.list_ingress_for_all_namespaces.call_args.kwargs
+    assert "namespace" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_k8s_ingress_list_label_selector_flows_through() -> None:
+    """``label_selector`` forwards to the API on the per-namespace path."""
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.client.NetworkingV1Api"
+        ) as networking_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = []
+        networking_cls.return_value.list_namespaced_ingress = AsyncMock(return_value=list_resp)
+        await connector.k8s_ingress_list(
+            _make_operator(),
+            _TARGET,
+            {"namespace": "argocd", "label_selector": "app=argocd-server"},
+        )
+    kwargs = networking_cls.return_value.list_namespaced_ingress.call_args.kwargs
+    assert kwargs["label_selector"] == "app=argocd-server"
+    assert kwargs["namespace"] == "argocd"
+
+
+@pytest.mark.asyncio
+async def test_k8s_configmap_list_all_namespaces_uses_for_all_namespaces() -> None:
+    """``all_namespaces=true`` routes through ``list_config_map_for_all_namespaces``.
+
+    Privacy contract still holds on the all-namespaces path: keys
+    only, no values. The list_row helper enforces it for both branches.
+    """
+    cms = [
+        _make_configmap(name="cm-1", namespace="argocd", data={"k": "v"}),
+        _make_configmap(name="cm-2", namespace="kube-system", data={"k2": "v2"}),
+    ]
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = cms
+        core_v1_cls.return_value.list_config_map_for_all_namespaces = AsyncMock(
+            return_value=list_resp
+        )
+        core_v1_cls.return_value.list_namespaced_config_map = AsyncMock()
+        result = await connector.k8s_configmap_list(
+            _make_operator(), _TARGET, {"all_namespaces": True}
+        )
+
+    assert result["total"] == 2
+    core_v1_cls.return_value.list_config_map_for_all_namespaces.assert_awaited_once()
+    core_v1_cls.return_value.list_namespaced_config_map.assert_not_awaited()
+    kwargs = core_v1_cls.return_value.list_config_map_for_all_namespaces.call_args.kwargs
+    assert "namespace" not in kwargs
+    # Privacy contract preserved on the cluster-wide path.
+    for row in result["rows"]:
+        assert "data" not in row
+        assert "binary_data" not in row
+
+
+@pytest.mark.asyncio
+async def test_k8s_configmap_list_label_selector_flows_through() -> None:
+    """``label_selector`` forwards to the API on the per-namespace path."""
+    connector = _make_connector()
+    with (
+        patch(
+            "meho_backplane.connectors.kubernetes.connector.config.new_client_from_config_dict",
+            new_callable=AsyncMock,
+            return_value=MagicMock(close=AsyncMock()),
+        ),
+        patch("meho_backplane.connectors.kubernetes.connector.client.CoreV1Api") as core_v1_cls,
+    ):
+        list_resp = MagicMock()
+        list_resp.items = []
+        core_v1_cls.return_value.list_namespaced_config_map = AsyncMock(return_value=list_resp)
+        await connector.k8s_configmap_list(
+            _make_operator(),
+            _TARGET,
+            {"namespace": "argocd", "label_selector": "managed-by=helm"},
+        )
+    kwargs = core_v1_cls.return_value.list_namespaced_config_map.call_args.kwargs
+    assert kwargs["label_selector"] == "managed-by=helm"
+    assert kwargs["namespace"] == "argocd"

--- a/docs/codebase/connectors-kubernetes.md
+++ b/docs/codebase/connectors-kubernetes.md
@@ -138,11 +138,11 @@ real operator through the same loader.
 | `k8s.pod.info`         | safe   | Full pod detail; exact name or unique prefix.                     |
 | `k8s.deployment.list`  | safe   | Deployments with live replica counts + image + strategy.          |
 | `k8s.deployment.info`  | safe   | Full deployment detail; exact name or unique prefix.              |
-| `k8s.service.list`     | safe   | `CoreV1Api.list_namespaced_service()` -- type / cluster_ip / ports / selector. |
-| `k8s.ingress.list`     | safe   | `NetworkingV1Api.list_namespaced_ingress()` -- class / hosts / TLS / rules. |
-| `k8s.configmap.list`   | safe   | `CoreV1Api.list_namespaced_config_map()` -- **keys only, NO values**. |
+| `k8s.service.list`     | safe   | `CoreV1Api.list_namespaced_service()` / `list_service_for_all_namespaces()` -- type / cluster_ip / ports / selector + `label_selector`. |
+| `k8s.ingress.list`     | safe   | `NetworkingV1Api.list_namespaced_ingress()` / `list_ingress_for_all_namespaces()` -- class / hosts / TLS / rules + `label_selector`. |
+| `k8s.configmap.list`   | safe   | `CoreV1Api.list_namespaced_config_map()` / `list_config_map_for_all_namespaces()` -- **keys only, NO values** + `label_selector`. |
 | `k8s.configmap.info`   | safe   | `CoreV1Api.read_namespaced_config_map()` -- full data + binary_data. |
-| `k8s.event.list`       | safe   | `CoreV1Api.list_namespaced_event()` -- pulls up to `MAX_EVENT_LIMIT` (500) rows, sorts client-side by `last_seen` desc, truncates to caller's `--limit`. Server has no `lastTimestamp` ordering guarantee. EventSeries `count` honoured. |
+| `k8s.event.list`       | safe   | `CoreV1Api.list_namespaced_event()` / `list_event_for_all_namespaces()` -- pulls up to `MAX_EVENT_LIMIT` (500) rows, sorts client-side by `last_seen` desc, truncates to caller's `--limit`. Server has no `lastTimestamp` ordering guarantee. EventSeries `count` honoured. Forwards `label_selector` + `field_selector`. |
 | `k8s.logs`             | safe   | `CoreV1Api.read_namespaced_pod_log()` non-streaming -- tail / container / since / previous + 1 MiB cap. |
 
 G3.2-T6 (CLI alias verbs + k3d E2E acceptance + operator-facing
@@ -158,24 +158,48 @@ op; the onboarding recipe in
 [`docs/cross-repo/kubernetes-onboarding.md`](../cross-repo/kubernetes-onboarding.md)
 is the operator cookbook for migrating off `kubectl-vcf.sh`.
 
-### Workload-op pagination (`k8s.pod.list` / `k8s.deployment.list`)
+### Shared list-op request shape (`ops_listparams.py`)
 
-The list handlers forward the standard k8s `label_selector` /
-`field_selector` / `limit` / `_continue` filter knobs to the API
-server so heavy-tenancy clusters can paginate server-side without
-streaming every row through the connector. The operator passes
-`limit=N` plus optional `continue_token=<cursor>` on each call; the
-response carries `next_continue` whenever the server signals more
-pages. Tokens are server-defined and expire after ~5-15 minutes; a
-stale token returns 410 ResourceExpired, and the handler propagates
-the API exception verbatim so the caller can restart without the
-token.
+Every namespaced list op on this connector
+(`k8s.pod.list`, `k8s.deployment.list`, `k8s.event.list`,
+`k8s.service.list`, `k8s.ingress.list`, `k8s.configmap.list`) shares
+the same input-parameter shape via the building blocks in
+[`ops_listparams.py`](../../backend/src/meho_backplane/connectors/kubernetes/ops_listparams.py):
 
-`namespace` and `all_namespaces` are mutually exclusive in the
-schema's `oneOf` clause -- exactly one must be supplied. The
-`all_namespaces=true` path routes through
-`list_pod_for_all_namespaces` / `list_deployment_for_all_namespaces`;
-the per-namespace path uses the `_namespaced_` variants.
+- `namespace` XOR `all_namespaces` -- the `oneOf` clause
+  (`NAMESPACE_XOR_ALL_NAMESPACES`) enforces exactly-one. The
+  `all_namespaces=true` path routes through the
+  `list_X_for_all_namespaces` variant; the per-namespace path uses
+  the `_namespaced_` variant.
+- `label_selector` -- forwarded server-side; same K8s selector syntax
+  for every op.
+
+Pod / deployment list additionally use the full base via
+`LIST_BASE_PROPERTIES`, which adds `field_selector` + `limit` +
+`continue_token`. The operator passes `limit=N` plus optional
+`continue_token=<cursor>` on each call; the response carries
+`next_continue` whenever the server signals more pages. Tokens are
+server-defined and expire after ~5-15 minutes; a stale token returns
+410 ResourceExpired, and the handler propagates the API exception
+verbatim so the caller can restart without the token.
+
+The event / service / ingress / configmap list ops deliberately omit
+some knobs of the full base:
+
+- `k8s.event.list` keeps `field_selector` + `limit` but omits
+  `continue_token` -- the handler's client-side recency-sort +
+  truncation contract supersedes server-side paging; the omission is
+  documented in `K8S_EVENT_LIST_PAGINATION_HINT`.
+- `k8s.service.list`, `k8s.ingress.list`, `k8s.configmap.list` omit
+  `field_selector` + `limit` + `continue_token` -- these resources
+  are typically O(10) per namespace and the
+  [G0.17-T1](https://github.com/evoila/meho/issues/1330) sweep
+  deferred the paging widening as a mechanical follow-up.
+
+See [`docs/codebase/api-shape-conventions.md`](api-shape-conventions.md)
+§10 for the convention this shared shape anchors (intra-connector
+list-op request-shape parity); the rule applies across connectors
+once siblings adopt the pattern.
 
 ### Workload-op prefix resolution (`k8s.pod.info` / `k8s.deployment.info`)
 


### PR DESCRIPTION
## Summary

- Converge `k8s.event.list` / `k8s.service.list` / `k8s.ingress.list` /
  `k8s.configmap.list` onto the `k8s.pod.list` input shape so the
  operator's "show me all Warning events cluster-wide" / "what
  argocd-labeled services exist across the cluster?" question maps to
  a single `{all_namespaces: true, ...}` call instead of an N-namespace
  client-side loop. RDC #771 Finding 24, surfaced during v0.8.0
  post-cycle rolling dogfood (2026-05-29).
- New `ops_listparams.py` module holds `LIST_BASE_PROPERTIES` +
  `NAMESPACE_XOR_ALL_NAMESPACES` + individual property building blocks.
  Every namespaced k8s list op now imports the shared shape so the XOR
  semantics + schema test stay in lockstep across ops (no copy-paste).
- Anchors §10 in `docs/codebase/api-shape-conventions.md`
  (intra-connector list-op request-shape parity); the §10 prose itself
  lands on branch `docs/api-shape-conventions` and is not touched in
  this PR.

## What changed

- `ops_listparams.py` (new): canonical shared building blocks
  (`LIST_BASE_PROPERTIES`, `NAMESPACE_XOR_ALL_NAMESPACES`,
  `NAMESPACE_PARAM`, `ALL_NAMESPACES_PARAM`, `LABEL_SELECTOR_PARAM`,
  `FIELD_SELECTOR_PARAM`, `LIMIT_PARAM`, `CONTINUE_TOKEN_PARAM`).
- `ops_workload.py`: refactor — imports shared blocks instead of
  defining `_LIST_BASE_PROPERTIES` locally. No behaviour change to
  pod / deployment list.
- `ops_events.py`: `K8S_EVENT_LIST_PARAMETER_SCHEMA` adds
  `all_namespaces` + `label_selector`, drops `required: [namespace]`,
  adopts the XOR `oneOf`. Keeps `field_selector` + `limit`. The
  deliberate `continue_token` omission stays documented on
  `K8S_EVENT_LIST_PAGINATION_HINT`. Updates LLM hints, EVENT_OPS
  description, module docstring.
- `ops_network.py` / `ops_config.py`: same pattern — each list op
  adopts `namespace` XOR `all_namespaces` + `label_selector`. Updates
  LLM hints, descriptions, docstrings.
- `connector.py`: `k8s_event_list`, `k8s_service_list`,
  `k8s_ingress_list`, `k8s_configmap_list` branch on `all_namespaces`
  between `list_namespaced_X(...)` and `list_X_for_all_namespaces(...)`;
  forward `label_selector` verbatim. ConfigMap privacy contract holds
  identically across both paths.
- Tests: parametrized `test_list_schemas_enforce_namespace_xor_all_namespaces`
  extended to the four newly widened ops; per-op `all_namespaces`
  dispatch test mirroring
  `test_k8s_pod_list_all_namespaces_uses_for_all_namespaces`;
  `label_selector` forwarding test per op.
- Docs: `docs/codebase/connectors-kubernetes.md` updated.
- CHANGELOG `[Unreleased]` Changed bullet citing Finding 24.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/connectors/kubernetes/` — clean
- [x] `pytest tests/test_connectors_k8s_workload.py
  tests/test_connectors_k8s_network_config.py
  tests/test_connectors_k8s_dispatcher_shim.py
  tests/test_connectors_k8s_core.py` — 122 passed
- [x] Full backend `pytest tests/ --ignore=tests/integration` — 5764
  passed, 194 skipped
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers,
  10 warnings (all pre-existing, no new violations introduced)
- [x] `cd cli && make snapshot-openapi && make generate` — no diff,
  as expected (per-op `parameter_schema` is DB-stored, not in
  OpenAPI route shape)
- [x] Schema-XOR parametrized test passes for
  `k8s.event.list`/`k8s.service.list`/`k8s.ingress.list`/`k8s.configmap.list`
- [x] Per-op `all_namespaces` dispatch tests confirm the
  `list_X_for_all_namespaces` variants are awaited
- [x] Per-op `label_selector` forwarding tests confirm the kwarg
  reaches the API

## Out of scope

- §10 prose in `docs/codebase/api-shape-conventions.md` is being
  landed separately by the user on branch `docs/api-shape-conventions`;
  no edit to that file here. Inline docstrings cross-reference §10
  for the codebase-side anchor.
- Server-side `limit` + `continue_token` paging widening on
  `service.list` / `ingress.list` / `configmap.list` — deferred per
  the issue's acceptance section. The lift is mechanical (same shape
  as workload list) and can land in a sibling task if a heavy-tenancy
  namespace surfaces. The conventions doc + this PR's docstrings
  record the deferral.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1330
