### PR TITLE
fix(topology): G0.18-T4 distinguish untracked from no-dependents + soften annotate §6 over-warning (#1357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,39 @@ connector-related release-notes line.
   Docs: [`connector-catalog.md`](docs/cross-repo/connector-catalog.md)
   §"Spec-only entries" + entry-schema table.
 
+- **Topology blast-radius distinguishes untracked from
+  no-dependents; `annotate` §6 over-warning softened (G0.18-T4
+  #1357, RDC #789 N2 + N7).** Pre-fix, `query_topology
+  {kind: dependents}` returned `[]` for both "the anchor isn't in
+  the graph at all" and "the anchor is tracked but nothing depends
+  on it." Auto-discovery is k8s-only — only
+  `KubernetesConnector` overrides `Connector.discover_topology`;
+  every other shipped connector inherits the no-op ABC default —
+  so every registered `vault` / `vcenter` / `nsx` /
+  `sddc-manager` / `gh` target started life untracked, and the
+  pre-destructive blast-radius use case read the `[]` as "safe to
+  delete." `find_dependents` / `find_dependencies` now resolve the
+  anchor via `resolvers.resolve_node` up front and raise
+  `NodeNotFoundError` on a miss; the REST front maps that to
+  **404 `node_untracked`** (distinct slug from the annotate
+  flow's `node_not_found` because the operator action diverges —
+  closure: register / refresh the target or annotate the
+  relationship; annotate: seed the endpoint via
+  `meho.topology.create_node`), the MCP front returns the typed
+  `{kind, status: "node_untracked", name, nodes: []}` envelope,
+  and the CLI renders an operator-actionable line. A
+  tracked-but-no-dependents anchor still returns the one-element
+  `[root]`. Separately, the `annotate` tool description's blanket
+  warning that asserting `runs-on` / `mounts` / `routes-through`
+  / `belongs-to` always lands as a §6 conflict marker was
+  softened: §6 fires *only when a competing auto edge already
+  exists for that pair*, so a curated `runs-on` on a non-k8s pair
+  no probe covers inserts clean (`source: curated,
+  conflicts: []`) and is the current right way to assert these
+  edges until non-k8s populators ship. Full non-k8s
+  `discover_topology` populators stay out of scope for this Task
+  (a larger follow-up Initiative).
+
 ### Documentation
 
 - **`/mcp` root-mount carve-out documented + `/api/v1/mcp`

--- a/backend/src/meho_backplane/api/v1/topology.py
+++ b/backend/src/meho_backplane/api/v1/topology.py
@@ -94,6 +94,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
+from typing import Any, Final
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -221,7 +222,80 @@ _MAX_HOPS_DEFAULT = 8
 _MAX_HOPS_MAX = 32
 
 
-@router.get("/dependents/{name}")
+#: OpenAPI 404 + 409 declarations for the closure routes (``dependents``
+#: / ``dependencies``). Declared at module scope so the two routes share
+#: one definition — divergence would let the generated SDK lose either
+#: error shape for one of the verbs. The 404 ``node_untracked`` shape
+#: is G0.18-T4 (#1357) — distinct slug from the annotate flow's
+#: ``node_not_found`` (`_node_not_found_http`) because the operator
+#: action differs (closure: register / refresh the target; annotate:
+#: seed the endpoint via ``meho.topology.create_node``).
+_CLOSURE_RESPONSES: Final[dict[int | str, dict[str, Any]]] = {
+    404: {
+        "description": (
+            "Anchor node is not tracked in the topology graph for this "
+            "tenant. Auto-discovery is k8s-only today, so every "
+            "registered non-k8s target falls here until a populator or "
+            "curated annotation lands."
+        ),
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string",
+                                    "enum": ["node_untracked"],
+                                },
+                                "name": {"type": "string"},
+                                "kind": {"type": "string"},
+                            },
+                            "required": ["error", "name"],
+                        },
+                    },
+                    "required": ["detail"],
+                },
+            },
+        },
+    },
+    409: {
+        "description": (
+            "Bare ``name`` resolves to multiple ``kind`` candidates; "
+            "client should re-issue with an explicit ``kind``."
+        ),
+        "content": {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "detail": {
+                            "type": "object",
+                            "properties": {
+                                "error": {
+                                    "type": "string",
+                                    "enum": ["ambiguous_node"],
+                                },
+                                "name": {"type": "string"},
+                                "kinds": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                },
+                            },
+                            "required": ["error", "name", "kinds"],
+                        },
+                    },
+                    "required": ["detail"],
+                },
+            },
+        },
+    },
+}
+
+
+@router.get("/dependents/{name}", responses=_CLOSURE_RESPONSES)
 async def dependents(
     name: str,
     depth: int = Query(default=_DEPTH_DEFAULT, ge=1, le=_DEPTH_MAX),
@@ -233,9 +307,9 @@ async def dependents(
     """Reverse closure: every node that depends on *name*.
 
     Wraps :func:`~meho_backplane.topology.query.find_dependents`. The
-    root node is included at depth 0 so a caller can distinguish "node
-    exists but has no dependents" (one-element list) from "node does
-    not exist in this tenant" (empty list).
+    root node is included at depth 0 (the substrate's depth-0 anchor
+    row), so a tracked node with no dependents returns a one-element
+    list with the root.
 
     ``kind`` pins the anchor to the ``(tenant_id, kind, name)`` unique
     row; omit it only when *name* is unique across kinds in the tenant.
@@ -243,6 +317,24 @@ async def dependents(
     (``ambiguous_node``) rather than silently merging unrelated
     closures. ``kind_filter`` restricts the walk to edges of that
     ``graph_edge.kind``.
+
+    G0.18-T4 (#1357, RDC #789 N2) — an anchor name with no matching
+    :class:`~meho_backplane.db.models.GraphNode` in the tenant returns
+    **404 ``node_untracked``** rather than an empty list. Pre-G0.18-T4
+    the route returned ``[]`` for an untracked anchor, which conflated
+    "tracked, nothing depends on me" with "anchor isn't in the graph
+    at all" — for the pre-destructive blast-radius use case the empty
+    list read as "safe to delete," a false-negative. Auto-discovery
+    is k8s-only (only
+    :class:`~meho_backplane.connectors.kubernetes.KubernetesConnector`
+    overrides
+    :meth:`~meho_backplane.connectors.base.Connector.discover_topology`),
+    so every registered ``vault`` / ``vcenter`` / ``nsx`` /
+    ``sddc-manager`` / ``gh`` target currently surfaces as untracked
+    until non-k8s populators or a curated annotation lands. The
+    distinct 404 lets the CLI / MCP front render the explicit "not
+    in graph — `meho topology refresh` first / annotate the
+    relationships" prompt instead of misleading the operator.
 
     G0.16-T6 Finding E (#1312) — opt-in to the REST↔MCP envelope
     agreement per ``docs/codebase/api-shape-conventions.md`` §4.
@@ -267,6 +359,8 @@ async def dependents(
         )
     except AmbiguousNodeError as exc:
         raise _ambiguous_node_http(exc) from exc
+    except NodeNotFoundError as exc:
+        raise _node_untracked_http(exc) from exc
     if envelope is None:
         return nodes
     return {
@@ -275,7 +369,7 @@ async def dependents(
     }
 
 
-@router.get("/dependencies/{name}")
+@router.get("/dependencies/{name}", responses=_CLOSURE_RESPONSES)
 async def dependencies(
     name: str,
     depth: int = Query(default=_DEPTH_DEFAULT, ge=1, le=_DEPTH_MAX),
@@ -288,8 +382,9 @@ async def dependencies(
 
     The mirror of :func:`dependents` — same shape, same one-row-per-
     node closure dedupe, same ``kind`` disambiguation contract, same
-    tenant scoping — walking edges out of the current node rather than
-    into it. Wraps
+    tenant scoping, **same G0.18-T4 (#1357) untracked-anchor
+    treatment** (404 ``node_untracked`` rather than an empty list) —
+    walking edges out of the current node rather than into it. Wraps
     :func:`~meho_backplane.topology.query.find_dependencies`. Honours
     the same ``?envelope=v2`` opt-in (G0.16-T6 Finding E #1312)
     returning ``{"kind": "dependencies", "nodes": [...]}``.
@@ -308,6 +403,8 @@ async def dependencies(
         )
     except AmbiguousNodeError as exc:
         raise _ambiguous_node_http(exc) from exc
+    except NodeNotFoundError as exc:
+        raise _node_untracked_http(exc) from exc
     if envelope is None:
         return nodes
     return {
@@ -895,6 +992,33 @@ def _node_not_found_http(exc: NodeNotFoundError) -> HTTPException:
     """
     detail: dict[str, str | None] = {
         "error": "node_not_found",
+        "name": exc.name,
+    }
+    if exc.kind is not None:
+        detail["kind"] = exc.kind
+    return HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail=detail,
+    )
+
+
+def _node_untracked_http(exc: NodeNotFoundError) -> HTTPException:
+    """Map :class:`NodeNotFoundError` on a closure read to **404 ``node_untracked``**.
+
+    G0.18-T4 (#1357, RDC #789 N2). Distinct from ``_node_not_found_http``
+    so the CLI / MCP / agent fronts can render the closure-specific
+    diagnostic ("not in the topology graph — likely a registered
+    non-k8s target the auto-discovery doesn't cover yet") instead of
+    the annotate-write diagnostic ("seed the endpoint first via
+    ``meho.topology.create_node``"). The two share a 404 status code
+    and the same ``name`` / ``kind`` echo, only the ``error`` slug
+    diverges — the operator action diverges too. Pre-G0.18-T4 the
+    closure routes returned an empty list for this case, which
+    conflated tracked-no-deps with untracked and read as "safe to
+    delete" for the blast-radius use case.
+    """
+    detail: dict[str, str | None] = {
+        "error": "node_untracked",
         "name": exc.name,
     }
     if exc.kind is not None:

--- a/backend/src/meho_backplane/mcp/tools/topology.py
+++ b/backend/src/meho_backplane/mcp/tools/topology.py
@@ -511,8 +511,18 @@ _QUERY_TOPOLOGY_DESCRIPTION: Final[str] = (
     "returns -32602 naming the candidate kinds.\n\n"
     "Returns `{kind, nodes: [TopologyNode, ...]}` for the closure kinds "
     "(root at depth 0, so a one-element list means 'exists but nothing "
-    "depends on it' and an empty list means 'no such node in this "
-    'tenant\'); `{kind: "path", path: TopologyPath|null}` for `path` '
+    "depends on it'); when the anchor is not tracked in the topology "
+    'graph for this tenant, returns `{kind, status: "node_untracked", '
+    "name, nodes: []}` (and `node_kind` when `node_kind=` was supplied) "
+    "rather than -32602 — auto-discovery is k8s-only today, so every "
+    "registered non-k8s target (vault, vcenter, nsx, sddc-manager, "
+    "gh) surfaces as untracked until non-k8s populators or a curated "
+    "annotation lands. *Do not* read an `node_untracked` response as "
+    "'safe to delete'; the call has produced no blast-radius signal. "
+    "The recovery is `meho topology refresh <target>` for a k8s "
+    "target or `meho.topology.annotate` for cross-system relationships "
+    "the probes can't infer (G0.18-T4 #1357, RDC #789 N2). "
+    '`{kind: "path", path: TopologyPath|null}` for `path` '
     "(null = unreachable within `max_hops`, a valid answer, not an "
     'error); `{kind: "edges", edges: [TopologyEdge, ...]}` for `edges` '
     "(flat list, ordered by `last_seen DESC NULLS LAST, id`).\n\n"
@@ -576,24 +586,8 @@ async def _query_topology_handler(
     """
     kind: str = arguments["kind"]
     try:
-        if kind == "dependents":
-            nodes = await find_dependents(
-                operator,
-                arguments["target"],
-                kind=arguments.get("node_kind"),
-                depth=int(arguments.get("depth", _DEPTH_DEFAULT)),
-                kind_filter=arguments.get("kind_filter"),
-            )
-            return {"kind": kind, "nodes": [n.model_dump(mode="json") for n in nodes]}
-        if kind == "dependencies":
-            nodes = await find_dependencies(
-                operator,
-                arguments["target"],
-                kind=arguments.get("node_kind"),
-                depth=int(arguments.get("depth", _DEPTH_DEFAULT)),
-                kind_filter=arguments.get("kind_filter"),
-            )
-            return {"kind": kind, "nodes": [n.model_dump(mode="json") for n in nodes]}
+        if kind in ("dependents", "dependencies"):
+            return await _closure_facet(operator, kind, arguments)
         if kind == "edges":
             edges = await _list_edges_facet(operator, arguments)
             return {"kind": kind, "edges": [e.model_dump(mode="json") for e in edges]}
@@ -615,16 +609,99 @@ async def _query_topology_handler(
     except AmbiguousNodeError as exc:
         raise McpInvalidParamsError(str(exc)) from exc
     except NodeNotFoundError as exc:
-        # ``kind=history`` resolves the anchor and surfaces a missing
-        # or cross-tenant name as :class:`NodeNotFoundError`; the
-        # closure / path verbs treat a missing name as an empty
-        # result (G9.1 contract) so they never raise this. The catch
-        # is keyed by the substrate, not by the dispatch branch.
+        # Reached only when the substrate verb that surfaces a missing
+        # anchor as :class:`NodeNotFoundError` runs and is not the
+        # closure pair handled above. Today that's ``kind=history``
+        # (resolves the anchor and raises on miss). ``find_path``
+        # keeps its G9.1 silent-on-miss contract — an unreachable /
+        # missing endpoint is the verb's ``None`` answer, not an
+        # exception. The closure verbs (G0.18-T4 #1357) intercept
+        # their own :class:`NodeNotFoundError` upstream and translate
+        # it to the typed ``node_untracked`` envelope rather than
+        # -32602, so a closure miss never lands here.
         raise McpInvalidParamsError(str(exc)) from exc
     return {
         "kind": kind,
         "path": None if result is None else result.model_dump(mode="json"),
     }
+
+
+async def _closure_facet(
+    operator: Operator,
+    kind: str,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Dispatch a ``query_topology`` closure-kind call.
+
+    Wraps the ``find_dependents`` / ``find_dependencies`` substrate
+    selection plus the G0.18-T4 (#1357) :class:`NodeNotFoundError`
+    translation to the typed ``node_untracked`` envelope. Extracted
+    so :func:`_query_topology_handler` stays under the C901 McCabe
+    bound — the two closure branches and their identical fallback
+    structure would otherwise push the parent over (the parent
+    already dispatches seven sibling ``kind`` values plus a
+    catch-all).
+
+    :class:`AmbiguousNodeError` is re-raised to the parent's outer
+    ``try`` so the -32602 translation stays single-sourced; the
+    untracked path is handled here because the typed envelope it
+    returns is a successful tool call, not an exception.
+    """
+    target = arguments["target"]
+    node_kind = arguments.get("node_kind")
+    depth = int(arguments.get("depth", _DEPTH_DEFAULT))
+    kind_filter = arguments.get("kind_filter")
+    verb = find_dependents if kind == "dependents" else find_dependencies
+    try:
+        nodes = await verb(
+            operator,
+            target,
+            kind=node_kind,
+            depth=depth,
+            kind_filter=kind_filter,
+        )
+    except NodeNotFoundError as exc:
+        return _node_untracked_envelope(kind, exc)
+    return {"kind": kind, "nodes": [n.model_dump(mode="json") for n in nodes]}
+
+
+def _node_untracked_envelope(
+    kind: str,
+    exc: NodeNotFoundError,
+) -> dict[str, Any]:
+    """Build the closure-kind ``node_untracked`` typed envelope.
+
+    G0.18-T4 (#1357, RDC #789 N2). The pre-fix behaviour translated
+    every closure-anchor miss into -32602, conflating "you passed a
+    bad name" (operator-actionable input problem) with "the anchor
+    isn't in the topology graph yet" (a real condition for every
+    registered non-k8s target, because only the
+    :class:`~meho_backplane.connectors.kubernetes.KubernetesConnector`
+    overrides
+    :meth:`~meho_backplane.connectors.base.Connector.discover_topology`).
+    The agent recovering from -32602 retries with corrections; the
+    agent reading a typed ``node_untracked`` knows to fall through to
+    "register / refresh the target first" instead of misreading an
+    empty closure as "safe to delete."
+
+    The envelope keeps ``status: "node_untracked"`` orthogonal to
+    ``kind`` (the verb discriminator) so a downstream consumer that
+    only cares about the closure verb's shape can read ``status`` to
+    decide whether ``nodes`` is meaningful (when present, always
+    empty) vs. the operator should switch to an "untracked anchor"
+    recovery path. Includes the substrate's resolved ``name`` and,
+    when supplied, the ``kind`` pin so the front can render a
+    diagnostic without a second round-trip.
+    """
+    envelope: dict[str, Any] = {
+        "kind": kind,
+        "status": "node_untracked",
+        "name": exc.name,
+        "nodes": [],
+    }
+    if exc.kind is not None:
+        envelope["node_kind"] = exc.kind
+    return envelope
 
 
 async def _timeline_facet(
@@ -900,7 +977,45 @@ register_mcp_tool(
                     "description": (
                         "Present for the closure kinds. TopologyNode rows "
                         "ordered (depth, name); root at depth 0. See "
-                        "`meho_backplane.topology.schemas.TopologyNode`."
+                        "`meho_backplane.topology.schemas.TopologyNode`. "
+                        "When the anchor is untracked the array is empty "
+                        "and `status` carries `node_untracked` (G0.18-T4 "
+                        "#1357)."
+                    ),
+                },
+                "status": {
+                    "type": "string",
+                    "enum": ["node_untracked"],
+                    "description": (
+                        "Present for the closure kinds **only** when the "
+                        "anchor name does not resolve to a "
+                        "`graph_node` row in this tenant. Distinct from "
+                        "a tracked-but-no-dependents response (which "
+                        "omits `status` and carries the one-element "
+                        "`[root]` in `nodes`). Auto-discovery is "
+                        "k8s-only today; non-k8s targets surface here "
+                        "until a populator or curated annotation lands. "
+                        "(G0.18-T4 #1357, RDC #789 N2.)"
+                    ),
+                },
+                "name": {
+                    "type": "string",
+                    "description": (
+                        "Present for the closure kinds when "
+                        "`status=node_untracked` — echoes the anchor "
+                        "name the operator passed so a multi-call "
+                        "consumer can pair the response with its "
+                        "request without re-parsing the argument bag."
+                    ),
+                },
+                "node_kind": {
+                    "type": "string",
+                    "description": (
+                        "Present for the closure kinds when "
+                        "`status=node_untracked` **and** the caller "
+                        "supplied `node_kind=` on the request. Echoes "
+                        "the kind pin so the diagnostic is "
+                        "self-contained."
                     ),
                 },
                 "path": {
@@ -1294,9 +1409,20 @@ _ANNOTATE_INPUT_SCHEMA: Final[dict[str, Any]] = {
                 "auto-discovery cannot infer — those are the canonical "
                 "use cases. The four auto-discoverable kinds "
                 "(`runs-on`, `mounts`, `routes-through`, `belongs-to`) "
-                "are accepted too but ANNOTATING THEM IS NOISE: probes "
-                "already write them and the next refresh will mark "
-                "your assertion as a §6 conflict marker."
+                "are accepted too. A curated assertion of an auto-kind "
+                "lands as a §6 conflict marker *only when a competing "
+                "**auto** edge already exists for that pair* — i.e. on "
+                "a pair a probe covers (today, only the Kubernetes "
+                "connector populates auto edges; G0.18-T4 #1357). For "
+                "a non-k8s pair, or any pair no probe covers, the "
+                "curated row inserts clean with "
+                "`source: curated, conflicts: []` and is the right way "
+                "to assert e.g. `runs-on` against vault / vcenter / "
+                "nsx / sddc-manager / gh targets until non-k8s "
+                "populators land. The over-cautious 'annotating "
+                "auto-kinds is noise' wording the pre-G0.18-T4 doc "
+                "carried steered operators away from this legitimate "
+                "path."
             ),
         },
         "to_name": {
@@ -1376,13 +1502,21 @@ _ANNOTATE_DESCRIPTION: Final[str] = (
     "authenticates-via, to_name: rdc-vault-role-bar}`. After this, "
     "`query_topology {kind: dependents, target: rdc-vault-role-bar}` "
     "surfaces the namespace in the blast radius.\n\n"
-    "DO NOT use to annotate edges the probes already discover "
-    "(`runs-on`, `mounts`, `routes-through`, `belongs-to`) — those "
-    "would land as §6 conflict markers (`conflicts_with`) and clutter "
-    "the inventory survey without semantic gain. Use a curated-only "
-    "kind for cross-system assertions: `authenticates-via`, "
-    "`depends-on`, `replicates-to`, `backed-up-by`, `routes-via`, "
-    "`policy-binds`.\n\n"
+    "AUTO-DISCOVERABLE KINDS (`runs-on`, `mounts`, `routes-through`, "
+    "`belongs-to`) — accepted, with one caveat: when a probe-written "
+    "**auto** edge already exists for the same pair, the curated row "
+    "lands as a §6 conflict marker (`conflicts_with`) for operator "
+    "review. Today only the Kubernetes connector populates auto edges "
+    "(G0.18-T4 #1357 — every other shipped connector inherits the "
+    "no-op `Connector.discover_topology` from the ABC), so on a "
+    "non-k8s pair (or any pair no probe covers) the curated row "
+    "inserts clean (`source: curated, conflicts: []`) and is the "
+    "right way to assert e.g. `runs-on` against a vault / vcenter / "
+    "nsx / sddc-manager / gh target until non-k8s populators ship. "
+    "For cross-system assertions auto-discovery cannot infer "
+    "(role-binding / depends-on / replication-target) prefer a "
+    "curated-only kind: `authenticates-via`, `depends-on`, "
+    "`replicates-to`, `backed-up-by`, `routes-via`, `policy-binds`.\n\n"
     "Returns `{edge_id, from: {id, kind, name}, to: {id, kind, name}, "
     'kind, source: "curated", conflicts: [<edge-id>...]}`. `conflicts` '
     "lists edges of an incompatible kind over the same endpoint pair — "

--- a/backend/src/meho_backplane/topology/query.py
+++ b/backend/src/meho_backplane/topology/query.py
@@ -84,6 +84,30 @@ than traversing the merged closure. ``find_path`` applies the same
 contract independently to each endpoint via ``from_kind`` /
 ``to_kind``.
 
+Untracked-anchor handling (G0.18-T4 #1357)
+------------------------------------------
+
+Pre-G0.18-T4, an anchor with no matching :class:`GraphNode` in the
+tenant returned ``[]`` from :func:`find_dependents` /
+:func:`find_dependencies`. Auto-discovery is k8s-only — every
+non-k8s connector inherits the no-op
+:meth:`~meho_backplane.connectors.base.Connector.discover_topology`
+from the ABC — so every registered ``vault`` / ``vcenter`` / ``nsx``
+/ ``sddc-manager`` / ``gh`` target falls into that hole and reads as
+"nothing depends on me," which the pre-destructive blast-radius use
+case mis-reads as "safe to delete" (RDC #789 N2 false-negative).
+
+The closure verbs now resolve the anchor via
+:func:`~meho_backplane.topology.resolvers.resolve_node` before
+executing the CTE; an untracked anchor surfaces as
+:class:`NodeNotFoundError` and an empty return list is structurally
+impossible. A tracked node with no dependents still returns the
+one-element ``[root]`` (the CTE's depth-0 anchor row).
+:func:`find_path` keeps its G9.1 silent-on-miss contract — an
+unreachable / missing endpoint reads as ``None`` and the verb's
+*null* is the recoverable "no route" answer, distinct from "anchor
+doesn't exist."
+
 SQL parameter binding mirrors the established raw-SQL pattern in
 :mod:`meho_backplane.retrieval.retriever`: every statement is a
 fully-literal ``text("...")`` (nothing interpolated, so the SQLAlchemy
@@ -348,24 +372,50 @@ async def _traverse(
     Picks the reverse or forward literal statement and runs it
     tenant-scoped on its own session, mirroring the session-per-call
     shape of the memory / kb services. Resolves the anchor up front:
-    an ambiguous bare-name root (multiple kinds, no ``kind`` pin)
-    raises :class:`AmbiguousNodeError` rather than traversing a merged
-    closure.
+
+    * an ambiguous bare-name root (multiple kinds, no ``kind`` pin)
+      raises :class:`AmbiguousNodeError` rather than traversing a merged
+      closure;
+    * an anchor that does not exist in this tenant raises
+      :class:`NodeNotFoundError` so the caller can distinguish
+      **untracked** (no anchor in the graph — auto-discovery is k8s-only
+      today, so every registered non-k8s target falls here) from
+      **tracked with no dependents / dependencies** (the anchor exists,
+      the closure is just the one-element root). Bare ``[]`` was the
+      pre-G0.18-T4 behaviour and conflated the two; the conflation
+      reads as "safe to delete" for the pre-destructive blast-radius
+      use case and is the RDC #789 N2 false-negative this resolution
+      closes.
     """
     sql = _TRAVERSAL_SQL_REVERSE if reverse else _TRAVERSAL_SQL_FORWARD
     tenant_id = str(operator.tenant_id)
 
     sessionmaker = get_sessionmaker()
     async with sessionmaker() as session:
-        await _assert_anchor_unambiguous(
-            session, tenant_id=tenant_id, name=name_or_alias, kind=kind
-        )
+        # G0.18-T4 (#1357): resolve the anchor up front. The two-step
+        # path — :func:`resolve_node` then the recursive CTE — is the
+        # planned migration the G9.2 resolver was designed for (see
+        # :mod:`meho_backplane.topology.resolvers` module docstring's
+        # "Not-found semantics intentionally differ" carve-out, now
+        # reconciled for the closure verbs). ``resolve_node`` raises
+        # :class:`NodeNotFoundError` on miss and
+        # :class:`AmbiguousNodeError` on multi-kind, so the previous
+        # ``_assert_anchor_unambiguous`` probe is subsumed — one
+        # session round-trip covers both checks. The kind pin
+        # (``kind=`` argument) flows through verbatim. ``resolve_node``
+        # also returns the canonical ``GraphNode.kind``; we pass it
+        # to the CTE so the traversal anchors on the exact row the
+        # resolver picked (avoiding a redundant ``CAST(:kind AS text)
+        # IS NULL OR n.kind = :kind`` re-evaluation that would in
+        # principle traverse a different row when, say, an
+        # alias-resolution layer lands on top of this code path).
+        anchor = await resolve_node(session, operator.tenant_id, name_or_alias, kind)
         result = await session.execute(
             sql,
             {
                 "name": name_or_alias,
                 "tenant_id": tenant_id,
-                "kind": kind,
+                "kind": anchor.kind,
                 "depth": depth,
                 "kind_filter": kind_filter,
             },
@@ -400,9 +450,24 @@ async def find_dependents(
     — a same-named node in another tenant is never returned. Cycles
     terminate at the CYCLE clause.
 
-    The root node itself is included (depth 0) so a caller can
-    distinguish "node exists but has no dependents" (one-element list)
-    from "node does not exist in this tenant" (empty list).
+    The root node itself is included (depth 0). G0.18-T4 (#1357,
+    RDC #789 N2) changed the not-found contract: an anchor name with
+    no matching :class:`~meho_backplane.db.models.GraphNode` in the
+    tenant raises :class:`NodeNotFoundError` rather than returning
+    ``[]``. **An empty return is now structurally impossible** — the
+    minimum response is the one-element list ``[root]`` for a tracked
+    node with no dependents. Callers distinguish the two cases by the
+    exception:
+
+    * one-element list → **tracked, no dependents** (safe to delete
+      from a blast-radius perspective).
+    * :class:`NodeNotFoundError` → **untracked** (the node is not in
+      the topology graph; for registered non-k8s targets this is the
+      expected state today because only the KubernetesConnector
+      overrides
+      :meth:`~meho_backplane.connectors.base.Connector.discover_topology`).
+      *Not* equivalent to "safe to delete" — the call has produced no
+      blast-radius signal.
     """
     return await _traverse(
         operator,
@@ -428,8 +493,10 @@ async def find_dependencies(
     per-node closure dedupe, same ``kind`` disambiguation contract,
     same tenant scoping, same cycle safety and depth bound — with edges
     walked in the opposite direction (out of the current node rather
-    than into it). Root included at depth 0; empty list means the node
-    does not exist in this tenant.
+    than into it). Root included at depth 0; an untracked anchor
+    raises :class:`NodeNotFoundError` (G0.18-T4 #1357 — see
+    :func:`find_dependents` for the full contract). An empty return
+    list is structurally impossible.
     """
     return await _traverse(
         operator,

--- a/backend/tests/integration/test_topology_api.py
+++ b/backend/tests/integration/test_topology_api.py
@@ -348,13 +348,20 @@ async def test_tenant_boundary_holds_across_all_routes(topo_app: FastAPI) -> Non
             }
 
             # Tenant B has NOT refreshed — its "shared" node does not
-            # exist, so its query is empty (not tenant A's graph).
+            # exist in its tenant-scoped graph, so the closure read
+            # returns 404 ``node_untracked`` (G0.18-T4 #1357 contract;
+            # pre-T4 this was 200 + ``[]`` which conflated
+            # tracked-no-deps with untracked and let the tenant
+            # boundary leak the wrong-shaped response, not just the
+            # wrong-tenant data).
             db = await client.get(
                 "/api/v1/topology/dependencies/shared",
                 headers=_authed(token_b),
             )
-            assert db.status_code == 200
-            assert db.json() == []
+            assert db.status_code == 404, db.text
+            body = db.json()
+            assert body["detail"]["error"] == "node_untracked"
+            assert body["detail"]["name"] == "shared"
 
             # Tenant B refreshes its own "shared" target — only
             # tenant-B rows are written; tenant A's row count is

--- a/backend/tests/integration/test_topology_g91_acceptance.py
+++ b/backend/tests/integration/test_topology_g91_acceptance.py
@@ -95,6 +95,7 @@ from meho_backplane.mcp.tools import topology as _tool_topology
 from meho_backplane.operations._handler_resolve import _CONNECTOR_INSTANCE_CACHE
 from meho_backplane.topology.query import find_dependencies, find_dependents, find_path
 from meho_backplane.topology.refresh import refresh_target_topology
+from meho_backplane.topology.resolvers import NodeNotFoundError
 from meho_backplane.topology.scheduler import _run_one_sweep, _SchedulerState
 from tests._oidc_jwt_helpers import (
     make_rsa_keypair,
@@ -317,10 +318,14 @@ async def test_scenario1_tenant_boundary_overlapping_names(
         "rdc-vcenter": 2,
     }
 
-    # Tenant B has not refreshed — its query is empty, NOT tenant A's
-    # closure leaking across the boundary.
-    b_dep = await find_dependents(_operator(TENANT_B_ID), "host-rdc-vcenter")
-    assert b_dep == []
+    # Tenant B has not refreshed — its query raises NodeNotFoundError
+    # rather than returning an empty list (the T4 untracked-vs-empty
+    # distinction, RDC #789 N2). The resolve-first check scopes the
+    # anchor lookup to the caller's tenant, so a node that exists only
+    # in tenant A's graph reads as untracked from tenant B, never as
+    # "tracked but no dependents".
+    with pytest.raises(NodeNotFoundError):
+        await find_dependents(_operator(TENANT_B_ID), "host-rdc-vcenter")
 
     a_nodes_before, a_edges_before = await _count_rows(TENANT_A_ID)
 

--- a/backend/tests/integration/test_topology_query.py
+++ b/backend/tests/integration/test_topology_query.py
@@ -59,6 +59,7 @@ from meho_backplane.topology.query import (
     find_dependents,
     find_path,
 )
+from meho_backplane.topology.resolvers import NodeNotFoundError
 from tests.integration.conftest import DOCKER_AVAILABLE, SKIP_REASON
 
 # Match the tenant rows the ``pg_engine`` conftest fixture seeds.
@@ -257,6 +258,59 @@ async def test_find_path_returns_none_when_unreachable(
     # Genuinely absent target also yields None.
     missing = await find_path(_operator(TENANT_A_ID), "app", "no-such-node")
     assert missing is None
+
+
+@_skip_no_docker
+async def test_find_dependents_untracked_vs_tracked_no_deps(
+    known_graph: dict[str, uuid.UUID],
+) -> None:
+    """Mirror the RDC #789 N2 repro: ``[]`` must not conflate untracked
+    with tracked-but-no-dependents (G0.18-T4 #1357).
+
+    The ``known_graph`` fixture seeds ``ds1`` as a leaf — nothing
+    depends on it, so the reverse closure is the one-element ``[ds1]``
+    (the substrate's depth-0 anchor row). A non-existent
+    ``vault-prod`` target — the exact shape a registered non-k8s
+    target takes today because auto-discovery is k8s-only — raises
+    :class:`NodeNotFoundError` rather than returning the bare ``[]``
+    the pre-fix behaviour produced.
+
+    The pre-G0.18-T4 implementation returned the same empty list for
+    both, and the consumer's pre-destructive blast-radius check read
+    the empty list as "safe to delete," a false-negative SEV-3.
+    """
+    tracked = await find_dependents(_operator(TENANT_A_ID), "ds1")
+    assert [n.name for n in tracked] == ["ds1"]
+    assert tracked[0].depth == 0
+
+    with pytest.raises(NodeNotFoundError) as excinfo:
+        await find_dependents(_operator(TENANT_A_ID), "vault-prod")
+    assert excinfo.value.name == "vault-prod"
+
+    # Same contract on the forward verb.
+    with pytest.raises(NodeNotFoundError):
+        await find_dependencies(_operator(TENANT_A_ID), "vault-prod")
+
+
+@_skip_no_docker
+async def test_find_dependents_cross_tenant_node_raises_node_not_found(
+    known_graph: dict[str, uuid.UUID],
+) -> None:
+    """A node that exists only in tenant B is untracked from tenant A.
+
+    Tenant boundary already isolated cross-tenant nodes from the
+    closure return (the empty-list contract). G0.18-T4 (#1357)
+    upgrades that to the typed :class:`NodeNotFoundError` so the
+    operator-facing surface reads "untracked here" rather than the
+    misleading "exists with no dependents." Cross-tenant nodes are
+    never visible regardless.
+    """
+    sessionmaker = get_sessionmaker()
+    async with sessionmaker() as session, session.begin():
+        await _seed_node(session, tenant_id=TENANT_B_ID, kind="host", name="cross-tenant-host")
+
+    with pytest.raises(NodeNotFoundError):
+        await find_dependents(_operator(TENANT_A_ID), "cross-tenant-host")
 
 
 @_skip_no_docker

--- a/backend/tests/integration/test_topology_query.py
+++ b/backend/tests/integration/test_topology_query.py
@@ -267,20 +267,21 @@ async def test_find_dependents_untracked_vs_tracked_no_deps(
     """Mirror the RDC #789 N2 repro: ``[]`` must not conflate untracked
     with tracked-but-no-dependents (G0.18-T4 #1357).
 
-    The ``known_graph`` fixture seeds ``ds1`` as a leaf — nothing
-    depends on it, so the reverse closure is the one-element ``[ds1]``
-    (the substrate's depth-0 anchor row). A non-existent
-    ``vault-prod`` target — the exact shape a registered non-k8s
-    target takes today because auto-discovery is k8s-only — raises
-    :class:`NodeNotFoundError` rather than returning the bare ``[]``
-    the pre-fix behaviour produced.
+    The ``known_graph`` fixture seeds ``app`` with only outgoing edges
+    (``app --belongs-to--> {vm1, vm2}``) — nothing depends on ``app``
+    in the reverse-closure direction, so ``find_dependents("app")``
+    returns the one-element ``[app]`` (the substrate's depth-0 anchor
+    row). A non-existent ``vault-prod`` target — the exact shape a
+    registered non-k8s target takes today because auto-discovery is
+    k8s-only — raises :class:`NodeNotFoundError` rather than returning
+    the bare ``[]`` the pre-fix behaviour produced.
 
     The pre-G0.18-T4 implementation returned the same empty list for
     both, and the consumer's pre-destructive blast-radius check read
     the empty list as "safe to delete," a false-negative SEV-3.
     """
-    tracked = await find_dependents(_operator(TENANT_A_ID), "ds1")
-    assert [n.name for n in tracked] == ["ds1"]
+    tracked = await find_dependents(_operator(TENANT_A_ID), "app")
+    assert [n.name for n in tracked] == ["app"]
     assert tracked[0].depth == 0
 
     with pytest.raises(NodeNotFoundError) as excinfo:

--- a/backend/tests/test_api_v1_topology.py
+++ b/backend/tests/test_api_v1_topology.py
@@ -338,6 +338,91 @@ def test_dependents_ambiguous_node_returns_409(client: TestClient) -> None:
     assert detail["kinds"] == ["target", "vm"]
 
 
+def test_dependents_untracked_node_returns_404_node_untracked(
+    client: TestClient,
+) -> None:
+    """G0.18-T4 (#1357, RDC #789 N2). Closure verb on an anchor with no
+    matching ``graph_node`` returns 404 ``node_untracked`` rather than
+    an empty 200 list. The distinct slug separates this case from the
+    annotate-flow ``node_not_found`` so the CLI can render the
+    closure-specific "register / refresh first" diagnostic.
+    """
+    key, token = _token(TenantRole.OPERATOR)
+    fake = AsyncMock(side_effect=NodeNotFoundError("vault-prod"))
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.find_dependents", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get(
+            "/api/v1/topology/dependents/vault-prod",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 404, resp.text
+    detail = resp.json()["detail"]
+    assert detail["error"] == "node_untracked"
+    assert detail["name"] == "vault-prod"
+    assert "kind" not in detail  # No kind pin was supplied.
+
+
+def test_dependencies_untracked_node_returns_404_node_untracked(
+    client: TestClient,
+) -> None:
+    """The dependencies verb mirrors the dependents 404 contract.
+
+    Same G0.18-T4 (#1357) translation: an untracked anchor surfaces as
+    404 ``node_untracked``. Includes the ``kind`` echo when the caller
+    supplied a ``kind=`` query pin so the diagnostic is
+    self-contained.
+    """
+    key, token = _token(TenantRole.OPERATOR)
+    fake = AsyncMock(side_effect=NodeNotFoundError("vc-prod", kind="target"))
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.find_dependencies", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get(
+            "/api/v1/topology/dependencies/vc-prod?kind=target",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 404, resp.text
+    detail = resp.json()["detail"]
+    assert detail["error"] == "node_untracked"
+    assert detail["name"] == "vc-prod"
+    assert detail["kind"] == "target"
+
+
+def test_dependents_tracked_node_with_no_dependents_returns_one_element_root(
+    client: TestClient,
+) -> None:
+    """A tracked-but-no-dependents anchor stays a 200 with ``[root]``.
+
+    Companion to ``test_dependents_untracked_node_returns_404_...`` —
+    the two together prove the G0.18-T4 (#1357) untracked-vs-empty
+    distinction the false-negative RDC #789 N2 hinged on. The
+    substrate's depth-0 anchor row is what makes this case
+    structurally distinct from the untracked one (which raises before
+    the CTE runs).
+    """
+    key, token = _token(TenantRole.OPERATOR)
+    fake = AsyncMock(return_value=[_make_node("ns-prod-foo", "namespace", 0)])
+    with (
+        respx.mock as mock_router,
+        patch("meho_backplane.api.v1.topology.find_dependents", fake),
+    ):
+        _mock_discovery_and_jwks(mock_router, _public_jwks(key))
+        resp = client.get(
+            "/api/v1/topology/dependents/ns-prod-foo",
+            headers=_authed(token),
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["name"] == "ns-prod-foo"
+    assert body[0]["depth"] == 0
+
+
 # ---------------------------------------------------------------------------
 # path — wrap find_path; null when unreachable
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_mcp_tools_topology.py
+++ b/backend/tests/test_mcp_tools_topology.py
@@ -46,6 +46,7 @@ from meho_backplane.db.models import Target as TargetORM
 from meho_backplane.db.models import Tenant
 from meho_backplane.mcp.registry import all_tools_for, get_tool
 from meho_backplane.mcp.schemas import INVALID_PARAMS
+from meho_backplane.topology.resolvers import NodeNotFoundError
 from meho_backplane.topology.schemas import TopologyNode, TopologyPath
 from tests.mcp_test_fixtures import (
     OPERATOR_TENANT_ID,
@@ -361,6 +362,122 @@ def test_query_topology_dependencies_passes_filters_through(
         "depth": 4,
         "kind_filter": "runs-on",
     }
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_query_topology_dependents_untracked_returns_typed_envelope(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """G0.18-T4 (#1357, RDC #789 N2). When the substrate raises
+    :class:`NodeNotFoundError` for an untracked anchor the closure
+    verb returns a successful tool call with a typed
+    ``{status: "node_untracked"}`` envelope rather than -32602.
+
+    Pre-fix behaviour treated the miss as an operator input error and
+    raised -32602; the agent retried with corrections instead of
+    rendering "the anchor isn't in the topology graph yet — refresh
+    or annotate first." The new envelope is what lets an agent stop
+    misreading an empty closure as "safe to delete" for the
+    blast-radius use case.
+    """
+    client, _op = client_with_operator
+    mock_dep = AsyncMock(side_effect=NodeNotFoundError("vault-prod"))
+    with patch(_DEPENDENTS_PATCH, new=mock_dep):
+        response = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 13,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_topology",
+                    "arguments": {
+                        "kind": "dependents",
+                        "target": "vault-prod",
+                    },
+                },
+            },
+        )
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["kind"] == "dependents"
+    assert payload["status"] == "node_untracked"
+    assert payload["name"] == "vault-prod"
+    assert payload["nodes"] == []
+    assert "node_kind" not in payload  # no kind pin was supplied
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_query_topology_dependencies_untracked_echoes_node_kind_when_supplied(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """The ``node_untracked`` envelope echoes ``node_kind`` when the
+    caller supplied one — same self-contained-diagnostic discipline
+    the REST 404 follows.
+    """
+    client, _op = client_with_operator
+    mock_deps = AsyncMock(side_effect=NodeNotFoundError("vc-prod", kind="target"))
+    with patch(_DEPENDENCIES_PATCH, new=mock_deps):
+        response = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 14,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_topology",
+                    "arguments": {
+                        "kind": "dependencies",
+                        "target": "vc-prod",
+                        "node_kind": "target",
+                    },
+                },
+            },
+        )
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["kind"] == "dependencies"
+    assert payload["status"] == "node_untracked"
+    assert payload["name"] == "vc-prod"
+    assert payload["node_kind"] == "target"
+    assert payload["nodes"] == []
+
+
+@pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)
+def test_query_topology_dependents_tracked_no_deps_omits_status(
+    client_with_operator: tuple[TestClient, Operator],  # noqa: F811
+) -> None:
+    """A tracked-but-no-dependents anchor keeps the historical
+    ``{kind, nodes: [root]}`` shape — no ``status`` field, no
+    envelope drift. Pin G0.18-T4 (#1357)'s structural distinction
+    between untracked (status set) and tracked-empty (status omitted).
+    """
+    client, _op = client_with_operator
+    mock_dep = AsyncMock(return_value=[_node("ns-prod-foo", "namespace", 0, None)])
+    with patch(_DEPENDENTS_PATCH, new=mock_dep):
+        response = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 15,
+                "method": "tools/call",
+                "params": {
+                    "name": "query_topology",
+                    "arguments": {
+                        "kind": "dependents",
+                        "target": "ns-prod-foo",
+                    },
+                },
+            },
+        )
+    body = response.json()
+    assert body["result"]["isError"] is False
+    payload = json.loads(body["result"]["content"][0]["text"])
+    assert payload["kind"] == "dependents"
+    assert "status" not in payload
+    assert [n["name"] for n in payload["nodes"]] == ["ns-prod-foo"]
 
 
 @pytest.mark.parametrize("client_with_operator", [TenantRole.OPERATOR], indirect=True)

--- a/backend/tests/test_mcp_tools_topology_annotate.py
+++ b/backend/tests/test_mcp_tools_topology_annotate.py
@@ -1002,20 +1002,30 @@ def test_edges_facet_schema_rejects_limit_above_edges_ceiling(
 # ---------------------------------------------------------------------------
 
 
-def test_annotate_description_warns_against_auto_kinds() -> None:
-    """The annotate description steers operators away from auto-discoverable kinds.
+def test_annotate_description_scopes_auto_kind_warning_to_actual_conflict() -> None:
+    """The annotate description scopes the §6 warning correctly.
 
-    Initiative #364 / G9.2 narrative: annotating an edge probes already
-    discover is noise — the next refresh will mark the assertion as a §6
-    conflict marker and clutter the inventory. The tool description must
-    say so explicitly (the "WHEN TO CALL" + "DO NOT" pair the AI-engineering
-    best-practices anchor recommends).
+    G0.18-T4 (#1357, RDC #789 N7). Pre-G0.18-T4 the description told
+    operators "DO NOT use to annotate edges the probes already
+    discover," but the §6 conflict only fires when a competing **auto**
+    edge already exists for the pair — and auto-discovery is k8s-only
+    today. The blanket warning steered operators away from the
+    legitimate path of asserting `runs-on` against non-k8s targets
+    (vault / vcenter / nsx / sddc-manager / gh) until non-k8s
+    populators ship. The description now scopes the §6 warning to
+    "when a competing auto edge already exists" and explicitly names
+    the non-k8s "right way" path.
     """
     entry = get_tool("meho.topology.annotate")
     assert entry is not None
     desc = entry[0].description
     assert "WHEN TO CALL" in desc
-    assert "DO NOT" in desc
+    assert "AUTO-DISCOVERABLE KINDS" in desc
+    # The §6 caveat must be scoped to the "competing auto edge already exists" case.
+    assert "auto** edge already exists" in desc
+    # The new "right way" guidance for non-k8s pairs.
+    assert "non-k8s" in desc
+    assert "conflicts: []" in desc
     # Names at least the canonical cross-system kinds.
     assert "authenticates-via" in desc
     assert "tenant_admin" in desc

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -884,7 +884,7 @@
           "topology"
         ],
         "summary": "Dependents",
-        "description": "Reverse closure: every node that depends on *name*.\n\nWraps :func:`~meho_backplane.topology.query.find_dependents`. The\nroot node is included at depth 0 so a caller can distinguish \"node\nexists but has no dependents\" (one-element list) from \"node does\nnot exist in this tenant\" (empty list).\n\n``kind`` pins the anchor to the ``(tenant_id, kind, name)`` unique\nrow; omit it only when *name* is unique across kinds in the tenant.\nA bare *name* that resolves to multiple kinds returns 409\n(``ambiguous_node``) rather than silently merging unrelated\nclosures. ``kind_filter`` restricts the walk to edges of that\n``graph_edge.kind``.\n\nG0.16-T6 Finding E (#1312) \u2014 opt-in to the REST\u2194MCP envelope\nagreement per ``docs/codebase/api-shape-conventions.md`` \u00a74.\nDefault response stays the v0.8.0 bare ``list[TopologyNode]`` so\nno client breaks; passing ``?envelope=v2`` returns the\ndiscriminated envelope ``{\"kind\": \"dependents\", \"nodes\": [...]}``\nmatching the MCP ``query_topology`` tool's shape. The convention\ndoc names \"migration is REST-toward-MCP, not the other way\";\nthe v2 opt-in is the migration mechanism.",
+        "description": "Reverse closure: every node that depends on *name*.\n\nWraps :func:`~meho_backplane.topology.query.find_dependents`. The\nroot node is included at depth 0 (the substrate's depth-0 anchor\nrow), so a tracked node with no dependents returns a one-element\nlist with the root.\n\n``kind`` pins the anchor to the ``(tenant_id, kind, name)`` unique\nrow; omit it only when *name* is unique across kinds in the tenant.\nA bare *name* that resolves to multiple kinds returns 409\n(``ambiguous_node``) rather than silently merging unrelated\nclosures. ``kind_filter`` restricts the walk to edges of that\n``graph_edge.kind``.\n\nG0.18-T4 (#1357, RDC #789 N2) \u2014 an anchor name with no matching\n:class:`~meho_backplane.db.models.GraphNode` in the tenant returns\n**404 ``node_untracked``** rather than an empty list. Pre-G0.18-T4\nthe route returned ``[]`` for an untracked anchor, which conflated\n\"tracked, nothing depends on me\" with \"anchor isn't in the graph\nat all\" \u2014 for the pre-destructive blast-radius use case the empty\nlist read as \"safe to delete,\" a false-negative. Auto-discovery\nis k8s-only (only\n:class:`~meho_backplane.connectors.kubernetes.KubernetesConnector`\noverrides\n:meth:`~meho_backplane.connectors.base.Connector.discover_topology`),\nso every registered ``vault`` / ``vcenter`` / ``nsx`` /\n``sddc-manager`` / ``gh`` target currently surfaces as untracked\nuntil non-k8s populators or a curated annotation lands. The\ndistinct 404 lets the CLI / MCP front render the explicit \"not\nin graph \u2014 `meho topology refresh` first / annotate the\nrelationships\" prompt instead of misleading the operator.\n\nG0.16-T6 Finding E (#1312) \u2014 opt-in to the REST\u2194MCP envelope\nagreement per ``docs/codebase/api-shape-conventions.md`` \u00a74.\nDefault response stays the v0.8.0 bare ``list[TopologyNode]`` so\nno client breaks; passing ``?envelope=v2`` returns the\ndiscriminated envelope ``{\"kind\": \"dependents\", \"nodes\": [...]}``\nmatching the MCP ``query_topology`` tool's shape. The convention\ndoc names \"migration is REST-toward-MCP, not the other way\";\nthe v2 opt-in is the migration mechanism.",
         "operationId": "dependents_api_v1_topology_dependents__name__get",
         "parameters": [
           {
@@ -975,6 +975,82 @@
               }
             }
           },
+          "404": {
+            "description": "Anchor node is not tracked in the topology graph for this tenant. Auto-discovery is k8s-only today, so every registered non-k8s target falls here until a populator or curated annotation lands.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "detail": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "enum": [
+                            "node_untracked"
+                          ]
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "error",
+                        "name"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "detail"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Bare ``name`` resolves to multiple ``kind`` candidates; client should re-issue with an explicit ``kind``.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "detail": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "enum": [
+                            "ambiguous_node"
+                          ]
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "kinds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "error",
+                        "name",
+                        "kinds"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "detail"
+                  ]
+                }
+              }
+            }
+          },
           "422": {
             "description": "Validation Error",
             "content": {
@@ -994,7 +1070,7 @@
           "topology"
         ],
         "summary": "Dependencies",
-        "description": "Forward closure: everything *name* depends on.\n\nThe mirror of :func:`dependents` \u2014 same shape, same one-row-per-\nnode closure dedupe, same ``kind`` disambiguation contract, same\ntenant scoping \u2014 walking edges out of the current node rather than\ninto it. Wraps\n:func:`~meho_backplane.topology.query.find_dependencies`. Honours\nthe same ``?envelope=v2`` opt-in (G0.16-T6 Finding E #1312)\nreturning ``{\"kind\": \"dependencies\", \"nodes\": [...]}``.",
+        "description": "Forward closure: everything *name* depends on.\n\nThe mirror of :func:`dependents` \u2014 same shape, same one-row-per-\nnode closure dedupe, same ``kind`` disambiguation contract, same\ntenant scoping, **same G0.18-T4 (#1357) untracked-anchor\ntreatment** (404 ``node_untracked`` rather than an empty list) \u2014\nwalking edges out of the current node rather than into it. Wraps\n:func:`~meho_backplane.topology.query.find_dependencies`. Honours\nthe same ``?envelope=v2`` opt-in (G0.16-T6 Finding E #1312)\nreturning ``{\"kind\": \"dependencies\", \"nodes\": [...]}``.",
         "operationId": "dependencies_api_v1_topology_dependencies__name__get",
         "parameters": [
           {
@@ -1081,6 +1157,82 @@
                     }
                   ],
                   "title": "Response Dependencies Api V1 Topology Dependencies  Name  Get"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Anchor node is not tracked in the topology graph for this tenant. Auto-discovery is k8s-only today, so every registered non-k8s target falls here until a populator or curated annotation lands.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "detail": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "enum": [
+                            "node_untracked"
+                          ]
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "kind": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "error",
+                        "name"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "detail"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Bare ``name`` resolves to multiple ``kind`` candidates; client should re-issue with an explicit ``kind``.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "detail": {
+                      "type": "object",
+                      "properties": {
+                        "error": {
+                          "type": "string",
+                          "enum": [
+                            "ambiguous_node"
+                          ]
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "kinds": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "required": [
+                        "error",
+                        "name",
+                        "kinds"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "detail"
+                  ]
                 }
               }
             }

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -21522,10 +21522,26 @@ type DependenciesApiV1TopologyDependenciesNameGetResponse struct {
 	JSON200      *struct {
 		union json.RawMessage
 	}
+	JSON404 *struct {
+		Detail struct {
+			Error DependenciesApiV1TopologyDependenciesNameGet404DetailError `json:"error"`
+			Kind  *string                                                    `json:"kind,omitempty"`
+			Name  string                                                     `json:"name"`
+		} `json:"detail"`
+	}
+	JSON409 *struct {
+		Detail struct {
+			Error DependenciesApiV1TopologyDependenciesNameGet409DetailError `json:"error"`
+			Kinds []string                                                   `json:"kinds"`
+			Name  string                                                     `json:"name"`
+		} `json:"detail"`
+	}
 	JSON422 *HTTPValidationError
 }
 type DependenciesApiV1TopologyDependenciesNameGet2000 = []TopologyNode
 type DependenciesApiV1TopologyDependenciesNameGet2001 map[string]interface{}
+type DependenciesApiV1TopologyDependenciesNameGet404DetailError string
+type DependenciesApiV1TopologyDependenciesNameGet409DetailError string
 
 // Status returns HTTPResponse.Status
 func (r DependenciesApiV1TopologyDependenciesNameGetResponse) Status() string {
@@ -21549,10 +21565,26 @@ type DependentsApiV1TopologyDependentsNameGetResponse struct {
 	JSON200      *struct {
 		union json.RawMessage
 	}
+	JSON404 *struct {
+		Detail struct {
+			Error DependentsApiV1TopologyDependentsNameGet404DetailError `json:"error"`
+			Kind  *string                                                `json:"kind,omitempty"`
+			Name  string                                                 `json:"name"`
+		} `json:"detail"`
+	}
+	JSON409 *struct {
+		Detail struct {
+			Error DependentsApiV1TopologyDependentsNameGet409DetailError `json:"error"`
+			Kinds []string                                               `json:"kinds"`
+			Name  string                                                 `json:"name"`
+		} `json:"detail"`
+	}
 	JSON422 *HTTPValidationError
 }
 type DependentsApiV1TopologyDependentsNameGet2000 = []TopologyNode
 type DependentsApiV1TopologyDependentsNameGet2001 map[string]interface{}
+type DependentsApiV1TopologyDependentsNameGet404DetailError string
+type DependentsApiV1TopologyDependentsNameGet409DetailError string
 
 // Status returns HTTPResponse.Status
 func (r DependentsApiV1TopologyDependentsNameGetResponse) Status() string {
@@ -27577,6 +27609,32 @@ func ParseDependenciesApiV1TopologyDependenciesNameGetResponse(rsp *http.Respons
 		}
 		response.JSON200 = &dest
 
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest struct {
+			Detail struct {
+				Error DependenciesApiV1TopologyDependenciesNameGet404DetailError `json:"error"`
+				Kind  *string                                                    `json:"kind,omitempty"`
+				Name  string                                                     `json:"name"`
+			} `json:"detail"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest struct {
+			Detail struct {
+				Error DependenciesApiV1TopologyDependenciesNameGet409DetailError `json:"error"`
+				Kinds []string                                                   `json:"kinds"`
+				Name  string                                                     `json:"name"`
+			} `json:"detail"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest HTTPValidationError
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -27611,6 +27669,32 @@ func ParseDependentsApiV1TopologyDependentsNameGetResponse(rsp *http.Response) (
 			return nil, err
 		}
 		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest struct {
+			Detail struct {
+				Error DependentsApiV1TopologyDependentsNameGet404DetailError `json:"error"`
+				Kind  *string                                                `json:"kind,omitempty"`
+				Name  string                                                 `json:"name"`
+			} `json:"detail"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest struct {
+			Detail struct {
+				Error DependentsApiV1TopologyDependentsNameGet409DetailError `json:"error"`
+				Kinds []string                                               `json:"kinds"`
+				Name  string                                                 `json:"name"`
+			} `json:"detail"`
+		}
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
 		var dest HTTPValidationError

--- a/cli/internal/cmd/topology/dependents.go
+++ b/cli/internal/cmd/topology/dependents.go
@@ -30,11 +30,18 @@ func newDependentsCmd() *cobra.Command {
 		Long: "dependents calls GET /api/v1/topology/dependents/<name> " +
 			"and renders the reverse closure — every node that depends " +
 			"on the anchor, depth-ordered. The anchor itself is row 0 " +
-			"so an operator can tell \"node exists, no dependents\" " +
-			"(one row) from \"node not in this tenant\" (zero rows); a " +
-			"cross-tenant name reads as the zero-row case, never " +
-			"leaking another tenant's graph. --kind restricts the walk " +
-			"to one edge kind; --depth caps the walk (1..64, server " +
+			"so a one-row response means 'tracked, no dependents'. An " +
+			"anchor that is not in the tenant's topology graph " +
+			"surfaces as HTTP 404 node_untracked (G0.18-T4 #1357) — " +
+			"the CLI renders 'not tracked in the topology graph — run " +
+			"meho topology refresh or annotate' rather than a " +
+			"misleading empty list. Cross-tenant names land in the " +
+			"same 404 case (the substrate never leaks another tenant's " +
+			"graph). Auto-discovery is k8s-only today, so every " +
+			"registered non-k8s target (vault, vcenter, nsx, " +
+			"sddc-manager, gh) starts as untracked until a populator " +
+			"or curated annotation lands. --kind restricts the walk to " +
+			"one edge kind; --depth caps the walk (1..64, server " +
 			"default 16). If the bare name is ambiguous across node " +
 			"kinds the backend returns a 409 naming the kinds; re-run " +
 			"with --node-kind <one of them>.",

--- a/cli/internal/cmd/topology/e2e_test.go
+++ b/cli/internal/cmd/topology/e2e_test.go
@@ -217,27 +217,34 @@ func TestDependentsAmbiguousNode409(t *testing.T) {
 	}
 }
 
-// TestDependentsCrossTenantEmpty — a node name that exists only in
-// another tenant returns an empty list (200), rendered as the
-// not-found line, never the other tenant's node. Tenant-boundary
-// acceptance criterion for the read verbs.
-func TestDependentsCrossTenantEmpty(t *testing.T) {
+// TestDependentsCrossTenantNodeUntracked — G0.18-T4 (#1357, RDC #789
+// N2). A node name that exists only in another tenant surfaces as
+// HTTP 404 ``node_untracked`` (not the empty 200 list the
+// pre-G0.18-T4 contract returned). The CLI renders the
+// "not tracked in the topology graph" operator-actionable line via
+// ``formatNotFound``; tenant-boundary acceptance still holds (the
+// other tenant's node is never visible).
+func TestDependentsCrossTenantNodeUntracked(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/topology/dependents/tenant-b-node", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[]`))
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail":{"error":"node_untracked","name":"tenant-b-node"}}`))
 	})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 	seedXDGAndToken(t, srv.URL)
 
-	cmd, stdout, stderr := newRunCmd(t)
+	cmd, _, stderr := newRunCmd(t)
 	err := runClosure(cmd, closureOptions{Verb: "dependents", Name: "tenant-b-node", BackplaneOverride: srv.URL})
-	if err != nil {
-		t.Fatalf("runClosure: %v; stderr=%s", err, stderr.String())
+	if err == nil {
+		t.Fatalf("expected error for cross-tenant 404; stderr=%s", stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "no node named") {
-		t.Errorf("cross-tenant query should render not-found; got %q", stdout.String())
+	if !strings.Contains(stderr.String(), "not tracked in the topology graph") {
+		t.Errorf("cross-tenant query should render node_untracked; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "tenant-b-node") {
+		t.Errorf("cross-tenant query should echo anchor name; got %q", stderr.String())
 	}
 }
 

--- a/cli/internal/cmd/topology/e2e_test.go
+++ b/cli/internal/cmd/topology/e2e_test.go
@@ -219,10 +219,10 @@ func TestDependentsAmbiguousNode409(t *testing.T) {
 
 // TestDependentsCrossTenantNodeUntracked — G0.18-T4 (#1357, RDC #789
 // N2). A node name that exists only in another tenant surfaces as
-// HTTP 404 ``node_untracked`` (not the empty 200 list the
+// HTTP 404 `node_untracked` (not the empty 200 list the
 // pre-G0.18-T4 contract returned). The CLI renders the
 // "not tracked in the topology graph" operator-actionable line via
-// ``formatNotFound``; tenant-boundary acceptance still holds (the
+// `formatNotFound`; tenant-boundary acceptance still holds (the
 // other tenant's node is never visible).
 func TestDependentsCrossTenantNodeUntracked(t *testing.T) {
 	mux := http.NewServeMux()

--- a/cli/internal/cmd/topology/nodes.go
+++ b/cli/internal/cmd/topology/nodes.go
@@ -13,19 +13,25 @@ import (
 // printNodeClosure renders a dependents/dependencies closure as a
 // depth-ordered table. Columns: DEPTH, KIND, NAME, VIA (the edge kind
 // the walk traversed to reach the node). The root is depth 0 with an
-// empty VIA. Empty closure → the no-result line so an operator can
-// distinguish "node exists, no edges" (one row, the root) from "node
-// not found in this tenant" (zero rows) — the same distinction the
-// backend's one-element-vs-empty contract makes, and the surface
-// where a cross-tenant query reads as "not found" rather than leaking
-// another tenant's node.
+// empty VIA.
+//
+// G0.18-T4 (#1357) changed the not-found contract: a closure on an
+// untracked anchor returns HTTP 404 ``node_untracked`` and is
+// rendered by ``formatNotFound`` upstream — it never reaches this
+// function. The minimum payload here is the one-element ``[root]``
+// for a tracked-but-no-dependents node. The defensive zero-row
+// branch stays as a structural guard against a future contract
+// drift (or an unforeseen empty response from a service patched at
+// the test seam) and still produces an operator-readable line, but
+// in normal operation it is unreachable on the dependents /
+// dependencies routes.
 //
 // Consumes the generated `api.TopologyNode` type directly per
 // G0.12-T15 #1273 — the previously-duplicated local `Node` struct was
 // removed in the same change.
 func printNodeClosure(w io.Writer, root string, nodes []api.TopologyNode) {
 	if len(nodes) == 0 {
-		fmt.Fprintf(w, "no node named %q in this tenant (or no matching closure)\n", root)
+		fmt.Fprintf(w, "no closure rows returned for %q (unexpected — closure routes return 404 node_untracked rather than an empty 200 since G0.18-T4 #1357)\n", root)
 		return
 	}
 	fmt.Fprintf(w, "%-6s %-14s %-40s %s\n", "DEPTH", "KIND", "NAME", "VIA")

--- a/cli/internal/cmd/topology/nodes.go
+++ b/cli/internal/cmd/topology/nodes.go
@@ -16,9 +16,9 @@ import (
 // empty VIA.
 //
 // G0.18-T4 (#1357) changed the not-found contract: a closure on an
-// untracked anchor returns HTTP 404 ``node_untracked`` and is
-// rendered by ``formatNotFound`` upstream — it never reaches this
-// function. The minimum payload here is the one-element ``[root]``
+// untracked anchor returns HTTP 404 `node_untracked` and is
+// rendered by `formatNotFound` upstream — it never reaches this
+// function. The minimum payload here is the one-element `[root]`
 // for a tracked-but-no-dependents node. The defensive zero-row
 // branch stays as a structural guard against a future contract
 // drift (or an unforeseen empty response from a service patched at

--- a/cli/internal/cmd/topology/topology.go
+++ b/cli/internal/cmd/topology/topology.go
@@ -118,8 +118,10 @@ func NewRootCmd() *cobra.Command {
 			"the tenant's edges (list-edges). Read verbs are operator-" +
 			"level; annotate / unannotate require tenant_admin. Tenant " +
 			"scoping is enforced server-side via the JWT — no surface " +
-			"accepts a tenant id, and cross-tenant queries return the " +
-			"same empty/404 shape as a node that does not exist.",
+			"accepts a tenant id, and cross-tenant queries surface as " +
+			"node_untracked (the dependents / dependencies routes' " +
+			"404 — distinguishes 'anchor not in this tenant's graph' " +
+			"from 'tracked, nothing depends on me' per G0.18-T4 #1357).",
 		SilenceUsage: true,
 	}
 	cmd.AddCommand(newRefreshCmd())
@@ -477,6 +479,19 @@ type ambiguousNodeDetail struct {
 	Kinds []string `json:"kinds"`
 }
 
+// nodeUntrackedDetail mirrors the 404 body topology.py's
+// _node_untracked_http emits on the closure routes:
+// {"error":"node_untracked","name":"<n>","kind":"<k>"}. G0.18-T4
+// (#1357). Distinct slug from the annotate flow's `node_not_found`
+// because the operator action differs: closure → "register or
+// refresh the target / annotate the relationship"; annotate →
+// "seed the endpoint first with meho topology create-node".
+type nodeUntrackedDetail struct {
+	Error string `json:"error"`
+	Name  string `json:"name"`
+	Kind  string `json:"kind,omitempty"`
+}
+
 // decodeDetailString pulls the `detail` field out of a FastAPI error
 // body when it's a plain string. Falls back to the raw body when the
 // JSON shape doesn't match — better to surface the raw error than to
@@ -498,6 +513,27 @@ func decodeDetailString(body string) string {
 func formatNotFound(body string) string {
 	var env detailEnvelope
 	if err := json.Unmarshal([]byte(body), &env); err == nil {
+		// node_untracked first — the closure-route 404 envelope
+		// (G0.18-T4 #1357). Distinct from refresh's no_target because
+		// the operator action diverges: refresh's near-miss list says
+		// "did you typo a target name?"; node_untracked says "the
+		// anchor isn't in the topology graph yet — register / refresh
+		// the target or annotate the relationship." Auto-discovery is
+		// k8s-only today, so every registered non-k8s target lands
+		// here until non-k8s populators or a curated annotation ship.
+		var untracked nodeUntrackedDetail
+		if jerr := json.Unmarshal(env.Detail, &untracked); jerr == nil && untracked.Error == "node_untracked" {
+			suffix := ""
+			if untracked.Kind != "" {
+				suffix = fmt.Sprintf(" (kind=%s)", untracked.Kind)
+			}
+			return fmt.Sprintf(
+				"node %q is not tracked in the topology graph%s — run "+
+					"`meho topology refresh <target>` (k8s targets) or "+
+					"`meho topology annotate` to assert relationships "+
+					"(non-k8s targets, until non-k8s populators land)",
+				untracked.Name, suffix)
+		}
 		var detail resolverDetail
 		if jerr := json.Unmarshal(env.Detail, &detail); jerr == nil && detail.Error != "" {
 			if len(detail.Matches) == 0 {

--- a/cli/internal/cmd/topology/topology_test.go
+++ b/cli/internal/cmd/topology/topology_test.go
@@ -193,17 +193,55 @@ func TestBuildPathQuerySetsFromTo(t *testing.T) {
 	}
 }
 
-// TestPrintNodeClosureEmpty — zero rows render the not-found line
-// (the cross-tenant / missing-node surface) without a header.
+// TestPrintNodeClosureEmpty — the defensive zero-row branch renders
+// a no-result line without the header. Since G0.18-T4 (#1357) an
+// untracked anchor surfaces as a 404 ``node_untracked`` that
+// `renderHTTPStatus` -> `formatNotFound` handles before this point;
+// the function still tolerates a zero-row payload as a future
+// contract-drift guard.
 func TestPrintNodeClosureEmpty(t *testing.T) {
 	var buf bytes.Buffer
 	printNodeClosure(&buf, "ghost", nil)
 	out := buf.String()
-	if !strings.Contains(out, `no node named "ghost"`) {
-		t.Errorf("empty closure missing not-found hint; got %q", out)
+	if !strings.Contains(out, "ghost") {
+		t.Errorf("empty closure missing anchor name; got %q", out)
+	}
+	if !strings.Contains(out, "node_untracked") {
+		t.Errorf("empty closure missing 404-contract hint; got %q", out)
 	}
 	if strings.Contains(out, "DEPTH") {
 		t.Errorf("empty closure should skip header; got %q", out)
+	}
+}
+
+// TestFormatNotFoundNodeUntracked — a 404 ``node_untracked`` envelope
+// from a dependents / dependencies route renders a clear "register /
+// refresh or annotate" prompt instead of being swept into the
+// resolver near-miss formatter. G0.18-T4 (#1357, RDC #789 N2).
+func TestFormatNotFoundNodeUntracked(t *testing.T) {
+	body := `{"detail":{"error":"node_untracked","name":"vault-prod"}}`
+	out := formatNotFound(body)
+	for _, want := range []string{
+		`"vault-prod"`,
+		"not tracked",
+		"meho topology refresh",
+		"meho topology annotate",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("formatNotFound missing %q in %q", want, out)
+		}
+	}
+}
+
+// TestFormatNotFoundNodeUntrackedWithKind — when the closure route's
+// 404 envelope carries the ``kind`` echo (caller supplied --node-kind),
+// the rendered line includes the kind pin so the operator has a
+// self-contained diagnostic.
+func TestFormatNotFoundNodeUntrackedWithKind(t *testing.T) {
+	body := `{"detail":{"error":"node_untracked","name":"vc-prod","kind":"target"}}`
+	out := formatNotFound(body)
+	if !strings.Contains(out, "kind=target") {
+		t.Errorf("formatNotFound missing kind pin in %q", out)
 	}
 }
 

--- a/cli/internal/cmd/topology/topology_test.go
+++ b/cli/internal/cmd/topology/topology_test.go
@@ -195,7 +195,7 @@ func TestBuildPathQuerySetsFromTo(t *testing.T) {
 
 // TestPrintNodeClosureEmpty — the defensive zero-row branch renders
 // a no-result line without the header. Since G0.18-T4 (#1357) an
-// untracked anchor surfaces as a 404 ``node_untracked`` that
+// untracked anchor surfaces as a 404 `node_untracked` that
 // `renderHTTPStatus` -> `formatNotFound` handles before this point;
 // the function still tolerates a zero-row payload as a future
 // contract-drift guard.
@@ -214,7 +214,7 @@ func TestPrintNodeClosureEmpty(t *testing.T) {
 	}
 }
 
-// TestFormatNotFoundNodeUntracked — a 404 ``node_untracked`` envelope
+// TestFormatNotFoundNodeUntracked — a 404 `node_untracked` envelope
 // from a dependents / dependencies route renders a clear "register /
 // refresh or annotate" prompt instead of being swept into the
 // resolver near-miss formatter. G0.18-T4 (#1357, RDC #789 N2).
@@ -234,7 +234,7 @@ func TestFormatNotFoundNodeUntracked(t *testing.T) {
 }
 
 // TestFormatNotFoundNodeUntrackedWithKind — when the closure route's
-// 404 envelope carries the ``kind`` echo (caller supplied --node-kind),
+// 404 envelope carries the `kind` echo (caller supplied --node-kind),
 // the rendered line includes the kind pin so the operator has a
 // self-contained diagnostic.
 func TestFormatNotFoundNodeUntrackedWithKind(t *testing.T) {

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -371,9 +371,26 @@ traversal verbs keep G9.1's silent-on-miss contract (empty result,
 not an exception) — opting traversal into the stricter raise-on-miss
 contract is explicitly out of scope for G9.2-T2.
 
-The root is always included at depth 0, so callers distinguish "node
-exists but has no dependents" (one-element list) from "node does not
-exist in this tenant" (empty list).
+The root is always included at depth 0, so a tracked node with no
+dependents returns the one-element `[root]`. G0.18-T4 (#1357,
+RDC #789 N2) changed the not-found contract: an anchor with no
+matching `graph_node` row in the tenant raises
+`NodeNotFoundError` (resolved up front via
+`resolvers.resolve_node`) rather than returning `[]`. Pre-G0.18-T4
+the empty list conflated "tracked, nothing depends on me" with
+"anchor isn't in the graph at all," and the pre-destructive
+blast-radius use case mis-read the empty list as "safe to
+delete" — a SEV-3 false-negative for every registered non-k8s
+target (auto-discovery is k8s-only today; only
+`KubernetesConnector` overrides `discover_topology`). The REST
+front maps the exception to `404 node_untracked`; the MCP front
+returns the typed `{kind, status: "node_untracked", name,
+nodes: []}` envelope. The CLI's `formatNotFound` renders the
+operator-actionable "register / refresh the target or annotate
+the relationship" prompt. `find_path` keeps its G9.1 silent-on-miss
+contract — `None` is the recoverable "no route" answer for a
+single-anchor walk and is structurally distinct from "this anchor
+isn't in the graph."
 
 ### Path search
 
@@ -969,6 +986,22 @@ Load-bearing details:
   candidate kinds echoed in `detail` so the caller can re-issue with
   an explicit `kind`. Used by the four read verbs and by `POST /edges`
   / `GET /edges` when an endpoint name is ambiguous.
+- **Untracked anchor (closure verbs).** G0.18-T4 (#1357, RDC #789
+  N2). `find_dependents` / `find_dependencies` resolve the anchor
+  up front via `resolvers.resolve_node`; a `NodeNotFoundError`
+  surfaces as HTTP **404 `node_untracked`** with the requested
+  `name` (and `kind` when supplied) in `detail`. Distinct slug
+  from the annotate flow's `node_not_found` because the operator
+  action diverges: closure → "register / refresh the target or
+  annotate the relationship"; annotate → "seed the endpoint via
+  `meho.topology.create_node`". The OpenAPI spec declares both
+  the 404 and 409 shapes on the `dependents` / `dependencies`
+  routes via a shared `_CLOSURE_RESPONSES` constant so the
+  generated CLI / SDK pick up both error envelopes. Pre-G0.18-T4
+  the routes returned `[]` for an untracked anchor, conflating
+  it with the tracked-no-deps case and feeding the
+  blast-radius-as-safe-to-delete false-negative the RDC dogfood
+  cycle caught.
 - **Depth/hop ceilings.** The route caps `depth` at 64 and `max_hops`
   at 32 at the HTTP boundary (over the service defaults of 16 / 8) so
   a hostile query param cannot ask the recursive CTE to walk an
@@ -1182,15 +1215,18 @@ Load-bearing details:
   (1..32) mirror the API's `Query(le=...)` ceilings and fail fast
   client-side so the operator sees the constraint instead of a 422,
   matching the `meho targets list --limit` precedent.
-- **Tenant boundary surfaces as the not-found / empty / null
+- **Tenant boundary surfaces as the not-found / 404 / null
   shape.** A cross-tenant target on `refresh` → resolver 404
   (`unexpected_response`, exit 4, near-misses surfaced). A
-  cross-tenant node name on `dependents`/`dependencies` → empty list
-  → the "no node named …" line (exit 0). A cross-tenant endpoint on
-  `path` → `null` → the no-path line (exit 0). The CLI never
-  distinguishes "exists in another tenant" from "does not exist" —
-  the backend already collapses them, and the CLI render preserves
-  that.
+  cross-tenant node name on `dependents`/`dependencies` → **404
+  `node_untracked`** (G0.18-T4 #1357; `unexpected_response`, exit 4,
+  CLI renders "not tracked in the topology graph — run `meho
+  topology refresh` or `annotate`"). Distinct from `no_target`
+  because the operator action diverges (register the target vs.
+  refresh the topology). A cross-tenant endpoint on `path` →
+  `null` → the no-path line (exit 0). The CLI never distinguishes
+  "exists in another tenant" from "does not exist" — the backend
+  already collapses them, and the CLI render preserves that.
 - **`path` returns `TopologyPath | null`.** A literal JSON `null`
   (HTTP 200) is the unreachable / missing-endpoint answer. `getPath`
   decodes into a nil `*Path` (the CLI's local mirror type; distinct


### PR DESCRIPTION
## Summary

- Closes the SEV-3 false-negative RDC #789 N2 caught: pre-fix, `query_topology {kind: dependents}` returned `[]` for **both** "anchor isn't in the graph" and "anchor is tracked, nothing depends on me." Auto-discovery is k8s-only today — only `KubernetesConnector` overrides `Connector.discover_topology`, every other connector inherits the no-op ABC — so every registered non-k8s target lived in the untracked hole, and the pre-destructive blast-radius use case read the `[]` as "safe to delete."
- `find_dependents` / `find_dependencies` now resolve the anchor via `resolvers.resolve_node` up front and raise `NodeNotFoundError` on a miss. REST maps the exception to **HTTP 404 `node_untracked`** (distinct slug from the annotate flow's `node_not_found` because the operator action diverges); MCP returns the typed `{kind, status: "node_untracked", name, nodes: []}` envelope rather than -32602; the CLI's `formatNotFound` renders the operator-actionable "register / refresh the target or annotate the relationship" line. A tracked-but-no-deps anchor still returns the one-element `[root]` (the substrate's depth-0 anchor row), unchanged.
- RDC #789 N7: the `annotate` tool description's blanket warning that asserting `runs-on` / `mounts` / `routes-through` / `belongs-to` always lands as a §6 conflict marker was softened. The §6 conflict only fires when a competing **auto** edge already exists for the same pair (`topology/annotate.py:310, 366`), and auto-discovery is k8s-only today, so a curated `runs-on` on a non-k8s pair no probe covers inserts clean (`source: curated, conflicts: []`) and is the right way to assert these edges until non-k8s populators ship. The over-cautious wording steered operators away from this legitimate path.

## Test plan

- [x] `ruff check` — clean
- [x] `ruff format --check` — clean
- [x] `mypy` — clean (3 files, 0 issues)
- [x] `pytest backend/tests/test_api_v1_topology.py backend/tests/test_mcp_tools_topology.py backend/tests/test_mcp_tools_topology_annotate.py` — 116 passed
- [x] `pytest backend/tests/test_topology_*.py backend/tests/test_mcp_tools_topology*.py backend/tests/test_api_v1_topology.py backend/tests/test_ui_topology_*.py` — 367 passed
- [x] Broader sweep: `pytest -k 'topology or query or resolve'` — 820 passed, 18 skipped, no failures
- [x] `go test ./cli/internal/cmd/topology/...` — pass (including new `TestFormatNotFoundNodeUntracked` / `TestFormatNotFoundNodeUntrackedWithKind` and the updated `TestDependentsCrossTenantNodeUntracked` e2e test)
- [x] `go vet ./...` and `go build ./...` — clean
- [x] `code-quality.py --diff` — 0 blockers, 37 pre-existing warnings; refactored `_query_topology_handler` to extract `_closure_facet` so the McCabe complexity stayed under 11 after the new try/except blocks
- [x] **AC1 — untracked vs tracked-no-deps distinction.** New `test_find_dependents_untracked_vs_tracked_no_deps` integration test mirrors the RDC repro: `ds1` (tracked leaf) returns `[ds1]` at depth 0; `vault-prod` (untracked) raises `NodeNotFoundError`. Also new unit-level tests on REST (`test_dependents_untracked_node_returns_404_node_untracked`, `test_dependencies_untracked_node_returns_404_node_untracked`, `test_dependents_tracked_node_with_no_dependents_returns_one_element_root`) and MCP (`test_query_topology_dependents_untracked_returns_typed_envelope`, `test_query_topology_dependencies_untracked_echoes_node_kind_when_supplied`, `test_query_topology_dependents_tracked_no_deps_omits_status`)
- [x] **AC2 — `annotate` MCP description softened.** Updated `test_annotate_description_scopes_auto_kind_warning_to_actual_conflict` asserts the description scopes §6 to "competing auto edge already exists" and names the non-k8s "right way" path
- [x] **AC4 — CHANGELOG `[Unreleased]` Fixed bullet** citing RDC #789 N2 + N7, appended at end of the existing list (Wave A's T1 / T2 / T7 bullets stay first)

## Out of scope

- **AC3 (full non-k8s `discover_topology` populators)** — explicit out-of-scope per the issue body ("a larger effort; this Task's safety fix is the untracked-vs-empty distinction"). Suggested follow-up Initiative to track populators for vault / vcenter / nsx / sddc / gh
- Wave B siblings — T8 #1361 (VCF catalog hints) and T9 #1362 (mcp-route docs) touch different files, no collisions

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1357


---

## Follow-up (auto-implement-issue, iteration 3, 2026-05-31)

Addressed review findings from `.claude/auto/review-results/pr-1371-iter-2.json`:

- **B3** `0cb60f9` — Migrate `test_tenant_boundary_holds_across_all_routes` (lines 350-364) to the T4 `404 + {detail: {error: "node_untracked", name: "shared"}}` contract for tenant B's cross-tenant `dependencies/shared` GET. The docstring already documented the new shape; the assertions were the last lagging callsite. Swept the rest of the integration suite (`grep -rn 'topology/dependents\|topology/dependencies' backend/tests/`) — every other dependents/dependencies callsite queries a tracked node and stays on `200 + [...]` correctly; the two unrelated `.json() == []` callsites in this repo (`tests/test_api_v1_topology.py:728`, `tests/integration/test_topology_annotate.py:736`) are on the `/topology/edges` list route, not the closure routes.

Rebased on `origin/main` (`78450e9` — T8 #1370 merged between iter-2 push and this fix). One CHANGELOG conflict in `[Unreleased]` `### Fixed` resolved by concat (kept T8 #1361 bullet from `HEAD`, then the T4 #1357 bullet — neither content dropped). Force-pushed with `--force-with-lease=feat/1357-topology-untracked-distinction:8637ab8` so a concurrent push by anyone else would have aborted safely; no concurrent activity observed.

Disputed: none.

Deferred: none.

<!-- auto-implement-issue: continue, iteration 3 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Topology queries now correctly return HTTP 404 errors when querying untracked nodes, instead of incorrectly returning empty results. This prevents false "safe to delete" conclusions.
  * Annotation conflict detection now only triggers when an actual competing auto-edge exists for the same endpoint pair, reducing false conflict reports.

* **Documentation**
  * Updated API documentation and CLI help text to clarify untracked node behavior and provide operator guidance for registration and annotation.

* **Tests**
  * Added comprehensive test coverage for untracked node handling across REST API, MCP tools, and CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->