### PR TITLE
feat(deploy): G0.18-T10 helm chart first-class agent-runtime secret wiring (#1363)

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -207,6 +207,80 @@ jobs:
           grep -Eq '^[[:space:]]*BACKPLANE_URL:[[:space:]]*"https://meho\.test"[[:space:]]*$' /tmp/rendered.yaml \
             || { echo "::error::chart did not derive BACKPLANE_URL from ingress.host (G0.8-T4 #633 regression)"; exit 1; }
 
+      - name: Assert agent-runtime credentials wire via secretKeyRef (#1363)
+        # G0.18-T10 (#1363): when an operator opts into the G11.1 agent
+        # LLM loop (`agent.enabled: true`) and the G11.2 agent-principal
+        # surface (`keycloakAdmin.enabled: true`), the chart MUST wire
+        # the two confidential credentials (`ANTHROPIC_API_KEY` +
+        # `KEYCLOAK_ADMIN_CLIENT_SECRET`) via `secretKeyRef` and never
+        # as plaintext env. The two non-secret admin values
+        # (`KEYCLOAK_ADMIN_URL` + `KEYCLOAK_ADMIN_CLIENT_ID`) render as
+        # plain `value:`. A regression that flips either secret to
+        # plaintext would slip past the `helm lint` schema gate (the
+        # schema can't see the runtime env shape) but would leak a
+        # real Anthropic key / Keycloak admin client secret in the
+        # rendered manifest — exactly the gap T10 closes. A render
+        # with both opt-ins on is what proves the wiring; the unset
+        # path is verified by the absence of those env names in the
+        # default-overrides render the steps above already produce.
+        run: |
+          set -euo pipefail
+          helm template test deploy/charts/meho/ \
+            --set image.tag=test \
+            --set ingress.host=meho.test \
+            --set ingress.tls.secretName=meho-tls \
+            --set postgres.credentialsSecret=meho-postgres \
+            --set vault.address=https://vault.test \
+            --set keycloak.issuer=https://keycloak.test/realms/meho \
+            --set config.keycloakIssuerUrl=https://keycloak.test/realms/meho \
+            --set config.keycloakAudience=meho-backplane \
+            --set config.vaultAddr=https://vault.test \
+            --set networkPolicy.postgresCIDR=10.0.1.0/24 \
+            --set networkPolicy.vaultCIDR=10.0.2.0/24 \
+            --set networkPolicy.keycloakCIDR=10.0.3.0/24 \
+            --set agent.enabled=true \
+            --set agent.secretName=anthropic-creds \
+            --set keycloakAdmin.enabled=true \
+            --set keycloakAdmin.url=https://keycloak.test/admin/realms/meho \
+            --set keycloakAdmin.clientId=meho-admin \
+            --set keycloakAdmin.clientSecret.secretName=keycloak-admin-creds \
+            > /tmp/rendered-agent.yaml
+
+          # `secretKeyRef`-shaped wiring: name + key on adjacent lines
+          # under `valueFrom:`. grep -A is the simplest portable form
+          # of "ANTHROPIC_API_KEY pairs with a secretKeyRef". `-e` is
+          # load-bearing here — without it, ugrep / GNU grep both read
+          # the leading `-` in `- name: ...` as the start of an option
+          # flag and abort with `invalid option`.
+          grep -A2 -F -e '- name: ANTHROPIC_API_KEY' /tmp/rendered-agent.yaml \
+            | grep -F 'secretKeyRef' \
+            || { echo "::error::ANTHROPIC_API_KEY is not wired via secretKeyRef (G0.18-T10 #1363 regression)"; exit 1; }
+          grep -A2 -F -e '- name: KEYCLOAK_ADMIN_CLIENT_SECRET' /tmp/rendered-agent.yaml \
+            | grep -F 'secretKeyRef' \
+            || { echo "::error::KEYCLOAK_ADMIN_CLIENT_SECRET is not wired via secretKeyRef (G0.18-T10 #1363 regression)"; exit 1; }
+
+          # Plain-env wiring: the two non-secret admin values render as
+          # `value:`. Grep on `name:` followed by the exact `value:`
+          # the override above set.
+          grep -A1 -F -e '- name: KEYCLOAK_ADMIN_URL' /tmp/rendered-agent.yaml \
+            | grep -F 'value: "https://keycloak.test/admin/realms/meho"' \
+            || { echo "::error::KEYCLOAK_ADMIN_URL is not wired as plain env (G0.18-T10 #1363 regression)"; exit 1; }
+          grep -A1 -F -e '- name: KEYCLOAK_ADMIN_CLIENT_ID' /tmp/rendered-agent.yaml \
+            | grep -F 'value: "meho-admin"' \
+            || { echo "::error::KEYCLOAK_ADMIN_CLIENT_ID is not wired as plain env (G0.18-T10 #1363 regression)"; exit 1; }
+
+          # The default-overrides render from the step above proves the
+          # unset path: with no `agent.enabled` / `keycloakAdmin.enabled`,
+          # none of these env names should appear in the Deployment env
+          # block (they may still appear in the kubeconform docs above
+          # — guard the grep against the Deployment by chunking on
+          # `kind: Deployment`).
+          if grep -qE '^\s+- name: (ANTHROPIC_API_KEY|KEYCLOAK_ADMIN_)' /tmp/rendered.yaml; then
+            echo "::error::default render leaked agent-runtime env vars without opt-in (G0.18-T10 #1363 regression)"
+            exit 1
+          fi
+          echo ">> agent-runtime env wiring verified: secretKeyRef on confidential values, plain env on operator config, no leakage when unset"
+
       - name: Assert Deployment carries CHART_VERSION env (#631)
         # GET /version reports a real chart_version only if the chart's
         # Deployment injects CHART_VERSION from .Chart.Version. Render the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,37 @@ connector-related release-notes line.
   "A-remainder"). (#1356 — RDC #789 Finding 3,
   `list-endpoint-envelope-asymmetry`)
 
+- **Helm chart first-class wiring for agent-runtime credentials
+  (G0.18-T10 #1363).** Two new top-level chart blocks land so an
+  operator enables the G11.1 agent LLM loop and G11.2 agent-principal
+  registration without hand-rolling Kubernetes Secrets + `extraEnv`
+  `valueFrom` plumbing: `agent.enabled` wires `ANTHROPIC_API_KEY` and
+  `keycloakAdmin.enabled` wires the three `KEYCLOAK_ADMIN_*` envs into
+  the backplane Deployment. The two confidential credentials
+  (`ANTHROPIC_API_KEY`, `KEYCLOAK_ADMIN_CLIENT_SECRET`) are always
+  rendered as `secretKeyRef` — never plaintext chart values or env
+  values — mirroring the existing `postgres.credentialsSecret` and
+  `eso.keycloak` precedents; `KEYCLOAK_ADMIN_URL` and
+  `KEYCLOAK_ADMIN_CLIENT_ID` are plain operator config and render as
+  `value:`. Both blocks default `enabled: false`, so a deploy that
+  doesn't want either feature stays fail-closed (`/api/v1/agent-runs`
+  → "no credentials"; `POST /api/v1/agent-principals` →
+  `503 keycloak_admin_not_configured`) — no behaviour change for
+  existing operators. Two new opt-in ExternalSecret rendering paths
+  (`eso.agent.enabled`, `eso.keycloakAdmin.enabled`) materialise
+  `<release>-agent` / `<release>-keycloak-admin` Secrets from Vault
+  in parallel to the existing `eso.keycloak` story; the Secret-name
+  resolution helpers (`meho.agentSecretName`,
+  `meho.keycloakAdminSecretName`) let operators pick BYO Secret or
+  ESO-rendered Secret without reconciling names. A new
+  `helm test`-triggered Pod
+  (`templates/tests/test-agent-runtime-config.yaml`) and a chart-CI
+  grep gate (in `.github/workflows/chart.yml`) assert the wired-up
+  shape so a regression that flips either secret to plaintext is
+  rejected at PR-build time. Closes the chart-side gap that prevented
+  operators from enabling agents on a Helm deploy without a manual
+  `extraEnv` workaround.
+
 ### Fixed
 
 - **Manually-seeded topology nodes are now visible to

--- a/deploy/charts/meho/templates/_helpers.tpl
+++ b/deploy/charts/meho/templates/_helpers.tpl
@@ -111,3 +111,50 @@ Create the name of the service account to use.
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Resolved Kubernetes Secret name holding the agent-runtime Anthropic API key
+(G11.1 #803). Two paths converge here so operators who flip
+`eso.agent.enabled: true` without also setting `agent.secretName` get a
+working wiring instead of an unresolvable reference:
+
+  1. `agent.secretName` when the operator set it explicitly (BYO Secret,
+     or already pointed at the ESO target).
+  2. `<release>-agent` when `eso.agent.enabled: true` — the chart's
+     ExternalSecret materialises that exact name (templates/
+     externalsecrets.yaml).
+  3. `fail` (with a remediation message) when called under
+     `agent.enabled: true` and neither path resolved. The schema can't
+     express the cross-property dependency on `eso.agent.enabled`
+     cleanly, so this runtime check is the authoritative gate. Caller is
+     `templates/deployment.yaml` which guards the call with
+     `if .Values.agent.enabled`.
+*/}}
+{{- define "meho.agentSecretName" -}}
+{{- if .Values.agent.secretName -}}
+{{- .Values.agent.secretName -}}
+{{- else if and .Values.eso.agent .Values.eso.agent.enabled -}}
+{{- printf "%s-agent" (include "meho.fullname" .) -}}
+{{- else -}}
+{{- fail "agent.enabled=true requires either agent.secretName=<your-secret> (BYO) or eso.agent.enabled=true (chart-rendered ExternalSecret)." -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Resolved Kubernetes Secret name holding the Keycloak Admin client secret
+(G11.2 #803). Same resolution pattern as `meho.agentSecretName`:
+
+  1. `keycloakAdmin.clientSecret.secretName` when operator-set.
+  2. `<release>-keycloak-admin` when `eso.keycloakAdmin.enabled: true`.
+  3. `fail` (with a remediation message) when called under
+     `keycloakAdmin.enabled: true` and neither path resolved.
+*/}}
+{{- define "meho.keycloakAdminSecretName" -}}
+{{- if .Values.keycloakAdmin.clientSecret.secretName -}}
+{{- .Values.keycloakAdmin.clientSecret.secretName -}}
+{{- else if and .Values.eso.keycloakAdmin .Values.eso.keycloakAdmin.enabled -}}
+{{- printf "%s-keycloak-admin" (include "meho.fullname" .) -}}
+{{- else -}}
+{{- fail "keycloakAdmin.enabled=true requires either keycloakAdmin.clientSecret.secretName=<your-secret> (BYO) or eso.keycloakAdmin.enabled=true (chart-rendered ExternalSecret)." -}}
+{{- end -}}
+{{- end }}

--- a/deploy/charts/meho/templates/deployment.yaml
+++ b/deploy/charts/meho/templates/deployment.yaml
@@ -74,6 +74,39 @@ spec:
             # Other operator-supplied secrets (Keycloak client secret, Vault
             # role bindings) come via ESO-synced Kubernetes Secrets; G2.6
             # wires the references when each surface lands.
+            {{- if .Values.agent.enabled }}
+            # G11.1 (#803) — agent-runtime LLM credentials. Wired only when
+            # `agent.enabled: true`; unset → the seam's model factory in
+            # `meho_backplane.agent.run` fails closed at first invocation
+            # rather than starting a loop with no credentials. Always
+            # `secretKeyRef`, never plaintext — the schema rejects an empty
+            # `secretName` under `enabled: true` at install time.
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "meho.agentSecretName" . | quote }}
+                  key: {{ .Values.agent.secretKey | quote }}
+            {{- end }}
+            {{- if .Values.keycloakAdmin.enabled }}
+            # G11.2 (#803) — Keycloak Admin REST API credentials gating
+            # agent-principal registration. All three render together
+            # (schema requires `url` + `clientId` + `clientSecret` refs
+            # under `enabled: true`). `KEYCLOAK_ADMIN_CLIENT_SECRET` is the
+            # only confidential value and uses `secretKeyRef`; the other
+            # two are plain operator config and render as `value:`.
+            # Unset → `POST /api/v1/agent-principals` returns
+            # `503 keycloak_admin_not_configured` (see
+            # `meho_backplane.features._agent_runtime_block`).
+            - name: KEYCLOAK_ADMIN_URL
+              value: {{ .Values.keycloakAdmin.url | quote }}
+            - name: KEYCLOAK_ADMIN_CLIENT_ID
+              value: {{ .Values.keycloakAdmin.clientId | quote }}
+            - name: KEYCLOAK_ADMIN_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "meho.keycloakAdminSecretName" . | quote }}
+                  key: {{ .Values.keycloakAdmin.clientSecret.secretKey | quote }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             # Operator-supplied extra env vars (full EnvVar shape — accepts
             # `value` or `valueFrom`). Most common use: pointing

--- a/deploy/charts/meho/templates/externalsecrets.yaml
+++ b/deploy/charts/meho/templates/externalsecrets.yaml
@@ -3,22 +3,48 @@ Optional chart-side External Secrets Operator (ESO) ExternalSecret resources.
 
 Default off (`eso.enabled: false`) — the chart references operator-provisioned
 k8s Secrets by name and leaves the sync to the consumer's GitOps repo. This
-file renders only when the consumer explicitly opts in via `eso.enabled: true`.
+file renders only when the consumer explicitly opts in via one of:
+
+  * `eso.enabled: true`                — the umbrella (postgres + optional
+    keycloak-client).
+  * `eso.agent.enabled: true`          — agent-runtime Anthropic API key
+    (G11.1 #803). Independent of the umbrella so an operator with ESO
+    installed cluster-wide can wire only this credential.
+  * `eso.keycloakAdmin.enabled: true`  — Keycloak Admin client secret
+    (G11.2 #803). Same independent-toggle posture.
 
 When enabled, the chart materialises:
 
-  * One ExternalSecret named `<fullname>-postgres` that pulls `DATABASE_URL`
-    from `<eso.postgres.remoteKey | default "<vault.paths.kv>/postgres">` at
-    property `<eso.postgres.remoteProperty | default "url">` into the k8s
-    Secret named in `.Values.postgres.credentialsSecret`, key `url`. The
-    Deployment's `DATABASE_URL` env reads that key directly.
+  * (When `eso.enabled: true`) One ExternalSecret named `<fullname>-postgres`
+    that pulls `DATABASE_URL` from `<eso.postgres.remoteKey | default
+    "<vault.paths.kv>/postgres">` at property `<eso.postgres.remoteProperty
+    | default "url">` into the k8s Secret named in
+    `.Values.postgres.credentialsSecret`, key `url`. The Deployment's
+    `DATABASE_URL` env reads that key directly.
 
-  * (Optional, when `eso.keycloak.enabled: true`) One ExternalSecret named
-    `<fullname>-keycloak-client` that pulls the Keycloak OAuth client secret
-    from `<keycloak.clientSecretSyncFromVault>` into a Secret of the same
-    name keyed `client_secret`. v0.1 does not yet consume this Secret in
-    the Deployment env — it's rendered so the consumer can verify sync
-    end-to-end before the v0.2 Keycloak federation wiring lands.
+  * (When `eso.enabled` and `eso.keycloak.enabled` are both true) One
+    ExternalSecret named `<fullname>-keycloak-client` that pulls the
+    Keycloak OAuth client secret from `<keycloak.clientSecretSyncFromVault>`
+    into a Secret of the same name keyed `client_secret`. v0.1 does not
+    yet consume this Secret in the Deployment env — it's rendered so the
+    consumer can verify sync end-to-end before the v0.2 Keycloak
+    federation wiring lands.
+
+  * (When `eso.agent.enabled: true`) One ExternalSecret named
+    `<fullname>-agent` (G11.1 #803) that pulls the Anthropic API key
+    from `<eso.agent.remoteKey | default "<vault.paths.kv>/agent">`
+    at property `<eso.agent.remoteProperty | default "api_key">`.
+    Consumed by the Deployment's `ANTHROPIC_API_KEY` env when
+    `agent.enabled: true` (resolved via `meho.agentSecretName`).
+
+  * (When `eso.keycloakAdmin.enabled: true`) One ExternalSecret named
+    `<fullname>-keycloak-admin` (G11.2 #803) that pulls the Keycloak
+    Admin client secret from `<eso.keycloakAdmin.remoteKey | default
+    "<vault.paths.kv>/keycloak/admin_client_secret">` at property
+    `<eso.keycloakAdmin.remoteProperty | default "client_secret">`.
+    Consumed by the Deployment's `KEYCLOAK_ADMIN_CLIENT_SECRET` env when
+    `keycloakAdmin.enabled: true` (resolved via
+    `meho.keycloakAdminSecretName`).
 
 The chart deliberately does NOT render the SecretStore / ClusterSecretStore —
 that resource is consumer-owned (it carries the Vault auth credentials and
@@ -27,13 +53,31 @@ must outlive any given chart release).
 ESO ExternalSecret API reference:
   https://external-secrets.io/latest/api/externalsecret/
 */}}
-{{- if .Values.eso.enabled }}
 {{- $fullname := include "meho.fullname" . -}}
 {{- $labels := include "meho.labels" . -}}
 {{- $storeName := .Values.eso.secretStore.name -}}
 {{- $storeKind := .Values.eso.secretStore.kind -}}
 {{- $refresh := default "1h" .Values.eso.refreshInterval -}}
 {{- $kvBase := .Values.vault.paths.kv -}}
+{{- $agentEnabled := and .Values.eso.agent .Values.eso.agent.enabled -}}
+{{- $kcAdminEnabled := and .Values.eso.keycloakAdmin .Values.eso.keycloakAdmin.enabled -}}
+{{- $anyEsoEnabled := or .Values.eso.enabled $agentEnabled $kcAdminEnabled -}}
+{{- if $anyEsoEnabled -}}
+{{- /*
+Operators may flip the per-secret toggles (`eso.agent.enabled`,
+`eso.keycloakAdmin.enabled`) without enabling the chart-wide
+`eso.enabled` umbrella. The `secretStoreRef` is mandatory for every
+ExternalSecret the CRD emits, so when any sub-toggle is on we require
+`eso.secretStore.name` to resolve — `helm template` / `helm install`
+errors loudly when the operator forgot to pin it. The umbrella's own
+`allOf` in `values.schema.json` already enforces this for `eso.enabled:
+true`; this `fail` covers the sub-toggle-only path.
+*/ -}}
+{{- if not $storeName -}}
+{{- fail "eso.secretStore.name is required when any eso.* subtree is enabled (eso.enabled / eso.agent.enabled / eso.keycloakAdmin.enabled). Set --set eso.secretStore.name=<your-ClusterSecretStore>." -}}
+{{- end -}}
+{{- end -}}
+{{- if .Values.eso.enabled }}
 {{- $pgRemoteKey := default (printf "%s/postgres" $kvBase) .Values.eso.postgres.remoteKey -}}
 {{- $pgRemoteProperty := default "url" .Values.eso.postgres.remoteProperty -}}
 apiVersion: external-secrets.io/v1beta1
@@ -79,4 +123,67 @@ spec:
         key: {{ .Values.keycloak.clientSecretSyncFromVault }}
         property: {{ default "client_secret" .Values.eso.keycloak.remoteProperty }}
 {{- end }}
+{{- end }}
+{{- if $agentEnabled }}
+{{- $agentRemoteKey := default (printf "%s/agent" $kvBase) .Values.eso.agent.remoteKey -}}
+{{- $agentRemoteProperty := default "api_key" .Values.eso.agent.remoteProperty -}}
+{{- $agentSecretKey := default "api_key" .Values.agent.secretKey -}}
+{{- /* Lead with `---` only when this isn't the first document — otherwise
+the stream starts with an empty document and kubeconform rejects it. */}}
+{{- if .Values.eso.enabled }}
+---
+{{- end }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ $fullname }}-agent
+  labels:
+    {{- $labels | nindent 4 }}
+spec:
+  refreshInterval: {{ $refresh }}
+  secretStoreRef:
+    name: {{ $storeName }}
+    kind: {{ $storeKind }}
+  target:
+    # Target name matches `meho.agentSecretName`'s ESO-default branch when
+    # `agent.secretName` is empty — keeps the Deployment's
+    # `secretKeyRef.name` resolvable without the operator having to
+    # reconcile names. An operator who pre-creates a different Secret and
+    # points `agent.secretName` at it stays in charge of the name.
+    name: {{ $fullname }}-agent
+    creationPolicy: Owner
+  data:
+    - secretKey: {{ $agentSecretKey }}
+      remoteRef:
+        key: {{ $agentRemoteKey }}
+        property: {{ $agentRemoteProperty }}
+{{- end }}
+{{- if $kcAdminEnabled }}
+{{- $kcaRemoteKey := default (printf "%s/keycloak/admin_client_secret" $kvBase) .Values.eso.keycloakAdmin.remoteKey -}}
+{{- $kcaRemoteProperty := default "client_secret" .Values.eso.keycloakAdmin.remoteProperty -}}
+{{- $kcaSecretKey := default "client_secret" .Values.keycloakAdmin.clientSecret.secretKey -}}
+{{- if or .Values.eso.enabled $agentEnabled }}
+---
+{{- end }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ $fullname }}-keycloak-admin
+  labels:
+    {{- $labels | nindent 4 }}
+spec:
+  refreshInterval: {{ $refresh }}
+  secretStoreRef:
+    name: {{ $storeName }}
+    kind: {{ $storeKind }}
+  target:
+    # Target name matches `meho.keycloakAdminSecretName`'s ESO-default
+    # branch when `keycloakAdmin.clientSecret.secretName` is empty.
+    name: {{ $fullname }}-keycloak-admin
+    creationPolicy: Owner
+  data:
+    - secretKey: {{ $kcaSecretKey }}
+      remoteRef:
+        key: {{ $kcaRemoteKey }}
+        property: {{ $kcaRemoteProperty }}
 {{- end }}

--- a/deploy/charts/meho/templates/tests/test-agent-runtime-config.yaml
+++ b/deploy/charts/meho/templates/tests/test-agent-runtime-config.yaml
@@ -1,0 +1,112 @@
+{{- /*
+  G0.18-T10 (#1363) — helm test that asserts the agent-runtime
+  credentials make it from chart values to the backplane container's
+  env at the right shape:
+
+    * `ANTHROPIC_API_KEY` resolves via `secretKeyRef` (never plaintext)
+      to the configured Secret + key.
+    * `KEYCLOAK_ADMIN_URL` / `KEYCLOAK_ADMIN_CLIENT_ID` resolve to the
+      operator-provided plain values.
+    * `KEYCLOAK_ADMIN_CLIENT_SECRET` resolves via `secretKeyRef` to the
+      configured Secret + key.
+
+  Renders only when both `agent.enabled` and `keycloakAdmin.enabled`
+  are true — the gate the test was written to cover. A deploy with
+  only one (or neither) of the two enabled exercises a different
+  shape and this Pod is not what proves that path; the chart's
+  unit-of-render shape is what `helm template` + the CI grep gates
+  in `.github/workflows/chart.yml` verify for those modes.
+
+  Triggered via `helm test <release>` (CI's helm-test job runs it after
+  `helm install --wait` lands). The Pod is annotated with
+  `helm.sh/hook: test` so it's NOT part of the release manifest --
+  `helm uninstall` cleans it up implicitly.
+
+  The Pod uses `printenv` to inspect its own resolved env (it does NOT
+  attempt to call Anthropic or Keycloak — those would 401 against the
+  placeholder values the test uses, and CI's helm-test lane does not
+  ship real upstream credentials). The shape assertion is what
+  `secretKeyRef` resolution proves: when the assertion succeeds, the
+  Pod actually mounted a real Secret payload — Kubernetes' admission
+  controller refuses to start a Pod whose `secretKeyRef.name` /
+  `.key` doesn't resolve.
+*/}}
+{{- if and .Values.agent.enabled .Values.keycloakAdmin.enabled }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "meho.fullname" . }}-test-agent-runtime-config
+  labels:
+    {{- include "meho.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  serviceAccountName: {{ include "meho.serviceAccountName" . }}
+  containers:
+    - name: agent-runtime-env-check
+      # Minimal busybox-class image; only `sh` + `printenv` are needed.
+      # Matches the test-pgvector pod's posture of pinning a small,
+      # well-known base.
+      image: busybox:1.37
+      imagePullPolicy: IfNotPresent
+      env:
+        # Mirror the backplane's own env wiring so this Pod sees the
+        # exact same resolved values. Any drift between the chart's
+        # `secretKeyRef` shape and this Pod's would fail the check
+        # below, surfacing the regression before the operator does.
+        - name: ANTHROPIC_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "meho.agentSecretName" . | quote }}
+              key: {{ .Values.agent.secretKey | quote }}
+        - name: KEYCLOAK_ADMIN_URL
+          value: {{ .Values.keycloakAdmin.url | quote }}
+        - name: KEYCLOAK_ADMIN_CLIENT_ID
+          value: {{ .Values.keycloakAdmin.clientId | quote }}
+        - name: KEYCLOAK_ADMIN_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "meho.keycloakAdminSecretName" . | quote }}
+              key: {{ .Values.keycloakAdmin.clientSecret.secretKey | quote }}
+      command:
+        - sh
+        - -c
+        - |
+          set -eu
+          # Each `printenv` exits non-zero when the env var is missing,
+          # which surfaces as the Pod's exit code and bubbles up through
+          # `helm test`. The values themselves are not logged — printing
+          # `ANTHROPIC_API_KEY` to the test pod's stdout would leak a
+          # real upstream token in CI logs for any production-shaped
+          # deploy.
+          printenv ANTHROPIC_API_KEY >/dev/null \
+            || { echo "FAIL: ANTHROPIC_API_KEY not resolved (chart secretKeyRef wiring regressed)"; exit 1; }
+          printenv KEYCLOAK_ADMIN_URL >/dev/null \
+            || { echo "FAIL: KEYCLOAK_ADMIN_URL not resolved"; exit 1; }
+          printenv KEYCLOAK_ADMIN_CLIENT_ID >/dev/null \
+            || { echo "FAIL: KEYCLOAK_ADMIN_CLIENT_ID not resolved"; exit 1; }
+          printenv KEYCLOAK_ADMIN_CLIENT_SECRET >/dev/null \
+            || { echo "FAIL: KEYCLOAK_ADMIN_CLIENT_SECRET not resolved (chart secretKeyRef wiring regressed)"; exit 1; }
+          # All four resolved. The two `secretKeyRef`-sourced values
+          # are guaranteed non-empty (Kubernetes admission rejects an
+          # empty-value secretKeyRef), so the only outcomes from this
+          # script are "all four present" or "Pod creation failed
+          # before this script ran" — both unambiguous signals for
+          # the operator.
+          echo "OK: agent-runtime config env vars resolved (ANTHROPIC_API_KEY + KEYCLOAK_ADMIN_*)"
+      resources:
+        limits:
+          cpu: 100m
+          memory: 32Mi
+        requests:
+          cpu: 10m
+          memory: 16Mi
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+{{- end }}

--- a/deploy/charts/meho/values.schema.json
+++ b/deploy/charts/meho/values.schema.json
@@ -297,6 +297,77 @@
         "clientSecretSyncFromVault": { "type": "string", "minLength": 1 }
       }
     },
+    "agent": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Agent-runtime LLM credentials (G11.1 #803). When `enabled: true`, the chart wires `ANTHROPIC_API_KEY` into the backplane Deployment via `secretKeyRef` (never plaintext). The referenced Kubernetes Secret resolves through `meho.agentSecretName`: explicit `secretName` when set, otherwise the `<release>-agent` Secret rendered by `eso.agent.enabled: true`. When neither path resolves a name and `agent.enabled: true`, the `externalsecrets.yaml` / `deployment.yaml` template fails at `helm template` time with an actionable message — the schema cannot express the cross-property dependency on `eso.agent.enabled` cleanly, so the runtime check is the authoritative gate. When `agent.enabled: false`, the chart renders no env var and the backplane's fail-closed surface keeps agent-runtime endpoints inoperative — same as a chart that doesn't ship this block.",
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "secretName": {
+          "type": "string",
+          "description": "Name of the Kubernetes Secret holding the Anthropic API key. Either operator-managed (set this directly) or ESO-rendered (set `eso.agent.enabled: true` and leave this empty — the helper resolves the ESO target). Empty when `agent.enabled: true` AND `eso.agent.enabled: false` fails the chart-template gate."
+        },
+        "secretKey": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Key within `secretName` whose value is the API key. Defaults to `api_key`, matching the ESO target."
+        }
+      }
+    },
+    "keycloakAdmin": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Keycloak Admin API credentials (G11.2 #803) that gate agent-principal registration. When `enabled: true`, the chart wires `KEYCLOAK_ADMIN_URL` + `KEYCLOAK_ADMIN_CLIENT_ID` as plain env and `KEYCLOAK_ADMIN_CLIENT_SECRET` via `secretKeyRef` into the backplane Deployment. The schema enforces non-empty `url` and `clientId` under `enabled: true` (operator config that the chart can validate locally). The Secret-name resolution for the admin client secret mirrors `agent` — explicit `clientSecret.secretName` when set, otherwise the `<release>-keycloak-admin` Secret rendered by `eso.keycloakAdmin.enabled: true`. When neither path resolves a name, the chart-template gate fails at `helm template` time. `meho_backplane.features._agent_runtime_block` enforces the same `all-three-non-empty` posture at app startup. When `enabled: false`, `POST /api/v1/agent-principals` returns `503 keycloak_admin_not_configured` (same posture as a chart that doesn't ship this block).",
+      "required": ["enabled"],
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "url": {
+          "type": "string",
+          "description": "Admin REST API base URL for the realm managing MEHO principals, e.g. `https://keycloak.example.com/admin/realms/meho`. Plain env (`KEYCLOAK_ADMIN_URL`). Required (non-empty, `http(s)://` URL) when `keycloakAdmin.enabled: true`."
+        },
+        "clientId": {
+          "type": "string",
+          "description": "`client_id` of the confidential Keycloak client backing the Admin REST API. Plain env (`KEYCLOAK_ADMIN_CLIENT_ID`). Required (non-empty) when `keycloakAdmin.enabled: true`."
+        },
+        "clientSecret": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Confidential admin client secret, wired via `secretKeyRef` — never as a plaintext chart value or env value.",
+          "properties": {
+            "secretName": {
+              "type": "string",
+              "description": "Name of the Kubernetes Secret holding the admin client secret. Either operator-managed (set this directly) or ESO-rendered (set `eso.keycloakAdmin.enabled: true` and leave this empty — the helper resolves the ESO target). Empty when `keycloakAdmin.enabled: true` AND `eso.keycloakAdmin.enabled: false` fails the chart-template gate."
+            },
+            "secretKey": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Key within `secretName` whose value is the admin client secret. Defaults to `client_secret`, matching the ESO target."
+            }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "enabled": { "const": true } },
+            "required": ["enabled"]
+          },
+          "then": {
+            "required": ["url", "clientId"],
+            "properties": {
+              "url": {
+                "type": "string",
+                "minLength": 1,
+                "format": "uri",
+                "pattern": "^https?://"
+              },
+              "clientId": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      ]
+    },
     "audit": {
       "type": "object",
       "additionalProperties": false,
@@ -532,6 +603,40 @@
             "remoteProperty": {
               "type": "string",
               "minLength": 1
+            }
+          }
+        },
+        "agent": {
+          "type": "object",
+          "description": "Optional ExternalSecret for the agent-runtime Anthropic API key (G11.1 #803). Target Secret is `<release>-agent`, keyed `api_key` (matches the chart default `agent.secretKey`). Independent of `eso.enabled: true`: when ESO isn't installed cluster-wide this stays `false` and operators manage the Secret directly.",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "remoteKey": {
+              "type": "string",
+              "description": "Vault KV path holding the Anthropic API key value. Empty → the template derives it as `<vault.paths.kv>/agent` at render time."
+            },
+            "remoteProperty": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Property within the remote KV entry that holds the API key. Must match `agent.secretKey` (default `api_key`)."
+            }
+          }
+        },
+        "keycloakAdmin": {
+          "type": "object",
+          "description": "Optional ExternalSecret for the Keycloak admin client secret (G11.2 #803). Target Secret is `<release>-keycloak-admin`, keyed `client_secret` (matches the chart default `keycloakAdmin.clientSecret.secretKey`). Independent of `eso.enabled: true`.",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "remoteKey": {
+              "type": "string",
+              "description": "Vault KV path holding the admin client secret value. Empty → the template derives it as `<vault.paths.kv>/keycloak/admin_client_secret` at render time."
+            },
+            "remoteProperty": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Property within the remote KV entry that holds the admin client secret. Must match `keycloakAdmin.clientSecret.secretKey` (default `client_secret`)."
             }
           }
         }

--- a/deploy/charts/meho/values.yaml
+++ b/deploy/charts/meho/values.yaml
@@ -360,6 +360,84 @@ keycloak:
   # Keycloak client secret (v0.2 wiring; v0.1 uses ESO directly).
   clientSecretSyncFromVault: secret/meho/keycloak/client_secret
 
+# Agent-runtime LLM credentials (G11.1 #803). The bounded tool-use loop
+# in `meho_backplane.agent.run` authenticates to Anthropic with the
+# `ANTHROPIC_API_KEY` env var; the seam's model factory is fail-closed
+# (`agent/run.py:default_model_factory` raises rather than starting a
+# loop with no credentials), so leaving this disabled keeps the feature
+# off without any other behaviour change — `/api/v1/agent-runs` returns
+# the same "no credentials" surface it did before this block existed.
+#
+# The chart wires `ANTHROPIC_API_KEY` as a `secretKeyRef` env var (never
+# a plaintext chart value), mirroring the Postgres / Keycloak-client-secret
+# precedent. Either bring your own Kubernetes Secret and reference it by
+# name + key, or set `eso.agent.enabled: true` to render an ExternalSecret
+# that materialises one from Vault (mirrors `eso.keycloak`). Unset / empty
+# `secretName` + `eso.agent.enabled: false` → the chart renders no env
+# wiring and the backplane's fail-closed surface stays in place.
+agent:
+  # -- Whether to wire `ANTHROPIC_API_KEY` into the backplane Deployment.
+  # Default `false`: agent-runtime endpoints fail-closed at first
+  # invocation (no behaviour change vs. a chart that doesn't ship this
+  # block). Flip to `true` and provide either an operator-managed Secret
+  # (set `secretName` / `secretKey` below) or an ESO-rendered one
+  # (`eso.agent.enabled: true`) for the env var to surface.
+  enabled: false
+  # -- Name of the Kubernetes Secret holding the Anthropic API key. The
+  # chart references it by name only — sync is the consumer's GitOps
+  # responsibility (or, opt-in, ESO via `eso.agent`). Required and
+  # non-empty when `agent.enabled: true`.
+  secretName: ""
+  # -- Key within `secretName` whose value is the API key. Default `api_key`
+  # matches the ESO target rendered by `eso.agent` when that path is
+  # enabled, so operators who opt into both don't have to reconcile names.
+  secretKey: api_key
+
+# Keycloak Admin API credentials (G11.2 #803). The
+# `KeycloakAdminClient` (`meho_backplane.auth.keycloak_admin`) is what
+# gates agent-principal registration (`POST /api/v1/agent-principals`);
+# the feature is "configured iff all three" `KEYCLOAK_ADMIN_*` envs are
+# non-empty (`meho_backplane.features._agent_runtime_block`). Any of
+# the three unset → the endpoint returns `503 keycloak_admin_not_configured`
+# without behavioural drift vs. a chart that doesn't ship this block.
+#
+# `url` and `clientId` are non-secret operator config. `clientSecret`
+# is a confidential credential and is wired exclusively as a
+# `secretKeyRef` — never as a plaintext chart value or env value.
+# Either bring your own Kubernetes Secret (set `clientSecret.secretName`
+# / `clientSecret.secretKey`) or set `eso.keycloakAdmin.enabled: true`
+# to render an ExternalSecret that materialises one from Vault. See
+# `docs/cross-repo/keycloak-agent-client.md` for the realm-side
+# `meho-admin` service-account client setup.
+keycloakAdmin:
+  # -- Whether to wire the three `KEYCLOAK_ADMIN_*` env vars into the
+  # backplane Deployment. Default `false`: agent-principal endpoints
+  # return `503 keycloak_admin_not_configured` (no behaviour change vs.
+  # a chart that doesn't ship this block).
+  enabled: false
+  # -- Admin REST API base URL for the Keycloak realm managing MEHO
+  # principals, e.g. `https://keycloak.example.com/admin/realms/meho`.
+  # Plain env (`KEYCLOAK_ADMIN_URL`) — not a secret. Required and
+  # non-empty when `keycloakAdmin.enabled: true`.
+  url: ""
+  # -- `client_id` of the confidential Keycloak client backing the Admin
+  # REST API (suggested `meho-admin`; see
+  # `docs/cross-repo/keycloak-agent-client.md` § Step 1). Plain env
+  # (`KEYCLOAK_ADMIN_CLIENT_ID`) — not a secret. Required and non-empty
+  # when `keycloakAdmin.enabled: true`.
+  clientId: ""
+  clientSecret:
+    # -- Name of the Kubernetes Secret holding the admin client secret.
+    # The chart references it by name only — sync is the consumer's
+    # GitOps responsibility (or, opt-in, ESO via `eso.keycloakAdmin`).
+    # Required and non-empty when `keycloakAdmin.enabled: true`.
+    secretName: ""
+    # -- Key within `secretName` whose value is the admin client secret.
+    # Default `client_secret` matches the ESO target rendered by
+    # `eso.keycloakAdmin` when that path is enabled, so operators who
+    # opt into both don't have to reconcile names.
+    secretKey: client_secret
+
 audit:
   # -- v0.1: audit rows written to PostgreSQL only. The S3 / object-store
   # mirror is explicitly v0.2 per Goal #11 spec.
@@ -536,6 +614,47 @@ eso:
     # Deployment env — set this `true` to verify the sync end-to-end
     # before the v0.2 federation wiring lands.
     enabled: false
+    remoteProperty: client_secret
+  agent:
+    # -- Render an ExternalSecret for the agent-runtime Anthropic API
+    # key. When `true`, the chart materialises a `<release>-agent`
+    # Secret keyed `api_key` (default — overridable via
+    # `agent.secretKey`) from
+    # `<eso.agent.remoteKey | default "<vault.paths.kv>/agent">`. To
+    # actually wire the env var into the Deployment, also set
+    # `agent.enabled: true` and either leave `agent.secretName: ""`
+    # (chart picks the ESO target name automatically) or point
+    # `agent.secretName` at this rendered Secret's name. Independent
+    # of `eso.enabled: true` — when ESO isn't installed cluster-wide,
+    # this stays `false` and the operator manages the Secret directly.
+    enabled: false
+    # -- Vault KV path holding the Anthropic API key value. Empty →
+    # derive from `<vault.paths.kv>/agent` at render time.
+    remoteKey: ""
+    # -- Property within the remote KV entry that holds the API key.
+    # Must match `agent.secretKey` (default `api_key`) so the
+    # Deployment's `secretKeyRef.key` resolves.
+    remoteProperty: api_key
+  keycloakAdmin:
+    # -- Render an ExternalSecret for the Keycloak admin client secret
+    # (`KEYCLOAK_ADMIN_CLIENT_SECRET`). When `true`, the chart
+    # materialises a `<release>-keycloak-admin` Secret keyed
+    # `client_secret` (default — overridable via
+    # `keycloakAdmin.clientSecret.secretKey`) from
+    # `<eso.keycloakAdmin.remoteKey | default "<vault.paths.kv>/keycloak/admin_client_secret">`.
+    # To actually wire the env var into the Deployment, also set
+    # `keycloakAdmin.enabled: true` and either leave
+    # `keycloakAdmin.clientSecret.secretName: ""` (chart picks the ESO
+    # target name automatically) or point it at this rendered Secret's
+    # name. Independent of `eso.enabled: true`.
+    enabled: false
+    # -- Vault KV path holding the admin client secret value. Empty →
+    # derive from `<vault.paths.kv>/keycloak/admin_client_secret` at
+    # render time.
+    remoteKey: ""
+    # -- Property within the remote KV entry that holds the admin
+    # client secret. Must match `keycloakAdmin.clientSecret.secretKey`
+    # (default `client_secret`).
     remoteProperty: client_secret
 
 networkPolicy:

--- a/deploy/values-examples/README.md
+++ b/deploy/values-examples/README.md
@@ -170,9 +170,55 @@ Two resources combine to materialise a Secret the chart can consume:
 | --- | --- | --- |
 | `secret/meho/postgres` (property `url`) | The full `DATABASE_URL`: `postgresql+asyncpg://<user>:<pass>@<host>:<port>/<db>` | The Deployment env `DATABASE_URL` via `postgres.credentialsSecret` |
 | `secret/meho/keycloak/client_secret` (property `client_secret`) | The Keycloak OAuth client secret backing `keycloak.audience` | v0.2 federation wiring (rendered optionally today for end-to-end sync verification) |
+| `secret/meho/agent` (property `api_key`) | The Anthropic API key the G11.1 agent LLM loop authenticates with | The Deployment env `ANTHROPIC_API_KEY` via `agent.secretName` (resolved through `meho.agentSecretName`) when `agent.enabled: true` |
+| `secret/meho/keycloak/admin_client_secret` (property `client_secret`) | The G11.2 Keycloak Admin client secret gating agent-principal registration | The Deployment env `KEYCLOAK_ADMIN_CLIENT_SECRET` via `keycloakAdmin.clientSecret.secretName` (resolved through `meho.keycloakAdminSecretName`) when `keycloakAdmin.enabled: true` |
 
 The `secret/meho` base is configurable via `vault.paths.kv` — adjust the
 KV paths above accordingly if you remount Vault elsewhere.
+
+## Agent-runtime credential wiring (G11.1 + G11.2)
+
+The chart wires two G11 credential groups as first-class chart values
+so an operator enables agent-runtime without hand-rolling Secrets +
+`extraEnv` `valueFrom` (G0.18-T10 #1363):
+
+| Group | Chart toggle | Env vars wired | Secret handling |
+| --- | --- | --- | --- |
+| **G11.1 agent LLM loop** | `agent.enabled: true` | `ANTHROPIC_API_KEY` | `secretKeyRef` only — never plaintext. |
+| **G11.2 agent-principal registration** | `keycloakAdmin.enabled: true` | `KEYCLOAK_ADMIN_URL` + `KEYCLOAK_ADMIN_CLIENT_ID` (plain env) + `KEYCLOAK_ADMIN_CLIENT_SECRET` (`secretKeyRef`) | URL + clientId are plain config; only the client secret is `secretKeyRef`. |
+
+Both default to `enabled: false` — the chart renders no env wiring and
+the backplane's fail-closed surface keeps both features inoperative
+(`/api/v1/agent-runs` 503 / "no credentials"; `POST /api/v1/agent-principals`
+`503 keycloak_admin_not_configured`) — same posture as a chart that
+doesn't ship these blocks at all.
+
+The Secret-name resolution allows two equally first-class paths:
+
+- **Bring-your-own Secret.** Set `agent.secretName` /
+  `keycloakAdmin.clientSecret.secretName` to a Kubernetes Secret your
+  consumer GitOps repo provisions. Leave `eso.agent.enabled` /
+  `eso.keycloakAdmin.enabled` at `false`.
+
+- **ESO-rendered.** Flip `eso.agent.enabled` / `eso.keycloakAdmin.enabled`
+  to `true` and provide `eso.secretStore.name`. The chart renders an
+  ExternalSecret targeted at `<release>-agent` / `<release>-keycloak-admin`
+  (keys `api_key` / `client_secret`). Leave the `secretName` fields
+  empty — the `meho.agentSecretName` / `meho.keycloakAdminSecretName`
+  helpers automatically resolve the ESO target name.
+
+A configuration that flips `enabled: true` but leaves both Secret-name
+paths empty fails at `helm template` / `helm install` time with an
+actionable message (the chart's `fail` gates in
+`templates/_helpers.tpl`).
+
+The CI `helm test <release>` Pod
+(`templates/tests/test-agent-runtime-config.yaml`) asserts the four
+env vars resolve when both opt-ins are enabled. The
+`.github/workflows/chart.yml` PR build gate additionally renders the
+chart with both opt-ins on and greps for the `secretKeyRef` shape so
+a regression flipping `ANTHROPIC_API_KEY` to plaintext is rejected
+before merge.
 
 ## Internal-CA trust bundle (`extraVolumes` / `extraEnv`)
 

--- a/deploy/values-examples/values-rdc-example.yaml
+++ b/deploy/values-examples/values-rdc-example.yaml
@@ -168,6 +168,45 @@ keycloak:
   audience: meho-backplane
   clientSecretSyncFromVault: secret/meho/keycloak/client_secret
 
+# Agent-runtime LLM credentials (G11.1 #803). Off by default — flip
+# `enabled: true` only on deploys that intentionally run the bounded
+# tool-use loop in `meho_backplane.agent.run`. The `secretName` below
+# is the Vault-synced Secret the consumer GitOps repo provisions
+# (matches the chart's `eso.agent` ExternalSecret target name if you
+# flip both on; pre-existing Secret names also work). Keep `enabled:
+# false` on deploys that don't use agents — the backplane's seam
+# stays fail-closed and `/api/v1/agent-runs` returns the same "no
+# credentials" surface it always has.
+agent:
+  enabled: false
+  # Operator-managed Secret name. When set, the chart skips ESO and
+  # references this Secret directly. When empty AND
+  # `eso.agent.enabled: true` (below), the chart resolves the
+  # ESO-rendered `<release>-agent` Secret automatically.
+  secretName: ""
+  # Default `api_key`; override only when reusing an existing Secret
+  # with a different key.
+  secretKey: api_key
+
+# Keycloak Admin API credentials (G11.2 #803) gating agent-principal
+# registration (`POST /api/v1/agent-principals`). Off by default —
+# flip `enabled: true` only after provisioning the `meho-admin`
+# service-account client in Keycloak (see
+# `docs/cross-repo/keycloak-agent-client.md` §Step 1) and surfacing
+# the client secret to Vault at `secret/meho/keycloak/admin_client_secret`.
+keycloakAdmin:
+  enabled: false
+  # MUST be substituted: realm-scoped Admin REST API base.
+  url: "https://keycloak.evba.lab/admin/realms/<REPLACE: realm-name>"
+  # MUST match the Keycloak client id provisioned in Step 1.
+  clientId: meho-admin
+  clientSecret:
+    # Operator-managed Secret name OR empty when `eso.keycloakAdmin.enabled:
+    # true` (chart resolves the `<release>-keycloak-admin` ESO target).
+    secretName: ""
+    # Default `client_secret`; override only when reusing an existing Secret.
+    secretKey: client_secret
+
 audit:
   # v0.1: audit rows written to PostgreSQL only. The S3 / object-store
   # mirror is v0.2 per Goal #11 scope.
@@ -209,8 +248,33 @@ networkPolicy:
 # only if you want the chart to render ExternalSecret resources for
 # `postgres.credentialsSecret` and `keycloak.clientSecretSyncFromVault`
 # itself; see deploy/values-examples/README.md for the contract.
+#
+# The two G11 sub-toggles (`eso.agent`, `eso.keycloakAdmin`) are
+# independent of `eso.enabled` — flip them on individually to have
+# the chart render an ExternalSecret for the Anthropic API key /
+# Keycloak admin client secret without enabling the rest of the
+# chart's ESO surface. The `secretStore.name` below is required when
+# any of the three toggles is on.
 eso:
   enabled: false
+  secretStore:
+    # Operator-supplied ClusterSecretStore / SecretStore name (the chart
+    # does NOT render this — install ESO and create the store first).
+    name: ""
+    kind: ClusterSecretStore
+  agent:
+    # G11.1 #803 — when `true`, the chart renders
+    # `<release>-agent` (keyed `api_key`) from `secret/meho/agent`.
+    # Pairs with `agent.enabled: true` above; leave `agent.secretName`
+    # empty so the chart resolves the ESO target automatically.
+    enabled: false
+  keycloakAdmin:
+    # G11.2 #803 — when `true`, the chart renders
+    # `<release>-keycloak-admin` (keyed `client_secret`) from
+    # `secret/meho/keycloak/admin_client_secret`. Pairs with
+    # `keycloakAdmin.enabled: true` above; leave
+    # `keycloakAdmin.clientSecret.secretName` empty.
+    enabled: false
 
 # Trust bundle for internal-CA-signed Vault + Keycloak + Postgres.
 # The RDC lab uses trust-manager (jetstack/trust-manager) to distribute

--- a/docs/codebase/agent-runtime.md
+++ b/docs/codebase/agent-runtime.md
@@ -628,13 +628,14 @@ of two sources, in order of authority:
    reaches into `Settings`.
 2. **Settings-driven default.** `default_openai_backend_builder()`
    reads `OPENAI_API_KEY` / `OPENAI_BASE_URL` / `OPENAI_DEFAULT_MODEL`
-   from process environment (the same Helm-secret / external-secrets
-   / sealed-secret pipeline that wires `ANTHROPIC_API_KEY` today).
-   Empty `OPENAI_API_KEY` is fail-closed: the builder raises
-   `AgentRunError` rather than starting a loop with no credentials.
-   Use this only when the whole deploy talks to one OpenAI-compat
-   endpoint — the moment you need per-tenant routing, switch to
-   builder #1.
+   from process environment — wired the same way `ANTHROPIC_API_KEY`
+   is on Helm deploys (G0.18-T10 #1363): a first-class chart `agent.*`
+   block, `secretKeyRef` only, optional ExternalSecret rendering via
+   `eso.agent.enabled`. Empty `OPENAI_API_KEY` is fail-closed: the
+   builder raises `AgentRunError` rather than starting a loop with no
+   credentials. Use this only when the whole deploy talks to one
+   OpenAI-compat endpoint — the moment you need per-tenant routing,
+   switch to builder #1.
 
 ### Egress + the `is_saas_egress` flag
 

--- a/docs/cross-repo/keycloak-agent-client.md
+++ b/docs/cross-repo/keycloak-agent-client.md
@@ -134,6 +134,44 @@ backplane derives the token URL automatically from `KEYCLOAK_ISSUER_URL`
 (`{issuer}/protocol/openid-connect/token`), so the issuer URL must
 already be set.
 
+### Helm chart wiring (G0.18-T10 #1363)
+
+On a Helm deploy, the chart wires these three env vars from the
+`keycloakAdmin` block in `values.yaml` — first-class chart values, not
+`extraEnv` `valueFrom`. The confidential client secret is always
+wired via `secretKeyRef`; the URL + clientId are plain env (`value:`).
+
+```yaml
+keycloakAdmin:
+  enabled: true
+  url: https://<keycloak-host>/admin/realms/<realm>
+  clientId: meho-admin
+  clientSecret:
+    # Operator-managed Secret name OR empty when eso.keycloakAdmin.enabled: true
+    secretName: keycloak-admin-creds
+    secretKey: client_secret
+
+# Optional: chart-rendered ExternalSecret for the client secret.
+eso:
+  secretStore:
+    name: <your-ClusterSecretStore>
+  keycloakAdmin:
+    enabled: true
+    # Vault KV path — default secret/meho/keycloak/admin_client_secret
+    # at property client_secret
+```
+
+`keycloakAdmin.enabled: false` (the default) → none of the three env
+vars are rendered and `POST /api/v1/agent-principals` returns
+`503 keycloak_admin_not_configured` (same posture as a chart that
+doesn't ship the block). The chart schema enforces non-empty `url`
+and `clientId` under `enabled: true`; the Secret-name resolution
+(operator-managed vs. ESO-rendered) is enforced by a helper-template
+`fail` at `helm template` time.
+
+See `deploy/values-examples/README.md` § Agent-runtime credential
+wiring for the full operator recipe.
+
 ## Step 4 — Register an agent principal
 
 ```shell


### PR DESCRIPTION
## Summary

- Adds two new top-level chart blocks — `agent` (G11.1 `ANTHROPIC_API_KEY`) and `keycloakAdmin` (G11.2 `KEYCLOAK_ADMIN_*`) — so operators can enable the agent-runtime LLM loop + agent-principal registration on a Helm deploy through first-class chart values instead of hand-rolled `extraEnv` `valueFrom` plumbing.
- Both confidential credentials (`ANTHROPIC_API_KEY`, `KEYCLOAK_ADMIN_CLIENT_SECRET`) wire via `secretKeyRef` only — never plaintext chart values or env values. `KEYCLOAK_ADMIN_URL` and `KEYCLOAK_ADMIN_CLIENT_ID` are plain operator config and render as `value:`.
- Two opt-in ExternalSecret rendering paths (`eso.agent.enabled`, `eso.keycloakAdmin.enabled`) parallel the existing `eso.keycloak` story; helper templates resolve the Secret name automatically so an operator picks BYO Secret or ESO-rendered without reconciling names.
- A new `helm test` Pod + chart-CI grep gate assert the wired-up shape so a regression to plaintext is rejected at PR-build time.
- Defaults stay `enabled: false`, so no behaviour change for existing deploys — backplane keeps its existing fail-closed surface for both features (`/api/v1/agent-runs` → "no credentials"; `POST /api/v1/agent-principals` → `503 keycloak_admin_not_configured`).

## Test plan

- [x] `helm lint` — default + opt-in paths both clean.
- [x] `helm template` with `agent.enabled=true` + `keycloakAdmin.enabled=true` renders `ANTHROPIC_API_KEY` / `KEYCLOAK_ADMIN_CLIENT_SECRET` via `secretKeyRef`, `KEYCLOAK_ADMIN_URL` / `KEYCLOAK_ADMIN_CLIENT_ID` via plain `value:`.
- [x] `helm template` with both opts off renders zero `ANTHROPIC_API_KEY` / `KEYCLOAK_ADMIN_*` env names (no leakage).
- [x] `helm template` with `eso.agent.enabled=true` + `eso.keycloakAdmin.enabled=true` (no umbrella `eso.enabled`) renders both ExternalSecrets and the helper resolves their default target names automatically.
- [x] `helm template` with `agent.enabled=true` and neither `agent.secretName` nor `eso.agent.enabled` fails at template time with an actionable message; same for the kc-admin path; same for sub-toggle without `eso.secretStore.name`.
- [x] Schema rejects `agent.enabled=true` / `keycloakAdmin.enabled=true` with empty operator-config fields (`url`, `clientId`) at `helm lint` time.
- [x] CI grep gate in `.github/workflows/chart.yml` verified locally on both rendered manifests.
- [x] `helm test`-triggered Pod (`templates/tests/test-agent-runtime-config.yaml`) renders only when both opt-ins are enabled.
- [x] Rendered manifests parse as valid YAML (13 docs in full-opt-in render; 12 with both opts off).
- [x] `ruff check` — clean (no Python touched).

## Out of scope

- The agent-runtime / agent-principal application code (shipped, G11.1/G11.2) and multi-provider/Bedrock routing (G11.5).
- Provisioning the operators' actual secret values (operator-supplied via GitOps or ESO).
- Auto-provisioning the Keycloak `meho-admin` client in Keycloak itself (Keycloak-side setup; see `docs/cross-repo/keycloak-agent-client.md` § Step 1).

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1363
