### PR TITLE
fix(topology): G0.18-T6 create_node writes graph_node_history (#1359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,27 @@ connector-related release-notes line.
 
 ### Fixed
 
+- **Manually-seeded topology nodes are now visible to
+  `query_topology kind=history` / `kind=timeline` (G0.18-T6 #1359,
+  RDC #789 F-A).** `meho.topology.create_node` wrote `audit_log` +
+  one broadcast event but no `graph_node_history` row, so a manual
+  seed was invisible to the per-resource history walk and the
+  tenant-wide timeline even though it surfaced in `query_audit` —
+  an audit-vs-graph-history asymmetry surfaced by the RDC consumer
+  finding when operators bootstrapping non-k8s targets via
+  `create_node` could not answer "when was this node added?"
+  through the history/timeline verbs. The hook now emits one
+  `graph_node_history` row per meaningful call sharing the call's
+  pre-allocated `audit_id` (chassis pre-allocation pattern shared
+  with refresh / annotate so history rows join back against
+  audit_log to recover the causing principal). Idempotent re-seeds
+  whose only change is the heartbeat `seeded_at` / `last_seen`
+  fields deliberately skip the emit — mirrors
+  `refresh._update_existing_node`'s `is_meaningful_update`
+  discipline and `annotate._annotate_curated_is_meaningful`'s
+  heartbeat strip — so a polling MCP agent does not balloon the
+  history table with empty UPDATED rows.
+
 - **`POST /api/v1/targets` accepts the `meho connector list` SDDC
   product token (G0.18-T2 #1355).** Closes #1312 acceptance B, which
   had been marked "already aligned" but the split persisted:

--- a/backend/src/meho_backplane/topology/nodes.py
+++ b/backend/src/meho_backplane/topology/nodes.py
@@ -61,7 +61,13 @@ import structlog
 from sqlalchemy import select
 
 from meho_backplane.broadcast import BroadcastEvent, publish_event
-from meho_backplane.db.models import _GRAPH_NODE_KINDS, AuditLog, GraphNode
+from meho_backplane.db.models import (
+    _GRAPH_NODE_KINDS,
+    AuditLog,
+    GraphHistoryChangeKind,
+    GraphNode,
+)
+from meho_backplane.topology.history import node_snapshot, record_node_change
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
@@ -95,6 +101,17 @@ _OP_CLASS = "write"
 #: op_id, mirroring :data:`refresh._AUDIT_METHOD` and
 #: :data:`annotate._AUDIT_METHOD_ANNOTATE`).
 _AUDIT_METHOD = "CREATE_NODE"
+
+#: Property keys that change on every :func:`create_or_get_node` call
+#: regardless of operator intent — heartbeats stripped from the
+#: meaningful-change comparison so an idempotent re-seed does not emit
+#: a phantom ``updated`` history row. ``seeded_at`` is the
+#: ``datetime.now(UTC).isoformat()`` stamped into ``properties`` on
+#: every call (the create-node side of the same heartbeat pattern
+#: :data:`annotate._ANNOTATE_HEARTBEAT_PROPERTY_KEYS` carries for
+#: ``annotated_at``). Top-level ``last_seen`` is also a heartbeat and
+#: is handled inside :func:`_create_node_is_meaningful` itself.
+_CREATE_NODE_HEARTBEAT_PROPERTY_KEYS: tuple[str, ...] = ("seeded_at",)
 
 
 class InvalidNodeKindError(ValueError):
@@ -204,6 +221,37 @@ def _build_audit_row(
     )
 
 
+def _create_node_is_meaningful(*, before: dict[str, Any] | None, after: dict[str, Any]) -> bool:
+    """Return ``True`` when the re-seed's snapshot reflects a real change.
+
+    Compares ``before`` to ``after`` after stripping the heartbeat
+    fields (top-level ``last_seen`` and
+    ``properties.seeded_at``) that change on every call regardless of
+    operator intent. Mirrors :func:`annotate._annotate_curated_is_meaningful`
+    and :func:`refresh._properties_differ` so all three history-emission
+    paths agree on what counts as a mutation — an idempotent re-seed
+    with the same ``(note, evidence_url)`` and no auto→curated
+    promotion is a no-op for history purposes.
+
+    ``before`` is ``None`` on a fresh insert; that path is always
+    meaningful (the row did not exist), so the caller treats ``None``
+    as the "always emit" case before calling this helper.
+    """
+    if before is None:
+        return True
+
+    def _strip(snapshot: dict[str, Any]) -> dict[str, Any]:
+        stripped = {k: v for k, v in snapshot.items() if k != "last_seen"}
+        props = stripped.get("properties")
+        if isinstance(props, dict):
+            stripped["properties"] = {
+                k: v for k, v in props.items() if k not in _CREATE_NODE_HEARTBEAT_PROPERTY_KEYS
+            }
+        return stripped
+
+    return _strip(before) != _strip(after)
+
+
 async def _publish(
     *,
     audit_id: uuid.UUID,
@@ -285,6 +333,21 @@ async def create_or_get_node(
     transaction. Publishes one :class:`BroadcastEvent` after commit
     (fail-open per the refresh / annotate pattern).
 
+    **Diff-on-write hook (G9.3-T2 #857).** A meaningful call adds one
+    :class:`GraphNodeHistory` row in the same transaction so
+    :func:`query_history` ``kind=history``  / ``kind=timeline`` reflect
+    manual seeds the same way they reflect auto-refresh changes (RDC
+    #789 finding F-A — manual seeds were previously invisible to the
+    history/timeline verbs because only :mod:`refresh` populated the
+    history tables). Fresh inserts emit a ``created`` row;
+    auto→curated promotions and property changes emit ``updated``; an
+    idempotent re-seed with the same ``(note, evidence_url)`` and no
+    promotion is a heartbeat-only mutation and emits no history row
+    (mirrors :func:`refresh._update_existing_node`'s
+    ``is_meaningful_update`` skip and
+    :func:`annotate._annotate_curated_is_meaningful`'s heartbeat
+    strip).
+
     Args:
         session: Caller-owned :class:`AsyncSession` with **no active
             transaction**. The function opens its own
@@ -315,6 +378,14 @@ async def create_or_get_node(
             :data:`_GRAPH_NODE_KINDS`.
     """
     canonical_kind = _validate_kind(kind)
+    # Pre-allocate ``audit_id`` so the history row's ``audit_id``
+    # references the same ``audit_log`` row this call writes (the
+    # chassis "audit-id pre-allocation" pattern shared with refresh /
+    # annotate). Generating it inside the ``session.begin()`` block
+    # would force the history hook to either re-read the audit row
+    # or carry a second id — both worse than threading the same
+    # uuid through.
+    audit_id = uuid.uuid4()
 
     async with session.begin():
         existing_stmt = select(GraphNode).where(
@@ -347,7 +418,16 @@ async def create_or_get_node(
             session.add(node)
             await session.flush()
             was_created = True
+            node_before: dict[str, Any] | None = None
         else:
+            # Capture the pre-mutation snapshot **before** rewriting
+            # ``properties`` / ``discovered_by`` / ``last_seen`` so
+            # the history row's ``before`` reflects the state the
+            # operator would have seen on a ``list-nodes``
+            # immediately prior to the re-seed (same discipline
+            # :func:`refresh._update_existing_node` and
+            # :func:`annotate._reannotate_existing_edge` use).
+            node_before = node_snapshot(existing)
             # Merge the manual-seed keys onto the existing properties
             # dict. Reassign rather than mutate so SQLAlchemy's JSONB
             # change-detection picks up the write (same reassign
@@ -370,7 +450,30 @@ async def create_or_get_node(
             node = existing
             was_created = False
 
-        audit_id = uuid.uuid4()
+        # Diff-on-write hook (G9.3-T2 #857). Emit exactly one
+        # ``graph_node_history`` row per meaningful call so
+        # ``query_topology kind=history|timeline`` reflect manual
+        # seeds the same way they reflect auto-refresh changes (RDC
+        # #789 F-A). Idempotent re-seeds whose only change is the
+        # heartbeat ``seeded_at`` / ``last_seen`` skip emission — the
+        # "no double-write" criterion on the get path.
+        node_after = node_snapshot(node)
+        if _create_node_is_meaningful(before=node_before, after=node_after):
+            record_node_change(
+                session,
+                node_id=node.id,
+                tenant_id=operator.tenant_id,
+                change_kind=(
+                    GraphHistoryChangeKind.CREATED
+                    if was_created
+                    else GraphHistoryChangeKind.UPDATED
+                ),
+                before=node_before,
+                after=node_after,
+                audit_id=audit_id,
+                valid_from=now,
+            )
+
         payload = _build_payload(
             node=node,
             note=note,

--- a/backend/tests/test_topology_create_node.py
+++ b/backend/tests/test_topology_create_node.py
@@ -52,7 +52,13 @@ from sqlalchemy import select
 
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.db.engine import get_sessionmaker
-from meho_backplane.db.models import AuditLog, GraphNode, Tenant
+from meho_backplane.db.models import (
+    AuditLog,
+    GraphHistoryChangeKind,
+    GraphNode,
+    GraphNodeHistory,
+    Tenant,
+)
 from meho_backplane.settings import get_settings
 from meho_backplane.topology import (
     InvalidNodeKindError,
@@ -60,6 +66,7 @@ from meho_backplane.topology import (
     annotate_edge,
     create_or_get_node,
 )
+from meho_backplane.topology.query import query_history, query_timeline
 
 _PUBLISH = "meho_backplane.topology.nodes.publish_event"
 
@@ -446,3 +453,278 @@ async def test_create_node_then_annotate_round_trip() -> None:
     assert edge.kind == "authenticates-via"
     assert edge.from_node_id == first.node.id
     assert edge.to_node_id == second.node.id
+
+
+# ---------------------------------------------------------------------------
+# graph_node_history diff-on-write hook (G0.18-T6 #1359, RDC #789 F-A)
+# ---------------------------------------------------------------------------
+#
+# Pre-#1359, ``create_or_get_node`` wrote audit_log + broadcast but no
+# ``graph_node_history`` row, so a manual seed was invisible to
+# ``query_topology kind=history|timeline`` even though it appeared in
+# ``query_audit`` — an audit-vs-graph-history asymmetry that breaks the
+# "when was this node added?" answer for any tenant that bootstrapped
+# via manual seeds rather than the refresh service. The hook now mirrors
+# :mod:`refresh` / :mod:`annotate`: one row per meaningful call sharing
+# the call's pre-allocated ``audit_id``, with heartbeat-only re-seeds
+# (``seeded_at`` / ``last_seen`` only) deliberately skipped to honour
+# the "no double-write" criterion on the get path.
+
+
+@pytest.mark.asyncio
+async def test_create_node_emits_created_history_row_visible_to_history_verb() -> None:
+    """Fresh insert emits a ``created`` history row, surfaced by ``query_history``.
+
+    Anchor acceptance criterion: ``query_topology kind=history
+    <manually-seeded-node>`` returns the create entry (issue body).
+    Drives the substrate end-to-end — seed via :func:`create_or_get_node`
+    then read back through :func:`query_history` — so a future drift in
+    the snapshot column projection, the audit_id pre-allocation, or the
+    history walk's index would fail this test rather than surfacing on
+    the next dogfood cycle.
+    """
+    tenant_id = await _seed_tenant()
+    sessionmaker = get_sessionmaker()
+
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            result = await create_or_get_node(
+                session,
+                _operator(tenant_id),
+                kind="vault-role",
+                name="rdc-vault",
+                note="seeded from INVENTORY.md L42",
+                evidence_url="https://example.test/inv#L42",
+            )
+
+    # Exactly one history row landed for this node, ``created``.
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(GraphNodeHistory).where(
+                        GraphNodeHistory.tenant_id == tenant_id,
+                        GraphNodeHistory.node_id == result.node.id,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    history = rows[0]
+    assert history.change_kind == GraphHistoryChangeKind.CREATED.value
+    # ``snapshot.before`` is None on a fresh insert; ``after`` carries
+    # the full post-insert projection so the temporal-replay verbs can
+    # reconstruct the seed without joining back against live tables.
+    assert history.snapshot["before"] is None
+    after = history.snapshot["after"]
+    assert after["kind"] == "vault-role"
+    assert after["name"] == "rdc-vault"
+    assert after["discovered_by"] == "op-1"
+    assert after["properties"]["note"] == "seeded from INVENTORY.md L42"
+    assert after["properties"]["evidence_url"] == "https://example.test/inv#L42"
+
+    # The history row's ``audit_id`` references the create_node call's
+    # ``audit_log`` row — same chassis "audit-id pre-allocation" pattern
+    # refresh / annotate use so the query layer can join history back
+    # against audit to recover the causing principal.
+    async with sessionmaker() as session:
+        audit = (
+            (await session.execute(select(AuditLog).where(AuditLog.tenant_id == tenant_id)))
+            .scalars()
+            .one()
+        )
+    assert history.audit_id == audit.id
+
+    # query_history surfaces the row through the operator-visible verb.
+    result_history = await query_history(_operator(tenant_id), "rdc-vault", kind="vault-role")
+    assert len(result_history.rows) == 1
+    assert result_history.rows[0].change_kind == GraphHistoryChangeKind.CREATED.value
+    assert result_history.rows[0].audit_id == audit.id
+
+
+@pytest.mark.asyncio
+async def test_create_node_seed_appears_in_timeline_verb() -> None:
+    """``query_topology kind=timeline`` includes the manually-seeded node.
+
+    Anchor acceptance criterion: ``kind=timeline`` includes the seed
+    (issue body). The timeline UNIONs ``graph_node_history`` +
+    ``graph_edge_history`` tenant-scoped — pre-#1359 the seed was
+    audited but invisible to this verb because no history row existed.
+    """
+    tenant_id = await _seed_tenant()
+    sessionmaker = get_sessionmaker()
+
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            result = await create_or_get_node(
+                session,
+                _operator(tenant_id),
+                kind="principal",
+                name="k8s-sa-prod",
+            )
+
+    timeline = await query_timeline(_operator(tenant_id))
+    # Exactly one entry — the create_node seed.
+    assert len(timeline.rows) == 1
+    entry = timeline.rows[0]
+    assert entry.source == "node"
+    assert entry.resource_id == result.node.id
+    assert entry.change_kind == GraphHistoryChangeKind.CREATED.value
+
+
+@pytest.mark.asyncio
+async def test_create_node_idempotent_reseed_does_not_double_write_history() -> None:
+    """No double-write when ``create_or_get_node`` hits the get path.
+
+    Acceptance criterion: an idempotent re-seed with the same
+    ``(kind, name)`` and identical ``(note, evidence_url)`` must not
+    emit a phantom ``updated`` history row. The only changes between
+    the two calls are the heartbeat fields (``seeded_at`` is
+    ``datetime.now(UTC).isoformat()``; ``last_seen`` is refreshed),
+    which mirror the heartbeat-skip discipline in
+    :func:`refresh._update_existing_node` (``is_meaningful_update``)
+    and :func:`annotate._annotate_curated_is_meaningful`. Without this
+    guard, repeated MCP polls of a bootstrap seed would balloon the
+    history table with empty UPDATED rows.
+    """
+    tenant_id = await _seed_tenant()
+    sessionmaker = get_sessionmaker()
+
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            first = await create_or_get_node(
+                session,
+                _operator(tenant_id),
+                kind="vault-role",
+                name="rdc-vault",
+                note="same",
+                evidence_url="https://example.test/same",
+            )
+        async with sessionmaker() as session:
+            second = await create_or_get_node(
+                session,
+                _operator(tenant_id),
+                kind="vault-role",
+                name="rdc-vault",
+                note="same",
+                evidence_url="https://example.test/same",
+            )
+
+    assert first.was_created is True
+    assert second.was_created is False
+
+    # Only the first call's ``created`` row exists — the second's
+    # heartbeat-only re-seed deliberately emits no history row.
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(GraphNodeHistory).where(
+                        GraphNodeHistory.tenant_id == tenant_id,
+                        GraphNodeHistory.node_id == first.node.id,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+    assert rows[0].change_kind == GraphHistoryChangeKind.CREATED.value
+
+
+@pytest.mark.asyncio
+async def test_create_node_meaningful_reseed_emits_updated_history_row() -> None:
+    """A re-seed with a *different* note emits one ``updated`` row.
+
+    Distinguishes the heartbeat-only no-op skip (covered above) from a
+    real property change — the operator updated ``note`` /
+    ``evidence_url`` on an already-seeded row and that mutation must
+    land in the history table so the operator-visible "what changed
+    for this node?" query reflects it.
+    """
+    tenant_id = await _seed_tenant()
+    sessionmaker = get_sessionmaker()
+
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            first = await create_or_get_node(
+                session,
+                _operator(tenant_id),
+                kind="vault-role",
+                name="rdc-vault",
+                note="first",
+            )
+        async with sessionmaker() as session:
+            second = await create_or_get_node(
+                session,
+                _operator(tenant_id),
+                kind="vault-role",
+                name="rdc-vault",
+                note="second",
+            )
+
+    assert first.was_created is True
+    assert second.was_created is False
+
+    async with sessionmaker() as session:
+        rows = (
+            (
+                await session.execute(
+                    select(GraphNodeHistory)
+                    .where(
+                        GraphNodeHistory.tenant_id == tenant_id,
+                        GraphNodeHistory.node_id == first.node.id,
+                    )
+                    .order_by(GraphNodeHistory.history_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 2
+    kinds = [row.change_kind for row in rows]
+    assert kinds == [GraphHistoryChangeKind.CREATED.value, GraphHistoryChangeKind.UPDATED.value]
+    # ``snapshot.before`` on the updated row captures the pre-mutation
+    # ``note='first'`` — the diff-on-write hook discipline that lets
+    # ``meho topology diff`` reconstruct the operator's edit without
+    # joining live tables.
+    update_row = rows[1]
+    assert update_row.snapshot["before"]["properties"]["note"] == "first"
+    assert update_row.snapshot["after"]["properties"]["note"] == "second"
+
+
+@pytest.mark.asyncio
+async def test_create_node_history_does_not_leak_across_tenants() -> None:
+    """A history row for tenant-B is invisible to a tenant-A history query.
+
+    The history walk's first WHERE clause is ``tenant_id = :tenant_id``;
+    this test pins that the create_node hook also wrote the row under
+    the correct tenant scope so the tenant-isolation invariant the
+    rest of the substrate enforces holds at the seed-emit point too.
+    """
+    tenant_a = await _seed_tenant(slug="tenant-a")
+    tenant_b = await _seed_tenant(slug="tenant-b")
+    sessionmaker = get_sessionmaker()
+
+    with patch(_PUBLISH, new=AsyncMock()):
+        async with sessionmaker() as session:
+            await create_or_get_node(
+                session,
+                _operator(tenant_b, sub="op-b"),
+                kind="vault-role",
+                name="rdc-vault",
+            )
+        async with sessionmaker() as session:
+            await create_or_get_node(
+                session,
+                _operator(tenant_a, sub="op-a"),
+                kind="vault-role",
+                name="rdc-vault",
+            )
+
+    timeline_a = await query_timeline(_operator(tenant_a, sub="op-a"))
+    assert len(timeline_a.rows) == 1
+    timeline_b = await query_timeline(_operator(tenant_b, sub="op-b"))
+    assert len(timeline_b.rows) == 1

--- a/docs/codebase/topology.md
+++ b/docs/codebase/topology.md
@@ -783,11 +783,17 @@ SSE / Slack feed.
 
 1. Validate `kind` against `_GRAPH_NODE_KINDS` (raise
    `InvalidNodeKindError` *before* any DB read).
-2. `async with session.begin()` — one transaction wraps the
-   lookup + upsert + audit write.
-3. Look up the existing row for the `(tenant_id, kind, name)` unique
+2. Pre-allocate `audit_id = uuid.uuid4()` (chassis "audit-id
+   pre-allocation" pattern shared with `refresh` / `annotate` —
+   the same uuid is threaded into the `audit_log` row and the
+   `graph_node_history` row so the temporal-query verbs can join
+   history back against audit to recover the causing principal).
+3. `async with session.begin()` — one transaction wraps the
+   lookup + upsert + history write + audit write.
+4. Look up the existing row for the `(tenant_id, kind, name)` unique
    tuple (the `graph_node_tenant_kind_name_idx` index). Found
-   → merge the four manual-seed property keys (`note`,
+   → capture `node_snapshot(existing)` as `before` *first*, then
+   merge the four manual-seed property keys (`note`,
    `evidence_url`, `seeded_by`, `seeded_at`) onto the existing JSONB
    (auto-discovered keys like `status`, `phase` are preserved),
    refresh `last_seen`, and promote `discovered_by` to the operator
@@ -796,17 +802,42 @@ SSE / Slack feed.
    with `discovered_by=operator.sub`, `target_id=None` (manual seeds
    never adopt onto a target — only the refresh service does that),
    `properties={note, evidence_url, seeded_by, seeded_at}`,
-   `first_seen = last_seen = now`.
-4. Add one `audit_log` row in the same session
+   `first_seen = last_seen = now`; `before` is `None`.
+5. Diff-on-write hook (G9.3-T2 #857; create_node side added by
+   G0.18-T6 #1359). Call `record_node_change` to add one
+   `graph_node_history` row per *meaningful* call (CREATED on fresh
+   insert; UPDATED on promotion or property change). An idempotent
+   re-seed with the same `(note, evidence_url)` and no promotion is
+   heartbeat-only (the `seeded_at` ISO timestamp and `last_seen`
+   change every call regardless of intent) and skips the emit per
+   `_create_node_is_meaningful` — same heartbeat-strip discipline
+   `annotate._annotate_curated_is_meaningful` and
+   `refresh._update_existing_node`'s `is_meaningful_update` use.
+   The row carries the pre-allocated `audit_id` from step 2.
+6. Add one `audit_log` row in the same session
    (`method="CREATE_NODE"`, `path="topology.create_node"`,
    `payload={op_id, op_class:"write", node_id, kind, name,
    was_created, note, evidence_url}`, `target_id` = the seeded
    node's own `target_id` when non-null, else `None`).
-5. Commit. Then publish one `BroadcastEvent` (`op_class="write"` —
+7. Commit. Then publish one `BroadcastEvent` (`op_class="write"` —
    set explicitly because the `.create_node` suffix is not in
    `_WRITE_SUFFIXES`; same rationale as `.annotate` /
    `.unannotate`). Publish is fail-open: a publish exception is
    logged, never raised.
+
+**Manual seeds are visible to `kind=history` / `kind=timeline`.**
+Before G0.18-T6 (#1359) the create_node hook wrote audit_log +
+broadcast but no `graph_node_history` row, so `query_topology
+kind=history <manually-seeded-node>` returned empty and
+`kind=timeline` omitted the seed even though it surfaced in
+`query_audit` — an audit-vs-graph-history asymmetry first surfaced
+in RDC #789 finding F-A. The hook now emits one history row per
+meaningful call so both verbs reflect manual seeds the same way
+they reflect auto-refresh changes. The atomicity contract
+`history.py` documents holds: a failure anywhere in the
+`session.begin()` block rolls the live row, the history row, and
+the audit row back together — the graph and the history table
+can never disagree about which mutations committed.
 
 **Idempotency invariant.** A repeat call with the same
 `(kind, name)` always returns `was_created=False` after the first


### PR DESCRIPTION
## Summary

- `meho.topology.create_node` now writes one `graph_node_history`
  row per meaningful call so manual seeds are visible to
  `query_topology kind=history` / `kind=timeline` — fixes RDC #789
  finding F-A where seeds appeared in `query_audit` but not in
  history/timeline because only `refresh` populated the history
  tables.
- The new hook shares the call's pre-allocated `audit_id` with the
  `audit_log` row (chassis pre-allocation pattern from `refresh` /
  `annotate`) so the temporal-query verbs can join history back
  against audit to recover the causing principal.
- Idempotent re-seeds with the same `(note, evidence_url)` and no
  auto→curated promotion skip the history emit (heartbeat-only
  mutation) — same `is_meaningful_update` / heartbeat-strip
  discipline `refresh` and `annotate` already use, so a polling
  agent does not balloon the history table with empty UPDATED rows.

## Test plan

- [x] `ruff check` — clean on changed files
- [x] `ruff format --check` — clean on changed files
- [x] `mypy backend/src/meho_backplane/topology/nodes.py` — clean
- [x] `pytest backend/tests/test_topology_create_node.py` — 13 passed (5 new)
- [x] `pytest backend/tests -k topology` — 439 passed, 45 skipped
- [x] AC: `create_or_get_node` (on actual create) writes a `graph_node_history` row consistent with refresh-path schema —
      `test_create_node_emits_created_history_row_visible_to_history_verb`
- [x] AC: `query_topology kind=history <manually-seeded-node>` returns the create entry — same test, drives `query_history` end-to-end
- [x] AC: `kind=timeline` includes the seed —
      `test_create_node_seed_appears_in_timeline_verb`
- [x] AC: no double-write when `create_or_get_node` hits the get path —
      `test_create_node_idempotent_reseed_does_not_double_write_history`
- [x] AC: CHANGELOG `[Unreleased]` Fixed bullet citing RDC #789 F-A

## Out of scope

- `unannotate` / edge-history changes (issue body).
- Backfilling history for nodes seeded before this lands (issue body).
- T4 #1357 `node_untracked` envelope / topology blast-radius work
  (auto-parked at iter 3, not in main; this PR does not depend on
  T4's behavior).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1359


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Manually-seeded topology nodes are now visible to history and timeline queries, resolving prior inconsistency where audit logs recorded these seeds but they remained hidden from topology history views.
  * Idempotent node re-seeds that only refresh heartbeat fields no longer create redundant history entries, improving system efficiency.

* **Documentation**
  * Updated topology documentation to reflect manual seed history behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->