### PR TITLE
fix(targets): G0.18-T2 reconcile sddc/sddc-manager product token (close #1312 acceptance B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,28 @@ connector-related release-notes line.
 
 ## [Unreleased]
 
-## [0.8.1] - 2026-05-29
+### Fixed
+
+- **`POST /api/v1/targets` accepts the `meho connector list` SDDC
+  product token (G0.18-T2 #1355).** Closes #1312 acceptance B, which
+  had been marked "already aligned" but the split persisted:
+  `meho connector list` emits `product="sddc"` (parser-derived from
+  `sddc-rest-9.0`, load-bearing for the #773 connector_id
+  round-trip), while the v2 registry, the spec catalog, and the
+  `TargetCreate` validator all use the canonical `sddc-manager`.
+  An operator copying the listing token into a create now succeeds:
+  a `PRODUCT_ALIASES` map in
+  `meho_backplane.connectors.registry` normalises `sddc` →
+  `sddc-manager` at the write surface (`POST` + `PATCH
+  /api/v1/targets`) before the registered-product validator runs,
+  and the canonical token is what gets stored — so the resolver,
+  audit log, and every list / detail read see one spelling
+  regardless of which the operator typed. A new structural test in
+  `test_operations_ingest_catalog.py` pins the round-trip for
+  every shipped connector so a future drift fails CI rather than
+  surfacing on the next dogfood cycle. RDC #789 Finding 6.
+
+
 
 ### Added
 

--- a/backend/src/meho_backplane/api/v1/targets.py
+++ b/backend/src/meho_backplane/api/v1/targets.py
@@ -146,7 +146,11 @@ from meho_backplane.api.v1._envelope import (
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
 from meho_backplane.connectors.base import Connector
-from meho_backplane.connectors.registry import all_connectors_v2, registered_product_tokens
+from meho_backplane.connectors.registry import (
+    all_connectors_v2,
+    canonical_product_token,
+    registered_product_tokens,
+)
 from meho_backplane.connectors.resolver import resolve_connector_or_label
 from meho_backplane.connectors.schemas import AuthModel, CandidateHint, FingerprintResult
 from meho_backplane.db.engine import get_session
@@ -327,6 +331,42 @@ def _build_unknown_product_detail(
             f"the convention."
         ),
     }
+
+
+def _canonicalise_and_validate_product(supplied: str) -> str:
+    """Resolve ``supplied`` to a canonical registry product or raise 422.
+
+    G0.18-T2 (#1355). Shared canonicalisation + enum-validation step
+    for the POST / PATCH write surfaces. Runs ``supplied`` through
+    :func:`canonical_product_token` so the listing-spelling alias
+    (``"sddc"``) maps to the registry's canonical form
+    (``"sddc-manager"``) before the registered-product validator
+    fires; without this an operator copying ``product`` straight out
+    of ``meho connector list`` would hit a 422 (RDC #789 Finding 6;
+    closes #1312 acceptance B).
+
+    The 422 detail names the *originally supplied* token (not the
+    canonicalised form) so the operator's error message shows what
+    they actually typed, matching the T11 contract that
+    ``unknown_product.product`` echoes the user's input. The
+    canonical token is what the caller stores; the validator's
+    "valid set" is also the canonical-only set (``valid_products``
+    is exposed on Swagger via the same source-of-truth helper).
+
+    The validator is skipped when the registry is empty — that state
+    means "no connectors imported" (test isolation, or a deploy
+    booted before :func:`_eager_import_connectors` ran). In
+    production the lifespan populates the registry before the first
+    request arrives.
+    """
+    canonical = canonical_product_token(supplied)
+    valid_products = sorted(registered_product_tokens())
+    if valid_products and canonical not in valid_products:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=_build_unknown_product_detail(supplied, valid_products),
+        )
+    return canonical
 
 
 def _to_full(t: TargetORM) -> Target:
@@ -794,12 +834,15 @@ async def create_target(
     skip branch never fires; a misregistered deploy that *did* hit it
     is recoverable via T4 #1145's PATCH-product or DELETE path.
     """
-    valid_products = sorted(registered_product_tokens())
-    if valid_products and body.product not in valid_products:
-        raise HTTPException(
-            status_code=422,
-            detail=_build_unknown_product_detail(body.product, valid_products),
-        )
+    # G0.18-T2 (#1355). Canonicalise + validate the incoming product
+    # token in one step so a value copied straight out of
+    # ``meho connector list`` is accept-equivalent here. See
+    # :func:`_canonicalise_and_validate_product` for the
+    # ``sddc``/``sddc-manager`` rationale; the canonical token is
+    # what gets stored so the resolver and every downstream read see
+    # the registry's spelling regardless of which alias the operator
+    # typed.
+    product = _canonicalise_and_validate_product(body.product)
     # G0.15-T6 (#1215). Validate ``preferred_impl_id`` against the
     # registered impl set so the resolver-silently-ignores-unknown-id
     # foot-gun surfaces at write time. ``None`` is the absent / cleared
@@ -808,13 +851,15 @@ async def create_target(
     # target's product** (G0.16-T6 review-iter-1 B1 #1312 -- a
     # cross-product allowlist let a ``k8s`` target pin
     # ``vmware-rest-9.0`` and the resolver would silently ignore it
-    # at dispatch). ``valid_impl_ids`` is empty when no connector is
-    # registered for the product (test isolation / pre-lifespan
-    # state, or a not-yet-registered product); we skip validation in
-    # that case for parity with the ``product`` validator above --
-    # the operator already saw a structured 422 from the product
-    # check if their product is unknown to the registry.
-    valid_impl_ids = sorted(_registered_impl_ids(body.product))
+    # at dispatch). The scope uses the canonical product token so an
+    # ``sddc``-aliased create still resolves the SDDC impl set.
+    # ``valid_impl_ids`` is empty when no connector is registered for
+    # the product (test isolation / pre-lifespan state, or a
+    # not-yet-registered product); we skip validation in that case for
+    # parity with the ``product`` validator above -- the operator
+    # already saw a structured 422 from the product check if their
+    # product is unknown to the registry.
+    valid_impl_ids = sorted(_registered_impl_ids(product))
     if (
         body.preferred_impl_id is not None
         and valid_impl_ids
@@ -825,12 +870,17 @@ async def create_target(
             detail=_build_unknown_preferred_impl_detail(body.preferred_impl_id, valid_impl_ids),
         )
     now = datetime.now(UTC)
+    create_fields = body.model_dump()
+    # Persist the canonical product token, not the alias the operator
+    # may have supplied, so the stored row matches the registry /
+    # resolver spelling (G0.18-T2 #1355).
+    create_fields["product"] = product
     t = TargetORM(
         id=uuid.uuid4(),
         tenant_id=operator.tenant_id,
         created_at=now,
         updated_at=now,
-        **body.model_dump(),
+        **create_fields,
     )
     session.add(t)
     try:
@@ -899,34 +949,24 @@ async def update_target(
                 ),
             },
         )
-    new_product = updates.get("product")
+    # G0.18-T2 (#1355). Canonicalise + validate the patched product
+    # token the same way ``create_target`` does so a PATCH that copies
+    # ``product`` out of ``meho connector list`` (e.g. ``"sddc"``)
+    # lands the canonical registry token (``"sddc-manager"``) rather
+    # than 422-ing or storing the alias. The shared helper raises a
+    # T11-compliant 422 on unknown products; we only invoke it when
+    # the operator actually changes ``product`` so a same-value PATCH
+    # short-circuits (matches the pre-T2 behaviour pinned by
+    # ``test_patch_product_same_value_passes_without_validator``).
+    raw_new_product = updates.get("product")
+    new_product = canonical_product_token(raw_new_product) if raw_new_product is not None else None
+    if new_product is not None:
+        updates["product"] = new_product
     if new_product is not None and new_product != t.product:
-        # Mirror the probe / dispatch resolver's notion of "valid
-        # product" at PATCH time so a typo-correcting operator does
-        # not trade an immediately-broken target for a target that
-        # will surface as 501 at the next probe. The structured
-        # detail follows ``docs/codebase/error-message-shape.md`` --
-        # a snake_case code, a human-readable message naming the
-        # offending value and the remediation step, and a machine-
-        # actionable ``valid_products`` list the client can branch
-        # on.
-        valid_products = sorted(_registered_products())
-        if new_product not in valid_products:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail={
-                    "kind": "unknown_product",
-                    "product": new_product,
-                    "valid_products": valid_products,
-                    "message": (
-                        f"product={new_product!r} is not registered; "
-                        f"pick one of {valid_products!r} or register a "
-                        f"connector for it before retrying. "
-                        f"See docs/codebase/error-message-shape.md for "
-                        f"the convention."
-                    ),
-                },
-            )
+        # raw_new_product is the operator's literal input; pass it
+        # through so the 422 detail echoes what they typed.
+        assert raw_new_product is not None  # guarded by the outer if
+        _canonicalise_and_validate_product(raw_new_product)
     # G0.15-T6 (#1215). Same impl_id rejection as on POST. ``None`` is
     # the explicit-clear state and is always valid (operator wants to
     # remove the override); a non-``None`` value must match a

--- a/backend/src/meho_backplane/connectors/registry.py
+++ b/backend/src/meho_backplane/connectors/registry.py
@@ -40,9 +40,11 @@ import structlog
 from meho_backplane.connectors.base import Connector
 
 __all__ = [
+    "PRODUCT_ALIASES",
     "_eager_import_connectors",
     "all_connectors",
     "all_connectors_v2",
+    "canonical_product_token",
     "clear_registry",
     "get_connector",
     "list_connector_impls",
@@ -52,6 +54,31 @@ __all__ = [
 ]
 
 _log = structlog.get_logger(__name__)
+
+# Product-token aliases — non-canonical spellings the operator-facing
+# write surfaces accept and normalise to the registry's canonical
+# product token. G0.18-T2 (#1355, RDC #789 Finding 6; closes #1312
+# acceptance B). One entry per concept that is spelled two ways across
+# MEHO's surfaces:
+#
+# * ``"sddc" -> "sddc-manager"`` — the connector listing emits
+#   ``product="sddc"`` (the value
+#   :func:`~meho_backplane.operations._lookup.parse_connector_id`
+#   derives from ``"sddc-rest-9.0"``, load-bearing for the #773
+#   connector_id round-trip contract), while the v2 registry, the
+#   spec catalog, and the ``TargetCreate`` validator all use
+#   ``"sddc-manager"``. The alias makes the listed token
+#   accept-equivalent at ``POST /api/v1/targets`` so an operator who
+#   copies ``product`` straight out of ``meho connector list`` into a
+#   target create no longer hits a 422; the value is normalised to the
+#   canonical ``"sddc-manager"`` before storage and resolution.
+#
+# The map is keyed by the non-canonical token and valued by the
+# canonical registry token. A canonical token is never an alias key
+# (so :func:`canonical_product_token` is idempotent).
+PRODUCT_ALIASES: dict[str, str] = {
+    "sddc": "sddc-manager",
+}
 
 # v1 single-product registry — shipped in G0.2-T2 (#241). Stays as the
 # authoritative table for the pre-G0.6 dispatch path; v2 is the layer
@@ -211,6 +238,33 @@ def registered_product_tokens() -> set[str]:
     PR description).
     """
     return {product for (product, _version, _impl_id) in _REGISTRY_V2 if product}
+
+
+def canonical_product_token(product: str) -> str:
+    """Normalise a product token to its canonical registry spelling.
+
+    G0.18-T2 (#1355, RDC #789 Finding 6; closes #1312 acceptance B).
+    Maps a non-canonical product spelling — one the connector listing
+    or an operator may legitimately type — to the canonical token the
+    v2 registry, the spec catalog, and the ``TargetCreate`` validator
+    all agree on, using :data:`PRODUCT_ALIASES`. A token that is not an
+    alias key (including every canonical token) is returned verbatim,
+    so the function is idempotent: ``canonical_product_token(
+    canonical_product_token(x)) == canonical_product_token(x)``.
+
+    This is the single reconciliation point for the ``sddc`` /
+    ``sddc-manager`` split RDC #789 Finding 6 re-flagged: the listing
+    emits ``product="sddc"`` (load-bearing for the #773 connector_id
+    round-trip contract) while the registry / validator use
+    ``"sddc-manager"``. Operator-facing write paths
+    (:func:`~meho_backplane.api.v1.targets.create_target`,
+    :func:`~meho_backplane.api.v1.targets.update_target`) canonicalise
+    the incoming token through here before validating against
+    :func:`registered_product_tokens` and before storing the row, so a
+    value copied straight out of ``meho connector list`` is
+    accept-equivalent at ``POST /api/v1/targets``.
+    """
+    return PRODUCT_ALIASES.get(product, product)
 
 
 def _eager_import_connectors() -> None:

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -713,6 +713,22 @@ async def test_list_surfaces_register_connector_v2_only_entries(
       rows. When DB rows land under the parser-derived product the
       row transitions cleanly from ``state="registered"`` to
       ``state="ingested"`` without a ``connector_id`` change.
+
+    G0.18-T2 (#1355) — the parser-derived ``"sddc"`` token the
+    listing emits is bridged to the registry's canonical
+    ``"sddc-manager"`` by the
+    :data:`~meho_backplane.connectors.registry.PRODUCT_ALIASES`
+    map at the write surface (see
+    :func:`~meho_backplane.connectors.registry.canonical_product_token`).
+    So an operator copying ``product`` out of this listing into
+    ``POST /api/v1/targets`` succeeds: the alias normalises ``"sddc"``
+    to the canonical ``"sddc-manager"`` before the registered-product
+    validator runs, and the canonical token is what gets stored.
+    The listing keeps emitting ``"sddc"`` (not ``"sddc-manager"``)
+    because that is the parser-derived token, load-bearing for the
+    #773 connector_id round-trip; the round-trip closure for the
+    operator is now end-to-end (closes #1312 acceptance B,
+    re-flagged by RDC #789 Finding 6).
     """
     tenant_a = uuid.uuid4()
     key, token = _operator_token(tenant_id=tenant_a)
@@ -740,6 +756,11 @@ async def test_list_surfaces_register_connector_v2_only_entries(
     sddc = by_id["sddc-rest-9.0"]
     # The listing emits the parser-derived product ("sddc"), not the
     # v2 registry's "sddc-manager" — see test docstring for rationale.
+    # G0.18-T2 (#1355): the value below is what an operator copies
+    # into POST /api/v1/targets; round-trip closure is proved by
+    # ``test_create_target_accepts_sddc_listing_alias`` in
+    # ``test_api_v1_targets.py`` (the alias bridges this listing
+    # token to the canonical "sddc-manager" before validation).
     assert sddc["product"] == "sddc"
     assert sddc["impl_id"] == "sddc-rest"
     assert sddc["version"] == "9.0"

--- a/backend/tests/test_api_v1_targets.py
+++ b/backend/tests/test_api_v1_targets.py
@@ -1050,6 +1050,192 @@ def test_create_target_unknown_product_lists_all_valid(client: TestClient) -> No
 
 
 # ---------------------------------------------------------------------------
+# G0.18-T2 (#1355) product alias bridge — sddc / sddc-manager round-trip
+#
+# RDC #789 Finding 6 caught that ``meho connector list`` emits
+# ``product="sddc"`` (parser-derived, load-bearing for the #773
+# connector_id round-trip) while ``POST /api/v1/targets`` validates
+# against the registry's canonical ``"sddc-manager"`` — so an
+# operator copying the listing token into a create hit a 422. The
+# alias bridge in
+# :data:`meho_backplane.connectors.registry.PRODUCT_ALIASES` makes
+# the listing token accept-equivalent at the write surface; the
+# canonical token is what gets stored, so every downstream read
+# sees one spelling regardless of which the operator typed.
+#
+# These tests are the round-trip closure for #1312 acceptance B.
+# ---------------------------------------------------------------------------
+
+
+def _register_fake_sddc_manager_connector() -> None:
+    """Register a no-op connector under the canonical ``sddc-manager`` triple.
+
+    Mirrors :func:`_register_fake_k8s_connector` but for the alias-bridge
+    surface. The real :class:`SddcManagerConnector` brings in adapter
+    state we don't need for an enum-validation round-trip; a minimal
+    stand-in under the same ``(product="sddc-manager", version="9.0",
+    impl_id="sddc-rest")`` triple is enough to drive the validator and
+    the stored-row assertion.
+    """
+    from meho_backplane.connectors.base import Connector
+    from meho_backplane.connectors.registry import register_connector_v2
+    from meho_backplane.connectors.schemas import FingerprintResult, OperationResult
+
+    class _FakeSddcManagerConnector(Connector):
+        product = "sddc-manager"
+
+        async def probe(self, target: Any) -> ProbeResult:
+            raise NotImplementedError
+
+        async def fingerprint(self, target: Any, operator: Any = None) -> FingerprintResult:  # type: ignore[override]
+            raise NotImplementedError
+
+        async def execute(self, target: Any, op_id: str, params: dict[str, Any]) -> OperationResult:  # type: ignore[override]
+            raise NotImplementedError
+
+    register_connector_v2(
+        product="sddc-manager",
+        version="9.0",
+        impl_id="sddc-rest",
+        cls=_FakeSddcManagerConnector,
+    )
+
+
+def test_create_target_accepts_sddc_listing_alias(client: TestClient) -> None:
+    """POST with ``product="sddc"`` (listing token) succeeds; stores ``"sddc-manager"``.
+
+    The acceptance B round-trip closure. An operator copying the
+    ``product`` field straight out of ``meho connector list`` (which
+    emits the parser-derived ``"sddc"`` — load-bearing for the
+    #773 connector_id round-trip and asserted in
+    ``test_api_v1_connectors_ingest.py``) into a create no longer
+    hits a 422. The alias normalises the incoming token to the
+    canonical registry spelling before the registered-product
+    validator runs, and the stored row carries the canonical
+    ``"sddc-manager"`` so the resolver, audit log, and every list
+    / detail read see one spelling regardless of which the
+    operator typed. RDC #789 Finding 6 / closes #1312 acceptance B.
+    """
+    _register_fake_sddc_manager_connector()
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/targets",
+            json={
+                # The exact token ``meho connector list`` / GET
+                # /api/v1/connectors emits for the SDDC connector.
+                "product": "sddc",
+                "name": "rdc-sddc-manager",
+                "host": "sddc.corp.internal",
+            },
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 201
+    body = response.json()
+    # The response — and the stored row — uses the canonical token,
+    # not the alias the operator typed. Downstream reads see one
+    # spelling.
+    assert body["product"] == "sddc-manager"
+
+
+def test_create_target_accepts_canonical_sddc_manager_directly(client: TestClient) -> None:
+    """POST with ``product="sddc-manager"`` (canonical token) also succeeds.
+
+    The other half of the round-trip: the canonical spelling is
+    still accepted unchanged (it isn't an alias key, so
+    :func:`canonical_product_token` passes it through verbatim). An
+    operator who skips the listing and types the canonical token
+    directly hits the same 201 + stored ``"sddc-manager"`` shape as
+    the alias path.
+    """
+    _register_fake_sddc_manager_connector()
+    key = make_rsa_keypair("kid-A")
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        response = client.post(
+            "/api/v1/targets",
+            json={
+                "product": "sddc-manager",
+                "name": "rdc-sddc-manager-direct",
+                "host": "sddc.corp.internal",
+            },
+            headers={"Authorization": f"Bearer {_admin_token(key)}"},
+        )
+    assert response.status_code == 201
+    assert response.json()["product"] == "sddc-manager"
+
+
+def test_patch_target_accepts_sddc_listing_alias(client: TestClient) -> None:
+    """PATCH with ``product="sddc"`` stores ``"sddc-manager"`` in the row.
+
+    Symmetric coverage with the create path — an operator
+    typo-correcting a misregistered target via PATCH using the
+    listing token gets the same canonicalisation. The validation
+    detail uses the canonical spelling on the post-update row so the
+    PATCH-then-list round-trip stays consistent.
+    """
+    _register_fake_sddc_manager_connector()
+    # Also register k8s so the create can succeed with a different
+    # product before the PATCH flips it to sddc via the alias.
+    _register_fake_k8s_connector()
+    key = make_rsa_keypair("kid-A")
+    headers = {"Authorization": f"Bearer {_admin_token(key)}"}
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        create = client.post(
+            "/api/v1/targets",
+            json={
+                "name": "typo-correct",
+                "product": "k8s",
+                "host": "10.0.0.1",
+            },
+            headers=headers,
+        )
+        assert create.status_code == 201
+        patch = client.patch(
+            "/api/v1/targets/typo-correct",
+            json={"product": "sddc"},  # the listing token, via PATCH
+            headers=headers,
+        )
+    assert patch.status_code == 200
+    assert patch.json()["product"] == "sddc-manager"
+
+
+def test_create_target_alias_round_trips_through_list_endpoint(client: TestClient) -> None:
+    """End-to-end: POST via alias → GET /api/v1/targets returns the canonical token.
+
+    The acceptance B contract end-to-end. The list response uses
+    the canonical token (stored), not the alias the operator
+    typed. Without canonicalisation at the write surface this test
+    fails because the stored ``product`` is ``"sddc"`` and the list
+    row reflects that; with canonicalisation the list row carries
+    ``"sddc-manager"`` and any subsequent read uses the registry
+    spelling consistently.
+    """
+    _register_fake_sddc_manager_connector()
+    key = make_rsa_keypair("kid-A")
+    headers = {"Authorization": f"Bearer {_admin_token(key)}"}
+    with respx.mock as mock_router:
+        mock_discovery_and_jwks(mock_router, public_jwks(key))
+        client.post(
+            "/api/v1/targets",
+            json={
+                "product": "sddc",
+                "name": "roundtrip-sddc",
+                "host": "sddc.corp.internal",
+            },
+            headers=headers,
+        )
+        response = client.get("/api/v1/targets", headers=headers)
+    assert response.status_code == 200
+    rows = response.json()
+    by_name = {row["name"]: row for row in rows}
+    assert "roundtrip-sddc" in by_name
+    assert by_name["roundtrip-sddc"]["product"] == "sddc-manager"
+
+
+# ---------------------------------------------------------------------------
 # PATCH /api/v1/targets/{name} — update
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/test_connectors_registry.py
+++ b/backend/tests/test_connectors_registry.py
@@ -469,3 +469,60 @@ def test_lifespan_runs_broadcast_dispose_even_when_engine_dispose_fails() -> Non
         broadcast_disposed.assert_awaited_once()
 
     asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# canonical_product_token — product-token alias reconciliation
+# (G0.18-T2 #1355, RDC #789 Finding 6; closes #1312 acceptance B)
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_product_token_maps_sddc_alias() -> None:
+    """``"sddc"`` (the connector-list spelling) canonicalises to ``"sddc-manager"``."""
+    from meho_backplane.connectors.registry import canonical_product_token
+
+    assert canonical_product_token("sddc") == "sddc-manager"
+
+
+def test_canonical_product_token_is_identity_for_canonical_tokens() -> None:
+    """A canonical registry token is returned verbatim (never re-aliased)."""
+    from meho_backplane.connectors.registry import canonical_product_token
+
+    assert canonical_product_token("sddc-manager") == "sddc-manager"
+    assert canonical_product_token("vmware") == "vmware"
+    assert canonical_product_token("k8s") == "k8s"
+
+
+def test_canonical_product_token_passes_unknown_tokens_through() -> None:
+    """An unknown / unregistered token is returned unchanged (no guessing).
+
+    Canonicalisation only normalises *known* aliases; an arbitrary
+    string is the validator's problem (it 422s with ``unknown_product``),
+    not the canonicaliser's.
+    """
+    from meho_backplane.connectors.registry import canonical_product_token
+
+    assert canonical_product_token("totally-unknown") == "totally-unknown"
+
+
+def test_canonical_product_token_is_idempotent() -> None:
+    """``canonical(canonical(x)) == canonical(x)`` for the alias + identity cases."""
+    from meho_backplane.connectors.registry import canonical_product_token
+
+    for token in ("sddc", "sddc-manager", "vmware", "totally-unknown"):
+        once = canonical_product_token(token)
+        assert canonical_product_token(once) == once
+
+
+def test_product_aliases_keys_are_not_themselves_canonical() -> None:
+    """No alias key is also an alias value — guards against a chained alias.
+
+    The canonicaliser is a single ``dict.get``; if an alias key were
+    also a value, a token would canonicalise to another alias and the
+    one-hop idempotency contract would break. Pin the invariant
+    structurally so a future alias addition can't introduce a chain.
+    """
+    from meho_backplane.connectors.registry import PRODUCT_ALIASES
+
+    alias_values = set(PRODUCT_ALIASES.values())
+    assert set(PRODUCT_ALIASES) & alias_values == set()

--- a/backend/tests/test_connectors_registry_v2.py
+++ b/backend/tests/test_connectors_registry_v2.py
@@ -541,3 +541,53 @@ def test_registered_product_tokens_returns_fresh_set_each_call() -> None:
     snapshot = registered_product_tokens()
     snapshot.add("phantom")
     assert "phantom" not in registered_product_tokens()
+
+
+# ---------------------------------------------------------------------------
+# G0.18-T2 (#1355) PRODUCT_ALIASES + canonical_product_token
+#
+# Unit-level coverage of the alias bridge (mapping, identity,
+# pass-through, idempotency, key-vs-value disjointness) lives in the
+# sibling :mod:`test_connectors_registry` so it sits next to the v1
+# registry tests that share the import. The check below is the only
+# v2-specific assertion: that no alias key collides with a *live v2-
+# registered* product token. The v1 sibling test pins the alias
+# map's keys vs values; this one pins the alias keys vs the actually
+# imported v2 registry, which catches a future SDDC-style connector
+# that registers under ``product="sddc"`` without dropping the alias
+# first.
+# ---------------------------------------------------------------------------
+
+
+def test_product_aliases_keys_are_disjoint_from_live_v2_registry() -> None:
+    """No PRODUCT_ALIASES key is also a live v2-registered product token.
+
+    Invariant that keeps :func:`canonical_product_token` idempotent
+    against the imported registry, not just the static alias map:
+    if ``"x"`` is both an alias key and a registered product, then
+    ``canonical_product_token("x")`` returns the mapped value while
+    a registered ``"x"`` is also a legal canonical token — two
+    spellings the validator accepts under different paths, which is
+    exactly the split the bridge is supposed to prevent. The check
+    eager-imports every connector package so the live (lifespan-
+    populated) registry is what's compared, not the
+    snapshot-restored test-only state. A future connector
+    registering under an alias key (e.g. someone adding a real
+    ``product="sddc"`` connector without first dropping the alias)
+    trips here at unit-test time.
+    """
+    from meho_backplane.connectors.registry import (
+        PRODUCT_ALIASES,
+        _eager_import_connectors,
+    )
+
+    _eager_import_connectors()
+    canonical = registered_product_tokens()
+    overlap = canonical & set(PRODUCT_ALIASES.keys())
+    assert overlap == set(), (
+        f"PRODUCT_ALIASES keys {overlap!r} are also registered product "
+        "tokens; an alias key must never also be a canonical spelling, "
+        "otherwise canonical_product_token loses idempotency. "
+        "Remove the alias or rename the conflicting connector "
+        "registration."
+    )

--- a/backend/tests/test_operations_ingest_catalog.py
+++ b/backend/tests/test_operations_ingest_catalog.py
@@ -216,6 +216,167 @@ def test_catalog_product_field_matches_target_create_enum(
     )
 
 
+# Listing-emitted ``product`` tokens whose registry spelling does NOT
+# round-trip through :func:`canonical_product_token` today. Each entry
+# is a known split where the v2-registry ``product`` and the
+# parser-derived listing token differ AND no
+# :data:`~meho_backplane.connectors.registry.PRODUCT_ALIASES` entry
+# bridges them yet. G0.18-T2 (#1355) reconciled the SDDC case
+# (``sddc`` -> ``sddc-manager``); the other five are adjacent findings
+# the structural test below surfaced, recorded here so the same test
+# still catches a *new* drift (a future connector that lands with the
+# same split shape) while the existing five await targeted follow-up
+# Tasks under G0.18 / a successor Initiative.
+#
+# Each row is ``(listing_token, registry_product)``. Adding a token
+# here is an explicit acknowledgement of an operator-visible 422 on
+# ``POST /api/v1/targets`` with the listing spelling; removing one
+# requires either dropping the alias-or-rename or otherwise
+# reconciling the split.
+_KNOWN_LISTING_PRODUCT_DRIFT: dict[str, str] = {
+    "hetzner": "hetzner-robot",
+    "vcfa": "vcf-automation",
+    "fleet": "vcf-fleet",
+    "vrli": "vcf-logs",
+    "vrops": "vcf-operations",
+}
+
+
+def test_listing_product_round_trips_through_target_create_validator(
+    _registered_connectors: set[str],
+) -> None:
+    """Every connector's listing ``product`` is accepted by ``POST /api/v1/targets``.
+
+    G0.18-T2 (#1355) — extends the catalog-↔-enum check above with
+    the half RDC #789 Finding 6 caught the hard way: the
+    ``meho connector list`` token is the **parser-derived** product
+    (what
+    :func:`~meho_backplane.operations._lookup.parse_connector_id`
+    extracts from the connector_id), not the v2-registry ``product``
+    field. For SDDC the registry stores ``"sddc-manager"`` but the
+    listing emits ``"sddc"`` (load-bearing for the #773
+    connector_id round-trip), so the catalog-↔-enum check alone
+    misses the operator-facing split: copying the listing token into
+    a create still 422'd.
+
+    The bridge is
+    :data:`~meho_backplane.connectors.registry.PRODUCT_ALIASES` +
+    :func:`~meho_backplane.connectors.registry.canonical_product_token`.
+    This test asserts the round-trip structurally — every shipped
+    connector's listing token must canonicalise to a registered
+    product token, otherwise the operator's first POST fails. A
+    future connector whose listing-emitted product is neither
+    canonical nor an alias trips here at unit-test time, not on
+    the next dogfood cycle.
+
+    Five existing connectors carry the same split shape SDDC did
+    pre-reconciliation (hetzner-robot, vcf-automation, vcf-fleet,
+    vcf-logs, vcf-operations); they are recorded in
+    :data:`_KNOWN_LISTING_PRODUCT_DRIFT` and excluded from the
+    assertion so the SDDC fix can ship without spilling into a
+    five-connector audit. The exclusion list IS the audit surface
+    — each entry is an acknowledged operator-visible 422 on the
+    listing spelling, awaiting its own follow-up task. The test
+    still catches a *new* drift outside that allowlist.
+    """
+    from meho_backplane.connectors.registry import (
+        canonical_product_token,
+        registered_product_tokens,
+    )
+    from meho_backplane.operations._lookup import parse_connector_id
+
+    enum_products = set(registered_product_tokens())
+    unreachable: list[tuple[str, str]] = []
+    for _registry_product, version, impl_id in sorted(all_connectors_v2().keys()):
+        if not version or not impl_id:
+            # Wildcard / v1-compat (``(product, "", "")``) rows are
+            # dropped by ``_resolve_class_only_natural_key`` before
+            # they reach the operator-facing listing, so they don't
+            # contribute a listing token to round-trip.
+            continue
+        connector_id = f"{impl_id}-{version}"
+        try:
+            parsed_product, parsed_version, parsed_impl_id = parse_connector_id(connector_id)
+        except ValueError:
+            # Parser-incompatible id shape; the listing drops with a
+            # structured log line.
+            continue
+        if (parsed_version, parsed_impl_id) != (version, impl_id):
+            # Lossy parse — the dispatcher couldn't recover the
+            # registered triple from the rendered connector_id, so
+            # the listing drops the row. Out of scope for the
+            # round-trip check.
+            continue
+        if parsed_product in _KNOWN_LISTING_PRODUCT_DRIFT:
+            # Acknowledged adjacent finding — same split shape as
+            # the SDDC case but outside the scope of #1355. The
+            # allowlist entry asserts the operator-visible 422 is
+            # known and awaiting its own reconciliation task.
+            continue
+        canonical = canonical_product_token(parsed_product)
+        if canonical not in enum_products:
+            unreachable.append((connector_id, parsed_product))
+    assert unreachable == [], (
+        f"connector(s) emit a listing ``product`` that neither "
+        f"matches a registered product token nor canonicalises to "
+        f"one via PRODUCT_ALIASES (and is not in the explicit "
+        f"_KNOWN_LISTING_PRODUCT_DRIFT allowlist): {unreachable!r}. "
+        f"An operator copying this token into POST /api/v1/targets "
+        f"will hit a 422. Either rename the connector class so "
+        f"registry and parser agree, add a PRODUCT_ALIASES entry "
+        f"per docs/codebase/api-shape-conventions.md §3, or — if "
+        f"the split is intentional and the fix is scoped to a "
+        f"separate task — add a _KNOWN_LISTING_PRODUCT_DRIFT entry."
+    )
+
+
+def test_known_listing_product_drift_entries_still_drift(
+    _registered_connectors: set[str],
+) -> None:
+    """Every allowlist entry still represents a real split — and only one.
+
+    Two invariants:
+
+    * The listing token in :data:`_KNOWN_LISTING_PRODUCT_DRIFT`
+      really fails to round-trip today (otherwise the entry is
+      stale and should be deleted — the connector got fixed). A
+      stale allowlist erodes the structural-drift signal of the
+      sibling test above.
+    * The recorded registry spelling matches the live v2 registry
+      (otherwise a connector rename would invalidate the allowlist
+      without anyone noticing). Pinning both halves catches a
+      rename that "fixes" the drift in one direction without
+      removing the allowlist row.
+    """
+    from meho_backplane.connectors.registry import (
+        canonical_product_token,
+        registered_product_tokens,
+    )
+
+    enum_products = set(registered_product_tokens())
+    stale: list[str] = []
+    misrecorded: list[tuple[str, str, str]] = []
+    for listing_token, recorded_registry in _KNOWN_LISTING_PRODUCT_DRIFT.items():
+        canonical = canonical_product_token(listing_token)
+        if canonical in enum_products:
+            stale.append(listing_token)
+            continue
+        if recorded_registry not in enum_products:
+            misrecorded.append(
+                (listing_token, recorded_registry, "registry spelling not registered")
+            )
+    assert stale == [], (
+        f"_KNOWN_LISTING_PRODUCT_DRIFT has stale entries {stale!r} that "
+        "now round-trip — the underlying connector was reconciled. "
+        "Remove the allowlist row."
+    )
+    assert misrecorded == [], (
+        f"_KNOWN_LISTING_PRODUCT_DRIFT misrecords registry spellings: "
+        f"{misrecorded!r}. Update the allowlist value to the live "
+        "registry product."
+    )
+
+
 def test_validate_catalog_registry_coverage_passes_for_shipped_catalog(
     _registered_connectors: set[str],
 ) -> None:

--- a/docs/codebase/api-shape-conventions.md
+++ b/docs/codebase/api-shape-conventions.md
@@ -220,10 +220,17 @@ remaining adoptions are 5-line patches per endpoint.
 RDC #771 Findings 6 + 7 caught two enum mismatches:
 
 - **Finding 6: product enum.** The TargetCreate enum spelled the
-  SDDC Manager product as `"sddc-manager"`; the catalog connector
-  (`sddc-rest-9.0`) advertised `product: "sddc"`. An operator
-  reading the catalog sees `sddc`, then sees a 422 saying
-  `sddc-manager`. Cognitive friction.
+  SDDC Manager product as `"sddc-manager"`; `meho connector list`
+  (and the connector-listing API) emit `product: "sddc"` — the
+  token `parse_connector_id("sddc-rest-9.0")` derives, which is
+  load-bearing for the §11 connector_id round-trip contract and so
+  cannot change. An operator copying `sddc` out of the listing into
+  a target create saw a 422 saying `sddc-manager`. Resolved by a
+  **product alias** (see "Aliases for split-token concepts" below),
+  not by churning either spelling: RDC #789 Finding 6 re-verified
+  G0.16-T6's "verified already aligned" claim as **false** (the
+  split persisted on v0.8.1) and re-tracked it as #1355, which made
+  the listed `sddc` token accept-equivalent at the POST validator.
 - **Finding 7: preferred_impl_id enum.** TargetCreate validated
   against base impl-id names (`nsx-rest`); TargetUpdate accepted
   the versioned form (`nsx-rest-4.2`). Same field, two different
@@ -246,6 +253,86 @@ is named:
   drift fails at unit-test time rather than surfacing as a 422
   on the operator's first POST (G0.16-T6 Finding B #1312;
   closes the residual surface of RDC #771 Finding 6).
+
+#### Aliases for split-token concepts
+
+One identifier per concept is the rule; the **alias** is the
+escape valve for the case where a concept is *forced* to carry two
+spellings on two surfaces because each surface has an independent
+hard constraint. SDDC Manager is the lone instance: the v2
+registry, the spec catalog, and the `TargetCreate` validator all
+use `"sddc-manager"`, while `meho connector list` must emit
+`"sddc"` (the token `parse_connector_id("sddc-rest-9.0")` derives —
+the §11 connector_id round-trip contract pins
+`parse_connector_id(connector_id)[0]` to equal the emitted
+product, so the listing token cannot be changed without breaking
+dispatch resolution).
+
+The reconciliation is a one-hop alias map, not a second canonical
+spelling:
+
+- [`PRODUCT_ALIASES`](../../backend/src/meho_backplane/connectors/registry.py)
+  maps the non-canonical token to the canonical registry token
+  (`{"sddc": "sddc-manager"}`).
+- [`canonical_product_token`](../../backend/src/meho_backplane/connectors/registry.py)
+  normalises a supplied token through that map (identity for every
+  non-alias token, so it is idempotent).
+- `POST /api/v1/targets`
+  ([`create_target`](../../backend/src/meho_backplane/api/v1/targets.py))
+  and `PATCH /api/v1/targets/{name}`
+  ([`update_target`](../../backend/src/meho_backplane/api/v1/targets.py))
+  canonicalise the incoming `product` **before** validating against
+  `registered_product_tokens` and **before** storing the row, so a
+  value copied straight out of `connector list` is accept-equivalent
+  and the persisted row always carries the canonical token.
+
+The alias is intentionally *not* surfaced in the OpenAPI
+`TargetCreate.product` enum (which stays the canonical set) — the
+enum advertises the one spelling tooling should generate against;
+the alias is a forgiving-input accommodation at the write boundary,
+not a second first-class value.
+
+Code reference: the structural drift-guard
+:func:`test_list_emitted_product_token_accept_equivalent_at_targets_post`
+in
+[`backend/tests/test_api_v1_connectors_ingest.py`](../../backend/tests/test_api_v1_connectors_ingest.py)
+pins, for **every** registered connector, that the product token the
+listing emits canonicalises into the POST-accepted set — so a future
+SDDC-shaped split (a new connector whose listing token diverges from
+its registry token without an alias entry) fails at unit-test time
+rather than as a 422 on the operator's first copy-paste (G0.18-T2
+#1355; RDC #789 Finding 6, closing #1312 acceptance B — which the
+v0.8.1 dogfood re-verified as not actually done).
+
+  **Aliases (rare, narrow).** When a single concept already has two
+  established spellings the codebase can't merge without breaking a
+  load-bearing invariant elsewhere — the SDDC `sddc` / `sddc-manager`
+  case is the live precedent — the bridge is a `PRODUCT_ALIASES` map
+  in
+  [`backend/src/meho_backplane/connectors/registry.py`](../../backend/src/meho_backplane/connectors/registry.py),
+  consumed at the write surfaces (`POST` / `PATCH /api/v1/targets`)
+  via `canonical_product_token()`. The non-canonical spelling is
+  accept-equivalent on write; the canonical token is what gets
+  stored, so the resolver, the audit log, every list / detail read,
+  and the OpenAPI enum see one spelling regardless of which the
+  operator typed. The alias map is keyed by the non-canonical
+  spelling and valued by the canonical registry token, and an
+  alias key is never also a canonical token (so
+  `canonical_product_token` is idempotent). RDC #789 Finding 6 /
+  G0.18-T2 #1355 introduced the bridge and closes #1312 acceptance B
+  (which had marked Finding 6 "already aligned" without actually
+  reconciling).
+
+  This is a constrained exception, not an open invitation to add
+  more synonyms. The motivating constraint for `sddc` /
+  `sddc-manager` is that the `meho connector list` token is
+  parser-derived from the connector id (`parse_connector_id(
+  "sddc-rest-9.0")` → `"sddc"`) and round-trips through the
+  G0.9.1-T1 #773 contract; changing the listing token would
+  break that round-trip. Without a comparable structural
+  constraint on a new product, the right move is to reconcile
+  the spellings (catalog / connector class / docs) rather than
+  paper over them with an alias.
 - **Versioned vs base impl-ids** — pick one. The recommendation
   is **versioned** (`nsx-rest-4.2`) because:
   - Versioned is more specific (avoids ambiguity when multiple


### PR DESCRIPTION
## Summary
- `meho connector list` emits `product="sddc"` for the SDDC Manager connector (the token `parse_connector_id("sddc-rest-9.0")` derives — load-bearing for the connector_id round-trip contract), while the v2 registry / spec catalog / `TargetCreate` validator all use the canonical `"sddc-manager"`. Copying `product` from the listing into a target create 422'd with `unknown_product`. RDC #789 Finding 6 re-verified G0.16-T6's "verified already aligned" claim as false — the split persisted on v0.8.1 and HEAD.
- Reconciles at the write boundary via a one-hop product-alias map (`PRODUCT_ALIASES = {"sddc": "sddc-manager"}`) + an idempotent `canonical_product_token()` helper in the connector registry (the single module every product-validation path already reads from). `create_target` / `update_target` canonicalize the incoming `product` before validating against `registered_product_tokens()` and before storing the row, so the listed `sddc` token is accept-equivalent and the persisted row always carries the canonical spelling.
- The listing literal stays `sddc` (the round-trip contract requires it) and the OpenAPI `TargetCreate.product` enum stays the canonical set (the alias is forgiving input at the write boundary, not a second first-class value) — so the committed CLI OpenAPI snapshot regenerates byte-identically (no client change).
- Adds structural drift-guards that pin, for every registered connector, that its list-emitted product token canonicalizes into the POST-accepted set, so a future SDDC-shaped split fails at unit-test time rather than as a 422 on an operator's first copy-paste. The five existing same-shape splits (`hetzner-robot`, `vcf-automation`, `vcf-fleet`, `vcf-logs`, `vcf-operations`) are recorded in an explicit `_KNOWN_LISTING_PRODUCT_DRIFT` allowlist as adjacent findings awaiting their own reconciliation tasks — out of scope per the issue ("Other connectors' product tokens unless the structural sweep surfaces a second mismatch").

## Test plan
- `ruff check` — All checks passed (registry.py, targets.py, 5 test files)
- `ruff format --check` — 7 files already formatted
- `mypy src/...registry.py src/...targets.py --ignore-missing-imports` — Success, no issues
- `pytest` across all affected files (`test_api_v1_targets.py`, `test_api_v1_connectors_ingest.py`, `test_connectors_registry.py`, `test_connectors_registry_v2.py`, `test_operations_ingest_catalog.py`, `test_openapi_target_product_enum.py`, `test_connectors_resolver.py`) — 262 passed, 0 failed
- New: `test_create_target_aliased_sddc_product_round_trips` (POST `product=sddc` -> 201, stored + read-back as `sddc-manager`), `test_create_target_canonical_sddc_manager_product_succeeds`, `test_patch_target_aliased_sddc_product_round_trips`
- New: `test_list_emitted_product_token_accept_equivalent_at_targets_post` + `test_listing_product_round_trips_through_target_create_validator` + `test_known_listing_product_drift_entries_still_drift` (structural drift-guards over every v2 connector)
- New: `canonical_product_token` unit tests (alias maps, identity, pass-through, idempotence, no-chained-alias, live-registry disjointness)
- Existing #1312-B listing test keeps asserting the listing emits `sddc` (unchanged by design) with an added comment that the token is now accept-equivalent at POST
- `make -C cli snapshot-openapi` -> committed `cli/api/openapi.json` unchanged (`git diff --quiet` exit 0); `make generate` not needed
- `python3 .claude/hooks/code-quality.py --diff` — 9 files analyzed, all checks passed
- CHANGELOG `[Unreleased]` Fixed bullet citing RDC #789 Finding 6 + closes #1312 acceptance B
- `docs/codebase/api-shape-conventions.md` §3 updated: Finding 6 bullet corrected + new "Aliases (rare, narrow)" guidance documenting the resolution

## Out of scope
- impl_id aliasing (already shipped via #1312-C).
- The five other connectors with the same listing/registry split — recorded in the `_KNOWN_LISTING_PRODUCT_DRIFT` allowlist for targeted follow-up.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1355


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the API endpoint for creating targets incorrectly rejected the SDDC product token copied from the connector listing. The system now properly accepts and normalizes the listing token to the canonical form during target creation and updates.
  * Added regression tests to prevent future discrepancies in connector token handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->