### PR TITLE
feat(runbooks): G12.3-T2 step-execution engine + runtime substitution helper

### DIFF
--- a/backend/src/meho_backplane/runbooks/engine.py
+++ b/backend/src/meho_backplane/runbooks/engine.py
@@ -1,0 +1,475 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Pure-function step-execution engine for runbook runs (G12.3-T2, #1301).
+
+The **load-bearing isolation** for Initiative #1198's adherence floor.
+Step opacity, verify gating, and the state-machine transitions all live
+in this module. Keeping it pure (no DB session, no HTTP, no MCP, no
+contextvars, no clocks except where an outcome explicitly carries a
+``completed_at`` produced by the caller) lets the property-style
+opacity tests be reviewed in isolation without transport noise.
+
+Two functions, both pure:
+
+* :func:`current_step_body` -- look up a step by id in the template and
+  return its substituted :class:`StepBody`. This is the **opacity
+  function**: by signature it returns *only* the requested step. There
+  is no overload that returns multiple steps.
+* :func:`advance` -- drive the state machine one step forward, taking
+  the run's current position and the operator's verify response, and
+  returning an :class:`AdvanceOutcome` that describes whether the run
+  progresses, completes, or fails. The service layer (G12.3-T3) reads
+  this outcome and writes the corresponding storage-level rows; the
+  engine never touches the DB.
+
+The engine never returns information about steps other than the one
+the caller asked about (or the immediately-next one, on successful
+advance). The two LOAD-BEARING regression tests (
+:func:`test_current_step_body_returns_only_one_step`,
+:func:`test_advance_outcome_next_step_body_is_only_next_step`) walk the
+serialised outcomes and assert no other step ids leak.
+
+Five typed exceptions communicate engine-level errors. T3's service
+catches each and translates it into the typed wire error that the REST
+routes (T5) and MCP tools (T6) surface as 400 / -32602:
+
+* :class:`RunAlreadyCompletedError` -- ``advance`` called on a run that
+  has already reached its terminal step.
+* :class:`PreviousStepNotVerifiedError` -- ``advance`` called with the
+  current step still ``pending``; only ``in_progress`` steps may
+  advance.
+* :class:`VerifyResponseRequiredError` -- ``advance`` called on a step
+  whose verify gate requires a response without one provided.
+* :class:`VerifyResponseMismatchError` -- the response shape does not
+  match the step's verify type (a ``confirm`` step received an
+  ``operation_call`` response or vice versa).
+* :class:`ConfirmVerifyAnswerNotYesError` -- raised only when a caller
+  explicitly tightens this invariant; the engine itself models ``no`` /
+  ``escalate`` as legitimate ``failed`` transitions, not exceptions.
+
+**Verify match semantics** (`verify.type='operation_call'`): structural
+equality + presence. Every key in the substituted ``expect`` must be
+present in the response's ``actual`` with structurally equal value.
+Extra keys in ``actual`` are ignored. Dicts compared recursively. Lists
+compared element-wise (also with recursion). Scalars compared by
+``==``. No JSONPath, no comparison operators, no boolean composition --
+per Initiative #1198 scope + the determinism postulate (#1177).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+from meho_backplane.runbooks.runs_schemas import (
+    ConfirmVerifyResponse,
+    OperationCallVerifyResponse,
+    StepBody,
+    StepBodyVerify,
+    VerifyResponse,
+)
+from meho_backplane.runbooks.schemas import (
+    ConfirmVerify,
+    OperationCallStep,
+    OperationCallVerify,
+    RunbookTemplateBody,
+    Step,
+)
+from meho_backplane.runbooks.substitution import resolve_substitutions
+
+__all__ = [
+    "AdvanceOutcome",
+    "ConfirmVerifyAnswerNotYesError",
+    "PreviousStepNotVerifiedError",
+    "RunAlreadyCompletedError",
+    "VerifyResponseMismatchError",
+    "VerifyResponseRequiredError",
+    "advance",
+    "current_step_body",
+]
+
+
+class RunAlreadyCompletedError(ValueError):
+    """Raised when :func:`advance` is called past the terminal step."""
+
+
+class PreviousStepNotVerifiedError(ValueError):
+    """Raised when :func:`advance` is called with the current step still ``pending``.
+
+    The state-machine contract: only a step the operator has explicitly
+    started (state ``in_progress``) may advance. A ``pending`` step has
+    not been picked up; a ``verified`` step has already advanced; a
+    ``failed`` step terminates the run path through the engine -- none
+    of these are valid inputs to ``advance``.
+    """
+
+
+class VerifyResponseRequiredError(ValueError):
+    """Raised when ``advance`` is called without a *verify_response* but one is required."""
+
+
+class VerifyResponseMismatchError(ValueError):
+    """Raised when the *verify_response* shape does not match the step's verify type.
+
+    A ``confirm`` step requires a :class:`ConfirmVerifyResponse`; an
+    ``operation_call`` step requires an :class:`OperationCallVerifyResponse`.
+    Mixing shapes is a contract violation by the caller (T3's service or
+    a direct unit-test caller), not a malformed wire payload (the
+    Pydantic discriminated union catches the latter at the boundary).
+    """
+
+
+class ConfirmVerifyAnswerNotYesError(ValueError):
+    """Reserved for callers that explicitly want a ``no``/``escalate`` to raise.
+
+    The engine itself does **not** raise this -- ``no`` and ``escalate``
+    are first-class ``failed`` transitions per Initiative #1198, not
+    error states. The class is exported so future surfaces that want to
+    treat a ``no``/``escalate`` as a hard error (e.g. a smoke test in
+    CI) can raise it without inventing their own exception type.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class AdvanceOutcome:
+    """The result of one :func:`advance` call.
+
+    Carries exactly one of three transitions:
+
+    * ``kind="next_step"`` -- the current step's verify passed; the next
+      step's body is in :attr:`next_step_body`. T3 writes the previous
+      step's state to ``verified`` and inserts the next step's row with
+      state ``pending``.
+    * ``kind="completed"`` -- the current step's verify passed and the
+      step was the last one; :attr:`completed_at` carries the engine's
+      transition timestamp (caller-supplied, so the engine stays
+      clock-free). T3 writes the run's state to ``completed`` with
+      ``completed_at`` populated.
+    * ``kind="failed"`` -- the verify failed (operator answered
+      ``no``/``escalate``, or the ``operation_call`` verify's ``actual``
+      did not match ``expect``). T3 writes the current step's state to
+      ``failed``; the run as a whole remains ``in_progress`` and the
+      operator either retries (by re-issuing ``runbook_next`` with a
+      corrected response) or aborts.
+
+    :attr:`verify_response_persisted` is the canonical response shape T3
+    should write to ``runbook_run_step_states.verify_response``. For
+    ``confirm`` steps this echoes the caller's response verbatim. For
+    ``operation_call`` steps the engine constructs a fresh
+    :class:`OperationCallVerifyResponse` with :attr:`matched` set to the
+    engine's verdict so the persisted row carries the substrate's
+    decision, not the caller's claim.
+    """
+
+    kind: Literal["next_step", "completed", "failed"]
+    next_step_body: StepBody | None = None
+    completed_at: datetime | None = None
+    verify_response_persisted: VerifyResponse | None = None
+
+
+def current_step_body(
+    template_body: RunbookTemplateBody,
+    current_step_id: str,
+    *,
+    target: str,
+    params: dict[str, object],
+) -> StepBody:
+    """Build the opaque :class:`StepBody` for the operator's current position.
+
+    Looks up the step by id in :attr:`RunbookTemplateBody.steps`, applies
+    :func:`resolve_substitutions` to every substitution-bearing field
+    (``body``; ``op_id``/``params`` for operation-call steps;
+    ``prompt`` / ``params`` / ``expect`` for the verify gate), and
+    returns a :class:`StepBody` reflecting only that step.
+
+    **This is the opacity function.** By signature it returns exactly
+    one step body; there is no overload that returns multiple steps,
+    the surrounding step list, or any structural hint about adjacent
+    positions. The return value is what flows out through T3's service
+    into the ``CurrentStepResponse`` the operator sees.
+
+    Raises :class:`KeyError` if *current_step_id* is not a step in
+    *template_body*. T3 translates that into the typed wire error.
+    """
+    step = _find_step(template_body, current_step_id)
+    return _build_step_body(step, target=target, params=params)
+
+
+def advance(
+    template_body: RunbookTemplateBody,
+    current_step_id: str,
+    previous_step_state: str,
+    *,
+    target: str,
+    params: dict[str, object],
+    verify_response: VerifyResponse | None = None,
+    completed_at: datetime | None = None,
+) -> AdvanceOutcome:
+    """Drive the state machine one step forward.
+
+    Pre-conditions:
+
+    * *current_step_id* names a step present in *template_body* (raises
+      :class:`KeyError` otherwise).
+    * *previous_step_state* describes the state of the **current step**
+      -- the engine's parameter name reflects that the caller has
+      already locked the "previous" step (the one before this advance
+      call) as ``verified``; what's pending is the verify of the step
+      we're advancing past. Must be ``in_progress`` -- a ``pending``
+      step has not been picked up by the operator, so there is nothing
+      to verify (raises :class:`PreviousStepNotVerifiedError`).
+
+    Behavior by the current step's :attr:`verify.type`:
+
+    * ``confirm``: the *verify_response* must be a
+      :class:`ConfirmVerifyResponse`. ``answer="yes"`` produces a
+      ``next_step`` outcome (or ``completed`` if the current step is
+      the last). ``"no"`` and ``"escalate"`` produce a ``failed``
+      outcome with the response echoed verbatim into
+      :attr:`AdvanceOutcome.verify_response_persisted`.
+    * ``operation_call``: the *verify_response* must be an
+      :class:`OperationCallVerifyResponse` whose :attr:`actual` carries
+      the dispatched call's return value (T3 populates this from
+      ``call_operation()`` before invoking the engine; the engine
+      itself does not dispatch). The engine compares ``actual`` to the
+      substituted ``expect`` by structural equality + presence and
+      surfaces the verdict as :attr:`OperationCallVerifyResponse.matched`
+      on a freshly constructed response (so the persisted row carries
+      the substrate's decision, not a caller-supplied claim).
+
+    Missing *verify_response* on a step whose verify gate requires one
+    raises :class:`VerifyResponseRequiredError`; a response of the
+    wrong shape (``confirm`` step + ``operation_call`` response or vice
+    versa) raises :class:`VerifyResponseMismatchError`.
+
+    *completed_at* is supplied by the caller when the engine determines
+    the step's verify passed *and* the step is the last one; the engine
+    is otherwise clock-free. T3 supplies ``datetime.now(UTC)`` from the
+    service layer so test code can pin the timestamp deterministically.
+    A ``completed`` outcome with no *completed_at* falls back to the
+    parsed ``StartRunRequest``-side default of ``None``; T3's writer
+    treats that as "use the row's CURRENT_TIMESTAMP default".
+    """
+    if previous_step_state != "in_progress":
+        raise PreviousStepNotVerifiedError(
+            f"current step {current_step_id!r} is in state {previous_step_state!r}; "
+            f"only 'in_progress' may advance",
+        )
+
+    step = _find_step(template_body, current_step_id)
+    verify = step.verify
+
+    verdict: tuple[bool, VerifyResponse]
+    if isinstance(verify, ConfirmVerify):
+        verdict = _evaluate_confirm(verify_response)
+    elif isinstance(verify, OperationCallVerify):
+        verdict = _evaluate_operation_call(verify, verify_response, target=target, params=params)
+    else:
+        # Defensive: the Verify discriminated union is closed over
+        # ConfirmVerify | OperationCallVerify, so this branch is
+        # unreachable from a Pydantic-validated template. Surface as a
+        # hard error so a future expansion that forgets to extend the
+        # engine fails closed rather than silently.
+        raise VerifyResponseMismatchError(
+            f"unknown verify type on step {current_step_id!r}: {type(verify).__name__}",
+        )
+
+    verify_passed, response_to_persist = verdict
+
+    if not verify_passed:
+        return AdvanceOutcome(
+            kind="failed",
+            verify_response_persisted=response_to_persist,
+        )
+
+    next_step = _next_step(template_body, current_step_id)
+    if next_step is None:
+        return AdvanceOutcome(
+            kind="completed",
+            completed_at=completed_at,
+            verify_response_persisted=response_to_persist,
+        )
+
+    return AdvanceOutcome(
+        kind="next_step",
+        next_step_body=_build_step_body(next_step, target=target, params=params),
+        verify_response_persisted=response_to_persist,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers -- not exported.
+# ---------------------------------------------------------------------------
+
+
+def _find_step(template_body: RunbookTemplateBody, step_id: str) -> Step:
+    """Return the step with *step_id* or raise :class:`KeyError`."""
+    for step in template_body.steps:
+        if step.id == step_id:
+            return step
+    raise KeyError(step_id)
+
+
+def _next_step(template_body: RunbookTemplateBody, current_step_id: str) -> Step | None:
+    """Return the step that follows *current_step_id* or ``None`` if it is the last."""
+    steps = template_body.steps
+    for index, step in enumerate(steps):
+        if step.id == current_step_id:
+            if index + 1 < len(steps):
+                return steps[index + 1]
+            return None
+    raise KeyError(current_step_id)
+
+
+def _build_step_body(step: Step, *, target: str, params: dict[str, object]) -> StepBody:
+    """Construct a :class:`StepBody` for *step* with substitutions resolved.
+
+    Branches on the step type to keep the populated fields consistent
+    with the wire shape from T1 (#1300): ``op_id`` / ``params`` carried
+    only for ``operation_call`` steps; ``prompt`` / ``op_id`` /
+    ``params`` / ``expect`` on the embedded :class:`StepBodyVerify`
+    populated only for the corresponding verify type.
+    """
+    body = _resolve_str(step.body, target=target, params=params)
+    verify_body = _build_step_body_verify(step.verify, target=target, params=params)
+    if isinstance(step, OperationCallStep):
+        return StepBody(
+            id=step.id,
+            title=step.title,
+            body=body,
+            type="operation_call",
+            op_id=step.op_id,
+            params=_resolve_dict(step.params, target=target, params=params),
+            verify=verify_body,
+        )
+    # ManualStep -- closed over Step union; the only other variant.
+    return StepBody(
+        id=step.id,
+        title=step.title,
+        body=body,
+        type="manual",
+        verify=verify_body,
+    )
+
+
+def _build_step_body_verify(
+    verify: ConfirmVerify | OperationCallVerify,
+    *,
+    target: str,
+    params: dict[str, object],
+) -> StepBodyVerify:
+    """Construct the substituted :class:`StepBodyVerify`."""
+    if isinstance(verify, ConfirmVerify):
+        return StepBodyVerify(
+            type="confirm",
+            prompt=_resolve_str(verify.prompt, target=target, params=params),
+        )
+    # OperationCallVerify -- closed over Verify union; the only other variant.
+    return StepBodyVerify(
+        type="operation_call",
+        op_id=verify.op_id,
+        params=_resolve_dict(verify.params, target=target, params=params),
+        expect=_resolve_dict(verify.expect, target=target, params=params),
+    )
+
+
+def _evaluate_confirm(
+    verify_response: VerifyResponse | None,
+) -> tuple[bool, ConfirmVerifyResponse]:
+    """Return ``(passed, persisted_response)`` for a ``confirm`` verify step.
+
+    Raises :class:`VerifyResponseRequiredError` if *verify_response* is
+    ``None`` and :class:`VerifyResponseMismatchError` if the response
+    is not a :class:`ConfirmVerifyResponse`.
+    """
+    if verify_response is None:
+        raise VerifyResponseRequiredError("confirm step requires a verify_response")
+    if not isinstance(verify_response, ConfirmVerifyResponse):
+        raise VerifyResponseMismatchError(
+            f"confirm step received a non-confirm verify_response: "
+            f"{type(verify_response).__name__}",
+        )
+    return verify_response.answer == "yes", verify_response
+
+
+def _evaluate_operation_call(
+    verify: OperationCallVerify,
+    verify_response: VerifyResponse | None,
+    *,
+    target: str,
+    params: dict[str, object],
+) -> tuple[bool, OperationCallVerifyResponse]:
+    """Return ``(passed, persisted_response)`` for an ``operation_call`` verify step.
+
+    Substitutes ``${...}`` in *verify*'s ``expect`` before comparing,
+    runs :func:`_matches` for structural-equality + presence, and
+    constructs a fresh :class:`OperationCallVerifyResponse` whose
+    :attr:`matched` reflects the engine's verdict (not the caller's
+    claim) so the persisted audit row carries the substrate's decision.
+    """
+    if verify_response is None:
+        raise VerifyResponseRequiredError("operation_call step requires a verify_response")
+    if not isinstance(verify_response, OperationCallVerifyResponse):
+        raise VerifyResponseMismatchError(
+            f"operation_call step received a non-operation_call verify_response: "
+            f"{type(verify_response).__name__}",
+        )
+    resolved_expect = _resolve_dict(verify.expect, target=target, params=params)
+    matched = _matches(verify_response.actual, resolved_expect)
+    return matched, OperationCallVerifyResponse(
+        type="operation_call",
+        matched=matched,
+        actual=verify_response.actual,
+    )
+
+
+def _matches(actual: object, expect: object) -> bool:
+    """Structural-equality + presence match -- the verify comparison contract.
+
+    Every key in *expect* must be present in *actual* with structurally
+    equal value. Extra keys in *actual* are ignored (the "presence"
+    half). Dicts compared recursively. Lists compared element-wise
+    (also with recursion). Scalars compared by ``==``.
+
+    Deliberately minimal: no JSONPath, no operators, no boolean
+    composition (per #1177's determinism postulate + Initiative
+    #1198's verify-surface scope). A future authoring need for richer
+    matching is a separate Initiative, not a quiet feature add here.
+    """
+    if isinstance(expect, dict):
+        if not isinstance(actual, dict):
+            return False
+        for key, expected_value in expect.items():
+            if key not in actual:
+                return False
+            if not _matches(actual[key], expected_value):
+                return False
+        return True
+    if isinstance(expect, list):
+        if not isinstance(actual, list) or len(actual) != len(expect):
+            return False
+        return all(_matches(a, e) for a, e in zip(actual, expect, strict=True))
+    return actual == expect
+
+
+def _resolve_str(value: str, *, target: str, params: dict[str, object]) -> str:
+    """Type-narrow wrapper around :func:`resolve_substitutions` for a string."""
+    resolved = resolve_substitutions(value, target=target, params=params)
+    # resolve_substitutions returns str for str input -- the cast is
+    # for the type checker, not for runtime.
+    assert isinstance(resolved, str)
+    return resolved
+
+
+def _resolve_dict(
+    value: dict[str, object],
+    *,
+    target: str,
+    params: dict[str, object],
+) -> dict[str, object]:
+    """Type-narrow wrapper around :func:`resolve_substitutions` for a dict."""
+    resolved = resolve_substitutions(value, target=target, params=params)
+    assert isinstance(resolved, dict)
+    return resolved

--- a/backend/src/meho_backplane/runbooks/substitution.py
+++ b/backend/src/meho_backplane/runbooks/substitution.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Runtime substitution of ``${run.target}`` / ``${run.params.X}`` tokens (G12.3-T2, #1301).
+
+Companion to :func:`meho_backplane.runbooks.schemas.validate_substitutions`
+-- T1 (#1295) rejects disallowed substitution patterns at **publish time**;
+this module **resolves** the allowed patterns at **advance time**, called
+from the engine (G12.3-T2) on the way to building a
+:class:`~meho_backplane.runbooks.runs_schemas.StepBody` for the operator's
+current position.
+
+Two patterns are allowlisted by Initiative #1198, both single-flat-level:
+
+* ``${run.target}`` -- the run's subject (the host, cluster, cert
+  thumbprint) supplied at ``runbook_start`` time.
+* ``${run.params.X}`` -- one of the named run parameters, where ``X``
+  matches ``[a-z_][a-z0-9_]*``. Nested paths (``${run.params.X.Y}``) are
+  not allowed and are rejected at publish time -- this module assumes the
+  body it walks has already cleared that gate.
+
+The function is **pure**: no DB session, no contextvars, no clocks. The
+service layer (G12.3-T3) is the boundary that supplies *target* and
+*params* from the persisted :class:`RunbookRun` row; this module is
+deliberately storage-blind.
+
+The regex constants are exported so the engine, the service, and future
+tests can share one source of truth. T1's :data:`_SUBSTITUTION_PATTERN`
+in :mod:`meho_backplane.runbooks.schemas` covers the publish-time
+allowlist surface (where rejecting *any* disallowed ``${...}`` is the
+point) and intentionally stays separate -- a future refactor (deferred
+to G12.3-T3 per #1301 scope) can have ``validate_substitutions`` import
+the same two narrow patterns from here, but T2 stays focused.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+__all__ = [
+    "RUN_PARAMS_PATTERN",
+    "RUN_TARGET_PATTERN",
+    "resolve_substitutions",
+]
+
+
+#: Matches the literal ``${run.target}`` substitution token.
+#:
+#: ``re.sub`` consumers replace every occurrence with the run's target
+#: string. There is no capture group -- the entire match is the token.
+RUN_TARGET_PATTERN: Final[re.Pattern[str]] = re.compile(r"\$\{run\.target\}")
+
+#: Matches ``${run.params.X}`` where ``X`` is ``[a-z_][a-z0-9_]*``.
+#:
+#: The single capture group is the bare parameter name (``X``) -- the
+#: substitution callback indexes ``params[X]`` to find the replacement.
+#: A nested ``${run.params.X.Y}`` does not match (the inner ``.`` would
+#: have to be part of the param-name grammar, which it is not) -- such
+#: patterns are publish-time-rejected by T1's :func:`validate_substitutions`.
+RUN_PARAMS_PATTERN: Final[re.Pattern[str]] = re.compile(r"\$\{run\.params\.([a-z_][a-z0-9_]*)\}")
+
+
+def resolve_substitutions(
+    value: object,
+    *,
+    target: str,
+    params: dict[str, object],
+) -> object:
+    """Walk *value* and resolve ``${run.target}`` / ``${run.params.X}``.
+
+    Recursive over ``str`` / ``dict`` / ``list``; other scalar types
+    (``int``, ``float``, ``bool``, ``None``) pass through verbatim.
+
+    For string values both regex patterns are applied:
+
+    * Each ``${run.target}`` occurrence is replaced with ``str(target)``.
+    * Each ``${run.params.X}`` occurrence is replaced with ``str(params[X])``.
+
+    For dict values the function recurses on each value; **keys stay
+    literal** -- a substitution smuggled into a key was already rejected
+    at publish time by :func:`meho_backplane.runbooks.schemas.validate_substitutions`,
+    so attempting to resolve one here would mask a contract violation.
+
+    For list values the function recurses on each element. The returned
+    container is a new ``list`` / ``dict`` (not a mutated copy) so the
+    caller's input is unchanged -- consistent with the
+    :class:`pydantic.BaseModel`'s frozen posture on the engine's inputs.
+
+    A non-resolvable ``${run.params.X}`` (key not present in *params*)
+    surfaces as :class:`KeyError` with the missing param name. T3's
+    service is expected to translate that into a typed error before it
+    reaches the engine -- so reaching this branch indicates a publish /
+    start invariant was bypassed (defense in depth).
+
+    The function does **not** validate the input against the allowlist
+    -- that is the publish-time gate's job. Any ``${something_else}``
+    pattern in *value* passes through verbatim (matched by neither
+    pattern), which is exactly the behavior the engine wants: the run-
+    time helper resolves the good patterns and leaves anything else
+    alone, because the publish gate already guaranteed nothing else can
+    be present in a well-formed template.
+    """
+    if isinstance(value, str):
+        return _resolve_string(value, target=target, params=params)
+    if isinstance(value, dict):
+        return {
+            key: resolve_substitutions(item, target=target, params=params)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [resolve_substitutions(item, target=target, params=params) for item in value]
+    return value
+
+
+def _resolve_string(value: str, *, target: str, params: dict[str, object]) -> str:
+    """Apply both substitution patterns to a single string.
+
+    Target replacement runs first so a ``${run.target}`` that resolves
+    to a literal string containing ``${run.params.X}`` is **not**
+    re-expanded (the resolved value is data, not template). Param
+    replacement runs second over the now-stripped-of-target string.
+    """
+    resolved = RUN_TARGET_PATTERN.sub(lambda _: target, value)
+    return RUN_PARAMS_PATTERN.sub(lambda m: _lookup_param(m.group(1), params), resolved)
+
+
+def _lookup_param(name: str, params: dict[str, object]) -> str:
+    """Return ``str(params[name])`` or raise :class:`KeyError`.
+
+    Wrapped in its own helper so the :func:`re.Pattern.sub` callback in
+    :func:`_resolve_string` stays a one-liner and the error surface is
+    explicit -- ``KeyError(name)`` carries the bare param name as the
+    arg, so the engine's :class:`KeyError` handler (T3) can surface a
+    typed error with the missing name intact.
+    """
+    if name not in params:
+        raise KeyError(name)
+    return str(params[name])

--- a/backend/tests/test_runbooks_engine.py
+++ b/backend/tests/test_runbooks_engine.py
@@ -1,0 +1,543 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.runbooks.engine` (G12.3-T2, #1301).
+
+Coverage matrix follows the Initiative #1198 acceptance bar:
+
+* **Opacity** -- :func:`current_step_body` and
+  :attr:`AdvanceOutcome.next_step_body` return exactly the requested /
+  immediately-next step; the LOAD-BEARING regression tests
+  (:func:`test_current_step_body_returns_only_one_step`,
+  :func:`test_advance_outcome_next_step_body_is_only_next_step`) walk
+  the serialised result and assert no other step ids leak.
+* **Verify by type** -- confirm yes/no/escalate paths, operation_call
+  match / mismatch / list match / recursive match.
+* **State-machine guards** -- ``pending`` previous-step raises;
+  unknown step id raises; verify_response missing on a gated step
+  raises; verify_response shape mismatch raises.
+* **Substitutions** -- the step body's ``${run.target}`` and
+  ``${run.params.X}`` are resolved in the returned StepBody.
+* **Purity** -- ``advance(X) == advance(X)`` across invocations.
+* **Terminal step** -- verify pass on the last step → ``completed``
+  outcome with caller-supplied ``completed_at``.
+
+The fixture-style helpers (``_make_template``, ``_confirm_response``,
+``_operation_call_response``) keep each test focused on the one
+behaviour it locks down without three lines of setup noise per case.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from meho_backplane.runbooks.engine import (
+    AdvanceOutcome,
+    PreviousStepNotVerifiedError,
+    VerifyResponseMismatchError,
+    VerifyResponseRequiredError,
+    advance,
+    current_step_body,
+)
+from meho_backplane.runbooks.runs_schemas import (
+    ConfirmVerifyResponse,
+    OperationCallVerifyResponse,
+    StepBody,
+)
+from meho_backplane.runbooks.schemas import (
+    ConfirmVerify,
+    ManualStep,
+    OperationCallStep,
+    OperationCallVerify,
+    RunbookTemplateBody,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture helpers -- keep tests focused.
+# ---------------------------------------------------------------------------
+
+
+def _confirm_step(step_id: str, *, prompt: str = "Did it work?") -> ManualStep:
+    """Build a ``manual`` step gated by a ``confirm`` verify."""
+    return ManualStep(
+        id=step_id,
+        title=f"Step {step_id}",
+        body=f"Body for {step_id}",
+        type="manual",
+        verify=ConfirmVerify(type="confirm", prompt=prompt),
+    )
+
+
+def _operation_call_step(step_id: str, *, expect: dict[str, object]) -> OperationCallStep:
+    """Build an ``operation_call`` step gated by an ``operation_call`` verify."""
+    return OperationCallStep(
+        id=step_id,
+        title=f"Step {step_id}",
+        body=f"Body for {step_id}",
+        type="operation_call",
+        op_id="kb.create",
+        params={"slug": step_id},
+        verify=OperationCallVerify(
+            type="operation_call",
+            op_id="kb.show",
+            params={"slug": step_id},
+            expect=expect,
+        ),
+    )
+
+
+def _five_step_template() -> RunbookTemplateBody:
+    """A 5-step template used by the opacity regression tests."""
+    return RunbookTemplateBody(
+        title="Five-step procedure",
+        description="for opacity tests",
+        steps=[_confirm_step(f"step-{i}") for i in range(1, 6)],
+    )
+
+
+def _confirm_response(answer: str) -> ConfirmVerifyResponse:
+    return ConfirmVerifyResponse(type="confirm", answer=answer)  # type: ignore[arg-type]
+
+
+def _operation_call_response(actual: dict[str, object]) -> OperationCallVerifyResponse:
+    return OperationCallVerifyResponse(type="operation_call", matched=False, actual=actual)
+
+
+# ---------------------------------------------------------------------------
+# Confirm verify -- the three answer transitions.
+# ---------------------------------------------------------------------------
+
+
+def test_advance_confirm_yes_returns_next_step() -> None:
+    template = _five_step_template()
+    outcome = advance(
+        template,
+        current_step_id="step-1",
+        previous_step_state="in_progress",
+        target="vc-01",
+        params={},
+        verify_response=_confirm_response("yes"),
+    )
+    assert outcome.kind == "next_step"
+    assert outcome.next_step_body is not None
+    assert outcome.next_step_body.id == "step-2"
+    # Persisted response echoes the caller's confirm payload verbatim.
+    assert isinstance(outcome.verify_response_persisted, ConfirmVerifyResponse)
+    assert outcome.verify_response_persisted.answer == "yes"
+
+
+def test_advance_confirm_no_returns_failed() -> None:
+    template = _five_step_template()
+    outcome = advance(
+        template,
+        current_step_id="step-1",
+        previous_step_state="in_progress",
+        target="vc-01",
+        params={},
+        verify_response=_confirm_response("no"),
+    )
+    assert outcome.kind == "failed"
+    assert outcome.next_step_body is None
+    assert isinstance(outcome.verify_response_persisted, ConfirmVerifyResponse)
+    assert outcome.verify_response_persisted.answer == "no"
+
+
+def test_advance_confirm_escalate_returns_failed() -> None:
+    template = _five_step_template()
+    outcome = advance(
+        template,
+        current_step_id="step-1",
+        previous_step_state="in_progress",
+        target="vc-01",
+        params={},
+        verify_response=_confirm_response("escalate"),
+    )
+    assert outcome.kind == "failed"
+    assert isinstance(outcome.verify_response_persisted, ConfirmVerifyResponse)
+    assert outcome.verify_response_persisted.answer == "escalate"
+
+
+def test_advance_confirm_missing_response_raises() -> None:
+    template = _five_step_template()
+    with pytest.raises(VerifyResponseRequiredError):
+        advance(
+            template,
+            current_step_id="step-1",
+            previous_step_state="in_progress",
+            target="vc-01",
+            params={},
+            verify_response=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Operation_call verify -- structural match semantics.
+# ---------------------------------------------------------------------------
+
+
+def test_advance_operation_call_match_returns_next_step() -> None:
+    template = RunbookTemplateBody(
+        title="op-call match",
+        description="...",
+        steps=[
+            _operation_call_step("s1", expect={"foo": 1}),
+            _confirm_step("s2"),
+        ],
+    )
+    outcome = advance(
+        template,
+        current_step_id="s1",
+        previous_step_state="in_progress",
+        target="vc-01",
+        params={},
+        verify_response=OperationCallVerifyResponse(
+            type="operation_call",
+            matched=False,  # engine will overwrite -- the caller's claim is ignored.
+            actual={"foo": 1, "bar": 2},
+        ),
+    )
+    assert outcome.kind == "next_step"
+    assert outcome.next_step_body is not None
+    assert outcome.next_step_body.id == "s2"
+    # Engine sets `matched` to its own verdict, not the caller's claim.
+    assert isinstance(outcome.verify_response_persisted, OperationCallVerifyResponse)
+    assert outcome.verify_response_persisted.matched is True
+    # Actual is retained verbatim for audit.
+    assert outcome.verify_response_persisted.actual == {"foo": 1, "bar": 2}
+
+
+def test_advance_operation_call_mismatch_returns_failed() -> None:
+    template = RunbookTemplateBody(
+        title="op-call mismatch",
+        description="...",
+        steps=[
+            _operation_call_step("s1", expect={"foo": 1}),
+            _confirm_step("s2"),
+        ],
+    )
+    outcome = advance(
+        template,
+        current_step_id="s1",
+        previous_step_state="in_progress",
+        target="vc-01",
+        params={},
+        verify_response=OperationCallVerifyResponse(
+            type="operation_call",
+            matched=True,  # engine ignores the caller's claim.
+            actual={"foo": 2},
+        ),
+    )
+    assert outcome.kind == "failed"
+    assert isinstance(outcome.verify_response_persisted, OperationCallVerifyResponse)
+    assert outcome.verify_response_persisted.matched is False
+    assert outcome.verify_response_persisted.actual == {"foo": 2}
+
+
+def test_advance_operation_call_recursive_match() -> None:
+    # Nested dict: expect is satisfied by a deeper structure with extra keys.
+    template = RunbookTemplateBody(
+        title="nested",
+        description="...",
+        steps=[
+            _operation_call_step(
+                "s1",
+                expect={"outer": {"inner": "value"}},
+            ),
+            _confirm_step("s2"),
+        ],
+    )
+    outcome = advance(
+        template,
+        current_step_id="s1",
+        previous_step_state="in_progress",
+        target="vc-01",
+        params={},
+        verify_response=OperationCallVerifyResponse(
+            type="operation_call",
+            matched=False,
+            actual={
+                "outer": {"inner": "value", "extra": 1},
+                "another_key": "ignored",
+            },
+        ),
+    )
+    assert outcome.kind == "next_step"
+
+
+def test_advance_operation_call_list_match() -> None:
+    # Lists compared element-wise; length must match.
+    template = RunbookTemplateBody(
+        title="lists",
+        description="...",
+        steps=[
+            _operation_call_step(
+                "s1",
+                expect={"items": [1, 2, 3]},
+            ),
+            _confirm_step("s2"),
+        ],
+    )
+    outcome_match = advance(
+        template,
+        current_step_id="s1",
+        previous_step_state="in_progress",
+        target="vc-01",
+        params={},
+        verify_response=OperationCallVerifyResponse(
+            type="operation_call",
+            matched=False,
+            actual={"items": [1, 2, 3]},
+        ),
+    )
+    assert outcome_match.kind == "next_step"
+
+    # Different length → mismatch.
+    outcome_mismatch = advance(
+        template,
+        current_step_id="s1",
+        previous_step_state="in_progress",
+        target="vc-01",
+        params={},
+        verify_response=OperationCallVerifyResponse(
+            type="operation_call",
+            matched=False,
+            actual={"items": [1, 2]},
+        ),
+    )
+    assert outcome_mismatch.kind == "failed"
+
+
+# ---------------------------------------------------------------------------
+# Terminal-step transition.
+# ---------------------------------------------------------------------------
+
+
+def test_advance_at_last_step_returns_completed() -> None:
+    template = RunbookTemplateBody(
+        title="two",
+        description="...",
+        steps=[_confirm_step("s1"), _confirm_step("s2")],
+    )
+    completed_at = datetime(2026, 5, 28, 12, 0, tzinfo=UTC)
+    outcome = advance(
+        template,
+        current_step_id="s2",
+        previous_step_state="in_progress",
+        target="vc-01",
+        params={},
+        verify_response=_confirm_response("yes"),
+        completed_at=completed_at,
+    )
+    assert outcome.kind == "completed"
+    assert outcome.completed_at == completed_at
+    assert outcome.next_step_body is None
+    assert isinstance(outcome.verify_response_persisted, ConfirmVerifyResponse)
+
+
+# ---------------------------------------------------------------------------
+# State-machine guards.
+# ---------------------------------------------------------------------------
+
+
+def test_advance_previous_not_in_progress_raises() -> None:
+    template = _five_step_template()
+    with pytest.raises(PreviousStepNotVerifiedError):
+        advance(
+            template,
+            current_step_id="step-1",
+            previous_step_state="pending",
+            target="vc-01",
+            params={},
+            verify_response=_confirm_response("yes"),
+        )
+
+
+def test_advance_unknown_step_id_raises_keyerror() -> None:
+    template = _five_step_template()
+    with pytest.raises(KeyError):
+        advance(
+            template,
+            current_step_id="not-in-template",
+            previous_step_state="in_progress",
+            target="vc-01",
+            params={},
+            verify_response=_confirm_response("yes"),
+        )
+
+
+def test_advance_confirm_step_with_operation_call_response_raises() -> None:
+    template = _five_step_template()
+    with pytest.raises(VerifyResponseMismatchError):
+        advance(
+            template,
+            current_step_id="step-1",
+            previous_step_state="in_progress",
+            target="vc-01",
+            params={},
+            verify_response=OperationCallVerifyResponse(
+                type="operation_call",
+                matched=True,
+                actual={},
+            ),
+        )
+
+
+def test_advance_operation_call_step_with_confirm_response_raises() -> None:
+    template = RunbookTemplateBody(
+        title="op",
+        description="...",
+        steps=[_operation_call_step("s1", expect={"foo": 1}), _confirm_step("s2")],
+    )
+    with pytest.raises(VerifyResponseMismatchError):
+        advance(
+            template,
+            current_step_id="s1",
+            previous_step_state="in_progress",
+            target="vc-01",
+            params={},
+            verify_response=_confirm_response("yes"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Opacity -- the load-bearing regression tests.
+# ---------------------------------------------------------------------------
+
+
+def test_current_step_body_returns_only_one_step() -> None:
+    """LOAD-BEARING: the opacity function returns exactly one step's contents.
+
+    Build a 5-step template, ask for step-3, serialise the returned
+    :class:`StepBody`, and assert by **string search** that none of the
+    other step ids appear anywhere in the serialised shape. String
+    search catches both field-name leaks (a field called ``step_1``
+    set to ``None``) and value-level leaks (an embedded body
+    referencing another step).
+    """
+    template = _five_step_template()
+    body = current_step_body(
+        template,
+        "step-3",
+        target="vc-01",
+        params={},
+    )
+    assert isinstance(body, StepBody)
+    assert body.id == "step-3"
+
+    serialised = json.dumps(body.model_dump(mode="json"))
+    for forbidden_id in ("step-1", "step-2", "step-4", "step-5"):
+        assert forbidden_id not in serialised, (
+            f"opacity leak: {forbidden_id!r} appears in current_step_body output: {serialised!r}"
+        )
+
+
+def test_advance_outcome_next_step_body_is_only_next_step() -> None:
+    """LOAD-BEARING: the post-advance step body is exactly the next step.
+
+    Same 5-step template; advance with a verify-pass on step-2. Walk
+    the serialised next_step_body and assert no other step id appears.
+    """
+    template = _five_step_template()
+    outcome = advance(
+        template,
+        current_step_id="step-2",
+        previous_step_state="in_progress",
+        target="vc-01",
+        params={},
+        verify_response=_confirm_response("yes"),
+    )
+    assert outcome.kind == "next_step"
+    assert outcome.next_step_body is not None
+    assert outcome.next_step_body.id == "step-3"
+
+    serialised = json.dumps(outcome.next_step_body.model_dump(mode="json"))
+    for forbidden_id in ("step-1", "step-2", "step-4", "step-5"):
+        assert forbidden_id not in serialised, (
+            f"opacity leak: {forbidden_id!r} appears in advance outcome: {serialised!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Substitution resolution at the engine boundary.
+# ---------------------------------------------------------------------------
+
+
+def test_current_step_body_substitutes_target_and_params() -> None:
+    """Substitutions in body, op-call params, and verify params resolve."""
+    template = RunbookTemplateBody(
+        title="sub",
+        description="...",
+        steps=[
+            OperationCallStep(
+                id="provision",
+                title="Provision VM",
+                body="connect to ${run.target}",
+                type="operation_call",
+                op_id="vm.create",
+                params={"size": "${run.params.size}", "host": "${run.target}"},
+                verify=OperationCallVerify(
+                    type="operation_call",
+                    op_id="vm.show",
+                    params={"host": "${run.target}"},
+                    expect={"size": "${run.params.size}"},
+                ),
+            ),
+        ],
+    )
+    body = current_step_body(
+        template,
+        "provision",
+        target="vc-01",
+        params={"size": "large"},
+    )
+    assert body.body == "connect to vc-01"
+    assert body.op_id == "vm.create"
+    assert body.params == {"size": "large", "host": "vc-01"}
+    assert body.verify.type == "operation_call"
+    assert body.verify.params == {"host": "vc-01"}
+    assert body.verify.expect == {"size": "large"}
+
+
+def test_advance_pure_function() -> None:
+    """Same inputs → same outputs across multiple invocations.
+
+    Property-style purity check: the engine has no hidden state, so
+    two invocations with identical args produce equal outcomes. The
+    dataclass is frozen + slots, so equality is structural.
+    """
+    template = _five_step_template()
+    args = {
+        "current_step_id": "step-2",
+        "previous_step_state": "in_progress",
+        "target": "vc-01",
+        "params": {},
+        "verify_response": _confirm_response("yes"),
+    }
+    outcome_a = advance(template, **args)  # type: ignore[arg-type]
+    outcome_b = advance(template, **args)  # type: ignore[arg-type]
+    assert outcome_a == outcome_b
+    assert isinstance(outcome_a, AdvanceOutcome)
+
+
+def test_advance_failed_outcome_carries_no_next_step() -> None:
+    """A ``failed`` outcome on any step (terminal or not) carries no next_step_body.
+
+    Locks the contract: T3's writer must not stumble into "the verify
+    failed but here's the next step anyway" -- the failed outcome
+    terminates this advance call's transition.
+    """
+    template = _five_step_template()
+    outcome = advance(
+        template,
+        current_step_id="step-2",
+        previous_step_state="in_progress",
+        target="vc-01",
+        params={},
+        verify_response=_confirm_response("no"),
+    )
+    assert outcome.kind == "failed"
+    assert outcome.next_step_body is None
+    assert outcome.completed_at is None

--- a/backend/tests/test_runbooks_substitution.py
+++ b/backend/tests/test_runbooks_substitution.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.runbooks.substitution` (G12.3-T2, #1301).
+
+The companion runtime helper to T1's publish-time
+:func:`meho_backplane.runbooks.schemas.validate_substitutions`:
+T1 rejects disallowed patterns, T2 resolves the allowlisted ones.
+
+Coverage matrix:
+
+* ``${run.target}`` resolves in a top-level string.
+* ``${run.params.X}`` resolves in a top-level string with a non-string
+  value (the contract is ``str(value)``).
+* Recursion into nested dicts -- the resolver walks through the
+  container shape, not just the top-level surface.
+* Missing param surfaces as :class:`KeyError` with the bare param name.
+* Non-string scalars (``int`` / ``bool`` / ``None``) pass through
+  unchanged -- the engine relies on this so it can pump a whole
+  ``params`` dict through ``resolve_substitutions`` without filtering.
+
+The regex constants are exercised indirectly by every test that
+substitutes; they are also referenced by name in the module-level
+``__all__`` assertion so a future rename surfaces the breakage at
+import time.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from meho_backplane.runbooks.substitution import (
+    RUN_PARAMS_PATTERN,
+    RUN_TARGET_PATTERN,
+    resolve_substitutions,
+)
+
+
+def test_resolve_target_in_string() -> None:
+    out = resolve_substitutions(
+        "do X on ${run.target}",
+        target="vc-01",
+        params={},
+    )
+    assert out == "do X on vc-01"
+
+
+def test_resolve_param_in_string() -> None:
+    # Non-string param value -- the resolver coerces via ``str()`` so
+    # the engine can pass arbitrary JSON-shaped params through.
+    out = resolve_substitutions(
+        "set ${run.params.threshold}",
+        target="ignored",
+        params={"threshold": 95},
+    )
+    assert out == "set 95"
+
+
+def test_resolve_nested_in_dict() -> None:
+    # The substitution walks into nested containers; keys stay literal.
+    payload = {
+        "host": "${run.target}",
+        "args": {
+            "threshold": "${run.params.threshold}",
+            "literal": "no-substitution-here",
+        },
+        "list_of_strings": ["${run.target}", "${run.params.region}"],
+    }
+    out = resolve_substitutions(
+        payload,
+        target="vc-01",
+        params={"threshold": 95, "region": "eu"},
+    )
+    assert out == {
+        "host": "vc-01",
+        "args": {
+            "threshold": "95",
+            "literal": "no-substitution-here",
+        },
+        "list_of_strings": ["vc-01", "eu"],
+    }
+
+
+def test_resolve_missing_param_raises_keyerror() -> None:
+    # A bare missing param: KeyError carrying the bare param name as
+    # the single arg so T3 can surface a typed wire error with the
+    # name intact.
+    with pytest.raises(KeyError) as excinfo:
+        resolve_substitutions(
+            "set ${run.params.missing}",
+            target="vc-01",
+            params={},
+        )
+    assert excinfo.value.args == ("missing",)
+
+
+def test_resolve_non_string_passthrough() -> None:
+    # Scalars other than str carry no substitution surface; the
+    # resolver returns them as-is so the engine can call
+    # ``resolve_substitutions`` over a params dict without filtering.
+    assert resolve_substitutions(42, target="vc-01", params={}) == 42
+    assert resolve_substitutions(True, target="vc-01", params={}) is True
+    assert resolve_substitutions(None, target="vc-01", params={}) is None
+    assert resolve_substitutions(3.14, target="vc-01", params={}) == 3.14
+
+
+def test_run_target_pattern_constant_matches_only_run_target() -> None:
+    # Locks the regex constant against accidental relaxation -- the
+    # engine and the publish-time helper share this single source of
+    # truth.
+    assert RUN_TARGET_PATTERN.findall("a ${run.target} b") == ["${run.target}"]
+    assert RUN_TARGET_PATTERN.findall("nothing here") == []
+    # The pattern must not also match ``${run.params.X}``.
+    assert RUN_TARGET_PATTERN.findall("${run.params.X}") == []
+
+
+def test_run_params_pattern_constant_captures_name() -> None:
+    # The single capture group is the bare parameter name -- the
+    # resolver depends on this exact group shape.
+    names = RUN_PARAMS_PATTERN.findall("${run.params.foo} and ${run.params.bar}")
+    assert names == ["foo", "bar"]
+    # Capital letters in the param name are not part of the grammar.
+    assert RUN_PARAMS_PATTERN.findall("${run.params.WithCaps}") == []
+    # Nested paths are not part of the grammar.
+    assert RUN_PARAMS_PATTERN.findall("${run.params.X.Y}") == []
+
+
+def test_resolve_multiple_occurrences_in_one_string() -> None:
+    # Both patterns can co-occur in a single string; both are resolved.
+    out = resolve_substitutions(
+        "on ${run.target}: ${run.params.action} from ${run.params.source}",
+        target="vc-01",
+        params={"action": "restart", "source": "operator-cli"},
+    )
+    assert out == "on vc-01: restart from operator-cli"
+
+
+def test_resolve_unrecognised_substitution_passes_through() -> None:
+    # A ``${foo}`` pattern that does not match either of the two
+    # allowlisted forms passes through verbatim -- the publish-time
+    # gate is the layer that rejects it; T2's resolver is intentionally
+    # narrow (resolve the good patterns, leave anything else alone).
+    out = resolve_substitutions(
+        "literal ${unknown.thing} stays put",
+        target="vc-01",
+        params={},
+    )
+    assert out == "literal ${unknown.thing} stays put"
+
+
+def test_resolve_preserves_input_immutability() -> None:
+    # The resolver returns a new container; the caller's dict is
+    # unchanged -- callers feed pydantic-frozen models, but downstream
+    # services may pass shared dicts too.
+    original_params = {"region": "eu"}
+    payload = {"args": {"region": "${run.params.region}"}}
+    out = resolve_substitutions(payload, target="vc-01", params=original_params)
+    assert out == {"args": {"region": "eu"}}
+    # The input payload is untouched.
+    assert payload == {"args": {"region": "${run.params.region}"}}
+    # The params dict is untouched.
+    assert original_params == {"region": "eu"}


### PR DESCRIPTION
## Summary

- Add the pure-function step-execution engine
  (`backend/src/meho_backplane/runbooks/engine.py`) and the runtime
  substitution helper
  (`backend/src/meho_backplane/runbooks/substitution.py`) — the
  **load-bearing isolation** for Initiative #1198's adherence floor.
  Step opacity, verify gating, and the state-machine transitions all
  live in the engine; keeping it storage-blind (no DB, no HTTP, no
  MCP, no contextvars, no clocks) lets the property-style opacity
  tests be reviewed without transport noise. T3 (#1308) wires this to
  the run lifecycle service.
- `current_step_body()` is the opacity function — by signature it
  returns exactly one step's substituted body; no overload exists that
  returns multiple. `advance()` drives the state machine one step
  forward and returns an `AdvanceOutcome` (kind ∈ `next_step` /
  `completed` / `failed`). Five typed exceptions communicate engine
  errors that T3 will surface as 400 / -32602.
- Verify match semantics for `operation_call`: structural equality +
  presence. Every key in `expect` must be present in `actual` with
  structurally equal value (extra keys ignored). Dicts recursive,
  lists element-wise, scalars by `==`. No JSONPath, no operators,
  no boolean composition — per #1177's determinism postulate and
  Initiative #1198's verify-surface scope.

## Test plan

- [x] `ruff check backend/src/meho_backplane/runbooks/ backend/tests/test_runbooks_*.py` — clean
- [x] `ruff format --check` — 8 files already formatted
- [x] `mypy backend/src/meho_backplane/runbooks/engine.py backend/src/meho_backplane/runbooks/substitution.py --ignore-missing-imports` — clean
- [x] `pytest backend/tests/test_runbooks_substitution.py backend/tests/test_runbooks_engine.py -v` — 28 passed
- [x] `pytest backend/tests/test_runbooks_schemas.py backend/tests/test_runbooks_runs_schemas.py backend/tests/test_runbooks_substitution.py backend/tests/test_runbooks_engine.py -q` — 63 passed (no regressions in T1 / G12.2-T1)
- [x] code-quality gate (`python3 .claude/hooks/code-quality.py --diff`) — 0 blockers, 4 warnings (large module docstrings + `advance` docstring + PLR0913 from the issue-prescribed API shape — recorded as adjacent findings)
- [x] **LOAD-BEARING opacity regression tests**:
  - `test_current_step_body_returns_only_one_step` — builds a 5-step template, asks for step-3, serialises the result, and string-searches the JSON for `step-1` / `step-2` / `step-4` / `step-5` (none appear).
  - `test_advance_outcome_next_step_body_is_only_next_step` — advances with verify-pass on step-2, serialises `outcome.next_step_body`, asserts the same string-search exclusion.
- [x] Acceptance criteria from #1301:
  - `substitution.py` with `resolve_substitutions()` + `RUN_TARGET_PATTERN` + `RUN_PARAMS_PATTERN` exported
  - `engine.py` with `advance()`, `current_step_body()`, `AdvanceOutcome` dataclass, 5 typed exceptions
  - Pure functions — no DB, no async, no contextvars, no clocks in the happy path
  - `current_step_body()` and `advance()`'s `next_step_body` opacity-property-tested
  - `_matches()` helper compares structurally with presence semantics

## Out of scope

- T3 (#1308) — service layer that wires the engine to DB reads/writes,
  dispatcher contextvar binding, audit-row writes, run-state persistence.
- T4 / T5 / T6 / T7 — `show_template` exception, REST routes, MCP tools,
  architecture doc.
- Refactoring T1's `validate_substitutions` to import the regex
  constants from T2 — explicitly deferred to T3's PR per the issue
  body so T2 stays focused on its slice.

Closes #1301
