### PR TITLE
docs(ingest): G0.18-T7 fix dead #405 reference + document build-time-only LLM-client wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,8 +130,6 @@ connector-related release-notes line.
   the 35 s window still raise the T11 error frame. The readiness
   probe's 5 s SLO is explicitly preserved.
 
-<<<<<<< HEAD
-=======
 - **Ingest LLM-grouping docs + `composite_l2_missing` envelope —
   honest "build-time-only" framing, dead `#405` reference removed
   (G0.18-T7 #1360, RDC #789 N9).** The previous wording cited
@@ -153,7 +151,6 @@ connector-related release-notes line.
   `LlmClient` adapter at lifespan startup remains the
   operator-side follow-up.
 
->>>>>>> dc15ec2 (docs(ingest): G0.18-T7 fix dead #405 reference + document build-time-only LLM-client wiring)
 ## [0.8.1] - 2026-05-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,30 @@ connector-related release-notes line.
   the 35 s window still raise the T11 error frame. The readiness
   probe's 5 s SLO is explicitly preserved.
 
+<<<<<<< HEAD
+=======
+- **Ingest LLM-grouping docs + `composite_l2_missing` envelope —
+  honest "build-time-only" framing, dead `#405` reference removed
+  (G0.18-T7 #1360, RDC #789 N9).** The previous wording cited
+  `T5 (#405)` / "production Anthropic adapter lands with G0.7-T5"
+  in multiple docstrings (`operations/ingest/pipeline.py`,
+  `api/v1/connectors_ingest.py`, `mcp/tools/connector_admin.py`,
+  `docs/codebase/spec-ingestion.md`, two test files), but `#405`
+  was G0.7-T5 = CLI verbs (CLOSED) and never tracked an LLM
+  adapter — and `settings.anthropic_api_key` flows only to the
+  agent runtime, so non-dry-run `meho connector ingest --catalog
+  <product>/<version>` 503s on every deploy (the chassis
+  `LlmClient` factory is fail-closed by default and FastAPI
+  lifespan startup has no caller for `set_llm_client_factory`).
+  The `composite_l2_missing` error envelope's escape-hatch hint
+  now names the limitation explicitly so operators don't follow
+  the suggested catalog command into a silent 503. New
+  `docs/codebase/spec-ingestion.md` §"LLM-client wiring (build-
+  time-only today)" documents the gap. Wiring a production
+  `LlmClient` adapter at lifespan startup remains the
+  operator-side follow-up.
+
+>>>>>>> dc15ec2 (docs(ingest): G0.18-T7 fix dead #405 reference + document build-time-only LLM-client wiring)
 ## [0.8.1] - 2026-05-29
 
 ### Added

--- a/backend/src/meho_backplane/api/v1/connectors_ingest.py
+++ b/backend/src/meho_backplane/api/v1/connectors_ingest.py
@@ -101,10 +101,17 @@ LLM-client injection
 The ingest route uses a module-level
 :data:`_llm_client_factory_dep` FastAPI dependency that resolves the
 :class:`LlmClientFactory` for the :class:`IngestionPipelineService`.
-Production wiring sets this via :func:`set_llm_client_factory` at
-app-startup time (G0.7-T5 will land the Anthropic adapter wire-up);
-tests inject a stub. The default factory raises
-:class:`LlmClientUnavailable`, which the route maps to 503.
+Production wiring would set this via :func:`set_llm_client_factory`
+at app-startup time, but **no production adapter is wired today** —
+``settings.anthropic_api_key`` flows only to the agent runtime
+(``agent/run.py``), not here. Tests inject a deterministic stub via
+the same hook (or via :class:`IngestionPipelineService`'s
+``llm_client_factory`` constructor argument). The default factory
+raises :class:`LlmClientUnavailable`, which the route maps to 503;
+on deployed backplanes that means non-dry-run ingest of an
+un-grouped connector fails closed and ``--catalog`` ingest grouping
+is build-time-only. See G0.18-T7 (#1360) for the doc cleanup and
+the operator-facing build-time-only framing.
 """
 
 from __future__ import annotations
@@ -200,9 +207,16 @@ def set_llm_client_factory(factory: LlmClientFactory) -> LlmClientFactory:
     """Install a new LLM-client factory; return the previous one.
 
     The previous factory is returned so callers can restore it after
-    a test or a feature-flagged deploy. Production wiring at app
-    startup (G0.7-T5) calls this once with the Anthropic adapter
-    factory; tests call it from their fixture setup.
+    a test or a feature-flagged deploy. **No production caller exists
+    today** — the chassis exposes this as the wire-up seam for a
+    production adapter (Anthropic Messages API or provider-routed via
+    G11.5), but FastAPI lifespan startup never invokes it and
+    ``settings.anthropic_api_key`` flows only to the agent runtime
+    (``agent/run.py``). Tests call this from their fixture setup with
+    a deterministic stub; without that, the chassis default
+    (:func:`default_llm_client_factory`) raises
+    :class:`LlmClientUnavailable` → HTTP 503. See G0.18-T7 (#1360)
+    for the doc cleanup and the build-time-only framing.
 
     The mutation is intentional rather than a FastAPI ``dependency_
     overrides`` entry: this factory needs to be reachable both from

--- a/backend/src/meho_backplane/connectors/vmware_rest/_catalog_command.py
+++ b/backend/src/meho_backplane/connectors/vmware_rest/_catalog_command.py
@@ -56,5 +56,18 @@ def catalog_command_for_vmware_rest(version: str) -> str:
     can run this verbatim; operators using ``POST
     /api/v1/connectors/ingest`` directly should land T9 (#1150)
     ``{"catalog_entry": "vmware/<version>"}`` instead.
+
+    Build-time-only caveat (G0.18-T7 #1360): non-dry-run ingest of an
+    un-grouped catalog entry needs an injected ``LlmClient`` for the
+    grouping pass, and the chassis ships no production adapter
+    today -- on deployed backplanes the returned command fails closed
+    with HTTP 503 / ``LlmClientUnavailable`` until an operator wires
+    :func:`meho_backplane.api.v1.connectors_ingest.set_llm_client_factory`
+    at FastAPI lifespan startup. The
+    :func:`~meho_backplane.operations._errors.result_composite_l2_missing`
+    envelope's human message names this limitation so operators don't
+    follow the suggested command into the 503; see
+    ``docs/codebase/spec-ingestion.md`` section "LLM-client wiring
+    (build-time-only today)".
     """
     return f"meho connector ingest --catalog vmware/{version}"

--- a/backend/src/meho_backplane/mcp/tools/connector_admin.py
+++ b/backend/src/meho_backplane/mcp/tools/connector_admin.py
@@ -184,8 +184,14 @@ async def _ingest_handler(
     :meth:`IngestionPipelineService.ingest`. The handler installs
     :func:`default_llm_client_factory` so a misconfigured chassis
     surfaces :class:`LlmClientUnavailable` rather than crashing
-    mid-grouping — the production Anthropic adapter wires its own
-    factory at the FastAPI lifespan layer once T5 (#405) lands.
+    mid-grouping. **No production adapter wires itself at the FastAPI
+    lifespan layer today** — a future operator-installed adapter
+    (Anthropic Messages API or provider-routed via G11.5) would call
+    :func:`meho_backplane.api.v1.connectors_ingest.set_llm_client_factory`
+    once at startup; until then, non-dry-run ingest of an un-grouped
+    connector via this MCP tool fails closed with
+    :class:`LlmClientUnavailable`. See G0.18-T7 (#1360) for the doc
+    cleanup and the operator-facing build-time-only framing.
 
     The response is the canonical :class:`IngestResponse` shape the
     REST route at ``POST /api/v1/connectors/ingest`` also returns.

--- a/backend/src/meho_backplane/operations/_errors.py
+++ b/backend/src/meho_backplane/operations/_errors.py
@@ -252,27 +252,38 @@ def result_composite_l2_missing(
     :class:`~meho_backplane.operations.composite.CompositeL2DependencyMissing`
     and the dispatcher converts it to this structured result.
 
-    Wording is the v0.9 reframe from G0.16-T1 (#1303). The v0.8.0
-    envelope cast the catalog command as "the remediation path" and
-    operators read it as the recommended next step; reality is the
-    opposite (per
+    Wording is the v0.9 reframe from G0.16-T1 (#1303), refined by
+    G0.18-T7 (#1360) to honestly state that the escape-hatch ingest
+    is build-time-only on current deploys. The v0.8.0 envelope cast
+    the catalog command as "the remediation path" and operators read
+    it as the recommended next step; reality is the opposite (per
     ``docs/codebase/api-shape-conventions.md`` §1) -- the curated
     daily-driver is the recommended path and the OpenAPI ingest is
     the escape hatch operators reach for when they're willing to
     handle vendor-shape responses without operator-shape envelopes
-    or ``requires_approval`` annotations. The reword preserves the
-    structured ``catalog_command`` field (the escape hatch must
-    remain usable) but the human message names the curation gap
-    first and the escape hatch second.
+    or ``requires_approval`` annotations.
+
+    G0.18-T7 (#1360) adds the build-time-only caveat: the chassis
+    does not wire a production ``LlmClient`` adapter at FastAPI
+    lifespan startup, so non-dry-run ``meho connector ingest
+    --catalog ...`` fails closed with HTTP 503 /
+    ``LlmClientUnavailable`` on deployed backplanes (RDC #789 N9
+    surfaced operators following the escape-hatch hint into a
+    silent 503). The structured ``catalog_command`` field stays
+    populated -- the operator-side fix is to install a real
+    ``LlmClient`` via
+    ``meho_backplane.api.v1.connectors_ingest.set_llm_client_factory(...)``
+    at lifespan startup; until then the human message names the
+    limitation so operators don't walk into the 503.
 
     The error shape still complies with the
     ``docs/codebase/error-message-shape.md`` convention (G0.14-T11
     #1141): a stable ``composite_l2_missing`` code, a
     diagnostic-bearing human message (curation gap + the missing
-    op-ids + the escape-hatch recipe + two doc references), and a
-    structured ``data`` payload (``missing_op_ids`` +
-    ``catalog_command``) so an agent can branch on the diagnostic
-    without re-parsing the human text.
+    op-ids + the escape-hatch recipe + the build-time-only caveat +
+    two doc references), and a structured ``data`` payload
+    (``missing_op_ids`` + ``catalog_command``) so an agent can branch
+    on the diagnostic without re-parsing the human text.
     """
     missing_repr = ", ".join(missing_op_ids) if missing_op_ids else "(none)"
     return OperationResult(
@@ -285,8 +296,14 @@ def result_composite_l2_missing(
             f"L1 wrapper that exposes these ops in operator shape. As an "
             f"escape hatch, run {catalog_command!r} to ingest the raw "
             f"vendor ops (vendor-shape responses, no approval annotations) "
-            f"and retry. See docs/codebase/api-shape-conventions.md "
-            f"section 1 for the strategic framing and "
+            f"and retry -- note that ingest grouping needs an injected "
+            f"LlmClient and is build-time-only on deployed backplanes "
+            f"today (returns 503 / LlmClientUnavailable until an "
+            f"operator wires set_llm_client_factory at lifespan startup; "
+            f"see G0.18-T7 #1360). See docs/codebase/api-shape-conventions.md "
+            f"section 1 for the strategic framing, "
+            f"docs/codebase/spec-ingestion.md section 'LLM-client wiring "
+            f"(build-time-only today)' for the 503 caveat, and "
             f"docs/codebase/connectors-vmware-rest.md for the L1+L2 "
             f"dispatch contract."
         ),

--- a/backend/src/meho_backplane/operations/ingest/llm_groups.py
+++ b/backend/src/meho_backplane/operations/ingest/llm_groups.py
@@ -41,11 +41,19 @@ operation groups first, then scope a query to one". The grouping
 pass + operator review (T4) is what produces that surface.
 
 The LLM client itself is injected as a :class:`LlmClient` Protocol so
-the chassis can swap the real Anthropic Messages-API adapter without
-re-plumbing T3. Production callers (T5's ``meho connector ingest``)
-will resolve a configured Sonnet/Haiku-backed implementation; tests
-inject a deterministic stub. There is no module-level singleton --
-every call site passes a client.
+the chassis can swap in a real Anthropic Messages-API adapter without
+re-plumbing T3. **No production adapter ships today** —
+``set_llm_client_factory`` (in
+:mod:`meho_backplane.api.v1.connectors_ingest`) is the wire-up seam,
+but FastAPI lifespan startup has no caller for it; ``meho connector
+ingest`` (CLI / REST / MCP) on a stock deploy returns HTTP 503 /
+``LlmClientUnavailable`` for any non-dry-run ingest until an
+operator-installed adapter (a Sonnet/Haiku-backed implementation, or
+a provider-routed shape via G11.5) is wired. Tests inject a
+deterministic stub via the same hook. There is no module-level
+singleton -- every call site passes a client. See G0.18-T7 (#1360)
+and ``docs/codebase/spec-ingestion.md`` §"LLM-client wiring
+(build-time-only today)" for the operator-facing framing.
 """
 
 from __future__ import annotations

--- a/backend/src/meho_backplane/operations/ingest/pipeline.py
+++ b/backend/src/meho_backplane/operations/ingest/pipeline.py
@@ -29,15 +29,27 @@ LLM-client injection
 --------------------
 
 The grouping pass requires an :class:`LlmClient` Protocol
-implementation. The chassis does not yet ship a production adapter
-(T5 of #389 lands the Anthropic Messages-API binding); to keep T6's
-REST surface workable both in tests and once the production adapter
-is wired, the pipeline accepts an injectable factory at construction
-time. The default factory raises :class:`LlmClientUnavailable` so
-calling ``POST /api/v1/connectors/ingest`` against a backplane that
-hasn't configured an LLM client returns 503 rather than crashing.
-Sibling tests / the CLI / the MCP tools each inject their own
-client.
+implementation. **No production adapter ships yet** — the chassis
+exposes :func:`set_llm_client_factory`
+(:mod:`meho_backplane.api.v1.connectors_ingest`) as the wire-up
+seam, but FastAPI lifespan startup has no caller for it, and
+``settings.anthropic_api_key`` flows only to the agent runtime
+(``agent/run.py``), not here. To keep T6's REST surface workable
+both in tests and once a production adapter lands, the pipeline
+accepts an injectable factory at construction time; the default
+factory raises :class:`LlmClientUnavailable` so calling
+``POST /api/v1/connectors/ingest`` against a backplane that hasn't
+configured an LLM client returns 503 rather than crashing. Sibling
+tests inject their own deterministic stub via
+``IngestionPipelineService(..., llm_client_factory=...)``; the
+CLI / REST / MCP surfaces all use the same fail-closed default,
+so ``meho connector ingest --catalog <product>/<version>`` is
+**build-time-only** on current deploys (CI fixtures inject the
+stub; deployed backplanes get the 503). Wiring a production
+adapter at lifespan startup — reading ``anthropic_api_key`` from
+settings into a real :class:`LlmClient` implementation — is the
+outstanding follow-up; see G0.18-T7 (#1360) for the doc/reference
+cleanup and the operator-facing build-time-only framing.
 
 Multi-spec merge
 ----------------
@@ -146,12 +158,24 @@ def default_llm_client_factory() -> LlmClient:
     T5, admin MCP tools at T7) can import the same fallback factory
     from :mod:`meho_backplane.operations.ingest` without reaching
     across the underscore boundary.
+
+    The detail message names the wire-up seam
+    (:func:`set_llm_client_factory`) rather than a tracking-issue
+    number — the previously-cited ``G0.7-T5 (#405)`` was the CLI verb
+    tree, not an LLM-adapter task, and ``settings.anthropic_api_key``
+    is read only by the agent runtime today. See G0.18-T7 (#1360)
+    for the dead-reference cleanup and the build-time-only framing.
     """
     raise LlmClientUnavailable(
         "no LLM client configured for spec-ingestion grouping; "
-        "the production Anthropic adapter lands with G0.7-T5 (#405). "
-        "Tests inject a deterministic stub via "
-        "IngestionPipelineService(..., llm_client_factory=...).",
+        "no production adapter is wired today. Tests inject a "
+        "deterministic stub via "
+        "IngestionPipelineService(..., llm_client_factory=...); "
+        "deployed backplanes require an operator to install a real "
+        "LlmClient at lifespan startup via "
+        "meho_backplane.api.v1.connectors_ingest.set_llm_client_factory(...). "
+        "Until that wiring lands, --catalog ingest grouping is "
+        "build-time-only.",
     )
 
 

--- a/backend/tests/acceptance/test_g07_vsphere_canary.py
+++ b/backend/tests/acceptance/test_g07_vsphere_canary.py
@@ -119,8 +119,13 @@ every CI run. The default stub returns deterministic group proposals
 ranks every canonical op in the top-3", not "the LLM produces good
 groups" (the latter is a manual operator-review step). An opt-in
 ``ANTHROPIC_API_KEY``-gated live-LLM run via
-``MEHO_G07_CANARY_LIVE_LLM=1`` exercises the real Anthropic adapter
-once the production adapter wires up (G0.7 follow-up #467).
+``MEHO_G07_CANARY_LIVE_LLM=1`` would exercise the real Anthropic
+adapter once a production ``LlmClient`` adapter is wired at
+FastAPI lifespan startup. **No production adapter ships today** —
+see ``docs/codebase/spec-ingestion.md`` §"LLM-client wiring
+(build-time-only today)" and G0.18-T7 (#1360) for the doc cleanup;
+the live-LLM variant is parked until an operator wires the
+adapter via ``set_llm_client_factory``.
 """
 
 from __future__ import annotations
@@ -1471,14 +1476,20 @@ async def test_canary_live_llm_grouping_produces_named_groups(
         "anthropic",
         reason="anthropic SDK not installed; live-LLM variant is opt-in",
     )
-    # The production LLM adapter lands in a sibling Task (#467);
-    # until then this stub raises BLOCKED-prerequisite so operators
-    # running this manually see a clear pointer rather than a
-    # silent skip.
+    # No production LlmClient adapter wires itself at FastAPI
+    # lifespan startup today -- the previously-cited ``Task #467``
+    # was G8.1-T3 (audit CLI verbs, CLOSED), never the Anthropic
+    # adapter. Keep this stub-skip so operators running the canary
+    # manually see a clear pointer rather than a silent skip. See
+    # G0.18-T7 (#1360) for the dead-reference cleanup +
+    # ``docs/codebase/spec-ingestion.md`` §"LLM-client wiring
+    # (build-time-only today)" for the operator-facing framing.
     pytest.skip(
-        "Live-LLM canary requires the production Anthropic adapter (Task #467). "
-        "Stubs cover the canary's correctness; this variant lands when the "
-        "adapter does.",
+        "Live-LLM canary requires a production Anthropic LlmClient "
+        "adapter wired at FastAPI lifespan startup; the chassis does "
+        "not yet ship one. Stubs cover the canary's correctness; this "
+        "variant lands when an operator installs the adapter (see "
+        "docs/codebase/spec-ingestion.md and G0.18-T7 #1360).",
     )
 
 

--- a/backend/tests/test_mcp_tools_connector_admin.py
+++ b/backend/tests/test_mcp_tools_connector_admin.py
@@ -518,9 +518,11 @@ def test_call_meho_connector_ingest_threads_specs_through(
     assert len(call_kwargs["specs"]) == 2
     assert call_kwargs["specs"][0].uri == "docs:vcenter-9.0/vcenter.yaml"
     assert call_kwargs["specs"][1].uri == "docs:vcenter-9.0/vi-json.yaml"
-    # Pipeline gets a factory; the default fail-closed factory is the
-    # production wiring the chassis swaps out at lifespan once the
-    # Anthropic adapter lands (T5 #405).
+    # Pipeline gets a factory; the chassis-shipped fail-closed
+    # default is what we install today (no production adapter is
+    # wired at FastAPI lifespan startup -- G0.18-T7 #1360). A
+    # future operator-installed adapter would replace it via
+    # ``set_llm_client_factory(...)``.
     assert pipeline.init_kwargs.get("llm_client_factory") is not None
 
 

--- a/backend/tests/test_operations_ingest_llm_groups.py
+++ b/backend/tests/test_operations_ingest_llm_groups.py
@@ -993,13 +993,18 @@ async def test_run_llm_grouping_with_real_claude_haiku(
 
     Note: this test exercises only the public surface; it does not
     pull the Anthropic SDK at import time. A concrete LlmClient
-    backed by ``anthropic.AsyncAnthropic`` lives in the chassis (when
-    that lands at T5 #405 or later); for v0.2 this test stays
-    as a manual sanity hook.
+    backed by ``anthropic.AsyncAnthropic`` does **not** yet ship in
+    the chassis -- ``set_llm_client_factory`` is the wire-up seam
+    but FastAPI lifespan startup has no caller for it (see
+    ``docs/codebase/spec-ingestion.md`` §"LLM-client wiring (build-
+    time-only today)" + G0.18-T7 #1360). For v0.2 this test stays as
+    a manual sanity hook.
     """
     pytest.skip(
         "real-LLM integration adapter not yet wired; "
-        "T5 (#405) lands the chassis LlmClient implementation",
+        "no production LlmClient ships in the chassis "
+        "(set_llm_client_factory has no lifespan caller). "
+        "Tracked under G0.18-T7 #1360.",
     )
 
 

--- a/docs/architecture/spec-ingestion.md
+++ b/docs/architecture/spec-ingestion.md
@@ -317,7 +317,7 @@ Resolution path: add a T3 enhancement pass that generates per-op `llm_instructio
 
 ### Gap 2 — live-LLM canary validation
 
-The G0.7 canary is currently stub-LLM-only — the acceptance test ships a deterministic path-prefix classifier so the suite stays reproducible and fast (~5 s ingest + ~1–2 s per benchmark query). A live-LLM variant gated on `MEHO_G07_CANARY_LIVE_LLM=1` is reserved for the day [Task #467](https://github.com/evoila/meho/issues/467) (Anthropic chassis adapter) lands. Once #467 ships, re-run the canary against harder queries (snapshot revert, performance-metrics query, host-network atomic mutation) that the path-prefix stub cannot trivially classify.
+The G0.7 canary is currently stub-LLM-only — the acceptance test ships a deterministic path-prefix classifier so the suite stays reproducible and fast (~5 s ingest + ~1–2 s per benchmark query). A live-LLM variant gated on `MEHO_G07_CANARY_LIVE_LLM=1` is reserved for the day a production Anthropic `LlmClient` adapter wires itself at FastAPI lifespan startup. **No such adapter ships today** — the previously-cited `Task #467` was [G8.1-T3 audit CLI verbs (CLOSED)](https://github.com/evoila/meho/issues/467), never the chassis adapter; the cleanup landed in [G0.18-T7 #1360](https://github.com/evoila/meho/issues/1360), and the build-time-only operator-facing framing now lives in [`docs/codebase/spec-ingestion.md`](../codebase/spec-ingestion.md#llm-client-wiring-build-time-only-today). Once an operator-installed adapter is wired (via `meho_backplane.api.v1.connectors_ingest.set_llm_client_factory(...)`), re-run the canary against harder queries (snapshot revert, performance-metrics query, host-network atomic mutation) that the path-prefix stub cannot trivially classify.
 
 ## References
 

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -33,8 +33,11 @@ The pipeline is broken into work items per Initiative #389:
   each op to a group in batches of 50. Proposed groups land
   `review_status='staged'`; each per-op `group_id` is set in the same
   transaction as the audit row. The LLM is injected as the
-  :class:`LlmClient` Protocol; production T5 wires the chassis
-  Anthropic adapter, tests inject a deterministic stub.
+  :class:`LlmClient` Protocol; tests inject a deterministic stub,
+  and **no production adapter is wired today** — see
+  [LLM-client wiring (build-time-only today)](#llm-client-wiring-build-time-only-today)
+  below for the lifespan-startup gap (G0.18-T7 / #1360) that keeps
+  non-dry-run `--catalog` ingest 503ing on deployed backplanes.
 * **T4 — Review-queue state machine** (`ingest/service.py`). Operators
   move connectors through `staged → enabled` (and `disabled` for
   regression rollback) before any op becomes dispatchable.
@@ -366,11 +369,19 @@ across T5's CLI verbs, T6's REST routes, and T7's admin MCP tools.
 
 The `LlmClient` Protocol is injected via a factory parameter so the
 chassis can lazy-resolve it; the default factory raises
-`LlmClientUnavailable` and the REST layer maps it onto HTTP 503. T5
-(#405) replaces the default with the production Anthropic-Messages-
-API adapter. The `embedding_service` parameter is the test seam to
-inject `AsyncMock` so unit tests don't pull the fastembed ONNX
-model from huggingface.co.
+`LlmClientUnavailable` and the REST layer maps it onto HTTP 503.
+**No production adapter ships today** — `set_llm_client_factory`
+(in `api/v1/connectors_ingest.py`) is the wire-up seam, but FastAPI
+lifespan startup has no caller for it and `settings.anthropic_api_key`
+flows only to the agent runtime (`agent/run.py:432`). See
+[LLM-client wiring (build-time-only today)](#llm-client-wiring-build-time-only-today)
+for the operator-facing framing; G0.18-T7 (#1360) tracks the doc
+cleanup and the build-time-only caveat in the
+`composite_l2_missing` envelope text.
+
+The `embedding_service` parameter is the test seam to inject
+`AsyncMock` so unit tests don't pull the fastembed ONNX model from
+huggingface.co.
 
 `ingest(..., dry_run=True)` short-circuits both the DB writes and
 the LLM call: parses every spec and returns the parser's
@@ -642,9 +653,12 @@ under the `TENANT_ADMIN` role).
 The `op_id` path segment uses the `:path` converter so operations
 whose natural key contains slashes (`"GET:/api/vcenter/cluster"`)
 round-trip through URL routing intact. The route module's
-`set_llm_client_factory(factory)` helper lets the production
-bootstrap (G0.7-T5) install the Anthropic adapter and lets tests
-inject deterministic stubs.
+`set_llm_client_factory(factory)` helper is the wire-up seam a
+future production bootstrap would call to install a real
+:class:`LlmClient` adapter; today only tests call it, so non-dry-
+run ingest grouping is build-time-only — see
+[LLM-client wiring (build-time-only today)](#llm-client-wiring-build-time-only-today)
+for the operator-facing framing.
 
 ### `parse_openapi(spec_path_or_uri, *, spec_source=None)` (`ingest/openapi.py`)
 
@@ -867,8 +881,63 @@ whose pod died was never going to finish. Durable cross-restart
 jobs are a v0.9 follow-up (the same migration that lands
 operator-cancellable jobs).
 
+## LLM-client wiring (build-time-only today)
+
+The grouping pass (T3, `run_llm_grouping` in
+`operations/ingest/llm_groups.py`) needs an injected `LlmClient`
+Protocol implementation. The chassis exposes the wire-up seam
+(`set_llm_client_factory` in
+[`api/v1/connectors_ingest.py`](../../backend/src/meho_backplane/api/v1/connectors_ingest.py))
+and the fail-closed default (`default_llm_client_factory` in
+[`operations/ingest/pipeline.py`](../../backend/src/meho_backplane/operations/ingest/pipeline.py)),
+but **no production caller invokes the seam at FastAPI lifespan
+startup**. `settings.anthropic_api_key` is read only by the agent
+runtime (`agent/run.py:432`) — never by the ingest pipeline.
+
+Operationally this means non-dry-run ingest of an un-grouped
+connector — whether via the CLI (`meho connector ingest --catalog
+<product>/<version>`), the REST route
+(`POST /api/v1/connectors/ingest`), or the admin MCP tool
+(`meho.connector.ingest`) — fails closed with HTTP 503 (the route
+maps `LlmClientUnavailable` onto 503; the CLI / MCP surfaces
+render their own operator-facing variant). The grouping pass only
+runs in CI / build contexts where the test fixture is in scope
+and the suite injects a deterministic stub via
+`IngestionPipelineService(..., llm_client_factory=...)`. From an
+operator's perspective, **`--catalog` ingest grouping is build-
+time-only today**.
+
+The `composite_l2_missing` error envelope
+(`operations/_errors.py:result_composite_l2_missing`) surfaces a
+catalog-ingest command as the escape hatch from a missing L2 sub-
+op; on current deploys that escape hatch returns 503 rather than
+completing the ingest, until a production adapter is wired. The
+envelope text and `docs/codebase/api-shape-conventions.md` §1's
+escape-hatch framing call out this limitation so operators don't
+walk into the 503 expecting success.
+
+**Operator action to take.** Wiring is a deploy-time concern, not
+a chassis bug — the pipeline accepts an injected factory as its
+documented extension point. Installing a production adapter
+(`AnthropicLlmClient` against the Messages API, or a provider-
+routed shape via G11.5) and calling `set_llm_client_factory(...)`
+once during FastAPI lifespan startup is the unblock path. There
+is no upstream tracking issue for this wire-up at the time of
+G0.18-T7 (#1360); an operator-filed Task under Goal #221 is the
+expected next step. Until then, treat `--catalog` ingest as a
+build-only path.
+
 ## Known issues
 
+* **`--catalog` ingest grouping is build-time-only on deployed
+  backplanes.** See
+  [LLM-client wiring (build-time-only today)](#llm-client-wiring-build-time-only-today)
+  above — no production `LlmClient` adapter ships in the chassis,
+  so non-dry-run ingest fails closed with 503 / `LlmClientUnavailable`
+  on every deploy until an operator wires
+  `set_llm_client_factory(...)` at FastAPI lifespan startup.
+  Tracked in G0.18-T7 (#1360, doc cleanup); the actual adapter
+  wire-up is the operator-side follow-up.
 * **Async-mode jobs don't survive pod restart.** The G0.16-T1
   `IngestJobRegistry` lives in process memory. A pod restart
   during a long-running ingest leaves the operator's client

--- a/docs/cross-repo/connector-ingestion.md
+++ b/docs/cross-repo/connector-ingestion.md
@@ -24,7 +24,7 @@ Typed connectors and ingested connectors are both first-class ([CLAUDE.md](../..
 - **Role.** Write verbs (`ingest`, `edit-group`, `edit-op`, `enable`, `disable`) require `tenant_admin`. Read verbs (`list`, `review`) require `operator`. The backplane returns HTTP 403 with the CLI exit code 5 if the wrong role tries a write verb.
 - **A running backplane.** `meho login <backplane-url>` writes a session token the CLI reuses across every verb. Override per-call with `--backplane <url>` when needed.
 - **The OpenAPI spec.** A path to a local file (`file:///abs/path/spec.yaml`) or an HTTPS URL the backplane can fetch (`https://vendor.example.com/openapi.yaml`). The CLI also accepts the `docs:<product>-<version>/<spec>.yaml` shorthand that resolves against `$CLAUDE_RDC_DOCS` when set; otherwise the shorthand is passed through for the backplane to resolve against its own checked-in docs corpus.
-- **An LLM client configured for the grouping pass.** Production deploys wire the Anthropic Messages-API adapter via [`IngestionPipelineService(..., llm_client_factory=...)`](../../backend/src/meho_backplane/operations/ingest/pipeline.py). If the adapter is unwired, the ingest REST route returns HTTP 503 `LlmClientUnavailable` and the CLI prints the structured error.
+- **An LLM client configured for the grouping pass.** This is the v0.9 reality check: **no production `LlmClient` adapter ships in the chassis today.** The wire-up seam exists ([`set_llm_client_factory`](../../backend/src/meho_backplane/api/v1/connectors_ingest.py)) and the constructor accepts an injected factory ([`IngestionPipelineService(..., llm_client_factory=...)`](../../backend/src/meho_backplane/operations/ingest/pipeline.py)), but FastAPI lifespan startup has no caller for the seam — `settings.anthropic_api_key` flows only to the agent runtime (`agent/run.py:432`). On a stock deploy the ingest REST route returns HTTP 503 `LlmClientUnavailable` for any non-dry-run ingest and the CLI prints the structured error; ingest grouping is build-time-only until an operator installs a real `LlmClient` (Anthropic Messages API or provider-routed via G11.5) and calls `set_llm_client_factory(...)` at lifespan startup. See [`docs/codebase/spec-ingestion.md` §"LLM-client wiring (build-time-only today)"](../codebase/spec-ingestion.md#llm-client-wiring-build-time-only-today) for the full operator-facing framing.
 - **Postgres with pgvector + FTS extensions.** v0.2 ships the `pgvector/pgvector:pg16`-derived chart image; local development uses the testcontainers fixture.
 
 ## Step-by-step
@@ -300,17 +300,17 @@ Resolution path: extend T3 with a per-op `llm_instructions` generation pass that
 
 ### Gap 3 — live-LLM canary validation
 
-**Status:** documented; gated on [Task #467](https://github.com/evoila/meho/issues/467).
+**Status:** documented; gated on an operator-installed production `LlmClient` adapter wired at FastAPI lifespan startup. **No such adapter ships today.** The previously-cited [`Task #467`](https://github.com/evoila/meho/issues/467) was [G8.1-T3 audit CLI verbs (CLOSED)](https://github.com/evoila/meho/issues/467), never the chassis adapter; the cleanup landed via [G0.18-T7 #1360](https://github.com/evoila/meho/issues/1360). See [`docs/codebase/spec-ingestion.md` §"LLM-client wiring (build-time-only today)"](../codebase/spec-ingestion.md#llm-client-wiring-build-time-only-today) for the operator-facing framing.
 
-The canary's acceptance test ships a deterministic stub-LLM that classifies ops by URL-path prefix. The stub keeps the test reproducible and fast but doesn't exercise the production Anthropic adapter's prompt-engineering or retry-policy edges.
+The canary's acceptance test ships a deterministic stub-LLM that classifies ops by URL-path prefix. The stub keeps the test reproducible and fast but doesn't exercise a live Anthropic adapter's prompt-engineering or retry-policy edges.
 
-A live-LLM variant exists at `MEHO_G07_CANARY_LIVE_LLM=1` but currently skips because [Task #467](https://github.com/evoila/meho/issues/467) (Anthropic chassis adapter) hasn't landed. Once #467 ships:
+A live-LLM variant exists at `MEHO_G07_CANARY_LIVE_LLM=1` but currently skips because no production `LlmClient` is wired via `meho_backplane.api.v1.connectors_ingest.set_llm_client_factory(...)` at FastAPI lifespan startup. Once an operator wires one:
 
 1. Re-run the canary with the env var set.
 2. Pick harder queries the path-prefix stub can't trivially classify — snapshot revert, performance-metrics query, host-network atomic mutation.
 3. Compare top-3 hit rate against the stub baseline to verify the live LLM doesn't regress retrieval quality.
 
-**File a Task** in #467's wake; do not block #467 on it.
+**File a Task** for the production-adapter wire-up itself (under Goal #221 / Initiative #389-family) before extending the canary; do not block the canary on it.
 
 ## References
 

--- a/docs/cross-repo/g07-vsphere-canary.md
+++ b/docs/cross-repo/g07-vsphere-canary.md
@@ -96,11 +96,19 @@ parameter-ref parser branch and #503 extended this canary):
   (T5, #486). The connector CLI talks to the REST API at
   ``http(s)://<backplane>/api/v1/connectors/ingest``.
 
-- An LLM client configured for the grouping pass. Production
-  deployments wire the Anthropic Messages-API adapter under
-  ``IngestionPipelineService(..., llm_client_factory=...)``; the
-  canary acceptance test uses a deterministic stub (see *Test
-  variant* below).
+- An LLM client configured for the grouping pass. **No production
+  ``LlmClient`` adapter ships in the chassis today** —
+  ``set_llm_client_factory`` is the wire-up seam, but FastAPI
+  lifespan startup has no caller for it, so non-dry-run ingest
+  returns HTTP 503 / ``LlmClientUnavailable`` on stock deploys.
+  Operators install a real adapter (Anthropic Messages-API binding
+  or provider-routed via G11.5) and pass it via
+  ``IngestionPipelineService(..., llm_client_factory=...)`` /
+  ``set_llm_client_factory(...)`` to unblock the canary on a live
+  backplane. The canary acceptance test uses a deterministic stub
+  (see *Test variant* below) so it can run without an adapter
+  wired. Full framing in
+  [``docs/codebase/spec-ingestion.md``](../codebase/spec-ingestion.md#llm-client-wiring-build-time-only-today).
 
 ## Operator procedure
 
@@ -237,8 +245,13 @@ runs the same procedure non-interactively against a
 testcontainers Postgres + a deterministic LLM stub that classifies
 ops by URL path prefix. The stub keeps the test reproducible and
 fast (~5 s ingest + ~1-2 s per benchmark query); a live-LLM variant
-gated on ``MEHO_G07_CANARY_LIVE_LLM=1`` is reserved for the day the
-production Anthropic adapter (Task #467) lands.
+gated on ``MEHO_G07_CANARY_LIVE_LLM=1`` is reserved for the day a
+production Anthropic ``LlmClient`` adapter is wired at FastAPI
+lifespan startup. No such adapter ships today (the previously-cited
+``Task #467`` was the audit CLI verb tracker, not an LLM adapter
+— see G0.18-T7 #1360 for the cleanup and
+``docs/codebase/spec-ingestion.md`` §"LLM-client wiring
+(build-time-only today)" for the operator-facing framing).
 
 The acceptance test asserts:
 

--- a/docs/cross-repo/g35-nsx-canary.md
+++ b/docs/cross-repo/g35-nsx-canary.md
@@ -94,9 +94,18 @@ against the **two-spec NSX corpus**:
 - **A running backplane with `meho connector ingest` available**
   (T5, #486). The connector CLI talks to the REST API at
   `http(s)://<backplane>/api/v1/connectors/ingest`.
-- **An LLM client configured for the grouping pass.** Production
-  deploys wire the Anthropic Messages-API adapter under
-  `IngestionPipelineService(..., llm_client_factory=...)`.
+- **An LLM client configured for the grouping pass.** **No
+  production `LlmClient` adapter ships in the chassis today** —
+  `set_llm_client_factory` is the wire-up seam but FastAPI
+  lifespan startup has no caller for it, so non-dry-run ingest
+  returns HTTP 503 / `LlmClientUnavailable` on stock deploys.
+  Operators install a real adapter (Anthropic Messages-API or
+  provider-routed via G11.5) and pass it via
+  `IngestionPipelineService(..., llm_client_factory=...)` to
+  unblock the canary on a live backplane; see
+  [`docs/codebase/spec-ingestion.md` §"LLM-client wiring
+  (build-time-only today)"](../codebase/spec-ingestion.md#llm-client-wiring-build-time-only-today)
+  for the operator-facing framing.
 - **A Vault path holding the NSX service-account credentials.**
   The `NsxConnector.session_loader` resolves
   `target.secret_ref` to a `{"username": ..., "password": ...}`

--- a/docs/cross-repo/g36-fleet-canary.md
+++ b/docs/cross-repo/g36-fleet-canary.md
@@ -84,9 +84,18 @@ the **vRSLCM LCM REST corpus**:
 - **A running backplane with `meho connector ingest` available**
   (T5, #486). The connector CLI talks to the REST API at
   `http(s)://<backplane>/api/v1/connectors/ingest`.
-- **An LLM client configured for the grouping pass.** Production
-  deploys wire the Anthropic Messages-API adapter under
-  `IngestionPipelineService(..., llm_client_factory=...)`.
+- **An LLM client configured for the grouping pass.** **No
+  production `LlmClient` adapter ships in the chassis today** —
+  `set_llm_client_factory` is the wire-up seam but FastAPI
+  lifespan startup has no caller for it, so non-dry-run ingest
+  returns HTTP 503 / `LlmClientUnavailable` on stock deploys.
+  Operators install a real adapter (Anthropic Messages-API or
+  provider-routed via G11.5) and pass it via
+  `IngestionPipelineService(..., llm_client_factory=...)` to
+  unblock the canary on a live backplane; see
+  [`docs/codebase/spec-ingestion.md` §"LLM-client wiring
+  (build-time-only today)"](../codebase/spec-ingestion.md#llm-client-wiring-build-time-only-today)
+  for the operator-facing framing.
 - **A Vault path holding the Fleet service-account credentials.**
   The `VcfFleetConnector` resolves
   `target.secret_ref` to a `{"username": ..., "password": ...}`

--- a/docs/cross-repo/g36-vcfa-canary.md
+++ b/docs/cross-repo/g36-vcfa-canary.md
@@ -102,9 +102,18 @@ against the **two-spec dual-plane VCFA corpus**:
   (T5, #486). The connector CLI talks to the REST API at
   `http(s)://<backplane>/api/v1/connectors/ingest`.
 
-- **An LLM client configured for the grouping pass.** Production
-  deploys wire the Anthropic Messages-API adapter under
-  `IngestionPipelineService(..., llm_client_factory=...)`.
+- **An LLM client configured for the grouping pass.** **No
+  production `LlmClient` adapter ships in the chassis today** —
+  `set_llm_client_factory` is the wire-up seam but FastAPI
+  lifespan startup has no caller for it, so non-dry-run ingest
+  returns HTTP 503 / `LlmClientUnavailable` on stock deploys.
+  Operators install a real adapter (Anthropic Messages-API or
+  provider-routed via G11.5) and pass it via
+  `IngestionPipelineService(..., llm_client_factory=...)` to
+  unblock the canary on a live backplane; see
+  [`docs/codebase/spec-ingestion.md` §"LLM-client wiring
+  (build-time-only today)"](../codebase/spec-ingestion.md#llm-client-wiring-build-time-only-today)
+  for the operator-facing framing.
 
 - **A Vault path holding the VCFA service-account credentials.**
   The `VcfAutomationConnector.credentials_loader` resolves

--- a/docs/cross-repo/g36-vrli-canary.md
+++ b/docs/cross-repo/g36-vrli-canary.md
@@ -95,9 +95,18 @@ against the **vRLI v2 API corpus**:
 - **A running backplane with `meho connector ingest` available**
   (T5, #486). The connector CLI talks to the REST API at
   `http(s)://<backplane>/api/v1/connectors/ingest`.
-- **An LLM client configured for the grouping pass.** Production
-  deploys wire the Anthropic Messages-API adapter under
-  `IngestionPipelineService(..., llm_client_factory=...)`.
+- **An LLM client configured for the grouping pass.** **No
+  production `LlmClient` adapter ships in the chassis today** —
+  `set_llm_client_factory` is the wire-up seam but FastAPI
+  lifespan startup has no caller for it, so non-dry-run ingest
+  returns HTTP 503 / `LlmClientUnavailable` on stock deploys.
+  Operators install a real adapter (Anthropic Messages-API or
+  provider-routed via G11.5) and pass it via
+  `IngestionPipelineService(..., llm_client_factory=...)` to
+  unblock the canary on a live backplane; see
+  [`docs/codebase/spec-ingestion.md` §"LLM-client wiring
+  (build-time-only today)"](../codebase/spec-ingestion.md#llm-client-wiring-build-time-only-today)
+  for the operator-facing framing.
 - **A Vault path holding the vRLI service-account credentials.**
   The `VcfLogsConnector` resolves `target.secret_ref` to a
   `{"username": ..., "password": ...}` pair posted to

--- a/docs/cross-repo/g36-vrops-canary.md
+++ b/docs/cross-repo/g36-vrops-canary.md
@@ -72,9 +72,18 @@ the vROps suite-api spec:
 - **A running backplane with `meho connector ingest` available.**
   The connector CLI talks to the REST API at
   `http(s)://<backplane>/api/v1/connectors/ingest`.
-- **An LLM client configured for the grouping pass.** Production
-  deploys wire the Anthropic Messages-API adapter under
-  `IngestionPipelineService(..., llm_client_factory=...)`.
+- **An LLM client configured for the grouping pass.** **No
+  production `LlmClient` adapter ships in the chassis today** —
+  `set_llm_client_factory` is the wire-up seam but FastAPI
+  lifespan startup has no caller for it, so non-dry-run ingest
+  returns HTTP 503 / `LlmClientUnavailable` on stock deploys.
+  Operators install a real adapter (Anthropic Messages-API or
+  provider-routed via G11.5) and pass it via
+  `IngestionPipelineService(..., llm_client_factory=...)` to
+  unblock the canary on a live backplane; see
+  [`docs/codebase/spec-ingestion.md` §"LLM-client wiring
+  (build-time-only today)"](../codebase/spec-ingestion.md#llm-client-wiring-build-time-only-today)
+  for the operator-facing framing.
 - **A Vault path holding the vROps service-account credentials.**
   The `VcfOperationsConnector._creds` cache resolves
   `target.secret_ref` to a `{"username": ..., "password": ...}`


### PR DESCRIPTION
## Summary

- The ingest LLM-grouping stack misdocumented itself: `pipeline.py:142-155`'s `default_llm_client_factory()` and many neighbouring docstrings/docs cited `T5 (#405)` / "production Anthropic adapter lands with G0.7-T5" / `Task #467` as where the adapter would ship, but `#405` was G0.7-T5 = CLI verbs (CLOSED) and `#467` was G8.1-T3 audit CLI verbs (CLOSED). Neither tracked an LLM adapter. Meanwhile `settings.anthropic_api_key` flows only to the agent runtime (`agent/run.py:432`) — not the ingest pipeline — and `set_llm_client_factory` (the wire-up seam) has zero production callers. So non-dry-run `meho connector ingest --catalog <product>/<version>` on a stock deploy 503s on every deploy and the `composite_l2_missing` envelope's escape-hatch hint sent operators (RDC #789 Finding N9) straight into the 503.
- Replaces the dead `#405` / `#467` references with honest "no production adapter wires itself at FastAPI lifespan startup today" framing across `pipeline.py`, `api/v1/connectors_ingest.py`, `mcp/tools/connector_admin.py`, `operations/ingest/llm_groups.py`, `connectors/vmware_rest/_catalog_command.py`, two affected tests, the architecture doc's Gap 2, and five `docs/cross-repo/` canary docs.
- Updates the `composite_l2_missing` envelope's human message to name the build-time-only caveat so operators don't follow the suggested catalog command into a silent 503. The structured `catalog_command` field stays populated — operators wanting to use it install a real `LlmClient` via `set_llm_client_factory(...)` at FastAPI lifespan startup.
- Adds `docs/codebase/spec-ingestion.md` §"LLM-client wiring (build-time-only today)" as the canonical operator-facing framing + a Known-issues entry; the architecture doc and the cross-repo connector-ingestion runbook both cross-link into it.
- CHANGELOG `[Unreleased]` Fixed bullet citing RDC #789 N9.

## Test plan

- [x] `ruff check` on 9 touched files — All checks passed
- [x] `ruff format --check` on 9 touched files — All already formatted
- [x] `mypy` on 6 touched src files — Success, no issues found
- [x] `pytest tests/test_operations_ingest_llm_groups.py tests/test_mcp_tools_connector_admin.py` — 48 passed, 1 skipped
- [x] `pytest tests/test_operations_composite.py tests/test_connectors_vmware_rest_composites_l2_preflight.py` — 18 passed (no regression in composite-error-shape assertions after the envelope text update)
- [x] `pytest tests/test_api_v1_connectors_ingest.py` — 57 passed (covers the routes whose module docstrings changed)
- [x] `pytest tests/acceptance/test_g07_vsphere_canary.py -k canary_live_llm` — skipped as expected (no production LlmClient wired)
- [x] All pre-commit hooks green (trailing whitespace, end-of-files, large-files, merge-conflict, private-key, mixed-line-ending, detect-secrets, conventional-commit)
- [x] DCO sign-off on the commit (Signed-off-by trailer present)

## Acceptance criteria

- [x] Dead `#405` / "G0.7-T5" reference removed/corrected in `pipeline.py:34-40,105,142-155` and `connectors/vmware_rest/_catalog_command.py:52` (now state "no production adapter wires itself today" + name the wire-up seam `set_llm_client_factory`).
- [x] `docs/codebase/spec-ingestion.md` + the `composite_l2_missing` envelope text in `operations/_errors.py:result_composite_l2_missing` state that `--catalog` ingest grouping needs an injected LLM client and is build-time-only on deployed backplanes.
- [x] Follow-up referenced: production-adapter wire-up is the operator-side follow-up (under Goal #221 / Initiative #389-family) — the doc cleanup explicitly names it as the unblock path. No new chassis-owned tracker filed because the adapter wire-up is a deploy-time concern by design (the pipeline's `llm_client_factory` is the documented extension point).
- [x] CHANGELOG `[Unreleased]` bullet citing RDC #789 N9.

## Out of scope

- Implementing the production ingest `AnthropicLlmClient` adapter (a separate, larger Task/Initiative — this Task only fixes the misleading reference + docs).
- The five other `docs/cross-repo/` canary docs' adapter-wire-up framing was updated for consistency; no behaviour change to the canaries themselves.

<!-- auto-implement-issue: fresh, iteration 1, --no-dance (orchestrator owns review) -->

Closes #1360


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated operator runbooks and internal documentation to clarify LLM client configuration requirements for connector ingestion grouping, including failure behavior and setup guidance across all supported platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/evoila/meho/pull/1368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->