### PR TITLE
fix(connectors): G0.18-T8 VCF catalog `next_step` hints honest about `--spec`-only rows (#1361)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,33 @@ connector-related release-notes line.
   `LlmClient` adapter at lifespan startup remains the
   operator-side follow-up.
 
+- **VCF-family catalog rows + `GET /api/v1/connectors` `next_step`
+  hints no longer over-promise `--catalog` ingest (G0.18-T8 #1361,
+  RDC #789 N8).** Rechecked the upstreams against G0.15-T2 (#1211):
+  `vmware/9.0` and `sddc-manager/9.0` still serve `text/html` from
+  the Broadcom Developer Portal (no regression — the catalog notes
+  already document the unusability, the route's
+  `catalog_entry_upstream_not_spec` 422 still fires). `nsx/4.2`
+  is still fqdn-templated (`<nsx-mgr-fqdn>`) under
+  `catalog_entry_templated_upstream`. The over-promising was
+  isolated to the listing's hint: for any `state="registered"`
+  row whose catalog entry exists, the hint blindly said "spec
+  available in catalog; run ingest" and pointed at
+  `--catalog <product>/<version>` — which 422'd for all three
+  VCF-family rows. Added a declarative `catalog_ingest:
+  "supported" | "spec-only"` field on `ConnectorSpecEntry`
+  (default `"supported"` for back-compat; the three VCF rows
+  opt into `"spec-only"`); the listing's `next_step` hint now
+  branches on it and emits the explicit-quadruple `--product …
+  --version … --impl … --spec <concrete-openapi-uri>` verb plus
+  a rationale calling out the upstream-shape limitation when
+  the row is spec-only. Route validation behaviour is unchanged
+  (the existing 422 envelopes still fire on direct catalog-shape
+  POSTs against these rows); the hint is now an honest
+  precursor instead of pointing operators at a broken verb.
+  Docs: [`connector-catalog.md`](docs/cross-repo/connector-catalog.md)
+  §"Spec-only entries" + entry-schema table.
+
 ### Documentation
 
 - **`/mcp` root-mount carve-out documented + `/api/v1/mcp`

--- a/backend/src/meho_backplane/operations/ingest/catalog.py
+++ b/backend/src/meho_backplane/operations/ingest/catalog.py
@@ -63,11 +63,23 @@ import difflib
 import functools
 import re
 from importlib import resources
+from typing import Literal
 
 import yaml
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+#: Declarative classifier for whether the catalog row's upstream URL(s)
+#: can drive a ``meho connector ingest --catalog <product>/<version>``
+#: invocation end-to-end. ``"supported"`` (the default) — the upstream
+#: serves an OpenAPI spec directly, the catalog path works as advertised.
+#: ``"spec-only"`` — the upstream is an HTML developer-portal landing page
+#: (Broadcom Developer Portal for the VCF family) or an appliance-served
+#: fqdn-templated URL (NSX manager) that the catalog can't dereference
+#: server-side. Operators must fetch the spec themselves and pass it via
+#: the explicit-quadruple ``--spec`` shape.
+CatalogIngestSupport = Literal["supported", "spec-only"]
 
 #: Package + resource name of the catalog YAML shipped as package data.
 _CATALOG_PACKAGE = "meho_backplane.operations.ingest"
@@ -218,6 +230,27 @@ class ConnectorSpecEntry(BaseModel):
     spec_info_versions_compatible: tuple[str, ...] | None = None
     sha256: str | None = Field(default=None, max_length=64)
     notes: str = Field(default="", max_length=2048)
+    #: Whether the catalog row's ``upstream`` URL(s) can drive
+    #: ``meho connector ingest --catalog`` end-to-end. Defaults to
+    #: ``"supported"`` for backwards compatibility with every
+    #: pre-G0.18-T8 row -- the validator already rejects malformed shapes
+    #: at parse time. Rows whose upstream is an HTML developer-portal
+    #: landing page (Broadcom for vmware/sddc-manager) or an
+    #: fqdn-templated appliance URL (NSX) must set ``"spec-only"`` so
+    #: ``GET /api/v1/connectors`` emits a ``next_step`` hint pointing
+    #: at ``--spec`` instead of over-promising ``--catalog`` --
+    #: G0.18-T8 (#1361) / RDC #789 N8.
+    #:
+    #: The route's ``_reject_unusable_entry`` 422 branches
+    #: (``catalog_entry_typed_connector``,
+    #: ``catalog_entry_templated_upstream``, plus the
+    #: ``UpstreamNotSpecError`` path that surfaces
+    #: ``catalog_entry_upstream_not_spec``) are unchanged; this field
+    #: is the declarative source of truth the listing's ``next_step``
+    #: emitter reads, not a new validation gate. Operators who ignore
+    #: the hint and POST a ``--catalog`` body anyway still hit the
+    #: existing structured 422s.
+    catalog_ingest: CatalogIngestSupport = "supported"
 
     @field_validator("product", "version", "impl_id", "requires_connector_class")
     @classmethod

--- a/backend/src/meho_backplane/operations/ingest/catalog.yaml
+++ b/backend/src/meho_backplane/operations/ingest/catalog.yaml
@@ -56,6 +56,14 @@ entries:
     upstream:
       - "https://developer.broadcom.com/xapis/vsphere-automation-api/latest/"
       - "https://developer.broadcom.com/xapis/virtual-infrastructure-json-api/latest/"
+    # G0.18-T8 (#1361, RDC #789 N8): the Broadcom Developer Portal
+    # landing pages above still serve text/html (rechecked
+    # 2026-05-31), so catalog-driven ingest 422s
+    # ``catalog_entry_upstream_not_spec``. Operators must fetch the
+    # raw specs from the appliance and pass via the explicit-
+    # quadruple ``--spec`` shape; ``GET /api/v1/connectors``
+    # surfaces that via the ``next_step`` hint.
+    catalog_ingest: spec-only
     spec_info_version: null
     # G0.16-T6 Finding H (#1312). vSphere ships its spec under the
     # explicit-quadruple ``info.version="9.0.0.0"`` form while the
@@ -92,6 +100,11 @@ entries:
     requires_connector_class: SddcManagerConnector
     upstream:
       - "https://developer.broadcom.com/xapis/sddc-manager-api/latest/"
+    # G0.18-T8 (#1361, RDC #789 N8): same Broadcom Developer Portal
+    # text/html landing page as vmware/9.0 (rechecked 2026-05-31);
+    # catalog-driven ingest 422s. Operators fetch from the appliance
+    # and pass via ``--spec``.
+    catalog_ingest: spec-only
     spec_info_version: null
     sha256: null
     notes: >-
@@ -128,6 +141,12 @@ entries:
     upstream:
       - "https://<nsx-mgr-fqdn>/api/v1/spec/openapi/nsx_api.yaml"
       - "https://developer.broadcom.com/xapis/nsx-t-data-center-rest-api/latest/"
+    # G0.18-T8 (#1361, RDC #789 N8): the first upstream is fqdn-
+    # templated (placeholder ``<nsx-mgr-fqdn>``); the second is the
+    # Broadcom Developer Portal text/html landing page. Neither
+    # supports catalog-driven ingest server-side. Operators fetch
+    # from the appliance and pass via ``--spec``.
+    catalog_ingest: spec-only
     spec_info_version: null
     sha256: null
     notes: >-

--- a/backend/src/meho_backplane/operations/ingest/list_connectors.py
+++ b/backend/src/meho_backplane/operations/ingest/list_connectors.py
@@ -112,12 +112,25 @@ def _next_step_for_registered(
     :func:`parse_connector_id`'s deterministic shortening, and looking up
     ``("sddc", "9.0")`` would always miss for SDDC.
 
-    Two branches:
+    Three branches:
 
-    * **Catalog hit** — verb points at ``meho connector ingest --catalog
-      <product>/<version>``; rationale says the spec is available in the
-      catalog. The CLI form is the same one the curated-on-ramp ships
-      (#915 / G0.7-T5); copying the verb verbatim closes the workflow.
+    * **Catalog hit, ``catalog_ingest="supported"``** — verb points at
+      ``meho connector ingest --catalog <product>/<version>``; rationale
+      says the spec is available in the catalog. The CLI form is the
+      same one the curated-on-ramp ships (#915 / G0.7-T5); copying the
+      verb verbatim closes the workflow.
+    * **Catalog hit, ``catalog_ingest="spec-only"``** — verb points at
+      the manual-mode ``meho connector ingest --product <p> --version
+      <v> --impl <i> --spec <uri>`` form using the catalog's native
+      product/version/impl triple. Rationale calls out that the
+      catalog row exists but its upstream is HTML-portal or
+      fqdn-templated, so catalog-driven ingest would 422 -- the
+      operator must fetch the spec themselves. Closes the v0.8.1
+      RDC dogfood signal (#789 N8): the previous "spec available in
+      catalog; run ingest" hint over-promised the VCF-family rows
+      whose upstream is fundamentally not raw YAML/JSON (G0.18-T8 /
+      #1361). The same triple the operator would have used after a
+      hit lands here, so the verb still copies-and-runs.
     * **Catalog miss** — verb points at the manual-mode ``meho connector
       ingest --product <p> --version <v> --impl <i> --spec <uri>``;
       rationale calls out the missing catalog entry so the operator
@@ -133,10 +146,23 @@ def _next_step_for_registered(
     workflow doesn't depend on the catalog being live.
     """
     entry = catalog.get(registry_product, registry_version) if catalog is not None else None
-    if entry is not None:
+    if entry is not None and entry.catalog_ingest == "supported":
         return NextStep(
             verb=f"meho connector ingest --catalog {entry.product}/{entry.version}",
             rationale="spec available in catalog; run ingest to populate operations",
+        )
+    if entry is not None and entry.catalog_ingest == "spec-only":
+        return NextStep(
+            verb=(
+                f"meho connector ingest --product {entry.product} "
+                f"--version {entry.version} --impl {entry.impl_id} "
+                f"--spec <concrete-openapi-uri>"
+            ),
+            rationale=(
+                "catalog upstream is HTML-portal or fqdn-templated and "
+                "cannot drive --catalog ingest server-side; fetch the "
+                "raw OpenAPI spec from the appliance and pass via --spec"
+            ),
         )
     return NextStep(
         verb=(

--- a/backend/tests/test_api_v1_connectors_ingest.py
+++ b/backend/tests/test_api_v1_connectors_ingest.py
@@ -842,7 +842,7 @@ async def test_list_registered_row_carries_catalog_next_step_hint(
     client: TestClient,
     _registered_class_only_connectors: None,
 ) -> None:
-    """Catalog-hit branch: ``state="registered"`` rows carry the ``--catalog`` verb.
+    """Catalog-hit + ``catalog_ingest="supported"``: row carries the ``--catalog`` verb.
 
     G0.13-T3 (#1133) AC #1 + #3 (catalog-hit half):
     rows with ``state="registered"`` include a ``next_step`` field with
@@ -850,11 +850,13 @@ async def test_list_registered_row_carries_catalog_next_step_hint(
     has it" — the verb points at ``meho connector ingest --catalog
     <product>/<version>``.
 
-    SDDC is the load-bearing case: the listing emits ``product="sddc"``
-    (parser-derived), but the catalog stores ``product="sddc-manager"``
-    (registry-side). The hint must use the catalog's native key, i.e.
-    ``--catalog sddc-manager/9.0`` not ``--catalog sddc/9.0``. Harbor
-    exercises the trivial case where registry and parsed product agree.
+    Harbor exercises the catalog-supported branch: its row's
+    ``catalog_ingest`` defaults to ``"supported"`` (the upstream is
+    `raw.githubusercontent.com` JSON, directly fetchable), so the hint
+    points at the ``--catalog`` verb. The SDDC-as-catalog-hit case has
+    moved to ``test_list_registered_row_spec_only_catalog_entry_points_at_spec``
+    after G0.18-T8 (#1361) reclassified VCF-family rows as
+    ``catalog_ingest: spec-only``.
     """
     tenant_a = uuid.uuid4()
     key, token = _operator_token(tenant_id=tenant_a)
@@ -871,13 +873,59 @@ async def test_list_registered_row_carries_catalog_next_step_hint(
     assert "catalog" in harbor["next_step"]["rationale"]
     assert "ingest" in harbor["next_step"]["rationale"]
 
+
+@pytest.mark.asyncio
+async def test_list_registered_row_spec_only_catalog_entry_points_at_spec(
+    client: TestClient,
+    _registered_class_only_connectors: None,
+) -> None:
+    """Catalog-hit + ``catalog_ingest="spec-only"``: row carries the ``--spec`` verb.
+
+    G0.18-T8 (#1361) / RDC #789 N8. The VCF-family rows
+    (``vmware/9.0``, ``sddc-manager/9.0``, ``nsx/4.2``) ship with
+    ``catalog_ingest: spec-only`` because their upstream URLs are
+    Broadcom Developer Portal HTML landing pages (vmware, sddc-manager)
+    or fqdn-templated appliance URLs (nsx) — neither shape can drive
+    ``meho connector ingest --catalog`` server-side. The previous hint
+    ("spec available in catalog; run ingest") sent operators into a
+    422; the refined hint points at the explicit-quadruple ``--spec``
+    form using the catalog's native triple so the verb still
+    copies-and-runs once the operator has the spec file in hand.
+
+    SDDC is the load-bearing case: the listing emits the parser-derived
+    ``product="sddc"`` but the catalog's native triple is
+    ``("sddc-manager", "9.0", "sddc-rest")``; the hint uses the
+    catalog's spelling so the operator's ``--product`` flag matches the
+    registered class (canonical_product_token handles the
+    listing-vs-registry split at write-time via PRODUCT_ALIASES, but
+    the manual-mode ingest path takes the catalog's spelling
+    verbatim).
+    """
+    tenant_a = uuid.uuid4()
+    key, token = _operator_token(tenant_id=tenant_a)
+    with respx.mock as mock_router:
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        response = client.get("/api/v1/connectors", headers=_authed(token))
+    assert response.status_code == 200
+    by_id = {c["connector_id"]: c for c in response.json()["connectors"]}
+
     sddc = by_id["sddc-rest-9.0"]
     assert sddc["state"] == "registered"
     assert sddc["next_step"] is not None
-    # Catalog lookup must use the *registry's* product ("sddc-manager"),
-    # not the parsed product ("sddc") — see _next_step_for_registered.
-    assert sddc["next_step"]["verb"] == "meho connector ingest --catalog sddc-manager/9.0"
-    assert "catalog" in sddc["next_step"]["rationale"]
+    verb = sddc["next_step"]["verb"]
+    # The refined hint must NOT promise the broken ``--catalog`` path.
+    assert "--catalog" not in verb
+    # And must direct the operator at ``--spec`` with the catalog's
+    # native triple (so the registered class resolves at ingest time).
+    assert "--product sddc-manager" in verb
+    assert "--version 9.0" in verb
+    assert "--impl sddc-rest" in verb
+    assert "--spec" in verb
+    rationale = sddc["next_step"]["rationale"]
+    # Rationale names the reason so an operator (or LLM agent) knows
+    # the catalog row isn't broken, it's just upstream-shape-bound.
+    assert "HTML-portal" in rationale or "fqdn-templated" in rationale
+    assert "--spec" in rationale
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_operations_ingest_catalog.py
+++ b/backend/tests/test_operations_ingest_catalog.py
@@ -756,3 +756,64 @@ def test_shipped_catalog_only_gh_and_vmware_rows_opt_in() -> None:
         assert entry.spec_info_versions_compatible is None, (
             f"{entry.product}/{entry.version} unexpectedly opts in"
         )
+
+
+# ---------------------------------------------------------------------------
+# catalog_ingest classifier (G0.18-T8 #1361 / RDC #789 N8) — declarative
+# input the listing's next_step hint reads to avoid over-promising
+# --catalog ingest against HTML-portal / fqdn-templated upstreams.
+# ---------------------------------------------------------------------------
+
+
+def test_entry_defaults_to_catalog_ingest_supported() -> None:
+    """``catalog_ingest`` defaults to ``"supported"`` for back-compat.
+
+    Pre-G0.18-T8 catalog rows never named the field; their semantics
+    were "upstream is fetchable -> --catalog works". The default
+    preserves that — only rows that explicitly opt into ``"spec-only"``
+    nudge the listing toward the manual-mode verb.
+    """
+    assert _entry().catalog_ingest == "supported"
+
+
+def test_entry_accepts_catalog_ingest_spec_only() -> None:
+    """An entry can opt into ``"spec-only"`` explicitly."""
+    entry = _entry(catalog_ingest="spec-only")
+    assert entry.catalog_ingest == "spec-only"
+
+
+def test_entry_rejects_unknown_catalog_ingest_value() -> None:
+    """Pydantic Literal-typing rejects values outside the two-element set."""
+    with pytest.raises(ValidationError):
+        _entry(catalog_ingest="maybe")  # type: ignore[arg-type]
+
+
+def test_shipped_catalog_marks_vcf_family_rows_spec_only() -> None:
+    """vmware/9.0, sddc-manager/9.0, nsx/4.2 ship ``catalog_ingest: spec-only``.
+
+    G0.18-T8 (#1361, RDC #789 N8). All three upstreams fundamentally
+    cannot drive ``meho connector ingest --catalog`` server-side:
+
+    * ``vmware/9.0`` + ``sddc-manager/9.0`` — Broadcom Developer Portal
+      ``text/html`` landing pages; the route's existing
+      ``catalog_entry_upstream_not_spec`` 422 fires.
+    * ``nsx/4.2`` — first upstream is fqdn-templated
+      (``<nsx-mgr-fqdn>``); the route's
+      ``catalog_entry_templated_upstream`` 422 fires.
+
+    Marking these rows ``"spec-only"`` is what lets the listing emit
+    an honest ``--spec`` ``next_step`` hint instead of the previous
+    "spec available in catalog; run ingest" line that sent operators
+    into a 422.
+    """
+    spec_only_pairs = {("vmware", "9.0"), ("sddc-manager", "9.0"), ("nsx", "4.2")}
+    for entry in load_catalog().entries:
+        if (entry.product, entry.version) in spec_only_pairs:
+            assert entry.catalog_ingest == "spec-only", (
+                f"{entry.product}/{entry.version} should be catalog_ingest: spec-only "
+                "because its upstream is HTML-portal or fqdn-templated"
+            )
+        else:
+            assert entry.catalog_ingest == "supported", (
+                f"{entry.product}/{entry.version} should default to catalog_ingest: supported"
+            )

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -10934,6 +10934,15 @@
             "maxLength": 2048,
             "title": "Notes",
             "default": ""
+          },
+          "catalog_ingest": {
+            "type": "string",
+            "enum": [
+              "supported",
+              "spec-only"
+            ],
+            "title": "Catalog Ingest",
+            "default": "supported"
           }
         },
         "additionalProperties": false,

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -77,6 +77,12 @@ const (
 	Yes      ConfirmVerifyResponseAnswer = "yes"
 )
 
+// Defines values for ConnectorSpecEntryCatalogIngest.
+const (
+	SpecOnly  ConnectorSpecEntryCatalogIngest = "spec-only"
+	Supported ConnectorSpecEntryCatalogIngest = "supported"
+)
+
 // Defines values for ConventionKind.
 const (
 	Operational ConventionKind = "operational"
@@ -1579,16 +1585,20 @@ type ConnectorReviewPayload struct {
 // the CLI's “ingest --catalog“ path (#915) refuses such an entry rather
 // than POSTing an empty “specs“ list.
 type ConnectorSpecEntry struct {
-	ImplId                     string    `json:"impl_id"`
-	Notes                      *string   `json:"notes,omitempty"`
-	Product                    string    `json:"product"`
-	RequiresConnectorClass     string    `json:"requires_connector_class"`
-	Sha256                     *string   `json:"sha256"`
-	SpecInfoVersion            *string   `json:"spec_info_version"`
-	SpecInfoVersionsCompatible *[]string `json:"spec_info_versions_compatible"`
-	Upstream                   *[]string `json:"upstream"`
-	Version                    string    `json:"version"`
+	CatalogIngest              *ConnectorSpecEntryCatalogIngest `json:"catalog_ingest,omitempty"`
+	ImplId                     string                           `json:"impl_id"`
+	Notes                      *string                          `json:"notes,omitempty"`
+	Product                    string                           `json:"product"`
+	RequiresConnectorClass     string                           `json:"requires_connector_class"`
+	Sha256                     *string                          `json:"sha256"`
+	SpecInfoVersion            *string                          `json:"spec_info_version"`
+	SpecInfoVersionsCompatible *[]string                        `json:"spec_info_versions_compatible"`
+	Upstream                   *[]string                        `json:"upstream"`
+	Version                    string                           `json:"version"`
 }
+
+// ConnectorSpecEntryCatalogIngest defines model for ConnectorSpecEntry.CatalogIngest.
+type ConnectorSpecEntryCatalogIngest string
 
 // Convention Full-row representation returned by GET-single / POST / PATCH.
 //

--- a/docs/codebase/spec-ingestion.md
+++ b/docs/codebase/spec-ingestion.md
@@ -540,7 +540,7 @@ Regression test:
 asserts the contract over a seeded DB that includes a stale-rename
 row and a class-side-only opless connector.
 
-#### `next_step` workflow-completion hint (G0.13-T3 / #1133)
+#### `next_step` workflow-completion hint (G0.13-T3 / #1133, G0.18-T8 / #1361)
 
 `state="registered"` rows carry a `next_step: NextStep` object that
 points at the verb that closes the workflow gap surfaced by the
@@ -552,16 +552,37 @@ operator action remaining.
 
 The hint comes from `_next_step_for_registered` in `list_connectors.py`.
 It consults the connector-spec catalog (`ingest/catalog.py`, #743) and
-emits one of two verb shapes:
+branches on the catalog entry's declarative
+`catalog_ingest: "supported" | "spec-only"` field (default
+`"supported"`; the VCF-family rows opt into `"spec-only"` —
+G0.18-T8 / #1361, RDC #789 N8). Three branches:
 
-* **Catalog hit** — verb points at `meho connector ingest --catalog
-  <product>/<version>`. Rationale says the spec is available in the
-  catalog. The CLI's `meho connector ingest --catalog ...` form
-  (G0.7-T5 / #405) drives the rest of the workflow.
+* **Catalog hit, `catalog_ingest="supported"`** — verb points at
+  `meho connector ingest --catalog <product>/<version>`. Rationale
+  says the spec is available in the catalog. The CLI's
+  `meho connector ingest --catalog ...` form (G0.7-T5 / #405) drives
+  the rest of the workflow.
+* **Catalog hit, `catalog_ingest="spec-only"`** — verb points at the
+  explicit-quadruple manual-mode form `meho connector ingest
+  --product <p> --version <v> --impl <i> --spec <concrete-openapi-uri>`
+  using the catalog's native `(product, version, impl_id)` triple.
+  Rationale calls out that the catalog row exists but its upstream
+  is HTML-portal or fqdn-templated, so a `--catalog` POST would
+  422 on the route's `catalog_entry_upstream_not_spec` /
+  `catalog_entry_templated_upstream` branches — the operator must
+  fetch the raw OpenAPI spec from the appliance themselves. The
+  three VCF-family rows (`vmware/9.0`, `sddc-manager/9.0`, `nsx/4.2`)
+  ride this branch; the previous "spec available in catalog; run
+  ingest" hint over-promised for all three. The triple matches what
+  the operator would have used after a successful `--catalog`
+  resolve, so the verb still copies-and-runs once the operator
+  sources the spec URI.
 * **Catalog miss** — verb points at `meho connector ingest --product
   <p> --version <v> --impl <i> --spec <upstream-openapi-uri>`.
   Rationale calls out the missing catalog entry so the operator
-  knows they need to source the OpenAPI spec themselves.
+  knows they need to source the OpenAPI spec themselves. Manual
+  mode is the same path G0.7-T5 already supports for one-off /
+  not-yet-curated specs (see `ingest.go`'s mode dispatch).
 
 The catalog lookup uses the **registry's** `(product, version)`, not
 the parser-derived shortening. The SDDC case is canonical: the
@@ -579,7 +600,12 @@ path.
 
 Regression tests:
 `tests/test_api_v1_connectors_ingest.py::test_list_registered_row_carries_catalog_next_step_hint`
-(catalog-hit branch incl. SDDC's registry-vs-parsed asymmetry),
+(catalog-hit / `supported` branch incl. SDDC's registry-vs-parsed
+asymmetry),
+`::test_list_registered_row_spec_only_catalog_entry_points_at_spec`
+(catalog-hit / `spec-only` branch — pins the explicit-quadruple
+`--spec` verb + the upstream-shape rationale for VCF-family rows;
+G0.18-T8 / #1361),
 `::test_list_registered_row_without_catalog_entry_points_at_manual_mode`
 (catalog-miss branch), and
 `::test_list_ingested_row_omits_next_step_hint`

--- a/docs/cross-repo/connector-catalog.md
+++ b/docs/cross-repo/connector-catalog.md
@@ -61,19 +61,20 @@ Each entry is validated by `ConnectorSpecEntry`:
 | `spec_info_versions_compatible` | **Optional label-vs-spec opt-in.** List of patterns the validator widens against. Each entry is either a glob (`"1.x"`, `"9.0.x"`) or a PEP 440 specifier set (`">=1.0,<2.0"`). When set, the ingest validator accepts a spec whose `info.version` matches any pattern even if it differs from this row's `version` label. `null` (default) preserves the historical verbatim/major-band check. See "Label-vs-spec decoupling" below. |
 | `sha256` | Advisory content hash MEHO smoke-tested against; optional, not enforced. |
 | `notes` | Operator context: sharp edges, version quirks, appliance-served vs portal-hosted, curation status. |
+| `catalog_ingest` | **Whether `meho connector ingest --catalog` actually works for this row.** `"supported"` (default) — the upstream serves an OpenAPI spec directly; `--catalog` runs end-to-end. `"spec-only"` — the upstream is an HTML developer-portal landing page or an fqdn-templated appliance URL the catalog can't dereference server-side; the operator must fetch the spec and pass via `--spec`. `GET /api/v1/connectors` reads this field to emit an honest `next_step` hint (G0.18-T8 #1361). See "Spec-only entries" below. |
 
 ## Current entries
 
-| Product / version | Shape | Spec source |
-|---|---|---|
-| `vmware` 9.0 | generic | `vcenter.yaml` + `vi-json.yaml` (appliance-served at `https://<vcenter-fqdn>/`; mirrored on the Broadcom Developer Portal) |
-| `sddc-manager` 9.0 | generic | SDDC Manager API (appliance-served; Broadcom Developer Portal) |
-| `harbor` 2.x | generic | `goharbor` `api/v2.0/swagger.yaml` — **Swagger 2.0**, needs conversion to OpenAPI 3.x before ingest |
-| `nsx` 4.2 | generic | `/api/v1/spec/openapi/nsx_api.yaml` (appliance-served; Broadcom Developer Portal mirror) |
-| `gh` v3 | generic | `rest-api-description/main/descriptions/api.github.com/api.github.com.json` — OpenAPI 3.0.3, direct-resolvable, `info.version` 1.1.4 (in compat band `1.x.x` — see Label-vs-spec decoupling below), ~700 paths / ~40 tags. Auth: GitHub App installation tokens (or fine-grained PAT). First-day on-ramp: [`github-connector.md`](./github-connector.md); credential setup: [`github-app-credential.md`](./github-app-credential.md). |
-| `vault` 1.x | typed | none (hand-coded connector) |
-| `k8s` 1.x | typed | none (typed; per-minor OpenAPI ingest is a future Goal #214 investigation) |
-| `bind9` 9.x | typed | none (SSH-only; no REST surface) |
+| Product / version | Shape | `catalog_ingest` | Spec source |
+|---|---|---|---|
+| `vmware` 9.0 | generic | `spec-only` | `vcenter.yaml` + `vi-json.yaml` (appliance-served at `https://<vcenter-fqdn>/`; mirrored on the Broadcom Developer Portal, which serves `text/html`) |
+| `sddc-manager` 9.0 | generic | `spec-only` | SDDC Manager API (appliance-served; Broadcom Developer Portal mirror is `text/html`) |
+| `harbor` 2.x | generic | `supported` | `goharbor` `api/v2.0/swagger.yaml` — **Swagger 2.0**, needs conversion to OpenAPI 3.x before ingest |
+| `nsx` 4.2 | generic | `spec-only` | `/api/v1/spec/openapi/nsx_api.yaml` (appliance-served, `<nsx-mgr-fqdn>`-templated; Broadcom Developer Portal mirror is `text/html`) |
+| `gh` v3 | generic | `supported` | `rest-api-description/main/descriptions/api.github.com/api.github.com.json` — OpenAPI 3.0.3, direct-resolvable, `info.version` 1.1.4 (in compat band `1.x.x` — see Label-vs-spec decoupling below), ~700 paths / ~40 tags. Auth: GitHub App installation tokens (or fine-grained PAT). First-day on-ramp: [`github-connector.md`](./github-connector.md); credential setup: [`github-app-credential.md`](./github-app-credential.md). |
+| `vault` 1.x | typed | n/a (typed) | none (hand-coded connector) |
+| `k8s` 1.x | typed | n/a (typed) | none (typed; per-minor OpenAPI ingest is a future Goal #214 investigation) |
+| `bind9` 9.x | typed | n/a (typed) | none (SSH-only; no REST surface) |
 
 `spec_info_version` and `sha256` are populated only after a connector's
 spec has been ingest-verified through MEHO, not from desk research. The
@@ -219,6 +220,68 @@ fall through to the historical verbatim check — the opt-in is PEP
 
 The choice is per-connector-family and lives in
 [`docs/codebase/api-shape-conventions.md` §9](../codebase/api-shape-conventions.md).
+
+## Spec-only entries (`catalog_ingest: spec-only`)
+
+A handful of upstreams in the curated catalog **cannot drive
+`--catalog` ingest end-to-end** even though the row's
+`(product, version, impl_id)` is correct. Two distinct shapes:
+
+1. **HTML developer-portal landing pages** — `vmware/9.0` and
+   `sddc-manager/9.0` cite the Broadcom Developer Portal
+   (`https://developer.broadcom.com/xapis/...`). Those URLs serve
+   `text/html`, not OpenAPI YAML/JSON; the route's
+   `catalog_entry_upstream_not_spec` 422 fires on any catalog-driven
+   ingest. The spec really is published by Broadcom (and served
+   directly by a deployed vCenter / SDDC Manager appliance), but the
+   public reference page is a portal, not the raw artefact.
+2. **Fqdn-templated appliance URLs** — `nsx/4.2`'s first upstream is
+   `https://<nsx-mgr-fqdn>/api/v1/spec/openapi/nsx_api.yaml`, with a
+   placeholder the backplane can't dereference server-side
+   (`catalog_entry_templated_upstream` 422). The Broadcom mirror
+   listed alongside it is again `text/html`.
+
+For these rows the catalog row sets `catalog_ingest: spec-only`.
+That has two operator-visible consequences:
+
+- **`GET /api/v1/connectors`** — the `state="registered"` row's
+  `next_step` hint points at `meho connector ingest --product <p>
+  --version <v> --impl <i> --spec <concrete-openapi-uri>` instead
+  of the previous `--catalog <product>/<version>` (which would
+  422). The rationale calls out the upstream-shape limitation so
+  an operator or LLM agent reading the listing understands the
+  catalog row isn't broken — the public spec source just isn't
+  fetchable.
+- **`POST /api/v1/connectors/ingest`** — unchanged from the
+  existing G0.14-T9 / G0.15-T2 contract. The route's structured
+  422 envelopes (`catalog_entry_upstream_not_spec`,
+  `catalog_entry_templated_upstream`) still fire if a caller
+  POSTs the catalog-driven shape against a spec-only row. The
+  `catalog_ingest` field is the declarative input the **hint**
+  reads, not a new validation gate; route behaviour is unchanged.
+
+**Operator workflow for spec-only entries.** Fetch the raw spec
+from the appliance the connector targets (vCenter, SDDC Manager,
+or NSX Manager) — typically `https://<appliance-fqdn>/api/...` or
+`https://<appliance-fqdn>/v1/...`. Save it locally
+(`/tmp/vcenter.yaml`, etc.) and pass via the explicit `--spec`
+flag:
+
+```bash
+meho connector ingest \
+    --product vmware --version 9.0 --impl vmware-rest \
+    --spec /tmp/vcenter.yaml --spec /tmp/vi-json.yaml
+```
+
+The `--product`/`--version`/`--impl` triple is what the catalog
+row carries (the `next_step` hint pre-fills it).
+
+**Curator workflow.** A new catalog row whose upstream is a
+developer portal page or carries `<placeholder>` characters
+should ship `catalog_ingest: spec-only`. If a vendor later
+publishes the raw spec at a directly-fetchable URL, flip the
+field back to `supported` (or omit it; the default is
+`supported`) and update the `upstream` URL in the same commit.
 
 ## Adding or updating an entry
 


### PR DESCRIPTION
## Summary

- **Recheck #1211 outcome (AC #1).** Verified upstream URLs on
  2026-05-31: `vmware/9.0` and `sddc-manager/9.0` Broadcom Developer
  Portal pages still serve `text/html`; `nsx/4.2` first upstream is
  still `<nsx-mgr-fqdn>`-templated. No regression — #1211's Option C
  (route-level structured 422) still fires correctly; the URLs are
  retained as documentation pointers. Marked the three rows
  `catalog_ingest: spec-only` instead of swapping to non-existent
  resolvable URLs.
- **Refined the over-promising `next_step` hint (AC #2 / RDC #789 N8).**
  Added declarative `catalog_ingest: "supported" | "spec-only"` field
  on `ConnectorSpecEntry` (Pydantic v2 Literal, default `"supported"`).
  `_next_step_for_registered` now branches on it: spec-only rows emit
  `meho connector ingest --product … --version … --impl … --spec
  <concrete-openapi-uri>` with a rationale naming the
  HTML-portal / fqdn-templated upstream limitation, instead of the
  previous "spec available in catalog; run ingest" line that pointed
  operators at the broken `--catalog <product>/<version>` verb.
- **Route validation behaviour is unchanged.** The existing
  `catalog_entry_upstream_not_spec` and
  `catalog_entry_templated_upstream` 422 envelopes still fire on
  direct catalog-shape POSTs against these rows; the new field is
  the declarative input the listing's hint reads, not a new
  validation gate.
- **Docs + CHANGELOG.** `docs/cross-repo/connector-catalog.md` gains a
  "Spec-only entries" section explaining the two upstream shapes
  (HTML developer-portal pages, fqdn-templated appliance URLs) and the
  operator workflow; the entry-schema table + Current entries table
  both surface the new `catalog_ingest` column. One `[Unreleased]`
  Fixed bullet citing RDC #789 N8.

## Test plan

- [x] `ruff check` — clean on touched files
- [x] `ruff format --check` — clean on touched files
- [x] `mypy --ignore-missing-imports` — Success: no issues found in 22 source files
- [x] `python3 .claude/hooks/code-quality.py --diff` — 0 blockers, 9 warnings (all pre-existing / docstring-driven)
- [x] **AC #3:** `pytest tests/test_api_v1_connectors_ingest.py -k "next_step or registered_row or class_only or spec_only or list_registered or list_surfaces_register_connector_v2_only"` — 6 passed, including the new `test_list_registered_row_spec_only_catalog_entry_points_at_spec`
- [x] **AC #1 / catalog schema:** `pytest tests/test_operations_ingest_catalog.py` — 52 passed, including the 4 new `catalog_ingest` tests (`test_entry_defaults_to_catalog_ingest_supported`, `test_entry_accepts_catalog_ingest_spec_only`, `test_entry_rejects_unknown_catalog_ingest_value`, `test_shipped_catalog_marks_vcf_family_rows_spec_only`)
- [x] **Full backend unit sweep:** `pytest tests/ -x -q --ignore=tests/acceptance --ignore=tests/contracts` — 5340 passed, 222 skipped, 0 failed in 558.51 s
- [x] **AC #4:** CHANGELOG `[Unreleased]` Fixed bullet appended, citing RDC #789 N8

## Out of scope

- The ingest LLM-grouping dead-end (N9) — separate Task #1360 (Wave A, already shipped under #1368).
- Hosting / proxying vendor specs ourselves.
- Surfacing `catalog_ingest` in the Go CLI's `meho connector catalog list` table — adjacent finding (the generated `api.ConnectorSpecEntry` struct doesn't yet expose the field; Go's lenient JSON decoder ignores unknown fields, so the API response stays backwards-compatible). Operator-facing rendering enhancement can be a follow-up.
- Sibling Wave-B tasks #1357 (topology blast-radius — `topology/` files) and #1362 (mcp-route docs only) — no file overlap with this change.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1361


---

## Follow-up (auto-implement-issue, iteration 2, 2026-05-31)

Addressed review findings from
`.claude/auto/review-results/pr-1370-iter-1.json`:

- **B1** `d62e5b0` — `chore(cli): regenerate OpenAPI snapshot + typed client for catalog_ingest`. Ran `cd cli && make snapshot-openapi && make generate`; `cli/api/openapi.json` gains the `catalog_ingest` enum + default, `cli/internal/api/client.gen.go` gains `ConnectorSpecEntryCatalogIngest` (with `Supported` / `SpecOnly`) and the `*ConnectorSpecEntryCatalogIngest` field on `ConnectorSpecEntry`. Fixes the RED `CLI API snapshot freshness` check.
- **B2** `2959e88` — `docs(codebase): spec-ingestion §next_step three-branch rewrite`. `docs/codebase/spec-ingestion.md` §`next_step` now describes all three branches (`catalog_ingest="supported"` / `="spec-only"` / catalog miss), cites G0.18-T8 / #1361 / RDC #789 N8 alongside G0.13-T3 / #1133, and adds `test_list_registered_row_spec_only_catalog_entry_points_at_spec` to the regression-tests list.

Rebased on `origin/main` (T9 #1369 merged after iteration 1); concat-resolved the `CHANGELOG.md [Unreleased]` overlap by keeping T8's `### Fixed` bullet and T9's `### Documentation` section.

<!-- auto-implement-issue: continue, iteration 2 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API now distinguishes between connectors supporting full catalog ingest and those requiring manual spec fetching.

* **Bug Fixes**
  * Fixed misleading ingest guidance for VCF-family connectors (VMware, SDDC Manager, NSX) in API responses.

* **Documentation**
  * Updated documentation clarifying ingest support distinctions and operator workflows for manual spec provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->