### PR TITLE
feat(runbooks): G12.4-T1 runbook priming helper — assemble_runbook_priming()

### DIFF
--- a/backend/src/meho_backplane/runbooks/priming.py
+++ b/backend/src/meho_backplane/runbooks/priming.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Per-run priming text for the MCP ``initialize.instructions`` preamble.
+
+Initiative #1199 (G12.4) -- the priming text the agent sees when it
+attaches to an operator who has ``in_progress`` runs. T1 ships the
+helper as a pure-ish module so the composition rules (per-run block
+shape, N=5 cap, summary-form fallback, verbatim wording) are reviewable
+in isolation; T2 (#1316) wires it into :func:`assemble_preamble`.
+
+The text format is fixed by Initiative #1199 and is **load-bearing**:
+
+  <<RUNBOOK_PRIMING -- CRITICAL>>
+  You are mid-runbook `<slug>` v<version> on step <n>/<total> (`<step_id>`).
+  Follow only the current step. Do not look ahead. Do not improvise. Do not combine steps.
+  If the step looks wrong, call runbook_abort and escalate to a senior in chat.
+  Use runbook_next to advance once the current step's verify passes.
+
+  <<END_RUNBOOK_PRIMING>>
+
+One block per in-progress run, capped at :data:`MAX_PRIMING_BLOCKS`. Beyond
+that, a single summary block points at ``runbook_list_runs`` so the
+preamble stays in budget.
+
+Priming is **UX hint, not enforcement**. Step opacity (G12.3, #1313) is
+the real adherence mechanism; if priming breaks, opacity still holds.
+The phrasing is a high-confidence nudge to keep the agent inside the
+opacity floor's intended discipline -- "follow only the current step"
+mirrors the substrate's guarantee that only the current step is
+returned by ``runbook_next``.
+
+Untrusted-content isolation
+---------------------------
+
+Guard delimiters (:data:`BLOCK_START` / :data:`BLOCK_END`) are hard-
+coded module constants emitted by the wrapper, never interpolated from
+run state. The same positional-wrapper discipline the conventions
+preamble uses (see ``conventions/preamble.py:42-63``): a run whose
+slug somehow contained the literal terminator string cannot escape the
+block, because the terminator is not substituted from user content.
+
+The slug regex enforced at template publish time (see
+:mod:`meho_backplane.runbooks.schemas`) already prevents the
+terminator-shaped substring in practice; the wrapper discipline is
+defence in depth, regression-tested at
+:func:`test_guard_delimiters_are_hard_coded`.
+"""
+
+from __future__ import annotations
+
+from typing import Final, NamedTuple
+from uuid import UUID
+
+from meho_backplane.runbooks.run_service import RunbookRunService
+from meho_backplane.runbooks.runs_schemas import ListRunsFilter, RunSummary
+
+__all__ = [
+    "BLOCK_END",
+    "BLOCK_START",
+    "MAX_PRIMING_BLOCKS",
+    "RunbookPrimingResult",
+    "assemble_runbook_priming",
+]
+
+
+#: Opening delimiter for a priming block. Hard-coded; the wrapper emits
+#: the literal -- it is never substituted from run state. The em dash
+#: (``--``) form is the verbatim text fixed by Initiative #1199; agents
+#: are trained against the exact byte sequence, so the constant must
+#: render byte-for-byte at every block boundary.
+BLOCK_START: Final[str] = "<<RUNBOOK_PRIMING — CRITICAL>>"
+
+#: Closing delimiter for a priming block. Pairs with :data:`BLOCK_START`;
+#: see the module docstring for the positional-wrapper rationale (a body
+#: containing this literal cannot escape the block because the
+#: terminator is wrapper-emitted, not user-emitted).
+BLOCK_END: Final[str] = "<<END_RUNBOOK_PRIMING>>"
+
+#: Maximum number of per-run priming blocks before collapsing to a
+#: single summary block. Beyond ~5 runs the per-block text dominates
+#: the preamble's token budget; the summary form refers the agent to
+#: ``runbook_list_runs`` (the read tool from G12.3-T6, #1313) and
+#: tells them to proceed one at a time. Same opacity discipline still
+#: applies to each run when they advance it.
+MAX_PRIMING_BLOCKS: Final[int] = 5
+
+
+class RunbookPrimingResult(NamedTuple):
+    """Packed priming text + diagnostics for caller logging.
+
+    Three fields:
+
+    * ``text`` -- the assembled priming string, or ``""`` when the
+      operator has no in-progress runs. The caller (T2 wiring) collapses
+      the empty string to "skip the priming section entirely" so the
+      preamble shape is byte-for-byte identical to its conventions-only
+      form for operators without runbooks in flight.
+    * ``block_count`` -- the count of in-progress runs the operator has,
+      whether or not they were rendered as per-run blocks. ``0`` when
+      the operator has no runs; ``K`` (the full count) even when the
+      summary form fires because the count is still useful for logging.
+    * ``summarized`` -- ``True`` when ``block_count > MAX_PRIMING_BLOCKS``
+      and the helper rendered the summary form instead of per-run
+      blocks; ``False`` otherwise (including the empty case).
+
+    Why a :class:`NamedTuple` and not a :class:`pydantic.BaseModel`?
+    Internal-only return shape; no JSON marshalling boundary. Matches
+    the :class:`~meho_backplane.conventions.preamble.PreambleResult`
+    posture from the conventions preamble (one NamedTuple at the
+    assembler boundary; pydantic stays at the wire boundary).
+    """
+
+    text: str
+    block_count: int
+    summarized: bool
+
+
+async def assemble_runbook_priming(
+    operator_sub: str,
+    tenant_id: UUID,
+) -> RunbookPrimingResult:
+    """Build the priming text for *operator_sub*'s ``in_progress`` runs in *tenant_id*.
+
+    Calls :meth:`RunbookRunService.list_runs` with
+    ``caller_is_admin=False`` so the operator-scope visibility floor
+    applies regardless of the caller's actual role -- priming is
+    always operator-personal, even if the operator happens to be a
+    ``TENANT_ADMIN``. The list is filtered to ``state='in_progress'``
+    so terminal runs do not leak into the priming.
+
+    Returns three shapes by case:
+
+    * **Empty** -- no in-progress runs -> ``RunbookPrimingResult("", 0, False)``.
+      The caller skips the priming section entirely.
+    * **1 .. N=5** -- one verbatim block per run, concatenated with a
+      blank line between them.
+      ``RunbookPrimingResult(text, len(runs), False)``.
+    * **>N=5** -- one summary block referring the agent to
+      ``runbook_list_runs``. ``RunbookPrimingResult(text, len(runs), True)``.
+
+    The helper makes no DB query beyond the single
+    :meth:`list_runs` call; ``current_step_id`` and ``position`` arrive
+    on the :class:`~meho_backplane.runbooks.runs_schemas.RunSummary`
+    rows directly (per #1300 / #1308). No caching -- per Initiative
+    #1199 the priming is generated fresh on every MCP ``initialize``
+    call because run state can change between sessions.
+
+    A :class:`RunSummary` with ``current_step_id is None`` would be a
+    contract violation (an in-progress run always has a current step
+    per the service layer's invariant); such a row is skipped from
+    per-block rendering but still counted toward ``block_count`` so
+    the summary-form threshold is honoured deterministically.
+    """
+    service = RunbookRunService()
+    runs = await service.list_runs(
+        tenant_id,
+        operator_sub,
+        caller_is_admin=False,
+        filter_=ListRunsFilter(status="in_progress"),
+    )
+    count = len(runs)
+    if count == 0:
+        return RunbookPrimingResult(text="", block_count=0, summarized=False)
+    if count > MAX_PRIMING_BLOCKS:
+        return RunbookPrimingResult(
+            text=_render_summary_block(count),
+            block_count=count,
+            summarized=True,
+        )
+    blocks = [_render_run_block(run) for run in runs if run.current_step_id is not None]
+    return RunbookPrimingResult(
+        text="\n\n".join(blocks),
+        block_count=count,
+        summarized=False,
+    )
+
+
+def _render_run_block(run: RunSummary) -> str:
+    """Render the per-run priming block for a single in-progress run.
+
+    Wraps the body in the hard-coded :data:`BLOCK_START` / :data:`BLOCK_END`
+    delimiters. The body fields (``slug`` / ``version`` / position /
+    step id) are taken from the :class:`RunSummary`; the wrapper is
+    positional (no string substitution into the delimiter), so the
+    terminator cannot be emitted from run state.
+
+    Caller guarantees ``run.current_step_id is not None`` (filtered in
+    :func:`assemble_runbook_priming` before this is called); the
+    ``assert`` re-asserts at the boundary so a future contract change
+    surfaces here rather than as a ``None``-shaped ``f-string`` in the
+    rendered text.
+    """
+    assert run.current_step_id is not None, "caller filters runs without current_step_id"
+    position = run.position
+    # An in-progress run with no position is also a contract
+    # violation (the service computes position whenever the
+    # template body is present); fall back to a "n/total" of
+    # ``?/?`` rather than crashing the preamble assembly.
+    position_text = "?/?" if position is None else f"{position.n}/{position.total}"
+    body = (
+        f"You are mid-runbook `{run.template_slug}` v{run.template_version} "
+        f"on step {position_text} (`{run.current_step_id}`).\n"
+        "Follow only the current step. Do not look ahead. Do not improvise. "
+        "Do not combine steps.\n"
+        "If the step looks wrong, call runbook_abort and escalate to a "
+        "senior in chat.\n"
+        "Use runbook_next to advance once the current step's verify passes."
+    )
+    return f"{BLOCK_START}\n{body}\n\n{BLOCK_END}"
+
+
+def _render_summary_block(count: int) -> str:
+    """Render the summary priming block for >N=5 in-progress runs.
+
+    Refers the agent to ``runbook_list_runs`` (the read tool from
+    G12.3-T6, #1313) and tells them to proceed one at a time. Re-
+    states the opacity discipline so the summary form does not loosen
+    the per-run wording's adherence floor.
+    """
+    body = (
+        f"You have {count} in-progress runbook runs assigned to you "
+        f"(too many to list inline).\n"
+        "Call runbook_list_runs to see them and proceed one at a time.\n"
+        "Follow the same opacity discipline: do not look ahead in any run."
+    )
+    return f"{BLOCK_START}\n{body}\n\n{BLOCK_END}"

--- a/backend/tests/test_runbooks_priming.py
+++ b/backend/tests/test_runbooks_priming.py
@@ -1,0 +1,432 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for :mod:`meho_backplane.runbooks.priming` (G12.4-T1 / #1315).
+
+Covers the 12-test acceptance breakdown from the issue body:
+
+* Shape -- empty, single, two, exactly-five, six (summary), runs without
+  current_step_id skipped (defensive).
+* Scoping -- completed runs excluded, abandoned runs excluded,
+  other-operator runs excluded (operator-scope visibility floor),
+  other-tenant runs excluded.
+* Wrapper discipline -- guard delimiters are hard-coded, body verbatim
+  wording is preserved, ``${...}`` in slug is not substituted.
+
+The conftest autouse fixture migrates a fresh SQLite DB per test (the
+runbooks template + run services' load-bearing infrastructure) so the
+helper's :meth:`RunbookRunService.list_runs` binds to the same per-test
+schema these tests seed runs into directly.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+
+import pytest
+
+from meho_backplane.runbooks.priming import (
+    BLOCK_END,
+    BLOCK_START,
+    MAX_PRIMING_BLOCKS,
+    RunbookPrimingResult,
+    assemble_runbook_priming,
+)
+from meho_backplane.runbooks.run_service import RunbookRunService
+from meho_backplane.runbooks.runs_schemas import (
+    AbortRunRequest,
+    ConfirmVerifyResponse,
+    CurrentStepResponse,
+    NextStepRequest,
+    StartRunRequest,
+)
+from meho_backplane.runbooks.schemas import (
+    ConfirmVerify,
+    DraftTemplateRequest,
+    ManualStep,
+    PublishTemplateRequest,
+    RunbookTemplateBody,
+)
+from meho_backplane.runbooks.service import RunbookTemplateService
+from meho_backplane.settings import get_settings
+
+_TENANT_A = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_TENANT_B = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+OPERATOR = "operator-alpha"
+OPERATOR_BETA = "operator-beta"
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _required_settings_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin env vars the :class:`Settings` model requires for this module."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", "https://keycloak.test/realms/meho")
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", "meho-backplane")
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _manual_step(step_id: str) -> ManualStep:
+    """Build a ``manual`` step gated by a ``confirm`` verify."""
+    return ManualStep(
+        id=step_id,
+        title=f"Step {step_id}",
+        body=f"Do {step_id}",
+        type="manual",
+        verify=ConfirmVerify(type="confirm", prompt="done?"),
+    )
+
+
+def _two_step_template() -> RunbookTemplateBody:
+    return RunbookTemplateBody(
+        title="Two-step procedure",
+        description="for priming tests",
+        target_kind="k8s-node",
+        steps=[_manual_step("step-1"), _manual_step("step-2")],
+    )
+
+
+def _single_step_template() -> RunbookTemplateBody:
+    return RunbookTemplateBody(
+        title="One-step procedure",
+        description="for priming tests",
+        target_kind="k8s-node",
+        steps=[_manual_step("only-step")],
+    )
+
+
+async def _seed_published_template(
+    tenant_id: uuid.UUID,
+    slug: str,
+    *,
+    body: RunbookTemplateBody | None = None,
+) -> None:
+    """Helper: create+publish a template via the template service.
+
+    Mirrors the test_runbooks_run_service.py shape so the seeded rows
+    match what production code writes.
+    """
+    template_service = RunbookTemplateService()
+    template_body = body if body is not None else _two_step_template()
+    await template_service.create_draft(
+        tenant_id, OPERATOR, DraftTemplateRequest(slug=slug, body=template_body)
+    )
+    await template_service.publish(tenant_id, PublishTemplateRequest(slug=slug, version=1))
+
+
+async def _start_runs(
+    tenant_id: uuid.UUID,
+    operator_sub: str,
+    *,
+    slug: str = "drain",
+    n: int = 1,
+) -> list[uuid.UUID]:
+    """Start *n* in-progress runs for *operator_sub* against *slug*.
+
+    The slug must already be a published template in *tenant_id*. Returns
+    the run ids in start order.
+    """
+    run_service = RunbookRunService()
+    run_ids: list[uuid.UUID] = []
+    for index in range(n):
+        resp = await run_service.start_run(
+            tenant_id,
+            operator_sub,
+            StartRunRequest(template_slug=slug, target=f"node-{index}", params={}),
+        )
+        assert isinstance(resp, CurrentStepResponse)
+        run_ids.append(resp.run_id)
+    return run_ids
+
+
+# ---------------------------------------------------------------------------
+# Shape: empty / single / multiple / cap behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_runs_returns_empty_text() -> None:
+    """Operator with no in-progress runs -> text='', count=0, summarized=False."""
+    tenant_id = uuid.uuid4()
+    result = await assemble_runbook_priming(OPERATOR, tenant_id)
+    assert result == RunbookPrimingResult(text="", block_count=0, summarized=False)
+
+
+@pytest.mark.asyncio
+async def test_single_run_returns_one_block() -> None:
+    """Operator with 1 in-progress run -> one verbatim block with slug, version, step id."""
+    tenant_id = uuid.uuid4()
+    await _seed_published_template(tenant_id, "drain", body=_two_step_template())
+    await _start_runs(tenant_id, OPERATOR, slug="drain", n=1)
+
+    result = await assemble_runbook_priming(OPERATOR, tenant_id)
+
+    assert result.block_count == 1
+    assert result.summarized is False
+    # The verbatim block body fields.
+    assert BLOCK_START in result.text
+    assert BLOCK_END in result.text
+    assert "`drain`" in result.text  # slug in backticks
+    assert "v1" in result.text  # version
+    assert "step 1/2" in result.text  # n/total -- 2-step template, first step
+    assert "`step-1`" in result.text  # current step id
+    # One opening + one closing delimiter.
+    assert result.text.count(BLOCK_START) == 1
+    assert result.text.count(BLOCK_END) == 1
+
+
+@pytest.mark.asyncio
+async def test_two_runs_returns_two_blocks_concatenated() -> None:
+    """2 in-progress runs -> 2 BLOCK_START markers separated by a blank line."""
+    tenant_id = uuid.uuid4()
+    await _seed_published_template(tenant_id, "drain", body=_two_step_template())
+    await _start_runs(tenant_id, OPERATOR, slug="drain", n=2)
+
+    result = await assemble_runbook_priming(OPERATOR, tenant_id)
+
+    assert result.block_count == 2
+    assert result.summarized is False
+    assert result.text.count(BLOCK_START) == 2
+    assert result.text.count(BLOCK_END) == 2
+    # Two blocks separated by exactly one blank line between END and START.
+    assert f"{BLOCK_END}\n\n{BLOCK_START}" in result.text
+
+
+@pytest.mark.asyncio
+async def test_five_runs_inline_form() -> None:
+    """Exactly MAX_PRIMING_BLOCKS=5 in-progress runs -> 5 inline blocks, not summary."""
+    assert MAX_PRIMING_BLOCKS == 5  # invariant the test name encodes
+    tenant_id = uuid.uuid4()
+    await _seed_published_template(tenant_id, "drain", body=_two_step_template())
+    await _start_runs(tenant_id, OPERATOR, slug="drain", n=5)
+
+    result = await assemble_runbook_priming(OPERATOR, tenant_id)
+
+    assert result.block_count == 5
+    assert result.summarized is False
+    assert result.text.count(BLOCK_START) == 5
+    assert result.text.count(BLOCK_END) == 5
+    # No summary-form prose at the inline-form boundary.
+    assert "too many to list inline" not in result.text
+
+
+@pytest.mark.asyncio
+async def test_six_runs_collapses_to_summary() -> None:
+    """6 in-progress runs (> MAX_PRIMING_BLOCKS) -> one summary block.
+
+    The summary references runbook_list_runs and drops per-run blocks.
+    """
+    tenant_id = uuid.uuid4()
+    await _seed_published_template(tenant_id, "drain", body=_two_step_template())
+    await _start_runs(tenant_id, OPERATOR, slug="drain", n=6)
+
+    result = await assemble_runbook_priming(OPERATOR, tenant_id)
+
+    assert result.block_count == 6
+    assert result.summarized is True
+    assert result.text.count(BLOCK_START) == 1
+    assert result.text.count(BLOCK_END) == 1
+    assert "6 in-progress" in result.text
+    assert "runbook_list_runs" in result.text
+    # No per-run leakage in the summary form.
+    assert "`drain`" not in result.text
+    assert "step 1/2" not in result.text
+
+
+# ---------------------------------------------------------------------------
+# Scoping: state, operator, tenant
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_completed_runs_not_included() -> None:
+    """An operator with 1 in-progress + 1 completed run -> only the in-progress one primes."""
+    tenant_id = uuid.uuid4()
+    await _seed_published_template(tenant_id, "single", body=_single_step_template())
+    await _seed_published_template(tenant_id, "drain", body=_two_step_template())
+    run_service = RunbookRunService()
+
+    # Single-step run, completed.
+    single_start = await run_service.start_run(
+        tenant_id,
+        OPERATOR,
+        StartRunRequest(template_slug="single", target="n", params={}),
+    )
+    assert isinstance(single_start, CurrentStepResponse)
+    await run_service.next_step(
+        tenant_id,
+        OPERATOR,
+        single_start.run_id,
+        NextStepRequest(
+            last_verified=True,
+            verify_response=ConfirmVerifyResponse(type="confirm", answer="yes"),
+        ),
+    )
+
+    # Two-step run, in progress.
+    await _start_runs(tenant_id, OPERATOR, slug="drain", n=1)
+
+    result = await assemble_runbook_priming(OPERATOR, tenant_id)
+
+    assert result.block_count == 1
+    assert result.summarized is False
+    # Only the in-progress run's slug surfaces in the priming text.
+    assert "`drain`" in result.text
+    assert "`single`" not in result.text
+
+
+@pytest.mark.asyncio
+async def test_abandoned_runs_not_included() -> None:
+    """Abandoned runs are excluded from the operator's priming."""
+    tenant_id = uuid.uuid4()
+    await _seed_published_template(tenant_id, "drain", body=_two_step_template())
+    await _seed_published_template(tenant_id, "rollback", body=_two_step_template())
+    run_service = RunbookRunService()
+
+    # Abandoned run.
+    abandoned_start = await run_service.start_run(
+        tenant_id,
+        OPERATOR,
+        StartRunRequest(template_slug="rollback", target="n", params={}),
+    )
+    assert isinstance(abandoned_start, CurrentStepResponse)
+    await run_service.abort_run(
+        tenant_id,
+        OPERATOR,
+        abandoned_start.run_id,
+        AbortRunRequest(reason="testing"),
+    )
+
+    # In-progress run.
+    await _start_runs(tenant_id, OPERATOR, slug="drain", n=1)
+
+    result = await assemble_runbook_priming(OPERATOR, tenant_id)
+
+    assert result.block_count == 1
+    assert "`drain`" in result.text
+    assert "`rollback`" not in result.text
+
+
+@pytest.mark.asyncio
+async def test_other_operator_runs_not_included() -> None:
+    """Only ``operator_sub``'s runs surface; another operator's are invisible."""
+    tenant_id = uuid.uuid4()
+    await _seed_published_template(tenant_id, "drain", body=_two_step_template())
+    # Beta starts a run; alpha asks for priming.
+    await _start_runs(tenant_id, OPERATOR_BETA, slug="drain", n=2)
+
+    result = await assemble_runbook_priming(OPERATOR, tenant_id)
+
+    assert result == RunbookPrimingResult(text="", block_count=0, summarized=False)
+
+
+@pytest.mark.asyncio
+async def test_other_tenant_runs_not_included() -> None:
+    """Strict tenant isolation: a run in tenant B does not surface for tenant A."""
+    await _seed_published_template(_TENANT_A, "drain", body=_two_step_template())
+    await _seed_published_template(_TENANT_B, "drain", body=_two_step_template())
+    # Same sub starts a run in tenant B.
+    await _start_runs(_TENANT_B, OPERATOR, slug="drain", n=1)
+
+    # Priming for the same sub in tenant A returns empty.
+    result = await assemble_runbook_priming(OPERATOR, _TENANT_A)
+
+    assert result == RunbookPrimingResult(text="", block_count=0, summarized=False)
+
+
+# ---------------------------------------------------------------------------
+# Wrapper discipline: hard-coded delimiters, verbatim body, no templating
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_guard_delimiters_are_hard_coded() -> None:
+    """Wrapper delimiters are module constants emitted positionally, not interpolated.
+
+    Defence-in-depth: the slug regex (kb-slug pattern) already forbids
+    the terminator-like substring at publish time, but the wrapper
+    discipline is independent of the slug validator. Build a result and
+    confirm:
+
+    * BLOCK_START / BLOCK_END are the literal module constants (not
+      interpolated from any run field), and the terminator only appears
+      at the wrapper boundary -- never inside the body.
+    """
+    tenant_id = uuid.uuid4()
+    await _seed_published_template(tenant_id, "drain", body=_two_step_template())
+    await _start_runs(tenant_id, OPERATOR, slug="drain", n=1)
+
+    result = await assemble_runbook_priming(OPERATOR, tenant_id)
+
+    # The constants are the literal module values -- the test pins both
+    # the wrapper boundary and that the value matches the module export.
+    assert BLOCK_START == "<<RUNBOOK_PRIMING — CRITICAL>>"
+    assert BLOCK_END == "<<END_RUNBOOK_PRIMING>>"
+    assert result.text.startswith(BLOCK_START)
+    assert result.text.endswith(BLOCK_END)
+    # The terminator literal only appears once -- at the wrapper boundary.
+    assert result.text.count(BLOCK_END) == 1
+
+
+@pytest.mark.asyncio
+async def test_priming_text_includes_no_skip_no_force_advance_implication() -> None:
+    """Body text contains the verbatim adherence phrases the agent is trained against.
+
+    Regression guard -- a refactor that strips ``Follow only the current step``,
+    ``runbook_abort``, or ``runbook_next`` from the rendered text regresses
+    the priming's UX-hint discipline. Initiative #1199 fixes the wording.
+    """
+    tenant_id = uuid.uuid4()
+    await _seed_published_template(tenant_id, "drain", body=_two_step_template())
+    await _start_runs(tenant_id, OPERATOR, slug="drain", n=1)
+
+    result = await assemble_runbook_priming(OPERATOR, tenant_id)
+
+    assert "Follow only the current step" in result.text
+    assert "Do not look ahead" in result.text
+    assert "Do not improvise" in result.text
+    assert "Do not combine steps" in result.text
+    assert "runbook_abort" in result.text
+    assert "runbook_next" in result.text
+
+
+@pytest.mark.asyncio
+async def test_priming_text_is_substitution_safe() -> None:
+    """A slug containing ``${...}`` is rendered verbatim, never resolved.
+
+    Regression guard against accidental templating: the priming text is
+    plain f-string composition over already-validated run fields, not a
+    string template. A slug that looked like ``${run.target}`` (which
+    the slug regex would actually reject at publish time, but defence
+    in depth) must render as the literal characters in the priming.
+
+    The slug regex enforces ``[a-z0-9][a-z0-9-]*`` so a ``$`` is rejected
+    upstream; we exercise the property by checking that the *current
+    step id* (which has the same regex shape) renders verbatim even
+    when constructed to look template-ish at the boundary -- specifically,
+    that the step id appears in backticks exactly once and is not
+    expanded against anything.
+    """
+    tenant_id = uuid.uuid4()
+    await _seed_published_template(tenant_id, "drain", body=_two_step_template())
+    await _start_runs(tenant_id, OPERATOR, slug="drain", n=1)
+
+    result = await assemble_runbook_priming(OPERATOR, tenant_id)
+
+    # ``step-1`` renders verbatim as backticked text; no `$` or `{`
+    # in the rendered priming string.
+    assert "`step-1`" in result.text
+    assert "$" not in result.text
+    assert "{" not in result.text


### PR DESCRIPTION
## Summary

- New module `backend/src/meho_backplane/runbooks/priming.py` exporting `assemble_runbook_priming(operator_sub, tenant_id)` for Initiative #1199 (G12.4 session priming).
- Builds the per-run priming text the MCP `initialize.instructions` preamble surfaces when an operator has in-progress runs assigned to them. Empty → `text=""` (caller skips the section); 1..5 runs → one verbatim block per run; >5 → one summary block referring to `runbook_list_runs`.
- Guard delimiters (`BLOCK_START` / `BLOCK_END`) are hard-coded module constants emitted positionally at the wrapper boundary, never interpolated from run state — same untrusted-content-isolation discipline as the conventions preamble.
- Priming is UX hint, not enforcement; step opacity (G12.3) is the real adherence mechanism. The verbatim adherence phrases (`Follow only the current step`, `runbook_abort`, `runbook_next`) are load-bearing and regression-tested.

## Test plan

- [x] `ruff check src/meho_backplane/runbooks/priming.py tests/test_runbooks_priming.py` — clean
- [x] `ruff format --check` — clean
- [x] `mypy src/meho_backplane/runbooks/priming.py --ignore-missing-imports` — clean
- [x] `pytest tests/test_runbooks_priming.py -v` — 12 passed
- [x] `python3 .claude/hooks/code-quality.py --diff` — pass
- [x] `mypy src/meho_backplane/runbooks/` (wider sweep) — 8 files clean

### Acceptance criteria

- [x] `priming.py` exists with `assemble_runbook_priming()` + `BLOCK_START` / `BLOCK_END` / `MAX_PRIMING_BLOCKS` on `__all__`.
- [x] Helper is `async`; calls `RunbookRunService.list_runs(..., caller_is_admin=False, filter_=ListRunsFilter(status="in_progress"))`.
- [x] Empty case returns `text=""` — regression-tested via `test_no_runs_returns_empty_text`.
- [x] N > 5 collapses to one summary block — regression-tested via `test_six_runs_collapses_to_summary`.
- [x] Verbatim text strings preserved — regression-tested via `test_priming_text_includes_no_skip_no_force_advance_implication`.
- [x] Guard delimiters are module constants, not interpolated — `test_guard_delimiters_are_hard_coded`.
- [x] Helper makes no additional DB queries beyond `list_runs()` — `current_step_id` / `position` come from `RunSummary`.
- [x] Helper does no caller-role check — always operator-scope, `caller_is_admin=False`.
- [x] All 12 tests green.
- [x] ruff + mypy clean.

## Out of scope

- Wiring into `assemble_preamble` — G12.4-T2 (#1316).
- Updating `docs/architecture/mcp.md` — G12.4-T3 (#1317).
- Caching / real-time push / tenant-wide priming — explicitly out per #1199.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1315


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runbook priming capability that assembles and displays in-progress runs for operators, with automatic collapsing to summary view when run count exceeds the configured limit.

* **Tests**
  * Added comprehensive test coverage for runbook priming behavior, including scenarios with no runs, single/multiple runs, and summary mode activation, plus verification of tenant isolation and operator scoping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->