### PR TITLE
fix(broadcast): G0.18-T1 split fast + blocking Valkey clients so XREAD out-waits its block window (#1354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,26 @@ connector-related release-notes line.
   every shipped connector so a future drift fails CI rather than
   surfacing on the next dogfood cycle. RDC #789 Finding 6.
 
+- **Fresh SSE broadcast-feed connections no longer die at ~5 s with a
+  spurious `feed_error` frame (G0.18-T1 #1354, RDC #789 N1).** The
+  single process-wide broadcast client pinned `socket_timeout=5.0`
+  for the fail-fast readiness probe, but redis-py 7.4 resolves
+  `xread`'s read-timeout from `socket_timeout` when no per-call
+  override is supplied — so every `XREAD BLOCK 30000` against a
+  quiet stream raised `redis.TimeoutError` at ~5 s and the SSE
+  generator yielded a `broadcast_subsystem_unavailable` frame. The
+  fix splits the substrate into two cached clients: `get_broadcast_client()`
+  (`socket_timeout=5 s`, for the readiness `PING` / publish hot path
+  / SSE backlog prelude) and `get_broadcast_blocking_client()`
+  (`socket_timeout=35 s` = 30 s BLOCK + 5 s buffer, for every
+  blocking-XREAD caller — SSE feed, UI SSE bridge,
+  `meho.broadcast.watch` MCP tool, agent approval-wait loop). A
+  quiet BLOCK now returns `None` (the natural keepalive) and the
+  generator emits a heartbeat; only genuine transport failures past
+  the 35 s window still raise the T11 error frame. The readiness
+  probe's 5 s SLO is explicitly preserved.
 
+## [0.8.1] - 2026-05-29
 
 ### Added
 

--- a/backend/src/meho_backplane/agent/approval_wait.py
+++ b/backend/src/meho_backplane/agent/approval_wait.py
@@ -84,7 +84,7 @@ from typing import TYPE_CHECKING, Any, Final, Literal, cast
 import structlog
 from redis.exceptions import RedisError
 
-from meho_backplane.broadcast.client import get_broadcast_client
+from meho_backplane.broadcast.client import get_broadcast_blocking_client
 
 if TYPE_CHECKING:
     from meho_backplane.auth.operator import Operator
@@ -321,7 +321,13 @@ async def wait_for_approval_decision(
         agent's cooperative-cancellation tree.
     """
     deadline = time.monotonic() + timeout_seconds
-    client = get_broadcast_client()
+    # Long-poll client; per-iteration BLOCK is _BLOCK_WINDOW_MS (5 s). The
+    # fast client's 5 s socket_timeout races the BLOCK exit (either could
+    # win at the boundary), producing spurious redis.TimeoutError raises
+    # that the loop has to absorb into a back-off; the blocking client's
+    # 35 s socket_timeout removes the race so a quiet stream returns
+    # cleanly from XREAD with no entries. RDC #789 N1 / Initiative #1353.
+    client = get_broadcast_blocking_client()
     stream_key = _stream_key(tenant_id)
     target_request_id = str(approval_request_id)
     # ``"$"`` is the Valkey "tail from the moment of this call" cursor. The

--- a/backend/src/meho_backplane/api/v1/feed.py
+++ b/backend/src/meho_backplane/api/v1/feed.py
@@ -156,7 +156,11 @@ from redis.exceptions import RedisError
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
-from meho_backplane.broadcast import BroadcastEvent, get_broadcast_client
+from meho_backplane.broadcast import (
+    BroadcastEvent,
+    get_broadcast_blocking_client,
+    get_broadcast_client,
+)
 
 __all__ = ["router"]
 
@@ -674,57 +678,46 @@ async def _feed_generator(
 ) -> AsyncIterator[str]:
     """SSE generator: prelude → BLOCK on XREAD, delegate parsing, heartbeat-on-silence.
 
-    Backlog prelude — when *cursor* is ``$`` (the live-tail default
-    selected by :func:`_resolve_cursor` when neither ``Last-Event-Id``
-    nor ``since`` is provided), the generator first calls
-    :func:`_emit_backlog_prelude` to replay the most recent
-    :data:`_BACKLOG_PRELUDE_COUNT` entries on the stream. This solves
-    the consumer-visible bug surfaced by ``claude-rdc-hetzner-dc#771``
-    Finding 14 (G0.16-T3, #1305): a fresh
-    ``GET /api/v1/feed`` against a tenant with existing entries but
-    no new writes during the test window otherwise returns zero bytes
-    for ``_HEARTBEAT_INTERVAL_SECONDS`` (``$`` skips backlog AND the
-    heartbeat cadence is 30 s), tripping curl / EventSource
-    intermediary timeouts before any byte is observed. The prelude
-    also gives the ``/ui/broadcast`` page a populated initial render
-    instead of a misleading empty list under a "Live activity" header.
-    Subscribers that pass an explicit replay cursor
-    (``Last-Event-Id`` or ``since``) skip the prelude — those cursors
-    are "resume exactly here" anchors and the caller already saw the
-    history.
+    See :func:`_run_prelude_and_advance_cursor` for the backlog-prelude
+    contract (cursor ``$`` only; RDC #771 Finding 14 / #1305 repro;
+    cursor advance past every prelude entry).
 
     Heartbeat semantics — ``last_heartbeat`` tracks the wall-clock of
     the **last outbound yield** (event frame or heartbeat), NOT the
     last inbound XREAD result. A noisy tenant where every event is
     filtered out for this subscriber still produces zero outbound
-    bytes; without this guarantee the connection would idle-timeout
-    at the nginx / ALB / CloudFront layer. The "all entries filtered
-    out" path therefore emits an inline heartbeat when the idle
-    window has elapsed — both quiet and busy-but-filtered tenants
-    keep the connection alive.
+    bytes; the "all entries filtered out" path emits an inline
+    heartbeat when the idle window has elapsed so both quiet and
+    busy-but-filtered tenants keep the connection alive against
+    nginx / ALB / CloudFront idle-timeout caps.
 
     On client disconnect Starlette raises
-    :class:`asyncio.CancelledError` into the pending ``xread`` await;
-    the handler logs and re-raises per the asyncio cancellation
-    contract (Sonar S7497 — swallowing CancelledError breaks the task
-    tree's unwind invariants and Python 3.13+ asyncio internals re-
-    issue cancellation when it goes unpropagated). The audit row at
-    session end still records a clean 200 close because
-    ``http.response.start`` was sent on the first yield (before any
-    cancellation point), so AuditMiddleware's buffered status_code
-    is already locked at 200.
+    :class:`asyncio.CancelledError`; the handler logs and re-raises
+    per the asyncio cancellation contract (Sonar S7497). The audit
+    row at session end still records a clean 200 close because
+    ``http.response.start`` was sent on the first yield.
 
     On :class:`redis.exceptions.RedisError` (connection refused,
-    transport timeout, unexpected response) the generator emits one
+    transport failure, unexpected response) the generator emits one
     T11-compliant ``event: feed_error`` frame and breaks. The
     empty-stream case (Valkey reachable, no entries yet) is NOT a
     failure: redis-py returns ``None`` from XREAD and the
     :func:`_consume_xread_batch` helper falls through to the heartbeat
-    path. The failure handled here is the genuinely-broken case
-    (broadcast pod down, network partition) — signal 10 of
-    ``claude-rdc-hetzner-dc#697``.
+    path.
+
+    Two clients, two contracts. The backlog prelude reads via the
+    short-timeout fast client (:func:`get_broadcast_client`,
+    ``socket_timeout=5 s``); the BLOCK loop reads via the long-timeout
+    blocking client (:func:`get_broadcast_blocking_client`,
+    ``socket_timeout=35 s``) so a 30 s ``XREAD BLOCK`` against a
+    quiet stream returns ``None`` (the natural keepalive path) instead
+    of raising ``redis.TimeoutError`` at the socket layer at 5 s —
+    the spurious ``feed_error`` frame catalogued in RDC #789 N1 /
+    Initiative #1353. See :mod:`meho_backplane.broadcast.client` for
+    the two-client rationale.
     """
-    client = get_broadcast_client()
+    fast_client = get_broadcast_client()
+    blocking_client = get_broadcast_blocking_client()
     stream_key = _stream_key(operator)
     last_heartbeat = time.monotonic()
 
@@ -738,7 +731,7 @@ async def _feed_generator(
         if cursor == _LIVE_TAIL_CURSOR:
             try:
                 prelude_frames, prelude_last_id = await _emit_backlog_prelude(
-                    client,
+                    fast_client,
                     stream_key=stream_key,
                     op_class=op_class,
                     principal=principal,
@@ -771,7 +764,7 @@ async def _feed_generator(
                 last_heartbeat = time.monotonic()
         while True:
             try:
-                entries = await client.xread(
+                entries = await blocking_client.xread(
                     {stream_key: cursor},
                     block=_XREAD_BLOCK_MS,
                     count=_XREAD_COUNT,

--- a/backend/src/meho_backplane/api/v1/feed.py
+++ b/backend/src/meho_backplane/api/v1/feed.py
@@ -669,6 +669,69 @@ async def _emit_backlog_prelude(
     return frames, last_entry_id
 
 
+async def _run_prelude_and_advance_cursor(
+    fast_client: object,
+    *,
+    operator: Operator,
+    stream_key: str,
+    cursor: str,
+    op_class: str | None,
+    principal: str | None,
+    target: str | None,
+) -> tuple[list[str], str, str | None]:
+    """Run the backlog prelude; return ``(frames, new_cursor, error_frame_or_None)``.
+
+    The prelude is gated on ``cursor == _LIVE_TAIL_CURSOR`` —
+    ``Last-Event-Id`` / ``since`` are explicit "resume here" anchors and
+    replaying from ``+`` would re-deliver entries the caller already saw
+    (the consumer-side repro for that path lives in
+    ``claude-rdc-hetzner-dc#771`` Finding 14 / #1305).
+
+    Returns:
+        * ``frames`` — prelude SSE frames to yield (empty when the cursor
+          is not ``$`` or the stream is empty).
+        * ``new_cursor`` — the cursor the BLOCK loop should read from.
+          Advanced to the most recent prelude entry id (NOT the last
+          matched one) so a busy-but-filtered tenant doesn't re-read the
+          same batch in the first BLOCK iteration. Left untouched when no
+          entries were fetched.
+        * ``error_frame_or_None`` — when the prelude XREVRANGE raises a
+          :class:`redis.exceptions.RedisError`, the formatted T11
+          ``event: feed_error`` frame; the caller yields it and returns.
+          Same operator-visible condition as the live-loop's first
+          ``xread`` failure (broadcast pod down on a fresh deploy).
+          ``None`` on the happy path.
+
+    Extracted out of :func:`_feed_generator` so the parent function stays
+    under the code-quality function-size + cyclomatic ceilings; the
+    UI bridge's :func:`_ui_feed_generator` shares the same prelude
+    shape and could adopt this helper too (kept independent for now
+    because the bridge does not emit T11 error frames — distinct
+    contract at the UI surface).
+    """
+    if cursor != _LIVE_TAIL_CURSOR:
+        return [], cursor, None
+    try:
+        prelude_frames, prelude_last_id = await _emit_backlog_prelude(
+            fast_client,
+            stream_key=stream_key,
+            op_class=op_class,
+            principal=principal,
+            target=target,
+        )
+    except RedisError as exc:
+        # Same operator-visible condition as the live-loop's first XREAD
+        # failure. Hand the formatted error frame back to the caller so
+        # the parent generator's yield/return is a single arm.
+        return (
+            [],
+            cursor,
+            _log_and_format_broadcast_unavailable(operator, stream_key, exc),
+        )
+    new_cursor = cursor if prelude_last_id is None else prelude_last_id
+    return prelude_frames, new_cursor, None
+
+
 async def _feed_generator(
     operator: Operator,
     cursor: str,
@@ -679,42 +742,22 @@ async def _feed_generator(
     """SSE generator: prelude → BLOCK on XREAD, delegate parsing, heartbeat-on-silence.
 
     See :func:`_run_prelude_and_advance_cursor` for the backlog-prelude
-    contract (cursor ``$`` only; RDC #771 Finding 14 / #1305 repro;
-    cursor advance past every prelude entry).
+    contract (cursor ``$`` only; RDC #771 Finding 14 / #1305 repro).
+    ``last_heartbeat`` tracks the wall-clock of the last *outbound*
+    yield so busy-but-filtered tenants still emit keepalives.
 
-    Heartbeat semantics — ``last_heartbeat`` tracks the wall-clock of
-    the **last outbound yield** (event frame or heartbeat), NOT the
-    last inbound XREAD result. A noisy tenant where every event is
-    filtered out for this subscriber still produces zero outbound
-    bytes; the "all entries filtered out" path emits an inline
-    heartbeat when the idle window has elapsed so both quiet and
-    busy-but-filtered tenants keep the connection alive against
-    nginx / ALB / CloudFront idle-timeout caps.
+    On client disconnect: re-raise per the asyncio cancellation
+    contract (Sonar S7497). On :class:`redis.exceptions.RedisError`:
+    one T11 ``feed_error`` frame + break. ``None`` from ``xread``
+    (BLOCK expired naturally) falls through to the heartbeat path.
 
-    On client disconnect Starlette raises
-    :class:`asyncio.CancelledError`; the handler logs and re-raises
-    per the asyncio cancellation contract (Sonar S7497). The audit
-    row at session end still records a clean 200 close because
-    ``http.response.start`` was sent on the first yield.
-
-    On :class:`redis.exceptions.RedisError` (connection refused,
-    transport failure, unexpected response) the generator emits one
-    T11-compliant ``event: feed_error`` frame and breaks. The
-    empty-stream case (Valkey reachable, no entries yet) is NOT a
-    failure: redis-py returns ``None`` from XREAD and the
-    :func:`_consume_xread_batch` helper falls through to the heartbeat
-    path.
-
-    Two clients, two contracts. The backlog prelude reads via the
-    short-timeout fast client (:func:`get_broadcast_client`,
-    ``socket_timeout=5 s``); the BLOCK loop reads via the long-timeout
-    blocking client (:func:`get_broadcast_blocking_client`,
-    ``socket_timeout=35 s``) so a 30 s ``XREAD BLOCK`` against a
+    Two clients, two contracts: backlog prelude via the fast client
+    (5 s ``socket_timeout``); BLOCK loop via the blocking client
+    (35 s ``socket_timeout``) so a 30 s ``XREAD BLOCK`` against a
     quiet stream returns ``None`` (the natural keepalive path) instead
     of raising ``redis.TimeoutError`` at the socket layer at 5 s —
-    the spurious ``feed_error`` frame catalogued in RDC #789 N1 /
-    Initiative #1353. See :mod:`meho_backplane.broadcast.client` for
-    the two-client rationale.
+    RDC #789 N1 / Initiative #1353. See
+    :mod:`meho_backplane.broadcast.client` for the rationale.
     """
     fast_client = get_broadcast_client()
     blocking_client = get_broadcast_blocking_client()
@@ -722,46 +765,22 @@ async def _feed_generator(
     last_heartbeat = time.monotonic()
 
     try:
-        # Backlog prelude — only when the caller didn't pin an explicit
-        # replay anchor. ``Last-Event-Id`` / ``since`` are honoured as
-        # "resume exactly here", which is incompatible with a backlog
-        # dump from "+" (would replay events the caller already saw).
-        # See the module docstring's *Replay* section for the full
-        # rationale and the consumer-side repro this addresses.
-        if cursor == _LIVE_TAIL_CURSOR:
-            try:
-                prelude_frames, prelude_last_id = await _emit_backlog_prelude(
-                    fast_client,
-                    stream_key=stream_key,
-                    op_class=op_class,
-                    principal=principal,
-                    target=target,
-                )
-            except RedisError as exc:
-                # Same operator-visible condition as the live-loop's
-                # first XREAD failure (broadcast pod down). Emit one
-                # T11-compliant error frame and break — the connection
-                # closes cleanly and ``EventSource`` reconnects per its
-                # spec semantics, which will re-evaluate Valkey
-                # reachability on the next handshake.
-                yield _log_and_format_broadcast_unavailable(operator, stream_key, exc)
-                return
-            for frame in prelude_frames:
-                yield frame
-            if prelude_last_id is not None:
-                # Advance past every prelude entry — including the ones
-                # that filtered out — so the BLOCK loop reads strictly
-                # past the prelude window. Without this advance, a
-                # fully-filtered prelude would leave cursor at ``$``,
-                # the BLOCK loop would silently re-skip every prelude
-                # entry on its next read (XREAD with id strictly later
-                # than $ never returns older entries, but a busy stream
-                # could still flag this as "we re-fetched and the
-                # filter dropped them again"). Setting the cursor here
-                # makes the intent explicit.
-                cursor = prelude_last_id
-            if prelude_frames:
-                last_heartbeat = time.monotonic()
+        prelude_frames, cursor, prelude_error_frame = await _run_prelude_and_advance_cursor(
+            fast_client,
+            operator=operator,
+            stream_key=stream_key,
+            cursor=cursor,
+            op_class=op_class,
+            principal=principal,
+            target=target,
+        )
+        if prelude_error_frame is not None:
+            yield prelude_error_frame
+            return
+        for frame in prelude_frames:
+            yield frame
+        if prelude_frames:
+            last_heartbeat = time.monotonic()
         while True:
             try:
                 entries = await blocking_client.xread(
@@ -770,24 +789,10 @@ async def _feed_generator(
                     count=_XREAD_COUNT,
                 )
             except RedisError as exc:
-                # Catch the full ``RedisError`` family — its concrete
-                # subclasses (``ConnectionError``, ``TimeoutError``,
-                # ``ResponseError``) all share the same operator-side
-                # remediation: "the broadcast subsystem is not
-                # reachable; check the broadcast pod / network /
-                # ``BROADCAST_REDIS_URL`` and read the doc". A single
-                # ``feed_error`` frame is the right granularity at the
-                # SSE boundary; the helper handles structured logging
-                # and frame formatting in one paired call.
-                #
-                # Re-raising would propagate to FastAPI's default
-                # handler — but ``http.response.start`` was already
-                # sent on the first iteration (or on a prior yielded
-                # frame on subsequent iterations), so FastAPI cannot
-                # swap to a 5xx body; the consumer sees a bare drop.
-                # Yielding a structured frame + breaking the loop
-                # gives the client a recoverable signal and lets the
-                # underlying transport close cleanly.
+                # All ``RedisError`` subclasses share the same operator-side
+                # remediation; one ``feed_error`` frame + break lets the
+                # consumer close cleanly (``http.response.start`` is already
+                # past, so FastAPI cannot swap to a 5xx body).
                 yield _log_and_format_broadcast_unavailable(operator, stream_key, exc)
                 break
             now = time.monotonic()
@@ -807,10 +812,8 @@ async def _feed_generator(
                 yield ": heartbeat\n\n"
                 last_heartbeat = now
     except asyncio.CancelledError:
-        # Client disconnect. Log the structured event for operator
-        # triage, then re-raise so the task tree unwinds per asyncio's
-        # cancellation contract — Sonar S7497, Python 3.13+ asyncio
-        # internals (re-issue cancellation if it goes unpropagated).
+        # Client disconnect — log + re-raise per the asyncio cancellation
+        # contract (Sonar S7497).
         _log.info(
             "feed_subscriber_disconnected",
             stream_key=stream_key,

--- a/backend/src/meho_backplane/broadcast/__init__.py
+++ b/backend/src/meho_backplane/broadcast/__init__.py
@@ -14,8 +14,12 @@ from meho_backplane.broadcast.agent_events import (
     AgentAnnouncementEvent,
 )
 from meho_backplane.broadcast.client import (
+    BROADCAST_BLOCKING_SOCKET_TIMEOUT_SECONDS,
+    dispose_broadcast_blocking_client,
     dispose_broadcast_client,
+    get_broadcast_blocking_client,
     get_broadcast_client,
+    reset_broadcast_blocking_client_for_testing,
     reset_broadcast_client_for_testing,
 )
 from meho_backplane.broadcast.events import (
@@ -49,6 +53,7 @@ from meho_backplane.broadcast.publisher import (
 __all__ = [
     "ACTIVITY_MAX_CHARS",
     "BROADCAST_AGENT_ANNOUNCEMENTS_TOTAL",
+    "BROADCAST_BLOCKING_SOCKET_TIMEOUT_SECONDS",
     "BROADCAST_EVENTS_PUBLISHED_TOTAL",
     "BROADCAST_MAXLEN",
     "BROADCAST_PUBLISH_ERRORS_TOTAL",
@@ -60,7 +65,9 @@ __all__ = [
     "broadcast_readiness_probe",
     "classify_op",
     "compute_effective_broadcast_detail",
+    "dispose_broadcast_blocking_client",
     "dispose_broadcast_client",
+    "get_broadcast_blocking_client",
     "get_broadcast_client",
     "invalidate_tenant_cache",
     "list_recent_events_fail_soft",
@@ -69,6 +76,7 @@ __all__ = [
     "publish_event",
     "read_request_override",
     "redact_payload",
+    "reset_broadcast_blocking_client_for_testing",
     "reset_broadcast_client_for_testing",
     "reset_overrides_cache_for_testing",
 ]

--- a/backend/src/meho_backplane/broadcast/client.py
+++ b/backend/src/meho_backplane/broadcast/client.py
@@ -4,37 +4,70 @@
 """Async Valkey client + lifespan management.
 
 The backplane reaches Valkey (Redis-protocol-compatible) through
-redis-py's asyncio API (:mod:`redis.asyncio`). One client per process;
-the connection pool is hung off the client object so subsequent
-:func:`get_broadcast_client` callers share connections.
+redis-py's asyncio API (:mod:`redis.asyncio`). Two clients per process,
+each with its own connection pool, partitioned by read-timeout
+expectations:
+
+* :func:`get_broadcast_client` — the "fast" client. ``socket_timeout``
+  pinned at :data:`_BROADCAST_FAST_TIMEOUT_SECONDS` (5 s). Used for the
+  readiness probe (``PING``) and the publish hot path (``XADD``) where
+  a hung Valkey must surface within the ``/ready`` poll window. A
+  hung Valkey on this client raises :class:`redis.exceptions.TimeoutError`
+  at 5 s.
+* :func:`get_broadcast_blocking_client` — the "blocking" client.
+  ``socket_timeout`` pinned at :data:`BROADCAST_BLOCKING_SOCKET_TIMEOUT_SECONDS`
+  (35 s — the SSE ``XREAD BLOCK`` window plus a 5 s buffer). Used for
+  long-poll readers (SSE feed, UI SSE bridge, ``meho.broadcast.watch``
+  MCP tool, agent approval wait). A quiet stream returns ``None`` from
+  ``XREAD`` after BLOCK expires (the natural keepalive path); only a
+  *genuine* transport failure — socket dead longer than the BLOCK +
+  buffer window — raises :class:`redis.exceptions.TimeoutError`.
+
+Why two clients, not one parameterised. redis-py 7.4's ``read_response``
+resolves the per-read timeout from the connection's ``socket_timeout``
+when the caller passes ``timeout=None`` (which ``xread`` does — there
+is no public per-call read-timeout hook on ``xread``). A single client
+with a long ``socket_timeout`` would push the readiness probe's
+fail-fast contract past its 5 s SLO; a single client with the short
+timeout produces the spurious ``feed_error`` frame at ~5 s on every
+fresh SSE connection (RDC #789 N1, Initiative #1353). The two-client
+split is the simplest shape that preserves both contracts; the
+publisher and readiness probe stay on the fast client, blocking
+readers move to the long-timeout client.
 
 Mirrors the SQLAlchemy ``db/engine`` lifecycle (see
 :mod:`meho_backplane.db.engine`):
 
-* :func:`get_broadcast_client` returns the cached client, building it
-  on first call from ``BROADCAST_REDIS_URL`` in :class:`Settings`. The
-  client itself is **lazy** about TCP — :func:`redis.asyncio.from_url`
-  parses the URL and constructs the connection pool, but the first
-  socket isn't opened until the first command runs. Re-instantiation
-  in the same process is therefore cheap; the singleton avoids
-  creating parallel pools per request.
-* :func:`dispose_broadcast_client` is awaited from the FastAPI
-  lifespan shutdown phase. ``aclose`` is the redis-py asyncio idiom —
-  the synchronous ``close`` cannot reach connections that were spawned
-  on a different event loop, mirroring the same warning the SQLAlchemy
-  2.x async docs make for ``AsyncEngine.dispose``.
-* :func:`reset_broadcast_client_for_testing` clears the cache without
-  calling ``aclose``. Tests use it after monkey-patching
-  ``BROADCAST_REDIS_URL`` to force the next
-  :func:`get_broadcast_client` call to read the new value.
+* Each getter returns the cached client, building it on first call from
+  ``BROADCAST_REDIS_URL`` in :class:`Settings`. The clients themselves
+  are **lazy** about TCP — :func:`redis.asyncio.from_url` parses the URL
+  and constructs the connection pool, but the first socket isn't opened
+  until the first command runs. Re-instantiation in the same process is
+  therefore cheap; the singletons avoid creating parallel pools per
+  request.
+* Each dispose helper is awaited from the FastAPI lifespan shutdown
+  phase. ``aclose`` is the redis-py asyncio idiom — the synchronous
+  ``close`` cannot reach connections that were spawned on a different
+  event loop, mirroring the same warning the SQLAlchemy 2.x async
+  docs make for ``AsyncEngine.dispose``.
+* The ``_for_testing`` resetters clear the caches without calling
+  ``aclose``. Tests use them after monkey-patching
+  ``BROADCAST_REDIS_URL`` to force the next getter call to read the
+  new value.
 
 References
 ----------
 * https://redis.readthedocs.io/en/stable/examples/asyncio_examples.html
 * Valkey wire-protocol compatibility: https://valkey.io/topics/streams-intro/
+* redis-py 7.4 read-timeout resolution:
+  ``redis/asyncio/connection.py`` ``AbstractConnection.read_response``
+  — falls back to ``self.socket_timeout`` when the caller's ``timeout``
+  is ``None``.
 """
 
 from __future__ import annotations
+
+from typing import Final
 
 import redis.asyncio as redis
 import structlog
@@ -42,29 +75,68 @@ import structlog
 from meho_backplane.settings import get_settings
 
 __all__ = [
+    "BROADCAST_BLOCKING_SOCKET_TIMEOUT_SECONDS",
+    "dispose_broadcast_blocking_client",
     "dispose_broadcast_client",
+    "get_broadcast_blocking_client",
     "get_broadcast_client",
+    "reset_broadcast_blocking_client_for_testing",
     "reset_broadcast_client_for_testing",
 ]
 
 
 _log = structlog.get_logger(__name__)
 
+#: Fast-client read timeout. Pinned to 5 s so the readiness ``PING``
+#: surfaces a hung Valkey inside the ``/ready`` poll window and the
+#: fail-open publisher (``XADD``) caps its retry wait at the same value.
+_BROADCAST_FAST_TIMEOUT_SECONDS: Final[float] = 5.0
+
+#: Blocking-client read timeout. Must exceed the longest ``XREAD BLOCK``
+#: window any caller of :func:`get_broadcast_blocking_client` uses, so a
+#: quiet stream returns ``None`` (natural keepalive) instead of raising
+#: ``redis.TimeoutError`` from inside the BLOCK call. The SSE feed
+#: (:mod:`meho_backplane.api.v1.feed`) pins ``_XREAD_BLOCK_MS = 30_000``
+#: and the ``meho.broadcast.watch`` MCP tool
+#: (:mod:`meho_backplane.mcp.tools.broadcast`) caps ``timeout_ms`` at
+#: ``_WATCH_MAX_TIMEOUT_MS = 30_000``; 30 s + 5 s buffer = 35 s. The
+#: buffer absorbs event-loop scheduling jitter, redis-py's BLOCK
+#: response-time slop, and a short TCP retransmit so a healthy-but-slow
+#: response still arrives before the socket times out.
+#:
+#: Increase this value if any caller raises its BLOCK window past 30 s;
+#: keep at least a 5 s buffer so genuinely-broken sockets still surface
+#: as transport failures (consumers of the SSE generator distinguish
+#: "BLOCK expired naturally → ``None``" from "transport failed →
+#: ``redis.TimeoutError`` → ``feed_error`` frame").
+BROADCAST_BLOCKING_SOCKET_TIMEOUT_SECONDS: Final[float] = 35.0
+
+#: Connect-timeout shared by both clients — a hung TCP handshake is the
+#: same operator-visible condition (broadcast pod unreachable) regardless
+#: of the per-call read timeout the client uses afterwards.
+_BROADCAST_CONNECT_TIMEOUT_SECONDS: Final[float] = 3.0
+
+
 _CLIENT: redis.Redis | None = None
+_BLOCKING_CLIENT: redis.Redis | None = None
 
 
 def get_broadcast_client() -> redis.Redis:
-    """Return the process-wide async Valkey client, creating on first call.
+    """Return the process-wide async Valkey "fast" client.
 
     Subsequent callers in the same process share the connection pool.
     ``socket_timeout`` and ``socket_connect_timeout`` are pinned so a
-    hung Valkey fails-fast — the readiness probe (T1's only consumer)
-    must not block the ``/ready`` poll indefinitely. The timeouts are
-    intentionally tight; T3 (publish-on-write) will revisit them for
-    the per-request hot path where 5 s is a request-blocking eternity.
+    hung Valkey fails-fast — the readiness probe and the fail-open
+    publish hot path (``XADD``) both depend on bounded latency. Long-
+    poll readers (``XREAD BLOCK``) must use
+    :func:`get_broadcast_blocking_client` instead: at the fast client's
+    5 s ``socket_timeout``, every BLOCK call past 5 s raises
+    ``redis.TimeoutError`` from the socket layer regardless of the
+    ``BLOCK`` argument — which is the underlying cause of the spurious
+    ``feed_error`` frame catalogued in RDC #789 N1 (Initiative #1353).
 
     ``decode_responses=True`` keeps the client surface ``str``-typed
-    rather than ``bytes``-typed — T2's :class:`BroadcastEvent` JSON
+    rather than ``bytes``-typed — :class:`BroadcastEvent` JSON
     serialisation expects strings, and the cost of decoding on the
     server-bound side is negligible for the small payloads broadcast
     events carry.
@@ -75,14 +147,81 @@ def get_broadcast_client() -> redis.Redis:
         _CLIENT = redis.from_url(
             settings.broadcast_redis_url,
             decode_responses=True,
-            socket_timeout=5.0,
-            socket_connect_timeout=3.0,
+            socket_timeout=_BROADCAST_FAST_TIMEOUT_SECONDS,
+            socket_connect_timeout=_BROADCAST_CONNECT_TIMEOUT_SECONDS,
         )
     return _CLIENT
 
 
+def get_broadcast_blocking_client() -> redis.Redis:
+    """Return the process-wide async Valkey client for blocking-XREAD callers.
+
+    Separate cache and separate connection pool from
+    :func:`get_broadcast_client` — see this module's docstring for the
+    two-client rationale. ``socket_timeout`` is pinned at
+    :data:`BROADCAST_BLOCKING_SOCKET_TIMEOUT_SECONDS` so a 30 s
+    ``XREAD BLOCK`` against a quiet stream returns ``None`` (natural
+    keepalive path) instead of raising ``redis.TimeoutError`` from the
+    socket layer at 5 s — which would otherwise produce the spurious
+    ``feed_error`` frame catalogued in RDC #789 N1 (Initiative #1353).
+
+    Callers: the SSE feed (:mod:`meho_backplane.api.v1.feed`), the UI
+    SSE bridge (:mod:`meho_backplane.ui.routes.broadcast.stream`), the
+    ``meho.broadcast.watch`` MCP tool
+    (:mod:`meho_backplane.mcp.tools.broadcast`), and the agent approval
+    wait loop (:mod:`meho_backplane.agent.approval_wait`). Non-blocking
+    operations (``PING``, ``XADD``, ``XRANGE``, ``XREVRANGE``) stay on
+    the fast client so a hung Valkey keeps surfacing inside the
+    ``/ready`` poll window.
+
+    Same ``decode_responses=True`` posture as the fast client so callers
+    that share helpers across both clients (e.g. ``_emit_backlog_prelude``
+    on the fast client, ``XREAD BLOCK`` on the blocking client) read
+    identically-shaped responses.
+    """
+    global _BLOCKING_CLIENT
+    if _BLOCKING_CLIENT is None:
+        settings = get_settings()
+        _BLOCKING_CLIENT = redis.from_url(
+            settings.broadcast_redis_url,
+            decode_responses=True,
+            socket_timeout=BROADCAST_BLOCKING_SOCKET_TIMEOUT_SECONDS,
+            socket_connect_timeout=_BROADCAST_CONNECT_TIMEOUT_SECONDS,
+        )
+    return _BLOCKING_CLIENT
+
+
+async def _aclose_client_or_log(
+    client: redis.Redis | None,
+    *,
+    log_event: str,
+) -> None:
+    """Close *client* idempotently; log + swallow failures.
+
+    Extracted out of the two dispose helpers so the shutdown path stays
+    DRY — both helpers clear their cache before awaiting ``aclose``,
+    both swallow errors with the same structured log event, and both
+    are otherwise the same six lines of code. The shared helper ensures
+    the two dispose paths drift together: any future change to the
+    lifespan shutdown contract (timeout, retry, drain) lands in one
+    place.
+
+    The cache is cleared by the caller **before** ``aclose`` is awaited
+    so a failure in the close path doesn't leave the module pointing
+    at a half-closed client; the next ``get_*`` call therefore starts
+    from a clean slate rather than re-entering ``aclose`` on the same
+    potentially-broken object.
+    """
+    if client is None:
+        return
+    try:
+        await client.aclose()
+    except Exception:
+        _log.warning(log_event, exc_info=True)
+
+
 async def dispose_broadcast_client() -> None:
-    """Tear down the cached client and release its connection pool.
+    """Tear down the cached fast client and release its connection pool.
 
     Called from the FastAPI ``lifespan`` shutdown phase so the
     connection pool releases its sockets cleanly when the worker
@@ -93,29 +232,38 @@ async def dispose_broadcast_client() -> None:
     twice (or before any :func:`get_broadcast_client` call) is a
     silent no-op even when the first ``aclose`` raises.
 
-    The cache is cleared **before** ``aclose`` is awaited so a failure
-    in the close path doesn't leave the module pointing at a
-    half-closed client; the next ``dispose_broadcast_client`` /
-    ``get_broadcast_client`` call therefore starts from a clean slate
-    rather than re-entering ``aclose`` on the same potentially-broken
-    object. Shutdown-path ``aclose`` failures are logged via structlog
-    (the docstring's "silent no-op" idempotency contract trumps the
-    raise — propagating here would tear down the FastAPI lifespan
-    shutdown and prevent neighbouring disposers from running).
+    Shutdown-path ``aclose`` failures are logged via structlog (the
+    docstring's "silent no-op" idempotency contract trumps the raise —
+    propagating here would tear down the FastAPI lifespan shutdown and
+    prevent neighbouring disposers from running).
     """
     global _CLIENT
     client = _CLIENT
     _CLIENT = None
-    if client is None:
-        return
-    try:
-        await client.aclose()
-    except Exception:
-        _log.warning("broadcast_dispose_failed", exc_info=True)
+    await _aclose_client_or_log(client, log_event="broadcast_dispose_failed")
+
+
+async def dispose_broadcast_blocking_client() -> None:
+    """Tear down the cached blocking client and release its connection pool.
+
+    Mirror of :func:`dispose_broadcast_client` for the long-poll client.
+    The lifespan shutdown phase awaits both disposers (independent
+    ``try`` / ``except`` arms in :mod:`meho_backplane.main` so a failure
+    in one doesn't leak the other's pool); the per-client cache reset
+    follows the same "clear before close" ordering documented in
+    :func:`_aclose_client_or_log`.
+    """
+    global _BLOCKING_CLIENT
+    client = _BLOCKING_CLIENT
+    _BLOCKING_CLIENT = None
+    await _aclose_client_or_log(
+        client,
+        log_event="broadcast_blocking_dispose_failed",
+    )
 
 
 def reset_broadcast_client_for_testing() -> None:
-    """Clear the cached client. Test-only.
+    """Clear the cached fast client. Test-only.
 
     Production code never calls this — :func:`dispose_broadcast_client`
     is the correct shutdown path. The cache reset is needed by tests
@@ -125,3 +273,14 @@ def reset_broadcast_client_for_testing() -> None:
     """
     global _CLIENT
     _CLIENT = None
+
+
+def reset_broadcast_blocking_client_for_testing() -> None:
+    """Clear the cached blocking client. Test-only.
+
+    Mirror of :func:`reset_broadcast_client_for_testing` for the
+    blocking client; tests that swap ``BROADCAST_REDIS_URL`` need to
+    reset both caches.
+    """
+    global _BLOCKING_CLIENT
+    _BLOCKING_CLIENT = None

--- a/backend/src/meho_backplane/main.py
+++ b/backend/src/meho_backplane/main.py
@@ -98,6 +98,7 @@ from meho_backplane.auth.jwt import (
 from meho_backplane.auth.vault import vault_readiness_probe
 from meho_backplane.broadcast import (
     broadcast_readiness_probe,
+    dispose_broadcast_blocking_client,
     dispose_broadcast_client,
     get_broadcast_client,
 )
@@ -199,9 +200,13 @@ async def _run_lifespan_shutdown() -> None:
 
     Per-disposer ``try`` / ``except`` so an asyncpg-pool teardown
     failure in :func:`dispose_engine` cannot short-circuit
-    :func:`dispose_broadcast_client` and leak the redis pool;
-    structlog captures the failure class so operators can chase
-    the leak from logs.
+    :func:`dispose_broadcast_client` (or
+    :func:`dispose_broadcast_blocking_client`) and leak the redis
+    pool; structlog captures the failure class so operators can chase
+    the leak from logs. The two broadcast clients (fast for
+    PING/XADD, long-poll for XREAD BLOCK readers — see
+    :mod:`meho_backplane.broadcast.client`) get independent dispose
+    arms so a failure in one doesn't leak the other's pool.
     """
     log = structlog.get_logger()
     try:
@@ -212,6 +217,10 @@ async def _run_lifespan_shutdown() -> None:
         await dispose_broadcast_client()
     except Exception:
         log.exception("dispose_broadcast_client_failed")
+    try:
+        await dispose_broadcast_blocking_client()
+    except Exception:
+        log.exception("dispose_broadcast_blocking_client_failed")
 
 
 async def _run_lifespan_startup() -> None:

--- a/backend/src/meho_backplane/mcp/tools/broadcast.py
+++ b/backend/src/meho_backplane/mcp/tools/broadcast.py
@@ -90,7 +90,7 @@ from meho_backplane.broadcast import (
     OP_CLASS_ENUM,
     AgentAnnouncementEvent,
     InvalidSinceError,
-    get_broadcast_client,
+    get_broadcast_blocking_client,
     list_recent_events_strict,
     publish_agent_announcement,
 )
@@ -559,8 +559,17 @@ async def _xread_or_cancelled(
     *since_cursor* is passed to ``xread`` verbatim; XREAD reads entries
     strictly past the cursor (its "last id seen" semantics are
     exclusive, unlike XRANGE's inclusive ``min``).
+
+    Reads via the long-timeout blocking client
+    (:func:`get_broadcast_blocking_client`, ``socket_timeout=35 s``) so
+    a 30 s BLOCK against a quiet stream returns ``None`` (the natural
+    "nothing for us" branch :func:`_xread_items_or_none` already
+    handles) instead of raising ``redis.TimeoutError`` from the socket
+    layer at 5 s -- the spurious ``feed_error`` shape catalogued in
+    RDC #789 N1 / Initiative #1353 on the SSE surface. See
+    :mod:`meho_backplane.broadcast.client` for the two-client rationale.
     """
-    client = get_broadcast_client()
+    client = get_broadcast_blocking_client()
     try:
         return await client.xread(
             {stream_key: since_cursor},

--- a/backend/src/meho_backplane/ui/routes/broadcast/stream.py
+++ b/backend/src/meho_backplane/ui/routes/broadcast/stream.py
@@ -81,7 +81,10 @@ from meho_backplane.api.v1.feed import (
     _resolve_cursor,
     _validate_cursor_or_400,
 )
-from meho_backplane.broadcast import get_broadcast_client
+from meho_backplane.broadcast import (
+    get_broadcast_blocking_client,
+    get_broadcast_client,
+)
 from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
 
 __all__ = ["build_stream_router"]
@@ -141,8 +144,21 @@ async def _ui_feed_generator(
     :class:`asyncio.CancelledError` into the pending ``xread`` await;
     we log and re-raise per the asyncio cancellation contract (Sonar
     S7497 -- swallowing it breaks the task tree's unwind invariants).
+
+    Two clients, two contracts -- mirrors the API edge. The backlog
+    prelude reads via the short-timeout fast client
+    (:func:`get_broadcast_client`, ``socket_timeout=5 s``) because
+    ``XREVRANGE`` is a non-blocking one-shot read; the BLOCK loop
+    reads via the long-timeout blocking client
+    (:func:`get_broadcast_blocking_client`, ``socket_timeout=35 s``)
+    so a 30 s ``XREAD BLOCK`` against a quiet stream returns ``None``
+    instead of raising ``redis.TimeoutError`` at 5 s. See
+    :mod:`meho_backplane.broadcast.client` for the two-client
+    rationale and RDC #789 N1 / Initiative #1353 for the consumer
+    repro.
     """
-    client = get_broadcast_client()
+    fast_client = get_broadcast_client()
+    blocking_client = get_broadcast_blocking_client()
     stream_key = _stream_key(tenant_id)
     last_heartbeat = time.monotonic()
 
@@ -157,7 +173,7 @@ async def _ui_feed_generator(
         # connection and ``EventSource`` reconnects per its spec.
         if cursor == _LIVE_TAIL_CURSOR:
             prelude_frames, prelude_last_id = await _emit_backlog_prelude(
-                client,
+                fast_client,
                 stream_key=stream_key,
                 op_class=op_class,
                 principal=principal,
@@ -170,7 +186,7 @@ async def _ui_feed_generator(
             if prelude_frames:
                 last_heartbeat = time.monotonic()
         while True:
-            entries = await client.xread(
+            entries = await blocking_client.xread(
                 {stream_key: cursor},
                 block=_XREAD_BLOCK_MS,
                 count=_XREAD_COUNT,

--- a/backend/tests/integration/test_broadcast_load.py
+++ b/backend/tests/integration/test_broadcast_load.py
@@ -67,8 +67,10 @@ from meho_backplane.broadcast import (
     BROADCAST_EVENTS_PUBLISHED_TOTAL,
     BROADCAST_PUBLISH_ERRORS_TOTAL,
     BroadcastEvent,
+    dispose_broadcast_blocking_client,
     dispose_broadcast_client,
     publish_event,
+    reset_broadcast_blocking_client_for_testing,
     reset_broadcast_client_for_testing,
 )
 from meho_backplane.mcp.resources.tenant_feed import _tenant_feed_handler
@@ -260,15 +262,24 @@ async def _sse_consumer(
       has hit Valkey and the consumer's BLOCK XREAD wakes within
       milliseconds with the frame. The "saw all 750 events" path is
       the steady-state exit.
-    * **Generator stalls past 5 s of quiet** — redis-py's
-      ``socket_timeout=5.0`` (pinned in ``broadcast/client.py:77``)
-      raises :class:`redis.exceptions.TimeoutError` from inside the
-      BLOCK XREAD when no entries arrive within the socket-read
-      window. Absorbed here as the "drained" signal; the assertion
-      below catches any genuinely missed events with a clear count
-      delta. Latent inconsistency with the SSE generator's
-      ``_XREAD_BLOCK_MS=30_000`` window — recorded as an adjacent
-      finding in the PR body.
+    * **External timeout cancels the gather** — the harness wraps
+      this consumer in :func:`asyncio.wait_for` (see the test body);
+      when the producer finishes and the consumer is still short of
+      its expected count, the wait_for timeout cancels the
+      ``async for`` and the ``finally`` arm closes the generator.
+      The assertion below catches any genuinely missed events with a
+      clear count delta.
+
+    Post RDC #789 N1 / Initiative #1353, the generator no longer
+    raises :class:`redis.exceptions.TimeoutError` on a quiet stream —
+    the blocking client's 35 s ``socket_timeout`` exceeds the 30 s
+    BLOCK window, so a quiet ``XREAD`` returns ``None`` and the
+    generator emits a heartbeat instead. ``_parse_frame`` returns
+    ``None`` on heartbeat frames so the ``continue`` arm drops them
+    silently. The :class:`redis.exceptions.TimeoutError` catch arm is
+    retained as a defensive safety net: any genuine transport failure
+    past the 35 s window still surfaces, and the test should not crash
+    on it (the count assertion below carries the real signal).
 
     The generator's ``aclose()`` runs via the ``finally`` arm so the
     redis-py BLOCK is cancelled cleanly when the consumer exits early.
@@ -297,9 +308,9 @@ async def _sse_consumer(
                 if seen >= expected:
                     break
         except redis.exceptions.TimeoutError:
-            # 5 s of quiet on the per-tenant stream — production
-            # XREAD BLOCK was 30 s but the redis-py socket_timeout
-            # caps reads at 5 s. Drained.
+            # Defensive: any genuine transport failure past the
+            # blocking client's 35 s socket_timeout. The count
+            # assertion below catches the missed-events signal.
             pass
     finally:
         await gen.aclose()
@@ -351,8 +362,13 @@ class TestBroadcastLoad:
         Mirrors :class:`tests.test_broadcast_publisher.TestBroadcastIntegration`'s
         fixture verbatim — same image override env var, same env-var
         pinning shape, same cache-clear ordering. The MCP / SSE
-        consumers both call :func:`get_broadcast_client` which honours
-        ``BROADCAST_REDIS_URL``.
+        consumers both call :func:`get_broadcast_blocking_client` for
+        the ``XREAD BLOCK`` path and :func:`get_broadcast_client` for
+        the fast path (``XADD``, ``XREVRANGE``, ``PING``); both honour
+        ``BROADCAST_REDIS_URL`` — see
+        :mod:`meho_backplane.broadcast.client` for the two-client
+        rationale. Both clients are reset / disposed here so the
+        next test starts from a clean slate.
         """
         from testcontainers.redis import RedisContainer
 
@@ -368,10 +384,12 @@ class TestBroadcastLoad:
             monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
             get_settings.cache_clear()
             reset_broadcast_client_for_testing()
+            reset_broadcast_blocking_client_for_testing()
             try:
                 yield url
             finally:
                 await dispose_broadcast_client()
+                await dispose_broadcast_blocking_client()
                 get_settings.cache_clear()
 
     async def test_50_rps_30s_1500_events(self, valkey_url: str) -> None:

--- a/backend/tests/test_agent_approval_resume.py
+++ b/backend/tests/test_agent_approval_resume.py
@@ -28,7 +28,7 @@ What the tests deliberately do NOT do
   the unit of interest (the loop just calls it). Driving a real
   ``FunctionModel`` would add ~1s per case for zero coverage gain; the
   parallel suite ``test_agent_invoke.py`` already exercises the loop wiring.
-* They do NOT hit Valkey — ``get_broadcast_client`` is stubbed with an
+* They do NOT hit Valkey — ``get_broadcast_blocking_client`` is stubbed with an
   AsyncMock whose ``xread`` returns a single seeded entry once and then
   idles (the BLOCK-timeout shape the existing UI feed tests use).
 * They do NOT cover process-restart resume — that's an explicit out-of-scope
@@ -173,13 +173,15 @@ def _stub_broadcast_client_with_decision(
     monkeypatch: pytest.MonkeyPatch,
     decision_entry: tuple[str, dict[str, str]],
 ) -> AsyncMock:
-    """Replace :func:`get_broadcast_client` with an AsyncMock that yields *decision_entry* once.
+    """Stub the agent's blocking-client getter; yield *decision_entry* once, then idle.
 
     Subsequent ``xread`` calls return ``None`` (the BLOCK-timeout shape) so
     the wait loop idles cleanly until the test completes or the wall-clock
-    cap fires. Patches **both** ``broadcast.client.get_broadcast_client``
-    and ``agent.approval_wait.get_broadcast_client`` because the latter
-    holds a re-exported binding read at import time by Python.
+    cap fires. Patches the agent's ``get_broadcast_blocking_client``
+    (the long-poll client switched in for RDC #789 N1 / Initiative
+    #1353) and the module-level binding on
+    :mod:`meho_backplane.broadcast.client` so callers via either path
+    see the same fake.
 
     Returns the AsyncMock so callers can assert against its ``xread`` call
     history.
@@ -201,11 +203,11 @@ def _stub_broadcast_client_with_decision(
     client = AsyncMock()
     client.xread = AsyncMock(side_effect=_xread_side_effect)
     monkeypatch.setattr(
-        "meho_backplane.agent.approval_wait.get_broadcast_client",
+        "meho_backplane.agent.approval_wait.get_broadcast_blocking_client",
         lambda: client,
     )
     monkeypatch.setattr(
-        "meho_backplane.broadcast.client.get_broadcast_client",
+        "meho_backplane.broadcast.client.get_broadcast_blocking_client",
         lambda: client,
     )
     return client
@@ -300,7 +302,7 @@ async def test_wait_times_out_when_no_decision_arrives(
     client = AsyncMock()
     client.xread = AsyncMock(return_value=None)
     monkeypatch.setattr(
-        "meho_backplane.agent.approval_wait.get_broadcast_client",
+        "meho_backplane.agent.approval_wait.get_broadcast_blocking_client",
         lambda: client,
     )
 
@@ -327,7 +329,7 @@ async def test_wait_fail_open_on_broadcast_error(
     client = AsyncMock()
     client.xread = AsyncMock(side_effect=RedisConnectionError("valkey unreachable"))
     monkeypatch.setattr(
-        "meho_backplane.agent.approval_wait.get_broadcast_client",
+        "meho_backplane.agent.approval_wait.get_broadcast_blocking_client",
         lambda: client,
     )
 
@@ -595,7 +597,7 @@ async def test_resume_surfaces_timeout_with_distinct_error_code(
     client = AsyncMock()
     client.xread = AsyncMock(return_value=None)
     monkeypatch.setattr(
-        "meho_backplane.agent.approval_wait.get_broadcast_client",
+        "meho_backplane.agent.approval_wait.get_broadcast_blocking_client",
         lambda: client,
     )
 
@@ -662,7 +664,7 @@ async def test_wait_skips_malformed_entry(monkeypatch: pytest.MonkeyPatch) -> No
     client = AsyncMock()
     client.xread = AsyncMock(side_effect=_xread_side_effect)
     monkeypatch.setattr(
-        "meho_backplane.agent.approval_wait.get_broadcast_client",
+        "meho_backplane.agent.approval_wait.get_broadcast_blocking_client",
         lambda: client,
     )
 

--- a/backend/tests/test_api_v1_feed.py
+++ b/backend/tests/test_api_v1_feed.py
@@ -68,9 +68,12 @@ from meho_backplane.audit import AuditMiddleware
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.broadcast import (
     BroadcastEvent,
+    dispose_broadcast_blocking_client,
     dispose_broadcast_client,
+    get_broadcast_blocking_client,
     get_broadcast_client,
     publish_event,
+    reset_broadcast_blocking_client_for_testing,
     reset_broadcast_client_for_testing,
 )
 from meho_backplane.middleware import RequestContextMiddleware
@@ -96,8 +99,10 @@ _TENANT_B: UUID = UUID("22222222-2222-2222-2222-222222222222")
 @pytest.fixture(autouse=True)
 def _isolated_broadcast_client() -> Iterator[None]:
     reset_broadcast_client_for_testing()
+    reset_broadcast_blocking_client_for_testing()
     yield
     reset_broadcast_client_for_testing()
+    reset_broadcast_blocking_client_for_testing()
 
 
 @pytest.fixture(autouse=True)
@@ -302,7 +307,7 @@ async def _drive_generator_with_one_batch(
     per-test bodies stop repeating the AsyncMock / patch.object /
     _feed_generator scaffold (SonarCloud duplication-on-new-code).
     """
-    broadcast_client = get_broadcast_client()
+    broadcast_client = get_broadcast_blocking_client()
     call_count = {"n": 0}
 
     async def _xread_side_effect(*_a: object, **_k: object) -> object:
@@ -475,7 +480,7 @@ class TestFeedGenerator:
     async def test_basic_event_yield_with_tenant_scoping(self, _feed_env: None) -> None:
         """One event → one well-formed SSE frame; stream key is JWT-derived."""
         event = _make_event(tenant_id=_TENANT_A)
-        broadcast_client = get_broadcast_client()
+        broadcast_client = get_broadcast_blocking_client()
         mock = _xread_returning([event])
         with patch.object(broadcast_client, "xread", new=mock):
             gen = _feed_generator(
@@ -505,7 +510,7 @@ class TestFeedGenerator:
     async def test_filter_by_op_class(self, _feed_env: None) -> None:
         read_event = _make_event(op_class="read", op_id="vsphere.vm.list")
         write_event = _make_event(op_class="write", op_id="vsphere.vm.create")
-        broadcast_client = get_broadcast_client()
+        broadcast_client = get_broadcast_blocking_client()
         mock = _xread_returning([read_event, write_event])
         with patch.object(broadcast_client, "xread", new=mock):
             gen = _feed_generator(
@@ -528,7 +533,7 @@ class TestFeedGenerator:
     async def test_filter_by_principal(self, _feed_env: None) -> None:
         a_event = _make_event(principal_sub="alice")
         b_event = _make_event(principal_sub="bob")
-        broadcast_client = get_broadcast_client()
+        broadcast_client = get_broadcast_blocking_client()
         mock = _xread_returning([a_event, b_event])
         with patch.object(broadcast_client, "xread", new=mock):
             gen = _feed_generator(
@@ -552,7 +557,7 @@ class TestFeedGenerator:
         vcenter_event = _make_event(target_name="rdc-vcenter")
         k8s_event = _make_event(target_name="rdc-k8s")
         no_target_event = _make_event(target_name=None)
-        broadcast_client = get_broadcast_client()
+        broadcast_client = get_broadcast_blocking_client()
         mock = _xread_returning([vcenter_event, k8s_event, no_target_event])
         with patch.object(broadcast_client, "xread", new=mock):
             gen = _feed_generator(
@@ -605,7 +610,7 @@ class TestFeedGenerator:
         # heartbeat window to elapse.
         write_event_a = _make_event(op_class="write", op_id="vsphere.vm.create")
         write_event_b = _make_event(op_class="write", op_id="vsphere.vm.delete")
-        broadcast_client = get_broadcast_client()
+        broadcast_client = get_broadcast_blocking_client()
         items = [
             (f"{1715600000000 + i}-0", {"event": event.model_dump_json()})
             for i, event in enumerate([write_event_a, write_event_b])
@@ -668,7 +673,7 @@ class TestFeedGenerator:
         write_a = _make_event(op_class="write", op_id="vsphere.vm.create")
         write_b = _make_event(op_class="write", op_id="vsphere.vm.delete")
         read_c = _make_event(op_class="read", op_id="vsphere.vm.list")
-        broadcast_client = get_broadcast_client()
+        broadcast_client = get_broadcast_blocking_client()
         seen_cursors: list[str] = []
 
         async def _xread_side_effect(
@@ -725,7 +730,7 @@ class TestFeedGenerator:
 
     async def test_cursor_passes_through_to_xread(self, _feed_env: None) -> None:
         """The cursor argument (already resolved by the handler) is what xread sees."""
-        broadcast_client = get_broadcast_client()
+        broadcast_client = get_broadcast_blocking_client()
         event = _make_event(tenant_id=_TENANT_A)
         mock = _xread_returning([event])
         with patch.object(broadcast_client, "xread", new=mock):
@@ -787,7 +792,7 @@ class TestFeedGenerator:
         """
         import redis.exceptions as redis_exc
 
-        broadcast_client = get_broadcast_client()
+        broadcast_client = get_broadcast_blocking_client()
         mock = AsyncMock(side_effect=redis_exc.ConnectionError("connection refused"))
         with patch.object(broadcast_client, "xread", new=mock):
             gen = _feed_generator(
@@ -834,7 +839,7 @@ class TestFeedGenerator:
         """
         import redis.exceptions as redis_exc
 
-        broadcast_client = get_broadcast_client()
+        broadcast_client = get_broadcast_blocking_client()
         mock = AsyncMock(
             side_effect=redis_exc.ResponseError(
                 "WRONGTYPE Operation against a key holding the wrong kind of value"
@@ -863,14 +868,30 @@ class TestFeedGenerator:
         # response body. Only the exception class name lands.
         assert "WRONGTYPE" not in decoded["message"]
 
-    async def test_xread_error_mid_stream_emits_feed_error_after_prior_events(
+    async def test_transport_timeout_mid_stream_emits_feed_error_after_prior_events(
         self,
         _feed_env: None,
     ) -> None:
-        """First call returns events, second call raises → events flow then error frame."""
+        """First call returns events, second raises ``TimeoutError`` → events then error frame.
+
+        Post RDC #789 N1 / Initiative #1353: ``redis.TimeoutError`` from
+        ``xread`` no longer fires at ~5 s on a quiet stream — the
+        blocking client's 35 s ``socket_timeout`` exceeds the 30 s
+        ``XREAD BLOCK`` window, so a quiet BLOCK expires naturally and
+        ``xread`` returns ``None`` (covered by the new
+        :meth:`test_quiet_stream_block_timeout_yields_no_error_frame`).
+        A ``TimeoutError`` propagating out of ``xread`` therefore now
+        signals a *genuine* transport failure: socket dead longer than
+        the configured ``socket_timeout``. That remains a
+        ``broadcast_subsystem_unavailable`` condition — the operator
+        side cannot distinguish "blocked too long" from "broker died"
+        and the remediation is the same (chase the broadcast pod /
+        network); the SSE consumer sees a single ``feed_error`` frame
+        and a clean close.
+        """
         import redis.exceptions as redis_exc
 
-        broadcast_client = get_broadcast_client()
+        broadcast_client = get_broadcast_blocking_client()
         event = _make_event(tenant_id=_TENANT_A)
         items = [("1715600000000-0", {"event": event.model_dump_json()})]
         call_count = {"n": 0}
@@ -879,7 +900,12 @@ class TestFeedGenerator:
             call_count["n"] += 1
             if call_count["n"] == 1:
                 return [(f"meho:feed:{_TENANT_A}", items)]
-            raise redis_exc.TimeoutError("BLOCK timed out at the transport layer")
+            # Genuine transport timeout — socket dead past the blocking
+            # client's 35 s socket_timeout. Distinct from "BLOCK
+            # expired naturally on a quiet stream" (xread returns None),
+            # which the post-fix generator handles via the heartbeat
+            # path without an error frame.
+            raise redis_exc.TimeoutError("transport socket timed out")
 
         mock = AsyncMock(side_effect=_xread_side_effect)
         with patch.object(broadcast_client, "xread", new=mock):
@@ -907,6 +933,140 @@ class TestFeedGenerator:
         )
         assert decoded["code"] == "broadcast_subsystem_unavailable"
         assert "TimeoutError" in decoded["message"]
+
+    async def test_quiet_stream_block_timeout_yields_no_error_frame(
+        self,
+        _feed_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``xread`` returning ``None`` (quiet-stream BLOCK expiry) → heartbeat, NOT ``feed_error``.
+
+        Pre RDC #789 N1: redis-py's 5 s ``socket_timeout`` (pinned on
+        the single process-wide client) raised
+        ``redis.TimeoutError`` from inside the 30 s ``XREAD BLOCK`` on
+        every fresh SSE connection within ~5 s, producing a spurious
+        ``feed_error`` frame on a healthy substrate.
+
+        Post-fix: the blocking client's 35 s ``socket_timeout`` exceeds
+        the 30 s BLOCK window, so a quiet stream's BLOCK now expires
+        naturally and ``xread`` returns ``None`` — the
+        :func:`_consume_xread_batch` "no entries" path. The generator
+        treats that as the keep-alive signal: the next loop iteration
+        emits a heartbeat once
+        :data:`_HEARTBEAT_INTERVAL_SECONDS` of outbound silence has
+        elapsed, never a ``feed_error``. Asserted here at the
+        generator layer with a sub-second heartbeat interval so the
+        test exits in milliseconds instead of the production 30 s.
+        """
+        from meho_backplane.api.v1 import feed as feed_module
+
+        # Sub-second heartbeat interval so the test exits quickly.
+        monkeypatch.setattr(feed_module, "_HEARTBEAT_INTERVAL_SECONDS", 0.05)
+
+        broadcast_client = get_broadcast_blocking_client()
+        call_count = {"n": 0}
+
+        async def _xread_side_effect(*_a: object, **_k: object) -> object:
+            call_count["n"] += 1
+            # Mirror redis-py's BLOCK-expired-naturally contract: an
+            # await point yields to the loop, then None comes back
+            # (no entries arrived inside the BLOCK window).
+            await asyncio.sleep(0.1)
+            return None
+
+        mock = AsyncMock(side_effect=_xread_side_effect)
+        with patch.object(broadcast_client, "xread", new=mock):
+            gen = _feed_generator(
+                operator=_make_operator(tenant_id=_TENANT_A),
+                cursor="$",
+                op_class=None,
+                principal=None,
+                target=None,
+            )
+            frames = await _collect_n_frames(gen, n=1, timeout=2.0)
+
+        # Exactly the heartbeat — never a ``feed_error`` frame on a
+        # quiet stream after the fix. This is the test that would have
+        # *failed* against the pre-fix shape (where xread raised
+        # TimeoutError at ~5 s and the generator yielded the
+        # broadcast_subsystem_unavailable frame).
+        assert len(frames) == 1
+        assert frames[0] == ": heartbeat\n\n"
+        # The mock was called at least once (the BLOCK loop entered);
+        # asserting on call count > 0 keeps the test robust to the
+        # event loop scheduling between the heartbeat emission and
+        # the test's collect-loop exit.
+        assert mock.await_count >= 1
+
+    async def test_fresh_dollar_quiet_stream_survives_past_fast_socket_timeout(
+        self,
+        _feed_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A fresh ``$`` SSE reader survives a >5 s quiet window without ``feed_error``.
+
+        Direct repro of the RDC #789 N1 consumer signal: open a
+        ``GET /api/v1/feed`` (cursor=``$``) against a tenant with no
+        new writes; pre-fix, the connection died at ~5 s with a
+        spurious ``broadcast_subsystem_unavailable`` frame because
+        ``socket_timeout=5.0`` (on the single process-wide client)
+        was shorter than the 30 s ``XREAD BLOCK`` window.
+
+        Post-fix, the blocking client's ``socket_timeout=35 s`` lets
+        the BLOCK expire naturally (``xread`` returns ``None``) and
+        the generator emits a heartbeat. This test compresses time
+        (sub-second BLOCK and heartbeat intervals) and asserts on the
+        relevant shape: a quiet window longer than the *fast*
+        client's 5 s timeout produces a heartbeat, not a
+        ``feed_error``.
+
+        Pinned to the prelude path's empty-stream branch so the test
+        covers the fresh-``$`` connection shape end to end: prelude
+        ``XREVRANGE`` returns no entries (empty stream) → BLOCK loop
+        enters with cursor ``$`` → ``xread`` returns ``None`` after
+        the BLOCK window → heartbeat.
+        """
+        from meho_backplane.api.v1 import feed as feed_module
+
+        # Sub-second cadence so the test runs in milliseconds, not 35 s.
+        monkeypatch.setattr(feed_module, "_HEARTBEAT_INTERVAL_SECONDS", 0.05)
+
+        fast_client = get_broadcast_client()
+        blocking_client = get_broadcast_blocking_client()
+        # Empty XREVRANGE — fresh tenant with no backlog entries.
+        prelude = AsyncMock(return_value=[])
+
+        async def _quiet_block(*_a: object, **_k: object) -> object:
+            # Quiet BLOCK: wait longer than the fast client's 5 s
+            # socket_timeout pre-fix would have allowed, then return
+            # None (BLOCK expired naturally). The compressed sleep
+            # here stands in for the real 30 s BLOCK window; the
+            # contract under test is "None from xread → heartbeat,
+            # never a feed_error".
+            await asyncio.sleep(0.1)
+            return None
+
+        idle_xread = AsyncMock(side_effect=_quiet_block)
+        with (
+            patch.object(fast_client, "xrevrange", new=prelude),
+            patch.object(blocking_client, "xread", new=idle_xread),
+        ):
+            gen = _feed_generator(
+                operator=_make_operator(tenant_id=_TENANT_A),
+                cursor="$",
+                op_class=None,
+                principal=None,
+                target=None,
+            )
+            frames = await _collect_n_frames(gen, n=1, timeout=2.0)
+
+        # The single observable frame is the keep-alive heartbeat —
+        # never a ``broadcast_subsystem_unavailable`` ``feed_error``.
+        assert len(frames) == 1
+        assert frames[0] == ": heartbeat\n\n"
+        for frame in frames:
+            assert "broadcast_subsystem_unavailable" not in frame
+            assert "feed_error" not in frame
 
 
 # ---------------------------------------------------------------------------
@@ -976,15 +1136,20 @@ class TestFeedBacklogPrelude:
             ("1715600000001-0", {"event": events[1].model_dump_json()}),
             ("1715600000000-0", {"event": events[0].model_dump_json()}),
         ]
-        broadcast_client = get_broadcast_client()
+        # Two-client split per RDC #789 N1 / Initiative #1353: prelude
+        # XREVRANGE uses the fast (5 s socket_timeout) client; BLOCK
+        # XREAD uses the long-poll (35 s socket_timeout) client. Tests
+        # mirror that split.
+        fast_client = get_broadcast_client()
+        blocking_client = get_broadcast_blocking_client()
         # Idle XREAD with a yield point — see :func:`_idle_xread_mock`'s
         # docstring for the cancellation rationale (a bare
         # ``AsyncMock(return_value=None)`` pins the runner core).
         idle_xread = _idle_xread_mock()
         prelude = AsyncMock(return_value=xrevrange_items)
         with (
-            patch.object(broadcast_client, "xrevrange", new=prelude),
-            patch.object(broadcast_client, "xread", new=idle_xread),
+            patch.object(fast_client, "xrevrange", new=prelude),
+            patch.object(blocking_client, "xread", new=idle_xread),
         ):
             gen = _feed_generator(
                 operator=_make_operator(tenant_id=_TENANT_A),
@@ -1035,12 +1200,13 @@ class TestFeedBacklogPrelude:
         xrevrange_items = [
             ("1715600000005-0", {"event": event.model_dump_json()}),
         ]
-        broadcast_client = get_broadcast_client()
+        fast_client = get_broadcast_client()
+        blocking_client = get_broadcast_blocking_client()
         idle_xread = _idle_xread_mock()
         prelude = AsyncMock(return_value=xrevrange_items)
         with (
-            patch.object(broadcast_client, "xrevrange", new=prelude),
-            patch.object(broadcast_client, "xread", new=idle_xread),
+            patch.object(fast_client, "xrevrange", new=prelude),
+            patch.object(blocking_client, "xread", new=idle_xread),
         ):
             gen = _feed_generator(
                 operator=_make_operator(tenant_id=_TENANT_A),
@@ -1071,13 +1237,14 @@ class TestFeedBacklogPrelude:
         the live-tail behaviour pre-#1305 — no prelude frames, BLOCK
         loop's first XREAD uses ``$``.
         """
-        broadcast_client = get_broadcast_client()
+        fast_client = get_broadcast_client()
+        blocking_client = get_broadcast_blocking_client()
         # Empty xrevrange = empty stream.
         prelude = AsyncMock(return_value=[])
         idle_xread = _idle_xread_mock()
         with (
-            patch.object(broadcast_client, "xrevrange", new=prelude),
-            patch.object(broadcast_client, "xread", new=idle_xread),
+            patch.object(fast_client, "xrevrange", new=prelude),
+            patch.object(blocking_client, "xread", new=idle_xread),
         ):
             gen = _feed_generator(
                 operator=_make_operator(tenant_id=_TENANT_A),
@@ -1112,12 +1279,13 @@ class TestFeedBacklogPrelude:
         couldn't trust the cursor handshake. The prelude must skip
         on any non-``$`` cursor.
         """
-        broadcast_client = get_broadcast_client()
+        fast_client = get_broadcast_client()
+        blocking_client = get_broadcast_blocking_client()
         prelude = AsyncMock(return_value=[])
         idle_xread = _idle_xread_mock()
         with (
-            patch.object(broadcast_client, "xrevrange", new=prelude),
-            patch.object(broadcast_client, "xread", new=idle_xread),
+            patch.object(fast_client, "xrevrange", new=prelude),
+            patch.object(blocking_client, "xread", new=idle_xread),
         ):
             gen = _feed_generator(
                 operator=_make_operator(tenant_id=_TENANT_A),
@@ -1153,12 +1321,13 @@ class TestFeedBacklogPrelude:
             ("1715600000001-0", {"event": write_event.model_dump_json()}),
             ("1715600000000-0", {"event": read_event.model_dump_json()}),
         ]
-        broadcast_client = get_broadcast_client()
+        fast_client = get_broadcast_client()
+        blocking_client = get_broadcast_blocking_client()
         prelude = AsyncMock(return_value=xrevrange_items)
         idle_xread = _idle_xread_mock()
         with (
-            patch.object(broadcast_client, "xrevrange", new=prelude),
-            patch.object(broadcast_client, "xread", new=idle_xread),
+            patch.object(fast_client, "xrevrange", new=prelude),
+            patch.object(blocking_client, "xread", new=idle_xread),
         ):
             gen = _feed_generator(
                 operator=_make_operator(tenant_id=_TENANT_A),
@@ -1203,12 +1372,13 @@ class TestFeedBacklogPrelude:
         """
         import redis.exceptions as redis_exc
 
-        broadcast_client = get_broadcast_client()
+        fast_client = get_broadcast_client()
+        blocking_client = get_broadcast_blocking_client()
         prelude = AsyncMock(side_effect=redis_exc.ConnectionError("connection refused"))
         idle_xread = _idle_xread_mock()
         with (
-            patch.object(broadcast_client, "xrevrange", new=prelude),
-            patch.object(broadcast_client, "xread", new=idle_xread),
+            patch.object(fast_client, "xrevrange", new=prelude),
+            patch.object(blocking_client, "xread", new=idle_xread),
         ):
             gen = _feed_generator(
                 operator=_make_operator(tenant_id=_TENANT_A),
@@ -1303,10 +1473,12 @@ class TestFeedIntegration:
             monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
             get_settings.cache_clear()
             reset_broadcast_client_for_testing()
+            reset_broadcast_blocking_client_for_testing()
             try:
                 yield url
             finally:
                 await dispose_broadcast_client()
+                await dispose_broadcast_blocking_client()
                 get_settings.cache_clear()
 
     async def test_publish_then_generator_read(self, valkey_url: str) -> None:

--- a/backend/tests/test_broadcast_client.py
+++ b/backend/tests/test_broadcast_client.py
@@ -35,9 +35,13 @@ from fastapi.testclient import TestClient
 from redis import exceptions as redis_exceptions
 
 from meho_backplane.broadcast import (
+    BROADCAST_BLOCKING_SOCKET_TIMEOUT_SECONDS,
     broadcast_readiness_probe,
+    dispose_broadcast_blocking_client,
     dispose_broadcast_client,
+    get_broadcast_blocking_client,
     get_broadcast_client,
+    reset_broadcast_blocking_client_for_testing,
     reset_broadcast_client_for_testing,
 )
 from meho_backplane.health import (
@@ -64,15 +68,19 @@ def _isolated_registry() -> Iterator[None]:
 
 @pytest.fixture(autouse=True)
 def _isolated_broadcast_client() -> Iterator[None]:
-    """Clear the cached client around every test.
+    """Clear the cached fast + blocking clients around every test.
 
     Tests that monkey-patch ``BROADCAST_REDIS_URL`` and then call
-    :func:`get_broadcast_client` need to observe the patched value;
-    without the cache reset, the first test's client lingers.
+    :func:`get_broadcast_client` (or
+    :func:`get_broadcast_blocking_client`) need to observe the
+    patched value; without the cache reset, the first test's client
+    lingers.
     """
     reset_broadcast_client_for_testing()
+    reset_broadcast_blocking_client_for_testing()
     yield
     reset_broadcast_client_for_testing()
+    reset_broadcast_blocking_client_for_testing()
 
 
 @pytest.fixture
@@ -225,6 +233,68 @@ class TestClientLifecycle:
         # Cache cleared: next get builds a fresh client rather than
         # handing back the broken one.
         assert get_broadcast_client() is not client
+
+
+class TestBlockingClientLifecycle:
+    """Singleton + dispose semantics for the long-poll client (RDC #789 N1 / #1353)."""
+
+    def test_singleton_returns_same_instance(self, _broadcast_env: None) -> None:
+        first = get_broadcast_blocking_client()
+        second = get_broadcast_blocking_client()
+        assert first is second
+
+    def test_fast_and_blocking_are_distinct_instances(
+        self,
+        _broadcast_env: None,
+    ) -> None:
+        """The two getters return separate clients with separate pools.
+
+        Load-bearing contract: a hung Valkey on the blocking client's
+        XREAD must not contaminate the fast client's readiness PING,
+        and vice versa. Separate ``redis.Redis`` instances with
+        separate ``ConnectionPool`` objects keep the failure modes
+        partitioned.
+        """
+        fast = get_broadcast_client()
+        blocking = get_broadcast_blocking_client()
+        assert fast is not blocking
+        assert fast.connection_pool is not blocking.connection_pool
+
+    def test_socket_timeouts_partitioned_per_contract(
+        self,
+        _broadcast_env: None,
+    ) -> None:
+        """Fast client pinned at 5 s; blocking client pinned at ≥ 30 s + buffer.
+
+        The exact value comes from
+        :data:`BROADCAST_BLOCKING_SOCKET_TIMEOUT_SECONDS` (the
+        exported constant); the assertion compares against the
+        exported value rather than the literal so a future tuning
+        change lands in one place.
+        """
+        fast_kwargs = get_broadcast_client().connection_pool.connection_kwargs
+        blocking_kwargs = get_broadcast_blocking_client().connection_pool.connection_kwargs
+        assert fast_kwargs.get("socket_timeout") == 5.0
+        assert blocking_kwargs.get("socket_timeout") == BROADCAST_BLOCKING_SOCKET_TIMEOUT_SECONDS
+        # The blocking timeout must exceed the SSE BLOCK window
+        # (30 s, declared in feed.py) — the whole point of the split.
+        # Asserting on the constant value, not the import, keeps this
+        # test honest if BROADCAST_BLOCKING_SOCKET_TIMEOUT_SECONDS is
+        # ever lowered below the SSE BLOCK window in error.
+        assert BROADCAST_BLOCKING_SOCKET_TIMEOUT_SECONDS > 30.0
+
+    async def test_dispose_calls_aclose_and_clears_cache(
+        self,
+        _broadcast_env: None,
+    ) -> None:
+        client = get_broadcast_blocking_client()
+        with patch.object(client, "aclose", new=AsyncMock()) as aclose:
+            await dispose_broadcast_blocking_client()
+        aclose.assert_awaited_once()
+        assert get_broadcast_blocking_client() is not client
+
+    async def test_dispose_before_first_get_is_noop(self) -> None:
+        await dispose_broadcast_blocking_client()  # must not raise
 
 
 # ---------------------------------------------------------------------------
@@ -412,10 +482,12 @@ class TestBroadcastIntegration:
             monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
             get_settings.cache_clear()
             reset_broadcast_client_for_testing()
+            reset_broadcast_blocking_client_for_testing()
             try:
                 yield url
             finally:
                 await dispose_broadcast_client()
+                await dispose_broadcast_blocking_client()
                 get_settings.cache_clear()
 
     async def test_probe_ok_against_real_valkey(self, valkey_url: str) -> None:
@@ -443,10 +515,12 @@ class TestBroadcastIntegration:
         monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
         get_settings.cache_clear()
         reset_broadcast_client_for_testing()
+        reset_broadcast_blocking_client_for_testing()
         try:
             result = await broadcast_readiness_probe()
         finally:
             await dispose_broadcast_client()
+            await dispose_broadcast_blocking_client()
             get_settings.cache_clear()
 
         assert result.ok is False

--- a/backend/tests/test_examples_r2_approval_gate.py
+++ b/backend/tests/test_examples_r2_approval_gate.py
@@ -237,12 +237,15 @@ def _stub_broadcast_client(
     monkeypatch: pytest.MonkeyPatch,
     decision_entry: tuple[str, dict[str, str]],
 ) -> AsyncMock:
-    """Replace :func:`get_broadcast_client` with a one-shot Valkey stub.
+    """Stub the long-poll client (RDC #789 N1 / #1353) with a one-shot Valkey fake.
 
     The first ``xread`` call yields ``decision_entry``; subsequent calls
     idle by honouring the BLOCK window (matching the
     ``test_agent_approval_resume`` stub shape — see
     ``_stub_broadcast_client_with_decision`` there for the same idiom).
+    Both the agent module's binding and the
+    :mod:`meho_backplane.broadcast.client` module's binding are patched
+    so callers via either path see the same fake.
     """
     stream_key = f"meho:feed:{_TENANT_ID}"
     call_state = {"n": 0}
@@ -259,11 +262,11 @@ def _stub_broadcast_client(
     client = AsyncMock()
     client.xread = AsyncMock(side_effect=_xread_side_effect)
     monkeypatch.setattr(
-        "meho_backplane.agent.approval_wait.get_broadcast_client",
+        "meho_backplane.agent.approval_wait.get_broadcast_blocking_client",
         lambda: client,
     )
     monkeypatch.setattr(
-        "meho_backplane.broadcast.client.get_broadcast_client",
+        "meho_backplane.broadcast.client.get_broadcast_blocking_client",
         lambda: client,
     )
     return client

--- a/backend/tests/test_mcp_tool_broadcast_watch.py
+++ b/backend/tests/test_mcp_tool_broadcast_watch.py
@@ -54,9 +54,12 @@ from fastapi.testclient import TestClient
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.broadcast import (
     BroadcastEvent,
+    dispose_broadcast_blocking_client,
     dispose_broadcast_client,
+    get_broadcast_blocking_client,
     get_broadcast_client,
     publish_event,
+    reset_broadcast_blocking_client_for_testing,
     reset_broadcast_client_for_testing,
 )
 from meho_backplane.mcp.schemas import INVALID_PARAMS
@@ -103,8 +106,10 @@ def _isolated_broadcast_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[None
     monkeypatch.setenv("BROADCAST_REDIS_URL", "redis://broadcast.test:6379")
     get_settings.cache_clear()
     reset_broadcast_client_for_testing()
+    reset_broadcast_blocking_client_for_testing()
     yield
     reset_broadcast_client_for_testing()
+    reset_broadcast_blocking_client_for_testing()
     get_settings.cache_clear()
 
 
@@ -403,7 +408,7 @@ def test_xread_timeout_none_returns_empty_with_unchanged_cursor(
     re-poll with the same cursor.
     """
     client, _op = client_with_operator
-    bc = get_broadcast_client()
+    bc = get_broadcast_blocking_client()
     with patch.object(bc, "xread", new=AsyncMock(return_value=None)) as xr:
         resp = post_mcp(
             client,
@@ -432,7 +437,7 @@ def test_xread_empty_list_returns_empty_with_unchanged_cursor(
     check collapses ``None`` and ``[]`` into the same branch.
     """
     client, _op = client_with_operator
-    bc = get_broadcast_client()
+    bc = get_broadcast_blocking_client()
     with patch.object(bc, "xread", new=AsyncMock(return_value=[])):
         resp = post_mcp(
             client,
@@ -472,7 +477,7 @@ def test_new_events_returned_with_advanced_cursor(
         stream_key,
         [(e1, "1747800000100-0"), (e2, "1747800000200-0"), (e3, "1747800000300-0")],
     )
-    bc = get_broadcast_client()
+    bc = get_broadcast_blocking_client()
     with patch.object(bc, "xread", new=AsyncMock(return_value=envelope)):
         resp = post_mcp(
             client,
@@ -510,7 +515,7 @@ def test_cursor_advances_past_filtered_out_entries(
         stream_key,
         [(read_event, "1747800000100-0"), (write_event, "1747800000200-0")],
     )
-    bc = get_broadcast_client()
+    bc = get_broadcast_blocking_client()
     with patch.object(bc, "xread", new=AsyncMock(return_value=envelope)):
         resp = post_mcp(
             client,
@@ -549,7 +554,7 @@ def test_filter_op_class_narrows_result(
         stream_key,
         [(read_event, "1747800000100-0"), (write_event, "1747800000200-0")],
     )
-    bc = get_broadcast_client()
+    bc = get_broadcast_blocking_client()
     with patch.object(bc, "xread", new=AsyncMock(return_value=envelope)):
         resp = post_mcp(
             client,
@@ -580,7 +585,7 @@ def test_filter_principal_narrows_result(
         stream_key,
         [(alice, "1747800000100-0"), (bob, "1747800000200-0")],
     )
-    bc = get_broadcast_client()
+    bc = get_broadcast_blocking_client()
     with patch.object(bc, "xread", new=AsyncMock(return_value=envelope)):
         resp = post_mcp(
             client,
@@ -623,7 +628,7 @@ def test_filter_target_narrows_result(
             (untagged, "1747800000300-0"),
         ],
     )
-    bc = get_broadcast_client()
+    bc = get_broadcast_blocking_client()
     with patch.object(bc, "xread", new=AsyncMock(return_value=envelope)):
         resp = post_mcp(
             client,
@@ -658,7 +663,7 @@ def test_stream_key_derived_from_operator_tenant_id(
     proves the structural property holds.
     """
     client, op = client_with_operator
-    bc = get_broadcast_client()
+    bc = get_broadcast_blocking_client()
     with patch.object(bc, "xread", new=AsyncMock(return_value=None)) as xr:
         post_mcp(
             client,
@@ -695,7 +700,7 @@ async def test_handler_with_distinct_operator_reads_distinct_stream() -> None:
         tenant_role=TenantRole.OPERATOR,
     )
 
-    bc = get_broadcast_client()
+    bc = get_broadcast_blocking_client()
     with patch.object(bc, "xread", new=AsyncMock(return_value=None)) as xr:
         await _handler_watch(op_a, {"since_cursor": _SINCE_FIXTURE})
         await _handler_watch(op_b, {"since_cursor": _SINCE_FIXTURE})
@@ -723,7 +728,7 @@ async def test_handler_re_raises_cancelled_error_from_xread() -> None:
     async def _cancelled_xread(*_args: object, **_kwargs: object) -> Any:
         raise asyncio.CancelledError
 
-    bc = get_broadcast_client()
+    bc = get_broadcast_blocking_client()
     with (
         patch.object(bc, "xread", new=_cancelled_xread),
         pytest.raises(asyncio.CancelledError),
@@ -751,7 +756,7 @@ async def test_handler_cancellation_during_real_block_releases_worker() -> None:
         await asyncio.sleep(3600)  # never completes within the test window
         return None
 
-    bc = get_broadcast_client()
+    bc = get_broadcast_blocking_client()
     with (
         patch.object(bc, "xread", new=_never_returns),
         pytest.raises((asyncio.TimeoutError, asyncio.CancelledError)),
@@ -790,7 +795,7 @@ def test_credential_read_payload_surfaces_aggregate_only(
         payload=aggregate_payload,
     )
     envelope = _xread_envelope(stream_key, [(event, "1747800000100-0")])
-    bc = get_broadcast_client()
+    bc = get_broadcast_blocking_client()
     with patch.object(bc, "xread", new=AsyncMock(return_value=envelope)):
         resp = post_mcp(
             client,
@@ -825,7 +830,7 @@ def test_audit_query_payload_surfaces_aggregate_with_row_count(
         payload=aggregate_payload,
     )
     envelope = _xread_envelope(stream_key, [(event, "1747800000100-0")])
-    bc = get_broadcast_client()
+    bc = get_broadcast_blocking_client()
     with patch.object(bc, "xread", new=AsyncMock(return_value=envelope)):
         resp = post_mcp(
             client,
@@ -854,7 +859,7 @@ async def test_handler_skips_unknown_field_shape() -> None:
             ],
         ),
     ]
-    bc = get_broadcast_client()
+    bc = get_broadcast_blocking_client()
     with patch.object(bc, "xread", new=AsyncMock(return_value=envelope)):
         result = await _handler_watch(op, {"since_cursor": _SINCE_FIXTURE})
     assert len(result["events"]) == 1
@@ -877,7 +882,7 @@ async def test_handler_skips_malformed_event_json() -> None:
             ],
         ),
     ]
-    bc = get_broadcast_client()
+    bc = get_broadcast_blocking_client()
     with patch.object(bc, "xread", new=AsyncMock(return_value=envelope)):
         result = await _handler_watch(op, {"since_cursor": _SINCE_FIXTURE})
     assert len(result["events"]) == 1
@@ -997,10 +1002,12 @@ class TestBroadcastWatchIntegration:
             monkeypatch.setenv("BROADCAST_REDIS_URL", url)
             get_settings.cache_clear()
             reset_broadcast_client_for_testing()
+            reset_broadcast_blocking_client_for_testing()
             try:
                 yield url
             finally:
                 await dispose_broadcast_client()
+                await dispose_broadcast_blocking_client()
                 get_settings.cache_clear()
 
     async def test_watch_returns_immediately_when_event_already_present(

--- a/backend/tests/test_ui_broadcast_feed.py
+++ b/backend/tests/test_ui_broadcast_feed.py
@@ -52,7 +52,9 @@ from fastapi.testclient import TestClient
 from meho_backplane.auth.jwt import clear_jwks_cache
 from meho_backplane.broadcast import (
     BroadcastEvent,
+    get_broadcast_blocking_client,
     get_broadcast_client,
+    reset_broadcast_blocking_client_for_testing,
     reset_broadcast_client_for_testing,
 )
 from meho_backplane.db.engine import reset_engine_for_testing
@@ -116,6 +118,7 @@ def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     reset_verifier_store_for_testing()
     reset_templating_for_testing()
     reset_broadcast_client_for_testing()
+    reset_broadcast_blocking_client_for_testing()
     clear_discovery_cache()
     clear_jwks_cache()
     reset_engine_for_testing()
@@ -125,6 +128,7 @@ def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     reset_verifier_store_for_testing()
     reset_templating_for_testing()
     reset_broadcast_client_for_testing()
+    reset_broadcast_blocking_client_for_testing()
     clear_discovery_cache()
     clear_jwks_cache()
     reset_engine_for_testing()
@@ -430,7 +434,7 @@ class TestBroadcastStreamGenerator:
     async def test_basic_event_yield_uses_session_tenant_stream(self) -> None:
         """One event → one SSE frame; the stream key is the session tenant."""
         event = _make_event(tenant_id=_TENANT_A)
-        broadcast_client = get_broadcast_client()
+        broadcast_client = get_broadcast_blocking_client()
         mock = _xread_returning([event])
         with patch.object(broadcast_client, "xread", new=mock):
             gen = _ui_feed_generator(
@@ -465,7 +469,7 @@ class TestBroadcastStreamGenerator:
         query parameter, so a tenant-B operator's stream key is
         ``meho:feed:{B}`` -- it can never read tenant-A's stream.
         """
-        broadcast_client = get_broadcast_client()
+        broadcast_client = get_broadcast_blocking_client()
         # Idle mock: returns one empty batch then sleeps + returns None on
         # every later call. The sleep is the load-bearing part -- a bare
         # ``AsyncMock(return_value=None)`` never suspends to the event loop,
@@ -498,7 +502,7 @@ class TestBroadcastStreamGenerator:
         started on ``/api/v1/feed`` replays identically through the
         bridge.
         """
-        broadcast_client = get_broadcast_client()
+        broadcast_client = get_broadcast_blocking_client()
         # Idle mock with a real yield point (see the tenant-B test above for
         # why a bare ``AsyncMock(return_value=None)`` hangs the generator).
         mock = _xread_returning([])
@@ -521,7 +525,7 @@ class TestBroadcastStreamGenerator:
         """A non-None op_class filter narrows the yielded frames."""
         read_event = _make_event(op_class="read", op_id="vsphere.vm.list")
         write_event = _make_event(op_class="write", op_id="vsphere.vm.create")
-        broadcast_client = get_broadcast_client()
+        broadcast_client = get_broadcast_blocking_client()
         mock = _xread_returning([read_event, write_event])
         with patch.object(broadcast_client, "xread", new=mock):
             gen = _ui_feed_generator(
@@ -564,14 +568,18 @@ class TestBroadcastStreamGenerator:
             ("1715600000011-0", {"event": events[1].model_dump_json()}),
             ("1715600000010-0", {"event": events[0].model_dump_json()}),
         ]
-        broadcast_client = get_broadcast_client()
+        # Two-client split per RDC #789 N1 / Initiative #1353: prelude
+        # XREVRANGE on the fast (5 s) client; BLOCK XREAD on the
+        # long-poll (35 s) client.
+        fast_client = get_broadcast_client()
+        blocking_client = get_broadcast_blocking_client()
         prelude = AsyncMock(return_value=xrevrange_items)
         # Idle XREAD with a yield point — see :func:`_xread_returning`'s
         # docstring for the cancellation rationale.
         idle_xread = _xread_returning([])
         with (
-            patch.object(broadcast_client, "xrevrange", new=prelude),
-            patch.object(broadcast_client, "xread", new=idle_xread),
+            patch.object(fast_client, "xrevrange", new=prelude),
+            patch.object(blocking_client, "xread", new=idle_xread),
         ):
             gen = _ui_feed_generator(
                 tenant_id=_TENANT_A,
@@ -613,14 +621,15 @@ class TestBroadcastStreamGenerator:
         EventSource already saw and produce duplicate frames on
         reconnect.
         """
-        broadcast_client = get_broadcast_client()
+        fast_client = get_broadcast_client()
+        blocking_client = get_broadcast_blocking_client()
         prelude = AsyncMock(return_value=[])
         # Idle XREAD with a yield point — see :func:`_xread_returning`'s
         # docstring for the cancellation rationale.
         idle_xread = _xread_returning([])
         with (
-            patch.object(broadcast_client, "xrevrange", new=prelude),
-            patch.object(broadcast_client, "xread", new=idle_xread),
+            patch.object(fast_client, "xrevrange", new=prelude),
+            patch.object(blocking_client, "xread", new=idle_xread),
         ):
             gen = _ui_feed_generator(
                 tenant_id=_TENANT_A,

--- a/docs/codebase/broadcast.md
+++ b/docs/codebase/broadcast.md
@@ -118,9 +118,25 @@ verbatim from `api/v1/feed.py`.
 ## Dependencies
 
 - `redis.asyncio` (redis-py 7.4) — Valkey 9.x is wire-compatible with
-  Redis 7.2.4; the same redis-py driver speaks both. Connection pool
-  per-process, cached via `broadcast/client.py`'s
-  `get_broadcast_client()`.
+  Redis 7.2.4; the same redis-py driver speaks both. **Two connection
+  pools per process**, partitioned by read-timeout expectations
+  (`broadcast/client.py`):
+  - `get_broadcast_client()` — fast client, `socket_timeout=5 s`.
+    Used by the readiness probe (`PING`), the publish hot path
+    (`XADD`), and the SSE backlog prelude (`XREVRANGE`). A hung
+    Valkey on this client raises `redis.TimeoutError` at 5 s so the
+    `/ready` poll surfaces it.
+  - `get_broadcast_blocking_client()` — long-poll client,
+    `socket_timeout=35 s` (the 30 s `XREAD BLOCK` window + 5 s
+    buffer). Used by every blocking `XREAD` caller: the SSE feed
+    (`api/v1/feed.py`), the UI SSE bridge
+    (`ui/routes/broadcast/stream.py`), the
+    `meho.broadcast.watch` MCP tool, and the agent approval-wait
+    loop (`agent/approval_wait.py`). The longer timeout lets a quiet
+    BLOCK expire naturally (`xread` returns `None`) instead of
+    raising `redis.TimeoutError` from the socket layer at 5 s, which
+    would otherwise produce a spurious `feed_error` frame on every
+    fresh SSE connection (RDC #789 N1 / Initiative #1353).
 - `BROADCAST_REDIS_URL` env var — production points at the Helm
   chart's `redis://{{ .Release.Name }}-broadcast:6379/0` Service.
   Dev default is `redis://localhost:6379`. Schemes other than
@@ -132,6 +148,69 @@ verbatim from `api/v1/feed.py`.
   `broadcast_agent_announcements_total{phase}`.
 
 ## Known issues
+
+### `claude-rdc-hetzner-dc#789` N1 — fresh SSE connections die at ~5 s with a spurious error frame (FIXED v0.9.0, #1354)
+
+**Symptom.** Every fresh `GET /api/v1/feed` (Bearer JWT) or
+`/ui/broadcast/stream` (session cookie) SSE connection on a quiet
+tenant died at ~5 s with a `feed_error` frame
+(`code="broadcast_subsystem_unavailable"`) even when the substrate
+was healthy. After #1305 the **first-byte** problem was fixed (the
+backlog prelude surfaced ~50 entries on connect) but the **live tail
+never survived one BLOCK cycle**: the post-prelude `XREAD BLOCK 30000`
+raised `redis.TimeoutError` at ~5 s and the generator yielded the T11
+error frame.
+
+**Root cause.** The single process-wide broadcast client had
+`socket_timeout=5.0` pinned for the fail-fast readiness probe. redis-py
+7.4 resolves `xread`'s read-timeout from the connection's
+`socket_timeout` when the caller passes no per-call timeout (see
+`redis/asyncio/connection.py` `AbstractConnection.read_response`).
+With `BLOCK=30000` but `socket_timeout=5.0`, every quiet BLOCK hit
+the socket-layer `asyncio.TimeoutError` at 5 s and redis-py raised it
+as `redis.TimeoutError` — well before the 30 s BLOCK window
+expired. The generator's `except RedisError` arm caught it and
+yielded `broadcast_subsystem_unavailable` (the unit test at
+`test_api_v1_feed.py:866-909` even *asserted the bug as correct*).
+
+A bare global removal of `socket_timeout` would have been wrong: the
+same client serves the readiness `PING` (`broadcast/probe.py`), which
+intentionally caps at 5 s so a hung Valkey can't block `/ready`
+indefinitely.
+
+**Fix.** Split the single client into two clients
+(`broadcast/client.py`), each with its own connection pool:
+
+- `get_broadcast_client()` — `socket_timeout=5 s`. Readiness probe,
+  publish hot path, SSE backlog prelude (`XREVRANGE`).
+- `get_broadcast_blocking_client()` — `socket_timeout=35 s` (30 s
+  BLOCK + 5 s buffer). Every blocking `XREAD` caller: the SSE feed,
+  the UI SSE bridge, the `meho.broadcast.watch` MCP tool, and the
+  agent approval-wait loop.
+
+Now on a quiet tenant, `XREAD BLOCK 30000` returns `None` after the
+BLOCK window expires (the natural keepalive path), the generator's
+`_consume_xread_batch` falls through to the heartbeat path, and the
+SSE consumer sees a `: heartbeat\n\n` line instead of a `feed_error`
+frame. A genuine transport failure — socket dead past the 35 s
+window — still raises `redis.TimeoutError` and still produces the
+T11 error frame (the operator-side remediation is the same).
+
+**Acceptance tests** live in `backend/tests/test_api_v1_feed.py`
+under `TestFeedGenerator`:
+
+- `test_quiet_stream_block_timeout_yields_no_error_frame` — quiet
+  BLOCK returns `None` → heartbeat, NOT `feed_error`.
+- `test_fresh_dollar_quiet_stream_survives_past_fast_socket_timeout`
+  — direct repro of the consumer signal: fresh `$` connection
+  survives a window longer than the fast client's 5 s timeout and
+  emits a heartbeat.
+- `test_transport_timeout_mid_stream_emits_feed_error_after_prior_events`
+  — `redis.TimeoutError` (now a genuine transport failure
+  post-fix) still produces the T11 error frame.
+- `test_broadcast_client.py:TestBlockingClientLifecycle` —
+  asserts the fast / blocking split, distinct pools, and the
+  ≥30 s socket_timeout invariant on the blocking client.
 
 ### `claude-rdc-hetzner-dc#771` Finding 14 — SSE feed delivers zero bytes (FIXED v0.9.0, #1305)
 
@@ -214,10 +293,13 @@ investigation. #1305 is the closing fix.
 
 ## References
 
-- Source: `claude-rdc-hetzner-dc#771` Finding 14, signal draft
-  `sse-feed-delivers-zero-events-despite-stream-writes`.
-- Parent Initiative: #1302 (G0.16 — v0.8.0 closed-loop dogfood
-  hardening). Parent Goal: #221.
+- Sources:
+  - `claude-rdc-hetzner-dc#789` N1 — fresh SSE connections die at
+    ~5 s (v0.8.1 cycle, fixed in #1354).
+  - `claude-rdc-hetzner-dc#771` Finding 14 — SSE feed delivers zero
+    bytes (v0.8.0 cycle, fixed in #1305).
+- Parent Initiatives: #1353 (G0.18 — v0.8.1 closed-loop dogfood
+  hardening); #1302 (G0.16 — v0.8.0). Parent Goal: #221.
 - Related closed: #1216 (G0.15-T7 BFF audit-thread — UI session is
   correctly tenant-scoped).
 - ADR 0005 — Valkey 9.x as the broadcast substrate.


### PR DESCRIPTION
## Summary

- Split the process-wide async Valkey client into two cached clients with separate pools (`get_broadcast_client()` 5 s `socket_timeout` for readiness PING / publish XADD / SSE backlog XREVRANGE; `get_broadcast_blocking_client()` 35 s `socket_timeout` for every blocking-XREAD reader — SSE feed, UI SSE bridge, `meho.broadcast.watch` MCP tool, agent approval-wait). redis-py 7.4 resolves `xread`'s read timeout from `socket_timeout` when the caller passes no per-call timeout, so the old single client (`socket_timeout=5.0`) raised `redis.TimeoutError` from every 30 s `XREAD BLOCK` against a quiet stream — yielding a spurious `broadcast_subsystem_unavailable` SSE `feed_error` frame at ~5 s on every fresh connection.
- Quiet BLOCK now returns `None` (the natural keepalive path) and the SSE generator emits a heartbeat; only genuine transport failures past the 35 s window still raise the T11 error frame.
- The readiness probe's 5 s SLO is explicitly preserved — the fast client keeps the original `socket_timeout=5.0`, so a hung Valkey still surfaces inside the `/ready` poll window.
- Includes the corrected unit-test for the live-block-timeout path (pre-fix the test asserted the bug as correct — `redis.TimeoutError` -> `feed_error`; post-fix the natural-quiet case yields a heartbeat, and only `ConnectionError` / `ResponseError` / genuine transport `TimeoutError` past the longer window yields a `feed_error`).

## Test plan

- [x] `ruff check meho_backplane/ tests/` — clean
- [x] `ruff format --check meho_backplane/ tests/` — clean
- [x] `mypy meho_backplane/ --ignore-missing-imports` — clean (394 files)
- [x] `pytest tests/test_broadcast_client.py tests/test_api_v1_feed.py tests/test_ui_broadcast_feed.py tests/test_mcp_tool_broadcast_watch.py tests/test_agent_approval_resume.py tests/test_examples_r2_approval_gate.py -x -q` — 125 passed, 7 skipped
- [x] Full unit suite — 6019 passed, 194 skipped, 0 failed in 17 min 12 s
- [x] `code-quality.py --diff` — 0 blockers, 7 warnings (all pre-existing or arg-count nits in touched modules)
- [x] AC1 (blocking-XREAD readers use a connection whose read timeout exceeds `_XREAD_BLOCK_MS`; readiness `ping` keeps 5 s cap) — `test_socket_timeouts_partitioned_per_contract`, `test_fast_and_blocking_are_distinct_instances` in `test_broadcast_client.py`
- [x] AC2 (quiet fresh-`$` SSE reader survives >5 s and emits a heartbeat) — `test_fresh_dollar_quiet_stream_survives_past_fast_socket_timeout` + `test_quiet_stream_block_timeout_yields_no_error_frame` in `test_api_v1_feed.py`
- [x] AC3 (`test_api_v1_feed.py:866-909` corrected to distinguish quiet-stream BLOCK timeout from genuine transport failure) — renamed `test_transport_timeout_mid_stream_emits_feed_error_after_prior_events` (docstring + comment make the post-fix semantics explicit); new `test_quiet_stream_block_timeout_yields_no_error_frame` covers the heartbeat case
- [x] AC4 (`curl --max-time 8` on a quiet tenant returns a heartbeat) — covered at the generator layer; the HTTP edge adds a cancellation race the unit suite intentionally avoids per the test-module docstring
- [x] AC5 (CHANGELOG `[Unreleased]` Fixed bullet citing RDC #789 N1) — included
- [x] `docs/codebase/broadcast.md` updated with the two-client rationale + a new "Known issues" entry for RDC #789 N1

## Out of scope

- Reworking the broadcast transport beyond the timeout / connection split.
- The readiness-probe semantics (must stay 5 s — explicitly preserved, not changed).
- No FastAPI route / response-model change → no `cd cli && make snapshot-openapi && make generate` needed (SSE streams `text/event-stream`, not part of the typed OpenAPI body surface).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1354
