### PR TITLE
fix(runbooks): G12.3-T3 follow-up — release DB session across verify dispatch + preserve falsy forensics

### DIFF
--- a/backend/src/meho_backplane/runbooks/run_service.py
+++ b/backend/src/meho_backplane/runbooks/run_service.py
@@ -102,6 +102,7 @@ from __future__ import annotations
 
 import time
 import uuid
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any, Literal
@@ -238,6 +239,28 @@ class MissingParamsError(ValueError):
     catching the gap at start time gives the operator a typed error
     before the run row lands.
     """
+
+
+@dataclass(frozen=True, slots=True)
+class _NextStepInputs:
+    """Pre-dispatch reads :meth:`RunbookRunService.next_step` carries across the gap.
+
+    Captured under the read-only session A and consumed by the
+    sessionless verify dispatch + the write-phase session B. The
+    ``template_body`` / ``current_step`` are pinned at start_run and
+    immutable for the run, so they remain valid after session A closes;
+    ``run`` is re-loaded fresh inside session B (the captured instance
+    is detached once its session closes and is only used for the
+    contextvar-binding read in the dispatch phase).
+    """
+
+    run: RunbookRun
+    template_body: RunbookTemplateBody
+    current_step: Step
+    current_step_id: str
+    current_state: str
+    run_target: str
+    run_params: dict[str, Any]
 
 
 class RunbookRunService:
@@ -380,14 +403,57 @@ class RunbookRunService:
           its ``verify_response``. Raises :class:`PreviousStepFailedError`
           so the caller's next move is :meth:`abort_run` rather than a
           spurious retry on a step the state machine no longer accepts.
+
+        Session lifetime: the method runs in three phases — a read-only
+        session A (:meth:`_load_next_step_inputs`) for the pre-dispatch
+        reads, a **sessionless** verify dispatch (so no pooled connection
+        is pinned across the external ``operation_call``), and a write
+        session B (:meth:`_write_next_step_outcome`) for the outcome. The
+        run + step states are re-loaded and re-validated at the start of
+        session B because a TENANT_ADMIN could have raced the dispatch
+        with :meth:`abort_run` (→ :class:`RunAlreadyTerminalError`) or
+        :meth:`reassign_run` (→ :class:`NotRunAssigneeError`); the
+        single-assignee / no-mutate-terminal invariants must hold at the
+        moment of the write, not just at the start of the call.
+        """
+        inputs = await self._load_next_step_inputs(tenant_id, operator_sub, run_id)
+
+        # Dispatch the verify with NO session checked out.
+        # ``template_body`` / ``current_step`` are pinned at start_run and
+        # immutable for the run, so they survive the gap; the run/step
+        # contextvar binding inside ``_resolve_verify_response`` is
+        # task-local and independent of session lifetime.
+        verify_response = await self._resolve_verify_response(
+            run=inputs.run,
+            current_step=inputs.current_step,
+            request_verify=request.verify_response,
+        )
+
+        return await self._write_next_step_outcome(
+            tenant_id, operator_sub, run_id, inputs, verify_response
+        )
+
+    async def _load_next_step_inputs(
+        self,
+        tenant_id: uuid.UUID,
+        operator_sub: str,
+        run_id: uuid.UUID,
+    ) -> _NextStepInputs:
+        """Phase A: read everything the dispatch + write need, under session A.
+
+        Releases the pooled connection on block exit — SQLAlchemy 2.0's
+        :class:`AsyncSession` holds its checked-out connection for the
+        whole ``async with`` block, so awaiting the connector dispatch
+        inside it would pin the connection for the full (multi-second)
+        call and starve the pool under load.
         """
         sessionmaker = get_sessionmaker()
-        async with sessionmaker() as session:
-            run = await self._require_run_assignee(session, tenant_id, run_id, operator_sub)
+        async with sessionmaker() as session_a:
+            run = await self._require_run_assignee(session_a, tenant_id, run_id, operator_sub)
             self._refuse_if_terminal(run)
 
-            template_body = await self._load_pinned_template_body(session, run)
-            step_states = await _load_step_states(session, run_id)
+            template_body = await self._load_pinned_template_body(session_a, run)
+            step_states = await _load_step_states(session_a, run_id)
             current_step_id = self._current_step_id_or_raise(run, step_states)
             current_state = step_states[current_step_id].state
 
@@ -396,34 +462,62 @@ class RunbookRunService:
                     f"previous step {current_step_id!r} is in 'failed' state; abort the run",
                 )
 
-            current_step = _find_step(template_body, current_step_id)
-            verify_response = await self._resolve_verify_response(
+            return _NextStepInputs(
                 run=run,
-                current_step=current_step,
-                request_verify=request.verify_response,
+                template_body=template_body,
+                current_step=_find_step(template_body, current_step_id),
+                current_step_id=current_step_id,
+                current_state=current_state,
+                run_target=run.target,
+                run_params=dict(run.params),
             )
 
-            now = datetime.now(UTC)
+    async def _write_next_step_outcome(
+        self,
+        tenant_id: uuid.UUID,
+        operator_sub: str,
+        run_id: uuid.UUID,
+        inputs: _NextStepInputs,
+        verify_response: VerifyResponse | None,
+    ) -> NextStepResponse:
+        """Phase C: advance + persist the outcome under a fresh session B.
+
+        Re-loads and re-validates the run + step states: a TENANT_ADMIN
+        could have raced the dispatch with :meth:`abort_run` (terminal
+        flip) or :meth:`reassign_run` (assignee change). The
+        single-assignee / no-mutate-terminal invariants must still hold
+        at write time, not just at the start of the call.
+        """
+        now = datetime.now(UTC)
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session_b:
+            run = await self._require_run_assignee(session_b, tenant_id, run_id, operator_sub)
+            self._refuse_if_terminal(run)
+            step_states = await _load_step_states(session_b, run_id)
+            if step_states[inputs.current_step_id].state == _STEP_FAILED:
+                raise PreviousStepFailedError(
+                    f"previous step {inputs.current_step_id!r} is in 'failed' state; abort the run",
+                )
+
             outcome = advance(
-                template_body,
-                current_step_id,
-                current_state,
-                target=run.target,
-                params=dict(run.params),
+                inputs.template_body,
+                inputs.current_step_id,
+                inputs.current_state,
+                target=inputs.run_target,
+                params=inputs.run_params,
                 verify_response=verify_response,
                 completed_at=now,
             )
-            response = await self._apply_outcome(
-                session=session,
+            return await self._apply_outcome(
+                session=session_b,
                 run=run,
-                template_body=template_body,
+                template_body=inputs.template_body,
                 step_states=step_states,
-                current_step_id=current_step_id,
+                current_step_id=inputs.current_step_id,
                 outcome=outcome,
                 now=now,
                 operator_sub=operator_sub,
             )
-        return response
 
     async def _apply_outcome(
         self,
@@ -912,7 +1006,7 @@ class RunbookRunService:
             step_id_var.reset(step_token)
             run_id_var.reset(run_token)
 
-        actual = call_result.get("result") or {}
+        actual = call_result.get("result", {})
         if not isinstance(actual, dict):
             # The verify's _matches() compares dict-shaped expect against
             # dict-shaped actual; a list/scalar result from a typed handler

--- a/backend/tests/test_runbooks_run_service.py
+++ b/backend/tests/test_runbooks_run_service.py
@@ -37,14 +37,20 @@ seed rows into directly.
 
 from __future__ import annotations
 
+import asyncio
+import time
 import uuid
 from collections.abc import AsyncIterator, Iterator
 from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 
 from meho_backplane.auth.operator import Operator
 from meho_backplane.connectors.base import Connector
@@ -1153,3 +1159,275 @@ async def test_post_completion_check_in_progress_returns_false() -> None:
 
     allowed = await run_service.can_show_template_post_completion(tenant_id, OPERATOR, "d", 1)
     assert allowed is False
+
+
+# ---------------------------------------------------------------------------
+# next_step session lifetime (#1352) -- the verify dispatch must not hold an
+# AsyncSession across the external ``call_operation`` await, and the outcome
+# write must re-validate run state in case a TENANT_ADMIN raced the gap with
+# ``abort_run`` / ``reassign_run``.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_next_step_aborted_during_dispatch_refuses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``abort_run`` landing between the read phase and the write phase wins.
+
+    Simulates a TENANT_ADMIN aborting the run while ``next_step`` is in
+    its (now sessionless) verify-dispatch phase. The post-dispatch
+    re-validation must observe the terminal flip and raise
+    :class:`RunAlreadyTerminalError` rather than overwriting the
+    abandoned state with a ``verified`` / ``in_progress`` outcome.
+    """
+    from meho_backplane.runbooks import run_service as run_service_mod
+
+    tenant_id = uuid.uuid4()
+    await _seed_published_template(tenant_id, "d", body=_two_step_template())
+    run_service = RunbookRunService()
+    start = await run_service.start_run(
+        tenant_id, OPERATOR, StartRunRequest(template_slug="d", target="n", params={})
+    )
+    assert isinstance(start, CurrentStepResponse)
+
+    original_resolve = run_service._resolve_verify_response
+
+    async def _abort_mid_dispatch(**kwargs: Any) -> Any:
+        # Fire the race inside the dispatch window: session A has closed,
+        # session B has not opened. An admin aborts the run here.
+        await run_service.abort_run(
+            tenant_id, ADMIN, start.run_id, AbortRunRequest(reason="raced"), caller_is_admin=True
+        )
+        return await original_resolve(**kwargs)
+
+    monkeypatch.setattr(run_service, "_resolve_verify_response", _abort_mid_dispatch)
+
+    with pytest.raises(RunAlreadyTerminalError):
+        await run_service.next_step(
+            tenant_id,
+            OPERATOR,
+            start.run_id,
+            NextStepRequest(
+                last_verified=True,
+                verify_response=ConfirmVerifyResponse(type="confirm", answer="yes"),
+            ),
+        )
+
+    # The aborted state survived; no step was flipped to verified.
+    sessionmaker = run_service_mod.get_sessionmaker()
+    async with sessionmaker() as session:
+        run = (
+            await session.scalars(select(RunbookRun).where(RunbookRun.run_id == start.run_id))
+        ).one()
+        assert run.state == "abandoned"
+        states = (
+            await session.scalars(
+                select(RunbookRunStepState).where(RunbookRunStepState.run_id == start.run_id)
+            )
+        ).all()
+        by_id = {s.step_id: s for s in states}
+        assert by_id["step-1"].state == "in_progress"
+        assert by_id["step-2"].state == "pending"
+
+
+@pytest.mark.asyncio
+async def test_next_step_reassigned_during_dispatch_refuses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``reassign_run`` landing in the dispatch gap revokes the caller's right.
+
+    A TENANT_ADMIN reassigns the run to another operator while the
+    original assignee's ``next_step`` is dispatching. The post-dispatch
+    re-validation must raise :class:`NotRunAssigneeError` rather than
+    advancing on behalf of the now-former assignee.
+    """
+    from meho_backplane.runbooks import run_service as run_service_mod
+
+    tenant_id = uuid.uuid4()
+    await _seed_published_template(tenant_id, "d", body=_two_step_template())
+    run_service = RunbookRunService()
+    start = await run_service.start_run(
+        tenant_id, OPERATOR, StartRunRequest(template_slug="d", target="n", params={})
+    )
+    assert isinstance(start, CurrentStepResponse)
+
+    original_resolve = run_service._resolve_verify_response
+
+    async def _reassign_mid_dispatch(**kwargs: Any) -> Any:
+        await run_service.reassign_run(
+            tenant_id, ADMIN, start.run_id, ReassignRunRequest(new_assignee=OPERATOR_BETA)
+        )
+        return await original_resolve(**kwargs)
+
+    monkeypatch.setattr(run_service, "_resolve_verify_response", _reassign_mid_dispatch)
+
+    with pytest.raises(NotRunAssigneeError):
+        await run_service.next_step(
+            tenant_id,
+            OPERATOR,
+            start.run_id,
+            NextStepRequest(
+                last_verified=True,
+                verify_response=ConfirmVerifyResponse(type="confirm", answer="yes"),
+            ),
+        )
+
+    # The run still belongs to OPERATOR_BETA and step-1 was not advanced.
+    sessionmaker = run_service_mod.get_sessionmaker()
+    async with sessionmaker() as session:
+        run = (
+            await session.scalars(select(RunbookRun).where(RunbookRun.run_id == start.run_id))
+        ).one()
+        assert run.assigned_to == OPERATOR_BETA
+        states = (
+            await session.scalars(
+                select(RunbookRunStepState).where(RunbookRunStepState.run_id == start.run_id)
+            )
+        ).all()
+        assert {s.step_id: s.state for s in states}["step-1"] == "in_progress"
+
+
+@pytest.mark.asyncio
+async def test_next_step_does_not_pin_connection_across_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A slow verify dispatch must not pin a pooled connection.
+
+    With a ``pool_size=1, max_overflow=0`` pool, the old single-session
+    shape held the lone connection for the full ``call_operation`` await,
+    so a concurrent query queued behind it for the entire (here 500ms)
+    dispatch. With the read/dispatch/write split, the connection is back
+    in the pool during the dispatch, so the concurrent probe returns
+    promptly. The assertion is a generous margin below the dispatch
+    duration -- a regression to the pinned shape would blow past it.
+    """
+    from meho_backplane.runbooks import run_service as run_service_mod
+
+    tenant_id = uuid.uuid4()
+    await _seed_published_template(tenant_id, "d", body=_two_step_template())
+    run_service = RunbookRunService()
+    start = await run_service.start_run(
+        tenant_id, OPERATOR, StartRunRequest(template_slug="d", target="n", params={})
+    )
+    assert isinstance(start, CurrentStepResponse)
+
+    # A single-connection pool over the same per-test SQLite file. The
+    # production engine factory prunes pool_size for SQLite URLs, so we
+    # build the constrained engine directly to make the pinning failure
+    # mode observable. aiosqlite uses AsyncAdaptedQueuePool for a
+    # file-backed URL, which honours pool_size / max_overflow.
+    db_url = get_settings().database_url
+    pinned_engine = create_async_engine(db_url, pool_size=1, max_overflow=0, pool_timeout=30)
+    pinned_sessionmaker = async_sessionmaker(pinned_engine, expire_on_commit=False)
+    monkeypatch.setattr(run_service_mod, "get_sessionmaker", lambda: pinned_sessionmaker)
+
+    dispatch_secs = 0.5
+
+    async def _slow_resolve(**kwargs: Any) -> Any:
+        # Stand in for a slow external connector dispatch. The real
+        # _resolve_verify_response would await call_operation here; the
+        # point is purely that no session is checked out during this await.
+        await asyncio.sleep(dispatch_secs)
+        return kwargs["request_verify"]
+
+    monkeypatch.setattr(run_service, "_resolve_verify_response", _slow_resolve)
+
+    dispatch_started = asyncio.Event()
+
+    async def _drive_next_step() -> None:
+        dispatch_started.set()
+        await run_service.next_step(
+            tenant_id,
+            OPERATOR,
+            start.run_id,
+            NextStepRequest(
+                last_verified=True,
+                verify_response=ConfirmVerifyResponse(type="confirm", answer="yes"),
+            ),
+        )
+
+    async def _probe() -> float:
+        await dispatch_started.wait()
+        # Let next_step reach its (sessionless) dispatch phase before we probe.
+        await asyncio.sleep(0.05)
+        t0 = time.perf_counter()
+        async with pinned_sessionmaker() as probe_session:
+            await probe_session.execute(text("SELECT 1"))
+        return time.perf_counter() - t0
+
+    try:
+        driver = asyncio.create_task(_drive_next_step())
+        probe_elapsed = await _probe()
+        await driver
+    finally:
+        await pinned_engine.dispose()
+
+    # The probe must not have queued behind the full dispatch. Half the
+    # dispatch window is a wide margin: the pinned shape would force the
+    # probe to wait the entire dispatch_secs.
+    assert probe_elapsed < dispatch_secs / 2, (
+        f"probe waited {probe_elapsed * 1000:.0f}ms -- connection was pinned "
+        f"across the {dispatch_secs * 1000:.0f}ms dispatch"
+    )
+
+
+@pytest.mark.asyncio
+async def test_next_step_falsy_operation_result_preserved_in_forensics(
+    db_session: AsyncSession,
+    stub_embedding_service: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A falsy ``result`` payload (``[]`` / ``0``) must survive into ``actual``.
+
+    The verify-dispatch path used ``call_result.get("result") or {}``,
+    which collapsed any falsy payload to ``{}`` and erased the forensics
+    record. The fix uses ``.get("result", {})`` so only an absent key
+    defaults; falsy-but-present values flow into the non-dict wrap and
+    round-trip into the persisted ``verify_response.actual``.
+    """
+    await _seed_stub_op(stub_embedding_service)
+
+    for slug, falsy_result, expected_actual in (
+        ("empty-list", [], {"result": []}),
+        ("zero", 0, {"result": 0}),
+    ):
+        tenant_id = uuid.uuid4()
+        await _seed_target(tenant_id, "n")
+        await _seed_published_template(tenant_id, slug, body=_op_call_template())
+        run_service = RunbookRunService()
+        start = await run_service.start_run(
+            tenant_id, OPERATOR, StartRunRequest(template_slug=slug, target="n", params={})
+        )
+        assert isinstance(start, CurrentStepResponse)
+
+        # Stub only the dispatch so _resolve_verify_response builds
+        # ``actual`` from a falsy ``result``; the connector-id resolution
+        # (a DB lookup before the dispatch) still runs against the seeded
+        # stub op.
+        async def _falsy_call(operator: Any, arguments: Any, _r: Any = falsy_result) -> Any:
+            return {"status": "success", "result": _r}
+
+        monkeypatch.setattr("meho_backplane.runbooks.run_service.call_operation", _falsy_call)
+
+        # expect={"ok": True} won't match a list/scalar actual, so the
+        # step fails -- but the verify_response is persisted before the
+        # PreviousStepFailedError is raised.
+        with pytest.raises(PreviousStepFailedError):
+            await run_service.next_step(
+                tenant_id,
+                OPERATOR,
+                start.run_id,
+                NextStepRequest(last_verified=True, verify_response=None),
+            )
+
+        row = (
+            await db_session.scalars(
+                select(RunbookRunStepState)
+                .where(RunbookRunStepState.run_id == start.run_id)
+                .where(RunbookRunStepState.step_id == "call-it")
+            )
+        ).one()
+        assert row.state == "failed"
+        assert isinstance(row.verify_response, dict)
+        assert row.verify_response["actual"] == expected_actual


### PR DESCRIPTION
## Summary
- `RunbookRunService.next_step` held its outer `AsyncSession` across the external `call_operation` verify dispatch. SQLAlchemy 2.0 pins a session's checked-out connection for the lifetime of its `async with` block, so the outer connection sat idle through the whole (multi-second) connector call — and `call_operation` opens its own session(s) for audit writes, so each in-flight step consumed ≥2 pooled connections, exhausting a capped pool under concurrency (M1 from the #1340 iter-1 review).
- Split `next_step` into a read-only **session A** (`_load_next_step_inputs`), a **sessionless** verify dispatch, and a write **session B** (`_write_next_step_outcome`). Session B re-loads and re-validates the run + step states, so a `TENANT_ADMIN` `abort_run` (terminal flip) or `reassign_run` (assignee change) landing in the dispatch gap is caught — the single-assignee / no-mutate-terminal invariants hold at write time, not just at call start.
- Fixed the forensics collapse in `_resolve_verify_response`: `call_result.get("result") or {}` discarded any falsy payload (`[]`, `0`, `""`, `False`) before the non-dict wrap could preserve it, so a list-shaped op returning an empty "no matches" result persisted as `{}` instead of `{"result": []}`. Now `.get("result", {})` — only an absent key defaults (M3 from the #1340 iter-1 review).
- The verify dispatch's run/step `contextvars` binding stays inside `_resolve_verify_response` (task-local, session-independent) — unchanged.

## Test plan
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean (808 files)
- [x] `mypy src/` — clean (394 files)
- [x] `pytest tests/test_runbooks_run_service.py` — 31 passed (27 existing + 4 new)
- [x] No `AsyncSession` held across the dispatch — verified by diff: the `_resolve_verify_response` call sits in the `next_step` orchestrator between two separate session-scoped helpers; `grep 'or {}'` returns nothing in the module.
- [x] Race coverage — `test_next_step_aborted_during_dispatch_refuses` (abort mid-dispatch → `RunAlreadyTerminalError`, aborted state survives) and `test_next_step_reassigned_during_dispatch_refuses` (reassign mid-dispatch → `NotRunAssigneeError`, step not advanced).
- [x] Connection-pinning regression — `test_next_step_does_not_pin_connection_across_dispatch` uses a `pool_size=1, max_overflow=0` engine + a 500ms stub dispatch; a concurrent probe completes promptly. Confirmed it **fails** against the pre-split single-session shape (true regression guard).
- [x] Falsy-result forensics — `test_next_step_falsy_operation_result_preserved_in_forensics` asserts `verify_response.actual` round-trips as `{"result": []}` / `{"result": 0}`. Confirmed it **fails** against the old `or {}` code.
- [x] No regression — `test_runbook_runs_api.py`, `test_mcp_tools_runbook_runs.py`, `test_runbooks_priming.py`, `test_audit_runbook_correlation.py`, `test_runbooks_engine.py` — 88 passed.

## Out of scope
- A generalised optimistic-concurrency wrapper for service methods (the session-B re-check is per-call here), renaming `_resolve_verify_response`, and a codebase-wide sweep for other `or {}` patterns — all deferred per the issue body.
- No OpenAPI / route / schema surface changed (service-layer only), so no CLI snapshot regen needed.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1352


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of falsy operation results (e.g., empty arrays, zero) being incorrectly discarded from forensic records.

* **Refactor**
  * Improved internal session lifecycle management to prevent database connection retention during external dispatch operations.
  * Enhanced state validation and re-checks before persisting changes.

* **Tests**
  * Added race condition tests for admin abort and reassignment scenarios during concurrent operations.
  * Added connection pooling regression tests to ensure resources are released properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->