### PR TITLE
feat(ui): G10.6-T1 runbooks read surface — /ui/runbooks catalog + opacity-floor-aware detail

### DIFF
--- a/backend/src/meho_backplane/ui/routes/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/__init__.py
@@ -21,10 +21,14 @@ ships the umbrella :func:`build_router` that aggregates:
 * :mod:`~meho_backplane.ui.routes.kb` -- ``GET /ui/kb``,
   ``POST /ui/kb/search``, ``GET /ui/kb/<slug>``,
   ``GET /ui/kb/<slug>/preview`` -- KB read surface (G10.2-T1 #870).
-* :mod:`~meho_backplane.ui.routes.stubs` -- now empty. All five
+* :mod:`~meho_backplane.ui.routes.runbooks` -- ``GET /ui/runbooks``,
+  ``GET /ui/runbooks/list`` (HTMX filter partial),
+  ``GET /ui/runbooks/<slug>`` -- runbooks read surface, catalog +
+  opacity-floor-aware template detail (G10.6-T1 #1382).
+* :mod:`~meho_backplane.ui.routes.stubs` -- now empty. All six
   surfaces (broadcast #867, topology #880, memory #877, connectors
-  #873, kb #870) ship real routers; no ``/ui/{slug}`` placeholder
-  remains.
+  #873, kb #870, runbooks #1382) ship real routers; no ``/ui/{slug}``
+  placeholder remains.
 
 Auth surfaces (``/ui/auth/login``, ``/ui/auth/callback``,
 ``/ui/auth/logout``) live under
@@ -49,6 +53,7 @@ from meho_backplane.ui.routes.connectors import build_router as build_connectors
 from meho_backplane.ui.routes.dashboard import build_dashboard_router
 from meho_backplane.ui.routes.kb import build_kb_router
 from meho_backplane.ui.routes.memory import build_memory_router
+from meho_backplane.ui.routes.runbooks import build_runbooks_router
 from meho_backplane.ui.routes.stubs import build_stubs_router
 from meho_backplane.ui.routes.topology import build_router as build_topology_router
 
@@ -59,13 +64,14 @@ __all__ = [
     "build_kb_router",
     "build_memory_router",
     "build_router",
+    "build_runbooks_router",
     "build_stubs_router",
     "build_topology_router",
 ]
 
 
 def build_router() -> APIRouter:
-    """Aggregate the dashboard + broadcast + topology + memory + connectors + kb routers.
+    """Aggregate the dashboard + surface routers (broadcast … runbooks).
 
     Order matters: FastAPI matches by registration order, so a
     surface Initiative's real router is included **before** the
@@ -75,11 +81,14 @@ def build_router() -> APIRouter:
     topology lands ``/ui/topology`` + ``/ui/topology/node/{id}``,
     memory lands ``/ui/memory`` + ``/ui/memory/{scope}/{slug}``,
     connectors lands ``/ui/connectors`` + ``/ui/connectors/{name}`` +
-    ``POST /ui/connectors/{name}/probe``, and kb lands ``/ui/kb`` +
-    ``/ui/kb/{slug}`` (+ search / preview) -- each owning its path.
-    All five surfaces now ship real routers, so the stubs aggregate
-    is empty; it is still included for symmetry and to keep the
-    retirement pattern's seam in place.
+    ``POST /ui/connectors/{name}/probe``, kb lands ``/ui/kb`` +
+    ``/ui/kb/{slug}`` (+ search / preview), and runbooks lands
+    ``/ui/runbooks`` + ``/ui/runbooks/list`` + ``/ui/runbooks/{slug}``
+    -- each owning its path. ``/ui/runbooks/list`` is registered before
+    ``/ui/runbooks/{slug}`` inside that router so the literal segment is
+    not bound as a slug. All six surfaces now ship real routers, so the
+    stubs aggregate is empty; it is still included for symmetry and to
+    keep the retirement pattern's seam in place.
     """
     router = APIRouter()
     router.include_router(build_dashboard_router())
@@ -90,5 +99,6 @@ def build_router() -> APIRouter:
     router.include_router(build_memory_router())
     router.include_router(build_connectors_router())
     router.include_router(build_kb_router())
+    router.include_router(build_runbooks_router())
     router.include_router(build_stubs_router())
     return router

--- a/backend/src/meho_backplane/ui/routes/dashboard.py
+++ b/backend/src/meho_backplane/ui/routes/dashboard.py
@@ -105,6 +105,12 @@ _SURFACE_TILES: Final[tuple[dict[str, str], ...]] = (
         "href": "/ui/memory",
         "icon": "\U0001f9e0",  # brain
     },
+    {
+        "title": "Runbooks",
+        "summary": "Browse runbook templates + lifecycle state.",
+        "href": "/ui/runbooks",
+        "icon": "\U0001f4d8",  # blue book
+    },
 )
 
 

--- a/backend/src/meho_backplane/ui/routes/runbooks/__init__.py
+++ b/backend/src/meho_backplane/ui/routes/runbooks/__init__.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Runbooks UI read surface package (G10.6-T1, #1382).
+
+Exports :func:`build_runbooks_router` -- the ``/ui/runbooks*`` router
+factory the umbrella :func:`meho_backplane.ui.routes.build_router`
+mounts (ahead of the stubs aggregate, first-match-wins). The catalog +
+detail handlers and the opacity-floor logic live in
+:mod:`meho_backplane.ui.routes.runbooks.routes`.
+"""
+
+from __future__ import annotations
+
+from meho_backplane.ui.routes.runbooks.routes import build_runbooks_router
+
+__all__ = ["build_runbooks_router"]

--- a/backend/src/meho_backplane/ui/routes/runbooks/routes.py
+++ b/backend/src/meho_backplane/ui/routes/runbooks/routes.py
@@ -1,0 +1,485 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Runbooks UI read surface: catalog browse + template detail.
+
+Initiative #1381 (G10.6 Runbooks UI), Task #1382 (T1). Three routes
+mounted under ``/ui/runbooks*`` that surface the G12.2 runbook template
+layer (REST: :mod:`meho_backplane.api.v1.runbook_templates`; service:
+:class:`~meho_backplane.runbooks.service.RunbookTemplateService`) to
+operators on the console. Authoring (T2) and lifecycle controls (T3)
+follow in sibling tasks; this surface is read-only.
+
+Route inventory
+---------------
+
+* ``GET /ui/runbooks`` -- catalog page. Lists the latest version of each
+  template slug for the operator's tenant (slug / version / title /
+  status / target_kind / edited_at) as DaisyUI rows with status badges.
+  ``status`` (draft / published / deprecated) and ``target_kind`` filters
+  drive an HTMX partial swap. ``HX-Request: true`` returns only the
+  ``runbooks/_list.html`` fragment; a direct navigation returns the full
+  page.
+
+* ``GET /ui/runbooks/list`` -- HTMX filter partial. Same projection as the
+  catalog, parameterised by the ``status`` / ``target_kind`` query params
+  the filter controls carry. Registered **before** ``/ui/runbooks/{slug}``
+  so FastAPI's first-match-wins routing does not swallow the literal
+  ``list`` segment as a slug parameter.
+
+* ``GET /ui/runbooks/{slug}`` -- template detail. Consumes
+  :meth:`~meho_backplane.runbooks.service.RunbookTemplateService.show_template`
+  and renders the title / description / target_kind / status plus the
+  ordered steps (``manual`` vs ``operation_call``, showing op_id / params)
+  and verify gates (``confirm`` prompt vs ``operation_call`` op_id /
+  params / expect). Each step ``body`` is rendered server-side via the KB
+  Markdown renderer :func:`~meho_backplane.ui.routes.kb.render.render_markdown`.
+
+Opacity floor
+-------------
+
+The G12.3-T4 (#1309) carve-out the REST ``show`` route enforces is
+mirrored here. A ``tenant_admin`` always sees the full steps. An
+``operator`` sees the full steps only when they have a ``completed`` or
+``abandoned`` run against the resolved ``(slug, version)`` -- the
+:meth:`~meho_backplane.runbooks.run_service.RunbookRunService.can_show_template_post_completion`
+predicate. An operator with no such run (or only an in-flight run) is
+*not* shown a raw 403: the detail view renders the catalog-level summary
+(title / description / target_kind / status / step count) plus a clear
+"step details are restricted until you complete a run of this template"
+notice. This matches the REST surface's ``403 detail="opacity_floor"``
+posture while keeping the console a navigable page rather than an error.
+
+The role lift fails **soft** to operator-level privileges (no admin) when
+the JWT round-trip can't complete (session row vanished mid-request, JWKS
+transiently unreachable) -- the same posture
+:func:`meho_backplane.ui.routes.connectors.operator.resolve_role_probe`
+adopts. The restricted-detail render is the safe default, never a 5xx.
+
+Tenant scoping
+--------------
+
+Every handler derives tenant identity from
+:class:`~meho_backplane.ui.auth.middleware.UISessionContext`. No query
+parameter or form field overrides tenant; a cross-tenant slug probe is
+invisible to the service's tenant filter and surfaces as the restricted
+state (operator) or 404 (admin) -- the same anti-enumeration posture the
+``/api/v1/runbooks/templates`` surface uses.
+
+RBAC
+----
+
+Both routes require ``operator`` minimum, enforced by
+:func:`~meho_backplane.ui.auth.middleware.require_ui_session`. The
+admin-vs-operator distinction the opacity-floor branch needs is resolved
+by re-verifying the session's access token (see :func:`_resolve_role`),
+not carried on the session row.
+
+References
+----------
+
+* HTMX 2.0.9 debounced filtering + ``HX-Request`` fragment swap:
+  https://htmx.org/attributes/hx-trigger/
+* DaisyUI 5.5.20 badges / cards / tables: https://daisyui.com/components/badge/
+* markdown-it-py 4.2.0 (shared KB renderer): https://markdown-it-py.readthedocs.io/
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Literal
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse
+
+from meho_backplane.auth.jwt import verify_jwt_for_audience
+from meho_backplane.auth.operator import Operator, TenantRole
+from meho_backplane.db.engine import get_sessionmaker
+from meho_backplane.runbooks.run_service import RunbookRunService
+from meho_backplane.runbooks.schemas import (
+    ListTemplatesFilter,
+    ShowTemplateResponse,
+    TemplateSummary,
+)
+from meho_backplane.runbooks.service import (
+    RunbookTemplateService,
+    TemplateNotFoundError,
+)
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth.middleware import UISessionContext, require_ui_session
+from meho_backplane.ui.auth.session_store import load_session
+from meho_backplane.ui.csrf import CSRF_COOKIE_NAME, mint_csrf_token
+from meho_backplane.ui.routes.kb.render import pygments_css, render_markdown
+from meho_backplane.ui.templating import get_templates
+
+__all__ = ["build_runbooks_router"]
+
+log = structlog.get_logger(__name__)
+
+#: The closed status vocabulary the list filter accepts. An out-of-vocab
+#: value trips a clean 422 at FastAPI's query-parameter boundary (matching
+#: the ``/api/v1/runbooks/templates`` list route's ``Literal`` typing)
+#: rather than constructing an invalid :class:`ListTemplatesFilter`.
+_StatusFilter = Literal["draft", "published", "deprecated"]
+
+#: Default + cap on the number of catalog rows surfaced. The REST list
+#: route caps at 500; the console page mirrors that ceiling so a tenant
+#: with a large template library still renders deterministically.
+_DEFAULT_LIMIT: Final[int] = 100
+_MAX_LIMIT: Final[int] = 500
+
+#: Cap on the free-text ``target_kind`` filter value. Generous enough for
+#: any real connector/resource kind label while keeping the query string
+#: representable and out of unbounded-input territory.
+_MAX_TARGET_KIND_LENGTH: Final[int] = 128
+
+#: Module-level ``Depends`` closure for the operator-session gate. Matches
+#: the B008 idiom the kb / dashboard routes use (no call in a default arg).
+_require_session = Depends(require_ui_session)
+
+
+@dataclass(frozen=True)
+class _DetailView:
+    """Resolved detail payload for one template + its opacity-floor verdict.
+
+    ``restricted`` is ``True`` when the caller is an operator without a
+    completed/abandoned run against ``(slug, version)`` -- the template
+    summary still renders, but :attr:`steps_rendered` is empty and the
+    template shows the restricted-detail notice. ``False`` means the full
+    steps are visible (admin, or post-completion operator).
+    """
+
+    template: ShowTemplateResponse
+    restricted: bool
+    steps_rendered: list[dict[str, object]]
+
+
+async def _resolve_role(session_ctx: UISessionContext) -> Operator | None:
+    """Re-verify the session's access token to lift the operator's role.
+
+    :class:`UISessionContext` carries ``operator_sub`` + ``tenant_id`` only,
+    so the admin-vs-operator distinction the opacity floor needs is resolved
+    by decrypting the stored access token and re-running the chassis JWT
+    chain (the same lift
+    :mod:`meho_backplane.ui.routes.connectors.operator` performs).
+
+    Fails **soft**: any hiccup (session row vanished between the middleware
+    check and here, JWKS transiently unreachable, identity mismatch on the
+    decoded token) returns ``None`` -- the caller then treats the request as
+    a plain operator (no admin privilege). The opacity-floor branch is the
+    safe default; an unavailable role lift must never 5xx the read surface.
+    """
+    try:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as db_session, db_session.begin():
+            decrypted = await load_session(db_session, session_ctx.session_id)
+        if decrypted is None:
+            return None
+        settings = get_settings()
+        operator = await verify_jwt_for_audience(
+            f"Bearer {decrypted.access_token}",
+            expected_audience=settings.keycloak_audience,
+        )
+    except Exception as exc:
+        log.info(
+            "ui_runbooks_role_lift_unavailable",
+            session_id=str(session_ctx.session_id),
+            reason=type(exc).__name__,
+        )
+        return None
+    # A token whose identity diverges from the session row is a security
+    # anomaly; treat it as "no admin" rather than honouring the elevated
+    # claim. The write surfaces (T2/T3) will gate hard; this read surface
+    # degrades to the restricted view.
+    if operator.sub != session_ctx.operator_sub or operator.tenant_id != session_ctx.tenant_id:
+        log.warning(
+            "ui_runbooks_role_lift_identity_mismatch",
+            session_sub=session_ctx.operator_sub,
+            token_sub=operator.sub,
+        )
+        return None
+    return operator
+
+
+def _render_steps(template: ShowTemplateResponse) -> list[dict[str, object]]:
+    """Project the template's ordered steps into render-ready dicts.
+
+    Each entry carries the raw step (for type / op_id / params access in
+    the template) plus the pre-rendered Markdown ``body_html`` so the
+    Jinja layer never calls the renderer itself. Both step kinds
+    (``manual`` / ``operation_call``) and both verify kinds (``confirm`` /
+    ``operation_call``) are surfaced; the template branches on the
+    ``.type`` discriminators.
+    """
+    return [
+        {
+            "step": step,
+            "body_html": render_markdown(step.body),
+        }
+        for step in template.steps
+    ]
+
+
+def _set_csrf_cookie(response: HTMLResponse, csrf_token: str) -> None:
+    """Set the JS-readable CSRF cookie on *response* (shared posture).
+
+    Mirrors the kb / dashboard surfaces: not ``HttpOnly`` (HTMX must read
+    it to echo ``X-CSRF-Token`` on any future state-changing request),
+    ``Secure`` + ``SameSite=Strict``, scoped to ``/ui``.
+    """
+    response.set_cookie(
+        key=CSRF_COOKIE_NAME,
+        value=csrf_token,
+        httponly=False,
+        secure=True,
+        samesite="strict",
+        path="/ui",
+    )
+
+
+async def _list_summaries(
+    tenant_id: object,
+    status: _StatusFilter | None,
+    target_kind: str | None,
+) -> list[TemplateSummary]:
+    """Fetch the catalog projection for the current tenant + filters."""
+    template_filter = ListTemplatesFilter(status=status, target_kind=target_kind)
+    return await RunbookTemplateService().list_templates(
+        tenant_id,  # type: ignore[arg-type]
+        template_filter,
+        limit=_DEFAULT_LIMIT,
+    )
+
+
+async def _render_index(
+    request: Request,
+    session: UISessionContext,
+    status: _StatusFilter | None,
+    target_kind: str | None,
+) -> HTMLResponse:
+    """Render the catalog page, or the HTMX ``_list.html`` fragment.
+
+    ``HX-Request: true`` -> the fragment only (filter swaps ``#runbooks-list``
+    in place). Direct navigation -> the full page. Both share the same
+    projection so the markup is identical.
+    """
+    summaries = await _list_summaries(session.tenant_id, status, target_kind)
+    csrf_token = mint_csrf_token(str(session.session_id))
+    context = {
+        "summaries": summaries,
+        "status_filter": status or "",
+        "target_kind_filter": target_kind or "",
+        "operator_sub": session.operator_sub,
+        "csrf_token": csrf_token,
+        "active_surface": "runbooks",
+        "page_title": "Runbooks",
+        "ready": False,
+    }
+    if request.headers.get("HX-Request") == "true":
+        return get_templates().TemplateResponse(request, "runbooks/_list.html", context)
+    response = get_templates().TemplateResponse(request, "runbooks/index.html", context)
+    _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+async def _render_list_fragment(
+    request: Request,
+    session: UISessionContext,
+    status: _StatusFilter | None,
+    target_kind: str | None,
+) -> HTMLResponse:
+    """Render the ``_list.html`` fragment for the HTMX filter controls."""
+    summaries = await _list_summaries(session.tenant_id, status, target_kind)
+    context = {
+        "summaries": summaries,
+        "status_filter": status or "",
+        "target_kind_filter": target_kind or "",
+        "active_surface": "runbooks",
+    }
+    return get_templates().TemplateResponse(request, "runbooks/_list.html", context)
+
+
+async def _render_detail(
+    request: Request,
+    session: UISessionContext,
+    slug: str,
+    version: int | None,
+) -> HTMLResponse:
+    """Render the opacity-floor-aware template detail page.
+
+    A ``tenant_admin`` always sees full steps. An ``operator`` sees full
+    steps only with a completed/abandoned run against the resolved
+    ``(slug, version)``; otherwise the summary + restricted-detail notice
+    renders (never a raw 403). A missing slug 404s for an admin and
+    collapses to the restricted state for an operator -- the same
+    anti-enumeration posture the REST ``show`` route uses.
+    """
+    operator = await _resolve_role(session)
+    is_admin = operator is not None and operator.tenant_role == TenantRole.TENANT_ADMIN
+    detail = await _resolve_detail(session, slug, version, is_admin=is_admin)
+    csrf_token = mint_csrf_token(str(session.session_id))
+    context = {
+        "template": detail.template,
+        "restricted": detail.restricted,
+        "steps_rendered": detail.steps_rendered,
+        "code_css": pygments_css(),
+        "is_admin": is_admin,
+        "operator_sub": session.operator_sub,
+        "csrf_token": csrf_token,
+        "active_surface": "runbooks",
+        "page_title": f"{detail.template.slug} · Runbooks",
+        "ready": False,
+    }
+    response = get_templates().TemplateResponse(request, "runbooks/detail.html", context)
+    _set_csrf_cookie(response, csrf_token)
+    return response
+
+
+def build_runbooks_router() -> APIRouter:
+    """Construct the ``/ui/runbooks*`` :class:`APIRouter`.
+
+    Factory function (not a module-level constant) so a test app can
+    construct parallel routers without shared route state -- same
+    convention as :func:`meho_backplane.ui.routes.kb.build_kb_router`.
+    The handler bodies live in module-level ``_render_*`` helpers; the
+    factory is thin registration.
+
+    ``/ui/runbooks/list`` is registered **before** ``/ui/runbooks/{slug}``
+    so FastAPI's first-match-wins routing does not bind the literal
+    ``list`` segment to the slug path parameter.
+    """
+    router = APIRouter(tags=["ui-runbooks"])
+
+    @router.get("/ui/runbooks", response_class=HTMLResponse)
+    async def runbooks_index(
+        request: Request,
+        session: UISessionContext = _require_session,
+        status: _StatusFilter | None = Query(default=None),
+        target_kind: str | None = Query(default=None, max_length=_MAX_TARGET_KIND_LENGTH),
+    ) -> HTMLResponse:
+        return await _render_index(request, session, status, target_kind)
+
+    @router.get("/ui/runbooks/list", response_class=HTMLResponse)
+    async def runbooks_list(
+        request: Request,
+        session: UISessionContext = _require_session,
+        status: _StatusFilter | None = Query(default=None),
+        target_kind: str | None = Query(default=None, max_length=_MAX_TARGET_KIND_LENGTH),
+    ) -> HTMLResponse:
+        return await _render_list_fragment(request, session, status, target_kind)
+
+    @router.get("/ui/runbooks/{slug}", response_class=HTMLResponse)
+    async def runbooks_detail(
+        slug: str,
+        request: Request,
+        session: UISessionContext = _require_session,
+        version: int | None = Query(default=None, ge=1),
+    ) -> HTMLResponse:
+        return await _render_detail(request, session, slug, version)
+
+    return router
+
+
+async def _resolve_detail(
+    session: UISessionContext,
+    slug: str,
+    version: int | None,
+    *,
+    is_admin: bool,
+) -> _DetailView:
+    """Resolve the template + its opacity-floor verdict for the detail view.
+
+    Dispatches to the admin or operator path. The admin path always shows
+    full steps (missing row -> 404). The operator path applies the
+    post-completion predicate and degrades to the restricted state rather
+    than leaking slug existence via a status-code differential.
+    """
+    templates_service = RunbookTemplateService()
+    if is_admin:
+        return await _resolve_detail_admin(templates_service, session, slug, version)
+    return await _resolve_detail_operator(
+        templates_service, RunbookRunService(), session, slug, version
+    )
+
+
+async def _resolve_detail_admin(
+    templates_service: RunbookTemplateService,
+    session: UISessionContext,
+    slug: str,
+    version: int | None,
+) -> _DetailView:
+    """Admin path: full steps; a missing/cross-tenant row 404s.
+
+    The service's tenant filter makes another tenant's row invisible, so a
+    cross-tenant probe raises :class:`TemplateNotFoundError` exactly as a
+    genuinely-absent slug does -- both collapse to 404.
+    """
+    try:
+        template = await templates_service.show_template(session.tenant_id, slug, version=version)
+    except TemplateNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="runbook_template_not_found") from exc
+    return _DetailView(template=template, restricted=False, steps_rendered=_render_steps(template))
+
+
+async def _resolve_detail_operator(
+    templates_service: RunbookTemplateService,
+    run_service: RunbookRunService,
+    session: UISessionContext,
+    slug: str,
+    version: int | None,
+) -> _DetailView:
+    """Operator path: opacity-floor-gated.
+
+    Resolve the row first (so the predicate checks the same version the
+    page would show). A missing/cross-tenant slug becomes a synthetic
+    restricted view so existence never leaks (mirrors the REST
+    ``opacity_floor`` 403). When the row resolves, the post-completion
+    predicate unlocks the full steps; otherwise the summary renders with
+    the restricted notice and the steps are withheld.
+    """
+    try:
+        template = await templates_service.show_template(session.tenant_id, slug, version=version)
+    except TemplateNotFoundError:
+        return _DetailView(
+            template=_restricted_placeholder(slug, version),
+            restricted=True,
+            steps_rendered=[],
+        )
+    unlocked = await run_service.can_show_template_post_completion(
+        session.tenant_id,
+        session.operator_sub,
+        slug,
+        template.version,
+    )
+    if unlocked:
+        return _DetailView(
+            template=template, restricted=False, steps_rendered=_render_steps(template)
+        )
+    return _DetailView(template=template, restricted=True, steps_rendered=[])
+
+
+def _restricted_placeholder(slug: str, version: int | None) -> ShowTemplateResponse:
+    """Build a minimal summary for an operator probing an unresolvable slug.
+
+    The detail view still renders a page (never a 404 for operators), but
+    no real template metadata leaks -- only the slug the operator typed and
+    the restricted notice. Timestamps are epoch sentinels; the template
+    never renders them in the restricted branch.
+    """
+    from datetime import UTC, datetime
+
+    epoch = datetime(1970, 1, 1, tzinfo=UTC)
+    return ShowTemplateResponse(
+        slug=slug,
+        version=version or 0,
+        title=slug,
+        description="",
+        target_kind=None,
+        status="draft",
+        steps=[],
+        created_by="",
+        created_at=epoch,
+        edited_by="",
+        edited_at=epoch,
+    )

--- a/backend/src/meho_backplane/ui/templates/base.html
+++ b/backend/src/meho_backplane/ui/templates/base.html
@@ -259,6 +259,16 @@
                 <span>Memory</span>
               </a>
             </li>
+            <li>
+              <a
+                href="/ui/runbooks"
+                class="flex items-center gap-2{% if active_surface == 'runbooks' %} menu-active{% endif %}"
+                {% if active_surface == 'runbooks' %}aria-current="page"{% endif %}
+              >
+                <span aria-hidden="true">&#x1F4D8;</span>
+                <span>Runbooks</span>
+              </a>
+            </li>
           </ul>
         </nav>
       </aside>

--- a/backend/src/meho_backplane/ui/templates/runbooks/_list.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/_list.html
@@ -1,0 +1,106 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Runbooks catalog results partial.
+
+  Initiative #1381 (G10.6 Runbooks UI), Task #1382 (T1). This fragment is
+  swapped into ``#runbooks-list`` by the HTMX filter controls (status
+  select + target_kind keyup); it is also included directly into
+  ``index.html`` for the initial full-page render so both paths share
+  identical markup.
+
+  Context variables:
+    summaries          -- list[TemplateSummary]: latest version per slug
+    status_filter      -- str: active status filter ("" = all)
+    target_kind_filter -- str: active target_kind filter ("" = all)
+
+  Layout:
+    * Non-empty: DaisyUI table of slug / version / title / status badge /
+      target_kind / edited_at, each row linking to the detail page.
+    * Empty: friendly empty-state card (filter-aware copy when a filter is
+      active).
+-#}
+<div id="runbooks-list" class="space-y-3">
+  {% if summaries %}
+    <div class="card bg-base-100 border-base-300 overflow-x-auto border shadow-sm">
+      <table class="table table-sm" aria-label="Runbook templates">
+        <thead>
+          <tr>
+            <th scope="col">Slug</th>
+            <th scope="col" class="hidden sm:table-cell">Title</th>
+            <th scope="col">Status</th>
+            <th scope="col">Ver</th>
+            <th scope="col" class="hidden md:table-cell">Target</th>
+            <th scope="col" class="hidden lg:table-cell">Edited</th>
+            <th scope="col" class="sr-only">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for tpl in summaries %}
+            <tr>
+              <td class="font-mono">
+                <a href="/ui/runbooks/{{ tpl.slug }}" class="link link-primary">{{ tpl.slug }}</a>
+              </td>
+              <td class="hidden sm:table-cell">{{ tpl.title }}</td>
+              <td>
+                {#- Status badge. DaisyUI semantic colour per lifecycle
+                    state; ``aria-label`` carries the same signal so the
+                    colour is never the only cue (WCAG 1.4.1). -#}
+                {% if tpl.status == "published" %}
+                  <span class="badge badge-success badge-outline" aria-label="Status: published">
+                    published
+                  </span>
+                {% elif tpl.status == "draft" %}
+                  <span class="badge badge-warning badge-outline" aria-label="Status: draft">
+                    draft
+                  </span>
+                {% else %}
+                  <span class="badge badge-ghost badge-outline" aria-label="Status: deprecated">
+                    deprecated
+                  </span>
+                {% endif %}
+              </td>
+              <td class="font-mono opacity-70">v{{ tpl.version }}</td>
+              <td class="hidden md:table-cell opacity-70">
+                {{ tpl.target_kind or "—" }}
+              </td>
+              <td class="hidden lg:table-cell text-xs opacity-70">
+                {{ tpl.edited_at.strftime("%Y-%m-%d %H:%M") }}
+              </td>
+              <td>
+                <a
+                  href="/ui/runbooks/{{ tpl.slug }}"
+                  class="btn btn-ghost btn-xs"
+                  aria-label="View template {{ tpl.slug }}"
+                >
+                  View
+                </a>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  {% else %}
+    {# Empty state — no templates match (or none exist for this tenant). #}
+    <div class="card bg-base-100 border-base-300 border shadow-sm">
+      <div class="card-body py-10 text-center">
+        {% if status_filter or target_kind_filter %}
+          <p class="text-lg opacity-60">No runbook templates match the current filters</p>
+          <p class="text-sm opacity-40">
+            Adjust the status or target filters, or
+            <a href="/ui/runbooks" class="link">clear them</a>.
+          </p>
+        {% else %}
+          <p class="text-lg opacity-60">No runbook templates yet</p>
+          <p class="text-sm opacity-40">
+            Author a template with
+            <code>meho runbook draft-template</code> via CLI; published
+            templates and drafts appear here.
+          </p>
+        {% endif %}
+      </div>
+    </div>
+  {% endif %}
+</div>

--- a/backend/src/meho_backplane/ui/templates/runbooks/detail.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/detail.html
@@ -1,0 +1,174 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Runbook template detail page: header (title / description / target_kind
+  / status) + ordered steps + verify gates. Opacity-floor-aware: an
+  operator without a completed run sees the summary plus a restricted
+  notice instead of the steps.
+
+  Initiative #1381 (G10.6 Runbooks UI), Task #1382 (T1).
+
+  Context variables:
+    template       -- ShowTemplateResponse: the resolved template (or a
+                      minimal restricted placeholder for an operator
+                      probing an unresolvable slug)
+    restricted     -- bool: True when steps are withheld (opacity floor)
+    steps_rendered -- list[{step, body_html}]: pre-rendered step bodies
+                      (empty when restricted)
+    is_admin       -- bool: caller is tenant_admin
+    code_css       -- str: pygments CSS for highlighted step-body code
+
+  Template blocks:
+    * ``page_title`` — overrides the ``<title>`` suffix.
+    * ``content`` — overrides the base.html main pane.
+-#}
+{% extends "base.html" %}
+
+{% block page_title %}{{ template.slug }} &middot; Runbooks{% endblock %}
+
+{% block content %}
+<section class="space-y-6">
+  {# ---------- Header ---------- #}
+  <header class="space-y-2">
+    <div class="flex flex-wrap items-center gap-3">
+      <a href="/ui/runbooks" class="btn btn-ghost btn-sm" aria-label="Back to runbooks catalog">
+        &larr; Catalog
+      </a>
+      <h1 class="font-mono text-2xl font-semibold">{{ template.slug }}</h1>
+      <span class="font-mono opacity-60">v{{ template.version }}</span>
+      {% if template.status == "published" %}
+        <span class="badge badge-success badge-outline" aria-label="Status: published">
+          published
+        </span>
+      {% elif template.status == "draft" %}
+        <span class="badge badge-warning badge-outline" aria-label="Status: draft">draft</span>
+      {% else %}
+        <span class="badge badge-ghost badge-outline" aria-label="Status: deprecated">
+          deprecated
+        </span>
+      {% endif %}
+    </div>
+    {% if not restricted %}
+      <p class="text-lg">{{ template.title }}</p>
+      {% if template.description %}
+        <p class="max-w-3xl opacity-70">{{ template.description }}</p>
+      {% endif %}
+      {% if template.target_kind %}
+        <p class="text-sm opacity-60">
+          Target kind: <code class="font-mono">{{ template.target_kind }}</code>
+        </p>
+      {% endif %}
+    {% endif %}
+  </header>
+
+  {% if restricted %}
+    {# ---------- Opacity-floor restricted notice ---------- #}
+    <div role="alert" class="alert alert-warning">
+      <span aria-hidden="true">&#128274;</span>
+      <div>
+        <h2 class="font-semibold">Step details are restricted</h2>
+        <p class="text-sm">
+          Step details are restricted until you complete a run of this
+          template. Once you have a completed (or abandoned) run of
+          <code class="font-mono">{{ template.slug }}</code>, the full
+          steps unlock here for post-run review. A tenant administrator
+          can see them at any time.
+        </p>
+      </div>
+    </div>
+  {% else %}
+    {# ---------- Steps ---------- #}
+    <div class="space-y-4">
+      <h2 class="text-xl font-semibold">
+        Steps
+        <span class="text-sm font-normal opacity-60">({{ steps_rendered | length }})</span>
+      </h2>
+      {% if steps_rendered %}
+        <ol class="space-y-4" role="list">
+          {% for item in steps_rendered %}
+            {%- set step = item.step -%}
+            <li class="card bg-base-100 border-base-300 border shadow-sm">
+              <div class="card-body space-y-3 py-4">
+                <div class="flex flex-wrap items-center gap-2">
+                  <span class="badge badge-neutral">{{ loop.index }}</span>
+                  <h3 class="card-title font-mono text-base">{{ step.id }}</h3>
+                  {% if step.type == "operation_call" %}
+                    <span class="badge badge-info badge-outline" aria-label="Step kind: operation call">
+                      operation_call
+                    </span>
+                  {% else %}
+                    <span class="badge badge-ghost badge-outline" aria-label="Step kind: manual">
+                      manual
+                    </span>
+                  {% endif %}
+                </div>
+                <p class="font-medium">{{ step.title }}</p>
+
+                {# Step body — server-rendered Markdown (shared KB renderer). #}
+                <div class="prose prose-sm max-w-none">{{ item.body_html }}</div>
+
+                {# operation_call steps carry an op_id + params payload. #}
+                {% if step.type == "operation_call" %}
+                  <div class="bg-base-200 rounded-box space-y-1 p-3 text-sm">
+                    <div>
+                      <span class="opacity-60">Operation:</span>
+                      <code class="font-mono">{{ step.op_id }}</code>
+                    </div>
+                    {% if step.params %}
+                      <div>
+                        <span class="opacity-60">Params:</span>
+                        <pre class="overflow-x-auto text-xs"><code>{{ step.params | tojson(indent=2) }}</code></pre>
+                      </div>
+                    {% endif %}
+                  </div>
+                {% endif %}
+
+                {# Verify gate — confirm prompt OR operation_call match. #}
+                {%- set verify = step.verify -%}
+                <div class="border-base-300 border-t pt-2">
+                  <p class="text-xs font-semibold uppercase tracking-wide opacity-60">Verify</p>
+                  {% if verify.type == "confirm" %}
+                    <p class="text-sm">
+                      <span class="badge badge-sm badge-outline mr-1">confirm</span>
+                      {{ verify.prompt }}
+                    </p>
+                  {% else %}
+                    <div class="space-y-1 text-sm">
+                      <p>
+                        <span class="badge badge-sm badge-outline mr-1">operation_call</span>
+                        <code class="font-mono">{{ verify.op_id }}</code>
+                      </p>
+                      {% if verify.params %}
+                        <div>
+                          <span class="opacity-60">Params:</span>
+                          <pre class="overflow-x-auto text-xs"><code>{{ verify.params | tojson(indent=2) }}</code></pre>
+                        </div>
+                      {% endif %}
+                      <div>
+                        <span class="opacity-60">Expect:</span>
+                        <pre class="overflow-x-auto text-xs"><code>{{ verify.expect | tojson(indent=2) }}</code></pre>
+                      </div>
+                    </div>
+                  {% endif %}
+                </div>
+              </div>
+            </li>
+          {% endfor %}
+        </ol>
+      {% else %}
+        <div class="card bg-base-100 border-base-300 border shadow-sm">
+          <div class="card-body py-8 text-center">
+            <p class="opacity-60">This template has no steps.</p>
+          </div>
+        </div>
+      {% endif %}
+    </div>
+  {% endif %}
+</section>
+
+{# Pygments CSS for any highlighted code in step bodies (shared KB style). #}
+{% if code_css %}
+  <style>{{ code_css | safe }}</style>
+{% endif %}
+{% endblock %}

--- a/backend/src/meho_backplane/ui/templates/runbooks/index.html
+++ b/backend/src/meho_backplane/ui/templates/runbooks/index.html
@@ -1,0 +1,98 @@
+{#-
+  SPDX-License-Identifier: Apache-2.0
+  Copyright (c) 2026 evoila Group
+
+  Runbooks catalog page: status + target_kind filters + the template
+  list. Read-only surface (authoring is T2, lifecycle controls T3).
+
+  Initiative #1381 (G10.6 Runbooks UI), Task #1382 (T1).
+
+  HTMX wiring:
+    * Status select: ``hx-trigger="change"`` fires ``GET /ui/runbooks/list``
+      with the current filter values.
+    * Target-kind input: ``hx-trigger="keyup changed delay:300ms"`` so a
+      keystroke that doesn't change the value doesn't fire a request.
+    * Both controls swap the ``#runbooks-list`` element
+      (``hx-target`` + ``hx-swap="outerHTML"``) and ``hx-include`` the
+      sibling filter so the server sees both values on every request.
+    * ``hx-push-url`` keeps the browser URL in sync so a filtered view is
+      copy/paste reproducible (and a direct nav renders the full page).
+    * The list is rendered server-side into ``_list.html``; that partial
+      is also included here for the initial render so both paths share
+      identical markup.
+
+  Template blocks:
+    * ``page_title`` — overrides the ``<title>`` suffix.
+    * ``content`` — overrides the base.html main pane.
+-#}
+{% extends "base.html" %}
+
+{% block page_title %}Runbooks &middot; MEHO Operator Console{% endblock %}
+
+{% block content %}
+<section class="space-y-4">
+  <header class="flex flex-wrap items-center justify-between gap-4">
+    <div>
+      <h1 class="text-2xl font-semibold">Runbooks</h1>
+      <p class="text-sm opacity-70">
+        Browse the tenant's runbook templates and their lifecycle state.
+      </p>
+    </div>
+  </header>
+
+  {# ---------- Filter bar ---------- #}
+  <div class="card bg-base-100 border-base-300 border shadow-sm">
+    <div class="card-body flex-row flex-wrap items-end gap-4 py-3">
+      <label class="form-control">
+        <div class="label">
+          <span class="label-text">Status</span>
+        </div>
+        <select
+          name="status"
+          class="select select-bordered select-sm"
+          aria-label="Filter by status"
+          hx-get="/ui/runbooks/list"
+          hx-target="#runbooks-list"
+          hx-swap="outerHTML"
+          hx-trigger="change"
+          hx-include="[name='target_kind']"
+          hx-push-url="true"
+        >
+          <option value="" {% if not status_filter %}selected{% endif %}>All</option>
+          <option value="draft" {% if status_filter == 'draft' %}selected{% endif %}>Draft</option>
+          <option value="published" {% if status_filter == 'published' %}selected{% endif %}>
+            Published
+          </option>
+          <option value="deprecated" {% if status_filter == 'deprecated' %}selected{% endif %}>
+            Deprecated
+          </option>
+        </select>
+      </label>
+
+      <label class="form-control w-full max-w-xs">
+        <div class="label">
+          <span class="label-text">Target kind</span>
+        </div>
+        <input
+          type="search"
+          name="target_kind"
+          value="{{ target_kind_filter }}"
+          placeholder="e.g. vmware.vcenter&hellip;"
+          class="input input-bordered input-sm w-full"
+          aria-label="Filter by target kind"
+          autocomplete="off"
+          hx-get="/ui/runbooks/list"
+          hx-target="#runbooks-list"
+          hx-swap="outerHTML"
+          hx-trigger="keyup changed delay:300ms"
+          hx-include="[name='status']"
+          hx-push-url="true"
+        />
+      </label>
+    </div>
+  </div>
+
+  {# ---------- List / catalog area ---------- #}
+  {% include "runbooks/_list.html" %}
+</section>
+{% endblock %}

--- a/backend/tests/test_ui_runbooks_list.py
+++ b/backend/tests/test_ui_runbooks_list.py
@@ -1,0 +1,777 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2026 evoila Group
+
+"""Behavioural tests for the runbooks UI read surface.
+
+Initiative #1381 (G10.6 Runbooks UI), Task #1382 (T1). Acceptance
+criteria on issue #1382:
+
+* ``GET /ui/runbooks`` returns 200 for an authenticated operator, lists
+  the tenant's templates with status badges; cross-tenant templates never
+  appear.
+* ``status`` + ``target_kind`` filters work via the HTMX partial
+  (``HX-Request`` -> ``_list.html`` fragment; direct nav -> full page).
+* ``GET /ui/runbooks/<slug>`` renders steps (both ``manual`` and
+  ``operation_call``) and both verify-gate kinds; step bodies are
+  server-rendered Markdown.
+* Opacity-floor: an operator with no completed run on ``(slug, version)``
+  gets the graceful restricted-detail state; a ``tenant_admin`` (or
+  post-completion operator) sees full steps.
+* Unauthenticated request to either route redirects per the chassis
+  convention; runbooks tile + sidebar link render on the dashboard.
+
+Suite shape mirrors :mod:`backend.tests.test_ui_kb_search` (the KB read
+surface precedent #870): a minimal FastAPI app wired with the BFF
+middlewares + the UI surface router, SQLite-backed seeding via the real
+:class:`~meho_backplane.runbooks.service.RunbookTemplateService`, and a
+pre-set session cookie. The opacity-floor admin path mints a real JWT via
+``tests._oidc_jwt_helpers`` so the role lift resolves ``tenant_admin``;
+the operator path relies on the soft-fail role lift (the seeded
+plaintext access token is not a valid JWT -> the lift returns "no admin"
+-> the post-completion predicate gates the steps).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+import warnings
+from collections.abc import Iterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+import respx
+from cryptography.fernet import Fernet
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from fastapi.testclient import TestClient
+
+from meho_backplane.auth.jwt import clear_jwks_cache
+from meho_backplane.auth.operator import TenantRole
+from meho_backplane.db.engine import get_sessionmaker, reset_engine_for_testing
+from meho_backplane.db.models import RunbookRun, Tenant
+from meho_backplane.runbooks.schemas import (
+    ConfirmVerify,
+    DraftTemplateRequest,
+    ManualStep,
+    OperationCallStep,
+    OperationCallVerify,
+    PublishTemplateRequest,
+    RunbookTemplateBody,
+)
+from meho_backplane.runbooks.service import RunbookTemplateService
+from meho_backplane.settings import get_settings
+from meho_backplane.ui.auth import SESSION_COOKIE_NAME, UISessionMiddleware
+from meho_backplane.ui.auth import build_router as build_ui_auth_router
+from meho_backplane.ui.auth.flow import (
+    clear_discovery_cache,
+    reset_verifier_store_for_testing,
+)
+from meho_backplane.ui.auth.session_store import (
+    create_session,
+    reset_fernet_cache_for_testing,
+)
+from meho_backplane.ui.csrf import CSRFMiddleware
+from meho_backplane.ui.paths import static_root_dir
+from meho_backplane.ui.routes import build_router as build_ui_router
+from meho_backplane.ui.templating import reset_templating_for_testing
+from tests._oidc_jwt_helpers import (
+    make_rsa_keypair as _make_rsa_keypair,
+)
+from tests._oidc_jwt_helpers import (
+    mint_token as _mint_token,
+)
+from tests._oidc_jwt_helpers import (
+    mock_discovery_and_jwks as _mock_discovery_and_jwks,
+)
+from tests._oidc_jwt_helpers import (
+    public_jwks as _public_jwks,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_BACKPLANE_URL = "https://meho.test"
+_DEFAULT_ISSUER = "https://keycloak.test/realms/meho"
+_DEFAULT_AUDIENCE = "meho-backplane"
+
+_TENANT_A = uuid.UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+_TENANT_B = uuid.UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+_OPERATOR_SUB = "op-42"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _bff_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Pin chassis + BFF env vars for every test (KB-suite baseline)."""
+    monkeypatch.setenv("KEYCLOAK_ISSUER_URL", _DEFAULT_ISSUER)
+    monkeypatch.setenv("KEYCLOAK_AUDIENCE", _DEFAULT_AUDIENCE)
+    monkeypatch.setenv("VAULT_ADDR", "https://vault.test")
+    monkeypatch.setenv("BACKPLANE_URL", _BACKPLANE_URL)
+    monkeypatch.setenv("UI_SESSION_ENCRYPTION_KEY", Fernet.generate_key().decode())
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_ID", "meho-web")
+    monkeypatch.setenv("UI_KEYCLOAK_CLIENT_SECRET", "test-client-secret")
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+    yield
+    get_settings.cache_clear()
+    reset_fernet_cache_for_testing()
+    reset_verifier_store_for_testing()
+    reset_templating_for_testing()
+    clear_discovery_cache()
+    clear_jwks_cache()
+    reset_engine_for_testing()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> FastAPI:
+    """Minimal FastAPI app wired for runbooks UI tests (KB-suite shape)."""
+    app = FastAPI()
+    app.add_middleware(CSRFMiddleware)
+    app.add_middleware(UISessionMiddleware)
+    app.mount(
+        "/ui/static",
+        StaticFiles(directory=str(static_root_dir()), check_dir=False),
+        name="ui_static",
+    )
+    app.include_router(build_ui_auth_router())
+    app.include_router(build_ui_router())
+    return app
+
+
+def _seed_tenant(tenant_id: uuid.UUID, slug: str) -> None:
+    """Insert one ``tenant`` row so FK constraints resolve."""
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            session.add(Tenant(id=tenant_id, slug=slug, name=f"Tenant {slug}"))
+
+    asyncio.run(_do())
+
+
+def _manual_body(
+    *,
+    title: str = "Drain node",
+    target_kind: str | None = "k8s-node",
+    step_body: str = "Run the **drain** command.",
+) -> RunbookTemplateBody:
+    """One manual step + confirm verify."""
+    return RunbookTemplateBody(
+        title=title,
+        description="Procedure for draining a node.",
+        target_kind=target_kind,
+        steps=[
+            ManualStep(
+                id="drain",
+                title="Drain the node",
+                body=step_body,
+                type="manual",
+                verify=ConfirmVerify(type="confirm", prompt="Node drained?"),
+            ),
+        ],
+    )
+
+
+def _mixed_body() -> RunbookTemplateBody:
+    """One manual + one operation_call step; both verify kinds present."""
+    return RunbookTemplateBody(
+        title="Rotate certificate",
+        description="Rotate the cluster's serving certificate.",
+        target_kind="vmware-vcenter",
+        steps=[
+            ManualStep(
+                id="prep",
+                title="Prepare the change window",
+                body="Announce the maintenance window.",
+                type="manual",
+                verify=ConfirmVerify(type="confirm", prompt="Window announced?"),
+            ),
+            OperationCallStep(
+                id="rotate-cert",
+                title="Rotate the serving cert",
+                body="Dispatch the rotation operation.",
+                type="operation_call",
+                op_id="vmware.composite.cert.rotate",
+                params={"target": "${run.target}"},
+                verify=OperationCallVerify(
+                    type="operation_call",
+                    op_id="vmware.cert.status",
+                    params={"target": "${run.target}"},
+                    expect={"valid": True},
+                ),
+            ),
+        ],
+    )
+
+
+def _seed_template(
+    *,
+    tenant_id: uuid.UUID,
+    slug: str,
+    body: RunbookTemplateBody,
+    publish: bool = False,
+) -> int:
+    """Create a draft template (optionally publishing it) and return its version."""
+
+    async def _do() -> int:
+        service = RunbookTemplateService()
+        resp = await service.create_draft(
+            tenant_id,
+            _OPERATOR_SUB,
+            DraftTemplateRequest(slug=slug, body=body),
+        )
+        if publish:
+            await service.publish(
+                tenant_id,
+                PublishTemplateRequest(slug=slug, version=resp.version),
+            )
+        return resp.version
+
+    return asyncio.run(_do())
+
+
+def _seed_run(
+    *,
+    tenant_id: uuid.UUID,
+    slug: str,
+    version: int,
+    assigned_to: str,
+    state: str = "completed",
+) -> None:
+    """Insert one ``runbook_runs`` row pinned to ``(slug, version)``."""
+
+    async def _do() -> None:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session:
+            session.add(
+                RunbookRun(
+                    tenant_id=tenant_id,
+                    template_slug=slug,
+                    template_version=version,
+                    assigned_to=assigned_to,
+                    target="host-1",
+                    params={},
+                    state=state,
+                    started_by=assigned_to,
+                    started_at=datetime.now(UTC),
+                )
+            )
+            await session.commit()
+
+    asyncio.run(_do())
+
+
+def _seed_session_sync(
+    *,
+    tenant_id: uuid.UUID,
+    operator_sub: str = _OPERATOR_SUB,
+    access_token: str = "access-token-plaintext",
+    lifetime: timedelta = timedelta(hours=1),
+) -> uuid.UUID:
+    """Create a ``web_session`` row carrying *access_token* and return its UUID."""
+
+    async def _do() -> uuid.UUID:
+        sessionmaker = get_sessionmaker()
+        async with sessionmaker() as session, session.begin():
+            decrypted = await create_session(
+                session,
+                operator_sub=operator_sub,
+                tenant_id=tenant_id,
+                access_token=access_token,
+                refresh_token="refresh-token-plaintext",
+                lifetime=lifetime,
+            )
+            return decrypted.id
+
+    return asyncio.run(_do())
+
+
+def _authenticated_client(session_id: uuid.UUID) -> TestClient:
+    """Return a TestClient with the session cookie pre-set."""
+    client = TestClient(_build_app(), follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE_NAME, str(session_id))
+    return client
+
+
+def _make_keypair_and_jwks() -> tuple[Any, dict[str, Any]]:
+    """Mint a stable RSA-2048 keypair + the matching JWKS document."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        keypair = _make_rsa_keypair("ui-runbooks-test-kid")
+    return keypair, _public_jwks(keypair)
+
+
+# ---------------------------------------------------------------------------
+# Authentication boundary
+# ---------------------------------------------------------------------------
+
+
+def test_runbooks_index_unauthenticated_redirects_to_login() -> None:
+    """``GET /ui/runbooks`` without a session 302s to the BFF login."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/runbooks")
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+
+
+def test_runbooks_detail_unauthenticated_redirects_to_login() -> None:
+    """``GET /ui/runbooks/<slug>`` without a session 302s to login."""
+    with respx.mock(assert_all_called=False):
+        client = TestClient(_build_app(), follow_redirects=False)
+        response = client.get("/ui/runbooks/some-template")
+    assert response.status_code == 302
+    assert response.headers["location"].startswith("/ui/auth/login?return_to=")
+
+
+# ---------------------------------------------------------------------------
+# GET /ui/runbooks -- catalog
+# ---------------------------------------------------------------------------
+
+
+def test_runbooks_index_lists_templates_with_status_badges() -> None:
+    """``GET /ui/runbooks`` lists the tenant's templates with status badges."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(tenant_id=_TENANT_A, slug="drain-node", body=_manual_body())
+    _seed_template(
+        tenant_id=_TENANT_A,
+        slug="rotate-cert",
+        body=_mixed_body(),
+        publish=True,
+    )
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "<title>Runbooks" in body
+    assert "drain-node" in body
+    assert "rotate-cert" in body
+    # Status badges for both lifecycle states present.
+    assert "draft" in body
+    assert "published" in body
+    # Sidebar runbooks link points to /ui/runbooks.
+    assert 'href="/ui/runbooks"' in body
+
+
+def test_runbooks_index_empty_state() -> None:
+    """A tenant with no templates renders the empty-state copy."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks")
+
+    assert response.status_code == 200, response.text
+    assert "No runbook templates yet" in response.text
+
+
+def test_runbooks_index_htmx_returns_fragment_only() -> None:
+    """``GET /ui/runbooks`` with ``HX-Request: true`` returns the fragment."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(tenant_id=_TENANT_A, slug="drain-node", body=_manual_body())
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks", headers={"HX-Request": "true"})
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'id="runbooks-list"' in body
+    assert "drain-node" in body
+    # Full-page chrome absent from the fragment.
+    assert "<!doctype html>" not in body.lower()
+
+
+# ---------------------------------------------------------------------------
+# GET /ui/runbooks/list -- HTMX filter partial
+# ---------------------------------------------------------------------------
+
+
+def test_runbooks_list_partial_returns_fragment() -> None:
+    """``GET /ui/runbooks/list`` returns the ``_list.html`` fragment."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(tenant_id=_TENANT_A, slug="drain-node", body=_manual_body())
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/list")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert 'id="runbooks-list"' in body
+    assert "drain-node" in body
+    assert "<!doctype html>" not in body.lower()
+
+
+def test_runbooks_list_filters_by_status() -> None:
+    """``status=published`` returns only published templates."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(tenant_id=_TENANT_A, slug="draft-only", body=_manual_body())
+    _seed_template(
+        tenant_id=_TENANT_A,
+        slug="published-one",
+        body=_mixed_body(),
+        publish=True,
+    )
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/list", params={"status": "published"})
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "published-one" in body
+    assert "draft-only" not in body
+
+
+def test_runbooks_list_filters_by_target_kind() -> None:
+    """``target_kind`` narrows the list to matching templates."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(
+        tenant_id=_TENANT_A,
+        slug="k8s-drain",
+        body=_manual_body(target_kind="k8s-node"),
+    )
+    _seed_template(
+        tenant_id=_TENANT_A,
+        slug="vcenter-cert",
+        body=_manual_body(target_kind="vmware-vcenter"),
+    )
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/list", params={"target_kind": "k8s-node"})
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "k8s-drain" in body
+    assert "vcenter-cert" not in body
+
+
+def test_runbooks_list_invalid_status_returns_422() -> None:
+    """An out-of-vocab ``status`` value trips a 422 at the query boundary."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/list", params={"status": "bogus"})
+
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /ui/runbooks/<slug> -- detail (admin / post-completion sees full steps)
+# ---------------------------------------------------------------------------
+
+
+def test_runbooks_detail_admin_renders_all_step_kinds() -> None:
+    """A tenant_admin sees both step kinds + both verify kinds, Markdown rendered."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(
+        tenant_id=_TENANT_A,
+        slug="rotate-cert",
+        body=_mixed_body(),
+        publish=True,
+    )
+
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OPERATOR_SUB,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.TENANT_ADMIN.value,
+    )
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token=access_token)
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/rotate-cert")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Both step kinds rendered.
+    assert "operation_call" in body
+    assert "manual" in body
+    # Step ids + op_id present.
+    assert "rotate-cert" in body
+    assert "vmware.composite.cert.rotate" in body
+    # operation_call verify op_id + expect present.
+    assert "vmware.cert.status" in body
+    # confirm verify prompt present.
+    assert "Window announced?" in body
+    # Step body Markdown rendered server-side (manual step has no markup,
+    # but the operation_call body is plain; assert the title renders).
+    assert "Rotate the serving cert" in body
+    # Not the restricted state.
+    assert "Step details are restricted" not in body
+
+
+def test_runbooks_detail_renders_markdown_step_body() -> None:
+    """The step body Markdown is rendered to HTML server-side."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(
+        tenant_id=_TENANT_A,
+        slug="drain-node",
+        body=_manual_body(step_body="Run the **drain** command and `kubectl cordon`."),
+        publish=True,
+    )
+
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OPERATOR_SUB,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.TENANT_ADMIN.value,
+    )
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token=access_token)
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/drain-node")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Markdown bold + inline code rendered to HTML.
+    assert "<strong>drain</strong>" in body
+    assert "<code>kubectl cordon</code>" in body
+
+
+def test_runbooks_detail_admin_missing_slug_404() -> None:
+    """A tenant_admin probing a missing slug gets 404."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OPERATOR_SUB,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.TENANT_ADMIN.value,
+    )
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token=access_token)
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/does-not-exist")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 404
+
+
+def test_runbooks_detail_post_completion_operator_sees_steps() -> None:
+    """An operator with a completed run sees the full steps."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    version = _seed_template(
+        tenant_id=_TENANT_A,
+        slug="drain-node",
+        body=_manual_body(),
+        publish=True,
+    )
+    # Completed run unlocks the post-completion read for this operator.
+    _seed_run(
+        tenant_id=_TENANT_A,
+        slug="drain-node",
+        version=version,
+        assigned_to=_OPERATOR_SUB,
+        state="completed",
+    )
+
+    # Plaintext access token -> role lift soft-fails -> treated as operator.
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/drain-node")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "Step details are restricted" not in body
+    assert "Drain the node" in body
+    assert "Node drained?" in body
+
+
+# ---------------------------------------------------------------------------
+# Opacity floor -- operator without a completed run sees the restricted state
+# ---------------------------------------------------------------------------
+
+
+def test_runbooks_detail_operator_without_run_restricted() -> None:
+    """An operator with no completed run gets the graceful restricted state."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_template(
+        tenant_id=_TENANT_A,
+        slug="drain-node",
+        body=_manual_body(),
+        publish=True,
+    )
+
+    # No run seeded -> can_show_template_post_completion is False; the
+    # plaintext token makes the role lift soft-fail to operator-level.
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/drain-node")
+
+    # Page renders (not a raw 403/error) with the restricted notice and the
+    # summary, but withholds the steps.
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "Step details are restricted" in body
+    # The catalog-level summary (slug) still renders.
+    assert "drain-node" in body
+    # The step internals are withheld.
+    assert "Node drained?" not in body
+
+
+def test_runbooks_detail_operator_in_progress_run_restricted() -> None:
+    """An in-progress run does NOT unlock the steps (opacity floor stays)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    version = _seed_template(
+        tenant_id=_TENANT_A,
+        slug="drain-node",
+        body=_manual_body(),
+        publish=True,
+    )
+    _seed_run(
+        tenant_id=_TENANT_A,
+        slug="drain-node",
+        version=version,
+        assigned_to=_OPERATOR_SUB,
+        state="in_progress",
+    )
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/drain-node")
+
+    assert response.status_code == 200, response.text
+    assert "Step details are restricted" in response.text
+
+
+def test_runbooks_detail_operator_missing_slug_restricted_not_404() -> None:
+    """An operator probing a missing slug gets the restricted state, not 404.
+
+    Anti-enumeration: an operator must not learn a slug exists (or not) via
+    a status-code differential -- the missing-slug path collapses to the
+    same restricted page the no-run path produces.
+    """
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/never-existed")
+
+    assert response.status_code == 200, response.text
+    assert "Step details are restricted" in response.text
+
+
+# ---------------------------------------------------------------------------
+# Cross-tenant isolation
+# ---------------------------------------------------------------------------
+
+
+def test_cross_tenant_template_not_in_catalog() -> None:
+    """Tenant B's template never appears in Tenant A's catalog."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_tenant(_TENANT_B, "tenant-b")
+    _seed_template(tenant_id=_TENANT_A, slug="tenant-a-rb", body=_manual_body())
+    _seed_template(tenant_id=_TENANT_B, slug="tenant-b-rb", body=_manual_body())
+
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    assert "tenant-a-rb" in body
+    assert "tenant-b-rb" not in body
+
+
+def test_cross_tenant_detail_admin_404() -> None:
+    """A tenant_admin reading another tenant's slug gets 404 (tenant-scoped)."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    _seed_tenant(_TENANT_B, "tenant-b")
+    _seed_template(
+        tenant_id=_TENANT_B,
+        slug="secret-rb",
+        body=_manual_body(),
+        publish=True,
+    )
+
+    keypair, jwks = _make_keypair_and_jwks()
+    access_token = _mint_token(
+        keypair,
+        sub=_OPERATOR_SUB,
+        tenant_id=str(_TENANT_A),
+        tenant_role=TenantRole.TENANT_ADMIN.value,
+    )
+    session_id = _seed_session_sync(tenant_id=_TENANT_A, access_token=access_token)
+
+    mock = respx.mock(assert_all_called=False)
+    mock.start()
+    try:
+        _mock_discovery_and_jwks(mock, jwks)
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/runbooks/secret-rb")
+    finally:
+        mock.stop()
+
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Dashboard tile + sidebar
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_renders_runbooks_tile_and_sidebar_link() -> None:
+    """The dashboard renders the Runbooks tile + the sidebar link."""
+    _seed_tenant(_TENANT_A, "tenant-a")
+    session_id = _seed_session_sync(tenant_id=_TENANT_A)
+    with respx.mock(assert_all_called=False):
+        client = _authenticated_client(session_id)
+        response = client.get("/ui/")
+
+    assert response.status_code == 200, response.text
+    body = response.text
+    # Tile + sidebar both link to /ui/runbooks.
+    assert 'href="/ui/runbooks"' in body
+    assert "Runbooks" in body

--- a/cli/api/openapi.json
+++ b/cli/api/openapi.json
@@ -9143,6 +9143,177 @@
         }
       }
     },
+    "/ui/runbooks": {
+      "get": {
+        "tags": [
+          "ui-runbooks"
+        ],
+        "summary": "Runbooks Index",
+        "operationId": "runbooks_index_ui_runbooks_get",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "draft",
+                "published",
+                "deprecated"
+              ],
+              "type": "string",
+              "nullable": true,
+              "title": "Status"
+            }
+          },
+          {
+            "name": "target_kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "nullable": true,
+              "title": "Target Kind"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/runbooks/list": {
+      "get": {
+        "tags": [
+          "ui-runbooks"
+        ],
+        "summary": "Runbooks List",
+        "operationId": "runbooks_list_ui_runbooks_list_get",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "draft",
+                "published",
+                "deprecated"
+              ],
+              "type": "string",
+              "nullable": true,
+              "title": "Status"
+            }
+          },
+          {
+            "name": "target_kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "maxLength": 128,
+              "nullable": true,
+              "title": "Target Kind"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ui/runbooks/{slug}": {
+      "get": {
+        "tags": [
+          "ui-runbooks"
+        ],
+        "summary": "Runbooks Detail",
+        "operationId": "runbooks_detail_ui_runbooks__slug__get",
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Slug"
+            }
+          },
+          {
+            "name": "version",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "nullable": true,
+              "title": "Version"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/": {
       "get": {
         "summary": "Root",

--- a/cli/internal/api/client.gen.go
+++ b/cli/internal/api/client.gen.go
@@ -370,9 +370,9 @@ const (
 
 // Defines values for ListTemplatesApiV1RunbooksTemplatesGetParamsStatus.
 const (
-	Deprecated ListTemplatesApiV1RunbooksTemplatesGetParamsStatus = "deprecated"
-	Draft      ListTemplatesApiV1RunbooksTemplatesGetParamsStatus = "draft"
-	Published  ListTemplatesApiV1RunbooksTemplatesGetParamsStatus = "published"
+	ListTemplatesApiV1RunbooksTemplatesGetParamsStatusDeprecated ListTemplatesApiV1RunbooksTemplatesGetParamsStatus = "deprecated"
+	ListTemplatesApiV1RunbooksTemplatesGetParamsStatusDraft      ListTemplatesApiV1RunbooksTemplatesGetParamsStatus = "draft"
+	ListTemplatesApiV1RunbooksTemplatesGetParamsStatusPublished  ListTemplatesApiV1RunbooksTemplatesGetParamsStatus = "published"
 )
 
 // Defines values for ListTriggersApiV1SchedulerTriggersGetParamsKind.
@@ -388,6 +388,20 @@ const (
 	ListTriggersApiV1SchedulerTriggersGetParamsStatusCancelled ListTriggersApiV1SchedulerTriggersGetParamsStatus = "cancelled"
 	ListTriggersApiV1SchedulerTriggersGetParamsStatusFired     ListTriggersApiV1SchedulerTriggersGetParamsStatus = "fired"
 	ListTriggersApiV1SchedulerTriggersGetParamsStatusPaused    ListTriggersApiV1SchedulerTriggersGetParamsStatus = "paused"
+)
+
+// Defines values for RunbooksIndexUiRunbooksGetParamsStatus.
+const (
+	RunbooksIndexUiRunbooksGetParamsStatusDeprecated RunbooksIndexUiRunbooksGetParamsStatus = "deprecated"
+	RunbooksIndexUiRunbooksGetParamsStatusDraft      RunbooksIndexUiRunbooksGetParamsStatus = "draft"
+	RunbooksIndexUiRunbooksGetParamsStatusPublished  RunbooksIndexUiRunbooksGetParamsStatus = "published"
+)
+
+// Defines values for RunbooksListUiRunbooksListGetParamsStatus.
+const (
+	Deprecated RunbooksListUiRunbooksListGetParamsStatus = "deprecated"
+	Draft      RunbooksListUiRunbooksListGetParamsStatus = "draft"
+	Published  RunbooksListUiRunbooksListGetParamsStatus = "published"
 )
 
 // AbortRunRequest Request body for “runbook_abort“ -- terminate the run mid-flight.
@@ -5508,6 +5522,29 @@ type UiMemoryListUiMemoryGetParams struct {
 	Tag   *string `form:"tag,omitempty" json:"tag,omitempty"`
 }
 
+// RunbooksIndexUiRunbooksGetParams defines parameters for RunbooksIndexUiRunbooksGet.
+type RunbooksIndexUiRunbooksGetParams struct {
+	Status     *RunbooksIndexUiRunbooksGetParamsStatus `form:"status,omitempty" json:"status,omitempty"`
+	TargetKind *string                                 `form:"target_kind,omitempty" json:"target_kind,omitempty"`
+}
+
+// RunbooksIndexUiRunbooksGetParamsStatus defines parameters for RunbooksIndexUiRunbooksGet.
+type RunbooksIndexUiRunbooksGetParamsStatus string
+
+// RunbooksListUiRunbooksListGetParams defines parameters for RunbooksListUiRunbooksListGet.
+type RunbooksListUiRunbooksListGetParams struct {
+	Status     *RunbooksListUiRunbooksListGetParamsStatus `form:"status,omitempty" json:"status,omitempty"`
+	TargetKind *string                                    `form:"target_kind,omitempty" json:"target_kind,omitempty"`
+}
+
+// RunbooksListUiRunbooksListGetParamsStatus defines parameters for RunbooksListUiRunbooksListGet.
+type RunbooksListUiRunbooksListGetParamsStatus string
+
+// RunbooksDetailUiRunbooksSlugGetParams defines parameters for RunbooksDetailUiRunbooksSlugGet.
+type RunbooksDetailUiRunbooksSlugGetParams struct {
+	Version *int `form:"version,omitempty" json:"version,omitempty"`
+}
+
 // UiTopologyTableUiTopologyGetParams defines parameters for UiTopologyTableUiTopologyGet.
 type UiTopologyTableUiTopologyGetParams struct {
 	Sort *MehoBackplaneUiRoutesTopologyTableSortColumn `form:"sort,omitempty" json:"sort,omitempty"`
@@ -6980,6 +7017,15 @@ type ClientInterface interface {
 	UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithBody(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithFormdataBody(ctx context.Context, scope MemoryScope, slug string, body UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RunbooksIndexUiRunbooksGet request
+	RunbooksIndexUiRunbooksGet(ctx context.Context, params *RunbooksIndexUiRunbooksGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RunbooksListUiRunbooksListGet request
+	RunbooksListUiRunbooksListGet(ctx context.Context, params *RunbooksListUiRunbooksListGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// RunbooksDetailUiRunbooksSlugGet request
+	RunbooksDetailUiRunbooksSlugGet(ctx context.Context, slug string, params *RunbooksDetailUiRunbooksSlugGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// UiTopologyTableUiTopologyGet request
 	UiTopologyTableUiTopologyGet(ctx context.Context, params *UiTopologyTableUiTopologyGetParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -9453,6 +9499,42 @@ func (c *Client) UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithBody(ctx c
 
 func (c *Client) UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithFormdataBody(ctx context.Context, scope MemoryScope, slug string, body UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostRequestWithFormdataBody(c.Server, scope, slug, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RunbooksIndexUiRunbooksGet(ctx context.Context, params *RunbooksIndexUiRunbooksGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRunbooksIndexUiRunbooksGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RunbooksListUiRunbooksListGet(ctx context.Context, params *RunbooksListUiRunbooksListGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRunbooksListUiRunbooksListGetRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) RunbooksDetailUiRunbooksSlugGet(ctx context.Context, slug string, params *RunbooksDetailUiRunbooksSlugGetParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewRunbooksDetailUiRunbooksSlugGetRequest(c.Server, slug, params)
 	if err != nil {
 		return nil, err
 	}
@@ -18550,6 +18632,192 @@ func NewUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostRequestWithBody(server 
 	return req, nil
 }
 
+// NewRunbooksIndexUiRunbooksGetRequest generates requests for RunbooksIndexUiRunbooksGet
+func NewRunbooksIndexUiRunbooksGetRequest(server string, params *RunbooksIndexUiRunbooksGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/runbooks")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Status != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, *params.Status); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.TargetKind != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "target_kind", runtime.ParamLocationQuery, *params.TargetKind); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewRunbooksListUiRunbooksListGetRequest generates requests for RunbooksListUiRunbooksListGet
+func NewRunbooksListUiRunbooksListGetRequest(server string, params *RunbooksListUiRunbooksListGetParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/runbooks/list")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Status != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, *params.Status); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.TargetKind != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "target_kind", runtime.ParamLocationQuery, *params.TargetKind); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewRunbooksDetailUiRunbooksSlugGetRequest generates requests for RunbooksDetailUiRunbooksSlugGet
+func NewRunbooksDetailUiRunbooksSlugGetRequest(server string, slug string, params *RunbooksDetailUiRunbooksSlugGetParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "slug", runtime.ParamLocationPath, slug)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/ui/runbooks/%s", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Version != nil {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "version", runtime.ParamLocationQuery, *params.Version); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewUiTopologyTableUiTopologyGetRequest generates requests for UiTopologyTableUiTopologyGet
 func NewUiTopologyTableUiTopologyGetRequest(server string, params *UiTopologyTableUiTopologyGetParams) (*http.Request, error) {
 	var err error
@@ -19452,6 +19720,15 @@ type ClientWithResponsesInterface interface {
 	UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithBodyWithResponse(ctx context.Context, scope MemoryScope, slug string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse, error)
 
 	UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostWithFormdataBodyWithResponse(ctx context.Context, scope MemoryScope, slug string, body UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostFormdataRequestBody, reqEditors ...RequestEditorFn) (*UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse, error)
+
+	// RunbooksIndexUiRunbooksGetWithResponse request
+	RunbooksIndexUiRunbooksGetWithResponse(ctx context.Context, params *RunbooksIndexUiRunbooksGetParams, reqEditors ...RequestEditorFn) (*RunbooksIndexUiRunbooksGetResponse, error)
+
+	// RunbooksListUiRunbooksListGetWithResponse request
+	RunbooksListUiRunbooksListGetWithResponse(ctx context.Context, params *RunbooksListUiRunbooksListGetParams, reqEditors ...RequestEditorFn) (*RunbooksListUiRunbooksListGetResponse, error)
+
+	// RunbooksDetailUiRunbooksSlugGetWithResponse request
+	RunbooksDetailUiRunbooksSlugGetWithResponse(ctx context.Context, slug string, params *RunbooksDetailUiRunbooksSlugGetParams, reqEditors ...RequestEditorFn) (*RunbooksDetailUiRunbooksSlugGetResponse, error)
 
 	// UiTopologyTableUiTopologyGetWithResponse request
 	UiTopologyTableUiTopologyGetWithResponse(ctx context.Context, params *UiTopologyTableUiTopologyGetParams, reqEditors ...RequestEditorFn) (*UiTopologyTableUiTopologyGetResponse, error)
@@ -22839,6 +23116,72 @@ func (r UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse) StatusCode() 
 	return 0
 }
 
+type RunbooksIndexUiRunbooksGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r RunbooksIndexUiRunbooksGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RunbooksIndexUiRunbooksGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type RunbooksListUiRunbooksListGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r RunbooksListUiRunbooksListGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RunbooksListUiRunbooksListGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type RunbooksDetailUiRunbooksSlugGetResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON422      *HTTPValidationError
+}
+
+// Status returns HTTPResponse.Status
+func (r RunbooksDetailUiRunbooksSlugGetResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r RunbooksDetailUiRunbooksSlugGetResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type UiTopologyTableUiTopologyGetResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -24697,6 +25040,33 @@ func (c *ClientWithResponses) UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostW
 		return nil, err
 	}
 	return ParseUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse(rsp)
+}
+
+// RunbooksIndexUiRunbooksGetWithResponse request returning *RunbooksIndexUiRunbooksGetResponse
+func (c *ClientWithResponses) RunbooksIndexUiRunbooksGetWithResponse(ctx context.Context, params *RunbooksIndexUiRunbooksGetParams, reqEditors ...RequestEditorFn) (*RunbooksIndexUiRunbooksGetResponse, error) {
+	rsp, err := c.RunbooksIndexUiRunbooksGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRunbooksIndexUiRunbooksGetResponse(rsp)
+}
+
+// RunbooksListUiRunbooksListGetWithResponse request returning *RunbooksListUiRunbooksListGetResponse
+func (c *ClientWithResponses) RunbooksListUiRunbooksListGetWithResponse(ctx context.Context, params *RunbooksListUiRunbooksListGetParams, reqEditors ...RequestEditorFn) (*RunbooksListUiRunbooksListGetResponse, error) {
+	rsp, err := c.RunbooksListUiRunbooksListGet(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRunbooksListUiRunbooksListGetResponse(rsp)
+}
+
+// RunbooksDetailUiRunbooksSlugGetWithResponse request returning *RunbooksDetailUiRunbooksSlugGetResponse
+func (c *ClientWithResponses) RunbooksDetailUiRunbooksSlugGetWithResponse(ctx context.Context, slug string, params *RunbooksDetailUiRunbooksSlugGetParams, reqEditors ...RequestEditorFn) (*RunbooksDetailUiRunbooksSlugGetResponse, error) {
+	rsp, err := c.RunbooksDetailUiRunbooksSlugGet(ctx, slug, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseRunbooksDetailUiRunbooksSlugGetResponse(rsp)
 }
 
 // UiTopologyTableUiTopologyGetWithResponse request returning *UiTopologyTableUiTopologyGetResponse
@@ -29172,6 +29542,84 @@ func ParseUiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse(rsp *http.Re
 	}
 
 	response := &UiMemoryPromoteSubmitUiMemoryScopeSlugPromotePostResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRunbooksIndexUiRunbooksGetResponse parses an HTTP response from a RunbooksIndexUiRunbooksGetWithResponse call
+func ParseRunbooksIndexUiRunbooksGetResponse(rsp *http.Response) (*RunbooksIndexUiRunbooksGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RunbooksIndexUiRunbooksGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRunbooksListUiRunbooksListGetResponse parses an HTTP response from a RunbooksListUiRunbooksListGetWithResponse call
+func ParseRunbooksListUiRunbooksListGetResponse(rsp *http.Response) (*RunbooksListUiRunbooksListGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RunbooksListUiRunbooksListGetResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 422:
+		var dest HTTPValidationError
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON422 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseRunbooksDetailUiRunbooksSlugGetResponse parses an HTTP response from a RunbooksDetailUiRunbooksSlugGetWithResponse call
+func ParseRunbooksDetailUiRunbooksSlugGetResponse(rsp *http.Response) (*RunbooksDetailUiRunbooksSlugGetResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &RunbooksDetailUiRunbooksSlugGetResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}


### PR DESCRIPTION
## Summary

- Ships the **G10.6-T1 runbooks read surface** on the operator console: a catalog browse page (`/ui/runbooks`) and an opacity-floor-aware template detail view (`/ui/runbooks/{slug}`), consuming the existing G12.2 runbook template layer (`RunbookTemplateService` / `RunbookRunService`).
- **Catalog** lists the latest version per slug (slug / version / title / status badge / target_kind / edited_at) as DaisyUI table rows; **status + target_kind filters** drive an HTMX partial swap (`HX-Request` → `runbooks/_list.html` fragment, direct nav → full page). The filter partial lives at `/ui/runbooks/list`, registered before `/ui/runbooks/{slug}` so the literal segment is never bound as a slug.
- **Detail** renders ordered steps (`manual` vs `operation_call`, with op_id/params) and both verify-gate kinds (`confirm` prompt vs `operation_call` op_id/params/expect); step bodies are server-rendered Markdown via the shared KB renderer.
- **Opacity floor:** a `tenant_admin` always sees full steps; an `operator` sees them only with a completed/abandoned run against the resolved `(slug, version)`, otherwise the page renders the summary plus a clear "restricted until you complete a run" notice — never a raw 403. The role lift re-verifies the session JWT and fails soft to operator-level; a missing slug collapses to the restricted state for operators (404 for admins) so existence never leaks via a status-code differential, mirroring the REST `show` route's `opacity_floor` posture.
- Wires the surface into `build_router()` (ahead of the stubs aggregate), the sidebar, and the dashboard tile grid; regenerates the CLI OpenAPI snapshot + typed Go client for the three new `/ui` routes.

## Test plan

- [x] `ruff check` / `ruff format --check` — clean (3 files)
- [x] `mypy` — clean (`src/meho_backplane/ui/routes/runbooks/` + touched `__init__.py` / `dashboard.py`)
- [x] `pytest tests/test_ui_runbooks_list.py` — **19 passed** (auth boundary, catalog + status badges, empty state, HTMX fragment vs full page, status + target_kind filters, invalid-status 422, admin all-step-kinds + both verify kinds, server-rendered Markdown, admin missing-slug 404, post-completion operator full steps, operator no-run / in-progress-run / missing-slug restricted, cross-tenant isolation, dashboard tile + sidebar)
- [x] Sibling UI regression (`test_ui_kb_search.py`, `test_ui_memory_list.py`, `test_ui_connectors_view.py`, `test_ui_chassis_smoke.py`) — green
- [x] `code-quality.py --diff` — 0 blockers
- [x] CLI: `make snapshot-openapi` + `make generate`; `go build ./internal/api/` — compiles

## Out of scope

- Authoring/editor (T2), publish/deprecate controls (T3), docs/acceptance round-trip (T4) — sibling tasks on #1381.
- Cross-version history browser (no backing list-versions endpoint), run-execution UI.

<!-- auto-implement-issue: fresh, iteration 1 -->

Closes #1382


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Runbooks UI surface with catalog browsing and detail pages for individual runbooks.
  * Runbooks can be filtered by status (draft, published, deprecated) and target kind.
  * Detail pages display runbook steps with operation information and verification guidance.
  * Dashboard now includes a Runbooks tile and sidebar navigation link.
  * Role-based visibility: admins see full details; operators see restricted content until run completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->