### PR TITLE
fix(runbooks): G12.3 422 response-shape conformance — emit Pydantic-list detail (#1364)

### DIFF
--- a/backend/src/meho_backplane/api/v1/_errors.py
+++ b/backend/src/meho_backplane/api/v1/_errors.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Shared typed-exception → ``HTTPException`` mapping for the ``api/v1`` routes.
+
+The runbook routes (and, in time, any other route that wants the
+property) raise a small typed-exception vocabulary; this module turns a
+caught exception into the canonical :class:`HTTPException` the route
+re-raises.
+
+The load-bearing reason this is a *shared* module rather than a
+per-route helper: **the 422 body shape has to match the OpenAPI
+schema FastAPI auto-generates for the route.** FastAPI declares every
+route's 422 response as the ``HTTPValidationError`` model — a list of
+``{"loc": [...], "msg": "...", "type": "..."}`` objects under
+``detail``. The framework's own ``RequestValidationError`` handler
+emits that list shape, but a hand-raised ``HTTPException(status_code=
+422, detail=str(exc))`` emits ``{"detail": "<string>"}`` instead. The
+two don't match, so a typed client generated from the OpenAPI spec
+(the Go CLI's oapi-codegen client, an openapi-python-client SDK, an
+openapi-typescript SDK) fails to deserialize the 422 body — it
+expects a list, gets a string, errors with a type mismatch.
+
+:func:`http_for` closes that gap: for a 422 it wraps the detail into
+the Pydantic validation-error list shape so the body round-trips
+through any codegen-generated SDK; for every other status it falls
+through to the plain ``{"detail": "<string>"}`` body (consistent with
+FastAPI convention — the OpenAPI schemas for 400 / 403 / 404 / 409
+don't declare a structured detail shape, so the string form is
+conformant there).
+
+The ``type`` tag in the 422 list entry is the discriminator typed
+clients key on (the Go CLI reads ``detail[0].type`` to tell
+``verify_response_required`` apart from ``verify_response_mismatch``);
+the ``loc`` tuple matches FastAPI's Pydantic-validation ``loc``
+convention so the entry is indistinguishable from a framework-emitted
+one.
+
+Usage — register each exception class once at module-import time, then
+map a caught instance:
+
+.. code-block:: python
+
+    from meho_backplane.api.v1._errors import http_for, register_error
+
+    register_error(
+        MissingParamsError,
+        status=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+        type_tag="missing_params",
+        loc=("body", "params"),
+    )
+    register_error(
+        RunNotFoundError,
+        status=http_status.HTTP_404_NOT_FOUND,
+    )
+
+    try:
+        ...
+    except (MissingParamsError, RunNotFoundError) as exc:
+        raise http_for(exc) from exc
+
+A registered exception class with no explicit ``type_tag`` / ``loc``
+(typical for the non-422 entries) carries ``None`` for both; those
+fields are only consulted on the 422 branch, so a 404 / 403 / 400
+entry never needs them.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from fastapi import HTTPException
+from fastapi import status as http_status
+
+__all__ = ["http_for", "register_error"]
+
+
+#: Registry of typed-exception class → ``(status, type_tag, loc)``.
+#: ``type_tag`` / ``loc`` are populated only for 422 entries (they
+#: feed the validation-error list entry); for other statuses they are
+#: ``None`` and never consulted. Populated by :func:`register_error`
+#: at each route module's import time. The strict lookup in
+#: :func:`http_for` is the point: an unregistered type raises
+#: :class:`KeyError`, which surfaces a missing-mapping bug at first
+#: call rather than letting it fall through to a silent 500.
+_ERROR_REGISTRY: Final[dict[type[Exception], tuple[int, str | None, tuple[str, ...] | None]]] = {}
+
+
+def register_error(
+    exc_cls: type[Exception],
+    *,
+    status: int,
+    type_tag: str | None = None,
+    loc: tuple[str, ...] | None = None,
+) -> None:
+    """Register the canonical HTTP mapping for *exc_cls*.
+
+    Args:
+        exc_cls: The typed exception class to map.
+        status: The HTTP status code the route surfaces for it.
+        type_tag: The structured-error ``type`` discriminator a typed
+            client keys on. Required for 422 entries (it lands in the
+            validation-error list entry); ignored for other statuses.
+        loc: The ``loc`` path for the 422 validation-error entry,
+            matching FastAPI's Pydantic-validation convention (e.g.
+            ``("body", "verify_response")`` or ``("path", "slug")``).
+            Defaults to ``("body",)`` on the 422 branch when omitted;
+            ignored for other statuses.
+
+    Idempotent re-registration of the same class overwrites the prior
+    mapping (so re-importing a route module under test reload is
+    harmless).
+    """
+    _ERROR_REGISTRY[exc_cls] = (status, type_tag, loc)
+
+
+def http_for(exc: Exception) -> HTTPException:
+    """Map a typed exception to its canonical :class:`HTTPException`.
+
+    For a 422 status, wraps the exception message into the Pydantic
+    validation-error **list** shape
+    (``{"detail": [{"loc": [...], "msg": str(exc), "type": <tag>}]}``)
+    so the body conforms to the ``HTTPValidationError`` schema FastAPI
+    auto-generates and any codegen-generated SDK deserializes it. For
+    every other status, emits the plain ``{"detail": "<string>"}``
+    body.
+
+    Looks the *concrete* type up in :data:`_ERROR_REGISTRY`; an
+    unregistered type raises :class:`KeyError` (treat that as a
+    contract bug — the handler caught something the route's
+    typed-error vocabulary doesn't promise to map). Returns an
+    :class:`HTTPException` the caller chains with ``from exc``.
+    """
+    status_code, type_tag, loc = _ERROR_REGISTRY[type(exc)]
+    if status_code == http_status.HTTP_422_UNPROCESSABLE_CONTENT:
+        detail: Any = [
+            {
+                "loc": list(loc) if loc is not None else ["body"],
+                "msg": str(exc),
+                "type": type_tag if type_tag is not None else "value_error",
+            }
+        ]
+    else:
+        detail = str(exc)
+    return HTTPException(status_code=status_code, detail=detail)

--- a/backend/src/meho_backplane/api/v1/runbook_runs.py
+++ b/backend/src/meho_backplane/api/v1/runbook_runs.py
@@ -110,6 +110,21 @@ Why some 400 vs 422 distinctions:
   doesn't satisfy what the engine needs -- Pydantic-style validation
   failure surface).
 
+The mapping is registered with the shared
+:func:`~meho_backplane.api.v1._errors.http_for` emitter at module
+import (see the ``register_error`` block below). The 422 entries emit
+the Pydantic validation-error LIST shape
+(``{"detail": [{"loc": [...], "msg": ..., "type": ...}]}``) so the body
+matches the ``HTTPValidationError`` schema FastAPI declares for the
+route's 422 response -- a typed client generated from the OpenAPI spec
+deserializes it cleanly and keys on ``detail[0].type``
+(``missing_params`` / ``verify_response_required`` /
+``verify_response_mismatch``). The non-422 entries keep the plain
+``{"detail": "<string>"}`` body (conformant -- the OpenAPI schemas for
+400 / 403 / 404 don't declare a structured shape). See
+:mod:`meho_backplane.api.v1._errors` and
+``docs/codebase/error-message-shape.md`` for the convention.
+
 Audit + broadcast contract
 --------------------------
 
@@ -158,10 +173,11 @@ import uuid
 from typing import Final, Literal
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi import status as http_status
 from pydantic import BaseModel, ConfigDict
 
+from meho_backplane.api.v1._errors import http_for, register_error
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
 from meho_backplane.runbooks.engine import (
@@ -214,42 +230,44 @@ _RUNBOOK_RUN_OP_IDS: Final[dict[str, str]] = {
     "list": "runbook.list_runs",
 }
 
-#: Typed-exception -> HTTP-status mapping. Centralised so each handler
-#: declares its mapping as a one-line tuple rather than open-coding the
-#: same ``raise HTTPException(...) from exc`` body N times. Order in
-#: the per-handler tuples matters only when one exception type is a
-#: subclass of another (none of these are -- the engine and service
-#: vocabularies inherit only from stdlib ``ValueError`` /
-#: ``LookupError`` / ``PermissionError``, never each other), so the
-#: tuples can be ordered for readability (404 / 403 / 400 / 422 by
-#: severity).
-_EXC_STATUS: Final[dict[type[Exception], int]] = {
-    RunNotFoundError: http_status.HTTP_404_NOT_FOUND,
-    TemplateNotFoundError: http_status.HTTP_404_NOT_FOUND,
-    NotRunAssigneeError: http_status.HTTP_403_FORBIDDEN,
-    DeprecatedTemplateError: http_status.HTTP_400_BAD_REQUEST,
-    RunAlreadyTerminalError: http_status.HTTP_400_BAD_REQUEST,
-    PreviousStepFailedError: http_status.HTTP_400_BAD_REQUEST,
-    PreviousStepNotVerifiedError: http_status.HTTP_400_BAD_REQUEST,
-    MissingParamsError: http_status.HTTP_422_UNPROCESSABLE_CONTENT,
-    VerifyResponseRequiredError: http_status.HTTP_422_UNPROCESSABLE_CONTENT,
-    VerifyResponseMismatchError: http_status.HTTP_422_UNPROCESSABLE_CONTENT,
-}
-
-
-def _http_for(exc: Exception) -> HTTPException:
-    """Map a typed service / engine exception to its canonical HTTPException.
-
-    Looks the *concrete* type up in :data:`_EXC_STATUS`. Returns an
-    :class:`HTTPException` chainable with ``from exc`` by the caller.
-    A type that isn't registered raises :class:`KeyError` -- treat that
-    as a contract bug (the handler caught something the module's
-    typed-error vocabulary doesn't promise to map). The strict lookup
-    is the point: silent fall-through to 500 would hide a missing
-    mapping; the strict lookup forces the contributor to either add
-    the type to :data:`_EXC_STATUS` or stop catching it at all.
-    """
-    return HTTPException(status_code=_EXC_STATUS[type(exc)], detail=str(exc))
+#: Typed-exception -> HTTP mapping, registered with the shared
+#: :func:`~meho_backplane.api.v1._errors.http_for` emitter at module
+#: import. Centralised so each handler maps a caught exception with one
+#: ``raise http_for(exc) from exc`` line rather than open-coding the
+#: ``HTTPException`` body N times. The 422 entries carry a ``type_tag``
+#: discriminator and a ``loc`` path so :func:`http_for` emits the
+#: Pydantic validation-error LIST shape the OpenAPI 422 schema declares
+#: (a typed client keys on ``detail[0].type``); the non-422 entries
+#: need neither (their ``{"detail": "<string>"}`` body is already
+#: schema-conformant). None of these exception types subclass each
+#: other (the engine and service vocabularies inherit only from stdlib
+#: ``ValueError`` / ``LookupError`` / ``PermissionError``), so the
+#: registry's concrete-type lookup is unambiguous.
+register_error(RunNotFoundError, status=http_status.HTTP_404_NOT_FOUND)
+register_error(TemplateNotFoundError, status=http_status.HTTP_404_NOT_FOUND)
+register_error(NotRunAssigneeError, status=http_status.HTTP_403_FORBIDDEN)
+register_error(DeprecatedTemplateError, status=http_status.HTTP_400_BAD_REQUEST)
+register_error(RunAlreadyTerminalError, status=http_status.HTTP_400_BAD_REQUEST)
+register_error(PreviousStepFailedError, status=http_status.HTTP_400_BAD_REQUEST)
+register_error(PreviousStepNotVerifiedError, status=http_status.HTTP_400_BAD_REQUEST)
+register_error(
+    MissingParamsError,
+    status=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+    type_tag="missing_params",
+    loc=("body", "params"),
+)
+register_error(
+    VerifyResponseRequiredError,
+    status=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+    type_tag="verify_response_required",
+    loc=("body", "verify_response"),
+)
+register_error(
+    VerifyResponseMismatchError,
+    status=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+    type_tag="verify_response_mismatch",
+    loc=("body", "verify_response"),
+)
 
 
 class RunbookListRunsResponse(BaseModel):
@@ -334,7 +352,7 @@ async def start_run(
     try:
         return await service.start_run(operator.tenant_id, operator.sub, request)
     except (DeprecatedTemplateError, TemplateNotFoundError, MissingParamsError) as exc:
-        raise _http_for(exc) from exc
+        raise http_for(exc) from exc
 
 
 @router.post("/{run_id}/next")
@@ -399,7 +417,7 @@ async def advance_run(
         VerifyResponseRequiredError,
         VerifyResponseMismatchError,
     ) as exc:
-        raise _http_for(exc) from exc
+        raise http_for(exc) from exc
 
 
 @router.post("/{run_id}/abort", response_model=AbortRunResponse)
@@ -448,7 +466,7 @@ async def abort_run(
             caller_is_admin=caller_is_admin,
         )
     except (RunNotFoundError, NotRunAssigneeError, RunAlreadyTerminalError) as exc:
-        raise _http_for(exc) from exc
+        raise http_for(exc) from exc
 
 
 @router.post("/{run_id}/reassign", response_model=ReassignRunResponse)
@@ -485,7 +503,7 @@ async def reassign_run(
     try:
         return await service.reassign_run(operator.tenant_id, operator.sub, run_id, request)
     except (RunNotFoundError, RunAlreadyTerminalError) as exc:
-        raise _http_for(exc) from exc
+        raise http_for(exc) from exc
 
 
 @router.get("", response_model=RunbookListRunsResponse)

--- a/backend/src/meho_backplane/api/v1/runbook_templates.py
+++ b/backend/src/meho_backplane/api/v1/runbook_templates.py
@@ -79,7 +79,11 @@ to the caller-facing status:
 * :class:`~meho_backplane.runbooks.service.TemplateNotDraftError` -> 400
 * :class:`~meho_backplane.runbooks.service.TemplateNotPublishedError` -> 400
 * :class:`~meho_backplane.runbooks.service.DuplicateDraftError` -> 409
-* :class:`~meho_backplane.kb.schemas.InvalidKbSlugError` -> 422
+* :class:`~meho_backplane.kb.schemas.InvalidKbSlugError` -> 422 (emitted
+  in the OpenAPI ``HTTPValidationError`` LIST shape via the shared
+  :func:`~meho_backplane.api.v1._errors.http_for` emitter so typed
+  clients deserialize it -- #1364; the non-422 mappings raise
+  ``HTTPException`` inline with the conformant plain string detail).
 
 Audit + broadcast contract
 --------------------------
@@ -128,6 +132,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi import status as http_status
 from pydantic import BaseModel, ConfigDict
 
+from meho_backplane.api.v1._errors import http_for, register_error
 from meho_backplane.auth.operator import Operator, TenantRole
 from meho_backplane.auth.rbac import require_role
 from meho_backplane.kb.schemas import InvalidKbSlugError, validate_slug
@@ -176,6 +181,17 @@ _RUNBOOK_OP_IDS: Final[dict[str, str]] = {
     "publish": "runbook.publish_template",
     "deprecate": "runbook.deprecate_template",
 }
+
+#: Register the one typed exception this surface maps through the shared
+#: ``http_for`` emitter -- a slug failing SLUG_PATTERN on the four write
+#: routes (draft / edit / publish / deprecate); ``type_tag`` / ``loc``
+#: feed the OpenAPI 422 validation-error LIST shape (see ``_errors``).
+register_error(
+    InvalidKbSlugError,
+    status=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
+    type_tag="invalid_kb_slug",
+    loc=("path", "slug"),
+)
 
 
 class RunbookTemplateListResponse(BaseModel):
@@ -252,10 +268,7 @@ async def draft_template(
             detail=str(exc),
         ) from exc
     except InvalidKbSlugError as exc:
-        raise HTTPException(
-            status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=str(exc),
-        ) from exc
+        raise http_for(exc) from exc
 
 
 @router.get("", response_model=RunbookTemplateListResponse)
@@ -465,10 +478,7 @@ async def edit_template(
     try:
         validate_slug(slug)
     except InvalidKbSlugError as exc:
-        raise HTTPException(
-            status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=str(exc),
-        ) from exc
+        raise http_for(exc) from exc
     structlog.contextvars.bind_contextvars(
         audit_op_id=_RUNBOOK_OP_IDS["edit"],
         audit_op_class="write",
@@ -517,10 +527,7 @@ async def publish_template(
     try:
         validate_slug(slug)
     except InvalidKbSlugError as exc:
-        raise HTTPException(
-            status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=str(exc),
-        ) from exc
+        raise http_for(exc) from exc
     structlog.contextvars.bind_contextvars(
         audit_op_id=_RUNBOOK_OP_IDS["publish"],
         audit_op_class="write",
@@ -572,10 +579,7 @@ async def deprecate_template(
     try:
         validate_slug(slug)
     except InvalidKbSlugError as exc:
-        raise HTTPException(
-            status_code=http_status.HTTP_422_UNPROCESSABLE_CONTENT,
-            detail=str(exc),
-        ) from exc
+        raise http_for(exc) from exc
     structlog.contextvars.bind_contextvars(
         audit_op_id=_RUNBOOK_OP_IDS["deprecate"],
         audit_op_class="write",

--- a/backend/tests/test_runbook_runs_api.py
+++ b/backend/tests/test_runbook_runs_api.py
@@ -417,7 +417,18 @@ def test_start_missing_params_422(client: TestClient) -> None:
             headers=_authed(token),
         )
     assert response.status_code == 422
-    assert "run.params" in response.json()["detail"]
+    # 422 body conforms to the OpenAPI HTTPValidationError LIST shape
+    # (#1364): {"detail": [{"loc": [...], "msg": ..., "type": ...}]} so
+    # a typed client (the Go CLI's oapi-codegen client) deserializes it
+    # cleanly and keys on detail[0].type.
+    detail = response.json()["detail"]
+    assert detail == [
+        {
+            "loc": ["body", "params"],
+            "msg": "template references run.params not supplied at start: cluster",
+            "type": "missing_params",
+        }
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -608,7 +619,13 @@ def test_next_previous_failed_400(client: TestClient) -> None:
 
 
 def test_next_verify_response_required_422(client: TestClient) -> None:
-    """Confirm step without a verify response -> 422."""
+    """Confirm step without a verify response -> 422 in the Pydantic-list shape.
+
+    #1364: the body conforms to the OpenAPI ``HTTPValidationError`` LIST
+    shape with ``type="verify_response_required"`` so the Go CLI's typed
+    client deserializes it and keys on ``detail[0].type`` to decide
+    whether to enter the interactive confirm prompt.
+    """
     run_id = uuid.uuid4()
     key, token = _operator_token()
     fake_next = AsyncMock(
@@ -625,6 +642,13 @@ def test_next_verify_response_required_422(client: TestClient) -> None:
             headers=_authed(token),
         )
     assert response.status_code == 422
+    assert response.json()["detail"] == [
+        {
+            "loc": ["body", "verify_response"],
+            "msg": "confirm step requires a verify_response",
+            "type": "verify_response_required",
+        }
+    ]
 
 
 def test_next_verify_response_mismatch_422(client: TestClient) -> None:
@@ -633,7 +657,9 @@ def test_next_verify_response_mismatch_422(client: TestClient) -> None:
     Regression on the engine's typed-mismatch path (e.g. caller sends a
     ``confirm`` response on an ``operation_call`` step). The route maps
     :class:`VerifyResponseMismatchError` to the same 422 surface as the
-    missing-response variant.
+    missing-response variant, emitting the Pydantic-list shape with
+    ``type="verify_response_mismatch"`` so the typed client tells it
+    apart from the required-response variant (#1364).
     """
     run_id = uuid.uuid4()
     key, token = _operator_token()
@@ -656,6 +682,13 @@ def test_next_verify_response_mismatch_422(client: TestClient) -> None:
             headers=_authed(token),
         )
     assert response.status_code == 422
+    assert response.json()["detail"] == [
+        {
+            "loc": ["body", "verify_response"],
+            "msg": "operation_call step expects operation_call verify response",
+            "type": "verify_response_mismatch",
+        }
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_runbook_templates_api.py
+++ b/backend/tests/test_runbook_templates_api.py
@@ -365,7 +365,13 @@ def test_draft_invalid_slug_422(client: TestClient) -> None:
 
 
 def test_draft_service_invalid_slug_422(client: TestClient) -> None:
-    """Service-side InvalidKbSlugError (defense in depth) → 422 from the route."""
+    """Service-side InvalidKbSlugError (defense in depth) → 422 from the route.
+
+    #1364: the body conforms to the OpenAPI ``HTTPValidationError`` LIST
+    shape — ``{"detail": [{"loc": ["path", "slug"], "msg": ...,
+    "type": "invalid_kb_slug"}]}`` — so a typed client deserializes it
+    cleanly instead of erroring on the legacy ``{"detail": "<string>"}``.
+    """
     key, token = _admin_token()
     fake_create = AsyncMock(side_effect=InvalidKbSlugError("slug does not match pattern"))
     with (
@@ -379,7 +385,13 @@ def test_draft_service_invalid_slug_422(client: TestClient) -> None:
             headers=_authed(token),
         )
     assert response.status_code == 422
-    assert "does not match" in response.json()["detail"]
+    assert response.json()["detail"] == [
+        {
+            "loc": ["path", "slug"],
+            "msg": "slug does not match pattern",
+            "type": "invalid_kb_slug",
+        }
+    ]
 
 
 def test_draft_operator_role_403(client: TestClient) -> None:
@@ -940,6 +952,25 @@ def test_deprecate_draft_400(client: TestClient) -> None:
 _MALFORMED_SLUG = "Bad-Caps"  # uppercase -> fails SLUG_PATTERN
 
 
+def _assert_invalid_kb_slug_shape(detail: Any) -> None:
+    """Assert *detail* is the conformant invalid-slug 422 list entry (#1364).
+
+    The four template write routes map ``InvalidKbSlugError`` through the
+    shared ``http_for`` emitter, which produces the Pydantic-list shape
+    ``{"detail": [{"loc": ["path", "slug"], "msg": ...,
+    "type": "invalid_kb_slug"}]}`` so a typed client deserializes the body
+    and keys on ``detail[0].type``. The ``msg`` carries the full
+    SLUG_PATTERN explanation verbatim, so we structurally pin ``loc`` /
+    ``type`` and substring-check the message.
+    """
+    assert isinstance(detail, list)
+    assert len(detail) == 1
+    entry = detail[0]
+    assert entry["loc"] == ["path", "slug"]
+    assert entry["type"] == "invalid_kb_slug"
+    assert "does not match" in entry["msg"]
+
+
 def test_edit_malformed_slug_422_no_service_call(client: TestClient) -> None:
     """PATCH on a malformed path slug → 422, service never invoked."""
     key, token = _admin_token()
@@ -955,6 +986,7 @@ def test_edit_malformed_slug_422_no_service_call(client: TestClient) -> None:
             headers=_authed(token),
         )
     assert response.status_code == 422
+    _assert_invalid_kb_slug_shape(response.json()["detail"])
     fake_edit.assert_not_awaited()
 
 
@@ -973,6 +1005,7 @@ def test_publish_malformed_slug_422_no_service_call(client: TestClient) -> None:
             headers=_authed(token),
         )
     assert response.status_code == 422
+    _assert_invalid_kb_slug_shape(response.json()["detail"])
     fake_publish.assert_not_awaited()
 
 
@@ -991,6 +1024,7 @@ def test_deprecate_malformed_slug_422_no_service_call(client: TestClient) -> Non
             headers=_authed(token),
         )
     assert response.status_code == 422
+    _assert_invalid_kb_slug_shape(response.json()["detail"])
     fake_deprecate.assert_not_awaited()
 
 

--- a/cli/internal/cmd/runbook/next.go
+++ b/cli/internal/cmd/runbook/next.go
@@ -6,7 +6,6 @@ package runbook
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -38,11 +37,15 @@ import (
 // thin HTTP wrapper:
 //
 //  1. Interactive verify prompt. When --verify-response is omitted
-//     AND the substrate's first answer is 422 VerifyResponseRequiredError
-//     (indicating a confirm-typed verify), the CLI prompts the
-//     operator on stdin (yes/no/escalate) and re-issues the call
-//     with the answer. The substrate is the verify oracle; the
-//     prompt is operator UX, not a security boundary.
+//     AND the substrate's first answer is a 422 whose typed body
+//     carries `type=verify_response_required` (indicating a
+//     confirm-typed verify), the CLI prompts the operator on stdin
+//     (yes/no/escalate) and re-issues the call with the answer. The
+//     422 body is the OpenAPI HTTPValidationError list shape (#1364),
+//     so the generated typed client deserializes it and the probe
+//     reads the `detail[0].type` discriminator directly. The
+//     substrate is the verify oracle; the prompt is operator UX, not
+//     a security boundary.
 //  2. Opacity rendering. Whether the response is the next step's
 //     body or the RunCompletedResponse marker, the CLI renders ONLY
 //     the current step (or the completion banner) -- never a list,
@@ -168,7 +171,7 @@ func runNextRun(cmd *cobra.Command, opts nextRunOptions) error {
 	// to let the substrate either dispatch the operation_call verify
 	// or surface VerifyResponseRequiredError on a confirm step we
 	// then prompt for.
-	body, fcode, ferr := postNext(cmd.Context(), backplaneURL, runID, answer)
+	resp, ferr := postNext(cmd.Context(), backplaneURL, runID, answer)
 	if ferr != nil {
 		return renderRequestError(cmd, backplaneURL, ferr, opts.JSONOut)
 	}
@@ -178,20 +181,22 @@ func runNextRun(cmd *cobra.Command, opts nextRunOptions) error {
 	// section, "pick (C) -- error-as-control-flow"). We only enter
 	// the prompt path when:
 	//   - the substrate said 422,
-	//   - the error detail indicates a verify response was required
-	//     (not, e.g., a mismatch -- those mean the operator's
-	//     supplied answer was wrong-shape, which is a re-prompt
-	//     loop a CLI shouldn't drive without operator intent),
+	//   - the typed 422 body's discriminator is
+	//     `verify_response_required` (not, e.g., a mismatch -- those
+	//     mean the operator's supplied answer was wrong-shape, which
+	//     is a re-prompt loop a CLI shouldn't drive without operator
+	//     intent),
 	//   - the operator did not pass --verify-response (we don't
 	//     prompt over a supplied answer; that's the scripted path
 	//     and we'd be drowning out the operator's explicit flag).
-	if fcode == http.StatusUnprocessableEntity && answer == "" && verifyResponseRequired(body) {
-		return promptAndRetryConfirm(cmd, backplaneURL, runID, body, opts)
+	if resp.StatusCode() == http.StatusUnprocessableEntity && answer == "" &&
+		verifyResponseRequired(resp.JSON422) {
+		return promptAndRetryConfirm(cmd, backplaneURL, runID, opts)
 	}
-	if fcode != http.StatusOK {
-		return renderHTTPStatus(cmd, backplaneURL, fcode, body, opts.JSONOut)
+	if resp.StatusCode() != http.StatusOK {
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
 	}
-	return renderNextResponse(cmd, backplaneURL, body, opts)
+	return renderNextResponse(cmd, backplaneURL, resp.Body, opts)
 }
 
 // postNext issues one POST to /next with the given verify-response
@@ -199,78 +204,41 @@ func runNextRun(cmd *cobra.Command, opts nextRunOptions) error {
 // dispatch an operation_call verify or surface
 // VerifyResponseRequiredError).
 //
-// Returns the body bytes verbatim, the status code, and any
-// transport error. We bypass the generated typed parser
-// (ParseAdvanceRunApiV1RunbooksRunsRunIdNextPostResponse) because:
+// Uses the generated typed client directly. The 422 body now conforms
+// to the OpenAPI HTTPValidationError list shape
+// (`{"detail": [{"loc", "msg", "type"}, ...]}`, #1364), so the
+// generated parser deserializes it into `resp.JSON422` instead of
+// erroring with a json.UnmarshalTypeError on the legacy
+// `{"detail": "<string>"}` body. verifyResponseRequired reads the
+// typed `resp.JSON422.Detail[0].Type` discriminator off that.
 //
-//  1. The 200 body is a discriminated union (kind=current_step |
-//     completed); the generated client lifts it into an anonymous
-//     struct with an unexported `union json.RawMessage` field, so
-//     we'd need to re-marshal the raw bytes to read the
-//     discriminator anyway. decodeNextStepResponse already does
-//     that on the raw bytes.
-//  2. The 422 body is FastAPI HTTPException(detail=str(exc)) --
-//     `{"detail": "<string>"}` -- which the generated parser
-//     rejects with a json.UnmarshalTypeError because the OpenAPI
-//     schema declares 422 as the validation-error list shape.
-//     Bypassing the typed parser lets the 422 body reach
-//     verifyResponseRequired's probe verbatim.
-//
-// The function reads the response body exactly once (defer Close)
-// and surfaces the bytes to the caller for both probing and
-// rendering.
+// The 200 body is still a discriminated union (kind=current_step |
+// completed) the codegen lifts into a struct with an unexported
+// raw-message union field; the caller routes it through
+// decodeNextStepResponse, which reads the kind discriminator off the
+// raw `resp.Body` bytes the typed envelope also carries. So the
+// typed envelope serves both surfaces: typed 422 for the probe, raw
+// `.Body` for the union render.
 func postNext(
 	ctx context.Context,
 	backplaneURL string,
 	runID uuid.UUID,
 	answer string,
-) ([]byte, int, error) {
+) (*api.AdvanceRunApiV1RunbooksRunsRunIdNextPostResponse, error) {
 	authed, err := newAuthedClient(ctx, backplaneURL)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	body := buildNextRequestBody(answer)
 	params := &api.AdvanceRunApiV1RunbooksRunsRunIdNextPostParams{}
-	// retryOn401 is generic over the typed response envelope;
-	// reuse it for the 401-refresh dance by routing through the
-	// raw *http.Response variant the generated client exposes, then
-	// pack it into a tiny shim that exposes StatusCode() the
-	// retry helper inspects.
-	resp, err := retryOn401(ctx, authed,
-		func(ctx context.Context) (*rawNextResponse, error) {
-			httpResp, herr := authed.AdvanceRunApiV1RunbooksRunsRunIdNextPost(
+	return retryOn401(ctx, authed,
+		func(ctx context.Context) (*api.AdvanceRunApiV1RunbooksRunsRunIdNextPostResponse, error) {
+			return authed.AdvanceRunApiV1RunbooksRunsRunIdNextPostWithResponse(
 				ctx, runID, params, body,
 			)
-			if herr != nil {
-				return nil, herr
-			}
-			defer func() { _ = httpResp.Body.Close() }()
-			bodyBytes, rerr := io.ReadAll(io.LimitReader(httpResp.Body, responseBodyCap))
-			if rerr != nil {
-				return nil, fmt.Errorf("read /next response body: %w", rerr)
-			}
-			return &rawNextResponse{
-				status: httpResp.StatusCode,
-				body:   bodyBytes,
-			}, nil
 		},
-		func(r *rawNextResponse) int { return r.status },
+		func(r *api.AdvanceRunApiV1RunbooksRunsRunIdNextPostResponse) int { return r.StatusCode() },
 	)
-	if err != nil {
-		return nil, 0, err
-	}
-	return resp.body, resp.status, nil
-}
-
-// rawNextResponse adapts an unparsed raw HTTP response to the
-// retryOn401 helper's "has a StatusCode() int" expectation. The
-// retry helper only reads the status code; it never decodes the
-// body. This keeps the 422-with-string-detail body (which the
-// generated typed parser would reject) reachable in the calling
-// function.
-type rawNextResponse struct {
-	status int
-	body   []byte
 }
 
 // buildNextRequestBody constructs the NextStepRequest payload. The
@@ -319,38 +287,27 @@ func makeConfirmVerifyResponse(answer string) api.NextStepRequest_VerifyResponse
 	return vr
 }
 
-// verifyResponseRequired probes the 422 body for the substrate's
-// VerifyResponseRequiredError signature. We match on the detail
-// string ("VerifyResponseRequiredError" emitted by str(exc) in the
-// runbook_runs.py route handler -- see _http_for and the engine's
-// exception classname). The probe is intentionally string-shaped
-// rather than parsing a structured envelope so a backend that
-// renames the field but keeps the exception classname continues to
-// work.
+// verifyResponseRequired reports whether the typed 422 body is the
+// substrate's "missing verify response" signal -- i.e. its first
+// validation-error entry's `type` discriminator is
+// `verify_response_required`.
 //
-// The fall-back tolerates the FastAPI validation-error shape that
-// 422 sometimes carries (a list of {loc, msg, type} dicts) -- a
-// real "missing verify response" should mention the message text;
-// anything else is a different 422 (verify_response_mismatch,
-// missing_params) and should NOT enter the prompt loop.
-func verifyResponseRequired(body []byte) bool {
-	trim := strings.TrimSpace(string(body))
-	if trim == "" {
+// The backend (#1364) emits 422s in the OpenAPI HTTPValidationError
+// list shape with a structured `type` tag per case
+// (`verify_response_required` / `verify_response_mismatch` /
+// `missing_params`), so the probe keys on that discriminator rather
+// than substring-matching the message. Only the required-response
+// case enters the interactive prompt loop; a mismatch or a
+// missing-params 422 is a different failure the operator must fix,
+// not re-prompt past.
+//
+// A nil body (no 422 payload parsed) or an empty detail list reports
+// false -- there is no discriminator to enter the prompt on.
+func verifyResponseRequired(body *api.HTTPValidationError) bool {
+	if body == nil || body.Detail == nil || len(*body.Detail) == 0 {
 		return false
 	}
-	if strings.Contains(trim, "VerifyResponseRequired") {
-		return true
-	}
-	// FastAPI HTTPException(detail=str(exc)) shape: {"detail": "<...>"}
-	var env struct {
-		Detail any `json:"detail"`
-	}
-	if err := json.Unmarshal(body, &env); err == nil {
-		if s, ok := env.Detail.(string); ok && strings.Contains(s, "VerifyResponseRequired") {
-			return true
-		}
-	}
-	return false
+	return (*body.Detail)[0].Type == "verify_response_required"
 }
 
 // promptAndRetryConfirm runs the interactive confirm prompt. Called
@@ -368,7 +325,6 @@ func promptAndRetryConfirm(
 	cmd *cobra.Command,
 	backplaneURL string,
 	runID uuid.UUID,
-	body []byte,
 	opts nextRunOptions,
 ) error {
 	// The substrate surfaces VerifyResponseRequiredError without
@@ -386,21 +342,20 @@ func promptAndRetryConfirm(
 	if perr != nil {
 		return output.RenderError(cmd.ErrOrStderr(), output.Unexpected(perr.Error()), opts.JSONOut)
 	}
-	retryBody, code, rerr := postNext(cmd.Context(), backplaneURL, runID, answer)
+	resp, rerr := postNext(cmd.Context(), backplaneURL, runID, answer)
 	if rerr != nil {
 		return renderRequestError(cmd, backplaneURL, rerr, opts.JSONOut)
 	}
-	if code != http.StatusOK {
+	if resp.StatusCode() != http.StatusOK {
 		// Don't recurse into the prompt loop on a second 422 -- a
 		// second VerifyResponseRequiredError after a valid answer
 		// means the run's state machine is in an unexpected place
 		// (the assignee got reassigned mid-prompt, the step
 		// concurrently transitioned to failed). Surface the body
 		// verbatim and exit.
-		return renderHTTPStatus(cmd, backplaneURL, code, retryBody, opts.JSONOut)
+		return renderHTTPStatus(cmd, backplaneURL, resp.StatusCode(), resp.Body, opts.JSONOut)
 	}
-	_ = body
-	return renderNextResponse(cmd, backplaneURL, retryBody, opts)
+	return renderNextResponse(cmd, backplaneURL, resp.Body, opts)
 }
 
 // readVerifyAnswer reads one line from cmd.InOrStdin(), trims

--- a/cli/internal/cmd/runbook/next_test.go
+++ b/cli/internal/cmd/runbook/next_test.go
@@ -17,6 +17,33 @@ import (
 	"github.com/evoila/meho/cli/internal/api"
 )
 
+// The runbook routes emit 422 bodies in the OpenAPI HTTPValidationError
+// list shape (#1364): {"detail": [{"loc", "msg", "type"}, ...]}. The
+// `type` discriminator is what the CLI's verifyResponseRequired probe
+// and renderHTTPStatus 422 branch key on. These fixtures mirror the
+// backend's conformant emission (see
+// backend/src/meho_backplane/api/v1/_errors.py).
+const (
+	// verifyResponseRequired422Body is the body the substrate returns
+	// when a confirm step is advanced without a verify_response. Its
+	// type=verify_response_required is the discriminator that enters
+	// the interactive prompt loop.
+	verifyResponseRequired422Body = `{"detail":[{"loc":["body","verify_response"],` +
+		`"msg":"confirm step requires a verify_response","type":"verify_response_required"}]}`
+
+	// verifyResponseMismatch422Body is the operation_call verify-fail
+	// body (substrate's dispatched verify mismatched). type=
+	// verify_response_mismatch must NOT enter the prompt loop.
+	verifyResponseMismatch422Body = `{"detail":[{"loc":["body","verify_response"],` +
+		`"msg":"verify mismatch: expected powered_on=true, got powered_on=false",` +
+		`"type":"verify_response_mismatch"}]}`
+
+	// verifyResponseMismatchShape422Body is a confirm-on-operation_call
+	// shape mismatch. Same type=verify_response_mismatch discriminator.
+	verifyResponseMismatchShape422Body = `{"detail":[{"loc":["body","verify_response"],` +
+		`"msg":"verify response shape mismatch","type":"verify_response_mismatch"}]}`
+)
+
 // TestRunNextWithExplicitVerifyResponseYes — issue test #6. With
 // `--verify-response yes`, the verb POSTs once with the answer
 // embedded; no prompt.
@@ -109,7 +136,7 @@ func TestRunNextInteractiveConfirmPrompt(t *testing.T) {
 				}
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusUnprocessableEntity)
-				fmt.Fprint(w, `{"detail":"VerifyResponseRequiredError: step-2 needs a confirm response"}`)
+				fmt.Fprint(w, verifyResponseRequired422Body)
 				return
 			}
 			// Second call: the prompt path supplied "yes".
@@ -165,8 +192,9 @@ func TestRunNextInteractiveInvalidAnswer(t *testing.T) {
 			n := atomic.AddInt32(&calls, 1)
 			_ = r
 			if n == 1 {
+				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusUnprocessableEntity)
-				fmt.Fprint(w, `{"detail":"VerifyResponseRequiredError"}`)
+				fmt.Fprint(w, verifyResponseRequired422Body)
 				return
 			}
 			step := confirmStepBody("s4", "Step 4", "B.", "p?")
@@ -211,8 +239,9 @@ func TestRunNextInteractiveEscalate(t *testing.T) {
 			var req api.NextStepRequest
 			readJSONBodyOf(t, raw, &req)
 			if n == 1 {
+				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusUnprocessableEntity)
-				fmt.Fprint(w, `{"detail":"VerifyResponseRequiredError"}`)
+				fmt.Fprint(w, verifyResponseRequired422Body)
 				return
 			}
 			confirm, _ := req.VerifyResponse.AsConfirmVerifyResponse()
@@ -341,14 +370,17 @@ func TestRunNextOperationCallVerifyPass(t *testing.T) {
 }
 
 // TestRunNextOperationCallVerifyFail — issue test #11. The
-// substrate's verify dispatch mismatched; backend returns 422
-// VerifyResponseMismatchError. The CLI surfaces the detail.
+// substrate's verify dispatch mismatched; backend returns a 422 with
+// type=verify_response_mismatch (the conformant list shape, #1364).
+// The CLI surfaces the detail (the 422 branch of renderHTTPStatus
+// renders the body verbatim, which carries the loc/msg/type entry).
 func TestRunNextOperationCallVerifyFail(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/runbooks/runs/77777777-7777-4777-8777-777777777777/next",
 		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnprocessableEntity)
-			fmt.Fprint(w, `{"detail":"VerifyResponseMismatchError: expected powered_on=true, got powered_on=false"}`)
+			fmt.Fprint(w, verifyResponseMismatch422Body)
 		})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -364,8 +396,8 @@ func TestRunNextOperationCallVerifyFail(t *testing.T) {
 		t.Fatal("expected error on verify mismatch")
 	}
 	out := stderr.String()
-	if !strings.Contains(out, "VerifyResponseMismatchError") {
-		t.Errorf("expected mismatch detail in stderr; got:\n%s", out)
+	if !strings.Contains(out, "verify_response_mismatch") {
+		t.Errorf("expected mismatch type discriminator in stderr; got:\n%s", out)
 	}
 	if !strings.Contains(out, "powered_on=false") {
 		t.Errorf("expected actual-vs-expected detail in stderr; got:\n%s", out)
@@ -481,8 +513,9 @@ func TestRunNext422NonRequiredErrorDoesNotPrompt(t *testing.T) {
 	mux.HandleFunc("/api/v1/runbooks/runs/bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb/next",
 		func(w http.ResponseWriter, _ *http.Request) {
 			atomic.AddInt32(&calls, 1)
+			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnprocessableEntity)
-			fmt.Fprint(w, `{"detail":"VerifyResponseMismatchError: shape mismatch"}`)
+			fmt.Fprint(w, verifyResponseMismatchShape422Body)
 		})
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -501,8 +534,8 @@ func TestRunNext422NonRequiredErrorDoesNotPrompt(t *testing.T) {
 	if got := atomic.LoadInt32(&calls); got != 1 {
 		t.Errorf("expected exactly 1 POST (no retry); got %d", got)
 	}
-	if !strings.Contains(stderr.String(), "VerifyResponseMismatchError") {
-		t.Errorf("expected mismatch detail; got %q", stderr.String())
+	if !strings.Contains(stderr.String(), "verify_response_mismatch") {
+		t.Errorf("expected mismatch type discriminator; got %q", stderr.String())
 	}
 }
 

--- a/cli/internal/cmd/runbook/start.go
+++ b/cli/internal/cmd/runbook/start.go
@@ -189,12 +189,28 @@ func runStartRun(cmd *cobra.Command, opts startRunOptions) error {
 	return nil
 }
 
-// postStartRun bypasses the generated typed-response parser for the
-// same reasons postNext does (see next.go's docstring): the 201
-// body is a discriminated union with an unexported union field,
-// and 422 FastAPI HTTPException bodies don't fit the
-// HTTPValidationError shape. Reading the raw bytes once keeps both
-// paths working through a single render layer.
+// rawNextResponse adapts an unparsed raw HTTP response to the
+// retryOn401 helper's "has a StatusCode() int" expectation. The retry
+// helper only reads the status code; it never decodes the body.
+//
+// postStartRun reads the raw bytes (rather than the generated typed
+// parser) because the 201 body is a discriminated union (kind=
+// current_step | completed) the codegen lifts into a struct with an
+// unexported `union json.RawMessage` field -- decodeNextStepResponse
+// re-reads the discriminator off the raw bytes anyway, so parsing
+// twice buys nothing. (`next`'s 200 path shares decodeNextStepResponse
+// but reads the raw bytes off the typed envelope's `.Body` field; see
+// next.go.)
+type rawNextResponse struct {
+	status int
+	body   []byte
+}
+
+// postStartRun reads the raw response bytes for the reason rawNextResponse
+// documents: the 201 body is a discriminated union with an unexported
+// union field, so decodeNextStepResponse re-reads the kind discriminator
+// off the raw bytes. Reading once keeps the 201 and the error paths
+// working through a single render layer.
 func postStartRun(
 	ctx context.Context,
 	backplaneURL string,

--- a/docs/codebase/cli.md
+++ b/docs/codebase/cli.md
@@ -119,15 +119,19 @@ names.
   - Both halves share the chassis (`runbook.go`, `yaml.go`): the
     `newAuthedClient` / `retryOn401` / `renderRequestError` /
     `renderHTTPStatus` helpers, the 1 MiB response-body cap, and the
-    FastAPI HTTPException detail decoder. The run-side verbs
-    (`start.go`, `next.go`) bypass the generated typed-response
-    parser for the discriminated-union response shapes (the codegen
-    lifts them into structs with an unexported `union json.RawMessage`
-    field) and decode the raw bytes directly via
-    `decodeNextStepResponse`; the bypass also keeps FastAPI's
-    `HTTPException(detail=str(exc))` 422 bodies reachable (the typed
-    parser rejects them because the schema declares 422 as the
-    Pydantic validation-error list shape).
+    FastAPI HTTPException detail decoder. The run-side verbs read the
+    raw response bytes for the **200/201 discriminated-union body**
+    (kind=current_step | completed) — the codegen lifts that into a
+    struct with an unexported `union json.RawMessage` field, so
+    `decodeNextStepResponse` re-reads the kind discriminator off the
+    raw bytes regardless. `start.go`'s `postStartRun` keeps the
+    `rawNextResponse` shim for that; `next.go`'s `postNext` now uses
+    the generated typed client (`...WithResponse`) directly, reading
+    `resp.Body` for the union render and the typed `resp.JSON422` for
+    the verify-prompt probe. The 422 bodies are now the OpenAPI
+    `HTTPValidationError` list shape (#1364), so the typed parser
+    deserializes them cleanly instead of rejecting the legacy
+    `{"detail": "<string>"}` body.
   - T3 (#1320) ships [`docs/cli/runbook.md`](../cli/runbook.md) — the
     operator-facing CLI reference for the eleven-verb tree (synopsis +
     role gate + exit codes per verb, three worked transcripts —
@@ -260,8 +264,8 @@ cli/
     │   │   ├── edit_template.go         # `meho runbook edit-template <slug> --from <file.yaml>` (PATCH /api/v1/runbooks/templates/{slug}); renders `forked_from` on the fork-on-edit path.
     │   │   ├── publish_template.go      # `meho runbook publish-template <slug> --version N` (POST /api/v1/runbooks/templates/{slug}/publish).
     │   │   ├── deprecate_template.go    # `meho runbook deprecate-template <slug> --version N` (POST /api/v1/runbooks/templates/{slug}/deprecate).
-    │   │   ├── start.go                 # T2 — `meho runbook start <slug> --target T [--param k=v ...]` (POST /api/v1/runbooks/runs). Hosts the opacity rendering helpers (stepBodyDTO + decodeNextStepResponse + renderCurrentStep) that next.go also consumes. Bypasses the generated typed parser for the discriminated-union 201 body; uses the rawNextResponse shim (defined in next.go) so retryOn401's generic still flows.
-    │   │   ├── next.go                  # T2 — `meho runbook next <run_id> [--verify-response yes|no|escalate]` (POST /api/v1/runbooks/runs/{run_id}/next). Load-bearing: hosts the interactive verify-prompt loop (probes 422 VerifyResponseRequiredError via verifyResponseRequired, then prompts on stdin), the buildNextRequestBody / makeConfirmVerifyResponse union builders, and renderNextResponse which routes between current_step and completed kinds. Also defines rawNextResponse — a tiny shim adapting raw `*http.Response` reads to retryOn401's generic API so the 422 HTTPException body reaches verifyResponseRequired verbatim.
+    │   │   ├── start.go                 # T2 — `meho runbook start <slug> --target T [--param k=v ...]` (POST /api/v1/runbooks/runs). Hosts the opacity rendering helpers (stepBodyDTO + decodeNextStepResponse + renderCurrentStep) that next.go also consumes. Reads the raw 201 discriminated-union body via the rawNextResponse shim (defined here) so decodeNextStepResponse can route on `kind` and retryOn401's generic still flows.
+    │   │   ├── next.go                  # T2 — `meho runbook next <run_id> [--verify-response yes|no|escalate]` (POST /api/v1/runbooks/runs/{run_id}/next). Load-bearing: hosts the interactive verify-prompt loop, the buildNextRequestBody / makeConfirmVerifyResponse union builders, and renderNextResponse which routes between current_step and completed kinds. Uses the generated typed client directly (#1364): postNext returns the typed *...Response, renderNextResponse reads `resp.Body` for the 200 union render, and verifyResponseRequired reads the typed `resp.JSON422.Detail[0].Type == "verify_response_required"` discriminator to decide whether to prompt.
     │   │   ├── abort.go                 # T2 — `meho runbook abort <run_id> [--reason "<text>"]` (POST /api/v1/runbooks/runs/{run_id}/abort). When `--reason` is missing: prompts on TTY (stdinIsTTY); exits 1 with abortExitCode1 wrapper on non-TTY. Mirrors the `meho kb delete` confirm-prompt pattern.
     │   │   ├── reassign.go              # T2 — `meho runbook reassign <run_id> --to <sub>` (POST /api/v1/runbooks/runs/{run_id}/reassign). Tenant_admin-only at the route gate; thin HTTP wrapper.
     │   │   ├── runs.go                  # T2 — `meho runbook runs [--assignee] [--status] [--template-slug] [--limit]` (GET /api/v1/runbooks/runs). 7-column table (RUN_ID truncated to 8 chars; full UUIDs in --json). Pass-through filters — the backend enforces role-based scoping (OPERATOR sees own; TENANT_ADMIN sees all unless narrowed).

--- a/docs/codebase/error-message-shape.md
+++ b/docs/codebase/error-message-shape.md
@@ -249,10 +249,50 @@ specifically referenced).
 | `PATCH /api/v1/targets/{name}` 422 (unknown_product) | structured `detail` with `kind='unknown_product'`, `product`, `valid_products[]`, `message` (`api/v1/targets.py` `update_target`) | compliant (structured) — landed in T4 #1145 | — |
 | `DELETE /api/v1/targets/{name}` 409 (target_has_references) | structured `detail` with `kind='target_has_references'`, `graph_node_refs`, `message` naming the `?force=true` remediation (`api/v1/targets.py` `delete_target`) | compliant (structured) — landed in T4 #1145 | — |
 | `vmware.composite.*` dispatch when L2 not ingested (signal 20) | structured `extras` with `error_code='composite_l2_missing'`, `missing_op_ids[]`, `catalog_command`; `error` message names the composite, the missing op-ids, the catalog command (`meho connector ingest --catalog vmware/9.0`), and a reference to `docs/codebase/connectors-vmware-rest.md`. Built by `result_composite_l2_missing` in `operations/_errors.py`; raised by `preflight_l2_dependencies` in `connectors/vmware_rest/composites/_preflight.py`. | compliant (structured) — landed in T10 #1151 (Option B / lazy pre-resolve on first call) | — |
+| `POST /api/v1/runbooks/runs` 422 (`missing_params`) and `POST /api/v1/runbooks/runs/{run_id}/next` 422 (`verify_response_required` / `verify_response_mismatch`) | Pydantic validation-error LIST `detail` (`[{"loc", "msg", "type"}]`) with a per-case `type` discriminator, via the shared `http_for` emitter in `api/v1/_errors.py` (registered in `runbook_runs.py`) | compliant (schema-conformant) — landed in #1364. Conforms to the `HTTPValidationError` schema FastAPI auto-declares for the route's 422, so the Go CLI's oapi-codegen client (and any OpenAPI-generated SDK) deserializes it; replaces the prior `detail=str(exc)` string body that forced the CLI's `rawNextResponse` shim | — |
+| `POST/PATCH /api/v1/runbooks/templates*` 422 (`invalid_kb_slug` on draft / edit / publish / deprecate) | Pydantic validation-error LIST `detail` with `type="invalid_kb_slug"`, `loc=["path","slug"]`, via the same `http_for` emitter (registered in `runbook_templates.py`) | compliant (schema-conformant) — landed in #1364 alongside the runs surface | — |
 
 The table is the audit artefact's deliverable, not a separate
 spreadsheet. Adding new error surfaces against the convention
 extends this table at the same time the surface lands.
+
+## OpenAPI-schema conformance for 422 bodies (#1364)
+
+Distinct from the *code + message + data* convention above (which
+governs the **content** of `HTTPException.detail`), this rule governs
+the **shape** of 422 bodies specifically, so typed clients generated
+from the OpenAPI spec can deserialize them.
+
+FastAPI auto-declares every route's 422 response as the
+`HTTPValidationError` model — a list under `detail`:
+
+```json
+{"detail": [{"loc": ["body", "<field>"], "msg": "...", "type": "..."}]}
+```
+
+The framework's own `RequestValidationError` handler emits that list
+shape, but a hand-raised `HTTPException(status_code=422,
+detail=str(exc))` emits `{"detail": "<string>"}` instead. The two
+don't match the declared schema, so a strict codegen client (the Go
+CLI's oapi-codegen client; an `openapi-python-client` /
+`openapi-typescript` SDK) errors on the list-vs-string mismatch
+rather than deserializing. Before #1364 the only mitigation was the
+CLI's `rawNextResponse` shim that bypassed the typed parser and read
+the raw bytes.
+
+**The rule:** a route that raises a 422 from a typed exception emits
+the body through the shared `http_for` emitter
+(`backend/src/meho_backplane/api/v1/_errors.py`), which wraps the
+detail into the validation-error list shape with a per-case `type`
+discriminator a client keys on. Register each exception once at module
+import via `register_error(exc_cls, status=..., type_tag=..., loc=...)`.
+Non-422 statuses (400 / 403 / 404 / 409) keep the plain string-detail
+body — their OpenAPI schemas don't declare a structured shape, so the
+string form is conformant there.
+
+The runbook routes are the first adopters (#1364). Other `api/v1/*`
+surfaces that raise a 422 with `detail=str(exc)` have the same latent
+mismatch; sweeping them is a follow-up, not part of #1364's scope.
 
 ## How to apply the convention
 


### PR DESCRIPTION
## Summary
- Normalize the runbook REST routes' 422 emissions to the FastAPI **Pydantic-list** shape (`{"detail": [{"loc": [...], "msg": "...", "type": "..."}]}`) so the body matches the `HTTPValidationError` schema FastAPI auto-declares for every route's 422 — typed clients generated from the OpenAPI spec (the Go CLI's oapi-codegen client; any `openapi-python-client` / `openapi-typescript` SDK) now deserialize it cleanly instead of erroring on the list-vs-string mismatch.
- Add one shared 422-emitter (`backend/src/meho_backplane/api/v1/_errors.py`) with a `register_error()` + `http_for()` pattern: 422 → list shape with a per-case `type` discriminator; non-422 (400/403/404/409) → the conformant plain string body. `runbook_runs.py`'s `_http_for`/`_EXC_STATUS` and the four inline `InvalidKbSlugError` 422 raises in `runbook_templates.py` all route through it.
- Drop the `rawNextResponse` shim from the CLI's `next.go`: `postNext` uses the generated typed client directly, `verifyResponseRequired` reads `resp.JSON422.Detail[0].Type == "verify_response_required"` (no more brittle substring sniffing), and `renderNextResponse` reads `resp.Body` for the 200 discriminated-union render. `start.go` keeps the shim for its 201 union body.
- Type tags: `missing_params` / `verify_response_required` / `verify_response_mismatch` (runs); `invalid_kb_slug` (templates).

## Test plan
- [x] `ruff check` / `ruff format --check` — clean
- [x] `mypy backend/src/` — clean (395 files)
- [x] `pytest backend/tests/test_runbook_runs_api.py backend/tests/test_runbook_templates_api.py` — 70 passed; the three runs 422 surfaces (`missing_params` / `verify_response_required` / `verify_response_mismatch`) and the four templates `invalid_kb_slug` surfaces (draft/edit/publish/deprecate) assert the full conformant list body
- [x] `cd cli && go test -race ./internal/cmd/runbook/...` — green; fixtures updated to emit the new 422 body shape (with `Content-Type: application/json` so the typed parser populates `JSON422`)
- [x] `cd cli && go test ./... && go vet ./...` — green
- [x] `golangci-lint run ./internal/cmd/runbook/...` (v2.12.2) — 0 issues on changed package
- [x] `cd cli && make snapshot-openapi && make generate` — **no diff** (the OpenAPI 422 schema was already correct; only the emitted body was wrong), so the `CLI API snapshot freshness` lane stays green
- [x] `code-quality.py --diff` — 0 blockers

## Out of scope
- Non-422 statuses (400/403/404/409) and non-runbook `api/v1/*` routes — same latent mismatch exists elsewhere; a sweep is a follow-up (noted in `docs/codebase/error-message-shape.md`).
- MCP tool 422s (JSON-RPC error codes, different contract).
- `runbook_templates.py` was already ~2 lines under the 600-line code-quality limit; this change nudges it to 602 (reported as a non-blocking pre-existing-file WARN). Splitting it into modules is explicitly out of this Task's scope.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1364
