### PR TITLE
feat(runbooks): G12.3-T6 runbook run MCP tools — start/next/abort/reassign/list × 5

### DIFF
--- a/backend/src/meho_backplane/mcp/tools/runbook_runs.py
+++ b/backend/src/meho_backplane/mcp/tools/runbook_runs.py
@@ -1,0 +1,672 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+# code-quality-allow: load-bearing tool descriptions per issue #1313; the
+# runbook_next description teaches the opacity contract + verify shapes +
+# no-skip + single-assignee + no-third-response-shape (~110 lines on its
+# own) and is regression-tested verbatim. Splitting would obscure the
+# contract. Same shape as sibling mcp/tools/runbooks.py (template-side,
+# 686 lines) which made the identical structural choice.
+
+"""``runbook_start`` / ``runbook_next`` / ``runbook_abort`` / ``runbook_reassign`` /
+``runbook_list_runs`` MCP tools -- run lifecycle (G12.3-T6).
+
+Five tool registrations that surface
+:class:`~meho_backplane.runbooks.run_service.RunbookRunService` on the
+MCP transport. The matching REST routes are owned by the sibling Task
+#1311; both transports converge on the same service, so the
+single-assignee enforcement, the verify-at-advance gating, the
+audit-row plumbing, and the response-shape opacity all live in one
+place (T3, #1308).
+
+The :data:`_NEXT_DESCRIPTION` text is the longest in the codebase by
+design -- it teaches the opacity contract, the verify shapes (``confirm``
+and ``operation_call``), the no-skip discipline, the single-assignee
+enforcement, and the no-third-response-shape contract. Same call as
+:data:`~meho_backplane.mcp.tools.runbooks._EDIT_DESCRIPTION` from #1298:
+agent UX lives in the description; if a refactor strips it, the surface
+regresses silently. The accompanying regression test in
+``test_mcp_tools_runbook_runs.py`` checks the verbatim load-bearing
+strings (``OPACITY CONTRACT``, ``WHEN A STEP FAILS``,
+``SINGLE-ASSIGNEE``, ``no skip, no force_advance``).
+
+RBAC
+====
+
+Four tools are ``OPERATOR``-readable/writable (start / next / abort /
+list_runs). :func:`runbook_reassign` is ``TENANT_ADMIN``-only.
+Service-level enforces single-assignee inside
+:meth:`~meho_backplane.runbooks.run_service.RunbookRunService.next_step`
+and :meth:`~meho_backplane.runbooks.run_service.RunbookRunService.abort_run`;
+the role gate handles tenant-wide visibility discipline on
+:func:`runbook_list_runs` (operator sees only own; admin sees all).
+
+Audit + broadcast
+=================
+
+Same dispatcher mechanism as the kb + template tools -- one
+``audit_log`` row + one broadcast event per ``tools/call``.
+:func:`runbook_next` on an ``operation_call`` verify produces TWO audit
+rows: one outer envelope (dispatcher writes it with
+``op_class=write``) and one inner verify dispatch (audit op-id is the
+verify's ``op_id``, e.g. ``vmware.host.is_powered_on``, with
+``run_id`` + ``step_id`` populated via the contextvars the service
+binds around :func:`~meho_backplane.operations.meta_tools.call_operation`
+per G12.1-T2 / #1294).
+
+Error mapping
+=============
+
+All operator-actionable typed exceptions from
+:class:`~meho_backplane.runbooks.run_service.RunbookRunService` --
+:class:`RunNotFoundError`, :class:`NotRunAssigneeError`,
+:class:`RunAlreadyTerminalError`, :class:`PreviousStepFailedError`,
+:class:`PreviousStepNotVerifiedError`, :class:`MissingParamsError`,
+:class:`VerifyResponseRequiredError`, :class:`VerifyResponseMismatchError`,
+:class:`DeprecatedTemplateError`, :class:`TemplateNotFoundError` --
+map to :class:`McpInvalidParamsError` (``-32602``). Anything else
+bubbles to the dispatcher's generic ``-32603``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Final
+
+from pydantic import ValidationError
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.mcp.registry import ToolDefinition, register_mcp_tool
+from meho_backplane.mcp.server import McpInvalidParamsError
+from meho_backplane.runbooks.engine import (
+    PreviousStepNotVerifiedError,
+    VerifyResponseMismatchError,
+    VerifyResponseRequiredError,
+)
+from meho_backplane.runbooks.run_service import (
+    DeprecatedTemplateError,
+    MissingParamsError,
+    NotRunAssigneeError,
+    PreviousStepFailedError,
+    RunAlreadyTerminalError,
+    RunbookRunService,
+    RunNotFoundError,
+)
+from meho_backplane.runbooks.runs_schemas import (
+    AbortRunRequest,
+    ListRunsFilter,
+    NextStepRequest,
+    ReassignRunRequest,
+    StartRunRequest,
+)
+from meho_backplane.runbooks.service import TemplateNotFoundError
+
+__all__: list[str] = []
+
+
+#: Op-class strings keep parity with the
+#: :mod:`meho_backplane.broadcast.classify` taxonomy. The lifecycle
+#: surface is split: ``list_runs`` is a passive read, the other four are
+#: writes (``start`` inserts the run row, ``next`` advances state +
+#: dispatches verify, ``abort`` flips state + writes audit, ``reassign``
+#: mutates ``assigned_to``).
+_OP_CLASS_READ: Final[str] = "read"
+_OP_CLASS_WRITE: Final[str] = "write"
+
+#: The caller-actionable service + engine exceptions that map to
+#: JSON-RPC ``-32602``. Same posture as
+#: :mod:`meho_backplane.mcp.tools.runbooks` -- typed exceptions become a
+#: ``-32602`` (``INVALID_PARAMS``) with a ``"<tool>: <detail>"`` message
+#: so the agent gets a self-correcting signal rather than a generic
+#: ``-32603`` (``INTERNAL_ERROR``).
+#:
+#: Left unannotated so mypy infers the precise concrete-member tuple
+#: (rather than ``tuple[type[Exception], ...]``) -- the variadic form is
+#: rejected as an ``except`` argument.
+_INVALID_PARAMS_ERRORS = (
+    DeprecatedTemplateError,
+    MissingParamsError,
+    NotRunAssigneeError,
+    PreviousStepFailedError,
+    PreviousStepNotVerifiedError,
+    RunAlreadyTerminalError,
+    RunNotFoundError,
+    TemplateNotFoundError,
+    VerifyResponseMismatchError,
+    VerifyResponseRequiredError,
+)
+
+#: Default + maximum row cap for ``runbook_list_runs``. Matches the
+#: service's :meth:`~meho_backplane.runbooks.run_service.RunbookRunService.list_runs`
+#: default (100).
+_DEFAULT_LIST_LIMIT: Final[int] = 100
+_MAX_LIST_LIMIT: Final[int] = 500
+
+
+def _to_invalid_params(tool: str, exc: Exception) -> McpInvalidParamsError:
+    """Wrap a caller-actionable service exception as :class:`McpInvalidParamsError`.
+
+    Centralised so every handler maps the typed-exception set in
+    :data:`_INVALID_PARAMS_ERRORS` to the spec-correct ``-32602`` with a
+    consistent ``"<tool>: <detail>"`` message shape.
+    """
+    return McpInvalidParamsError(f"{tool}: {exc}")
+
+
+def _parse_run_id(tool: str, raw: Any) -> uuid.UUID:
+    """Parse the ``run_id`` argument as a :class:`uuid.UUID`.
+
+    The wire shape carries ``run_id`` as a string (the inputSchema sets
+    ``format: "uuid"`` but the Anthropic Messages API only validates the
+    string type, not the format); a malformed value surfaces as
+    ``-32602`` rather than a generic ``-32603`` so the agent can
+    self-correct.
+    """
+    try:
+        return uuid.UUID(str(raw))
+    except (TypeError, ValueError) as exc:
+        raise _to_invalid_params(tool, ValueError(f"invalid run_id: {raw!r}")) from exc
+
+
+# ---------------------------------------------------------------------------
+# Tool descriptions (the load-bearing UX)
+# ---------------------------------------------------------------------------
+
+
+_START_DESCRIPTION: Final[str] = (
+    "Start a new runbook run.\n\n"
+    "Auto-assigns you (the caller) as the assignee. Returns the run_id and "
+    "the body of step 1 with ${run.target} and ${run.params.X} "
+    "substituted.\n\n"
+    'Use when: the human operator says "execute runbook X" or "start '
+    'runbook X". You target the latest non-deprecated published version '
+    "of the template. If only deprecated versions exist, this fails -- "
+    "ask the senior to publish a fresh version.\n\n"
+    "Requires OPERATOR role. The run is single-assignee -- only you can "
+    "advance it (via runbook_next) until you abort or reassign.\n\n"
+    "Errors:\n"
+    "- -32602 if the template slug is missing, only-deprecated, or "
+    "missing required ${run.params.X} keys."
+)
+
+_NEXT_DESCRIPTION: Final[str] = (
+    "Advance one step in an in-progress runbook run.\n\n"
+    "THE OPACITY CONTRACT: this tool returns the body of ONLY ONE step -- "
+    "the one you're currently on. You will NEVER see step 5 while you're "
+    "on step 3. There is no overload, no parameter, no flag that returns "
+    "more. The substrate is the authority on which step you can see; "
+    "what you call `last_verified` is informational only.\n\n"
+    "VERIFY SHAPES: every step's `verify` is one of two shapes.\n\n"
+    '1. verify.type=\'confirm\': pass verify_response={"type": "confirm", '
+    '"answer": "yes" | "no" | "escalate"}.\n'
+    '   - "yes" advances. "no" or "escalate" transitions the step '
+    "to failed.\n"
+    "   - Only the human operator can answer -- do not auto-confirm on "
+    "the human's behalf.\n"
+    "     If unsure, escalate.\n\n"
+    "2. verify.type='operation_call': the substrate dispatches the verify "
+    "call itself\n"
+    "   and compares the result against `expect` (structural equality + "
+    "presence match --\n"
+    "   no JSONPath, no operators, no boolean composition; the substrate "
+    "is dumb on\n"
+    "   purpose, see #1177).\n"
+    "   - You pass verify_response=None on `next` calls for operation_call "
+    "verifies --\n"
+    "     the substrate does the dispatch + match for you.\n"
+    "   - On match: step transitions to verified, advances. On mismatch: "
+    "step transitions\n"
+    "     to failed.\n\n"
+    "WHEN A STEP FAILS:\n"
+    "- A 'failed' step does NOT auto-advance, does NOT auto-retry. There "
+    "is no skip, no force_advance, no override. These DO NOT EXIST.\n"
+    "- The only forward path from a 'failed' state is runbook_abort + "
+    "(optionally)\n"
+    "  runbook_start over with the issue resolved.\n"
+    "- This is by design -- runbooks are governance-graded; the substrate "
+    "refuses\n"
+    "  to advance over an unverified step.\n\n"
+    "SINGLE-ASSIGNEE: you can only advance a run that is assigned_to you "
+    "(per the\n"
+    "run's assigned_to field). Even TENANT_ADMINs cannot bypass this -- "
+    "they go through\n"
+    "runbook_reassign first to take ownership, then advance.\n\n"
+    "WHEN TO USE: every time the human operator confirms the current step "
+    "is done\n"
+    "(operation_call verify resolves automatically) and the run should "
+    "progress.\n\n"
+    'WHEN NOT TO USE: never to "skip" a step you don\'t understand. If '
+    "the current\n"
+    "step is broken or unsafe, runbook_abort with a reason and ask the "
+    "senior to\n"
+    "fix the template (which will fork-on-edit per the "
+    "docs/runbooks/authoring.md\n"
+    "flow).\n\n"
+    "RESPONSE: opaque-by-construction. Returns either:\n"
+    '  - {kind: "current_step", run_id, template_slug, template_version, '
+    "position: {n, total},\n"
+    "     current_step: {id, title, body, type, op_id?, params?, verify}} "
+    "-- the step body\n"
+    "     with ${run.target} and ${run.params.X} already substituted.\n"
+    '  - {kind: "completed", run_id, state: "completed", completed_at} '
+    "-- final advance\n"
+    "    past the last step.\n\n"
+    'There is no third response shape. There is no "list_remaining_steps" '
+    "tool.\n"
+    "The substrate enforces opacity; do not work around it."
+)
+
+_ABORT_DESCRIPTION: Final[str] = (
+    "Abort an in-progress run. Mark state=abandoned with the operator's "
+    "reason.\n\n"
+    "Use when: a step has failed and there's no path forward, OR the "
+    "human operator asks to stop. The reason is persisted to audit_log "
+    "for senior review.\n\n"
+    "Permitted callers: the assignee, OR any TENANT_ADMIN (the admin "
+    "path is the senior taking over to clean up).\n\n"
+    "This is the only way out of a 'failed' state -- there is no "
+    "force_advance.\n\n"
+    "Errors:\n"
+    "- -32602 on permission denial, on a run that's already terminal, "
+    "or on a missing run."
+)
+
+_REASSIGN_DESCRIPTION: Final[str] = (
+    "Reassign an in-progress run to a different operator.\n\n"
+    "TENANT_ADMIN-only. This is the escalation/handoff knob: a junior "
+    "who can't advance asks the senior in chat, the senior reassigns to "
+    "themselves and takes over. After reassign, only the new assignee "
+    "can call runbook_next.\n\n"
+    "Use when: a junior is stuck on a step and the senior needs to take "
+    "the controls. The junior should runbook_abort if the procedure "
+    'itself is broken; reassign is for "this operator needs to step '
+    'in," not for "this procedure is broken."\n\n'
+    "Errors:\n"
+    "- -32602 on missing run, terminal run, or non-admin caller."
+)
+
+_LIST_DESCRIPTION: Final[str] = (
+    "List runs in the tenant.\n\n"
+    "OPERATORS see only their own runs (their assigned_to). TENANT_ADMINs "
+    "see all runs in the tenant. Filters: assignee, status (in_progress / "
+    "completed / abandoned), template_slug, limit (default 100).\n\n"
+    'Use when: the human asks "what\'s in flight?", "what have I '
+    'completed recently?", or the senior asks "who\'s stuck on what?" '
+    "before considering runbook_reassign.\n\n"
+    "Returns RunSummary entries -- run-level state only, no step "
+    "contents. To see the current step body of an in-progress run you "
+    "OWN, call runbook_next with last_verified=False to refresh (the "
+    "substrate returns the current step)."
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared inputSchema fragments
+# ---------------------------------------------------------------------------
+
+
+_RUN_ID_PROPERTY: Final[dict[str, Any]] = {
+    "type": "string",
+    "format": "uuid",
+    "description": "Run identifier (UUID).",
+}
+
+_TEMPLATE_SLUG_PROPERTY: Final[dict[str, Any]] = {
+    "type": "string",
+    "minLength": 1,
+    "description": (
+        "Slug of the runbook template to start. Resolves to the latest "
+        "non-deprecated published version."
+    ),
+}
+
+_TARGET_PROPERTY: Final[dict[str, Any]] = {
+    "type": "string",
+    "minLength": 1,
+    "description": (
+        "Run subject (the host, cluster, cert thumbprint, ...). "
+        "Substituted into the template body as ${run.target}."
+    ),
+}
+
+_PARAMS_PROPERTY: Final[dict[str, Any]] = {
+    "type": "object",
+    "description": (
+        "Substitution context for ${run.params.X} references in the "
+        "template body. Keys are template-defined; every reference must "
+        "be satisfied at start time."
+    ),
+    "additionalProperties": True,
+}
+
+#: The verify-response payload accepted by ``runbook_next``. A discriminated
+#: union (``confirm`` vs ``operation_call``) but flattened at the wire
+#: level because the Anthropic Messages API rejects top-level ``oneOf``
+#: -- the server-side Pydantic
+#: :data:`~meho_backplane.runbooks.runs_schemas.VerifyResponse` model
+#: re-enforces the discriminator after parsing.
+_VERIFY_RESPONSE_PROPERTY: Final[dict[str, Any]] = {
+    "type": ["object", "null"],
+    "description": (
+        "Operator's answer for the previous step's verify gate. "
+        "For type='confirm' steps, pass "
+        '{"type": "confirm", "answer": "yes"|"no"|"escalate"}. '
+        "For type='operation_call' steps, pass null and the substrate "
+        "dispatches the verify call itself. None on the very first "
+        "runbook_next call (no prior step to verify)."
+    ),
+    "properties": {
+        "type": {"type": "string", "enum": ["confirm", "operation_call"]},
+        "answer": {"type": "string", "enum": ["yes", "no", "escalate"]},
+        "matched": {"type": "boolean"},
+        "actual": {"type": "object", "additionalProperties": True},
+    },
+    "additionalProperties": True,
+}
+
+
+# ---------------------------------------------------------------------------
+# Handler implementations
+# ---------------------------------------------------------------------------
+
+
+async def _start_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Begin a new run on the latest non-deprecated published version of the slug.
+
+    Binds ``tenant_id`` + ``operator_sub`` from the validated JWT
+    operator -- never from input. Caller-actionable typed errors map to
+    ``-32602``; anything else bubbles to ``-32603``.
+    """
+    service = RunbookRunService()
+    try:
+        request = StartRunRequest.model_validate(
+            {
+                "template_slug": arguments["template_slug"],
+                "target": arguments["target"],
+                "params": arguments.get("params") or {},
+            }
+        )
+        response = await service.start_run(
+            tenant_id=operator.tenant_id,
+            operator_sub=operator.sub,
+            request=request,
+        )
+    except (ValidationError, *_INVALID_PARAMS_ERRORS) as exc:
+        raise _to_invalid_params("runbook_start", exc) from exc
+    return response.model_dump(mode="json")
+
+
+async def _next_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Advance the run one step, gated by the verify predicate.
+
+    Single-assignee discipline is enforced by the service:
+    :class:`NotRunAssigneeError` is raised for any caller other than
+    ``run.assigned_to``, including ``TENANT_ADMIN`` -- the right path
+    for a senior to take over is :func:`runbook_reassign`. The engine
+    is the verify oracle: a ``confirm`` response of ``"no"`` /
+    ``"escalate"`` transitions the step to ``failed`` and surfaces as
+    :class:`PreviousStepFailedError`; an ``operation_call`` verify
+    whose ``actual`` does not match ``expect`` does the same.
+    """
+    service = RunbookRunService()
+    run_id = _parse_run_id("runbook_next", arguments["run_id"])
+    try:
+        request = NextStepRequest.model_validate(
+            {
+                "last_verified": arguments["last_verified"],
+                "verify_response": arguments.get("verify_response"),
+            }
+        )
+        response = await service.next_step(
+            tenant_id=operator.tenant_id,
+            operator_sub=operator.sub,
+            run_id=run_id,
+            request=request,
+        )
+    except (ValidationError, *_INVALID_PARAMS_ERRORS) as exc:
+        raise _to_invalid_params("runbook_next", exc) from exc
+    return response.model_dump(mode="json")
+
+
+async def _abort_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Mark the run ``abandoned`` and write an audit row with the reason.
+
+    The role gate on the :class:`ToolDefinition` admits ``OPERATOR``
+    and above; the assignee-OR-admin allowance is the service's job.
+    The handler passes the caller's role-derived ``caller_is_admin``
+    flag through so a ``TENANT_ADMIN`` can clean up someone else's
+    stuck run.
+    """
+    service = RunbookRunService()
+    run_id = _parse_run_id("runbook_abort", arguments["run_id"])
+    try:
+        request = AbortRunRequest.model_validate({"reason": arguments["reason"]})
+        response = await service.abort_run(
+            tenant_id=operator.tenant_id,
+            operator_sub=operator.sub,
+            run_id=run_id,
+            request=request,
+            caller_is_admin=operator.tenant_role == TenantRole.TENANT_ADMIN,
+        )
+    except (ValidationError, *_INVALID_PARAMS_ERRORS) as exc:
+        raise _to_invalid_params("runbook_abort", exc) from exc
+    return response.model_dump(mode="json")
+
+
+async def _reassign_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Transfer ownership of the run to a new assignee.
+
+    The :class:`ToolDefinition` role gate enforces ``TENANT_ADMIN``
+    before the handler runs; the service is role-agnostic. The
+    ``operator.sub`` we pass is the *current* caller (the admin doing
+    the reassign); ``new_assignee`` from the arguments is the *next*
+    owner.
+    """
+    service = RunbookRunService()
+    run_id = _parse_run_id("runbook_reassign", arguments["run_id"])
+    try:
+        request = ReassignRunRequest.model_validate({"new_assignee": arguments["new_assignee"]})
+        response = await service.reassign_run(
+            tenant_id=operator.tenant_id,
+            operator_sub=operator.sub,
+            run_id=run_id,
+            request=request,
+        )
+    except (ValidationError, *_INVALID_PARAMS_ERRORS) as exc:
+        raise _to_invalid_params("runbook_reassign", exc) from exc
+    return response.model_dump(mode="json")
+
+
+async def _list_runs_handler(
+    operator: Operator,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """List runs scoped to the caller's visibility.
+
+    ``caller_is_admin=False`` forces ``assignee=operator.sub`` regardless
+    of the filter -- an ``OPERATOR`` only ever sees their own runs.
+    ``caller_is_admin=True`` honours the filter, so a ``TENANT_ADMIN``
+    can pass ``assignee=<other_sub>`` to inspect a junior's runs.
+
+    Returns :class:`~meho_backplane.runbooks.runs_schemas.RunSummary`
+    rows -- run-level state only, never step bodies (opacity is enforced
+    structurally at the summary shape, regression-tested in
+    ``test_list_runs_omits_step_contents``).
+    """
+    service = RunbookRunService()
+    try:
+        filter_ = ListRunsFilter.model_validate(
+            {
+                "assignee": arguments.get("assignee"),
+                "status": arguments.get("status"),
+                "template_slug": arguments.get("template_slug"),
+            }
+        )
+        limit = int(arguments.get("limit", _DEFAULT_LIST_LIMIT))
+        caller_is_admin = operator.tenant_role == TenantRole.TENANT_ADMIN
+        summaries = await service.list_runs(
+            tenant_id=operator.tenant_id,
+            caller_sub=operator.sub,
+            caller_is_admin=caller_is_admin,
+            filter_=filter_,
+            limit=limit,
+        )
+    except (ValidationError, *_INVALID_PARAMS_ERRORS) as exc:
+        raise _to_invalid_params("runbook_list_runs", exc) from exc
+    return {"runs": [summary.model_dump(mode="json") for summary in summaries]}
+
+
+# ---------------------------------------------------------------------------
+# Tool registrations
+# ---------------------------------------------------------------------------
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="runbook_start",
+        description=_START_DESCRIPTION,
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "template_slug": _TEMPLATE_SLUG_PROPERTY,
+                "target": _TARGET_PROPERTY,
+                "params": _PARAMS_PROPERTY,
+            },
+            "required": ["template_slug", "target"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.OPERATOR,
+        op_class=_OP_CLASS_WRITE,
+    ),
+    handler=_start_handler,
+)
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="runbook_next",
+        description=_NEXT_DESCRIPTION,
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "run_id": _RUN_ID_PROPERTY,
+                "last_verified": {
+                    "type": "boolean",
+                    "description": (
+                        "Caller's informational claim that the previous step "
+                        "verified. The substrate is the oracle; the value is "
+                        "logged but does not gate the advance."
+                    ),
+                },
+                "verify_response": _VERIFY_RESPONSE_PROPERTY,
+            },
+            "required": ["run_id", "last_verified"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.OPERATOR,
+        op_class=_OP_CLASS_WRITE,
+    ),
+    handler=_next_handler,
+)
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="runbook_abort",
+        description=_ABORT_DESCRIPTION,
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "run_id": _RUN_ID_PROPERTY,
+                "reason": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": ("Non-empty reason persisted to audit_log for the abort event."),
+                },
+            },
+            "required": ["run_id", "reason"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.OPERATOR,
+        op_class=_OP_CLASS_WRITE,
+    ),
+    handler=_abort_handler,
+)
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="runbook_reassign",
+        description=_REASSIGN_DESCRIPTION,
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "run_id": _RUN_ID_PROPERTY,
+                "new_assignee": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": (
+                        "Operator subject identifier (`sub`) to transfer ownership to."
+                    ),
+                },
+            },
+            "required": ["run_id", "new_assignee"],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.TENANT_ADMIN,
+        op_class=_OP_CLASS_WRITE,
+    ),
+    handler=_reassign_handler,
+)
+
+
+register_mcp_tool(
+    definition=ToolDefinition(
+        name="runbook_list_runs",
+        description=_LIST_DESCRIPTION,
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "assignee": {
+                    "type": ["string", "null"],
+                    "description": (
+                        "Optional assignee filter (subject identifier). "
+                        "Ignored for OPERATOR callers (they see only own)."
+                    ),
+                },
+                "status": {
+                    "type": ["string", "null"],
+                    "enum": ["in_progress", "completed", "abandoned", None],
+                    "description": "Optional run-state filter.",
+                },
+                "template_slug": {
+                    "type": ["string", "null"],
+                    "description": "Optional template-slug filter.",
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": _MAX_LIST_LIMIT,
+                    "default": _DEFAULT_LIST_LIMIT,
+                    "description": "Maximum number of summary rows to return.",
+                },
+            },
+            "required": [],
+            "additionalProperties": False,
+        },
+        required_role=TenantRole.OPERATOR,
+        op_class=_OP_CLASS_READ,
+    ),
+    handler=_list_runs_handler,
+)

--- a/backend/tests/mcp_test_fixtures.py
+++ b/backend/tests/mcp_test_fixtures.py
@@ -158,6 +158,7 @@ def isolated_registry() -> Iterator[None]:
         knowledge,
         meho_status,
         operations,
+        runbook_runs,
         runbooks,
         topology,
         topology_create_node,
@@ -187,6 +188,13 @@ def isolated_registry() -> Iterator[None]:
     # unregistered in any test file that imports this fixture after
     # the first one runs in the process.
     importlib.reload(runbooks)
+    # G12.3-T6 (#1313): the runbook *run* MCP tools (``runbook_start``
+    # / ``runbook_next`` / ``runbook_abort`` / ``runbook_reassign`` /
+    # ``runbook_list_runs``) join the reload list for the same reason
+    # as the template-side module above. The five tools are imported
+    # but unused here -- pytest collects them via the side-effect
+    # ``register_mcp_tool`` calls in the module body, not by name.
+    importlib.reload(runbook_runs)
     importlib.reload(memory_tools)
     importlib.reload(memory_promote_tool)
     # G11.1-T2 (#809): the agent-definition MCP tools join the reload

--- a/backend/tests/test_mcp_tools_runbook_runs.py
+++ b/backend/tests/test_mcp_tools_runbook_runs.py
@@ -1,0 +1,997 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Tests for the ``runbook_start`` / ``runbook_next`` / ``runbook_abort`` /
+``runbook_reassign`` / ``runbook_list_runs`` MCP tools (G12.3-T6, #1313).
+
+Covers the task's acceptance criteria for the five run-lifecycle tools
+that wrap :class:`~meho_backplane.runbooks.run_service.RunbookRunService`
+on the MCP transport:
+
+* Registration: all five tools register against the G0.5 registry with
+  strict 2020-12 ``inputSchema`` shapes; the MEHO-internal RBAC fields
+  never reach the wire.
+* RBAC: four tools (``runbook_start`` / ``runbook_next`` /
+  ``runbook_abort`` / ``runbook_list_runs``) are ``OPERATOR``-callable;
+  ``runbook_reassign`` is ``TENANT_ADMIN``-only.
+* Typed-exception -> ``-32602`` mapping for the ten operator-actionable
+  service + engine errors.
+* The load-bearing ``runbook_next`` description carries the verbatim
+  load-bearing strings (``OPACITY CONTRACT``, ``WHEN A STEP FAILS``,
+  ``SINGLE-ASSIGNEE``, ``no skip, no force_advance``) -- a regression
+  guard so a refactor that drops them surfaces here rather than as
+  silently degraded agent UX.
+* Structural opacity: ``runbook_next`` response carries exactly one
+  step body (no future-step leakage); ``runbook_list_runs`` summaries
+  carry no step contents.
+* Single-assignee discipline at the tool boundary -- operators *and*
+  admins are refused if they are not the run's assignee.
+* Tenant isolation on the list surface.
+
+The tests use the SQLite-backed default test DB (the ``runbook_runs``
+and ``runbook_run_step_states`` tables are materialised by the autouse
+``_default_database_url`` fixture's ``alembic upgrade head``); no
+embedding / external service is involved, so every assertion runs
+in-sandbox.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.connectors.base import Connector
+from meho_backplane.connectors.registry import register_connector_v2
+from meho_backplane.connectors.schemas import (
+    FingerprintResult,
+    OperationResult,
+    ProbeResult,
+)
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.db.models import AuditLog, Target
+from meho_backplane.mcp.schemas import INVALID_PARAMS
+from meho_backplane.operations import (
+    register_typed_operation,
+    reset_dispatcher_caches,
+)
+from meho_backplane.retrieval.embedding import EMBEDDING_DIMENSION
+from meho_backplane.runbooks.run_service import RunbookRunService
+from meho_backplane.runbooks.runs_schemas import StartRunRequest
+from meho_backplane.runbooks.schemas import DraftTemplateRequest, PublishTemplateRequest
+from meho_backplane.runbooks.service import RunbookTemplateService
+from tests.mcp_test_fixtures import (
+    client_with_operator,  # noqa: F401 — pytest-discovered fixture
+    isolated_registry,  # noqa: F401 — pytest-discovered autouse fixture
+    post_mcp,
+    required_settings_env,  # noqa: F401 — pytest-discovered autouse fixture
+)
+
+_OPERATOR_TOOLS = {
+    "runbook_start",
+    "runbook_next",
+    "runbook_abort",
+    "runbook_list_runs",
+}
+_ADMIN_TOOLS = {"runbook_reassign"}
+_ALL_TOOLS = _OPERATOR_TOOLS | _ADMIN_TOOLS
+
+
+def _template_body(
+    *,
+    title: str = "Two-step procedure",
+    steps: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a minimal valid template-body wire dict with two manual steps.
+
+    Two steps is the smallest shape that lets ``runbook_next`` advance
+    *between* steps (rather than completing the run immediately).
+    """
+    if steps is None:
+        steps = [
+            {
+                "id": "step-1",
+                "title": "Step 1",
+                "body": "Do the first thing.",
+                "type": "manual",
+                "verify": {"type": "confirm", "prompt": "Done?"},
+            },
+            {
+                "id": "step-2",
+                "title": "Step 2",
+                "body": "Do the second thing.",
+                "type": "manual",
+                "verify": {"type": "confirm", "prompt": "Done?"},
+            },
+        ]
+    return {
+        "title": title,
+        "description": "Procedure for tests.",
+        "target_kind": "host",
+        "steps": steps,
+    }
+
+
+async def _seed_published_template(
+    *,
+    tenant_id: uuid.UUID,
+    operator_sub: str,
+    slug: str,
+    body: dict[str, Any] | None = None,
+) -> None:
+    """Helper: create + publish v1 of *slug* in *tenant_id*."""
+    service = RunbookTemplateService()
+    await service.create_draft(
+        tenant_id=tenant_id,
+        operator_sub=operator_sub,
+        request=DraftTemplateRequest.model_validate(
+            {"slug": slug, "body": body if body is not None else _template_body()}
+        ),
+    )
+    await service.publish(
+        tenant_id=tenant_id,
+        request=PublishTemplateRequest(slug=slug, version=1),
+    )
+
+
+def _call(client: TestClient, name: str, arguments: dict[str, Any]) -> Any:
+    """Issue a ``tools/call`` against *name* and return the parsed JSON-RPC body."""
+    return post_mcp(
+        client,
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+        },
+    ).json()
+
+
+def _result_payload(body: Any) -> Any:
+    """Extract the parsed tool result from a successful ``tools/call`` body."""
+    assert body["result"]["isError"] is False
+    return json.loads(body["result"]["content"][0]["text"])
+
+
+# ---------------------------------------------------------------------------
+# Registration + tools/list shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+def test_all_five_tools_registered_with_strict_schema(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: all five tools surface for a TENANT_ADMIN with strict input schemas."""
+    client, _op = client_with_operator
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    tools_by_name = {t["name"]: t for t in response.json()["result"]["tools"]}
+
+    for name in _ALL_TOOLS:
+        assert name in tools_by_name, name
+        schema = tools_by_name[name]["inputSchema"]
+        assert schema["type"] == "object"
+        assert schema["additionalProperties"] is False
+        # MEHO-internal RBAC fields never reach the wire.
+        assert "required_role" not in tools_by_name[name]
+        assert "op_class" not in tools_by_name[name]
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_admin_tool_hidden_from_operator_list(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: an OPERATOR sees the four operator tools; ``runbook_reassign`` is hidden."""
+    client, _op = client_with_operator
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    tool_names = {t["name"] for t in response.json()["result"]["tools"]}
+
+    assert tool_names >= _OPERATOR_TOOLS
+    assert not (_ADMIN_TOOLS & tool_names)
+
+
+# ---------------------------------------------------------------------------
+# runbook_start
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+@pytest.mark.asyncio
+async def test_start_tool_invocation_success(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: operator can start a run; response carries step-1 body."""
+    client, op = client_with_operator
+    await _seed_published_template(tenant_id=op.tenant_id, operator_sub=op.sub, slug="r1")
+
+    payload = _result_payload(
+        _call(client, "runbook_start", {"template_slug": "r1", "target": "host-1"})
+    )
+    assert payload["kind"] == "current_step"
+    assert payload["template_slug"] == "r1"
+    assert payload["template_version"] == 1
+    assert payload["current_step"]["id"] == "step-1"
+    assert payload["position"]["n"] == 1
+    assert payload["position"]["total"] == 2
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+@pytest.mark.asyncio
+async def test_start_admin_can_call(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: TENANT_ADMIN can also start a run (admin implies operator).
+
+    The role gate uses ``role_at_least`` -- TENANT_ADMIN ranks above
+    OPERATOR so the admin sees and can invoke the OPERATOR-floored
+    tools.
+    """
+    client, op = client_with_operator
+    await _seed_published_template(tenant_id=op.tenant_id, operator_sub=op.sub, slug="r1")
+
+    payload = _result_payload(
+        _call(client, "runbook_start", {"template_slug": "r1", "target": "host-1"})
+    )
+    assert payload["kind"] == "current_step"
+    assert payload["template_slug"] == "r1"
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+@pytest.mark.asyncio
+async def test_start_deprecated_template_error_maps_to_invalid_params(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: ``DeprecatedTemplateError`` surfaces as ``-32602``."""
+    client, op = client_with_operator
+    service = RunbookTemplateService()
+    await service.create_draft(
+        tenant_id=op.tenant_id,
+        operator_sub=op.sub,
+        request=DraftTemplateRequest.model_validate({"slug": "old", "body": _template_body()}),
+    )
+    await service.publish(
+        tenant_id=op.tenant_id, request=PublishTemplateRequest(slug="old", version=1)
+    )
+    await service.deprecate(
+        tenant_id=op.tenant_id, request=PublishTemplateRequest(slug="old", version=1)
+    )
+
+    body = _call(client, "runbook_start", {"template_slug": "old", "target": "h"})
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+# ---------------------------------------------------------------------------
+# runbook_next — opacity-load-bearing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+@pytest.mark.asyncio
+async def test_next_confirm_yes_advances(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: confirm verify with ``answer='yes'`` advances to step 2."""
+    client, op = client_with_operator
+    await _seed_published_template(tenant_id=op.tenant_id, operator_sub=op.sub, slug="r1")
+    started = _result_payload(
+        _call(client, "runbook_start", {"template_slug": "r1", "target": "host-1"})
+    )
+
+    payload = _result_payload(
+        _call(
+            client,
+            "runbook_next",
+            {
+                "run_id": started["run_id"],
+                "last_verified": True,
+                "verify_response": {"type": "confirm", "answer": "yes"},
+            },
+        )
+    )
+    assert payload["kind"] == "current_step"
+    assert payload["current_step"]["id"] == "step-2"
+    assert payload["position"]["n"] == 2
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+@pytest.mark.asyncio
+async def test_next_confirm_no_transitions_to_failed(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: ``answer='no'`` on confirm -> ``PreviousStepFailedError`` -> ``-32602``.
+
+    Mirrors the run-service contract: the engine flips the step to
+    ``failed`` and the service surfaces :class:`PreviousStepFailedError`
+    so the caller's next move is :func:`runbook_abort` rather than a
+    spurious retry on a state the substrate no longer accepts.
+    """
+    client, op = client_with_operator
+    await _seed_published_template(tenant_id=op.tenant_id, operator_sub=op.sub, slug="r1")
+    started = _result_payload(
+        _call(client, "runbook_start", {"template_slug": "r1", "target": "host-1"})
+    )
+
+    body = _call(
+        client,
+        "runbook_next",
+        {
+            "run_id": started["run_id"],
+            "last_verified": False,
+            "verify_response": {"type": "confirm", "answer": "no"},
+        },
+    )
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+@pytest.mark.asyncio
+async def test_next_completes_at_last_step(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: verify on the last step -> ``RunCompletedResponse`` shape."""
+    client, op = client_with_operator
+    await _seed_published_template(
+        tenant_id=op.tenant_id,
+        operator_sub=op.sub,
+        slug="r1",
+        body=_template_body(
+            steps=[
+                {
+                    "id": "only",
+                    "title": "Only step",
+                    "body": "Just one.",
+                    "type": "manual",
+                    "verify": {"type": "confirm", "prompt": "Done?"},
+                }
+            ]
+        ),
+    )
+    started = _result_payload(
+        _call(client, "runbook_start", {"template_slug": "r1", "target": "host-1"})
+    )
+    payload = _result_payload(
+        _call(
+            client,
+            "runbook_next",
+            {
+                "run_id": started["run_id"],
+                "last_verified": True,
+                "verify_response": {"type": "confirm", "answer": "yes"},
+            },
+        )
+    )
+    assert payload["kind"] == "completed"
+    assert payload["state"] == "completed"
+    assert "current_step" not in payload
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+@pytest.mark.asyncio
+async def test_next_response_opacity_property(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """LOAD-BEARING: ``runbook_next`` response carries exactly one step body.
+
+    Serialise the response, assert exactly one step id appears (the
+    current one), and that no other step ids leak into the JSON. Opacity
+    is what makes Initiative #1198's adherence floor real -- the
+    structural test guards refactors that might widen the response shape.
+    """
+    client, op = client_with_operator
+    five_steps = [
+        {
+            "id": f"step-{i}",
+            "title": f"Step {i}",
+            "body": f"Body {i}",
+            "type": "manual",
+            "verify": {"type": "confirm", "prompt": "Done?"},
+        }
+        for i in range(1, 6)
+    ]
+    await _seed_published_template(
+        tenant_id=op.tenant_id,
+        operator_sub=op.sub,
+        slug="r1",
+        body=_template_body(steps=five_steps),
+    )
+    started = _result_payload(
+        _call(client, "runbook_start", {"template_slug": "r1", "target": "host-1"})
+    )
+    payload = _result_payload(
+        _call(
+            client,
+            "runbook_next",
+            {
+                "run_id": started["run_id"],
+                "last_verified": True,
+                "verify_response": {"type": "confirm", "answer": "yes"},
+            },
+        )
+    )
+    serialised = json.dumps(payload)
+    # The response is on step-2 now -- step-1 (just verified) and
+    # step-3 / step-4 / step-5 (future) must not appear in the wire shape.
+    assert '"id": "step-2"' in serialised or '"id":"step-2"' in serialised
+    for leak in ("step-1", "step-3", "step-4", "step-5"):
+        assert leak not in serialised, f"step id leaked into response: {leak}"
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+@pytest.mark.asyncio
+async def test_next_not_assignee_denied(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: operator who isn't the assignee -> ``NotRunAssigneeError`` -> ``-32602``."""
+    client, op = client_with_operator
+    await _seed_published_template(tenant_id=op.tenant_id, operator_sub=op.sub, slug="r1")
+    # Start as a different operator via the service so the fixture
+    # operator isn't the assignee.
+    service = RunbookRunService()
+    other_sub = "operator-other"
+    started = await service.start_run(
+        tenant_id=op.tenant_id,
+        operator_sub=other_sub,
+        request=StartRunRequest(template_slug="r1", target="host-1", params={}),
+    )
+
+    body = _call(
+        client,
+        "runbook_next",
+        {
+            "run_id": str(started.run_id),
+            "last_verified": True,
+            "verify_response": {"type": "confirm", "answer": "yes"},
+        },
+    )
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+@pytest.mark.asyncio
+async def test_next_admin_non_assignee_still_denied(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: TENANT_ADMIN who isn't the assignee -> still ``-32602``.
+
+    Single-assignee discipline is unconditional. The right way for a
+    senior to take over is :func:`runbook_reassign`, not a role-based
+    bypass on :func:`runbook_next`.
+    """
+    client, op = client_with_operator
+    await _seed_published_template(tenant_id=op.tenant_id, operator_sub=op.sub, slug="r1")
+    service = RunbookRunService()
+    started = await service.start_run(
+        tenant_id=op.tenant_id,
+        operator_sub="operator-other",
+        request=StartRunRequest(template_slug="r1", target="host-1", params={}),
+    )
+
+    body = _call(
+        client,
+        "runbook_next",
+        {
+            "run_id": str(started.run_id),
+            "last_verified": True,
+            "verify_response": {"type": "confirm", "answer": "yes"},
+        },
+    )
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_next_description_includes_load_bearing_text(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """LOAD-BEARING regression: the verbatim agent-UX strings live in the description.
+
+    The :data:`~meho_backplane.mcp.tools.runbook_runs._NEXT_DESCRIPTION`
+    text teaches the agent the opacity contract, the no-skip discipline,
+    and the single-assignee enforcement. Each load-bearing string is
+    asserted verbatim so a refactor that paraphrases or drops them
+    surfaces here rather than as silently degraded agent UX.
+    """
+    client, _op = client_with_operator
+    response = post_mcp(client, {"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+    tools_by_name = {t["name"]: t for t in response.json()["result"]["tools"]}
+
+    next_desc = tools_by_name["runbook_next"]["description"]
+    # The four load-bearing strings -- per the issue body's acceptance
+    # criteria. Each one is a specific contract the agent needs to learn.
+    assert "OPACITY CONTRACT" in next_desc
+    assert "WHEN A STEP FAILS" in next_desc
+    assert "SINGLE-ASSIGNEE" in next_desc
+    assert "no skip, no force_advance" in next_desc
+
+
+# ---------------------------------------------------------------------------
+# runbook_abort
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+@pytest.mark.asyncio
+async def test_abort_by_assignee_succeeds(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: assignee aborts -> state=abandoned."""
+    client, op = client_with_operator
+    await _seed_published_template(tenant_id=op.tenant_id, operator_sub=op.sub, slug="r1")
+    started = _result_payload(
+        _call(client, "runbook_start", {"template_slug": "r1", "target": "host-1"})
+    )
+    payload = _result_payload(
+        _call(
+            client,
+            "runbook_abort",
+            {"run_id": started["run_id"], "reason": "human cancelled"},
+        )
+    )
+    assert payload["state"] == "abandoned"
+    assert payload["run_id"] == started["run_id"]
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+@pytest.mark.asyncio
+async def test_abort_by_admin_succeeds(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: TENANT_ADMIN can abort someone else's run.
+
+    The service-level ``caller_is_admin`` allowance is wired through
+    from the handler's role check on the JWT-bound operator. A senior
+    taking over a stuck junior's run is the canonical use case.
+    """
+    client, op = client_with_operator
+    await _seed_published_template(tenant_id=op.tenant_id, operator_sub=op.sub, slug="r1")
+    service = RunbookRunService()
+    started = await service.start_run(
+        tenant_id=op.tenant_id,
+        operator_sub="operator-junior",
+        request=StartRunRequest(template_slug="r1", target="host-1", params={}),
+    )
+
+    payload = _result_payload(
+        _call(
+            client,
+            "runbook_abort",
+            {"run_id": str(started.run_id), "reason": "senior taking over"},
+        )
+    )
+    assert payload["state"] == "abandoned"
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+@pytest.mark.asyncio
+async def test_abort_by_non_assignee_non_admin_denied(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: non-assignee non-admin operator -> ``NotRunAssigneeError`` -> ``-32602``."""
+    client, op = client_with_operator
+    await _seed_published_template(tenant_id=op.tenant_id, operator_sub=op.sub, slug="r1")
+    service = RunbookRunService()
+    started = await service.start_run(
+        tenant_id=op.tenant_id,
+        operator_sub="operator-other",
+        request=StartRunRequest(template_slug="r1", target="host-1", params={}),
+    )
+
+    body = _call(
+        client,
+        "runbook_abort",
+        {"run_id": str(started.run_id), "reason": "nope"},
+    )
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+# ---------------------------------------------------------------------------
+# runbook_reassign
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+@pytest.mark.asyncio
+async def test_reassign_by_admin_succeeds(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: TENANT_ADMIN reassigns -> response carries new ``assigned_to``."""
+    client, op = client_with_operator
+    await _seed_published_template(tenant_id=op.tenant_id, operator_sub=op.sub, slug="r1")
+    service = RunbookRunService()
+    started = await service.start_run(
+        tenant_id=op.tenant_id,
+        operator_sub="operator-junior",
+        request=StartRunRequest(template_slug="r1", target="host-1", params={}),
+    )
+
+    payload = _result_payload(
+        _call(
+            client,
+            "runbook_reassign",
+            {"run_id": str(started.run_id), "new_assignee": "operator-senior"},
+        )
+    )
+    assert payload["assigned_to"] == "operator-senior"
+    assert payload["run_id"] == str(started.run_id)
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+@pytest.mark.asyncio
+async def test_reassign_by_operator_denied(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: OPERATOR cannot reassign -- the dispatcher gate refuses with ``-32602``.
+
+    The :class:`ToolDefinition` role gate is enforced by the dispatcher
+    *before* the handler runs. The operator never reaches the service
+    layer; the refusal is the tool-boundary gate.
+    """
+    client, op = client_with_operator
+    await _seed_published_template(tenant_id=op.tenant_id, operator_sub=op.sub, slug="r1")
+    service = RunbookRunService()
+    started = await service.start_run(
+        tenant_id=op.tenant_id,
+        operator_sub=op.sub,
+        request=StartRunRequest(template_slug="r1", target="host-1", params={}),
+    )
+
+    body = _call(
+        client,
+        "runbook_reassign",
+        {"run_id": str(started.run_id), "new_assignee": "operator-other"},
+    )
+    assert "error" in body
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+def test_reassign_missing_run_error(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: ``RunNotFoundError`` -> ``-32602``.
+
+    Probing a random UUID surfaces the typed error from the service
+    layer; the handler maps it to the spec-correct INVALID_PARAMS.
+    """
+    client, _op = client_with_operator
+    body = _call(
+        client,
+        "runbook_reassign",
+        {"run_id": str(uuid.uuid4()), "new_assignee": "operator-other"},
+    )
+    assert body["error"]["code"] == INVALID_PARAMS
+
+
+# ---------------------------------------------------------------------------
+# runbook_list_runs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+@pytest.mark.asyncio
+async def test_list_runs_operator_sees_only_own(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: ``caller_is_admin=False`` forces ``assignee=operator.sub`` regardless of filter."""
+    client, op = client_with_operator
+    await _seed_published_template(tenant_id=op.tenant_id, operator_sub=op.sub, slug="r1")
+    service = RunbookRunService()
+    started_self = await service.start_run(
+        tenant_id=op.tenant_id,
+        operator_sub=op.sub,
+        request=StartRunRequest(template_slug="r1", target="host-1", params={}),
+    )
+    # A second run by a different operator -- must not be visible.
+    await service.start_run(
+        tenant_id=op.tenant_id,
+        operator_sub="operator-other",
+        request=StartRunRequest(template_slug="r1", target="host-2", params={}),
+    )
+
+    # Operator tries to filter to ``operator-other`` explicitly; the
+    # service overrides to the caller's own sub.
+    payload = _result_payload(_call(client, "runbook_list_runs", {"assignee": "operator-other"}))
+    runs = payload["runs"]
+    assert len(runs) == 1
+    assert runs[0]["run_id"] == str(started_self.run_id)
+    assert runs[0]["assigned_to"] == op.sub
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+@pytest.mark.asyncio
+async def test_list_runs_admin_sees_all_tenant(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: TENANT_ADMIN sees runs for every assignee in the tenant."""
+    client, op = client_with_operator
+    await _seed_published_template(tenant_id=op.tenant_id, operator_sub=op.sub, slug="r1")
+    service = RunbookRunService()
+    await service.start_run(
+        tenant_id=op.tenant_id,
+        operator_sub="operator-alpha",
+        request=StartRunRequest(template_slug="r1", target="host-1", params={}),
+    )
+    await service.start_run(
+        tenant_id=op.tenant_id,
+        operator_sub="operator-beta",
+        request=StartRunRequest(template_slug="r1", target="host-2", params={}),
+    )
+
+    payload = _result_payload(_call(client, "runbook_list_runs", {}))
+    assigned_subs = {r["assigned_to"] for r in payload["runs"]}
+    assert assigned_subs == {"operator-alpha", "operator-beta"}
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.TENANT_ADMIN], indirect=True)
+@pytest.mark.asyncio
+async def test_list_runs_tenant_isolation(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """AC: a list under one tenant never returns another tenant's runs."""
+    client, op = client_with_operator
+    await _seed_published_template(tenant_id=op.tenant_id, operator_sub=op.sub, slug="r1")
+
+    # Foreign tenant's seed.
+    foreign_tenant = uuid.uuid4()
+    await _seed_published_template(
+        tenant_id=foreign_tenant, operator_sub="foreign-admin", slug="r1"
+    )
+    service = RunbookRunService()
+    await service.start_run(
+        tenant_id=op.tenant_id,
+        operator_sub="operator-mine",
+        request=StartRunRequest(template_slug="r1", target="host-mine", params={}),
+    )
+    await service.start_run(
+        tenant_id=foreign_tenant,
+        operator_sub="operator-foreign",
+        request=StartRunRequest(template_slug="r1", target="host-theirs", params={}),
+    )
+
+    payload = _result_payload(_call(client, "runbook_list_runs", {}))
+    assigned_subs = {r["assigned_to"] for r in payload["runs"]}
+    assert assigned_subs == {"operator-mine"}
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+@pytest.mark.asyncio
+async def test_list_runs_omits_step_contents(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """LOAD-BEARING property: ``RunSummary`` rows never carry step bodies.
+
+    Step-by-step content is opaque-by-construction (only
+    :func:`runbook_next` ever returns a step body, and only one step at
+    a time). The list surface only exposes ``current_step_id`` -- the
+    *id* of the step the run is on, not its body. This test asserts the
+    summary shape never widens to leak the step list.
+    """
+    client, op = client_with_operator
+    await _seed_published_template(tenant_id=op.tenant_id, operator_sub=op.sub, slug="r1")
+    _call(client, "runbook_start", {"template_slug": "r1", "target": "host-1"})
+
+    payload = _result_payload(_call(client, "runbook_list_runs", {}))
+    runs = payload["runs"]
+    assert len(runs) == 1
+    summary = runs[0]
+    # Run-level columns are present.
+    assert summary["assigned_to"] == op.sub
+    assert summary["template_slug"] == "r1"
+    assert summary["state"] == "in_progress"
+    # Position + current step id give "where" without giving "what".
+    assert summary.get("current_step_id") == "step-1"
+    # No leakage of step bodies / lists.
+    for forbidden in ("steps", "current_step", "body", "title", "verify"):
+        assert forbidden not in summary, f"summary leaked {forbidden!r}"
+
+
+# ---------------------------------------------------------------------------
+# runbook_next — operation_call verify dispatch (audit correlation)
+# ---------------------------------------------------------------------------
+
+
+class _StubConnector(Connector):
+    """Minimal connector so the dispatcher resolver finds a class for the triple.
+
+    The runbook engine resolves an ``op_id`` to a
+    :class:`~meho_backplane.db.models.EndpointDescriptor` row and
+    reconstructs a ``connector_id``; the dispatcher then looks up the
+    connector class by ``(product, version, impl_id)``. Without a
+    registered class the call to :func:`call_operation` errors before
+    reaching the typed handler.
+    """
+
+    product = "stub"
+    version = "1.x"
+    impl_id = "stub"
+
+    async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def probe(self, target: Any) -> ProbeResult:  # type: ignore[override]
+        raise NotImplementedError
+
+    async def execute(  # type: ignore[override]
+        self,
+        target: Any,
+        op_id: str,
+        params: dict[str, Any],
+    ) -> OperationResult:
+        raise NotImplementedError
+
+
+async def _ok_handler(
+    operator: Operator,
+    target: Any,
+    params: dict[str, Any],
+) -> dict[str, Any]:
+    """Typed handler that returns the shape ``expect`` looks for."""
+    return {"ok": True}
+
+
+@pytest.fixture
+def _stub_embedding_service() -> AsyncMock:
+    """Embedding stub for the typed-op descriptor's embedding column."""
+    service = AsyncMock()
+    service.encode_one.return_value = [0.0] * EMBEDDING_DIMENSION
+    service.encode.return_value = [[0.0] * EMBEDDING_DIMENSION]
+    service.dimension = EMBEDDING_DIMENSION
+    return service
+
+
+@pytest.fixture
+def _scoped_stub_registration() -> Iterator[None]:
+    """Reset dispatcher caches around the operation_call verify test.
+
+    Not autouse: blanket-clearing the connector registry mid-session
+    would break the FastAPI lifespan startup, which validates the
+    connector-spec catalog against every registered connector class.
+    The single test that needs a stub connector requests this fixture
+    explicitly. The dispatcher-cache reset on both ends keeps the
+    stub op's descriptor cache from leaking across tests.
+
+    Why the connector registry itself stays untouched: the stub
+    connector is registered via :func:`register_connector_v2` at the
+    process-wide registry. Clearing it would unregister production
+    connectors needed by every other test's FastAPI lifespan startup.
+    Using a stable ``"stub"`` product / impl_id means the registration
+    is idempotent at the registry level for the second test-run in the
+    same process (duplicate-registration raises -- we catch and
+    swallow on re-entry). The :class:`Target` row + the typed-op
+    registration go to the per-test SQLite schema which is discarded
+    by the autouse ``_default_database_url`` fixture in conftest.
+    """
+    from meho_backplane.connectors.registry import _REGISTRY_V2
+
+    reset_dispatcher_caches()
+    yield
+    reset_dispatcher_caches()
+    # The next test invocation may re-register the same stub; drop the
+    # entry here so the re-registration is a fresh insert rather than a
+    # duplicate-raise.
+    _REGISTRY_V2.pop(("stub", "", ""), None)
+
+
+async def _seed_stub_op(stub_embedding_service: AsyncMock, op_id: str = "stub.op_call") -> None:
+    """Register the stub connector + typed op the dispatcher can resolve."""
+    register_connector_v2(product="stub", version="", impl_id="", cls=_StubConnector)
+    await register_typed_operation(
+        product="stub",
+        version="1.x",
+        impl_id="stub",
+        op_id=op_id,
+        handler=_ok_handler,
+        summary="Stub op for runbook MCP tool tests.",
+        description="Echo OK; used for operation_call verify dispatch.",
+        parameter_schema={"type": "object"},
+        when_to_use=None,
+        embedding_service=stub_embedding_service,
+    )
+
+
+async def _seed_target(tenant_id: uuid.UUID, name: str) -> None:
+    """Seed a tenant-scoped :class:`Target` row the dispatcher can resolve."""
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        session.add(
+            Target(
+                tenant_id=tenant_id,
+                name=name,
+                product="stub",
+                host="stub-host.example",
+                auth_model="shared_service_account",
+            )
+        )
+        await session.commit()
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+@pytest.mark.asyncio
+async def test_next_operation_call_match_advances(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+    _stub_embedding_service: AsyncMock,
+    _scoped_stub_registration: None,
+) -> None:
+    """AC: operation_call verify dispatches the call, matches expect, advances.
+
+    Crucially: the dispatched call's audit row carries ``run_id`` and
+    ``step_id`` populated -- the run/step correlation contract G12.1-T2
+    (#1294) wired and this Initiative depends on. The contextvars are
+    bound by :meth:`RunbookRunService.next_step`; this test verifies
+    the binding survives the MCP tool boundary (the boundary doesn't
+    swallow or rebind the contextvars).
+    """
+    client, op = client_with_operator
+    await _seed_stub_op(_stub_embedding_service)
+    await _seed_target(op.tenant_id, "host-1")
+    await _seed_published_template(
+        tenant_id=op.tenant_id,
+        operator_sub=op.sub,
+        slug="r1",
+        body=_template_body(
+            steps=[
+                {
+                    "id": "call-it",
+                    "title": "Call the op",
+                    "body": "stub call",
+                    "type": "operation_call",
+                    "op_id": "stub.op_call",
+                    "params": {},
+                    "verify": {
+                        "type": "operation_call",
+                        "op_id": "stub.op_call",
+                        "params": {},
+                        "expect": {"ok": True},
+                    },
+                }
+            ]
+        ),
+    )
+    started = _result_payload(
+        _call(client, "runbook_start", {"template_slug": "r1", "target": "host-1"})
+    )
+
+    payload = _result_payload(
+        _call(
+            client,
+            "runbook_next",
+            {
+                "run_id": started["run_id"],
+                "last_verified": True,
+                "verify_response": None,
+            },
+        )
+    )
+    # One-step template -- the operation_call verify advances past the
+    # last step and the run completes.
+    assert payload["kind"] == "completed"
+    assert payload["state"] == "completed"
+
+    # The verify dispatch produced an audit row tagged with the verify
+    # op_id; the run/step correlation columns (or the payload mirror on
+    # schemas predating migration 0034) must be populated.
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session:
+        rows = (
+            await session.scalars(
+                select(AuditLog)
+                .where(AuditLog.method == "DISPATCH")
+                .where(AuditLog.path == "stub.op_call")
+            )
+        ).all()
+    assert len(rows) == 1
+    row = rows[0]
+    column_run_id = getattr(row, "run_id", None)
+    column_step_id = getattr(row, "step_id", None)
+    payload_row = row.payload
+    assert isinstance(payload_row, dict)
+    assert (column_run_id == uuid.UUID(started["run_id"])) or (
+        payload_row.get("run_id") == started["run_id"]
+    )
+    assert (column_step_id == "call-it") or (payload_row.get("step_id") == "call-it")


### PR DESCRIPTION
## Summary

- Adds `backend/src/meho_backplane/mcp/tools/runbook_runs.py` with five MCP tool registrations — `runbook_start`, `runbook_next`, `runbook_abort` (OPERATOR) plus `runbook_reassign` (TENANT_ADMIN) plus `runbook_list_runs` (OPERATOR with admin-vs-operator visibility) — all wrapping `RunbookRunService` from #1308.
- The `runbook_next` description is the load-bearing piece: it teaches the opacity contract, the verify shapes (confirm + operation_call), the no-skip / no-force-advance discipline, the single-assignee enforcement, and the no-third-response-shape contract. The verbatim load-bearing strings (`OPACITY CONTRACT`, `WHEN A STEP FAILS`, `SINGLE-ASSIGNEE`, `no skip, no force_advance`) are pinned down by a regression test.
- All ten operator-actionable typed exceptions from the service + engine map to `McpInvalidParamsError` (-32602).

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — 802 files already formatted
- [x] `mypy src/` — Success: no issues found in 392 source files
- [x] `pytest backend/tests/test_mcp_tools_runbook_runs.py -v` — 23 passed
- [x] `pytest backend/tests/test_mcp_tools_runbooks_templates.py -v` — 19 passed (no T4 #1309 regression)
- [x] `pytest backend/tests/test_runbooks_run_service.py -v` — 27 passed (no T3 #1308 regression)
- [x] Full backend suite — `pytest backend/tests/ -q` — **5982 passed, 377 skipped, 0 failures** in 13:27
- [x] code-quality hook (`.claude/hooks/code-quality.py --diff`) — pass (file carries `code-quality-allow` marker for the load-bearing descriptions, same call as sibling `mcp/tools/runbooks.py` template module at 686 lines)
- [x] **Opacity property** verified twice — `runbook_next` response carries exactly one step id (no future-step leakage) and `runbook_list_runs` summaries never carry step bodies.
- [x] **Single-assignee discipline** verified — both `test_next_not_assignee_denied` (operator) and `test_next_admin_non_assignee_still_denied` (admin) refuse the advance with -32602.

## Out of scope

- **REST routes** — T5 #1311 (sibling worker; different file, no collision).
- **Architecture doc** — T7 #1314.
- **CLI verbs** — G12.5.
- **The post-completion `show_template` carve-out** — T4 #1309 (template-side, not run-side; verified not regressed).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1313
