### PR TITLE
feat(runbooks): G12.2-T2 runbook template service layer — CRUD + fork-from-published + in_flight_run_count

### DIFF
--- a/backend/src/meho_backplane/runbooks/service.py
+++ b/backend/src/meho_backplane/runbooks/service.py
@@ -1,0 +1,593 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tenant-scoped :class:`RunbookTemplateService` over the G12.1 storage substrate.
+
+Initiative #1197 (G12.2) T2 surface. The REST routes (T3) and MCP tools
+(T4) wrap this service rather than touching
+:mod:`meho_backplane.db.models` directly, so the versioning algebra
+(edit-draft vs fork-from-published), the status state machine
+(``draft -> published -> deprecated``), and the ``in_flight_run_count``
+query all live in one place.
+
+Concurrency model
+-----------------
+
+:class:`RunbookTemplateService` is stateless and method-scoped: each
+public method opens its own :class:`AsyncSession` via
+:func:`~meho_backplane.db.engine.get_sessionmaker` and commits
+synchronously before returning. This mirrors
+:class:`meho_backplane.kb.service.KbService` -- the service is trivially
+instantiable (no constructor parameters) and never shares transaction
+state across calls.
+
+Tenant scoping
+--------------
+
+Every public method takes ``tenant_id`` as the first parameter -- no
+contextvar resolution. The route / MCP layers (T3 / T4) bind the value
+from the operator's JWT; the service is testable in isolation and the
+tenant boundary is auditable at the call site. Every query filters on
+``tenant_id`` so cross-tenant reads are structurally impossible.
+
+RBAC
+----
+
+This service does **not** enforce roles. A senior-vs-operator gate on
+who may draft / publish / deprecate is the route / MCP boundary's job
+(T3 / T4). The service is willing to read or write any row inside the
+tenant it was handed.
+
+Versioning algebra
+------------------
+
+The load-bearing decision is in :meth:`RunbookTemplateService.update_or_fork`:
+the caller does not pick the path. If a draft exists for the slug, the
+edit mutates it in place (version unchanged). If only published /
+deprecated versions exist, the edit forks a new draft at
+``max(version) + 1`` and reports the source it forked from -- including
+how many runs are still pinned to that source version
+(:attr:`~meho_backplane.runbooks.schemas.ForkInfo.in_flight_run_count`).
+That count is the **only** read of ``runbook_runs`` from the template
+side; G12.3's run service is the durable owner of that table.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Literal
+
+import structlog
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import RunbookRun, RunbookTemplate
+from meho_backplane.kb.schemas import validate_slug
+from meho_backplane.runbooks.schemas import (
+    DeprecateTemplateRequest,
+    DeprecateTemplateResponse,
+    DraftTemplateRequest,
+    DraftTemplateResponse,
+    EditTemplateRequest,
+    EditTemplateResponse,
+    ForkInfo,
+    ListTemplatesFilter,
+    PublishTemplateRequest,
+    PublishTemplateResponse,
+    RunbookTemplateBody,
+    ShowTemplateResponse,
+    Step,
+    TemplateSummary,
+)
+
+__all__ = [
+    "DeprecatedTemplateError",
+    "DuplicateDraftError",
+    "RunbookTemplateService",
+    "TemplateNotDraftError",
+    "TemplateNotFoundError",
+    "TemplateNotPublishedError",
+]
+
+
+#: The closed status vocabulary, mirroring the ``CheckConstraint`` on
+#: :class:`~meho_backplane.db.models.RunbookTemplate`. Used by
+#: :func:`_narrow_status` to coerce the ``str`` column into the
+#: ``Literal``-typed response fields.
+_TemplateStatus = Literal["draft", "published", "deprecated"]
+_TEMPLATE_STATUSES: frozenset[str] = frozenset({"draft", "published", "deprecated"})
+
+#: The run state that counts toward :class:`ForkInfo.in_flight_run_count`.
+#: Matches the ``runbook_runs.state`` vocabulary on
+#: :class:`~meho_backplane.db.models.RunbookRun` (``in_progress`` /
+#: ``completed`` / ``abandoned``); only ``in_progress`` runs are pinned to
+#: a version the senior cares about when deciding whether to fork.
+_IN_PROGRESS_STATE: str = "in_progress"
+
+
+class TemplateNotFoundError(LookupError):
+    """Raised when ``(tenant_id, slug, version?)`` doesn't resolve to a row."""
+
+
+class TemplateNotDraftError(ValueError):
+    """Raised when publish is called against a non-draft template."""
+
+
+class TemplateNotPublishedError(ValueError):
+    """Raised when deprecate is called against a non-published template."""
+
+
+class DuplicateDraftError(ValueError):
+    """Raised when ``create_draft`` finds an existing draft for the same slug."""
+
+
+class DeprecatedTemplateError(ValueError):
+    """Raised by ``start_run`` (G12.3) against a deprecated version.
+
+    Defined here so the runbook service module owns the full error
+    vocabulary even though the consumer is the G12.3 run service.
+    """
+
+
+class RunbookTemplateService:
+    """Tenant-scoped CRUD + versioning over runbook templates.
+
+    Stateless and async; instantiate once and call freely. Each public
+    method opens its own DB session, commits, and closes -- no shared
+    transaction state across calls. The class ships with no constructor
+    parameters: every dependency (the engine) is bound via the
+    module-level singletons the G0.4 substrate set up.
+    """
+
+    async def create_draft(
+        self,
+        tenant_id: uuid.UUID,
+        operator_sub: str,
+        request: DraftTemplateRequest,
+    ) -> DraftTemplateResponse:
+        """Insert a new draft for *request.slug*.
+
+        ``version=1`` when no row exists for the slug; otherwise raises
+        :class:`DuplicateDraftError` -- the slug already has a version
+        (a draft, or a published/deprecated history), so the caller wants
+        :meth:`update_or_fork`, not a second v1. The slug is revalidated
+        against
+        :data:`~meho_backplane.kb.schemas.SLUG_PATTERN` at the service
+        boundary -- defense in depth even though the request model
+        already enforced it.
+        """
+        validate_slug(request.slug)
+
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            latest = await _resolve_latest_version(session, tenant_id, request.slug)
+            if latest is not None:
+                raise DuplicateDraftError(
+                    f"slug {request.slug!r} already has a version "
+                    f"(latest={latest}); use edit to fork or mutate the draft"
+                )
+
+            now = datetime.now(UTC)
+            row = RunbookTemplate(
+                tenant_id=tenant_id,
+                slug=request.slug,
+                version=1,
+                title=request.body.title,
+                description=request.body.description,
+                target_kind=request.body.target_kind,
+                steps=_steps_to_storage(request.body.steps),
+                status="draft",
+                created_by=operator_sub,
+                created_at=now,
+                edited_by=operator_sub,
+                edited_at=now,
+            )
+            session.add(row)
+            await session.commit()
+
+        structlog.get_logger().info(
+            "runbook_draft_created",
+            tenant_id=str(tenant_id),
+            slug=request.slug,
+            version=1,
+        )
+        return DraftTemplateResponse(slug=request.slug, version=1, status="draft")
+
+    async def update_or_fork(
+        self,
+        tenant_id: uuid.UUID,
+        operator_sub: str,
+        request: EditTemplateRequest,
+    ) -> EditTemplateResponse:
+        """Edit a draft in place, or fork a new draft from the latest published.
+
+        Two paths, picked by the service (the caller does not choose):
+
+        1. A draft exists for the slug -> mutate it in place. The version
+           is unchanged, ``edited_by`` / ``edited_at`` advance, and
+           :attr:`EditTemplateResponse.forked_from` is ``None``.
+        2. Only published / deprecated versions exist -> fork a new draft
+           at ``max(version) + 1`` (``status='draft'``).
+           :attr:`EditTemplateResponse.forked_from` carries the source
+           version's slug + version + ``in_flight_run_count``.
+
+        Raises :class:`TemplateNotFoundError` when the slug has no rows at
+        all (nothing to edit or fork from).
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            draft = await self._load_draft(session, tenant_id, request.slug)
+            now = datetime.now(UTC)
+
+            if draft is not None:
+                # Path 1: in-place draft mutation. Version stays.
+                draft.title = request.body.title
+                draft.description = request.body.description
+                draft.target_kind = request.body.target_kind
+                draft.steps = _steps_to_storage(request.body.steps)
+                draft.edited_by = operator_sub
+                draft.edited_at = now
+                version = draft.version
+                await session.commit()
+                forked_from: ForkInfo | None = None
+            else:
+                # Path 2: fork from the latest version. No draft exists,
+                # so the latest is a published or deprecated row.
+                source_version = await _resolve_latest_version(session, tenant_id, request.slug)
+                if source_version is None:
+                    raise TemplateNotFoundError(
+                        f"no template for slug {request.slug!r}; nothing to edit or fork"
+                    )
+                in_flight = await _count_in_flight_runs(
+                    session, tenant_id, request.slug, source_version
+                )
+                version = source_version + 1
+                row = RunbookTemplate(
+                    tenant_id=tenant_id,
+                    slug=request.slug,
+                    version=version,
+                    title=request.body.title,
+                    description=request.body.description,
+                    target_kind=request.body.target_kind,
+                    steps=_steps_to_storage(request.body.steps),
+                    status="draft",
+                    created_by=operator_sub,
+                    created_at=now,
+                    edited_by=operator_sub,
+                    edited_at=now,
+                )
+                session.add(row)
+                await session.commit()
+                forked_from = ForkInfo(
+                    slug=request.slug,
+                    version=source_version,
+                    in_flight_run_count=in_flight,
+                )
+
+        structlog.get_logger().info(
+            "runbook_template_edited",
+            tenant_id=str(tenant_id),
+            slug=request.slug,
+            version=version,
+            forked=forked_from is not None,
+        )
+        return EditTemplateResponse(
+            slug=request.slug,
+            version=version,
+            status="draft",
+            forked_from=forked_from,
+        )
+
+    async def publish(
+        self,
+        tenant_id: uuid.UUID,
+        request: PublishTemplateRequest,
+    ) -> PublishTemplateResponse:
+        """Promote ``(tenant_id, slug, version)`` from draft to published.
+
+        Idempotent: re-publishing an already-published version is a no-op
+        and returns the same response. Raises
+        :class:`TemplateNotFoundError` when the row doesn't exist and
+        :class:`TemplateNotDraftError` when it exists but is deprecated.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            row = await self._load_exact(session, tenant_id, request.slug, request.version)
+            if row is None:
+                raise TemplateNotFoundError(
+                    f"no template {request.slug!r} v{request.version} for tenant"
+                )
+            if row.status == "published":
+                # Idempotent no-op -- already in the target state.
+                return PublishTemplateResponse(
+                    slug=request.slug, version=request.version, status="published"
+                )
+            if row.status != "draft":
+                raise TemplateNotDraftError(
+                    f"template {request.slug!r} v{request.version} is "
+                    f"{row.status!r}, not draft; cannot publish"
+                )
+            row.status = "published"
+            await session.commit()
+
+        structlog.get_logger().info(
+            "runbook_template_published",
+            tenant_id=str(tenant_id),
+            slug=request.slug,
+            version=request.version,
+        )
+        return PublishTemplateResponse(
+            slug=request.slug, version=request.version, status="published"
+        )
+
+    async def deprecate(
+        self,
+        tenant_id: uuid.UUID,
+        request: DeprecateTemplateRequest,
+    ) -> DeprecateTemplateResponse:
+        """Retire ``(tenant_id, slug, version)`` from published to deprecated.
+
+        Idempotent: re-deprecating an already-deprecated version is a
+        no-op and returns the same response. Raises
+        :class:`TemplateNotFoundError` when the row doesn't exist and
+        :class:`TemplateNotPublishedError` when it exists but is still a
+        draft.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            row = await self._load_exact(session, tenant_id, request.slug, request.version)
+            if row is None:
+                raise TemplateNotFoundError(
+                    f"no template {request.slug!r} v{request.version} for tenant"
+                )
+            if row.status == "deprecated":
+                # Idempotent no-op -- already in the target state.
+                return DeprecateTemplateResponse(
+                    slug=request.slug, version=request.version, status="deprecated"
+                )
+            if row.status != "published":
+                raise TemplateNotPublishedError(
+                    f"template {request.slug!r} v{request.version} is "
+                    f"{row.status!r}, not published; cannot deprecate"
+                )
+            row.status = "deprecated"
+            await session.commit()
+
+        structlog.get_logger().info(
+            "runbook_template_deprecated",
+            tenant_id=str(tenant_id),
+            slug=request.slug,
+            version=request.version,
+        )
+        return DeprecateTemplateResponse(
+            slug=request.slug, version=request.version, status="deprecated"
+        )
+
+    async def list_templates(
+        self,
+        tenant_id: uuid.UUID,
+        filter_: ListTemplatesFilter,
+        limit: int = 100,
+    ) -> list[TemplateSummary]:
+        """Return the latest version of each slug for *tenant_id*, newest-edited first.
+
+        Each slug shows up once with its latest version *regardless of
+        status* (so operators see drafts that have no published version
+        yet). The optional ``filter_.status`` / ``filter_.target_kind``
+        narrow the set of rows considered before the latest-per-slug
+        projection is applied -- a ``status='published'`` filter returns
+        the latest *published* version of each slug, skipping slugs whose
+        only versions are drafts.
+
+        Ordered by ``edited_at`` descending and capped at *limit* rows.
+        """
+        if limit < 0:
+            raise ValueError(f"limit must be >= 0; got {limit}")
+        if limit == 0:
+            return []
+
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            # Subquery: the max version per slug among the rows that pass
+            # the status / target_kind filters. Correlating the outer
+            # query against this keeps "latest per slug" portable across
+            # SQLite (test) and PostgreSQL (prod) without a window
+            # function or DISTINCT ON.
+            latest = (
+                select(
+                    RunbookTemplate.slug.label("slug"),
+                    func.max(RunbookTemplate.version).label("version"),
+                )
+                .where(RunbookTemplate.tenant_id == tenant_id)
+                .group_by(RunbookTemplate.slug)
+            )
+            if filter_.status is not None:
+                latest = latest.where(RunbookTemplate.status == filter_.status)
+            if filter_.target_kind is not None:
+                latest = latest.where(RunbookTemplate.target_kind == filter_.target_kind)
+            latest_sub = latest.subquery()
+
+            stmt = (
+                select(RunbookTemplate)
+                .join(
+                    latest_sub,
+                    (RunbookTemplate.slug == latest_sub.c.slug)
+                    & (RunbookTemplate.version == latest_sub.c.version),
+                )
+                .where(RunbookTemplate.tenant_id == tenant_id)
+                .order_by(RunbookTemplate.edited_at.desc())
+                .limit(limit)
+            )
+            result = await session.execute(stmt)
+            rows = result.scalars().all()
+
+        return [
+            TemplateSummary(
+                slug=row.slug,
+                version=row.version,
+                title=row.title,
+                status=_narrow_status(row.status),
+                target_kind=row.target_kind,
+                edited_at=row.edited_at,
+            )
+            for row in rows
+        ]
+
+    async def show_template(
+        self,
+        tenant_id: uuid.UUID,
+        slug: str,
+        version: int | None = None,
+    ) -> ShowTemplateResponse:
+        """Return the full template body for ``(tenant_id, slug, version)``.
+
+        Resolves the latest version when *version* is ``None``. Returns
+        the complete surface including the ordered ``steps``. RBAC is the
+        route's job -- the service returns any tenant-scoped row it finds.
+        Raises :class:`TemplateNotFoundError` when nothing resolves.
+        """
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            if version is None:
+                resolved = await _resolve_latest_version(session, tenant_id, slug)
+                if resolved is None:
+                    raise TemplateNotFoundError(f"no template for slug {slug!r} for tenant")
+                version = resolved
+
+            row = await self._load_exact(session, tenant_id, slug, version)
+            if row is None:
+                raise TemplateNotFoundError(f"no template {slug!r} v{version} for tenant")
+
+        return ShowTemplateResponse(
+            slug=row.slug,
+            version=row.version,
+            title=row.title,
+            description=row.description,
+            target_kind=row.target_kind,
+            status=_narrow_status(row.status),
+            steps=_steps_from_storage(row.steps),
+            created_by=row.created_by,
+            created_at=row.created_at,
+            edited_by=row.edited_by,
+            edited_at=row.edited_at,
+        )
+
+    async def _load_draft(
+        self,
+        session: AsyncSession,
+        tenant_id: uuid.UUID,
+        slug: str,
+    ) -> RunbookTemplate | None:
+        """Return the single draft row for *slug*, or ``None`` if none exists.
+
+        The versioning invariant (a slug has at most one draft at a time:
+        ``create_draft`` refuses a second, ``publish`` consumes the draft)
+        means this ``LIMIT 1`` is unambiguous.
+        """
+        result = await session.execute(
+            select(RunbookTemplate)
+            .where(
+                RunbookTemplate.tenant_id == tenant_id,
+                RunbookTemplate.slug == slug,
+                RunbookTemplate.status == "draft",
+            )
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def _load_exact(
+        self,
+        session: AsyncSession,
+        tenant_id: uuid.UUID,
+        slug: str,
+        version: int,
+    ) -> RunbookTemplate | None:
+        """Return the row for the exact ``(tenant_id, slug, version)`` triple."""
+        result = await session.execute(
+            select(RunbookTemplate).where(
+                RunbookTemplate.tenant_id == tenant_id,
+                RunbookTemplate.slug == slug,
+                RunbookTemplate.version == version,
+            )
+        )
+        return result.scalar_one_or_none()
+
+
+async def _resolve_latest_version(
+    session: AsyncSession,
+    tenant_id: uuid.UUID,
+    slug: str,
+) -> int | None:
+    """Return ``max(version)`` for ``(tenant_id, slug)``, or ``None`` if no rows."""
+    latest: int | None = await session.scalar(
+        select(func.max(RunbookTemplate.version)).where(
+            RunbookTemplate.tenant_id == tenant_id,
+            RunbookTemplate.slug == slug,
+        )
+    )
+    return latest
+
+
+async def _count_in_flight_runs(
+    session: AsyncSession,
+    tenant_id: uuid.UUID,
+    slug: str,
+    version: int,
+) -> int:
+    """Count ``in_progress`` runs pinned to ``(tenant_id, slug, version)``.
+
+    The only read of ``runbook_runs`` from the template-side service.
+    G12.3's run service is the durable owner of the table; this read
+    feeds the senior's fork decision (how many runs are still bound to
+    the version being forked).
+    """
+    count = await session.scalar(
+        select(func.count())
+        .select_from(RunbookRun)
+        .where(
+            RunbookRun.tenant_id == tenant_id,
+            RunbookRun.template_slug == slug,
+            RunbookRun.template_version == version,
+            RunbookRun.state == _IN_PROGRESS_STATE,
+        )
+    )
+    return count or 0
+
+
+def _steps_to_storage(steps: list[Step]) -> list[dict[str, object]]:
+    """Serialise validated Pydantic steps to the ``steps`` JSONB column shape."""
+    return [step.model_dump(mode="json") for step in steps]
+
+
+def _steps_from_storage(steps: list[dict[str, object]]) -> list[Step]:
+    """Re-validate stored step dicts back into the discriminated-union models.
+
+    The round-trip through :class:`RunbookTemplateBody` reuses the
+    template-level validators (step-id uniqueness, substitution
+    allowlist) so a row that somehow reached storage malformed surfaces
+    at read time rather than leaking an unvalidated shape to the caller.
+    """
+    return RunbookTemplateBody(
+        title="",
+        description="",
+        target_kind=None,
+        steps=steps,  # type: ignore[arg-type]
+    ).steps
+
+
+def _narrow_status(status: str) -> _TemplateStatus:
+    """Narrow the ``str`` status column to the ``Literal`` the responses expect.
+
+    The DB ``CheckConstraint`` on ``runbook_templates.status`` guarantees
+    one of ``draft`` / ``published`` / ``deprecated`` at write time. This
+    helper re-asserts that closed set at read time so an out-of-vocabulary
+    value (a hand-edited row, a future migration gap) surfaces as a clean
+    ``ValueError`` here rather than as a Pydantic validation error one
+    layer up -- and keeps the ``str -> Literal`` narrowing localised for
+    the type checker.
+    """
+    if status not in _TEMPLATE_STATUSES:
+        raise ValueError(f"unexpected template status: {status!r}")
+    return status  # type: ignore[return-value]

--- a/backend/tests/test_runbooks_template_service.py
+++ b/backend/tests/test_runbooks_template_service.py
@@ -1,0 +1,451 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.runbooks.service`.
+
+Coverage matrix (G12.2-T2 / #1296 acceptance criteria):
+
+* ``create_draft`` -- fresh slug -> version=1, status=draft; second draft
+  on the same slug -> ``DuplicateDraftError``.
+* ``update_or_fork`` -- mutates an existing draft in place (version
+  unchanged, ``forked_from=None``); forks a new draft from a published
+  version (version bumped, ``forked_from`` populated with the source's
+  ``in_flight_run_count``). Only ``in_progress`` runs count.
+* ``publish`` -- draft -> published; idempotent re-publish; typed errors
+  on deprecated / missing.
+* ``deprecate`` -- published -> deprecated; idempotent; typed errors on
+  draft.
+* ``list_templates`` -- status filter narrows; latest per slug regardless
+  of status with no filter; tenant isolation.
+* ``show_template`` -- resolves latest when version is ``None``; resolves
+  a specific version; raises on missing.
+
+The SQLite path is the load-bearing test driver: the conftest autouse
+fixture applies the migrated schema (``runbook_templates`` +
+``runbook_runs`` from migration 0034) to a per-test SQLite DB and points
+``DATABASE_URL`` at it, so the service's ``get_sessionmaker()`` binds to
+the same DB these tests seed ``runbook_runs`` rows into directly.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+from datetime import UTC, datetime
+
+import pytest
+
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import RunbookRun
+from meho_backplane.kb.schemas import InvalidKbSlugError
+from meho_backplane.runbooks.schemas import (
+    ConfirmVerify,
+    DeprecateTemplateRequest,
+    DraftTemplateRequest,
+    EditTemplateRequest,
+    ListTemplatesFilter,
+    ManualStep,
+    PublishTemplateRequest,
+    RunbookTemplateBody,
+)
+from meho_backplane.runbooks.service import (
+    DuplicateDraftError,
+    RunbookTemplateService,
+    TemplateNotDraftError,
+    TemplateNotFoundError,
+    TemplateNotPublishedError,
+)
+from meho_backplane.settings import get_settings
+
+OPERATOR = "operator-sub-1"
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin env vars the :class:`Settings` model requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _body(title: str = "Drain node", *, step_body: str = "Run the drain.") -> RunbookTemplateBody:
+    """Build a minimal valid template body with one manual step."""
+    return RunbookTemplateBody(
+        title=title,
+        description="Procedure for draining a node.",
+        target_kind="k8s-node",
+        steps=[
+            ManualStep(
+                id="drain",
+                title="Drain the node",
+                body=step_body,
+                type="manual",
+                verify=ConfirmVerify(type="confirm", prompt="Node drained?"),
+            )
+        ],
+    )
+
+
+async def _seed_run(
+    tenant_id: uuid.UUID,
+    slug: str,
+    version: int,
+    state: str,
+) -> None:
+    """Insert one ``runbook_runs`` row pinned to *(slug, version)* in *state*."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            RunbookRun(
+                tenant_id=tenant_id,
+                template_slug=slug,
+                template_version=version,
+                assigned_to="op",
+                target="host-1",
+                params={},
+                state=state,
+                started_by="op",
+                started_at=datetime.now(UTC),
+            )
+        )
+        await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# create_draft
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_draft_first_version() -> None:
+    """A fresh slug yields version=1, status=draft."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+
+    resp = await service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug="drain-node", body=_body())
+    )
+
+    assert resp.slug == "drain-node"
+    assert resp.version == 1
+    assert resp.status == "draft"
+
+
+@pytest.mark.asyncio
+async def test_create_draft_duplicate_raises() -> None:
+    """A second create_draft on a slug that already has a version raises."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+    await service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug="drain-node", body=_body())
+    )
+
+    with pytest.raises(DuplicateDraftError):
+        await service.create_draft(
+            tenant_id, OPERATOR, DraftTemplateRequest(slug="drain-node", body=_body())
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_draft_invalid_slug_raises() -> None:
+    """The service revalidates the slug at its boundary (defense in depth)."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+
+    # Bypass the request model's pattern check by constructing without
+    # validation so the service-layer guard is what fires.
+    request = DraftTemplateRequest.model_construct(slug="Bad Slug", body=_body())
+    with pytest.raises(InvalidKbSlugError):
+        await service.create_draft(tenant_id, OPERATOR, request)
+
+
+# ---------------------------------------------------------------------------
+# update_or_fork
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_or_fork_mutates_draft_in_place() -> None:
+    """A slug with a draft at v1: edit mutates it in place; version stays 1."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+    await service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug="drain-node", body=_body())
+    )
+    show_before = await service.show_template(tenant_id, "drain-node")
+
+    resp = await service.update_or_fork(
+        tenant_id,
+        "operator-2",
+        EditTemplateRequest(
+            slug="drain-node", body=_body(title="Drain node v2", step_body="Updated.")
+        ),
+    )
+
+    assert resp.version == 1
+    assert resp.status == "draft"
+    assert resp.forked_from is None
+
+    show_after = await service.show_template(tenant_id, "drain-node")
+    assert show_after.title == "Drain node v2"
+    assert show_after.edited_by == "operator-2"
+    assert show_after.edited_at >= show_before.edited_at
+
+
+@pytest.mark.asyncio
+async def test_update_or_fork_forks_from_published() -> None:
+    """A slug whose only version is published forks a new draft at v2."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+    await service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug="drain-node", body=_body())
+    )
+    await service.publish(tenant_id, PublishTemplateRequest(slug="drain-node", version=1))
+
+    resp = await service.update_or_fork(
+        tenant_id,
+        OPERATOR,
+        EditTemplateRequest(slug="drain-node", body=_body(title="Forked")),
+    )
+
+    assert resp.version == 2
+    assert resp.status == "draft"
+    assert resp.forked_from is not None
+    assert resp.forked_from.slug == "drain-node"
+    assert resp.forked_from.version == 1
+    assert resp.forked_from.in_flight_run_count == 0
+
+
+@pytest.mark.asyncio
+async def test_update_or_fork_in_flight_run_count() -> None:
+    """Fork reports only in_progress runs pinned to the source version."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+    await service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug="drain-node", body=_body())
+    )
+    await service.publish(tenant_id, PublishTemplateRequest(slug="drain-node", version=1))
+
+    # Three in-progress runs against v1 are counted.
+    for _ in range(3):
+        await _seed_run(tenant_id, "drain-node", 1, "in_progress")
+    # Completed / abandoned runs against v1 are NOT counted.
+    await _seed_run(tenant_id, "drain-node", 1, "completed")
+    await _seed_run(tenant_id, "drain-node", 1, "abandoned")
+    # An in-progress run against a different version is NOT counted.
+    await _seed_run(tenant_id, "drain-node", 2, "in_progress")
+
+    resp = await service.update_or_fork(
+        tenant_id, OPERATOR, EditTemplateRequest(slug="drain-node", body=_body())
+    )
+
+    assert resp.forked_from is not None
+    assert resp.forked_from.in_flight_run_count == 3
+
+
+@pytest.mark.asyncio
+async def test_update_or_fork_missing_slug_raises() -> None:
+    """Editing a slug with no rows at all raises TemplateNotFoundError."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+
+    with pytest.raises(TemplateNotFoundError):
+        await service.update_or_fork(
+            tenant_id, OPERATOR, EditTemplateRequest(slug="ghost", body=_body())
+        )
+
+
+# ---------------------------------------------------------------------------
+# publish
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_publish_valid() -> None:
+    """A v1 draft publishes; a re-publish is an idempotent no-op."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+    await service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug="drain-node", body=_body())
+    )
+
+    resp = await service.publish(tenant_id, PublishTemplateRequest(slug="drain-node", version=1))
+    assert resp.status == "published"
+    assert resp.version == 1
+
+    again = await service.publish(tenant_id, PublishTemplateRequest(slug="drain-node", version=1))
+    assert again.status == "published"
+
+
+@pytest.mark.asyncio
+async def test_publish_against_deprecated_raises() -> None:
+    """Publishing a deprecated version raises TemplateNotDraftError."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+    await service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug="drain-node", body=_body())
+    )
+    await service.publish(tenant_id, PublishTemplateRequest(slug="drain-node", version=1))
+    await service.deprecate(tenant_id, DeprecateTemplateRequest(slug="drain-node", version=1))
+
+    with pytest.raises(TemplateNotDraftError):
+        await service.publish(tenant_id, PublishTemplateRequest(slug="drain-node", version=1))
+
+
+@pytest.mark.asyncio
+async def test_publish_against_missing_raises() -> None:
+    """Publishing a non-existent template raises TemplateNotFoundError."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+
+    with pytest.raises(TemplateNotFoundError):
+        await service.publish(tenant_id, PublishTemplateRequest(slug="ghost", version=1))
+
+
+# ---------------------------------------------------------------------------
+# deprecate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deprecate_valid() -> None:
+    """A published v1 deprecates; a re-deprecate is an idempotent no-op."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+    await service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug="drain-node", body=_body())
+    )
+    await service.publish(tenant_id, PublishTemplateRequest(slug="drain-node", version=1))
+
+    resp = await service.deprecate(
+        tenant_id, DeprecateTemplateRequest(slug="drain-node", version=1)
+    )
+    assert resp.status == "deprecated"
+
+    again = await service.deprecate(
+        tenant_id, DeprecateTemplateRequest(slug="drain-node", version=1)
+    )
+    assert again.status == "deprecated"
+
+
+@pytest.mark.asyncio
+async def test_deprecate_against_draft_raises() -> None:
+    """Deprecating a still-draft version raises TemplateNotPublishedError."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+    await service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug="drain-node", body=_body())
+    )
+
+    with pytest.raises(TemplateNotPublishedError):
+        await service.deprecate(tenant_id, DeprecateTemplateRequest(slug="drain-node", version=1))
+
+
+# ---------------------------------------------------------------------------
+# list_templates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_templates_filters() -> None:
+    """status filter returns only that status; no filter returns latest per slug."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+    # alpha: v1 published, v2 draft (fork). beta: v1 draft only.
+    await service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug="alpha", body=_body())
+    )
+    await service.publish(tenant_id, PublishTemplateRequest(slug="alpha", version=1))
+    await service.update_or_fork(
+        tenant_id, OPERATOR, EditTemplateRequest(slug="alpha", body=_body())
+    )
+    await service.create_draft(tenant_id, OPERATOR, DraftTemplateRequest(slug="beta", body=_body()))
+
+    # No filter: latest per slug regardless of status -> alpha v2 (draft), beta v1.
+    all_rows = await service.list_templates(tenant_id, ListTemplatesFilter())
+    by_slug = {r.slug: r for r in all_rows}
+    assert by_slug["alpha"].version == 2
+    assert by_slug["alpha"].status == "draft"
+    assert by_slug["beta"].version == 1
+
+    # status='published': only alpha v1 (beta has no published version).
+    published = await service.list_templates(tenant_id, ListTemplatesFilter(status="published"))
+    assert [(r.slug, r.version) for r in published] == [("alpha", 1)]
+
+
+@pytest.mark.asyncio
+async def test_list_templates_tenant_isolation() -> None:
+    """Two tenants with the same slug each see only their own row."""
+    service = RunbookTemplateService()
+    tenant_a = uuid.uuid4()
+    tenant_b = uuid.uuid4()
+    await service.create_draft(
+        tenant_a, OPERATOR, DraftTemplateRequest(slug="shared", body=_body("A"))
+    )
+    await service.create_draft(
+        tenant_b, OPERATOR, DraftTemplateRequest(slug="shared", body=_body("B"))
+    )
+
+    rows_a = await service.list_templates(tenant_a, ListTemplatesFilter())
+    rows_b = await service.list_templates(tenant_b, ListTemplatesFilter())
+
+    assert [r.slug for r in rows_a] == ["shared"]
+    assert rows_a[0].title == "A"
+    assert [r.slug for r in rows_b] == ["shared"]
+    assert rows_b[0].title == "B"
+
+
+# ---------------------------------------------------------------------------
+# show_template
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_show_template_resolves_latest_when_version_none() -> None:
+    """With version=None, show resolves the max version."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+    await service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug="drain-node", body=_body())
+    )
+    await service.publish(tenant_id, PublishTemplateRequest(slug="drain-node", version=1))
+    await service.update_or_fork(
+        tenant_id, OPERATOR, EditTemplateRequest(slug="drain-node", body=_body("v2"))
+    )
+
+    resp = await service.show_template(tenant_id, "drain-node")
+    assert resp.version == 2
+    assert resp.title == "v2"
+    assert len(resp.steps) == 1
+
+
+@pytest.mark.asyncio
+async def test_show_template_specific_version() -> None:
+    """A pinned version is returned even when a later version exists."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+    await service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug="drain-node", body=_body("v1"))
+    )
+    await service.publish(tenant_id, PublishTemplateRequest(slug="drain-node", version=1))
+    await service.update_or_fork(
+        tenant_id, OPERATOR, EditTemplateRequest(slug="drain-node", body=_body("v2"))
+    )
+
+    resp = await service.show_template(tenant_id, "drain-node", version=1)
+    assert resp.version == 1
+    assert resp.title == "v1"
+    assert resp.status == "published"
+
+
+@pytest.mark.asyncio
+async def test_show_template_missing_raises() -> None:
+    """Showing a non-existent slug raises TemplateNotFoundError."""
+    service = RunbookTemplateService()
+    tenant_id = uuid.uuid4()
+
+    with pytest.raises(TemplateNotFoundError):
+        await service.show_template(tenant_id, "ghost")


### PR DESCRIPTION
## Summary
- Adds `RunbookTemplateService` (`backend/src/meho_backplane/runbooks/service.py`) — the storage-facing service the G12.2 REST routes (T3) and MCP tools (T4) will wrap. Pure service: no HTTP, no MCP, no RBAC; `tenant_id` is a parameter on every method (no contextvar reads), each method opens its own `AsyncSession` and commits before returning, mirroring `KbService`.
- Implements the versioning algebra in one `update_or_fork` entry point: a draft mutates in place (version unchanged, `forked_from=None`); a published/deprecated-only slug forks a new draft at `max(version)+1` and returns `ForkInfo` with the source version's `in_flight_run_count`.
- `in_flight_run_count` is a `COUNT(*)` over `runbook_runs` in `state='in_progress'` pinned to the source `(tenant_id, slug, version)` — the only read of `runbook_runs` from the template side (G12.3 owns that table).
- `publish` (draft→published) and `deprecate` (published→deprecated) are idempotent on already-target-state rows and raise typed exceptions (`TemplateNotFoundError` / `TemplateNotDraftError` / `TemplateNotPublishedError`) for the route layer to translate.

## Test plan
- [x] `ruff check backend/src/meho_backplane/runbooks/ tests/test_runbooks_template_service.py` — clean
- [x] `ruff format` — clean
- [x] `mypy backend/src/meho_backplane/runbooks/service.py --ignore-missing-imports` — clean
- [x] `pytest backend/tests/test_runbooks_template_service.py -v` — 17 passed (15 acceptance-criteria cases + invalid-slug guard + fork-on-missing-slug guard)
- [x] `pytest tests/test_runbooks_schemas.py tests/test_kb_service.py` — 38 passed (no regression)
- [x] code-quality gate `--diff` — 0 blockers (3 warnings, all under blocking thresholds)
- [x] `create_draft` first version → v1/draft; duplicate slug → `DuplicateDraftError`
- [x] `update_or_fork` in-place draft edit (version stays, `forked_from=None`); fork-from-published (v2 draft, `forked_from.version=1`); `in_flight_run_count=3` counts only in-progress runs on the source version
- [x] `publish` / `deprecate` valid + idempotent + typed errors on wrong state / missing
- [x] `list_templates` status filter + latest-per-slug + tenant isolation
- [x] `show_template` resolves latest when `version=None`, resolves a pinned version, raises on missing

## Out of scope
- REST routes (T3), MCP tools (T4), multi-session drafting docs (T5), run-side service (G12.3), RBAC, step-shape validation (already in T1 schemas).
- No OpenAPI surface touched (pure service, no FastAPI routes) — `make snapshot-openapi`/`generate` not required.

## Adjacent findings (deferred)
- No `docs/codebase/runbooks*.md` exists for the area yet (T1 schemas merged without one). Deferred rather than writing a service-only doc that T3/T4/T5 would immediately invalidate; the initiative should land one area doc once the surfaces stabilise.
- `service.py` is 594 lines and `update_or_fork`/`list_templates` are 84/69 lines (mostly docstrings); all under the code-quality blocking thresholds (600 / 100). Recorded, not refactored.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1296
