### PR TITLE
feat(runbooks): G12.5-T1 meho runbook CLI chassis + 6 template verbs

### DIFF
--- a/cli/internal/cmd/root.go
+++ b/cli/internal/cmd/root.go
@@ -35,6 +35,7 @@ import (
 	"github.com/evoila/meho/cli/internal/cmd/operation"
 	"github.com/evoila/meho/cli/internal/cmd/pfsense"
 	"github.com/evoila/meho/cli/internal/cmd/retrieval"
+	"github.com/evoila/meho/cli/internal/cmd/runbook"
 	"github.com/evoila/meho/cli/internal/cmd/scheduler"
 	sddcmanager "github.com/evoila/meho/cli/internal/cmd/sddc-manager"
 	"github.com/evoila/meho/cli/internal/cmd/targets"
@@ -156,6 +157,20 @@ func newRootCmd() *cobra.Command {
 	// registerDynamicSubcommands so the backplane manifest cannot
 	// shadow the built-in `kb` parent.
 	root.AddCommand(kb.NewRootCmd())
+
+	// G12.5-T1 (#1318) -- runbook template authoring verbs
+	// (list-templates / show-template / draft-template / edit-template /
+	// publish-template / deprecate-template) for Initiative #1200.
+	// Wraps the six /api/v1/runbooks/templates routes shipped by
+	// G12.2-T3 (#1297). T1 ships the chassis + template verbs; T2
+	// (#1319) extends with the five run verbs (start / next / abort /
+	// reassign / runs). Read verbs (list-templates) are operator-level;
+	// show-template is tenant_admin with the post-completion carve-out
+	// (#1309); write verbs (draft/edit/publish/deprecate) require
+	// tenant_admin. Registered before registerDynamicSubcommands so
+	// the backplane manifest cannot shadow the built-in `runbook`
+	// parent.
+	root.AddCommand(runbook.NewRootCmd())
 
 	// G7.1-T3 (#315) -- conventions verbs (list / show / create / edit /
 	// delete / history) for Initiative #229 (tenant conventions). Wraps

--- a/cli/internal/cmd/runbook/deprecate_template.go
+++ b/cli/internal/cmd/runbook/deprecate_template.go
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package runbook
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newDeprecateTemplateCmd returns the `meho runbook
+// deprecate-template` command.
+//
+// CLI shape (per issue #1318):
+//
+//	meho runbook deprecate-template <slug> --version N [--json]
+//	  [--backplane URL]
+//
+// Wraps POST /api/v1/runbooks/templates/{slug}/deprecate. Role:
+// tenant_admin.
+//
+// Mark a published version as deprecated. In-flight runs continue
+// to advance (they're pinned), but new `runbook start` calls
+// against this version are refused — the backend's runbook_start
+// falls back to the latest non-deprecated published version of the
+// slug.
+//
+// Exit codes:
+//   - 0   deprecated successfully (200)
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (incl. 404 slug_not_found, 400 on
+//     attempting to deprecate a draft / already-deprecated version)
+//   - 5   insufficient_role
+func newDeprecateTemplateCmd() *cobra.Command {
+	var (
+		version           int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "deprecate-template <slug>",
+		Short: "Mark a published version as deprecated (tenant_admin)",
+		Long: "deprecate-template calls POST " +
+			"/api/v1/runbooks/templates/{slug}/deprecate. Tenant_admin only.\n\n" +
+			"In-flight runs continue to advance (they're pinned), but " +
+			"new `meho runbook start` calls against this version are " +
+			"refused — the backend falls back to the latest non-deprecated " +
+			"published version of the slug.\n\n" +
+			"Use when: a procedure is no longer current (cert validity " +
+			"period changed, a backend was upgraded) and you want to stop " +
+			"new operators starting against it.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDeprecateTemplate(cmd, deprecateTemplateOptions{
+				Slug:              args[0],
+				Version:           version,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().IntVar(&version, "version", 0,
+		"template version to deprecate (required; positive integer)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw DeprecateTemplateResponse JSON instead of the human confirmation")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type deprecateTemplateOptions struct {
+	Slug              string
+	Version           int
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runDeprecateTemplate(cmd *cobra.Command, opts deprecateTemplateOptions) error {
+	if opts.Slug == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("deprecate-template requires a non-empty <slug> argument"),
+			opts.JSONOut,
+		)
+	}
+	if opts.Version <= 0 {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("deprecate-template requires --version N (positive integer)"),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	resp, err := postDeprecateTemplate(cmd.Context(), backplaneURL, opts.Slug, opts.Version)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	if resp.JSON200 == nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without a DeprecateTemplateResponse payload",
+				backplaneURL,
+			)),
+			opts.JSONOut,
+		)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
+	}
+	printDeprecateSummary(cmd.OutOrStdout(), resp.JSON200)
+	return nil
+}
+
+func postDeprecateTemplate(
+	ctx context.Context,
+	backplaneURL, slug string,
+	version int,
+) (*api.DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	body := api.UnderscoreVersionBody{Version: version}
+	params := &api.DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostParams{}
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostResponse, error) {
+			return authed.DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostWithResponse(
+				ctx, slug, params, body,
+			)
+		},
+		func(r *api.DeprecateTemplateApiV1RunbooksTemplatesSlugDeprecatePostResponse) int {
+			return r.StatusCode()
+		},
+	)
+}
+
+func printDeprecateSummary(w io.Writer, r *api.DeprecateTemplateResponse) {
+	if r == nil {
+		return
+	}
+	fmt.Fprintf(w, "Deprecated %s@%d (status=%s)\n", r.Slug, r.Version, r.Status)
+}

--- a/cli/internal/cmd/runbook/deprecate_template_test.go
+++ b/cli/internal/cmd/runbook/deprecate_template_test.go
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package runbook
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/api"
+)
+
+// TestRunDeprecateTemplateHappyPath — POST to .../deprecate carries
+// the right version body and renders the 1-line confirmation.
+func TestRunDeprecateTemplateHappyPath(t *testing.T) {
+	var sawBody api.UnderscoreVersionBody
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates/vcenter-cert-rotation/deprecate", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST; got %s", r.Method)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		readJSONBodyOf(t, raw, &sawBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(api.DeprecateTemplateResponse{
+			Slug: "vcenter-cert-rotation", Version: sawBody.Version, Status: "deprecated",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runDeprecateTemplate(cmd, deprecateTemplateOptions{
+		Slug: "vcenter-cert-rotation", Version: 2, BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runDeprecateTemplate: %v; stderr=%s", err, stderr.String())
+	}
+	if sawBody.Version != 2 {
+		t.Errorf("wire version: got %d; want 2", sawBody.Version)
+	}
+	if !strings.Contains(stdout.String(), "Deprecated vcenter-cert-rotation@2") {
+		t.Errorf("expected deprecated line; got %q", stdout.String())
+	}
+}
+
+// TestRunDeprecateTemplateRequiresVersion — missing --version fails
+// fast.
+func TestRunDeprecateTemplateRequiresVersion(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runDeprecateTemplate(cmd, deprecateTemplateOptions{Slug: "x"})
+	if err == nil {
+		t.Fatal("expected error for missing --version")
+	}
+	if !strings.Contains(stderr.String(), "--version") {
+		t.Errorf("expected --version hint; got %q", stderr.String())
+	}
+}
+
+// TestRunDeprecateTemplate404SurfacesSlugNotFound — slug_not_found.
+func TestRunDeprecateTemplate404SurfacesSlugNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates/missing/deprecate", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"detail":"slug_not_found"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runDeprecateTemplate(cmd, deprecateTemplateOptions{
+		Slug: "missing", Version: 1, BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(stderr.String(), "slug_not_found") {
+		t.Errorf("expected detail; got %q", stderr.String())
+	}
+}
+
+// TestRunDeprecateTemplate403SurfacesInsufficientRole — tenant_admin
+// required.
+func TestRunDeprecateTemplate403SurfacesInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates/x/deprecate", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"detail":"Insufficient role: tenant_admin required"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runDeprecateTemplate(cmd, deprecateTemplateOptions{
+		Slug: "x", Version: 1, BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(stderr.String(), "tenant_admin required") {
+		t.Errorf("expected role hint; got %q", stderr.String())
+	}
+	type ec interface{ ExitCode() int }
+	if x, ok := err.(ec); !ok || x.ExitCode() != 5 {
+		t.Errorf("expected ExitCode 5; got %v", err)
+	}
+}
+
+// TestRunDeprecateTemplate400OnDraftSurfacesDetail — backend's 400
+// for "cannot deprecate a draft" surfaces verbatim.
+func TestRunDeprecateTemplate400OnDraftSurfacesDetail(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates/x/deprecate", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprint(w, `{"detail":"cannot deprecate a draft; publish it first"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runDeprecateTemplate(cmd, deprecateTemplateOptions{
+		Slug: "x", Version: 1, BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(stderr.String(), "publish it first") {
+		t.Errorf("expected backend detail; got %q", stderr.String())
+	}
+}
+
+// TestRunDeprecateTemplateJSONHappyPath — --json emits the envelope.
+func TestRunDeprecateTemplateJSONHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates/x/deprecate", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(api.DeprecateTemplateResponse{
+			Slug: "x", Version: 1, Status: "deprecated",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	err := runDeprecateTemplate(cmd, deprecateTemplateOptions{
+		Slug: "x", Version: 1, JSONOut: true, BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runDeprecateTemplate --json: %v", err)
+	}
+	var decoded api.DeprecateTemplateResponse
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
+	}
+	if decoded.Status != "deprecated" {
+		t.Errorf("envelope.status: %q", decoded.Status)
+	}
+}

--- a/cli/internal/cmd/runbook/draft_template.go
+++ b/cli/internal/cmd/runbook/draft_template.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package runbook
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newDraftTemplateCmd returns the `meho runbook draft-template`
+// command.
+//
+// CLI shape (per issue #1318):
+//
+//	meho runbook draft-template <slug> --from <file.yaml> [--json]
+//	  [--backplane URL]
+//
+// Wraps POST /api/v1/runbooks/templates. Role: tenant_admin —
+// operator-role JWT lands as 403 insufficient_role.
+//
+// Use when: a senior is about to walk you through a procedure (cert
+// rotation, host onboarding, vault unseal-after-restart) and wants
+// it captured as a governance-graded artifact. The verb creates the
+// first draft (version=1, status=draft); if a draft already exists
+// for this slug the backend rejects with 409 / draft_already_exists
+// and the operator should use `edit-template` instead.
+//
+// The --from YAML file is parsed locally, pre-flight validated
+// (slug regex, step id uniqueness + grammar, step / verify type
+// allowlists, substitution allowlist), and only then POSTed. The
+// backend re-validates authoritatively at the wire so any drift
+// between this CLI's pre-flight and the backend's schemas.py is
+// caught by a 422.
+//
+// Exit codes:
+//   - 0   draft created (201)
+//   - 1   YAML parse / pre-flight failure (no HTTP call made)
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (incl. 409 draft_already_exists, 422
+//     validation failure)
+//   - 5   insufficient_role
+func newDraftTemplateCmd() *cobra.Command {
+	var (
+		fromPath          string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "draft-template <slug>",
+		Short: "Create the first draft of a new runbook template (tenant_admin)",
+		Long: "draft-template calls POST /api/v1/runbooks/templates to " +
+			"create the first draft of a new slug. Tenant_admin only — " +
+			"operator-role JWT lands as 403 insufficient_role.\n\n" +
+			"--from <file.yaml> is required: the template body is read " +
+			"from the YAML file, pre-flighted locally (slug regex, step " +
+			"id uniqueness, step / verify type allowlists, substitution " +
+			"allowlist), and only then POSTed. Pre-flight is a UX layer " +
+			"— the backend re-validates authoritatively.\n\n" +
+			"If a draft already exists for the slug, the backend " +
+			"refuses (409). Use `meho runbook edit-template` to mutate " +
+			"the existing draft.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDraftTemplate(cmd, draftTemplateOptions{
+				Slug:              args[0],
+				FromPath:          fromPath,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&fromPath, "from", "",
+		"path to the YAML file describing the template body (required)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw DraftTemplateResponse JSON instead of the human summary")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type draftTemplateOptions struct {
+	Slug              string
+	FromPath          string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runDraftTemplate(cmd *cobra.Command, opts draftTemplateOptions) error {
+	if opts.Slug == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("draft-template requires a non-empty <slug> argument"),
+			opts.JSONOut,
+		)
+	}
+	if opts.FromPath == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("draft-template requires --from <file.yaml>"),
+			opts.JSONOut,
+		)
+	}
+	yamlBody, err := loadYAMLTemplate(opts.FromPath)
+	if err != nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()),
+			opts.JSONOut,
+		)
+	}
+	if err := validateYAMLTemplate(opts.Slug, yamlBody); err != nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()),
+			opts.JSONOut,
+		)
+	}
+	wireBody, err := buildRunbookTemplateBody(yamlBody)
+	if err != nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	resp, err := postDraftTemplate(cmd.Context(), backplaneURL, opts.Slug, wireBody)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode() != http.StatusCreated {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	if resp.JSON201 == nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 201 without a DraftTemplateResponse payload",
+				backplaneURL,
+			)),
+			opts.JSONOut,
+		)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp.JSON201)
+	}
+	printDraftSummary(cmd.OutOrStdout(), resp.JSON201)
+	return nil
+}
+
+func postDraftTemplate(
+	ctx context.Context,
+	backplaneURL, slug string,
+	body api.RunbookTemplateBody,
+) (*api.DraftTemplateApiV1RunbooksTemplatesPostResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	req := api.DraftTemplateRequest{Slug: slug, Body: body}
+	params := &api.DraftTemplateApiV1RunbooksTemplatesPostParams{}
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.DraftTemplateApiV1RunbooksTemplatesPostResponse, error) {
+			return authed.DraftTemplateApiV1RunbooksTemplatesPostWithResponse(ctx, params, req)
+		},
+		func(r *api.DraftTemplateApiV1RunbooksTemplatesPostResponse) int { return r.StatusCode() },
+	)
+}
+
+// printDraftSummary renders the 2-line success summary the issue
+// body's AC specifies: `Created draft <slug>@<version>` + a status
+// line. The version is always 1 for a fresh draft, but the backend
+// is the source of truth so we render whatever it returned (rather
+// than hardcoding "1").
+func printDraftSummary(w io.Writer, r *api.DraftTemplateResponse) {
+	if r == nil {
+		return
+	}
+	fmt.Fprintf(w, "Created draft %s@%d\n", r.Slug, r.Version)
+	fmt.Fprintf(w, "Status: %s\n", r.Status)
+}

--- a/cli/internal/cmd/runbook/draft_template_test.go
+++ b/cli/internal/cmd/runbook/draft_template_test.go
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package runbook
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/api"
+)
+
+// TestRunDraftTemplateHappyPath — happy path: YAML loads, pre-flight
+// passes, POST to /api/v1/runbooks/templates carries the right
+// payload, 201 response renders the 2-line summary.
+func TestRunDraftTemplateHappyPath(t *testing.T) {
+	var sawBody api.DraftTemplateRequest
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST; got %s", r.Method)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		readJSONBodyOf(t, raw, &sawBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(api.DraftTemplateResponse{
+			Slug: sawBody.Slug, Version: 1, Status: "draft",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	path := writeYAML(t, validYAML)
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runDraftTemplate(cmd, draftTemplateOptions{
+		Slug: "vcenter-cert-rotation", FromPath: path, BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runDraftTemplate: %v; stderr=%s", err, stderr.String())
+	}
+	if sawBody.Slug != "vcenter-cert-rotation" {
+		t.Errorf("wire slug: %q", sawBody.Slug)
+	}
+	if sawBody.Body.Title == "" || len(sawBody.Body.Steps) != 2 {
+		t.Errorf("wire body steps: %d title=%q", len(sawBody.Body.Steps), sawBody.Body.Title)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Created draft vcenter-cert-rotation@1") {
+		t.Errorf("expected created-draft line; got %q", out)
+	}
+	if !strings.Contains(out, "Status: draft") {
+		t.Errorf("expected status line; got %q", out)
+	}
+}
+
+// TestRunDraftTemplateJSONHappyPath — --json emits the raw envelope.
+func TestRunDraftTemplateJSONHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(api.DraftTemplateResponse{
+			Slug: "x", Version: 1, Status: "draft",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	path := writeYAML(t, validYAML)
+	cmd, stdout, _ := newRunCmd(t)
+	err := runDraftTemplate(cmd, draftTemplateOptions{
+		Slug: "vcenter-cert-rotation", FromPath: path, JSONOut: true, BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runDraftTemplate --json: %v", err)
+	}
+	var decoded api.DraftTemplateResponse
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
+	}
+	if decoded.Slug != "x" || decoded.Status != "draft" {
+		t.Errorf("envelope: %+v", decoded)
+	}
+}
+
+// TestRunDraftTemplateRequiresFromFlag — missing --from short-circuits
+// before any HTTP call.
+func TestRunDraftTemplateRequiresFromFlag(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runDraftTemplate(cmd, draftTemplateOptions{Slug: "x"})
+	if err == nil {
+		t.Fatal("expected error for missing --from")
+	}
+	if !strings.Contains(stderr.String(), "--from") {
+		t.Errorf("expected --from hint; got %q", stderr.String())
+	}
+}
+
+// TestRunDraftTemplateRejectsBadSlugBeforeHTTP — invalid slug fails
+// pre-flight; no HTTP call made (AC test 6).
+func TestRunDraftTemplateRejectsBadSlugBeforeHTTP(t *testing.T) {
+	httpCalls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates", func(w http.ResponseWriter, _ *http.Request) {
+		httpCalls++
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	path := writeYAML(t, validYAML)
+	cmd, _, stderr := newRunCmd(t)
+	err := runDraftTemplate(cmd, draftTemplateOptions{
+		Slug: "BAD_SLUG", FromPath: path, BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error for bad slug")
+	}
+	if httpCalls != 0 {
+		t.Errorf("expected zero HTTP calls; got %d", httpCalls)
+	}
+	if !strings.Contains(stderr.String(), "does not match") {
+		t.Errorf("expected slug-regex hint; got %q", stderr.String())
+	}
+}
+
+// TestRunDraftTemplateRejectsDuplicateStepIDBeforeHTTP — duplicate
+// step ids fail pre-flight; no HTTP call (AC test 7).
+func TestRunDraftTemplateRejectsDuplicateStepIDBeforeHTTP(t *testing.T) {
+	httpCalls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates", func(_ http.ResponseWriter, _ *http.Request) {
+		httpCalls++
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	bad := strings.Replace(validYAML, "issue-new-cert", "revoke-old-cert", 1)
+	path := writeYAML(t, bad)
+	cmd, _, stderr := newRunCmd(t)
+	err := runDraftTemplate(cmd, draftTemplateOptions{
+		Slug: "ok-slug", FromPath: path, BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error for duplicate step id")
+	}
+	if httpCalls != 0 {
+		t.Errorf("expected zero HTTP calls; got %d", httpCalls)
+	}
+	if !strings.Contains(stderr.String(), "duplicate step id") {
+		t.Errorf("expected dup-id hint; got %q", stderr.String())
+	}
+}
+
+// TestRunDraftTemplateRejectsBadSubstitutionBeforeHTTP — disallowed
+// `${...}` patterns fail pre-flight; no HTTP call (AC test 8).
+func TestRunDraftTemplateRejectsBadSubstitutionBeforeHTTP(t *testing.T) {
+	httpCalls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates", func(_ http.ResponseWriter, _ *http.Request) {
+		httpCalls++
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	bad := strings.Replace(validYAML, "${run.target}", "${run.bad.path}", 1)
+	path := writeYAML(t, bad)
+	cmd, _, stderr := newRunCmd(t)
+	err := runDraftTemplate(cmd, draftTemplateOptions{
+		Slug: "ok-slug", FromPath: path, BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error for disallowed substitution")
+	}
+	if httpCalls != 0 {
+		t.Errorf("expected zero HTTP calls; got %d", httpCalls)
+	}
+	if !strings.Contains(stderr.String(), "disallowed substitution") {
+		t.Errorf("expected substitution-allowlist hint; got %q", stderr.String())
+	}
+}
+
+// TestRunDraftTemplateRejectsBadYAMLBeforeHTTP — malformed YAML fails
+// at parse time with a `line N:` hint; no HTTP call (AC test 9).
+func TestRunDraftTemplateRejectsBadYAMLBeforeHTTP(t *testing.T) {
+	httpCalls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates", func(_ http.ResponseWriter, _ *http.Request) {
+		httpCalls++
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	// Make the YAML decoder unhappy — start a flow scalar with `{`
+	// that never closes. yaml.v3 surfaces this with a clear
+	// `line N:` parse error.
+	bad := "title: { unterminated flow\n"
+	path := writeYAML(t, bad)
+	cmd, _, stderr := newRunCmd(t)
+	err := runDraftTemplate(cmd, draftTemplateOptions{
+		Slug: "ok-slug", FromPath: path, BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error for bad YAML")
+	}
+	if httpCalls != 0 {
+		t.Errorf("expected zero HTTP calls; got %d", httpCalls)
+	}
+	if !strings.Contains(stderr.String(), "line") {
+		t.Errorf("expected line: hint in stderr; got %q", stderr.String())
+	}
+}
+
+// TestRunDraftTemplate403SurfacesInsufficientRole — operator-role
+// JWT lands 403; CLI exits 5.
+func TestRunDraftTemplate403SurfacesInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"detail":"Insufficient role: tenant_admin required"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	path := writeYAML(t, validYAML)
+	cmd, _, stderr := newRunCmd(t)
+	err := runDraftTemplate(cmd, draftTemplateOptions{
+		Slug: "vcenter-cert-rotation", FromPath: path, BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(stderr.String(), "tenant_admin required") {
+		t.Errorf("expected role hint; got %q", stderr.String())
+	}
+	type ec interface{ ExitCode() int }
+	if x, ok := err.(ec); !ok || x.ExitCode() != 5 {
+		t.Errorf("expected ExitCode 5; got %v", err)
+	}
+}
+
+// TestRunDraftTemplate409SurfacesDraftAlreadyExists — POST against
+// an existing draft surfaces the backend's 409 detail.
+func TestRunDraftTemplate409SurfacesDraftAlreadyExists(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		fmt.Fprint(w, `{"detail":"draft_already_exists"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	path := writeYAML(t, validYAML)
+	cmd, _, stderr := newRunCmd(t)
+	err := runDraftTemplate(cmd, draftTemplateOptions{
+		Slug: "vcenter-cert-rotation", FromPath: path, BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(stderr.String(), "draft_already_exists") {
+		t.Errorf("expected detail; got %q", stderr.String())
+	}
+}
+
+// TestRunDraftTemplate422SurfacesValidationDetail — backend's 422
+// envelope (with `loc` path) survives the round-trip.
+func TestRunDraftTemplate422SurfacesValidationDetail(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		fmt.Fprint(w, `{"detail":[{"loc":["body","slug"],"msg":"value does not match SLUG_PATTERN"}]}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	path := writeYAML(t, validYAML)
+	cmd, _, stderr := newRunCmd(t)
+	err := runDraftTemplate(cmd, draftTemplateOptions{
+		Slug: "vcenter-cert-rotation", FromPath: path, BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(stderr.String(), "SLUG_PATTERN") {
+		t.Errorf("expected backend detail; got %q", stderr.String())
+	}
+}

--- a/cli/internal/cmd/runbook/edit_template.go
+++ b/cli/internal/cmd/runbook/edit_template.go
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package runbook
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newEditTemplateCmd returns the `meho runbook edit-template`
+// command.
+//
+// CLI shape (per issue #1318):
+//
+//	meho runbook edit-template <slug> --from <file.yaml> [--json]
+//	  [--backplane URL]
+//
+// Wraps PATCH /api/v1/runbooks/templates/{slug}. Role: tenant_admin.
+//
+// Edit semantics depend on the template's current status (backend
+// decides; the CLI just surfaces the response):
+//
+//   - If a draft exists for this slug → edit IN PLACE; no version
+//     bump; forked_from is nil in the response.
+//   - If only published/deprecated versions exist → FORK to a new
+//     draft at version=max+1; forked_from carries the source
+//     coordinates plus the in-flight run count pinned to the
+//     version being forked from.
+//
+// The --from YAML file is parsed locally and pre-flighted with the
+// same allowlist as draft-template before the PATCH is issued.
+//
+// Exit codes:
+//   - 0   draft edited (200)
+//   - 1   YAML parse / pre-flight failure (no HTTP call made)
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (incl. 404 slug_not_found, 422
+//     validation failure)
+//   - 5   insufficient_role
+func newEditTemplateCmd() *cobra.Command {
+	var (
+		fromPath          string
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "edit-template <slug>",
+		Short: "Edit a draft template — in-place or fork-on-publish (tenant_admin)",
+		Long: "edit-template calls PATCH /api/v1/runbooks/templates/{slug}. " +
+			"Tenant_admin only.\n\n" +
+			"If a draft exists for this slug, the edit lands in place " +
+			"(no version bump). If only published/deprecated versions " +
+			"exist, the edit FORKS to a new draft at version=max+1; the " +
+			"response carries `forked_from` so you can see how many " +
+			"in-flight runs are still pinned to the version you're " +
+			"forking from (a non-zero count means juniors are mid-procedure " +
+			"on the older version — they stay pinned).\n\n" +
+			"MULTI-SESSION DRAFTING: a senior+agent walk-through of a " +
+			"real cert-rotation runbook is rarely a single session. " +
+			"Start with draft-template, edit-template repeatedly across " +
+			"sessions, then publish-template once the senior signs off. " +
+			"Drafts are mutable across sessions; published versions are " +
+			"pinned for in-flight runs.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runEditTemplate(cmd, editTemplateOptions{
+				Slug:              args[0],
+				FromPath:          fromPath,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&fromPath, "from", "",
+		"path to the YAML file describing the template body (required)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw EditTemplateResponse JSON instead of the human summary")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type editTemplateOptions struct {
+	Slug              string
+	FromPath          string
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runEditTemplate(cmd *cobra.Command, opts editTemplateOptions) error {
+	if opts.Slug == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("edit-template requires a non-empty <slug> argument"),
+			opts.JSONOut,
+		)
+	}
+	if opts.FromPath == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("edit-template requires --from <file.yaml>"),
+			opts.JSONOut,
+		)
+	}
+	yamlBody, err := loadYAMLTemplate(opts.FromPath)
+	if err != nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()),
+			opts.JSONOut,
+		)
+	}
+	if err := validateYAMLTemplate(opts.Slug, yamlBody); err != nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()),
+			opts.JSONOut,
+		)
+	}
+	wireBody, err := buildRunbookTemplateBody(yamlBody)
+	if err != nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(err.Error()),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	resp, err := patchEditTemplate(cmd.Context(), backplaneURL, opts.Slug, wireBody)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	if resp.JSON200 == nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without an EditTemplateResponse payload",
+				backplaneURL,
+			)),
+			opts.JSONOut,
+		)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
+	}
+	printEditSummary(cmd.OutOrStdout(), resp.JSON200)
+	return nil
+}
+
+func patchEditTemplate(
+	ctx context.Context,
+	backplaneURL, slug string,
+	body api.RunbookTemplateBody,
+) (*api.EditTemplateApiV1RunbooksTemplatesSlugPatchResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	params := &api.EditTemplateApiV1RunbooksTemplatesSlugPatchParams{}
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.EditTemplateApiV1RunbooksTemplatesSlugPatchResponse, error) {
+			return authed.EditTemplateApiV1RunbooksTemplatesSlugPatchWithResponse(ctx, slug, params, body)
+		},
+		func(r *api.EditTemplateApiV1RunbooksTemplatesSlugPatchResponse) int { return r.StatusCode() },
+	)
+}
+
+// printEditSummary renders the human summary line(s) for an edit
+// response. The shape depends on whether the edit was an in-place
+// mutation of an existing draft or a fork from a published version:
+//
+//   - draft-edit (forked_from == nil): one line —
+//     `Edited slug@version (status=draft)`.
+//   - fork-on-edit (forked_from != nil): two lines —
+//     `Edited slug@version (forked from slug@prev, N in-flight runs
+//     on previous version)`. Surfaces in_flight_run_count so the
+//     senior sees how many juniors are still pinned to the older
+//     version (the fork warning Initiative #1200 calls out).
+func printEditSummary(w io.Writer, r *api.EditTemplateResponse) {
+	if r == nil {
+		return
+	}
+	if r.ForkedFrom == nil {
+		fmt.Fprintf(w, "Edited %s@%d (status=%s)\n", r.Slug, r.Version, r.Status)
+		return
+	}
+	fmt.Fprintf(w,
+		"Edited %s@%d (forked from %s@%d, %d in-flight run(s) on previous version, status=%s)\n",
+		r.Slug, r.Version,
+		r.ForkedFrom.Slug, r.ForkedFrom.Version,
+		r.ForkedFrom.InFlightRunCount,
+		r.Status,
+	)
+}

--- a/cli/internal/cmd/runbook/edit_template_test.go
+++ b/cli/internal/cmd/runbook/edit_template_test.go
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package runbook
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/api"
+)
+
+// TestRunEditTemplateHappyPathDraftInPlace — edit in place when only
+// a draft exists: response has forked_from == nil and the summary
+// is the single-line shape.
+func TestRunEditTemplateHappyPathDraftInPlace(t *testing.T) {
+	var sawBody api.RunbookTemplateBody
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates/vcenter-cert-rotation", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Errorf("expected PATCH; got %s", r.Method)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		readJSONBodyOf(t, raw, &sawBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(api.EditTemplateResponse{
+			Slug: "vcenter-cert-rotation", Version: 1, Status: "draft", ForkedFrom: nil,
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	path := writeYAML(t, validYAML)
+	cmd, stdout, _ := newRunCmd(t)
+	err := runEditTemplate(cmd, editTemplateOptions{
+		Slug: "vcenter-cert-rotation", FromPath: path, BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runEditTemplate: %v", err)
+	}
+	if sawBody.Title == "" || len(sawBody.Steps) != 2 {
+		t.Errorf("wire body: %+v", sawBody)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Edited vcenter-cert-rotation@1") {
+		t.Errorf("expected edited line; got %q", out)
+	}
+	if strings.Contains(out, "forked from") {
+		t.Errorf("expected no fork notice for in-place edit; got %q", out)
+	}
+}
+
+// TestRunEditTemplateHappyPathForkOnEdit — editing a published-only
+// template forks to a new draft and the summary surfaces
+// `forked_from.in_flight_run_count`.
+func TestRunEditTemplateHappyPathForkOnEdit(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates/vcenter-cert-rotation", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(api.EditTemplateResponse{
+			Slug: "vcenter-cert-rotation", Version: 2, Status: "draft",
+			ForkedFrom: &api.ForkInfo{Slug: "vcenter-cert-rotation", Version: 1, InFlightRunCount: 3},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	path := writeYAML(t, validYAML)
+	cmd, stdout, _ := newRunCmd(t)
+	err := runEditTemplate(cmd, editTemplateOptions{
+		Slug: "vcenter-cert-rotation", FromPath: path, BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runEditTemplate fork: %v", err)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Edited vcenter-cert-rotation@2") {
+		t.Errorf("expected edited line; got %q", out)
+	}
+	if !strings.Contains(out, "forked from vcenter-cert-rotation@1") {
+		t.Errorf("expected fork notice; got %q", out)
+	}
+	if !strings.Contains(out, "3 in-flight") {
+		t.Errorf("expected in-flight count; got %q", out)
+	}
+}
+
+// TestRunEditTemplateRequiresFromFlag — missing --from short-circuits.
+func TestRunEditTemplateRequiresFromFlag(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runEditTemplate(cmd, editTemplateOptions{Slug: "x"})
+	if err == nil {
+		t.Fatal("expected error for missing --from")
+	}
+	if !strings.Contains(stderr.String(), "--from") {
+		t.Errorf("expected --from hint; got %q", stderr.String())
+	}
+}
+
+// TestRunEditTemplate404SurfacesSlugNotFound — slug_not_found surfaces
+// the backend's detail.
+func TestRunEditTemplate404SurfacesSlugNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates/missing", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"detail":"slug_not_found"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	path := writeYAML(t, validYAML)
+	cmd, _, stderr := newRunCmd(t)
+	err := runEditTemplate(cmd, editTemplateOptions{
+		Slug: "missing", FromPath: path, BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(stderr.String(), "slug_not_found") {
+		t.Errorf("expected detail; got %q", stderr.String())
+	}
+}
+
+// TestRunEditTemplate403SurfacesInsufficientRole — tenant_admin
+// required.
+func TestRunEditTemplate403SurfacesInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates/x", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"detail":"Insufficient role: tenant_admin required"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	path := writeYAML(t, validYAML)
+	cmd, _, stderr := newRunCmd(t)
+	err := runEditTemplate(cmd, editTemplateOptions{
+		Slug: "x", FromPath: path, BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(stderr.String(), "tenant_admin required") {
+		t.Errorf("expected role hint; got %q", stderr.String())
+	}
+	type ec interface{ ExitCode() int }
+	if x, ok := err.(ec); !ok || x.ExitCode() != 5 {
+		t.Errorf("expected ExitCode 5; got %v", err)
+	}
+}
+
+// TestRunEditTemplate422SurfacesValidationDetail — backend 422 round-trips.
+func TestRunEditTemplate422SurfacesValidationDetail(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates/x", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		fmt.Fprint(w, `{"detail":[{"loc":["body","body","steps",0,"verify"],"msg":"value does not match discriminator type"}]}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	path := writeYAML(t, validYAML)
+	cmd, _, stderr := newRunCmd(t)
+	err := runEditTemplate(cmd, editTemplateOptions{
+		Slug: "x", FromPath: path, BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(stderr.String(), "discriminator type") {
+		t.Errorf("expected backend detail; got %q", stderr.String())
+	}
+}
+
+// TestRunEditTemplateJSONHappyPath — --json emits the raw envelope
+// including forked_from when set.
+func TestRunEditTemplateJSONHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates/x", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(api.EditTemplateResponse{
+			Slug: "x", Version: 2, Status: "draft",
+			ForkedFrom: &api.ForkInfo{Slug: "x", Version: 1, InFlightRunCount: 7},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	path := writeYAML(t, validYAML)
+	cmd, stdout, _ := newRunCmd(t)
+	err := runEditTemplate(cmd, editTemplateOptions{
+		Slug: "x", FromPath: path, JSONOut: true, BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runEditTemplate --json: %v", err)
+	}
+	var decoded api.EditTemplateResponse
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
+	}
+	if decoded.ForkedFrom == nil || decoded.ForkedFrom.InFlightRunCount != 7 {
+		t.Errorf("envelope.ForkedFrom: %+v", decoded.ForkedFrom)
+	}
+}

--- a/cli/internal/cmd/runbook/list_templates.go
+++ b/cli/internal/cmd/runbook/list_templates.go
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package runbook
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newListTemplatesCmd returns the `meho runbook list-templates`
+// command.
+//
+// CLI shape (per issue #1318):
+//
+//	meho runbook list-templates \
+//	  [--status published|draft|deprecated] \
+//	  [--target-kind KIND] \
+//	  [--limit N] \
+//	  [--json] \
+//	  [--backplane URL]
+//
+// Wraps GET /api/v1/runbooks/templates. Role: operator (the backend
+// projects the list to a 6-column summary; full step bodies require
+// show-template's tighter role gate).
+//
+// Default output: 5-column table (SLUG, VERSION, STATUS,
+// TARGET_KIND, EDITED_AT). `--json` emits the raw
+// RunbookTemplateListResponse envelope for jq pipelines.
+//
+// Exit codes:
+//   - 0   list returned cleanly (including zero rows)
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response
+//   - 5   insufficient_role
+func newListTemplatesCmd() *cobra.Command {
+	var (
+		statusFilter      string
+		targetKind        string
+		limit             int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "list-templates",
+		Short: "List runbook templates in your tenant",
+		Long: "list-templates calls GET /api/v1/runbooks/templates and " +
+			"renders the runbook templates registered in the operator's " +
+			"tenant, slug-sorted. Filters: --status (draft / published / " +
+			"deprecated), --target-kind (free-form connector kind like " +
+			"`vmware-rest`). --limit caps the page size (server-side " +
+			"default 100, max 500). Does NOT return step bodies — use " +
+			"`meho runbook show-template` (tenant_admin) to read full " +
+			"step content.\n\n" +
+			"Operators see this surface to discover available procedures " +
+			"before `meho runbook start` (G12.5-T2 #1319). " +
+			"Tenant_admins see the same to audit what's in flight.",
+		Args:          cobra.NoArgs,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runListTemplates(cmd, listTemplatesOptions{
+				Status:            statusFilter,
+				TargetKind:        targetKind,
+				Limit:             limit,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&statusFilter, "status", "",
+		"filter by lifecycle status: draft, published, or deprecated")
+	cmd.Flags().StringVar(&targetKind, "target-kind", "",
+		"filter by target_kind (free-form connector kind like `vmware-rest`)")
+	cmd.Flags().IntVar(&limit, "limit", 0,
+		"max templates per page (1..500, server default 100 when omitted)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw RunbookTemplateListResponse JSON instead of the human table")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type listTemplatesOptions struct {
+	Status            string
+	TargetKind        string
+	Limit             int
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runListTemplates(cmd *cobra.Command, opts listTemplatesOptions) error {
+	// Fail fast on out-of-range --limit. The backend's Query(le=500)
+	// would otherwise surface a 422 on a negative or oversized value;
+	// fast-fail saves the network round-trip.
+	if opts.Limit < 0 || opts.Limit > 500 {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--limit must be between 1 and 500; got %d", opts.Limit)),
+			opts.JSONOut,
+		)
+	}
+	// Validate the status enum locally so a typo (`--status published `
+	// with a trailing space, `--status pub`) lands as a CLI error
+	// rather than a 422. The three allowlisted values are pinned to
+	// the backend's `Literal["draft", "published", "deprecated"]`.
+	if opts.Status != "" {
+		switch opts.Status {
+		case "draft", "published", "deprecated":
+			// ok
+		default:
+			return output.RenderError(
+				cmd.ErrOrStderr(),
+				output.Unexpected(fmt.Sprintf(
+					"--status must be one of draft, published, deprecated; got %q",
+					opts.Status,
+				)),
+				opts.JSONOut,
+			)
+		}
+	}
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	resp, err := getTemplateList(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	if resp.JSON200 == nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without a template list payload",
+				backplaneURL,
+			)),
+			opts.JSONOut,
+		)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
+	}
+	printTemplateListTable(cmd.OutOrStdout(), resp.JSON200)
+	return nil
+}
+
+// listTemplatesParams maps the CLI flags onto the generated query-param
+// shape. Each pointer field is set only when the operator supplied the
+// flag so the backplane's own defaults apply for unset values.
+func listTemplatesParams(opts listTemplatesOptions) *api.ListTemplatesApiV1RunbooksTemplatesGetParams {
+	params := &api.ListTemplatesApiV1RunbooksTemplatesGetParams{}
+	if opts.Status != "" {
+		s := api.ListTemplatesApiV1RunbooksTemplatesGetParamsStatus(opts.Status)
+		params.Status = &s
+	}
+	if opts.TargetKind != "" {
+		tk := opts.TargetKind
+		params.TargetKind = &tk
+	}
+	if opts.Limit > 0 {
+		l := opts.Limit
+		params.Limit = &l
+	}
+	return params
+}
+
+func getTemplateList(
+	ctx context.Context,
+	backplaneURL string,
+	opts listTemplatesOptions,
+) (*api.ListTemplatesApiV1RunbooksTemplatesGetResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	params := listTemplatesParams(opts)
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.ListTemplatesApiV1RunbooksTemplatesGetResponse, error) {
+			return authed.ListTemplatesApiV1RunbooksTemplatesGetWithResponse(ctx, params)
+		},
+		func(r *api.ListTemplatesApiV1RunbooksTemplatesGetResponse) int { return r.StatusCode() },
+	)
+}
+
+// printTemplateListTable renders the list as a compact, scannable
+// 5-column table — SLUG, VERSION, STATUS, TARGET_KIND, EDITED_AT.
+// Matches the existing CLI table conventions (`meho kb list`,
+// `meho conventions list`). The full ISO-8601 timestamp is kept
+// verbatim (not truncated) because operators correlating with audit
+// rows want the precise edited_at; the column is sized for the
+// worst-case Go `time.Time`-formatted shape (RFC3339 with nanos).
+func printTemplateListTable(w io.Writer, r *api.RunbookTemplateListResponse) {
+	if r == nil || len(r.Templates) == 0 {
+		fmt.Fprintln(w, "no runbook templates registered in this tenant")
+		return
+	}
+	fmt.Fprintf(w, "%-40s %-7s %-10s %-20s %s\n",
+		"SLUG", "VERSION", "STATUS", "TARGET_KIND", "EDITED_AT")
+	for _, t := range r.Templates {
+		targetKind := "-"
+		if t.TargetKind != nil && *t.TargetKind != "" {
+			targetKind = *t.TargetKind
+		}
+		fmt.Fprintf(w, "%-40s %-7d %-10s %-20s %s\n",
+			truncate(t.Slug, 40),
+			t.Version,
+			string(t.Status),
+			truncate(targetKind, 20),
+			t.EditedAt.UTC().Format("2006-01-02T15:04:05Z"),
+		)
+	}
+}

--- a/cli/internal/cmd/runbook/list_templates_test.go
+++ b/cli/internal/cmd/runbook/list_templates_test.go
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package runbook
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/evoila/meho/cli/internal/api"
+)
+
+func newTemplateSummary(slug string, version int, status api.TemplateSummaryStatus, kind string) api.TemplateSummary {
+	tk := kind
+	var tkPtr *string
+	if kind != "" {
+		tkPtr = &tk
+	}
+	return api.TemplateSummary{
+		Slug:       slug,
+		Version:    version,
+		Title:      "Title for " + slug,
+		Status:     status,
+		TargetKind: tkPtr,
+		EditedAt:   time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+// TestRunListTemplatesHappyPath — GET hits the right path, query
+// params are honoured, and the human table renders with all five
+// columns.
+func TestRunListTemplatesHappyPath(t *testing.T) {
+	var lastQuery string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET; got %s", r.Method)
+		}
+		lastQuery = r.URL.RawQuery
+		resp := api.RunbookTemplateListResponse{Templates: []api.TemplateSummary{
+			newTemplateSummary("vcenter-cert-rotation", 3, api.TemplateSummaryStatusPublished, "vmware-rest"),
+			newTemplateSummary("vault-unseal", 1, api.TemplateSummaryStatusDraft, ""),
+		}}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runListTemplates(cmd, listTemplatesOptions{
+		Status:            "published",
+		TargetKind:        "vmware-rest",
+		Limit:             50,
+		BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runListTemplates: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(lastQuery, "status=published") {
+		t.Errorf("expected status=published in query; got %q", lastQuery)
+	}
+	if !strings.Contains(lastQuery, "target_kind=vmware-rest") {
+		t.Errorf("expected target_kind in query; got %q", lastQuery)
+	}
+	if !strings.Contains(lastQuery, "limit=50") {
+		t.Errorf("expected limit=50 in query; got %q", lastQuery)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"SLUG", "VERSION", "STATUS", "TARGET_KIND", "EDITED_AT",
+		"vcenter-cert-rotation", "vault-unseal",
+		"published", "draft", "vmware-rest",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected stdout to contain %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunListTemplatesEmpty — empty list emits a one-liner, not a
+// header-only table.
+func TestRunListTemplatesEmpty(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(api.RunbookTemplateListResponse{Templates: nil})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	err := runListTemplates(cmd, listTemplatesOptions{BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runListTemplates empty: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "no runbook templates") {
+		t.Errorf("expected empty-list hint; got %q", stdout.String())
+	}
+}
+
+// TestRunListTemplatesJSON — --json emits the round-tripped envelope.
+func TestRunListTemplatesJSON(t *testing.T) {
+	expected := api.RunbookTemplateListResponse{Templates: []api.TemplateSummary{
+		newTemplateSummary("x", 1, api.TemplateSummaryStatusDraft, ""),
+	}}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(expected)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	err := runListTemplates(cmd, listTemplatesOptions{JSONOut: true, BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runListTemplates --json: %v", err)
+	}
+	var decoded api.RunbookTemplateListResponse
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
+	}
+	if len(decoded.Templates) != 1 || decoded.Templates[0].Slug != "x" {
+		t.Errorf("envelope: %+v", decoded)
+	}
+}
+
+// TestRunListTemplatesRejectsBadStatus — bad --status fails fast.
+func TestRunListTemplatesRejectsBadStatus(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runListTemplates(cmd, listTemplatesOptions{Status: "pub"})
+	if err == nil {
+		t.Fatal("expected error for bad --status")
+	}
+	if !strings.Contains(stderr.String(), "draft, published, deprecated") {
+		t.Errorf("expected enum hint; got %q", stderr.String())
+	}
+}
+
+// TestRunListTemplatesRejectsOutOfRangeLimit — --limit > 500 fails
+// fast (mirrors the backend's Query(le=500) cap).
+func TestRunListTemplatesRejectsOutOfRangeLimit(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runListTemplates(cmd, listTemplatesOptions{Limit: 501})
+	if err == nil {
+		t.Fatal("expected error for oversized --limit")
+	}
+	if !strings.Contains(stderr.String(), "between 1 and 500") {
+		t.Errorf("expected range hint; got %q", stderr.String())
+	}
+}
+
+// TestRunListTemplates403SurfacesInsufficientRole — operator-role
+// JWT lands 403; the CLI must classify as insufficient_role exit 5.
+func TestRunListTemplates403SurfacesInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"detail":"Insufficient role: operator required"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runListTemplates(cmd, listTemplatesOptions{BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(stderr.String(), "Insufficient role") {
+		t.Errorf("expected role hint; got %q", stderr.String())
+	}
+	type ec interface{ ExitCode() int }
+	if x, ok := err.(ec); !ok || x.ExitCode() != 5 {
+		t.Errorf("expected ExitCode 5; got %v", err)
+	}
+}
+
+// TestRunListTemplatesNetworkError — when the backend refuses the
+// connection, the CLI classifies as unreachable exit 3.
+func TestRunListTemplatesNetworkError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.Close() // close immediately so connections refuse
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runListTemplates(cmd, listTemplatesOptions{BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatal("expected error on closed server")
+	}
+	if !strings.Contains(stderr.String(), "unreachable") {
+		t.Errorf("expected unreachable classification; got %q", stderr.String())
+	}
+	type ec interface{ ExitCode() int }
+	if x, ok := err.(ec); !ok || x.ExitCode() != 3 {
+		t.Errorf("expected ExitCode 3; got %v", err)
+	}
+}
+
+// TestListTemplatesParamsOmitsZeroValues — pointer fields stay nil
+// when the operator didn't supply the corresponding flag, so the
+// backplane's defaults apply.
+func TestListTemplatesParamsOmitsZeroValues(t *testing.T) {
+	got := listTemplatesParams(listTemplatesOptions{})
+	if got.Status != nil {
+		t.Errorf("expected nil Status; got %v", *got.Status)
+	}
+	if got.TargetKind != nil {
+		t.Errorf("expected nil TargetKind; got %v", *got.TargetKind)
+	}
+	if got.Limit != nil {
+		t.Errorf("expected nil Limit; got %v", *got.Limit)
+	}
+}
+
+// TestListTemplatesParamsSetsAllFilters — supplied flags reach the
+// typed params shape with the right discriminator.
+func TestListTemplatesParamsSetsAllFilters(t *testing.T) {
+	got := listTemplatesParams(listTemplatesOptions{
+		Status: "draft", TargetKind: "vmware-rest", Limit: 25,
+	})
+	if got.Status == nil || string(*got.Status) != "draft" {
+		t.Errorf("expected Status=draft; got %+v", got.Status)
+	}
+	if got.TargetKind == nil || *got.TargetKind != "vmware-rest" {
+		t.Errorf("expected TargetKind=vmware-rest; got %+v", got.TargetKind)
+	}
+	if got.Limit == nil || *got.Limit != 25 {
+		t.Errorf("expected Limit=25; got %+v", got.Limit)
+	}
+}

--- a/cli/internal/cmd/runbook/publish_template.go
+++ b/cli/internal/cmd/runbook/publish_template.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package runbook
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newPublishTemplateCmd returns the `meho runbook publish-template`
+// command.
+//
+// CLI shape (per issue #1318):
+//
+//	meho runbook publish-template <slug> --version N [--json]
+//	  [--backplane URL]
+//
+// Wraps POST /api/v1/runbooks/templates/{slug}/publish. Role:
+// tenant_admin.
+//
+// Flip a draft template to published. Idempotent on
+// already-published versions. After publish, the template becomes
+// the latest start target for `meho runbook start` (G12.5-T2 #1319).
+// Previous published versions stay addressable for in-flight runs
+// (pinned at start time) and for `show-template`.
+//
+// Exit codes:
+//   - 0   published successfully (200) or already-published (no-op)
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (incl. 404 slug_not_found, 400 on
+//     attempting to publish a deprecated version)
+//   - 5   insufficient_role
+func newPublishTemplateCmd() *cobra.Command {
+	var (
+		version           int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "publish-template <slug>",
+		Short: "Flip a draft template to published (tenant_admin)",
+		Long: "publish-template calls POST " +
+			"/api/v1/runbooks/templates/{slug}/publish. Tenant_admin only.\n\n" +
+			"--version pins the version to publish (the version returned " +
+			"by the draft-template / edit-template call you want to flip). " +
+			"Idempotent on already-published versions: a second publish " +
+			"against the same (slug, version) returns 200 with no state " +
+			"change.\n\n" +
+			"After publish, the template becomes the latest start target " +
+			"for `meho runbook start` (G12.5-T2). Previous published " +
+			"versions stay addressable for in-flight runs (pinned at " +
+			"start time) and for `show-template`.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPublishTemplate(cmd, publishTemplateOptions{
+				Slug:              args[0],
+				Version:           version,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().IntVar(&version, "version", 0,
+		"template version to publish (required; the value returned by draft-template / edit-template)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw PublishTemplateResponse JSON instead of the human confirmation")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type publishTemplateOptions struct {
+	Slug              string
+	Version           int
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runPublishTemplate(cmd *cobra.Command, opts publishTemplateOptions) error {
+	if opts.Slug == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("publish-template requires a non-empty <slug> argument"),
+			opts.JSONOut,
+		)
+	}
+	if opts.Version <= 0 {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("publish-template requires --version N (positive integer)"),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	resp, err := postPublishTemplate(cmd.Context(), backplaneURL, opts.Slug, opts.Version)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	if resp.JSON200 == nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without a PublishTemplateResponse payload",
+				backplaneURL,
+			)),
+			opts.JSONOut,
+		)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
+	}
+	printPublishSummary(cmd.OutOrStdout(), resp.JSON200)
+	return nil
+}
+
+func postPublishTemplate(
+	ctx context.Context,
+	backplaneURL, slug string,
+	version int,
+) (*api.PublishTemplateApiV1RunbooksTemplatesSlugPublishPostResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	body := api.UnderscoreVersionBody{Version: version}
+	params := &api.PublishTemplateApiV1RunbooksTemplatesSlugPublishPostParams{}
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.PublishTemplateApiV1RunbooksTemplatesSlugPublishPostResponse, error) {
+			return authed.PublishTemplateApiV1RunbooksTemplatesSlugPublishPostWithResponse(
+				ctx, slug, params, body,
+			)
+		},
+		func(r *api.PublishTemplateApiV1RunbooksTemplatesSlugPublishPostResponse) int {
+			return r.StatusCode()
+		},
+	)
+}
+
+func printPublishSummary(w io.Writer, r *api.PublishTemplateResponse) {
+	if r == nil {
+		return
+	}
+	fmt.Fprintf(w, "Published %s@%d (status=%s)\n", r.Slug, r.Version, r.Status)
+}

--- a/cli/internal/cmd/runbook/publish_template_test.go
+++ b/cli/internal/cmd/runbook/publish_template_test.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package runbook
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/evoila/meho/cli/internal/api"
+)
+
+// TestRunPublishTemplateHappyPath — POST to .../publish carries the
+// right `version` payload; 200 response renders the 1-line
+// confirmation.
+func TestRunPublishTemplateHappyPath(t *testing.T) {
+	var sawBody api.UnderscoreVersionBody
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates/vcenter-cert-rotation/publish", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST; got %s", r.Method)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		readJSONBodyOf(t, raw, &sawBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(api.PublishTemplateResponse{
+			Slug: "vcenter-cert-rotation", Version: sawBody.Version, Status: "published",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runPublishTemplate(cmd, publishTemplateOptions{
+		Slug: "vcenter-cert-rotation", Version: 3, BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runPublishTemplate: %v; stderr=%s", err, stderr.String())
+	}
+	if sawBody.Version != 3 {
+		t.Errorf("wire version: got %d; want 3", sawBody.Version)
+	}
+	if !strings.Contains(stdout.String(), "Published vcenter-cert-rotation@3") {
+		t.Errorf("expected published line; got %q", stdout.String())
+	}
+}
+
+// TestRunPublishTemplateRequiresVersion — missing --version fails
+// fast.
+func TestRunPublishTemplateRequiresVersion(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runPublishTemplate(cmd, publishTemplateOptions{Slug: "x"})
+	if err == nil {
+		t.Fatal("expected error for missing --version")
+	}
+	if !strings.Contains(stderr.String(), "--version") {
+		t.Errorf("expected --version hint; got %q", stderr.String())
+	}
+}
+
+// TestRunPublishTemplate404SurfacesSlugNotFound — slug_not_found
+// surfaces the backend's detail.
+func TestRunPublishTemplate404SurfacesSlugNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates/missing/publish", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"detail":"slug_not_found"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runPublishTemplate(cmd, publishTemplateOptions{
+		Slug: "missing", Version: 1, BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(stderr.String(), "slug_not_found") {
+		t.Errorf("expected detail; got %q", stderr.String())
+	}
+}
+
+// TestRunPublishTemplate403SurfacesInsufficientRole — tenant_admin
+// required.
+func TestRunPublishTemplate403SurfacesInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates/x/publish", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"detail":"Insufficient role: tenant_admin required"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runPublishTemplate(cmd, publishTemplateOptions{
+		Slug: "x", Version: 1, BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(stderr.String(), "tenant_admin required") {
+		t.Errorf("expected role hint; got %q", stderr.String())
+	}
+	type ec interface{ ExitCode() int }
+	if x, ok := err.(ec); !ok || x.ExitCode() != 5 {
+		t.Errorf("expected ExitCode 5; got %v", err)
+	}
+}
+
+// TestRunPublishTemplateNetworkError — connection refused → exit 3.
+func TestRunPublishTemplateNetworkError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runPublishTemplate(cmd, publishTemplateOptions{
+		Slug: "x", Version: 1, BackplaneOverride: srv.URL,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(stderr.String(), "unreachable") {
+		t.Errorf("expected unreachable; got %q", stderr.String())
+	}
+	type ec interface{ ExitCode() int }
+	if x, ok := err.(ec); !ok || x.ExitCode() != 3 {
+		t.Errorf("expected ExitCode 3; got %v", err)
+	}
+}
+
+// TestRunPublishTemplateJSONHappyPath — --json emits the envelope.
+func TestRunPublishTemplateJSONHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates/x/publish", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(api.PublishTemplateResponse{
+			Slug: "x", Version: 1, Status: "published",
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	err := runPublishTemplate(cmd, publishTemplateOptions{
+		Slug: "x", Version: 1, JSONOut: true, BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runPublishTemplate --json: %v", err)
+	}
+	var decoded api.PublishTemplateResponse
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
+	}
+	if decoded.Status != "published" {
+		t.Errorf("envelope.status: %q", decoded.Status)
+	}
+}

--- a/cli/internal/cmd/runbook/runbook.go
+++ b/cli/internal/cmd/runbook/runbook.go
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+// Package runbook hosts the cobra commands under `meho runbook ...`
+// for G12.5-T1 (#1318) of Initiative #1200. T1 ships the chassis
+// (root cobra command, output formatting, error rendering, YAML
+// parsing for the import verbs) plus the six template verbs that
+// wrap the G12.2 REST surface (#1297):
+//
+//   - `meho runbook list-templates [--status S] [--target-kind K]
+//     [--limit N] [--json]` — list templates in the operator's tenant
+//     via GET /api/v1/runbooks/templates. Role: operator.
+//   - `meho runbook show-template <slug> [--version N] [--json]` —
+//     fetch a single template (full step body) via GET
+//     /api/v1/runbooks/templates/{slug}. Role: tenant_admin (with the
+//     post-completion carve-out implemented backend-side per #1309).
+//   - `meho runbook draft-template <slug> --from <file.yaml>
+//     [--json]` — create the first draft of a new slug via POST
+//     /api/v1/runbooks/templates. Role: tenant_admin.
+//   - `meho runbook edit-template <slug> --from <file.yaml>
+//     [--json]` — edit the current draft (in place) or fork a
+//     published version into a new draft via PATCH
+//     /api/v1/runbooks/templates/{slug}. Role: tenant_admin.
+//   - `meho runbook publish-template <slug> --version N [--json]` —
+//     flip a draft to published via POST
+//     /api/v1/runbooks/templates/{slug}/publish. Role: tenant_admin.
+//   - `meho runbook deprecate-template <slug> --version N [--json]` —
+//     mark a published version as deprecated via POST
+//     /api/v1/runbooks/templates/{slug}/deprecate. Role: tenant_admin.
+//
+// G12.5-T2 (#1319) extends the same parent with the five run verbs
+// (start / next / abort / reassign / runs); G12.5-T3 (#1320) ships
+// the operator-facing CLI docs.
+//
+// Every verb wraps one G12.2 route and drives the generated
+// `api.ClientWithResponses` directly via `api.NewAuthedClient`. The
+// helper trio (`newAuthedClient` / `retryOn401` / `renderHTTPStatus`)
+// mirrors the kb / memory / conventions packages — duplicated by
+// design (avoids cyclic imports between sibling cobra packages),
+// same shape across the codebase.
+//
+// The two non-trivial verbs are `draft-template` and `edit-template`:
+// both accept `--from <file.yaml>`, parse the YAML into a struct
+// matching the backend's `RunbookTemplateBody` shape, run a local
+// pre-flight (slug regex, step-id uniqueness, step / verify type
+// allowlists, substitution allowlist), and only then POST/PATCH.
+// The pre-flight is a UX layer, not a security boundary — the
+// backend re-validates authoritatively (see
+// `backend/src/meho_backplane/runbooks/schemas.py`'s
+// `_validate_step_ids_unique_and_substitutions_allowlisted` and
+// `validate_substitutions`).
+package runbook
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// NewRootCmd returns the `meho runbook` parent command. The command
+// is grafted onto the top-level meho command tree by cmd/root.go
+// alongside `meho kb`, `meho memory`, and the other v0.2 verb trees.
+// The parent itself takes no args and prints its own help; every
+// piece of behaviour lives in the per-subcommand RunE closures.
+//
+// T1 (#1318) registers six template verbs; T2 (#1319) extends the
+// parent with five run verbs (start / next / abort / reassign /
+// runs) in a follow-up PR.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "runbook",
+		Short: "Author and operate runbook templates (list/show/draft/edit/publish/deprecate)",
+		Long: "Operate runbook templates from the operator shell. " +
+			"Authors (tenant_admin) draft, edit, publish, and deprecate " +
+			"templates; operators list-templates and (post-completion) " +
+			"show-template after a run finishes. Read verbs are " +
+			"operator-level by default; write verbs and unconditional " +
+			"show-template require tenant_admin. Tenant scoping is " +
+			"enforced server-side via the JWT.",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newListTemplatesCmd())
+	cmd.AddCommand(newShowTemplateCmd())
+	cmd.AddCommand(newDraftTemplateCmd())
+	cmd.AddCommand(newEditTemplateCmd())
+	cmd.AddCommand(newPublishTemplateCmd())
+	cmd.AddCommand(newDeprecateTemplateCmd())
+	return cmd
+}
+
+// errMissingAccessToken is the sentinel newAuthedClient returns when
+// the stored token row exists but its `access_token` field is empty.
+// Credential-state failure → renderRequestError maps it to
+// auth_expired (exit 2) with a `meho login` hint. Same shape as the
+// sibling typed-client migrations (kb, memory, conventions).
+var errMissingAccessToken = errors.New("meho: stored token has no access_token")
+
+// responseBodyCap bounds the bytes the runbook verb tree's transport
+// will read off any backplane response body before surfacing
+// `*http.MaxBytesError`. 1 MiB is generous for every documented
+// runbook template payload — list pages cap at the backend's
+// `Query(le=500)` limit × ~256-byte summary rows; show returns one
+// template whose `steps` JSONB is bounded by author convention but
+// has no documented hard cap (audited median ~8 KB). Without the
+// cap, an adversarial or runaway backplane response could OOM the
+// CLI because the generated `Parse*Response` helpers call
+// `io.ReadAll(rsp.Body)` on an unbounded body. The cap is installed
+// at the transport layer via `api.AuthedClientOptions.ResponseBodyLimit`
+// so it applies uniformly to every typed verb on the same
+// `AuthedClient`. Same value the kb / conventions packages adopted.
+const responseBodyCap int64 = 1 << 20
+
+// newAuthedClient builds an api.AuthedClient for the supplied
+// backplane URL and verifies a non-empty bearer is loaded. Centralised
+// so every verb's typed-call path goes through the same
+// "stored-token-loaded + non-empty bearer" gate. Opts into the
+// transport-layer response-body cap so the generated typed parsers
+// can't be pinned by an unbounded backplane response.
+func newAuthedClient(ctx context.Context, backplaneURL string) (*api.AuthedClient, error) {
+	authed, err := api.NewAuthedClient(ctx, backplaneURL, api.AuthedClientOptions{
+		ResponseBodyLimit: responseBodyCap,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if authed.AccessToken() == "" {
+		return nil, errMissingAccessToken
+	}
+	return authed, nil
+}
+
+// retryOn401 invokes call once, and if the typed response carries a
+// 401, runs a one-shot bearer refresh and re-issues call. Mirrors
+// the behaviour `api.AuthedClient.GetHealth` implements, generalised
+// so every runbook verb runs the same transparent-retry contract.
+//
+// statusOf reads the StatusCode off the typed response envelope (the
+// generated *Response types expose StatusCode() through their embedded
+// *http.Response). A nil response counts as "no retry" — the
+// transport already failed and the caller surfaces err directly.
+func retryOn401[R any](
+	ctx context.Context,
+	authed *api.AuthedClient,
+	call func(ctx context.Context) (*R, error),
+	statusOf func(*R) int,
+) (*R, error) {
+	resp, err := call(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil || statusOf(resp) != http.StatusUnauthorized {
+		return resp, nil
+	}
+	if rerr := authed.Refresh(ctx); rerr != nil {
+		return resp, rerr
+	}
+	return call(ctx)
+}
+
+// renderRequestError translates a transport-layer request error into
+// the right output.StructuredError category. Same mapping the kb
+// verb tree uses — credential-state failures route to auth_expired
+// (exit 2), parse / cap failures route to unexpected_response (exit
+// 4), everything else falls through to unreachable (exit 3).
+//
+// Parse / cap failures route to `output.Unexpected` (exit 4) rather
+// than `output.Unreachable` (exit 3): a 1 MiB body cap firing or a
+// JSON decode rejecting a malformed payload is a contract / shape
+// failure on the server side, not a transport-down failure on the
+// operator's side.
+func renderRequestError(
+	cmd *cobra.Command,
+	backplaneURL string,
+	err error,
+	jsonOut bool,
+) error {
+	if errors.Is(err, errMissingAccessToken) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored credentials for %s are incomplete; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsTokenNotFound(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"no stored credentials for %s; run `meho login %s`",
+				backplaneURL, backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	if api.IsNoRefreshToken(err) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"stored token rejected and no refresh_token present; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	}
+	var maxBytesErr *http.MaxBytesError
+	var syntaxErr *json.SyntaxError
+	var unmarshalErr *json.UnmarshalTypeError
+	if errors.As(err, &maxBytesErr) ||
+		errors.As(err, &syntaxErr) ||
+		errors.As(err, &unmarshalErr) ||
+		errors.Is(err, io.ErrUnexpectedEOF) {
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+			jsonOut,
+		)
+	}
+	return output.RenderError(cmd.ErrOrStderr(),
+		output.Unreachable(fmt.Sprintf("call %s: %v", backplaneURL, err)),
+		jsonOut,
+	)
+}
+
+// renderHTTPStatus classifies a non-2xx response (or 401 after a
+// failed refresh) carried in the typed envelope into the right
+// StructuredError category. The mapping mirrors the kb tree's
+// renderHTTPStatus with template-specific 4xx surfaces:
+//
+//   - 401 → auth_expired (refresh impossible / token rejected).
+//   - 403 → insufficient_role with the backend's detail string.
+//     The backend renders `Insufficient role: tenant_admin required`
+//     for the write verbs and `Insufficient role: tenant_admin
+//     required (post-completion exception not satisfied)` for the
+//     show-template post-completion carve-out (#1309).
+//   - 400 → unexpected with the backend's detail (e.g. publish on
+//     a deprecated version → `cannot publish a deprecated version`).
+//   - 404 → unexpected with the backend's detail (e.g.
+//     `slug_not_found`; cross-tenant probes land here per the
+//     no-existence-leak posture).
+//   - 409 → unexpected with the backend's detail (e.g.
+//     `draft_already_exists` from POST against an existing draft).
+//   - 422 → unexpected wrapping the FastAPI validation envelope
+//     (invalid slug, malformed step body, disallowed substitution
+//     pattern). The backend's detail array carries `loc` for the
+//     offending YAML / JSON path; preserving the envelope lets
+//     operators paste it into the issue when reporting.
+//   - Other non-2xx → unexpected with the raw body.
+func renderHTTPStatus(
+	cmd *cobra.Command,
+	backplaneURL string,
+	statusCode int,
+	body []byte,
+	jsonOut bool,
+) error {
+	bodyStr := strings.TrimSpace(string(body))
+	switch statusCode {
+	case http.StatusUnauthorized:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.AuthExpired(fmt.Sprintf(
+				"backplane rejected the stored token; run `meho login %s`",
+				backplaneURL,
+			)),
+			jsonOut,
+		)
+	case http.StatusForbidden:
+		// The role error message is operator-readable and load-bearing
+		// — the issue body's AC pins "This verb requires TENANT_ADMIN
+		// role" rendering on 403. The backend already emits that exact
+		// shape ("Insufficient role: tenant_admin required"); we
+		// surface its detail verbatim rather than re-translating so
+		// the wording stays in lock-step with the backend's surface
+		// (and with the post-completion carve-out variant for
+		// show-template).
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.InsufficientRole(decodeDetailString(bodyStr)),
+			jsonOut,
+		)
+	case http.StatusBadRequest:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(decodeDetailString(bodyStr)),
+			jsonOut,
+		)
+	case http.StatusNotFound:
+		// The substrate returns `slug_not_found` for genuine absence
+		// and cross-tenant probes alike — the conflation prevents
+		// leaking tenant boundaries via status-code differential.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(decodeDetailString(bodyStr)),
+			jsonOut,
+		)
+	case http.StatusConflict:
+		// G12.2's draft / publish surface uses 409 for state-machine
+		// rejections (draft already exists, version not in the
+		// expected state). Surface the detail verbatim so the
+		// operator sees which transition failed.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(decodeDetailString(bodyStr)),
+			jsonOut,
+		)
+	case http.StatusUnprocessableEntity:
+		// 422 from invalid slug shape, malformed step body, or a
+		// disallowed substitution pattern. The backend emits the
+		// FastAPI validation envelope; preserving the body lets the
+		// operator see the `loc` path of the offending field.
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("invalid request: %s", bodyStr)),
+			jsonOut,
+		)
+	default:
+		return output.RenderError(cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("call %s: HTTP %d: %s",
+				backplaneURL, statusCode, bodyStr)),
+			jsonOut,
+		)
+	}
+}
+
+// detailEnvelope models FastAPI's HTTPException JSON shape.
+type detailEnvelope struct {
+	Detail json.RawMessage `json:"detail"`
+}
+
+// decodeDetailString pulls the `detail` field out of a FastAPI error
+// body when it's a plain string. Falls back to the trimmed raw body
+// when the JSON shape doesn't match (non-JSON body or `detail` is a
+// structured value such as the FastAPI validation list).
+func decodeDetailString(body string) string {
+	var env detailEnvelope
+	if err := json.Unmarshal([]byte(body), &env); err == nil {
+		var s string
+		if jerr := json.Unmarshal(env.Detail, &s); jerr == nil && s != "" {
+			return s
+		}
+	}
+	return strings.TrimSpace(body)
+}
+
+// pathEscape escapes a single path segment for use inside a backend
+// URL. The generated typed client's path-parameter encoding uses the
+// same `url.PathEscape` rule under the hood; we export the helper for
+// tests that pin operator-typical slug shapes (dots, hyphens) survive
+// encoding intact.
+func pathEscape(segment string) string {
+	return url.PathEscape(segment)
+}
+
+// truncate cuts s to maxLen runes, appending an ellipsis when
+// truncation happened. Rune-aware so multi-byte UTF-8 survives the
+// cut. Same shape as the sibling-package helpers.
+func truncate(s string, maxLen int) string {
+	if maxLen < 1 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	return string(runes[:maxLen-1]) + "…"
+}

--- a/cli/internal/cmd/runbook/runbook_test.go
+++ b/cli/internal/cmd/runbook/runbook_test.go
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package runbook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/auth"
+	"github.com/evoila/meho/cli/internal/backplane"
+)
+
+// seedXDGAndToken seeds a per-test config dir + token store that
+// backplane.Resolve / api.NewAuthedClient will read. Mirrors the kb /
+// audit / memory tree helpers verbatim — the runbook tree consumes
+// the same auth seam, so a single helper shape works.
+func seedXDGAndToken(t *testing.T, backplaneURL string) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("MEHO_KEYRING_DISABLE", "1")
+	store, err := auth.NewFileStore()
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	service, user := auth.KeyForBackplane(backplaneURL)
+	if err := store.Save(service, user, auth.StoredToken{
+		BackplaneURL: backplaneURL,
+		AccessToken:  "eyJ.test.token",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(1 * time.Hour),
+	}); err != nil {
+		t.Fatalf("store.Save: %v", err)
+	}
+	if err := auth.SaveConfigAt(
+		filepath.Join(dir, "meho", "config.json"),
+		auth.Config{BackplaneURL: backplaneURL},
+	); err != nil {
+		t.Fatalf("SaveConfigAt: %v", err)
+	}
+	return dir
+}
+
+// newRunCmd builds a fresh cobra.Command with stdout/stderr buffers
+// attached. The runXxx helpers consume cmd.OutOrStdout / cmd.ErrOrStderr;
+// tests inspect the buffers afterwards.
+func newRunCmd(t *testing.T) (*cobra.Command, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	cmd.SetContext(ctx)
+	return cmd, &stdout, &stderr
+}
+
+// TestNewRootCmdRegistersAllSixVerbs — AC1: every advertised verb
+// has a cobra subcommand. The CLI manifest is the contract operators
+// build muscle memory around; dropping a verb silently is the
+// regression class we want to catch at unit-time.
+func TestNewRootCmdRegistersAllSixVerbs(t *testing.T) {
+	root := NewRootCmd()
+	want := map[string]bool{
+		"list-templates":     false,
+		"show-template":      false,
+		"draft-template":     false,
+		"edit-template":      false,
+		"publish-template":   false,
+		"deprecate-template": false,
+	}
+	for _, sub := range root.Commands() {
+		name := strings.SplitN(sub.Use, " ", 2)[0]
+		if _, ok := want[name]; ok {
+			want[name] = true
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("subcommand %q not registered under `meho runbook`", name)
+		}
+	}
+}
+
+// TestRootCmdHelpListsAllVerbs — the parent's help text should
+// mention every verb so operators new to the surface find them.
+func TestRootCmdHelpListsAllVerbs(t *testing.T) {
+	root := NewRootCmd()
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("`meho runbook --help` failed: %v", err)
+	}
+	help := buf.String()
+	for _, want := range []string{
+		"list-templates", "show-template", "draft-template",
+		"edit-template", "publish-template", "deprecate-template",
+		"tenant_admin",
+	} {
+		if !strings.Contains(help, want) {
+			t.Errorf("expected `meho runbook --help` to mention %q; got:\n%s", want, help)
+		}
+	}
+}
+
+// TestDecodeDetailStringFromFastAPI — FastAPI's HTTPException body
+// is {"detail": "<string>"}; decodeDetailString must extract it.
+func TestDecodeDetailStringFromFastAPI(t *testing.T) {
+	body := `{"detail": "slug_not_found"}`
+	if got := decodeDetailString(body); got != "slug_not_found" {
+		t.Errorf("decodeDetailString: got %q", got)
+	}
+}
+
+// TestDecodeDetailStringFallback — non-FastAPI body returns the raw
+// trimmed body rather than swallowing it.
+func TestDecodeDetailStringFallback(t *testing.T) {
+	body := "  plain text error\n"
+	if got := decodeDetailString(body); got != "plain text error" {
+		t.Errorf("decodeDetailString fallback: got %q", got)
+	}
+}
+
+// TestPathEscapePreservesSlugChars — runbook slugs are the kb slug
+// pattern verbatim; PathEscape must not mangle operator-typical
+// characters (dots, hyphens, digits). The typed-client embeds the
+// same `url.PathEscape` rule when building
+// `/api/v1/runbooks/templates/{slug}` paths.
+func TestPathEscapePreservesSlugChars(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"vcenter-cert-rotation", "vcenter-cert-rotation"},
+		{"vcenter-9.0-overview", "vcenter-9.0-overview"},
+		{"a", "a"},
+		{"slug-with-dot.0.1", "slug-with-dot.0.1"},
+	}
+	for _, c := range cases {
+		if got := pathEscape(c.in); got != c.want {
+			t.Errorf("pathEscape(%q): got %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestTruncateRuneAware — multi-byte UTF-8 stays valid when the
+// table renderer truncates a long slug / preview.
+func TestTruncateRuneAware(t *testing.T) {
+	if got := truncate("café", 3); got != "ca…" {
+		t.Fatalf("truncate multi-byte: got %q; want %q", got, "ca…")
+	}
+	if got := truncate("hello", 10); got != "hello" {
+		t.Fatalf("truncate within budget: got %q; want %q", got, "hello")
+	}
+	if got := truncate("anything", 0); got != "" {
+		t.Fatalf("truncate maxLen=0 should be empty; got %q", got)
+	}
+}
+
+// TestRenderRequestErrorEmptyBearerMapsToAuthExpired — an empty
+// stored bearer is a credential-state failure (the token row exists
+// but its access_token is empty); renderRequestError must map it to
+// auth_expired (exit 2) with a `meho login` hint.
+func TestRenderRequestErrorEmptyBearerMapsToAuthExpired(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := renderRequestError(cmd, "https://meho.test", errMissingAccessToken, false)
+	if err == nil {
+		t.Fatalf("expected non-nil error from renderRequestError")
+	}
+	if !strings.Contains(stderr.String(), "auth_expired") {
+		t.Errorf("expected auth_expired classification; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "meho login") {
+		t.Errorf("expected `meho login` hint; got %q", stderr.String())
+	}
+	type ec interface{ ExitCode() int }
+	if x, ok := err.(ec); !ok || x.ExitCode() != 2 {
+		t.Errorf("expected ExitCode 2 (auth_expired); got %v", err)
+	}
+}
+
+// TestRenderHTTPStatus404SurfacesDetail pins the 404 → unexpected
+// mapping for `slug_not_found`.
+func TestRenderHTTPStatus404SurfacesDetail(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := renderHTTPStatus(cmd, "https://meho.test", http.StatusNotFound,
+		[]byte(`{"detail":"slug_not_found"}`), false)
+	if err == nil {
+		t.Fatalf("expected non-nil error")
+	}
+	if !strings.Contains(stderr.String(), "slug_not_found") {
+		t.Errorf("expected detail in stderr; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "unexpected_response") {
+		t.Errorf("expected unexpected_response classification; got %q", stderr.String())
+	}
+}
+
+// TestRenderHTTPStatus403SurfacesInsufficientRole — backend's
+// tenant_admin-required detail survives the round-trip into stderr.
+// The issue body's AC ties role denial to "This verb requires
+// TENANT_ADMIN role" — we surface whatever the backend rendered to
+// keep terminology aligned with the MCP tool description path.
+func TestRenderHTTPStatus403SurfacesInsufficientRole(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := renderHTTPStatus(cmd, "https://meho.test", http.StatusForbidden,
+		[]byte(`{"detail":"Insufficient role: tenant_admin required"}`), false)
+	if err == nil {
+		t.Fatalf("expected non-nil error")
+	}
+	if !strings.Contains(stderr.String(), "insufficient_role") {
+		t.Errorf("expected insufficient_role classification; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "tenant_admin required") {
+		t.Errorf("expected backend detail in stderr; got %q", stderr.String())
+	}
+	type ec interface{ ExitCode() int }
+	if x, ok := err.(ec); !ok || x.ExitCode() != 5 {
+		t.Errorf("expected ExitCode 5 (insufficient_role); got %v", err)
+	}
+}
+
+// TestRenderHTTPStatus409SurfacesDetail — draft_already_exists from
+// POST against an existing draft. The 409 case is unique to the
+// runbook surface (vs the kb tree's renderer) so it gets a direct
+// test.
+func TestRenderHTTPStatus409SurfacesDetail(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := renderHTTPStatus(cmd, "https://meho.test", http.StatusConflict,
+		[]byte(`{"detail":"draft_already_exists"}`), false)
+	if err == nil {
+		t.Fatalf("expected non-nil error")
+	}
+	if !strings.Contains(stderr.String(), "draft_already_exists") {
+		t.Errorf("expected detail in stderr; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "unexpected_response") {
+		t.Errorf("expected unexpected_response classification; got %q", stderr.String())
+	}
+}
+
+// TestRenderHTTPStatus422WrapsValidationDetail — 422 from the
+// disallowed-substitution path renders with the `invalid request:`
+// prefix and the FastAPI envelope intact (the substrate emits a
+// structured list for some 422s; preserving the body lets operators
+// paste it into the issue without losing context).
+func TestRenderHTTPStatus422WrapsValidationDetail(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	body := `{"detail":[{"loc":["body","body","steps",0,"body"],"msg":"disallowed substitution pattern: ${evil}"}]}`
+	err := renderHTTPStatus(cmd, "https://meho.test", http.StatusUnprocessableEntity,
+		[]byte(body), false)
+	if err == nil {
+		t.Fatalf("expected non-nil error")
+	}
+	if !strings.Contains(stderr.String(), "invalid request") {
+		t.Errorf("expected `invalid request` prefix; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "disallowed substitution") {
+		t.Errorf("expected substrate detail preserved; got %q", stderr.String())
+	}
+}
+
+// TestClassifyBackplaneErrorRoutesByCause — ErrConfigNotFound (or
+// any error wrapping it) maps to AuthExpired; everything else maps
+// to Unexpected. Same routing ladder as the kb sibling.
+func TestClassifyBackplaneErrorRoutesByCause(t *testing.T) {
+	wrappedNotFound := &backplane.NotConfiguredError{Inner: auth.ErrConfigNotFound}
+	se := backplane.ClassifyError(wrappedNotFound)
+	if se == nil || se.Code != "auth_expired" {
+		t.Fatalf("ErrConfigNotFound wrapper should classify as auth_expired; got %+v", se)
+	}
+	parseFailure := errors.New("invalid URL")
+	se = backplane.ClassifyError(parseFailure)
+	if se == nil || se.Code != "unexpected_response" {
+		t.Fatalf("parse failure should classify as unexpected; got %+v", se)
+	}
+}
+
+// readJSONBodyOf decodes a request body for handler assertions. Kept
+// in the shared helper file so per-verb tests don't each need a
+// local decoder helper.
+func readJSONBodyOf(t *testing.T, raw []byte, into any) {
+	t.Helper()
+	if err := json.Unmarshal(raw, into); err != nil {
+		t.Fatalf("decode body: %v\n%s", err, raw)
+	}
+}

--- a/cli/internal/cmd/runbook/show_template.go
+++ b/cli/internal/cmd/runbook/show_template.go
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package runbook
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/evoila/meho/cli/internal/api"
+	"github.com/evoila/meho/cli/internal/backplane"
+	"github.com/evoila/meho/cli/internal/output"
+)
+
+// newShowTemplateCmd returns the `meho runbook show-template`
+// command.
+//
+// CLI shape (per issue #1318):
+//
+//	meho runbook show-template <slug> [--version N] [--json]
+//	  [--backplane URL]
+//
+// Wraps GET /api/v1/runbooks/templates/{slug}. Role: tenant_admin
+// unconditionally; OPERATOR role passes only when the operator has a
+// completed or abandoned run against (slug, version) — the
+// post-completion carve-out (G12.3-T4 #1309) is implemented
+// backend-side, the CLI just surfaces whatever the backend returns.
+//
+// Default output: heading-formatted block — title + metadata, then
+// description, then a numbered list of steps with verify summary.
+// `--json` emits the raw ShowTemplateResponse for round-trip use
+// (the body shape mirrors the YAML import format closely enough that
+// a senior can copy the JSON, edit, and pipe back through `meho
+// runbook edit-template --from /dev/stdin` after YAML conversion).
+//
+// Exit codes:
+//   - 0   template rendered cleanly
+//   - 2   auth_expired
+//   - 3   unreachable
+//   - 4   unexpected_response (incl. 404 slug_not_found)
+//   - 5   insufficient_role (incl. opacity_floor — runbook in flight,
+//     post-completion carve-out not yet satisfied)
+func newShowTemplateCmd() *cobra.Command {
+	var (
+		version           int
+		jsonOut           bool
+		backplaneOverride string
+	)
+	cmd := &cobra.Command{
+		Use:   "show-template <slug>",
+		Short: "Read the full body of a runbook template, including step contents",
+		Long: "show-template calls GET /api/v1/runbooks/templates/{slug} " +
+			"and writes the full template (title, description, ordered " +
+			"steps with verify summary) to stdout. --version pins to a " +
+			"specific version; omitted means the latest non-deprecated " +
+			"version the operator can see.\n\n" +
+			"ROLE GATE: tenant_admin unconditionally; operator only with " +
+			"the post-completion carve-out — once the operator has a " +
+			"completed or abandoned run against (slug, version), they " +
+			"can read the template for post-mortem / learning. While a " +
+			"run is in flight against this slug the 403 still holds " +
+			"(opacity_floor; the operator stays scoped to `meho runbook " +
+			"next` step-by-step rendering at run time).\n\n" +
+			"--json emits the raw ShowTemplateResponse envelope so a " +
+			"senior can round-trip the template through their editor.",
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runShowTemplate(cmd, showTemplateOptions{
+				Slug:              args[0],
+				Version:           version,
+				JSONOut:           jsonOut,
+				BackplaneOverride: backplaneOverride,
+			})
+		},
+	}
+	cmd.Flags().IntVar(&version, "version", 0,
+		"pin to a specific template version (default: latest non-deprecated)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false,
+		"emit raw ShowTemplateResponse JSON instead of the human-readable block")
+	cmd.Flags().StringVar(&backplaneOverride, "backplane", "",
+		"backplane URL to query (defaults to the URL recorded by the most recent `meho login`)")
+	return cmd
+}
+
+type showTemplateOptions struct {
+	Slug              string
+	Version           int
+	JSONOut           bool
+	BackplaneOverride string
+}
+
+func runShowTemplate(cmd *cobra.Command, opts showTemplateOptions) error {
+	if opts.Slug == "" {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected("show-template requires a non-empty <slug> argument"),
+			opts.JSONOut,
+		)
+	}
+	if opts.Version < 0 {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("--version must be non-negative; got %d", opts.Version)),
+			opts.JSONOut,
+		)
+	}
+	backplaneURL, err := backplane.Resolve(opts.BackplaneOverride)
+	if err != nil {
+		return output.RenderError(cmd.ErrOrStderr(), backplane.ClassifyError(err), opts.JSONOut)
+	}
+	resp, err := getTemplate(cmd.Context(), backplaneURL, opts)
+	if err != nil {
+		return renderRequestError(cmd, backplaneURL, err, opts.JSONOut)
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
+	}
+	if resp.JSON200 == nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf(
+				"call %s: HTTP 200 without a template payload",
+				backplaneURL,
+			)),
+			opts.JSONOut,
+		)
+	}
+	if opts.JSONOut {
+		return output.PrintJSON(cmd.OutOrStdout(), resp.JSON200)
+	}
+	if err := printTemplateBlock(cmd.OutOrStdout(), resp.JSON200); err != nil {
+		return output.RenderError(
+			cmd.ErrOrStderr(),
+			output.Unexpected(fmt.Sprintf("render template: %v", err)),
+			opts.JSONOut,
+		)
+	}
+	return nil
+}
+
+func getTemplate(
+	ctx context.Context,
+	backplaneURL string,
+	opts showTemplateOptions,
+) (*api.ShowTemplateApiV1RunbooksTemplatesSlugGetResponse, error) {
+	authed, err := newAuthedClient(ctx, backplaneURL)
+	if err != nil {
+		return nil, err
+	}
+	params := &api.ShowTemplateApiV1RunbooksTemplatesSlugGetParams{}
+	if opts.Version > 0 {
+		v := opts.Version
+		params.Version = &v
+	}
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.ShowTemplateApiV1RunbooksTemplatesSlugGetResponse, error) {
+			return authed.ShowTemplateApiV1RunbooksTemplatesSlugGetWithResponse(ctx, opts.Slug, params)
+		},
+		func(r *api.ShowTemplateApiV1RunbooksTemplatesSlugGetResponse) int { return r.StatusCode() },
+	)
+}
+
+// printTemplateBlock renders the template as a heading-formatted
+// human-readable block. The format is operator-readable (not a
+// substitute for the JSON round-trip): heading line, metadata
+// key-value pairs, then a numbered step list with verify summary.
+//
+// Returns an error only when the union-typed step body fails to
+// decode (a malformed wire response — the generated client would
+// already have rejected this at parse time, so practically
+// unreachable). Splitting the error path out keeps the renderer
+// honest about edge cases instead of silently falling back to a
+// blank line.
+func printTemplateBlock(w io.Writer, r *api.ShowTemplateResponse) error {
+	if r == nil {
+		return nil
+	}
+	fmt.Fprintf(w, "Template: %s@%d\n", r.Slug, r.Version)
+	fmt.Fprintf(w, "Title:       %s\n", r.Title)
+	fmt.Fprintf(w, "Status:      %s\n", string(r.Status))
+	targetKind := "-"
+	if r.TargetKind != nil && *r.TargetKind != "" {
+		targetKind = *r.TargetKind
+	}
+	fmt.Fprintf(w, "Target kind: %s\n", targetKind)
+	fmt.Fprintf(w, "Created by:  %s (%s)\n",
+		r.CreatedBy, r.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"))
+	fmt.Fprintf(w, "Edited by:   %s (%s)\n",
+		r.EditedBy, r.EditedAt.UTC().Format("2006-01-02T15:04:05Z"))
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Description:")
+	for _, line := range strings.Split(strings.TrimRight(r.Description, "\n"), "\n") {
+		fmt.Fprintf(w, "  %s\n", line)
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "Steps (%d):\n", len(r.Steps))
+	for i, item := range r.Steps {
+		if err := printStep(w, i+1, item); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// printStep renders a single step's title, type, body, and verify
+// summary. The step body is rendered as a Markdown-style indented
+// block; the verify summary is a one-liner showing the verify type
+// plus its discriminating field (prompt for confirm, op_id for
+// operation_call).
+//
+// Uses the generated union helpers (Discriminator + As*Step) to route
+// on the step type. An unknown discriminator returns an error rather
+// than rendering an empty step — practically unreachable given the
+// typed parser would have already failed, but worth surfacing rather
+// than silently dropping a step.
+func printStep(w io.Writer, n int, item api.ShowTemplateResponse_Steps_Item) error {
+	discriminator, err := item.Discriminator()
+	if err != nil {
+		return fmt.Errorf("read step %d discriminator: %w", n, err)
+	}
+	switch discriminator {
+	case "manual":
+		step, err := item.AsManualStep()
+		if err != nil {
+			return fmt.Errorf("step %d: decode manual step: %w", n, err)
+		}
+		fmt.Fprintf(w, "  %d. [manual] %s (id: %s)\n", n, step.Title, step.Id)
+		printIndentedBody(w, step.Body)
+		printManualVerify(w, step.Verify)
+	case "operation_call":
+		step, err := item.AsOperationCallStep()
+		if err != nil {
+			return fmt.Errorf("step %d: decode operation_call step: %w", n, err)
+		}
+		fmt.Fprintf(w, "  %d. [operation_call] %s (id: %s, op_id: %s)\n",
+			n, step.Title, step.Id, step.OpId)
+		printIndentedBody(w, step.Body)
+		printOpCallVerify(w, step.Verify)
+	default:
+		return fmt.Errorf("step %d: unknown step type %q", n, discriminator)
+	}
+	return nil
+}
+
+// printIndentedBody renders the step body indented by 6 spaces (4 for
+// step number indent, 2 for body indent), preserving embedded
+// newlines. Trailing newlines are stripped.
+func printIndentedBody(w io.Writer, body string) {
+	if body == "" {
+		return
+	}
+	for _, line := range strings.Split(strings.TrimRight(body, "\n"), "\n") {
+		fmt.Fprintf(w, "      %s\n", line)
+	}
+}
+
+// printManualVerify renders a manual step's verify gate as a
+// one-liner. confirm verify shows the prompt; operation_call verify
+// shows the op_id.
+func printManualVerify(w io.Writer, v api.ManualStep_Verify) {
+	discriminator, err := v.Discriminator()
+	if err != nil {
+		fmt.Fprintf(w, "      verify: (unreadable: %v)\n", err)
+		return
+	}
+	switch discriminator {
+	case "confirm":
+		c, _ := v.AsConfirmVerify()
+		fmt.Fprintf(w, "      verify: confirm — %s\n", truncate(c.Prompt, 80))
+	case "operation_call":
+		c, _ := v.AsOperationCallVerify()
+		fmt.Fprintf(w, "      verify: operation_call op_id=%s\n", c.OpId)
+	default:
+		fmt.Fprintf(w, "      verify: (unknown type %q)\n", discriminator)
+	}
+}
+
+// printOpCallVerify is the operation_call-step-flavour analogue.
+// Identical to printManualVerify except for the input type — the
+// generated client defines `ManualStep_Verify` and
+// `OperationCallStep_Verify` as distinct types even though they hold
+// the same union shape.
+func printOpCallVerify(w io.Writer, v api.OperationCallStep_Verify) {
+	discriminator, err := v.Discriminator()
+	if err != nil {
+		fmt.Fprintf(w, "      verify: (unreadable: %v)\n", err)
+		return
+	}
+	switch discriminator {
+	case "confirm":
+		c, _ := v.AsConfirmVerify()
+		fmt.Fprintf(w, "      verify: confirm — %s\n", truncate(c.Prompt, 80))
+	case "operation_call":
+		c, _ := v.AsOperationCallVerify()
+		fmt.Fprintf(w, "      verify: operation_call op_id=%s\n", c.OpId)
+	default:
+		fmt.Fprintf(w, "      verify: (unknown type %q)\n", discriminator)
+	}
+}

--- a/cli/internal/cmd/runbook/show_template_test.go
+++ b/cli/internal/cmd/runbook/show_template_test.go
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package runbook
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/evoila/meho/cli/internal/api"
+)
+
+// buildShowResponse synthesises a wire ShowTemplateResponse with two
+// steps (manual + operation_call) to mirror the validYAML fixture. The
+// generated step union types require explicit From*Step setters; this
+// helper hides that ceremony from the test bodies.
+func buildShowResponse(t *testing.T, slug string, version int, status api.ShowTemplateResponseStatus) api.ShowTemplateResponse {
+	t.Helper()
+	var step0 api.ShowTemplateResponse_Steps_Item
+	var step0Verify api.ManualStep_Verify
+	if err := step0Verify.FromConfirmVerify(api.ConfirmVerify{Type: "confirm", Prompt: "Did it work?"}); err != nil {
+		t.Fatalf("step0 verify: %v", err)
+	}
+	if err := step0.FromManualStep(api.ManualStep{
+		Id: "revoke-old-cert", Title: "Revoke", Body: "Run revoke-cert ${run.target}.",
+		Type: "manual", Verify: step0Verify,
+	}); err != nil {
+		t.Fatalf("step0: %v", err)
+	}
+
+	var step1 api.ShowTemplateResponse_Steps_Item
+	var step1Verify api.OperationCallStep_Verify
+	if err := step1Verify.FromOperationCallVerify(api.OperationCallVerify{
+		Type: "operation_call", OpId: "vault.pki.cert",
+		Params: map[string]interface{}{"serial": "abc"},
+		Expect: map[string]interface{}{"revoked": false},
+	}); err != nil {
+		t.Fatalf("step1 verify: %v", err)
+	}
+	if err := step1.FromOperationCallStep(api.OperationCallStep{
+		Id: "issue-new-cert", Title: "Issue", Body: "Dispatching.",
+		Type: "operation_call", OpId: "vault.pki.issue",
+		Params: map[string]interface{}{"common_name": "x"},
+		Verify: step1Verify,
+	}); err != nil {
+		t.Fatalf("step1: %v", err)
+	}
+
+	tk := "vmware-rest"
+	return api.ShowTemplateResponse{
+		Slug: slug, Version: version,
+		Title: "T", Description: "First line\nSecond line", TargetKind: &tk,
+		Status:    status,
+		Steps:     []api.ShowTemplateResponse_Steps_Item{step0, step1},
+		CreatedBy: "alice", CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		EditedBy: "bob", EditedAt: time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+// TestRunShowTemplateHappyPath — GET on the right path; body renders
+// title, status, target_kind, description, and a numbered step list
+// with verify summary.
+func TestRunShowTemplateHappyPath(t *testing.T) {
+	var rawQuery string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates/vcenter-cert-rotation", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET; got %s", r.Method)
+		}
+		rawQuery = r.URL.RawQuery
+		resp := buildShowResponse(t, "vcenter-cert-rotation", 3, api.ShowTemplateResponseStatusPublished)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, stderr := newRunCmd(t)
+	err := runShowTemplate(cmd, showTemplateOptions{
+		Slug: "vcenter-cert-rotation", Version: 3, BackplaneOverride: srv.URL,
+	})
+	if err != nil {
+		t.Fatalf("runShowTemplate: %v; stderr=%s", err, stderr.String())
+	}
+	if !strings.Contains(rawQuery, "version=3") {
+		t.Errorf("expected version=3 in query; got %q", rawQuery)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"Template: vcenter-cert-rotation@3",
+		"Status:      published",
+		"Target kind: vmware-rest",
+		"First line",
+		"Second line",
+		"[manual]",
+		"[operation_call]",
+		"verify: confirm",
+		"verify: operation_call op_id=vault.pki.cert",
+		"revoke-old-cert",
+		"issue-new-cert",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected stdout to contain %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunShowTemplateJSONHappyPath — --json emits the raw envelope.
+func TestRunShowTemplateJSONHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates/x", func(w http.ResponseWriter, _ *http.Request) {
+		resp := buildShowResponse(t, "x", 1, api.ShowTemplateResponseStatusDraft)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, stdout, _ := newRunCmd(t)
+	err := runShowTemplate(cmd, showTemplateOptions{Slug: "x", JSONOut: true, BackplaneOverride: srv.URL})
+	if err != nil {
+		t.Fatalf("runShowTemplate --json: %v", err)
+	}
+	var decoded api.ShowTemplateResponse
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout not JSON: %v; %q", err, stdout.String())
+	}
+	if decoded.Slug != "x" || decoded.Version != 1 {
+		t.Errorf("envelope: slug=%q version=%d", decoded.Slug, decoded.Version)
+	}
+}
+
+// TestRunShowTemplate404SurfacesSlugNotFound — slug_not_found is the
+// substrate's shape for both genuine absence and cross-tenant probes.
+func TestRunShowTemplate404SurfacesSlugNotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates/missing", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"detail":"slug_not_found"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runShowTemplate(cmd, showTemplateOptions{Slug: "missing", BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+	if !strings.Contains(stderr.String(), "slug_not_found") {
+		t.Errorf("expected slug_not_found in stderr; got %q", stderr.String())
+	}
+	type ec interface{ ExitCode() int }
+	if x, ok := err.(ec); !ok || x.ExitCode() != 4 {
+		t.Errorf("expected ExitCode 4; got %v", err)
+	}
+}
+
+// TestRunShowTemplate403SurfacesInsufficientRole — opacity_floor /
+// no-carve-out paths land as 403; CLI must classify exit 5.
+func TestRunShowTemplate403SurfacesInsufficientRole(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/runbooks/templates/locked", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		fmt.Fprint(w, `{"detail":"Insufficient role: tenant_admin required (post-completion exception not satisfied)"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	seedXDGAndToken(t, srv.URL)
+
+	cmd, _, stderr := newRunCmd(t)
+	err := runShowTemplate(cmd, showTemplateOptions{Slug: "locked", BackplaneOverride: srv.URL})
+	if err == nil {
+		t.Fatal("expected error on 403")
+	}
+	if !strings.Contains(stderr.String(), "post-completion") {
+		t.Errorf("expected backend detail in stderr; got %q", stderr.String())
+	}
+	type ec interface{ ExitCode() int }
+	if x, ok := err.(ec); !ok || x.ExitCode() != 5 {
+		t.Errorf("expected ExitCode 5; got %v", err)
+	}
+}
+
+// TestRunShowTemplateRejectsEmptySlug — empty positional arg.
+func TestRunShowTemplateRejectsEmptySlug(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runShowTemplate(cmd, showTemplateOptions{Slug: ""})
+	if err == nil {
+		t.Fatal("expected error for empty slug")
+	}
+	if !strings.Contains(stderr.String(), "non-empty <slug>") {
+		t.Errorf("expected slug hint; got %q", stderr.String())
+	}
+}
+
+// TestRunShowTemplateRejectsNegativeVersion — --version must be
+// non-negative.
+func TestRunShowTemplateRejectsNegativeVersion(t *testing.T) {
+	cmd, _, stderr := newRunCmd(t)
+	err := runShowTemplate(cmd, showTemplateOptions{Slug: "x", Version: -1})
+	if err == nil {
+		t.Fatal("expected error for negative --version")
+	}
+	if !strings.Contains(stderr.String(), "non-negative") {
+		t.Errorf("expected non-negative hint; got %q", stderr.String())
+	}
+}

--- a/cli/internal/cmd/runbook/yaml.go
+++ b/cli/internal/cmd/runbook/yaml.go
@@ -1,0 +1,440 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package runbook
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"regexp"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/evoila/meho/cli/internal/api"
+)
+
+// slugPattern mirrors `backend/src/meho_backplane/kb/schemas.py`'s
+// `SLUG_PATTERN` verbatim (reused by the runbooks schemas module per
+// the backend module docstring). The CLI re-implements the regex
+// inline so the pre-flight catches a bad slug without paying a network
+// round-trip; the backend re-validates authoritatively at the wire so
+// this duplication is a UX layer, not a security boundary. If the
+// backend ever tightens the pattern, this regex must be updated in
+// lock-step — there is no live config exchange.
+var slugPattern = regexp.MustCompile(`^[a-z](?:[a-z0-9.\-]*[a-z0-9])?$`)
+
+// stepIDPattern mirrors `backend/src/meho_backplane/runbooks/schemas.py`'s
+// `STEP_ID_PATTERN` — tighter than the slug pattern (no dots) because
+// step ids are short procedure handles authors type by hand
+// (`revoke-old-cert`, `verify-cluster-quorum`).
+var stepIDPattern = regexp.MustCompile(`^[a-z][a-z0-9\-]{0,63}$`)
+
+// substitutionPattern matches every `${...}` occurrence. The inner
+// group is captured non-greedily so adjacent substitutions in one
+// string are matched independently. Mirrors `_SUBSTITUTION_PATTERN`
+// in the backend's runbooks/schemas.py.
+var substitutionPattern = regexp.MustCompile(`\$\{([^}]*)\}`)
+
+// paramNamePattern mirrors `_PARAM_NAME_PATTERN` in the backend's
+// runbooks/schemas.py — `run.params.X` where `X` is a single flat
+// level (no dots inside), matching `[a-z_][a-z0-9_]*`. Nested paths
+// like `${run.params.X.Y}` are rejected.
+var paramNamePattern = regexp.MustCompile(`^run\.params\.[a-z_][a-z0-9_]*$`)
+
+// yamlTemplateBody is the on-disk shape the CLI parses out of a
+// `--from <file.yaml>` argument. Mirrors the backend's
+// `RunbookTemplateBody` (and per-step models) one-to-one. The wire
+// shape going to the backend is the generated `api.RunbookTemplateBody`
+// (built by buildRunbookTemplateBody below); this intermediate shape
+// exists so YAML field tags can drive `yaml.v3`'s decoder without
+// disturbing the generated client's JSON tags.
+//
+// `yaml.v3` carries line / column info on every decode error and on
+// every node (Node.Line, Node.Column); we don't introspect that here,
+// the decoder's default error string ("yaml: line N: ...") is enough
+// to point operators at the offending YAML line.
+type yamlTemplateBody struct {
+	Title       string     `yaml:"title"`
+	Description string     `yaml:"description"`
+	TargetKind  *string    `yaml:"target_kind,omitempty"`
+	Steps       []yamlStep `yaml:"steps"`
+}
+
+// yamlStep is the per-step shape — a discriminated union on `type`
+// matching the backend's `Step = OperationCallStep | ManualStep`.
+// Fields irrelevant to the chosen `type` are silently allowed to be
+// absent (the CLI's pre-flight cross-checks them) — yaml.v3 doesn't
+// natively support discriminated unions, so the decode is permissive
+// and the validator narrows.
+//
+// `OpID` and `Params` are only meaningful for `type=operation_call`
+// steps. Pre-flight rejects `op_id`/`params` on a `type=manual` step
+// rather than silently dropping them.
+type yamlStep struct {
+	ID     string                 `yaml:"id"`
+	Title  string                 `yaml:"title"`
+	Body   string                 `yaml:"body"`
+	Type   string                 `yaml:"type"`
+	OpID   string                 `yaml:"op_id,omitempty"`
+	Params map[string]interface{} `yaml:"params,omitempty"`
+	Verify yamlVerify             `yaml:"verify"`
+}
+
+// yamlVerify is the per-verify shape — a discriminated union on
+// `type` matching the backend's `Verify = ConfirmVerify |
+// OperationCallVerify`. Fields irrelevant to the chosen `type` are
+// pre-flighted in validateYAMLTemplate.
+type yamlVerify struct {
+	Type   string                 `yaml:"type"`
+	Prompt string                 `yaml:"prompt,omitempty"`
+	OpID   string                 `yaml:"op_id,omitempty"`
+	Params map[string]interface{} `yaml:"params,omitempty"`
+	Expect map[string]interface{} `yaml:"expect,omitempty"`
+}
+
+// loadYAMLTemplate reads the file at path and unmarshals it as a
+// runbook template body. The error message embeds the path so the
+// operator sees which file failed when piping several `meho runbook
+// draft-template` invocations through a shell loop.
+//
+// yaml.v3's decoder surfaces parse errors with a `line N: ` prefix;
+// the path-on-disk is prepended so operators see both the file and
+// the offending line. The default decoder is non-strict (unknown
+// keys are silently ignored) — pre-flight is the strict layer, the
+// decoder just turns bytes into the intermediate struct.
+func loadYAMLTemplate(path string) (*yamlTemplateBody, error) {
+	blob, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read --from file %q: %w", path, err)
+	}
+	var body yamlTemplateBody
+	if err := yaml.Unmarshal(blob, &body); err != nil {
+		// yaml.v3's error format already includes "line N:".
+		return nil, fmt.Errorf("parse --from file %q: %w", path, err)
+	}
+	return &body, nil
+}
+
+// validateSlug applies the slug regex pre-flight. Returns an error
+// suitable for surfacing under output.Unexpected (the operator-visible
+// hint matches the backend's 422 detail string format).
+func validateSlug(slug string) error {
+	if !slugPattern.MatchString(slug) {
+		return fmt.Errorf(
+			"slug %q does not match %q -- must start with [a-z], "+
+				"end with [a-z0-9], and contain only [a-z0-9.-] in between",
+			slug, slugPattern.String(),
+		)
+	}
+	return nil
+}
+
+// validateSubstitutions walks an arbitrary value recursively and
+// rejects every `${...}` pattern except the two allowlisted forms
+// (`${run.target}` and `${run.params.X}` with X = `[a-z_][a-z0-9_]*`).
+// Pure 1:1 port of the backend's `validate_substitutions` (
+// `backend/src/meho_backplane/runbooks/schemas.py:105`). Walks
+// strings, dict keys + values, and list items; scalars carry no
+// substitution surface so nothing else is traversed.
+//
+// The pre-flight runs over every step body, op-call params, verify
+// params, and verify expect — same fields the backend's
+// `_validate_step_ids_unique_and_substitutions_allowlisted` walks.
+// Defense in depth: the backend re-walks at publish + advance time.
+func validateSubstitutions(value interface{}) error {
+	switch v := value.(type) {
+	case string:
+		for _, match := range substitutionPattern.FindAllStringSubmatch(v, -1) {
+			inner := match[1]
+			if inner == "run.target" {
+				continue
+			}
+			if paramNamePattern.MatchString(inner) {
+				continue
+			}
+			return fmt.Errorf("disallowed substitution pattern: %s", match[0])
+		}
+	case map[string]interface{}:
+		for key, item := range v {
+			if err := validateSubstitutions(key); err != nil {
+				return err
+			}
+			if err := validateSubstitutions(item); err != nil {
+				return err
+			}
+		}
+	case []interface{}:
+		for _, item := range v {
+			if err := validateSubstitutions(item); err != nil {
+				return err
+			}
+		}
+	}
+	// Other scalar types (int, float, bool, nil) carry no
+	// substitution surface; nothing to walk.
+	return nil
+}
+
+// validateYAMLTemplate enforces the template-level invariants the
+// backend's model validator enforces:
+//
+//  1. Slug matches SLUG_PATTERN.
+//  2. Step ids are unique within the template.
+//  3. Each step id matches STEP_ID_PATTERN.
+//  4. Each step `type` is `manual` or `operation_call`.
+//  5. Each verify `type` is `confirm` or `operation_call`.
+//  6. `op_id` is set when (and only when) `type=operation_call`
+//     (mirrors the discriminated-union shape on both step + verify).
+//  7. Every string in every step body / op-call params / verify
+//     params / verify expect satisfies the substitution allowlist.
+//
+// The pre-flight is not a security boundary — the backend
+// re-validates at the wire so any drift between this code and the
+// backend's schemas.py is caught by a 422. The pre-flight value is
+// strictly UX: a fast-fail loop on the operator's workstation
+// instead of a network round-trip per typo.
+//
+// Returns nil on success; a wrapped error on the first failure so
+// the operator gets one actionable problem at a time. The error
+// strings mirror the backend's wording wherever possible so an
+// operator reading both the CLI error and the backend's 422 detail
+// sees consistent terminology.
+func validateYAMLTemplate(slug string, body *yamlTemplateBody) error {
+	if err := validateSlug(slug); err != nil {
+		return err
+	}
+	if body == nil {
+		return errors.New("template body is empty")
+	}
+	if body.Title == "" {
+		return errors.New("template title is required")
+	}
+	if body.Description == "" {
+		return errors.New("template description is required")
+	}
+	if len(body.Steps) == 0 {
+		return errors.New("template must declare at least one step")
+	}
+	seen := make(map[string]bool, len(body.Steps))
+	for i, step := range body.Steps {
+		// Step id presence + grammar.
+		if step.ID == "" {
+			return fmt.Errorf("step %d: id is required", i+1)
+		}
+		if !stepIDPattern.MatchString(step.ID) {
+			return fmt.Errorf(
+				"step %d: id %q does not match %q -- "+
+					"start with [a-z], remainder [a-z0-9-], max 64 chars",
+				i+1, step.ID, stepIDPattern.String(),
+			)
+		}
+		if seen[step.ID] {
+			return fmt.Errorf("duplicate step id: %q", step.ID)
+		}
+		seen[step.ID] = true
+
+		// Step-level required fields.
+		if step.Title == "" {
+			return fmt.Errorf("step %q: title is required", step.ID)
+		}
+		if step.Body == "" {
+			return fmt.Errorf("step %q: body is required", step.ID)
+		}
+
+		// Step type discriminator + per-type fields.
+		switch step.Type {
+		case "manual":
+			if step.OpID != "" || step.Params != nil {
+				return fmt.Errorf(
+					"step %q: type=manual must not carry op_id or params; "+
+						"set type=operation_call to dispatch via the registry",
+					step.ID,
+				)
+			}
+		case "operation_call":
+			if step.OpID == "" {
+				return fmt.Errorf("step %q: type=operation_call requires op_id", step.ID)
+			}
+			if err := validateSubstitutions(step.Params); err != nil {
+				return fmt.Errorf("step %q params: %w", step.ID, err)
+			}
+		case "":
+			return fmt.Errorf("step %q: type is required (manual or operation_call)", step.ID)
+		default:
+			return fmt.Errorf(
+				"step %q: unknown type %q (allowed: manual, operation_call)",
+				step.ID, step.Type,
+			)
+		}
+
+		// Verify discriminator + per-type fields.
+		switch step.Verify.Type {
+		case "confirm":
+			if step.Verify.Prompt == "" {
+				return fmt.Errorf("step %q: verify.type=confirm requires verify.prompt", step.ID)
+			}
+			if step.Verify.OpID != "" || step.Verify.Params != nil || step.Verify.Expect != nil {
+				return fmt.Errorf(
+					"step %q: verify.type=confirm must not carry op_id / params / expect",
+					step.ID,
+				)
+			}
+		case "operation_call":
+			if step.Verify.OpID == "" {
+				return fmt.Errorf("step %q: verify.type=operation_call requires verify.op_id", step.ID)
+			}
+			if step.Verify.Prompt != "" {
+				return fmt.Errorf(
+					"step %q: verify.type=operation_call must not carry verify.prompt",
+					step.ID,
+				)
+			}
+			if err := validateSubstitutions(step.Verify.Params); err != nil {
+				return fmt.Errorf("step %q verify.params: %w", step.ID, err)
+			}
+			if err := validateSubstitutions(step.Verify.Expect); err != nil {
+				return fmt.Errorf("step %q verify.expect: %w", step.ID, err)
+			}
+		case "":
+			return fmt.Errorf("step %q: verify.type is required (confirm or operation_call)", step.ID)
+		default:
+			return fmt.Errorf(
+				"step %q: unknown verify.type %q (allowed: confirm, operation_call)",
+				step.ID, step.Verify.Type,
+			)
+		}
+
+		// Substitution allowlist over the step body (manual + op-call
+		// both carry a body that may include `${run.target}` /
+		// `${run.params.X}` substitutions).
+		if err := validateSubstitutions(step.Body); err != nil {
+			return fmt.Errorf("step %q body: %w", step.ID, err)
+		}
+	}
+	return nil
+}
+
+// buildRunbookTemplateBody converts the local YAML struct into the
+// generated `api.RunbookTemplateBody` wire shape. The step union is
+// built via the generated `FromManualStep` / `FromOperationCallStep`
+// helpers; the verify union via `FromConfirmVerify` /
+// `FromOperationCallVerify`.
+//
+// The pre-flight guarantees this function is called only on a body
+// that passed validateYAMLTemplate, so the discriminator switch never
+// needs a default branch error; the helper returns an error only when
+// the generated union helpers themselves fail (a JSON marshal
+// failure on a deeply weird params/expect blob would be the only
+// trigger — practically unreachable for a YAML-parsed body, but
+// surfaced cleanly rather than panicking).
+func buildRunbookTemplateBody(body *yamlTemplateBody) (api.RunbookTemplateBody, error) {
+	out := api.RunbookTemplateBody{
+		Title:       body.Title,
+		Description: body.Description,
+		Steps:       make([]api.RunbookTemplateBody_Steps_Item, 0, len(body.Steps)),
+	}
+	if body.TargetKind != nil && *body.TargetKind != "" {
+		tk := *body.TargetKind
+		out.TargetKind = &tk
+	}
+	for i, step := range body.Steps {
+		verifyUnion, err := buildVerifyUnion(step.Verify)
+		if err != nil {
+			return out, fmt.Errorf("step %q: %w", step.ID, err)
+		}
+		var item api.RunbookTemplateBody_Steps_Item
+		switch step.Type {
+		case "manual":
+			manual := api.ManualStep{
+				Id:     step.ID,
+				Title:  step.Title,
+				Body:   step.Body,
+				Type:   "manual",
+				Verify: verifyUnion.manual,
+			}
+			if err := item.FromManualStep(manual); err != nil {
+				return out, fmt.Errorf("step %q: marshal manual step: %w", step.ID, err)
+			}
+		case "operation_call":
+			// Default empty map when the YAML omitted params on an
+			// operation_call step; the backend's OperationCallStep
+			// requires `params: dict[str, object]` to be present
+			// (empty dict is acceptable).
+			params := step.Params
+			if params == nil {
+				params = map[string]interface{}{}
+			}
+			opCall := api.OperationCallStep{
+				Id:     step.ID,
+				Title:  step.Title,
+				Body:   step.Body,
+				Type:   "operation_call",
+				OpId:   step.OpID,
+				Params: params,
+				Verify: verifyUnion.opCall,
+			}
+			if err := item.FromOperationCallStep(opCall); err != nil {
+				return out, fmt.Errorf("step %q: marshal operation_call step: %w", step.ID, err)
+			}
+		default:
+			return out, fmt.Errorf("step %d (id %q): unreachable step type %q after pre-flight",
+				i+1, step.ID, step.Type)
+		}
+		out.Steps = append(out.Steps, item)
+	}
+	return out, nil
+}
+
+// verifyUnions carries both the manual-step and op-call-step verify
+// union flavours. The generated client defines `ManualStep_Verify`
+// and `OperationCallStep_Verify` as distinct types (even though they
+// hold structurally identical unions), so buildVerifyUnion populates
+// both flavours from one yamlVerify and the caller picks the one
+// matching its step type.
+type verifyUnions struct {
+	manual api.ManualStep_Verify
+	opCall api.OperationCallStep_Verify
+}
+
+// buildVerifyUnion converts a yamlVerify into both step-flavour
+// verify unions. The discriminator is the yamlVerify.Type field,
+// which has already been validated against the allowlist by
+// validateYAMLTemplate.
+func buildVerifyUnion(v yamlVerify) (verifyUnions, error) {
+	out := verifyUnions{}
+	switch v.Type {
+	case "confirm":
+		c := api.ConfirmVerify{Type: "confirm", Prompt: v.Prompt}
+		if err := out.manual.FromConfirmVerify(c); err != nil {
+			return out, fmt.Errorf("marshal confirm verify (manual): %w", err)
+		}
+		if err := out.opCall.FromConfirmVerify(c); err != nil {
+			return out, fmt.Errorf("marshal confirm verify (operation_call): %w", err)
+		}
+	case "operation_call":
+		params := v.Params
+		if params == nil {
+			params = map[string]interface{}{}
+		}
+		expect := v.Expect
+		if expect == nil {
+			expect = map[string]interface{}{}
+		}
+		c := api.OperationCallVerify{
+			Type:   "operation_call",
+			OpId:   v.OpID,
+			Params: params,
+			Expect: expect,
+		}
+		if err := out.manual.FromOperationCallVerify(c); err != nil {
+			return out, fmt.Errorf("marshal operation_call verify (manual): %w", err)
+		}
+		if err := out.opCall.FromOperationCallVerify(c); err != nil {
+			return out, fmt.Errorf("marshal operation_call verify (operation_call): %w", err)
+		}
+	default:
+		return out, fmt.Errorf("unreachable verify type %q after pre-flight", v.Type)
+	}
+	return out, nil
+}

--- a/cli/internal/cmd/runbook/yaml_test.go
+++ b/cli/internal/cmd/runbook/yaml_test.go
@@ -222,9 +222,9 @@ func TestValidateYAMLTemplateAllowsRunParams(t *testing.T) {
 // TestValidateYAMLTemplateRejectsNestedRunParams — `${run.params.X.Y}`
 // is rejected (nested paths are not in the allowlist).
 func TestValidateYAMLTemplateRejectsNestedRunParams(t *testing.T) {
-	bad := strings.Replace(validYAML,
+	bad := strings.ReplaceAll(validYAML,
 		"${run.params.cn}",
-		"${run.params.cn.nested}", -1) //nolint:gocritic // exhaustive replacement intended
+		"${run.params.cn.nested}")
 	body, _ := loadYAMLTemplate(writeYAML(t, bad))
 	err := validateYAMLTemplate("vcenter-cert-rotation", body)
 	if err == nil {

--- a/cli/internal/cmd/runbook/yaml_test.go
+++ b/cli/internal/cmd/runbook/yaml_test.go
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 evoila Group
+
+package runbook
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// validYAML is the canonical valid template body — exercises both
+// step types, both verify types, and a `${run.target}` substitution.
+// Tests that need a specific failure mode mutate this baseline.
+const validYAML = `title: Cert rotation — vCenter
+description: Rotate the cert on a managed vCenter target.
+target_kind: vmware-rest
+steps:
+  - id: revoke-old-cert
+    title: Revoke the existing cert
+    body: |
+      Run revoke-cert ${run.target} against the vault PKI.
+    type: manual
+    verify:
+      type: confirm
+      prompt: Did the revoke succeed?
+  - id: issue-new-cert
+    title: Issue a new cert
+    body: |
+      Dispatching to the PKI engine on ${run.target}.
+    type: operation_call
+    op_id: vault.pki.issue
+    params:
+      common_name: ${run.params.cn}
+    verify:
+      type: operation_call
+      op_id: vault.pki.cert
+      params:
+        serial: ${run.params.cn}
+      expect:
+        revoked: false
+`
+
+func writeYAML(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "template.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write yaml: %v", err)
+	}
+	return path
+}
+
+// TestLoadYAMLTemplateHappyPath — parsing the canonical template
+// returns every field intact and routes the step / verify types
+// correctly.
+func TestLoadYAMLTemplateHappyPath(t *testing.T) {
+	body, err := loadYAMLTemplate(writeYAML(t, validYAML))
+	if err != nil {
+		t.Fatalf("loadYAMLTemplate: %v", err)
+	}
+	if body.Title != "Cert rotation — vCenter" {
+		t.Errorf("title: %q", body.Title)
+	}
+	if body.TargetKind == nil || *body.TargetKind != "vmware-rest" {
+		t.Errorf("target_kind: %+v", body.TargetKind)
+	}
+	if len(body.Steps) != 2 {
+		t.Fatalf("expected 2 steps; got %d", len(body.Steps))
+	}
+	if body.Steps[0].Type != "manual" {
+		t.Errorf("steps[0].type: %q", body.Steps[0].Type)
+	}
+	if body.Steps[1].Type != "operation_call" {
+		t.Errorf("steps[1].type: %q", body.Steps[1].Type)
+	}
+	if body.Steps[0].Verify.Type != "confirm" {
+		t.Errorf("steps[0].verify.type: %q", body.Steps[0].Verify.Type)
+	}
+	if body.Steps[1].Verify.Type != "operation_call" {
+		t.Errorf("steps[1].verify.type: %q", body.Steps[1].Verify.Type)
+	}
+}
+
+// TestLoadYAMLTemplateParseErrorIncludesLine — malformed YAML
+// surfaces yaml.v3's `line N:` error format wrapped with the path.
+// Test 9 (AC): YAML parse error → exit 1 with line:col of the
+// offending field.
+func TestLoadYAMLTemplateParseErrorIncludesLine(t *testing.T) {
+	bad := "title: ok\ndescription: missing-colon-here\nsteps\n  - id: x\n"
+	_, err := loadYAMLTemplate(writeYAML(t, bad))
+	if err == nil {
+		t.Fatal("expected YAML parse error")
+	}
+	if !strings.Contains(err.Error(), "line") {
+		t.Errorf("expected line: hint in error; got %q", err.Error())
+	}
+}
+
+// TestLoadYAMLTemplateMissingFile — missing path surfaces a clear
+// filesystem error rather than a panic.
+func TestLoadYAMLTemplateMissingFile(t *testing.T) {
+	_, err := loadYAMLTemplate("/no/such/path/template.yaml")
+	if err == nil {
+		t.Fatal("expected missing-file error")
+	}
+}
+
+// TestValidateYAMLTemplateHappyPath — the canonical template passes
+// pre-flight without errors.
+func TestValidateYAMLTemplateHappyPath(t *testing.T) {
+	body, err := loadYAMLTemplate(writeYAML(t, validYAML))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if err := validateYAMLTemplate("vcenter-cert-rotation", body); err != nil {
+		t.Errorf("validateYAMLTemplate: %v", err)
+	}
+}
+
+// TestValidateYAMLTemplateRejectsBadSlug — slug regex pre-flight
+// (AC test 6).
+func TestValidateYAMLTemplateRejectsBadSlug(t *testing.T) {
+	body, _ := loadYAMLTemplate(writeYAML(t, validYAML))
+	err := validateYAMLTemplate("BAD_SLUG", body)
+	if err == nil {
+		t.Fatal("expected slug-regex error")
+	}
+	if !strings.Contains(err.Error(), "does not match") {
+		t.Errorf("expected regex hint; got %q", err.Error())
+	}
+}
+
+// TestValidateYAMLTemplateRejectsDuplicateStepID — duplicate step
+// ids fail pre-flight (AC test 7).
+func TestValidateYAMLTemplateRejectsDuplicateStepID(t *testing.T) {
+	dup := strings.Replace(validYAML, "issue-new-cert", "revoke-old-cert", 1)
+	body, _ := loadYAMLTemplate(writeYAML(t, dup))
+	err := validateYAMLTemplate("vcenter-cert-rotation", body)
+	if err == nil {
+		t.Fatal("expected duplicate step id error")
+	}
+	if !strings.Contains(err.Error(), "duplicate step id") {
+		t.Errorf("expected dup-id message; got %q", err.Error())
+	}
+}
+
+// TestValidateYAMLTemplateRejectsBadStepID — step id grammar
+// (lowercase + digit + hyphen, no dots, ≤64 chars).
+func TestValidateYAMLTemplateRejectsBadStepID(t *testing.T) {
+	bad := strings.Replace(validYAML, "id: revoke-old-cert", "id: Revoke_old.Cert", 1)
+	body, _ := loadYAMLTemplate(writeYAML(t, bad))
+	err := validateYAMLTemplate("vcenter-cert-rotation", body)
+	if err == nil {
+		t.Fatal("expected step-id grammar error")
+	}
+}
+
+// TestValidateYAMLTemplateRejectsBadStepType — `type` outside the
+// allowlist fails pre-flight.
+func TestValidateYAMLTemplateRejectsBadStepType(t *testing.T) {
+	bad := strings.Replace(validYAML, "type: manual", "type: scripted", 1)
+	body, _ := loadYAMLTemplate(writeYAML(t, bad))
+	err := validateYAMLTemplate("vcenter-cert-rotation", body)
+	if err == nil {
+		t.Fatal("expected step-type error")
+	}
+	if !strings.Contains(err.Error(), "unknown type") {
+		t.Errorf("expected unknown-type message; got %q", err.Error())
+	}
+}
+
+// TestValidateYAMLTemplateRejectsBadVerifyType — verify.type outside
+// the allowlist fails pre-flight.
+func TestValidateYAMLTemplateRejectsBadVerifyType(t *testing.T) {
+	bad := strings.Replace(validYAML, "type: confirm", "type: gut-feeling", 1)
+	body, _ := loadYAMLTemplate(writeYAML(t, bad))
+	err := validateYAMLTemplate("vcenter-cert-rotation", body)
+	if err == nil {
+		t.Fatal("expected verify-type error")
+	}
+	if !strings.Contains(err.Error(), "unknown verify.type") {
+		t.Errorf("expected unknown verify-type message; got %q", err.Error())
+	}
+}
+
+// TestValidateYAMLTemplateRejectsBadSubstitution — disallowed
+// `${...}` patterns fail pre-flight (AC test 8). The substitution
+// allowlist mirrors the backend's `validate_substitutions`.
+func TestValidateYAMLTemplateRejectsBadSubstitution(t *testing.T) {
+	bad := strings.Replace(validYAML,
+		"Run revoke-cert ${run.target}",
+		"Run revoke-cert ${run.bad.path}", 1)
+	body, _ := loadYAMLTemplate(writeYAML(t, bad))
+	err := validateYAMLTemplate("vcenter-cert-rotation", body)
+	if err == nil {
+		t.Fatal("expected disallowed-substitution error")
+	}
+	if !strings.Contains(err.Error(), "disallowed substitution") {
+		t.Errorf("expected substitution hint; got %q", err.Error())
+	}
+}
+
+// TestValidateYAMLTemplateAllowsRunTarget — `${run.target}` is in
+// the allowlist; the canonical template uses it and must pass.
+func TestValidateYAMLTemplateAllowsRunTarget(t *testing.T) {
+	body, _ := loadYAMLTemplate(writeYAML(t, validYAML))
+	if err := validateYAMLTemplate("vcenter-cert-rotation", body); err != nil {
+		t.Errorf("validateYAMLTemplate (allow run.target): %v", err)
+	}
+}
+
+// TestValidateYAMLTemplateAllowsRunParams — `${run.params.X}` with
+// `X = [a-z_][a-z0-9_]*` is in the allowlist.
+func TestValidateYAMLTemplateAllowsRunParams(t *testing.T) {
+	body, _ := loadYAMLTemplate(writeYAML(t, validYAML))
+	if err := validateYAMLTemplate("vcenter-cert-rotation", body); err != nil {
+		t.Errorf("validateYAMLTemplate (allow run.params.X): %v", err)
+	}
+}
+
+// TestValidateYAMLTemplateRejectsNestedRunParams — `${run.params.X.Y}`
+// is rejected (nested paths are not in the allowlist).
+func TestValidateYAMLTemplateRejectsNestedRunParams(t *testing.T) {
+	bad := strings.Replace(validYAML,
+		"${run.params.cn}",
+		"${run.params.cn.nested}", -1) //nolint:gocritic // exhaustive replacement intended
+	body, _ := loadYAMLTemplate(writeYAML(t, bad))
+	err := validateYAMLTemplate("vcenter-cert-rotation", body)
+	if err == nil {
+		t.Fatal("expected nested-param error")
+	}
+}
+
+// TestValidateYAMLTemplateRejectsEmptyTitle — title is required.
+func TestValidateYAMLTemplateRejectsEmptyTitle(t *testing.T) {
+	bad := strings.Replace(validYAML,
+		"title: Cert rotation — vCenter",
+		"title: \"\"", 1)
+	body, _ := loadYAMLTemplate(writeYAML(t, bad))
+	err := validateYAMLTemplate("vcenter-cert-rotation", body)
+	if err == nil {
+		t.Fatal("expected title-required error")
+	}
+}
+
+// TestValidateYAMLTemplateRejectsNoSteps — at least one step
+// required.
+func TestValidateYAMLTemplateRejectsNoSteps(t *testing.T) {
+	body := &yamlTemplateBody{
+		Title:       "Title",
+		Description: "Desc",
+		Steps:       nil,
+	}
+	err := validateYAMLTemplate("ok-slug", body)
+	if err == nil {
+		t.Fatal("expected no-steps error")
+	}
+}
+
+// TestValidateYAMLTemplateManualStepMustNotCarryOpID — fail-fast on a
+// manual step that smuggles op_id.
+func TestValidateYAMLTemplateManualStepMustNotCarryOpID(t *testing.T) {
+	bad := `title: T
+description: D
+steps:
+  - id: x
+    title: t
+    body: b
+    type: manual
+    op_id: should.not.be.here
+    verify:
+      type: confirm
+      prompt: ok?
+`
+	body, _ := loadYAMLTemplate(writeYAML(t, bad))
+	err := validateYAMLTemplate("ok-slug", body)
+	if err == nil {
+		t.Fatal("expected manual+op_id error")
+	}
+}
+
+// TestValidateYAMLTemplateOpCallStepRequiresOpID — an operation_call
+// step must carry op_id.
+func TestValidateYAMLTemplateOpCallStepRequiresOpID(t *testing.T) {
+	bad := `title: T
+description: D
+steps:
+  - id: x
+    title: t
+    body: b
+    type: operation_call
+    verify:
+      type: confirm
+      prompt: ok?
+`
+	body, _ := loadYAMLTemplate(writeYAML(t, bad))
+	err := validateYAMLTemplate("ok-slug", body)
+	if err == nil {
+		t.Fatal("expected op_id required error")
+	}
+}
+
+// TestBuildRunbookTemplateBodyRoundtripsSteps — the local YAML body
+// round-trips through buildRunbookTemplateBody into the generated
+// wire shape preserving the discriminator + per-step fields.
+func TestBuildRunbookTemplateBodyRoundtripsSteps(t *testing.T) {
+	body, _ := loadYAMLTemplate(writeYAML(t, validYAML))
+	if err := validateYAMLTemplate("vcenter-cert-rotation", body); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	wire, err := buildRunbookTemplateBody(body)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if wire.Title != body.Title || wire.Description != body.Description {
+		t.Errorf("title/description not threaded: %+v", wire)
+	}
+	if len(wire.Steps) != 2 {
+		t.Fatalf("expected 2 wire steps; got %d", len(wire.Steps))
+	}
+	// Step 0 — discriminator round-trip via the generated union helper.
+	d0, err := wire.Steps[0].Discriminator()
+	if err != nil {
+		t.Fatalf("step[0] discriminator: %v", err)
+	}
+	if d0 != "manual" {
+		t.Errorf("step[0] discriminator: got %q; want manual", d0)
+	}
+	manual, err := wire.Steps[0].AsManualStep()
+	if err != nil {
+		t.Fatalf("as manual: %v", err)
+	}
+	if manual.Id != "revoke-old-cert" || manual.Type != "manual" {
+		t.Errorf("manual step fields: %+v", manual)
+	}
+	// Verify step 1's op_id survived.
+	opCall, err := wire.Steps[1].AsOperationCallStep()
+	if err != nil {
+		t.Fatalf("as op_call: %v", err)
+	}
+	if opCall.OpId != "vault.pki.issue" {
+		t.Errorf("op_call.OpId: got %q", opCall.OpId)
+	}
+}
+
+// TestValidateSubstitutionsAllowsScalarTypes — non-string, non-map,
+// non-list values carry no substitution surface; the walker must
+// silently accept them.
+func TestValidateSubstitutionsAllowsScalarTypes(t *testing.T) {
+	for _, v := range []interface{}{42, 3.14, true, nil} {
+		if err := validateSubstitutions(v); err != nil {
+			t.Errorf("scalar %v should pass: %v", v, err)
+		}
+	}
+}
+
+// TestValidateSubstitutionsWalksMapKeys — a substitution smuggled
+// into a dict key is just as dangerous as one in a value (mirrors
+// the backend's validate_substitutions).
+func TestValidateSubstitutionsWalksMapKeys(t *testing.T) {
+	v := map[string]interface{}{"${evil}": "ok"}
+	if err := validateSubstitutions(v); err == nil {
+		t.Error("expected dict-key substitution to be rejected")
+	}
+}

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -79,6 +79,23 @@ names.
   real HTTP submission layer (POST `/api/v1/memory`), post-login nudge,
   marker file, and `docs/cli/memory-migration.md`. Depends on
   `charm.land/huh/v2` (MIT).
+- `meho runbook ...` (G12.5-T1 #1318) — runbook template authoring
+  surface (`list-templates`, `show-template`, `draft-template`,
+  `edit-template`, `publish-template`, `deprecate-template`) wrapping
+  the six `/api/v1/runbooks/templates*` routes shipped by G12.2-T3
+  (#1297). The two non-trivial verbs (`draft-template` /
+  `edit-template`) accept `--from <file.yaml>` and run a local
+  pre-flight (slug regex, step-id uniqueness + grammar, step / verify
+  type allowlists, substitution allowlist over every string) that
+  mirrors the backend's
+  `_validate_step_ids_unique_and_substitutions_allowlisted` in
+  `backend/src/meho_backplane/runbooks/schemas.py`. Pre-flight is a
+  UX layer — the backend re-validates authoritatively at the wire.
+  Read verbs are operator-level (with the tenant_admin / post-completion
+  carve-out on `show-template`, implemented backend-side per #1309);
+  write verbs require tenant_admin. T2 (#1319) extends the parent
+  with the five run verbs (`start`, `next`, `abort`, `reassign`,
+  `runs`); T3 (#1320) ships `docs/cli/runbook.md`.
 
 ## Module layout
 
@@ -197,6 +214,23 @@ cli/
     │   │   ├── memory_test.go    # --dry-run envelope, --non-interactive filter, machine-local skip, empty-dir guard, wire-body stability.
     │   │   ├── submit.go         # doSubmit + spinner + RememberApiV1MemoryPostWithResponse via api.AuthedClient + retryOn401 generic. G0.12-T11 #1269 dropped the in-package HTTP helper trio (doAuthedRequest/sendRequest/httpError) + the local `source_id`-in-body bug the typed RememberBody schema's `extra="forbid"` would have rejected on a real backend (httptest mock masked it). isTransient retry logic preserved.
     │   │   └── submit_test.go    # typed RememberBody body shape, same-slug rerun stable, no-source_id-on-wire, transient retry, summary line, --mark-migrated, 201-without-payload nil-guard, 401/403/422 classification, no-backplane → auth_expired.
+    │   ├── runbook/           # G12.5-T1 #1318 — `meho runbook …` runbook template authoring verb tree. Initiative #1200; wraps the six /api/v1/runbooks/templates routes shipped by G12.2-T3 #1297.
+    │   │   ├── runbook.go               # NewRootCmd + newAuthedClient / retryOn401 / renderRequestError / renderHTTPStatus typed-client helpers + path-escape / truncate helpers.
+    │   │   ├── yaml.go                  # YAML parsing + local pre-flight validators (slug regex, step-id grammar, step / verify type allowlists, substitution allowlist over every string). Mirrors `backend/src/meho_backplane/runbooks/schemas.py`'s `_validate_step_ids_unique_and_substitutions_allowlisted` + `validate_substitutions`.
+    │   │   ├── list_templates.go        # `meho runbook list-templates` (GET /api/v1/runbooks/templates).
+    │   │   ├── show_template.go         # `meho runbook show-template <slug>` (GET /api/v1/runbooks/templates/{slug}); heading + numbered step list + verify summary.
+    │   │   ├── draft_template.go        # `meho runbook draft-template <slug> --from <file.yaml>` (POST /api/v1/runbooks/templates).
+    │   │   ├── edit_template.go         # `meho runbook edit-template <slug> --from <file.yaml>` (PATCH /api/v1/runbooks/templates/{slug}); renders `forked_from` on the fork-on-edit path.
+    │   │   ├── publish_template.go      # `meho runbook publish-template <slug> --version N` (POST /api/v1/runbooks/templates/{slug}/publish).
+    │   │   ├── deprecate_template.go    # `meho runbook deprecate-template <slug> --version N` (POST /api/v1/runbooks/templates/{slug}/deprecate).
+    │   │   ├── runbook_test.go          # helpers + register-all-six-verbs + URL-normalisation + body/role/path-escape contract tests.
+    │   │   ├── yaml_test.go             # YAML parse error, pre-flight matrix (slug regex, dup step id, step/verify type allowlists, substitution allowlist incl. nested-param rejection), buildRunbookTemplateBody discriminator round-trip.
+    │   │   ├── list_templates_test.go   # query-param emit (status/target_kind/limit) + 5-col table render + JSON envelope + 403/network error tests.
+    │   │   ├── show_template_test.go    # version query + heading + step-list render + 404 / 403 (incl. post-completion exception) tests.
+    │   │   ├── draft_template_test.go   # POST body shape + pre-flight short-circuits (bad slug, dup step id, disallowed substitution, bad YAML — all zero HTTP calls) + 403/409/422 surface tests.
+    │   │   ├── edit_template_test.go    # PATCH body shape + draft-in-place vs fork-on-edit summary + 404 / 403 / 422 tests.
+    │   │   ├── publish_template_test.go # POST body shape + 1-line confirmation + 404 / 403 / network-error tests.
+    │   │   └── deprecate_template_test.go # POST body shape + 1-line confirmation + 400 cannot-deprecate-draft + 403 tests.
     │   ├── vmware/            # G3.1-T7 #511 — `meho vmware …` alias verb tree (connector_id="vmware-rest-9.0" pre-baked).
     │   ├── vault/             # G3.3-T6 #550 — `meho vault …` alias verb tree (connector_id="vault-1.x" pre-baked).
     │   └── topology/          # G9.1-T6 #454 + G9.2-T6 #599 — `meho topology refresh/dependents/dependencies/path/annotate/unannotate/list-edges` over the T5 REST surface (#453, #597).


### PR DESCRIPTION
## Summary

- Add `meho runbook` subcommand chassis + six template verbs wrapping the G12.2 REST surface (#1297): `list-templates`, `show-template`, `draft-template`, `edit-template`, `publish-template`, `deprecate-template`.
- The two non-trivial verbs (`draft-template` / `edit-template`) accept `--from <file.yaml>` and run a local pre-flight (slug regex, step-id uniqueness + grammar, step / verify type allowlists, substitution allowlist over every string) before any HTTP call — UX layer only; the backend re-validates authoritatively at the wire.
- Pre-flight allowlist regex + slug pattern mirror `backend/src/meho_backplane/runbooks/schemas.py`'s `_validate_step_ids_unique_and_substitutions_allowlisted` and `validate_substitutions` verbatim; drift is caught by a backend 422.
- CLI help text and 403 wording aligned with the operator-facing MCP tool descriptions.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l ./internal/cmd/runbook/` — clean
- [x] `go test -race -cover ./internal/cmd/runbook/...` — 80.5% coverage, all tests pass
- [x] `go test -race ./...` — full CLI suite green, no regressions
- [x] `python3 .claude/hooks/code-quality.py --diff` — exit 0 (no diff-mode violations)
- [x] AC1 — `cli/internal/cmd/runbook/` directory exists with `runbook.go` + 6 verb files + 6 verb test files + shared `yaml.go` + `yaml_test.go` + `runbook_test.go`
- [x] AC2 — `meho runbook` root registered on `cmd/root.go` next to `meho kb`
- [x] AC3 — all 6 verbs wrap their REST routes (verified via mock-backend tests, body shape pinned via `readJSONBodyOf` decode)
- [x] AC4 — YAML pre-flight runs before HTTP for `draft-template` / `edit-template`; per-rule rejection tests confirm zero HTTP calls on a pre-flight failure (slug regex, dup step id, disallowed substitution, bad YAML)
- [x] AC5 — table for `list-templates` (5 columns), heading + numbered step list for `show-template`, 1-line / 2-line summaries for the write verbs
- [x] AC6 — `--json` works on every verb and emits raw backend JSON
- [x] AC7 — error rendering covers 400/403/404/409/422/5xx, network failure, and YAML pre-flight failures with the right exit codes (1/2/3/4/5)
- [x] AC8 — generated typed client already current as of #1342's iter-2 fix; no `make generate` required
- [x] AC9 — `docs/codebase/cli.md` updated to describe the new verb tree

## Out of scope

- Run verbs (`start`, `next`, `abort`, `reassign`, `runs`) — G12.5-T2 #1319.
- Dedicated CLI docs at `docs/cli/runbook.md` — G12.5-T3 #1320.
- TUI / interactive step-stepper, watch-mode, branded CLI output — out per Initiative #1200.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1318


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runbook template authoring CLI commands: `draft-template`, `edit-template`, `publish-template`, `deprecate-template`, `list-templates`, and `show-template`
  * Users can now author, manage, and publish runbook templates via YAML files with built-in validation
  * Added JSON output support across all runbook commands for programmatic integration

* **Documentation**
  * Added CLI documentation for the runbook template authoring workflow and API integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->