### PR TITLE
docs(changelog): record v0.8.1 release on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-05-29
+
 ### Added
 
 - **Catalog field `spec_info_versions_compatible` for label-vs-spec
@@ -215,6 +217,13 @@ connector-related release-notes line.
   matching, so an operator typing either form lands on the same
   connector. The unknown-impl 422 lists both forms in
   `valid_impl_ids` for branchable client recovery.
+- **CLI commands migrated to the generated typed API client (G0.12).**
+  The `agent`, `agent-principal`, `approvals`, `audit`, `broadcast`,
+  `connector`, `conventions`, `kb`, `memory`, `migrate`, `retrieval`,
+  `scheduler`, `targets`, and `topology` command groups — plus the
+  operation verbs — now issue requests through the OpenAPI-generated
+  typed transport instead of hand-rolled HTTP. Internal refactor; no
+  operator-facing flag or output change. (G0.12-T1–T16, #1262–#1277)
 
 ### Fixed
 


### PR DESCRIPTION
Post-release reconciliation for the **v0.8.1** maintenance cut (tagged + published from `release/v0.8.1`).

v0.8.1 shipped the v0.8.0-cycle dogfood-hardening wave (G0.16-T1–T6), G0.17-T1 (k8s list-op request-shape parity / Finding 24), and the G0.12 CLI typed-client migration — deliberately **excluding the G12 runbook work** on `main`, reserved for **v0.9.0**.

Records that on `main`'s CHANGELOG:
- Rolls the `[Unreleased]` bullets (same work, now shipped) under `## [0.8.1] - 2026-05-29`.
- Adds the G0.12 CLI-migration rollup bullet (was uncited).
- Leaves `[Unreleased]` empty — in-flight G12 runbook work (#1327/#1328/#1331/#1333 + follow-ups) populates it for v0.9.0.

CHANGELOG-only; matches the `[0.8.1]` section already published. Release: https://github.com/evoila/meho/releases/tag/v0.8.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)